### PR TITLE
fix(ci): install node-gyp before pnpm install (mcp-javascript-ci on Node-24)

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yml
+++ b/.github/actions/setup-pnpm-node/action.yml
@@ -34,6 +34,15 @@ runs:
         cache: "pnpm"
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
+    # node-gyp is no longer bundled on PATH under Node-24 + npm-11, so any
+    # native-module install lifecycle script (e.g. node-pty's prebuild fallback
+    # in mcp-server) ELIFECYCLEs with "sh: 1: node-gyp: not found". Install it
+    # globally so spawned scripts can resolve it via PATH.
+    - name: Install node-gyp
+      if: inputs.install-dir != ''
+      shell: bash
+      run: npm install -g node-gyp@latest
+
     - name: Install dependencies
       if: inputs.install-dir != ''
       shell: bash

--- a/.github/workflows/mcp-javascript-ci.yml
+++ b/.github/workflows/mcp-javascript-ci.yml
@@ -31,6 +31,7 @@ jobs:
             relevant:
               - 'mcp-server/**'
               - '.github/workflows/mcp-javascript-ci.yml'
+              - '.github/actions/setup-pnpm-node/**'
               - '.github/.release-please-manifest.json'
 
   typecheck:


### PR DESCRIPTION
## Summary
- mcp-javascript-ci has been red on main since df3b0a1f7 ("chore(ci): bump all Node-20 actions to Node-24 #4050")
- Root cause: `node-pty@1.1.0` has no Linux-x64 prebuild for Node-24's ABI, so its install lifecycle falls back to `node-gyp rebuild`. Under Node-24 + npm-11, `node-gyp` is not on PATH, so `pnpm install --frozen-lockfile` ELIFECYCLEs
- Fix: install `node-gyp@latest` globally in the shared `.github/actions/setup-pnpm-node` composite before `pnpm install`, gated on the existing `install-dir != ''` condition (workflows that only use the composite for node/pnpm setup are unaffected)

## Evidence
Failing run on df3b0a1f7: https://github.com/langwatch/langwatch/actions/runs/25849623261

Excerpt:
```
.../node-pty@1.1.0/node_modules/node-pty install: sh: 1: node-gyp: not found
 ELIFECYCLE  Command failed.
```

Last green mcp-javascript-ci on main: 80d7b081e (commit before #4050).

## Test plan
- [ ] mcp-javascript-ci on this PR's branch passes (validates the fix on a clean Node-24 runner)
- [ ] No other workflow using `.github/actions/setup-pnpm-node` regresses
- [ ] `npm install -g node-gyp@latest` adds only ~3–5s per job

🤖 Generated with [Claude Code](https://claude.com/claude-code)