### PR TITLE
build(go_service): native cross-compile to fix multi-arch build slowness

### DIFF
--- a/Dockerfile.go_service
+++ b/Dockerfile.go_service
@@ -1,21 +1,32 @@
-﻿# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7
 
 # ─── Build stage ──────────────────────────────────────────────────────────────
-FROM golang:1.26.2-alpine AS build
+# Pin the build stage to the host arch (BUILDPLATFORM) and let Go cross-compile
+# to TARGETARCH natively. This avoids QEMU emulation when buildx is producing
+# images for an arch different from the host, which is the difference between
+# a 30-second compile and a 30-minute one.
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS build
 WORKDIR /src
 RUN apk add --no-cache git ca-certificates tzdata
 
-# Dependency layer (cached until go.mod/go.sum change).
+ARG TARGETOS
+ARG TARGETARCH
+
+# Dependency layer (cached until go.mod/go.sum change). The module cache is
+# arch-independent, but keying both caches by TARGETARCH keeps buildx from
+# churning a shared dir when producing multiple platforms in the same job.
 COPY go.mod go.sum ./
-RUN go mod download && go mod verify
+RUN --mount=type=cache,target=/go/pkg/mod,id=go-mod-${TARGETARCH} \
+    go mod download && go mod verify
 
 # Copy only Go source directories needed for the build.
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 COPY services/ services/
 ARG VERSION=dev
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux go build \
+RUN --mount=type=cache,target=/go/pkg/mod,id=go-mod-${TARGETARCH} \
+    --mount=type=cache,target=/root/.cache/go-build,id=go-build-${TARGETARCH} \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
       -ldflags="-s -w -X main.Version=${VERSION}" \
       -trimpath \
       -o /out/service ./cmd/service


### PR DESCRIPTION
## Summary

- Switch `Dockerfile.go_service` to use `--platform=\$BUILDPLATFORM` + `GOOS/GOARCH=\$TARGETOS/\$TARGETARCH` so the Go compiler always runs **on the host arch** and cross-compiles natively to the target arch. No more QEMU on the Go workload.
- Add a `/go/pkg/mod` cache mount alongside the existing build cache, keyed per-arch.

## Why

Sister repo `langwatch-saas` builds this image multi-arch via buildx on an arm64 self-hosted runner. The amd64 stage was being produced under QEMU userspace emulation, which is famously terrible for Go's parallel compiler. Builds that used to finish in ~7min were stalling out, repeatedly hitting the 30-min CI timeout (e.g. `langwatch-saas` run 25818785770).

## Local benchmark (M-series host)

| Build                                   | Compile | Total |
| --------------------------------------- | ------- | ----- |
| `linux/arm64` (native)                  | 19s     | 67s   |
| `linux/amd64` (cross-compile from arm64) | 23s     | 52s   |

Both produce correct-arch binaries (`docker image inspect ... --format '{{.Architecture}}'`).

## Test plan
- [x] `docker buildx build --platform linux/arm64 -f Dockerfile.go_service --load .` succeeds
- [x] `docker buildx build --platform linux/amd64 -f Dockerfile.go_service --load .` succeeds and produces `amd64/linux`
- [ ] `go-services.yaml` CI on this PR is green and finishes well under previous wall-clock
- [ ] Once merged, `langwatch-saas` bumps the submodule and confirms the multi-arch build CI is also fast (separate PR there focuses on dropping amd64 entirely since prod is arm64-only)

Companion: langwatch-saas PR `fix/gateway-build-timeout`.