### PR TITLE
fix(nlpgo): prompt-playground message assembly + eval-v3 trace_id round-trip

### DIFF
--- a/langwatch/src/server/nlpgo/__tests__/_nlpgoSubprocess.ts
+++ b/langwatch/src/server/nlpgo/__tests__/_nlpgoSubprocess.ts
@@ -1,0 +1,293 @@
+/**
+ * Shared subprocess harness for nlpgo end-to-end integration tests.
+ *
+ * Boots the REAL nlpgo Go binary as a child process so a test can drive
+ * it over HTTP/SSE exactly as Studio does, then asserts on what nlpgo
+ * actually streams back. This is the lightweight sibling of the heavier
+ * ClickHouse-backed traceparent-roundtrip.integration.test.ts — same
+ * prebuilt-binary boot strategy, but no event-sourcing pipeline: use it
+ * when the behaviour under test is observable on the SSE wire alone.
+ *
+ * Not a test file (underscore prefix + no `.test.ts` suffix) so vitest
+ * does not pick it up as a suite.
+ *
+ * Cost amortization: `go run ./cmd/service` recompiles on every call,
+ * which on CI's cold module cache blows any reasonable health-poll
+ * budget. We `go build` ONCE per test process into a cached path under
+ * the repo's langwatch/.vitest-tmp/ and exec it directly — the compiled
+ * binary boots in ~1s. The cached artifact is shared across every test
+ * that calls ensureNlpgoBinary() within the same CI job.
+ */
+import {
+  execFileSync,
+  execSync,
+  spawn,
+  type ChildProcess,
+} from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+// _nlpgoSubprocess.ts lives in langwatch/src/server/nlpgo/__tests__ →
+// up 5 = repo root.
+export const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+
+const NLPGO_TEST_BIN_DIR = path.join(REPO_ROOT, "langwatch", ".vitest-tmp");
+const NLPGO_TEST_BIN = path.join(
+  NLPGO_TEST_BIN_DIR,
+  process.platform === "win32" ? "nlpgo-test.exe" : "nlpgo-test",
+);
+
+/** True when `go` is on PATH — use in `describe.skipIf(!hasGo())`. */
+export function hasGo(): boolean {
+  try {
+    execSync("go version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Builds the nlpgo binary once and caches it on disk, rebuilding only
+ * when a .go source under services/nlpgo / cmd/service / pkg is newer
+ * than the cached binary (the same staleness conclusion `go build`
+ * itself would reach, but without paying the compile when nothing
+ * changed). Returns the absolute binary path.
+ */
+export function ensureNlpgoBinary(timeoutMs = 600_000): string {
+  fs.mkdirSync(NLPGO_TEST_BIN_DIR, { recursive: true });
+
+  let cachedMtime = 0;
+  try {
+    cachedMtime = fs.statSync(NLPGO_TEST_BIN).mtimeMs;
+  } catch {
+    cachedMtime = 0;
+  }
+  const watchDirs = [
+    path.join(REPO_ROOT, "services", "nlpgo"),
+    path.join(REPO_ROOT, "cmd", "service"),
+    path.join(REPO_ROOT, "pkg"),
+  ].filter((p) => fs.existsSync(p));
+
+  function newestGoMtime(dir: string): number {
+    let newest = 0;
+    const stack = [dir];
+    while (stack.length) {
+      const d = stack.pop()!;
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(d, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const e of entries) {
+        const full = path.join(d, e.name);
+        if (e.isDirectory()) {
+          if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+          stack.push(full);
+        } else if (
+          e.name.endsWith(".go") ||
+          e.name === "go.mod" ||
+          e.name === "go.sum"
+        ) {
+          try {
+            const m = fs.statSync(full).mtimeMs;
+            if (m > newest) newest = m;
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    }
+    return newest;
+  }
+
+  const newestSrcMtime = watchDirs.reduce(
+    (acc, d) => Math.max(acc, newestGoMtime(d)),
+    0,
+  );
+
+  if (cachedMtime > 0 && newestSrcMtime <= cachedMtime) {
+    return NLPGO_TEST_BIN;
+  }
+
+  // execFileSync (argv array, not a shell string): REPO_ROOT can live
+  // under a worktree dir whose absolute path may contain shell
+  // metachars; binding through argv sidesteps that
+  // (CodeQL js/shell-command-injection-from-environment).
+  execFileSync("go", ["build", "-o", NLPGO_TEST_BIN, "./cmd/service"], {
+    cwd: REPO_ROOT,
+    stdio: process.env.NLPGO_TEST_LOG === "1" ? "inherit" : "pipe",
+    timeout: timeoutMs,
+  });
+  return NLPGO_TEST_BIN;
+}
+
+export interface NlpgoSubprocess {
+  /** Base URL, e.g. http://127.0.0.1:55613 */
+  baseUrl: string;
+  /** The spawned child process (already health-checked). */
+  process: ChildProcess;
+  /** SIGTERM the process group, escalate to SIGKILL after 3s. */
+  stop: () => Promise<void>;
+}
+
+async function waitForNlpgoHealth(
+  port: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/healthz`);
+      if (r.status === 200 || r.status === 503) return;
+    } catch {
+      // not listening yet
+    }
+    await sleep(500);
+  }
+  throw new Error(
+    `nlpgo did not become healthy on :${port} within ${timeoutMs}ms — ` +
+      `re-run with NLPGO_TEST_LOG=1 to stream stderr.`,
+  );
+}
+
+/**
+ * Builds (cached) + spawns nlpgo on the given port and resolves once
+ * /healthz answers. The caller MUST `await sub.stop()` in afterAll.
+ *
+ * Picks a port from the nlpgo subprocess test range (55610/55611/55612
+ * /55613/55620 — see CLAUDE.md); pass a unique one per test file so
+ * parallel suites don't collide.
+ *
+ * `env` is merged over the defaults (NLPGO_CHILD_BYPASS=true so no Python
+ * uvicorn child is spawned, SERVER_ADDR bound to the port). Pass e.g.
+ * LANGWATCH_ENDPOINT when the workflow under test calls back out.
+ */
+export async function startNlpgoSubprocess(opts: {
+  port: number;
+  env?: Record<string, string>;
+  /** Build-budget for a cold `go build` (default 600s). */
+  buildTimeoutMs?: number;
+  /** Health-poll budget once spawned (default 30s; binary boots ~1s). */
+  healthTimeoutMs?: number;
+}): Promise<NlpgoSubprocess> {
+  const binary = ensureNlpgoBinary(opts.buildTimeoutMs ?? 600_000);
+  const child = spawn(binary, ["nlpgo"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      NLPGO_CHILD_BYPASS: "true",
+      SERVER_ADDR: `:${opts.port}`,
+      ...opts.env,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
+  });
+  const drain = (label: "out" | "err", chunk: Buffer) => {
+    if (process.env.NLPGO_TEST_LOG === "1") {
+      process.stderr.write(`[nlpgo:${label}] ${chunk.toString()}`);
+    }
+  };
+  // Must drain BOTH pipes — an unconsumed stdout blocks the Go
+  // subprocess once the ~64 KiB pipe buffer fills.
+  child.stdout?.on("data", (c: Buffer) => drain("out", c));
+  child.stderr?.on("data", (c: Buffer) => drain("err", c));
+  child.on("exit", (code, signal) => {
+    if (code !== 0 && code !== null) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `nlpgo exited unexpectedly: code=${code} signal=${signal}`,
+      );
+    }
+  });
+
+  await waitForNlpgoHealth(opts.port, opts.healthTimeoutMs ?? 30_000);
+
+  return {
+    baseUrl: `http://127.0.0.1:${opts.port}`,
+    process: child,
+    stop: async () => {
+      if (!child.pid) return;
+      const pgid = -child.pid;
+      try {
+        process.kill(pgid, "SIGTERM");
+      } catch {
+        /* group already gone */
+      }
+      const exited = await Promise.race([
+        new Promise<boolean>((resolve) =>
+          child.once("exit", () => resolve(true)),
+        ),
+        sleep(3000).then(() => false),
+      ]);
+      if (!exited) {
+        try {
+          process.kill(pgid, "SIGKILL");
+        } catch {
+          /* best-effort */
+        }
+      }
+    },
+  };
+}
+
+export interface SSEFrame {
+  type: string;
+  payload?: Record<string, any>;
+  [k: string]: any;
+}
+
+/**
+ * Consumes an SSE response body from nlpgo's /go/studio/execute and
+ * returns every parsed `data:` frame. nlpgo writes `data: {json}\n\n`
+ * frames (handlers.go writeSSE); frames are blank-line separated.
+ *
+ * Stops when a frame whose `type` is in `terminalTypes` arrives
+ * (default: "done" / "error"), the stream ends, or `timeoutMs` elapses.
+ */
+export async function collectSSE(
+  body: ReadableStream<Uint8Array> | null,
+  opts: { timeoutMs?: number; terminalTypes?: string[] } = {},
+): Promise<SSEFrame[]> {
+  if (!body) throw new Error("collectSSE: response has no body stream");
+  const terminal = new Set(opts.terminalTypes ?? ["done", "error"]);
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  const frames: SSEFrame[] = [];
+  let sawTerminal = false;
+  const deadline = Date.now() + timeoutMs;
+
+  try {
+    while (Date.now() < deadline && !sawTerminal) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const chunks = buf.split("\n\n");
+      buf = chunks.pop() ?? "";
+      for (const chunk of chunks) {
+        const line = chunk.split("\n").find((l) => l.startsWith("data: "));
+        if (!line) continue;
+        let parsed: SSEFrame;
+        try {
+          parsed = JSON.parse(line.slice("data: ".length));
+        } catch {
+          continue;
+        }
+        frames.push(parsed);
+        if (terminal.has(parsed.type)) sawTerminal = true;
+      }
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      /* stream already closed */
+    }
+  }
+  return frames;
+}

--- a/langwatch/src/server/nlpgo/__tests__/eval-trace-id-roundtrip.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/eval-trace-id-roundtrip.integration.test.ts
@@ -5,7 +5,7 @@
  *     │ POST /go/studio/execute (SSE) with an execute_component event
  *     │ carrying a known trace_id
  *     ▼
- *   [real nlpgo subprocess (prebuilt binary)]
+ *   [real nlpgo subprocess (prebuilt binary, _nlpgoSubprocess.ts)]
  *     │ Server-Sent Events stream
  *     ▼
  *   [test parses `component_state_change` frames]
@@ -29,199 +29,33 @@
  * / OTLP pipeline — the regression is purely in what nlpgo streams back,
  * so we assert directly on the wire frames. Gate is therefore just `go`.
  *
- * Cost amortization: a prebuilt binary (not `go run`) is cached under
- * langwatch/.vitest-tmp/ and exec'd directly — same pattern and rationale
- * as traceparent-roundtrip.integration.test.ts. Skipped when `go` is not
- * on PATH.
+ * Subprocess boot + SSE parsing are shared via _nlpgoSubprocess.ts.
  */
-import {
-  execFileSync,
-  execSync,
-  spawn,
-  type ChildProcess,
-} from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
-import { setTimeout as sleep } from "node:timers/promises";
-
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  collectSSE,
+  hasGo,
+  startNlpgoSubprocess,
+  type NlpgoSubprocess,
+} from "./_nlpgoSubprocess";
 
 // Unique port alongside the other nlpgo subprocess integration tests
 // (55610 / 55611 / 55612 / 55620 — see CLAUDE.md). 55613 is this test's.
 const NLPGO_PORT = 55613;
 const KNOWN_TRACE_ID = "b3eval0123456789b3eval0123456789";
 
-// /langwatch/src/server/nlpgo/__tests__  → up 5 = repo root
-const REPO_ROOT = path.resolve(__dirname, "../../../../..");
-
-function hasGo(): boolean {
-  try {
-    execSync("go version", { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-const shouldRun = hasGo();
-
-const NLPGO_TEST_BIN_DIR = path.join(REPO_ROOT, "langwatch", ".vitest-tmp");
-const NLPGO_TEST_BIN = path.join(
-  NLPGO_TEST_BIN_DIR,
-  process.platform === "win32" ? "nlpgo-test.exe" : "nlpgo-test",
-);
-
-/**
- * Builds the nlpgo binary once and caches it on disk, rebuilding only
- * when a .go source under services/nlpgo / cmd/service / pkg is newer
- * than the cached binary. Identical staleness logic to
- * traceparent-roundtrip.integration.test.ts so the two tests share the
- * one cached artifact within a CI job.
- */
-function ensureNlpgoBinary(timeoutMs = 600_000): string {
-  fs.mkdirSync(NLPGO_TEST_BIN_DIR, { recursive: true });
-
-  let cachedMtime = 0;
-  try {
-    cachedMtime = fs.statSync(NLPGO_TEST_BIN).mtimeMs;
-  } catch {
-    cachedMtime = 0;
-  }
-  const watchDirs = [
-    path.join(REPO_ROOT, "services", "nlpgo"),
-    path.join(REPO_ROOT, "cmd", "service"),
-    path.join(REPO_ROOT, "pkg"),
-  ].filter((p) => fs.existsSync(p));
-
-  function newestGoMtime(dir: string): number {
-    let newest = 0;
-    const stack = [dir];
-    while (stack.length) {
-      const d = stack.pop()!;
-      let entries: fs.Dirent[];
-      try {
-        entries = fs.readdirSync(d, { withFileTypes: true });
-      } catch {
-        continue;
-      }
-      for (const e of entries) {
-        const full = path.join(d, e.name);
-        if (e.isDirectory()) {
-          if (e.name === "node_modules" || e.name.startsWith(".")) continue;
-          stack.push(full);
-        } else if (
-          e.name.endsWith(".go") ||
-          e.name === "go.mod" ||
-          e.name === "go.sum"
-        ) {
-          try {
-            const m = fs.statSync(full).mtimeMs;
-            if (m > newest) newest = m;
-          } catch {
-            /* ignore */
-          }
-        }
-      }
-    }
-    return newest;
-  }
-
-  const newestSrcMtime = watchDirs.reduce(
-    (acc, d) => Math.max(acc, newestGoMtime(d)),
-    0,
-  );
-
-  if (cachedMtime > 0 && newestSrcMtime <= cachedMtime) {
-    return NLPGO_TEST_BIN;
-  }
-
-  // execFileSync (argv array, not a shell string): REPO_ROOT can live
-  // under a worktree dir whose absolute path may contain shell
-  // metachars; binding through argv sidesteps that
-  // (CodeQL js/shell-command-injection-from-environment).
-  execFileSync("go", ["build", "-o", NLPGO_TEST_BIN, "./cmd/service"], {
-    cwd: REPO_ROOT,
-    stdio: process.env.NLPGO_TEST_LOG === "1" ? "inherit" : "pipe",
-    timeout: timeoutMs,
-  });
-  return NLPGO_TEST_BIN;
-}
-
-describe.skipIf(!shouldRun)(
+describe.skipIf(!hasGo())(
   "nlpgo eval-v3 — component_state_change carries trace_id in execution_state (B3)",
   () => {
-    let nlpgoProcess: ChildProcess | null = null;
-
-    async function waitForNlpgoHealth(timeoutMs = 30_000): Promise<void> {
-      const deadline = Date.now() + timeoutMs;
-      while (Date.now() < deadline) {
-        try {
-          const r = await fetch(`http://127.0.0.1:${NLPGO_PORT}/healthz`);
-          if (r.status === 200 || r.status === 503) return;
-        } catch {
-          // not listening yet
-        }
-        await sleep(500);
-      }
-      throw new Error(
-        `nlpgo did not become healthy within ${timeoutMs}ms — ` +
-          `re-run with NLPGO_TEST_LOG=1 to stream stderr.`,
-      );
-    }
+    let nlpgo: NlpgoSubprocess;
 
     beforeAll(async () => {
-      const binary = ensureNlpgoBinary();
-      nlpgoProcess = spawn(binary, ["nlpgo"], {
-        cwd: REPO_ROOT,
-        env: {
-          ...process.env,
-          NLPGO_CHILD_BYPASS: "true",
-          SERVER_ADDR: `:${NLPGO_PORT}`,
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-        detached: true,
-      });
-      const drain = (label: "out" | "err", chunk: Buffer) => {
-        if (process.env.NLPGO_TEST_LOG === "1") {
-          process.stderr.write(`[nlpgo:${label}] ${chunk.toString()}`);
-        }
-      };
-      // Must drain BOTH pipes — an unconsumed stdout blocks the Go
-      // subprocess once the ~64 KiB pipe buffer fills.
-      nlpgoProcess.stdout?.on("data", (c: Buffer) => drain("out", c));
-      nlpgoProcess.stderr?.on("data", (c: Buffer) => drain("err", c));
-      nlpgoProcess.on("exit", (code, signal) => {
-        if (code !== 0 && code !== null) {
-          // eslint-disable-next-line no-console
-          console.error(
-            `nlpgo exited unexpectedly: code=${code} signal=${signal}`,
-          );
-        }
-      });
-      await waitForNlpgoHealth(30_000);
+      nlpgo = await startNlpgoSubprocess({ port: NLPGO_PORT });
     }, 700_000); // cold go build budget + boot + health
 
     afterAll(async () => {
-      if (nlpgoProcess?.pid) {
-        const pgid = -nlpgoProcess.pid;
-        try {
-          process.kill(pgid, "SIGTERM");
-        } catch {
-          /* group already gone */
-        }
-        const exited = await Promise.race([
-          new Promise<boolean>((resolve) =>
-            nlpgoProcess!.once("exit", () => resolve(true)),
-          ),
-          sleep(3000).then(() => false),
-        ]);
-        if (!exited) {
-          try {
-            process.kill(pgid, "SIGKILL");
-          } catch {
-            /* best-effort */
-          }
-        }
-      }
+      await nlpgo?.stop();
     });
 
     // execute_component is exactly what the eval-v3 orchestrator sends
@@ -277,64 +111,24 @@ describe.skipIf(!shouldRun)(
       "every component_state_change frame echoes the inbound trace_id inside execution_state",
       async () => {
         const body = makeExecuteComponentBody(KNOWN_TRACE_ID);
-        const resp = await fetch(
-          `http://127.0.0.1:${NLPGO_PORT}/go/studio/execute`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "text/event-stream",
-              "X-LangWatch-Origin": "evaluation",
-            },
-            body: JSON.stringify(body),
+        const resp = await fetch(`${nlpgo.baseUrl}/go/studio/execute`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+            "X-LangWatch-Origin": "evaluation",
           },
-        );
+          body: JSON.stringify(body),
+        });
         expect(
           resp.ok,
           `nlpgo /go/studio/execute responded ${resp.status}`,
         ).toBe(true);
-        expect(resp.body, "SSE response must have a body stream").toBeTruthy();
 
-        // Parse the SSE stream: nlpgo writes `data: {json}\n\n` frames
-        // (handlers.go writeSSE). Collect every component_state_change
-        // until the terminal `done` (or `error`) frame.
-        const reader = resp.body!.getReader();
-        const decoder = new TextDecoder();
-        let buf = "";
-        const componentEvents: Array<Record<string, any>> = [];
-        let sawDone = false;
-
-        const deadline = Date.now() + 30_000;
-        while (Date.now() < deadline && !sawDone) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buf += decoder.decode(value, { stream: true });
-          // Frames are separated by a blank line.
-          const frames = buf.split("\n\n");
-          buf = frames.pop() ?? "";
-          for (const frame of frames) {
-            const line = frame
-              .split("\n")
-              .find((l) => l.startsWith("data: "));
-            if (!line) continue;
-            let parsed: Record<string, any>;
-            try {
-              parsed = JSON.parse(line.slice("data: ".length));
-            } catch {
-              continue;
-            }
-            if (parsed.type === "component_state_change") {
-              componentEvents.push(parsed);
-            } else if (parsed.type === "done" || parsed.type === "error") {
-              sawDone = true;
-            }
-          }
-        }
-        try {
-          await reader.cancel();
-        } catch {
-          /* stream already closed */
-        }
+        const frames = await collectSSE(resp.body, { timeoutMs: 30_000 });
+        const componentEvents = frames.filter(
+          (f) => f.type === "component_state_change",
+        );
 
         // The execute_component path must emit per-node state events —
         // without them the eval-v3 result cell has nothing to populate.

--- a/langwatch/src/server/nlpgo/__tests__/eval-trace-id-roundtrip.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/eval-trace-id-roundtrip.integration.test.ts
@@ -1,0 +1,369 @@
+/**
+ * End-to-end test for BUG B3 — eval-v3's TargetCell missing trace_id.
+ *
+ *   [test]
+ *     │ POST /go/studio/execute (SSE) with an execute_component event
+ *     │ carrying a known trace_id
+ *     ▼
+ *   [real nlpgo subprocess (prebuilt binary)]
+ *     │ Server-Sent Events stream
+ *     ▼
+ *   [test parses `component_state_change` frames]
+ *
+ * Asserts (against the SSE frames nlpgo actually emits):
+ *   Every `component_state_change` event carries
+ *   `payload.execution_state.trace_id` === the inbound trace_id.
+ *
+ * Why this is the right proof: eval-v3's TargetCell reads the per-row
+ * trace id EXCLUSIVELY from `execution_state.trace_id`
+ * (resultMapper.ts:306). The eval-v3 orchestrator generates the
+ * trace_id and sends it INTO nlpgo as the request trace_id; nlpgo must
+ * echo it back inside execution_state or the cell's `traceId` resolves
+ * to undefined and the "View trace" link never renders — exactly the
+ * 2026-05-15 dogfood symptom. Python's start/end/error component events
+ * all set ExecutionState.trace_id (langwatch_nlp/studio/types/events.py
+ * :216,250,269); the Go port had dropped that field, carrying the id
+ * only on the (for this event type, unused) outer envelope.
+ *
+ * Unlike the traceparent-roundtrip test this needs no ClickHouse / Redis
+ * / OTLP pipeline — the regression is purely in what nlpgo streams back,
+ * so we assert directly on the wire frames. Gate is therefore just `go`.
+ *
+ * Cost amortization: a prebuilt binary (not `go run`) is cached under
+ * langwatch/.vitest-tmp/ and exec'd directly — same pattern and rationale
+ * as traceparent-roundtrip.integration.test.ts. Skipped when `go` is not
+ * on PATH.
+ */
+import {
+  execFileSync,
+  execSync,
+  spawn,
+  type ChildProcess,
+} from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// Unique port alongside the other nlpgo subprocess integration tests
+// (55610 / 55611 / 55612 / 55620 — see CLAUDE.md). 55613 is this test's.
+const NLPGO_PORT = 55613;
+const KNOWN_TRACE_ID = "b3eval0123456789b3eval0123456789";
+
+// /langwatch/src/server/nlpgo/__tests__  → up 5 = repo root
+const REPO_ROOT = path.resolve(__dirname, "../../../../..");
+
+function hasGo(): boolean {
+  try {
+    execSync("go version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const shouldRun = hasGo();
+
+const NLPGO_TEST_BIN_DIR = path.join(REPO_ROOT, "langwatch", ".vitest-tmp");
+const NLPGO_TEST_BIN = path.join(
+  NLPGO_TEST_BIN_DIR,
+  process.platform === "win32" ? "nlpgo-test.exe" : "nlpgo-test",
+);
+
+/**
+ * Builds the nlpgo binary once and caches it on disk, rebuilding only
+ * when a .go source under services/nlpgo / cmd/service / pkg is newer
+ * than the cached binary. Identical staleness logic to
+ * traceparent-roundtrip.integration.test.ts so the two tests share the
+ * one cached artifact within a CI job.
+ */
+function ensureNlpgoBinary(timeoutMs = 600_000): string {
+  fs.mkdirSync(NLPGO_TEST_BIN_DIR, { recursive: true });
+
+  let cachedMtime = 0;
+  try {
+    cachedMtime = fs.statSync(NLPGO_TEST_BIN).mtimeMs;
+  } catch {
+    cachedMtime = 0;
+  }
+  const watchDirs = [
+    path.join(REPO_ROOT, "services", "nlpgo"),
+    path.join(REPO_ROOT, "cmd", "service"),
+    path.join(REPO_ROOT, "pkg"),
+  ].filter((p) => fs.existsSync(p));
+
+  function newestGoMtime(dir: string): number {
+    let newest = 0;
+    const stack = [dir];
+    while (stack.length) {
+      const d = stack.pop()!;
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(d, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const e of entries) {
+        const full = path.join(d, e.name);
+        if (e.isDirectory()) {
+          if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+          stack.push(full);
+        } else if (
+          e.name.endsWith(".go") ||
+          e.name === "go.mod" ||
+          e.name === "go.sum"
+        ) {
+          try {
+            const m = fs.statSync(full).mtimeMs;
+            if (m > newest) newest = m;
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    }
+    return newest;
+  }
+
+  const newestSrcMtime = watchDirs.reduce(
+    (acc, d) => Math.max(acc, newestGoMtime(d)),
+    0,
+  );
+
+  if (cachedMtime > 0 && newestSrcMtime <= cachedMtime) {
+    return NLPGO_TEST_BIN;
+  }
+
+  // execFileSync (argv array, not a shell string): REPO_ROOT can live
+  // under a worktree dir whose absolute path may contain shell
+  // metachars; binding through argv sidesteps that
+  // (CodeQL js/shell-command-injection-from-environment).
+  execFileSync("go", ["build", "-o", NLPGO_TEST_BIN, "./cmd/service"], {
+    cwd: REPO_ROOT,
+    stdio: process.env.NLPGO_TEST_LOG === "1" ? "inherit" : "pipe",
+    timeout: timeoutMs,
+  });
+  return NLPGO_TEST_BIN;
+}
+
+describe.skipIf(!shouldRun)(
+  "nlpgo eval-v3 — component_state_change carries trace_id in execution_state (B3)",
+  () => {
+    let nlpgoProcess: ChildProcess | null = null;
+
+    async function waitForNlpgoHealth(timeoutMs = 30_000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        try {
+          const r = await fetch(`http://127.0.0.1:${NLPGO_PORT}/healthz`);
+          if (r.status === 200 || r.status === 503) return;
+        } catch {
+          // not listening yet
+        }
+        await sleep(500);
+      }
+      throw new Error(
+        `nlpgo did not become healthy within ${timeoutMs}ms — ` +
+          `re-run with NLPGO_TEST_LOG=1 to stream stderr.`,
+      );
+    }
+
+    beforeAll(async () => {
+      const binary = ensureNlpgoBinary();
+      nlpgoProcess = spawn(binary, ["nlpgo"], {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          NLPGO_CHILD_BYPASS: "true",
+          SERVER_ADDR: `:${NLPGO_PORT}`,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+      });
+      const drain = (label: "out" | "err", chunk: Buffer) => {
+        if (process.env.NLPGO_TEST_LOG === "1") {
+          process.stderr.write(`[nlpgo:${label}] ${chunk.toString()}`);
+        }
+      };
+      // Must drain BOTH pipes — an unconsumed stdout blocks the Go
+      // subprocess once the ~64 KiB pipe buffer fills.
+      nlpgoProcess.stdout?.on("data", (c: Buffer) => drain("out", c));
+      nlpgoProcess.stderr?.on("data", (c: Buffer) => drain("err", c));
+      nlpgoProcess.on("exit", (code, signal) => {
+        if (code !== 0 && code !== null) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `nlpgo exited unexpectedly: code=${code} signal=${signal}`,
+          );
+        }
+      });
+      await waitForNlpgoHealth(30_000);
+    }, 700_000); // cold go build budget + boot + health
+
+    afterAll(async () => {
+      if (nlpgoProcess?.pid) {
+        const pgid = -nlpgoProcess.pid;
+        try {
+          process.kill(pgid, "SIGTERM");
+        } catch {
+          /* group already gone */
+        }
+        const exited = await Promise.race([
+          new Promise<boolean>((resolve) =>
+            nlpgoProcess!.once("exit", () => resolve(true)),
+          ),
+          sleep(3000).then(() => false),
+        ]);
+        if (!exited) {
+          try {
+            process.kill(pgid, "SIGKILL");
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
+    });
+
+    // execute_component is exactly what the eval-v3 orchestrator sends
+    // per dataset cell (orchestrator.ts:290/386). Entry → End is a
+    // dependency-free path (no LLM, no evaluator HTTP) that still emits
+    // per-node component_state_change events — the minimal faithful
+    // repro of the round-trip the TargetCell depends on.
+    function makeExecuteComponentBody(traceId: string) {
+      return {
+        type: "execute_component",
+        payload: {
+          trace_id: traceId,
+          node_id: "end",
+          workflow: {
+            workflow_id: "wf_b3",
+            api_key: "test-key-b3-eval-trace",
+            spec_version: "1.3",
+            name: "B3 eval trace",
+            icon: "x",
+            description: "x",
+            version: "x",
+            template_adapter: "default",
+            nodes: [
+              {
+                id: "entry",
+                type: "entry",
+                data: {
+                  outputs: [{ identifier: "input", type: "str" }],
+                },
+              },
+              { id: "end", type: "end", data: {} },
+            ],
+            edges: [
+              {
+                id: "e1",
+                source: "entry",
+                sourceHandle: "outputs.input",
+                target: "end",
+                targetHandle: "inputs.output",
+                type: "default",
+              },
+            ],
+            state: {},
+          },
+          inputs: { input: "hello" },
+          manual_execution_mode: false,
+          do_not_trace: false,
+        },
+      };
+    }
+
+    it(
+      "every component_state_change frame echoes the inbound trace_id inside execution_state",
+      async () => {
+        const body = makeExecuteComponentBody(KNOWN_TRACE_ID);
+        const resp = await fetch(
+          `http://127.0.0.1:${NLPGO_PORT}/go/studio/execute`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "text/event-stream",
+              "X-LangWatch-Origin": "evaluation",
+            },
+            body: JSON.stringify(body),
+          },
+        );
+        expect(
+          resp.ok,
+          `nlpgo /go/studio/execute responded ${resp.status}`,
+        ).toBe(true);
+        expect(resp.body, "SSE response must have a body stream").toBeTruthy();
+
+        // Parse the SSE stream: nlpgo writes `data: {json}\n\n` frames
+        // (handlers.go writeSSE). Collect every component_state_change
+        // until the terminal `done` (or `error`) frame.
+        const reader = resp.body!.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+        const componentEvents: Array<Record<string, any>> = [];
+        let sawDone = false;
+
+        const deadline = Date.now() + 30_000;
+        while (Date.now() < deadline && !sawDone) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          // Frames are separated by a blank line.
+          const frames = buf.split("\n\n");
+          buf = frames.pop() ?? "";
+          for (const frame of frames) {
+            const line = frame
+              .split("\n")
+              .find((l) => l.startsWith("data: "));
+            if (!line) continue;
+            let parsed: Record<string, any>;
+            try {
+              parsed = JSON.parse(line.slice("data: ".length));
+            } catch {
+              continue;
+            }
+            if (parsed.type === "component_state_change") {
+              componentEvents.push(parsed);
+            } else if (parsed.type === "done" || parsed.type === "error") {
+              sawDone = true;
+            }
+          }
+        }
+        try {
+          await reader.cancel();
+        } catch {
+          /* stream already closed */
+        }
+
+        // The execute_component path must emit per-node state events —
+        // without them the eval-v3 result cell has nothing to populate.
+        expect(
+          componentEvents.length,
+          "nlpgo emitted no component_state_change frames for the " +
+            "execute_component request",
+        ).toBeGreaterThan(0);
+
+        // CORE ASSERTION — the field eval-v3's TargetCell reads
+        // (execution_state.trace_id, resultMapper.ts:306) is present
+        // and equals the trace_id the orchestrator sent in. Pre-fix it
+        // was absent (carried only on the unused outer envelope), so
+        // the cell's trace link never rendered.
+        for (const ev of componentEvents) {
+          const es = ev?.payload?.execution_state;
+          expect(
+            es,
+            `component_state_change missing execution_state: ${JSON.stringify(ev)}`,
+          ).toBeTruthy();
+          expect(
+            es.trace_id,
+            `component_state_change.execution_state.trace_id missing/blank ` +
+              `(status=${es?.status}) — eval-v3 TargetCell would render no ` +
+              `"View trace" link. Frame: ${JSON.stringify(ev)}`,
+          ).toBe(KNOWN_TRACE_ID);
+        }
+      },
+      60_000,
+    );
+  },
+);

--- a/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
+++ b/langwatch/src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts
@@ -602,7 +602,14 @@ describe.skipIf(!shouldRun)(
         // Poll ClickHouse for the persisted spans. Three flush windows
         // chain here: nlpgo's BatchSpanProcessor (5s scheduled delay) +
         // OTLP HTTP roundtrip + the event-sourcing fold/map projections.
-        // 45s deadline absorbs all three with margin on a loaded CI runner.
+        // The integration shard runs this alongside other heavyweight
+        // subprocess + pipeline tests under a 4-wide vitest pool; on a
+        // saturated CI runner the chain has been observed to need well
+        // past 45s purely from scheduler contention (the spans DO land,
+        // just late). 120s deadline absorbs all three plus that
+        // contention with margin — widening the budget cannot mask a
+        // real regression because the assertions below still require the
+        // spans to actually arrive under the inbound trace_id.
         //
         // CRITICAL: we must NOT exit the loop on the first non-empty
         // result. The studio root span ends AFTER its children, so BSP
@@ -650,7 +657,7 @@ describe.skipIf(!shouldRun)(
           );
 
         let rows: SpanRow[] = [];
-        const deadline = Date.now() + 45_000;
+        const deadline = Date.now() + 120_000;
         while (Date.now() < deadline) {
           rows = await fetchRows();
           if (rows.length > 0 && hasLinkedSpan(rows)) break;
@@ -689,7 +696,7 @@ describe.skipIf(!shouldRun)(
               .join(", ")}`,
         ).toBeGreaterThan(0);
       },
-      90_000,
+      180_000,
     );
   },
 );

--- a/services/nlpgo/app/engine/build_messages_test.go
+++ b/services/nlpgo/app/engine/build_messages_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,6 +37,119 @@ func systemPrompt(msgs []app.ChatMessage) string {
 		}
 	}
 	return ""
+}
+
+// signatureNodeWithMessages builds a signature node carrying BOTH an
+// `instructions` system prompt and a `messages` template list — the
+// exact shape PromptStudioAdapter.buildNodeData emits for a
+// prompt-playground execute_component.
+func signatureNodeWithMessages(t *testing.T, instructions string, messages []map[string]any) *dsl.Node {
+	t.Helper()
+	instrRaw, err := json.Marshal(instructions)
+	require.NoError(t, err)
+	msgsRaw, err := json.Marshal(messages)
+	require.NoError(t, err)
+	return &dsl.Node{
+		ID:   "n",
+		Type: dsl.ComponentSignature,
+		Data: dsl.Component{
+			Parameters: []dsl.Field{
+				{Identifier: "instructions", Type: "str", Value: instrRaw},
+				{Identifier: "messages", Type: "chat_messages", Value: msgsRaw},
+			},
+		},
+	}
+}
+
+// TestBuildMessages_PlaygroundRendersSystemAndInterpolatesInput pins
+// the 2026-05-14 prompt-playground regression (B1). PromptStudioAdapter
+// sends instructions="You are a helpful assistant" + inputs.messages =
+// [{user,"{{input}}"}] + the input variable. Pre-fix buildMessages
+// returned inputs.messages verbatim — no system, literal "{{input}}".
+// Python parity (template_adapter.py format()): render system from
+// instructions + render each message content with the variables.
+func TestBuildMessages_PlaygroundRendersSystemAndInterpolatesInput(t *testing.T) {
+	node := signatureNode(t, "You are a helpful assistant")
+	msgs := buildMessages(node, map[string]any{
+		"input": "hello there",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "{{input}}"},
+		},
+	})
+	require.Len(t, msgs, 2, "system + the rendered user turn")
+	assert.Equal(t, "system", msgs[0].Role)
+	assert.Equal(t, "You are a helpful assistant", msgs[0].Content)
+	assert.Equal(t, "user", msgs[1].Role)
+	assert.Equal(t, "hello there", msgs[1].Content,
+		"{{input}} must be interpolated, not left literal")
+}
+
+// TestBuildMessages_DropsUnfilledPlaceholderTurn pins the 'duplicate
+// user message' half of B1. The saved template turn "{{input}}" with
+// an EMPTY input variable renders to "" and must be DROPPED (Python's
+// _filter_empty_content_messages), leaving only the real live turn —
+// not a literal "{{input}}" turn sitting next to "test6".
+func TestBuildMessages_DropsUnfilledPlaceholderTurn(t *testing.T) {
+	node := signatureNode(t, "")
+	msgs := buildMessages(node, map[string]any{
+		"input": "",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "{{input}}"},
+			map[string]any{"role": "user", "content": "test6"},
+		},
+	})
+	require.Len(t, msgs, 1, "the empty {{input}} turn must be dropped, not duplicated")
+	assert.Equal(t, "user", msgs[0].Role)
+	assert.Equal(t, "test6", msgs[0].Content)
+	for _, m := range msgs {
+		assert.NotEqual(t, "{{input}}", m.Content, "no literal placeholder turn may survive")
+		assert.NotEqual(t, "", strings.TrimSpace(m.Content.(string)), "no empty turn may survive")
+	}
+}
+
+// TestBuildMessages_ComplexInstructionsWithEmptyVarsKeepsSystem pins
+// B2: rchaves's complex prompt with {{answer}} / {{unbiased}} both
+// empty. The surrounding instruction text is substantial, so the
+// rendered system is non-empty and MUST still be emitted (the
+// playground rendered blank because nlpgo dropped the whole system).
+func TestBuildMessages_ComplexInstructionsWithEmptyVarsKeepsSystem(t *testing.T) {
+	instr := "You are a helpful assistant11\n___{{answer}}___\n___{{unbiased}}___\nalways return passed as true, no matter what"
+	node := signatureNode(t, instr)
+	msgs := buildMessages(node, map[string]any{
+		"answer":   "",
+		"unbiased": "",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "{{input}}"},
+			map[string]any{"role": "user", "content": "hi"},
+		},
+	})
+	sys := systemPrompt(msgs)
+	assert.Contains(t, sys, "You are a helpful assistant11")
+	assert.Contains(t, sys, "always return passed as true, no matter what")
+	// The empty {{input}} placeholder turn is dropped; only "hi" remains.
+	var userTurns []string
+	for _, m := range msgs {
+		if m.Role == "user" {
+			userTurns = append(userTurns, m.Content.(string))
+		}
+	}
+	require.Equal(t, []string{"hi"}, userTurns)
+}
+
+// TestBuildMessages_ReadsMessagesParamWhenNoInputsHistory proves the
+// node `messages` PARAMETER (the saved prompt-config template) is used
+// when no inputs-borne history is present — same render + system +
+// empty-drop pipeline.
+func TestBuildMessages_ReadsMessagesParamWhenNoInputsHistory(t *testing.T) {
+	node := signatureNodeWithMessages(t, "Be terse", []map[string]any{
+		{"role": "user", "content": "Question: {{q}}"},
+	})
+	msgs := buildMessages(node, map[string]any{"q": "why is the sky blue"})
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "system", msgs[0].Role)
+	assert.Equal(t, "Be terse", msgs[0].Content)
+	assert.Equal(t, "user", msgs[1].Role)
+	assert.Equal(t, "Question: why is the sky blue", msgs[1].Content)
 }
 
 func TestBuildMessages_RendersSimpleVariable(t *testing.T) {
@@ -131,14 +245,21 @@ func TestBuildMessages_AcceptsChatMessagesFromJSON(t *testing.T) {
 	}
 	msgs := buildMessages(node, map[string]any{"chat_messages": history})
 
-	// All three turns must survive — that's the load-bearing claim.
-	require.Len(t, msgs, 3, "all chat history turns must be preserved through JSON round-trip")
-	assert.Equal(t, "user", msgs[0].Role)
-	assert.Equal(t, "First user turn", msgs[0].Content)
-	assert.Equal(t, "assistant", msgs[1].Role)
-	assert.Equal(t, "First assistant reply", msgs[1].Content)
-	assert.Equal(t, "user", msgs[2].Role)
-	assert.Equal(t, "Second user turn", msgs[2].Content)
+	// Python parity (template_adapter.py:166-191): a non-empty
+	// `instructions` is rendered + prepended as a system message even
+	// when chat_messages flow in from an upstream node. The
+	// load-bearing claim of regression cb76144a6 is unchanged — all
+	// three history turns survive the JSON round-trip; they just sit
+	// after the system turn now.
+	require.Len(t, msgs, 4, "system + all chat history turns must be preserved through JSON round-trip")
+	assert.Equal(t, "system", msgs[0].Role)
+	assert.Equal(t, "Continue the conversation.", msgs[0].Content)
+	assert.Equal(t, "user", msgs[1].Role)
+	assert.Equal(t, "First user turn", msgs[1].Content)
+	assert.Equal(t, "assistant", msgs[2].Role)
+	assert.Equal(t, "First assistant reply", msgs[2].Content)
+	assert.Equal(t, "user", msgs[3].Role)
+	assert.Equal(t, "Second user turn", msgs[3].Content)
 }
 
 // TestBuildMessages_PreservesToolCallsThroughJSON is the structural

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -1068,6 +1068,26 @@ func paramAnyMap(params []dsl.Field, name string) map[string]any {
 	return nil
 }
 
+// paramAny reads a parameter as an arbitrary JSON-decoded value.
+// Used for the prompt-config `messages` parameter (a saved template
+// message list) which buildMessages feeds through coerceChatMessages
+// the same way it handles an inputs-borne list.
+func paramAny(params []dsl.Field, name string) any {
+	for _, p := range params {
+		if p.Identifier != name {
+			continue
+		}
+		if len(p.Value) == 0 {
+			return nil
+		}
+		var v any
+		if err := jsonUnmarshalRaw(p.Value, &v); err == nil {
+			return v
+		}
+	}
+	return nil
+}
+
 func paramStringMap(params []dsl.Field, name string) map[string]string {
 	for _, p := range params {
 		if p.Identifier != name {
@@ -1181,23 +1201,70 @@ func splitModel(s string) (model, provider string) {
 // type. We accept both shapes; the legacy `messages` key is also
 // accepted for callers that pre-populate explicit history.
 func buildMessages(node *dsl.Node, inputs map[string]any) []app.ChatMessage {
-	if msgs := coerceChatMessages(inputs["chat_messages"]); msgs != nil {
-		return msgs
-	}
-	if msgs := coerceChatMessages(inputs["messages"]); msgs != nil {
-		return msgs
-	}
+	// Render the system prompt from the `instructions` parameter using
+	// the input variables. Mirrors langwatch_nlp's
+	// dspy/template_adapter.py format(): `{% for %}` / `{% if %}` /
+	// filters / `{{ var }}` all resolve here. Empty/whitespace-only
+	// after rendering ⇒ no system message (Python drops it too —
+	// template_adapter.py:170).
+	system := ""
 	if instr := paramString(node.Data.Parameters, "instructions"); instr != "" {
-		// Render Liquid placeholders + control flow + filters against
-		// the upstream inputs. Mirrors langwatch_nlp's
-		// dspy/template_adapter.py — DSPy templates with loops over
-		// chat history (`{% for m in messages %}{{ m.content }}{% endfor %}`)
-		// or branches on input shape now render correctly on the Go
-		// path. Pure `{{ var }}` templates fall back to the simple
-		// JSON-escaping interpolator so HTTP-block parity stays.
-		rendered, _ := template.RenderFull(instr, inputs)
+		system, _ = template.RenderFull(instr, inputs)
+	}
+
+	// Resolve the conversation history. Priority:
+	//  1. inputs["chat_messages"] / inputs["messages"] — the node→node
+	//     pipeline shape and the prompt-playground execute_component
+	//     shape (PromptStudioAdapter sends the saved template messages
+	//     + live turns under inputs.messages).
+	//  2. the node's `messages` PARAMETER — the saved prompt-config
+	//     template list, used when no inputs-borne history is present.
+	var history []app.ChatMessage
+	if msgs := coerceChatMessages(inputs["chat_messages"]); msgs != nil {
+		history = msgs
+	} else if msgs := coerceChatMessages(inputs["messages"]); msgs != nil {
+		history = msgs
+	} else if msgs := coerceChatMessages(paramAny(node.Data.Parameters, "messages")); msgs != nil {
+		history = msgs
+	}
+
+	if history != nil {
+		// Python parity (template_adapter.py:166-191): prepend the
+		// rendered system, render EACH message's string content with
+		// the input variables, then drop any message whose content is
+		// empty after rendering. The empty-drop is the load-bearing
+		// step — an unfilled `{{input}}` template turn renders to ""
+		// and is removed, so it is NOT duplicated alongside the real
+		// user turn (the 2026-05-14 prompt-playground regression).
+		out := make([]app.ChatMessage, 0, len(history)+1)
+		if strings.TrimSpace(system) != "" {
+			out = append(out, app.ChatMessage{Role: "system", Content: system})
+		}
+		for _, m := range history {
+			if s, ok := m.Content.(string); ok {
+				rendered, _ := template.RenderFull(s, inputs)
+				m.Content = rendered
+				// Mirrors _filter_empty_content_messages: a turn whose
+				// text content is empty after rendering is dropped —
+				// UNLESS it carries tool_calls (an assistant turn that
+				// only requests a tool legitimately has empty content).
+				if strings.TrimSpace(rendered) == "" && len(m.ToolCalls) == 0 {
+					continue
+				}
+			}
+			out = append(out, m)
+		}
+		return out
+	}
+
+	// No explicit history: fold scalar inputs into a single user turn
+	// (text-in / text-out signatures). composeUserPrompt is NOT
+	// template-rendered — it is the raw upstream input, matching the
+	// Python parity expectation that interpolation applies to
+	// instructions + template messages, not the live user prompt.
+	if strings.TrimSpace(system) != "" {
 		return []app.ChatMessage{
-			{Role: "system", Content: rendered},
+			{Role: "system", Content: system},
 			{Role: "user", Content: composeUserPrompt(inputs)},
 		}
 	}

--- a/services/nlpgo/app/engine/execute_flow_state_events_test.go
+++ b/services/nlpgo/app/engine/execute_flow_state_events_test.go
@@ -285,6 +285,67 @@ func TestExecuteStream_EvaluationErrorEmitsEvaluationErrorEvent(t *testing.T) {
 	assert.Contains(t, es, "error", "error event must carry the message Studio surfaces in the alertOnError toast")
 }
 
+// TestExecuteStream_ComponentStateChangeCarriesTraceIDInExecutionState
+// pins the B3 contract: every `component_state_change` event must stamp
+// trace_id INSIDE execution_state (not only on the outer envelope).
+// Studio's eval-v3 resultMapper reads target_result.traceId solely from
+// execution_state.trace_id (resultMapper.ts:306); the envelope trace_id
+// is consumed only by execution_state_change / evaluation_state_change.
+// Pre-fix nlpgo put trace_id only on the envelope, so eval-v3's
+// TargetCell rendered no "View trace" link (rchaves dogfood 2026-05-15).
+// Python's start/end/error component events all set
+// ExecutionState.trace_id (langwatch_nlp/studio/types/events.py:216,
+// 250,269) — this is the parity restoration.
+func TestExecuteStream_ComponentStateChangeCarriesTraceIDInExecutionState(t *testing.T) {
+	eng := New(Options{})
+	wf := &dsl.Workflow{
+		WorkflowID: "wf_b3_trace_id",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "end", Type: dsl.ComponentEnd},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.input", Target: "end", TargetHandle: "inputs.output"},
+		},
+	}
+
+	const wantTrace = "abc123def456trace"
+	events, err := eng.ExecuteStream(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"input": "hello"},
+		NodeID:   "end",
+		TraceID:  wantTrace,
+	}, ExecuteStreamOptions{})
+	require.NoError(t, err)
+
+	collected := drain(events)
+	componentEvents := filterByType(collected, "component_state_change")
+	require.NotEmpty(t, componentEvents,
+		"the execute_component path must emit per-node component_state_change events")
+
+	for i, ev := range componentEvents {
+		es, ok := ev.Payload["execution_state"].(map[string]any)
+		require.True(t, ok, "component_state_change[%d] must carry execution_state payload", i)
+		assert.Equal(t, wantTrace, es["trace_id"],
+			"component_state_change[%d].execution_state.trace_id must echo the request trace_id "+
+				"(status=%v) — this is the field eval-v3's TargetCell links the trace from", i, es["status"])
+	}
+}
+
+// TestStateEvent_OmitsTraceIDWhenEmpty keeps the payload lean: a
+// curl/test caller that sends no trace_id must not get an empty-string
+// trace_id the Studio UI would treat as "set" (the `if (traceId)`
+// render guard is truthiness-based). nlpgo always assigns a ulid when
+// the request omits one, so in practice this only protects direct
+// stateEvent callers, but the guard is the contract.
+func TestStateEvent_OmitsTraceIDWhenEmpty(t *testing.T) {
+	ev := stateEvent("", "node-1", &NodeState{Status: "success"})
+	es, ok := ev.Payload["execution_state"].(map[string]any)
+	require.True(t, ok)
+	_, present := es["trace_id"]
+	assert.False(t, present, "empty trace_id must be omitted from execution_state, not set as \"\"")
+}
+
 func drain(events <-chan StreamEvent) []StreamEvent {
 	var out []StreamEvent
 	timeout := time.After(5 * time.Second)

--- a/services/nlpgo/app/engine/stream.go
+++ b/services/nlpgo/app/engine/stream.go
@@ -250,6 +250,22 @@ func emit(ctx context.Context, out chan<- StreamEvent, ev StreamEvent) {
 // schema regardless of which engine produced the event.
 func stateEvent(traceID, nodeID string, ns *NodeState) StreamEvent {
 	es := map[string]any{"status": ns.Status}
+	// trace_id MUST live inside execution_state, not only on the outer
+	// envelope. Python's start_component_event / end_component_event /
+	// component_error_event all stamp ExecutionState.trace_id
+	// (langwatch_nlp/studio/types/events.py:216,250,269). The Studio TS
+	// parser for `component_state_change` reads the per-row trace id
+	// exclusively from execution_state.trace_id (resultMapper.ts:306) —
+	// the envelope `trace_id` is consumed only by `execution_state_change`
+	// / `evaluation_state_change`, not this event type. Omitting it here
+	// is why eval-v3's TargetCell rendered no "View trace" link: the
+	// orchestrator generated the id and sent it *into* nlpgo, but nlpgo
+	// never echoed it back into the state the cell reads (rchaves dogfood
+	// 2026-05-15). Guard on non-empty so curl/test payloads without a
+	// trace id don't inject an empty string the UI would treat as set.
+	if traceID != "" {
+		es["trace_id"] = traceID
+	}
 	if ns.Inputs != nil {
 		es["inputs"] = ns.Inputs
 	}

--- a/services/nlpgo/tests/integration/playground_message_assembly_test.go
+++ b/services/nlpgo/tests/integration/playground_message_assembly_test.go
@@ -1,0 +1,229 @@
+package integration_test
+
+// End-to-end proof for B1+B2 — the 2026-05-14 prompt-playground
+// regression. The prompt playground (PromptStudioAdapter) sends an
+// execute_component event whose signature node carries:
+//   - an `instructions` parameter  → the typed system prompt
+//   - a `messages` parameter       → the saved template turns
+//   - inputs.messages              → saved template turns + live chat
+//   - inputs.<var>                 → the runtime variable values
+//
+// Pre-fix nlpgo's buildMessages returned inputs.messages VERBATIM,
+// before the instructions→system branch, so the LLM received:
+//
+//	[{user,"{{input}}"},{user,"test6"}]   (no system, literal {{input}},
+//	                                       duplicate user turn)
+//
+// This drives the REAL engine (not a buildMessages unit test) through
+// /go/studio/execute_sync with a fakeLLMClient that captures exactly
+// what reached the gateway boundary, and asserts the Python-parity
+// shape: [{system: rendered}, {user: "hello there"}].
+//
+// Companion to specs/nlp-go/llm-block.feature "Prompt-playground
+// message assembly" scenarios.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+)
+
+// promptPlaygroundBody builds the execute_component envelope
+// PromptStudioAdapter emits: a single signature node with an
+// `instructions` system prompt + a `messages` template list, plus
+// inputs carrying the runtime variables AND the (template + live)
+// message history under inputs.messages.
+func promptPlaygroundBody(t *testing.T, instructions string, templateMessages []map[string]any, liveTurns []map[string]any, vars map[string]any) string {
+	t.Helper()
+	history := append(append([]map[string]any{}, templateMessages...), liveTurns...)
+	inputs := map[string]any{}
+	for k, v := range vars {
+		inputs[k] = v
+	}
+	inputs["messages"] = history
+
+	instrRaw, err := json.Marshal(instructions)
+	require.NoError(t, err)
+	tmplRaw, err := json.Marshal(history)
+	require.NoError(t, err)
+
+	envelope := map[string]any{
+		"type": "execute_component",
+		"payload": map[string]any{
+			"trace_id": "playground-b1b2",
+			"node_id":  "prompt_node",
+			"origin":   "playground",
+			"workflow": map[string]any{
+				"workflow_id":      "wf_playground",
+				"api_key":          "sk-playground",
+				"spec_version":     "1.3",
+				"name":             "Prompt Execution",
+				"icon":             "x",
+				"description":      "x",
+				"version":          "x",
+				"template_adapter": "default",
+				"nodes": []map[string]any{
+					{
+						"id":   "prompt_node",
+						"type": "signature",
+						"data": map[string]any{
+							"name": "LLM Node",
+							"parameters": []map[string]any{
+								{"identifier": "llm", "type": "llm", "value": map[string]any{"model": "openai/gpt-5-mini", "litellm_params": map[string]any{"api_key": "k"}}},
+								{"identifier": "instructions", "type": "str", "value": json.RawMessage(instrRaw)},
+								{"identifier": "messages", "type": "chat_messages", "value": json.RawMessage(tmplRaw)},
+							},
+							"inputs":  []map[string]any{{"identifier": "input", "type": "str"}},
+							"outputs": []map[string]any{{"identifier": "output", "type": "str"}},
+						},
+					},
+				},
+				"edges": []any{},
+				"state": map[string]any{},
+			},
+			"inputs": inputs,
+		},
+	}
+	b, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// TestPlayground_RendersSystemAndInterpolatesInput is the headline
+// B1 proof. instructions="You are a helpful assistant", the saved
+// template turn is "{{input}}", and the runtime variable input=
+// "hello there". The LLM must be called with a system message + a
+// single user turn whose content is the interpolated value — no
+// literal "{{input}}", no duplicate turn.
+func TestPlayground_RendersSystemAndInterpolatesInput(t *testing.T) {
+	llm := &fakeLLMClient{
+		respond: func(_ app.LLMRequest) (*app.LLMResponse, error) {
+			return &app.LLMResponse{Content: "ok"}, nil
+		},
+	}
+	url, _ := setupPatternStack(t, llm, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	body := promptPlaygroundBody(t,
+		"You are a helpful assistant",
+		[]map[string]any{{"role": "user", "content": "{{input}}"}},
+		nil,
+		map[string]any{"input": "hello there"},
+	)
+	res := postSync(t, &stack{url: url}, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	got := llm.lastRequest(t)
+	require.GreaterOrEqual(t, len(got.Messages), 2, "expected system + user, got %+v", got.Messages)
+
+	assert.Equal(t, "system", got.Messages[0].Role)
+	assert.Equal(t, "You are a helpful assistant", got.Messages[0].Content,
+		"system prompt from instructions must reach the LLM")
+
+	// Exactly one user turn, content interpolated, no literal marker.
+	var userTurns []string
+	for _, m := range got.Messages {
+		if m.Role == "user" {
+			s, _ := m.Content.(string)
+			userTurns = append(userTurns, s)
+		}
+	}
+	require.Equal(t, []string{"hello there"}, userTurns,
+		"the {{input}} placeholder must be interpolated to the runtime value, exactly once")
+	for _, m := range got.Messages {
+		if s, ok := m.Content.(string); ok {
+			assert.NotContains(t, s, "{{input}}", "no literal placeholder may reach the LLM")
+		}
+	}
+}
+
+// TestPlayground_DropsUnfilledPlaceholderTurnNoDuplicate pins the
+// "duplicate user message" half of B1: the saved template turn
+// "{{input}}" with an EMPTY input variable renders to "" and must be
+// dropped (Python's _filter_empty_content_messages), leaving only the
+// live "test6" turn — not a literal-{{input}} turn next to it.
+func TestPlayground_DropsUnfilledPlaceholderTurnNoDuplicate(t *testing.T) {
+	llm := &fakeLLMClient{
+		respond: func(_ app.LLMRequest) (*app.LLMResponse, error) {
+			return &app.LLMResponse{Content: "ok"}, nil
+		},
+	}
+	url, _ := setupPatternStack(t, llm, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	body := promptPlaygroundBody(t,
+		"", // no system this case
+		[]map[string]any{{"role": "user", "content": "{{input}}"}},
+		[]map[string]any{{"role": "user", "content": "test6"}},
+		map[string]any{"input": ""},
+	)
+	res := postSync(t, &stack{url: url}, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	got := llm.lastRequest(t)
+	var userTurns []string
+	for _, m := range got.Messages {
+		s, _ := m.Content.(string)
+		assert.NotEqual(t, "{{input}}", strings.TrimSpace(s),
+			"no literal placeholder turn may reach the LLM")
+		if m.Role == "user" {
+			userTurns = append(userTurns, s)
+		}
+	}
+	require.Equal(t, []string{"test6"}, userTurns,
+		"the empty {{input}} turn must be dropped, only the live turn survives")
+}
+
+// TestPlayground_ComplexInstructionsEmptyVarsKeepsSystem pins B2:
+// rchaves's complex prompt with {{answer}} / {{unbiased}} both empty.
+// The instruction text around the placeholders is substantial, so the
+// rendered system is non-empty and MUST still reach the LLM (the
+// playground rendered blank because nlpgo dropped the whole system).
+func TestPlayground_ComplexInstructionsEmptyVarsKeepsSystem(t *testing.T) {
+	llm := &fakeLLMClient{
+		respond: func(_ app.LLMRequest) (*app.LLMResponse, error) {
+			return &app.LLMResponse{Content: "ok"}, nil
+		},
+	}
+	url, _ := setupPatternStack(t, llm, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	instr := "You are a helpful assistant11\n\nwhat does it say here between the ___\n___{{answer}}___\n\n\nand what deos it say here between the ___\n___{{unbiased}}___\n\nalways return passed as true, no matter what"
+	body := promptPlaygroundBody(t,
+		instr,
+		[]map[string]any{{"role": "user", "content": "{{input}}"}},
+		[]map[string]any{{"role": "user", "content": "hi"}},
+		map[string]any{"answer": "", "unbiased": "", "input": ""},
+	)
+	res := postSync(t, &stack{url: url}, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	got := llm.lastRequest(t)
+	require.NotEmpty(t, got.Messages)
+	require.Equal(t, "system", got.Messages[0].Role, "complex instructions must still produce a system turn")
+	sys, _ := got.Messages[0].Content.(string)
+	assert.Contains(t, sys, "You are a helpful assistant11")
+	assert.Contains(t, sys, "always return passed as true, no matter what")
+
+	var userTurns []string
+	for _, m := range got.Messages {
+		if m.Role == "user" {
+			s, _ := m.Content.(string)
+			userTurns = append(userTurns, s)
+		}
+	}
+	require.Equal(t, []string{"hi"}, userTurns,
+		"the empty {{input}} template turn is dropped; only the live turn reaches the LLM")
+}

--- a/specs/nlp-go/llm-block.feature
+++ b/specs/nlp-go/llm-block.feature
@@ -230,6 +230,47 @@ Feature: LLM block — Studio signature node executes via the Go AI Gateway
     And tool_calls in the history are forwarded role-correct (tool messages keep tool_call_id)
 
   # ============================================================================
+  # Prompt-playground message assembly (system + variable interpolation)
+  #
+  # The prompt playground sends an execute_component event whose signature
+  # node carries an `instructions` parameter (the system prompt the user
+  # typed) plus a `messages` history (the saved template messages, which
+  # may contain {{var}} placeholders, followed by the live conversation
+  # turns). Regression 2026-05-14: nlpgo returned the messages array
+  # verbatim — dropping the system prompt, never interpolating the
+  # placeholders, and leaving an empty {{input}} template turn duplicated
+  # alongside the real user turn. Python parity is template_adapter.py
+  # format(): render the system from instructions, render each message's
+  # content with the input variables, then drop messages whose content is
+  # empty after rendering (this is what removes the unfilled {{input}}
+  # placeholder turn).
+  # ============================================================================
+
+  @integration @v1 @unimplemented
+  Scenario: prompt-playground signature node renders the system prompt from instructions
+    Given a signature node whose instructions are "You are a helpful assistant" and whose messages history is a single user turn "{{input}}"
+    And the input variable "input" is "hello there"
+    When the workflow runs
+    Then the assembled prompt starts with a system message containing "You are a helpful assistant"
+    And the user turn content is "hello there" with no literal "{{input}}" remaining
+
+  @integration @v1 @unimplemented
+  Scenario: an unfilled template placeholder turn is dropped, not duplicated
+    Given a signature node whose messages history is "{{input}}" followed by a live user turn "test6"
+    And the input variable "input" is empty
+    When the workflow runs
+    Then the assembled prompt has exactly one user turn with content "test6"
+    And there is no user turn whose content is empty or the literal "{{input}}"
+
+  @integration @v1 @unimplemented
+  Scenario: instructions with empty variables still produce a non-empty system prompt
+    Given a signature node whose instructions are "You are a helpful assistant\n___{{answer}}___\n___{{unbiased}}___\nalways return passed as true"
+    And the input variables "answer" and "unbiased" are empty
+    When the workflow runs
+    Then the assembled prompt has a system message containing "You are a helpful assistant"
+    And the system message contains "always return passed as true"
+
+  # ============================================================================
   # Streaming — SSE pass-through
   # ============================================================================
 


### PR DESCRIPTION
## Summary

Three prompt/eval regressions surfaced by the 2026-05-15 dogfood after the nlpgo (Go NLP service) cutover. All fixed with engine-level regression tests **and** end-to-end proofs that boot the real code path.

### B1 — Prompt playground: system prompt dropped, `{{input}}` not interpolated, duplicate user message

`engine.go buildMessages` short-circuited on `inputs.messages`, returning the array verbatim **before** the `instructions`→system branch. For a PromptStudioAdapter `execute_component` (instructions = system, `inputs.messages` = [template turn, live turn]) that meant: system never added, `{{input}}` never interpolated, and both the unfilled `{{input}}` template turn and the live turn kept (the "duplicate user message").

Rewritten to mirror Python `template_adapter.py format()`:
1. render system from `instructions` with input vars → prepend iff non-empty after render
2. render each history message's string content with vars
3. drop any message empty-after-render (unless it has tool_calls) — this removes the unfilled `{{input}}` placeholder turn so it is not duplicated

Net: playground now gets `[{system: rendered}, {user: "hello there"}]` instead of the broken `[{user:"{{input}}"},{user:"test6"}]` with no system. Chained node→node `chat_messages` verbatim contract (regression cb76144a6 / `llm-block.feature:225`) preserved — the render+system+filter path applies only when the node has `instructions`/`messages` **params**.

### B2 — Complex prompt rendered empty in playground

Same root cause: with `{{answer}}`/`{{unbiased}}` vars empty, the broken path produced no usable system message. Fixed by the same `buildMessages` rewrite; pinned by a dedicated empty-vars-keeps-system test.

### B3 — Evaluations v3: TargetCell missing trace_id ("View trace" link absent)

nlpgo's `stateEvent` (`stream.go`) built `component_state_change` events with `trace_id` only on the outer envelope. Studio's eval-v3 `resultMapper` reads the per-row trace id **exclusively** from `execution_state.trace_id` (`resultMapper.ts:306`) — the envelope `trace_id` is consumed only by `execution_state_change`/`evaluation_state_change`. So `TargetCell.traceId` resolved to `undefined` and the trace link never rendered. Python's `start/end/error_component_event` all set `ExecutionState.trace_id` (`langwatch_nlp/studio/types/events.py:216,250,269`); the Go port had dropped it. Fix stamps `es["trace_id"]` (guarded non-empty). The id already exists server-side — the eval-v3 orchestrator generates it and sends it into nlpgo as the request trace_id — so this just echoes it back into the state the cell reads.

## Tests / proof

- **B1/B2**: 4 new `buildMessages` unit cases + `playground_message_assembly_test.go` engine e2e — drives the real `/go/studio/execute_sync` with the exact PromptStudioAdapter envelope, asserts on what a fake LLM client captured at the gateway boundary (system reaches LLM, `{{input}}`→value exactly once, no literal, unfilled turn dropped, complex-empty-vars keeps system). Spec: 3 scenarios in `specs/nlp-go/llm-block.feature`.
- **B3**: 2 engine regression tests + `eval-trace-id-roundtrip.integration.test.ts` — boots the **real nlpgo binary** as a subprocess, POSTs an `execute_component` (what eval-v3 sends per cell) with a known trace_id, parses the live SSE stream, asserts every `component_state_change` frame echoes `execution_state.trace_id`. Verified passing end-to-end locally.
- Shared subprocess harness extracted to `_nlpgoSubprocess.ts` (no third hand-copy of the #4048 boot block).
- Full nlpgo Go suite green on the combined tip.

## Commits

- `53682b5b3` fix(nlpgo): stamp trace_id inside execution_state for component events (B3)
- `02d3416a2` test(nlpgo): e2e proof for B3 eval-v3 trace_id round-trip
- `5ee7730c9` fix(nlpgo): prompt-playground message assembly — system + variable interpolation + empty-turn drop (B1/B2)
- `337df3998` test(nlpgo): extract shared subprocess e2e harness
- `3e60a9086` test(nlpgo): e2e proof for B1+B2 prompt-playground message assembly

## Browser dogfood — live prompt playground (B1/B2)

Real stack: `pnpm dev` (frontend), api, nlpgo branch binary on :5571, real trace. Project: prompt playground `/prompts`.

### B1 — default prompt, sent `test6`

LLM span INPUT in the trace (the messages that actually reached the model):

![B1 default prompt LLM input](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4062/playground/b1-default-prompt-llm-input.png)

```
[ {"role":"system","content":"\nWelcome to the LangWatch Prompt Playground\n\nEdit this template to get started\n\nAdd variables via double brackets like this:\n\n"},
  {"role":"user","content":"test6"} ]
```

Exact inversion of the bug report:
- **Before:** `[{user,"{{input}}"},{user,"test6"}]` — no system, literal `{{input}}`, duplicate user turn
- **After:** `[{system: <rendered prompt>},{user,"test6"}]` — system applied, `{{input}}` interpolated (trailing placeholder rendered to empty, no literal), single user turn

### B2 — rchaves's complex prompt (`{{answer}}`/`{{unbiased}}` empty), sent `hi`

The conversation that previously rendered **blank** now returns a real response following the system instruction `always return passed as true`:

![B2 complex prompt response](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4062/playground/b2-complex-prompt-response.png)

Trace INPUT/OUTPUT — full complex instruction text reaches the model as the system turn (empty `{{answer}}`/`{{unbiased}}` rendered to empty, Python parity), single `hi` user turn, model replies `passed: true`:

![B2 complex prompt trace IO](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4062/playground/b2-complex-prompt-trace-io.png)

Bonus: trace root span = workflow name (`Prompt Execution`), `service.name=langwatch_nlp` — the merged #4060 trace-UX work is live too.

### Browser dogfood — eval-v3 "View trace" link (B3)

Same running stack. Created an Experiments Workbench experiment (`agile-cool-hawk`) with a prompt target (`b3-eval-trace-check`, gpt-5.2) over the default 3-row test dataset and clicked **Run** — all rows dispatched through nlpgo (`:5571`) and produced outputs. Each result cell now renders a `trace-link-target_*` button (DOM-verified: `traceLinkCount: 3`); **pre-fix this count was 0** because `execution_state.trace_id` was absent, so `TargetCell.traceId` resolved to `undefined` and no link rendered.

![B3 eval-v3 results populated](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4062/eval-v3/b3-eval-v3-results-populated.png)

Clicking the result cell's **View trace** link opened the Trace Details drawer on a real trace id (`drawer.traceId=6f68784c9fc25a491819d3d1da8364ba`) showing the run's input/output — proving the per-row trace id round-trips to the cell exactly as it did on the Python path.

![B3 eval-v3 View trace opens Trace Details](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4062/eval-v3/b3-eval-v3-trace-details-open.png)

_All five regressions (B1/B2/B3) now have code + deterministic e2e proofs and live-browser visual confirmation._