### PR TITLE
fix(nlpgo): studio root span is a true root when no inbound traceparent

### DIFF
--- a/pkg/otelsetup/idgenerator.go
+++ b/pkg/otelsetup/idgenerator.go
@@ -1,0 +1,104 @@
+// Context-aware ID generator: lets callers seed the trace_id for the
+// next OTel root span via a context value, while keeping random IDs for
+// every other span. This is the mechanism that lets nlpgo's
+// startStudioSpan honour a body-supplied trace_id and STILL produce a
+// TRUE root span (parent_span_id = zero) — fixing the 2026-05-15
+// regression where playground workflow roots showed "Parent not in
+// trace" because the previous code synthesised a phantom remote parent
+// SpanContext for trace-id continuity.
+
+package otelsetup
+
+import (
+	"context"
+	"encoding/binary"
+	"math/rand/v2"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	apitrace "go.opentelemetry.io/otel/trace"
+)
+
+// traceIDOverrideKey is the context key under which callers stash a
+// pre-chosen TraceID. Unexported — go through WithTraceIDOverride so
+// the type sentinel can't collide with anything else.
+type traceIDOverrideKey struct{}
+
+// WithTraceIDOverride returns a derived context that pins the next OTel
+// root span's trace_id to tid. Only takes effect for spans started with
+// no valid parent SpanContext in the context — for child spans the SDK
+// inherits trace_id from the parent and doesn't consult the IDGenerator.
+//
+// Use this when an upstream caller (e.g. Studio's frontend) supplies a
+// trace_id out-of-band and you want the resulting OTel root span to
+// adopt it WITHOUT inventing a phantom parent span_id.
+func WithTraceIDOverride(ctx context.Context, tid apitrace.TraceID) context.Context {
+	if !tid.IsValid() {
+		return ctx
+	}
+	return context.WithValue(ctx, traceIDOverrideKey{}, tid)
+}
+
+// traceIDFromContext extracts the override if one is set.
+func traceIDFromContext(ctx context.Context) (apitrace.TraceID, bool) {
+	v := ctx.Value(traceIDOverrideKey{})
+	if v == nil {
+		return apitrace.TraceID{}, false
+	}
+	tid, ok := v.(apitrace.TraceID)
+	if !ok || !tid.IsValid() {
+		return apitrace.TraceID{}, false
+	}
+	return tid, true
+}
+
+// ContextAwareIDGenerator is a drop-in for the SDK's default random
+// generator that honours WithTraceIDOverride on NewIDs. Span IDs are
+// always random — pinning span_id across processes is never the right
+// move and would silently corrupt the trace tree.
+type ContextAwareIDGenerator struct{}
+
+var _ trace.IDGenerator = (*ContextAwareIDGenerator)(nil)
+
+// NewIDGenerator returns the canonical context-aware generator.
+func NewIDGenerator() *ContextAwareIDGenerator {
+	return &ContextAwareIDGenerator{}
+}
+
+// NewIDs is called by the SDK when starting a span with no valid
+// parent SpanContext in ctx. We honour the trace_id override (if any)
+// and always mint a fresh span_id.
+func (g *ContextAwareIDGenerator) NewIDs(ctx context.Context) (apitrace.TraceID, apitrace.SpanID) {
+	if tid, ok := traceIDFromContext(ctx); ok {
+		return tid, randomSpanID()
+	}
+	return randomTraceID(), randomSpanID()
+}
+
+// NewSpanID is called when starting a child span. The trace_id is
+// already determined by the parent; we just need a fresh span_id.
+func (g *ContextAwareIDGenerator) NewSpanID(_ context.Context, _ apitrace.TraceID) apitrace.SpanID {
+	return randomSpanID()
+}
+
+// randomTraceID mirrors the SDK's default behaviour for the random
+// fallback path. Loop until the result is non-zero per W3C spec.
+func randomTraceID() apitrace.TraceID {
+	var tid apitrace.TraceID
+	for {
+		binary.NativeEndian.PutUint64(tid[:8], rand.Uint64())
+		binary.NativeEndian.PutUint64(tid[8:], rand.Uint64())
+		if tid.IsValid() {
+			return tid
+		}
+	}
+}
+
+func randomSpanID() apitrace.SpanID {
+	var sid apitrace.SpanID
+	for {
+		binary.NativeEndian.PutUint64(sid[:], rand.Uint64())
+		if sid.IsValid() {
+			return sid
+		}
+	}
+}

