### PR TITLE
docs: add LANGWATCH_PROJECT_ID to all instrumentation guides

### DIFF
--- a/docs/datasets/programmatic-access.mdx
+++ b/docs/datasets/programmatic-access.mdx
@@ -26,6 +26,10 @@ const langwatch = new LangWatch();
   </Tab>
 </Tabs>
 
+<Note>
+  If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set the `LANGWATCH_PROJECT_ID` environment variable (or pass `project_id`/`projectId` to the SDK) so the SDK knows which project to access. You can find the project ID in your project settings.
+</Note>
+
 ## List Datasets
 
 Retrieve all datasets for your project with pagination support.

--- a/docs/evaluations/experiments/sdk.mdx
+++ b/docs/evaluations/experiments/sdk.mdx
@@ -45,7 +45,12 @@ Be sure to login or create an account on the link that will be displayed, then p
   <Tab title="Environment Variable">
 ```bash
 export LANGWATCH_API_KEY=your_api_key
+export LANGWATCH_PROJECT_ID=your_project_id  # Required for service API keys
 ```
+
+<Note>
+  `LANGWATCH_PROJECT_ID` is required when using a **service API key** (e.g. for CI/CD or multi-project setups). Project API keys obtained via `langwatch.login()` or from the project settings page already have the project context built in.
+</Note>
   </Tab>
 </Tabs>
 

--- a/docs/integration/go/guide.mdx
+++ b/docs/integration/go/guide.mdx
@@ -51,8 +51,13 @@ Get started in just a few minutes by installing the SDK and instrumenting your a
 
   ```bash
   export LANGWATCH_API_KEY="your-langwatch-api-key"
+  export LANGWATCH_PROJECT_ID="your-project-id"  # Required for service API keys
   export OPENAI_API_KEY="your-openai-api-key"
   ```
+
+  <Note>
+    `LANGWATCH_PROJECT_ID` is required when using a **service API key** (e.g. for CI/CD or multi-project setups). Project API keys obtained from the project settings page already have the project context built in.
+  </Note>
 
   <Check>
   You can verify your API key is set by running `echo $LANGWATCH_API_KEY`
@@ -323,7 +328,8 @@ The SDK respects these environment variables for configuration:
 
 | Variable | Description |
 | --- | --- |
-| `LANGWATCH_API_KEY` | **Required.** Your LangWatch project API key. |
+| `LANGWATCH_API_KEY` | **Required.** Your LangWatch API key. |
+| `LANGWATCH_PROJECT_ID` | Your LangWatch project ID. **Required** when using a service API key. |
 | `LANGWATCH_ENDPOINT` | The LangWatch collector endpoint. Defaults to `https://app.langwatch.ai`. |
 
 ## Filtering Spans

