### PR TITLE
feat(api): add teams REST API for admin automation

### DIFF
--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -27408,6 +27408,9 @@
           },
           "404": {
             "description": "Team not found"
+          },
+          "422": {
+            "description": "Validation error (invalid name)"
           }
         }
       },
@@ -27900,7 +27903,15 @@
             "type": "string",
             "format": "date-time"
           }
-        }
+        },
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "organizationId",
+          "createdAt",
+          "updatedAt"
+        ]
       }
     },
     "securitySchemes": {

--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -27193,6 +27193,278 @@
         ],
         "description": "Archive (soft-delete) a workflow"
       }
+    },
+    "/api/teams": {
+      "get": {
+        "operationId": "listTeams",
+        "summary": "List teams",
+        "description": "List all non-archived teams for the organization (paginated). Requires an admin API key with team:view permission.",
+        "security": [
+          {
+            "admin_api_key": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of teams",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Team"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key token"
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createTeam",
+        "summary": "Create a team",
+        "description": "Create a new team in the organization. Requires team:create permission.",
+        "security": [
+          {
+            "admin_api_key": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "Team name"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Team created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Team"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key token"
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation"
+          },
+          "422": {
+            "description": "Validation error (missing or invalid name)"
+          }
+        }
+      }
+    },
+    "/api/teams/{id}": {
+      "get": {
+        "operationId": "getTeam",
+        "summary": "Get team",
+        "description": "Get a team by its ID. Returns 404 if the team does not exist or belongs to a different organization. Requires team:view permission.",
+        "security": [
+          {
+            "admin_api_key": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Team ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Team"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key token"
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation"
+          },
+          "404": {
+            "description": "Team not found or belongs to another organization"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateTeam",
+        "summary": "Update team",
+        "description": "Update a team's fields. Requires team:update permission.",
+        "security": [
+          {
+            "admin_api_key": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Team ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "New team name"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Team"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key token"
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation"
+          },
+          "404": {
+            "description": "Team not found"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "archiveTeam",
+        "summary": "Archive team",
+        "description": "Archive a team (soft-delete). Sets archivedAt timestamp. The team will no longer appear in list or get operations. Requires team:delete permission.",
+        "security": [
+          {
+            "admin_api_key": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Team ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Archived team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "archivedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key token"
+          },
+          "403": {
+            "description": "Insufficient permissions for this operation"
+          },
+          "404": {
+            "description": "Team not found"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -27598,6 +27870,35 @@
                 }
               }
             }
+          }
+        }
+      },
+      "Team": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Team ID (prefixed with team_)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Team name"
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-friendly team identifier"
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "ID of the owning organization"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       }

--- a/docs/api-reference/teams/archive-team.mdx
+++ b/docs/api-reference/teams/archive-team.mdx
@@ -1,0 +1,4 @@
+---
+title: "Archive team"
+openapi: "DELETE /api/teams/{id}"
+---

--- a/docs/api-reference/teams/create-team.mdx
+++ b/docs/api-reference/teams/create-team.mdx
@@ -1,0 +1,4 @@
+---
+title: "Create team"
+openapi: "POST /api/teams"
+---

--- a/docs/api-reference/teams/get-team.mdx
+++ b/docs/api-reference/teams/get-team.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get team"
+openapi: "GET /api/teams/{id}"
+---

--- a/docs/api-reference/teams/list-teams.mdx
+++ b/docs/api-reference/teams/list-teams.mdx
@@ -1,0 +1,4 @@
+---
+title: "List teams"
+openapi: "GET /api/teams"
+---

--- a/docs/api-reference/teams/overview.mdx
+++ b/docs/api-reference/teams/overview.mdx
@@ -1,0 +1,54 @@
+---
+title: 'Overview'
+description: 'Create, list, update, and archive LangWatch teams programmatically. Designed for automated provisioning and cleanup of team structures.'
+---
+
+## Intro
+
+The Teams API lets you manage LangWatch teams via REST. Teams are organizational units that group projects and members together.
+
+This API is designed for service-to-service automation (e.g. provisioning team structures for new departments, cleaning up orphaned teams from test runs), not for end-user access.
+
+## Authentication
+
+The Teams API requires an **organization-level API key** with `team:manage` permission (created in Settings > API Keys). Pass it as a Bearer token:
+
+```
+Authorization: Bearer sk-lw-<id>_<secret>
+```
+
+Project API keys (`X-Auth-Token`) cannot be used here — they lack organization context.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/teams` | List all teams in the organization |
+| `POST` | `/api/teams` | Create a new team |
+| `GET` | `/api/teams/{id}` | Get team details |
+| `PATCH` | `/api/teams/{id}` | Update a team |
+| `DELETE` | `/api/teams/{id}` | Archive a team (soft-delete) |
+
+## Soft Delete
+
+`DELETE` does not permanently remove a team. It sets an `archivedAt` timestamp, making the team invisible to list and get operations. Archived teams can still be referenced in historical data (e.g. past project associations).
+
+## Typical Flow
+
+1. Create an admin API key in Settings > API Keys with `team:manage` permission
+2. Call `POST /api/teams` with a team name
+3. Use the returned team `id` when creating projects via the Projects API
+
+```bash
+# Create team
+curl -X POST https://app.langwatch.ai/api/teams \
+  -H "Authorization: Bearer sk-lw-..." \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Engineering"}'
+
+# Use team ID to create a project
+curl -X POST https://app.langwatch.ai/api/projects \
+  -H "Authorization: Bearer sk-lw-..." \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My Project", "teamId": "<team_id>", "language": "python", "framework": "langchain"}'
+```

--- a/docs/api-reference/teams/update-team.mdx
+++ b/docs/api-reference/teams/update-team.mdx
@@ -1,0 +1,4 @@
+---
+title: "Update team"
+openapi: "PATCH /api/teams/{id}"
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -707,6 +707,17 @@
             ]
           },
           {
+            "group": "Teams",
+            "pages": [
+              "api-reference/teams/overview",
+              "api-reference/teams/list-teams",
+              "api-reference/teams/create-team",
+              "api-reference/teams/get-team",
+              "api-reference/teams/update-team",
+              "api-reference/teams/archive-team"
+            ]
+          },
+          {
             "group": "API Keys",
             "pages": [
               "api-reference/api-keys/overview",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -29174,6 +29174,110 @@ This event marks the end of a scenario run and includes the final results.
     -   `unmetCriteria`: A list of criteria that were not met.
 ---
 
+# FILE: ./api-reference/teams/archive-team.mdx
+
+---
+title: "Archive team"
+openapi: "DELETE /api/teams/{id}"
+---
+
+---
+
+# FILE: ./api-reference/teams/create-team.mdx
+
+---
+title: "Create team"
+openapi: "POST /api/teams"
+---
+
+---
+
+# FILE: ./api-reference/teams/get-team.mdx
+
+---
+title: "Get team"
+openapi: "GET /api/teams/{id}"
+---
+
+---
+
+# FILE: ./api-reference/teams/list-teams.mdx
+
+---
+title: "List teams"
+openapi: "GET /api/teams"
+---
+
+---
+
+# FILE: ./api-reference/teams/overview.mdx
+
+---
+title: 'Overview'
+description: 'Create, list, update, and archive LangWatch teams programmatically. Designed for automated provisioning and cleanup of team structures.'
+---
+
+## Intro
+
+The Teams API lets you manage LangWatch teams via REST. Teams are organizational units that group projects and members together.
+
+This API is designed for service-to-service automation (e.g. provisioning team structures for new departments, cleaning up orphaned teams from test runs), not for end-user access.
+
+## Authentication
+
+The Teams API requires an **organization-level API key** with `team:manage` permission (created in Settings > API Keys). Pass it as a Bearer token:
+
+```
+Authorization: Bearer sk-lw-<id>_<secret>
+```
+
+Project API keys (`X-Auth-Token`) cannot be used here — they lack organization context.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/teams` | List all teams in the organization |
+| `POST` | `/api/teams` | Create a new team |
+| `GET` | `/api/teams/{id}` | Get team details |
+| `PATCH` | `/api/teams/{id}` | Update a team |
+| `DELETE` | `/api/teams/{id}` | Archive a team (soft-delete) |
+
+## Soft Delete
+
+`DELETE` does not permanently remove a team. It sets an `archivedAt` timestamp, making the team invisible to list and get operations. Archived teams can still be referenced in historical data (e.g. past project associations).
+
+## Typical Flow
+
+1. Create an admin API key in Settings > API Keys with `team:manage` permission
+2. Call `POST /api/teams` with a team name
+3. Use the returned team `id` when creating projects via the Projects API
+
+```bash
+# Create team
+curl -X POST https://app.langwatch.ai/api/teams \
+  -H "Authorization: Bearer sk-lw-..." \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Engineering"}'
+
+# Use team ID to create a project
+curl -X POST https://app.langwatch.ai/api/projects \
+  -H "Authorization: Bearer sk-lw-..." \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My Project", "teamId": "<team_id>", "language": "python", "framework": "langchain"}'
+```
+
+---
+
+# FILE: ./api-reference/teams/update-team.mdx
+
+---
+title: "Update team"
+openapi: "PATCH /api/teams/{id}"
+---
+
+---
+
 # FILE: ./api-reference/traces/create-public-trace-path.mdx
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -59,6 +59,15 @@ Always navigate to docs links using the .md extension for better readability.
 - [Update project](https://langwatch.ai/docs/api-reference/projects/update-project.md)
 - [Archive project](https://langwatch.ai/docs/api-reference/projects/archive-project.md)
 
+## Teams
+
+- [Overview](https://langwatch.ai/docs/api-reference/teams/overview.md): Create, list, update, and archive LangWatch teams programmatically. Designed for automated provisioning and cleanup of team structures.
+- [List teams](https://langwatch.ai/docs/api-reference/teams/list-teams.md)
+- [Create team](https://langwatch.ai/docs/api-reference/teams/create-team.md)
+- [Get team](https://langwatch.ai/docs/api-reference/teams/get-team.md)
+- [Update team](https://langwatch.ai/docs/api-reference/teams/update-team.md)
+- [Archive team](https://langwatch.ai/docs/api-reference/teams/archive-team.md)
+
 ## API Keys
 
 - [Overview](https://langwatch.ai/docs/api-reference/api-keys/overview.md): Create and manage API keys programmatically. Supports personal keys (user-scoped) and service keys (project-scoped, for automation).

--- a/langwatch/src/app/api/middleware/team-service.ts
+++ b/langwatch/src/app/api/middleware/team-service.ts
@@ -1,0 +1,14 @@
+import type { MiddlewareHandler } from "hono";
+
+import { prisma } from "~/server/db";
+import { TeamRestService } from "~/server/app-layer/teams/team.service";
+import { PrismaTeamRepository } from "~/server/app-layer/teams/repositories/team.prisma.repository";
+
+export type TeamServiceMiddlewareVariables = {
+  teamService: TeamRestService;
+};
+
+export const teamServiceMiddleware: MiddlewareHandler = async (c, next) => {
+  c.set("teamService", new TeamRestService(new PrismaTeamRepository(prisma)));
+  await next();
+};

--- a/langwatch/src/app/api/teams/[[...route]]/app.ts
+++ b/langwatch/src/app/api/teams/[[...route]]/app.ts
@@ -1,0 +1,213 @@
+import type { Organization } from "@prisma/client";
+import { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import { validator as zValidator } from "hono-openapi/zod";
+import { z } from "zod";
+import {
+  TeamNotFoundError,
+  type TeamRestService,
+} from "~/server/app-layer/teams/team.service";
+import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
+import type { OrgAuthMiddlewareVariables } from "../../middleware/org-auth";
+import { orgAuthMiddleware, requireOrgPermission } from "../../middleware/org-auth";
+import type { TeamServiceMiddlewareVariables } from "../../middleware/team-service";
+import { teamServiceMiddleware } from "../../middleware/team-service";
+import { loggerMiddleware } from "../../middleware/logger";
+import { tracerMiddleware } from "../../middleware/tracer";
+import { NotFoundError } from "../../shared/errors";
+import { handleTeamError } from "./error-handler";
+
+patchZodOpenapi();
+
+type Variables = OrgAuthMiddlewareVariables & TeamServiceMiddlewareVariables;
+
+const paginationQuerySchema = z.object({
+  page: z.coerce.number().int().positive().optional().default(1),
+  limit: z.coerce.number().int().positive().max(1000).optional().default(50),
+});
+
+const createTeamSchema = z.object({
+  name: z.string().min(1, "name is required").max(255),
+});
+
+const updateTeamSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+});
+
+function validationHook(
+  result: { success: boolean; error?: { issues: Array<{ message?: string; path?: (string | number)[] }> } },
+  c: { json: (body: unknown, status: number) => Response },
+): Response | undefined {
+  if (!result.success) {
+    const issue = result.error?.issues?.[0];
+    return c.json(
+      {
+        error: "Unprocessable Entity",
+        message: issue?.message ?? "Validation failed",
+        path: issue?.path,
+      },
+      422,
+    );
+  }
+  return undefined;
+}
+
+function teamResponse(team: {
+  id: string;
+  name: string;
+  slug: string;
+  organizationId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}) {
+  return {
+    id: team.id,
+    name: team.name,
+    slug: team.slug,
+    organizationId: team.organizationId,
+    createdAt: team.createdAt,
+    updatedAt: team.updatedAt,
+  };
+}
+
+export const app = new Hono<{ Variables: Variables }>()
+  .basePath("/api/teams")
+  .use(tracerMiddleware({ name: "teams" }))
+  .use(loggerMiddleware())
+  .use(orgAuthMiddleware)
+  .use(teamServiceMiddleware)
+  .onError(handleTeamError)
+
+  .get(
+    "/",
+    describeRoute({
+      description: "List all non-archived teams for the organization (paginated)",
+    }),
+    requireOrgPermission("team:view"),
+    zValidator("query", paginationQuerySchema),
+    async (c) => {
+      const organization = c.get("organization") as Organization;
+      const { page, limit } = c.req.valid("query");
+      const service = c.get("teamService") as TeamRestService;
+
+      const result = await service.listByOrganization({
+        organizationId: organization.id,
+        page,
+        limit,
+      });
+
+      return c.json({
+        data: result.data.map(teamResponse),
+        pagination: result.pagination,
+      });
+    },
+  )
+
+  .post(
+    "/",
+    describeRoute({
+      description: "Create a new team",
+    }),
+    requireOrgPermission("team:create"),
+    zValidator("json", createTeamSchema, validationHook),
+    async (c) => {
+      const organization = c.get("organization") as Organization;
+      const body = c.req.valid("json");
+      const service = c.get("teamService") as TeamRestService;
+
+      const team = await service.create({
+        organizationId: organization.id,
+        name: body.name,
+      });
+
+      return c.json(teamResponse(team), 201);
+    },
+  )
+
+  .get(
+    "/:id",
+    describeRoute({
+      description: "Get a team by its id",
+    }),
+    requireOrgPermission("team:view"),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("teamService") as TeamRestService;
+
+      const team = await service.getById({
+        id,
+        organizationId: organization.id,
+      });
+      if (!team) {
+        throw new NotFoundError("Team not found");
+      }
+
+      return c.json(teamResponse(team));
+    },
+  )
+
+  .patch(
+    "/:id",
+    describeRoute({
+      description: "Update a team by its id",
+    }),
+    requireOrgPermission("team:update"),
+    zValidator("json", updateTeamSchema, validationHook),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const body = c.req.valid("json");
+      const service = c.get("teamService") as TeamRestService;
+
+      let team;
+      try {
+        team = await service.update({
+          id,
+          organizationId: organization.id,
+          data: {
+            ...(body.name !== undefined && { name: body.name }),
+          },
+        });
+      } catch (error) {
+        if (error instanceof TeamNotFoundError) {
+          throw new NotFoundError("Team not found");
+        }
+        throw error;
+      }
+
+      return c.json(teamResponse(team));
+    },
+  )
+
+  .delete(
+    "/:id",
+    describeRoute({
+      description: "Archive a team (soft-delete)",
+    }),
+    requireOrgPermission("team:delete"),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("teamService") as TeamRestService;
+
+      let team;
+      try {
+        team = await service.archive({
+          id,
+          organizationId: organization.id,
+        });
+      } catch (error) {
+        if (error instanceof TeamNotFoundError) {
+          throw new NotFoundError("Team not found");
+        }
+        throw error;
+      }
+
+      return c.json({
+        id: team.id,
+        name: team.name,
+        archivedAt: team.archivedAt,
+      });
+    },
+  );

--- a/langwatch/src/app/api/teams/[[...route]]/error-handler.ts
+++ b/langwatch/src/app/api/teams/[[...route]]/error-handler.ts
@@ -1,0 +1,37 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { createLogger } from "../../../../utils/logger/server";
+import { HttpError, InternalServerError } from "../../shared/errors";
+import { errorSchema } from "../../shared/schemas";
+
+const logger = createLogger("langwatch:api:teams:errors");
+
+export const handleTeamError = async (
+  error: Error & { status?: ContentfulStatusCode },
+  c: Context,
+): Promise<Response> => {
+  const status =
+    error instanceof HttpError ? error.status : (error.status ?? 500);
+
+  logger.error(
+    {
+      path: c.req.path,
+      method: c.req.method,
+      routeParams: c.req.param(),
+      status,
+      error: {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      },
+    },
+    `Teams API Error [${status}]: ${error.message || String(error)}`,
+  );
+
+  if (error instanceof HttpError) {
+    return c.json(errorSchema.parse(error), error.status);
+  }
+
+  const internalError = new InternalServerError();
+  return c.json(errorSchema.parse(internalError), internalError.status);
+};

--- a/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
@@ -120,11 +120,13 @@ describe("Feature: Teams REST API", () => {
   });
 
   describe("Authentication", () => {
+    /** @scenario Rejects unauthenticated requests */
     it("returns 401 without auth header", async () => {
       const res = await app.request("/api/teams");
       expect(res.status).toBe(401);
     });
 
+    /** @scenario Rejects invalid API key */
     it("returns 401 with invalid API key", async () => {
       const res = await app.request("/api/teams", {
         headers: { Authorization: "Bearer sk-lw-invalid_token" },
@@ -134,6 +136,7 @@ describe("Feature: Teams REST API", () => {
   });
 
   describe("POST /api/teams", () => {
+    /** @scenario Creates a team */
     it("creates a team and returns 201", async () => {
       const res = await api.post("/api/teams", {
         name: "My Test Team",
@@ -149,6 +152,7 @@ describe("Feature: Teams REST API", () => {
       expect(body.updatedAt).toBeDefined();
     });
 
+    /** @scenario Rejects create when name is missing */
     it("returns 422 when name is missing", async () => {
       const res = await api.post("/api/teams", {});
       expect(res.status).toBe(422);
@@ -157,11 +161,13 @@ describe("Feature: Teams REST API", () => {
       expect(body.error).toBe("Unprocessable Entity");
     });
 
+    /** @scenario Rejects create when name is empty */
     it("returns 422 when name is empty", async () => {
       const res = await api.post("/api/teams", { name: "" });
       expect(res.status).toBe(422);
     });
 
+    /** @scenario Rejects create when name exceeds 255 characters */
     it("returns 422 when name exceeds 255 characters", async () => {
       const res = await api.post("/api/teams", { name: "a".repeat(256) });
       expect(res.status).toBe(422);
@@ -169,6 +175,7 @@ describe("Feature: Teams REST API", () => {
   });
 
   describe("GET /api/teams", () => {
+    /** @scenario Lists non-archived teams for the organization */
     it("lists non-archived teams for the organization", async () => {
       const res = await api.get("/api/teams");
       expect(res.status).toBe(200);
@@ -180,6 +187,7 @@ describe("Feature: Teams REST API", () => {
       expect(body.pagination.page).toBe(1);
     });
 
+    /** @scenario Paginates team list */
     it("paginates results", async () => {
       const res = await api.get("/api/teams?page=1&limit=2");
       expect(res.status).toBe(200);
@@ -188,6 +196,7 @@ describe("Feature: Teams REST API", () => {
       expect(body.pagination.limit).toBe(2);
     });
 
+    /** @scenario Excludes teams from other organizations */
     it("excludes teams from other organizations", async () => {
       await prisma.team.create({
         data: {
@@ -207,6 +216,7 @@ describe("Feature: Teams REST API", () => {
   });
 
   describe("GET /api/teams/:id", () => {
+    /** @scenario Returns a team by id */
     it("returns a team by id", async () => {
       const createRes = await api.post("/api/teams", {
         name: `Get Test ${nanoid(6)}`,
@@ -221,11 +231,13 @@ describe("Feature: Teams REST API", () => {
       expect(body.name).toBe(created.name);
     });
 
+    /** @scenario Returns 404 for non-existent team */
     it("returns 404 for non-existent team", async () => {
       const res = await api.get("/api/teams/team_doesnotexist");
       expect(res.status).toBe(404);
     });
 
+    /** @scenario Returns 404 for team in another organization */
     it("returns 404 for team in another organization", async () => {
       const otherTeam = await prisma.team.create({
         data: {
@@ -241,6 +253,7 @@ describe("Feature: Teams REST API", () => {
   });
 
   describe("PATCH /api/teams/:id", () => {
+    /** @scenario Updates team name */
     it("updates team name", async () => {
       const createRes = await api.post("/api/teams", {
         name: `Patch Test ${nanoid(6)}`,
@@ -257,6 +270,7 @@ describe("Feature: Teams REST API", () => {
       expect(body.id).toBe(created.id);
     });
 
+    /** @scenario Returns 404 when updating non-existent team */
     it("returns 404 for non-existent team", async () => {
       const res = await api.patch("/api/teams/team_ghost", {
         name: "Whatever",
@@ -266,6 +280,7 @@ describe("Feature: Teams REST API", () => {
   });
 
   describe("DELETE /api/teams/:id", () => {
+    /** @scenario Archives a team */
     it("archives the team", async () => {
       const createRes = await api.post("/api/teams", {
         name: `Delete Test ${nanoid(6)}`,
@@ -280,6 +295,7 @@ describe("Feature: Teams REST API", () => {
       expect(body.archivedAt).toBeDefined();
     });
 
+    /** @scenario Archived team is inaccessible via GET */
     it("makes the team inaccessible via GET after archival", async () => {
       const createRes = await api.post("/api/teams", {
         name: `Archive Test ${nanoid(6)}`,
@@ -292,6 +308,7 @@ describe("Feature: Teams REST API", () => {
       expect(getRes.status).toBe(404);
     });
 
+    /** @scenario Archived team is excluded from list */
     it("excludes archived teams from list", async () => {
       const createRes = await api.post("/api/teams", {
         name: `Archive List Test ${nanoid(6)}`,
@@ -306,11 +323,13 @@ describe("Feature: Teams REST API", () => {
       expect(ids).not.toContain(created.id);
     });
 
+    /** @scenario Returns 404 when deleting non-existent team */
     it("returns 404 for non-existent team", async () => {
       const res = await api.delete("/api/teams/team_nope");
       expect(res.status).toBe(404);
     });
 
+    /** @scenario Returns 404 when deleting already-archived team */
     it("returns 404 for already-archived team", async () => {
       const createRes = await api.post("/api/teams", {
         name: `Double Archive ${nanoid(6)}`,
@@ -369,11 +388,13 @@ describe("Feature: Teams REST API", () => {
         }),
     };
 
+    /** @scenario Viewer can list teams */
     it("allows viewer to list teams", async () => {
       const res = await viewerApi.get("/api/teams");
       expect(res.status).toBe(200);
     });
 
+    /** @scenario Viewer cannot create a team */
     it("returns 403 when viewer creates a team", async () => {
       const res = await viewerApi.post("/api/teams", { name: "Blocked Team" });
       expect(res.status).toBe(403);
@@ -382,6 +403,7 @@ describe("Feature: Teams REST API", () => {
       expect(body.error).toBe("Forbidden");
     });
 
+    /** @scenario Viewer cannot update a team */
     it("returns 403 when viewer updates a team", async () => {
       const createRes = await api.post("/api/teams", {
         name: `Perm Test ${nanoid(6)}`,
@@ -394,6 +416,7 @@ describe("Feature: Teams REST API", () => {
       expect(res.status).toBe(403);
     });
 
+    /** @scenario Viewer cannot delete a team */
     it("returns 403 when viewer deletes a team", async () => {
       const createRes = await api.post("/api/teams", {
         name: `Perm Del Test ${nanoid(6)}`,

--- a/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
@@ -310,5 +310,98 @@ describe("Feature: Teams REST API", () => {
       const res = await api.delete("/api/teams/team_nope");
       expect(res.status).toBe(404);
     });
+
+    it("returns 404 for already-archived team", async () => {
+      const createRes = await api.post("/api/teams", {
+        name: `Double Archive ${nanoid(6)}`,
+      });
+      const created = await createRes.json();
+      await api.delete(`/api/teams/${created.id}`);
+
+      const res = await api.delete(`/api/teams/${created.id}`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("Permission denial", () => {
+    let viewerToken: string;
+
+    beforeAll(async () => {
+      const apiKeyService = ApiKeyService.create(prisma);
+      const viewerKey = await apiKeyService.create({
+        name: `teams-viewer-${nanoid(6)}`,
+        userId,
+        createdByUserId: userId,
+        organizationId: testOrganization.id,
+        permissionMode: "scoped",
+        bindings: [
+          {
+            role: TeamUserRole.VIEWER,
+            scopeType: RoleBindingScopeType.ORGANIZATION,
+            scopeId: testOrganization.id,
+          },
+        ],
+      });
+      viewerToken = viewerKey.token;
+    });
+
+    const viewerApi = {
+      get: (path: string) =>
+        app.request(path, {
+          headers: { Authorization: `Bearer ${viewerToken}`, "Content-Type": "application/json" },
+        }),
+      post: (path: string, body: unknown) =>
+        app.request(path, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${viewerToken}`, "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+      patch: (path: string, body: unknown) =>
+        app.request(path, {
+          method: "PATCH",
+          headers: { Authorization: `Bearer ${viewerToken}`, "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+      delete: (path: string) =>
+        app.request(path, {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${viewerToken}`, "Content-Type": "application/json" },
+        }),
+    };
+
+    it("allows viewer to list teams", async () => {
+      const res = await viewerApi.get("/api/teams");
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 403 when viewer creates a team", async () => {
+      const res = await viewerApi.post("/api/teams", { name: "Blocked Team" });
+      expect(res.status).toBe(403);
+
+      const body = await res.json();
+      expect(body.error).toBe("Forbidden");
+    });
+
+    it("returns 403 when viewer updates a team", async () => {
+      const createRes = await api.post("/api/teams", {
+        name: `Perm Test ${nanoid(6)}`,
+      });
+      const created = await createRes.json();
+
+      const res = await viewerApi.patch(`/api/teams/${created.id}`, {
+        name: "Nope",
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 when viewer deletes a team", async () => {
+      const createRes = await api.post("/api/teams", {
+        name: `Perm Del Test ${nanoid(6)}`,
+      });
+      const created = await createRes.json();
+
+      const res = await viewerApi.delete(`/api/teams/${created.id}`);
+      expect(res.status).toBe(403);
+    });
   });
 });

--- a/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
@@ -17,35 +17,38 @@ describe("Feature: Teams REST API", () => {
 
   let testOrganization: Organization;
   let otherOrganization: Organization;
-  let patToken: string;
+  let apiKeyToken: string;
   let userId: string;
 
-  const authHeaders = () => ({
-    Authorization: `Bearer ${patToken}`,
-    "Content-Type": "application/json",
-  });
+  function createApiClient(tokenFn: () => string) {
+    const headers = () => ({
+      Authorization: `Bearer ${tokenFn()}`,
+      "Content-Type": "application/json",
+    });
+    return {
+      get: (path: string) =>
+        app.request(path, { headers: headers() }),
+      post: (path: string, body: unknown) =>
+        app.request(path, {
+          method: "POST",
+          headers: headers(),
+          body: JSON.stringify(body),
+        }),
+      patch: (path: string, body: unknown) =>
+        app.request(path, {
+          method: "PATCH",
+          headers: headers(),
+          body: JSON.stringify(body),
+        }),
+      delete: (path: string) =>
+        app.request(path, {
+          method: "DELETE",
+          headers: headers(),
+        }),
+    };
+  }
 
-  const api = {
-    get: (path: string) =>
-      app.request(path, { headers: authHeaders() }),
-    post: (path: string, body: unknown) =>
-      app.request(path, {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      }),
-    patch: (path: string, body: unknown) =>
-      app.request(path, {
-        method: "PATCH",
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      }),
-    delete: (path: string) =>
-      app.request(path, {
-        method: "DELETE",
-        headers: authHeaders(),
-      }),
-  };
+  const api = createApiClient(() => apiKeyToken);
 
   beforeAll(async () => {
     testOrganization = await prisma.organization.create({
@@ -98,7 +101,7 @@ describe("Feature: Teams REST API", () => {
         },
       ],
     });
-    patToken = created.token;
+    apiKeyToken = created.token;
   });
 
   afterAll(async () => {
@@ -343,7 +346,7 @@ describe("Feature: Teams REST API", () => {
   });
 
   describe("Permission denial", () => {
-    let viewerToken: string;
+    let viewerKeyToken: string;
 
     beforeAll(async () => {
       const apiKeyService = ApiKeyService.create(prisma);
@@ -361,32 +364,10 @@ describe("Feature: Teams REST API", () => {
           },
         ],
       });
-      viewerToken = viewerKey.token;
+      viewerKeyToken = viewerKey.token;
     });
 
-    const viewerApi = {
-      get: (path: string) =>
-        app.request(path, {
-          headers: { Authorization: `Bearer ${viewerToken}`, "Content-Type": "application/json" },
-        }),
-      post: (path: string, body: unknown) =>
-        app.request(path, {
-          method: "POST",
-          headers: { Authorization: `Bearer ${viewerToken}`, "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        }),
-      patch: (path: string, body: unknown) =>
-        app.request(path, {
-          method: "PATCH",
-          headers: { Authorization: `Bearer ${viewerToken}`, "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        }),
-      delete: (path: string) =>
-        app.request(path, {
-          method: "DELETE",
-          headers: { Authorization: `Bearer ${viewerToken}`, "Content-Type": "application/json" },
-        }),
-    };
+    const viewerApi = createApiClient(() => viewerKeyToken);
 
     /** @scenario Viewer cannot list teams */
     it("returns 403 when viewer lists teams", async () => {

--- a/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
@@ -1,0 +1,314 @@
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+  type Organization,
+} from "@prisma/client";
+import { generate } from "@langwatch/ksuid";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import { prisma } from "~/server/db";
+import { ApiKeyService } from "~/server/api-key/api-key.service";
+import { app } from "../[[...route]]/app";
+
+describe("Feature: Teams REST API", () => {
+  const ns = `teams-api-${nanoid(8)}`;
+
+  let testOrganization: Organization;
+  let otherOrganization: Organization;
+  let patToken: string;
+  let userId: string;
+
+  const authHeaders = () => ({
+    Authorization: `Bearer ${patToken}`,
+    "Content-Type": "application/json",
+  });
+
+  const api = {
+    get: (path: string) =>
+      app.request(path, { headers: authHeaders() }),
+    post: (path: string, body: unknown) =>
+      app.request(path, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(body),
+      }),
+    patch: (path: string, body: unknown) =>
+      app.request(path, {
+        method: "PATCH",
+        headers: authHeaders(),
+        body: JSON.stringify(body),
+      }),
+    delete: (path: string) =>
+      app.request(path, {
+        method: "DELETE",
+        headers: authHeaders(),
+      }),
+  };
+
+  beforeAll(async () => {
+    testOrganization = await prisma.organization.create({
+      data: { name: "Teams Test Org", slug: `--test-org-${ns}` },
+    });
+
+    otherOrganization = await prisma.organization.create({
+      data: { name: "Other Org", slug: `--other-org-${ns}` },
+    });
+
+    const user = await prisma.user.create({
+      data: {
+        name: "Teams Test User",
+        email: `test-${ns}@example.com`,
+      },
+    });
+    userId = user.id;
+
+    await prisma.organizationUser.create({
+      data: {
+        userId,
+        organizationId: testOrganization.id,
+        role: OrganizationUserRole.ADMIN,
+      },
+    });
+
+    await prisma.roleBinding.create({
+      data: {
+        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+        organizationId: testOrganization.id,
+        userId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: testOrganization.id,
+      },
+    });
+
+    const apiKeyService = ApiKeyService.create(prisma);
+    const created = await apiKeyService.create({
+      name: `teams-key-${nanoid(6)}`,
+      userId,
+      createdByUserId: userId,
+      organizationId: testOrganization.id,
+      permissionMode: "scoped",
+      bindings: [
+        {
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: testOrganization.id,
+        },
+      ],
+    });
+    patToken = created.token;
+  });
+
+  afterAll(async () => {
+    await prisma.team.deleteMany({
+      where: { organizationId: { in: [testOrganization.id, otherOrganization.id] } },
+    }).catch(() => {});
+    await prisma.roleBinding.deleteMany({
+      where: { organizationId: { in: [testOrganization.id, otherOrganization.id] } },
+    }).catch(() => {});
+    await prisma.apiKey.deleteMany({
+      where: { organizationId: testOrganization.id },
+    }).catch(() => {});
+    await prisma.organizationUser.deleteMany({
+      where: { organizationId: testOrganization.id },
+    }).catch(() => {});
+    await prisma.organization.deleteMany({
+      where: { id: { in: [testOrganization.id, otherOrganization.id] } },
+    }).catch(() => {});
+  });
+
+  describe("Authentication", () => {
+    it("returns 401 without auth header", async () => {
+      const res = await app.request("/api/teams");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 with invalid API key", async () => {
+      const res = await app.request("/api/teams", {
+        headers: { Authorization: "Bearer sk-lw-invalid_token" },
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/teams", () => {
+    it("creates a team and returns 201", async () => {
+      const res = await api.post("/api/teams", {
+        name: "My Test Team",
+      });
+      expect(res.status).toBe(201);
+
+      const body = await res.json();
+      expect(body.id).toMatch(/^team_/);
+      expect(body.name).toBe("My Test Team");
+      expect(body.slug).toContain("my-test-team");
+      expect(body.organizationId).toBe(testOrganization.id);
+      expect(body.createdAt).toBeDefined();
+      expect(body.updatedAt).toBeDefined();
+    });
+
+    it("returns 422 when name is missing", async () => {
+      const res = await api.post("/api/teams", {});
+      expect(res.status).toBe(422);
+
+      const body = await res.json();
+      expect(body.error).toBe("Unprocessable Entity");
+    });
+
+    it("returns 422 when name is empty", async () => {
+      const res = await api.post("/api/teams", { name: "" });
+      expect(res.status).toBe(422);
+    });
+
+    it("returns 422 when name exceeds 255 characters", async () => {
+      const res = await api.post("/api/teams", { name: "a".repeat(256) });
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe("GET /api/teams", () => {
+    it("lists non-archived teams for the organization", async () => {
+      const res = await api.get("/api/teams");
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.data).toBeDefined();
+      expect(Array.isArray(body.data)).toBe(true);
+      expect(body.pagination).toBeDefined();
+      expect(body.pagination.page).toBe(1);
+    });
+
+    it("paginates results", async () => {
+      const res = await api.get("/api/teams?page=1&limit=2");
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.pagination.limit).toBe(2);
+    });
+
+    it("excludes teams from other organizations", async () => {
+      await prisma.team.create({
+        data: {
+          name: "Other Org Team",
+          slug: `--other-team-${nanoid(8)}`,
+          organizationId: otherOrganization.id,
+        },
+      });
+
+      const res = await api.get("/api/teams");
+      const body = await res.json();
+
+      for (const team of body.data) {
+        expect(team.organizationId).toBe(testOrganization.id);
+      }
+    });
+  });
+
+  describe("GET /api/teams/:id", () => {
+    it("returns a team by id", async () => {
+      const createRes = await api.post("/api/teams", {
+        name: `Get Test ${nanoid(6)}`,
+      });
+      const created = await createRes.json();
+
+      const res = await api.get(`/api/teams/${created.id}`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.id).toBe(created.id);
+      expect(body.name).toBe(created.name);
+    });
+
+    it("returns 404 for non-existent team", async () => {
+      const res = await api.get("/api/teams/team_doesnotexist");
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for team in another organization", async () => {
+      const otherTeam = await prisma.team.create({
+        data: {
+          name: "Cross Org Team",
+          slug: `--cross-org-${nanoid(8)}`,
+          organizationId: otherOrganization.id,
+        },
+      });
+
+      const res = await api.get(`/api/teams/${otherTeam.id}`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/teams/:id", () => {
+    it("updates team name", async () => {
+      const createRes = await api.post("/api/teams", {
+        name: `Patch Test ${nanoid(6)}`,
+      });
+      const created = await createRes.json();
+
+      const res = await api.patch(`/api/teams/${created.id}`, {
+        name: "Updated Team Name",
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.name).toBe("Updated Team Name");
+      expect(body.id).toBe(created.id);
+    });
+
+    it("returns 404 for non-existent team", async () => {
+      const res = await api.patch("/api/teams/team_ghost", {
+        name: "Whatever",
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/teams/:id", () => {
+    it("archives the team", async () => {
+      const createRes = await api.post("/api/teams", {
+        name: `Delete Test ${nanoid(6)}`,
+      });
+      const created = await createRes.json();
+
+      const res = await api.delete(`/api/teams/${created.id}`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.id).toBe(created.id);
+      expect(body.archivedAt).toBeDefined();
+    });
+
+    it("makes the team inaccessible via GET after archival", async () => {
+      const createRes = await api.post("/api/teams", {
+        name: `Archive Test ${nanoid(6)}`,
+      });
+      const created = await createRes.json();
+
+      await api.delete(`/api/teams/${created.id}`);
+
+      const getRes = await api.get(`/api/teams/${created.id}`);
+      expect(getRes.status).toBe(404);
+    });
+
+    it("excludes archived teams from list", async () => {
+      const createRes = await api.post("/api/teams", {
+        name: `Archive List Test ${nanoid(6)}`,
+      });
+      const created = await createRes.json();
+
+      await api.delete(`/api/teams/${created.id}`);
+
+      const listRes = await api.get("/api/teams");
+      const body = await listRes.json();
+      const ids = body.data.map((t: { id: string }) => t.id);
+      expect(ids).not.toContain(created.id);
+    });
+
+    it("returns 404 for non-existent team", async () => {
+      const res = await api.delete("/api/teams/team_nope");
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts
@@ -388,10 +388,10 @@ describe("Feature: Teams REST API", () => {
         }),
     };
 
-    /** @scenario Viewer can list teams */
-    it("allows viewer to list teams", async () => {
+    /** @scenario Viewer cannot list teams */
+    it("returns 403 when viewer lists teams", async () => {
       const res = await viewerApi.get("/api/teams");
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(403);
     });
 
     /** @scenario Viewer cannot create a team */

--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -23,6 +23,7 @@ import { app as scenariosApp } from "../app/api/scenarios/[[...route]]/app";
 import { app as secretsApp } from "../app/api/secrets/[[...route]]/app";
 import { app as simulationRunsApp } from "../app/api/simulation-runs/[[...route]]/app";
 import { app as suitesApp } from "../app/api/suites/[[...route]]/app";
+import { app as teamsApp } from "../app/api/teams/[[...route]]/app";
 import { app as tracesApp } from "../app/api/traces/[[...route]]/app";
 import { app as triggersApp } from "../app/api/triggers/[[...route]]/app";
 import { app as workflowsCrudApp } from "../app/api/workflows/[[...route]]/app";
@@ -89,6 +90,7 @@ export function createApiRouter() {
   api.route("/", secretsApp);
   api.route("/", simulationRunsApp);
   api.route("/", suitesApp);
+  api.route("/", teamsApp);
   api.route("/", tracesApp);
   api.route("/", triggersApp);
   api.route("/", workflowsCrudApp);      // CRUD — complements workflowsApp (code-completion, post_event)

--- a/langwatch/src/server/app-layer/teams/repositories/team.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/teams/repositories/team.prisma.repository.ts
@@ -1,0 +1,82 @@
+import type { PrismaClient, Team } from "@prisma/client";
+import type {
+  CreateTeamInput,
+  PaginatedResult,
+  TeamRepository,
+  UpdateTeamInput,
+} from "./team.repository";
+
+export class PrismaTeamRepository implements TeamRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<Team | null> {
+    return this.prisma.team.findUnique({ where: { id } });
+  }
+
+  async findAllByOrganization({
+    organizationId,
+    page,
+    limit,
+  }: {
+    organizationId: string;
+    page: number;
+    limit: number;
+  }): Promise<PaginatedResult<Team>> {
+    const where = { organizationId, archivedAt: null };
+    const [data, total] = await Promise.all([
+      this.prisma.team.findMany({
+        where,
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      }),
+      this.prisma.team.count({ where }),
+    ]);
+    return { data, pagination: { page, limit, total } };
+  }
+
+  async findBySlugInOrganization({
+    slug,
+    organizationId,
+  }: {
+    slug: string;
+    organizationId: string;
+  }): Promise<Team | null> {
+    return this.prisma.team.findFirst({ where: { slug, organizationId } });
+  }
+
+  async create(data: CreateTeamInput): Promise<Team> {
+    return this.prisma.team.create({ data });
+  }
+
+  async update({
+    id,
+    organizationId,
+    data,
+  }: {
+    id: string;
+    organizationId: string;
+    data: UpdateTeamInput;
+  }): Promise<Team | null> {
+    const where = { id, organizationId, archivedAt: null };
+    const result = await this.prisma.team.updateMany({ where, data });
+    if (result.count === 0) return null;
+    return this.prisma.team.findUnique({ where: { id } });
+  }
+
+  async archive({
+    id,
+    organizationId,
+  }: {
+    id: string;
+    organizationId: string;
+  }): Promise<Team | null> {
+    const where = { id, organizationId, archivedAt: null };
+    const result = await this.prisma.team.updateMany({
+      where,
+      data: { archivedAt: new Date() },
+    });
+    if (result.count === 0) return null;
+    return this.prisma.team.findUnique({ where: { id } });
+  }
+}

--- a/langwatch/src/server/app-layer/teams/repositories/team.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/teams/repositories/team.prisma.repository.ts
@@ -42,7 +42,7 @@ export class PrismaTeamRepository implements TeamRepository {
     slug: string;
     organizationId: string;
   }): Promise<Team | null> {
-    return this.prisma.team.findFirst({ where: { slug, organizationId } });
+    return this.prisma.team.findFirst({ where: { slug, organizationId, archivedAt: null } });
   }
 
   async create(data: CreateTeamInput): Promise<Team> {

--- a/langwatch/src/server/app-layer/teams/repositories/team.repository.ts
+++ b/langwatch/src/server/app-layer/teams/repositories/team.repository.ts
@@ -1,0 +1,40 @@
+import type { Team } from "@prisma/client";
+
+export interface CreateTeamInput {
+  id: string;
+  name: string;
+  slug: string;
+  organizationId: string;
+}
+
+export interface UpdateTeamInput {
+  name?: string;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  pagination: { page: number; limit: number; total: number };
+}
+
+export interface TeamRepository {
+  findById(id: string): Promise<Team | null>;
+  findAllByOrganization(params: {
+    organizationId: string;
+    page: number;
+    limit: number;
+  }): Promise<PaginatedResult<Team>>;
+  findBySlugInOrganization(params: {
+    slug: string;
+    organizationId: string;
+  }): Promise<Team | null>;
+  create(data: CreateTeamInput): Promise<Team>;
+  update(params: {
+    id: string;
+    organizationId: string;
+    data: UpdateTeamInput;
+  }): Promise<Team | null>;
+  archive(params: {
+    id: string;
+    organizationId: string;
+  }): Promise<Team | null>;
+}

--- a/langwatch/src/server/app-layer/teams/team.service.ts
+++ b/langwatch/src/server/app-layer/teams/team.service.ts
@@ -1,0 +1,94 @@
+import { nanoid } from "nanoid";
+import { slugify } from "~/utils/slugify";
+import type { Team } from "@prisma/client";
+import type {
+  PaginatedResult,
+  TeamRepository,
+} from "./repositories/team.repository";
+
+export class TeamNotFoundError extends Error {
+  name = "TeamNotFoundError" as const;
+}
+
+export class TeamSlugConflictError extends Error {
+  name = "TeamSlugConflictError" as const;
+}
+
+export class TeamRestService {
+  constructor(readonly repo: TeamRepository) {}
+
+  async getById({
+    id,
+    organizationId,
+  }: {
+    id: string;
+    organizationId: string;
+  }): Promise<Team | null> {
+    const team = await this.repo.findById(id);
+    if (!team || team.organizationId !== organizationId || team.archivedAt) {
+      return null;
+    }
+    return team;
+  }
+
+  async listByOrganization(params: {
+    organizationId: string;
+    page: number;
+    limit: number;
+  }): Promise<PaginatedResult<Team>> {
+    return this.repo.findAllByOrganization(params);
+  }
+
+  async create({
+    organizationId,
+    name,
+  }: {
+    organizationId: string;
+    name: string;
+  }): Promise<Team> {
+    const teamNanoId = nanoid();
+    const id = `team_${teamNanoId}`;
+    const slug =
+      slugify(name, { lower: true, strict: true }) +
+      "-" +
+      id.substring(0, 11);
+
+    const existing = await this.repo.findBySlugInOrganization({
+      slug,
+      organizationId,
+    });
+    if (existing) {
+      throw new TeamSlugConflictError(
+        "A team with this name already exists in the organization.",
+      );
+    }
+
+    return this.repo.create({ id, name, slug, organizationId });
+  }
+
+  async update({
+    id,
+    organizationId,
+    data,
+  }: {
+    id: string;
+    organizationId: string;
+    data: { name?: string };
+  }): Promise<Team> {
+    const team = await this.repo.update({ id, organizationId, data });
+    if (!team) throw new TeamNotFoundError("Team not found");
+    return team;
+  }
+
+  async archive({
+    id,
+    organizationId,
+  }: {
+    id: string;
+    organizationId: string;
+  }): Promise<Team> {
+    const team = await this.repo.archive({ id, organizationId });
+    if (!team) throw new TeamNotFoundError("Team not found");
+    return team;
+  }
+}

--- a/specs/teams/teams-rest-api.feature
+++ b/specs/teams/teams-rest-api.feature
@@ -146,10 +146,10 @@ Feature: Teams REST API
   # ============================================================================
 
   @integration
-  Scenario: Viewer can list teams
+  Scenario: Viewer cannot list teams
     Given I am authenticated with a viewer-scoped API key
     When I GET /api/teams
-    Then the response status is 200
+    Then the response status is 403
 
   @integration
   Scenario: Viewer cannot create a team

--- a/specs/teams/teams-rest-api.feature
+++ b/specs/teams/teams-rest-api.feature
@@ -1,0 +1,172 @@
+Feature: Teams REST API
+
+  As an admin using the LangWatch API
+  I want to manage teams via REST endpoints
+  So that I can automate team provisioning and cleanup
+
+  Background:
+    Given an organization exists
+    And I am authenticated with an org-scoped API key
+
+  # ============================================================================
+  # Authentication
+  # ============================================================================
+
+  @integration
+  Scenario: Rejects unauthenticated requests
+    When I call GET /api/teams without an auth header
+    Then the response status is 401
+
+  @integration
+  Scenario: Rejects invalid API key
+    When I call GET /api/teams with an invalid Bearer token
+    Then the response status is 401
+
+  # ============================================================================
+  # Create
+  # ============================================================================
+
+  @integration
+  Scenario: Creates a team
+    When I POST /api/teams with name "My Test Team"
+    Then the response status is 201
+    And the response contains a team id starting with "team_"
+    And the response contains the name, slug, organizationId, createdAt, updatedAt
+
+  @integration
+  Scenario: Rejects create when name is missing
+    When I POST /api/teams with an empty body
+    Then the response status is 422
+
+  @integration
+  Scenario: Rejects create when name is empty
+    When I POST /api/teams with name ""
+    Then the response status is 422
+
+  @integration
+  Scenario: Rejects create when name exceeds 255 characters
+    When I POST /api/teams with a name longer than 255 characters
+    Then the response status is 422
+
+  # ============================================================================
+  # List
+  # ============================================================================
+
+  @integration
+  Scenario: Lists non-archived teams for the organization
+    When I GET /api/teams
+    Then the response status is 200
+    And the response contains a paginated data array
+
+  @integration
+  Scenario: Paginates team list
+    When I GET /api/teams with page=1 and limit=2
+    Then the response pagination limit is 2
+
+  @integration
+  Scenario: Excludes teams from other organizations
+    Given a team exists in a different organization
+    When I GET /api/teams
+    Then the response contains only teams from my organization
+
+  # ============================================================================
+  # Get by ID
+  # ============================================================================
+
+  @integration
+  Scenario: Returns a team by id
+    Given a team exists in my organization
+    When I GET /api/teams/:id
+    Then the response status is 200
+    And the response contains the team
+
+  @integration
+  Scenario: Returns 404 for non-existent team
+    When I GET /api/teams/team_doesnotexist
+    Then the response status is 404
+
+  @integration
+  Scenario: Returns 404 for team in another organization
+    Given a team exists in a different organization
+    When I GET /api/teams/:otherId
+    Then the response status is 404
+
+  # ============================================================================
+  # Update
+  # ============================================================================
+
+  @integration
+  Scenario: Updates team name
+    Given a team exists in my organization
+    When I PATCH /api/teams/:id with name "Updated Name"
+    Then the response status is 200
+    And the response name is "Updated Name"
+
+  @integration
+  Scenario: Returns 404 when updating non-existent team
+    When I PATCH /api/teams/team_ghost with name "Whatever"
+    Then the response status is 404
+
+  # ============================================================================
+  # Delete (archive)
+  # ============================================================================
+
+  @integration
+  Scenario: Archives a team
+    Given a team exists in my organization
+    When I DELETE /api/teams/:id
+    Then the response status is 200
+    And the response contains archivedAt
+
+  @integration
+  Scenario: Archived team is inaccessible via GET
+    Given a team has been archived
+    When I GET /api/teams/:id
+    Then the response status is 404
+
+  @integration
+  Scenario: Archived team is excluded from list
+    Given a team has been archived
+    When I GET /api/teams
+    Then the archived team is not in the response
+
+  @integration
+  Scenario: Returns 404 when deleting non-existent team
+    When I DELETE /api/teams/team_nope
+    Then the response status is 404
+
+  @integration
+  Scenario: Returns 404 when deleting already-archived team
+    Given a team has been archived
+    When I DELETE /api/teams/:id
+    Then the response status is 404
+
+  # ============================================================================
+  # Permission denial
+  # ============================================================================
+
+  @integration
+  Scenario: Viewer can list teams
+    Given I am authenticated with a viewer-scoped API key
+    When I GET /api/teams
+    Then the response status is 200
+
+  @integration
+  Scenario: Viewer cannot create a team
+    Given I am authenticated with a viewer-scoped API key
+    When I POST /api/teams with name "Blocked Team"
+    Then the response status is 403
+
+  @integration
+  Scenario: Viewer cannot update a team
+    Given I am authenticated with a viewer-scoped API key
+    And a team exists in my organization
+    When I PATCH /api/teams/:id with name "Nope"
+    Then the response status is 403
+
+  @integration
+  Scenario: Viewer cannot delete a team
+    Given I am authenticated with a viewer-scoped API key
+    And a team exists in my organization
+    When I DELETE /api/teams/:id
+    Then the response status is 403


### PR DESCRIPTION
## Summary

- Adds `/api/teams` endpoint with full CRUD (POST, GET list, GET by id, PATCH, DELETE)
- Follows the same Route → Service → Repository layering as `/api/projects`
- All operations scoped to the authenticated organization via `orgAuthMiddleware`
- Soft-delete via `archivedAt` timestamp, archived teams excluded from list and slug checks
- Zod validation with `validationHook` returning 422 for invalid input
- Permissions: `team:view`, `team:create`, `team:update`, `team:delete` (covered by `team:manage` hierarchy)
- Full API documentation: OpenAPI spec, doc pages, llms.txt
- BDD feature file with 23 scenarios, all bound via `@scenario` annotations

## Files changed

**Implementation (Route → Service → Repository)**
| File | Purpose |
|------|---------|
| `langwatch/src/server/app-layer/teams/repositories/team.repository.ts` | Repository interface |
| `langwatch/src/server/app-layer/teams/repositories/team.prisma.repository.ts` | Prisma implementation |
| `langwatch/src/server/app-layer/teams/team.service.ts` | Service layer with domain errors |
| `langwatch/src/app/api/middleware/team-service.ts` | Service injection middleware |
| `langwatch/src/app/api/teams/[[...route]]/app.ts` | Hono routes with validation |
| `langwatch/src/app/api/teams/[[...route]]/error-handler.ts` | Error handler |
| `langwatch/src/server/api-router.ts` | Route registration |

**Tests & Specs**
| File | Purpose |
|------|---------|
| `langwatch/src/app/api/teams/__tests__/teams-rest-api.integration.test.ts` | 22 integration tests |
| `specs/teams/teams-rest-api.feature` | 23 BDD scenarios |

**Documentation**
| File | Purpose |
|------|---------|
| `docs/api-reference/teams/*.mdx` | 6 API reference pages |
| `docs/api-reference/openapiLangWatch.json` | Team schema + endpoints |
| `docs/docs.json` | Navigation entry |
| `docs/llms.txt` + `docs/llms-full.txt` | LLM context index |

## Test plan

- [x] Integration tests: auth (401), CRUD, validation (422), org isolation (404), archive behavior
- [x] Permission denial: viewer gets 403 on create/update/delete/list
- [x] Double-archive returns 404
- [x] Feature parity: 23/23 scenarios bound
- [x] Security tested against localhost: injection, mass assignment, path traversal, cross-org isolation
- [x] `pnpm typecheck` clean
- [x] CI green (54/54 checks)

Closes #4054