### PR TITLE
fix(boxd-fork): make boxd-golden-reset succeed end-to-end (#3901 follow-up)

### DIFF
--- a/scripts/__tests__/boxd-fork.unit.bats
+++ b/scripts/__tests__/boxd-fork.unit.bats
@@ -326,3 +326,64 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = "alice--langwatch-golden" ]
 }
+
+# @scenario "boxd_golden_reset passes -y to non-interactive destroy"
+@test "boxd_golden_reset: 'boxd destroy' is invoked with -y so it doesn't prompt" {
+  # `boxd destroy` requires --confirm/-y or it prompts and aborts. The
+  # reset is already gated by BOXD_FORK_YES=1, so the inner destroy must
+  # be non-interactive.
+  run grep -E '\$BOXD_BIN" destroy "\$vm" -y' "$SCRIPT_DIR/boxd-fork.sh"
+  [ "$status" -eq 0 ]
+}
+
+# @scenario "corepack enable is sudo'd so it can write /usr/bin/pnpm"
+@test "boxd_golden: 'corepack enable' is invoked with sudo (needs root for /usr/bin symlink)" {
+  # corepack enable creates symlinks in /usr/bin and fails EACCES as a
+  # non-root user. The provisioning recipe runs as the VM's default user,
+  # so the call needs sudo.
+  run grep -E 'sudo corepack enable' "$SCRIPT_DIR/boxd-fork.sh"
+  [ "$status" -eq 0 ]
+}
+
+# @scenario "provisioning recipe wraps remote command in bash -c"
+@test "boxd_golden: provisioning recipe invokes bash -c so 'set -o pipefail' works under dash" {
+  # boxd exec runs the remote command under /bin/sh, which is dash on
+  # Ubuntu/Debian. Dash does not support 'set -o pipefail' — the recipe
+  # must wrap in 'bash -c' or the first line dies with
+  # "/bin/sh: set: Illegal option -o pipefail" and provisioning fails.
+  run grep -E '\$BOXD_BIN" exec "\$vm" -- bash -c' "$SCRIPT_DIR/boxd-fork.sh"
+  [ "$status" -eq 0 ]
+}
+
+# @scenario "no 'boxd exec ... -- \"...\"' sends 'set -o pipefail' to dash"
+@test "boxd-fork.sh: 'set -o pipefail' inside a boxd-exec recipe must be preceded by 'bash -c'" {
+  # Regression guard for the dash-vs-bash mismatch: 'boxd exec' runs the
+  # remote command under /bin/sh (dash), which can't parse pipefail.
+  # For every line containing 'set -o pipefail', walk backwards up to 20
+  # lines and require that the enclosing 'boxd exec' invocation includes
+  # 'bash -c' before the opening quote of the recipe.
+  awk '
+    {
+      lines[NR] = $0
+      if ($0 ~ /set -[a-zA-Z]*o[a-zA-Z]* pipefail/) pipefail_lines[NR] = 1
+    }
+    END {
+      bad = 0
+      for (n in pipefail_lines) {
+        found_exec = 0; ok = 0
+        for (i = n; i >= n - 20 && i > 0; i--) {
+          if (lines[i] ~ /\$BOXD_BIN" exec /) {
+            found_exec = 1
+            if (lines[i] ~ /bash -c/) ok = 1
+            break
+          }
+        }
+        if (found_exec && !ok) {
+          print "BAD line " n ": pipefail in boxd-exec recipe without bash -c"
+          bad = 1
+        }
+      }
+      exit bad
+    }
+  ' "$SCRIPT_DIR/boxd-fork.sh"
+}

--- a/scripts/boxd-fork.sh
+++ b/scripts/boxd-fork.sh
@@ -661,7 +661,10 @@ EOF
   # $BOXD_FORK_REPO is interpolated directly into the remote shell here —
   # safe because the regex validation above restricts it to
   # [A-Za-z0-9._-]+/[A-Za-z0-9._-]+ (no shell metacharacters possible).
