### PR TITLE
feat(langy): propose_suggestion tool + system prompt — Mastra-only producer (PR-5.1)

### DIFF
--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -41,6 +41,7 @@ import {
   LANGY_EXPERT_MODE_SUFFIX,
   LANGY_NON_EXPERT_MODE_SUFFIX,
   LANGY_SYSTEM_PROMPT,
+  buildLangySuggestionInstructions,
 } from "~/server/services/langy/prompts";
 import { ConversationToolIdSet } from "~/server/services/langy/toolIdValidator";
 import { buildLangyTools } from "~/server/services/langy/tools";
@@ -64,12 +65,16 @@ const LANGY_FALLBACK_MODEL = "openai/gpt-5-mini";
 function buildSystemPrompt(opts: {
   projectMemory: string | null;
   mode: LangyMode;
+  suggestionInstructions?: string;
 }): string {
   const segments = [LANGY_SYSTEM_PROMPT];
   if (opts.mode === "expert") {
     segments.push(LANGY_EXPERT_MODE_SUFFIX);
   } else {
     segments.push(LANGY_NON_EXPERT_MODE_SUFFIX);
+  }
+  if (opts.suggestionInstructions) {
+    segments.push(opts.suggestionInstructions);
   }
   if (opts.projectMemory) {
     segments.push(
@@ -323,6 +328,27 @@ app.post("/langy/chat", async (c) => {
   const promptService = new PromptService(prisma);
   const seenIds = new ConversationToolIdSet();
 
+  // Phase 4 spike (PR-4.3): route a small slice of traffic through Mastra.
+  // Default-off; flip via PostHog or FEATURE_FLAG_FORCE_ENABLE. The legacy
+  // streamText path below stays the production default until PR-4.5 cutover.
+  const useMastra = await featureFlagService.isEnabled(
+    "release_ui_langy_mastra_enabled",
+    session.user.id,
+    false,
+    { projectId },
+  );
+
+  // Phase-5 producer (PR-5.1) is Mastra-only — the chip-emitting tool and
+  // the system-prompt instructions are both gated behind `useMastra` so the
+  // legacy path stays unchanged until cutover.
+  const suggestionsEnabled = useMastra;
+  const suggestionEmissionTracker = suggestionsEnabled
+    ? { count: 0 }
+    : undefined;
+  const dismissedSuggestionKinds = suggestionsEnabled
+    ? prefs.dismissedSuggestionKinds
+    : [];
+
   const toolCtx = {
     projectId,
     experimentSlug,
@@ -333,6 +359,9 @@ app.post("/langy/chat", async (c) => {
     projectService,
     promptService,
     seenIds,
+    suggestionsEnabled,
+    suggestionEmissionTracker,
+    dismissedSuggestionKinds,
   };
 
   const tools = buildLangyTools(toolCtx);
@@ -340,18 +369,13 @@ app.post("/langy/chat", async (c) => {
   const systemPrompt = buildSystemPrompt({
     projectMemory,
     mode: prefs.mode as LangyMode,
+    suggestionInstructions: suggestionsEnabled
+      ? buildLangySuggestionInstructions({
+          dismissedKinds: dismissedSuggestionKinds,
+        })
+      : undefined,
   });
   const modelMessages = await convertToModelMessages(messages);
-
-  // Phase 4 spike (PR-4.3): route a small slice of traffic through Mastra.
-  // Default-off; flip via PostHog or FEATURE_FLAG_FORCE_ENABLE. The legacy
-  // streamText path below stays the production default until PR-4.5 cutover.
-  const useMastra = await featureFlagService.isEnabled(
-    "release_ui_langy_mastra_enabled",
-    session.user.id,
-    false,
-    { projectId },
-  );
   // Phase 4 safety note: the Mastra path now uses Mastra's Memory primitive
   // (PR-4.4b — `LangyMastraMemory` adapter is the sole writer of assistant
   // + tool + user turns on this branch; the legacy `onFinish` hook is NOT

--- a/langwatch/src/server/services/langy/prompts.ts
+++ b/langwatch/src/server/services/langy/prompts.ts
@@ -51,6 +51,42 @@ export const LANGY_SYSTEM_PROMPT = `You are Langy, the in-product AI assistant f
 - If the user wants to choose a model, ask them which and then pass it in settings.model when proposing.
 - Mention the chosen model briefly in your reply so the user can catch it before applying.`;
 
+/**
+ * Producer half of Phase 5: instructs the agent to (optionally) emit one
+ * post-turn suggestion chip via the `propose_suggestion` tool. The renderer
+ * lives in `src/components/langy/SuggestionChip.tsx` (PR-5.2).
+ *
+ * Only injected on the Mastra path — the legacy AI-SDK path stays unchanged
+ * until the cutover lands. Parameterized by the user's saved
+ * `dismissedSuggestionKinds` so the agent knows which kinds to skip.
+ */
+export function buildLangySuggestionInstructions({
+  dismissedKinds,
+}: {
+  dismissedKinds: string[];
+}): string {
+  const hiddenList =
+    dismissedKinds.length === 0
+      ? "(none)"
+      : dismissedKinds.map((k) => `\`${k}\``).join(", ");
+  return `
+## Post-turn suggestions
+You MAY end a turn with at most one call to \`propose_suggestion\` — a small chip rendered below your answer with a single follow-up action.
+
+Hard rules:
+- AT MOST ONE \`propose_suggestion\` call per turn. Calling it twice in the same turn is a bug.
+- Call it LAST, after the answer is otherwise complete. Not as the first move.
+- Do NOT suggest when: the previous turn applied a proposal; the user is troubleshooting an error or stack trace; the user has asked you to stop suggesting.
+- Do NOT suggest a kind the user has hidden. Hidden kinds: ${hiddenList}.
+- The \`action\` must be concrete:
+  - \`open_proposal\` → reference a proposal ID you proposed in THIS turn.
+  - \`open_url\` → a path within this project.
+  - \`ask_followup\` → a question you would want the user to ask back.
+- \`label\` and \`rationale\` are each ONE short line. The chip is subtle — it's a nudge, not a card.
+
+Only suggest when there's a genuinely useful next step. If in doubt, skip it.`;
+}
+
 export const LANGY_EXPERT_MODE_SUFFIX = `
 ## Mode: expert
 - Be terse. Drop confirmations the user did not ask for. Skip restating the question. Use jargon freely.`;

--- a/langwatch/src/server/services/langy/tools/__tests__/suggestions.unit.test.ts
+++ b/langwatch/src/server/services/langy/tools/__tests__/suggestions.unit.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the propose_suggestion tool (PR-5.1).
+ *
+ * Binds the producer scenarios in specs/assistant/langy-proactive.feature:
+ *   - "Langy emits at most one suggestion per turn"
+ *   - "Dismissed kinds do not reappear" (server-side enforcement on top of
+ *      the frontend filter from PR-5.2)
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { ConversationToolIdSet } from "../../toolIdValidator";
+import { isLangySuggestion } from "../../suggestion";
+import { makeProposeSuggestion } from "../suggestions";
+import type { LangyConversationContext } from "../types";
+
+function makeCtx(opts: {
+  dismissedSuggestionKinds?: string[];
+  suggestionEmissionTracker?: { count: number };
+} = {}): LangyConversationContext {
+  return {
+    projectId: "project-1",
+    seenIds: new ConversationToolIdSet(),
+    batchEvaluationService:
+      {} as LangyConversationContext["batchEvaluationService"],
+    datasetService: {} as LangyConversationContext["datasetService"],
+    evaluatorService: {} as LangyConversationContext["evaluatorService"],
+    experimentService: {} as LangyConversationContext["experimentService"],
+    projectService: {} as LangyConversationContext["projectService"],
+    promptService: {} as LangyConversationContext["promptService"],
+    suggestionsEnabled: true,
+    suggestionEmissionTracker: opts.suggestionEmissionTracker,
+    dismissedSuggestionKinds: opts.dismissedSuggestionKinds,
+  };
+}
+
+function invokeTool(toolDef: unknown, input: unknown): Promise<unknown> {
+  const exec = (toolDef as { execute: (i: unknown) => Promise<unknown> })
+    .execute;
+  return exec(input);
+}
+
+const sampleInput = {
+  kind: "rerun-stale-experiment",
+  label: "Rerun the stale experiment",
+  rationale: "It hasn't run in 3 weeks.",
+  action: { type: "ask_followup" as const, prompt: "Rerun the experiment" },
+};
+
+describe("propose_suggestion tool", () => {
+  describe("given a fresh per-turn tracker and no dismissed kinds", () => {
+    describe("when the agent calls propose_suggestion once", () => {
+      it("returns a valid LangySuggestion with the marker stamped on", async () => {
+        const tracker = { count: 0 };
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: tracker }),
+        );
+        const result = await invokeTool(tool, sampleInput);
+        expect(isLangySuggestion(result)).toBe(true);
+        expect((result as { kind: string }).kind).toBe(
+          "rerun-stale-experiment",
+        );
+      });
+
+      it("increments the per-turn counter to enforce the one-per-turn rule", async () => {
+        const tracker = { count: 0 };
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: tracker }),
+        );
+        await invokeTool(tool, sampleInput);
+        expect(tracker.count).toBe(1);
+      });
+    });
+  });
+
+  describe("given the tracker already shows one emission this turn", () => {
+    describe("when the agent tries to propose a second suggestion", () => {
+      it("returns a structured suggestion_limit_exceeded error, not a suggestion", async () => {
+        const tracker = { count: 1 };
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: tracker }),
+        );
+        const result = (await invokeTool(tool, sampleInput)) as {
+          error?: { code: string; kind: string };
+        };
+        expect(result.error?.code).toBe("suggestion_limit_exceeded");
+        expect(result.error?.kind).toBe("rerun-stale-experiment");
+      });
+
+      it("does NOT bump the counter past 1", async () => {
+        const tracker = { count: 1 };
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: tracker }),
+        );
+        await invokeTool(tool, sampleInput);
+        expect(tracker.count).toBe(1);
+      });
+    });
+  });
+
+  describe("given the kind is in the user's dismissedSuggestionKinds list", () => {
+    describe("when the agent tries to propose that kind anyway", () => {
+      it("returns a structured suggestion_kind_dismissed error", async () => {
+        const tracker = { count: 0 };
+        const tool = makeProposeSuggestion(
+          makeCtx({
+            suggestionEmissionTracker: tracker,
+            dismissedSuggestionKinds: ["rerun-stale-experiment"],
+          }),
+        );
+        const result = (await invokeTool(tool, sampleInput)) as {
+          error?: { code: string; kind: string };
+        };
+        expect(result.error?.code).toBe("suggestion_kind_dismissed");
+      });
+
+      it("does NOT consume the per-turn budget — agent can still try a different kind", async () => {
+        const tracker = { count: 0 };
+        const tool = makeProposeSuggestion(
+          makeCtx({
+            suggestionEmissionTracker: tracker,
+            dismissedSuggestionKinds: ["rerun-stale-experiment"],
+          }),
+        );
+        await invokeTool(tool, sampleInput);
+        expect(tracker.count).toBe(0);
+      });
+    });
+  });
+
+  describe("given action variants", () => {
+    describe("when the action is open_proposal", () => {
+      it("passes the proposalId through to the chip payload", async () => {
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: { count: 0 } }),
+        );
+        const result = (await invokeTool(tool, {
+          ...sampleInput,
+          action: { type: "open_proposal", proposalId: "prop_abc" },
+        })) as { action: { type: string; proposalId?: string } };
+        expect(result.action.type).toBe("open_proposal");
+        expect(result.action.proposalId).toBe("prop_abc");
+      });
+    });
+
+    describe("when the action is open_url", () => {
+      it("passes the href through", async () => {
+        const tool = makeProposeSuggestion(
+          makeCtx({ suggestionEmissionTracker: { count: 0 } }),
+        );
+        const result = (await invokeTool(tool, {
+          ...sampleInput,
+          action: { type: "open_url", href: "/experiments/demo" },
+        })) as { action: { type: string; href?: string } };
+        expect(result.action.type).toBe("open_url");
+        expect(result.action.href).toBe("/experiments/demo");
+      });
+    });
+  });
+});
+
+describe("buildLangyTools — suggestion gating (PR-5.1 Mastra-only)", () => {
+  describe("given suggestionsEnabled is false (legacy path)", () => {
+    it("does not register propose_suggestion", async () => {
+      const { buildLangyTools } = await import("../index");
+      const ctx = makeCtx();
+      ctx.suggestionsEnabled = false;
+      const tools = buildLangyTools(ctx);
+      expect((tools as Record<string, unknown>).propose_suggestion).toBeUndefined();
+    });
+  });
+
+  describe("given suggestionsEnabled is true (Mastra path)", () => {
+    it("registers propose_suggestion alongside the other tools", async () => {
+      const { buildLangyTools } = await import("../index");
+      const ctx = makeCtx({ suggestionEmissionTracker: { count: 0 } });
+      const tools = buildLangyTools(ctx);
+      expect((tools as Record<string, unknown>).propose_suggestion).toBeDefined();
+    });
+  });
+});

