### PR TITLE
docs: remove legacy wording from API reference

### DIFF
--- a/docs/api-reference/projects/overview.mdx
+++ b/docs/api-reference/projects/overview.mdx
@@ -17,7 +17,7 @@ The Projects API requires an **organization-level API key** (created in Settings
 Authorization: Bearer sk-lw-<id>_<secret>
 ```
 
-Legacy project API keys (`X-Auth-Token`) cannot be used — they lack organization context.
+Project API keys (`X-Auth-Token`) cannot be used here — they lack organization context.
 
 ## Endpoints
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -28920,7 +28920,7 @@ The Projects API requires an **organization-level API key** (created in Settings
 Authorization: Bearer sk-lw-<id>_<secret>
 ```
 
-Legacy project API keys (`X-Auth-Token`) cannot be used — they lack organization context.
+Project API keys (`X-Auth-Token`) cannot be used here — they lack organization context.
 
 ## Endpoints
 


### PR DESCRIPTION
## Summary
- Replaces "Legacy project API keys" with "Project API keys" in the Projects API overview page
- Regenerates llms.txt to reflect the change

Follow-up to #3951 — caught a stale "Legacy" reference in the docs that shipped with the merged PR.