### PR TITLE
fix(traces): fall back to org membership for trace visibility

### DIFF
--- a/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
@@ -74,6 +74,7 @@ const createMockOrganizationRepository = (): {
 } => ({
   getOrganizationIdByTeamId: vi.fn(),
   getUserOrgRole: vi.fn(),
+  getUserOrgRoleByTeamId: vi.fn(),
   getProjectIds: vi.fn(),
   getFeature: vi.fn(),
   findWithAdmins: vi.fn(),

--- a/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/subscription.service.unit.test.ts
@@ -73,6 +73,7 @@ const createMockOrganizationRepository = (): {
   [K in keyof OrganizationRepository]: ReturnType<typeof vi.fn>;
 } => ({
   getOrganizationIdByTeamId: vi.fn(),
+  getUserOrgRole: vi.fn(),
   getProjectIds: vi.fn(),
   getFeature: vi.fn(),
   findWithAdmins: vi.fn(),

--- a/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
@@ -18,6 +18,12 @@ const mockPrisma = {
   roleBinding: {
     findMany: vi.fn(),
   },
+  team: {
+    findUnique: vi.fn(),
+  },
+  organizationUser: {
+    findFirst: vi.fn(),
+  },
 } as any;
 
 const mockSession = {
@@ -123,7 +129,7 @@ describe("getUserProtectionsForProject", () => {
     });
   });
 
-  describe("when user has no RoleBinding", () => {
+  describe("when user has no team RoleBinding and no org membership", () => {
     beforeEach(() => {
       mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
         teamId: "team-1",
@@ -134,9 +140,109 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
+      mockPrisma.team.findUnique.mockResolvedValue({
+        organizationId: "org-1",
+      });
+      mockPrisma.organizationUser.findFirst.mockResolvedValue(null);
     });
 
-    it("denies visibility even for VISIBLE_TO_ALL", async () => {
+    it("denies visibility for VISIBLE_TO_ALL", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+
+  describe("when user has no team RoleBinding but is org MEMBER", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([]);
+      mockPrisma.team.findUnique.mockResolvedValue({
+        organizationId: "org-1",
+      });
+      mockPrisma.organizationUser.findFirst.mockResolvedValue({
+        role: "MEMBER",
+      });
+    });
+
+    it("grants visibility for VISIBLE_TO_ALL via org fallback", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(true);
+      expect(result.canSeeCapturedOutput).toBe(true);
+    });
+
+    it("denies visibility for VISIBLE_TO_ADMIN", async () => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+      });
+
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+
+  describe("when user has no team RoleBinding but is org ADMIN", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ADMIN,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([]);
+      mockPrisma.team.findUnique.mockResolvedValue({
+        organizationId: "org-1",
+      });
+      mockPrisma.organizationUser.findFirst.mockResolvedValue({
+        role: "ADMIN",
+      });
+    });
+
+    it("grants visibility for VISIBLE_TO_ADMIN via org admin fallback", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(true);
+      expect(result.canSeeCapturedOutput).toBe(true);
+    });
+
+    it("denies visibility for REDACTED_TO_ALL even as org admin", async () => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.REDACTED_TO_ALL,
+      });
+
       const result = await getUserProtectionsForProject(
         { prisma: mockPrisma, session: mockSession },
         { projectId: "project-1" },

--- a/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
@@ -12,8 +12,7 @@ vi.mock("../rbac", () => ({
 }));
 
 const mockOrgService = {
-  getOrganizationIdByTeamId: vi.fn(),
-  getUserOrgRole: vi.fn(),
+  getUserOrgRoleByTeamId: vi.fn(),
 };
 
 vi.mock("~/server/app-layer/app", () => ({
@@ -143,8 +142,7 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockOrgService.getOrganizationIdByTeamId.mockResolvedValue("org-1");
-      mockOrgService.getUserOrgRole.mockResolvedValue(null);
+      mockOrgService.getUserOrgRoleByTeamId.mockResolvedValue(null);
     });
 
     it("denies visibility for VISIBLE_TO_ALL", async () => {
@@ -169,8 +167,7 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockOrgService.getOrganizationIdByTeamId.mockResolvedValue("org-1");
-      mockOrgService.getUserOrgRole.mockResolvedValue("MEMBER");
+      mockOrgService.getUserOrgRoleByTeamId.mockResolvedValue("MEMBER");
     });
 
     it("grants visibility for VISIBLE_TO_ALL via org fallback", async () => {
@@ -213,8 +210,7 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockOrgService.getOrganizationIdByTeamId.mockResolvedValue("org-1");
-      mockOrgService.getUserOrgRole.mockResolvedValue("ADMIN");
+      mockOrgService.getUserOrgRoleByTeamId.mockResolvedValue("ADMIN");
     });
 
     it("grants visibility for VISIBLE_TO_ADMIN via org admin fallback", async () => {
@@ -257,8 +253,7 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockOrgService.getOrganizationIdByTeamId.mockResolvedValue("org-1");
-      mockOrgService.getUserOrgRole.mockResolvedValue("EXTERNAL");
+      mockOrgService.getUserOrgRoleByTeamId.mockResolvedValue("EXTERNAL");
     });
 
     it("denies visibility even for VISIBLE_TO_ALL", async () => {

--- a/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
@@ -11,18 +11,21 @@ vi.mock("../rbac", () => ({
   isDemoProject: vi.fn(() => false),
 }));
 
+const mockOrgService = {
+  getOrganizationIdByTeamId: vi.fn(),
+  getUserOrgRole: vi.fn(),
+};
+
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: () => ({ organizations: mockOrgService }),
+}));
+
 const mockPrisma = {
   project: {
     findUniqueOrThrow: vi.fn(),
   },
   roleBinding: {
     findMany: vi.fn(),
-  },
-  team: {
-    findUnique: vi.fn(),
-  },
-  organizationUser: {
-    findFirst: vi.fn(),
   },
 } as any;
 
@@ -140,10 +143,8 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockPrisma.team.findUnique.mockResolvedValue({
-        organizationId: "org-1",
-      });
-      mockPrisma.organizationUser.findFirst.mockResolvedValue(null);
+      mockOrgService.getOrganizationIdByTeamId.mockResolvedValue("org-1");
+      mockOrgService.getUserOrgRole.mockResolvedValue(null);
     });
 
     it("denies visibility for VISIBLE_TO_ALL", async () => {
@@ -168,12 +169,8 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockPrisma.team.findUnique.mockResolvedValue({
-        organizationId: "org-1",
-      });
-      mockPrisma.organizationUser.findFirst.mockResolvedValue({
-        role: "MEMBER",
-      });
+      mockOrgService.getOrganizationIdByTeamId.mockResolvedValue("org-1");
+      mockOrgService.getUserOrgRole.mockResolvedValue("MEMBER");
     });
 
     it("grants visibility for VISIBLE_TO_ALL via org fallback", async () => {
@@ -216,12 +213,8 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockPrisma.team.findUnique.mockResolvedValue({
-        organizationId: "org-1",
-      });
-      mockPrisma.organizationUser.findFirst.mockResolvedValue({
-        role: "ADMIN",
-      });
+      mockOrgService.getOrganizationIdByTeamId.mockResolvedValue("org-1");
+      mockOrgService.getUserOrgRole.mockResolvedValue("ADMIN");
     });
 
     it("grants visibility for VISIBLE_TO_ADMIN via org admin fallback", async () => {
@@ -264,12 +257,8 @@ describe("getUserProtectionsForProject", () => {
       });
 
       mockPrisma.roleBinding.findMany.mockResolvedValue([]);
-      mockPrisma.team.findUnique.mockResolvedValue({
-        organizationId: "org-1",
-      });
-      mockPrisma.organizationUser.findFirst.mockResolvedValue({
-        role: "EXTERNAL",
-      });
+      mockOrgService.getOrganizationIdByTeamId.mockResolvedValue("org-1");
+      mockOrgService.getUserOrgRole.mockResolvedValue("EXTERNAL");
     });
 
     it("denies visibility even for VISIBLE_TO_ALL", async () => {

--- a/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
+++ b/langwatch/src/server/api/__tests__/protections-rolebinding.unit.test.ts
@@ -253,6 +253,36 @@ describe("getUserProtectionsForProject", () => {
     });
   });
 
+  describe("when user has no team RoleBinding but is org EXTERNAL", () => {
+    beforeEach(() => {
+      mockPrisma.project.findUniqueOrThrow.mockResolvedValue({
+        teamId: "team-1",
+        capturedInputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+        capturedOutputVisibility:
+          ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
+      });
+
+      mockPrisma.roleBinding.findMany.mockResolvedValue([]);
+      mockPrisma.team.findUnique.mockResolvedValue({
+        organizationId: "org-1",
+      });
+      mockPrisma.organizationUser.findFirst.mockResolvedValue({
+        role: "EXTERNAL",
+      });
+    });
+
+    it("denies visibility even for VISIBLE_TO_ALL", async () => {
+      const result = await getUserProtectionsForProject(
+        { prisma: mockPrisma, session: mockSession },
+        { projectId: "project-1" },
+      );
+
+      expect(result.canSeeCapturedInput).toBe(false);
+      expect(result.canSeeCapturedOutput).toBe(false);
+    });
+  });
+
   describe("when visibility is REDACTED_TO_ALL", () => {
     beforeEach(() => {
       mockPrisma.project.findUniqueOrThrow.mockResolvedValue({

--- a/langwatch/src/server/api/utils.ts
+++ b/langwatch/src/server/api/utils.ts
@@ -8,6 +8,7 @@ import {
 import type { Session } from "~/server/auth";
 import type { Protections } from "../elasticsearch/protections";
 import { hasProjectPermission, isDemoProject } from "./rbac";
+import { getApp } from "~/server/app-layer/app";
 
 export const extractCheckKeys = (
   inputObject: Record<string, any>,
@@ -134,23 +135,20 @@ export async function getUserProtectionsForProject(
   let isMemberOfTeam = teamBindings.length > 0;
 
   if (!isMemberOfTeam) {
-    const team = await ctx.prisma.team.findUnique({
-      where: { id: project.teamId },
-      select: { organizationId: true },
-    });
+    const orgService = getApp().organizations;
+    const organizationId = await orgService.getOrganizationIdByTeamId(
+      project.teamId,
+    );
 
-    if (team) {
-      const orgUser = await ctx.prisma.organizationUser.findFirst({
-        where: {
-          userId: ctx.session.user.id,
-          organizationId: team.organizationId,
-        },
-        select: { role: true },
+    if (organizationId) {
+      const orgRole = await orgService.getUserOrgRole({
+        userId: ctx.session.user.id,
+        organizationId,
       });
 
-      if (orgUser && orgUser.role !== OrganizationUserRole.EXTERNAL) {
+      if (orgRole && orgRole !== OrganizationUserRole.EXTERNAL) {
         isMemberOfTeam = true;
-        if (orgUser.role === OrganizationUserRole.ADMIN) {
+        if (orgRole === OrganizationUserRole.ADMIN) {
           isAdminForTeam = true;
         }
       }

--- a/langwatch/src/server/api/utils.ts
+++ b/langwatch/src/server/api/utils.ts
@@ -115,8 +115,8 @@ export async function getUserProtectionsForProject(
     };
   }
 
-  // For signed in users, check their team permissions via RoleBinding
-  const bindings = await ctx.prisma.roleBinding.findMany({
+  // Check team-level role bindings
+  const teamBindings = await ctx.prisma.roleBinding.findMany({
     where: {
       userId: ctx.session.user.id,
       scopeType: RoleBindingScopeType.TEAM,
@@ -127,10 +127,34 @@ export async function getUserProtectionsForProject(
     },
   });
 
-  const isAdminForTeam = bindings.some(
+  let isAdminForTeam = teamBindings.some(
     (binding) => binding.role === TeamUserRole.ADMIN,
   );
-  const isMemberOfTeam = bindings.length > 0;
+  let isMemberOfTeam = teamBindings.length > 0;
+
+  if (!isMemberOfTeam) {
+    const team = await ctx.prisma.team.findUnique({
+      where: { id: project.teamId },
+      select: { organizationId: true },
+    });
+
+    if (team) {
+      const orgUser = await ctx.prisma.organizationUser.findFirst({
+        where: {
+          userId: ctx.session.user.id,
+          organizationId: team.organizationId,
+        },
+        select: { role: true },
+      });
+
+      if (orgUser) {
+        isMemberOfTeam = true;
+        if (orgUser.role === "ADMIN") {
+          isAdminForTeam = true;
+        }
+      }
+    }
+  }
 
   const obtainVisibilityLevel = (
     visibility: ProjectSensitiveDataVisibilityLevel,

--- a/langwatch/src/server/api/utils.ts
+++ b/langwatch/src/server/api/utils.ts
@@ -135,23 +135,16 @@ export async function getUserProtectionsForProject(
   let isMemberOfTeam = teamBindings.length > 0;
 
   if (!isMemberOfTeam) {
-    const orgService = getApp().organizations;
-    const organizationId = await orgService.getOrganizationIdByTeamId(
-      project.teamId,
-    );
+    const orgRole = await getApp().organizations.getUserOrgRoleByTeamId({
+      userId: ctx.session.user.id,
+      teamId: project.teamId,
+    });
 
-    if (organizationId) {
-      const orgRole = await orgService.getUserOrgRole({
-        userId: ctx.session.user.id,
-        organizationId,
-      });
-
-      if (orgRole && orgRole !== OrganizationUserRole.EXTERNAL) {
-        isMemberOfTeam = true;
-        if (orgRole === OrganizationUserRole.ADMIN) {
-          isAdminForTeam = true;
-        }
-      }
+    if (orgRole === OrganizationUserRole.ADMIN) {
+      isMemberOfTeam = true;
+      isAdminForTeam = true;
+    } else if (orgRole === OrganizationUserRole.MEMBER) {
+      isMemberOfTeam = true;
     }
   }
 

--- a/langwatch/src/server/api/utils.ts
+++ b/langwatch/src/server/api/utils.ts
@@ -1,5 +1,6 @@
 import {
   type PrismaClient,
+  OrganizationUserRole,
   ProjectSensitiveDataVisibilityLevel,
   RoleBindingScopeType,
   TeamUserRole,
@@ -147,9 +148,9 @@ export async function getUserProtectionsForProject(
         select: { role: true },
       });
 
-      if (orgUser) {
+      if (orgUser && orgUser.role !== OrganizationUserRole.EXTERNAL) {
         isMemberOfTeam = true;
-        if (orgUser.role === "ADMIN") {
+        if (orgUser.role === OrganizationUserRole.ADMIN) {
           isAdminForTeam = true;
         }
       }

--- a/langwatch/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
@@ -14,6 +14,7 @@ describe("OrganizationService", () => {
   const mockRepo: OrganizationRepository = {
     getOrganizationIdByTeamId: vi.fn(),
     getUserOrgRole: vi.fn(),
+    getUserOrgRoleByTeamId: vi.fn(),
     getProjectIds: vi.fn(),
     getFeature: vi.fn(),
     findWithAdmins: vi.fn(),

--- a/langwatch/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/organizations/__tests__/organization.service.unit.test.ts
@@ -13,6 +13,7 @@ vi.mock("../../tracing", () => ({
 describe("OrganizationService", () => {
   const mockRepo: OrganizationRepository = {
     getOrganizationIdByTeamId: vi.fn(),
+    getUserOrgRole: vi.fn(),
     getProjectIds: vi.fn(),
     getFeature: vi.fn(),
     findWithAdmins: vi.fn(),

--- a/langwatch/src/server/app-layer/organizations/organization.service.ts
+++ b/langwatch/src/server/app-layer/organizations/organization.service.ts
@@ -111,6 +111,13 @@ export class OrganizationService {
     return this.repo.getOrganizationIdByTeamId(teamId);
   }
 
+  async getUserOrgRole(params: {
+    userId: string;
+    organizationId: string;
+  }): Promise<OrganizationUserRole | null> {
+    return this.repo.getUserOrgRole(params);
+  }
+
   async getProjectIds(organizationId: string): Promise<string[]> {
     return this.repo.getProjectIds(organizationId);
   }

--- a/langwatch/src/server/app-layer/organizations/organization.service.ts
+++ b/langwatch/src/server/app-layer/organizations/organization.service.ts
@@ -118,6 +118,13 @@ export class OrganizationService {
     return this.repo.getUserOrgRole(params);
   }
 
+  async getUserOrgRoleByTeamId(params: {
+    userId: string;
+    teamId: string;
+  }): Promise<OrganizationUserRole | null> {
+    return this.repo.getUserOrgRoleByTeamId(params);
+  }
+
   async getProjectIds(organizationId: string): Promise<string[]> {
     return this.repo.getProjectIds(organizationId);
   }

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -50,6 +50,20 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
     return team?.organizationId ?? null;
   }
 
+  async getUserOrgRole({
+    userId,
+    organizationId,
+  }: {
+    userId: string;
+    organizationId: string;
+  }): Promise<OrganizationUserRole | null> {
+    const orgUser = await this.prisma.organizationUser.findFirst({
+      where: { userId, organizationId },
+      select: { role: true },
+    });
+    return orgUser?.role ?? null;
+  }
+
   async getProjectIds(organizationId: string): Promise<string[]> {
     const projects = await this.prisma.project.findMany({
       where: { team: { organizationId } },

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -57,8 +57,25 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
     userId: string;
     organizationId: string;
   }): Promise<OrganizationUserRole | null> {
+    const orgUser = await this.prisma.organizationUser.findUnique({
+      where: { userId_organizationId: { userId, organizationId } },
+      select: { role: true },
+    });
+    return orgUser?.role ?? null;
+  }
+
+  async getUserOrgRoleByTeamId({
+    userId,
+    teamId,
+  }: {
+    userId: string;
+    teamId: string;
+  }): Promise<OrganizationUserRole | null> {
     const orgUser = await this.prisma.organizationUser.findFirst({
-      where: { userId, organizationId },
+      where: {
+        userId,
+        organization: { teams: { some: { id: teamId } } },
+      },
       select: { role: true },
     });
     return orgUser?.role ?? null;

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.repository.ts
@@ -229,6 +229,10 @@ export interface OrganizationRepository {
     userId: string;
     organizationId: string;
   }): Promise<OrganizationUserRole | null>;
+  getUserOrgRoleByTeamId(params: {
+    userId: string;
+    teamId: string;
+  }): Promise<OrganizationUserRole | null>;
   getProjectIds(organizationId: string): Promise<string[]>;
   getFeature(
     organizationId: string,
@@ -309,6 +313,13 @@ export class NullOrganizationRepository implements OrganizationRepository {
   async getUserOrgRole(_params: {
     userId: string;
     organizationId: string;
+  }): Promise<OrganizationUserRole | null> {
+    return null;
+  }
+
+  async getUserOrgRoleByTeamId(_params: {
+    userId: string;
+    teamId: string;
   }): Promise<OrganizationUserRole | null> {
     return null;
   }

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.repository.ts
@@ -225,6 +225,10 @@ export interface UpdateTeamMemberRoleInput {
 
 export interface OrganizationRepository {
   getOrganizationIdByTeamId(teamId: string): Promise<string | null>;
+  getUserOrgRole(params: {
+    userId: string;
+    organizationId: string;
+  }): Promise<OrganizationUserRole | null>;
   getProjectIds(organizationId: string): Promise<string[]>;
   getFeature(
     organizationId: string,
@@ -299,6 +303,13 @@ export interface OrganizationRepository {
 
 export class NullOrganizationRepository implements OrganizationRepository {
   async getOrganizationIdByTeamId(_teamId: string): Promise<string | null> {
+    return null;
+  }
+
+  async getUserOrgRole(_params: {
+    userId: string;
+    organizationId: string;
+  }): Promise<OrganizationUserRole | null> {
     return null;
   }
 

--- a/langwatch/src/server/teams/team.service.ts
+++ b/langwatch/src/server/teams/team.service.ts
@@ -90,6 +90,7 @@ export class TeamService {
             include: {
               user: { select: { id: true, name: true, email: true } },
               group: { select: { id: true, name: true, scimSource: true } },
+              apiKey: { select: { id: true, name: true } },
               customRole: { select: { id: true, name: true } },
             },
           }),
@@ -103,6 +104,7 @@ export class TeamService {
                 include: {
                   user: { select: { id: true, name: true, email: true } },
                   group: { select: { id: true, name: true, scimSource: true } },
+                  apiKey: { select: { id: true, name: true } },
                   customRole: { select: { id: true, name: true } },
                 },
               })
@@ -176,7 +178,7 @@ export class TeamService {
             groupId: null as string | null,
             viaGroupId: null as string | null,
             viaGroupName: null as string | null,
-            name: b.user?.name ?? b.user?.email ?? "Unknown",
+            name: b.user?.name ?? b.user?.email ?? b.apiKey?.name ?? "Unknown",
             email: b.user?.email ?? null,
             role: b.role,
             customRoleId: b.customRoleId,
@@ -288,7 +290,7 @@ export class TeamService {
               userId: b.userId,
               groupId: b.groupId,
               viaGroupName: b.groupId ? b.group?.name ?? null : null,
-              name: b.user?.name ?? b.group?.name ?? "Unknown",
+              name: b.user?.name ?? b.group?.name ?? b.apiKey?.name ?? "Unknown",
               email: b.user?.email ?? null,
               role: b.role,
               customRoleId: b.customRoleId,


### PR DESCRIPTION
## Summary

- `getUserProtectionsForProject` only checked team-level `RoleBinding` rows when deciding whether to show or redact trace inputs/outputs
- When a project is created via API with `newTeamName` and no `userId` (service API key), the auto-created team has **zero members**
- Org admins could navigate to the project (RBAC grants access via org scope) but saw all inputs/outputs as `[REDACTED]` because the visibility check only looked at team scope
- Now falls back to `OrganizationUser` membership when no team binding exists: org members count as team members, org admins as team admins
- EXTERNAL (Lite Member) org users are explicitly excluded via allowlist (only ADMIN and MEMBER grant access), so any future role variants fail closed
- Service API key bindings now display the key's name instead of "Unknown" in the teams settings page

### How it works

```
Team RoleBinding found?
  → yes → use it (unchanged)
  → no  → single-query org lookup via getUserOrgRoleByTeamId
           → org ADMIN    → treat as team admin
           → org MEMBER   → treat as team member
           → org EXTERNAL → denied (allowlist, fails closed)
           → any other    → denied
           → not in org   → denied
```

The fallback query only fires when there's no team-level binding, so existing flows are unaffected.

### Root cause

The rest of the RBAC system (`resolveProjectPermission` in `rbac.ts`) checks 3 scopes: PROJECT → TEAM → ORGANIZATION. The visibility logic was never aligned — it only checked TEAM scope. This was true in the original `TeamUser` implementation and carried over when #3424 migrated it to `RoleBinding`.

### Additional fix: "Unknown" in teams settings

Service API key RoleBindings have `userId=null` and `groupId=null`. The teams settings page (`team.service.ts`) resolved binding names via `user?.name ?? group?.name`, falling through to "Unknown". Now includes `apiKey` in the RoleBinding query and uses `apiKey?.name` as a fallback.

## Test plan

- [x] 11 unit tests (5 org-fallback scenarios including EXTERNAL guard + 6 existing adjusted)
- [x] 47 tests pass across all affected files (protections, org service, billing)
- [x] Typecheck clean
- [x] Adversarial review: EXTERNAL escalation caught and fixed
- [x] E2E verified: provision → send traces → visible inputs/outputs on local