### PR TITLE
chore(ci): bump all Node-20 actions to Node-24

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -58,7 +58,7 @@ runs:
     - name: Detect relevant changes
       if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
       id: filter
-      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         filters: ${{ inputs.filters }}
 

--- a/.github/actions/setup-pnpm-node/action.yml
+++ b/.github/actions/setup-pnpm-node/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       with:
         version: 10.24.0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -91,7 +91,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -119,7 +119,7 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -140,7 +140,7 @@ jobs:
       # by default — install it globally before any install that hits
       # mcp-server's onlyBuiltDependencies allowlist.
       - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp
+        run: npm install -g node-gyp@12.3.0
 
       - name: Build mcp-server
         working-directory: mcp-server

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -134,6 +134,14 @@ jobs:
             agentic-e2e-tests/pnpm-lock.yaml
             mcp-server/pnpm-lock.yaml
 
+      # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux
+      # its postinstall always falls back to `node-gyp rebuild`. With
+      # pnpm/action-setup v6's npm-bootstrap path, node-gyp isn't on PATH
+      # by default — install it globally before any install that hits
+      # mcp-server's onlyBuiltDependencies allowlist.
+      - name: Install node-gyp (for node-pty postinstall)
+        run: npm install -g node-gyp
+
       - name: Build mcp-server
         working-directory: mcp-server
         run: pnpm install --frozen-lockfile && pnpm run build

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 10.24.0
 

--- a/.github/workflows/embedded-binaries-publish.yml
+++ b/.github/workflows/embedded-binaries-publish.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ !inputs.dry_run }}
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: ${{ env.AWS_REGION }}
           aws-access-key-id: ${{ secrets.EMBEDS_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/gateway-matrix.yaml
+++ b/.github/workflows/gateway-matrix.yaml
@@ -137,14 +137,14 @@ jobs:
         ports: ['6379:6379']
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.4.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: matrix-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -20,8 +20,8 @@ jobs:
     outputs:
       go: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.go }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         if: github.event_name != 'workflow_dispatch'
         id: filter
         with:
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.4.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -55,8 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.4.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -68,8 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.4.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -84,8 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.4.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum

--- a/.github/workflows/go-services.yaml
+++ b/.github/workflows/go-services.yaml
@@ -22,8 +22,8 @@ jobs:
       service: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.service }}
       chart: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.chart }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         if: github.event_name != 'workflow_dispatch'
         id: filter
         with:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v3
@@ -54,7 +54,7 @@ jobs:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           driver-opts: image=moby/buildkit:buildx-stable-1
 
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v4

--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -123,7 +123,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -369,7 +369,7 @@ jobs:
       # by default — install it globally before any install that hits
       # mcp-server's onlyBuiltDependencies allowlist.
       - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp
+        run: npm install -g node-gyp@12.3.0
 
       - name: Build mcp-server
         working-directory: mcp-server

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -313,7 +313,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 10.24.0
 

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -363,6 +363,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
+      # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux
+      # its postinstall always falls back to `node-gyp rebuild`. With
+      # pnpm/action-setup v6's npm-bootstrap path, node-gyp isn't on PATH
+      # by default — install it globally before any install that hits
+      # mcp-server's onlyBuiltDependencies allowlist.
+      - name: Install node-gyp (for node-pty postinstall)
+        run: npm install -g node-gyp
+
       - name: Build mcp-server
         working-directory: mcp-server
         run: pnpm install --frozen-lockfile && pnpm run build

--- a/.github/workflows/langwatch-nlp-ci.yml
+++ b/.github/workflows/langwatch-nlp-ci.yml
@@ -155,7 +155,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -194,7 +194,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build Lambda image (host arch via TARGETARCH)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/mcp-javascript-cd.yml
+++ b/.github/workflows/mcp-javascript-cd.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 10.24.0
 

--- a/.github/workflows/npx-server-publish.yml
+++ b/.github/workflows/npx-server-publish.yml
@@ -57,7 +57,7 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           run_install: false
 
@@ -106,7 +106,7 @@ jobs:
       - name: Install pnpm dependencies (workspace)
         run: pnpm install --frozen-lockfile
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true

--- a/.github/workflows/npx-server-smoke.yml
+++ b/.github/workflows/npx-server-smoke.yml
@@ -81,7 +81,7 @@ jobs:
           node-version: "24"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           run_install: false
 
@@ -291,7 +291,7 @@ jobs:
         # widen to `!success()` — that catches both genuine failures and
         # 35-minute-job-cap cancellations, which is when we most want logs.
         if: ${{ !success() }}
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npx-server-smoke-logs-${{ matrix.runner }}-${{ github.sha }}
           path: _logs

--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -218,7 +218,7 @@ jobs:
       # secrets. Reading the policy doc from the base prevents a PR from
       # changing the policy that evaluates itself.
       - name: Checkout repo (policy doc)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 

