### PR TITLE
fix(api-keys): exclude archived project bindings from personal key creation

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/apiKey.myBindings.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/apiKey.myBindings.unit.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
+import { apiKeyRouter } from "../apiKey";
+import { createInnerTRPCContext } from "../../trpc";
+
+vi.mock("nanoid", () => ({
+  nanoid: vi.fn(() => "mock-nano-id"),
+  customAlphabet: vi.fn(
+    () => () => "mock48characterrandomstringforapikeygeneration",
+  ),
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    skipPermissionCheck:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+vi.mock("../../../auditLog", () => ({
+  auditLog: vi.fn(() => Promise.resolve()),
+}));
+
+const ORG_ID = "org_1";
+const USER_ID = "user_1";
+const ACTIVE_PROJECT_ID = "project_active";
+const ARCHIVED_PROJECT_ID = "project_archived";
+
+function buildMockPrisma() {
+  return {
+    organizationUser: {
+      findFirst: vi.fn().mockResolvedValue({ userId: USER_ID }),
+    },
+    roleBinding: {
+      findMany: vi.fn().mockResolvedValue([
+        {
+          id: "rb_1",
+          role: TeamUserRole.ADMIN,
+          customRoleId: null,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: ORG_ID,
+        },
+        {
+          id: "rb_2",
+          role: TeamUserRole.ADMIN,
+          customRoleId: null,
+          scopeType: RoleBindingScopeType.PROJECT,
+          scopeId: ACTIVE_PROJECT_ID,
+        },
+        {
+          id: "rb_3",
+          role: TeamUserRole.ADMIN,
+          customRoleId: null,
+          scopeType: RoleBindingScopeType.PROJECT,
+          scopeId: ARCHIVED_PROJECT_ID,
+        },
+      ]),
+    },
+    organization: {
+      findMany: vi
+        .fn()
+        .mockResolvedValue([{ id: ORG_ID, name: "Test Org" }]),
+    },
+    team: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    project: {
+      findMany: vi.fn().mockResolvedValue([
+        { id: ACTIVE_PROJECT_ID, name: "Active Project" },
+      ]),
+    },
+    customRole: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as PrismaClient;
+}
+
+describe("apiKey.myBindings", () => {
+  let caller: ReturnType<typeof apiKeyRouter.createCaller>;
+  let mockPrisma: PrismaClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = buildMockPrisma();
+
+    const ctx = createInnerTRPCContext({
+      session: {
+        user: { id: USER_ID },
+        expires: "1",
+      },
+      req: undefined,
+      res: undefined,
+      permissionChecked: true,
+      publiclyShared: false,
+    });
+
+    ctx.prisma = mockPrisma;
+    caller = apiKeyRouter.createCaller(ctx);
+  });
+
+  describe("when user has bindings to both active and archived projects", () => {
+    it("excludes bindings to archived projects", async () => {
+      const result = await caller.myBindings({ organizationId: ORG_ID });
+
+      const projectBindings = result.filter(
+        (b) => b.scopeType === RoleBindingScopeType.PROJECT,
+      );
+
+      expect(projectBindings).toHaveLength(1);
+      expect(projectBindings[0]!.scopeId).toBe(ACTIVE_PROJECT_ID);
+      expect(
+        result.find((b) => b.scopeId === ARCHIVED_PROJECT_ID),
+      ).toBeUndefined();
+    });
+
+    it("keeps organization-scoped bindings unchanged", async () => {
+      const result = await caller.myBindings({ organizationId: ORG_ID });
+
+      const orgBindings = result.filter(
+        (b) => b.scopeType === RoleBindingScopeType.ORGANIZATION,
+      );
+
+      expect(orgBindings).toHaveLength(1);
+      expect(orgBindings[0]!.scopeId).toBe(ORG_ID);
+    });
+
+    it("queries projects with archivedAt null filter", async () => {
+      await caller.myBindings({ organizationId: ORG_ID });
+
+      expect(
+        (mockPrisma.project.findMany as ReturnType<typeof vi.fn>),
+      ).toHaveBeenCalledWith({
+        where: {
+          id: { in: [ACTIVE_PROJECT_ID, ARCHIVED_PROJECT_ID] },
+          archivedAt: null,
+        },
+        select: { id: true, name: true },
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/apiKey.ts
+++ b/langwatch/src/server/api/routers/apiKey.ts
@@ -120,7 +120,7 @@ export const apiKeyRouter = createTRPCRouter({
           : Promise.resolve([]),
         projectIds.size
           ? ctx.prisma.project.findMany({
-              where: { id: { in: [...projectIds] } },
+              where: { id: { in: [...projectIds] }, archivedAt: null },
               select: { id: true, name: true },
             })
           : Promise.resolve([]),
@@ -134,21 +134,28 @@ export const apiKeyRouter = createTRPCRouter({
 
       const orgName = new Map(orgs.map((o) => [o.id, o.name]));
       const teamName = new Map(teams.map((t) => [t.id, t.name]));
+      const activeProjectIds = new Set(projects.map((p) => p.id));
       const projectName = new Map(projects.map((p) => [p.id, p.name]));
       const customRoleName = new Map(customRoles.map((r) => [r.id, r.name]));
 
-      return bindings.map((b) => ({
-        ...b,
-        scopeName:
-          b.scopeType === RoleBindingScopeType.ORGANIZATION
-            ? orgName.get(b.scopeId) ?? null
-            : b.scopeType === RoleBindingScopeType.TEAM
-              ? teamName.get(b.scopeId) ?? null
-              : projectName.get(b.scopeId) ?? null,
-        customRoleName: b.customRoleId
-          ? customRoleName.get(b.customRoleId) ?? null
-          : null,
-      }));
+      return bindings
+        .filter(
+          (b) =>
+            b.scopeType !== RoleBindingScopeType.PROJECT ||
+            activeProjectIds.has(b.scopeId),
+        )
+        .map((b) => ({
+          ...b,
+          scopeName:
+            b.scopeType === RoleBindingScopeType.ORGANIZATION
+              ? orgName.get(b.scopeId) ?? null
+              : b.scopeType === RoleBindingScopeType.TEAM
+                ? teamName.get(b.scopeId) ?? null
+                : projectName.get(b.scopeId) ?? null,
+          customRoleName: b.customRoleId
+            ? customRoleName.get(b.customRoleId) ?? null
+            : null,
+        }));
     }),
 
   /**


### PR DESCRIPTION
## Summary
- Fix personal API key creation failing when user has role bindings to archived projects
- The `myBindings` query now filters out archived projects (`archivedAt: null`) and excludes their bindings from the response
- Stale project bindings are never sent to the create endpoint, preventing the "Project not found or archived" error

## Root Cause
The `apiKey.myBindings` tRPC query returned ALL user role bindings including those for archived projects. When the frontend built the bindings array for "All" permissions mode, it included archived project bindings. The backend's `resolveAndValidateScope()` then correctly rejected them — but the user had no way to work around it.

## Changes
- `apiKey.ts` (`myBindings` query): Added `archivedAt: null` filter to project lookup, and filter out bindings to archived projects before returning
- New regression test: `apiKey.myBindings.unit.test.ts`

## Test plan
- [x] Regression test verifies archived project bindings are excluded
- [x] Regression test verifies active project bindings are preserved
- [x] Regression test verifies the query includes `archivedAt: null`
- [x] Existing api-key service tests pass (14/14)
- [x] Typecheck passes
- [x] CI green

Closes #4065