--- a/langwatch/src/server/services/langy/tools/index.ts
+++ b/langwatch/src/server/services/langy/tools/index.ts
@@ -34,12 +34,13 @@ import {
 } from "./workbench";
 import { makeSearchTraces } from "./traces";
 import { makeSearchPastRuns } from "./runs";
+import { makeProposeSuggestion } from "./suggestions";
 import type { LangyConversationContext } from "./types";
 
 export type { LangyConversationContext } from "./types";
 
 export function buildLangyTools(ctx: LangyConversationContext) {
-  return {
+  const base = {
     list_evaluators: makeListEvaluators(ctx),
     get_evaluator_details: makeGetEvaluatorDetails(ctx),
     list_prompts: makeListPrompts(ctx),
@@ -61,4 +62,6 @@ export function buildLangyTools(ctx: LangyConversationContext) {
     search_prompts: makeSearchPrompts(ctx),
     search_past_runs: makeSearchPastRuns(ctx),
   };
+  if (!ctx.suggestionsEnabled) return base;
+  return { ...base, propose_suggestion: makeProposeSuggestion(ctx) };
 }

--- a/langwatch/src/server/services/langy/tools/suggestions.ts
+++ b/langwatch/src/server/services/langy/tools/suggestions.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import { defineLangyTool } from "../defineLangyTool";
+import {
+  langySuggestionActionSchema,
+  type LangySuggestion,
+} from "../suggestion";
+import type { LangyConversationContext } from "./types";
+
+const proposeSuggestionInputSchema = z.object({
+  kind: z
+    .string()
+    .min(1)
+    .describe(
+      "Short kebab-case identifier for the *category* of nudge (e.g. 'rerun-stale-experiment', 'add-evaluator', 'open-failing-row'). The user can hide an entire kind via 'Don't show again'.",
+    ),
+  label: z
+    .string()
+    .min(1)
+    .describe("One short line shown as the chip body. Imperative voice."),
+  rationale: z
+    .string()
+    .min(1)
+    .describe(
+      "One short line of subtext under the label — why this might help.",
+    ),
+  action: langySuggestionActionSchema.describe(
+    "What clicking the chip does — open_proposal | open_url | ask_followup.",
+  ),
+});
+
+const suggestionAlreadyEmittedError = (kind: string) =>
+  ({
+    error: {
+      code: "suggestion_limit_exceeded" as const,
+      message:
+        "Only one suggestion is allowed per turn. The current turn already emitted one.",
+      kind,
+    },
+  }) as const;
+
+const suggestionKindDismissedError = (kind: string) =>
+  ({
+    error: {
+      code: "suggestion_kind_dismissed" as const,
+      message:
+        "The user has dismissed this kind of suggestion. Don't propose it again.",
+      kind,
+    },
+  }) as const;
+
+const suggestionToolOutputSchema = z.union([
+  z.object({
+    langySuggestion: z.literal(true),
+    kind: z.string(),
+    label: z.string(),
+    rationale: z.string(),
+    action: langySuggestionActionSchema,
+  }),
+  z.object({
+    error: z.object({
+      code: z.union([
+        z.literal("suggestion_limit_exceeded"),
+        z.literal("suggestion_kind_dismissed"),
+      ]),
+      message: z.string(),
+      kind: z.string(),
+    }),
+  }),
+]);
+
+export function makeProposeSuggestion(ctx: LangyConversationContext) {
+  return defineLangyTool({
+    name: "propose_suggestion",
+    description:
+      "Emit at most ONE post-turn suggestion chip with a follow-up action. Call this as the LAST step of your turn, only when there's a genuinely useful next step. Hard rules: max one call per turn; never call after the previous turn applied a proposal; never call when the user is troubleshooting an error; never call for a kind the user has dismissed.",
+    inputSchema: proposeSuggestionInputSchema,
+    outputSchema: suggestionToolOutputSchema,
+    execute: async ({ kind, label, rationale, action }) => {
+      const dismissed = ctx.dismissedSuggestionKinds ?? [];
+      if (dismissed.includes(kind)) {
+        return suggestionKindDismissedError(kind);
+      }
+      const tracker = ctx.suggestionEmissionTracker;
+      if (tracker && tracker.count >= 1) {
+        return suggestionAlreadyEmittedError(kind);
+      }
+      if (tracker) tracker.count += 1;
+      const suggestion: LangySuggestion = {
+        langySuggestion: true,
+        kind,
+        label,
+        rationale,
+        action,
+      };
+      return suggestion;
+    },
+  });
+}

--- a/langwatch/src/server/services/langy/tools/types.ts
+++ b/langwatch/src/server/services/langy/tools/types.ts
@@ -27,4 +27,22 @@ export interface LangyConversationContext {
   projectService: ProjectService;
   promptService: PromptService;
   seenIds: ConversationToolIdSet;
+  /**
+   * Phase-5 producer (PR-5.1, Mastra-only). When true, `propose_suggestion`
+   * is registered with the agent. Left unset on the legacy AI-SDK path so
+   * suggestions stay off until the Mastra cutover completes.
+   */
+  suggestionsEnabled?: boolean;
+  /**
+   * Per-turn counter consumed by `propose_suggestion` to enforce the
+   * "at most one suggestion per turn" rule. The route creates a fresh
+   * `{ count: 0 }` object per chat POST since one POST = one turn.
+   */
+  suggestionEmissionTracker?: { count: number };
+  /**
+   * The user's saved "don't show this kind again" list, loaded from
+   * `LangyUserPreferences`. The propose_suggestion tool refuses kinds in
+   * this list as a server-side belt to the frontend filter in PR-5.2.
+   */
+  dismissedSuggestionKinds?: string[];
 }


### PR DESCRIPTION
## Summary

Producer half of **Langy Phase 5**, stacked on top of [PR-5.2](https://github.com/langwatch/langwatch/pull/4028). Adds a `propose_suggestion` tool that the **Mastra agent only** calls (at most once) at the end of a turn to emit a chip payload matching the `LangySuggestion` contract from PR-5.2.

Refs #3958. Targets `feat/langy-pr-5.2-suggestion-chip`; re-target to `langy-v2-integration` once 5.2 merges.

### Why Mastra-only

Per the [phase-5 plan](https://github.com/langwatch/langwatch/blob/langy-v2-integration/specs/assistant/implementation-plan.md#phase-5--post-turn-inline-suggestions-2-prs-3-4-days), 5.1 ships only against the Mastra runtime — the legacy AI-SDK path will be removed in the (yet-to-land) cutover, so writing 5.1 for both would mean writing throwaway code in `streamText` land. Tool registration, prompt injection, and per-turn tracker are all gated on `ctx.suggestionsEnabled = useMastra`.

To exercise it locally:
```bash
echo "FEATURE_FLAG_FORCE_ENABLE=release_ui_langy_mastra_enabled" >> langwatch/.env
make dev-full
```

### What's in

- **`propose_suggestion` tool** (`tools/suggestions.ts`) — defineLangyTool with three action variants (`open_proposal` / `open_url` / `ask_followup`). Two **hard guards** at execute time:
  - Max one suggestion per turn — second call returns `suggestion_limit_exceeded`
  - Kind in user's `dismissedSuggestionKinds` — returns `suggestion_kind_dismissed`
  
  Both return structured error envelopes rather than a chip, so the agent gets a comprehensible tool result.
- **`buildLangyTools` gating** — omits the tool entirely when `ctx.suggestionsEnabled` is false. Legacy path never sees it.
- **`buildLangySuggestionInstructions`** — new prompt block, parameterized by the user's hidden kinds. Soft suppression rules (don't suggest after applying a proposal, when troubleshooting, when user said "stop") live here.
- **Route plumbing** — `langy.ts` loads `dismissedSuggestionKinds` from prefs (already a Prisma column from earlier work), creates a fresh `{ count: 0 }` tracker per chat POST, threads both into toolCtx + the system prompt.

### What's NOT in

- Cutover / legacy removal — that's a separate PR by whoever owns Phase 4.5.
- "Don't show after applied proposal" / "stop suggesting" runtime detection — soft via prompt only. Hard guards would need parsing prior-turn message parts and a conversation-scope "user said stop" flag. Spec accepts soft enforcement; revisit only if metrics show abuse.
- Telemetry / scenario test that drives a real LLM end-to-end. Unit tests cover the guard semantics; the prompt → tool contract is exercised manually in dev (see make-dev verification step below).

## Test plan

- [x] `pnpm typecheck` clean
- [x] All 152 langy tests pass (10 new, 0 regressions)
- [ ] CI on stacked base
- [ ] **`make dev-full` + flag flip + browser:** open Langy, send "what should I do next on this experiment?", verify a chip appears and clicking it triggers the expected action (next message, navigation, or proposal scroll)