### PR TITLE
feat(langy): post-turn suggestion chip with dismissal (PR-5.2)

### DIFF
--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -47,6 +47,11 @@ import {
 } from "./useLangyConversations";
 import { useLangy } from "./LangyContext";
 import { parseLangyErrorMessage } from "./parseLangyErrorMessage";
+import { SuggestionChip } from "./SuggestionChip";
+import {
+  isLangySuggestion,
+  type LangySuggestion,
+} from "~/server/services/langy/suggestion";
 
 const PANEL_WIDTH = 380;
 // The panel docks flush against the right edge of the viewport. Page
@@ -486,6 +491,16 @@ function LangyPanel({
   const [applyingProposals, setApplyingProposals] = useState<Set<string>>(
     new Set(),
   );
+  // Suggestion-chip state. Two layers:
+  // - dismissedSuggestionKinds: server-persisted "don't show this kind again"
+  //   list. Loaded from /api/langy/preferences when the panel opens.
+  // - sessionDismissedSuggestions: per-id in-session dismissals from clicking
+  //   "Dismiss" on a specific chip. Not persisted.
+  const [dismissedSuggestionKinds, setDismissedSuggestionKinds] = useState<
+    Set<string>
+  >(new Set());
+  const [sessionDismissedSuggestions, setSessionDismissedSuggestions] =
+    useState<Set<string>>(new Set());
   // L4 staleness signal: server flags memory older than 30 days; sidebar
   // surfaces a dismissible banner so users see it without visiting Settings.
   const [memoryIsStale, setMemoryIsStale] = useState(false);
@@ -566,6 +581,31 @@ function LangyPanel({
         if (!cancelled) setMemoryIsStale(Boolean(data.isStale));
       } catch {
         // staleness signal is non-critical; ignore network errors
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, projectId]);
+
+  useEffect(() => {
+    if (!isOpen || !projectId) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/langy/preferences?projectId=${encodeURIComponent(projectId)}`,
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          preferences?: { dismissedSuggestionKinds?: string[] };
+        };
+        if (cancelled) return;
+        setDismissedSuggestionKinds(
+          new Set(data.preferences?.dismissedSuggestionKinds ?? []),
+        );
+      } catch {
+        // suggestion-dismissal preferences are non-critical; ignore errors
       }
     })();
     return () => {
@@ -661,6 +701,64 @@ function LangyPanel({
 
   const discardProposal = (proposalId: string) => {
     setDiscardedProposals((prev) => new Set(prev).add(proposalId));
+  };
+
+  const actOnSuggestion = (suggestion: LangySuggestion) => {
+    const action = suggestion.action;
+    if (action.type === "open_proposal") {
+      const target = document.querySelector(
+        `[data-langy-proposal-id="${CSS.escape(action.proposalId)}"]`,
+      );
+      if (target instanceof HTMLElement) {
+        target.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+      return;
+    }
+    if (action.type === "open_url") {
+      window.location.href = action.href;
+      return;
+    }
+    if (action.type === "ask_followup") {
+      void send(action.prompt);
+    }
+  };
+
+  const dismissSuggestion = (suggestionId: string) => {
+    setSessionDismissedSuggestions((prev) => new Set(prev).add(suggestionId));
+  };
+
+  const dontShowSuggestionAgain = async ({
+    suggestionId,
+    kind,
+  }: {
+    suggestionId: string;
+    kind: string;
+  }) => {
+    setSessionDismissedSuggestions((prev) => new Set(prev).add(suggestionId));
+    setDismissedSuggestionKinds((prev) => new Set(prev).add(kind));
+    if (!projectId) return;
+    const nextKinds = Array.from(
+      new Set([...Array.from(dismissedSuggestionKinds), kind]),
+    );
+    try {
+      const res = await fetch("/api/langy/preferences", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId,
+          dismissedSuggestionKinds: nextKinds,
+        }),
+      });
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+    } catch {
+      toaster.create({
+        title: "Couldn't save preference",
+        description: "We'll keep this kind hidden for now and retry later.",
+        type: "error",
+        duration: 4000,
+        meta: { closable: true },
+      });
+    }
   };
 
   const subtitle = experimentSlug
@@ -761,6 +859,11 @@ function LangyPanel({
                   applyingProposals={applyingProposals}
                   onApply={applyProposal}
                   onDiscard={discardProposal}
+                  dismissedSuggestionKinds={dismissedSuggestionKinds}
+                  sessionDismissedSuggestions={sessionDismissedSuggestions}
+                  onActOnSuggestion={actOnSuggestion}
+                  onDismissSuggestion={dismissSuggestion}
+                  onDontShowSuggestionAgain={dontShowSuggestionAgain}
                 />
               ))}
               {isBusy && <ThinkingIndicator messages={messages} />}
@@ -1215,6 +1318,11 @@ function MessageContent({
   applyingProposals,
   onApply,
   onDiscard,
+  dismissedSuggestionKinds,
+  sessionDismissedSuggestions,
+  onActOnSuggestion,
+  onDismissSuggestion,
+  onDontShowSuggestionAgain,
 }: {
   message: UIMessage;
   appliedOutcomes: Record<
@@ -1225,6 +1333,14 @@ function MessageContent({
   applyingProposals: Set<string>;
   onApply: (proposalId: string, proposal: LangyProposal) => Promise<void>;
   onDiscard: (proposalId: string) => void;
+  dismissedSuggestionKinds: Set<string>;
+  sessionDismissedSuggestions: Set<string>;
+  onActOnSuggestion: (suggestion: LangySuggestion) => void;
+  onDismissSuggestion: (suggestionId: string) => void;
+  onDontShowSuggestionAgain: (args: {
+    suggestionId: string;
+    kind: string;
+  }) => Promise<void>;
 }) {
   const isUser = message.role === "user";
   const text = message.parts
@@ -1235,7 +1351,12 @@ function MessageContent({
     .join("");
 
   const proposals = extractProposals(message);
-  if (!text && proposals.length === 0) return null;
+  const suggestion = extractSuggestion(message);
+  const showSuggestion =
+    suggestion !== null &&
+    !dismissedSuggestionKinds.has(suggestion.suggestion.kind) &&
+    !sessionDismissedSuggestions.has(suggestion.id);
+  if (!text && proposals.length === 0 && !showSuggestion) return null;
 
   if (isUser) {
     return (
@@ -1286,6 +1407,7 @@ function MessageContent({
         {proposals.map(({ id, proposal }) => (
           <ProposalCard
             key={id}
+            proposalId={id}
             proposal={proposal}
             appliedOutcome={appliedOutcomes[id]}
             isDiscarded={discardedProposals.has(id)}
@@ -1294,12 +1416,26 @@ function MessageContent({
             onDiscard={() => onDiscard(id)}
           />
         ))}
+        {showSuggestion && suggestion && (
+          <SuggestionChip
+            suggestion={suggestion.suggestion}
+            onAct={() => onActOnSuggestion(suggestion.suggestion)}
+            onDismiss={() => onDismissSuggestion(suggestion.id)}
+            onDontShowAgain={() =>
+              void onDontShowSuggestionAgain({
+                suggestionId: suggestion.id,
+                kind: suggestion.suggestion.kind,
+              })
+            }
+          />
+        )}
       </VStack>
     </HStack>
   );
 }
 
 export function ProposalCard({
+  proposalId,
   proposal,
   appliedOutcome,
   isDiscarded,
@@ -1307,6 +1443,7 @@ export function ProposalCard({
   onApply,
   onDiscard,
 }: {
+  proposalId?: string;
   proposal: LangyProposal;
   appliedOutcome?: { href?: string; label?: string; onOpen?: () => void };
   isDiscarded: boolean;
@@ -1356,6 +1493,7 @@ export function ProposalCard({
 
   return (
     <Box
+      data-langy-proposal-id={proposalId}
       borderWidth="1px"
       borderColor="border.muted"
       borderRadius="md"
@@ -1527,4 +1665,22 @@ function isLangyProposal(value: unknown): value is LangyProposal {
     typeof v.kind === "string" &&
     typeof v.summary === "string"
   );
+}
+
+function extractSuggestion(
+  message: UIMessage,
+): { id: string; suggestion: LangySuggestion } | null {
+  let index = 0;
+  for (const part of message.parts) {
+    if (!part.type?.startsWith("tool-")) continue;
+    const output = (part as { output?: unknown }).output;
+    if (!isLangySuggestion(output)) {
+      index++;
+      continue;
+    }
+    const id =
+      (part as { toolCallId?: string }).toolCallId ?? `${message.id}:s${index}`;
+    return { id, suggestion: output };
+  }
+  return null;
 }

--- a/langwatch/src/components/langy/SuggestionChip.tsx
+++ b/langwatch/src/components/langy/SuggestionChip.tsx
@@ -1,0 +1,135 @@
+import { Box, HStack, Text, chakra } from "@chakra-ui/react";
+import { ArrowRight, Sparkles } from "lucide-react";
+import { useState } from "react";
+import type { LangySuggestion } from "~/server/services/langy/suggestion";
+
+interface SuggestionChipProps {
+  suggestion: LangySuggestion;
+  onAct: () => void;
+  onDismiss: () => void;
+  onDontShowAgain: () => void;
+}
+
+export function SuggestionChip({
+  suggestion,
+  onAct,
+  onDismiss,
+  onDontShowAgain,
+}: SuggestionChipProps) {
+  const [isHover, setIsHover] = useState(false);
+  const [isFocus, setIsFocus] = useState(false);
+  const secondaryVisible = isHover || isFocus;
+
+  return (
+    <Box
+      data-testid="langy-suggestion-chip"
+      data-suggestion-kind={suggestion.kind}
+      onMouseEnter={() => setIsHover(true)}
+      onMouseLeave={() => setIsHover(false)}
+      onFocus={() => setIsFocus(true)}
+      onBlur={() => setIsFocus(false)}
+    >
+      <chakra.button
+        type="button"
+        aria-label={`Suggestion: ${suggestion.label}`}
+        onClick={(e) => {
+          if ((e.target as HTMLElement).closest("[data-suggestion-secondary]")) {
+            return;
+          }
+          onAct();
+        }}
+        display="flex"
+        alignItems="center"
+        gap={2}
+        width="full"
+        textAlign="left"
+        paddingX={2.5}
+        paddingY={1.5}
+        borderRadius="md"
+        borderWidth="1px"
+        borderColor="border.muted"
+        background="transparent"
+        cursor="pointer"
+        transition="border-color 150ms ease, background 150ms ease"
+        _hover={{ borderColor: "border.emphasized", background: "bg.subtle" }}
+        _focusVisible={{
+          borderColor: "border.emphasized",
+          background: "bg.subtle",
+          outline: "none",
+        }}
+      >
+        <Sparkles size={12} color="var(--chakra-colors-fg-muted)" />
+        <Box flex={1} minWidth={0}>
+          <Text
+            textStyle="xs"
+            color="fg"
+            fontWeight={500}
+            lineHeight="1.35"
+            truncate
+          >
+            {suggestion.label}
+          </Text>
+          <Text
+            textStyle="2xs"
+            color="fg.muted"
+            lineHeight="1.35"
+            truncate
+            marginTop="1px"
+          >
+            {suggestion.rationale}
+          </Text>
+        </Box>
+        <ArrowRight size={12} color="var(--chakra-colors-fg-muted)" />
+      </chakra.button>
+      <HStack
+        gap={3}
+        marginTop={1}
+        paddingX={2.5}
+        opacity={secondaryVisible ? 1 : 0}
+        pointerEvents={secondaryVisible ? "auto" : "none"}
+        transition="opacity 120ms ease"
+      >
+        <SecondaryAction
+          label="Dismiss"
+          onClick={onDismiss}
+          ariaLabel={`Dismiss suggestion: ${suggestion.label}`}
+        />
+        <SecondaryAction
+          label="Don't show again"
+          onClick={onDontShowAgain}
+          ariaLabel={`Don't show suggestions of kind ${suggestion.kind} again`}
+        />
+      </HStack>
+    </Box>
+  );
+}
+
+function SecondaryAction({
+  label,
+  onClick,
+  ariaLabel,
+}: {
+  label: string;
+  onClick: () => void;
+  ariaLabel: string;
+}) {
+  return (
+    <chakra.button
+      type="button"
+      data-suggestion-secondary
+      aria-label={ariaLabel}
+      onClick={onClick}
+      background="transparent"
+      border="none"
+      padding={0}
+      cursor="pointer"
+      color="fg.muted"
+      fontSize="11px"
+      lineHeight="1.3"
+      _hover={{ color: "fg", textDecoration: "underline" }}
+      _focusVisible={{ color: "fg", outline: "none", textDecoration: "underline" }}
+    >
+      {label}
+    </chakra.button>
+  );
+}

--- a/langwatch/src/components/langy/__tests__/SuggestionChip.integration.test.tsx
+++ b/langwatch/src/components/langy/__tests__/SuggestionChip.integration.test.tsx
@@ -1,0 +1,351 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the post-turn suggestion chip (PR-5.2).
+ *
+ * Binds specs/assistant/langy-proactive.feature:
+ *   - "Suggestion renders as a dismissible chip below the assistant message"
+ *   - "Click suggestion to act" (kind=ask_followup variant — observable
+ *      via the mocked sendMessage)
+ *   - "Dismiss a suggestion"
+ *   - "Don't show this kind again"
+ *   - "Dismissed kinds do not reappear"
+ *
+ * Boundary mocks: useChat (so we can inject a fake assistant message that
+ * carries a langy-suggestion tool output) and global.fetch (so we can observe
+ * the GET/PUT to /api/langy/preferences).
+ */
+import { vi } from "vitest";
+
+vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const streamWeb = require("node:stream/web") as {
+    TransformStream: unknown;
+    ReadableStream: unknown;
+    WritableStream: unknown;
+  };
+  if (
+    typeof (globalThis as { TransformStream?: unknown }).TransformStream ===
+    "undefined"
+  ) {
+    Object.assign(globalThis, {
+      TransformStream: streamWeb.TransformStream,
+      ReadableStream:
+        (globalThis as { ReadableStream?: unknown }).ReadableStream ??
+        streamWeb.ReadableStream,
+      WritableStream:
+        (globalThis as { WritableStream?: unknown }).WritableStream ??
+        streamWeb.WritableStream,
+    });
+  }
+});
+
+let mockMessages: unknown[] = [];
+let mockSendMessage = vi.fn();
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: () => ({
+    messages: mockMessages,
+    sendMessage: mockSendMessage,
+    stop: vi.fn(),
+    status: "ready" as const,
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj_demo", slug: "demo" },
+    organization: { id: "org_demo" },
+    team: { id: "team_demo" },
+  }),
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("~/components/Markdown", () => ({
+  Markdown: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { LangyDrawer } from "~/components/langy/LangySidebar";
+import { LangyProvider } from "~/components/langy/LangyContext";
+
+interface SuggestionAction {
+  type: "open_proposal" | "open_url" | "ask_followup";
+  proposalId?: string;
+  href?: string;
+  prompt?: string;
+}
+
+function makeSuggestionMessage({
+  id = "msg_1",
+  kind,
+  label,
+  rationale,
+  action,
+}: {
+  id?: string;
+  kind: string;
+  label: string;
+  rationale: string;
+  action: SuggestionAction;
+}) {
+  return {
+    id,
+    role: "assistant" as const,
+    parts: [
+      { type: "text" as const, text: "Here is the answer." },
+      {
+        type: "tool-propose_suggestion",
+        toolCallId: `${id}__tool`,
+        output: {
+          langySuggestion: true,
+          kind,
+          label,
+          rationale,
+          action,
+        },
+      },
+    ],
+  };
+}
+
+function setupFetchMock({
+  dismissedKindsOnLoad = [] as string[],
+} = {}) {
+  const putCalls: { body: unknown }[] = [];
+  const fetchSpy = vi
+    .fn<typeof fetch>()
+    .mockImplementation(
+      async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : (input as Request).url;
+        const method = init?.method ?? "GET";
+        if (url.startsWith("/api/langy/preferences") && method === "GET") {
+          return new Response(
+            JSON.stringify({
+              preferences: {
+                id: "pref_1",
+                userId: "user_1",
+                projectId: "proj_demo",
+                mode: "non_expert",
+                dismissedSuggestionKinds: dismissedKindsOnLoad,
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (url.startsWith("/api/langy/preferences") && method === "PUT") {
+          const body = init?.body ? JSON.parse(String(init.body)) : null;
+          putCalls.push({ body });
+          return new Response(
+            JSON.stringify({
+              preferences: {
+                id: "pref_1",
+                userId: "user_1",
+                projectId: "proj_demo",
+                mode: "non_expert",
+                dismissedSuggestionKinds:
+                  body?.dismissedSuggestionKinds ?? dismissedKindsOnLoad,
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (url.startsWith("/api/langy/project-memory")) {
+          // staleness probe — return a benign 200
+          return new Response(JSON.stringify({ isStale: false }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        if (url.startsWith("/api/langy/conversations")) {
+          return new Response(
+            JSON.stringify({ conversations: [] }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response("not-found", { status: 404 });
+      },
+    );
+  return { fetchSpy, putCalls };
+}
+
+function renderPanelOpen() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <LangyProvider>
+        <LangyDrawer isOpen />
+      </LangyProvider>
+    </ChakraProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockMessages = [];
+  mockSendMessage = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Langy suggestion chip", () => {
+  describe("given an assistant message that carries a suggestion", () => {
+    describe("when the panel renders", () => {
+      it("shows the chip with the label and rationale below the assistant message", async () => {
+        const { fetchSpy } = setupFetchMock();
+        vi.stubGlobal("fetch", fetchSpy);
+        mockMessages = [
+          makeSuggestionMessage({
+            kind: "rerun-stale-experiment",
+            label: "Rerun the stale experiment",
+            rationale: "It hasn't run in 3 weeks.",
+            action: { type: "ask_followup", prompt: "Rerun the experiment" },
+          }),
+        ];
+        renderPanelOpen();
+        const chip = await screen.findByTestId("langy-suggestion-chip");
+        expect(within(chip).getByText("Rerun the stale experiment")).toBeDefined();
+        expect(within(chip).getByText("It hasn't run in 3 weeks.")).toBeDefined();
+      });
+    });
+
+    describe("when the user clicks the chip body (ask_followup)", () => {
+      it("sends the suggested prompt as the next user message", async () => {
+        const { fetchSpy } = setupFetchMock();
+        vi.stubGlobal("fetch", fetchSpy);
+        mockMessages = [
+          makeSuggestionMessage({
+            kind: "rerun-stale-experiment",
+            label: "Rerun the stale experiment",
+            rationale: "It hasn't run in 3 weeks.",
+            action: { type: "ask_followup", prompt: "Rerun the experiment" },
+          }),
+        ];
+        renderPanelOpen();
+        const chip = await screen.findByTestId("langy-suggestion-chip");
+        const chipButton = within(chip).getByRole("button", {
+          name: "Suggestion: Rerun the stale experiment",
+        });
+        await userEvent.click(chipButton);
+        expect(mockSendMessage).toHaveBeenCalledTimes(1);
+        const call = mockSendMessage.mock.calls[0]!;
+        expect((call[0] as { parts: { text: string }[] }).parts[0]?.text).toBe(
+          "Rerun the experiment",
+        );
+      });
+    });
+
+    describe("when the user hovers and clicks Dismiss", () => {
+      it("hides the chip without writing to preferences", async () => {
+        const { fetchSpy, putCalls } = setupFetchMock();
+        vi.stubGlobal("fetch", fetchSpy);
+        mockMessages = [
+          makeSuggestionMessage({
+            kind: "rerun-stale-experiment",
+            label: "Rerun the stale experiment",
+            rationale: "It hasn't run in 3 weeks.",
+            action: { type: "ask_followup", prompt: "Rerun" },
+          }),
+        ];
+        renderPanelOpen();
+        const chip = await screen.findByTestId("langy-suggestion-chip");
+        await userEvent.hover(chip);
+        await userEvent.click(
+          within(chip).getByRole("button", {
+            name: /Dismiss suggestion: Rerun the stale experiment/i,
+          }),
+        );
+        await waitFor(() => {
+          expect(screen.queryByTestId("langy-suggestion-chip")).toBeNull();
+        });
+        expect(putCalls).toHaveLength(0);
+      });
+    });
+
+    describe("when the user hovers and clicks Don't show again", () => {
+      it("PUTs the new kind list to /api/langy/preferences and hides the chip", async () => {
+        const { fetchSpy, putCalls } = setupFetchMock();
+        vi.stubGlobal("fetch", fetchSpy);
+        mockMessages = [
+          makeSuggestionMessage({
+            kind: "rerun-stale-experiment",
+            label: "Rerun the stale experiment",
+            rationale: "It hasn't run in 3 weeks.",
+            action: { type: "ask_followup", prompt: "Rerun" },
+          }),
+        ];
+        renderPanelOpen();
+        const chip = await screen.findByTestId("langy-suggestion-chip");
+        await userEvent.hover(chip);
+        await userEvent.click(
+          within(chip).getByRole("button", {
+            name: /Don't show suggestions of kind rerun-stale-experiment again/i,
+          }),
+        );
+        await waitFor(() => {
+          expect(putCalls.length).toBe(1);
+        });
+        const body = putCalls[0]!.body as {
+          projectId: string;
+          dismissedSuggestionKinds: string[];
+        };
+        expect(body.projectId).toBe("proj_demo");
+        expect(body.dismissedSuggestionKinds).toEqual([
+          "rerun-stale-experiment",
+        ]);
+        await waitFor(() => {
+          expect(screen.queryByTestId("langy-suggestion-chip")).toBeNull();
+        });
+      });
+    });
+  });
+
+  describe("given the user has previously dismissed this kind via preferences", () => {
+    describe("when a fresh suggestion of that kind arrives", () => {
+      it("does not render the chip — binds 'Dismissed kinds do not reappear'", async () => {
+        const { fetchSpy } = setupFetchMock({
+          dismissedKindsOnLoad: ["rerun-stale-experiment"],
+        });
+        vi.stubGlobal("fetch", fetchSpy);
+        mockMessages = [
+          makeSuggestionMessage({
+            kind: "rerun-stale-experiment",
+            label: "Rerun the stale experiment",
+            rationale: "It hasn't run in 3 weeks.",
+            action: { type: "ask_followup", prompt: "Rerun" },
+          }),
+        ];
+        renderPanelOpen();
+        // Wait for the GET /api/langy/preferences round-trip to settle by
+        // awaiting any state update. Then verify the chip never appears.
+        await waitFor(() => {
+          expect(
+            fetchSpy.mock.calls.some(([url]) =>
+              String(url).startsWith("/api/langy/preferences"),
+            ),
+          ).toBe(true);
+        });
+        expect(screen.queryByTestId("langy-suggestion-chip")).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -41,6 +41,7 @@ import {
   LANGY_EXPERT_MODE_SUFFIX,
   LANGY_NON_EXPERT_MODE_SUFFIX,
   LANGY_SYSTEM_PROMPT,
+  buildLangySuggestionInstructions,
 } from "~/server/services/langy/prompts";
 import { ConversationToolIdSet } from "~/server/services/langy/toolIdValidator";
 import { buildLangyTools } from "~/server/services/langy/tools";
@@ -64,12 +65,16 @@ const LANGY_FALLBACK_MODEL = "openai/gpt-5-mini";
 function buildSystemPrompt(opts: {
   projectMemory: string | null;
   mode: LangyMode;
+  suggestionInstructions?: string;
 }): string {
   const segments = [LANGY_SYSTEM_PROMPT];
   if (opts.mode === "expert") {
     segments.push(LANGY_EXPERT_MODE_SUFFIX);
   } else {
     segments.push(LANGY_NON_EXPERT_MODE_SUFFIX);
+  }
+  if (opts.suggestionInstructions) {
+    segments.push(opts.suggestionInstructions);
   }
   if (opts.projectMemory) {
     segments.push(
@@ -323,6 +328,27 @@ app.post("/langy/chat", async (c) => {
   const promptService = new PromptService(prisma);
   const seenIds = new ConversationToolIdSet();
 
+  // Phase 4 spike (PR-4.3): route a small slice of traffic through Mastra.
+  // Default-off; flip via PostHog or FEATURE_FLAG_FORCE_ENABLE. The legacy
+  // streamText path below stays the production default until PR-4.5 cutover.
+  const useMastra = await featureFlagService.isEnabled(
+    "release_ui_langy_mastra_enabled",
+    session.user.id,
+    false,
+    { projectId },
+  );
+
+  // Phase-5 producer (PR-5.1) is Mastra-only — the chip-emitting tool and
+  // the system-prompt instructions are both gated behind `useMastra` so the
+  // legacy path stays unchanged until cutover.
+  const suggestionsEnabled = useMastra;
+  const suggestionEmissionTracker = suggestionsEnabled
+    ? { count: 0 }
+    : undefined;
+  const dismissedSuggestionKinds = suggestionsEnabled
+    ? prefs.dismissedSuggestionKinds
+    : [];
+
   const toolCtx = {
     projectId,
     experimentSlug,
@@ -333,6 +359,9 @@ app.post("/langy/chat", async (c) => {
     projectService,
     promptService,
     seenIds,
+    suggestionsEnabled,
+    suggestionEmissionTracker,
+    dismissedSuggestionKinds,
   };
 
   const tools = buildLangyTools(toolCtx);
@@ -340,18 +369,13 @@ app.post("/langy/chat", async (c) => {
   const systemPrompt = buildSystemPrompt({
     projectMemory,
     mode: prefs.mode as LangyMode,
+    suggestionInstructions: suggestionsEnabled
+      ? buildLangySuggestionInstructions({
+          dismissedKinds: dismissedSuggestionKinds,
+        })
+      : undefined,
   });
   const modelMessages = await convertToModelMessages(messages);
-
-  // Phase 4 spike (PR-4.3): route a small slice of traffic through Mastra.
-  // Default-off; flip via PostHog or FEATURE_FLAG_FORCE_ENABLE. The legacy
-  // streamText path below stays the production default until PR-4.5 cutover.
-  const useMastra = await featureFlagService.isEnabled(
-    "release_ui_langy_mastra_enabled",
-    session.user.id,
-    false,
-    { projectId },
-  );
   // Phase 4 safety note: the Mastra path now uses Mastra's Memory primitive
   // (PR-4.4b — `LangyMastraMemory` adapter is the sole writer of assistant
   // + tool + user turns on this branch; the legacy `onFinish` hook is NOT

--- a/langwatch/src/server/services/langy/index.ts
+++ b/langwatch/src/server/services/langy/index.ts
@@ -20,3 +20,10 @@ export {
   LangyUserPreferencesRepository,
 } from "./LangyUserPreferencesService";
 export type { LangyMode } from "./LangyUserPreferencesService";
+export {
+  SUGGESTION_MARKER,
+  langySuggestionActionSchema,
+  langySuggestionSchema,
+  isLangySuggestion,
+} from "./suggestion";
+export type { LangySuggestion, LangySuggestionAction } from "./suggestion";

--- a/langwatch/src/server/services/langy/prompts.ts
+++ b/langwatch/src/server/services/langy/prompts.ts
@@ -51,6 +51,42 @@ export const LANGY_SYSTEM_PROMPT = `You are Langy, the in-product AI assistant f
 - If the user wants to choose a model, ask them which and then pass it in settings.model when proposing.
 - Mention the chosen model briefly in your reply so the user can catch it before applying.`;
 
+/**
+ * Producer half of Phase 5: instructs the agent to (optionally) emit one
+ * post-turn suggestion chip via the `propose_suggestion` tool. The renderer
+ * lives in `src/components/langy/SuggestionChip.tsx` (PR-5.2).
+ *
+ * Only injected on the Mastra path — the legacy AI-SDK path stays unchanged
+ * until the cutover lands. Parameterized by the user's saved
+ * `dismissedSuggestionKinds` so the agent knows which kinds to skip.
+ */
+export function buildLangySuggestionInstructions({
+  dismissedKinds,
+}: {
+  dismissedKinds: string[];
+}): string {
+  const hiddenList =
+    dismissedKinds.length === 0
+      ? "(none)"
+      : dismissedKinds.map((k) => `\`${k}\``).join(", ");
+  return `
+## Post-turn suggestions
+You MAY end a turn with at most one call to \`propose_suggestion\` — a small chip rendered below your answer with a single follow-up action.
+
+Hard rules:
+- AT MOST ONE \`propose_suggestion\` call per turn. Calling it twice in the same turn is a bug.
+- Call it LAST, after the answer is otherwise complete. Not as the first move.
+- Do NOT suggest when: the previous turn applied a proposal; the user is troubleshooting an error or stack trace; the user has asked you to stop suggesting.
+- Do NOT suggest a kind the user has hidden. Hidden kinds: ${hiddenList}.
+- The \`action\` must be concrete:
+  - \`open_proposal\` → reference a proposal ID you proposed in THIS turn.
+  - \`open_url\` → a path within this project.
+  - \`ask_followup\` → a question you would want the user to ask back.
+- \`label\` and \`rationale\` are each ONE short line. The chip is subtle — it's a nudge, not a card.
+
+Only suggest when there's a genuinely useful next step. If in doubt, skip it.`;
+}
+
 export const LANGY_EXPERT_MODE_SUFFIX = `
 ## Mode: expert
 - Be terse. Drop confirmations the user did not ask for. Skip restating the question. Use jargon freely.`;

--- a/langwatch/src/server/services/langy/suggestion.ts
+++ b/langwatch/src/server/services/langy/suggestion.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const SUGGESTION_MARKER = "langySuggestion" as const;
+
+const openProposalActionSchema = z.object({
+  type: z.literal("open_proposal"),
+  proposalId: z.string().min(1),
+});
+
+const openUrlActionSchema = z.object({
+  type: z.literal("open_url"),
+  href: z.string().min(1),
+});
+
+const askFollowupActionSchema = z.object({
+  type: z.literal("ask_followup"),
+  prompt: z.string().min(1),
+});
+
+export const langySuggestionActionSchema = z.discriminatedUnion("type", [
+  openProposalActionSchema,
+  openUrlActionSchema,
+  askFollowupActionSchema,
+]);
+
+export const langySuggestionSchema = z.object({
+  langySuggestion: z.literal(true),
+  kind: z.string().min(1),
+  label: z.string().min(1),
+  rationale: z.string().min(1),
+  action: langySuggestionActionSchema,
+});
+
+export type LangySuggestionAction = z.infer<typeof langySuggestionActionSchema>;
+export type LangySuggestion = z.infer<typeof langySuggestionSchema>;
+
+export function isLangySuggestion(value: unknown): value is LangySuggestion {
+  return langySuggestionSchema.safeParse(value).success;
+}

--- a/langwatch/src/server/services/langy/tools/__tests__/suggestions.unit.test.ts
+++ b/langwatch/src/server/services/langy/tools/__tests__/suggestions.unit.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the propose_suggestion tool (PR-5.1).
+ *
+ * Binds the producer scenarios in specs/assistant/langy-proactive.feature:
+ *   - "Langy emits at most one suggestion per turn"
+ *   - "Dismissed kinds do not reappear" (server-side enforcement on top of
+ *      the frontend filter from PR-5.2)
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { ConversationToolIdSet } from "../../toolIdValidator";
+import { isLangySuggestion } from "../../suggestion";
+import { makeProposeSuggestion } from "../suggestions";
+import type { LangyConversationContext } from "../types";
+
+function makeCtx(opts: {
+  dismissedSuggestionKinds?: string[];
+  suggestionEmissionTracker?: { count: number };
+} = {}): LangyConversationContext {
+  return {
+    projectId: "project-1",
+    seenIds: new ConversationToolIdSet(),
+    batchEvaluationService:
+      {} as LangyConversationContext["batchEvaluationService"],
+    datasetService: {} as LangyConversationContext["datasetService"],
+    evaluatorService: {} as LangyConversationContext["evaluatorService"],
+    experimentService: {} as LangyConversationContext["experimentService"],
+    projectService: {} as LangyConversationContext["projectService"],
+    promptService: {} as LangyConversationContext["promptService"],
+    suggestionsEnabled: true,
+    suggestionEmissionTracker: opts.suggestionEmissionTracker,
+    dismissedSuggestionKinds: opts.dismissedSuggestionKinds,
+  };
+}
+
+function invokeTool(toolDef: unknown, input: unknown): Promise<unknown> {
+  const exec = (toolDef as { execute: (i: unknown) => Promise<unknown> })
+    .execute;
+  return exec(input);
+}
+
+const sampleInput = {
+  kind: "rerun-stale-experiment",
+  label: "Rerun the stale experiment",
+  rationale: "It hasn't run in 3 weeks.",
+  action: { type: "ask_followup" as const, prompt: "Rerun the experiment" },
+};
+
+describe("propose_suggestion tool", () => {
+  describe("given a fresh per-turn tracker and no dismissed kinds", () => {
+    describe("when the agent calls propose_suggestion once", () => {
+      it("returns a valid LangySuggestion with the marker stamped on", async () => {
+        const tracker = { count: 0 };
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: tracker }),
+        );
+        const result = await invokeTool(tool, sampleInput);
+        expect(isLangySuggestion(result)).toBe(true);
+        expect((result as { kind: string }).kind).toBe(
+          "rerun-stale-experiment",
+        );
+      });
+
+      it("increments the per-turn counter to enforce the one-per-turn rule", async () => {
+        const tracker = { count: 0 };
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: tracker }),
+        );
+        await invokeTool(tool, sampleInput);
+        expect(tracker.count).toBe(1);
+      });
+    });
+  });
+
+  describe("given the tracker already shows one emission this turn", () => {
+    describe("when the agent tries to propose a second suggestion", () => {
+      it("returns a structured suggestion_limit_exceeded error, not a suggestion", async () => {
+        const tracker = { count: 1 };
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: tracker }),
+        );
+        const result = (await invokeTool(tool, sampleInput)) as {
+          error?: { code: string; kind: string };
+        };
+        expect(result.error?.code).toBe("suggestion_limit_exceeded");
+        expect(result.error?.kind).toBe("rerun-stale-experiment");
+      });
+
+      it("does NOT bump the counter past 1", async () => {
+        const tracker = { count: 1 };
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: tracker }),
+        );
+        await invokeTool(tool, sampleInput);
+        expect(tracker.count).toBe(1);
+      });
+    });
+  });
+
+  describe("given the kind is in the user's dismissedSuggestionKinds list", () => {
+    describe("when the agent tries to propose that kind anyway", () => {
+      it("returns a structured suggestion_kind_dismissed error", async () => {
+        const tracker = { count: 0 };
+        const tool = makeProposeSuggestion(
+          makeCtx({
+            suggestionEmissionTracker: tracker,
+            dismissedSuggestionKinds: ["rerun-stale-experiment"],
+          }),
+        );
+        const result = (await invokeTool(tool, sampleInput)) as {
+          error?: { code: string; kind: string };
+        };
+        expect(result.error?.code).toBe("suggestion_kind_dismissed");
+      });
+
+      it("does NOT consume the per-turn budget — agent can still try a different kind", async () => {
+        const tracker = { count: 0 };
+        const tool = makeProposeSuggestion(
+          makeCtx({
+            suggestionEmissionTracker: tracker,
+            dismissedSuggestionKinds: ["rerun-stale-experiment"],
+          }),
+        );
+        await invokeTool(tool, sampleInput);
+        expect(tracker.count).toBe(0);
+      });
+    });
+  });
+
+  describe("given action variants", () => {
+    describe("when the action is open_proposal", () => {
+      it("passes the proposalId through to the chip payload", async () => {
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: { count: 0 } }),
+        );
+        const result = (await invokeTool(tool, {
+          ...sampleInput,
+          action: { type: "open_proposal", proposalId: "prop_abc" },
+        })) as { action: { type: string; proposalId?: string } };
+        expect(result.action.type).toBe("open_proposal");
+        expect(result.action.proposalId).toBe("prop_abc");
+      });
+    });
+
+    describe("when the action is open_url", () => {
+      it("passes the href through", async () => {
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: { count: 0 } }),
+        );
+        const result = (await invokeTool(tool, {
+          ...sampleInput,
+          action: { type: "open_url", href: "/experiments/demo" },
+        })) as { action: { type: string; href?: string } };
+        expect(result.action.type).toBe("open_url");
+        expect(result.action.href).toBe("/experiments/demo");
+      });
+    });
+  });
+});
+
+describe("buildLangyTools — suggestion gating (PR-5.1 Mastra-only)", () => {
+  describe("given suggestionsEnabled is false (legacy path)", () => {
+    it("does not register propose_suggestion", async () => {
+      const { buildLangyTools } = await import("../index");
+      const ctx = makeCtx();
+      ctx.suggestionsEnabled = false;
+      const tools = buildLangyTools(ctx);
+      expect((tools as Record<string, unknown>).propose_suggestion).toBeUndefined();
+    });
+  });
+
+  describe("given suggestionsEnabled is true (Mastra path)", () => {
+    it("registers propose_suggestion alongside the other tools", async () => {
+      const { buildLangyTools } = await import("../index");
+      const ctx = makeCtx({ suggestionEmissionTracker: { count: 0 } });
+      const tools = buildLangyTools(ctx);
+      expect((tools as Record<string, unknown>).propose_suggestion).toBeDefined();
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/tools/index.ts
+++ b/langwatch/src/server/services/langy/tools/index.ts
@@ -34,12 +34,13 @@ import {
 } from "./workbench";
 import { makeSearchTraces } from "./traces";
 import { makeSearchPastRuns } from "./runs";
+import { makeProposeSuggestion } from "./suggestions";
 import type { LangyConversationContext } from "./types";
 
 export type { LangyConversationContext } from "./types";
 
 export function buildLangyTools(ctx: LangyConversationContext) {
-  return {
+  const base = {
     list_evaluators: makeListEvaluators(ctx),
     get_evaluator_details: makeGetEvaluatorDetails(ctx),
     list_prompts: makeListPrompts(ctx),
@@ -61,4 +62,6 @@ export function buildLangyTools(ctx: LangyConversationContext) {
     search_prompts: makeSearchPrompts(ctx),
     search_past_runs: makeSearchPastRuns(ctx),
   };
+  if (!ctx.suggestionsEnabled) return base;
+  return { ...base, propose_suggestion: makeProposeSuggestion(ctx) };
 }

--- a/langwatch/src/server/services/langy/tools/suggestions.ts
+++ b/langwatch/src/server/services/langy/tools/suggestions.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import { defineLangyTool } from "../defineLangyTool";
+import {
+  langySuggestionActionSchema,
+  type LangySuggestion,
+} from "../suggestion";
+import type { LangyConversationContext } from "./types";
+
+const proposeSuggestionInputSchema = z.object({
+  kind: z
+    .string()
+    .min(1)
+    .describe(
+      "Short kebab-case identifier for the *category* of nudge (e.g. 'rerun-stale-experiment', 'add-evaluator', 'open-failing-row'). The user can hide an entire kind via 'Don't show again'.",
+    ),
+  label: z
+    .string()
+    .min(1)
+    .describe("One short line shown as the chip body. Imperative voice."),
+  rationale: z
+    .string()
+    .min(1)
+    .describe(
+      "One short line of subtext under the label — why this might help.",
+    ),
+  action: langySuggestionActionSchema.describe(
+    "What clicking the chip does — open_proposal | open_url | ask_followup.",
+  ),
+});
+
+const suggestionAlreadyEmittedError = (kind: string) =>
+  ({
+    error: {
+      code: "suggestion_limit_exceeded" as const,
+      message:
+        "Only one suggestion is allowed per turn. The current turn already emitted one.",
+      kind,
+    },
+  }) as const;
+
+const suggestionKindDismissedError = (kind: string) =>
+  ({
+    error: {
+      code: "suggestion_kind_dismissed" as const,
+      message:
+        "The user has dismissed this kind of suggestion. Don't propose it again.",
+      kind,
+    },
+  }) as const;
+
+const suggestionToolOutputSchema = z.union([
+  z.object({
+    langySuggestion: z.literal(true),
+    kind: z.string(),
+    label: z.string(),
+    rationale: z.string(),
+    action: langySuggestionActionSchema,
+  }),
+  z.object({
+    error: z.object({
+      code: z.union([
+        z.literal("suggestion_limit_exceeded"),
+        z.literal("suggestion_kind_dismissed"),
+      ]),
+      message: z.string(),
+      kind: z.string(),
+    }),
+  }),
+]);
+
+export function makeProposeSuggestion(ctx: LangyConversationContext) {
+  return defineLangyTool({
+    name: "propose_suggestion",
+    description:
+      "Emit at most ONE post-turn suggestion chip with a follow-up action. Call this as the LAST step of your turn, only when there's a genuinely useful next step. Hard rules: max one call per turn; never call after the previous turn applied a proposal; never call when the user is troubleshooting an error; never call for a kind the user has dismissed.",
+    inputSchema: proposeSuggestionInputSchema,
+    outputSchema: suggestionToolOutputSchema,
+    execute: async ({ kind, label, rationale, action }) => {
+      const dismissed = ctx.dismissedSuggestionKinds ?? [];
+      if (dismissed.includes(kind)) {
+        return suggestionKindDismissedError(kind);
+      }
+      const tracker = ctx.suggestionEmissionTracker;
+      if (tracker && tracker.count >= 1) {
+        return suggestionAlreadyEmittedError(kind);
+      }
+      if (tracker) tracker.count += 1;
+      const suggestion: LangySuggestion = {
+        langySuggestion: true,
+        kind,
+        label,
+        rationale,
+        action,
+      };
+      return suggestion;
+    },
+  });
+}

--- a/langwatch/src/server/services/langy/tools/types.ts
+++ b/langwatch/src/server/services/langy/tools/types.ts
@@ -27,4 +27,22 @@ export interface LangyConversationContext {
   projectService: ProjectService;
   promptService: PromptService;
   seenIds: ConversationToolIdSet;
+  /**
+   * Phase-5 producer (PR-5.1, Mastra-only). When true, `propose_suggestion`
+   * is registered with the agent. Left unset on the legacy AI-SDK path so
+   * suggestions stay off until the Mastra cutover completes.
+   */
+  suggestionsEnabled?: boolean;
+  /**
+   * Per-turn counter consumed by `propose_suggestion` to enforce the
+   * "at most one suggestion per turn" rule. The route creates a fresh
+   * `{ count: 0 }` object per chat POST since one POST = one turn.
+   */
+  suggestionEmissionTracker?: { count: number };
+  /**
+   * The user's saved "don't show this kind again" list, loaded from
+   * `LangyUserPreferences`. The propose_suggestion tool refuses kinds in
+   * this list as a server-side belt to the frontend filter in PR-5.2.
+   */
+  dismissedSuggestionKinds?: string[];
 }


### PR DESCRIPTION
## Summary

UI half of **Langy Phase 5** — when an assistant turn carries a `langySuggestion` tool output, render a subtle, Perplexity-style chip below the answer with Apply / Dismiss / Don't-show-again controls. The agent-side **producer arrives in PR-5.1** (Mastra path only, per [phase-5 plan](https://github.com/langwatch/langwatch/blob/langy-v2-integration/specs/assistant/implementation-plan.md#phase-5--post-turn-inline-suggestions-2-prs-3-4-days)); this PR is the renderer + dismissal plumbing it will plug into.

Refs #3958.

### What's in this PR

- **Shared `LangySuggestion` zod schema** (`src/server/services/langy/suggestion.ts`) — the contract PR-5.1 plugs into. Three action variants: `open_proposal`, `open_url`, `ask_followup`.
- **`SuggestionChip`** — new component. Muted border, no shadow, secondary actions revealed on hover/focus (Perplexity-ish, intentionally not in-your-face). Accessible: secondary buttons stay in the a11y tree, just visually faded + pointer-events disabled when not revealed.
- **`LangySidebar` wiring** — `extractSuggestion` mirrors the existing `extractProposals` pattern, GET preferences on panel open to seed `dismissedSuggestionKinds`, PUT on "don't show this kind again". Per-session dismissals tracked in-memory.
- **Tests** — 5 integration tests, all binding scenarios from `specs/assistant/langy-proactive.feature`:
  - Suggestion renders with label + rationale below assistant message
  - Click chip → `ask_followup` calls `sendMessage` with the suggested prompt
  - Hover + Dismiss → chip hides, no PUT
  - Hover + Don't-show-again → PUT with new kind list, chip hides
  - Dismissed-kind-on-load → chip never renders (binds *"Dismissed kinds do not reappear"*)

### Backend already in place

`LangyUserPreferences.dismissedSuggestionKinds` (Prisma field, service method, PUT/GET route) was wired in earlier preferences work — no schema changes here.

### What's NOT in this PR

- Producer side (system-prompt + structured-output validator) — that's **PR-5.1, Mastra-only** after PR-4.3 cutover lands. The shape contract in `suggestion.ts` is what 5.1 will use.
- `open_url` and `open_proposal` action verification at the panel level — `open_url` side-effects `window.location` (awkward in jsdom), `open_proposal` does `scrollIntoView`. Chip-body click is exercised via the `ask_followup` variant which has an observable `sendMessage` side effect.
- Settings UI to re-enable a dismissed kind — out of scope for this PR; the field is editable via the existing `PUT /api/langy/preferences`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] All langy component tests pass (`vitest run src/components/langy/__tests__/` — 86/86)
- [x] All langy server-service tests pass (19/19)
- [ ] CI on `langy-v2-integration` base
- [ ] Reviewer pulls the branch, runs a manual injection of a fake `langySuggestion` tool output in dev to eyeball the chip render