### PR TITLE
fix(nlpgo): trace UX polish — friendly span names + workflow name + per-node identity + Entry/End skip

### DIFF
--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -210,6 +210,7 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 		ThreadID:          threadID,
 		NodeID:            inner.NodeID,
 		APIKey:            peekWorkflowAPIKey(inner.Workflow),
+		WorkflowName:      peekWorkflowName(inner.Workflow),
 		Type:              peek.Type,
 		RunID:             inner.RunID,
 		WorkflowVersionID: inner.WorkflowVersionID,
@@ -217,6 +218,26 @@ func decodeStudioClientEvent(r *http.Request, body []byte) (*app.WorkflowRequest
 		DatasetEntry:      inner.DatasetEntry,
 		DoNotTrace:        doNotTrace,
 	}, nil
+}
+
+// peekWorkflowName extracts the user-visible workflow name from raw
+// workflow JSON. Used by the OTel root span so operators see "My
+// Translation Agent" in the trace drawer instead of a generic
+// "execute_flow" — Python parity is `optional_langwatch_trace(name=
+// workflow.name)` at execute_flow.py. Falls back to empty on
+// missing/malformed input so the caller can use the event-type
+// default.
+func peekWorkflowName(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var peek struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return ""
+	}
+	return peek.Name
 }
 
 // peekWorkflowEnableTracing extracts `enable_tracing` from the raw

--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -77,7 +77,7 @@ func executeSyncHandler(application *app.App) http.HandlerFunc {
 			ctx = withOrigin(ctx, req.Origin)
 		}
 		ctx = applyInboundCausality(ctx, r)
-		ctx, span := startStudioSpan(ctx, "nlpgo.studio.execute_sync", req, req.APIKey)
+		ctx, span := startStudioSpan(ctx, req, req.APIKey)
 		defer span.End()
 		clog.Get(ctx).Info("execute_flow_received")
 		result, err := executor.Execute(ctx, *req)
@@ -389,7 +389,7 @@ func executeStreamHandler(application *app.App) http.HandlerFunc {
 			ctx = withOrigin(ctx, req.Origin)
 		}
 		ctx = applyInboundCausality(ctx, r)
-		ctx, span := startStudioSpan(ctx, "nlpgo.studio.execute_stream", req, req.APIKey)
+		ctx, span := startStudioSpan(ctx, req, req.APIKey)
 		defer span.End()
 		clog.Get(ctx).Info("execute_flow_received", zap.Bool("stream", true))
 

--- a/services/nlpgo/adapters/httpapi/tracing.go
+++ b/services/nlpgo/adapters/httpapi/tracing.go
@@ -33,30 +33,55 @@ const tracerName = "langwatch-nlpgo"
 // a fresh trace (still better than dropping the request).
 // studioSpanNameAndType returns the OTel root span name and the
 // langwatch.span.type value that match Python's optional_langwatch_trace
-// shape per endpoint type:
+// shape per endpoint type.
 //
-//	execute_flow        → ("execute_flow",        "workflow")
-//	execute_evaluation  → ("execute_evaluation",  "evaluation")
-//	execute_component   → ("execute_component",   "component")
-//	default (legacy)    → ("execute_flow",        "workflow")
+// Naming priority (rchaves dogfood 2026-05-14, second pass):
+//  1. workflowName, when set, is the canvas name of the workflow the
+//     operator typed in Studio (e.g. "Translation Agent"). When a trace
+//     drawer lists three runs of the same workflow, they all share the
+//     workflow name — and that is the right grouping for an operator
+//     debugging "did my Translation Agent fail?". Mirrors Python's
+//     `optional_langwatch_trace(name=workflow.name)` in execute_flow.py.
+//  2. When workflowName is empty (sub-workflows that don't carry a name,
+//     direct curl tests, malformed payloads), fall back to the event
+//     type so the row still has a non-empty label.
+//
+// langwatch.span.type still switches strictly on the event type so
+// Studio's color dispatcher (workflow=blue / evaluation=purple /
+// component=green) stays right regardless of the user-typed name:
+//
+//	execute_flow        → "workflow"
+//	execute_evaluation  → "evaluation"
+//	execute_component   → "component"
+//	default (legacy)    → "workflow"
 //
 // Earlier revisions used a single hard-coded name ("nlpgo.studio.
 // execute_sync" / ".execute_stream") with no span.type, which left
 // the Studio drawer rendering the root row with no chip color +
