### PR TITLE
fix: use 100dvh for 404 page container to fill full viewport

### DIFF
--- a/langwatch/src/components/NotFoundScene.tsx
+++ b/langwatch/src/components/NotFoundScene.tsx
@@ -242,7 +242,7 @@ export function NotFoundScene() {
     <Center
       ref={containerRef}
       width="100%"
-      height="100%"
+      height="100dvh"
       minHeight="400px"
       overflow="hidden"
       position="relative"


### PR DESCRIPTION
## Summary

The 404 page's perspective grid background only covers the top ~half of the viewport. The bottom half is plain white, making it look broken.

## Root Cause

The `<Center>` container in `NotFoundScene.tsx` uses `height="100%"`, which resolves to the height of `DashboardLayout`'s content area — not the full viewport. Since the content (404 text + buttons) is short, the container doesn't stretch to fill the screen.

The canvas (`position: absolute; inset: 0`) fills its parent, but the parent itself is too short.

## Fix

Changed `height="100%"` to `height="100dvh"` (dynamic viewport height) to ensure the container stretches to fill the entire screen.

Fixes #4055