### PR TITLE
fix(dev): pnpm pin + repo-root workspace mounts so compose.dev.yml matches CI

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -134,6 +134,13 @@ services:
     working_dir: /app
     volumes:
       - ./langwatch:/app
+      # The repo-root pnpm-workspace.yaml + package.json define the
+      # outer workspace pnpm walks up to from /app. Without these two
+      # bind-mounts, pnpm stops at /app/pnpm-workspace.yaml and computes
+      # a different effective overrides config than the lockfile was
+      # generated against, breaking `pnpm install --frozen-lockfile`.
+      - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
+      - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
@@ -175,6 +182,13 @@ services:
     working_dir: /app
     volumes:
       - ./langwatch:/app
+      # The repo-root pnpm-workspace.yaml + package.json define the
+      # outer workspace pnpm walks up to from /app. Without these two
+      # bind-mounts, pnpm stops at /app/pnpm-workspace.yaml and computes
+      # a different effective overrides config than the lockfile was
+      # generated against, breaking `pnpm install --frozen-lockfile`.
+      - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
+      - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
@@ -237,6 +251,13 @@ services:
     profiles: [workers, scenarios, full]
     volumes:
       - ./langwatch:/app
+      # The repo-root pnpm-workspace.yaml + package.json define the
+      # outer workspace pnpm walks up to from /app. Without these two
+      # bind-mounts, pnpm stops at /app/pnpm-workspace.yaml and computes
+      # a different effective overrides config than the lockfile was
+      # generated against, breaking `pnpm install --frozen-lockfile`.
+      - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
+      - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
@@ -330,6 +351,13 @@ services:
     profiles: [test, scenarios, full]
     volumes:
       - ./langwatch:/app
+      # The repo-root pnpm-workspace.yaml + package.json define the
+      # outer workspace pnpm walks up to from /app. Without these two
+      # bind-mounts, pnpm stops at /app/pnpm-workspace.yaml and computes
+      # a different effective overrides config than the lockfile was
+      # generated against, breaking `pnpm install --frozen-lockfile`.
+      - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
+      - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro

--- a/langwatch/package.json
+++ b/langwatch/package.json
@@ -355,5 +355,6 @@
     "@rollup/rollup-linux-x64-gnu": "^4.60.2",
     "bufferutil": "^4.1.0"
   },
-  "workspaces": []
+  "workspaces": [],
+  "packageManager": "pnpm@10.24.0"
 }


### PR DESCRIPTION
## Problem

`pnpm install --frozen-lockfile` (which the dev compose init service runs via `CI=true`) fails out-of-the-box on a fresh checkout:

```
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

…even though the lockfile is committed and the CI workflow installs it cleanly.

## Two independent root causes

### 1. pnpm version drift

CI's `setup-pnpm-node` action pins **pnpm 10.24.0**. `langwatch/package.json` has no `packageManager` field, so **every other environment** (dev containers, golden VMs, contributor laptops) picks whatever corepack defaults to — currently **pnpm 11.x**.

pnpm 11 has:
- stricter overrides validation than 10.24.0
- an `allowBuilds:` scaffolder that writes interactive prompts (`set this to true or false`) into `pnpm-workspace.yaml` during non-interactive runs, corrupting the file for subsequent `--frozen-lockfile` runs

Pinning to 10.24.0 (commit 1) matches CI exactly and stops the drift.

### 2. Compose hides the repo-root workspace files

The `init` / `app` / etc. services bind-mount only `./langwatch:/app`. When pnpm runs from `/app` inside the container, it walks up looking for the workspace root, finds `/app/pnpm-workspace.yaml`, and **stops** — never seeing the repo-root `pnpm-workspace.yaml` + `package.json`.

But the committed lockfile was generated by pnpm running from the `langwatch/` subdir of the **full** checkout, where it walks up to the repo-root `pnpm-workspace.yaml` (which declares the outer monorepo and has no overrides) and uses **that** as the workspace root. The two contexts therefore compute different effective override configs, and `--frozen-lockfile` correctly rejects the mismatch.

Mounting the two repo-root files into the same paths the container walks up to (commit 2) makes the in-compose pnpm see the same workspace shape CI does, with no changes to `langwatch/pnpm-workspace.yaml` or the lockfile.

## Verification

Reproduced on a fresh `git clone` of `main`:
- before: `docker compose -f compose.dev.yml up -d` → init exits 1 with the error above
- after both commits: init exits 0, app starts, `https://<host>/` returns 200

`pnpm install --frozen-lockfile && pnpm run build` continues to pass in CI (same pnpm version, same lockfile, same overrides — no functional change to the install graph).

## Scope

Two small, focused commits:
- `fix(deps): pin pnpm@10.24.0 in langwatch/package.json` — 1 line
- `fix(dev): mount repo-root workspace files into compose.dev.yml services` — adds 2 bind-mount lines + a comment to each of the 4 services that bind `./langwatch:/app`

No code changes, no lockfile regen.