### PR TITLE
fix(traces): ingest OpenInference llm.token_count.* tokens

### DIFF
--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/openinference.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/__tests__/openinference.unit.test.ts
@@ -195,4 +195,89 @@ describe("OpenInferenceExtractor", () => {
       );
     });
   });
+
+  describe("when llm.token_count.* attributes are present", () => {
+    it("maps prompt/completion counts to canonical gen_ai.usage.*", () => {
+      const ctx = createExtractorContext({
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 751,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION]: 94,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL]: 845,
+      });
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS]).toBe(751);
+      expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(94);
+    });
+
+    it("maps reasoning + cache_read + cache_write to canonical keys", () => {
+      const ctx = createExtractorContext({
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING]:
+          12,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ]:
+          120,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE]:
+          30,
+      });
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS]).toBe(12);
+      expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]).toBe(120);
+      expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]).toBe(
+        30,
+      );
+    });
+
+    it("consumes all llm.token_count.* keys so they don't leak into params", () => {
+      const ctx = createExtractorContext({
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 751,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION]: 94,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL]: 845,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING]:
+          12,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ]:
+          120,
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE]:
+          30,
+      });
+
+      extractor.apply(ctx);
+
+      const remaining = [
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT,
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION,
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL,
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
+      ];
+      for (const key of remaining) {
+        expect(ctx.bag.attrs.has(key)).toBe(false);
+      }
+    });
+
+    it("records a rule when any token-count attribute is present", () => {
+      const ctx = createExtractorContext({
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 10,
+      });
+
+      extractor.apply(ctx);
+
+      expect(ctx.recordRule).toHaveBeenCalledWith(
+        "openinference:llm.token_count",
+      );
+    });
+
+    it("does not overwrite a canonical token already set by gen_ai.usage.*", () => {
+      const ctx = createExtractorContext({
+        [ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT]: 999,
+      });
+      ctx.out[ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS] = 42;
+
+      extractor.apply(ctx);
+
+      expect(ctx.out[ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS]).toBe(42);
+    });
+  });
 });

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_constants.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_constants.ts
@@ -164,6 +164,18 @@ export const ATTR_KEYS = {
   OPENINFERENCE_USER_ID: "user.id",
   OPENINFERENCE_SESSION_ID: "session.id",
   OPENINFERENCE_TAG_TAGS: "tag.tags",
+  // OpenInference token-usage attributes (llm.token_count.*) — emitted by
+  // openinference.instrumentation.{openai,anthropic,langchain,...}.
+  // Mapped to canonical gen_ai.usage.* by OpenInferenceExtractor.
+  OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT: "llm.token_count.prompt",
+  OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION: "llm.token_count.completion",
+  OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL: "llm.token_count.total",
+  OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING:
+    "llm.token_count.completion_details.reasoning",
+  OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ:
+    "llm.token_count.prompt_details.cache_read",
+  OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE:
+    "llm.token_count.prompt_details.cache_write",
 
   // Haystack attributes
   RETRIEVAL_DOCUMENTS: "retrieval.documents",

--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/openinference.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/openinference.ts
@@ -19,6 +19,7 @@
 
 import { ATTR_KEYS } from "./_constants";
 import { ALLOWED_SPAN_TYPES } from "./_extraction";
+import { asNumber } from "./_guards";
 import type { CanonicalAttributesExtractor, ExtractorContext } from "./_types";
 
 export class OpenInferenceExtractor implements CanonicalAttributesExtractor {
@@ -82,6 +83,68 @@ export class OpenInferenceExtractor implements CanonicalAttributesExtractor {
       const labelsStr = typeof tags === "string" ? tags : JSON.stringify(tags);
       ctx.setAttrIfAbsent(ATTR_KEYS.LANGWATCH_LABELS, labelsStr);
       ctx.recordRule(`${this.id}:tag.tags`);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Token Usage (llm.token_count.*)
+    // OpenInference instrumentors (openai, anthropic, langchain, ...) emit
+    // token counts under this namespace. Map them to canonical gen_ai.usage.*
+    // so downstream cost computation picks them up.
+    // ─────────────────────────────────────────────────────────────────────────
+    const prompt = asNumber(
+      attrs.take(ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT),
+    );
+    if (prompt !== null) {
+      ctx.setAttrIfAbsent(ATTR_KEYS.GEN_AI_USAGE_INPUT_TOKENS, prompt);
+    }
+    const completion = asNumber(
+      attrs.take(ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION),
+    );
+    if (completion !== null) {
+      ctx.setAttrIfAbsent(ATTR_KEYS.GEN_AI_USAGE_OUTPUT_TOKENS, completion);
+    }
+    // `total` is consumed (so it doesn't leak into params) but not stored —
+    // total tokens are always derived as prompt + completion downstream.
+    attrs.take(ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_TOTAL);
+
+    const reasoning = asNumber(
+      attrs.take(
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
+      ),
+    );
+    if (reasoning !== null) {
+      ctx.setAttrIfAbsent(ATTR_KEYS.GEN_AI_USAGE_REASONING_TOKENS, reasoning);
+    }
+    const cacheRead = asNumber(
+      attrs.take(
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+      ),
+    );
+    if (cacheRead !== null) {
+      ctx.setAttrIfAbsent(
+        ATTR_KEYS.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        cacheRead,
+      );
+    }
+    const cacheWrite = asNumber(
+      attrs.take(
+        ATTR_KEYS.OPENINFERENCE_LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
+      ),
+    );
+    if (cacheWrite !== null) {
+      ctx.setAttrIfAbsent(
+        ATTR_KEYS.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+        cacheWrite,
+      );
+    }
+    if (
+      prompt !== null ||
+      completion !== null ||
+      reasoning !== null ||
+      cacheRead !== null ||
+      cacheWrite !== null
+    ) {
+      ctx.recordRule(`${this.id}:llm.token_count`);
     }
   }
 }

--- a/specs/traces/openinference-token-ingest.feature
+++ b/specs/traces/openinference-token-ingest.feature
@@ -1,0 +1,88 @@
+Feature: Ingest OpenInference token-count attributes
+  As an operator forwarding OTel traces from OpenInference instrumentors
+  I want LangWatch's collector to extract `llm.token_count.*` attributes
+  So that trace tokens and cost are computed even without LiteLLM / OpenLLMetry
+
+  # =========================================================================
+  # Why this exists
+  # =========================================================================
+  #
+  # The new event-sourcing canonicalisation pipeline
+  # (`server/app-layer/traces/canonicalisation/extractors/`) maps two upstream
+  # conventions into canonical `gen_ai.usage.*` attributes:
+  #
+  #   - Vercel AI SDK (`VercelExtractor`):    `ai.usage.{...}`
+  #   - OpenLLMetry/OTel (`GenAIExtractor`):   `gen_ai.usage.{...}`
+  #
+  # OpenInference (Arize Phoenix) — the other major OTel-GenAI convention,
+  # used by `openinference.instrumentation.{openai,anthropic,langchain,...}` —
+  # emits a third shape: `llm.token_count.*`.
+  #
+  # Before this feature, OpenInference token counts were dropped silently by
+  # the canonicalisation pipeline: they leaked into span params (because the
+  # whole attribute map gets dumped there) but never reached
+  # `gen_ai.usage.{input,output}_tokens`, so downstream cost computation
+  # never fired for OpenInference-instrumented spans.
+  #
+  # =========================================================================
+  # Attribute mapping (handled by `OpenInferenceExtractor.apply`)
+  # =========================================================================
+  #
+  #   llm.token_count.prompt                          → gen_ai.usage.input_tokens
+  #   llm.token_count.completion                      → gen_ai.usage.output_tokens
+  #   llm.token_count.completion_details.reasoning    → gen_ai.usage.reasoning_tokens
+  #   llm.token_count.prompt_details.cache_read       → gen_ai.usage.cache_read.input_tokens
+  #   llm.token_count.prompt_details.cache_write      → gen_ai.usage.cache_creation.input_tokens
+  #
+  # `llm.token_count.total` is consumed (so it doesn't leak into params) but
+  # not stored — total tokens are always derived as prompt + completion
+  # downstream.
+  #
+  # Precedence: `setAttrIfAbsent` is used throughout, so any canonical value
+  # already set by `GenAIExtractor` (which runs before `OpenInferenceExtractor`
+  # in the pipeline) wins.
+
+  Background:
+    Given an LLM span produced by an OpenInference instrumentor
+    And the existing `gen_ai.usage.*` and `ai.usage.*` mappings still work
+
+  Scenario: Prompt and completion tokens are extracted
+    Given the span carries attributes
+      | key                          | value |
+      | llm.token_count.prompt       | 751   |
+      | llm.token_count.completion   | 94    |
+    When the canonicalisation pipeline runs
+    Then `gen_ai.usage.input_tokens` is 751
+    And `gen_ai.usage.output_tokens` is 94
+
+  Scenario: Reasoning tokens are extracted
+    Given the span carries
+      | key                                            | value |
+      | llm.token_count.completion_details.reasoning   | 12    |
+    When the canonicalisation pipeline runs
+    Then `gen_ai.usage.reasoning_tokens` is 12
+
+  Scenario: Cache-read / cache-write tokens are extracted
+    Given the span carries
+      | key                                         | value |
+      | llm.token_count.prompt_details.cache_read   | 120   |
+      | llm.token_count.prompt_details.cache_write  | 30    |
+    When the canonicalisation pipeline runs
+    Then `gen_ai.usage.cache_read.input_tokens` is 120
+    And `gen_ai.usage.cache_creation.input_tokens` is 30
+
+  Scenario: All llm.token_count.* keys are consumed (no leaking into params)
+    Given the span carries every `llm.token_count.*` attribute
+    When the canonicalisation pipeline runs
+    Then none of those keys remain in the attribute bag
+
+  Scenario: Canonical gen_ai.usage.* set by GenAIExtractor wins
+    Given the span carries both `gen_ai.usage.input_tokens=42` and `llm.token_count.prompt=999`
+    When the canonicalisation pipeline runs
+    Then `gen_ai.usage.input_tokens` stays 42 (no overwrite)
+
+  Scenario: Cost is computed downstream once tokens are populated
+    Given a model entry exists in the registry that matches the span's model
+    And the span carries `llm.token_count.prompt=751` and `llm.token_count.completion=94`
+    When the trace is processed end-to-end
+    Then the trace metrics report a non-null `total_cost`


### PR DESCRIPTION
## Summary
- OpenInference instrumentors (`openinference.instrumentation.{openai,anthropic,langchain,...}`, used by Arize Phoenix and similar stacks) emit token counts under `llm.token_count.*` — a namespace the canonicalisation pipeline didn't handle. Those attributes leaked into span params but never reached `gen_ai.usage.{input,output}_tokens`, so cost computation downstream never fired for OpenInference traces.
- `OpenInferenceExtractor` now maps `llm.token_count.*` → canonical `gen_ai.usage.*` (using `setAttrIfAbsent`, so the higher-priority `GenAIExtractor` keeps precedence when both shapes are present on a span).
- Spec added at `specs/traces/openinference-token-ingest.feature`; unit tests cover the happy path, the consume-and-don't-leak invariant, and the precedence rule.

## Mapping
| OpenInference attribute | Canonical attribute |
|---|---|
| `llm.token_count.prompt` | `gen_ai.usage.input_tokens` |
| `llm.token_count.completion` | `gen_ai.usage.output_tokens` |
| `llm.token_count.completion_details.reasoning` | `gen_ai.usage.reasoning_tokens` |
| `llm.token_count.prompt_details.cache_read` | `gen_ai.usage.cache_read.input_tokens` |
| `llm.token_count.prompt_details.cache_write` | `gen_ai.usage.cache_creation.input_tokens` |
| `llm.token_count.total` | consumed and discarded (derived downstream) |

## Why this matters
Reproduced live against `app.langwatch.ai` with a customer-report demo experiment: traces had full `token_count` JSON visible in the span PARAMS panel, but the experiment's Total Cost chart showed `$0` across every target. Root cause was this dropped mapping; tiktoken fallback in `addLLMTokensCount` can paper over missing tokens with rough estimates, but real provider-reported counts beat estimates and only the real counts trigger `estimateCost`.

## Test plan
- [x] `pnpm vitest run src/server/app-layer/traces/canonicalisation/extractors/__tests__/openinference.unit.test.ts` — 20/20 (5 new scenarios).
- [x] `pnpm vitest run src/server/app-layer/traces/canonicalisation` — 303/303.
- [x] `pnpm vitest run src/server/traces src/server/app-layer` — 1238/1238 after `pnpm prisma generate`.
- [x] CI green.
- [x] CodeRabbit clean.
- [x] End-to-end QA: re-ran the reproducing experiment via the OpenLLMetry equivalent of the dropped mapping (same canonical `gen_ai.usage.*` codepath this PR routes OpenInference through) and confirmed cost > 0 with `tokens_estimated: false` — see follow-up comment.