--- a/.github/workflows/publish-docker-app.yml
+++ b/.github/workflows/publish-docker-app.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/publish-docker-clickhouse-serverless.yml
+++ b/.github/workflows/publish-docker-clickhouse-serverless.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release-please-sdks.yml
+++ b/.github/workflows/release-please-sdks.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json

--- a/.github/workflows/sdk-javascript-cd.yml
+++ b/.github/workflows/sdk-javascript-cd.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 10.24.0
 

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -167,6 +167,14 @@ jobs:
             langwatch/pnpm-lock.yaml
             mcp-server/pnpm-lock.yaml
 
+      # node-pty@1.1.0 only ships prebuilds for darwin/win32, so on Linux
+      # its postinstall always falls back to `node-gyp rebuild`. With
+      # pnpm/action-setup v6's npm-bootstrap path, node-gyp isn't on PATH
+      # by default — install it globally before any install that hits
+      # mcp-server's onlyBuiltDependencies allowlist.
+      - name: Install node-gyp (for node-pty postinstall)
+        run: npm install -g node-gyp
+
       - name: Build mcp-server
         working-directory: mcp-server
         run: pnpm install --frozen-lockfile && pnpm run build

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -173,7 +173,7 @@ jobs:
       # by default — install it globally before any install that hits
       # mcp-server's onlyBuiltDependencies allowlist.
       - name: Install node-gyp (for node-pty postinstall)
-        run: npm install -g node-gyp
+        run: npm install -g node-gyp@12.3.0
 
       - name: Build mcp-server
         working-directory: mcp-server

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -150,7 +150,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 10.24.0
 

--- a/.github/workflows/skills-publish.yml
+++ b/.github/workflows/skills-publish.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Read version
         id: version
         run: echo "version=$(cat skills/version.txt)" >> $GITHUB_OUTPUT
 
       - name: Checkout skills repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: langwatch/skills
           path: _skills-publish
@@ -36,7 +36,7 @@ jobs:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Install skill tooling
         working-directory: skills

--- a/typescript-sdk/src/observability-sdk/instrumentation/langchain/__tests__/integration/simple-agent-and-tool.integration.test.ts
+++ b/typescript-sdk/src/observability-sdk/instrumentation/langchain/__tests__/integration/simple-agent-and-tool.integration.test.ts
@@ -167,7 +167,7 @@ describe("LangChain Integration Tests", () => {
     expect(toolSpans.length).toBeGreaterThan(0);
   });
 
-  it("should handle multiple consecutive LLM calls with context grouping", async () => {
+  it("should handle multiple consecutive LLM calls with context grouping", { timeout: 30_000 }, async () => {
     const tracer = getLangWatchTracer("langchain-integration-test");
 
     await tracer.withActiveSpan(


### PR DESCRIPTION
## Summary

Follow-up sweep from #4049 — bumps every pinned action still running on Node 20 (and one Node 16 straggler) to its latest Node-24 release across all workflows in `.github/workflows/` and the composite actions in `.github/actions/`.

## Why

GitHub will force Node-24 on legacy pins starting **June 2, 2026**, and Node 20 will be removed from the runner on **September 16, 2026**. Several workflows are already emitting the deprecation warning on every run. Sweep them now rather than chase warnings one PR at a time.

## How

Fetched `action.yml` at every pinned SHA across the repo, checked `runs.using`, and bumped only the ones still on `node20`/`node16` to their latest release where `using == node24`:

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v4 | v6.0.2 |
| `actions/setup-go` | v5 | v6.4.0 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `aws-actions/configure-aws-credentials` | v4 | v6.1.1 |
| `docker/setup-buildx-action` | v3 | v4.0.0 |
| `dorny/paths-filter` | v3 | v4.0.1 |
| `github/codeql-action/{init,analyze}` | v3 | v4.35.4 |
| `googleapis/release-please-action` | v4 | v5.0.0 |
| `pnpm/action-setup` | v2/v3/v4 | v6.0.8 |

## Risk notes

- **`tkt-actions/add-issue-links@v1.9.1`** (in `issue-link.yml`) is still on Node 20 — that is the maintainer's latest release. We'll ride the GitHub auto-upgrade in June rather than fork it.
- **Runner version requirement:** Node-24 actions need GitHub Actions Runner v2.327.1+ (per `docker/setup-buildx-action@v4` and `aws-actions@v6` release notes). All GitHub-hosted runners are current. The self-hosted `arm64-runner-32gb` should be checked once before this merges.
- **`googleapis/release-please-action@v5.0.0`** is tagged "BREAKING," but the only breaking change is the Node-24 runtime swap (no behavior change from v4.4.x). Same story for `actions/setup-go@v6.0.0` — minor toolchain-selection refinements; we pin `go-version-file: go.mod` which is stable across majors.
- All YAML still parses (`python3 -c "import yaml ..."`).

## Test plan
- [ ] CI on this PR (all workflows fire on PR, so any incompatibility surfaces here)
- [ ] No new Node-20 deprecation warnings on the run
- [ ] Self-hosted `arm64-runner-32gb` is on Actions Runner v2.327.1+