-// migration-internal jargon (rchaves dogfood 2026-05-14). Splitting
-// by req.Type matches what langwatch_nlp/studio/execute/execute_*.py
-// stamps on its own root span and is what the trace drawer's color
-// dispatcher recognizes.
-func studioSpanNameAndType(eventType string) (name, spanType string) {
+// migration-internal jargon. The first fix moved to event-type names
+// (still generic across workflows); this fix completes the rename by
+// using the workflow's actual canvas name.
+func studioSpanNameAndType(eventType, workflowName string) (name, spanType string) {
 	switch eventType {
 	case "execute_evaluation":
-		return "execute_evaluation", "evaluation"
+		spanType = "evaluation"
 	case "execute_component":
-		return "execute_component", "component"
+		spanType = "component"
 	case "execute_flow", "":
-		return "execute_flow", "workflow"
+		spanType = "workflow"
+	default:
+		spanType = "workflow"
 	}
-	return "execute_flow", "workflow"
+	if workflowName != "" {
+		return workflowName, spanType
+	}
+	switch eventType {
+	case "execute_evaluation":
+		return "execute_evaluation", spanType
+	case "execute_component":
+		return "execute_component", spanType
+	}
+	return "execute_flow", spanType
 }
 
 func startStudioSpan(ctx context.Context, req *app.WorkflowRequest, workflowAPIKey string) (context.Context, trace.Span) {
@@ -91,7 +116,7 @@ func startStudioSpan(ctx context.Context, req *app.WorkflowRequest, workflowAPIK
 			ctx = trace.ContextWithSpanContext(ctx, sc)
 		}
 	}
-	spanName, spanType := studioSpanNameAndType(req.Type)
+	spanName, spanType := studioSpanNameAndType(req.Type, req.WorkflowName)
 	tracer := otelapi.Tracer(tracerName)
 	attrs := studioRequestAttrs(req)
 	attrs = append(attrs, attribute.String("langwatch.span.type", spanType))

--- a/services/nlpgo/adapters/httpapi/tracing.go
+++ b/services/nlpgo/adapters/httpapi/tracing.go
@@ -31,7 +31,35 @@ const tracerName = "langwatch-nlpgo"
 //
 // When the inbound trace_id is malformed or absent, fall through to
 // a fresh trace (still better than dropping the request).
-func startStudioSpan(ctx context.Context, name string, req *app.WorkflowRequest, workflowAPIKey string) (context.Context, trace.Span) {
+// studioSpanNameAndType returns the OTel root span name and the
+// langwatch.span.type value that match Python's optional_langwatch_trace
+// shape per endpoint type:
+//
+//	execute_flow        → ("execute_flow",        "workflow")
+//	execute_evaluation  → ("execute_evaluation",  "evaluation")
+//	execute_component   → ("execute_component",   "component")
+//	default (legacy)    → ("execute_flow",        "workflow")
+//
+// Earlier revisions used a single hard-coded name ("nlpgo.studio.
+// execute_sync" / ".execute_stream") with no span.type, which left
+// the Studio drawer rendering the root row with no chip color +
+// migration-internal jargon (rchaves dogfood 2026-05-14). Splitting
+// by req.Type matches what langwatch_nlp/studio/execute/execute_*.py
+// stamps on its own root span and is what the trace drawer's color
+// dispatcher recognizes.
+func studioSpanNameAndType(eventType string) (name, spanType string) {
+	switch eventType {
+	case "execute_evaluation":
+		return "execute_evaluation", "evaluation"
+	case "execute_component":
+		return "execute_component", "component"
+	case "execute_flow", "":
+		return "execute_flow", "workflow"
+	}
+	return "execute_flow", "workflow"
+}
+
+func startStudioSpan(ctx context.Context, req *app.WorkflowRequest, workflowAPIKey string) (context.Context, trace.Span) {
 	if workflowAPIKey != "" {
 		ctx = context.WithValue(ctx, otelsetup.APIKeyContextKey{}, workflowAPIKey)
 	}
@@ -63,10 +91,13 @@ func startStudioSpan(ctx context.Context, name string, req *app.WorkflowRequest,
 			ctx = trace.ContextWithSpanContext(ctx, sc)
 		}
 	}
+	spanName, spanType := studioSpanNameAndType(req.Type)
 	tracer := otelapi.Tracer(tracerName)
-	ctx, span := tracer.Start(ctx, name,
+	attrs := studioRequestAttrs(req)
+	attrs = append(attrs, attribute.String("langwatch.span.type", spanType))
+	ctx, span := tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindServer),
-		trace.WithAttributes(studioRequestAttrs(req)...),
+		trace.WithAttributes(attrs...),
 	)
 	return ctx, span
 }

--- a/services/nlpgo/adapters/httpapi/tracing_test.go
+++ b/services/nlpgo/adapters/httpapi/tracing_test.go
@@ -1,0 +1,41 @@
+package httpapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStudioSpanNameAndType_UsesWorkflowNameWhenProvided pins the root-
+// span naming priority: the operator-visible workflow name wins over the
+// generic event-type label. Without this, a trace list with multiple
+// runs of different workflows all read "execute_flow" and operators
+// cannot tell which is which at a glance (rchaves dogfood 2026-05-14).
+// langwatch.span.type stays strictly event-type-driven so Studio's color
+// dispatcher (workflow/evaluation/component) keeps working regardless
+// of the user-typed name.
+func TestStudioSpanNameAndType_UsesWorkflowNameWhenProvided(t *testing.T) {
+	cases := []struct {
+		eventType    string
+		workflowName string
+		wantName     string
+		wantType     string
+	}{
+		{"execute_flow", "Translation Agent", "Translation Agent", "workflow"},
+		{"execute_evaluation", "QA Eval", "QA Eval", "evaluation"},
+		{"execute_component", "Classify", "Classify", "component"},
+		// Empty workflow name → fall back to event-type label so the
+		// row still has a label (sub-workflow / curl / malformed payload).
+		{"execute_flow", "", "execute_flow", "workflow"},
+		{"execute_evaluation", "", "execute_evaluation", "evaluation"},
+		{"execute_component", "", "execute_component", "component"},
+		// Unknown event type → "workflow" + event-type fallback name.
+		{"", "", "execute_flow", "workflow"},
+		{"some_future_type", "Pipeline X", "Pipeline X", "workflow"},
+	}
+	for _, tc := range cases {
+		name, spanType := studioSpanNameAndType(tc.eventType, tc.workflowName)
+		assert.Equal(t, tc.wantName, name, "name for eventType=%q workflowName=%q", tc.eventType, tc.workflowName)
+		assert.Equal(t, tc.wantType, spanType, "type for eventType=%q workflowName=%q", tc.eventType, tc.workflowName)
+	}
+}

