### PR TITLE
fix(docker): use Go cross-compilation instead of QEMU emulation

### DIFF
--- a/Dockerfile.go_service
+++ b/Dockerfile.go_service
@@ -1,7 +1,7 @@
 ﻿# syntax=docker/dockerfile:1.7
 
 # ─── Build stage ──────────────────────────────────────────────────────────────
-FROM golang:1.26.2-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS build
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates tzdata
 
@@ -14,8 +14,10 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 COPY services/ services/
 ARG VERSION=dev
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux go build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -ldflags="-s -w -X main.Version=${VERSION}" \
       -trimpath \
       -o /out/service ./cmd/service


### PR DESCRIPTION
## Summary
- The multi-arch Docker build for `langwatch-gateway` was timing out at 30min in CI because the Go compiler ran under QEMU emulation on a non-native architecture runner (~30-50x slower than native)
- Pins the build stage to the host platform via `--platform=$BUILDPLATFORM` and uses `TARGETOS`/`TARGETARCH` build args for Go's native cross-compilation
- This brings the cross-arch Go build from ~30min (QEMU) to ~1min (native cross-compile), well within the timeout

## Test plan
- [ ] Verify multi-arch build completes successfully in CI (both `go-services.yaml` and `build-and-push-artifacts.yaml`)
- [ ] Verify both `linux/amd64` and `linux/arm64` images are pushed and functional