### PR TITLE
fix(parity): add 3 feature-file scenarios for #4036 bats tests

### DIFF
--- a/specs/setup/boxd-fork-vm.feature
+++ b/specs/setup/boxd-fork-vm.feature
@@ -142,3 +142,26 @@ Feature: boxd Makefile orchestrates per-PR / per-branch / per-issue VM forks
     When I run "make boxd-golden-reset BOXD_FORK_YES=1"
     Then the existing VM is destroyed
     And a new VM is created with the same name
+
+  # --- Golden provisioning recipe (regression coverage for #4036) ---
+  # `boxd exec` evaluates remote commands under /bin/sh (dash on Ubuntu/Debian),
+  # which does not understand bashisms. The provisioning recipe needs explicit
+  # bash, a confirmed destroy, and root for /usr/bin/pnpm symlinks.
+
+  @unit
+  Scenario: provisioning recipe wraps remote command in bash -c
+    Given the boxd_golden provisioning recipe sends a multi-line command via "boxd exec"
+    When the recipe contains "set -o pipefail"
+    Then the invocation must wrap the recipe in "bash -c" so dash does not abort on bashisms
+
+  @unit
+  Scenario: boxd_golden_reset passes -y to non-interactive destroy
+    Given BOXD_FORK_YES=1 has already gated user-level consent
+    When boxd_golden_reset invokes "boxd destroy" on an existing VM
+    Then "-y" is passed so the destroy does not prompt and abort
+
+  @unit
+  Scenario: corepack enable is sudo'd so it can write /usr/bin/pnpm
+    Given the provisioning recipe runs as the VM's default non-root user
+    When the recipe enables corepack to install pnpm
+    Then "corepack enable" runs under sudo so the /usr/bin/pnpm symlink succeeds


### PR DESCRIPTION
## Why

#4036 broke `feature-parity` on main. The PR added 3 new bats tests with `# @scenario "..."` annotations but didn't add matching `Scenario:` blocks to any feature file. `check-feature-parity` enforces 1-to-1 binding and FAILed on the merge commit.

Direct Slack ping from Andrew: `Job: feature-parity / Commit: 12e7a7c`.

## What changed

Added 3 scenarios to `specs/setup/boxd-fork-vm.feature` under a new "Golden provisioning recipe (regression coverage for #4036)" section. Each scenario maps 1:1 to the bats test it now binds:

- `provisioning recipe wraps remote command in bash -c` — dash-vs-bash guard
- `boxd_golden_reset passes -y to non-interactive destroy` — non-interactive destroy guard
- `corepack enable is sudo'd so it can write /usr/bin/pnpm` — root-needed-for-symlink guard

These scenarios are unit-level (`@unit`) since the bats tests are textual greps over `scripts/boxd-fork.sh`, not integration tests against a real VM.

## Test plan

```bash
cd langwatch && pnpm check:feature-parity
# OK: 1031 enforced scenario(s) bound across 407 file(s).
```

Without this PR, parity fails with:

```
✗ @scenario boxd_golden_reset passes -y to non-interactive destroy
✗ @scenario corepack enable is sudo'd so it can write /usr/bin/pnpm
✗ @scenario provisioning recipe wraps remote command in bash -c
FAIL: 3 unknown annotation(s).
```

## How I can prove I was successful

No playable artifact — see Test plan. Verified locally that `pnpm check:feature-parity` passes after this change.

## Anything surprising?

This is the second main-breaking miss from the #3901 / #4036 chain. The bats-annotation parity check is the right primitive but it's silent during the PR's own CI — `check:feature-parity` only fails post-merge when the feature file diff is on `main`. Worth thinking about whether the parity job should run on every PR that touches `*.bats`, not just on `main`. Filing as a follow-up thought, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)