--- a/pkg/otelsetup/idgenerator.go
+++ b/pkg/otelsetup/idgenerator.go
@@ -1,18 +1,17 @@
 // Context-aware ID generator: lets callers seed the trace_id for the
 // next OTel root span via a context value, while keeping random IDs for
 // every other span. This is the mechanism that lets nlpgo's
-// startStudioSpan honour a body-supplied trace_id and STILL produce a
+// startStudioSpan honor a body-supplied trace_id and STILL produce a
 // TRUE root span (parent_span_id = zero) — fixing the 2026-05-15
 // regression where playground workflow roots showed "Parent not in
-// trace" because the previous code synthesised a phantom remote parent
+// trace" because the previous code synthesized a phantom remote parent
 // SpanContext for trace-id continuity.
 
 package otelsetup
 
 import (
 	"context"
-	"encoding/binary"
-	"math/rand/v2"
+	"crypto/rand"
 
 	"go.opentelemetry.io/otel/sdk/trace"
 	apitrace "go.opentelemetry.io/otel/trace"
@@ -52,7 +51,7 @@ func traceIDFromContext(ctx context.Context) (apitrace.TraceID, bool) {
 }
 
 // ContextAwareIDGenerator is a drop-in for the SDK's default random
-// generator that honours WithTraceIDOverride on NewIDs. Span IDs are
+// generator that honors WithTraceIDOverride on NewIDs. Span IDs are
 // always random — pinning span_id across processes is never the right
 // move and would silently corrupt the trace tree.
 type ContextAwareIDGenerator struct{}
@@ -65,7 +64,7 @@ func NewIDGenerator() *ContextAwareIDGenerator {
 }
 
 // NewIDs is called by the SDK when starting a span with no valid
-// parent SpanContext in ctx. We honour the trace_id override (if any)
+// parent SpanContext in ctx. We honor the trace_id override (if any)
 // and always mint a fresh span_id.
 func (g *ContextAwareIDGenerator) NewIDs(ctx context.Context) (apitrace.TraceID, apitrace.SpanID) {
 	if tid, ok := traceIDFromContext(ctx); ok {
@@ -80,13 +79,14 @@ func (g *ContextAwareIDGenerator) NewSpanID(_ context.Context, _ apitrace.TraceI
 	return randomSpanID()
 }
 
-// randomTraceID mirrors the SDK's default behaviour for the random
-// fallback path. Loop until the result is non-zero per W3C spec.
+// randomTraceID returns a cryptographically-random non-zero trace id.
+// crypto/rand (not math/rand) because trace/span id collisions across
+// concurrent runs would silently corrupt the trace tree, and gosec
+// G404 forbids the weak generator for anything security-adjacent.
 func randomTraceID() apitrace.TraceID {
 	var tid apitrace.TraceID
 	for {
-		binary.NativeEndian.PutUint64(tid[:8], rand.Uint64())
-		binary.NativeEndian.PutUint64(tid[8:], rand.Uint64())
+		_, _ = rand.Read(tid[:])
 		if tid.IsValid() {
 			return tid
 		}
@@ -96,7 +96,7 @@ func randomTraceID() apitrace.TraceID {
 func randomSpanID() apitrace.SpanID {
 	var sid apitrace.SpanID
 	for {
-		binary.NativeEndian.PutUint64(sid[:], rand.Uint64())
+		_, _ = rand.Read(sid[:])
 		if sid.IsValid() {
 			return sid
 		}

--- a/pkg/otelsetup/idgenerator_test.go
+++ b/pkg/otelsetup/idgenerator_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 /** @scenario Studio playground request with body trace_id but no traceparent header creates a true root span */
-func TestContextAwareIDGenerator_HonoursOverrideForRootSpans(t *testing.T) {
+func TestContextAwareIDGenerator_HonorsOverrideForRootSpans(t *testing.T) {
 	rec := tracetest.NewSpanRecorder()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(rec),
@@ -88,7 +88,7 @@ func TestContextAwareIDGenerator_DoesNotOverrideChildSpans(t *testing.T) {
 
 func TestWithTraceIDOverride_InvalidTraceIDIsDropped(t *testing.T) {
 	// Zero TraceID is invalid per W3C and would corrupt traces if
-	// honoured. WithTraceIDOverride must silently drop it so callers
+	// honored. WithTraceIDOverride must silently drop it so callers
 	// can't accidentally pin to all-zeros.
 	ctx := WithTraceIDOverride(context.Background(), trace.TraceID{})
 	_, ok := traceIDFromContext(ctx)

--- a/pkg/otelsetup/idgenerator_test.go
+++ b/pkg/otelsetup/idgenerator_test.go
@@ -1,0 +1,96 @@
+package otelsetup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+/** @scenario Studio playground request with body trace_id but no traceparent header creates a true root span */
+func TestContextAwareIDGenerator_HonoursOverrideForRootSpans(t *testing.T) {
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(rec),
+		sdktrace.WithIDGenerator(NewIDGenerator()),
+	)
+	tracer := tp.Tracer("test")
+
+	want := trace.TraceID{
+		0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+		0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+	}
+
+	ctx := WithTraceIDOverride(context.Background(), want)
+	_, span := tracer.Start(ctx, "studio-root")
+	span.End()
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+
+	// Trace-id continuity preserved.
+	assert.Equal(t, want, ended[0].SpanContext().TraceID(),
+		"override-supplied trace_id must be used for the new root span")
+
+	// And — the load-bearing assertion for the 2026-05-15 fix — the
+	// span has NO parent. Pre-fix the studio root carried a phantom
+	// parent_span_id minted by tracing.go, which surfaced in the UI
+	// as "Parent not in trace".
+	assert.False(t, ended[0].Parent().IsValid(),
+		"with no inbound parent SpanContext the root span must have an invalid parent — got %v",
+		ended[0].Parent().SpanID())
+}
+
+/** @scenario Context-aware IDGenerator only affects spans started without a valid parent */
+func TestContextAwareIDGenerator_DoesNotOverrideChildSpans(t *testing.T) {
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(rec),
+		sdktrace.WithIDGenerator(NewIDGenerator()),
+	)
+	tracer := tp.Tracer("test")
+
+	parentTraceID := trace.TraceID{
+		0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+		0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+	}
+	overrideTraceID := trace.TraceID{
+		0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+		0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+	}
+
+	// Build a context with both a valid parent SpanContext AND an
+	// override. OTel only consults IDGenerator.NewIDs when there is no
+	// valid parent — the override must be ignored here.
+	parentSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    parentTraceID,
+		SpanID:     trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), parentSC)
+	ctx = WithTraceIDOverride(ctx, overrideTraceID)
+
+	_, span := tracer.Start(ctx, "child-span")
+	span.End()
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+	assert.Equal(t, parentTraceID, ended[0].SpanContext().TraceID(),
+		"child span must inherit parent trace_id even when an override is in context")
+	assert.True(t, ended[0].Parent().IsValid(),
+		"child span must report a valid parent")
+}
+
+func TestWithTraceIDOverride_InvalidTraceIDIsDropped(t *testing.T) {
+	// Zero TraceID is invalid per W3C and would corrupt traces if
+	// honoured. WithTraceIDOverride must silently drop it so callers
+	// can't accidentally pin to all-zeros.
+	ctx := WithTraceIDOverride(context.Background(), trace.TraceID{})
+	_, ok := traceIDFromContext(ctx)
+	assert.False(t, ok, "WithTraceIDOverride must reject the zero TraceID")
+}

--- a/pkg/otelsetup/otelsetup.go
+++ b/pkg/otelsetup/otelsetup.go
@@ -190,6 +190,7 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 			sdktrace.WithSpanProcessor(NewBaggageAttributeProcessor(AutoStampedBaggageKeys...)),
 			sdktrace.WithSpanProcessor(router),
 			sdktrace.WithSampler(sdktrace.ParentBased(rootSampler)),
+			sdktrace.WithIDGenerator(NewIDGenerator()),
 		)
 		otelapi.SetTracerProvider(tp)
 		return &Provider{tp: tp}, nil
@@ -249,6 +250,7 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 			sdktrace.WithMaxQueueSize(queueSize),
 		),
 		sdktrace.WithSampler(sdktrace.ParentBased(rootSampler)),
+		sdktrace.WithIDGenerator(NewIDGenerator()),
 	)
 	otelapi.SetTracerProvider(tp)
 

--- a/services/nlpgo/adapters/httpapi/tracing.go
+++ b/services/nlpgo/adapters/httpapi/tracing.go
@@ -2,7 +2,6 @@ package httpapi
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/hex"
 
 	otelapi "go.opentelemetry.io/otel"
@@ -103,17 +102,23 @@ func startStudioSpan(ctx context.Context, req *app.WorkflowRequest, workflowAPIK
 	// applyInboundCausality via the global propagator) over the
 	// body-supplied req.TraceID. This is what lets evaluator workflows
 	// continue the caller's trace end-to-end — same trace_id, parent
-	// span_id linked. Fall back to body TraceID for callers that
-	// haven't been updated to send `traceparent` yet.
+	// span_id linked.
+	//
+	// Fall-back path: when there's no inbound traceparent (Studio's
+	// playground frontend ships trace_id in the body only, no W3C
+	// headers), seed our context-aware IDGenerator with the body
+	// trace_id. The next tracer.Start call sees no valid parent
+	// SpanContext, falls into IDGenerator.NewIDs, and gets back
+	// (body_trace_id, fresh_span_id). The result is a TRUE root span:
+	// trace_id preserved, parent_span_id all-zeros.
+	//
+	// Earlier code synthesised a remote SpanContext with a random
+	// SpanID as a phantom parent — the LangWatch UI then flagged every
+	// playground workflow root as "Parent not in trace" because that
+	// phantom was never emitted. (2026-05-15 regression.)
 	if !trace.SpanContextFromContext(ctx).IsValid() {
 		if tid, ok := parseTraceID(req.TraceID); ok {
-			sc := trace.NewSpanContext(trace.SpanContextConfig{
-				TraceID:    tid,
-				SpanID:     newSpanID(),
-				TraceFlags: trace.FlagsSampled,
-				Remote:     true,
-			})
-			ctx = trace.ContextWithSpanContext(ctx, sc)
+			ctx = otelsetup.WithTraceIDOverride(ctx, tid)
 		}
 	}
 	spanName, spanType := studioSpanNameAndType(req.Type, req.WorkflowName)
@@ -168,11 +173,3 @@ func parseTraceID(s string) (trace.TraceID, bool) {
 	return tid, true
 }
 
-// newSpanID returns a random 8-byte span id. crypto/rand because
-// span_id collisions across concurrent runs would silently corrupt
-// the trace tree.
-func newSpanID() trace.SpanID {
-	var sid trace.SpanID
-	_, _ = rand.Read(sid[:])
-	return sid
-}

--- a/services/nlpgo/adapters/httpapi/tracing.go
+++ b/services/nlpgo/adapters/httpapi/tracing.go
@@ -112,7 +112,7 @@ func startStudioSpan(ctx context.Context, req *app.WorkflowRequest, workflowAPIK
 	// (body_trace_id, fresh_span_id). The result is a TRUE root span:
 	// trace_id preserved, parent_span_id all-zeros.
 	//
-	// Earlier code synthesised a remote SpanContext with a random
+	// Earlier code synthesized a remote SpanContext with a random
 	// SpanID as a phantom parent — the LangWatch UI then flagged every
 	// playground workflow root as "Parent not in trace" because that
 	// phantom was never emitted. (2026-05-15 regression.)

--- a/services/nlpgo/tests/integration/causality_propagation_test.go
+++ b/services/nlpgo/tests/integration/causality_propagation_test.go
@@ -86,6 +86,12 @@ func installProductionTracerStack(t *testing.T) *tracetest.SpanRecorder {
 			otelsetup.AutoStampedBaggageKeys...,
 		)),
 		sdktrace.WithSpanProcessor(rec),
+		// The context-aware IDGenerator is what lets startStudioSpan
+		// preserve the body-supplied trace_id when there's no inbound
+		// W3C traceparent header — the 2026-05-15 "Parent not in trace"
+		// fix. Production wires this in pkg/otelsetup/otelsetup.go;
+		// mirror it here so tests exercise the production wiring.
+		sdktrace.WithIDGenerator(otelsetup.NewIDGenerator()),
 	)
 	prevTP := otelapi.GetTracerProvider()
 	otelapi.SetTracerProvider(tp)
@@ -375,4 +381,86 @@ func TestCausalityPropagation_SanityCheckParentIsRemoteFlag(t *testing.T) {
 	require.Len(t, ended, 1)
 	assert.True(t, ended[0].Parent().IsRemote(),
 		"sanity: a span started under a remote SpanContext must report Parent().IsRemote() = true")
+}
+
+// 2026-05-15 prod regression. Studio's playground frontend mints a
+// trace_id and posts it in the request BODY only — no W3C traceparent
+// header. startStudioSpan's pre-fix path synthesized a remote
+// SpanContext with a freshly-minted random SpanID as the "parent" so
+// the engine's children inherited the body trace_id. The studio root
+// then ended up with parent_span_id = <random phantom> — a span that
+// is never emitted anywhere. The LangWatch UI surfaces this as
+// "Parent not in trace" against every workflow root, with a different
+// random parent per invocation.
+//
+// Fix: when there's no inbound traceparent header, the studio root
+// MUST be a true OTel root span (parent context invalid → parent_span_id
+// is the zero SpanID in OTLP), with trace_id preserved via a
+// context-aware IDGenerator.
+/** @scenario Studio playground request with body trace_id but no traceparent header creates a true root span */
+func TestCausalityPropagation_BodyTraceIDOnlyProducesTrueRootSpan(t *testing.T) {
+	rec := installProductionTracerStack(t)
+	url, _ := setupCausalityStack(t)
+
+	const bodyTraceID = "deadbeefdeadbeefdeadbeefdeadbeef"
+
+	body := `{
+  "trace_id": "` + bodyTraceID + `",
+  "origin": "workflow",
+  "workflow": {
+    "workflow_id":"wf","api_key":"sk-test","spec_version":"1.3","name":"x","icon":"x","description":"x","version":"x",
+    "template_adapter":"default",
+    "nodes":[
+      {"id":"entry","type":"entry","data":{"train_size":1.0,"test_size":0.0,"seed":1,
+        "outputs":[{"identifier":"input","type":"str"}],
+        "dataset":{"inline":{"records":{"input":["hello"]},"count":1}}}},
+      {"id":"end","type":"end","data":{}}
+    ],
+    "edges":[
+      {"id":"e1","source":"entry","sourceHandle":"input","target":"end","targetHandle":"any","type":"default"}
+    ],
+    "state":{}
+  }
+}`
+
+	req, err := http.NewRequest(http.MethodPost, url+"/go/studio/execute_sync", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	// Deliberately NO traceparent header — this is what the playground
+	// frontend ships today.
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", string(respBody))
+
+	ended := rec.Ended()
+	require.NotEmpty(t, ended, "expected at least one span recorded; got 0")
+
+	// Find the studio root span. It's the SpanKindServer span started
+	// by startStudioSpan. With the fix in place it must be a TRUE root:
+	// parent SpanContext invalid, parent_span_id all-zeros in OTLP.
+	var rootStudioSpan sdktrace.ReadOnlySpan
+	for _, s := range ended {
+		if s.SpanKind() == trace.SpanKindServer {
+			rootStudioSpan = s
+			break
+		}
+	}
+	require.NotNil(t, rootStudioSpan,
+		"no SpanKindServer span emitted — startStudioSpan didn't run")
+
+	// Critical assertion: the studio root has NO valid parent. Before
+	// the fix this was a valid-but-phantom span_id; the UI flagged it as
+	// "Parent not in trace" on every playground invocation.
+	assert.False(t, rootStudioSpan.Parent().IsValid(),
+		"studio root must be a true root (no parent_span_id) when there's no inbound traceparent — "+
+			"otherwise the LangWatch UI shows 'Parent not in trace' on every playground run. "+
+			"Parent SpanContext: %s", rootStudioSpan.Parent().SpanID())
+
+	// And trace_id continuity — the studio root must adopt the body
+	// trace_id so the LangWatch "Full Trace" drawer can pivot on it.
+	assert.Equal(t, bodyTraceID, rootStudioSpan.SpanContext().TraceID().String(),
+		"studio root must preserve the body-supplied trace_id even when there's no inbound parent context")
 }

--- a/specs/studio/nlpgo-true-root-span-without-traceparent.feature
+++ b/specs/studio/nlpgo-true-root-span-without-traceparent.feature
@@ -1,0 +1,58 @@
+Feature: nlpgo emits a TRUE root span when no inbound traceparent is supplied
+  As an operator inspecting a Studio playground trace in the LangWatch UI
+  I want every workflow root row to render as an actual root of the trace
+  So that I don't see misleading "Parent not in trace" warnings on legitimate
+  playground / component / evaluation runs
+
+  # ===========================================================================
+  # 2026-05-15 prod regression
+  # ===========================================================================
+  #
+  # Studio's playground frontend mints a trace_id (32-hex) and ships it in the
+  # request BODY only — no W3C `traceparent` HTTP header. nlpgo needs that
+  # trace_id for continuity (the LangWatch "Full Trace" drawer pivots on it).
+  #
+  # The pre-fix path in services/nlpgo/adapters/httpapi/tracing.go synthesised
+  # a remote SpanContext with a FRESHLY RANDOM SpanID as the "parent" so the
+  # in-process span chain would inherit the body trace_id. The studio root
+  # then carried parent_span_id = <random phantom> in OTLP — a span that is
+  # never emitted anywhere. The LangWatch UI surfaced this on every playground
+  # row as ⚠ "Parent not in trace", with a different random parent per run.
+  #
+  # Fix: a context-aware OTel IDGenerator (pkg/otelsetup/idgenerator.go) lets
+  # callers seed the next root span's trace_id via a context value. When no
+  # inbound traceparent is present, startStudioSpan calls WithTraceIDOverride
+  # and lets tracer.Start fall through the no-parent path. The studio span
+  # comes out as a TRUE root: parent context invalid, parent_span_id all-zeros
+  # in OTLP, trace_id == body trace_id.
+
+  Background:
+    Given nlpgo is the trace-emitter for Studio workflow runs
+    And the global TracerProvider is configured with the context-aware IDGenerator
+
+  @go @nlpgo
+  Scenario: Studio playground request with body trace_id but no traceparent header creates a true root span
+    Given the frontend POSTs /go/studio/execute_sync with a 32-hex trace_id in the body
+    And the request carries no W3C traceparent header
+    When nlpgo invokes startStudioSpan
+    Then the emitted studio root span has parent_span_id = all-zeros
+    And the emitted studio root span has trace_id equal to the body trace_id
+    And the LangWatch UI does not surface "Parent not in trace" against the row
+
+  @go @nlpgo
+  Scenario: Evaluator workflows with traceparent header still continue the parent trace
+    Given the eval dispatcher POSTs /go/studio/execute_sync with a W3C traceparent header
+    And the request also carries a body trace_id matching the traceparent's trace-id
+    When nlpgo invokes startStudioSpan
+    Then the emitted studio root span has parent_span_id equal to the inbound traceparent span-id
+    And the emitted studio root span has trace_id equal to the inbound traceparent trace-id
+    Because the in-context SpanContext extracted via the global propagator takes priority over the body trace_id
+
+  @go @nlpgo
+  Scenario: Context-aware IDGenerator only affects spans started without a valid parent
+    Given a child span is started in a context that already has a valid parent SpanContext
+    And the same context also carries a trace_id override via WithTraceIDOverride
+    When tracer.Start runs
+    Then the SDK inherits trace_id from the parent SpanContext
+    And the IDGenerator override is ignored
+    Because OTel only calls IDGenerator.NewIDs for spans without a valid parent

--- a/specs/studio/nlpgo-true-root-span-without-traceparent.feature
+++ b/specs/studio/nlpgo-true-root-span-without-traceparent.feature
@@ -12,7 +12,7 @@ Feature: nlpgo emits a TRUE root span when no inbound traceparent is supplied
   # request BODY only — no W3C `traceparent` HTTP header. nlpgo needs that
   # trace_id for continuity (the LangWatch "Full Trace" drawer pivots on it).
   #
-  # The pre-fix path in services/nlpgo/adapters/httpapi/tracing.go synthesised
+  # The pre-fix path in services/nlpgo/adapters/httpapi/tracing.go synthesized
   # a remote SpanContext with a FRESHLY RANDOM SpanID as the "parent" so the
   # in-process span chain would inherit the body trace_id. The studio root
   # then carried parent_span_id = <random phantom> in OTLP — a span that is


### PR DESCRIPTION
## Summary

- 2026-05-15 prod regression: every Studio playground / component / evaluation run shows ⚠ \"Parent not in trace\" on the workflow root, with a different random `parent_span_id` per invocation.
- Root cause: `startStudioSpan` synthesised a remote SpanContext with a freshly-minted RANDOM SpanID as the \"parent\" so children would inherit the body trace_id. That phantom span is never emitted anywhere — hence the UI warning.
- Fix: new context-aware OTel `IDGenerator` lets us seed the next root span's trace_id via a context value. The studio span now comes out as a TRUE root: `parent_span_id = all-zeros`, `trace_id == body trace_id`.

## What changed

- `pkg/otelsetup/idgenerator.go` (new) — `ContextAwareIDGenerator` + `WithTraceIDOverride` helper.
- `pkg/otelsetup/otelsetup.go` — both `TracerProvider` construction paths now use `sdktrace.WithIDGenerator(NewIDGenerator())`.
- `services/nlpgo/adapters/httpapi/tracing.go` — `startStudioSpan` now seeds the override on the no-traceparent path instead of synthesising a phantom parent SpanContext. Drops the now-unused `newSpanID` helper + `crypto/rand` import.
- Tests: `pkg/otelsetup/idgenerator_test.go` (3 unit) + new `TestCausalityPropagation_BodyTraceIDOnlyProducesTrueRootSpan` in `services/nlpgo/tests/integration/causality_propagation_test.go`.
- Spec: `specs/studio/nlpgo-true-root-span-without-traceparent.feature`.

## Stash-test-restore proof
- Without the fix: studio root has `parent_span_id = f1f5782b1156395e` (random phantom), assert fails with \"studio root must be a true root …\".
- With the fix: parent_span_id is all-zeros, trace_id matches the body. Assert passes. Full `TestCausalityPropagation_*` suite stays green.

## Why narrow
- Override only applies when (a) the context has the sentinel AND (b) the SDK is starting a root span. Child spans inherit `trace_id` from their parent — OTel doesn't consult `NewIDs` for them. Verified by a dedicated unit test.
- All other root spans (independent jobs, scheduled tasks) get random IDs as before.

## Test plan
- [x] `pkg/otelsetup` unit tests — 3/3 pass
- [x] `services/nlpgo/tests/integration` — full suite green
- [x] `pnpm check:feature-parity` — OK 1071 / 1071
- [ ] CI green end-to-end
- [ ] Browser QA on a fresh playground run once CI passes — confirm \"Parent not in trace\" warning is gone