-  if ! "$BOXD_BIN" exec "$vm" -- "
+  # boxd exec runs the remote command under /bin/sh (dash on Ubuntu/Debian),
+  # which doesn't grok 'set -o pipefail'. Wrap in 'bash -c' so the recipe
+  # gets bash semantics — pipefail is load-bearing for curl|bash safety.
+  if ! "$BOXD_BIN" exec "$vm" -- bash -c "
     set -euo pipefail
     if ! command -v node >/dev/null 2>&1 \\
        || [ \"\$(node --version 2>/dev/null | cut -d. -f1 | tr -d v)\" -lt 18 ]; then
@@ -671,7 +674,7 @@ EOF
     if [ ! -d langwatch ]; then
       git clone https://github.com/$BOXD_FORK_REPO.git langwatch
     fi
-    cd langwatch && corepack enable && pnpm -w install
+    cd langwatch && sudo corepack enable && pnpm -w install
   "; then
     echo "ERROR: provisioning $vm failed. Inspect with 'boxd connect $vm'." >&2
     return 1
@@ -691,7 +694,9 @@ boxd_golden_reset() {
   fi
   if boxd_vm_exists "$vm"; then
     printf 'Destroying %s\n' "$vm" >&2
-    if ! "$BOXD_BIN" destroy "$vm" >/dev/null 2>&1; then
+    # `boxd destroy` requires --confirm/-y to be non-interactive. We've
+    # already gated on BOXD_FORK_YES=1 above for user-level consent.
+    if ! "$BOXD_BIN" destroy "$vm" -y >/dev/null 2>&1; then
       echo "ERROR: 'boxd destroy $vm' failed; aborting reset." >&2
       return 1
     fi


### PR DESCRIPTION
## Why

`make boxd-golden-reset` against a fresh VM was broken on `main` immediately after #3901 merged — exit 1 at the first provisioning line. Three independent regressions, each blocking the canonical fresh-bring-up path that the PR was supposed to deliver.

Surfaced while validating the merged env-rewrite logic for the `<ns>--langwatch-golden` VM (the path new users will take).

## What changed

Three small fixes to `scripts/boxd-fork.sh`, each with a textual regression test in the unit bats suite:

1. **`set -o pipefail` under dash** — `boxd exec "$vm" -- "..."` evaluates the remote command under `/bin/sh` (dash on Ubuntu/Debian), which can't parse `pipefail`. The recipe died on its first line, so node install / git clone / pnpm install never ran. Wrap in `bash -c`.
2. **`boxd destroy` interactive prompt** — `boxd destroy` requires `--confirm`/`-y`. The reset already gates on `BOXD_FORK_YES=1` for user consent, so pass `-y` to the inner destroy.
3. **`corepack enable` EACCES** — corepack symlinks into `/usr/bin/` and fails as a non-root user. Add `sudo`.

## How it works

The first one is the load-bearing fix and the class of bug worth remembering: anything sent through `boxd exec` runs under dash, not bash, regardless of what shebang lives inside the script that called it. The recipe block in `boxd_golden()` is the only multi-line recipe in this file; the other call sites are single commands.

Regression tests are textual greps over `scripts/boxd-fork.sh`, scoped narrowly:
- `bash -c` precedes any `set -o pipefail` inside a boxd-exec recipe
- `boxd destroy` is invoked with `-y`
- `corepack enable` is prefixed with `sudo`

Textual guards are appropriate here because each fix is a single shell flag/wrapper that can't reasonably be tested without spinning a real VM, which the unit suite is not allowed to do.

## Test plan

```bash
bats scripts/__tests__/boxd-fork.unit.bats --filter "boxd_golden|destroy.*-y|pipefail|bash -c|corepack"
```

All 5 tests pass (3 new + 2 pre-existing). End-to-end:

```bash
BOXD_FORK_YES=1 make boxd-golden-reset
# → Done. Override the seed step by defining a seed-golden target.
# VM provisioned successfully.
```

Without any of the three fixes, the reset fails at:
1. `/bin/sh: set: Illegal option -o pipefail`
2. `error: destroying a VM is permanent and cannot be undone.`
3. `EACCES: permission denied, symlink '../lib/node_modules/corepack/dist/pnpm.js' -> '/usr/bin/pnpm'`

## How I can prove I was successful

No playable artifact — see Test plan. The validation is a successful `make boxd-golden-reset` against a real boxd VM (`drewdrewthis--langwatch-golden`), confirmed during this work to reach `Done. Override the seed step by defining a seed-golden target.`

## Anything surprising?

Worth auditing: there are 4 other `"$BOXD_BIN" exec "$vm" -- "..."` call sites in this file. None of them currently use `set -o pipefail`, but they're all subject to the same dash semantics — anything bashism added there will silently break. The new bats regression test guards the recipe class, not those sites individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)