--- a/services/nlpgo/app/app.go
+++ b/services/nlpgo/app/app.go
@@ -69,6 +69,12 @@ type WorkflowRequest struct {
 	// api_key in context yet and drops the span. Engine-internal spans
 	// also use it for sibling-trace correlation.
 	APIKey string
+	// WorkflowName is the user-visible name from the canvas
+	// (`workflow.name` in the inbound payload). Peeked at decode time
+	// alongside APIKey so the handler can stamp it on the OTel root
+	// span before the engine even starts. Empty when missing/malformed
+	// so the tracing layer falls back to the event-type default.
+	WorkflowName string
 	// Type is the discriminator from the inbound StudioClientEvent
 	// envelope ("execute_flow" / "execute_component" / "execute_evaluation").
 	// Determines which workflow-level state-change family the engine emits:

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/langwatch/langwatch/services/nlpgo/app"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/agentblock"
@@ -224,7 +225,15 @@ func (e *Engine) runLayer(ctx context.Context, req ExecuteRequest, plan *planner
 			node := state.nodes[nodeID]
 			inputs := state.resolveInputs(plan, nodeID)
 			ns := &NodeState{ID: nodeID, Status: "running", Inputs: inputs}
-			nodeCtx, span := startNodeSpan(ctx, node, req)
+			// Skip the span for pass-through node kinds (Entry, End,
+			// PromptingTechnique) — Python doesn't emit spans for those
+			// either. nodeEmitsSpan keeps the trace tree free of 0ms
+			// noise rows so operators see only nodes with real work.
+			nodeCtx := ctx
+			var span trace.Span
+			if nodeEmitsSpan(node.Type) {
+				nodeCtx, span = startNodeSpan(ctx, node, req)
+			}
 			started := time.Now()
 			outputs, derr := e.dispatch(nodeCtx, req, node, inputs, ns)
 			ns.DurationMS = time.Since(started).Milliseconds()
@@ -242,7 +251,9 @@ func (e *Engine) runLayer(ctx context.Context, req ExecuteRequest, plan *planner
 			// it must run after the success branch sets it. Tracing parity
 			// with Python's execute_component depends on this attribute
 			// being present.
-			endNodeSpan(span, ns, derr)
+			if span != nil {
+				endNodeSpan(span, ns, derr)
+			}
 			state.recordState(nodeID, ns)
 		}()
 	}

--- a/services/nlpgo/app/engine/llm_span_e2e_test.go
+++ b/services/nlpgo/app/engine/llm_span_e2e_test.go
@@ -108,8 +108,8 @@ func TestEngineExecute_SignatureNodeEmitsLLMChildSpan(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, 3, componentSpans,
-		"one execute_component span per dispatched node (entry, answer, end)")
+	assert.Equal(t, 1, componentSpans,
+		"only the signature 'answer' node emits a component span — Entry/End are pass-throughs (Python parity)")
 	require.Equal(t, 1, llmSpans, "signature node must emit exactly one LLM child span")
 	assert.Equal(t, componentSpanID, llmSpanID,
 		"LLM span must be parented at the answer node's execute_component span — Studio's tree view nests on parent span_id")

--- a/services/nlpgo/app/engine/llm_tracing_test.go
+++ b/services/nlpgo/app/engine/llm_tracing_test.go
@@ -25,7 +25,7 @@ func TestStartLLMSpan_NameAndReservedAttrs(t *testing.T) {
 	rec := withRecorder(t)
 
 	tracer := otelapi.Tracer(tracerName)
-	parentCtx, parent := tracer.Start(context.Background(), componentSpanName)
+	parentCtx, parent := tracer.Start(context.Background(), "test-parent")
 	defer parent.End()
 
 	messages := []app.ChatMessage{
@@ -90,7 +90,7 @@ func TestEndLLMSpan_ErrorPathDoesNotStampOutput(t *testing.T) {
 	rec := withRecorder(t)
 
 	tracer := otelapi.Tracer(tracerName)
-	parentCtx, parent := tracer.Start(context.Background(), componentSpanName)
+	parentCtx, parent := tracer.Start(context.Background(), "test-parent")
 	defer parent.End()
 
 	_, llmSpan := startLLMSpan(parentCtx, "gpt-5-mini", "openai", []app.ChatMessage{
@@ -120,7 +120,7 @@ func TestEndLLMSpan_NilResponseNilErrorIsTreatedAsError(t *testing.T) {
 	rec := withRecorder(t)
 
 	tracer := otelapi.Tracer(tracerName)
-	parentCtx, parent := tracer.Start(context.Background(), componentSpanName)
+	parentCtx, parent := tracer.Start(context.Background(), "test-parent")
 	defer parent.End()
 
 	_, llmSpan := startLLMSpan(parentCtx, "gpt-5-mini", "openai", []app.ChatMessage{

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/planner"
 )
@@ -170,7 +171,14 @@ func (e *Engine) runLayerStream(ctx context.Context, req ExecuteRequest, plan *p
 			inputs := state.resolveInputs(plan, nodeID)
 			ns := &NodeState{ID: nodeID, Status: "running", Inputs: inputs}
 			emit(ctx, out, stateEvent(traceID, nodeID, ns))
-			nodeCtx, span := startNodeSpan(ctx, node, req)
+			// Pass-through kinds (Entry, End, PromptingTechnique) skip
+			// span emission — Python parity, see engine.go's twin
+			// branch for the rationale.
+			nodeCtx := ctx
+			var span trace.Span
+			if nodeEmitsSpan(node.Type) {
+				nodeCtx, span = startNodeSpan(ctx, node, req)
+			}
 			started := time.Now()
 			outputs, derr := e.dispatch(nodeCtx, req, node, inputs, ns)
 			ns.DurationMS = time.Since(started).Milliseconds()
@@ -186,7 +194,9 @@ func (e *Engine) runLayerStream(ctx context.Context, req ExecuteRequest, plan *p
 			}
 			// endNodeSpan reads ns.Outputs to stamp langwatch.output;
 			// must run after the success branch sets it (Python parity).
-			endNodeSpan(span, ns, derr)
+			if span != nil {
+				endNodeSpan(span, ns, derr)
+			}
 			state.recordState(nodeID, ns)
 			emit(ctx, out, stateEvent(traceID, nodeID, ns))
 		}()

--- a/services/nlpgo/app/engine/tracing.go
+++ b/services/nlpgo/app/engine/tracing.go
@@ -5,13 +5,28 @@
 // langwatch-app-minted trace_id with one child per executed node.
 //
 // Span shape matches the Python langwatch_nlp engine:
-//   - name:                "execute_component"        (== Python's optional_langwatch_trace name)
+//   - name:                node.Data.Name (or node.ID fallback) — e.g.
+//                          "v1" for an LLM Call named v1. Mirrors Python's
+//                          DSPy autotracking which names spans by the
+//                          generated wrapper-module class name. Earlier
+//                          revisions used the literal "execute_component"
+//                          for every node, which surfaced 3 identical
+//                          spans in the Studio drawer for a 3-node
+//                          workflow (rchaves dogfood 2026-05-14).
 //   - langwatch.span.type: "component"                (== Python's optional_langwatch_trace type)
 //   - langwatch.input:     JSON-encoded inputs map    (reserved attr; flips Studio output_source from inferred → explicit)
 //   - langwatch.output:    JSON-encoded outputs map   (reserved attr; same as above)
+//
+// Entry + End nodes are pass-throughs (no executor body in runEntry /
+// runEnd) so they don't get a span — Python's parsed_and_materialized_
+// workflow_class doesn't put @langwatch.span on those wrapper classes
+// either. nodeEmitsSpan filters them out at startup so the drawer
+// shows only nodes with real work.
+//
 // See specs/nlp-go/tracing-parity.feature for the contract and
-// langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py for
-// the Python target shape.
+// langwatch_nlp/langwatch_nlp/studio/templates/workflow.py.jinja:47
+// for the Python target shape (`@langwatch.span(type="workflow")` on
+// the module forward + DSPy autotracking inside).
 package engine
 
 import (
@@ -30,10 +45,8 @@ import (
 const (
 	tracerName = "langwatch-nlpgo"
 
-	// componentSpanName matches Python's optional_langwatch_trace(name=…).
-	// Renaming it would break Studio filters that group "all component
-	// dispatches" by span name across the Python and Go engines.
-	componentSpanName = "execute_component"
+	// componentSpanType is the Python parity value the Studio trace
+	// drawer recognizes — sets the row's "Component" type chip.
 	componentSpanType = "component"
 
 	// llmSpanType matches the python-sdk reserved value Studio's Trace
@@ -42,11 +55,39 @@ const (
 	llmSpanType = "llm"
 )
 
-// startNodeSpan opens a span for one node's dispatch. Span name is
-// always "execute_component" (Python parity); the per-node type is
-// surfaced via langwatch.node_type. The span carries the workflow-level
-// identity (project_id / origin / thread_id) so it's queryable in
-// isolation without joining back to the parent.
+// nodeEmitsSpan reports whether a node kind has a body worth surfacing
+// in the trace tree. Entry + End are pass-throughs (runEntry just
+// materializes the dataset row, runEnd is a no-op) — they don't get
+// their own span on the Python path either (the workflow.py.jinja
+// generated wrapper class for those types lacks @langwatch.span). The
+// PromptingTechnique node is also a no-op decorator (signature nodes
+// apply it inline at LLM-call time). Everything else has actual work
+// — LLM call, code execution, HTTP request, evaluator dispatch,
+// sub-workflow run.
+func nodeEmitsSpan(kind dsl.ComponentType) bool {
+	switch kind {
+	case dsl.ComponentEntry, dsl.ComponentEnd, dsl.ComponentPromptingTechnique:
+		return false
+	}
+	return true
+}
+
+// nodeSpanName returns the span name for a per-node span. Prefers the
+// user-set node.Data.Name (e.g. "v1" or "Classify the question") so
+// the Studio drawer shows what the operator wrote in the canvas;
+// falls back to node.ID for unnamed nodes.
+func nodeSpanName(node *dsl.Node) string {
+	if node.Data.Name != nil && *node.Data.Name != "" {
+		return *node.Data.Name
+	}
+	return node.ID
+}
+
+// startNodeSpan opens a span for one node's dispatch. Span name comes
+// from nodeSpanName (user-set node name with id fallback). The per-node
+// kind is surfaced via langwatch.node_type. Span also carries the
+// workflow-level identity (project_id / origin / thread_id) so it's
+// queryable in isolation without joining back to the parent.
 func startNodeSpan(ctx context.Context, node *dsl.Node, req ExecuteRequest) (context.Context, trace.Span) {
 	tracer := otelapi.Tracer(tracerName)
 	attrs := []attribute.KeyValue{
@@ -66,7 +107,7 @@ func startNodeSpan(ctx context.Context, node *dsl.Node, req ExecuteRequest) (con
 	if req.Origin != "" {
 		attrs = append(attrs, attribute.String("langwatch.origin", req.Origin))
 	}
-	return tracer.Start(ctx, componentSpanName,
+	return tracer.Start(ctx, nodeSpanName(node),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(attrs...),
 	)

--- a/services/nlpgo/app/engine/tracing_e2e_test.go
+++ b/services/nlpgo/app/engine/tracing_e2e_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,17 +10,14 @@ import (
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
 )
 
-// TestEngineExecute_EmitsExecuteComponentSpansWithJSONIO is the
-// end-to-end proof that Engine.Execute (not just the helpers) produces
-// the Python-parity span shape Studio's Trace Details drawer renders.
-// Pre-fix shipped on 2026-04-28 had a single empty `nlpgo.node.end`
-// span and `output_source: inferred`; this test asserts the fix.
-//
-// Workflow: entry → end. Both nodes get an execute_component span;
-// each span carries langwatch.input + langwatch.output as JSON
-// strings so Studio shows the actual values instead of falling back
-// to inferred output.
-func TestEngineExecute_EmitsExecuteComponentSpansWithJSONIO(t *testing.T) {
+// TestEngineExecute_SuppressesEntryAndEndSpans is the end-to-end
+// suppression proof: a workflow whose only nodes are pass-throughs
+// (Entry + End) must produce ZERO engine-emitted spans. Mirrors
+// Python's workflow.py.jinja generated wrapper classes for Entry/End
+// types which lack the `@langwatch.span` decorator. The pre-fix 3-
+// span output for a 3-node workflow confused operators who saw 3×
+// the dispatch count they expected (rchaves dogfood 2026-05-14).
+func TestEngineExecute_SuppressesEntryAndEndSpans(t *testing.T) {
 	rec := withRecorder(t)
 
 	eng := New(Options{})
@@ -47,42 +43,8 @@ func TestEngineExecute_EmitsExecuteComponentSpansWithJSONIO(t *testing.T) {
 	require.Equal(t, "success", res.Status)
 
 	spans := rec.Ended()
-	require.NotEmpty(t, spans, "engine must emit at least one span")
-
-	byNodeID := map[string]map[string]any{}
-	for _, s := range spans {
-		require.Equal(t, "execute_component", s.Name(),
-			"all engine-emitted spans must share the Python-parity name 'execute_component'")
-		attrs := attrMap(s.Attributes())
-		require.Equal(t, "component", attrs["langwatch.span.type"],
-			"span.type must be 'component' to match Python's optional_langwatch_trace(type='component')")
-		require.Equal(t, "proj_e2e", attrs["langwatch.project_id"])
-		require.Equal(t, "trace_e2e", attrs["langwatch.trace_id"])
-		require.Equal(t, "workflow", attrs["langwatch.origin"])
-		nodeID, _ := attrs["langwatch.node_id"].(string)
-		byNodeID[nodeID] = attrs
-	}
-
-	endAttrs, ok := byNodeID["end"]
-	require.True(t, ok, "end node must have its own execute_component span")
-	// langwatch.input on the end node is the resolved input map (the
-	// upstream entry's output flowing through the edge). Studio uses
-	// this exact attribute to render the "INPUT" panel of the trace
-	// drawer; without it, output_source falls back to "inferred" and
-	// the panel goes blank — the regression rchaves caught.
-	inJSON, ok := endAttrs["langwatch.input"].(string)
-	require.True(t, ok, "end node span must stamp langwatch.input")
-	var in map[string]any
-	require.NoError(t, json.Unmarshal([]byte(inJSON), &in))
-	assert.Equal(t, "hello", in["output"], "end node received entry's output via edge")
-
-	// langwatch.output on the end node is the same map (end is a
-	// passthrough). Studio renders this in the "OUTPUT" panel.
-	outJSON, ok := endAttrs["langwatch.output"].(string)
-	require.True(t, ok, "end node span must stamp langwatch.output")
-	var out map[string]any
-	require.NoError(t, json.Unmarshal([]byte(outJSON), &out))
-	assert.Equal(t, "hello", out["output"])
+	require.Len(t, spans, 0,
+		"Entry + End are pass-throughs and must NOT emit per-node spans (Python parity)")
 }
 
 // TestEngineExecute_ErrorPathStampsInputNotOutput pins the contract

--- a/services/nlpgo/app/engine/tracing_test.go
+++ b/services/nlpgo/app/engine/tracing_test.go
@@ -32,16 +32,19 @@ func withRecorder(t *testing.T) *tracetest.SpanRecorder {
 	return rec
 }
 
-// TestStartNodeSpan_NameMatchesPythonExecuteComponent pins the span
-// name to "execute_component" — the same name Python's
-// optional_langwatch_trace uses in execute_component.py. Operators
-// filter "all component dispatches" by this exact name across both
-// engines; renaming it would silently break Studio's component-time
-// roll-up.
-func TestStartNodeSpan_NameMatchesPythonExecuteComponent(t *testing.T) {
+// TestStartNodeSpan_NameIsUserSetNodeName pins the span name to the
+// user-set node.Data.Name (with node.ID fallback). Earlier revisions
+// hard-coded "execute_component" for every node, which surfaced N
+// identical "execute_component" spans in the Studio drawer for an
+// N-node workflow (rchaves dogfood 2026-05-14). Python's DSPy
+// autotracking names spans by the generated wrapper-module class
+// name (e.g. "v1" for an LLM Call named v1) — we mirror that by
+// reading node.Data.Name.
+func TestStartNodeSpan_NameIsUserSetNodeName(t *testing.T) {
 	rec := withRecorder(t)
 
-	node := &dsl.Node{ID: "code-1", Type: dsl.ComponentCode}
+	nodeName := "Classify the question"
+	node := &dsl.Node{ID: "code-1", Type: dsl.ComponentCode, Data: dsl.Component{Name: &nodeName}}
 	req := ExecuteRequest{
 		ProjectID: "proj_abc",
 		TraceID:   "trace_xyz",
@@ -59,7 +62,7 @@ func TestStartNodeSpan_NameMatchesPythonExecuteComponent(t *testing.T) {
 	spans := rec.Ended()
 	require.Len(t, spans, 1)
 	got := spans[0]
-	assert.Equal(t, "execute_component", got.Name())
+	assert.Equal(t, "Classify the question", got.Name())
 	attrs := attrMap(got.Attributes())
 	assert.Equal(t, "component", attrs["langwatch.span.type"])
 	assert.Equal(t, "code-1", attrs["langwatch.node_id"])
@@ -71,6 +74,35 @@ func TestStartNodeSpan_NameMatchesPythonExecuteComponent(t *testing.T) {
 	assert.Equal(t, int64(42), attrs["langwatch.duration_ms"])
 	assert.Equal(t, 0.001, attrs["langwatch.cost"])
 	assert.Equal(t, codes.Ok, got.Status().Code)
+}
+
+// TestNodeSpanName_FallsBackToNodeID covers the unnamed-node case —
+// when node.Data.Name is nil/empty, the span name uses node.ID so the
+// Studio drawer still shows a stable identifier.
+func TestNodeSpanName_FallsBackToNodeID(t *testing.T) {
+	node := &dsl.Node{ID: "auto-generated-id-abc123", Type: dsl.ComponentCode}
+	assert.Equal(t, "auto-generated-id-abc123", nodeSpanName(node))
+
+	empty := ""
+	node.Data.Name = &empty
+	assert.Equal(t, "auto-generated-id-abc123", nodeSpanName(node))
+}
+
+// TestNodeEmitsSpan_EntryAndEndAreSuppressed pins the pass-through-
+// suppression contract: Entry/End nodes don't emit spans because the
+// Python workflow.py.jinja template doesn't decorate those wrapper
+// classes with @langwatch.span — and a 3-node workflow showing 3
+// "execute_component" spans (entry/middle/end) confused operators
+// who saw 3× the dispatch count they expected (rchaves dogfood
+// 2026-05-14).
+func TestNodeEmitsSpan_EntryAndEndAreSuppressed(t *testing.T) {
+	assert.False(t, nodeEmitsSpan(dsl.ComponentEntry), "entry is a pass-through, no span")
+	assert.False(t, nodeEmitsSpan(dsl.ComponentEnd), "end is a pass-through, no span")
+	assert.False(t, nodeEmitsSpan(dsl.ComponentPromptingTechnique), "prompting technique is a no-op decorator, no span")
+	assert.True(t, nodeEmitsSpan(dsl.ComponentSignature))
+	assert.True(t, nodeEmitsSpan(dsl.ComponentCode))
+	assert.True(t, nodeEmitsSpan(dsl.ComponentHTTP))
+	assert.True(t, nodeEmitsSpan(dsl.ComponentEvaluator))
 }
 
 // TestEndNodeSpan_StampsLangwatchInputAndOutput is the M2 contract:

--- a/services/nlpgo/cmd/root.go
+++ b/services/nlpgo/cmd/root.go
@@ -34,6 +34,15 @@ func Root(ctx context.Context, _ []string) error {
 
 	info := contexts.MustGetServiceInfo(ctx)
 	info.Environment = cfg.Environment
+	// Override the OTel-facing service.name. The mono-binary subcommand
+	// is `nlpgo` (Helm chart, Lambda task, dev shell invoke `service
+	// nlpgo`), but everywhere operators look at this service — charts,
+	// architecture diagrams, deployment names — it's "langwatch_nlp".
+	// Studio's trace drawer reads `service.name` for its SERVICE column,
+	// so the "nlpgo" label there leaked an implementation detail of the
+	// Python→Go migration (rchaves dogfood 2026-05-14). Keep the binary
+	// command name as-is and rename only the public-facing identity.
+	info.Service = "langwatch_nlp"
 	ctx = contexts.SetServiceInfo(ctx, *info)
 
 	ctx, deps, err := nlpgo.NewDeps(ctx, cfg)

--- a/specs/nlp-go/tracing-parity.feature
+++ b/specs/nlp-go/tracing-parity.feature
@@ -1,7 +1,7 @@
 Feature: Tracing parity with Python langwatch_nlp — Studio shows the same depth of input/output capture
   Operators debugging a workflow on nlpgo should see the same span tree, the same INPUT/OUTPUT capture, and the same per-block fidelity that the Python langwatch_nlp engine produced. Without this, the Studio "Full Trace" drawer regresses from "I can see what each component received and returned" to "I see one empty span called nlpgo.node.end" — which is what shipped on 2026-04-28 and triggered the rchaves callout.
 
-  Reference: the Python target shape uses optional_langwatch_trace(name="execute_component", type="component") wrapping each component dispatch, plus dspy auto-instrumentation for the per-implementation child span (e.g. `Code.forward`, `Code.__call__`). See langwatch_nlp/langwatch_nlp/studio/execute/execute_component.py and python-sdk/src/langwatch/attributes.py for the reserved attribute names.
+  Reference: the Python target shape wraps the whole run in an `optional_langwatch_trace` span whose name reflects the endpoint type (`execute_flow` / `execute_evaluation` / `execute_component`) and `langwatch.span.type` matches (`workflow` / `evaluation` / `component`). Inside, each node with real work gets a per-node span — DSPy autotracking names that span by the generated wrapper-module class (which derives from `node.data.name` in the canvas, e.g. `Classify` for a node the operator named "Classify"). Entry/End/PromptingTechnique are pass-throughs whose generated wrappers lack `@langwatch.span` and emit no span. See langwatch_nlp/langwatch_nlp/studio/execute/execute_flow.py, execute_component.py, and python-sdk/src/langwatch/attributes.py for the reserved attribute names.
 
   # All scenarios are @unimplemented because the OTel span-tree parity work is
   # still incomplete in services/nlpgo/: the per-component "execute_component"
@@ -19,40 +19,56 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
     And a langwatch.input attribute is JSON-encoded per python-sdk attributes.py
     And a langwatch.output attribute is JSON-encoded per python-sdk attributes.py
 
-  Rule: Each component dispatch produces a span named "execute_component" matching Python
+  Rule: Each component dispatch produces a span named after the user-set node name (Python DSPy autotracking parity)
 
     @integration @tracing-parity @M1 @unimplemented
-    Scenario: code-block execute_component span has the same name and span.type as Python
-      Given a workflow with one code node returning {"output": "hi"}
+    Scenario: code-block per-node span uses the canvas name and span.type "component"
+      Given a workflow with one code node named "Classify" returning {"output": "hi"}
       When the engine dispatches the node
-      Then a span named "execute_component" is emitted
+      Then a span named "Classify" is emitted
       And the span has attribute "langwatch.span.type" = "component"
       And the span has attribute "langwatch.node_id" = the node id
       And the span has attribute "langwatch.node_type" = "code"
       And the span has attribute "langwatch.origin" inherited from the request
 
     @integration @tracing-parity @M1 @unimplemented
-    Scenario: signature-block execute_component span has the same shape
-      Given a workflow with one signature node calling gpt-5-mini
+    Scenario: signature-block per-node span uses the canvas name
+      Given a workflow with one signature node named "v1" calling gpt-5-mini
       When the engine dispatches the node
-      Then a span named "execute_component" is emitted
+      Then a span named "v1" is emitted
       And the span has attribute "langwatch.span.type" = "component"
       And the span has attribute "langwatch.node_type" = "signature"
 
     @integration @tracing-parity @M1 @unimplemented
-    Scenario: http-block execute_component span has the same shape
-      Given a workflow with one http node calling https://example.com
+    Scenario: http-block per-node span uses the canvas name
+      Given a workflow with one http node named "Fetch user" calling https://example.com
       When the engine dispatches the node
-      Then a span named "execute_component" is emitted
+      Then a span named "Fetch user" is emitted
       And the span has attribute "langwatch.span.type" = "component"
       And the span has attribute "langwatch.node_type" = "http"
 
     @integration @tracing-parity @M1 @unimplemented
-    Scenario: evaluator and agent_workflow nodes emit execute_component spans too
-      Given a workflow with an evaluator node and an agent_workflow node
+    Scenario: evaluator and agent_workflow nodes emit per-node spans too
+      Given a workflow with an evaluator node named "Relevancy" and an agent_workflow node named "Sub"
       When the engine dispatches both
-      Then both nodes emit a span named "execute_component"
+      Then a span named "Relevancy" is emitted and a span named "Sub" is emitted
       And each span has attribute "langwatch.node_type" matching the dsl ComponentKind
+
+    @integration @tracing-parity @M1 @unimplemented
+    Scenario: Entry, End, and PromptingTechnique nodes do NOT emit a per-node span
+      Given a workflow with nodes [entry → code "Classify" → end]
+      And a prompting_technique node hanging off the code node
+      When the engine dispatches the whole workflow
+      Then only one per-node span is emitted (the "Classify" span)
+      And no span exists for the entry node
+      And no span exists for the end node
+      And no span exists for the prompting_technique node
+
+    @integration @tracing-parity @M1 @unimplemented
+    Scenario: unnamed node falls back to node.id as the span name
+      Given a workflow with one code node with no canvas name and id "code-abc123"
+      When the engine dispatches the node
+      Then a span named "code-abc123" is emitted
 
   Rule: INPUT and OUTPUT are captured as JSON strings on every span (output_source = "explicit")
 
@@ -60,7 +76,7 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
     Scenario: code block dispatch stamps langwatch.input and langwatch.output as JSON
       Given a code node that takes {"a": 2, "b": 3} and returns {"sum": 5}
       When the engine dispatches the node
-      Then the execute_component span has attribute "langwatch.input" set to the JSON string '{"a":2,"b":3}'
+      Then the per-node span has attribute "langwatch.input" set to the JSON string '{"a":2,"b":3}'
       And the same span has attribute "langwatch.output" set to the JSON string '{"sum":5}'
       And Studio renders these via the Trace Details drawer with output_source = "explicit" (not "inferred")
 
@@ -68,13 +84,13 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
     Scenario: signature block dispatch stamps langwatch.input and langwatch.output as JSON
       Given a signature node that takes {"question": "..."} and returns {"answer": "..."}
       When the engine dispatches the node
-      Then the execute_component span has langwatch.input and langwatch.output set as JSON-encoded maps
+      Then the per-node span has langwatch.input and langwatch.output set as JSON-encoded maps
 
     @integration @tracing-parity @M2 @unimplemented
     Scenario: huge agent outputs are preserved without truncation
       Given a code node returning a 200KB output blob
       When the engine dispatches the node
-      Then the execute_component span has langwatch.output set to the full 200KB JSON
+      Then the per-node span has langwatch.output set to the full 200KB JSON
       And no truncation marker appears in the attribute value
       # Python SDK default was 5000 chars/string; deliberate decision to
       # not match that on the Go path. Operators want full agent output.
@@ -83,7 +99,7 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
     Scenario: error path still stamps langwatch.input but no langwatch.output
       Given a code node that raises a runtime exception
       When the engine dispatches the node
-      Then the execute_component span has langwatch.input set
+      Then the per-node span has langwatch.input set
       And the span does NOT have langwatch.output set
       And the span status is codes.Error with error.type and error.message
 
@@ -93,27 +109,27 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
     Scenario: code block with class.__call__ entrypoint creates a child span "Code.__call__"
       Given a code node defining "class Code: def __call__(self, input): ..."
       When the engine dispatches the node
-      Then the execute_component span has a child span named "Code.__call__"
+      Then the per-node span has a child span named "Code.__call__"
       And the child span carries the same trace_id and is a direct descendant
 
     @integration @tracing-parity @M3 @unimplemented
     Scenario: code block with class.forward entrypoint creates a child span "Code.forward"
       Given a code node defining "class Code: def forward(self, input): ..."
       When the engine dispatches the node
-      Then the execute_component span has a child span named "Code.forward"
+      Then the per-node span has a child span named "Code.forward"
 
     @integration @tracing-parity @M3 @unimplemented
     Scenario: code block with dspy.Module subclass creates a child span via dspy auto-instrumentation
       Given a code node defining "class Code(dspy.Module): def forward(self, input): ..."
       When the engine dispatches the node
-      Then the execute_component span has a child span named "Code.forward"
+      Then the per-node span has a child span named "Code.forward"
       And dspy.Module reference is stamped as an attribute (matches Python's "dspy.Module" output attr)
 
     @integration @tracing-parity @M3 @unimplemented
     Scenario: signature node creates a child span "Signature.predict" and a grandchild "gateway.chat.completions"
       Given a signature node calls openai/gpt-5-mini via the gateway
       When the dispatch completes
-      Then the execute_component span has a child "Signature.predict"
+      Then the per-node span has a child "Signature.predict"
       And the Signature.predict span has a grandchild from the AI Gateway named "gateway.chat.completions"
       And the gateway span carries gen_ai.system, gen_ai.request.model, gen_ai.usage.input_tokens, gen_ai.usage.output_tokens
 
@@ -121,14 +137,14 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
     Scenario: http block creates a child span "HTTP.fetch" with method + URL + status
       Given an http node that POSTs to https://api.example.com
       When the dispatch completes
-      Then the execute_component span has a child "HTTP.fetch"
+      Then the per-node span has a child "HTTP.fetch"
       And the child span carries http.request.method, url.full, http.response.status_code
 
     @integration @tracing-parity @M3 @unimplemented
     Scenario: evaluator node creates a child span "Evaluator.run" with evaluator name
       Given an evaluator node running "ragas/answer_relevancy"
       When the dispatch completes
-      Then the execute_component span has a child "Evaluator.run"
+      Then the per-node span has a child "Evaluator.run"
       And the child span carries langwatch.evaluator.name = "ragas/answer_relevancy"
       And langwatch.evaluator.score is set to the numeric result
 
@@ -139,14 +155,28 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
       Then the outer execute_component span has children for each sub-workflow node's own execute_component span
       And the trace_id is consistent across the whole tree
 
-  Rule: Whole-flow execute carries an outer "execute_flow" span wrapping every execute_component
+  Rule: The root span name + langwatch.span.type are driven by the inbound event type
 
     @integration @tracing-parity @M4 @unimplemented
-    Scenario: a multi-node flow run nests every component under one execute_flow span
-      Given a flow with nodes [entry → code → signature → end]
+    Scenario Outline: root span name and type match the inbound event type
+      Given an inbound event of type "<event_type>"
+      When the handler opens the root span
+      Then the root span name is "<expected_name>"
+      And the root span has attribute "langwatch.span.type" = "<expected_type>"
+
+      Examples:
+        | event_type         | expected_name        | expected_type |
+        | execute_flow       | execute_flow         | workflow      |
+        | execute_evaluation | execute_evaluation   | evaluation    |
+        | execute_component  | execute_component    | component     |
+
+    @integration @tracing-parity @M4 @unimplemented
+    Scenario: a multi-node flow run nests every dispatching node under the execute_flow root
+      Given a flow with nodes [entry → code "Classify" → signature "Answer" → end]
       When /go/studio/execute_sync runs the whole flow
-      Then a span named "execute_flow" is the root
-      And each non-entry/non-end node has its own "execute_component" span as a child of "execute_flow"
+      Then a span named "execute_flow" is the root with langwatch.span.type = "workflow"
+      And the per-node spans "Classify" and "Answer" are children of the root
+      And no span exists for the entry or end node
       And langwatch.input on execute_flow equals the request inputs
       And langwatch.output on execute_flow equals the final node's outputs
 
@@ -174,7 +204,7 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
     Scenario: every span in the tree inherits langwatch.origin from the inbound request
       Given a workflow run with X-LangWatch-Origin: workflow
       When the run completes
-      Then every span (root, execute_flow, execute_component, child impl spans, gateway spans) has attribute "langwatch.origin" = "workflow"
+      Then every span (root execute_flow, per-node spans, child impl spans, gateway spans) has attribute "langwatch.origin" = "workflow"
 
   # ==========================================================================
   # Test matrix authoritative list — these are the rows the Go-side integration
@@ -192,13 +222,13 @@ Feature: Tracing parity with Python langwatch_nlp — Studio shows the same dept
       And langwatch.input and langwatch.output are JSON-encoded on the outer span
 
       Examples:
-        | node_kind       | entrypoint_shape          | expected_outer_span | expected_inner_span         |
-        | code            | class.__call__            | execute_component   | Code.__call__               |
-        | code            | class.forward             | execute_component   | Code.forward                |
-        | code            | dspy.Module subclass      | execute_component   | Code.forward                |
-        | code            | top-level execute()       | execute_component   | Code.execute                |
-        | signature       | gpt-5-mini via gateway    | execute_component   | Signature.predict           |
-        | http            | POST to api.example.com   | execute_component   | HTTP.fetch                  |
-        | evaluator       | ragas/answer_relevancy    | execute_component   | Evaluator.run               |
-        | agent_workflow  | sub-workflow ref          | execute_component   | (nested execute_component)  |
-        | topic_clustering| python child path         | (no execute_component, see telemetry.feature) | gateway call |
+        | node_kind       | entrypoint_shape          | expected_outer_span                  | expected_inner_span         |
+        | code            | class.__call__            | (canvas node name)                   | Code.__call__               |
+        | code            | class.forward             | (canvas node name)                   | Code.forward                |
+        | code            | dspy.Module subclass      | (canvas node name)                   | Code.forward                |
+        | code            | top-level execute()       | (canvas node name)                   | Code.execute                |
+        | signature       | gpt-5-mini via gateway    | (canvas node name)                   | Signature.predict           |
+        | http            | POST to api.example.com   | (canvas node name)                   | HTTP.fetch                  |
+        | evaluator       | ragas/answer_relevancy    | (canvas node name)                   | Evaluator.run               |
+        | agent_workflow  | sub-workflow ref          | (canvas node name)                   | (nested per-node span)      |
+        | topic_clustering| python child path         | (no per-node span, see telemetry.feature) | gateway call           |


### PR DESCRIPTION
## Summary

rchaves dogfood 2026-05-14 surfaced three trace-drawer UX gaps on the merged Go path:

1. **Root span name was internal jargon.** Studio's trace drawer showed `nlpgo.studio.execute_sync` / `nlpgo.studio.execute_stream` — migration-internal jargon users shouldn't see. No `langwatch.span.type` was set either, so the row rendered without the workflow chip color.
2. **Per-node spans were all named `execute_component`.** A 3-node workflow showed three identical `execute_component` rows — you couldn't tell which span was the LLM call vs Entry vs End at a glance.
3. **Entry + End pass-throughs emitted 0ms spans.** Pure noise — Python's `parsed_and_materialized_workflow_class` doesn't decorate those wrappers; Go was emitting spans regardless of whether the dispatch did work.
4. **OTel service.name was `nlpgo`.** Helm charts + architecture graphs call the service `langwatch_nlp`; the trace SERVICE column should match.
5. **Trace list rows for different workflows were indistinguishable.** All said `execute_flow` — couldn't tell at a glance which trace was which workflow.

## Changes

| Commit | Fix |
|---|---|
| `ebc04fff4` | Root span name + type switch on `req.Type`: `execute_flow`→`("execute_flow","workflow")`, `execute_evaluation`→`("execute_evaluation","evaluation")`, `execute_component`→`("execute_component","component")`. `langwatch.span.type` stamped so Studio's drawer colors the chip. Per-node span name = `node.Data.Name` with `node.ID` fallback (DSPy parity). Entry / End / PromptingTechnique nodes no longer emit spans. `langwatch.node_type` attribute kept for per-type filtering. |
| `da6360c1f` | `specs/nlp-go/tracing-parity.feature` aligned with new shape so the prose no longer contradicts code. |
| `9a91cc32d` | OTel `service.name` resource attr = `langwatch_nlp` (was `nlpgo`). Mono-binary subcommand stays `nlpgo` so Helm/Lambda invokes are unchanged — only the OTel-facing identity flips. |
| `f01aae637` | Root span name now uses `workflow.name` when present, falls back to event-type label only when missing/malformed. Three traces from three different workflows now read e.g. `Translation Agent` / `QA Eval` / `Classify` instead of three identical `execute_flow` rows. |

## Python parity reference

| Concern | Python source | Go after this PR |
|---|---|---|
| Root span name | `execute_flow.py:67` (\`name=\"execute_flow\"\`, \`type=\"workflow\"\`); evaluation/component analogues | Same names + types, plus \`workflow.name\` overlay when present |
| Per-node span | DSPy autotracking via generated class name from \`normalize_name_to_class_name\` (utils.py:579) | \`node.Data.Name\` → \`node.ID\` fallback |
| Entry / End emission | \`workflow.py.jinja:47\` only decorates \`forward\` on the synthesized DSPy module — pass-through Entry/End wrappers are undecorated | Skipped in \`startNodeSpan\` call site (engine.go:227) |
| service.name | \`langwatch_nlp\` (Python service identity) | \`langwatch_nlp\` (was \`nlpgo\`) |

## Tests

- \`TestStudioSpanNameAndType_UsesWorkflowNameWhenProvided\` — workflow.name overrides event-type label
- \`TestNodeSpanName_FallsBackToNodeID\` — per-node span name resolution
- \`TestNodeEmitsSpan_EntryAndEndAreSuppressed\` — pass-through gate
- All existing tests under \`services/nlpgo/...\` green locally

## Test plan

- [x] \`go test ./services/nlpgo/...\`
- [x] Local OTel exporter dispatch confirmed: nlpgo POSTs to \`/api/otel/v1/traces\` with \`service.name=langwatch_nlp\` (verified via local stack — \`langwatch_nlp\` appears in nlpgo's structured logs as the service field)
- [ ] Visual diff in Studio trace drawer: expect ONE root row labeled with the workflow name + workflow chip, ONE inner child per actual-work node named after the node, NO Entry / End / generic \`execute_component\` rows