### PR TITLE
fix(traces): fix /api/traces/search pagination crash on page 2+

### DIFF
--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -125,23 +125,29 @@ describe("ClickHouseTraceService", () => {
   });
 
   describe("getAllTracesForProject()", () => {
+    // Helper: set up the standard 4-mock sequence for fetchTracesWithPagination
+    // count → IDs → data → evaluations
+    const setupStandardMocks = (traceIds: string[]) => {
+      const summaryRows = traceIds.map((id) => makeSummaryRow(id));
+      const idRows = traceIds.map((id) => ({ TraceId: id }));
+      mockClickHouseQuery
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+        })
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve(idRows),
+        })
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve(summaryRows),
+        })
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve([]),
+        });
+    };
+
     describe("when includeSpans is false or not provided", () => {
       it("returns traces with empty spans", async () => {
-        const summaryRow = makeSummaryRow("trace-1");
-
-        // First call: count query
-        mockClickHouseQuery
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([{ total: "1" }]),
-          })
-          // Second call: summary query
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([summaryRow]),
-          })
-          // Third call: evaluation query
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([]),
-          });
+        setupStandardMocks(["trace-1"]);
 
         const service = new ClickHouseTraceService({
           project: { findUnique: mockPrismaFindUnique },
@@ -161,18 +167,7 @@ describe("ClickHouseTraceService", () => {
 
     describe("when traceIds is provided", () => {
       it("includes TraceId IN clause in the queries", async () => {
-        const summaryRow = makeSummaryRow("trace-A");
-
-        mockClickHouseQuery
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([{ total: "1" }]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([summaryRow]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([]),
-          });
+        setupStandardMocks(["trace-A"]);
 
         const service = new ClickHouseTraceService({
           project: { findUnique: mockPrismaFindUnique },
@@ -200,7 +195,7 @@ describe("ClickHouseTraceService", () => {
           "trace-B",
         ]);
 
-        // Verify the data query (2nd call) contains the TraceId IN clause
+        // Verify the IDs query (2nd call) contains the TraceId IN clause
         const dataCall = mockClickHouseQuery.mock.calls[1]!;
         expect(dataCall[0].query).toContain(
           "ts.TraceId IN ({traceIds:Array(String)})",
@@ -212,18 +207,7 @@ describe("ClickHouseTraceService", () => {
       });
 
       it("returns only matching traces", async () => {
-        const summaryRow = makeSummaryRow("trace-A");
-
-        mockClickHouseQuery
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([{ total: "1" }]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([summaryRow]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([]),
-          });
+        setupStandardMocks(["trace-A"]);
 
         const service = new ClickHouseTraceService({
           project: { findUnique: mockPrismaFindUnique },
@@ -248,18 +232,7 @@ describe("ClickHouseTraceService", () => {
 
     describe("when traceIds is undefined", () => {
       it("does not include TraceId IN clause in the queries", async () => {
-        const summaryRow = makeSummaryRow("trace-1");
-
-        mockClickHouseQuery
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([{ total: "1" }]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([summaryRow]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([]),
-          });
+        setupStandardMocks(["trace-1"]);
 
         const service = new ClickHouseTraceService({
           project: { findUnique: mockPrismaFindUnique },
@@ -302,17 +275,7 @@ describe("ClickHouseTraceService", () => {
         ).toString("base64");
 
       const setupMocksForCursorTest = () => {
-        const summaryRow = makeSummaryRow("trace-1");
-        mockClickHouseQuery
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([{ total: "1" }]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([summaryRow]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([]),
-          });
+        setupStandardMocks(["trace-1"]);
       };
 
       describe("when scrollId is passed via options", () => {
@@ -335,7 +298,7 @@ describe("ClickHouseTraceService", () => {
           // The data query (2nd call) includes the keyset cursor condition on deduped values
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
           );
           expect(dataCall[0].query_params.lastTimestamp).toBe(cursorTimestamp);
           expect(dataCall[0].query_params.lastTraceId).toBe(cursorTraceId);
@@ -366,10 +329,10 @@ describe("ClickHouseTraceService", () => {
           // input.scrollId is ignored — only options.scrollId is read
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
           );
         });
       });
@@ -392,10 +355,10 @@ describe("ClickHouseTraceService", () => {
           // The data query (2nd call) must NOT contain cursor condition
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
           );
         });
       });
@@ -419,10 +382,10 @@ describe("ClickHouseTraceService", () => {
           // The data query (2nd call) must NOT contain cursor condition
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
           );
         });
       });
@@ -448,10 +411,10 @@ describe("ClickHouseTraceService", () => {
 
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
           );
         });
       });
@@ -476,27 +439,17 @@ describe("ClickHouseTraceService", () => {
 
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
+            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
           );
         });
       });
     });
 
     const setupMocksForQueryTest = () => {
-      const summaryRow = makeSummaryRow("trace-1");
-      mockClickHouseQuery
-        .mockResolvedValueOnce({
-          json: () => Promise.resolve([{ total: "1" }]),
-        })
-        .mockResolvedValueOnce({
-          json: () => Promise.resolve([summaryRow]),
-        })
-        .mockResolvedValueOnce({
-          json: () => Promise.resolve([]),
-        });
+      setupStandardMocks(["trace-1"]);
     };
 
     describe("when query is provided", () => {
@@ -643,18 +596,7 @@ describe("ClickHouseTraceService", () => {
 
     describe("when query is too short", () => {
       it("does not include LIKE clause for queries under 3 characters", async () => {
-        const summaryRow = makeSummaryRow("trace-1");
-
-        mockClickHouseQuery
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([{ total: "1" }]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([summaryRow]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([]),
-          });
+        setupStandardMocks(["trace-1"]);
 
         const service = new ClickHouseTraceService({
           project: { findUnique: mockPrismaFindUnique },
@@ -673,18 +615,7 @@ describe("ClickHouseTraceService", () => {
 
     describe("when query is undefined", () => {
       it("does not include LIKE clause in queries", async () => {
-        const summaryRow = makeSummaryRow("trace-1");
-
-        mockClickHouseQuery
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([{ total: "1" }]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([summaryRow]),
-          })
-          .mockResolvedValueOnce({
-            json: () => Promise.resolve([]),
-          });
+        setupStandardMocks(["trace-1"]);
 
         const service = new ClickHouseTraceService({
           project: { findUnique: mockPrismaFindUnique },
@@ -713,23 +644,27 @@ describe("ClickHouseTraceService", () => {
         const spanRow = makeSpanRow("trace-1", "span-1");
 
         mockClickHouseQuery
-          // 1st call: count query (fetchTracesWithPagination)
+          // 1st call: count query
           .mockResolvedValueOnce({
             json: () => Promise.resolve([{ total: "1" }]),
           })
-          // 2nd call: summary query (fetchTracesWithPagination)
+          // 2nd call: IDs query
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ TraceId: "trace-1" }]),
+          })
+          // 3rd call: data query (fetchTracesWithPagination)
           .mockResolvedValueOnce({
             json: () => Promise.resolve([summaryRow]),
           })
-          // 3rd call: trace summary query (fetchTracesWithSpansJoined - summaries)
+          // 4th call: trace summary query (fetchTracesWithSpansJoined - summaries)
           .mockResolvedValueOnce({
             json: () => Promise.resolve([summaryRow]),
           })
-          // 4th call: spans query (fetchTracesWithSpansJoined - spans)
+          // 5th call: spans query (fetchTracesWithSpansJoined - spans)
           .mockResolvedValueOnce({
             json: () => Promise.resolve([spanRow]),
           })
-          // 5th call: evaluation query
+          // 6th call: evaluation query
           .mockResolvedValueOnce({
             json: () => Promise.resolve([]),
           });

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -332,10 +332,10 @@ describe("ClickHouseTraceService", () => {
 
           expect(result).not.toBeNull();
 
-          // The data query (2nd call) includes the keyset cursor condition
+          // The data query (2nd call) includes the keyset cursor condition on deduped values
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
           );
           expect(dataCall[0].query_params.lastTimestamp).toBe(cursorTimestamp);
           expect(dataCall[0].query_params.lastTraceId).toBe(cursorTraceId);
@@ -366,10 +366,10 @@ describe("ClickHouseTraceService", () => {
           // input.scrollId is ignored — only options.scrollId is read
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
           );
         });
       });
@@ -392,10 +392,10 @@ describe("ClickHouseTraceService", () => {
           // The data query (2nd call) must NOT contain cursor condition
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
           );
         });
       });
@@ -419,10 +419,10 @@ describe("ClickHouseTraceService", () => {
           // The data query (2nd call) must NOT contain cursor condition
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
           );
         });
       });
@@ -448,10 +448,10 @@ describe("ClickHouseTraceService", () => {
 
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
           );
         });
       });
@@ -476,10 +476,10 @@ describe("ClickHouseTraceService", () => {
 
           const dataCall = mockClickHouseQuery.mock.calls[1]!;
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) <",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) <",
           );
           expect(dataCall[0].query).not.toContain(
-            "(toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) >",
+            "(toUnixTimestamp64Milli(s._oa), s.TraceId) >",
           );
         });
       });

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -661,10 +661,11 @@ export class ClickHouseTraceService {
             {
               projectId: input.projectId,
               error: error instanceof Error ? error.message : error,
+              stack: error instanceof Error ? error.stack : undefined,
             },
             "Failed to fetch all traces from ClickHouse",
           );
-          throw new Error("Failed to fetch all traces for project");
+          throw error;
         }
       },
     );
@@ -1361,13 +1362,13 @@ export class ClickHouseTraceService {
           ? ` AND (${searchableColumns.map((col) => `${col} LIKE {searchQuery:String}`).join(" OR ")})`
           : "";
 
-        // Keyset cursor condition — applied AFTER GROUP BY on deduped values
+        // Keyset cursor condition — inside WHERE for partition pruning
         let cursorCondition = "";
         if (cursor) {
           cursorCondition =
             sortDirection === "desc"
-              ? " WHERE (toUnixTimestamp64Milli(s._oa), s.TraceId) < ({lastTimestamp:UInt64}, {lastTraceId:String})"
-              : " WHERE (toUnixTimestamp64Milli(s._oa), s.TraceId) > ({lastTimestamp:UInt64}, {lastTraceId:String})";
+              ? " AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) < ({lastTimestamp:UInt64}, {lastTraceId:String})"
+              : " AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) > ({lastTimestamp:UInt64}, {lastTraceId:String})";
         }
 
         const orderDirection = sortDirection === "desc" ? "DESC" : "ASC";
@@ -1385,12 +1386,15 @@ export class ClickHouseTraceService {
             : {}),
         };
 
-        // Run count + data queries in parallel.
-        // Two-phase data query: inner subquery finds the target TraceIds using
-        // only lightweight columns (so the sort fits in memory), then the outer
-        // query fetches full data for just those IDs.
-        // uniq() uses HyperLogLog (~2 % error) which is fine for pagination.
-        const [countResult, summaryResult] = await Promise.all([
+        const cursorParams = {
+          lastTimestamp: cursor?.lastTimestamp ?? 0,
+          lastTraceId: cursor?.lastTraceId ?? "",
+        };
+
+        // Step 1: Find page trace IDs + count in parallel.
+        // The ID query is lightweight (no heavy columns), and the count uses
+        // HyperLogLog (~2% error) which is fine for pagination display.
+        const [countResult, idsResult] = await Promise.all([
           clickHouseClient.query({
             query: `
               SELECT uniq(ts.TraceId) as total
@@ -1407,83 +1411,97 @@ export class ClickHouseTraceService {
           }),
           clickHouseClient.query({
             query: `
-              SELECT
-                ts.TraceId AS ts_TraceId,
-                ts.SpanCount AS ts_SpanCount,
-                ts.TotalDurationMs AS ts_TotalDurationMs,
-                ts.ComputedIOSchemaVersion AS ts_ComputedIOSchemaVersion,
-                ts.TimeToFirstTokenMs AS ts_TimeToFirstTokenMs,
-                ts.TimeToLastTokenMs AS ts_TimeToLastTokenMs,
-                ts.TokensPerSecond AS ts_TokensPerSecond,
-                ts.ContainsErrorStatus AS ts_ContainsErrorStatus,
-                ts.ContainsOKStatus AS ts_ContainsOKStatus,
-                ts.ErrorMessage AS ts_ErrorMessage,
-                ts.Models AS ts_Models,
-                ts.TotalCost AS ts_TotalCost,
-                ts.TokensEstimated AS ts_TokensEstimated,
-                ts.TotalPromptTokenCount AS ts_TotalPromptTokenCount,
-                ts.TotalCompletionTokenCount AS ts_TotalCompletionTokenCount,
-                ts.TopicId AS ts_TopicId,
-                ts.SubTopicId AS ts_SubTopicId,
-                ts.HasAnnotation AS ts_HasAnnotation,
-                ts.AnnotationIds AS ts_AnnotationIds,
-                ts.ComputedInput AS ts_ComputedInput,
-                ts.ComputedOutput AS ts_ComputedOutput,
-                ts.Attributes AS ts_Attributes,
-                ts.TraceName AS ts_TraceName,
-                toUnixTimestamp64Milli(ts.OccurredAt) AS ts_OccurredAt,
-                toUnixTimestamp64Milli(ts.CreatedAt) AS ts_CreatedAt,
-                toUnixTimestamp64Milli(ts.UpdatedAt) AS ts_UpdatedAt
-              FROM trace_summaries ts
-              WHERE ts.TenantId = {tenantId:String}
-                AND ts.TraceId IN (
-                  SELECT s.TraceId
-                  FROM (
-                    SELECT ts.TraceId AS TraceId,
-                           argMax(ts.OccurredAt, ts.UpdatedAt) AS _oa
-                    FROM trace_summaries ts
-                    WHERE ts.TenantId = {tenantId:String}
-                      AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-                      AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
-                      ${extraFilters}
-                      ${traceIdFilter}
-                      ${searchFilter}
-                    GROUP BY ts.TraceId
-                  ) s
+              SELECT s.TraceId
+              FROM (
+                SELECT ts.TraceId AS TraceId,
+                       argMax(ts.OccurredAt, ts.UpdatedAt) AS _oa
+                FROM trace_summaries ts
+                WHERE ts.TenantId = {tenantId:String}
+                  AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+                  AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+                  ${extraFilters}
+                  ${traceIdFilter}
+                  ${searchFilter}
                   ${cursorCondition}
-                  ORDER BY s._oa ${orderDirection}, s.TraceId ${orderDirection}
-                  LIMIT {pageSize:UInt32}
-                )
-                AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
-                  SELECT TenantId, TraceId, max(UpdatedAt)
-                  FROM trace_summaries
-                  WHERE TenantId = {tenantId:String}
-                    AND OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-                    AND OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
-                  GROUP BY TenantId, TraceId
-                )
-              ORDER BY ts.OccurredAt ${orderDirection}, ts.TraceId ${orderDirection}
+                GROUP BY ts.TraceId
+              ) s
+              ORDER BY s._oa ${orderDirection}, s.TraceId ${orderDirection}
+              LIMIT {pageSize:UInt32}
             `,
             query_params: {
               ...sharedParams,
-              lastTimestamp: cursor?.lastTimestamp ?? 0,
-              lastTraceId: cursor?.lastTraceId ?? "",
+              ...cursorParams,
               pageSize,
             },
             format: "JSONEachRow",
           }),
         ]);
 
-        const [countRows, summaryRows] = await Promise.all([
+        const [countRows, idRows] = await Promise.all([
           countResult.json() as Promise<Array<{ total: string }>>,
-          summaryResult.json() as Promise<TraceSummaryRow[]>,
+          idsResult.json() as Promise<Array<{ TraceId: string }>>,
         ]);
 
         const totalHits = parseInt(countRows[0]?.total ?? "0", 10);
+        const pageTraceIds = idRows.map((r) => r.TraceId);
 
-        if (summaryRows.length === 0) {
+        if (pageTraceIds.length === 0) {
           return { traces: [], totalHits, lastTrace: null };
         }
+
+        // Step 2: Fetch full data for just the page's trace IDs.
+        // The dedup subquery is scoped to pageTraceIds so it only reads
+        // N traces instead of the entire table.
+        const summaryResult = await clickHouseClient.query({
+          query: `
+            SELECT
+              ts.TraceId AS ts_TraceId,
+              ts.SpanCount AS ts_SpanCount,
+              ts.TotalDurationMs AS ts_TotalDurationMs,
+              ts.ComputedIOSchemaVersion AS ts_ComputedIOSchemaVersion,
+              ts.TimeToFirstTokenMs AS ts_TimeToFirstTokenMs,
+              ts.TimeToLastTokenMs AS ts_TimeToLastTokenMs,
+              ts.TokensPerSecond AS ts_TokensPerSecond,
+              ts.ContainsErrorStatus AS ts_ContainsErrorStatus,
+              ts.ContainsOKStatus AS ts_ContainsOKStatus,
+              ts.ErrorMessage AS ts_ErrorMessage,
+              ts.Models AS ts_Models,
+              ts.TotalCost AS ts_TotalCost,
+              ts.TokensEstimated AS ts_TokensEstimated,
+              ts.TotalPromptTokenCount AS ts_TotalPromptTokenCount,
+              ts.TotalCompletionTokenCount AS ts_TotalCompletionTokenCount,
+              ts.TopicId AS ts_TopicId,
+              ts.SubTopicId AS ts_SubTopicId,
+              ts.HasAnnotation AS ts_HasAnnotation,
+              ts.AnnotationIds AS ts_AnnotationIds,
+              ts.ComputedInput AS ts_ComputedInput,
+              ts.ComputedOutput AS ts_ComputedOutput,
+              ts.Attributes AS ts_Attributes,
+              ts.TraceName AS ts_TraceName,
+              toUnixTimestamp64Milli(ts.OccurredAt) AS ts_OccurredAt,
+              toUnixTimestamp64Milli(ts.CreatedAt) AS ts_CreatedAt,
+              toUnixTimestamp64Milli(ts.UpdatedAt) AS ts_UpdatedAt
+            FROM trace_summaries ts
+            WHERE ts.TenantId = {tenantId:String}
+              AND ts.TraceId IN ({pageTraceIds:Array(String)})
+              AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
+                SELECT TenantId, TraceId, max(UpdatedAt)
+                FROM trace_summaries
+                WHERE TenantId = {tenantId:String}
+                  AND TraceId IN ({pageTraceIds:Array(String)})
+                GROUP BY TenantId, TraceId
+              )
+            ORDER BY ts.OccurredAt ${orderDirection}, ts.TraceId ${orderDirection}
+          `,
+          query_params: {
+            tenantId: projectId,
+            pageTraceIds,
+          },
+          format: "JSONEachRow",
+        });
+
+        const summaryRows =
+          await summaryResult.json() as TraceSummaryRow[];
 
         const traces: Trace[] = summaryRows.map((row) => {
           const summary = this.rowToTraceSummaryData(row);

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1483,11 +1483,15 @@ export class ClickHouseTraceService {
               toUnixTimestamp64Milli(ts.UpdatedAt) AS ts_UpdatedAt
             FROM trace_summaries ts
             WHERE ts.TenantId = {tenantId:String}
+              AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+              AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
               AND ts.TraceId IN ({pageTraceIds:Array(String)})
               AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
                 SELECT TenantId, TraceId, max(UpdatedAt)
                 FROM trace_summaries
                 WHERE TenantId = {tenantId:String}
+                  AND OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+                  AND OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
                   AND TraceId IN ({pageTraceIds:Array(String)})
                 GROUP BY TenantId, TraceId
               )
@@ -1495,6 +1499,8 @@ export class ClickHouseTraceService {
           `,
           query_params: {
             tenantId: projectId,
+            startDate: startDate ?? 0,
+            endDate: endDate ?? Date.now(),
             pageTraceIds,
           },
           format: "JSONEachRow",

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1361,13 +1361,13 @@ export class ClickHouseTraceService {
           ? ` AND (${searchableColumns.map((col) => `${col} LIKE {searchQuery:String}`).join(" OR ")})`
           : "";
 
-        // Keyset cursor condition — only for the data query
+        // Keyset cursor condition — applied AFTER GROUP BY on deduped values
         let cursorCondition = "";
         if (cursor) {
           cursorCondition =
             sortDirection === "desc"
-              ? " AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) < ({lastTimestamp:UInt64}, {lastTraceId:String})"
-              : " AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) > ({lastTimestamp:UInt64}, {lastTraceId:String})";
+              ? " WHERE (toUnixTimestamp64Milli(s._oa), s.TraceId) < ({lastTimestamp:UInt64}, {lastTraceId:String})"
+              : " WHERE (toUnixTimestamp64Milli(s._oa), s.TraceId) > ({lastTimestamp:UInt64}, {lastTraceId:String})";
         }
 
         const orderDirection = sortDirection === "desc" ? "DESC" : "ASC";
@@ -1448,9 +1448,9 @@ export class ClickHouseTraceService {
                       ${extraFilters}
                       ${traceIdFilter}
                       ${searchFilter}
-                      ${cursorCondition}
                     GROUP BY ts.TraceId
                   ) s
+                  ${cursorCondition}
                   ORDER BY s._oa ${orderDirection}, s.TraceId ${orderDirection}
                   LIMIT {pageSize:UInt32}
                 )
@@ -1458,6 +1458,8 @@ export class ClickHouseTraceService {
                   SELECT TenantId, TraceId, max(UpdatedAt)
                   FROM trace_summaries
                   WHERE TenantId = {tenantId:String}
+                    AND OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+                    AND OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
                   GROUP BY TenantId, TraceId
                 )
               ORDER BY ts.OccurredAt ${orderDirection}, ts.TraceId ${orderDirection}


### PR DESCRIPTION
## Summary

- Split the monolithic pagination query into a lightweight ID query + scoped data fetch, eliminating the full-table dedup scan that caused ClickHouse OOM/timeouts on page 2+
- Propagate the original ClickHouse error instead of swallowing it with a generic message
- Add time bounds to all query steps for ClickHouse partition pruning

## Context

Customer report: daily export flow fetching traces via `/api/traces/search` into Snowflake. Hit two bugs in sequence:

1. **pageSize 1000** (default) → `RangeError: Invalid string length` — V8 limit on `JSON.stringify()`. Fixed by PR #3927 (streaming).
2. **Reduced to pageSize 200** → page 1 works, page 2+ crashes with 500. This PR fixes that.

## Root cause

The pagination data query contained an outer dedup subquery that scanned the **entire** `trace_summaries` table on every page:

```sql
AND (TenantId, TraceId, UpdatedAt) IN (
  SELECT TenantId, TraceId, max(UpdatedAt)
  FROM trace_summaries
  WHERE TenantId = ?
  GROUP BY TenantId, TraceId  -- full table scan, no partition pruning
)
```

For projects with heavy trace volumes, this caused ClickHouse OOM or timeout. The real error was invisible because the catch block at line 659 replaced it with `"Failed to fetch all traces for project"`.

Page 1 often worked because ClickHouse could short-circuit the LIMIT optimization, but page 2+ (with cursor) forced full materialization before filtering.

## Fix

Split into two sequential steps:

1. **ID query** (lightweight, parallel with count): finds the page's trace IDs using cursor + GROUP BY + LIMIT. Only reads TraceId and OccurredAt columns.
2. **Data query** (scoped): fetches full trace data for only those N trace IDs, with dedup scoped to the same N IDs instead of the whole table. Both outer and inner queries include OccurredAt time bounds for partition pruning.

Also re-throws the original ClickHouse error so future crashes show the real cause.

## Best practices compliance

Verified against `dev/docs/best_practices/clickhouse-queries.md`:

| Practice | Status |
|----------|--------|
| IN-Tuple dedup (no heavy columns in dedup subquery) | OK |
| `argMax(OccurredAt, UpdatedAt)` for pagination sort | OK |
| Partition key filter (OccurredAt) on all queries | OK |
| TenantId always required | OK |

## Test plan

- [x] All 20 ClickHouse trace service unit tests pass
- [x] All 9 search-traces API unit tests pass
- [x] CI green
- [x] Manual: pageSize 200, heavy traces — 2 pages, 347 traces, no crashes
- [x] Manual: pageSize 50, heavy traces — 9 pages, 432 traces, no crashes, zero duplicates