### PR TITLE
feat(langy): migrate all 20 Langy tools to defineLangyTool (Phase 3 — closes #3956)

### DIFF
--- a/langwatch/src/server/routes/__tests__/langy.tool-output-validation.e2e.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy.tool-output-validation.e2e.test.ts
@@ -1,0 +1,455 @@
+/**
+ * E2E test: drives the real Hono /api/langy/chat route with a
+ * MockLanguageModelV3 that calls a tool whose downstream returns a
+ * malformed payload. Asserts the validated `tool_output_invalid`
+ * envelope is what the model receives back as the tool result on its
+ * second turn — i.e. the malformed payload never reaches the model.
+ *
+ * Named `.e2e.test.ts` for clarity (the test drives the full request
+ * pipeline through Hono), but it runs under the regular `pnpm test:unit`
+ * runner because no real services are involved — all downstreams are
+ * mocked at the import boundary.
+ */
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DoStreamFactory = (...args: any[]) => Promise<{ stream: ReadableStream<any> }>;
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede the route import.
+// ---------------------------------------------------------------------------
+
+const mockGetServerAuthSession = vi.fn();
+const mockHasProjectPermission = vi.fn();
+const mockCheckRateLimit = vi.fn();
+const mockGetVercelAIModel = vi.fn();
+const mockEnsureConversation = vi.fn();
+const mockTouchConversation = vi.fn();
+const mockGetProjectMemory = vi.fn();
+const mockGetUserPrefs = vi.fn();
+const mockAppendMessage = vi.fn();
+const mockFeatureFlagIsEnabled = vi.fn();
+const mockStreamLangyMastraResponse = vi.fn();
+const mockEsSearch = vi.fn();
+const mockEvaluatorGetAllWithFields = vi.fn();
+const mockEvaluatorGetBySlug = vi.fn();
+const mockExperimentFindFirst = vi.fn();
+const mockDatasetFindMany = vi.fn();
+const mockBatchEvaluationFindMany = vi.fn();
+const mockPromptServiceGetAllPrompts = vi.fn();
+
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: (...args: unknown[]) =>
+    mockGetServerAuthSession(...args),
+}));
+
+vi.mock("~/server/api/rbac", () => ({
+  hasProjectPermission: (...args: unknown[]) =>
+    mockHasProjectPermission(...args),
+}));
+
+vi.mock("~/server/middleware/rate-limit-langy", () => ({
+  LANGY_TOOL_CALLS_PER_MESSAGE: 5,
+  checkLangyMessageRateLimit: (...args: unknown[]) =>
+    mockCheckRateLimit(...args),
+}));
+
+vi.mock("~/server/modelProviders/utils", () => ({
+  getVercelAIModel: (...args: unknown[]) => mockGetVercelAIModel(...args),
+}));
+
+vi.mock("~/server/app-layer/clients/tokenizer/tiktoken.client", () => ({
+  TiktokenClient: class {
+    async countTokens(): Promise<number> {
+      return 1;
+    }
+  },
+}));
+
+vi.mock("~/server/auditLog", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/server/elasticsearch", () => ({
+  esClient: vi.fn(async () => ({ search: mockEsSearch })),
+  TRACE_INDEX: { alias: "trace_alias" },
+}));
+
+vi.mock("~/server/evaluators/evaluator.service", () => ({
+  EvaluatorService: {
+    create: () => ({
+      getAllWithFields: (...args: unknown[]) =>
+        mockEvaluatorGetAllWithFields(...args),
+      getBySlug: (...args: unknown[]) => mockEvaluatorGetBySlug(...args),
+    }),
+  },
+}));
+
+vi.mock("~/server/prompt-config/prompt.service", () => ({
+  PromptService: class {
+    async getAllPrompts(...args: unknown[]): Promise<unknown> {
+      return mockPromptServiceGetAllPrompts(...args);
+    }
+    async getPromptByIdOrHandle(): Promise<null> {
+      return null;
+    }
+  },
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    experiment: {
+      findFirst: (...args: unknown[]) => mockExperimentFindFirst(...args),
+    },
+    dataset: {
+      findMany: (...args: unknown[]) => mockDatasetFindMany(...args),
+      findFirst: vi.fn(),
+    },
+    datasetRecord: { findMany: vi.fn() },
+    batchEvaluation: {
+      findMany: (...args: unknown[]) => mockBatchEvaluationFindMany(...args),
+    },
+    llmPromptConfig: { findMany: vi.fn() },
+    project: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: {
+    isEnabled: (...args: unknown[]) => mockFeatureFlagIsEnabled(...args),
+  },
+}));
+
+vi.mock("~/server/services/langy/mastra-agent", () => ({
+  streamLangyMastraResponse: (...args: unknown[]) =>
+    mockStreamLangyMastraResponse(...args),
+}));
+
+vi.mock("~/server/services/langy", () => ({
+  LangyConversationService: {
+    create: () => ({
+      ensureConversation: (...args: unknown[]) =>
+        mockEnsureConversation(...args),
+      touch: (...args: unknown[]) => mockTouchConversation(...args),
+    }),
+  },
+  LangyMessageService: {
+    create: () => ({
+      append: (...args: unknown[]) => mockAppendMessage(...args),
+    }),
+  },
+  LangyProjectMemoryService: {
+    create: () => ({
+      getById: (...args: unknown[]) => mockGetProjectMemory(...args),
+    }),
+  },
+  LangyUserPreferencesService: {
+    create: () => ({
+      getById: (...args: unknown[]) => mockGetUserPrefs(...args),
+    }),
+  },
+}));
+
+const { app } = await import("../langy");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface CapturedCall {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  prompt?: Array<{ role: string; content: any }>;
+}
+
+function makeToolCallingStubModel(toolName: string, input: unknown) {
+  const stringifiedInput = JSON.stringify(input);
+  const captures: CapturedCall[] = [];
+  let turnIndex = 0;
+  const turnBuilders = [
+    () =>
+      simulateReadableStream({
+        chunks: [
+          { type: "stream-start", warnings: [] },
+          { type: "response-metadata", id: "rsp-1", modelId: "mock-1" },
+          { type: "tool-input-start", id: "tc-1", toolName },
+          { type: "tool-input-delta", id: "tc-1", delta: stringifiedInput },
+          { type: "tool-input-end", id: "tc-1" },
+          {
+            type: "tool-call",
+            toolCallId: "tc-1",
+            toolName,
+            input: stringifiedInput,
+          },
+          {
+            type: "finish",
+            finishReason: "tool-calls",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ],
+        initialDelayInMs: null,
+        chunkDelayInMs: null,
+      }),
+    () =>
+      simulateReadableStream({
+        chunks: [
+          { type: "stream-start", warnings: [] },
+          { type: "response-metadata", id: "rsp-2", modelId: "mock-1" },
+          { type: "text-start", id: "txt-1" },
+          { type: "text-delta", id: "txt-1", delta: "ok" },
+          { type: "text-end", id: "txt-1" },
+          {
+            type: "finish",
+            finishReason: "stop",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          },
+        ],
+        initialDelayInMs: null,
+        chunkDelayInMs: null,
+      }),
+  ];
+  const doStream: DoStreamFactory = async (args: unknown) => {
+    captures.push(args as CapturedCall);
+    const builder =
+      turnBuilders[turnIndex] ?? turnBuilders[turnBuilders.length - 1]!;
+    turnIndex += 1;
+    return { stream: builder() as never };
+  };
+  const model = new MockLanguageModelV3({ doStream });
+  return { model, captures };
+}
+
+async function readBody(res: Response): Promise<string> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let acc = "";
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    acc += decoder.decode(value);
+  }
+  return acc;
+}
+
+function findToolResultContent(captures: CapturedCall[]): string {
+  // Second-turn prompt contains a 'tool' message whose content is the
+  // tool's return value. We stringify the whole second-turn prompt and
+  // search for the envelope literal — robust to AI-SDK message shape
+  // changes.
+  const second = captures[1];
+  return second ? JSON.stringify(second.prompt ?? second) : "";
+}
+
+// ---------------------------------------------------------------------------
+// Default-happy mocks
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetServerAuthSession.mockResolvedValue({
+    user: { id: "user_42", email: "tester@example.com" },
+    expires: "2099-01-01",
+  });
+  mockHasProjectPermission.mockResolvedValue(true);
+  mockCheckRateLimit.mockResolvedValue({ allowed: true });
+  mockGetProjectMemory.mockResolvedValue(null);
+  mockGetUserPrefs.mockResolvedValue({ mode: "non-expert" });
+  mockFeatureFlagIsEnabled.mockResolvedValue(false);
+  mockStreamLangyMastraResponse.mockReset();
+  mockEnsureConversation.mockResolvedValue({ id: "conv_test_abc" });
+  mockTouchConversation.mockResolvedValue(undefined);
+  mockAppendMessage.mockResolvedValue(undefined);
+  mockEvaluatorGetAllWithFields.mockResolvedValue([]);
+  mockEvaluatorGetBySlug.mockResolvedValue(null);
+  mockExperimentFindFirst.mockResolvedValue(null);
+  mockDatasetFindMany.mockResolvedValue([]);
+  mockBatchEvaluationFindMany.mockResolvedValue([]);
+  mockPromptServiceGetAllPrompts.mockResolvedValue([]);
+});
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+async function postChat(body: Record<string, unknown>): Promise<Response> {
+  return app.request("/api/langy/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/langy/chat — runtime tool-output validation E2E", () => {
+  describe("when search_traces' elasticsearch downstream returns hits with non-string _id", () => {
+    it("hands the model a tool_output_invalid envelope, never the malformed payload", async () => {
+      mockEsSearch.mockResolvedValueOnce({
+        hits: { hits: [{ _id: 99999, _source: {} }] },
+      });
+      const { model, captures } = makeToolCallingStubModel("search_traces", {
+        query: "hallucinations",
+        limit: 5,
+      });
+      mockGetVercelAIModel.mockResolvedValue(model);
+
+      const res = await postChat({
+        projectId: "proj_demo",
+        messages: [
+          {
+            id: "m1",
+            role: "user",
+            parts: [{ type: "text", text: "find traces about hallucinations" }],
+          },
+        ],
+      });
+      await readBody(res);
+
+      expect(res.status).toBe(200);
+      expect(captures.length).toBeGreaterThanOrEqual(2);
+
+      const secondTurnDump = findToolResultContent(captures);
+      expect(secondTurnDump).toContain("tool_output_invalid");
+      expect(secondTurnDump).not.toContain("99999");
+    });
+  });
+
+  describe("when search_past_runs' prisma downstream returns a row with non-string id", () => {
+    it("hands the model a tool_output_invalid envelope", async () => {
+      mockBatchEvaluationFindMany.mockResolvedValueOnce([
+        {
+          id: 88888,
+          experimentId: "exp-1",
+          createdAt: new Date(),
+          status: "complete",
+          score: 1,
+          passed: true,
+          evaluation: "evaluation-name",
+        },
+      ]);
+      const { model, captures } = makeToolCallingStubModel(
+        "search_past_runs",
+        { limit: 5 },
+      );
+      mockGetVercelAIModel.mockResolvedValue(model);
+
+      const res = await postChat({
+        projectId: "proj_demo",
+        messages: [
+          {
+            id: "m1",
+            role: "user",
+            parts: [{ type: "text", text: "show me past runs" }],
+          },
+        ],
+      });
+      await readBody(res);
+
+      const secondTurnDump = findToolResultContent(captures);
+      expect(secondTurnDump).toContain("tool_output_invalid");
+      expect(secondTurnDump).not.toContain("88888");
+    });
+  });
+
+  describe("when list_datasets' prisma downstream returns a row with non-string id", () => {
+    it("hands the model a tool_output_invalid envelope", async () => {
+      mockDatasetFindMany.mockResolvedValueOnce([
+        {
+          id: 77777,
+          slug: "ds-1",
+          name: "Dataset 1",
+          columnTypes: [],
+          _count: { datasetRecords: 0 },
+        },
+      ]);
+      const { model, captures } = makeToolCallingStubModel(
+        "list_datasets",
+        {},
+      );
+      mockGetVercelAIModel.mockResolvedValue(model);
+
+      const res = await postChat({
+        projectId: "proj_demo",
+        messages: [
+          {
+            id: "m1",
+            role: "user",
+            parts: [{ type: "text", text: "list datasets" }],
+          },
+        ],
+      });
+      await readBody(res);
+
+      const secondTurnDump = findToolResultContent(captures);
+      expect(secondTurnDump).toContain("tool_output_invalid");
+      expect(secondTurnDump).not.toContain("77777");
+    });
+  });
+
+  describe("when list_prompts' promptService returns a row with non-string id", () => {
+    it("hands the model a tool_output_invalid envelope", async () => {
+      mockPromptServiceGetAllPrompts.mockResolvedValueOnce([
+        {
+          id: 66666,
+          handle: "p-1",
+          name: "Prompt 1",
+          model: "openai/gpt-5-mini",
+          scope: "project",
+        },
+      ]);
+      const { model, captures } = makeToolCallingStubModel(
+        "list_prompts",
+        {},
+      );
+      mockGetVercelAIModel.mockResolvedValue(model);
+
+      const res = await postChat({
+        projectId: "proj_demo",
+        messages: [
+          {
+            id: "m1",
+            role: "user",
+            parts: [{ type: "text", text: "list prompts" }],
+          },
+        ],
+      });
+      await readBody(res);
+
+      const secondTurnDump = findToolResultContent(captures);
+      expect(secondTurnDump).toContain("tool_output_invalid");
+      expect(secondTurnDump).not.toContain("66666");
+    });
+  });
+
+  describe("when list_evaluators' evaluatorService returns a project evaluator with non-string id", () => {
+    it("hands the model a tool_output_invalid envelope", async () => {
+      mockEvaluatorGetAllWithFields.mockResolvedValueOnce([
+        {
+          id: 55555,
+          slug: "e-1",
+          name: "Eval 1",
+          type: "custom",
+          fields: [{ identifier: "f1" }],
+        },
+      ]);
+      const { model, captures } = makeToolCallingStubModel("list_evaluators", {
+        scope: "project",
+      });
+      mockGetVercelAIModel.mockResolvedValue(model);
+
+      const res = await postChat({
+        projectId: "proj_demo",
+        messages: [
+          {
+            id: "m1",
+            role: "user",
+            parts: [{ type: "text", text: "list evaluators" }],
+          },
+        ],
+      });
+      await readBody(res);
+
+      const secondTurnDump = findToolResultContent(captures);
+      expect(secondTurnDump).toContain("tool_output_invalid");
+      expect(secondTurnDump).not.toContain("55555");
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/tools/__tests__/datasets.tool-validation.unit.test.ts
+++ b/langwatch/src/server/services/langy/tools/__tests__/datasets.tool-validation.unit.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  LANGY_TOOL_OUTPUT_INVALID_CODE,
+  langyToolErrorEnvelope,
+} from "../../defineLangyTool";
+import {
+  makeGetDatasetDetails,
+  makeListDatasets,
+  makeProposeAddDatasetRows,
+  makeProposeCreateDataset,
+} from "../datasets";
+import { ConversationToolIdSet } from "../../toolIdValidator";
+import type { LangyToolContext } from "../types";
+
+function makeCtx(
+  prismaLike: Record<string, unknown> = {},
+  seenIds: ConversationToolIdSet = new ConversationToolIdSet(),
+): LangyToolContext {
+  return {
+    projectId: "project-1",
+    seenIds,
+    evaluatorService: {} as LangyToolContext["evaluatorService"],
+    promptService: {} as LangyToolContext["promptService"],
+    prisma: prismaLike as unknown as LangyToolContext["prisma"],
+  };
+}
+
+function invokeTool(toolDef: unknown, input: unknown): Promise<unknown> {
+  const exec = (toolDef as { execute: (i: unknown) => Promise<unknown> })
+    .execute;
+  return exec(input);
+}
+
+function expectInvalidEnvelope(result: unknown) {
+  expect(langyToolErrorEnvelope.safeParse(result).success).toBe(true);
+  expect((result as { error: { code: string } }).error.code).toBe(
+    LANGY_TOOL_OUTPUT_INVALID_CODE,
+  );
+}
+
+describe("list_datasets tool-output validation", () => {
+  describe("when prisma returns a dataset row whose id is not a string", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      const prismaLike = {
+        dataset: {
+          findMany: vi.fn().mockResolvedValueOnce([
+            {
+              id: 999,
+              slug: "ds-1",
+              name: "Dataset 1",
+              columnTypes: [],
+              _count: { datasetRecords: 0 },
+            },
+          ]),
+        },
+      };
+      const toolDef = makeListDatasets(makeCtx(prismaLike));
+      const result = await invokeTool(toolDef, {});
+
+      expectInvalidEnvelope(result);
+    });
+  });
+
+  describe("when prisma returns a well-formed dataset row", () => {
+    it("returns the parsed items array", async () => {
+      const prismaLike = {
+        dataset: {
+          findMany: vi.fn().mockResolvedValueOnce([
+            {
+              id: "ds-1",
+              slug: "ds-1-slug",
+              name: "Dataset 1",
+              columnTypes: [{ name: "col", type: "string" }],
+              _count: { datasetRecords: 3 },
+            },
+          ]),
+        },
+      };
+      const toolDef = makeListDatasets(makeCtx(prismaLike));
+      const result = (await invokeTool(toolDef, {})) as {
+        items: Array<{ id: string }>;
+      };
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe("ds-1");
+    });
+  });
+});
+
+describe("get_dataset_details tool-output validation", () => {
+  describe("when prisma returns a dataset but sampleRows has malformed id", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      const prismaLike = {
+        dataset: {
+          findFirst: vi.fn().mockResolvedValueOnce({
+            id: "ds-1",
+            slug: "ds-1",
+            name: "ds-1",
+            columnTypes: [],
+            _count: { datasetRecords: 1 },
+          }),
+        },
+        datasetRecord: {
+          findMany: vi.fn().mockResolvedValueOnce([{ id: 42, entry: {} }]),
+        },
+      };
+      const toolDef = makeGetDatasetDetails(makeCtx(prismaLike));
+      const result = await invokeTool(toolDef, {
+        datasetId: "ds-1",
+        sampleRowLimit: 5,
+      });
+
+      expectInvalidEnvelope(result);
+    });
+  });
+
+  describe("when the dataset is not found", () => {
+    it("returns the error branch matching its union variant", async () => {
+      const prismaLike = {
+        dataset: { findFirst: vi.fn().mockResolvedValueOnce(null) },
+      };
+      const toolDef = makeGetDatasetDetails(makeCtx(prismaLike));
+      const result = (await invokeTool(toolDef, {
+        datasetId: "missing",
+        sampleRowLimit: 0,
+      })) as { error?: string };
+
+      expect(result.error).toContain("No dataset found");
+      expect(langyToolErrorEnvelope.safeParse(result).success).toBe(false);
+    });
+  });
+});
+
+describe("propose_create_dataset tool-output validation", () => {
+  describe("when the proposal is well-formed", () => {
+    it("returns the proposal envelope", async () => {
+      const toolDef = makeProposeCreateDataset(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        name: "New Dataset",
+        columns: [{ name: "col1", type: "string" as const }],
+        rationale: "because",
+      })) as { langyProposal: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.kind).toBe("datasets.create");
+    });
+  });
+});
+
+describe("propose_add_dataset_rows tool-output validation", () => {
+  describe("when the dataset id was not surfaced earlier", () => {
+    it("returns the error branch matching its union variant", async () => {
+      const toolDef = makeProposeAddDatasetRows(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        datasetId: "ds-unsurfaced",
+        rows: [{ col: "v" }],
+        rationale: "r",
+      })) as { error?: string };
+
+      expect(result.error).toContain("not surfaced");
+    });
+  });
+
+  describe("when the dataset is surfaced and exists", () => {
+    it("returns the proposal envelope", async () => {
+      const seen = new ConversationToolIdSet();
+      seen.record("dataset_id", "ds-1");
+      const prismaLike = {
+        dataset: {
+          findFirst: vi.fn().mockResolvedValueOnce({
+            id: "ds-1",
+            name: "Dataset 1",
+            slug: "ds-1",
+          }),
+        },
+      };
+      const toolDef = makeProposeAddDatasetRows(makeCtx(prismaLike, seen));
+      const result = (await invokeTool(toolDef, {
+        datasetId: "ds-1",
+        rows: [{ col: "v" }],
+        rationale: "r",
+      })) as { langyProposal: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.kind).toBe("datasets.addRows");
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/tools/__tests__/evaluators.tool-validation.unit.test.ts
+++ b/langwatch/src/server/services/langy/tools/__tests__/evaluators.tool-validation.unit.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("~/server/evaluations/evaluators.generated", () => ({
+  AVAILABLE_EVALUATORS: {
+    "ragas/answer_relevancy": {
+      name: "Answer Relevancy",
+      description: "Checks answer relevancy",
+      category: "RAG",
+      isGuardrail: false,
+      requiredFields: ["question", "answer"],
+      optionalFields: [],
+      result: {},
+      docsUrl: "https://docs",
+    },
+  },
+}));
+
+vi.mock("~/server/evaluations/getEvaluator", () => ({
+  getEvaluatorDefaultSettings: vi.fn(() => ({})),
+  getEvaluatorDefinitions: vi.fn(() => ({})),
+}));
+
+import {
+  LANGY_TOOL_OUTPUT_INVALID_CODE,
+  langyToolErrorEnvelope,
+} from "../../defineLangyTool";
+import {
+  makeGetEvaluatorDetails,
+  makeListEvaluators,
+  makeProposeAddEvaluatorToWorkbench,
+  makeProposeCreateEvaluator,
+  makeProposeDeleteEvaluator,
+  makeProposeUpdateEvaluator,
+} from "../evaluators";
+import { ConversationToolIdSet } from "../../toolIdValidator";
+import type { LangyToolContext } from "../types";
+
+function makeCtx(opts: {
+  prismaLike?: Record<string, unknown>;
+  evaluatorServiceLike?: Record<string, unknown>;
+  seenIds?: ConversationToolIdSet;
+} = {}): LangyToolContext {
+  return {
+    projectId: "project-1",
+    seenIds: opts.seenIds ?? new ConversationToolIdSet(),
+    evaluatorService:
+      (opts.evaluatorServiceLike ??
+        {}) as unknown as LangyToolContext["evaluatorService"],
+    promptService: {} as LangyToolContext["promptService"],
+    prisma:
+      (opts.prismaLike ?? {}) as unknown as LangyToolContext["prisma"],
+  };
+}
+
+function invokeTool(toolDef: unknown, input: unknown): Promise<unknown> {
+  const exec = (toolDef as { execute: (i: unknown) => Promise<unknown> })
+    .execute;
+  return exec(input);
+}
+
+function expectInvalidEnvelope(result: unknown) {
+  expect(langyToolErrorEnvelope.safeParse(result).success).toBe(true);
+  expect((result as { error: { code: string } }).error.code).toBe(
+    LANGY_TOOL_OUTPUT_INVALID_CODE,
+  );
+}
+
+describe("list_evaluators tool-output validation", () => {
+  describe("when evaluatorService returns a project evaluator with non-string id", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      const evaluatorServiceLike = {
+        getAllWithFields: vi.fn().mockResolvedValueOnce([
+          {
+            id: 99,
+            slug: "e-1",
+            name: "Eval 1",
+            type: "custom",
+            fields: [{ identifier: "f1" }],
+          },
+        ]),
+      };
+      const toolDef = makeListEvaluators(makeCtx({ evaluatorServiceLike }));
+      const result = await invokeTool(toolDef, { scope: "project" });
+
+      expectInvalidEnvelope(result);
+    });
+  });
+
+  describe("when scope is built_in and the catalog has a well-formed entry", () => {
+    it("returns the parsed items array", async () => {
+      const toolDef = makeListEvaluators(makeCtx());
+      const result = (await invokeTool(toolDef, { scope: "built_in" })) as {
+        items: Array<{ source: string }>;
+      };
+
+      expect(result.items.length).toBeGreaterThan(0);
+      expect(result.items[0]?.source).toBe("built_in");
+    });
+  });
+});
+
+describe("get_evaluator_details tool-output validation", () => {
+  describe("when neither slug nor evaluatorType is provided", () => {
+    it("returns the error variant", async () => {
+      const toolDef = makeGetEvaluatorDetails(makeCtx());
+      const result = (await invokeTool(toolDef, {})) as { error?: string };
+
+      expect(result.error).toContain("Provide either");
+    });
+  });
+
+  describe("when looking up a built-in evaluator that doesn't exist", () => {
+    it("returns the error variant", async () => {
+      const toolDef = makeGetEvaluatorDetails(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        evaluatorType: "ragas/does_not_exist",
+      })) as { error?: string };
+
+      expect(result.error).toContain("No built-in evaluator");
+    });
+  });
+});
+
+describe("propose_create_evaluator tool-output validation", () => {
+  describe("when the evaluator type was not surfaced", () => {
+    it("returns the error variant", async () => {
+      const toolDef = makeProposeCreateEvaluator(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        name: "New",
+        evaluatorType: "ragas/answer_relevancy",
+        rationale: "r",
+      })) as { error?: string };
+
+      expect(result.error).toContain("not surfaced");
+    });
+  });
+
+  describe("when the evaluator type was surfaced", () => {
+    it("returns the proposal envelope", async () => {
+      const seen = new ConversationToolIdSet();
+      seen.record("evaluator_type", "ragas/answer_relevancy");
+      const prismaLike = {
+        project: {
+          findUnique: vi.fn().mockResolvedValueOnce({
+            defaultModel: "openai/gpt-5-mini",
+            embeddingsModel: "openai/text-embedding-3-small",
+          }),
+        },
+      };
+      const toolDef = makeProposeCreateEvaluator(
+        makeCtx({ prismaLike, seenIds: seen }),
+      );
+      const result = (await invokeTool(toolDef, {
+        name: "New",
+        evaluatorType: "ragas/answer_relevancy",
+        rationale: "r",
+      })) as { langyProposal: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.kind).toBe("evaluators.create");
+    });
+  });
+});
+
+describe("propose_update_evaluator tool-output validation", () => {
+  describe("when the slug was not surfaced", () => {
+    it("returns the error variant", async () => {
+      const toolDef = makeProposeUpdateEvaluator(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        slug: "unsurfaced",
+        rationale: "r",
+      })) as { error?: string };
+
+      expect(result.error).toContain("not surfaced");
+    });
+  });
+
+  describe("when the slug was surfaced and the evaluator exists", () => {
+    it("returns the proposal envelope", async () => {
+      const seen = new ConversationToolIdSet();
+      seen.record("evaluator_slug", "e-1");
+      const evaluatorServiceLike = {
+        getBySlug: vi.fn().mockResolvedValueOnce({
+          id: "ev-id-1",
+          name: "Eval 1",
+          slug: "e-1",
+          config: { evaluatorType: "custom", settings: {} },
+        }),
+      };
+      const toolDef = makeProposeUpdateEvaluator(
+        makeCtx({ evaluatorServiceLike, seenIds: seen }),
+      );
+      const result = (await invokeTool(toolDef, {
+        slug: "e-1",
+        name: "Renamed",
+        rationale: "r",
+      })) as { langyProposal: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.kind).toBe("evaluators.update");
+    });
+  });
+});
+
+describe("propose_delete_evaluator tool-output validation", () => {
+  describe("when the slug was surfaced and the evaluator exists", () => {
+    it("returns the proposal envelope with destructive: true", async () => {
+      const seen = new ConversationToolIdSet();
+      seen.record("evaluator_slug", "e-1");
+      const evaluatorServiceLike = {
+        getBySlug: vi.fn().mockResolvedValueOnce({
+          id: "ev-id-1",
+          name: "Eval 1",
+          slug: "e-1",
+        }),
+      };
+      const toolDef = makeProposeDeleteEvaluator(
+        makeCtx({ evaluatorServiceLike, seenIds: seen }),
+      );
+      const result = (await invokeTool(toolDef, {
+        slug: "e-1",
+        rationale: "r",
+      })) as { langyProposal: true; destructive: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.destructive).toBe(true);
+      expect(result.kind).toBe("evaluators.delete");
+    });
+  });
+});
+
+describe("propose_add_evaluator_to_workbench tool-output validation", () => {
+  describe("when the slug was surfaced and the evaluator exists", () => {
+    it("returns the proposal envelope", async () => {
+      const seen = new ConversationToolIdSet();
+      seen.record("evaluator_slug", "e-1");
+      const evaluatorServiceLike = {
+        getBySlug: vi.fn().mockResolvedValueOnce({
+          id: "ev-id-1",
+          name: "Eval 1",
+          slug: "e-1",
+          config: { evaluatorType: "ragas/answer_relevancy" },
+        }),
+        enrichWithFields: vi.fn().mockImplementation(async (e: unknown) => ({
+          ...(e as Record<string, unknown>),
+          fields: [],
+        })),
+      };
+      const toolDef = makeProposeAddEvaluatorToWorkbench(
+        makeCtx({ evaluatorServiceLike, seenIds: seen }),
+      );
+      const result = (await invokeTool(toolDef, {
+        slug: "e-1",
+        rationale: "r",
+      })) as { langyProposal: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.kind).toBe("workbench.addEvaluator");
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/tools/__tests__/prompts.tool-validation.unit.test.ts
+++ b/langwatch/src/server/services/langy/tools/__tests__/prompts.tool-validation.unit.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  LANGY_TOOL_OUTPUT_INVALID_CODE,
+  langyToolErrorEnvelope,
+} from "../../defineLangyTool";
+import {
+  makeGetPromptDetails,
+  makeListPrompts,
+  makeProposeCreatePrompt,
+  makeProposeUpdatePrompt,
+  makeSearchPrompts,
+} from "../prompts";
+import { ConversationToolIdSet } from "../../toolIdValidator";
+import type { LangyToolContext } from "../types";
+
+function makeCtx(opts: {
+  prismaLike?: Record<string, unknown>;
+  promptServiceLike?: Record<string, unknown>;
+  seenIds?: ConversationToolIdSet;
+} = {}): LangyToolContext {
+  return {
+    projectId: "project-1",
+    seenIds: opts.seenIds ?? new ConversationToolIdSet(),
+    evaluatorService: {} as LangyToolContext["evaluatorService"],
+    promptService:
+      opts.promptServiceLike as unknown as LangyToolContext["promptService"] ??
+      ({} as LangyToolContext["promptService"]),
+    prisma:
+      (opts.prismaLike ?? {}) as unknown as LangyToolContext["prisma"],
+  };
+}
+
+function invokeTool(toolDef: unknown, input: unknown): Promise<unknown> {
+  const exec = (toolDef as { execute: (i: unknown) => Promise<unknown> })
+    .execute;
+  return exec(input);
+}
+
+function expectInvalidEnvelope(result: unknown) {
+  expect(langyToolErrorEnvelope.safeParse(result).success).toBe(true);
+  expect((result as { error: { code: string } }).error.code).toBe(
+    LANGY_TOOL_OUTPUT_INVALID_CODE,
+  );
+}
+
+describe("list_prompts tool-output validation", () => {
+  describe("when promptService returns a row whose id is not a string", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      const promptServiceLike = {
+        getAllPrompts: vi.fn().mockResolvedValueOnce([
+          {
+            id: 1,
+            handle: "p-1",
+            name: "Prompt 1",
+            model: "openai/gpt-5-mini",
+            scope: "project",
+          },
+        ]),
+      };
+      const toolDef = makeListPrompts(makeCtx({ promptServiceLike }));
+      const result = await invokeTool(toolDef, {});
+
+      expectInvalidEnvelope(result);
+    });
+  });
+
+  describe("when promptService returns a well-formed row", () => {
+    it("returns the parsed items array", async () => {
+      const promptServiceLike = {
+        getAllPrompts: vi.fn().mockResolvedValueOnce([
+          {
+            id: "p-1",
+            handle: "p-1",
+            name: "Prompt 1",
+            model: "openai/gpt-5-mini",
+            scope: "project",
+          },
+        ]),
+      };
+      const toolDef = makeListPrompts(makeCtx({ promptServiceLike }));
+      const result = (await invokeTool(toolDef, {})) as {
+        items: Array<{ id: string }>;
+      };
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.id).toBe("p-1");
+    });
+  });
+});
+
+describe("get_prompt_details tool-output validation", () => {
+  describe("when the prompt is not found", () => {
+    it("returns the error variant", async () => {
+      const promptServiceLike = {
+        getPromptByIdOrHandle: vi.fn().mockResolvedValueOnce(null),
+      };
+      const toolDef = makeGetPromptDetails(makeCtx({ promptServiceLike }));
+      const result = (await invokeTool(toolDef, {
+        idOrHandle: "missing",
+      })) as { error?: string };
+
+      expect(result.error).toContain("No prompt found");
+    });
+  });
+
+  describe("when the prompt is found but its id field is non-string", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      const promptServiceLike = {
+        getPromptByIdOrHandle: vi.fn().mockResolvedValueOnce({
+          id: 42,
+          handle: "p-1",
+          scope: "project",
+          model: "openai/gpt-5-mini",
+        }),
+      };
+      const toolDef = makeGetPromptDetails(makeCtx({ promptServiceLike }));
+      const result = await invokeTool(toolDef, { idOrHandle: "p-1" });
+
+      expectInvalidEnvelope(result);
+    });
+  });
+});
+
+describe("search_prompts tool-output validation", () => {
+  describe("when prisma returns rows whose handle is null", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      const prismaLike = {
+        llmPromptConfig: {
+          findMany: vi.fn().mockResolvedValueOnce([
+            { id: "p-1", handle: null, name: "Prompt 1" },
+          ]),
+        },
+      };
+      const toolDef = makeSearchPrompts(makeCtx({ prismaLike }));
+      const result = await invokeTool(toolDef, { query: "x", limit: 5 });
+
+      expectInvalidEnvelope(result);
+    });
+  });
+});
+
+describe("propose_create_prompt tool-output validation", () => {
+  describe("when the proposal is well-formed", () => {
+    it("returns the proposal envelope", async () => {
+      const toolDef = makeProposeCreatePrompt(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        handle: "rag-qa",
+        messages: [{ role: "user", content: "Q" }],
+        rationale: "fits",
+      })) as { langyProposal: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.kind).toBe("prompts.create");
+    });
+  });
+});
+
+describe("propose_update_prompt tool-output validation", () => {
+  describe("when the prompt id was not surfaced earlier", () => {
+    it("returns the error variant", async () => {
+      const toolDef = makeProposeUpdatePrompt(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        id: "p-unsurfaced",
+        commitMessage: "msg",
+        rationale: "r",
+      })) as { error?: string };
+
+      expect(result.error).toContain("not surfaced");
+    });
+  });
+
+  describe("when the prompt is surfaced and exists", () => {
+    it("returns the proposal envelope", async () => {
+      const seen = new ConversationToolIdSet();
+      seen.record("prompt_id", "p-1");
+      const promptServiceLike = {
+        getPromptByIdOrHandle: vi.fn().mockResolvedValueOnce({
+          id: "p-1",
+          handle: "p-1",
+        }),
+      };
+      const toolDef = makeProposeUpdatePrompt(
+        makeCtx({ promptServiceLike, seenIds: seen }),
+      );
+      const result = (await invokeTool(toolDef, {
+        id: "p-1",
+        commitMessage: "tweak",
+        rationale: "r",
+      })) as { langyProposal: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.kind).toBe("prompts.update");
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/tools/__tests__/traces-runs.tool-validation.unit.test.ts
+++ b/langwatch/src/server/services/langy/tools/__tests__/traces-runs.tool-validation.unit.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const { searchMock } = vi.hoisted(() => ({ searchMock: vi.fn() }));
+
+vi.mock("~/server/elasticsearch", () => ({
+  esClient: vi.fn(async () => ({ search: searchMock })),
+  TRACE_INDEX: { alias: "trace_alias" },
+}));
+
+import {
+  LANGY_TOOL_OUTPUT_INVALID_CODE,
+  langyToolErrorEnvelope,
+} from "../../defineLangyTool";
+import { makeSearchPastRuns } from "../runs";
+import { makeSearchTraces } from "../traces";
+import { ConversationToolIdSet } from "../../toolIdValidator";
+import type { LangyToolContext } from "../types";
+
+function makeCtx(
+  prismaLike: Record<string, unknown> = {},
+): LangyToolContext {
+  return {
+    projectId: "project-1",
+    seenIds: new ConversationToolIdSet(),
+    evaluatorService: {} as LangyToolContext["evaluatorService"],
+    promptService: {} as LangyToolContext["promptService"],
+    prisma: prismaLike as unknown as LangyToolContext["prisma"],
+  };
+}
+
+function invokeTool(toolDef: unknown, input: unknown): Promise<unknown> {
+  const exec = (toolDef as { execute: (i: unknown) => Promise<unknown> })
+    .execute;
+  return exec(input);
+}
+
+describe("search_traces tool-output validation", () => {
+  describe("when elasticsearch returns hits whose _id is not a string", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      searchMock.mockResolvedValueOnce({
+        hits: { hits: [{ _id: 42, _source: {} }] },
+      });
+      const toolDef = makeSearchTraces(makeCtx());
+      const result = await invokeTool(toolDef, { query: "x", limit: 5 });
+
+      expect(langyToolErrorEnvelope.safeParse(result).success).toBe(true);
+      expect((result as { error: { code: string } }).error.code).toBe(
+        LANGY_TOOL_OUTPUT_INVALID_CODE,
+      );
+    });
+
+    it("does not leak the malformed items array to the caller", async () => {
+      searchMock.mockResolvedValueOnce({
+        hits: { hits: [{ _id: 42, _source: {} }] },
+      });
+      const toolDef = makeSearchTraces(makeCtx());
+      const result = await invokeTool(toolDef, { query: "x", limit: 5 });
+
+      expect(result).not.toHaveProperty("items");
+    });
+  });
+
+  describe("when elasticsearch returns well-formed hits", () => {
+    it("returns the parsed items array", async () => {
+      searchMock.mockResolvedValueOnce({
+        hits: {
+          hits: [
+            {
+              _id: "trace-1",
+              _source: {
+                timestamps: { started_at: 1700000000 },
+                input: { value: "hello world" },
+              },
+            },
+          ],
+        },
+      });
+      const toolDef = makeSearchTraces(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        query: "x",
+        limit: 5,
+      })) as { items: Array<{ traceId: string }> };
+
+      expect(result.items).toEqual([
+        {
+          traceId: "trace-1",
+          startedAt: 1700000000,
+          snippet: "hello world",
+        },
+      ]);
+    });
+  });
+});
+
+describe("search_past_runs tool-output validation", () => {
+  describe("when prisma returns a row whose id is not a string", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      const prismaLike = {
+        batchEvaluation: {
+          findMany: vi.fn().mockResolvedValueOnce([
+            {
+              id: 123,
+              experimentId: "exp-1",
+              createdAt: new Date(),
+              status: "complete",
+              score: 1,
+              passed: true,
+              evaluation: "evaluation-name",
+            },
+          ]),
+        },
+      };
+      const toolDef = makeSearchPastRuns(makeCtx(prismaLike));
+      const result = await invokeTool(toolDef, { limit: 5 });
+
+      expect(langyToolErrorEnvelope.safeParse(result).success).toBe(true);
+      expect((result as { error: { code: string } }).error.code).toBe(
+        LANGY_TOOL_OUTPUT_INVALID_CODE,
+      );
+    });
+
+    it("does not leak the malformed rows to the caller", async () => {
+      const prismaLike = {
+        batchEvaluation: {
+          findMany: vi.fn().mockResolvedValueOnce([
+            {
+              id: 123,
+              experimentId: "exp-1",
+              createdAt: new Date(),
+              status: "complete",
+              score: 1,
+              passed: true,
+              evaluation: "evaluation-name",
+            },
+          ]),
+        },
+      };
+      const toolDef = makeSearchPastRuns(makeCtx(prismaLike));
+      const result = await invokeTool(toolDef, { limit: 5 });
+
+      expect(result).not.toHaveProperty("items");
+    });
+  });
+
+  describe("when prisma returns well-formed rows", () => {
+    it("returns the parsed items array", async () => {
+      const createdAt = new Date("2026-05-13T00:00:00Z");
+      const prismaLike = {
+        batchEvaluation: {
+          findMany: vi.fn().mockResolvedValueOnce([
+            {
+              id: "run-1",
+              experimentId: "exp-1",
+              createdAt,
+              status: "complete",
+              score: 0.8,
+              passed: true,
+              evaluation: "evaluation-name",
+            },
+          ]),
+        },
+      };
+      const toolDef = makeSearchPastRuns(makeCtx(prismaLike));
+      const result = (await invokeTool(toolDef, { limit: 5 })) as {
+        items: Array<{ id: string }>;
+      };
+
+      expect(result.items).toEqual([
+        {
+          id: "run-1",
+          experimentId: "exp-1",
+          createdAt,
+          status: "complete",
+          score: 0.8,
+          passed: true,
+          evaluation: "evaluation-name",
+        },
+      ]);
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/tools/__tests__/workbench.tool-validation.unit.test.ts
+++ b/langwatch/src/server/services/langy/tools/__tests__/workbench.tool-validation.unit.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  LANGY_TOOL_OUTPUT_INVALID_CODE,
+  langyToolErrorEnvelope,
+} from "../../defineLangyTool";
+import {
+  makeFindFailingRows,
+  makeGetWorkbenchState,
+  makeProposeRunWorkbench,
+} from "../workbench";
+import { ConversationToolIdSet } from "../../toolIdValidator";
+import type { LangyToolContext } from "../types";
+
+function makeCtx(opts: {
+  prismaLike?: Record<string, unknown>;
+  experimentSlug?: string;
+} = {}): LangyToolContext {
+  return {
+    projectId: "project-1",
+    experimentSlug: opts.experimentSlug,
+    seenIds: new ConversationToolIdSet(),
+    evaluatorService: {} as LangyToolContext["evaluatorService"],
+    promptService: {} as LangyToolContext["promptService"],
+    prisma:
+      (opts.prismaLike ?? {}) as unknown as LangyToolContext["prisma"],
+  };
+}
+
+function invokeTool(toolDef: unknown, input: unknown): Promise<unknown> {
+  const exec = (toolDef as { execute: (i: unknown) => Promise<unknown> })
+    .execute;
+  return exec(input);
+}
+
+function expectInvalidEnvelope(result: unknown) {
+  expect(langyToolErrorEnvelope.safeParse(result).success).toBe(true);
+  expect((result as { error: { code: string } }).error.code).toBe(
+    LANGY_TOOL_OUTPUT_INVALID_CODE,
+  );
+}
+
+describe("get_workbench_state tool-output validation", () => {
+  describe("when no experiment slug is set on the context", () => {
+    it("returns the error variant matching workbenchErrorSchema", async () => {
+      const toolDef = makeGetWorkbenchState(makeCtx());
+      const result = (await invokeTool(toolDef, {})) as { error?: string };
+
+      expect(result.error).toContain("No experiment is currently open");
+    });
+  });
+
+  describe("when the experiment has no saved workbench state", () => {
+    it("returns the empty-state variant with experimentName + message", async () => {
+      const prismaLike = {
+        experiment: {
+          findFirst: vi.fn().mockResolvedValueOnce({
+            name: "My Experiment",
+            workbenchState: null,
+          }),
+        },
+      };
+      const toolDef = makeGetWorkbenchState(
+        makeCtx({ prismaLike, experimentSlug: "exp-1" }),
+      );
+      const result = (await invokeTool(toolDef, {})) as {
+        experimentName?: string;
+        message?: string;
+      };
+
+      expect(result.experimentName).toBe("My Experiment");
+      expect(result.message).toContain("no saved workbench state");
+    });
+  });
+
+  describe("when the experiment record itself is shaped wrong", () => {
+    it("returns the tool_output_invalid envelope", async () => {
+      const prismaLike = {
+        experiment: {
+          findFirst: vi.fn().mockResolvedValueOnce({
+            name: 999,
+            workbenchState: null,
+          }),
+        },
+      };
+      const toolDef = makeGetWorkbenchState(
+        makeCtx({ prismaLike, experimentSlug: "exp-1" }),
+      );
+      const result = await invokeTool(toolDef, {});
+
+      expectInvalidEnvelope(result);
+    });
+  });
+});
+
+describe("find_failing_rows tool-output validation", () => {
+  describe("when no experiment is open", () => {
+    it("returns the error variant", async () => {
+      const toolDef = makeFindFailingRows(makeCtx());
+      const result = (await invokeTool(toolDef, { limit: 5 })) as {
+        error?: string;
+      };
+
+      expect(result.error).toContain("No experiment is currently open");
+    });
+  });
+
+  describe("when the experiment has no workbench state", () => {
+    it("returns the error variant", async () => {
+      const prismaLike = {
+        experiment: {
+          findFirst: vi.fn().mockResolvedValueOnce({ workbenchState: null }),
+        },
+      };
+      const toolDef = makeFindFailingRows(
+        makeCtx({ prismaLike, experimentSlug: "exp-1" }),
+      );
+      const result = (await invokeTool(toolDef, { limit: 5 })) as {
+        error?: string;
+      };
+
+      expect(result.error).toContain("no results yet");
+    });
+  });
+});
+
+describe("propose_run_workbench tool-output validation", () => {
+  describe("when the proposal is well-formed", () => {
+    it("returns the proposal envelope", async () => {
+      const toolDef = makeProposeRunWorkbench(makeCtx());
+      const result = (await invokeTool(toolDef, {
+        rationale: "ready to run",
+      })) as { langyProposal: true; kind: string };
+
+      expect(result.langyProposal).toBe(true);
+      expect(result.kind).toBe("workbench.run");
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/tools/datasets.ts
+++ b/langwatch/src/server/services/langy/tools/datasets.ts
@@ -1,12 +1,26 @@
-import { tool } from "ai";
 import { z } from "zod";
+import { defineLangyTool } from "../defineLangyTool";
 import type { LangyToolContext } from "./types";
 
+const datasetErrorSchema = z.object({ error: z.string() });
+
 export function makeListDatasets(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "list_datasets",
     description:
       "Lists the datasets in the caller's project with their column schema and row count.",
     inputSchema: z.object({}),
+    outputSchema: z.object({
+      items: z.array(
+        z.object({
+          id: z.string(),
+          slug: z.string(),
+          name: z.string(),
+          columnTypes: z.unknown(),
+          rowCount: z.number(),
+        }),
+      ),
+    }),
     execute: async () => {
       const datasets = await ctx.prisma.dataset.findMany({
         where: { projectId: ctx.projectId, archivedAt: null },
@@ -28,7 +42,8 @@ export function makeListDatasets(ctx: LangyToolContext) {
 }
 
 export function makeGetDatasetDetails(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "get_dataset_details",
     description:
       "Fetch a dataset's schema and a sample of its rows so you can understand its content before proposing additions or changes.",
     inputSchema: z.object({
@@ -37,6 +52,19 @@ export function makeGetDatasetDetails(ctx: LangyToolContext) {
         .describe("The dataset id as returned by list_datasets."),
       sampleRowLimit: z.number().int().min(0).max(20).default(5),
     }),
+    outputSchema: z.union([
+      datasetErrorSchema,
+      z.object({
+        id: z.string(),
+        slug: z.string(),
+        name: z.string(),
+        columnTypes: z.unknown(),
+        rowCount: z.number(),
+        sampleRows: z.array(
+          z.object({ id: z.string(), entry: z.unknown() }),
+        ),
+      }),
+    ]),
     execute: async ({ datasetId, sampleRowLimit }) => {
       const dataset = await ctx.prisma.dataset.findFirst({
         where: { id: datasetId, projectId: ctx.projectId, archivedAt: null },
@@ -66,8 +94,26 @@ export function makeGetDatasetDetails(ctx: LangyToolContext) {
   });
 }
 
+const datasetCreateProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("datasets.create"),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({
+    name: z.string(),
+    columnTypes: z.array(
+      z.object({
+        name: z.string(),
+        type: z.enum(["string", "boolean", "number", "date", "list", "json"]),
+      }),
+    ),
+    initialRows: z.array(z.record(z.string(), z.unknown())),
+  }),
+});
+
 export function makeProposeCreateDataset(_ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_create_dataset",
     description:
       "Propose creating a new dataset with a schema (column names + types) and optional seed rows you author inline. Use this before propose_add_dataset_rows if the dataset does not yet exist.",
     inputSchema: z.object({
@@ -89,17 +135,18 @@ export function makeProposeCreateDataset(_ctx: LangyToolContext) {
         .min(1)
         .describe("Schema: column name + value type."),
       initialRows: z
-        .array(z.record(z.unknown()))
+        .array(z.record(z.string(), z.unknown()))
         .optional()
         .describe(
           "Optional seed rows. Each row is an object mapping column name to value. Keep values consistent with declared column types.",
         ),
       rationale: z.string(),
     }),
+    outputSchema: datasetCreateProposalSchema,
     execute: async ({ name, columns, initialRows, rationale }) => {
       return {
-        langyProposal: true,
-        kind: "datasets.create",
+        langyProposal: true as const,
+        kind: "datasets.create" as const,
         summary: `Create dataset "${name}"${
           initialRows?.length ? ` with ${initialRows.length} row(s)` : ""
         }`,
@@ -114,19 +161,32 @@ export function makeProposeCreateDataset(_ctx: LangyToolContext) {
   });
 }
 
+const datasetAddRowsProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("datasets.addRows"),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({
+    datasetId: z.string(),
+    rows: z.array(z.record(z.string(), z.unknown())),
+  }),
+});
+
 export function makeProposeAddDatasetRows(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_add_dataset_rows",
     description:
       "Propose appending rows to an existing dataset. Each row is an object mapping column name to value. Values must be consistent with the dataset's column types (call get_dataset_details first to confirm).",
     inputSchema: z.object({
       datasetId: z.string(),
       rows: z
-        .array(z.record(z.unknown()))
+        .array(z.record(z.string(), z.unknown()))
         .min(1)
         .max(50)
         .describe("Up to 50 rows; each row is { columnName: value }."),
       rationale: z.string(),
     }),
+    outputSchema: z.union([datasetErrorSchema, datasetAddRowsProposalSchema]),
     execute: async ({ datasetId, rows, rationale }) => {
       if (!ctx.seenIds.has("dataset_id", datasetId)) {
         return {
@@ -141,8 +201,8 @@ export function makeProposeAddDatasetRows(ctx: LangyToolContext) {
         return { error: `No dataset found with id '${datasetId}'.` };
       }
       return {
-        langyProposal: true,
-        kind: "datasets.addRows",
+        langyProposal: true as const,
+        kind: "datasets.addRows" as const,
         summary: `Add ${rows.length} row(s) to "${dataset.name}"`,
         rationale,
         payload: {

--- a/langwatch/src/server/services/langy/tools/evaluators.ts
+++ b/langwatch/src/server/services/langy/tools/evaluators.ts
@@ -1,14 +1,37 @@
-import { tool } from "ai";
 import { z } from "zod";
 import { AVAILABLE_EVALUATORS } from "~/server/evaluations/evaluators.generated";
 import {
   getEvaluatorDefaultSettings,
   getEvaluatorDefinitions,
 } from "~/server/evaluations/getEvaluator";
+import { defineLangyTool } from "../defineLangyTool";
 import type { LangyToolContext } from "./types";
 
+const evaluatorErrorSchema = z.object({ error: z.string() });
+
+const projectEvaluatorListItemSchema = z.object({
+  source: z.literal("project"),
+  id: z.string(),
+  slug: z.string().nullable(),
+  name: z.string(),
+  type: z.string(),
+  inputs: z.array(z.string()),
+});
+
+const builtinEvaluatorListItemSchema = z.object({
+  source: z.literal("built_in"),
+  evaluatorType: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  category: z.string().optional(),
+  isGuardrail: z.boolean().optional(),
+  requiredFields: z.array(z.string()).optional(),
+  optionalFields: z.array(z.string()).optional(),
+});
+
 export function makeListEvaluators(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "list_evaluators",
     description:
       "Lists evaluators available to the caller's project. Returns both the custom project evaluators and the built-in catalog. Use this before suggesting or explaining any evaluator.",
     inputSchema: z.object({
@@ -18,6 +41,14 @@ export function makeListEvaluators(ctx: LangyToolContext) {
         .describe(
           "Which set to return: the user's project evaluators, the built-in catalog, or both.",
         ),
+    }),
+    outputSchema: z.object({
+      items: z.array(
+        z.union([
+          projectEvaluatorListItemSchema,
+          builtinEvaluatorListItemSchema,
+        ]),
+      ),
     }),
     execute: async ({ scope }) => {
       const items: Array<Record<string, unknown>> = [];
@@ -63,8 +94,32 @@ export function makeListEvaluators(ctx: LangyToolContext) {
   });
 }
 
+const projectEvaluatorDetailsSchema = z.object({
+  source: z.literal("project"),
+  id: z.string(),
+  slug: z.string().nullable(),
+  name: z.string(),
+  type: z.string(),
+  fields: z.unknown(),
+  outputFields: z.unknown(),
+});
+
+const builtinEvaluatorDetailsSchema = z.object({
+  source: z.literal("built_in"),
+  evaluatorType: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  category: z.string().optional(),
+  isGuardrail: z.boolean().optional(),
+  requiredFields: z.array(z.string()).optional(),
+  optionalFields: z.array(z.string()).optional(),
+  result: z.unknown(),
+  docsUrl: z.string().optional(),
+});
+
 export function makeGetEvaluatorDetails(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "get_evaluator_details",
     description:
       "Fetches details for a single evaluator, either by project slug (for custom project evaluators) or by built-in type key (for catalog entries). Provide exactly one of `slug` or `evaluatorType`.",
     inputSchema: z.object({
@@ -79,6 +134,11 @@ export function makeGetEvaluatorDetails(ctx: LangyToolContext) {
           "Built-in evaluator type key, for example 'ragas/answer_relevancy'.",
         ),
     }),
+    outputSchema: z.union([
+      evaluatorErrorSchema,
+      projectEvaluatorDetailsSchema,
+      builtinEvaluatorDetailsSchema,
+    ]),
     execute: async ({ slug, evaluatorType }) => {
       if (slug) {
         const evaluator = await ctx.evaluatorService.getBySlug({
@@ -94,7 +154,7 @@ export function makeGetEvaluatorDetails(ctx: LangyToolContext) {
         ctx.seenIds.record("evaluator_slug", evaluator.slug);
         const enriched = await ctx.evaluatorService.enrichWithFields(evaluator);
         return {
-          source: "project",
+          source: "project" as const,
           id: enriched.id,
           slug: enriched.slug,
           name: enriched.name,
@@ -115,7 +175,7 @@ export function makeGetEvaluatorDetails(ctx: LangyToolContext) {
           };
         }
         return {
-          source: "built_in",
+          source: "built_in" as const,
           evaluatorType,
           name: def.name,
           description: def.description,
@@ -135,8 +195,24 @@ export function makeGetEvaluatorDetails(ctx: LangyToolContext) {
   });
 }
 
+const evaluatorCreateProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("evaluators.create"),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({
+    name: z.string(),
+    type: z.literal("evaluator"),
+    config: z.object({
+      evaluatorType: z.string(),
+      settings: z.record(z.string(), z.unknown()),
+    }),
+  }),
+});
+
 export function makeProposeCreateEvaluator(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_create_evaluator",
     description:
       "Propose creating a new evaluator in the project. The user will see a preview card and click Apply to commit. Use this when the user asks for a new evaluator that doesn't yet exist.",
     inputSchema: z.object({
@@ -151,7 +227,7 @@ export function makeProposeCreateEvaluator(ctx: LangyToolContext) {
           "The built-in evaluator type key, e.g. 'ragas/answer_relevancy'. Must match one you found via list_evaluators('built_in').",
         ),
       settings: z
-        .record(z.unknown())
+        .record(z.string(), z.unknown())
         .optional()
         .describe(
           "Optional settings override. Leave empty to use defaults from the evaluator definition.",
@@ -162,6 +238,10 @@ export function makeProposeCreateEvaluator(ctx: LangyToolContext) {
           "One short sentence explaining why this evaluator fits the user's goal.",
         ),
     }),
+    outputSchema: z.union([
+      evaluatorErrorSchema,
+      evaluatorCreateProposalSchema,
+    ]),
     execute: async ({ name, evaluatorType, settings, rationale }) => {
       if (!ctx.seenIds.has("evaluator_type", evaluatorType)) {
         return {
@@ -192,8 +272,8 @@ export function makeProposeCreateEvaluator(ctx: LangyToolContext) {
           ? mergedSettings.model
           : undefined;
       return {
-        langyProposal: true,
-        kind: "evaluators.create",
+        langyProposal: true as const,
+        kind: "evaluators.create" as const,
         summary: `Create evaluator "${name}" (${evaluatorType})`,
         rationale: chosenModel
           ? `${rationale} Uses ${chosenModel} (project default).`
@@ -211,21 +291,39 @@ export function makeProposeCreateEvaluator(ctx: LangyToolContext) {
   });
 }
 
+const evaluatorUpdateProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("evaluators.update"),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({
+    id: z.string(),
+    evaluatorType: z.string().optional(),
+    name: z.string().optional(),
+    config: z.record(z.string(), z.unknown()),
+  }),
+});
+
 export function makeProposeUpdateEvaluator(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_update_evaluator",
     description:
       "Propose updating an existing project evaluator's name or settings. Call get_evaluator_details first so you only override what you actually want to change. Settings are merged over the evaluator's current config.",
     inputSchema: z.object({
       slug: z.string().describe("Slug of the project evaluator to update."),
       name: z.string().min(1).max(255).optional(),
       settings: z
-        .record(z.unknown())
+        .record(z.string(), z.unknown())
         .optional()
         .describe(
           "Partial settings to merge over the evaluator's current settings object.",
         ),
       rationale: z.string(),
     }),
+    outputSchema: z.union([
+      evaluatorErrorSchema,
+      evaluatorUpdateProposalSchema,
+    ]),
     execute: async ({ slug, name, settings, rationale }) => {
       if (!ctx.seenIds.has("evaluator_slug", slug)) {
         return {
@@ -253,8 +351,8 @@ export function makeProposeUpdateEvaluator(ctx: LangyToolContext) {
       if (name && name !== evaluator.name) changedFields.push("name");
       if (settings) changedFields.push(...Object.keys(settings));
       return {
-        langyProposal: true,
-        kind: "evaluators.update",
+        langyProposal: true as const,
+        kind: "evaluators.update" as const,
         summary: `Update evaluator "${evaluator.name}"${
           changedFields.length ? ` (${changedFields.join(", ")})` : ""
         }`,
@@ -271,8 +369,21 @@ export function makeProposeUpdateEvaluator(ctx: LangyToolContext) {
   });
 }
 
+const evaluatorDeleteProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("evaluators.delete"),
+  destructive: z.literal(true),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+});
+
 export function makeProposeDeleteEvaluator(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_delete_evaluator",
     description:
       "Propose archiving (soft-deleting) an existing project evaluator. This is a destructive action — only propose it when the user explicitly asks. Existing workbench references to this evaluator will break once archived.",
     inputSchema: z.object({
@@ -283,6 +394,10 @@ export function makeProposeDeleteEvaluator(ctx: LangyToolContext) {
           "Why the user wants to delete this evaluator, or a short confirmation of what they asked.",
         ),
     }),
+    outputSchema: z.union([
+      evaluatorErrorSchema,
+      evaluatorDeleteProposalSchema,
+    ]),
     execute: async ({ slug, rationale }) => {
       if (!ctx.seenIds.has("evaluator_slug", slug)) {
         return {
@@ -297,9 +412,9 @@ export function makeProposeDeleteEvaluator(ctx: LangyToolContext) {
         return { error: `No project evaluator with slug '${slug}'.` };
       }
       return {
-        langyProposal: true,
-        kind: "evaluators.delete",
-        destructive: true,
+        langyProposal: true as const,
+        kind: "evaluators.delete" as const,
+        destructive: true as const,
         summary: `Archive evaluator "${evaluator.name}"`,
         rationale,
         payload: {
@@ -311,8 +426,22 @@ export function makeProposeDeleteEvaluator(ctx: LangyToolContext) {
   });
 }
 
+const workbenchAddEvaluatorProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("workbench.addEvaluator"),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({
+    dbEvaluatorId: z.string(),
+    evaluatorType: z.string(),
+    name: z.string(),
+    fields: z.unknown(),
+  }),
+});
+
 export function makeProposeAddEvaluatorToWorkbench(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_add_evaluator_to_workbench",
     description:
       "Propose adding an existing project evaluator as a column in the current experiment workbench. Only works for evaluators that already exist in the project (use propose_create_evaluator first if needed).",
     inputSchema: z.object({
@@ -321,6 +450,10 @@ export function makeProposeAddEvaluatorToWorkbench(ctx: LangyToolContext) {
         .describe("Slug of the existing project evaluator to add."),
       rationale: z.string(),
     }),
+    outputSchema: z.union([
+      evaluatorErrorSchema,
+      workbenchAddEvaluatorProposalSchema,
+    ]),
     execute: async ({ slug, rationale }) => {
       if (!ctx.seenIds.has("evaluator_slug", slug)) {
         return {
@@ -339,8 +472,8 @@ export function makeProposeAddEvaluatorToWorkbench(ctx: LangyToolContext) {
         (enriched.config as { evaluatorType?: string } | null)?.evaluatorType ??
         `custom/${enriched.slug}`;
       return {
-        langyProposal: true,
-        kind: "workbench.addEvaluator",
+        langyProposal: true as const,
+        kind: "workbench.addEvaluator" as const,
         summary: `Add "${enriched.name}" to this workbench`,
         rationale,
         payload: {

--- a/langwatch/src/server/services/langy/tools/prompts.ts
+++ b/langwatch/src/server/services/langy/tools/prompts.ts
@@ -1,12 +1,31 @@
-import { tool } from "ai";
 import { z } from "zod";
+import { defineLangyTool } from "../defineLangyTool";
 import type { LangyToolContext } from "./types";
 
+const promptErrorSchema = z.object({ error: z.string() });
+
+const messageSchema = z.object({
+  role: z.enum(["system", "user", "assistant"]),
+  content: z.string(),
+});
+
 export function makeListPrompts(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "list_prompts",
     description:
       "Lists the prompts defined in the caller's project. Returns handle, name, model, and a short preview.",
     inputSchema: z.object({}),
+    outputSchema: z.object({
+      items: z.array(
+        z.object({
+          id: z.string(),
+          handle: z.string(),
+          name: z.string(),
+          model: z.string().nullable().optional(),
+          scope: z.string().nullable().optional(),
+        }),
+      ),
+    }),
     execute: async () => {
       const prompts = await ctx.promptService.getAllPrompts({
         projectId: ctx.projectId,
@@ -18,11 +37,11 @@ export function makeListPrompts(ctx: LangyToolContext) {
       }
       return {
         items: prompts.map((p: Record<string, unknown>) => ({
-          id: p.id,
-          handle: p.handle,
-          name: p.name ?? p.handle,
-          model: p.model,
-          scope: p.scope,
+          id: p.id as string,
+          handle: p.handle as string,
+          name: (p.name ?? p.handle) as string,
+          model: p.model as string | null | undefined,
+          scope: p.scope as string | null | undefined,
         })),
       };
     },
@@ -30,7 +49,8 @@ export function makeListPrompts(ctx: LangyToolContext) {
 }
 
 export function makeGetPromptDetails(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "get_prompt_details",
     description:
       "Fetch the full config for a single prompt by handle or id: model, temperature, maxTokens, message templates, and declared inputs/outputs.",
     inputSchema: z.object({
@@ -38,6 +58,21 @@ export function makeGetPromptDetails(ctx: LangyToolContext) {
         .string()
         .describe("The prompt id or handle, as returned by list_prompts."),
     }),
+    outputSchema: z.union([
+      promptErrorSchema,
+      z.object({
+        id: z.string(),
+        handle: z.string(),
+        scope: z.unknown(),
+        model: z.unknown(),
+        temperature: z.unknown(),
+        maxTokens: z.unknown(),
+        messages: z.unknown(),
+        inputs: z.unknown(),
+        outputs: z.unknown(),
+        version: z.unknown(),
+      }),
+    ]),
     execute: async ({ idOrHandle }) => {
       const prompt = await ctx.promptService.getPromptByIdOrHandle({
         idOrHandle,
@@ -48,8 +83,8 @@ export function makeGetPromptDetails(ctx: LangyToolContext) {
       }
       const p = prompt as Record<string, unknown>;
       return {
-        id: p.id,
-        handle: p.handle,
+        id: p.id as string,
+        handle: p.handle as string,
         scope: p.scope,
         model: p.model,
         temperature: p.temperature,
@@ -64,12 +99,22 @@ export function makeGetPromptDetails(ctx: LangyToolContext) {
 }
 
 export function makeSearchPrompts(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "search_prompts",
     description:
       "Search prompts in this project by handle/name keyword. Use when looking for an existing prompt to reference or update.",
     inputSchema: z.object({
       query: z.string().min(1),
       limit: z.number().int().min(1).max(20).default(10),
+    }),
+    outputSchema: z.object({
+      items: z.array(
+        z.object({
+          id: z.string(),
+          handle: z.string(),
+          name: z.string(),
+        }),
+      ),
     }),
     execute: async ({ query, limit }) => {
       const rows = await ctx.prisma.llmPromptConfig.findMany({
@@ -98,8 +143,23 @@ export function makeSearchPrompts(ctx: LangyToolContext) {
   });
 }
 
+const promptCreateProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("prompts.create"),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({
+    handle: z.string(),
+    messages: z.array(messageSchema),
+    model: z.string().optional(),
+    temperature: z.number().optional(),
+    maxTokens: z.number().optional(),
+  }),
+});
+
 export function makeProposeCreatePrompt(_ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_create_prompt",
     description:
       "Propose creating a new prompt in the project. Returns a card the user approves to commit. The handle must be unique within the project; use kebab-case or snake_case.",
     inputSchema: z.object({
@@ -111,12 +171,7 @@ export function makeProposeCreatePrompt(_ctx: LangyToolContext) {
           "Unique, URL-safe prompt handle (e.g. 'rag-qa', 'support-triage').",
         ),
       messages: z
-        .array(
-          z.object({
-            role: z.enum(["system", "user", "assistant"]),
-            content: z.string(),
-          }),
-        )
+        .array(messageSchema)
         .min(1)
         .describe("Chat-style message templates that define the prompt."),
       model: z
@@ -133,6 +188,7 @@ export function makeProposeCreatePrompt(_ctx: LangyToolContext) {
           "One short sentence explaining why this prompt fits the user's goal.",
         ),
     }),
+    outputSchema: promptCreateProposalSchema,
     execute: async ({
       handle,
       messages,
@@ -142,8 +198,8 @@ export function makeProposeCreatePrompt(_ctx: LangyToolContext) {
       rationale,
     }) => {
       return {
-        langyProposal: true,
-        kind: "prompts.create",
+        langyProposal: true as const,
+        kind: "prompts.create" as const,
         summary: `Create prompt "${handle}"`,
         rationale,
         payload: {
@@ -158,8 +214,24 @@ export function makeProposeCreatePrompt(_ctx: LangyToolContext) {
   });
 }
 
+const promptUpdateProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("prompts.update"),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({
+    id: z.string(),
+    commitMessage: z.string(),
+    messages: z.array(messageSchema).optional(),
+    model: z.string().optional(),
+    temperature: z.number().optional(),
+    maxTokens: z.number().optional(),
+  }),
+});
+
 export function makeProposeUpdatePrompt(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_update_prompt",
     description:
       "Propose updating an existing prompt by creating a new version. A commitMessage is required. Call get_prompt_details first so you only send fields you actually want to change.",
     inputSchema: z.object({
@@ -170,19 +242,13 @@ export function makeProposeUpdatePrompt(ctx: LangyToolContext) {
         .string()
         .min(1)
         .describe("Short description of what this revision changes."),
-      messages: z
-        .array(
-          z.object({
-            role: z.enum(["system", "user", "assistant"]),
-            content: z.string(),
-          }),
-        )
-        .optional(),
+      messages: z.array(messageSchema).optional(),
       model: z.string().optional(),
       temperature: z.number().min(0).max(2).optional(),
       maxTokens: z.number().int().positive().optional(),
       rationale: z.string(),
     }),
+    outputSchema: z.union([promptErrorSchema, promptUpdateProposalSchema]),
     execute: async ({
       id,
       commitMessage,
@@ -205,8 +271,8 @@ export function makeProposeUpdatePrompt(ctx: LangyToolContext) {
         return { error: `No prompt found with id '${id}'.` };
       }
       return {
-        langyProposal: true,
-        kind: "prompts.update",
+        langyProposal: true as const,
+        kind: "prompts.update" as const,
         summary: `Update prompt "${(existing as { handle?: string }).handle ?? id}"`,
         rationale,
         payload: {

--- a/langwatch/src/server/services/langy/tools/runs.ts
+++ b/langwatch/src/server/services/langy/tools/runs.ts
@@ -1,14 +1,29 @@
-import { tool } from "ai";
 import { z } from "zod";
+import { defineLangyTool } from "../defineLangyTool";
 import type { LangyToolContext } from "./types";
 
 export function makeSearchPastRuns(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "search_past_runs",
     description:
       "Search past evaluation runs (BatchEvaluation) for this project, optionally filtered by experiment slug, ordered by recency.",
     inputSchema: z.object({
       experimentSlug: z.string().optional(),
       limit: z.number().int().min(1).max(20).default(10),
+    }),
+    outputSchema: z.object({
+      items: z.array(
+        z.object({
+          id: z.string(),
+          experimentId: z.string(),
+          createdAt: z.date(),
+          status: z.string(),
+          score: z.number(),
+          passed: z.boolean(),
+          evaluation: z.string(),
+        }),
+      ),
+      error: z.string().optional(),
     }),
     execute: async ({ experimentSlug, limit }) => {
       const where: Record<string, unknown> = { projectId: ctx.projectId };

--- a/langwatch/src/server/services/langy/tools/traces.ts
+++ b/langwatch/src/server/services/langy/tools/traces.ts
@@ -1,13 +1,14 @@
-import { tool } from "ai";
 import { z } from "zod";
 import { esClient, TRACE_INDEX } from "~/server/elasticsearch";
 import { createLogger } from "~/utils/logger/server";
+import { defineLangyTool } from "../defineLangyTool";
 import type { LangyToolContext } from "./types";
 
 const logger = createLogger("langwatch:langy:tools:traces");
 
 export function makeSearchTraces(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "search_traces",
     description:
       "Keyword search over recent traces in this project (BM25 over input/output text and error messages — not semantic). Use when the user asks to 'find traces' with specific words or phrases in them ('error', 'timeout', a particular customer name). Returns a small list of trace ids with brief context. Tool result is per-turn only — do not persist or recall ids across conversations.",
     inputSchema: z.object({
@@ -16,6 +17,16 @@ export function makeSearchTraces(ctx: LangyToolContext) {
         .min(1)
         .describe("Free-text query (e.g. 'hallucinations', 'rag failures')."),
       limit: z.number().int().min(1).max(20).default(10),
+    }),
+    outputSchema: z.object({
+      items: z.array(
+        z.object({
+          traceId: z.string(),
+          startedAt: z.number().nullable(),
+          snippet: z.string().nullable(),
+        }),
+      ),
+      error: z.string().optional(),
     }),
     execute: async ({ query, limit }) => {
       try {

--- a/langwatch/src/server/services/langy/tools/workbench.ts
+++ b/langwatch/src/server/services/langy/tools/workbench.ts
@@ -1,7 +1,7 @@
-import { tool } from "ai";
 import { z } from "zod";
 import { persistedEvaluationsV3StateSchema } from "~/evaluations-v3/types/persistence";
 import { parseEvaluationResult } from "~/utils/evaluationResults";
+import { defineLangyTool } from "../defineLangyTool";
 import type { LangyToolContext } from "./types";
 
 type ParsedState = ReturnType<typeof persistedEvaluationsV3StateSchema.parse>;
@@ -196,11 +196,76 @@ function extractRowInputs(
   return undefined;
 }
 
+const workbenchErrorSchema = z.object({
+  error: z.string(),
+  details: z.string().optional(),
+});
+
+const workbenchEmptyStateSchema = z.object({
+  experimentName: z.string(),
+  message: z.string(),
+});
+
+const workbenchSummarySchema = z.object({
+  experimentName: z.string(),
+  activeDatasetId: z.string().nullable().optional(),
+  datasets: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+      columns: z.array(z.string().optional()),
+      datasetId: z.string().optional(),
+    }),
+  ),
+  targets: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string().optional(),
+      name: z.string(),
+    }),
+  ),
+  evaluators: z.array(
+    z.object({
+      id: z.string(),
+      evaluatorType: z.string(),
+      name: z.string(),
+      dbEvaluatorId: z.string().nullable().optional(),
+    }),
+  ),
+  results: z
+    .array(
+      z.object({
+        targetId: z.string(),
+        rowsEvaluated: z.number(),
+        errors: z.number(),
+        perEvaluator: z.array(
+          z.object({
+            evaluatorId: z.string(),
+            evaluatorName: z.string(),
+            passed: z.number(),
+            failed: z.number(),
+            processed: z.number(),
+            error: z.number(),
+            skipped: z.number(),
+            pending: z.number(),
+          }),
+        ),
+      }),
+    )
+    .nullable(),
+});
+
 export function makeGetWorkbenchState(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "get_workbench_state",
     description:
       "Inspect the current experiment workbench: what datasets, targets, and evaluators are configured, plus summary statistics from the last run (pass/fail/error counts per target). Call this before answering any question about the current experiment's setup or results.",
     inputSchema: z.object({}),
+    outputSchema: z.union([
+      workbenchErrorSchema,
+      workbenchEmptyStateSchema,
+      workbenchSummarySchema,
+    ]),
     execute: async () => {
       if (!ctx.experimentSlug) {
         return {
@@ -237,8 +302,28 @@ export function makeGetWorkbenchState(ctx: LangyToolContext) {
   });
 }
 
+const failingRowsSchema = z.object({
+  rows: z.array(
+    z.object({
+      targetId: z.string(),
+      rowIndex: z.number(),
+      inputs: z.record(z.string(), z.unknown()).optional(),
+      failingEvaluators: z.array(
+        z.object({
+          evaluatorId: z.string(),
+          evaluatorName: z.string(),
+          status: z.string(),
+          details: z.string().optional(),
+        }),
+      ),
+    }),
+  ),
+  total: z.number(),
+});
+
 export function makeFindFailingRows(ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "find_failing_rows",
     description:
       "Return rows from the current workbench where an evaluator reported a failed or error status. Use this to investigate why an experiment is underperforming. Returns at most `limit` rows with their input values and which evaluators flagged them.",
     inputSchema: z.object({
@@ -254,6 +339,7 @@ export function makeFindFailingRows(ctx: LangyToolContext) {
         .describe("Optional: restrict to a single target id."),
       limit: z.number().int().min(1).max(20).default(10),
     }),
+    outputSchema: z.union([workbenchErrorSchema, failingRowsSchema]),
     execute: async ({ evaluatorSlug, targetId, limit }) => {
       if (!ctx.experimentSlug) {
         return { error: "No experiment is currently open." };
@@ -303,8 +389,17 @@ export function makeFindFailingRows(ctx: LangyToolContext) {
   });
 }
 
+const workbenchRunProposalSchema = z.object({
+  langyProposal: z.literal(true),
+  kind: z.literal("workbench.run"),
+  summary: z.string(),
+  rationale: z.string(),
+  payload: z.object({}),
+});
+
 export function makeProposeRunWorkbench(_ctx: LangyToolContext) {
-  return tool({
+  return defineLangyTool({
+    name: "propose_run_workbench",
     description:
       "Propose running the current experiment (kicks off all target × evaluator cells). Returns a proposal card the user clicks Apply to execute. Use this when the user asks to 'run', 'evaluate', 'execute', or 'kick off' the experiment.",
     inputSchema: z.object({
@@ -314,10 +409,11 @@ export function makeProposeRunWorkbench(_ctx: LangyToolContext) {
           "One short sentence explaining why running now makes sense (e.g. 'all mappings look configured, ready to run').",
         ),
     }),
+    outputSchema: workbenchRunProposalSchema,
     execute: async ({ rationale }) => {
       return {
-        langyProposal: true,
-        kind: "workbench.run",
+        langyProposal: true as const,
+        kind: "workbench.run" as const,
         summary: "Run the evaluation on all targets and evaluators",
         rationale,
         payload: {},

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -186,6 +186,11 @@ Feature: Langy in-product AI assistant — baseline (v1)
     When Langy receives the tool result
     Then the model receives a "tool_output_invalid" error envelope instead of the raw payload
 
+  Scenario: prompt tools output is shape-validated before the model sees it
+    Given a prompt tool (list, get details, search, propose create, propose update) returns a payload that does not match its declared shape
+    When Langy receives the tool result
+    Then the model receives a "tool_output_invalid" error envelope instead of the raw payload
+
   # ============================================================================
   # Read-only boundary (v1)
   # ============================================================================

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -181,6 +181,11 @@ Feature: Langy in-product AI assistant — baseline (v1)
     When Langy receives the tool result
     Then the model receives a "tool_output_invalid" error envelope instead of the raw rows
 
+  Scenario: dataset tools output is shape-validated before the model sees it
+    Given a dataset tool (list, get details, propose create, propose add rows) returns a payload that does not match its declared shape
+    When Langy receives the tool result
+    Then the model receives a "tool_output_invalid" error envelope instead of the raw payload
+
   # ============================================================================
   # Read-only boundary (v1)
   # ============================================================================

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -191,6 +191,11 @@ Feature: Langy in-product AI assistant — baseline (v1)
     When Langy receives the tool result
     Then the model receives a "tool_output_invalid" error envelope instead of the raw payload
 
+  Scenario: workbench tools output is shape-validated before the model sees it
+    Given a workbench tool (get state, find failing rows, propose run) returns a payload that does not match its declared shape
+    When Langy receives the tool result
+    Then the model receives a "tool_output_invalid" error envelope instead of the raw payload
+
   # ============================================================================
   # Read-only boundary (v1)
   # ============================================================================

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -196,6 +196,11 @@ Feature: Langy in-product AI assistant — baseline (v1)
     When Langy receives the tool result
     Then the model receives a "tool_output_invalid" error envelope instead of the raw payload
 
+  Scenario: evaluator tools output is shape-validated before the model sees it
+    Given an evaluator tool (list, get details, propose create, propose update, propose delete, propose add to workbench) returns a payload that does not match its declared shape
+    When Langy receives the tool result
+    Then the model receives a "tool_output_invalid" error envelope instead of the raw payload
+
   # ============================================================================
   # Read-only boundary (v1)
   # ============================================================================

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -171,6 +171,16 @@ Feature: Langy in-product AI assistant — baseline (v1)
     And the envelope does not include raw stack traces
     And the failure is logged for telemetry with the tool name
 
+  Scenario: search_traces output is shape-validated before the model sees it
+    Given the trace search tool returns a payload that does not match its declared shape
+    When Langy receives the tool result
+    Then the model receives a "tool_output_invalid" error envelope instead of the raw payload
+
+  Scenario: search_past_runs output is shape-validated before the model sees it
+    Given the past-runs search tool returns rows that do not match their declared shape
+    When Langy receives the tool result
+    Then the model receives a "tool_output_invalid" error envelope instead of the raw rows
+
   # ============================================================================
   # Read-only boundary (v1)
   # ============================================================================


### PR DESCRIPTION
## Summary

Migrates **all 20 Langy tools** to the [`defineLangyTool`](https://github.com/langwatch/langwatch/blob/langy-v2-integration/langwatch/src/server/services/langy/defineLangyTool.ts) helper (landed in #4010), so every tool's output is **Zod-validated at runtime** before reaching the model. Closes the final unchecked Phase-3 acceptance criterion in #3956: *"All tool outputs validated by Zod schema before reaching the model."*

Why this matters: the AI SDK's bare `tool()` accepts an `outputSchema` for compile-time types but does **not** enforce it at runtime (verified by reading the SDK source). Without `defineLangyTool`, a tool with a mapping bug or a downstream shape regression silently feeds garbage to the model — leading to hallucinated answers and potential data leaks. The helper:

- Parses every tool's return value through Zod **before** the model sees it
- On shape mismatch, returns a structured `{ error: { code: "tool_output_invalid", message, issues } }` envelope instead — the model gets a clear failure signal and can recover gracefully
- Strips unknown fields via Zod's default `.strip()` behaviour, so internal/PII fields can't accidentally leak through a tool boundary
- Logs failures with the tool name + Zod issues for telemetry

## Per-family breakdown

| Family | File | Tools | Commits |
|---|---|---|---|
| traces + runs | `traces.ts`, `runs.ts` | 2 (`search_traces`, `search_past_runs`) | `0c71ec45a` |
| datasets | `datasets.ts` | 4 (`list_datasets`, `get_dataset_details`, `propose_create_dataset`, `propose_add_dataset_rows`) | `33c0f1b29` |
| prompts | `prompts.ts` | 5 (`list_prompts`, `get_prompt_details`, `search_prompts`, `propose_create_prompt`, `propose_update_prompt`) | `87ace7ed9` |
| workbench | `workbench.ts` | 3 (`get_workbench_state`, `find_failing_rows`, `propose_run_workbench`) | `2fa879673` |
| evaluators | `evaluators.ts` | 6 (`list_evaluators`, `get_evaluator_details`, `propose_create_evaluator`, `propose_update_evaluator`, `propose_delete_evaluator`, `propose_add_evaluator_to_workbench`) | `2b318ebaa` |

**Behaviour unchanged in every tool** — only the wrapper swapped and `outputSchema` added. For `propose_*` tools whose `execute` has two legitimate return paths (an error variant and a proposal variant), `outputSchema` is modelled as a Zod union so the validator accepts both but blocks anything else. `propose_delete_evaluator` keeps its `destructive: true` literal in the schema so the sidebar's destructive-proposal gating continues to work.

## Tests

- **Per-family unit tests** under `langwatch/src/server/services/langy/tools/__tests__/` — one file per family (`traces-runs`, `datasets`, `prompts`, `workbench`, `evaluators`). Each mocks downstream (Prisma / Elasticsearch / EvaluatorService / PromptService) at the `LangyToolContext` boundary and asserts: (a) malformed downstream → `langyToolErrorEnvelope` returned, (b) legitimate error branch → matches its union variant, (c) happy path → parsed shape returned.
- **End-to-end route tests** at `langwatch/src/server/routes/__tests__/langy.tool-output-validation.e2e.test.ts` — drives the **real `POST /api/langy/chat` Hono route** with a `MockLanguageModelV3` that calls a real tool factory. Tests assert the validated `tool_output_invalid` envelope is what the model receives on its second turn (by inspecting the LLM stub's captured second `doStream` prompt), and that the raw malformed payload never appears in that prompt. Covers one canonical tool per family (5 E2E tests total).

### Local verification

```
pnpm typecheck               # green
pnpm test:unit src/server/services/langy src/server/routes/__tests__/langy
# Test Files  14 passed (14)
# Tests       129 passed (129)
```

The new langy E2E file emits 5 expected log warnings (one per family — the validator catching the seeded malformed shape) and asserts the envelope reaches the model:

```
"tool":"search_traces","issues":[{"code":"invalid_type","expected":"string","received":"number",...}]
"tool":"search_past_runs","issues":[{"code":"invalid_type","expected":"string","received":"number",...}]
"tool":"list_datasets","issues":[{"code":"invalid_type","expected":"string","received":"number",...}]
"tool":"list_prompts","issues":[{"code":"invalid_type","expected":"string","received":"number",...}]
"tool":"list_evaluators","issues":[{"code":"invalid_union",...}]
```

## Specs

Added BDD scenarios per family under "Tool-output validation (PR-3.3)" in `specs/assistant/langy-baseline.feature`. Each scenario describes the user-visible behaviour ("the model receives a tool_output_invalid envelope instead of the raw payload").

## Test-file naming note

The original task spec called for `*.integration.test.ts`. Per `CLAUDE.md`, `*.integration.test.ts` is reserved for tests that hit real services — these mock all downstreams. So:
- Per-family unit tests are `*.unit.test.ts` to match the existing `defineLangyTool.unit.test.ts` next to them.
- The route-driving suite is `*.e2e.test.ts` to flag that it exercises the full Hono pipeline, but it still runs under `pnpm test:unit` since no Docker/real services are needed.

Happy to rename if reviewers prefer different suffixes.

## Test plan

- [x] `pnpm typecheck` green
- [x] All 14 langy test files green (129 tests)
- [x] All 5 family E2E tests confirm the validator catches malformed output through the live Hono chat route
- [x] No behaviour change in any tool — only `outputSchema` declared and the wrapper swapped
- [x] No changes to `tools/index.ts` registry

Closes #3956 (this is the final Phase-3 acceptance box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)