### PR TITLE
fix(dev): mount repo-root workspace files so Docker compose matches local pnpm

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -134,6 +134,8 @@ services:
     working_dir: /app
     volumes:
       - ./langwatch:/app
+      - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
+      - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
@@ -175,6 +177,8 @@ services:
     working_dir: /app
     volumes:
       - ./langwatch:/app
+      - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
+      - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
@@ -237,6 +241,8 @@ services:
     profiles: [workers, scenarios, full]
     volumes:
       - ./langwatch:/app
+      - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
+      - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro
@@ -330,6 +336,8 @@ services:
     profiles: [test, scenarios, full]
     volumes:
       - ./langwatch:/app
+      - ./pnpm-workspace.yaml:/pnpm-workspace.yaml:ro
+      - ./package.json:/package.json:ro
       - ./mcp-server:/mcp-server
       - ./langevals:/langevals
       - ./typescript-sdk:/typescript-sdk:ro


### PR DESCRIPTION
## Summary

- Fixes `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` in `make quickstart` / Docker init
- **Root cause** (credit to #4044 for the analysis): Docker only mounts `./langwatch:/app`, so pnpm can't walk up to the repo-root `pnpm-workspace.yaml` and `package.json`. This means (a) corepack doesn't see the `packageManager: pnpm@10.24.0` field, defaulting to pnpm 11, and (b) pnpm computes a different workspace shape than the lockfile was generated against
- **Fix**: Mount `./pnpm-workspace.yaml` and `./package.json` at `/` (read-only) in init, app, workers, and ai-server containers — so the in-container pnpm sees the same workspace tree as local dev
- 1 file changed, 8 lines added. No lockfile regen, no override reshuffling, no version pinning in package.json

## Test plan

- [x] Docker `node:24` with `CI=true` picks up pnpm 10.24.0 via corepack (from mounted `package.json`)
- [x] mcp-server: `pnpm install --frozen-lockfile` passes
- [x] langwatch: `pnpm install --frozen-lockfile` passes — "Lockfile is up to date"
- [ ] `make quickstart` with profile 1 (dev) completes end-to-end