### PR TITLE
fix(trace-summary): pin origin against eval-chain child spans

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
@@ -92,6 +92,68 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
     });
   });
 
+  describe("when an evaluator workflow emits child spans on a customer's trace", () => {
+    // 2026-05-14 prod regression. Loop-prevention PR #4048 made eval
+    // workflow spans (running in nlpgo) continue the parent trace via
+    // W3C traceparent. Those spans land on the customer's trace as
+    // children with langwatch.origin="evaluation" + causality_depth=1.
+    // The previous "explicit origin on any span always wins" rule then
+    // overwrote the customer's resolved origin (playground, application,
+    // etc.) on the trace summary as the eval spans arrived.
+    /** @scenario Eval-emitted child spans do not flip the trace summary origin */
+    it("preserves the customer trace's origin once the root span has resolved it", () => {
+      const rootSpan = createTestSpan({
+        id: "root-1",
+        spanId: "root-1",
+        parentSpanId: null,
+        spanAttributes: {
+          "langwatch.origin": "playground",
+        },
+      });
+
+      // Eval workflow's first span: child of customer's root, carrying
+      // depth=1 + explicit origin=evaluation (stamped by nlpgo's
+      // BaggageAttributeProcessor + startStudioSpan attrs).
+      const evalChildSpan = createTestSpan({
+        id: "eval-child-1",
+        spanId: "eval-child-1",
+        parentSpanId: "root-1",
+        spanAttributes: {
+          "langwatch.origin": "evaluation",
+          "langwatch.reserved.causality_depth": "1",
+        },
+      });
+
+      let state = applySpanToSummary({ state: createInitState(), span: rootSpan });
+      state = applySpanToSummary({ state, span: evalChildSpan });
+
+      expect(state.attributes["langwatch.origin"]).toBe("playground");
+    });
+
+    /** @scenario Standalone eval trace (no parent) still resolves to evaluation */
+    it("still resolves origin=evaluation when the eval IS the top-level trace", () => {
+      // Standalone eval trace — no inbound traceparent, eval workflow
+      // creates its own root span with origin=evaluation. The trace
+      // summary must NOT mistakenly classify this as a customer trace.
+      const evalRootSpan = createTestSpan({
+        id: "eval-root",
+        spanId: "eval-root",
+        parentSpanId: null,
+        spanAttributes: {
+          "langwatch.origin": "evaluation",
+          "langwatch.reserved.causality_depth": "1",
+        },
+      });
+
+      const state = applySpanToSummary({
+        state: createInitState(),
+        span: evalRootSpan,
+      });
+
+      expect(state.attributes["langwatch.origin"]).toBe("evaluation");
+    });
+  });
+
   describe("when no span sets langwatch.origin", () => {
     /** @scenario "Traces without any origin attribute remain unset" */
     it("does not set langwatch.origin in summary attributes", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts
@@ -100,7 +100,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
     // The previous "explicit origin on any span always wins" rule then
     // overwrote the customer's resolved origin (playground, application,
     // etc.) on the trace summary as the eval spans arrived.
-    /** @scenario Eval-emitted child spans do not flip the trace summary origin */
+    /** @scenario Eval-emitted child span does not flip the customer trace's origin */
     it("preserves the customer trace's origin once the root span has resolved it", () => {
       const rootSpan = createTestSpan({
         id: "root-1",
@@ -130,7 +130,7 @@ describe("applySpanToSummary() langwatch.origin hoisting", () => {
       expect(state.attributes["langwatch.origin"]).toBe("playground");
     });
 
-    /** @scenario Standalone eval trace (no parent) still resolves to evaluation */
+    /** @scenario Standalone eval trace still resolves to evaluation */
     it("still resolves origin=evaluation when the eval IS the top-level trace", () => {
       // Standalone eval trace — no inbound traceparent, eval workflow
       // creates its own root span with origin=evaluation. The trace

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-origin.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-origin.service.ts
@@ -97,11 +97,40 @@ export class TraceOriginService {
     const explicitOrigin = span.spanAttributes["langwatch.origin"];
     const hasExplicitOrigin =
       typeof explicitOrigin === "string" && explicitOrigin !== "";
+    const existingOrigin = state.attributes["langwatch.origin"];
+
+    // Eval-chain detection: nlpgo's BaggageAttributeProcessor stamps
+    // langwatch.reserved.causality_depth on every span emitted during
+    // an evaluator workflow run (set by post-PR-#4048 loop prevention).
+    // A non-root span with depth>=1 is by definition an eval child
+    // riding in on someone else's traceparent — its origin must NOT
+    // be allowed to flip the customer trace's resolved origin.
+    const rawDepth = span.spanAttributes["langwatch.reserved.causality_depth"];
+    const causalityDepth =
+      typeof rawDepth === "string"
+        ? parseInt(rawDepth, 10) || 0
+        : typeof rawDepth === "number"
+          ? rawDepth
+          : 0;
+    const isEvalChainChild = !isRootSpan && causalityDepth >= 1;
 
     if (hasExplicitOrigin) {
-      // Explicit langwatch.origin on any span always wins — it's a
-      // deliberate, high-confidence signal (SDK or platform).
-      mergedAttributes["langwatch.origin"] = explicitOrigin as string;
+      if (isEvalChainChild && existingOrigin) {
+        // 2026-05-14 prod regression: eval workflow spans now continue
+        // the parent trace via W3C traceparent (PR #4048). They land on
+        // the customer's trace as children with origin="evaluation" +
+        // causality_depth=1; the previous "explicit always wins" rule
+        // then flipped the trace summary's origin from playground /
+        // application to evaluation as the eval spans arrived.
+        mergedAttributes["langwatch.origin"] = existingOrigin;
+      } else {
+        // Explicit langwatch.origin on any other span wins — it's a
+        // deliberate, high-confidence signal (SDK or platform). This
+        // also covers the SDK-heuristic-application → explicit-platform
+        // upgrade path on distributed traces where the root span isn't
+        // the platform's root.
+        mergedAttributes["langwatch.origin"] = explicitOrigin as string;
+      }
     } else {
       // For root spans, always try legacy markers first — a root with a
       // legacy marker should override a provisional origin (e.g. "application")

--- a/specs/traces/explicit-application-origin.feature
+++ b/specs/traces/explicit-application-origin.feature
@@ -225,6 +225,41 @@ Feature: Explicit application origin for race condition prevention
     Then no origin tag is shown
 
   # ===========================================================================
+  # Eval-chain origin pinning (2026-05-14 prod regression)
+  # ===========================================================================
+  #
+  # PR #4048 wired loop prevention end-to-end: nlpgo evaluator workflows
+  # now continue the parent trace via W3C traceparent and stamp every
+  # emitted span with `langwatch.reserved.causality_depth = N+1`.
+  # As a side effect, those eval spans carry `langwatch.origin = "evaluation"`
+  # and land on the customer's trace as children. The fold projection's
+  # previous rule "explicit origin on any span always wins" then
+  # overwrote the customer's resolved origin (playground / application /
+  # etc.) on the trace summary, mis-classifying the trace.
+  #
+  # Fix: a non-root span carrying causality_depth >= 1 is by definition
+  # an eval child riding in on someone else's traceparent. Its explicit
+  # origin must NOT flip the trace summary once an origin is resolved.
+
+  @unit @scenario
+  Scenario: Eval-emitted child span does not flip the customer trace's origin
+    Given the root span resolved langwatch.origin = "playground"
+    And later an eval workflow emits a child span on the same trace
+    And that child span carries langwatch.origin = "evaluation"
+    And that child span carries langwatch.reserved.causality_depth = "1"
+    When the fold projection processes the eval child span
+    Then the trace summary's langwatch.origin remains "playground"
+
+  @unit @scenario
+  Scenario: Standalone eval trace still resolves to evaluation
+    Given an eval workflow runs without an inbound traceparent
+    And its root span carries langwatch.origin = "evaluation"
+    And its root span carries langwatch.reserved.causality_depth = "1"
+    When the fold projection processes the eval root span
+    Then the trace summary's langwatch.origin is "evaluation"
+    Because root spans always define the trace's origin regardless of depth
+
+  # ===========================================================================
   # Race condition scenarios (the core problem this feature prevents)
   # ===========================================================================
 


### PR DESCRIPTION
## Summary

- A 2026-05-14 prod regression after PR #4048: trace summaries show `langwatch.origin = "evaluation"` instead of the customer trace's actual origin (`playground`, `application`, etc.) once an eval workflow runs against the trace.
- Root cause: PR #4048 wired loop prevention end-to-end. nlpgo eval workflows now continue the parent trace via W3C traceparent and stamp every span with `langwatch.reserved.causality_depth >= 1`. Those eval spans carry `langwatch.origin = "evaluation"` and land as children of the customer's root. The fold projection's previous rule (\"explicit origin on any span always wins\") flipped the trace summary as the eval spans arrived.
- Fix in `TraceOriginService.hoistOrigin`: a NON-ROOT span carrying `causality_depth >= 1` cannot flip the trace summary's origin once one is resolved.

## What changed
- `langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-origin.service.ts` — narrow rule based on `(isRoot, causalityDepth)`.
- `langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryOrigin.unit.test.ts` — 2 regression scenarios (bug case + standalone-eval-trace case).
- `specs/traces/explicit-application-origin.feature` — spec section for the eval-chain pin behavior.

## Why narrow
- **Root spans always win** regardless of depth — covers standalone eval traces (eval IS the top-level activity).
- **Non-root, depth=0** spans keep the old \"explicit wins\" semantics — preserves the existing SDK-heuristic → explicit-platform upgrade path that the existing test at `traceSummaryOrigin.unit.test.ts:650` exercises.
- Only **non-root, depth>=1** spans get pinned out of the override path.

## Stash-test-restore proof
- New regression test fails on main with `Expected \"playground\" / Received \"evaluation\"` — the exact prod symptom rchaves caught in the UI screenshot.
- 33/33 origin-suite tests pass with the fix, including the pre-existing SDK-heuristic upgrade case.
- 411/411 trace-processing unit tests pass.

## Test plan
- [x] Targeted unit suite (`traceSummaryOrigin.unit.test.ts`)
- [x] Broader trace-processing unit suite (411 tests)
- [x] Trace-processing integration suite (testcontainers Redis + ClickHouse)
- [x] Typecheck clean
- [ ] CI green end-to-end
- [ ] Browser QA on a fresh playground → eval flow once CI passes