### PR TITLE
fix(scenarios): escape scalar interpolations in HTTP agent body templates as JSON

### DIFF
--- a/langwatch/src/server/scenarios/execution/__tests__/http-body-json-safety.integration.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/http-body-json-safety.integration.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration regression for the customer n8n failure:
+ *
+ *   HTTP 422: Unprocessable Entity ... {"code":422,"message":"Failed to parse
+ *   request body","hint":"Bad control character in string literal in JSON ..."}
+ *
+ * Drives the real SerializedHttpAgentAdapter against a local server that
+ * behaves like the n8n webhook did: it `JSON.parse`s the request body and
+ * answers 422 with the same error shape when parsing fails. With a
+ * conversation turn that contains a raw newline, quote and backslash, the body
+ * the adapter sends must still be valid JSON.
+ *
+ * Covers the @integration scenario in
+ * specs/scenarios/http-agent-body-template-json-safety.feature.
+ */
+
+import { createServer, type Server } from "node:http";
+import { AgentRole, type AgentInput } from "@langwatch/scenario";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { HttpAgentData } from "../types";
+
+// Use native fetch so localhost isn't blocked by SSRF protection.
+vi.mock("~/utils/ssrfProtection", () => ({
+  ssrfSafeFetch: async (url: string, init?: RequestInit) =>
+    fetch(url, init),
+}));
+
+const { SerializedHttpAgentAdapter } = await import(
+  "../serialized-adapters/http-agent.adapter"
+);
+
+interface N8nLikeServer {
+  url: string;
+  lastParsedBody: () => unknown;
+  close: () => Promise<void>;
+}
+
+/**
+ * Mimics the n8n webhook: JSON-parses the body, replies 422 with n8n's exact
+ * error envelope on failure, and echoes the parsed body on success.
+ */
+async function createN8nLikeServer(): Promise<N8nLikeServer> {
+  let parsed: unknown;
+
+  const server: Server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c: Buffer) => (body += c.toString()));
+    req.on("end", () => {
+      try {
+        parsed = JSON.parse(body);
+      } catch (e) {
+        res.writeHead(422, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            code: 422,
+            message: "Failed to parse request body",
+            hint: e instanceof Error ? e.message : String(e),
+          }),
+        );
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          choices: [{ message: { role: "assistant", content: "ok" } }],
+        }),
+      );
+    });
+  });
+
+  const port: number = await new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      typeof addr === "object" && addr
+        ? resolve(addr.port)
+        : reject(new Error("no address"));
+    });
+    server.on("error", reject);
+  });
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    lastParsedBody: () => parsed,
+    close: () =>
+      new Promise((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+describe("HTTP agent body JSON safety (n8n regression)", () => {
+  let srv: N8nLikeServer;
+
+  beforeAll(async () => {
+    srv = await createN8nLikeServer();
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  function config(overrides?: Partial<HttpAgentData>): HttpAgentData {
+    return {
+      type: "http",
+      agentId: "n8n-agent",
+      url: srv.url,
+      method: "POST",
+      headers: [],
+      outputPath: "$.choices[0].message.content",
+      ...overrides,
+    };
+  }
+
+  function input(content: string): AgentInput {
+    return {
+      threadId: "thread-1",
+      messages: [{ role: "user", content }],
+      newMessages: [{ role: "user", content }],
+      requestedRole: AgentRole.AGENT,
+      scenarioState: {} as AgentInput["scenarioState"],
+      scenarioConfig: {} as AgentInput["scenarioConfig"],
+    };
+  }
+
+  describe("given an n8n-style body template and an awkward conversation turn", () => {
+    describe("when the adapter calls the webhook", () => {
+      it("sends a body the server can JSON-parse (no HTTP 422)", async () => {
+        const adapter = new SerializedHttpAgentAdapter(
+          config({
+            bodyTemplate:
+              '{"chatInput": "{{ input }}", "sessionId": "{{ threadId }}"}',
+          }),
+        );
+        const awkward =
+          'Please summarize:\n\n"Q3 results"\nwith a path C:\\reports\\q3';
+
+        const result = await adapter.call(input(awkward));
+
+        expect(result).toBe("ok");
+        expect(srv.lastParsedBody()).toEqual({
+          chatInput: awkward,
+          sessionId: "thread-1",
+        });
+      });
+    });
+  });
+
+  describe("given the default thread_id + messages template", () => {
+    describe("when a turn contains newlines and quotes", () => {
+      it("still posts a parseable body", async () => {
+        const adapter = new SerializedHttpAgentAdapter(
+          config({
+            bodyTemplate:
+              '{\n  "thread_id": "{{threadId}}",\n  "messages": {{messages}}\n}',
+          }),
+        );
+
+        await adapter.call(input('line\nbreak and a "quote"'));
+
+        expect(srv.lastParsedBody()).toEqual({
+          thread_id: "thread-1",
+          messages: [
+            { role: "user", content: 'line\nbreak and a "quote"' },
+          ],
+        });
+      });
+    });
+  });
+
+  describe("given the bug were not fixed", () => {
+    it("a raw-newline body would have produced the customer's 422", async () => {
+      // Sanity-anchor: the un-escaped body the old code produced really is
+      // rejected by the same server, proving the regression target is real.
+      const brokenBody = '{"chatInput": "line one\nline two"}';
+      const res = await fetch(srv.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: brokenBody,
+      });
+
+      expect(res.status).toBe(422);
+      expect((await res.json()).message).toBe("Failed to parse request body");
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/execution/__tests__/http-body-json-safety.integration.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/http-body-json-safety.integration.test.ts
@@ -126,6 +126,7 @@ describe("HTTP agent body JSON safety (n8n regression)", () => {
 
   describe("given an n8n-style body template and an awkward conversation turn", () => {
     describe("when the adapter calls the webhook", () => {
+      /** @scenario Adapter posts a parseable body to a real HTTP endpoint */
       it("sends a body the server can JSON-parse (no HTTP 422)", async () => {
         const adapter = new SerializedHttpAgentAdapter(
           config({

--- a/langwatch/src/server/scenarios/execution/__tests__/http-body-json-safety.integration.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/http-body-json-safety.integration.test.ts
@@ -20,16 +20,14 @@ import { createServer, type Server } from "node:http";
 import { AgentRole, type AgentInput } from "@langwatch/scenario";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { HttpAgentData } from "../types";
+import { SerializedHttpAgentAdapter } from "../serialized-adapters/http-agent.adapter";
 
-// Use native fetch so localhost isn't blocked by SSRF protection.
+// Use native fetch so localhost isn't blocked by SSRF protection. Vitest hoists
+// vi.mock above the static import below, so the adapter still gets the mock.
 vi.mock("~/utils/ssrfProtection", () => ({
   ssrfSafeFetch: async (url: string, init?: RequestInit) =>
     fetch(url, init),
 }));
-
-const { SerializedHttpAgentAdapter } = await import(
-  "../serialized-adapters/http-agent.adapter"
-);
 
 interface N8nLikeServer {
   url: string;
@@ -50,13 +48,15 @@ async function createN8nLikeServer(): Promise<N8nLikeServer> {
     req.on("end", () => {
       try {
         parsed = JSON.parse(body);
-      } catch (e) {
+      } catch {
+        // Static hint mirroring n8n's envelope without echoing the parser
+        // exception/stack into the response (CodeQL: stack-trace exposure).
         res.writeHead(422, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
             code: 422,
             message: "Failed to parse request body",
-            hint: e instanceof Error ? e.message : String(e),
+            hint: "Bad control character in string literal in JSON",
           }),
         );
         return;

--- a/langwatch/src/server/scenarios/execution/__tests__/http-template-engine.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/http-template-engine.unit.test.ts
@@ -30,11 +30,15 @@ function inputWith(content: string | unknown[]): AgentInput {
   };
 }
 
-function render(
-  template: string,
-  input: AgentInput,
-  scenarioMappings?: Record<string, FieldMapping>,
-): string {
+function render({
+  template,
+  input,
+  scenarioMappings,
+}: {
+  template: string;
+  input: AgentInput;
+  scenarioMappings?: Record<string, FieldMapping>;
+}): string {
   return renderBodyTemplate({
     template,
     context: buildTemplateContext({ input, scenarioMappings }),
@@ -46,10 +50,10 @@ describe("body template JSON safety", () => {
     describe("when the value contains a newline", () => {
       /** @scenario A user message with a newline is escaped inside a JSON string literal */
       it("escapes it so the body is valid JSON", () => {
-        const body = render(
-          '{"chatInput": "{{ input }}"}',
-          inputWith("line one\nline two"),
-        );
+        const body = render({
+          template: '{"chatInput": "{{ input }}"}',
+          input: inputWith("line one\nline two"),
+        });
 
         expect(() => JSON.parse(body)).not.toThrow();
         expect(JSON.parse(body).chatInput).toBe("line one\nline two");
@@ -59,10 +63,10 @@ describe("body template JSON safety", () => {
     describe("when the value contains a double quote", () => {
       /** @scenario A user message containing a double quote is escaped */
       it("escapes it so the body is valid JSON", () => {
-        const body = render(
-          '{"chatInput": "{{ input }}"}',
-          inputWith('she said "hi"'),
-        );
+        const body = render({
+          template: '{"chatInput": "{{ input }}"}',
+          input: inputWith('she said "hi"'),
+        });
 
         expect(JSON.parse(body).chatInput).toBe('she said "hi"');
       });
@@ -71,10 +75,10 @@ describe("body template JSON safety", () => {
     describe("when the value contains a backslash", () => {
       /** @scenario A user message containing a backslash is escaped */
       it("escapes it so the body is valid JSON", () => {
-        const body = render(
-          '{"chatInput": "{{ input }}"}',
-          inputWith("path C:\\temp\\new"),
-        );
+        const body = render({
+          template: '{"chatInput": "{{ input }}"}',
+          input: inputWith("path C:\\temp\\new"),
+        });
 
         expect(JSON.parse(body).chatInput).toBe("path C:\\temp\\new");
       });
@@ -82,10 +86,10 @@ describe("body template JSON safety", () => {
 
     describe("when the value contains a tab and a carriage return", () => {
       it("escapes both control characters", () => {
-        const body = render(
-          '{"chatInput": "{{ input }}"}',
-          inputWith("a\tb\rc"),
-        );
+        const body = render({
+          template: '{"chatInput": "{{ input }}"}',
+          input: inputWith("a\tb\rc"),
+        });
 
         expect(JSON.parse(body).chatInput).toBe("a\tb\rc");
       });
@@ -101,7 +105,7 @@ describe("body template JSON safety", () => {
         { role: "assistant", content: 'reply with "quotes"' },
       ];
 
-      const body = render('{"messages": {{messages}}}', input);
+      const body = render({ template: '{"messages": {{messages}}}', input });
 
       const parsed = JSON.parse(body);
       expect(Array.isArray(parsed.messages)).toBe(true);
@@ -115,10 +119,10 @@ describe("body template JSON safety", () => {
         { role: "user", content: 'multi\nline "quoted" \\slash' },
       ];
 
-      const body = render(
-        '{\n  "thread_id": "{{threadId}}",\n  "messages": {{messages}}\n}',
+      const body = render({
+        template: '{\n  "thread_id": "{{threadId}}",\n  "messages": {{messages}}\n}',
         input,
-      );
+      });
 
       const parsed = JSON.parse(body);
       expect(parsed.thread_id).toBe("thread-1");
@@ -129,7 +133,10 @@ describe("body template JSON safety", () => {
   describe("given structured (non-string) message content", () => {
     it("still injects {{input}} raw so {\"input\": {{input}}} stays valid", () => {
       const structured = [{ type: "text", text: "Hello world" }];
-      const body = render('{"input": {{input}}}', inputWith(structured));
+      const body = render({
+        template: '{"input": {{input}}}',
+        input: inputWith(structured),
+      });
 
       expect(JSON.parse(body).input).toEqual(structured);
     });
@@ -138,7 +145,10 @@ describe("body template JSON safety", () => {
   describe("given the raw filter", () => {
     /** @scenario A user can opt a scalar out of escaping with the raw filter */
     it("opts a scalar out of JSON escaping", () => {
-      const body = render('{"passthrough": {{ input | raw }}}', inputWith('{"a":1}'));
+      const body = render({
+        template: '{"passthrough": {{ input | raw }}}',
+        input: inputWith('{"a":1}'),
+      });
 
       expect(JSON.parse(body).passthrough).toEqual({ a: 1 });
     });
@@ -147,11 +157,13 @@ describe("body template JSON safety", () => {
   describe("given scenario mappings", () => {
     /** @scenario Mapped scenario fields routed to a string slot are escaped */
     it("escapes a field mapped to the scenario input", () => {
-      const body = render(
-        '{"q": "{{query}}"}',
-        inputWith("has a\nnewline"),
-        { query: { type: "source", sourceId: "scenario", path: ["input"] } },
-      );
+      const body = render({
+        template: '{"q": "{{query}}"}',
+        input: inputWith("has a\nnewline"),
+        scenarioMappings: {
+          query: { type: "source", sourceId: "scenario", path: ["input"] },
+        },
+      });
 
       expect(JSON.parse(body).q).toBe("has a\nnewline");
     });
@@ -160,21 +172,23 @@ describe("body template JSON safety", () => {
       const input = inputWith("hi");
       input.messages = [{ role: "user", content: "line\nbreak" }];
 
-      const body = render(
-        '{"history": {{context}}}',
+      const body = render({
+        template: '{"history": {{context}}}',
         input,
-        { context: { type: "source", sourceId: "scenario", path: ["messages"] } },
-      );
+        scenarioMappings: {
+          context: { type: "source", sourceId: "scenario", path: ["messages"] },
+        },
+      });
 
       expect(JSON.parse(body).history).toEqual(input.messages);
     });
 
     it("escapes a static value mapping containing control characters", () => {
-      const body = render(
-        '{"sys": "{{ctx}}"}',
-        inputWith("hi"),
-        { ctx: { type: "value", value: 'line\nwith "quote"' } },
-      );
+      const body = render({
+        template: '{"sys": "{{ctx}}"}',
+        input: inputWith("hi"),
+        scenarioMappings: { ctx: { type: "value", value: 'line\nwith "quote"' } },
+      });
 
       expect(JSON.parse(body).sys).toBe('line\nwith "quote"');
     });

--- a/langwatch/src/server/scenarios/execution/__tests__/http-template-engine.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/http-template-engine.unit.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @vitest-environment node
+ *
+ * Covers specs/scenarios/http-agent-body-template-json-safety.feature.
+ *
+ * Regression: a customer's scenario against an n8n webhook failed with
+ * `HTTP 422 ... Bad control character in string literal in JSON` because the
+ * body template `{"chatInput": "{{ input }}"}` interpolated a conversation
+ * turn containing a raw newline straight into a JSON string literal. The body
+ * engine must JSON-escape scalar interpolations the way the URL engine
+ * URL-encodes its own.
+ */
+
+import { AgentRole, type AgentInput } from "@langwatch/scenario";
+import { describe, expect, it } from "vitest";
+import {
+  buildTemplateContext,
+  renderBodyTemplate,
+} from "../http-template-engine";
+import type { FieldMapping } from "../types";
+
+function inputWith(content: string | unknown[]): AgentInput {
+  return {
+    threadId: "thread-1",
+    messages: [{ role: "user", content: content as string }],
+    newMessages: [{ role: "user", content: content as string }],
+    requestedRole: AgentRole.AGENT,
+    scenarioState: {} as AgentInput["scenarioState"],
+    scenarioConfig: {} as AgentInput["scenarioConfig"],
+  };
+}
+
+function render(
+  template: string,
+  input: AgentInput,
+  scenarioMappings?: Record<string, FieldMapping>,
+): string {
+  return renderBodyTemplate({
+    template,
+    context: buildTemplateContext({ input, scenarioMappings }),
+  });
+}
+
+describe("body template JSON safety", () => {
+  describe("given a scalar value interpolated inside a JSON string literal", () => {
+    describe("when the value contains a newline", () => {
+      it("escapes it so the body is valid JSON", () => {
+        const body = render(
+          '{"chatInput": "{{ input }}"}',
+          inputWith("line one\nline two"),
+        );
+
+        expect(() => JSON.parse(body)).not.toThrow();
+        expect(JSON.parse(body).chatInput).toBe("line one\nline two");
+      });
+    });
+
+    describe("when the value contains a double quote", () => {
+      it("escapes it so the body is valid JSON", () => {
+        const body = render(
+          '{"chatInput": "{{ input }}"}',
+          inputWith('she said "hi"'),
+        );
+
+        expect(JSON.parse(body).chatInput).toBe('she said "hi"');
+      });
+    });
+
+    describe("when the value contains a backslash", () => {
+      it("escapes it so the body is valid JSON", () => {
+        const body = render(
+          '{"chatInput": "{{ input }}"}',
+          inputWith("path C:\\temp\\new"),
+        );
+
+        expect(JSON.parse(body).chatInput).toBe("path C:\\temp\\new");
+      });
+    });
+
+    describe("when the value contains a tab and a carriage return", () => {
+      it("escapes both control characters", () => {
+        const body = render(
+          '{"chatInput": "{{ input }}"}',
+          inputWith("a\tb\rc"),
+        );
+
+        expect(JSON.parse(body).chatInput).toBe("a\tb\rc");
+      });
+    });
+  });
+
+  describe("given the pre-serialized conversation history", () => {
+    it("injects {{messages}} as a raw JSON array, not an escaped string", () => {
+      const input = inputWith("hello");
+      input.messages = [
+        { role: "user", content: "first\nturn" },
+        { role: "assistant", content: 'reply with "quotes"' },
+      ];
+
+      const body = render('{"messages": {{messages}}}', input);
+
+      const parsed = JSON.parse(body);
+      expect(Array.isArray(parsed.messages)).toBe(true);
+      expect(parsed.messages).toEqual(input.messages);
+    });
+
+    it("keeps the default threadId+messages template valid for awkward turns", () => {
+      const input = inputWith("hi");
+      input.messages = [
+        { role: "user", content: 'multi\nline "quoted" \\slash' },
+      ];
+
+      const body = render(
+        '{\n  "thread_id": "{{threadId}}",\n  "messages": {{messages}}\n}',
+        input,
+      );
+
+      const parsed = JSON.parse(body);
+      expect(parsed.thread_id).toBe("thread-1");
+      expect(parsed.messages).toEqual(input.messages);
+    });
+  });
+
+  describe("given structured (non-string) message content", () => {
+    it("still injects {{input}} raw so {\"input\": {{input}}} stays valid", () => {
+      const structured = [{ type: "text", text: "Hello world" }];
+      const body = render('{"input": {{input}}}', inputWith(structured));
+
+      expect(JSON.parse(body).input).toEqual(structured);
+    });
+  });
+
+  describe("given the raw filter", () => {
+    it("opts a scalar out of JSON escaping", () => {
+      const body = render('{"passthrough": {{ input | raw }}}', inputWith('{"a":1}'));
+
+      expect(JSON.parse(body).passthrough).toEqual({ a: 1 });
+    });
+  });
+
+  describe("given scenario mappings", () => {
+    it("escapes a field mapped to the scenario input", () => {
+      const body = render(
+        '{"q": "{{query}}"}',
+        inputWith("has a\nnewline"),
+        { query: { type: "source", sourceId: "scenario", path: ["input"] } },
+      );
+
+      expect(JSON.parse(body).q).toBe("has a\nnewline");
+    });
+
+    it("injects a field mapped to messages as raw JSON", () => {
+      const input = inputWith("hi");
+      input.messages = [{ role: "user", content: "line\nbreak" }];
+
+      const body = render(
+        '{"history": {{context}}}',
+        input,
+        { context: { type: "source", sourceId: "scenario", path: ["messages"] } },
+      );
+
+      expect(JSON.parse(body).history).toEqual(input.messages);
+    });
+
+    it("escapes a static value mapping containing control characters", () => {
+      const body = render(
+        '{"sys": "{{ctx}}"}',
+        inputWith("hi"),
+        { ctx: { type: "value", value: 'line\nwith "quote"' } },
+      );
+
+      expect(JSON.parse(body).sys).toBe('line\nwith "quote"');
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/execution/__tests__/http-template-engine.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/http-template-engine.unit.test.ts
@@ -44,6 +44,7 @@ function render(
 describe("body template JSON safety", () => {
   describe("given a scalar value interpolated inside a JSON string literal", () => {
     describe("when the value contains a newline", () => {
+      /** @scenario A user message with a newline is escaped inside a JSON string literal */
       it("escapes it so the body is valid JSON", () => {
         const body = render(
           '{"chatInput": "{{ input }}"}',
@@ -56,6 +57,7 @@ describe("body template JSON safety", () => {
     });
 
     describe("when the value contains a double quote", () => {
+      /** @scenario A user message containing a double quote is escaped */
       it("escapes it so the body is valid JSON", () => {
         const body = render(
           '{"chatInput": "{{ input }}"}',
@@ -67,6 +69,7 @@ describe("body template JSON safety", () => {
     });
 
     describe("when the value contains a backslash", () => {
+      /** @scenario A user message containing a backslash is escaped */
       it("escapes it so the body is valid JSON", () => {
         const body = render(
           '{"chatInput": "{{ input }}"}',
@@ -90,6 +93,7 @@ describe("body template JSON safety", () => {
   });
 
   describe("given the pre-serialized conversation history", () => {
+    /** @scenario Pre-serialized conversation history is still injected as raw JSON */
     it("injects {{messages}} as a raw JSON array, not an escaped string", () => {
       const input = inputWith("hello");
       input.messages = [
@@ -104,6 +108,7 @@ describe("body template JSON safety", () => {
       expect(parsed.messages).toEqual(input.messages);
     });
 
+    /** @scenario The default body template survives an awkward conversation */
     it("keeps the default threadId+messages template valid for awkward turns", () => {
       const input = inputWith("hi");
       input.messages = [
@@ -131,6 +136,7 @@ describe("body template JSON safety", () => {
   });
 
   describe("given the raw filter", () => {
+    /** @scenario A user can opt a scalar out of escaping with the raw filter */
     it("opts a scalar out of JSON escaping", () => {
       const body = render('{"passthrough": {{ input | raw }}}', inputWith('{"a":1}'));
 
@@ -139,6 +145,7 @@ describe("body template JSON safety", () => {
   });
 
   describe("given scenario mappings", () => {
+    /** @scenario Mapped scenario fields routed to a string slot are escaped */
     it("escapes a field mapped to the scenario input", () => {
       const body = render(
         '{"q": "{{query}}"}',

--- a/langwatch/src/server/scenarios/execution/http-template-engine.ts
+++ b/langwatch/src/server/scenarios/execution/http-template-engine.ts
@@ -3,7 +3,10 @@
  *
  * Two engines with identical filter sets but different output handling:
  *   - `urlLiquid`: URL-encodes interpolated values by default. `| raw` opts out.
- *   - `bodyLiquid`: renders values verbatim — body templates are JSON, not URLs.
+ *   - `bodyLiquid`: JSON-string-escapes scalar interpolations by default so a
+ *     raw newline / quote / backslash in a conversation turn can't break the
+ *     body's JSON. Pre-serialized JSON (the `messages` array) is injected raw,
+ *     and `| raw` opts an individual expression out of escaping.
  *
  * Both adapters (DB-backed and serialized) use these engines so HTTP agents
  * render URL and body templates through one render pipeline.
@@ -11,8 +14,35 @@
 
 import type { AgentInput } from "@langwatch/scenario";
 import { Liquid } from "liquidjs";
-import { resolveFieldMappings } from "./resolve-field-mappings";
+import {
+  resolveFieldMappings,
+  sourceFieldOf,
+} from "./resolve-field-mappings";
 import type { FieldMapping } from "./types";
+
+/**
+ * Marks a context value as already-serialized JSON that must be interpolated
+ * into a body template verbatim (the conversation `messages` array, or
+ * structured `input` content). `bodyLiquid`'s `outputEscape` returns these
+ * unescaped; every other value is treated as a scalar string and
+ * JSON-string-escaped.
+ */
+export class RawJson {
+  constructor(private readonly json: string) {}
+  toString(): string {
+    return this.json;
+  }
+}
+
+/**
+ * Escape a scalar for safe interpolation inside a JSON string literal
+ * (`"{{ value }}"`) without adding the surrounding quotes the template already
+ * supplies. `JSON.stringify` handles control characters, quotes, backslashes
+ * and lone surrogates per the JSON spec; we strip only its outer quotes.
+ */
+function escapeForJsonStringLiteral(value: unknown): string {
+  return JSON.stringify(String(value ?? "")).slice(1, -1);
+}
 
 const DEFAULT_SCENARIO_THREAD_ID = "scenario-test";
 
@@ -53,21 +83,36 @@ const urlLiquid = new Liquid({
 });
 urlLiquid.registerFilter("raw", { handler: identity, raw: true });
 
-/** Body template engine. No default encoding — bodies are JSON. */
-const bodyLiquid = new Liquid();
+/**
+ * Body template engine. `outputEscape` JSON-string-escapes every `{{ expr }}`
+ * output so a control character / quote / backslash in a conversation turn
+ * can't break the body's JSON (the n8n "Failed to parse request body" class of
+ * bug). Values wrapped in `RawJson` (the pre-serialized `messages` array) pass
+ * through verbatim, and `| raw` opts an individual expression out — both
+ * mirror how `urlLiquid` skips encoding for `raw`-tagged filters.
+ */
+const bodyLiquid = new Liquid({
+  outputEscape: (value) =>
+    value instanceof RawJson
+      ? value.toString()
+      : escapeForJsonStringLiteral(value),
+});
 bodyLiquid.registerFilter("raw", { handler: identity, raw: true });
 
 /**
  * Build the Liquid context shared by `url` and `bodyTemplate` rendering.
  *
  * Base context (always present, derived from AgentInput):
- *   - `messages` — JSON-encoded messages array
- *   - `threadId` — thread ID or default sentinel
- *   - `input` — last user message content (string, JSON-stringified if structured)
+ *   - `messages` — JSON-encoded messages array, wrapped in `RawJson` so body
+ *     templates inject it as a raw JSON array, not an escaped string
+ *   - `threadId` — thread ID or default sentinel (scalar string)
+ *   - `input` — last user message content. A string when the turn is text;
+ *     structured content is JSON-stringified and wrapped in `RawJson` so
+ *     `{"input": {{input}}}` keeps injecting it as a raw object/array.
  *
- * `scenarioMappings` output is merged last and overrides base keys so users
- * can redefine `input` to be a structured object without breaking existing
- * templates.
+ * Scalar values stay plain strings; `bodyLiquid` JSON-string-escapes them on
+ * interpolation. `scenarioMappings` output is merged last and overrides base
+ * keys, preserving each mapping's raw-vs-scalar treatment.
  */
 export function buildTemplateContext({
   input,
@@ -77,20 +122,35 @@ export function buildTemplateContext({
   scenarioMappings?: Record<string, FieldMapping>;
 }): Record<string, unknown> {
   const lastUserMessage = input.messages.findLast((m) => m.role === "user");
+  const inputIsStructured =
+    lastUserMessage !== undefined &&
+    typeof lastUserMessage.content !== "string";
   const base: Record<string, unknown> = {
-    messages: JSON.stringify(input.messages),
+    messages: new RawJson(JSON.stringify(input.messages)),
     threadId: input.threadId ?? DEFAULT_SCENARIO_THREAD_ID,
     input:
       lastUserMessage === undefined
         ? undefined
-        : typeof lastUserMessage.content === "string"
-          ? lastUserMessage.content
-          : JSON.stringify(lastUserMessage.content),
+        : inputIsStructured
+          ? new RawJson(JSON.stringify(lastUserMessage.content))
+          : (lastUserMessage.content as string),
   };
 
-  const mapped = scenarioMappings
-    ? resolveFieldMappings({ fieldMappings: scenarioMappings, agentInput: input })
-    : {};
+  const mapped: Record<string, unknown> = {};
+  if (scenarioMappings) {
+    const resolved = resolveFieldMappings({
+      fieldMappings: scenarioMappings,
+      agentInput: input,
+    });
+    for (const [identifier, mapping] of Object.entries(scenarioMappings)) {
+      const value = resolved[identifier];
+      if (value === undefined) continue;
+      const field = sourceFieldOf(mapping);
+      const isRawJson =
+        field === "messages" || (field === "input" && inputIsStructured);
+      mapped[identifier] = isRawJson ? new RawJson(value) : value;
+    }
+  }
 
   return { ...base, ...mapped };
 }

--- a/langwatch/src/server/scenarios/execution/resolve-field-mappings.ts
+++ b/langwatch/src/server/scenarios/execution/resolve-field-mappings.ts
@@ -44,6 +44,28 @@ export function resolveFieldMappings({
   return resolved;
 }
 
+/** Canonical scenario source fields a mapping can resolve to. */
+export type ScenarioSourceField = "input" | "messages" | "threadId";
+
+/**
+ * The canonical scenario source field a mapping resolves to, or `null` for
+ * static `value` mappings and unknown/unsupported sources. Callers use this to
+ * decide JSON treatment: `messages` is a pre-serialized JSON array (inject
+ * raw), everything else is a scalar string (must be JSON-escaped).
+ */
+export function sourceFieldOf(
+  mapping: FieldMapping,
+): ScenarioSourceField | null {
+  if (mapping.type === "value" || mapping.sourceId !== "scenario") {
+    return null;
+  }
+  const [rawField] = mapping.path;
+  const field = LEGACY_FIELD_NAMES[rawField ?? ""] ?? rawField;
+  return field === "input" || field === "messages" || field === "threadId"
+    ? field
+    : null;
+}
+
 function resolveMapping({
   mapping,
   agentInput,

--- a/specs/scenarios/http-agent-body-template-json-safety.feature
+++ b/specs/scenarios/http-agent-body-template-json-safety.feature
@@ -1,0 +1,77 @@
+Feature: HTTP agent body templates always render valid JSON
+  As a user running scenarios against an external HTTP agent (n8n, custom webhook)
+  I want scenario-provided values interpolated into the body template to be JSON-safe
+  So that multi-line or quote-containing conversation turns don't produce a body
+  the upstream rejects with "Failed to parse request body".
+
+  Background: tracking a customer report. A scenario pointed at an n8n webhook
+  failed with `HTTP 422: Unprocessable Entity` and the upstream hint
+  "Bad control character in string literal in JSON at position 90". The body
+  template `{"chatInput": "{{ input }}"}` interpolated a user message that
+  contained a raw newline straight into a JSON string literal, so the bytes
+  LangWatch sent were not valid JSON. The body template engine must escape
+  scalar string interpolations the way the URL engine already URL-encodes its
+  interpolations.
+
+  @unit
+  Scenario: A user message with a newline is escaped inside a JSON string literal
+    Given an HTTP agent with body template '{"chatInput": "{{ input }}"}'
+    And the last user message content is "line one\nline two"
+    When the adapter builds the request body
+    Then the rendered body parses as JSON
+    And the parsed "chatInput" equals "line one\nline two"
+
+  @unit
+  Scenario: A user message containing a double quote is escaped
+    Given an HTTP agent with body template '{"chatInput": "{{ input }}"}'
+    And the last user message content is 'she said "hi"'
+    When the adapter builds the request body
+    Then the rendered body parses as JSON
+    And the parsed "chatInput" equals 'she said "hi"'
+
+  @unit
+  Scenario: A user message containing a backslash is escaped
+    Given an HTTP agent with body template '{"chatInput": "{{ input }}"}'
+    And the last user message content is "path C:\temp\new"
+    When the adapter builds the request body
+    Then the rendered body parses as JSON
+    And the parsed "chatInput" equals "path C:\temp\new"
+
+  @unit
+  Scenario: Pre-serialized conversation history is still injected as raw JSON
+    Given an HTTP agent with body template '{"messages": {{messages}}}'
+    And the conversation has messages with multi-line content
+    When the adapter builds the request body
+    Then the rendered body parses as JSON
+    And the parsed "messages" is the conversation array, not a JSON string
+
+  @unit
+  Scenario: The default body template survives an awkward conversation
+    Given an HTTP agent using the default template with "threadId" and "messages"
+    And a conversation whose turns contain newlines and quotes
+    When the adapter builds the request body
+    Then the rendered body parses as JSON
+
+  @unit
+  Scenario: A user can opt a scalar out of escaping with the raw filter
+    Given an HTTP agent with body template '{"raw": {{ input | raw }}}'
+    And the last user message content is the literal JSON object '{"a":1}'
+    When the adapter builds the request body
+    Then the parsed "raw" equals the object {"a": 1}
+
+  @unit
+  Scenario: Mapped scenario fields routed to a string slot are escaped
+    Given an HTTP agent with body template '{"q": "{{query}}"}'
+    And "query" is mapped to the scenario input
+    And the scenario input contains a newline
+    When the adapter builds the request body
+    Then the rendered body parses as JSON
+
+  @integration
+  Scenario: Adapter posts a parseable body to a real HTTP endpoint
+    Given a local echo server that JSON-parses the request body and 422s on failure
+    And an HTTP agent with body template '{"chatInput": "{{ input }}"}'
+    And a user message that contains a newline and a double quote
+    When the adapter calls the endpoint
+    Then the echo server parses the body successfully
+    And the adapter does not raise an HTTP 422

--- a/specs/scenarios/http-agent-body-template-json-safety.feature
+++ b/specs/scenarios/http-agent-body-template-json-safety.feature
@@ -32,10 +32,10 @@ Feature: HTTP agent body templates always render valid JSON
   @unit
   Scenario: A user message containing a backslash is escaped
     Given an HTTP agent with body template '{"chatInput": "{{ input }}"}'
-    And the last user message content is "path C:\temp\new"
+    And the last user message content is the literal path "C:\\temp\\new"
     When the adapter builds the request body
     Then the rendered body parses as JSON
-    And the parsed "chatInput" equals "path C:\temp\new"
+    And the parsed "chatInput" equals the literal path "C:\\temp\\new"
 
   @unit
   Scenario: Pre-serialized conversation history is still injected as raw JSON


### PR DESCRIPTION
## Problem

A customer running scenarios against an agent hosted in n8n hit:

```
HTTP 422: Unprocessable Entity from https://n8n.…/webhook/…
{"code":422,"message":"Failed to parse request body",
 "hint":"Bad control character in string literal in JSON at position 90"}
```

That 422 is **n8n's** parser rejecting the body **we sent** — not n8n returning bad JSON. PR #3647 didn't cause this; it's the diagnostics PR that surfaced the upstream hint instead of a bare `HTTP 422`.

### Root cause

The HTTP agent **body template** engine (`bodyLiquid`) interpolated values **verbatim** — it had no output escaping, unlike its sibling `urlLiquid` which URL-encodes interpolations. So a template like:

```json
{ "chatInput": "{{ input }}" }
```

dropped the last user message straight into a JSON string literal. The moment a conversation turn contained a raw newline, quote or backslash (multi-turn simulator messages routinely do), the rendered bytes were no longer valid JSON and the upstream rejected them. The no-template path never broke because it goes through `JSON.stringify`.

## Fix

`bodyLiquid` now JSON-string-escapes every `{{ expr }}` output by default (control chars, quotes, backslashes — via `JSON.stringify`), exactly mirroring how `urlLiquid` URL-encodes its own and honors a `| raw` opt-out.

Pre-serialized JSON that must be injected raw — the `messages` array, and structured (non-string) `input` content — is wrapped in a `RawJson` marker that `outputEscape` passes through untouched. `| raw` remains an explicit per-expression escape hatch. **Every existing template shape keeps working** (`{"messages": {{messages}}}`, `{"input": {{input}}}` with structured content, mapped fields, Liquid conditionals).

## Tests

- **BDD spec**: `specs/scenarios/http-agent-body-template-json-safety.feature`
- **Unit**: `http-template-engine.unit.test.ts` — newline / quote / backslash / tab+CR escaping, raw-JSON passthrough, `| raw` opt-out, scenario-mapping cases
- **Integration regression**: `http-body-json-safety.integration.test.ts` — drives the real `SerializedHttpAgentAdapter` against a local server that behaves like the n8n webhook (JSON-parses the body, answers 422 with n8n's exact envelope on failure). Includes a sanity anchor proving the pre-fix body really does produce the customer's 422.
- Full scenarios execution + adapters suite: **286 unit + 23 integration passing**, full project typecheck clean.


## QA — proved end to end

Drove the real `SerializedHttpAgentAdapter` + real template engine with the customer's template shape and a realistic multi-line turn. **Before** reproduces the customer's exact failure class (`Bad control character in string literal in JSON`); **after** the body round-trips cleanly. Regression suite is green against a local server that behaves like the n8n webhook.

![before/after proof](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4064/proof/before-after.png)