### PR TITLE
fix(loop-prevention): four prod bugs caught by 2026-05-14 dogfood

### DIFF
--- a/langwatch/.gitignore
+++ b/langwatch/.gitignore
@@ -81,6 +81,10 @@ node_modules/
 # Vitest browser-mode test attachment cache (regenerated on each run)
 /.vitest-attachments/
 
+# Compiled-once test binaries (nlpgo e2e). Cached across runs so the
+# `go build` cost is paid once per CI job, not per spawn.
+/.vitest-tmp/
+
 # Local-only experimental package — not part of the shipped app
 /packages/insanity-check/
 

--- a/langwatch/src/features/traces-v2/utils/__tests__/previewFormatter.unit.test.ts
+++ b/langwatch/src/features/traces-v2/utils/__tests__/previewFormatter.unit.test.ts
@@ -239,6 +239,23 @@ describe("formatPreview", () => {
       expect(result.text).toBe("Hello via parts.text");
     });
 
+    it("accepts AI SDK v5 `reasoning` parts as renderable text", () => {
+      // v5 splits chain-of-thought into its own part; the visible text
+      // still lives in `.text`. Treating it as renderable keeps the
+      // preview useful rather than falling through to JSON wrapper.
+      const input = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [
+            { type: "reasoning", text: "Thinking about the answer…" },
+            { type: "text", text: "Final answer." },
+          ],
+        },
+      ]);
+      const result = formatPreview(input, { maxChars: 200 });
+      expect(result.text).toBe("Thinking about the answer… Final answer.");
+    });
+
     it("falls through to JSON when parts has no text-typed entries", () => {
       // Image-only message: no text to extract. Preview falls through
       // to the wrapper JSON rather than fabricating "(blob)" — caller

--- a/langwatch/src/features/traces-v2/utils/__tests__/previewFormatter.unit.test.ts
+++ b/langwatch/src/features/traces-v2/utils/__tests__/previewFormatter.unit.test.ts
@@ -172,6 +172,86 @@ describe("formatPreview", () => {
       const result = formatPreview(input, { maxChars: 80 });
       expect(result.text).toBe("Here is the answer");
     });
+
+    // Regression for the 2026-05-14 prod report: the new traces explorer
+    // was rendering message-shaped traces (Genkit / AI SDK / Mastra) as
+    // raw JSON because unwrapChatArray only knew the `content` field.
+    // Backend's extractMessageContentText already handles `parts`; the
+    // renderer was the lone gap.
+    it("walks Genkit/Mastra-style `parts` arrays with {type:text, content:...}", () => {
+      const input = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", content: "I can see this is a G'nger Refresh Juice" },
+          ],
+        },
+      ]);
+      const result = formatPreview(input, { maxChars: 80 });
+      expect(result.text).toBe("I can see this is a G'nger Refresh Juice");
+      expect(result.role).toBe("assistant");
+    });
+
+    it("skips non-text parts (blob, image, reasoning) and surfaces only text parts", () => {
+      // Real prod payload shape: user uploads a product image (blob)
+      // plus a structured text description. Preview must show the text.
+      const input = JSON.stringify([
+        {
+          role: "user",
+          parts: [
+            {
+              type: "blob",
+              modality: "image",
+              mime_type: "image/png",
+              content: "iVBORw0KGgo...",
+            },
+            { type: "text", content: "Product: G'nger Refresh juice 200 ml" },
+          ],
+        },
+      ]);
+      const result = formatPreview(input, { maxChars: 200 });
+      expect(result.text).toBe("Product: G'nger Refresh juice 200 ml");
+      expect(result.role).toBe("user");
+    });
+
+    it("joins multiple text parts with a space", () => {
+      const input = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [
+            { type: "text", content: "First part." },
+            { type: "text", content: "Second part." },
+          ],
+        },
+      ]);
+      const result = formatPreview(input, { maxChars: 200 });
+      expect(result.text).toBe("First part. Second part.");
+    });
+
+    it("accepts Anthropic-shaped parts with {type:text, text:...}", () => {
+      const input = JSON.stringify([
+        {
+          role: "assistant",
+          parts: [{ type: "text", text: "Hello via parts.text" }],
+        },
+      ]);
+      const result = formatPreview(input, { maxChars: 80 });
+      expect(result.text).toBe("Hello via parts.text");
+    });
+
+    it("falls through to JSON when parts has no text-typed entries", () => {
+      // Image-only message: no text to extract. Preview falls through
+      // to the wrapper JSON rather than fabricating "(blob)" — caller
+      // can show the raw shape if needed.
+      const input = JSON.stringify([
+        {
+          role: "user",
+          parts: [{ type: "blob", modality: "image", mime_type: "image/png" }],
+        },
+      ]);
+      const result = formatPreview(input, { maxChars: 200 });
+      expect(result.text).toContain("blob");
+    });
   });
 
   describe("given a top-level Anthropic typed block", () => {

--- a/langwatch/src/features/traces-v2/utils/previewFormatter.ts
+++ b/langwatch/src/features/traces-v2/utils/previewFormatter.ts
@@ -226,6 +226,14 @@ function unwrapChatArray(arr: unknown[]): UnwrapResult | null {
  * visible rather than rendering "(blob)" placeholders that the caller
  * couldn't distinguish from a real text "(blob)".
  */
+// Typed `parts` entries we treat as user-meaningful prose. `text` covers
+// Anthropic / Genkit / Mastra and AI SDK v4. `reasoning` is AI SDK v5
+// where the model's chain-of-thought lands in a sibling part with its
+// own `.text` string — same wire shape, different `type`. Skipping it
+// would re-introduce the wrapper-JSON failure mode this PR is fixing,
+// just for the next payload generation.
+const RENDERABLE_PART_TYPES = new Set(["text", "reasoning"]);
+
 function extractMessagePartsText(parts: unknown[]): string | null {
   const texts: string[] = [];
   for (const part of parts) {
@@ -236,9 +244,9 @@ function extractMessagePartsText(parts: unknown[]): string | null {
     if (!part || typeof part !== "object") continue;
     const p = part as { type?: unknown; text?: unknown; content?: unknown };
 
-    // Typed part: only "text" is renderable as a preview string.
+    // Typed part: only renderable types contribute to the preview.
     if (typeof p.type === "string") {
-      if (p.type !== "text") continue;
+      if (!RENDERABLE_PART_TYPES.has(p.type)) continue;
       if (typeof p.text === "string") {
         texts.push(p.text);
       } else if (typeof p.content === "string") {

--- a/langwatch/src/features/traces-v2/utils/previewFormatter.ts
+++ b/langwatch/src/features/traces-v2/utils/previewFormatter.ts
@@ -48,6 +48,15 @@ const UNWRAP_KEY_ALLOWLIST = new Set([
 interface ChatMessageLike {
   role?: string;
   content?: unknown;
+  /**
+   * Genkit / AI SDK / Mastra emit a `parts` array (sibling of `content`),
+   * where each part is `{ type: "text" | "blob" | "reasoning" | ..., content? | text? }`.
+   * The backend's `extractMessageContentText` handles this shape; without
+   * the matching support here, the new traces explorer renders these
+   * payloads as raw JSON. Reported on 2026-05-14 by rchaves with a real
+   * G'nger product-classification trace.
+   */
+  parts?: unknown;
   tool_calls?: Array<{ function?: { name?: string } }>;
 }
 
@@ -185,12 +194,67 @@ function unwrapChatArray(arr: unknown[]): UnwrapResult | null {
         role: normaliseRole(m.role),
       };
     }
+    // Try `content` first (OpenAI / Anthropic), then `parts` (Genkit /
+    // AI SDK / Mastra). Either may carry the readable payload, and
+    // some integrations populate both — content wins when present.
     const content = extractMessageContent(m.content);
     if (content) {
       return { text: content, role: normaliseRole(m.role) };
     }
+    if (Array.isArray(m.parts)) {
+      const fromParts = extractMessagePartsText(m.parts);
+      if (fromParts) {
+        return { text: fromParts, role: normaliseRole(m.role) };
+      }
+    }
   }
   return null;
+}
+
+/**
+ * Pull text out of a `parts` array. Each part is typically one of:
+ *   - `{ type: "text", content: "..." }`  ← Genkit / Mastra
+ *   - `{ type: "text", text: "..." }`     ← Anthropic style
+ *   - `{ type: "blob" | "image" | "reasoning" | ... }` ← skip; non-text
+ *   - `{ content: "..." }` / `{ text: "..." }` ← typeless wrapper
+ *   - plain string                            ← rare; pass through
+ *
+ * Skips non-text parts so a multi-modal message (image + text)
+ * surfaces just the text in a one-line preview. Non-text parts that
+ * *are* the whole content (e.g. an image-only message) intentionally
+ * yield no preview — fall-through to JSON.stringify keeps the wrapper
+ * visible rather than rendering "(blob)" placeholders that the caller
+ * couldn't distinguish from a real text "(blob)".
+ */
+function extractMessagePartsText(parts: unknown[]): string | null {
+  const texts: string[] = [];
+  for (const part of parts) {
+    if (typeof part === "string") {
+      texts.push(part);
+      continue;
+    }
+    if (!part || typeof part !== "object") continue;
+    const p = part as { type?: unknown; text?: unknown; content?: unknown };
+
+    // Typed part: only "text" is renderable as a preview string.
+    if (typeof p.type === "string") {
+      if (p.type !== "text") continue;
+      if (typeof p.text === "string") {
+        texts.push(p.text);
+      } else if (typeof p.content === "string") {
+        texts.push(p.content);
+      }
+      continue;
+    }
+
+    // Typeless part: accept text or content directly.
+    if (typeof p.text === "string") {
+      texts.push(p.text);
+    } else if (typeof p.content === "string") {
+      texts.push(p.content);
+    }
+  }
+  return texts.length > 0 ? texts.join(" ") : null;
 }
 
 /**

--- a/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../errors";
 import {
   EvaluationExecutionService,
+  extractParentTraceForNlpgo,
   maxCausalityDepthOfSpans,
   type EvaluationExecutionDeps,
   type ModelEnvResolver,
@@ -110,6 +111,109 @@ function createTestService(overrides: TestOverrides = {}) {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("extractParentTraceForNlpgo", () => {
+  // Returns the traceparent context (traceId + rootSpan.span_id) that
+  // gets propagated as a W3C `traceparent` header from TS to nlpgo so
+  // eval workflow spans land as children of the parent trace. Returning
+  // undefined makes nlpgo fall back to body-supplied trace_id (no
+  // parent linkage) — preferable to a fake parent_span_id that would
+  // render under a non-existent span in Studio's waterfall.
+  const VALID_TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+  const VALID_ROOT_SPAN_ID = "b7ad6b7169203331";
+
+  /** @scenario extractParentTraceForNlpgo returns context for valid OTel trace */
+  it("returns {traceId, parentSpanId} when trace_id is 32-hex and root span is 16-hex", () => {
+    const trace = buildTrace({
+      trace_id: VALID_TRACE_ID,
+      spans: [
+        {
+          span_id: VALID_ROOT_SPAN_ID,
+          parent_id: null,
+          trace_id: VALID_TRACE_ID,
+          type: "span",
+          timestamps: { started_at: 0, finished_at: 0 },
+        } as any,
+      ],
+    });
+    expect(extractParentTraceForNlpgo(trace)).toEqual({
+      traceId: VALID_TRACE_ID,
+      parentSpanId: VALID_ROOT_SPAN_ID,
+    });
+  });
+
+  it("lowercases the IDs so callers pass either case", () => {
+    const trace = buildTrace({
+      trace_id: VALID_TRACE_ID.toUpperCase(),
+      spans: [
+        {
+          span_id: VALID_ROOT_SPAN_ID.toUpperCase(),
+          parent_id: null,
+          trace_id: VALID_TRACE_ID.toUpperCase(),
+          type: "span",
+          timestamps: { started_at: 0, finished_at: 0 },
+        } as any,
+      ],
+    });
+    const result = extractParentTraceForNlpgo(trace);
+    expect(result?.traceId).toBe(VALID_TRACE_ID);
+    expect(result?.parentSpanId).toBe(VALID_ROOT_SPAN_ID);
+  });
+
+  /** @scenario extractParentTraceForNlpgo returns undefined for legacy trace_id shapes */
+  it("returns undefined when trace_id is the legacy trace_<nanoid> shape", () => {
+    const trace = buildTrace({
+      trace_id: "trace_abc123xyz",
+      spans: [
+        {
+          span_id: VALID_ROOT_SPAN_ID,
+          parent_id: null,
+          trace_id: "trace_abc123xyz",
+          type: "span",
+          timestamps: { started_at: 0, finished_at: 0 },
+        } as any,
+      ],
+    });
+    expect(extractParentTraceForNlpgo(trace)).toBeUndefined();
+  });
+
+  it("returns undefined when there is no root span", () => {
+    const trace = buildTrace({
+      trace_id: VALID_TRACE_ID,
+      spans: [
+        {
+          span_id: "0000000000000001",
+          // Not a root — has a parent_id.
+          parent_id: "0000000000000099",
+          trace_id: VALID_TRACE_ID,
+          type: "span",
+          timestamps: { started_at: 0, finished_at: 0 },
+        } as any,
+      ],
+    });
+    expect(extractParentTraceForNlpgo(trace)).toBeUndefined();
+  });
+
+  it("returns undefined when trace is undefined", () => {
+    expect(extractParentTraceForNlpgo(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when the root span_id is malformed (not 16-hex)", () => {
+    const trace = buildTrace({
+      trace_id: VALID_TRACE_ID,
+      spans: [
+        {
+          span_id: "span_legacy_format",
+          parent_id: null,
+          trace_id: VALID_TRACE_ID,
+          type: "span",
+          timestamps: { started_at: 0, finished_at: 0 },
+        } as any,
+      ],
+    });
+    expect(extractParentTraceForNlpgo(trace)).toBeUndefined();
+  });
+});
 
 describe("EvaluationExecutionService", () => {
   describe("executeForTrace()", () => {
@@ -223,6 +327,12 @@ describe("EvaluationExecutionService", () => {
           }),
           undefined,
           expect.any(Number),
+          // parentTrace: defaultTrace's trace_id is "trace-1" (not
+          // 32-hex), so extractParentTraceForNlpgo returns undefined.
+          // Adapter-level OTel trace_ids would set this to a real
+          // {traceId, parentSpanId} — separately covered by
+          // extractParentTraceForNlpgo's own tests.
+          undefined,
         );
       });
 

--- a/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
@@ -213,6 +213,67 @@ describe("extractParentTraceForNlpgo", () => {
     });
     expect(extractParentTraceForNlpgo(trace)).toBeUndefined();
   });
+
+  describe("when the trace has multiple parent-less spans", () => {
+    // Broken / multi-source instrumentation can leave more than one
+    // root. find() would pick whichever happened to land first in the
+    // array — non-deterministic across re-runs. We pin the choice on
+    // earliest started_at (with span_id tie-break) so two consecutive
+    // eval runs against the same trace produce identical traceparent
+    // linkage.
+    const EARLIER_SPAN = "1111111111111111";
+    const LATER_SPAN = "9999999999999999";
+
+    it("picks the earliest started_at root deterministically", () => {
+      const trace = buildTrace({
+        trace_id: VALID_TRACE_ID,
+        spans: [
+          {
+            span_id: LATER_SPAN,
+            parent_id: null,
+            trace_id: VALID_TRACE_ID,
+            type: "span",
+            timestamps: { started_at: 200, finished_at: 300 },
+          } as any,
+          {
+            span_id: EARLIER_SPAN,
+            parent_id: null,
+            trace_id: VALID_TRACE_ID,
+            type: "span",
+            timestamps: { started_at: 100, finished_at: 150 },
+          } as any,
+        ],
+      });
+      expect(extractParentTraceForNlpgo(trace)?.parentSpanId).toBe(
+        EARLIER_SPAN,
+      );
+    });
+
+    it("falls back to span_id ordering when started_at ties", () => {
+      const trace = buildTrace({
+        trace_id: VALID_TRACE_ID,
+        spans: [
+          {
+            span_id: LATER_SPAN,
+            parent_id: null,
+            trace_id: VALID_TRACE_ID,
+            type: "span",
+            timestamps: { started_at: 100, finished_at: 150 },
+          } as any,
+          {
+            span_id: EARLIER_SPAN,
+            parent_id: null,
+            trace_id: VALID_TRACE_ID,
+            type: "span",
+            timestamps: { started_at: 100, finished_at: 150 },
+          } as any,
+        ],
+      });
+      expect(extractParentTraceForNlpgo(trace)?.parentSpanId).toBe(
+        EARLIER_SPAN,
+      );
+    });
+  });
 });
 
 describe("EvaluationExecutionService", () => {

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -65,7 +65,36 @@ export interface WorkflowExecutor {
     inputs: Record<string, string>,
     versionId?: string,
     causalityDepth?: number,
+    parentTrace?: { traceId: string; parentSpanId: string },
   ): Promise<{ result: SingleEvaluationResult; status: string }>;
+}
+
+const TRACE_ID_HEX = /^[0-9a-fA-F]{32}$/;
+const SPAN_ID_HEX = /^[0-9a-fA-F]{16}$/;
+
+/**
+ * Extract the W3C `traceparent` context for the eval workflow from the
+ * parent trace. nlpgo needs both pieces (32-hex trace_id + 16-hex root
+ * span_id) so its emitted spans land as children of the parent trace
+ * in Studio's waterfall rather than as a separate orphan trace.
+ *
+ * Returns `undefined` when the parent trace doesn't have OTel-standard
+ * IDs (legacy `trace_<nanoid>` shape, missing root span) — in that
+ * case nlpgo falls back to body-supplied req.TraceID and emits without
+ * a parent linkage. Callers should NOT default-emit a synthesized
+ * parent: a synth parent_span_id would render under a non-existent
+ * span in the waterfall, which is worse UX than a separate trace.
+ */
+export function extractParentTraceForNlpgo(
+  trace: Trace | undefined,
+): { traceId: string; parentSpanId: string } | undefined {
+  if (!trace?.trace_id || !TRACE_ID_HEX.test(trace.trace_id)) return undefined;
+  const rootSpan = trace.spans?.find((s) => !s.parent_id);
+  if (!rootSpan?.span_id || !SPAN_ID_HEX.test(rootSpan.span_id)) return undefined;
+  return {
+    traceId: trace.trace_id.toLowerCase(),
+    parentSpanId: rootSpan.span_id.toLowerCase(),
+  };
 }
 
 /**
@@ -467,12 +496,19 @@ export class EvaluationExecutionService {
       ...data,
     };
 
+    // W3C trace context: link the eval workflow's spans to the parent
+    // trace's root span so Studio's waterfall renders them as a child
+    // sub-tree (not a separate orphan trace, which is the 2026-05-14
+    // bug rchaves caught in prod).
+    const parentTrace = extractParentTraceForNlpgo(trace);
+
     const response = await this.deps.workflowExecutor.runEvaluationWorkflow(
       resolvedWorkflowId,
       projectId,
       requestBody as Record<string, string>,
       undefined,
       parentCausalityDepth,
+      parentTrace,
     );
 
     if (response.status !== "success") {

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -89,7 +89,22 @@ export function extractParentTraceForNlpgo(
   trace: Trace | undefined,
 ): { traceId: string; parentSpanId: string } | undefined {
   if (!trace?.trace_id || !TRACE_ID_HEX.test(trace.trace_id)) return undefined;
-  const rootSpan = trace.spans?.find((s) => !s.parent_id);
+
+  // Broken / multi-source instrumentation can leave a trace with more
+  // than one parent-less span. `find()` would then pick whichever span
+  // happened to be ingested first — non-deterministic across re-runs.
+  // Sort by started_at (earliest is the true root in any sane trace)
+  // with span_id as the tie-breaker to keep two consecutive eval runs
+  // pinned to the same parent_span_id.
+  const rootCandidates = (trace.spans ?? []).filter((s) => !s.parent_id);
+  if (rootCandidates.length === 0) return undefined;
+  rootCandidates.sort((a, b) => {
+    const aStart = a.timestamps?.started_at ?? Number.MAX_SAFE_INTEGER;
+    const bStart = b.timestamps?.started_at ?? Number.MAX_SAFE_INTEGER;
+    if (aStart !== bStart) return aStart - bStart;
+    return (a.span_id ?? "").localeCompare(b.span_id ?? "");
+  });
+  const rootSpan = rootCandidates[0];
   if (!rootSpan?.span_id || !SPAN_ID_HEX.test(rootSpan.span_id)) return undefined;
   return {
     traceId: trace.trace_id.toLowerCase(),

--- a/langwatch/src/server/background/workers/evaluationsWorker.ts
+++ b/langwatch/src/server/background/workers/evaluationsWorker.ts
@@ -70,7 +70,10 @@ import {
 } from "../../app-layer/evaluations/azure-safety-env";
 import { getAzureSafetyEnvFromProject } from "../../app-layer/evaluations/azure-safety-env.server";
 import { runEvaluationWorkflow } from "../../workflows/runWorkflow";
-import { maxCausalityDepthOfSpans } from "../../app-layer/evaluations/evaluation-execution.service";
+import {
+  extractParentTraceForNlpgo,
+  maxCausalityDepthOfSpans,
+} from "../../app-layer/evaluations/evaluation-execution.service";
 import {
   EVALUATIONS_QUEUE,
   updateEvaluationStatusInES,
@@ -848,12 +851,19 @@ const customEvaluation = async (
     throw new Error("Workflow ID is required");
   }
 
+  // W3C trace context — same as eval-execution.service: pass the
+  // parent trace's root span so nlpgo emits eval spans as a child
+  // sub-tree of the trace being evaluated, not as an orphan trace.
+  // See 2026-05-14 prod regression.
+  const parentTrace = extractParentTraceForNlpgo(trace);
+
   const response = await runEvaluationWorkflow(
     resolvedWorkflowId,
     project.id,
     requestBody,
     undefined,
     parentCausalityDepth,
+    parentTrace,
   );
 
   const { result, status } = response;

--- a/langwatch/src/server/background/workers/evaluationsWorker.ts
+++ b/langwatch/src/server/background/workers/evaluationsWorker.ts
@@ -841,9 +841,15 @@ const customEvaluation = async (
     throw new Error("Project not found");
   }
 
+  // do_not_trace=false on the wire so eval-emitted spans land under
+  // the parent trace's traceparent context (post-2026-05-14 fix). The
+  // explicit do_not_trace=false arg passed to runEvaluationWorkflow
+  // below already overrides this default, but pinning the field on
+  // the body itself keeps the wire shape honest if a future refactor
+  // drops the explicit override on runWorkflow.
   const requestBody: Record<string, any> = {
     trace_id: trace?.trace_id,
-    do_not_trace: true,
+    do_not_trace: false,
     ...data,
   };
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.test.ts
@@ -306,6 +306,47 @@ describe("RecordSpanCommand", () => {
         expect(emittedSpan.events[0]!.attributes).toHaveLength(0);
       });
 
+      /** @scenario Reserved causality_depth attribute passes through strip */
+      it("preserves langwatch.reserved.causality_depth on the emitted span (loop-prevention contract)", async () => {
+        // Regression for the post-2026-05-11 bug: stripReservedAttributes
+        // was nuking the very attribute the evaluationTrigger reactor
+        // reads to detect loops, silently disabling loop prevention.
+        // The fix is a passthrough allowlist; this test pins the
+        // attribute name as load-bearing — renaming or removing the
+        // entry would silently re-break loop prevention in production.
+        const command = createMockCommand(
+          "project-123",
+          "trace-1",
+          "span-1",
+          [
+            {
+              key: "langwatch.reserved.causality_depth",
+              value: { stringValue: "1" },
+            },
+            {
+              key: "langwatch.reserved.pii_redaction_status",
+              value: { stringValue: "true" },
+            },
+            { key: "gen_ai.prompt", value: { stringValue: "hello" } },
+          ],
+        );
+
+        const events = await handler.handle(command);
+
+        const emittedSpan = events[0]!.data.span;
+        const depthAttr = emittedSpan.attributes.find(
+          (a) => a.key === "langwatch.reserved.causality_depth",
+        );
+        expect(depthAttr).toBeDefined();
+        expect(depthAttr!.value).toEqual({ stringValue: "1" });
+
+        // Other reserved attrs are still stripped (allowlist is narrow).
+        const piiAttr = emittedSpan.attributes.find(
+          (a) => a.key === "langwatch.reserved.pii_redaction_status",
+        );
+        expect(piiAttr).toBeUndefined();
+      });
+
       it("preserves original command data when stripping reserved attributes", async () => {
         const command = createMockCommand(
           "project-123",

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
@@ -234,9 +234,30 @@ export class RecordSpanCommand implements CommandHandler<
   }
 
   /**
-   * Strips any `langwatch.reserved.*` attributes from a span and its events/links.
-   * These attributes are reserved for system use and must not be set by users.
+   * Strips user-submitted `langwatch.reserved.*` attributes from a span
+   * and its events/links/resource. These attributes are reserved for
+   * system use and must not be settable by customer SDKs.
+   *
+   * EXCEPTIONS — system-emitted attributes that ride in on OTLP from
+   * trusted internal services (nlpgo, langevals, etc.) and MUST survive
+   * this strip because downstream reactors depend on them:
+   *
+   *   - `langwatch.reserved.causality_depth` — stamped by nlpgo's
+   *     `BaggageAttributeProcessor` on every span emitted during an
+   *     evaluator workflow run. The evaluationTrigger reactor reads
+   *     this on the inbound span_received event to block infinite
+   *     loops (post-2026-05-11 incident). Stripping it here would
+   *     silently disable the loop-prevention guard in production.
+   *
+   * If a customer SDK does manage to set one of these from outside,
+   * worst case is a one-shot eval-skip on their own trace — bounded
+   * impact, and bypassing requires knowing internal attribute names.
+   * Far preferable to silently breaking loop prevention.
    */
+  private static readonly RESERVED_ATTR_PASSTHROUGH = new Set<string>([
+    "langwatch.reserved.causality_depth",
+  ]);
+
   private static stripReservedAttributes(
     span: OtlpSpan,
     resource: OtlpResource | null,
@@ -246,7 +267,10 @@ export class RecordSpanCommand implements CommandHandler<
 
     const strip = (attributes: OtlpSpan["attributes"]): OtlpSpan["attributes"] => {
       const filtered = attributes.filter((attr) => {
-        if (attr.key.startsWith(RESERVED_PREFIX)) {
+        if (
+          attr.key.startsWith(RESERVED_PREFIX) &&
+          !RecordSpanCommand.RESERVED_ATTR_PASSTHROUGH.has(attr.key)
+        ) {
           logger.warn(
             { attributeKey: attr.key },
             "Stripped user-submitted langwatch.reserved.* attribute",

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
@@ -233,6 +233,10 @@ export class RecordSpanCommand implements CommandHandler<
     };
   }
 
+  private static readonly RESERVED_ATTR_PASSTHROUGH = new Set<string>([
+    "langwatch.reserved.causality_depth",
+  ]);
+
   /**
    * Strips user-submitted `langwatch.reserved.*` attributes from a span
    * and its events/links/resource. These attributes are reserved for
@@ -254,10 +258,6 @@ export class RecordSpanCommand implements CommandHandler<
    * impact, and bypassing requires knowing internal attribute names.
    * Far preferable to silently breaking loop prevention.
    */
-  private static readonly RESERVED_ATTR_PASSTHROUGH = new Set<string>([
-    "langwatch.reserved.causality_depth",
-  ]);
-
   private static stripReservedAttributes(
     span: OtlpSpan,
     resource: OtlpResource | null,

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-io-accumulation.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/__tests__/trace-io-accumulation.service.unit.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit test for TraceIOAccumulationService's preferText handling.
+ *
+ * Background — 2026-05-14 prod UX regression: trace summaries showed
+ * the raw JSON wrapper (e.g. `{"output":"Hey there"}`) instead of the
+ * extracted human-readable text (`Hey there`). Root cause: the
+ * accumulator was using `JSON.stringify(outputResult.raw)` instead of
+ * the already-extracted `outputResult.text` field that
+ * `extractRichIOFromSpan` populates by running `messagesToText` /
+ * `extractTextFromPlainJson`.
+ *
+ * This test pins the new behaviour: when the extraction service
+ * successfully unwraps the payload (via COMMON_TEXT_KEYS like
+ * `output`, `text`, `answer`, etc.), the trace summary's
+ * computedOutput is the extracted text, not the raw wrapper.
+ */
+import { describe, expect, it } from "vitest";
+import { TraceIOAccumulationService } from "../trace-io-accumulation.service";
+import type { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import type { NormalizedSpan } from "../../../schemas/spans";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+
+function emptyState(): TraceSummaryData {
+  return {
+    traceId: "t1",
+    spanCount: 0,
+    totalDurationMs: 0,
+    computedIOSchemaVersion: "2026-04-28",
+    computedInput: null,
+    computedOutput: null,
+    timeToFirstTokenMs: null,
+    timeToLastTokenMs: null,
+    tokensPerSecond: null,
+    containsErrorStatus: false,
+    containsOKStatus: false,
+    errorMessage: null,
+    models: [],
+    totalCost: null,
+    tokensEstimated: false,
+    totalPromptTokenCount: null,
+    totalCompletionTokenCount: null,
+    outputFromRootSpan: false,
+    outputSpanEndTimeMs: 0,
+    blockedByGuardrail: false,
+    rootSpanType: "span",
+    containsAi: false,
+    containsPrompt: false,
+    selectedPromptId: null,
+    selectedPromptSpanId: null,
+    selectedPromptStartTimeMs: null,
+    lastUsedPromptId: null,
+    lastUsedPromptVersionNumber: null,
+    lastUsedPromptVersionId: null,
+    lastUsedPromptSpanId: null,
+    lastUsedPromptStartTimeMs: null,
+    topicId: null,
+    subTopicId: null,
+    annotationIds: [],
+    traceName: "",
+    rootSpanStartTimeMs: 0,
+    attributes: {},
+    events: [],
+    scenarioRoleCosts: {},
+    scenarioRoleLatencies: {},
+    scenarioRoleSpans: {},
+    spanCosts: {},
+    occurredAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    LastEventOccurredAt: 0,
+  } as unknown as TraceSummaryData;
+}
+
+function rootSpan(overrides?: Partial<NormalizedSpan>): NormalizedSpan {
+  return {
+    traceId: "t1",
+    spanId: "s1",
+    parentSpanId: null,
+    name: "root",
+    startTimeUnixMs: 0,
+    endTimeUnixMs: 1000,
+    spanAttributes: {},
+    resourceAttributes: {},
+    events: [],
+    links: [],
+    ...overrides,
+  } as unknown as NormalizedSpan;
+}
+
+/**
+ * Stub IO extraction service. The accumulator delegates payload
+ * understanding to this — we just need to control what it returns.
+ */
+function stubExtractor(opts: {
+  input?: { raw: unknown; text: string; source: "gen_ai" | "langwatch" };
+  output?: { raw: unknown; text: string; source: "gen_ai" | "langwatch" };
+}): TraceIOExtractionService {
+  return {
+    extractRichIOFromSpan: (
+      _span: NormalizedSpan,
+      type: "input" | "output",
+    ) => (type === "input" ? opts.input ?? null : opts.output ?? null),
+    extractFallbackIOFromSpan: () => null,
+  } as unknown as TraceIOExtractionService;
+}
+
+describe("TraceIOAccumulationService — preferText behaviour", () => {
+  /** @scenario Accumulator uses extracted text not raw JSON wrapper */
+  it("uses the extracted human-readable text when present (unwraps {output:'...'} → '...')", () => {
+    const extractor = stubExtractor({
+      input: {
+        raw: { input: "hey there" },
+        text: "hey there",
+        source: "langwatch",
+      },
+      output: {
+        // The exact prod regression payload: nlpgo's workflow emits
+        // `langwatch.output = {"output":"Hey what can I help you with today?"}`.
+        raw: { output: "Hey what can I help you with today?" },
+        text: "Hey what can I help you with today?",
+        source: "langwatch",
+      },
+    });
+    const accumulator = new TraceIOAccumulationService(extractor);
+
+    const result = accumulator.accumulateIO({
+      state: emptyState(),
+      span: rootSpan(),
+    });
+
+    expect(result.computedInput).toBe("hey there");
+    expect(result.computedOutput).toBe(
+      "Hey what can I help you with today?",
+    );
+    // The bug we're fixing produced these instead:
+    expect(result.computedOutput).not.toBe(
+      JSON.stringify({ output: "Hey what can I help you with today?" }),
+    );
+  });
+
+  /** @scenario Accumulator falls back to raw stringification when no text extracted */
+  it("falls back to JSON.stringify(raw) when text extraction returns empty (preserves non-null guarantee)", () => {
+    const extractor = stubExtractor({
+      output: {
+        // Unknown shape — the extraction service couldn't pull a clean
+        // text out, so it returns an empty `text` and the raw payload.
+        // We still want computedOutput non-null so the UI doesn't
+        // render `<empty>` for spans that DO have output data.
+        raw: { weird_shape: { nested: [1, 2, 3] } },
+        text: "",
+        source: "langwatch",
+      },
+    });
+    const accumulator = new TraceIOAccumulationService(extractor);
+
+    const result = accumulator.accumulateIO({
+      state: emptyState(),
+      span: rootSpan(),
+    });
+
+    expect(result.computedOutput).toBe(
+      JSON.stringify({ weird_shape: { nested: [1, 2, 3] } }),
+    );
+  });
+
+  it("uses the raw string directly when raw is already a plain string", () => {
+    const extractor = stubExtractor({
+      output: {
+        raw: "Already a plain string",
+        text: "Already a plain string",
+        source: "langwatch",
+      },
+    });
+    const accumulator = new TraceIOAccumulationService(extractor);
+
+    const result = accumulator.accumulateIO({
+      state: emptyState(),
+      span: rootSpan(),
+    });
+
+    expect(result.computedOutput).toBe("Already a plain string");
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
@@ -246,5 +246,10 @@ export class TraceIOAccumulationService {
 function preferText(text: string | null | undefined, raw: unknown): string {
   if (typeof text === "string" && text.length > 0) return text;
   if (typeof raw === "string") return raw;
+  // JSON.stringify(undefined) returns the literal value `undefined`,
+  // not the string "undefined". Guard explicitly so a future caller
+  // that hands us `undefined` doesn't silently corrupt the trace
+  // summary with a non-string value cast to string.
+  if (raw === undefined) return "";
   return JSON.stringify(raw);
 }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
@@ -148,18 +148,24 @@ export class TraceIOAccumulationService {
       inputResult &&
       (isRoot || computedInput === null || currentInputIsFallback)
     ) {
-      const raw = inputResult.raw;
-      computedInput = typeof raw === "string" ? raw : JSON.stringify(raw);
+      // Use the EXTRACTED text — extractRichIOFromSpan already runs
+      // messagesToText / extractTextFromPlainJson to pull the clean
+      // human-readable string out of common wrappers (e.g. unwrap
+      // `{"output":"Hey there"}` → `"Hey there"`). Discarding that and
+      // re-stringifying `raw` is what caused the 2026-05-14 prod UX
+      // regression where trace summaries showed the wrapper JSON
+      // instead of the actual text.
+      computedInput = preferText(inputResult.text, inputResult.raw);
       inputIsFallback = false;
     } else if (!inputResult && computedInput === null) {
-      // Semantic heuristics didn't find anything. Fall back to a stringified
-      // payload so ComputedInput is non-null when the span has real data,
+      // Semantic heuristics didn't find anything. Fall back to the
+      // service's `text` (best-effort stringification of the wrapper)
+      // so ComputedInput is non-null when the span has real data,
       // but ONLY if no prior span already contributed a semantic match.
       const inputFallback =
         this.traceIOExtractionService.extractFallbackIOFromSpan(span, "input");
       if (inputFallback) {
-        const raw = inputFallback.raw;
-        computedInput = typeof raw === "string" ? raw : JSON.stringify(raw);
+        computedInput = preferText(inputFallback.text, inputFallback.raw);
         inputIsFallback = true;
       }
     }
@@ -183,8 +189,10 @@ export class TraceIOAccumulationService {
           currentEndTime: outputSpanEndTimeMs,
         });
       if (shouldOverride) {
-        const raw = outputResult.raw;
-        computedOutput = typeof raw === "string" ? raw : JSON.stringify(raw);
+        // Use the extracted text (unwrapped from common JSON wrappers
+        // like `{"output":"..."}`), not the raw payload. See input
+        // branch above for the full rationale.
+        computedOutput = preferText(outputResult.text, outputResult.raw);
         outputFromRootSpan = isRoot;
         outputSpanEndTimeMs = span.endTimeUnixMs;
         outputSource = isExplicit
@@ -204,8 +212,7 @@ export class TraceIOAccumulationService {
           "output",
         );
       if (outputFallback) {
-        const raw = outputFallback.raw;
-        computedOutput = typeof raw === "string" ? raw : JSON.stringify(raw);
+        computedOutput = preferText(outputFallback.text, outputFallback.raw);
         outputSpanEndTimeMs = span.endTimeUnixMs;
         outputIsFallback = true;
       }
@@ -222,4 +229,22 @@ export class TraceIOAccumulationService {
       outputIsFallback,
     };
   }
+}
+
+/**
+ * Prefer the extracted human-readable text over the raw payload.
+ * The IO extraction service runs messagesToText / extractTextFromPlainJson
+ * to unwrap common payload shapes (e.g. `{"output":"Hey"}` → `"Hey"`,
+ * gen_ai messages → joined content text). When that succeeds, use it
+ * for the trace summary. Fall back to stringifying the raw payload
+ * only when extraction returned no text — keeps NON-null guarantee
+ * for spans that have data but unknown shape.
+ *
+ * Exported via the existing accumulation surface — tests cover this
+ * via the fold projection, not directly.
+ */
+function preferText(text: string | null | undefined, raw: unknown): string {
+  if (typeof text === "string" && text.length > 0) return text;
+  if (typeof raw === "string") return raw;
+  return JSON.stringify(raw);
 }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/loopPrevention.reactor.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/loopPrevention.reactor.integration.test.ts
@@ -1,0 +1,551 @@
+/**
+ * Real integration test for online-evaluator loop prevention.
+ *
+ * Scope (honest):
+ *   - Uses testcontainers (Redis + ClickHouse) — REAL infrastructure.
+ *   - Drives recordSpan through the REAL EventSourcing pipeline,
+ *     real TraceSummaryFoldProjection, real CH writes.
+ *   - Reads fold state back from REAL ClickHouse.
+ *   - Invokes the REAL evaluationTrigger reactor's handle() with a
+ *     constructed event + foldState (read from CH) to assert on the
+ *     loop-prevention behaviour.
+ *
+ *   The reactor's BullMQ queue worker is NOT exercised in this test.
+ *   That is harness plumbing, not feature behaviour, and other reactor
+ *   integration tests in this codebase (e.g.
+ *   customEvaluationSync.reactor.integration.test.ts) are `.skip`'d for
+ *   the same reason — making BullMQ reactor pickup reliable in the
+ *   vitest harness is a separate problem from "does the reactor
+ *   correctly block depth>=1 spans against real fold state from real
+ *   ClickHouse." This test answers the latter, which is the
+ *   post-2026-05-11 incident question.
+ *
+ * What this test proves:
+ *   1. recordSpan + the trace-processing pipeline + CH persistence
+ *      survive a depth=0 span and produce a foldState with
+ *      langwatch.origin resolved.
+ *   2. The REAL evaluationTrigger reactor (createEvaluationTriggerReactor)
+ *      against that REAL foldState DISPATCHES one executeEvaluation
+ *      per enabled ON_MESSAGE monitor.
+ *   3. The same reactor with a depth=1 span event BLOCKS dispatch
+ *      and increments the `langwatch_evaluator_loop_blocked_total`
+ *      counter with reason="depth_direct".
+ *   4. The same reactor with a fresh depth=0 span on the same trace
+ *      DISPATCHES again. The guard is per-span, not per-trace —
+ *      legitimate new app activity must still re-trigger evaluation.
+ *   5. LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD=1 bypasses the depth
+ *      check (emergency rollback path).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
+import { SpanStorageClickHouseRepository } from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
+import { TraceSummaryService } from "~/server/app-layer/traces/trace-summary.service";
+import { TraceSummaryClickHouseRepository } from "~/server/app-layer/traces/repositories/trace-summary.clickhouse.repository";
+import type { AggregateType } from "../../../..";
+import { definePipeline } from "../../../..";
+import {
+  getTestClickHouseClient,
+  getTestRedisConnection,
+} from "../../../../__tests__/integration/testContainers";
+import {
+  cleanupTestDataForTenant,
+  createTestTenantId,
+  getTenantIdString,
+} from "../../../../__tests__/integration/testHelpers";
+import { EventSourcing } from "../../../../eventSourcing";
+import { EventStoreClickHouse } from "../../../../stores/eventStoreClickHouse";
+import { EventRepositoryClickHouse } from "../../../../stores/repositories/eventRepositoryClickHouse";
+import { RecordSpanCommand } from "../../commands/recordSpanCommand";
+import { AssignTopicCommand } from "../../commands/assignTopicCommand";
+import { SpanStorageMapProjection } from "../../projections/spanStorage.mapProjection";
+import {
+  TraceSummaryFoldProjection,
+  type TraceSummaryData,
+} from "../../projections/traceSummary.foldProjection";
+import type {
+  SpanReceivedEvent,
+  TraceProcessingEvent,
+} from "../../schemas/events";
+import { SPAN_RECEIVED_EVENT_TYPE } from "../../schemas/constants";
+import type { OtlpSpan } from "../../schemas/otlp";
+import { SpanAppendStore } from "../../projections/spanStorage.store";
+import { TraceSummaryStore } from "../../projections/traceSummary.store";
+import { createEvaluationTriggerReactor } from "../evaluationTrigger.reactor";
+import { MonitorService } from "~/server/app-layer/monitors/monitor.service";
+import type {
+  MonitorRepository,
+  MonitorSummary,
+  MonitorWithEvaluator,
+} from "~/server/app-layer/monitors/repositories/monitor.repository";
+import type { ExecuteEvaluationCommandData } from "../../../evaluation-processing/schemas/commands";
+import { evaluatorLoopBlockedCounter } from "~/server/metrics";
+
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+);
+
+// ---------------------------------------------------------------------------
+// Fakes wired into the real pipeline.
+// ---------------------------------------------------------------------------
+
+class TestRecordSpanCommand extends RecordSpanCommand {
+  static override readonly schema = RecordSpanCommand.schema;
+  constructor() {
+    super({
+      piiRedactionService: { redactSpan: async () => {} },
+      costEnrichmentService: { enrichSpan: async () => {} },
+      tokenEstimationService: { estimateSpanTokens: async () => {} },
+    });
+  }
+}
+
+function makeFakeMonitorRepository(): MonitorRepository {
+  const monitor: MonitorSummary = {
+    id: "monitor_test_loop_prevention",
+    checkType: "workflow",
+    name: "Loop Prevention Test Monitor",
+    threadIdleTimeout: null,
+    evaluator: { name: "test/evaluator" },
+  };
+  const fullMonitor: MonitorWithEvaluator = {
+    id: monitor.id,
+    checkType: monitor.checkType,
+    sample: 1.0,
+    preconditions: null,
+    parameters: null,
+    mappings: null,
+    level: null,
+    evaluator: {
+      config: {},
+      type: "workflow",
+      workflowId: "wf_test",
+    },
+  };
+  return {
+    async getEnabledOnMessageMonitors() {
+      return [monitor];
+    },
+    async getMonitorById() {
+      return fullMonitor;
+    },
+  };
+}
+
+function makeCapturingEvaluationDispatcher() {
+  const captured: ExecuteEvaluationCommandData[] = [];
+  return {
+    captured,
+    dispatch: async (data: ExecuteEvaluationCommandData) => {
+      captured.push(data);
+    },
+  };
+}
+
+const noopReactor = { name: "noop", options: {}, handle: async () => {} };
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function buildAppOriginSpan(opts: {
+  traceId: string;
+  spanId: string;
+  depth: number;
+  startedAtMs?: number;
+}): OtlpSpan {
+  const startNano = BigInt(opts.startedAtMs ?? Date.now()) * 1_000_000n;
+  const endNano = startNano + 1_000_000_000n;
+  const attrs: Array<{
+    key: string;
+    value: { stringValue?: string; intValue?: string };
+  }> = [
+    { key: "langwatch.origin", value: { stringValue: "application" } },
+    { key: "langwatch.span.type", value: { stringValue: "span" } },
+  ];
+  if (opts.depth > 0) {
+    attrs.push({
+      key: "langwatch.reserved.causality_depth",
+      value: { stringValue: String(opts.depth) },
+    });
+  }
+  return {
+    traceId: opts.traceId,
+    spanId: opts.spanId,
+    parentSpanId: null,
+    name: "test-span",
+    kind: 1,
+    startTimeUnixNano: startNano.toString(),
+    endTimeUnixNano: endNano.toString(),
+    attributes: attrs,
+    events: [],
+    links: [],
+    status: { code: 1, message: null },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  } as unknown as OtlpSpan;
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+}
+
+/**
+ * Mirrors the SpanReceivedEvent shape produced by recordSpan's
+ * emitEvents step. The reactor reads `event.data.span.attributes` for
+ * the depth check, and `event.occurredAt` for the recency gate. Other
+ * fields are passed through to dispatchEvaluations but not consulted
+ * by the loop-prevention logic.
+ */
+function buildSpanReceivedEvent(opts: {
+  tenantId: string;
+  traceId: string;
+  span: OtlpSpan;
+}): SpanReceivedEvent {
+  return {
+    type: SPAN_RECEIVED_EVENT_TYPE,
+    tenantId: opts.tenantId,
+    aggregateId: opts.traceId,
+    occurredAt: Date.now(),
+    data: {
+      span: opts.span as any,
+      resource: { attributes: [], droppedAttributesCount: 0 } as any,
+      instrumentationScope: { name: "langwatch.test" } as any,
+      piiRedactionLevel: "DISABLED",
+    },
+    metadata: {
+      spanId: (opts.span as any).spanId,
+      traceId: opts.traceId,
+    },
+  } as unknown as SpanReceivedEvent;
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  { timeoutMs, label }: { timeoutMs: number; label: string },
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`waitFor(${label}) timed out after ${timeoutMs}ms`);
+}
+
+/**
+ * Reads the prom-client counter so assertions can be delta-based and
+ * isolated from parallel tests.
+ */
+async function readBlockedCounter(reason: string): Promise<number> {
+  const metric = await (evaluatorLoopBlockedCounter as any).get();
+  for (const v of metric.values ?? []) {
+    if (v.labels?.reason === reason) {
+      return v.value as number;
+    }
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasTestcontainers)(
+  "evaluationTrigger reactor — loop prevention against real pipeline state",
+  () => {
+    let eventSourcing: EventSourcing;
+    let tracePipeline: ReturnType<typeof createTracePipeline>;
+    let traceSummaryStore: TraceSummaryStore;
+    let tenantId: ReturnType<typeof createTestTenantId>;
+    let tenantIdString: string;
+    let dispatcher: ReturnType<typeof makeCapturingEvaluationDispatcher>;
+    let reactor: ReturnType<typeof createEvaluationTriggerReactor>;
+
+    function createTracePipeline() {
+      const clickHouseClient = getTestClickHouseClient();
+      const redisConnection = getTestRedisConnection();
+      if (!clickHouseClient || !redisConnection) {
+        throw new Error("ClickHouse + Redis required.");
+      }
+
+      const eventStore = new EventStoreClickHouse(
+        new EventRepositoryClickHouse(async () => clickHouseClient),
+      );
+      eventSourcing = EventSourcing.createWithStores({
+        eventStore,
+        clickhouse: async () => clickHouseClient,
+        redis: redisConnection,
+        processRole: "worker",
+      });
+
+      const spanAppendStore = new SpanAppendStore(
+        new SpanStorageService(
+          new SpanStorageClickHouseRepository(async () => clickHouseClient),
+        ).repository,
+      );
+      traceSummaryStore = new TraceSummaryStore(
+        new TraceSummaryService(
+          new TraceSummaryClickHouseRepository(async () => clickHouseClient),
+        ).repository,
+      );
+
+      // Build the REAL evaluationTrigger reactor with a capturing
+      // dispatcher. We won't rely on the BullMQ-scheduled call path;
+      // the test invokes reactor.handle() directly with foldState
+      // read from CH. The reactor instance is the production code.
+      const monitorService = new MonitorService(makeFakeMonitorRepository());
+      dispatcher = makeCapturingEvaluationDispatcher();
+      reactor = createEvaluationTriggerReactor({
+        monitors: monitorService,
+        evaluation: dispatcher.dispatch,
+      });
+
+      const pipelineName = `trace_loop_prevention_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const pipelineDef = definePipeline<TraceProcessingEvent>()
+        .withName(pipelineName)
+        .withAggregateType("trace" as AggregateType)
+        .withFoldProjection(
+          "traceSummary",
+          new TraceSummaryFoldProjection({ store: traceSummaryStore }) as any,
+        )
+        .withMapProjection(
+          "spanStorage",
+          new SpanStorageMapProjection({ store: spanAppendStore }) as any,
+        )
+        .withReactor("traceSummary", "evaluationTrigger", noopReactor as any)
+        .withReactor("traceSummary", "customEvaluationSync", noopReactor as any)
+        .withReactor("traceSummary", "traceUpdateBroadcast", noopReactor as any)
+        .withReactor("traceSummary", "simulationMetricsSync", noopReactor as any)
+        .withReactor("traceSummary", "projectMetadata", noopReactor as any)
+        .withReactor("spanStorage", "spanStorageBroadcast", noopReactor as any)
+        .withCommand("recordSpan", TestRecordSpanCommand as any)
+        .withCommand("assignTopic", AssignTopicCommand as any)
+        .build();
+
+      const registered = eventSourcing.register(pipelineDef);
+      return {
+        ...registered,
+        ready: () => registered.service.waitUntilReady(),
+      };
+    }
+
+    beforeEach(async () => {
+      tracePipeline = createTracePipeline();
+      tenantId = createTestTenantId();
+      tenantIdString = getTenantIdString(tenantId);
+      await tracePipeline.ready();
+    }, 30_000);
+
+    afterEach(async () => {
+      await eventSourcing.close();
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await cleanupTestDataForTenant(tenantIdString);
+    });
+
+    /**
+     * Sends one recordSpan command and waits for the trace_summaries
+     * row to land in ClickHouse with a resolved origin. Returns the
+     * persisted foldState — the same shape the reactor receives in
+     * production via ReactorContext.foldState.
+     */
+    async function sendSpanAndAwaitFold(
+      span: OtlpSpan,
+    ): Promise<TraceSummaryData> {
+      await tracePipeline.commands.recordSpan.send({
+        tenantId: tenantIdString,
+        span: span as any,
+        resource: { attributes: [], droppedAttributesCount: 0 } as any,
+        instrumentationScope: { name: "langwatch.test" } as any,
+        piiRedactionLevel: "DISABLED",
+        occurredAt: Date.now(),
+      });
+
+      let fold: TraceSummaryData | null = null;
+      await waitFor(
+        async () => {
+          fold = await traceSummaryStore.get(
+            (span as any).traceId,
+            { tenantId: tenantIdString } as any,
+          );
+          return !!fold?.attributes?.["langwatch.origin"];
+        },
+        {
+          timeoutMs: 20_000,
+          label: "trace_summaries row with resolved origin in CH",
+        },
+      );
+      if (!fold) throw new Error("fold became null after waitFor");
+      return fold;
+    }
+
+    /** @scenario Incoming span with causality_depth=0 still triggers evaluations */
+    it("dispatches one executeEvaluation per monitor when depth=0", async () => {
+      const traceId = generateId("trace");
+      const spanId = generateId("span");
+      const span = buildAppOriginSpan({ traceId, spanId, depth: 0 });
+
+      const foldState = await sendSpanAndAwaitFold(span);
+      expect(foldState.attributes["langwatch.origin"]).toBe("application");
+
+      await reactor.handle(buildSpanReceivedEvent({
+        tenantId: tenantIdString,
+        traceId,
+        span,
+      }) as any, {
+        tenantId: tenantIdString,
+        aggregateId: traceId,
+        foldState,
+      } as any);
+
+      expect(dispatcher.captured).toHaveLength(1);
+      expect(dispatcher.captured[0]!.evaluatorId).toBe(
+        "monitor_test_loop_prevention",
+      );
+      expect(dispatcher.captured[0]!.tenantId).toBe(tenantIdString);
+      expect(dispatcher.captured[0]!.traceId).toBe(traceId);
+    });
+
+    /** @scenario Incoming span with causality_depth=1 does not trigger evaluations */
+    it("BLOCKS dispatch when the incoming span carries causality_depth=1", async () => {
+      const traceId = generateId("trace");
+
+      // First seed the trace with an app-origin span so foldState has
+      // a resolved origin (otherwise the originGuardedReactor returns
+      // early before reaching the depth check).
+      const seedSpan = buildAppOriginSpan({
+        traceId,
+        spanId: generateId("seed"),
+        depth: 0,
+      });
+      const foldState = await sendSpanAndAwaitFold(seedSpan);
+      expect(foldState.attributes["langwatch.origin"]).toBe("application");
+
+      // Now construct the eval-emitted span (depth=1) and invoke the
+      // reactor with it as the incoming event.
+      const evalSpan = buildAppOriginSpan({
+        traceId,
+        spanId: generateId("eval"),
+        depth: 1,
+      });
+
+      const beforeBlocked = await readBlockedCounter("depth_direct");
+      const dispatchesBefore = dispatcher.captured.length;
+
+      await reactor.handle(buildSpanReceivedEvent({
+        tenantId: tenantIdString,
+        traceId,
+        span: evalSpan,
+      }) as any, {
+        tenantId: tenantIdString,
+        aggregateId: traceId,
+        foldState,
+      } as any);
+
+      expect(dispatcher.captured.length).toBe(dispatchesBefore);
+      const afterBlocked = await readBlockedCounter("depth_direct");
+      expect(afterBlocked - beforeBlocked).toBe(1);
+    });
+
+    /** @scenario Causality guard is per-span — fresh app activity still re-triggers */
+    it("re-dispatches when a fresh depth=0 span arrives after a depth=1 noise span", async () => {
+      const traceId = generateId("trace");
+
+      // 1. Initial app-origin span — should dispatch.
+      const span1 = buildAppOriginSpan({
+        traceId,
+        spanId: generateId("s1"),
+        depth: 0,
+      });
+      const fold1 = await sendSpanAndAwaitFold(span1);
+      await reactor.handle(buildSpanReceivedEvent({
+        tenantId: tenantIdString,
+        traceId,
+        span: span1,
+      }) as any, {
+        tenantId: tenantIdString,
+        aggregateId: traceId,
+        foldState: fold1,
+      } as any);
+      const dispatchesAfter1 = dispatcher.captured.length;
+      expect(dispatchesAfter1).toBe(1);
+
+      // 2. Eval-emitted span on same trace (depth=1) — must NOT add a dispatch.
+      const span2 = buildAppOriginSpan({
+        traceId,
+        spanId: generateId("s2"),
+        depth: 1,
+      });
+      // The eval-emitted span also goes through the real pipeline.
+      const fold2 = await sendSpanAndAwaitFold(span2);
+      await reactor.handle(buildSpanReceivedEvent({
+        tenantId: tenantIdString,
+        traceId,
+        span: span2,
+      }) as any, {
+        tenantId: tenantIdString,
+        aggregateId: traceId,
+        foldState: fold2,
+      } as any);
+      expect(dispatcher.captured.length).toBe(dispatchesAfter1);
+
+      // 3. Fresh app-origin span (depth=0) later on SAME trace —
+      //    legitimate new activity, MUST dispatch again.
+      const span3 = buildAppOriginSpan({
+        traceId,
+        spanId: generateId("s3"),
+        depth: 0,
+      });
+      const fold3 = await sendSpanAndAwaitFold(span3);
+      await reactor.handle(buildSpanReceivedEvent({
+        tenantId: tenantIdString,
+        traceId,
+        span: span3,
+      }) as any, {
+        tenantId: tenantIdString,
+        aggregateId: traceId,
+        foldState: fold3,
+      } as any);
+      expect(dispatcher.captured.length).toBe(dispatchesAfter1 + 1);
+    });
+
+    /** @scenario LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD bypasses depth check */
+    it("kill switch — LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD=1 dispatches even on depth=1", async () => {
+      const traceId = generateId("trace");
+      const seedSpan = buildAppOriginSpan({
+        traceId,
+        spanId: generateId("seed"),
+        depth: 0,
+      });
+      const foldState = await sendSpanAndAwaitFold(seedSpan);
+
+      const evalSpan = buildAppOriginSpan({
+        traceId,
+        spanId: generateId("eval"),
+        depth: 1,
+      });
+
+      const prev = process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD;
+      process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD = "1";
+      try {
+        const dispatchesBefore = dispatcher.captured.length;
+        await reactor.handle(buildSpanReceivedEvent({
+          tenantId: tenantIdString,
+          traceId,
+          span: evalSpan,
+        }) as any, {
+          tenantId: tenantIdString,
+          aggregateId: traceId,
+          foldState,
+        } as any);
+        expect(dispatcher.captured.length).toBe(dispatchesBefore + 1);
+      } finally {
+        if (prev === undefined) {
+          delete process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD;
+        } else {
+          process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD = prev;
+        }
+      }
+    });
+  },
+);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/loopPrevention.reactor.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/loopPrevention.reactor.integration.test.ts
@@ -63,11 +63,7 @@ import {
   TraceSummaryFoldProjection,
   type TraceSummaryData,
 } from "../../projections/traceSummary.foldProjection";
-import type {
-  SpanReceivedEvent,
-  TraceProcessingEvent,
-} from "../../schemas/events";
-import { SPAN_RECEIVED_EVENT_TYPE } from "../../schemas/constants";
+import type { TraceProcessingEvent } from "../../schemas/events";
 import type { OtlpSpan } from "../../schemas/otlp";
 import { SpanAppendStore } from "../../projections/spanStorage.store";
 import { TraceSummaryStore } from "../../projections/traceSummary.store";
@@ -189,36 +185,6 @@ function buildAppOriginSpan(opts: {
 
 function generateId(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).substring(7)}`;
-}
-
-/**
- * Mirrors the SpanReceivedEvent shape produced by recordSpan's
- * emitEvents step. The reactor reads `event.data.span.attributes` for
- * the depth check, and `event.occurredAt` for the recency gate. Other
- * fields are passed through to dispatchEvaluations but not consulted
- * by the loop-prevention logic.
- */
-function buildSpanReceivedEvent(opts: {
-  tenantId: string;
-  traceId: string;
-  span: OtlpSpan;
-}): SpanReceivedEvent {
-  return {
-    type: SPAN_RECEIVED_EVENT_TYPE,
-    tenantId: opts.tenantId,
-    aggregateId: opts.traceId,
-    occurredAt: Date.now(),
-    data: {
-      span: opts.span as any,
-      resource: { attributes: [], droppedAttributesCount: 0 } as any,
-      instrumentationScope: { name: "langwatch.test" } as any,
-      piiRedactionLevel: "DISABLED",
-    },
-    metadata: {
-      spanId: (opts.span as any).spanId,
-      traceId: opts.traceId,
-    },
-  } as unknown as SpanReceivedEvent;
 }
 
 async function waitFor(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/loopPrevention.reactor.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/loopPrevention.reactor.integration.test.ts
@@ -37,7 +37,7 @@
  *      check (emergency rollback path).
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
 import { SpanStorageClickHouseRepository } from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
 import { TraceSummaryService } from "~/server/app-layer/traces/trace-summary.service";
@@ -252,7 +252,7 @@ async function readBlockedCounter(reason: string): Promise<number> {
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!hasTestcontainers)(
-  "evaluationTrigger reactor — loop prevention against real pipeline state",
+  "evaluationTrigger reactor — loop prevention end-to-end through the real event-sourcing pipeline",
   () => {
     let eventSourcing: EventSourcing;
     let tracePipeline: ReturnType<typeof createTracePipeline>;
@@ -260,7 +260,6 @@ describe.skipIf(!hasTestcontainers)(
     let tenantId: ReturnType<typeof createTestTenantId>;
     let tenantIdString: string;
     let dispatcher: ReturnType<typeof makeCapturingEvaluationDispatcher>;
-    let reactor: ReturnType<typeof createEvaluationTriggerReactor>;
 
     function createTracePipeline() {
       const clickHouseClient = getTestClickHouseClient();
@@ -291,15 +290,20 @@ describe.skipIf(!hasTestcontainers)(
       );
 
       // Build the REAL evaluationTrigger reactor with a capturing
-      // dispatcher. We won't rely on the BullMQ-scheduled call path;
-      // the test invokes reactor.handle() directly with foldState
-      // read from CH. The reactor instance is the production code.
+      // dispatcher and wire it into the pipeline so the
+      // GroupQueueProcessor actually fires it when spans land.
+      // Override `delay` to 0 — production default is 30s, which is
+      // a deliberate dedup window but unhelpful for tests.
       const monitorService = new MonitorService(makeFakeMonitorRepository());
       dispatcher = makeCapturingEvaluationDispatcher();
-      reactor = createEvaluationTriggerReactor({
+      const realReactor = createEvaluationTriggerReactor({
         monitors: monitorService,
         evaluation: dispatcher.dispatch,
       });
+      const fastReactor = {
+        ...realReactor,
+        options: { ...realReactor.options, delay: 0 },
+      };
 
       const pipelineName = `trace_loop_prevention_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
       const pipelineDef = definePipeline<TraceProcessingEvent>()
@@ -313,7 +317,7 @@ describe.skipIf(!hasTestcontainers)(
           "spanStorage",
           new SpanStorageMapProjection({ store: spanAppendStore }) as any,
         )
-        .withReactor("traceSummary", "evaluationTrigger", noopReactor as any)
+        .withReactor("traceSummary", "evaluationTrigger", fastReactor as any)
         .withReactor("traceSummary", "customEvaluationSync", noopReactor as any)
         .withReactor("traceSummary", "traceUpdateBroadcast", noopReactor as any)
         .withReactor("traceSummary", "simulationMetricsSync", noopReactor as any)
@@ -330,6 +334,17 @@ describe.skipIf(!hasTestcontainers)(
       };
     }
 
+    // Stale Redis jobs from prior test-file runs (different pipeline
+    // names) cause "Unknown job in global queue" rejections that
+    // block this run's reactors from picking up work. Flush once
+    // before any test in this suite executes.
+    beforeAll(async () => {
+      const redisConnection = getTestRedisConnection();
+      if (redisConnection) {
+        await redisConnection.flushall();
+      }
+    });
+
     beforeEach(async () => {
       tracePipeline = createTracePipeline();
       tenantId = createTestTenantId();
@@ -344,14 +359,13 @@ describe.skipIf(!hasTestcontainers)(
     });
 
     /**
-     * Sends one recordSpan command and waits for the trace_summaries
-     * row to land in ClickHouse with a resolved origin. Returns the
-     * persisted foldState — the same shape the reactor receives in
-     * production via ReactorContext.foldState.
+     * Push a span through the real GroupQueueProcessor pipeline.
+     * Awaits the trace_summaries row landing in ClickHouse so the
+     * fold projection definitely ran before we move on. Reactor
+     * dispatch is asynchronous afterwards — assert on
+     * `dispatcher.captured` directly in the tests.
      */
-    async function sendSpanAndAwaitFold(
-      span: OtlpSpan,
-    ): Promise<TraceSummaryData> {
+    async function recordSpan(span: OtlpSpan): Promise<void> {
       await tracePipeline.commands.recordSpan.send({
         tenantId: tenantIdString,
         span: span as any,
@@ -361,10 +375,9 @@ describe.skipIf(!hasTestcontainers)(
         occurredAt: Date.now(),
       });
 
-      let fold: TraceSummaryData | null = null;
       await waitFor(
         async () => {
-          fold = await traceSummaryStore.get(
+          const fold = await traceSummaryStore.get(
             (span as any).traceId,
             { tenantId: tenantIdString } as any,
           );
@@ -375,28 +388,34 @@ describe.skipIf(!hasTestcontainers)(
           label: "trace_summaries row with resolved origin in CH",
         },
       );
-      if (!fold) throw new Error("fold became null after waitFor");
-      return fold;
+    }
+
+    /**
+     * Quiet window after a span lands. The real evaluationTrigger
+     * reactor is dispatched asynchronously by the GroupQueueProcessor;
+     * `recordSpan` only awaits the fold. We need to give the worker a
+     * polling cycle to pick up the reactor job and either call dispatch
+     * or block it. 1500ms is comfortably above the dispatcher's BRPOP
+     * timeout cadence at signalTimeoutSec=5 with delay=0 jobs.
+     */
+    async function quietReactorWindow(): Promise<void> {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
     }
 
     /** @scenario Incoming span with causality_depth=0 still triggers evaluations */
     it("dispatches one executeEvaluation per monitor when depth=0", async () => {
       const traceId = generateId("trace");
-      const spanId = generateId("span");
-      const span = buildAppOriginSpan({ traceId, spanId, depth: 0 });
-
-      const foldState = await sendSpanAndAwaitFold(span);
-      expect(foldState.attributes["langwatch.origin"]).toBe("application");
-
-      await reactor.handle(buildSpanReceivedEvent({
-        tenantId: tenantIdString,
+      const span = buildAppOriginSpan({
         traceId,
-        span,
-      }) as any, {
-        tenantId: tenantIdString,
-        aggregateId: traceId,
-        foldState,
-      } as any);
+        spanId: generateId("span"),
+        depth: 0,
+      });
+
+      await recordSpan(span);
+      await waitFor(() => dispatcher.captured.length >= 1, {
+        timeoutMs: 20_000,
+        label: "reactor dispatched evaluation through the real queue",
+      });
 
       expect(dispatcher.captured).toHaveLength(1);
       expect(dispatcher.captured[0]!.evaluatorId).toBe(
@@ -410,41 +429,38 @@ describe.skipIf(!hasTestcontainers)(
     it("BLOCKS dispatch when the incoming span carries causality_depth=1", async () => {
       const traceId = generateId("trace");
 
-      // First seed the trace with an app-origin span so foldState has
-      // a resolved origin (otherwise the originGuardedReactor returns
-      // early before reaching the depth check).
-      const seedSpan = buildAppOriginSpan({
-        traceId,
-        spanId: generateId("seed"),
-        depth: 0,
+      // Seed: app-origin depth=0 span establishes the trace's origin
+      // on the fold (required for the originGuardedReactor wrapper
+      // to fire its inner handler at all).
+      await recordSpan(
+        buildAppOriginSpan({
+          traceId,
+          spanId: generateId("seed"),
+          depth: 0,
+        }),
+      );
+      // The seed itself triggers one dispatch. Wait for it so we
+      // have a stable baseline to assert no further dispatch happens.
+      await waitFor(() => dispatcher.captured.length >= 1, {
+        timeoutMs: 20_000,
+        label: "seed depth=0 dispatched",
       });
-      const foldState = await sendSpanAndAwaitFold(seedSpan);
-      expect(foldState.attributes["langwatch.origin"]).toBe("application");
-
-      // Now construct the eval-emitted span (depth=1) and invoke the
-      // reactor with it as the incoming event.
-      const evalSpan = buildAppOriginSpan({
-        traceId,
-        spanId: generateId("eval"),
-        depth: 1,
-      });
-
-      const beforeBlocked = await readBlockedCounter("depth_direct");
       const dispatchesBefore = dispatcher.captured.length;
+      const beforeBlocked = await readBlockedCounter("depth_direct");
 
-      await reactor.handle(buildSpanReceivedEvent({
-        tenantId: tenantIdString,
-        traceId,
-        span: evalSpan,
-      }) as any, {
-        tenantId: tenantIdString,
-        aggregateId: traceId,
-        foldState,
-      } as any);
+      // Eval-emitted span (depth=1) — must be blocked by the reactor.
+      await recordSpan(
+        buildAppOriginSpan({
+          traceId,
+          spanId: generateId("eval"),
+          depth: 1,
+        }),
+      );
+      await quietReactorWindow();
 
       expect(dispatcher.captured.length).toBe(dispatchesBefore);
       const afterBlocked = await readBlockedCounter("depth_direct");
-      expect(afterBlocked - beforeBlocked).toBe(1);
+      expect(afterBlocked - beforeBlocked).toBeGreaterThanOrEqual(1);
     });
 
     /** @scenario Causality guard is per-span — fresh app activity still re-triggers */
@@ -452,92 +468,112 @@ describe.skipIf(!hasTestcontainers)(
       const traceId = generateId("trace");
 
       // 1. Initial app-origin span — should dispatch.
-      const span1 = buildAppOriginSpan({
-        traceId,
-        spanId: generateId("s1"),
-        depth: 0,
+      await recordSpan(
+        buildAppOriginSpan({
+          traceId,
+          spanId: generateId("s1"),
+          depth: 0,
+        }),
+      );
+      await waitFor(() => dispatcher.captured.length >= 1, {
+        timeoutMs: 20_000,
+        label: "first depth=0 dispatched",
       });
-      const fold1 = await sendSpanAndAwaitFold(span1);
-      await reactor.handle(buildSpanReceivedEvent({
-        tenantId: tenantIdString,
-        traceId,
-        span: span1,
-      }) as any, {
-        tenantId: tenantIdString,
-        aggregateId: traceId,
-        foldState: fold1,
-      } as any);
       const dispatchesAfter1 = dispatcher.captured.length;
       expect(dispatchesAfter1).toBe(1);
 
-      // 2. Eval-emitted span on same trace (depth=1) — must NOT add a dispatch.
-      const span2 = buildAppOriginSpan({
-        traceId,
-        spanId: generateId("s2"),
-        depth: 1,
-      });
-      // The eval-emitted span also goes through the real pipeline.
-      const fold2 = await sendSpanAndAwaitFold(span2);
-      await reactor.handle(buildSpanReceivedEvent({
-        tenantId: tenantIdString,
-        traceId,
-        span: span2,
-      }) as any, {
-        tenantId: tenantIdString,
-        aggregateId: traceId,
-        foldState: fold2,
-      } as any);
+      // 2. Eval-emitted span on same trace (depth=1) — must NOT add a
+      //    dispatch. The reactor dedup window (30s makeJobId TTL) is
+      //    irrelevant here because the depth check returns BEFORE the
+      //    queue's dedup applies — that's exactly the guarantee.
+      await recordSpan(
+        buildAppOriginSpan({
+          traceId,
+          spanId: generateId("s2"),
+          depth: 1,
+        }),
+      );
+      await quietReactorWindow();
       expect(dispatcher.captured.length).toBe(dispatchesAfter1);
 
       // 3. Fresh app-origin span (depth=0) later on SAME trace —
-      //    legitimate new activity, MUST dispatch again.
-      const span3 = buildAppOriginSpan({
-        traceId,
-        spanId: generateId("s3"),
-        depth: 0,
-      });
-      const fold3 = await sendSpanAndAwaitFold(span3);
-      await reactor.handle(buildSpanReceivedEvent({
-        tenantId: tenantIdString,
-        traceId,
-        span: span3,
-      }) as any, {
-        tenantId: tenantIdString,
-        aggregateId: traceId,
-        foldState: fold3,
-      } as any);
+      //    legitimate new activity, MUST dispatch again. The reactor
+      //    has `makeJobId(...) = eval-trigger:tenant:trace` plus a
+      //    30s TTL — to bypass the queue-side dedup of this case we
+      //    nuke the dedup keys for this trace before re-dispatching.
+      //    (In production, the 30s window IS the dedup; tests just
+      //    need to prove the depth check itself doesn't pin the
+      //    trace forever.)
+      const redis = getTestRedisConnection()!;
+      const dedupKeys = await redis.keys(
+        `*eval-trigger:${tenantIdString}:${traceId}*`,
+      );
+      if (dedupKeys.length > 0) {
+        await redis.del(...dedupKeys);
+      }
+
+      await recordSpan(
+        buildAppOriginSpan({
+          traceId,
+          spanId: generateId("s3"),
+          depth: 0,
+        }),
+      );
+      await waitFor(
+        () => dispatcher.captured.length >= dispatchesAfter1 + 1,
+        {
+          timeoutMs: 20_000,
+          label: "fresh depth=0 re-dispatched on the same trace",
+        },
+      );
       expect(dispatcher.captured.length).toBe(dispatchesAfter1 + 1);
     });
 
     /** @scenario LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD bypasses depth check */
     it("kill switch — LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD=1 dispatches even on depth=1", async () => {
       const traceId = generateId("trace");
-      const seedSpan = buildAppOriginSpan({
-        traceId,
-        spanId: generateId("seed"),
-        depth: 0,
-      });
-      const foldState = await sendSpanAndAwaitFold(seedSpan);
 
-      const evalSpan = buildAppOriginSpan({
-        traceId,
-        spanId: generateId("eval"),
-        depth: 1,
+      // Seed to establish origin on fold + clear baseline.
+      await recordSpan(
+        buildAppOriginSpan({
+          traceId,
+          spanId: generateId("seed"),
+          depth: 0,
+        }),
+      );
+      await waitFor(() => dispatcher.captured.length >= 1, {
+        timeoutMs: 20_000,
+        label: "seed dispatched",
       });
+      const dispatchesBefore = dispatcher.captured.length;
+
+      // Clear queue-side dedup so the next eval-trigger isn't suppressed
+      // by the 30s window for this trace.
+      const redis = getTestRedisConnection()!;
+      const dedupKeys = await redis.keys(
+        `*eval-trigger:${tenantIdString}:${traceId}*`,
+      );
+      if (dedupKeys.length > 0) {
+        await redis.del(...dedupKeys);
+      }
 
       const prev = process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD;
       process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD = "1";
       try {
-        const dispatchesBefore = dispatcher.captured.length;
-        await reactor.handle(buildSpanReceivedEvent({
-          tenantId: tenantIdString,
-          traceId,
-          span: evalSpan,
-        }) as any, {
-          tenantId: tenantIdString,
-          aggregateId: traceId,
-          foldState,
-        } as any);
+        await recordSpan(
+          buildAppOriginSpan({
+            traceId,
+            spanId: generateId("eval"),
+            depth: 1,
+          }),
+        );
+        await waitFor(
+          () => dispatcher.captured.length >= dispatchesBefore + 1,
+          {
+            timeoutMs: 20_000,
+            label: "kill switch lets depth=1 dispatch through the queue",
+          },
+        );
         expect(dispatcher.captured.length).toBe(dispatchesBefore + 1);
       } finally {
         if (prev === undefined) {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/loopPrevention.reactor.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/loopPrevention.reactor.integration.test.ts
@@ -402,31 +402,37 @@ describe.skipIf(!hasTestcontainers)(
       await new Promise((resolve) => setTimeout(resolve, 1500));
     }
 
-    /** @scenario Incoming span with causality_depth=0 still triggers evaluations */
-    it("dispatches one executeEvaluation per monitor when depth=0", async () => {
-      const traceId = generateId("trace");
-      const span = buildAppOriginSpan({
-        traceId,
-        spanId: generateId("span"),
-        depth: 0,
-      });
+    describe("given an incoming span with causality_depth=0", () => {
+      describe("when the span is recorded through the pipeline", () => {
+        /** @scenario Incoming span with causality_depth=0 still triggers evaluations */
+        it("dispatches one executeEvaluation per monitor", async () => {
+          const traceId = generateId("trace");
+          const span = buildAppOriginSpan({
+            traceId,
+            spanId: generateId("span"),
+            depth: 0,
+          });
 
-      await recordSpan(span);
-      await waitFor(() => dispatcher.captured.length >= 1, {
-        timeoutMs: 20_000,
-        label: "reactor dispatched evaluation through the real queue",
-      });
+          await recordSpan(span);
+          await waitFor(() => dispatcher.captured.length >= 1, {
+            timeoutMs: 20_000,
+            label: "reactor dispatched evaluation through the real queue",
+          });
 
-      expect(dispatcher.captured).toHaveLength(1);
-      expect(dispatcher.captured[0]!.evaluatorId).toBe(
-        "monitor_test_loop_prevention",
-      );
-      expect(dispatcher.captured[0]!.tenantId).toBe(tenantIdString);
-      expect(dispatcher.captured[0]!.traceId).toBe(traceId);
+          expect(dispatcher.captured).toHaveLength(1);
+          expect(dispatcher.captured[0]!.evaluatorId).toBe(
+            "monitor_test_loop_prevention",
+          );
+          expect(dispatcher.captured[0]!.tenantId).toBe(tenantIdString);
+          expect(dispatcher.captured[0]!.traceId).toBe(traceId);
+        });
+      });
     });
 
-    /** @scenario Incoming span with causality_depth=1 does not trigger evaluations */
-    it("BLOCKS dispatch when the incoming span carries causality_depth=1", async () => {
+    describe("given an incoming span with causality_depth=1", () => {
+      describe("when the span is recorded after a depth=0 seed", () => {
+        /** @scenario Incoming span with causality_depth=1 does not trigger evaluations */
+        it("blocks dispatch and increments the loop-blocked counter", async () => {
       const traceId = generateId("trace");
 
       // Seed: app-origin depth=0 span establishes the trace's origin
@@ -458,13 +464,17 @@ describe.skipIf(!hasTestcontainers)(
       );
       await quietReactorWindow();
 
-      expect(dispatcher.captured.length).toBe(dispatchesBefore);
-      const afterBlocked = await readBlockedCounter("depth_direct");
-      expect(afterBlocked - beforeBlocked).toBeGreaterThanOrEqual(1);
+          expect(dispatcher.captured.length).toBe(dispatchesBefore);
+          const afterBlocked = await readBlockedCounter("depth_direct");
+          expect(afterBlocked - beforeBlocked).toBeGreaterThanOrEqual(1);
+        });
+      });
     });
 
-    /** @scenario Causality guard is per-span — fresh app activity still re-triggers */
-    it("re-dispatches when a fresh depth=0 span arrives after a depth=1 noise span", async () => {
+    describe("given a trace that has already seen depth=0 then depth=1", () => {
+      describe("when a fresh depth=0 span arrives later on the same trace", () => {
+        /** @scenario Causality guard is per-span — fresh app activity still re-triggers */
+        it("re-dispatches because the depth check is per-span, not per-trace", async () => {
       const traceId = generateId("trace");
 
       // 1. Initial app-origin span — should dispatch.
@@ -526,11 +536,15 @@ describe.skipIf(!hasTestcontainers)(
           label: "fresh depth=0 re-dispatched on the same trace",
         },
       );
-      expect(dispatcher.captured.length).toBe(dispatchesAfter1 + 1);
+          expect(dispatcher.captured.length).toBe(dispatchesAfter1 + 1);
+        });
+      });
     });
 
-    /** @scenario LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD bypasses depth check */
-    it("kill switch — LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD=1 dispatches even on depth=1", async () => {
+    describe("given LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD=1", () => {
+      describe("when a depth=1 span arrives that would normally be blocked", () => {
+        /** @scenario LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD bypasses depth check */
+        it("the kill switch lets the dispatch through anyway", async () => {
       const traceId = generateId("trace");
 
       // Seed to establish origin on fold + clear baseline.
@@ -582,6 +596,8 @@ describe.skipIf(!hasTestcontainers)(
           process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD = prev;
         }
       }
+        });
+      });
     });
   },
 );

--- a/langwatch/src/server/nlpgo/__tests__/nlpgoFetch.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/nlpgoFetch.integration.test.ts
@@ -63,7 +63,11 @@ vi.mock("../../../optimization_studio/server/lambda", () => ({
 }));
 
 const NLPGO_PORT = 5562;
-const REPO_ROOT = path.resolve(__dirname, "../../../../../..");
+// /langwatch/src/server/nlpgo/__tests__  → up 5 = repo root.
+// Was 6 historically (landed at worktrees/ instead of the repo) which
+// silently broke `go run ./cmd/service` with "directory not found"
+// any time OPENAI_API_KEY was set in the env that the test ran in.
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
 
 let nlpgoProcess: ChildProcess | null = null;
 

--- a/langwatch/src/server/nlpgo/__tests__/nlpgoFetch.unit.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/nlpgoFetch.unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { formatTraceparent } from "../nlpgoFetch";
+
+/**
+ * Unit tests for the W3C traceparent header formatting in nlpgoFetch.
+ *
+ * Why this matters: nlpgoFetch is the dispatch boundary between TS
+ * (eval-execution.service) and the nlpgo subprocess. Without a valid
+ * `traceparent` header on the request, nlpgo's `startStudioSpan` cannot
+ * extract a parent SpanContext and the eval workflow emits spans on a
+ * brand-new trace_id — orphaned from the trace it was evaluating.
+ *
+ * This is the exact prod bug rchaves caught on 2026-05-14: the eval
+ * ran, nlpgo emitted spans, but the spans landed under a separate
+ * trace_id with no link back to the parent.
+ *
+ * These tests pin the wire-format contract so a future refactor can't
+ * silently regress it.
+ */
+describe("nlpgoFetch.formatTraceparent", () => {
+  /** @scenario formatTraceparent builds a valid W3C traceparent header */
+  it("formats a valid W3C traceparent header", () => {
+    const header = formatTraceparent({
+      traceId: "0af7651916cd43dd8448eb211c80319c",
+      parentSpanId: "b7ad6b7169203331",
+    });
+    expect(header).toBe(
+      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+    );
+  });
+
+  it("lowercases hex input so producers can pass either case", () => {
+    const header = formatTraceparent({
+      traceId: "0AF7651916CD43DD8448EB211C80319C",
+      parentSpanId: "B7AD6B7169203331",
+    });
+    expect(header).toBe(
+      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+    );
+  });
+
+  /** @scenario formatTraceparent rejects malformed traceId */
+  it("rejects a traceId that is not 32 hex chars (loud failure beats silent broken header)", () => {
+    expect(() =>
+      formatTraceparent({
+        traceId: "trace_legacy_format",
+        parentSpanId: "b7ad6b7169203331",
+      }),
+    ).toThrow(/invalid traceId/);
+  });
+
+  /** @scenario formatTraceparent rejects malformed parentSpanId */
+  it("rejects a parentSpanId that is not 16 hex chars", () => {
+    expect(() =>
+      formatTraceparent({
+        traceId: "0af7651916cd43dd8448eb211c80319c",
+        parentSpanId: "not-16-hex",
+      }),
+    ).toThrow(/invalid parentSpanId/);
+  });
+
+  it("rejects non-hex characters disguised as right length", () => {
+    expect(() =>
+      formatTraceparent({
+        traceId: "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+        parentSpanId: "b7ad6b7169203331",
+      }),
+    ).toThrow(/invalid traceId/);
+  });
+});

--- a/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
@@ -599,10 +599,18 @@ describe.skipIf(!shouldRun)(
           true,
         );
 
-        // Poll ClickHouse for the persisted spans. Two flush windows
-        // chain here: nlpgo's BatchSpanProcessor (5s default) + the
-        // event-sourcing fold/map projection workers (sub-second).
-        // 25s deadline absorbs both with margin.
+        // Poll ClickHouse for the persisted spans. Three flush windows
+        // chain here: nlpgo's BatchSpanProcessor (5s scheduled delay) +
+        // OTLP HTTP roundtrip + the event-sourcing fold/map projections.
+        // 45s deadline absorbs all three with margin on a loaded CI runner.
+        //
+        // CRITICAL: we must NOT exit the loop on the first non-empty
+        // result. The studio root span ends AFTER its children, so BSP
+        // exports it in a LATER batch — children show up first, root
+        // second. If we asserted on the first non-empty snapshot, we'd
+        // see only execute_component(parent=studio_root) rows and miss
+        // the studio_root(parent=inbound) row that the assertion actually
+        // depends on. Exit only when the load-bearing row arrives.
         const ch = getTestClickHouseClient()!;
 
         interface SpanRow {
@@ -612,9 +620,7 @@ describe.skipIf(!shouldRun)(
           SpanName: string;
         }
 
-        let rows: SpanRow[] = [];
-        const deadline = Date.now() + 25_000;
-        while (Date.now() < deadline && rows.length === 0) {
+        async function fetchRows(): Promise<SpanRow[]> {
           const result = await ch.query({
             query: `
               SELECT TraceId, SpanId, ParentSpanId, SpanName
@@ -635,8 +641,20 @@ describe.skipIf(!shouldRun)(
             },
             format: "JSONEachRow",
           });
-          rows = await result.json<SpanRow>();
-          if (rows.length === 0) await sleep(500);
+          return await result.json<SpanRow>();
+        }
+
+        const hasLinkedSpan = (rows: SpanRow[]): boolean =>
+          rows.some(
+            (r) => (r.ParentSpanId ?? "").toLowerCase() === PARENT_SPAN_ID,
+          );
+
+        let rows: SpanRow[] = [];
+        const deadline = Date.now() + 45_000;
+        while (Date.now() < deadline) {
+          rows = await fetchRows();
+          if (rows.length > 0 && hasLinkedSpan(rows)) break;
+          await sleep(500);
         }
 
         // CORE ASSERTION 1 — spans landed in CH under the INBOUND trace_id.

--- a/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
@@ -40,7 +40,12 @@
  *   - `go` is not on PATH
  *   - testcontainers Redis + ClickHouse are not running
  */
-import { execSync, spawn, type ChildProcess } from "node:child_process";
+import {
+  execFileSync,
+  execSync,
+  spawn,
+  type ChildProcess,
+} from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
@@ -180,11 +185,20 @@ function ensureNlpgoBinary(timeoutMs = 600_000): string {
 
   // Cold/stale: actually compile. `go build` honours module cache, so
   // back-to-back runs in the same CI job are fast even after the first.
-  execSync(`go build -o ${NLPGO_TEST_BIN} ./cmd/service`, {
-    cwd: REPO_ROOT,
-    stdio: process.env.NLPGO_TEST_LOG === "1" ? "inherit" : "pipe",
-    timeout: timeoutMs,
-  });
+  // execFileSync (not execSync) — pass argv as an array so the shell
+  // never interprets the binary path. REPO_ROOT can sit under a worktree
+  // dir like `.claude/worktrees/...` whose absolute path could in
+  // principle contain spaces or shell metachars; binding through argv
+  // sidesteps that entirely (CodeQL js/shell-command-injection-from-environment).
+  execFileSync(
+    "go",
+    ["build", "-o", NLPGO_TEST_BIN, "./cmd/service"],
+    {
+      cwd: REPO_ROOT,
+      stdio: process.env.NLPGO_TEST_LOG === "1" ? "inherit" : "pipe",
+      timeout: timeoutMs,
+    },
+  );
   return NLPGO_TEST_BIN;
 }
 

--- a/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
@@ -30,10 +30,16 @@
  * wire format but doesn't prove the spans actually survive the
  * roundtrip and land where Studio queries them.
  *
- * Skipped when:
- *   - `go` is not on PATH (CI without Go toolchain)
+ * Opt-in: this test spawns a real Go subprocess (`go run`), which on
+ * a cold module cache takes well over CI's nlpgo-health budget. It is
+ * therefore skipped unless explicitly enabled via NLPGO_E2E=1. Run it
+ * locally to validate the full roundtrip before shipping pipeline /
+ * traceparent / OTLP changes.
+ *
+ * Skipped when ANY of:
+ *   - NLPGO_E2E is not "1"
+ *   - `go` is not on PATH
  *   - testcontainers Redis + ClickHouse are not running
- *   - SKIP_NLPGO_E2E=1 is set
  */
 import { execSync, spawn, type ChildProcess } from "node:child_process";
 import http from "node:http";
@@ -98,7 +104,7 @@ function hasGo(): boolean {
   }
 }
 const shouldRun =
-  hasTestcontainers && hasGo() && process.env.SKIP_NLPGO_E2E !== "1";
+  process.env.NLPGO_E2E === "1" && hasTestcontainers && hasGo();
 
 const noopReactor = { name: "noop", options: {}, handle: async () => {} };
 
@@ -244,6 +250,18 @@ describe.skipIf(!shouldRun)(
       langwatchSrv = http.createServer((req, res) => {
         const chunks: Buffer[] = [];
         req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("error", (err) => {
+          if (process.env.NLPGO_TEST_LOG === "1") {
+            // eslint-disable-next-line no-console
+            console.error("[fake-langwatch] request stream error", err);
+          }
+          try {
+            res.statusCode = 500;
+            res.end();
+          } catch {
+            /* response may already be closed */
+          }
+        });
         req.on("end", () => {
           void (async () => {
             const body = Buffer.concat(chunks);
@@ -308,11 +326,15 @@ describe.skipIf(!shouldRun)(
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
       });
-      nlpgoProcess.stderr?.on("data", (chunk: Buffer) => {
+      const drain = (label: "out" | "err", chunk: Buffer) => {
         if (process.env.NLPGO_TEST_LOG === "1") {
-          process.stderr.write(`[nlpgo] ${chunk.toString()}`);
+          process.stderr.write(`[nlpgo:${label}] ${chunk.toString()}`);
         }
-      });
+      };
+      // Must drain BOTH pipes — leaving stdout unconsumed will block the
+      // Go subprocess on writes once the Linux pipe buffer (~64 KiB) fills.
+      nlpgoProcess.stdout?.on("data", (chunk: Buffer) => drain("out", chunk));
+      nlpgoProcess.stderr?.on("data", (chunk: Buffer) => drain("err", chunk));
       nlpgoProcess.on("exit", (code, signal) => {
         if (code !== 0 && code !== null) {
           // eslint-disable-next-line no-console
@@ -446,7 +468,6 @@ describe.skipIf(!shouldRun)(
           // children create a fresh trace_id (the 2026-05-14 bug).
           do_not_trace: false,
           run_evaluations: false,
-          origin: "evaluation",
         },
       };
     }

--- a/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
@@ -1,0 +1,553 @@
+/**
+ * Full-loop end-to-end test for traceparent propagation:
+ *
+ *   [test]
+ *     │ POST /go/studio/execute_sync with traceparent + workflow body
+ *     ▼
+ *   [real nlpgo subprocess (`go run ./cmd/service nlpgo`)]
+ *     │ HTTP/proto OTLP export
+ *     ▼
+ *   [fake langwatch HTTP server]
+ *     │ /api/otel/v1/traces → decode OTLP → call
+ *     │  TraceRequestCollectionService.handleOtlpTraceRequest(...)
+ *     ▼
+ *   [real EventSourcing trace-processing pipeline]
+ *     │ RecordSpanCommand → fold + spanStorage projections
+ *     ▼
+ *   [real ClickHouse (testcontainers)]
+ *     │
+ *     └── SELECT * FROM stored_spans WHERE TraceId = <parent>
+ *
+ * Asserts (against the spans persisted in ClickHouse):
+ *   1. Spans landed under the INBOUND trace_id (not a fresh one).
+ *   2. At least one span has parent_span_id == inbound span_id,
+ *      proving Studio's waterfall will render the eval as a child
+ *      of the trace it was evaluating.
+ *
+ * This is the test rchaves asked for after the 2026-05-14 dogfood
+ * caught eval spans landing on orphan traces. Previous attempts
+ * stopped at "decode the OTLP bytes nlpgo emits" — that proves the
+ * wire format but doesn't prove the spans actually survive the
+ * roundtrip and land where Studio queries them.
+ *
+ * Skipped when:
+ *   - `go` is not on PATH (CI without Go toolchain)
+ *   - testcontainers Redis + ClickHouse are not running
+ *   - SKIP_NLPGO_E2E=1 is set
+ */
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
+import { SpanStorageClickHouseRepository } from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
+import { TraceSummaryService } from "~/server/app-layer/traces/trace-summary.service";
+import { TraceSummaryClickHouseRepository } from "~/server/app-layer/traces/repositories/trace-summary.clickhouse.repository";
+import { TraceRequestCollectionService } from "~/server/app-layer/traces/trace-request-collection.service";
+import {
+  definePipeline,
+  type AggregateType,
+} from "~/server/event-sourcing";
+import {
+  getTestClickHouseClient,
+  getTestRedisConnection,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import {
+  cleanupTestDataForTenant,
+  createTestTenantId,
+  getTenantIdString,
+} from "~/server/event-sourcing/__tests__/integration/testHelpers";
+import { EventSourcing } from "~/server/event-sourcing/eventSourcing";
+import { EventStoreClickHouse } from "~/server/event-sourcing/stores/eventStoreClickHouse";
+import { EventRepositoryClickHouse } from "~/server/event-sourcing/stores/repositories/eventRepositoryClickHouse";
+import { RecordSpanCommand } from "~/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand";
+import { AssignTopicCommand } from "~/server/event-sourcing/pipelines/trace-processing/commands/assignTopicCommand";
+import { SpanStorageMapProjection } from "~/server/event-sourcing/pipelines/trace-processing/projections/spanStorage.mapProjection";
+import { TraceSummaryFoldProjection } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection";
+import type { TraceProcessingEvent } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
+import { SpanAppendStore } from "~/server/event-sourcing/pipelines/trace-processing/projections/spanStorage.store";
+import { TraceSummaryStore } from "~/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.store";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const otlpRoot = require("@opentelemetry/otlp-transformer/build/src/generated/root");
+const ExportTraceServiceRequest = (otlpRoot as any).opentelemetry.proto
+  .collector.trace.v1.ExportTraceServiceRequest;
+
+// Unique port for this test alongside the other nlpgo subprocess
+// integration tests (55610 / 55611 / 55620 — see CLAUDE.md).
+const NLPGO_PORT = 55612;
+const PARENT_TRACE_ID = "0123456789abcdef0123456789abcdef";
+const PARENT_SPAN_ID = "0011223344556677";
+
+// /langwatch/src/server/nlpgo/__tests__  → up 5 = repo root
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+);
+function hasGo(): boolean {
+  try {
+    execSync("go version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const shouldRun =
+  hasTestcontainers && hasGo() && process.env.SKIP_NLPGO_E2E !== "1";
+
+const noopReactor = { name: "noop", options: {}, handle: async () => {} };
+
+describe.skipIf(!shouldRun)(
+  "nlpgo traceparent — full roundtrip through real event-sourcing pipeline into ClickHouse",
+  () => {
+    let nlpgoProcess: ChildProcess | null = null;
+    let langwatchSrv: http.Server | null = null;
+    let langwatchUrl = "";
+
+    let eventSourcing: EventSourcing;
+    let tracePipeline: {
+      commands: { recordSpan: { send: (data: any) => Promise<void> } };
+      service: { waitUntilReady: () => Promise<void> };
+    };
+    let tenantId: ReturnType<typeof createTestTenantId>;
+    let tenantIdString: string;
+
+    function createTracePipeline() {
+      const clickHouseClient = getTestClickHouseClient();
+      const redisConnection = getTestRedisConnection();
+      if (!clickHouseClient || !redisConnection) {
+        throw new Error("ClickHouse + Redis required.");
+      }
+
+      const eventStore = new EventStoreClickHouse(
+        new EventRepositoryClickHouse(async () => clickHouseClient),
+      );
+      eventSourcing = EventSourcing.createWithStores({
+        eventStore,
+        clickhouse: async () => clickHouseClient,
+        redis: redisConnection,
+        processRole: "worker",
+      });
+
+      const spanAppendStore = new SpanAppendStore(
+        new SpanStorageService(
+          new SpanStorageClickHouseRepository(async () => clickHouseClient),
+        ).repository,
+      );
+      const traceSummaryStore = new TraceSummaryStore(
+        new TraceSummaryService(
+          new TraceSummaryClickHouseRepository(async () => clickHouseClient),
+        ).repository,
+      );
+
+      const pipelineName = `trace_nlpgo_e2e_${Date.now()}_${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+      const pipelineDef = definePipeline<TraceProcessingEvent>()
+        .withName(pipelineName)
+        .withAggregateType("trace" as AggregateType)
+        .withFoldProjection(
+          "traceSummary",
+          new TraceSummaryFoldProjection({ store: traceSummaryStore }) as any,
+        )
+        .withMapProjection(
+          "spanStorage",
+          new SpanStorageMapProjection({ store: spanAppendStore }) as any,
+        )
+        .withReactor("traceSummary", "evaluationTrigger", noopReactor as any)
+        .withReactor("traceSummary", "customEvaluationSync", noopReactor as any)
+        .withReactor("traceSummary", "traceUpdateBroadcast", noopReactor as any)
+        .withReactor(
+          "traceSummary",
+          "simulationMetricsSync",
+          noopReactor as any,
+        )
+        .withReactor("traceSummary", "projectMetadata", noopReactor as any)
+        .withReactor("spanStorage", "spanStorageBroadcast", noopReactor as any)
+        // REAL RecordSpanCommand with no-op PII/cost/token deps —
+        // same pattern as the other event-sourcing integration tests.
+        .withCommand(
+          "recordSpan",
+          class extends RecordSpanCommand {
+            static override readonly schema = RecordSpanCommand.schema;
+            constructor() {
+              super({
+                piiRedactionService: { redactSpan: async () => {} } as any,
+                costEnrichmentService: { enrichSpan: async () => {} } as any,
+                tokenEstimationService: {
+                  estimateSpanTokens: async () => {},
+                } as any,
+              });
+            }
+          } as any,
+        )
+        .withCommand("assignTopic", AssignTopicCommand as any)
+        .build();
+
+      const registered = eventSourcing.register(pipelineDef);
+      return {
+        commands: registered.commands as any,
+        service: registered.service as any,
+      };
+    }
+
+    async function waitForNlpgoHealth(timeoutMs = 90_000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        try {
+          const r = await fetch(`http://127.0.0.1:${NLPGO_PORT}/healthz`);
+          if (r.status === 200 || r.status === 503) return;
+        } catch {
+          // not listening yet
+        }
+        await sleep(500);
+      }
+      throw new Error(
+        `nlpgo did not become healthy within ${timeoutMs}ms — ` +
+          `re-run with NLPGO_TEST_LOG=1 to stream stderr.`,
+      );
+    }
+
+    beforeAll(async () => {
+      // Flush Redis once so reactor-job orphans from prior runs don't
+      // log "Unknown job in global queue" noise (matches the
+      // loopPrevention.reactor.integration.test.ts pattern).
+      const redis = getTestRedisConnection();
+      if (redis) await redis.flushall();
+
+      tracePipeline = createTracePipeline();
+      tenantId = createTestTenantId();
+      tenantIdString = getTenantIdString(tenantId);
+      await tracePipeline.service.waitUntilReady();
+
+      // Trace request collection service wired to the SAME recordSpan
+      // command dispatcher the pipeline uses — so nlpgo's OTLP feeds
+      // straight into the event-sourcing flow that lands in CH.
+      const traceCollection = new TraceRequestCollectionService({
+        dedup: {
+          tryAcquireProcessingLock: async () => true,
+          tryConfirmProcessed: async () => undefined,
+          tryReleaseOnFailure: async () => undefined,
+        } as any,
+        recordSpan: (data) => tracePipeline.commands.recordSpan.send(data),
+      });
+
+      // Fake langwatch HTTP server.
+      //   /api/otel/v1/traces: decode → dispatch into pipeline.
+      //   /api/evaluations/...: canned eval result so the evaluator
+      //     block has somewhere to call.
+      langwatchSrv = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          void (async () => {
+            const body = Buffer.concat(chunks);
+            const url = req.url ?? "";
+            try {
+              if (url.includes("/api/otel/v1/traces")) {
+                const decoded = ExportTraceServiceRequest.decode(
+                  new Uint8Array(body),
+                );
+                await traceCollection.handleOtlpTraceRequest(
+                  tenantIdString,
+                  decoded,
+                  "DISABLED",
+                );
+                res.statusCode = 200;
+                res.setHeader("Content-Type", "application/json");
+                res.end(JSON.stringify({ partialSuccess: {} }));
+                return;
+              }
+              if (
+                url.includes("/api/evaluations/") &&
+                url.endsWith("/evaluate")
+              ) {
+                res.statusCode = 200;
+                res.setHeader("Content-Type", "application/json");
+                res.end(
+                  JSON.stringify({
+                    status: "processed",
+                    score: 1,
+                    passed: true,
+                    details: "ok",
+                  }),
+                );
+                return;
+              }
+              res.statusCode = 404;
+              res.end();
+            } catch (err) {
+              // eslint-disable-next-line no-console
+              console.error("[fake-langwatch] handler failed", err);
+              res.statusCode = 500;
+              res.end();
+            }
+          })();
+        });
+      });
+      await new Promise<void>((resolve) =>
+        langwatchSrv!.listen(0, "127.0.0.1", () => resolve()),
+      );
+      langwatchUrl = `http://127.0.0.1:${(langwatchSrv.address() as AddressInfo).port}`;
+
+      // Spawn nlpgo.
+      nlpgoProcess = spawn("go", ["run", "./cmd/service", "nlpgo"], {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          NLPGO_CHILD_BYPASS: "true",
+          SERVER_ADDR: `:${NLPGO_PORT}`,
+          LANGWATCH_ENDPOINT: langwatchUrl,
+          NLPGO_ENGINE_LANGWATCH_BASE_URL: langwatchUrl,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+      });
+      nlpgoProcess.stderr?.on("data", (chunk: Buffer) => {
+        if (process.env.NLPGO_TEST_LOG === "1") {
+          process.stderr.write(`[nlpgo] ${chunk.toString()}`);
+        }
+      });
+      nlpgoProcess.on("exit", (code, signal) => {
+        if (code !== 0 && code !== null) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `nlpgo exited unexpectedly: code=${code} signal=${signal}`,
+          );
+        }
+      });
+
+      await waitForNlpgoHealth();
+    }, 150_000);
+
+    afterAll(async () => {
+      if (nlpgoProcess?.pid) {
+        const pgid = -nlpgoProcess.pid;
+        try {
+          process.kill(pgid, "SIGTERM");
+        } catch {
+          /* group already gone */
+        }
+        const exited = await Promise.race([
+          new Promise<boolean>((resolve) =>
+            nlpgoProcess!.once("exit", () => resolve(true)),
+          ),
+          sleep(3000).then(() => false),
+        ]);
+        if (!exited) {
+          try {
+            process.kill(pgid, "SIGKILL");
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
+      if (langwatchSrv) {
+        await new Promise<void>((resolve) =>
+          langwatchSrv!.close(() => resolve()),
+        );
+      }
+      if (eventSourcing) {
+        await eventSourcing.close();
+        await sleep(1000);
+      }
+      await cleanupTestDataForTenant(tenantIdString);
+    });
+
+    function makeWorkflowBody(traceId: string) {
+      return {
+        type: "execute_flow",
+        payload: {
+          trace_id: traceId,
+          origin: "evaluation",
+          workflow: {
+            workflow_id: "wf",
+            // Non-empty api_key is load-bearing: nlpgo's TenantRouter
+            // drops spans whose context has no api_key.
+            api_key: "test-key-traceparent-e2e",
+            spec_version: "1.3",
+            name: "x",
+            icon: "x",
+            description: "x",
+            version: "x",
+            template_adapter: "default",
+            nodes: [
+              {
+                id: "entry",
+                type: "entry",
+                data: {
+                  train_size: 1.0,
+                  test_size: 0.0,
+                  seed: 1,
+                  outputs: [
+                    { identifier: "input", type: "str" },
+                    { identifier: "output", type: "str" },
+                  ],
+                  dataset: {
+                    inline: {
+                      records: { input: ["hello"], output: ["hello"] },
+                      count: 1,
+                    },
+                  },
+                },
+              },
+              {
+                id: "eval",
+                type: "evaluator",
+                data: {
+                  parameters: [
+                    {
+                      identifier: "evaluator",
+                      type: "str",
+                      value: "langevals/exact_match",
+                    },
+                  ],
+                },
+              },
+              { id: "end", type: "end", data: {} },
+            ],
+            edges: [
+              {
+                id: "e1",
+                source: "entry",
+                sourceHandle: "input",
+                target: "eval",
+                targetHandle: "input",
+                type: "default",
+              },
+              {
+                id: "e2",
+                source: "entry",
+                sourceHandle: "output",
+                target: "eval",
+                targetHandle: "output",
+                type: "default",
+              },
+              {
+                id: "e3",
+                source: "eval",
+                sourceHandle: "any",
+                target: "end",
+                targetHandle: "any",
+                type: "default",
+              },
+            ],
+            state: {},
+          },
+          inputs: [{ input: "hello", output: "hello" }],
+          manual_execution_mode: false,
+          // do_not_trace=false is the load-bearing bit: with true,
+          // nlpgo's startStudioSpan returns a no-op and the engine's
+          // children create a fresh trace_id (the 2026-05-14 bug).
+          do_not_trace: false,
+          run_evaluations: false,
+          origin: "evaluation",
+        },
+      };
+    }
+
+    it(
+      "every span persisted in ClickHouse shares the inbound trace_id, and at least one links back to the inbound span_id",
+      async () => {
+        const traceparent = `00-${PARENT_TRACE_ID}-${PARENT_SPAN_ID}-01`;
+        const body = makeWorkflowBody(PARENT_TRACE_ID);
+
+        const resp = await fetch(
+          `http://127.0.0.1:${NLPGO_PORT}/go/studio/execute_sync`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              traceparent,
+              "X-LangWatch-Origin": "evaluation",
+              "X-LangWatch-Causality-Depth": "0",
+            },
+            body: JSON.stringify(body),
+          },
+        );
+        const respText = await resp.text();
+        expect(resp.ok, `nlpgo response ${resp.status}: ${respText}`).toBe(
+          true,
+        );
+
+        // Poll ClickHouse for the persisted spans. Two flush windows
+        // chain here: nlpgo's BatchSpanProcessor (5s default) + the
+        // event-sourcing fold/map projection workers (sub-second).
+        // 25s deadline absorbs both with margin.
+        const ch = getTestClickHouseClient()!;
+
+        interface SpanRow {
+          TraceId: string;
+          SpanId: string;
+          ParentSpanId: string | null;
+          SpanName: string;
+        }
+
+        let rows: SpanRow[] = [];
+        const deadline = Date.now() + 25_000;
+        while (Date.now() < deadline && rows.length === 0) {
+          const result = await ch.query({
+            query: `
+              SELECT TraceId, SpanId, ParentSpanId, SpanName
+              FROM stored_spans
+              WHERE TenantId = {tenantId:String}
+                AND TraceId = {traceId:String}
+                AND (TenantId, TraceId, SpanId, UpdatedAt) IN (
+                  SELECT TenantId, TraceId, SpanId, max(UpdatedAt)
+                  FROM stored_spans
+                  WHERE TenantId = {tenantId:String}
+                    AND TraceId = {traceId:String}
+                  GROUP BY TenantId, TraceId, SpanId
+                )
+            `,
+            query_params: {
+              tenantId: tenantIdString,
+              traceId: PARENT_TRACE_ID,
+            },
+            format: "JSONEachRow",
+          });
+          rows = await result.json<SpanRow>();
+          if (rows.length === 0) await sleep(500);
+        }
+
+        // CORE ASSERTION 1 — spans landed in CH under the INBOUND trace_id.
+        // Pre-fix, this query would return zero rows because nlpgo
+        // had emitted them under a fresh trace_id.
+        expect(
+          rows.length,
+          `no spans landed in CH under the inbound trace_id ${PARENT_TRACE_ID} — ` +
+            `nlpgo either didn't emit OTLP or emitted them under a different trace_id (the 2026-05-14 bug)`,
+        ).toBeGreaterThan(0);
+
+        // CORE ASSERTION 2 — every row matches the inbound trace_id.
+        // (Defense in depth — the query filter already enforces this,
+        // but pin it as a behavioral contract anyway.)
+        for (const row of rows) {
+          expect(row.TraceId.toLowerCase()).toBe(PARENT_TRACE_ID);
+        }
+
+        // CORE ASSERTION 3 — at least one span has parent_span_id
+        // matching the inbound span_id. This is the load-bearing
+        // claim: in Studio's waterfall the eval workflow's root span
+        // renders as a child of the parent trace's root span.
+        const linkedToParent = rows.filter(
+          (r) => (r.ParentSpanId ?? "").toLowerCase() === PARENT_SPAN_ID,
+        );
+        expect(
+          linkedToParent.length,
+          `no span has ParentSpanId == inbound ${PARENT_SPAN_ID} — ` +
+            `startStudioSpan failed to extract the W3C parent context. ` +
+            `Spans seen: ${rows
+              .map((r) => `${r.SpanName}(parent=${r.ParentSpanId ?? "<root>"})`)
+              .join(", ")}`,
+        ).toBeGreaterThan(0);
+      },
+      90_000,
+    );
+  },
+);

--- a/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
@@ -30,18 +30,18 @@
  * wire format but doesn't prove the spans actually survive the
  * roundtrip and land where Studio queries them.
  *
- * Opt-in: this test spawns a real Go subprocess (`go run`), which on
- * a cold module cache takes well over CI's nlpgo-health budget. It is
- * therefore skipped unless explicitly enabled via NLPGO_E2E=1. Run it
- * locally to validate the full roundtrip before shipping pipeline /
- * traceparent / OTLP changes.
+ * Cost amortization: `go run ./cmd/service` recompiles on every call,
+ * which on CI's cold module cache exceeds any reasonable health-poll
+ * budget. Instead we `go build` the binary ONCE per test process into
+ * a cached path under the repo's .vitest-tmp/ and exec it directly —
+ * the compiled binary boots in ~1s.
  *
  * Skipped when ANY of:
- *   - NLPGO_E2E is not "1"
  *   - `go` is not on PATH
  *   - testcontainers Redis + ClickHouse are not running
  */
 import { execSync, spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
@@ -103,8 +103,90 @@ function hasGo(): boolean {
     return false;
   }
 }
-const shouldRun =
-  process.env.NLPGO_E2E === "1" && hasTestcontainers && hasGo();
+const shouldRun = hasTestcontainers && hasGo();
+
+// Cached compiled binary. Lives under the repo's .vitest-tmp/ so a
+// single CI shard or local re-run reuses the build artifact across
+// vitest restarts. `os.tmpdir()` would work too, but keeping it inside
+// the repo means `make clean` / artifact cleanup picks it up.
+const NLPGO_TEST_BIN_DIR = path.join(REPO_ROOT, "langwatch", ".vitest-tmp");
+const NLPGO_TEST_BIN = path.join(
+  NLPGO_TEST_BIN_DIR,
+  process.platform === "win32" ? "nlpgo-test.exe" : "nlpgo-test",
+);
+
+/**
+ * Builds the nlpgo binary once and caches it on disk. Subsequent calls
+ * skip the build if the cached binary is newer than the most-recently
+ * modified .go source file under services/nlpgo (cheap staleness check
+ * matching what `go build` itself would conclude).
+ *
+ * Returns the absolute path to the binary.
+ */
+function ensureNlpgoBinary(timeoutMs = 600_000): string {
+  fs.mkdirSync(NLPGO_TEST_BIN_DIR, { recursive: true });
+
+  // Cheap staleness check: rebuild if any .go file under services/nlpgo
+  // or cmd/service is newer than the cached binary's mtime.
+  let cachedMtime = 0;
+  try {
+    cachedMtime = fs.statSync(NLPGO_TEST_BIN).mtimeMs;
+  } catch {
+    cachedMtime = 0;
+  }
+  const watchDirs = [
+    path.join(REPO_ROOT, "services", "nlpgo"),
+    path.join(REPO_ROOT, "cmd", "service"),
+    path.join(REPO_ROOT, "pkg"),
+  ].filter((p) => fs.existsSync(p));
+
+  function newestGoMtime(dir: string): number {
+    let newest = 0;
+    const stack = [dir];
+    while (stack.length) {
+      const d = stack.pop()!;
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(d, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const e of entries) {
+        const full = path.join(d, e.name);
+        if (e.isDirectory()) {
+          if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+          stack.push(full);
+        } else if (e.name.endsWith(".go") || e.name === "go.mod" || e.name === "go.sum") {
+          try {
+            const m = fs.statSync(full).mtimeMs;
+            if (m > newest) newest = m;
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    }
+    return newest;
+  }
+
+  const newestSrcMtime = watchDirs.reduce(
+    (acc, d) => Math.max(acc, newestGoMtime(d)),
+    0,
+  );
+
+  if (cachedMtime > 0 && newestSrcMtime <= cachedMtime) {
+    return NLPGO_TEST_BIN;
+  }
+
+  // Cold/stale: actually compile. `go build` honours module cache, so
+  // back-to-back runs in the same CI job are fast even after the first.
+  execSync(`go build -o ${NLPGO_TEST_BIN} ./cmd/service`, {
+    cwd: REPO_ROOT,
+    stdio: process.env.NLPGO_TEST_LOG === "1" ? "inherit" : "pipe",
+    timeout: timeoutMs,
+  });
+  return NLPGO_TEST_BIN;
+}
 
 const noopReactor = { name: "noop", options: {}, handle: async () => {} };
 
@@ -313,8 +395,13 @@ describe.skipIf(!shouldRun)(
       );
       langwatchUrl = `http://127.0.0.1:${(langwatchSrv.address() as AddressInfo).port}`;
 
-      // Spawn nlpgo.
-      nlpgoProcess = spawn("go", ["run", "./cmd/service", "nlpgo"], {
+      // Build nlpgo (cached). The build itself can take a couple of
+      // minutes on a cold CI module cache; subsequent runs in the same
+      // job are near-instant because of the staleness check.
+      const binary = ensureNlpgoBinary();
+
+      // Spawn the pre-built binary. It boots in ~1s.
+      nlpgoProcess = spawn(binary, ["nlpgo"], {
         cwd: REPO_ROOT,
         env: {
           ...process.env,
@@ -344,8 +431,10 @@ describe.skipIf(!shouldRun)(
         }
       });
 
-      await waitForNlpgoHealth();
-    }, 150_000);
+      // Health check on the pre-built binary — boots in ~1s, give it
+      // 30s on a slow CI runner.
+      await waitForNlpgoHealth(30_000);
+    }, 700_000); // build (up to 600s cold) + boot + health window
 
     afterAll(async () => {
       if (nlpgoProcess?.pid) {

--- a/langwatch/src/server/nlpgo/nlpgoFetch.ts
+++ b/langwatch/src/server/nlpgo/nlpgoFetch.ts
@@ -32,12 +32,20 @@ const SPAN_ID_HEX_RE = /^[0-9a-fA-F]{16}$/;
  * than silently emitting a broken header (silent breakage = orphan
  * traces in prod, the exact failure mode we're fixing).
  *
+ * The `sampled` flag defaults to true because every existing caller
+ * is in the evaluator chain, where we always want to record. If a
+ * future caller is propagating from a non-sampled inbound trace, it
+ * MUST pass `sampled: false` so we don't force-sample downstream.
+ *
  * Exported for unit tests.
  */
-export function formatTraceparent(parent: {
-  traceId: string;
-  parentSpanId: string;
-}): string {
+export function formatTraceparent(
+  parent: {
+    traceId: string;
+    parentSpanId: string;
+  },
+  options: { sampled?: boolean } = {},
+): string {
   if (!TRACE_ID_HEX_RE.test(parent.traceId)) {
     throw new Error(
       `nlpgoFetch.formatTraceparent: invalid traceId (need 32 hex chars), got: ${JSON.stringify(parent.traceId)}`,
@@ -48,7 +56,8 @@ export function formatTraceparent(parent: {
       `nlpgoFetch.formatTraceparent: invalid parentSpanId (need 16 hex chars), got: ${JSON.stringify(parent.parentSpanId)}`,
     );
   }
-  return `00-${parent.traceId.toLowerCase()}-${parent.parentSpanId.toLowerCase()}-01`;
+  const flags = options.sampled === false ? "00" : "01";
+  return `00-${parent.traceId.toLowerCase()}-${parent.parentSpanId.toLowerCase()}-${flags}`;
 }
 
 export interface NLPGOFetchOptions<TBody = unknown> {

--- a/langwatch/src/server/nlpgo/nlpgoFetch.ts
+++ b/langwatch/src/server/nlpgo/nlpgoFetch.ts
@@ -23,6 +23,34 @@ export type NLPOrigin =
  */
 const NLP_GO_FLAG = "release_nlp_go_engine_enabled";
 
+const TRACE_ID_HEX_RE = /^[0-9a-fA-F]{32}$/;
+const SPAN_ID_HEX_RE = /^[0-9a-fA-F]{16}$/;
+
+/**
+ * Format a W3C `traceparent` header value. Validates that traceId and
+ * parentSpanId are well-formed hex; throws on malformed input rather
+ * than silently emitting a broken header (silent breakage = orphan
+ * traces in prod, the exact failure mode we're fixing).
+ *
+ * Exported for unit tests.
+ */
+export function formatTraceparent(parent: {
+  traceId: string;
+  parentSpanId: string;
+}): string {
+  if (!TRACE_ID_HEX_RE.test(parent.traceId)) {
+    throw new Error(
+      `nlpgoFetch.formatTraceparent: invalid traceId (need 32 hex chars), got: ${JSON.stringify(parent.traceId)}`,
+    );
+  }
+  if (!SPAN_ID_HEX_RE.test(parent.parentSpanId)) {
+    throw new Error(
+      `nlpgoFetch.formatTraceparent: invalid parentSpanId (need 16 hex chars), got: ${JSON.stringify(parent.parentSpanId)}`,
+    );
+  }
+  return `00-${parent.traceId.toLowerCase()}-${parent.parentSpanId.toLowerCase()}-01`;
+}
+
 export interface NLPGOFetchOptions<TBody = unknown> {
   /** projectId is the distinct_id used for the per-project flag rollout. */
   projectId: string;
@@ -48,6 +76,27 @@ export interface NLPGOFetchOptions<TBody = unknown> {
    * on its spans in that case.
    */
   causalityDepth?: number;
+  /**
+   * Parent trace context for W3C `traceparent` propagation. When set,
+   * nlpgo's spans inherit `traceId` so the eval workflow appears as
+   * a child sub-tree of the parent trace in Studio's waterfall view
+   * instead of landing on a separate trace.
+   *
+   * Without this, nlpgo's `applyInboundCausality` finds no traceparent
+   * header, `startStudioSpan` falls through to a fresh trace, and
+   * eval spans become orphans of the original trace they evaluate.
+   * This is exactly the bug rchaves caught in prod on 2026-05-14
+   * (eval ran, spans emitted, but landed on a new trace_id).
+   *
+   * `parentSpanId` is the 16-hex span_id the eval root span should
+   * link to as its parent. Callers should pass the root span_id of
+   * the parent trace so the waterfall renders cleanly; a synthesized
+   * value still gives trace_id continuity but loses the linkage UI.
+   */
+  parentTrace?: {
+    traceId: string;
+    parentSpanId: string;
+  };
 }
 
 export interface NLPGOFetchResult<T> {
@@ -99,6 +148,15 @@ export async function nlpgoFetch<T = unknown>(
   if (opts.causalityDepth !== undefined) {
     const callerDepth = Math.max(0, Math.floor(opts.causalityDepth));
     headers["X-LangWatch-Causality-Depth"] = String(callerDepth);
+  }
+
+  // W3C traceparent — makes the receiving service's spans inherit our
+  // trace_id and parent_span_id. Without this header, nlpgo creates a
+  // new trace_id for the evaluation, breaking the parent-child link
+  // (the 2026-05-14 orphan-trace bug rchaves caught in prod).
+  // Format: 00-<32-hex traceId>-<16-hex parentSpanId>-<flags>
+  if (opts.parentTrace) {
+    headers["traceparent"] = formatTraceparent(opts.parentTrace);
   }
 
   const functionArn = process.env.LANGWATCH_NLP_LAMBDA_CONFIG

--- a/langwatch/src/server/routes/__tests__/playground-proxy.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/playground-proxy.integration.test.ts
@@ -35,7 +35,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // (which would put aigateway on :5573 by the +N*10 convention). High
 // enough not to clash with any normal dev server or another test slot.
 const NLPGO_PORT = 55620;
-const REPO_ROOT = path.resolve(__dirname, "../../../../../..");
+// /langwatch/src/server/routes/__tests__  → up 5 = repo root.
+// Was 6 historically; "directory not found" on `go run ./cmd/service`
+// whenever OPENAI_API_KEY happened to be set in the test env.
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
 
 let nlpgoProcess: ChildProcess | null = null;
 

--- a/langwatch/src/server/workflows/runWorkflow.ts
+++ b/langwatch/src/server/workflows/runWorkflow.ts
@@ -106,6 +106,7 @@ export async function runEvaluationWorkflow(
   inputs: Record<string, string>,
   versionId?: string,
   causalityDepth?: number,
+  parentTrace?: { traceId: string; parentSpanId: string },
 ): Promise<{
   result: SingleEvaluationResult;
   status: ExecutionStatus;
@@ -116,13 +117,24 @@ export async function runEvaluationWorkflow(
       projectId,
       inputs,
       versionId,
-      true, // do_not_trace
+      // do_not_trace=false: we WANT the evaluator's spans to land on
+      // the parent trace so they show in Studio's waterfall as a
+      // child sub-tree. This was historically `true` to avoid an
+      // eval-of-eval loop (pre-2026-05-11 fix), but loop prevention
+      // now lives in the depth-attribute reactor — the do_not_trace
+      // path is now actively harmful: it skips parent-context setup
+      // in nlpgo's startStudioSpan so eval child spans (LLM calls,
+      // execute_component) get a fresh trace_id and land as a
+      // separate orphan trace. See the 2026-05-14 prod regression
+      // reported by rchaves.
+      false, // do_not_trace
       false, // run_evaluations - disable evaluators inside the workflow when running as an online evaluation
       "evaluation",
       // Always pass a concrete depth (default 0) so the downstream
       // header gate in nlpgoFetch sees this as an evaluator-chain call
       // even when the parent had no depth attribute yet.
       causalityDepth ?? 0,
+      parentTrace,
     );
 
     // Process the result
@@ -168,6 +180,7 @@ export async function runWorkflow(
   run_evaluations?: boolean,
   origin: NLPOrigin = "workflow",
   causalityDepth?: number,
+  parentTrace?: { traceId: string; parentSpanId: string },
 ) {
   const workflow = await prisma.workflow.findUnique({
     where: { id: workflowId, projectId },
@@ -231,6 +244,7 @@ export async function runWorkflow(
     body: event,
     origin,
     causalityDepth,
+    parentTrace,
   });
 
   if (!response.ok) {

--- a/services/nlpgo/tests/integration/causality_propagation_test.go
+++ b/services/nlpgo/tests/integration/causality_propagation_test.go
@@ -1,0 +1,378 @@
+// Component integration test for W3C trace-context + causality-depth
+// propagation INSIDE nlpgo.
+//
+// Scope: this is NOT an e2e test. It runs nlpgo's router + engine +
+// evaluator-block IN-PROCESS via httptest, stamps the production OTel
+// stack onto the global tracer/propagator, captures spans via a
+// SpanRecorder, and asserts on the propagation chain WITHIN nlpgo's
+// process boundary. The downstream half — OTLP roundtrip into
+// langwatch's event-sourcing pipeline, ClickHouse persistence,
+// evaluationTrigger reactor block — is covered by the langwatch-side
+// e2e test, not here.
+//
+// What this test DOES prove (all internal to nlpgo):
+//   1. POSTing /go/studio/execute_sync with `traceparent` makes the
+//      emitted spans share the inbound trace_id within the process.
+//   2. The studio root span's parent_span_id equals the inbound
+//      traceparent's span_id (parent linkage, not a fresh root).
+//   3. EVERY in-process span emitted during the run — root, children
+//      across goroutines — carries `langwatch.reserved.causality_depth`
+//      stamped from baggage by BaggageAttributeProcessor.
+//   4. The outbound HTTP call from evaluatorblock to the (fake)
+//      LangWatch app carries `traceparent` + `baggage` +
+//      `X-LangWatch-Causality-Depth` headers, with the same trace_id
+//      we started with.
+//
+// What this test does NOT prove (handled by the langwatch-side e2e):
+//   - Spans survive OTLP serialization and reach a real collector.
+//   - ClickHouse stores the depth attribute on the span row.
+//   - The TS evaluationTrigger reactor actually reads it and blocks
+//     re-dispatch on the real pipeline.
+//
+// Wiring matches production (NewBaggageAttributeProcessor from
+// pkg/otelsetup, the TraceContext+Baggage composite propagator), so a
+// regression in any of: applyInboundCausality, startStudioSpan,
+// BaggageAttributeProcessor, or the evaluatorblock propagator inject
+// will still surface here.
+
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	otelapi "go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/langwatch/langwatch/pkg/health"
+	"github.com/langwatch/langwatch/pkg/otelsetup"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/httpapi"
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/agentblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/codeblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/evaluatorblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
+)
+
+// installProductionTracerStack swaps in the same SpanProcessor +
+// TextMapPropagator combo that pkg/otelsetup configures on prod boot,
+// using a SpanRecorder as the underlying exporter so tests can observe
+// emitted spans. The previous global tracer/propagator is restored on
+// t.Cleanup so concurrent test files don't leak state into each other.
+func installProductionTracerStack(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		// The BaggageAttributeProcessor is the LOAD-BEARING piece for
+		// loop prevention: it stamps every span at OnStart with the
+		// causality_depth value carried via context baggage. Without
+		// this, only the root span set by startStudioSpan would have the
+		// attribute, and child spans emitted from goroutines would slip
+		// through the reactor's depth check.
+		sdktrace.WithSpanProcessor(otelsetup.NewBaggageAttributeProcessor(
+			otelsetup.AutoStampedBaggageKeys...,
+		)),
+		sdktrace.WithSpanProcessor(rec),
+	)
+	prevTP := otelapi.GetTracerProvider()
+	otelapi.SetTracerProvider(tp)
+
+	// The composite TraceContext + Baggage propagator is what makes
+	// applyInboundCausality see the inbound `traceparent` AND lets the
+	// evaluator-block outbound HTTP inject both headers on egress.
+	prevProp := otelapi.GetTextMapPropagator()
+	otelapi.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	t.Cleanup(func() {
+		otelapi.SetTracerProvider(prevTP)
+		otelapi.SetTextMapPropagator(prevProp)
+	})
+	return rec
+}
+
+// capturedRequest is what setupCausalityStack records about each
+// outbound call the evaluator-block makes to the (fake) LangWatch app.
+// We snapshot exactly what we'll assert against — header values and the
+// body — so the test stays decoupled from the http.Request lifecycle.
+type capturedRequest struct {
+	path                string
+	traceparent         string
+	baggage             string
+	depthHeader         string
+	xLangwatchTraceID   string
+}
+
+func setupCausalityStack(t *testing.T) (url string, captured *[]capturedRequest) {
+	t.Helper()
+	requests := []capturedRequest{}
+	out := &requests
+
+	// Fake LangWatch evaluator server — receives the outbound call from
+	// evaluatorblock. We capture the propagation headers as they
+	// arrive on the wire.
+	lwSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, capturedRequest{
+			path:              r.URL.Path,
+			traceparent:       r.Header.Get("traceparent"),
+			baggage:           r.Header.Get("baggage"),
+			depthHeader:       r.Header.Get(httpapi.CausalityDepthHeader),
+			xLangwatchTraceID: r.Header.Get("X-LangWatch-Trace-Id"),
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "processed",
+			"score":  1.0,
+			"passed": true,
+		})
+	}))
+	t.Cleanup(lwSrv.Close)
+
+	httpExec := httpblock.New(httpblock.Options{})
+	codeExec, err := codeblock.New(codeblock.Options{})
+	require.NoError(t, err)
+	evalExec := evaluatorblock.New(evaluatorblock.Options{})
+	agentRunner := agentblock.NewWorkflowRunner(agentblock.WorkflowRunnerOptions{})
+
+	eng := engine.New(engine.Options{
+		HTTP:             httpExec,
+		Code:             codeExec,
+		Evaluator:        evalExec,
+		AgentWorkflow:    agentRunner,
+		LangWatchBaseURL: lwSrv.URL,
+	})
+
+	application := app.New(app.WithWorkflowExecutor(executorAdapter{eng: eng}))
+	probes := health.New("test")
+	probes.MarkStarted()
+	router := httpapi.NewRouter(httpapi.RouterDeps{
+		App:     application,
+		Health:  probes,
+		Version: "test",
+	})
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	return srv.URL, out
+}
+
+// minimalEvaluatorWorkflow — entry → evaluator → end with one record.
+// Re-used across the propagation scenarios; the workflow itself isn't
+// the SUT, the trace propagation through it is.
+const minimalEvaluatorWorkflow = `{
+  "trace_id": "trace_existing_from_body",
+  "origin": "evaluation",
+  "workflow": {
+    "workflow_id":"wf","api_key":"sk-test","spec_version":"1.3","name":"x","icon":"x","description":"x","version":"x",
+    "template_adapter":"default",
+    "nodes":[
+      {"id":"entry","type":"entry","data":{"train_size":1.0,"test_size":0.0,"seed":1,
+        "outputs":[{"identifier":"input","type":"str"},{"identifier":"output","type":"str"}],
+        "dataset":{"inline":{"records":{"input":["hello"],"output":["hello"]},"count":1}}}},
+      {"id":"eval","type":"evaluator","data":{
+        "parameters":[
+          {"identifier":"evaluator","type":"str","value":"langevals/exact_match"}
+        ]}},
+      {"id":"end","type":"end","data":{}}
+    ],
+    "edges":[
+      {"id":"e1","source":"entry","sourceHandle":"input","target":"eval","targetHandle":"input","type":"default"},
+      {"id":"e2","source":"entry","sourceHandle":"output","target":"eval","targetHandle":"output","type":"default"},
+      {"id":"e3","source":"eval","sourceHandle":"any","target":"end","targetHandle":"any","type":"default"}
+    ],
+    "state":{}
+  }
+}`
+
+// postWithTraceContext POSTs the request carrying a W3C traceparent +
+// X-LangWatch-Causality-Depth header. Returns nothing — assertions are
+// done against the SpanRecorder and captured outbound requests.
+func postWithTraceContext(
+	t *testing.T,
+	url, body, inboundTraceID, inboundSpanID string,
+	inboundDepth int,
+) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url+"/go/studio/execute_sync", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-LangWatch-Origin", "evaluation")
+	req.Header.Set("traceparent", "00-"+inboundTraceID+"-"+inboundSpanID+"-01")
+	req.Header.Set(httpapi.CausalityDepthHeader, itoaTest(inboundDepth))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", string(respBody))
+}
+
+// itoaTest avoids a strconv import just to format depth values in this
+// one helper. Hand-rolling keeps the import surface minimal so future
+// refactors don't have to think about it.
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	if n == 1 {
+		return "1"
+	}
+	// We only ever pass 0/1 in this test today. Defensive: fall through
+	// to a single-digit decimal so a future caller doesn't silently
+	// stringify garbage.
+	return string(rune('0' + (n % 10)))
+}
+
+/** @scenario nlpgo handler extracts traceparent header and continues parent trace */
+func TestCausalityPropagation_RootSpanContinuesParentTrace(t *testing.T) {
+	rec := installProductionTracerStack(t)
+	url, _ := setupCausalityStack(t)
+
+	const inboundTraceID = "0af7651916cd43dd8448eb211c80319c"
+	const inboundSpanID = "b7ad6b7169203331"
+	postWithTraceContext(t, url, minimalEvaluatorWorkflow, inboundTraceID, inboundSpanID, 0)
+
+	ended := rec.Ended()
+	require.NotEmpty(t, ended, "expected at least one span recorded; got 0")
+
+	// Find the studio root span by name. startStudioSpan calls
+	// tracer.Start with kind=SpanKindServer; identify it by parent
+	// (its parent should be the REMOTE inbound span context).
+	var rootStudioSpan sdktrace.ReadOnlySpan
+	for _, s := range ended {
+		if s.Parent().IsValid() && s.Parent().IsRemote() {
+			rootStudioSpan = s
+			break
+		}
+	}
+	require.NotNil(t, rootStudioSpan,
+		"no studio root span found with a remote parent — applyInboundCausality "+
+			"did not extract the inbound traceparent into ctx, or startStudioSpan "+
+			"started a fresh trace instead of continuing the inbound one")
+
+	assert.Equal(t, inboundTraceID, rootStudioSpan.SpanContext().TraceID().String(),
+		"studio root span trace_id must equal inbound traceparent's trace-id")
+	assert.Equal(t, inboundSpanID, rootStudioSpan.Parent().SpanID().String(),
+		"studio root span's parent span_id must equal inbound traceparent's span-id")
+}
+
+/** @scenario Every span emitted during an nlpgo evaluator run carries causality_depth via SpanProcessor */
+func TestCausalityPropagation_AllSpansShareTraceIDAndCarryDepth(t *testing.T) {
+	rec := installProductionTracerStack(t)
+	url, _ := setupCausalityStack(t)
+
+	const inboundTraceID = "11112222333344445555666677778888"
+	const inboundSpanID = "aaaabbbbccccdddd"
+	postWithTraceContext(t, url, minimalEvaluatorWorkflow, inboundTraceID, inboundSpanID, 0)
+
+	ended := rec.Ended()
+	require.GreaterOrEqual(t, len(ended), 2,
+		"expected the studio root span and at least one child span (eval node); got %d",
+		len(ended))
+
+	// Every recorded span must share the inbound trace_id.
+	for _, s := range ended {
+		if got := s.SpanContext().TraceID().String(); got != inboundTraceID {
+			t.Errorf("span %q has trace_id %s, want %s — trace context did not propagate through engine goroutines",
+				s.Name(), got, inboundTraceID)
+		}
+	}
+
+	// Every recorded span must carry langwatch.reserved.causality_depth = "1"
+	// (inbound was 0 → handler stamps incoming+1 onto baggage; the
+	// BaggageAttributeProcessor stamps the attribute on every span via
+	// OnStart, not just root).
+	for _, s := range ended {
+		var found bool
+		var value string
+		for _, attr := range s.Attributes() {
+			if string(attr.Key) == otelsetup.BaggageKeyCausalityDepth {
+				found = true
+				value = attr.Value.AsString()
+				break
+			}
+		}
+		if !found {
+			t.Errorf("span %q missing %s attribute — BaggageAttributeProcessor did not stamp it",
+				s.Name(), otelsetup.BaggageKeyCausalityDepth)
+			continue
+		}
+		if value != "1" {
+			t.Errorf("span %q has %s=%s, want \"1\" (inbound 0 + 1)",
+				s.Name(), otelsetup.BaggageKeyCausalityDepth, value)
+		}
+	}
+}
+
+/** @scenario Outbound HTTP from nlpgo evaluator block carries traceparent + baggage + depth header */
+func TestCausalityPropagation_OutboundHTTPInjectsTraceparentAndDepth(t *testing.T) {
+	_ = installProductionTracerStack(t)
+	url, captured := setupCausalityStack(t)
+
+	const inboundTraceID = "0123456789abcdef0123456789abcdef"
+	const inboundSpanID = "0011223344556677"
+	postWithTraceContext(t, url, minimalEvaluatorWorkflow, inboundTraceID, inboundSpanID, 0)
+
+	require.Len(t, *captured, 1,
+		"expected exactly one outbound call to the fake LangWatch app, got %d", len(*captured))
+	rec := (*captured)[0]
+
+	// 1. traceparent must be set and share the inbound trace_id.
+	require.NotEmpty(t, rec.traceparent,
+		"evaluatorblock did not inject traceparent on the outbound request — "+
+			"OTel propagator was not invoked or context lost the span")
+	// W3C format: 00-<32-hex tid>-<16-hex sid>-<flags>
+	parts := strings.Split(rec.traceparent, "-")
+	require.Len(t, parts, 4, "malformed traceparent %q", rec.traceparent)
+	assert.Equal(t, inboundTraceID, parts[1],
+		"outbound traceparent trace-id must equal the inbound trace-id we started with")
+
+	// 2. baggage header must contain the causality_depth member.
+	require.NotEmpty(t, rec.baggage, "baggage header missing on outbound request")
+	assert.Contains(t, rec.baggage, otelsetup.BaggageKeyCausalityDepth,
+		"baggage header is missing the causality_depth member — Baggage propagator not applied")
+
+	// 3. X-LangWatch-Causality-Depth header set to current (1) for
+	//    non-OTel consumers (the langwatch app's collector reads this
+	//    plain header to feed the dispatcher's reactor).
+	assert.Equal(t, "1", rec.depthHeader,
+		"X-LangWatch-Causality-Depth header must be \"1\" — incoming 0 + 1")
+}
+
+// Confirm Span.SpanContextConfig.Remote → ReadOnlySpan.Parent().IsRemote()
+// is the property we expect to use as the "this is the root continuing a
+// remote trace" heuristic. Trivial sanity test; cheap to keep so a
+// refactor in tracetest can't silently invalidate the bigger tests.
+func TestCausalityPropagation_SanityCheckParentIsRemoteFlag(t *testing.T) {
+	rec := installProductionTracerStack(t)
+
+	tracer := otelapi.Tracer("sanity")
+	ctx := trace.ContextWithSpanContext(t.Context(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		SpanID:     trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	}))
+	_, span := tracer.Start(ctx, "child-of-remote")
+	span.End()
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+	assert.True(t, ended[0].Parent().IsRemote(),
+		"sanity: a span started under a remote SpanContext must report Parent().IsRemote() = true")
+}

--- a/services/nlpgo/tests/integration/causality_propagation_test.go
+++ b/services/nlpgo/tests/integration/causality_propagation_test.go
@@ -255,7 +255,7 @@ func TestCausalityPropagation_RootSpanContinuesParentTrace(t *testing.T) {
 	// (its parent should be the REMOTE inbound span context).
 	var rootStudioSpan sdktrace.ReadOnlySpan
 	for _, s := range ended {
-		if s.Parent().IsValid() && s.Parent().IsRemote() {
+		if s.SpanKind() == trace.SpanKindServer && s.Parent().IsValid() && s.Parent().IsRemote() {
 			rootStudioSpan = s
 			break
 		}

--- a/specs/monitors/online-evaluator-loop-prevention.feature
+++ b/specs/monitors/online-evaluator-loop-prevention.feature
@@ -91,6 +91,50 @@ Feature: Online-evaluator infinite-loop prevention
     And a warning is logged that the guard is disabled
 
   # ============================================================================
+  # TS-side dispatch: traceparent + parent-span context propagation to nlpgo.
+  #
+  # The eval-execution service runs in TS. It calls nlpgoFetch to dispatch
+  # the eval workflow. For nlpgo's emitted spans to land as children of the
+  # parent trace (not as a separate orphan trace — the 2026-05-14 prod bug),
+  # nlpgoFetch must send a valid W3C `traceparent` header derived from the
+  # parent trace's root span.
+  # ============================================================================
+
+  @unit @loop-prevention @traceparent
+  Scenario: formatTraceparent builds a valid W3C traceparent header
+    Given traceId is a 32-hex string
+    And parentSpanId is a 16-hex string
+    When formatTraceparent is called
+    Then the result is "00-<traceId>-<parentSpanId>-01"
+
+  @unit @loop-prevention @traceparent
+  Scenario: formatTraceparent rejects malformed traceId
+    Given a non-32-hex traceId
+    When formatTraceparent is called
+    Then it throws (loud failure — silent broken header would orphan traces in prod)
+
+  @unit @loop-prevention @traceparent
+  Scenario: formatTraceparent rejects malformed parentSpanId
+    Given a non-16-hex parentSpanId
+    When formatTraceparent is called
+    Then it throws
+
+  @unit @loop-prevention @traceparent
+  Scenario: extractParentTraceForNlpgo returns context for valid OTel trace
+    Given the parent trace has a 32-hex trace_id and a 16-hex root span_id
+    When extractParentTraceForNlpgo runs
+    Then it returns the lowercased trace_id and root span_id
+
+  @unit @loop-prevention @traceparent
+  Scenario: extractParentTraceForNlpgo returns undefined for legacy trace_id shapes
+    Given the parent trace has a legacy trace_<nanoid> trace_id
+    When extractParentTraceForNlpgo runs
+    Then it returns undefined
+    # nlpgo falls back to body-supplied trace_id when no traceparent header
+    # arrives — better than synthesizing a parent_span_id that would
+    # render under a non-existent span in Studio's waterfall.
+
+  # ============================================================================
   # nlpgo-side guarantees (Go tests live in services/nlpgo/...)
   # ============================================================================
 

--- a/specs/monitors/online-evaluator-loop-prevention.feature
+++ b/specs/monitors/online-evaluator-loop-prevention.feature
@@ -60,6 +60,17 @@ Feature: Online-evaluator infinite-loop prevention
     When the evaluationTrigger reactor fires for this event
     Then one executeEvaluation command is dispatched per monitor
 
+  @integration @loop-prevention @depth-direct
+  Scenario: Causality guard is per-span — fresh app activity still re-triggers
+    Given a span_received event arrives with depth=0 and the reactor dispatches evaluation
+    And a second span_received event arrives on the same trace with depth=1
+    And the reactor blocks dispatch for the depth=1 event
+    When a third span_received event arrives on the same trace with depth=0
+    Then the reactor dispatches evaluation again for the third event
+    # The guard is per-span, not per-trace. New legitimate app activity on
+    # an already-evaluated trace must still trigger evaluation — only the
+    # evaluator's own emitted spans (depth>=1) are blocked.
+
   @integration @unit @loop-prevention @kill-switch
   Scenario: LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD bypasses depth check
     Given the env var "LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD" is set to "1"

--- a/specs/monitors/online-evaluator-loop-prevention.feature
+++ b/specs/monitors/online-evaluator-loop-prevention.feature
@@ -71,6 +71,17 @@ Feature: Online-evaluator infinite-loop prevention
     # an already-evaluated trace must still trigger evaluation — only the
     # evaluator's own emitted spans (depth>=1) are blocked.
 
+  @unit @loop-prevention @depth-direct
+  Scenario: Reserved causality_depth attribute passes through strip
+    Given recordSpan strips user-submitted langwatch.reserved.* attributes
+    When a span arrives carrying langwatch.reserved.causality_depth=1
+    Then the attribute survives stripping
+    And the emitted span_received event carries the depth attribute
+    # The original 2026-05-11 fix was silently disabled in production
+    # because recordSpan's strip nuked the very attribute the reactor
+    # uses for loop detection. The fix adds a narrow passthrough
+    # allowlist; this scenario pins the attribute name as load-bearing.
+
   @integration @unit @loop-prevention @kill-switch
   Scenario: LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD bypasses depth check
     Given the env var "LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD" is set to "1"

--- a/specs/trace-processing/io-accumulation.feature
+++ b/specs/trace-processing/io-accumulation.feature
@@ -1,0 +1,32 @@
+Feature: Trace I/O accumulation — human-readable summary text
+  As an operator scanning trace summaries in the Studio
+  I want the input/output columns to show the extracted text from
+  message-shaped payloads, not the raw JSON wrapper
+  So that the summary surface is actually readable.
+
+  # Why this exists — 2026-05-14 prod regression
+  #
+  # nlpgo's workflow evaluators emit `langwatch.output` as a wrapper
+  # object like `{"output":"Hey there"}`. The IO extraction service
+  # ran `messagesToText` / `extractTextFromPlainJson` to pull out
+  # the clean text into `outputResult.text`, but the accumulator
+  # ignored that field and `JSON.stringify(outputResult.raw)` instead.
+  # Result: trace summaries showed `{"output":"Hey there"}` to users
+  # instead of `Hey there`.
+
+  Background:
+    Given the trace-processing pipeline is folding span events
+
+  @unit @trace-summary
+  Scenario: Accumulator uses extracted text not raw JSON wrapper
+    Given a span has `langwatch.output` = `{"output":"Hey there"}`
+    And the IO extraction service unwraps it into text "Hey there"
+    When the IO accumulator folds the span into the trace summary
+    Then computedOutput is "Hey there" (not the JSON wrapper)
+
+  @unit @trace-summary
+  Scenario: Accumulator falls back to raw stringification when no text extracted
+    Given a span has a wrapper of an unknown shape
+    And the IO extraction service returns empty text
+    When the IO accumulator folds the span
+    Then computedOutput is JSON.stringify(raw) (non-null guarantee preserved)


### PR DESCRIPTION
## TL;DR

Four independent production bugs the previous PR's tests didn't catch. Driving the real langwatch event-sourcing pipeline through testcontainers (Redis + ClickHouse) + actually looking at the prod traces explorer surfaced each one. All four now have unit/integration tests; bug 1, 3 and 4 are proven by the **stash-test-restore** methodology (verified each test FAILS on the unfixed code before claiming the fix works).

| # | Bug | What broke | Proof |
|---|---|---|---|
| 1 | `recordSpan.stripReservedAttributes()` was stripping `langwatch.reserved.causality_depth` | Reactor never saw the depth attribute on inbound spans → loop prevention silently disabled in production since merge | Integration test against testcontainers: depth=1 spans now block dispatch + increment `loop-blocked` counter |
| 2 | nlpgoFetch sent no `traceparent` header + `do_not_trace=true` short-circuited nlpgo's parent-context setup | Every eval workflow run created an orphan trace (the 2026-05-14 screenshot showing the eval's spans on a separate trace from the trace being evaluated) | Unit tests for `formatTraceparent` + `extractParentTraceForNlpgo`; HOW PROVEN: see "Honesty section" below |
| 3 | Accumulator did `JSON.stringify(outputResult.raw)` instead of using `outputResult.text` | Trace summaries showed `{"output":"Hey there"}` instead of `Hey there` | Stash-fix-restore: test fails with `expected '{"input":"hey there"}' to be 'hey there'` without fix |
| 4 | `previewFormatter.unwrapChatArray` knew `content` but not `parts` (Vercel AI SDK / Gemini-shape multi-modal payloads) | New /traces explorer rendered the raw 4KB JSON wrapper (incl. base64 image blobs) for any message-shaped trace using `parts` | Stash-fix-restore: 4 new tests fail without fix, all 29 pass with fix |

---

## Bug 1 — `langwatch.reserved.causality_depth` was being stripped

`recordSpanCommand.stripReservedAttributes()` (predates #3976) nukes every `langwatch.reserved.*` attribute from incoming OTLP spans because user SDKs aren't supposed to set them. The loop-prevention design relies on nlpgo's `BaggageAttributeProcessor` stamping exactly that namespace on every eval-emitted span. Strip → reactor sees no depth → dispatches → ∞.

**Fix:** narrow passthrough allowlist (one entry: `langwatch.reserved.causality_depth`).

**Test:** `loopPrevention.reactor.integration.test.ts` runs against testcontainers Redis + CH, drives spans through the **real** `GroupQueueProcessor`, real fold projection, real `evaluationTrigger` reactor. 4/4 scenarios pass deterministically across 3 consecutive runs:
- depth=0 → dispatches one executeEvaluation per monitor
- depth=1 → BLOCKS dispatch + increments `langwatch_evaluator_loop_blocked_total{reason=depth_direct}`
- per-span guard: fresh depth=0 on same trace after a depth=1 noise span → re-dispatches
- `LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD=1` bypasses depth check

---

## Bug 2 — Eval spans landed on an orphan trace

Two compounding causes:

**(a)** `nlpgoFetch` sent `X-LangWatch-Causality-Depth` and `X-LangWatch-Origin` but **no `traceparent` header**. nlpgo's `applyInboundCausality` saw nothing to extract.

**(b)** `runEvaluationWorkflow` hard-coded `do_not_trace: true`. nlpgo's `startStudioSpan` early-returns a no-op span on that flag — **before** the body-supplied trace_id fallback runs. So even though the body carried the parent trace_id, ctx never got a SpanContext, and inner engine spans (execute_component, LLM calls) created a fresh trace_id.

The `do_not_trace=true` predated the depth-attribute loop prevention; it was a different layer for the same concern, redundant now and actively harmful.

**Fix:**
- `nlpgoFetch`: new `parentTrace?: {traceId, parentSpanId}` option; when set, emits a valid W3C `traceparent` header (`00-<traceId>-<parentSpanId>-01`).
- `formatTraceparent()` validates both fields are well-formed hex; throws on malformed input rather than silently emitting a broken header.
- `runEvaluationWorkflow`: drops `do_not_trace: true`.
- `evaluation-execution.service`: new `extractParentTraceForNlpgo(trace)` plucks the parent trace's root span_id (when both trace_id and root span_id are OTel-standard 32-hex/16-hex). Returns undefined for legacy `trace_<nanoid>` shapes — better than synthesizing a parent_span_id that would render under a non-existent span in Studio's waterfall.
- **Wired through both call sites** of `runEvaluationWorkflow`: `evaluation-execution.service.runCustomEvaluation` AND `background/workers/evaluationsWorker.customEvaluation` (caught the second one on review).

---

## Bug 3 — Trace-summary `computedOutput` showed wrapper JSON

nlpgo emits `langwatch.output = {"output":"Hey there"}`. The IO extraction service correctly unwraps via `messagesToText` / `extractTextFromPlainJson`, populating `outputResult.text`. The IO accumulator threw `text` away and did `JSON.stringify(outputResult.raw)`, so users saw `{"output":"Hey there"}` in trace summaries.

**Fix:** new `preferText(text, raw)` helper. Use the extracted text when present, fall back to `JSON.stringify(raw)` only when extraction returned empty (non-null guarantee preserved).

---

## Bug 4 — Traces explorer rendered `parts` payloads as raw JSON

The new `/traces` explorer's `previewFormatter.unwrapChatArray` walked chat-shaped arrays but only knew `content`. Messages with `parts` (Vercel AI SDK, Gemini API, Mastra) fell through to raw-JSON rendering — the rchaves screenshot showed a 4KB base64-encoded image blob followed by `[{"role":"user","parts":[...]}]` raw in the UI.

The **backend's** `extractMessageContentText` already handled `parts`. Just the renderer was the gap.

**Fix:** new `extractMessagePartsText` mirrors the backend's shape support (`{type:"text", content|text}`, typeless wrapper, plain string). Skips non-text parts so a multi-modal message (image + text) surfaces just the text in the preview.

---

## Honesty section — what's PROVEN vs INFERRED

The user explicitly asked me to be honest about this after I overclaimed on a prior PR.

**Stash-fix-restore proven (test verified to FAIL on unfixed code):**
- Bug 1: full integration test through real `GroupQueueProcessor` against testcontainers — the test was written first against the strip behavior, then the fix landed and made it pass. 4/4 deterministic across 3 runs.
- Bug 3: unit test on `TraceIOAccumulationService` — stashed the `preferText` change, ran, got `expected '{"input":"hey there"}' to be 'hey there'`. Restored, 3/3 pass.
- Bug 4: unit tests on `previewFormatter` — stashed the parts support, 4 new tests fail with the exact "wrapper JSON shown instead of text" symptom; restored, all 29 pass.

**Wire-format proven, end-to-end NOT proven:**
- Bug 2: each individual link is unit-tested (`formatTraceparent` builds a valid header; `extractParentTraceForNlpgo` returns the right context shape; the nlpgo-side `causality_propagation_test.go` proves nlpgo extracts traceparent into ctx and stamps depth on every emitted span). But there is **no single end-to-end test that** spawns nlpgo as a subprocess, lets it emit OTLP back into a real langwatch collector, and asserts the resulting CH-stored eval span has `trace_id == parent_trace_id`. The chain logic is correct on inspection, but rchaves's original "did we ever spin up nlp and run a proper integration test" question still applies to bug 2 specifically — fixable in a follow-up.

**Regression scope check:**
- `pnpm test:unit src/server/event-sourcing src/server/app-layer/traces src/server/nlpgo src/server/app-layer/evaluations` → 6982 pass
- `pnpm test:unit src/features/traces-v2` → 251 pass
- `pnpm check:feature-parity` → 1045 scenarios bound, all clean
- `pnpm test:unit src/server/background src/server/app-layer/evaluations` → 156 pass (covers the second call-site fix)

Total **7233+ unit tests pass, 0 regressions** across event-sourcing transformation, traces canonicalisation, traces-v2 rendering, eval execution, nlpgo dispatch, background workers.

## Files

| File | Change |
|---|---|
| `langwatch/.../commands/recordSpanCommand.ts` | `RESERVED_ATTR_PASSTHROUGH` allowlist (bug 1) |
| `langwatch/.../commands/__tests__/recordSpanCommand.test.ts` | Unit regression pinning the passthrough |
| `langwatch/.../reactors/__tests__/loopPrevention.reactor.integration.test.ts` | Real-queue integration test (bug 1 proof) |
| `langwatch/.../nlpgoFetch.ts` | `parentTrace` option + `formatTraceparent` helper (bug 2) |
| `langwatch/.../nlpgoFetch.unit.test.ts` | Unit tests for traceparent wire format |
| `langwatch/.../runWorkflow.ts` | Drop `do_not_trace=true`; thread `parentTrace` through (bug 2) |
| `langwatch/.../evaluation-execution.service.ts` | `extractParentTraceForNlpgo` helper (bug 2) |
| `langwatch/.../evaluation-execution.service.unit.test.ts` | 5 unit tests for the helper |
| `langwatch/.../background/workers/evaluationsWorker.ts` | Wire parentTrace through second call site (bug 2) |
| `langwatch/.../trace-io-accumulation.service.ts` | `preferText` (bug 3) |
| `langwatch/.../trace-io-accumulation.service.unit.test.ts` | 3 unit tests, exact prod payload |
| `langwatch/.../traces-v2/utils/previewFormatter.ts` | `extractMessagePartsText` (bug 4) |
| `langwatch/.../previewFormatter.unit.test.ts` | 4 new tests, real prod payload shape |
| `services/nlpgo/tests/integration/causality_propagation_test.go` | Restored from closed PR #4035 with corrected scope language (NOT e2e) |
| `specs/monitors/online-evaluator-loop-prevention.feature` | Per-span re-dispatch scenario + traceparent scenarios + reserved-attr passthrough scenario |
| `specs/trace-processing/io-accumulation.feature` | New spec for the accumulator preferText behavior |
| `specs/event-sourcing/tenant-soft-cap.feature` | (already merged earlier) |

You should consider bugs 1+2 a production incident — loop prevention has been silently broken since merge, and every eval workflow run has been creating an orphan trace.