--- a/docs/integration/opentelemetry/guide.mdx
+++ b/docs/integration/opentelemetry/guide.mdx
@@ -19,6 +19,7 @@ import LLMsTxtProtip from "/snippets/llms-txt-protip.mdx";
 ## Prerequisites
 
 - Obtain your `LANGWATCH_API_KEY` from the [LangWatch dashboard](https://app.langwatch.ai/)
+- If using a **service API key**, also obtain your `LANGWATCH_PROJECT_ID` from your project settings
 - Install the OpenTelemetry SDK for your programming language
 
 ## LangWatch OTEL API Endpoint
@@ -219,7 +220,12 @@ Set these environment variables for authentication:
 
 ```bash
 export LANGWATCH_API_KEY="your-api-key-here"
+export LANGWATCH_PROJECT_ID="your-project-id-here"  # Required for service API keys
 ```
+
+<Note>
+  `LANGWATCH_PROJECT_ID` is required when using a **service API key** (e.g. for CI/CD or multi-project setups). Project API keys obtained from the project settings page already have the project context built in.
+</Note>
 
 ## Verification
 

--- a/docs/integration/python/guide.mdx
+++ b/docs/integration/python/guide.mdx
@@ -33,6 +33,8 @@ Integrate LangWatch into your Python application to start observing your LLM int
 
 First, you need a LangWatch API key. Sign up at [app.langwatch.ai](https://app.langwatch.ai) and find your API key in your project settings. The SDK will automatically use the `LANGWATCH_API_KEY` environment variable if it is set.
 
+If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set `LANGWATCH_PROJECT_ID` so the SDK knows which project to send traces to. You can find the project ID in your project settings.
+
 ## Start Instrumenting
 
 First, ensure you have the SDK installed:
@@ -171,6 +173,7 @@ exclude_rules = [
 
 langwatch.setup(
     api_key=os.getenv("LANGWATCH_API_KEY"),
+    project_id=os.getenv("LANGWATCH_PROJECT_ID"), # Required for service API keys
     endpoint_url="https://your-langwatch-instance.com", # Optional: Defaults to env var or cloud
     base_attributes={
       AttributeKey.ServiceName: "my-awesome-service",
@@ -194,6 +197,11 @@ langwatch.setup(
 <ParamField path="api_key" type="str | None">
   Your LangWatch API key. If not provided, it uses the `LANGWATCH_API_KEY`
   environment variable.
+</ParamField>
+
+<ParamField path="project_id" type="str | None">
+  Your LangWatch project ID. Required when using a service API key. If not
+  provided, it uses the `LANGWATCH_PROJECT_ID` environment variable.
 </ParamField>
 
 <ParamField path="endpoint_url" type="str | None">

--- a/docs/integration/python/tutorials/manual-instrumentation.mdx
+++ b/docs/integration/python/tutorials/manual-instrumentation.mdx
@@ -18,7 +18,7 @@ from langwatch.types import RAGChunk
 from langwatch.attributes import AttributeKey # For semantic attribute keys
 import asyncio # Assuming async operation
 
-langwatch.setup()
+langwatch.setup()  # Reads LANGWATCH_API_KEY and LANGWATCH_PROJECT_ID from environment
 
 async def rag_retrieval_manual(query: str):
     # Use async with for the span, instead of a decorator

--- a/docs/integration/quick-start.mdx
+++ b/docs/integration/quick-start.mdx
@@ -26,6 +26,10 @@ Let's get cracking.
     ```
 
     This will add the `LANGWATCH_API_KEY` to your local `.env` file.
+
+    <Note>
+      If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set `LANGWATCH_PROJECT_ID` in your `.env` file so the SDK knows which project to send traces to. You can find the project ID in your project settings.
+    </Note>
   </Step>
 
   <Step title="Let LangWatch MCP do the rest for you (Optional)">
@@ -77,6 +81,7 @@ from langwatch.instrumentors import OpenAIInstrumentor
 
 langwatch.setup(
     api_key=os.getenv("LANGWATCH_API_KEY"), # Your LangWatch API key
+    project_id=os.getenv("LANGWATCH_PROJECT_ID"), # Required for service API keys
     instrumentors=[OpenAIInstrumentor()] # Add the instrumentor for your LLM
 )
 ```
@@ -100,6 +105,7 @@ export function register() {
     serviceName: 'your-app-name', // Give your service a clear name
     traceExporter: new LangWatchExporter({
       apiKey: process.env.LANGWATCH_API_KEY, // Your LangWatch API key
+      projectId: process.env.LANGWATCH_PROJECT_ID, // Required for service API keys
     })
   });
 }

--- a/docs/integration/typescript/guide.mdx
+++ b/docs/integration/typescript/guide.mdx
@@ -65,8 +65,13 @@ The `@ai-sdk/openai` and `ai` packages are only required for the example in this
 
 ```bash
 export LANGWATCH_API_KEY=your_langwatch_api_key_here
+export LANGWATCH_PROJECT_ID=your_project_id_here  # Required for service API keys
 export OPENAI_API_KEY=your_openai_api_key_here
 ```
+
+<Note>
+  `LANGWATCH_PROJECT_ID` is required when using a **service API key** (e.g. for CI/CD or multi-project setups). Project API keys obtained via `npx langwatch login` or from the project settings page already have the project context built in.
+</Note>
 
 ### Step 3: Your First LLM Trace
 
@@ -257,6 +262,7 @@ const handle = setupObservability({
   // Optional: Custom API key (defaults to LANGWATCH_API_KEY env var)
   langwatch: {
     apiKey: process.env.LANGWATCH_API_KEY,
+    projectId: process.env.LANGWATCH_PROJECT_ID, // Required for service API keys
   },
 
   // Optional: Global attributes for all traces
@@ -369,6 +375,7 @@ If you don't call `shutdown()`, some traces may be lost when your application te
 1. **Set up environment**:
 ```bash
 export LANGWATCH_API_KEY=your_key
+export LANGWATCH_PROJECT_ID=your_project_id  # Required for service API keys
 export NODE_ENV=development
 ```
 

--- a/docs/integration/typescript/tutorials/manual-instrumentation.mdx
+++ b/docs/integration/typescript/tutorials/manual-instrumentation.mdx
@@ -339,6 +339,7 @@ import { FilterableBatchSpanProcessor, LangWatchExporter } from "langwatch";
 const processor = new FilterableBatchSpanProcessor(
   new LangWatchExporter({
     apiKey: "your-api-key",
+    projectId: "your-project-id", // Required for service API keys
   }),
   [
     { attribute: "http.url", value: "/health" },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -442,6 +442,10 @@ Let's get cracking.
     ```
 
     This will add the `LANGWATCH_API_KEY` to your local `.env` file.
+
+    <Note>
+      If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set `LANGWATCH_PROJECT_ID` in your `.env` file so the SDK knows which project to send traces to. You can find the project ID in your project settings.
+    </Note>
   </Step>
 
   <Step title="Let LangWatch MCP do the rest for you (Optional)">
@@ -493,6 +497,7 @@ from langwatch.instrumentors import OpenAIInstrumentor
 
 langwatch.setup(
     api_key=os.getenv("LANGWATCH_API_KEY"), # Your LangWatch API key
+    project_id=os.getenv("LANGWATCH_PROJECT_ID"), # Required for service API keys
     instrumentors=[OpenAIInstrumentor()] # Add the instrumentor for your LLM
 )
 ```
@@ -516,6 +521,7 @@ export function register() {
     serviceName: 'your-app-name', // Give your service a clear name
     traceExporter: new LangWatchExporter({
       apiKey: process.env.LANGWATCH_API_KEY, // Your LangWatch API key
+      projectId: process.env.LANGWATCH_PROJECT_ID, // Required for service API keys
     })
   });
 }
@@ -4752,7 +4758,7 @@ from langwatch.types import RAGChunk
 from langwatch.attributes import AttributeKey # For semantic attribute keys
 import asyncio # Assuming async operation
 
-langwatch.setup()
+langwatch.setup()  # Reads LANGWATCH_API_KEY and LANGWATCH_PROJECT_ID from environment
 
 async def rag_retrieval_manual(query: str):
     # Use async with for the span, instead of a decorator
@@ -7760,6 +7766,7 @@ import { FilterableBatchSpanProcessor, LangWatchExporter } from "langwatch";
 const processor = new FilterableBatchSpanProcessor(
   new LangWatchExporter({
     apiKey: "your-api-key",
+    projectId: "your-project-id", // Required for service API keys
   }),
   [
     { attribute: "http.url", value: "/health" },
@@ -10054,6 +10061,7 @@ This guide shows you how to set up OpenTelemetry instrumentation in any language
 ## Prerequisites
 
 - Obtain your `LANGWATCH_API_KEY` from the [LangWatch dashboard](https://app.langwatch.ai/)
+- If using a **service API key**, also obtain your `LANGWATCH_PROJECT_ID` from your project settings
 - Install the OpenTelemetry SDK for your programming language
 
 ## LangWatch OTEL API Endpoint
@@ -10256,7 +10264,12 @@ Set these environment variables for authentication:
 
 ```bash
 export LANGWATCH_API_KEY="your-api-key-here"
+export LANGWATCH_PROJECT_ID="your-project-id-here"  # Required for service API keys
 ```
+
+<Note>
+  `LANGWATCH_PROJECT_ID` is required when using a **service API key** (e.g. for CI/CD or multi-project setups). Project API keys obtained from the project settings page already have the project context built in.
+</Note>
 
 ## Verification
 
@@ -13570,6 +13583,10 @@ const langwatch = new LangWatch();
 ```
 
 
+
+<Note>
+  If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set the `LANGWATCH_PROJECT_ID` environment variable (or pass `project_id`/`projectId` to the SDK) so the SDK knows which project to access. You can find the project ID in your project settings.
+</Note>
 
 ## List Datasets
 
@@ -18408,7 +18425,12 @@ Be sure to login or create an account on the link that will be displayed, then p
 
 ```bash
 export LANGWATCH_API_KEY=your_api_key
+export LANGWATCH_PROJECT_ID=your_project_id  # Required for service API keys
 ```
+
+<Note>
+  `LANGWATCH_PROJECT_ID` is required when using a **service API key** (e.g. for CI/CD or multi-project setups). Project API keys obtained via `langwatch.login()` or from the project settings page already have the project context built in.
+</Note>
 
 
 

--- a/docs/snippets/prerequests-ts.mdx
+++ b/docs/snippets/prerequests-ts.mdx
@@ -16,6 +16,7 @@ Ensure `LANGWATCH_API_KEY` is set:
 <Tab title="Environment variable">
 ```bash .env
 LANGWATCH_API_KEY='your_api_key_here'
+LANGWATCH_PROJECT_ID='your_project_id_here'
 ```
 </Tab>
 <Tab title="Client parameters">
@@ -24,7 +25,12 @@ import { LangWatch } from 'langwatch';
 
 const langwatch = new LangWatch({
   apiKey: 'your_api_key_here',
+  projectId: 'your_project_id_here',
 });
 ```
 </Tab>
 </Tabs>
+
+<Note>
+  If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set `LANGWATCH_PROJECT_ID` so the SDK knows which project to send traces to. You can find the project ID in your project settings. Project API keys obtained via `npx langwatch login` or from the project settings page already have the project context built in.
+</Note>

--- a/docs/snippets/prerequests.mdx
+++ b/docs/snippets/prerequests.mdx
@@ -16,6 +16,7 @@ Ensure `LANGWATCH_API_KEY` is set:
 <Tab title="Environment variable">
 ```bash
 export LANGWATCH_API_KEY='your_api_key_here'
+export LANGWATCH_PROJECT_ID='your_project_id_here'
 ```
 </Tab>
 <Tab title="Runtime">
@@ -40,3 +41,7 @@ def main():
 ```
 </Tab>
 </Tabs>
+
+<Note>
+  If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set `LANGWATCH_PROJECT_ID` so the SDK knows which project to send traces to. You can find the project ID in your project settings. Project API keys obtained via `npx langwatch login` or from the project settings page already have the project context built in.
+</Note>

--- a/docs/snippets/prerequests.mdx
+++ b/docs/snippets/prerequests.mdx
@@ -43,5 +43,5 @@ def main():
 </Tabs>
 
 <Note>
-  If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set `LANGWATCH_PROJECT_ID` so the SDK knows which project to send traces to. You can find the project ID in your project settings. Project API keys obtained via `npx langwatch login` or from the project settings page already have the project context built in.
+  If you are using a **service API key** (e.g. for CI/CD or multi-project setups), you must also set `LANGWATCH_PROJECT_ID` so the SDK knows which project to send traces to. You can find the project ID in your project settings. Project API keys obtained from the project settings page already have the project context built in.
 </Note>


### PR DESCRIPTION
## Summary

- Added `LANGWATCH_PROJECT_ID` to all SDK instrumentation docs (Python, TypeScript, Go, OpenTelemetry, experiments, datasets)
- Updated shared prerequisite snippets (`prerequests.mdx`, `prerequests-ts.mdx`) which are reused across many pages
- Added `project_id`/`projectId` to code examples in quick-start, full setup, and manual instrumentation guides
- Each mention includes a note clarifying it's required for **service API keys** (CI/CD, multi-project), while project API keys from the dashboard already have project context built in
- Regenerated `llms-full.txt` to reflect the docs changes

## Context

After updating API keys to support service API keys, the docs only showed `LANGWATCH_API_KEY`. All three SDKs already support `LANGWATCH_PROJECT_ID` via env var and constructor param, but users had no way to discover this from the docs.

## Files changed (12)

- `docs/snippets/prerequests.mdx` — Python shared snippet
- `docs/snippets/prerequests-ts.mdx` — TypeScript shared snippet
- `docs/integration/quick-start.mdx` — Quick start guide
- `docs/integration/python/guide.mdx` — Python guide + added `project_id` param field
- `docs/integration/typescript/guide.mdx` — TypeScript guide
- `docs/integration/go/guide.mdx` — Go guide + env vars table
- `docs/integration/opentelemetry/guide.mdx` — OpenTelemetry guide
- `docs/integration/python/tutorials/manual-instrumentation.mdx` — Python manual instrumentation
- `docs/integration/typescript/tutorials/manual-instrumentation.mdx` — TypeScript manual instrumentation
- `docs/evaluations/experiments/sdk.mdx` — Experiments SDK
- `docs/datasets/programmatic-access.mdx` — Datasets programmatic access
- `docs/llms-full.txt` — Regenerated LLMs full text

## Test plan

- [x] CI green (check_links, check_generated_files, docs-complete all pass)
- [x] CodeRabbit review comment addressed (removed `npx` reference from Python snippet)