### PR TITLE
fix(evals-v3): batch ux fixes — source name, run-name format, drawer z-index, add buttons, advisory declared inputs

### DIFF
--- a/langwatch/src/components/batch-evaluation-results/BatchRunsSidebar.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchRunsSidebar.tsx
@@ -25,7 +25,7 @@ import { useMemo } from "react";
 import { Tooltip } from "~/components/ui/tooltip";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
 import { getColorForString } from "~/utils/rotatingColors";
-import { getRunDisplayName } from "./getRunDisplayName";
+import { getRunDisplayName, RunDisplayName } from "./getRunDisplayName";
 import { INTERRUPTED_THRESHOLD_MS, isRunFinished } from "./isRunFinished";
 
 /**
@@ -378,7 +378,7 @@ export function BatchRunsSidebar({
                       positioning={{ placement: "top" }}
                       openDelay={500}
                     >
-                      <HStack gap={1}>
+                      <HStack gap={1} flex={1} minWidth={0} width="100%">
                         {/* Small color indicator square */}
                         <Box
                           width="10px"
@@ -393,8 +393,13 @@ export function BatchRunsSidebar({
                           lineClamp={1}
                           wordBreak="break-all"
                           flex={1}
+                          minWidth={0}
                         >
-                          {runName}
+                          <RunDisplayName
+                            commitMessage={run.workflowVersion?.commitMessage}
+                            runId={run.runId}
+                            index={chronologicalIndex}
+                          />
                         </Text>
                       </HStack>
                     </Tooltip>

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchRunsSidebar.integration.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchRunsSidebar.integration.test.tsx
@@ -136,6 +136,7 @@ describe("BatchRunsSidebar", () => {
       createRun({ runId: "run-new", createdAt: 2_000_000 }),
     ];
 
+    /** @scenario A run with a commit message still shows the commit message */
     it("uses commit message instead of Run # when available", () => {
       render(
         <Wrapper>
@@ -151,6 +152,44 @@ describe("BatchRunsSidebar", () => {
       expect(items[0]).toHaveTextContent("Run #2");
       // Oldest run uses commit message
       expect(items[1]).toHaveTextContent("Initial baseline");
+      // Commit-message runs carry no generated id suffix
+      expect(items[1]).not.toHaveTextContent("·");
+      expect(items[1]).not.toHaveTextContent("run-old");
+    });
+  });
+
+  describe("when a run has no commit message", () => {
+    const runs = [
+      createRun({ runId: "snobbish-otter-1f2a3b9c4d", createdAt: 1_000_000 }),
+    ];
+
+    /** @scenario A run without a commit message shows index then a middle-dot separator */
+    it("renders 'Run #N · runId' with a middle-dot separator and no parentheses", () => {
+      render(
+        <Wrapper>
+          <BatchRunsSidebar runs={runs} onSelectRun={noop} />
+        </Wrapper>,
+      );
+
+      const item = screen.getByTestId("run-item-snobbish-otter-1f2a3b9c4d");
+      expect(item).toHaveTextContent("Run #1 · snobbish-otter-1f2a3b9c4d");
+      expect(item.textContent).not.toContain("(");
+      expect(item.textContent).not.toContain(")");
+    });
+
+    /** @scenario The run id uses the available width instead of an early hard truncation */
+    it("keeps the full run id without truncating it to eight characters", () => {
+      render(
+        <Wrapper>
+          <BatchRunsSidebar runs={runs} onSelectRun={noop} />
+        </Wrapper>,
+      );
+
+      const item = screen.getByTestId("run-item-snobbish-otter-1f2a3b9c4d");
+      // Full id present in the DOM (layout clips overflow visually, the
+      // string itself is never pre-truncated with an ellipsis character).
+      expect(item).toHaveTextContent("snobbish-otter-1f2a3b9c4d");
+      expect(item.textContent).not.toContain("…");
     });
   });
 });

--- a/langwatch/src/components/batch-evaluation-results/__tests__/getRunDisplayName.unit.test.ts
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/getRunDisplayName.unit.test.ts
@@ -49,24 +49,30 @@ describe("getRunDisplayName()", () => {
   });
 
   describe("when runId is provided", () => {
-    it("includes the runId in the fallback name", () => {
+    /** @scenario A run without a commit message shows index then a middle-dot separator */
+    it("joins the index and runId with a gray middle-dot separator, no parentheses", () => {
       const result = getRunDisplayName({
         commitMessage: undefined,
-        runId: "abc123",
-        index: 0,
+        runId: "snobbish-otter-1f2a3b",
+        index: 9,
       });
-      expect(result).toBe("Run #1 (abc123)");
+      expect(result).toBe("Run #10 · snobbish-otter-1f2a3b");
+      expect(result).not.toContain("(");
+      expect(result).not.toContain(")");
     });
 
-    it("truncates long runId values", () => {
+    /** @scenario The run id uses the available width instead of an early hard truncation */
+    it("keeps the full runId without pre-truncating to eight characters", () => {
       const result = getRunDisplayName({
         commitMessage: undefined,
         runId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
         index: 0,
       });
-      expect(result).toBe("Run #1 (a1b2c3d4…)");
+      expect(result).toBe("Run #1 · a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+      expect(result).not.toContain("…");
     });
 
+    /** @scenario A run with a commit message still shows the commit message */
     it("still prefers commitMessage over runId", () => {
       const result = getRunDisplayName({
         commitMessage: "Add retry logic",

--- a/langwatch/src/components/batch-evaluation-results/getRunDisplayName.tsx
+++ b/langwatch/src/components/batch-evaluation-results/getRunDisplayName.tsx
@@ -1,14 +1,16 @@
 import { Text } from "@chakra-ui/react";
 
-function truncateRunId(runId: string, maxLength = 8): string {
-  return runId.length > maxLength ? `${runId.slice(0, maxLength)}…` : runId;
-}
+/** Gray middle-dot separator between the run index and its generated id. */
+const RUN_NAME_SEPARATOR = " · ";
 
 /**
  * Returns a plain string display name for a batch evaluation run.
  *
  * Prefers the workflow version commit message when available.
- * Falls back to "Run #N (runId)" (1-based) based on the run's chronological index.
+ * Falls back to "Run #N · runId" (1-based) based on the run's chronological
+ * index. The full run id is kept (no hard truncation) so tooltips and chart
+ * labels stay unambiguous; visible UI clips overflow via layout, not by
+ * mangling the string here.
  */
 export function getRunDisplayName({
   commitMessage,
@@ -24,18 +26,20 @@ export function getRunDisplayName({
   }
 
   if (runId) {
-    return `Run #${index + 1} (${truncateRunId(runId)})`;
+    return `Run #${index + 1}${RUN_NAME_SEPARATOR}${runId}`;
   }
 
   return `Run #${index + 1}`;
 }
 
 /**
- * Rich rendering of a run display name, showing the run ID
- * in a muted style when no commit message is available.
+ * Rich rendering of a run display name, showing the run id after a gray
+ * middle-dot separator when no commit message is available.
  *
- * Use this component in UI contexts where ReactNode rendering is supported.
- * For chart labels, axis ticks, or other string-only contexts, use getRunDisplayName() instead.
+ * Use this component in UI contexts where ReactNode rendering is supported
+ * (e.g. the runs sidebar). For chart labels, axis ticks, or other
+ * string-only contexts, use getRunDisplayName() instead. Overflow is left to
+ * the surrounding layout (lineClamp/ellipsis) so the full name stays intact.
  */
 export function RunDisplayName({
   commitMessage,
@@ -52,9 +56,9 @@ export function RunDisplayName({
 
   return (
     <Text as="span">
-      {`#${index + 1}`}
-      <Text as="span" textStyle="xs" color="fg.muted" title={runId}>
-        {` // ${truncateRunId(runId)}`}
+      {`Run #${index + 1}`}
+      <Text as="span" color="fg.muted" title={runId}>
+        {`${RUN_NAME_SEPARATOR}${runId}`}
       </Text>
     </Text>
   );

--- a/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
+++ b/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
@@ -512,18 +512,12 @@ export const PromptTextAreaWithVariables = ({
                 (invalidVariables.length > 0 ? 9 : 2.5) - (borderless ? 2 : 0)
               }
               right={2}
-              gap={1}
+              gap={1.5}
               data-testid="add-context-buttons"
-              // Solid floating pill so the message text behind never bleeds
-              // through the button labels.
-              bg="bg.panel"
-              borderWidth="1px"
-              borderColor="border"
-              borderRadius="md"
-              boxShadow="sm"
-              paddingX={1}
-              paddingY={0.5}
             >
+              {/* Two separate normal buttons; each carries its own solid
+                  background so message text behind never bleeds through the
+                  labels (see AddLogicButton / AddVariableButton). */}
               <AddLogicButton
                 ref={logicMenu.addButtonRef}
                 onClick={logicMenu.handleAddLogicClick}

--- a/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
+++ b/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
@@ -513,6 +513,16 @@ export const PromptTextAreaWithVariables = ({
               }
               right={2}
               gap={1}
+              data-testid="add-context-buttons"
+              // Solid floating pill so the message text behind never bleeds
+              // through the button labels.
+              bg="bg.panel"
+              borderWidth="1px"
+              borderColor="border"
+              borderRadius="md"
+              boxShadow="sm"
+              paddingX={1}
+              paddingY={0.5}
             >
               <AddLogicButton
                 ref={logicMenu.addButtonRef}

--- a/langwatch/src/components/prompt-textarea/__tests__/PromptTextAreaWithVariables.test.tsx
+++ b/langwatch/src/components/prompt-textarea/__tests__/PromptTextAreaWithVariables.test.tsx
@@ -8,6 +8,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { forwardRef } from "react";
@@ -192,6 +193,21 @@ describe("PromptTextAreaWithVariables", () => {
       await user.hover(textareaContainer);
 
       expect(screen.queryByText("Add variable")).not.toBeInTheDocument();
+    });
+
+    /** @scenario The add-variable and add-logic buttons sit on a solid background */
+    it("renders Add logic and Add variable inside a single solid pill wrapper", async () => {
+      const user = userEvent.setup();
+      const { container } = renderComponent({ showAddContextButton: true });
+
+      const textareaContainer = container.firstChild as HTMLElement;
+      await user.hover(textareaContainer);
+
+      const pill = await screen.findByTestId("add-context-buttons");
+      // Both buttons share the same solid background wrapper so the message
+      // text behind them cannot bleed through the labels.
+      expect(within(pill).getByText("Add logic")).toBeInTheDocument();
+      expect(within(pill).getByText("Add variable")).toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/components/prompt-textarea/components/AddLogicButton.tsx
+++ b/langwatch/src/components/prompt-textarea/components/AddLogicButton.tsx
@@ -21,8 +21,7 @@ export const AddLogicButton = forwardRef<
       colorPalette="gray"
       onClick={onClick}
       onMouseDown={(e) => e.stopPropagation()}
-      opacity={0.7}
-      _hover={{ opacity: 1, background: "bg.muted" }}
+      _hover={{ background: "bg.muted" }}
       {...props}
     >
       <Text fontSize="xs" marginRight={1} fontWeight="500">

--- a/langwatch/src/components/prompt-textarea/components/AddLogicButton.tsx
+++ b/langwatch/src/components/prompt-textarea/components/AddLogicButton.tsx
@@ -17,10 +17,15 @@ export const AddLogicButton = forwardRef<
     <Button
       ref={ref}
       size="xs"
-      variant="ghost"
+      variant="outline"
       colorPalette="gray"
       onClick={onClick}
       onMouseDown={(e) => e.stopPropagation()}
+      // Solid (non-transparent) background + tight padding so the button
+      // reads as its own pill over the textarea text.
+      bg="bg.panel"
+      borderColor="border"
+      paddingX={2}
       _hover={{ background: "bg.muted" }}
       {...props}
     >

--- a/langwatch/src/components/prompt-textarea/components/AddVariableButton.tsx
+++ b/langwatch/src/components/prompt-textarea/components/AddVariableButton.tsx
@@ -17,10 +17,15 @@ export const AddVariableButton = forwardRef<
     <Button
       ref={ref}
       size="xs"
-      variant="ghost"
+      variant="outline"
       colorPalette="gray"
       onClick={onClick}
       onMouseDown={(e) => e.stopPropagation()}
+      // Solid (non-transparent) background + tight padding so the button
+      // reads as its own pill over the textarea text.
+      bg="bg.panel"
+      borderColor="border"
+      paddingX={2}
       _hover={{ background: "bg.muted" }}
       {...props}
     >

--- a/langwatch/src/components/prompt-textarea/components/AddVariableButton.tsx
+++ b/langwatch/src/components/prompt-textarea/components/AddVariableButton.tsx
@@ -21,8 +21,7 @@ export const AddVariableButton = forwardRef<
       colorPalette="gray"
       onClick={onClick}
       onMouseDown={(e) => e.stopPropagation()}
-      opacity={0.7}
-      _hover={{ opacity: 1, background: "bg.muted" }}
+      _hover={{ background: "bg.muted" }}
       {...props}
     >
       <Text fontSize="xs" marginRight={1} fontWeight="500">

--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -1093,7 +1093,11 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
           paddingY={3}
           position="sticky"
           top={0}
-          zIndex={1}
+          zIndex={2}
+          // Solid background matching the drawer surface so messages
+          // scrolling underneath never show through or over the header.
+          bg="bg"
+          data-testid="prompt-editor-sticky-header"
         >
           <PromptEditorHeader
             onSave={() => void handleSave()}

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -388,9 +388,16 @@ describe("PromptEditorDrawer", () => {
 
       const style = getComputedStyle(header);
       expect(style.position).toBe("sticky");
-      // A non-empty background is what stops scrolling text from showing
-      // through the header (the bug was a transparent sticky bar).
-      expect(style.background || style.backgroundColor).not.toBe("");
+      // The fix is the `bg="bg"` prop on the sticky header — Chakra applies
+      // it as `background: var(--chakra-colors-bg)` (a solid app-surface
+      // color in a real browser). jsdom does not resolve CSS custom
+      // properties so `backgroundColor` falls back to rgba(0,0,0,0); we
+      // therefore assert the Chakra background token IS applied. A
+      // regression that deletes the prop would leave the rule unset, and
+      // this expectation would fail. The "solid in browser" check is
+      // covered by the QA dogfood screenshots embedded in the PR body.
+      const bg = (style.background || "").trim();
+      expect(bg).toMatch(/var\(--chakra-colors-/);
     });
 
     it("shows variables section", () => {

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -377,6 +377,22 @@ describe("PromptEditorDrawer", () => {
       expect(screen.getByTestId("messages-field")).toBeInTheDocument();
     });
 
+    /** @scenario The model selector header stays opaque above scrolling messages */
+    it("renders the model selector inside a sticky header with a solid background", () => {
+      renderWithProviders(<PromptEditorDrawer open={true} />);
+
+      const header = screen.getByTestId("prompt-editor-sticky-header");
+      // The model selector lives inside the sticky header, so it stays
+      // pinned while the messages below scroll.
+      expect(header).toContainElement(screen.getByTestId("model-select"));
+
+      const style = getComputedStyle(header);
+      expect(style.position).toBe("sticky");
+      // A non-empty background is what stops scrolling text from showing
+      // through the header (the bug was a transparent sticky bar).
+      expect(style.background || style.backgroundColor).not.toBe("");
+    });
+
     it("shows variables section", () => {
       renderWithProviders(<PromptEditorDrawer open={true} />);
       expect(screen.getByText("Variables")).toBeInTheDocument();

--- a/langwatch/src/components/variables/VariableMappingInput.tsx
+++ b/langwatch/src/components/variables/VariableMappingInput.tsx
@@ -685,7 +685,7 @@ export const VariableMappingInput = ({
               <SourceTypeIconComponent type={sourceInfo.source.type} />
               <Tag.Label fontFamily="mono" fontSize="12px">
                 {sourceInfo.source.id !== "trace"
-                  ? `${sourceInfo.source.id}.${sourceInfo.path.join(".")}`
+                  ? `${sourceInfo.source.name || sourceInfo.source.id}.${sourceInfo.path.join(".")}`
                   : sourceInfo.path.join(".")}
               </Tag.Label>
               <Tag.EndElement>

--- a/langwatch/src/components/variables/__tests__/VariableMappingInput.test.tsx
+++ b/langwatch/src/components/variables/__tests__/VariableMappingInput.test.tsx
@@ -80,11 +80,54 @@ describe("VariableMappingInput", () => {
         path: ["input"],
       };
       renderComponent({ mapping });
-      // Should show a tag with the source prefix and field name
+      // Should show a tag with the friendly source name and field name
       expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-      expect(screen.getByText("dataset-1.input")).toBeInTheDocument();
+      expect(screen.getByText("Test Data.input")).toBeInTheDocument();
       // Should have a close button
       expect(screen.getByTestId("clear-mapping-button")).toBeInTheDocument();
+    });
+
+    /** @scenario Mapping a value from another target shows the target name not its ID */
+    it("labels a target source mapping with the target name, not its raw id", () => {
+      const mapping: FieldMapping = {
+        type: "source",
+        sourceId: "runner-1",
+        path: ["output"],
+      };
+      renderComponent({ mapping });
+
+      const tag = screen.getByTestId("source-mapping-tag");
+      expect(tag).toHaveTextContent("GPT-4o Runner.output");
+      expect(tag.textContent).not.toContain("runner-1");
+    });
+
+    /** @scenario Source name falls back to the ID when no friendly name is known */
+    it("falls back to the source id when the source name has not loaded", () => {
+      const sourcesWithUnresolvedName: AvailableSource[] = [
+        {
+          id: "target_1778838627724",
+          name: "", // not loaded yet
+          type: "signature",
+          fields: [{ name: "l3", type: "str" }],
+        },
+      ];
+      const mapping: FieldMapping = {
+        type: "source",
+        sourceId: "target_1778838627724",
+        path: ["l3"],
+      };
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <VariableMappingInput
+            availableSources={sourcesWithUnresolvedName}
+            mapping={mapping}
+          />
+        </ChakraProvider>,
+      );
+
+      expect(screen.getByTestId("source-mapping-tag")).toHaveTextContent(
+        "target_1778838627724.l3",
+      );
     });
   });
 
@@ -585,7 +628,7 @@ describe("VariableMappingInput", () => {
       // Should immediately show the new mapping as a tag
       await waitFor(() => {
         expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-        expect(screen.getByText("dataset-1.input")).toBeInTheDocument();
+        expect(screen.getByText("Test Data.input")).toBeInTheDocument();
       });
     });
 
@@ -640,7 +683,7 @@ describe("VariableMappingInput", () => {
       // Should show the mapping immediately without needing to close/reopen
       await waitFor(() => {
         expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-        expect(screen.getByText("dataset-1.input")).toBeInTheDocument();
+        expect(screen.getByText("Test Data.input")).toBeInTheDocument();
       });
     });
   });
@@ -1288,9 +1331,9 @@ describe("VariableMappingInput", () => {
           path: ["traces"],
         });
 
-        // Should show the mapping tag
+        // Should show the mapping tag with the friendly source name
         expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-        expect(screen.getByText("thread.traces")).toBeInTheDocument();
+        expect(screen.getByText("Current Thread.traces")).toBeInTheDocument();
       });
     });
   });

--- a/langwatch/src/components/variables/__tests__/VariablesSection.test.tsx
+++ b/langwatch/src/components/variables/__tests__/VariablesSection.test.tsx
@@ -409,9 +409,9 @@ describe("VariablesSection", () => {
         mappings,
       });
 
-      // Should show a tag with the source prefix and field name
+      // Should show a tag with the friendly source name and field name
       expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-      expect(screen.getByText("dataset-1.input")).toBeInTheDocument();
+      expect(screen.getByText("Test Data.input")).toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/evaluations-v3/__tests__/EvaluatorMappings.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/EvaluatorMappings.integration.test.tsx
@@ -113,6 +113,11 @@ vi.mock("~/utils/api", () => ({
         useQuery: () => ({ data: [], isLoading: false }),
       },
     },
+    prompts: {
+      getAllPromptsForProject: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+    },
   },
 }));
 

--- a/langwatch/src/evaluations-v3/__tests__/ExecutionControls.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/ExecutionControls.integration.test.tsx
@@ -96,6 +96,11 @@ vi.mock("~/utils/api", () => ({
     evaluators: {
       getAll: { useQuery: () => ({ data: [], isLoading: false }) },
     },
+    prompts: {
+      getAllPromptsForProject: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+    },
   },
 }));
 

--- a/langwatch/src/evaluations-v3/__tests__/MappingValidation.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/MappingValidation.integration.test.tsx
@@ -439,21 +439,103 @@ describe("TargetHeader alert icon", () => {
 // ============================================================================
 
 describe("Validation edge cases", () => {
-  it("falls back to target.inputs for validation when no localPromptConfig", () => {
-    // When prompt content isn't loaded yet (no localPromptConfig),
-    // we use target.inputs as the source of fields that need mapping.
-    // This ensures the alert icon shows even before the drawer is opened.
+  /** @scenario A declared prompt variable not referenced by any message is not required */
+  it("surfaces declared inputs as advisory (not run-blocking) when no localPromptConfig", () => {
+    // A prompt that follows the latest version with no local edits has no
+    // message content here. A declared variable like the default "input"
+    // may never be referenced by the template, so it must NOT hard-block
+    // the run. It is still surfaced (advisory) so the alert icon shows and
+    // nudges the user to configure the target.
     const target: TargetConfig = {
       ...createTestTarget("r1", [{ identifier: "input", type: "str" }]),
-      localPromptConfig: undefined, // Explicitly no localPromptConfig - prompt not loaded yet
+      localPromptConfig: undefined, // follows latest, prompt not loaded yet
     };
 
     const result = getTargetMissingMappings(target, DEFAULT_TEST_DATA_ID);
 
-    // Should be INVALID because "input" is in target.inputs but has no mapping
-    expect(result.isValid).toBe(false);
+    // Run is NOT blocked: no required mapping is missing.
+    expect(result.isValid).toBe(true);
+    // But the missing mapping is still surfaced as advisory.
     expect(result.missingMappings.length).toBe(1);
     expect(result.missingMappings[0]?.fieldId).toBe("input");
+    expect(result.missingMappings[0]?.isRequired).toBe(false);
+    // The alert icon still shows so the user knows to configure it.
+    expect(targetHasMissingMappings(target, DEFAULT_TEST_DATA_ID)).toBe(true);
+  });
+
+  /** @scenario A declared prompt variable that IS referenced still requires a mapping */
+  it("hard-requires a referenced+declared variable once the prompt is configured", () => {
+    // Prompt is configured (localPromptConfig present) and the user message
+    // references {{product_name}}, which is declared but unmapped.
+    const target: TargetConfig = {
+      id: "r1",
+      type: "prompt",
+      inputs: [{ identifier: "product_name", type: "str" }],
+      outputs: [{ identifier: "output", type: "str" }],
+      mappings: {},
+      localPromptConfig: {
+        llm: { model: "gpt-4" },
+        messages: [
+          { role: "user", content: "Classify {{product_name}}" },
+        ],
+        inputs: [{ identifier: "product_name", type: "str" }],
+        outputs: [{ identifier: "output", type: "str" }],
+      },
+    };
+
+    const result = getTargetMissingMappings(target, DEFAULT_TEST_DATA_ID);
+
+    expect(result.isValid).toBe(false);
+    expect(result.missingMappings.map((m) => m.fieldId)).toContain(
+      "product_name",
+    );
+    expect(
+      result.missingMappings.find((m) => m.fieldId === "product_name")
+        ?.isRequired,
+    ).toBe(true);
+  });
+
+  /** @scenario A declared prompt variable not referenced by any message is not required */
+  it("does not block the run when an explicit user message omits a declared 'input'", () => {
+    // Mirrors the reported bug: explicit user message uses real variables,
+    // but the prompt still carries a default declared "input" it never
+    // references. The experiment must be runnable.
+    const target: TargetConfig = {
+      id: "r1",
+      type: "prompt",
+      inputs: [
+        { identifier: "input", type: "str" },
+        { identifier: "product_name", type: "str" },
+      ],
+      outputs: [{ identifier: "output", type: "str" }],
+      mappings: {},
+      localPromptConfig: {
+        llm: { model: "gpt-4" },
+        messages: [
+          {
+            role: "user",
+            content: "Classify this product: {{product_name}}",
+          },
+        ],
+        inputs: [
+          { identifier: "input", type: "str" },
+          { identifier: "product_name", type: "str" },
+        ],
+        outputs: [{ identifier: "output", type: "str" }],
+      },
+    };
+
+    const result = getTargetMissingMappings(target, DEFAULT_TEST_DATA_ID);
+
+    // "input" is declared but never referenced -> not flagged at all.
+    expect(
+      result.missingMappings.some((m) => m.fieldId === "input"),
+    ).toBe(false);
+    // "product_name" IS referenced + declared + unmapped -> required.
+    expect(
+      result.missingMappings.find((m) => m.fieldId === "product_name")
+        ?.isRequired,
+    ).toBe(true);
   });
 
   it("uses localPromptConfig.inputs when it differs from target.inputs (form-added variables)", () => {

--- a/langwatch/src/evaluations-v3/components/RunEvaluationButton.tsx
+++ b/langwatch/src/evaluations-v3/components/RunEvaluationButton.tsx
@@ -20,6 +20,7 @@ import { useDrawer } from "~/hooks/useDrawer";
 import { useEvaluationsV3Store } from "../hooks/useEvaluationsV3Store";
 import { useExecuteEvaluation } from "../hooks/useExecuteEvaluation";
 import { useOpenTargetEditor } from "../hooks/useOpenTargetEditor";
+import { useResolveTargetName } from "../hooks/useResolveTargetName";
 import {
   convertFromUIMapping,
   convertToUIMapping,
@@ -36,6 +37,7 @@ export const RunEvaluationButton = ({
 }: RunEvaluationButtonProps) => {
   const { openDrawer } = useDrawer();
   const { openTargetEditor } = useOpenTargetEditor();
+  const resolveTargetName = useResolveTargetName();
   const { status, progress, execute, abort, isAborting } =
     useExecuteEvaluation();
 
@@ -109,7 +111,7 @@ export const RunEvaluationButton = ({
         if (target) {
           availableSources.push({
             id: target.id,
-            name: target.id, // Display name will be resolved by the drawer
+            name: resolveTargetName(target),
             type: "signature" as const,
             fields: target.outputs.map((o) => ({
               name: o.identifier,

--- a/langwatch/src/evaluations-v3/components/TargetSection/TargetVariablesPanel.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/TargetVariablesPanel.tsx
@@ -45,11 +45,17 @@ type TargetVariablesPanelProps = {
  * Convert the active dataset and targets to AvailableSource format for the VariablesSection.
  * Only the active dataset is included as a source - sources are scoped per-dataset.
  */
-const buildAvailableSources = (
-  activeDataset: DatasetReference | undefined,
-  otherTargets: TargetConfig[],
-  resolveTargetName: (target: TargetConfig) => string,
-): AvailableSource[] => {
+type BuildAvailableSourcesParams = {
+  activeDataset: DatasetReference | undefined;
+  otherTargets: TargetConfig[];
+  resolveTargetName: (target: TargetConfig) => string;
+};
+
+const buildAvailableSources = ({
+  activeDataset,
+  otherTargets,
+  resolveTargetName,
+}: BuildAvailableSourcesParams): AvailableSource[] => {
   const sources: AvailableSource[] = [];
 
   // Add only the active dataset as a source
@@ -184,7 +190,12 @@ export const TargetVariablesPanel = ({
 
   // Build available sources for mapping (only active dataset)
   const availableSources = useMemo(
-    () => buildAvailableSources(activeDataset, otherTargets, resolveTargetName),
+    () =>
+      buildAvailableSources({
+        activeDataset,
+        otherTargets,
+        resolveTargetName,
+      }),
     [activeDataset, otherTargets, resolveTargetName],
   );
 

--- a/langwatch/src/evaluations-v3/components/TargetSection/TargetVariablesPanel.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/TargetVariablesPanel.tsx
@@ -9,6 +9,7 @@ import {
   VariablesSection,
 } from "~/components/variables";
 import type { Field } from "~/optimization_studio/types/dsl";
+import { useResolveTargetName } from "../../hooks/useResolveTargetName";
 import type { DatasetReference, FieldMapping, TargetConfig } from "../../types";
 import { getUsedFields } from "../../utils/mappingValidation";
 
@@ -47,6 +48,7 @@ type TargetVariablesPanelProps = {
 const buildAvailableSources = (
   activeDataset: DatasetReference | undefined,
   otherTargets: TargetConfig[],
+  resolveTargetName: (target: TargetConfig) => string,
 ): AvailableSource[] => {
   const sources: AvailableSource[] = [];
 
@@ -69,7 +71,7 @@ const buildAvailableSources = (
     const sourceType = target.type === "prompt" ? "signature" : "code";
     sources.push({
       id: target.id,
-      name: target.id, // Name will be resolved by the panel component
+      name: resolveTargetName(target),
       type: sourceType,
       fields: target.outputs.map((output) => ({
         name: output.identifier,
@@ -177,10 +179,13 @@ export const TargetVariablesPanel = ({
     [datasets, activeDatasetId],
   );
 
+  // Resolve other-target source labels to human-readable names
+  const resolveTargetName = useResolveTargetName();
+
   // Build available sources for mapping (only active dataset)
   const availableSources = useMemo(
-    () => buildAvailableSources(activeDataset, otherTargets),
-    [activeDataset, otherTargets],
+    () => buildAvailableSources(activeDataset, otherTargets, resolveTargetName),
+    [activeDataset, otherTargets, resolveTargetName],
   );
 
   // Convert target inputs to variables

--- a/langwatch/src/evaluations-v3/components/TargetSection/__tests__/TargetVariablesPanel.test.tsx
+++ b/langwatch/src/evaluations-v3/components/TargetSection/__tests__/TargetVariablesPanel.test.tsx
@@ -22,6 +22,14 @@ vi.mock("../../../hooks/useTargetName", () => ({
   useTargetName: () => "Web Search",
 }));
 
+// Resolver returns a friendly name for the chained prompt target, and falls
+// back to the raw id when no entity/name is known.
+vi.mock("../../../hooks/useResolveTargetName", () => ({
+  useResolveTargetName:
+    () => (t: { id: string; promptId?: string }) =>
+      t.promptId === "prompt-cat" ? "category_classifier" : t.id,
+}));
+
 const mockDatasets: DatasetReference[] = [
   {
     id: "dataset-1",
@@ -118,9 +126,10 @@ describe("TargetVariablesPanel", () => {
 
     it("shows mapped variable as a tag", () => {
       renderComponent();
-      // The mapped field should show as a closable tag with source prefix and field name
+      // The mapped field should show as a closable tag with the friendly
+      // source name and field name
       expect(screen.getByTestId("source-mapping-tag")).toBeInTheDocument();
-      expect(screen.getByText("dataset-1.input_text")).toBeInTheDocument();
+      expect(screen.getByText("Test Dataset.input_text")).toBeInTheDocument();
     });
 
     it("shows helper text", () => {
@@ -210,11 +219,36 @@ describe("TargetVariablesPanel", () => {
         await user.click(emptyInput);
 
         await waitFor(() => {
-          // Name is resolved from target.id since names are now fetched via hooks
+          // Falls back to target.id when the target has no resolvable entity
           expect(screen.getByText("target-2")).toBeInTheDocument();
           expect(screen.getByText("search_results")).toBeInTheDocument();
         });
       }
+    });
+
+    /** @scenario Chaining one target into another shows the upstream target name */
+    it("labels an upstream prompt target source with its resolved name", async () => {
+      const user = userEvent.setup();
+      const upstream: TargetConfig = {
+        ...mockOtherTarget,
+        id: "target_1778838627724",
+        promptId: "prompt-cat",
+      };
+      renderComponent({ otherTargets: [upstream] });
+
+      const inputs = screen.getAllByRole("textbox");
+      const emptyInput = inputs.find(
+        (input) => !(input as HTMLInputElement).value,
+      );
+      expect(emptyInput).toBeDefined();
+      await user.click(emptyInput!);
+
+      await waitFor(() => {
+        expect(screen.getByText("category_classifier")).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText("target_1778838627724"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/langwatch/src/evaluations-v3/hooks/useEvaluatorMappings.ts
+++ b/langwatch/src/evaluations-v3/hooks/useEvaluatorMappings.ts
@@ -78,7 +78,9 @@ export const useEvaluatorMappings = (
     if (target) {
       sources.push({
         id: target.id,
-        name: target.id, // Name will be resolved by the caller
+        // Fallback label only; consumers resolve the friendly target name
+        // via useResolveTargetName before rendering the mapping tag.
+        name: target.id,
         type: "signature" as const,
         fields: target.outputs.map((output) => ({
           name: output.identifier,

--- a/langwatch/src/evaluations-v3/hooks/useResolveTargetName.ts
+++ b/langwatch/src/evaluations-v3/hooks/useResolveTargetName.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { useTargetNameMap } from "~/hooks/useTargetNameMap";
+import type { TargetConfig } from "../types";
+
+/**
+ * Returns a resolver that maps a target to its human-readable display name
+ * (prompt handle / agent name), falling back to the internal target id when
+ * the name has not loaded yet or the entity is unknown.
+ *
+ * Used so variable-mapping sources show "category_classifier.l3" instead of
+ * "target_1778838627724.l3".
+ */
+export function useResolveTargetName(): (
+  target: Pick<
+    TargetConfig,
+    "id" | "promptId" | "dbAgentId" | "targetEvaluatorId"
+  >,
+) => string {
+  const nameMap = useTargetNameMap();
+
+  return useCallback(
+    (target) => {
+      const entityId =
+        target.promptId ?? target.dbAgentId ?? target.targetEvaluatorId;
+      return (entityId && nameMap.get(entityId)) || target.id;
+    },
+    [nameMap],
+  );
+}

--- a/langwatch/src/evaluations-v3/hooks/useTargetName.ts
+++ b/langwatch/src/evaluations-v3/hooks/useTargetName.ts
@@ -48,10 +48,14 @@ export const useTargetName = (target: TargetConfig): string => {
       },
     );
 
-  // Return empty string while loading, then the name once loaded
+  // Return empty string while loading, then the name once loaded.
+  // For prompts, prefer the globally-unique handle, then the plain name
+  // (always present on LlmPromptConfig), then "New Prompt" as last resort.
+  // A placeholder prompt with no handle yet should still render a label.
   if (target.type === "prompt") {
     if (target.promptId && promptLoading) return "";
-    return target.promptId ? prompt?.handle ?? "" : "New Prompt";
+    if (!target.promptId) return "New Prompt";
+    return prompt?.handle ?? prompt?.name ?? "New Prompt";
   }
   if (target.type === "agent") {
     if (agentLoading) return "";

--- a/langwatch/src/evaluations-v3/utils/mappingValidation.ts
+++ b/langwatch/src/evaluations-v3/utils/mappingValidation.ts
@@ -244,6 +244,17 @@ export const getTargetMissingMappings = (
     };
   }
 
+  // For a prompt target that follows the latest version with no local
+  // edits, we don't have the message templates, so `usedFields` is a coarse
+  // proxy (all declared inputs). A prompt scaffold can declare variables it
+  // never references (e.g. the default `input`), so we cannot prove these
+  // are actually required. Surface them as an advisory (alert) instead of a
+  // hard requirement so an unreferenced declared variable never blocks the
+  // run. Once the prompt is opened/edited (localPromptConfig present) the
+  // `{{var}}`-based detection is exact and these become hard-required again.
+  const isUnprovenPromptUsage =
+    target.type === "prompt" && !target.localPromptConfig;
+
   // Standard validation for prompts and code agents
   for (const fieldId of usedFields) {
     // Skip if not in inputs list - user hasn't defined this variable
@@ -255,7 +266,7 @@ export const getTargetMissingMappings = (
       missingMappings.push({
         fieldId,
         fieldName: fieldId,
-        isRequired: true,
+        isRequired: !isUnprovenPromptUsage,
       });
     }
   }
@@ -269,16 +280,22 @@ export const getTargetMissingMappings = (
 /**
  * Check if a target has any missing mappings (simpler check for UI alerts).
  *
+ * Drives the alert icon, so it surfaces ANY missing mapping — including
+ * advisory ones (a follow-latest prompt whose declared variables can't yet
+ * be proven required). Advisory misses still warn the user to configure the
+ * target, but they do not hard-block the run (see `getTargetMissingMappings`
+ * and the `isValid` gate used by the run button).
+ *
  * @param target - The target to check
  * @param datasetId - The dataset to check against
- * @returns true if there are missing required mappings
+ * @returns true if there are any missing mappings (required or advisory)
  */
 export const targetHasMissingMappings = (
   target: TargetConfig,
   datasetId: string,
 ): boolean => {
-  const { isValid } = getTargetMissingMappings(target, datasetId);
-  return !isValid;
+  const { missingMappings } = getTargetMissingMappings(target, datasetId);
+  return missingMappings.length > 0;
 };
 
 // ============================================================================

--- a/langwatch/src/hooks/useTargetNameMap.ts
+++ b/langwatch/src/hooks/useTargetNameMap.ts
@@ -28,7 +28,10 @@ export function useTargetNameMap(): Map<string, string> {
     }
     if (prompts) {
       for (const prompt of prompts) {
-        map.set(prompt.id, prompt.handle ?? prompt.id);
+        // Prefer the globally-unique handle, then the plain name (always
+        // present), then the id as last resort. This keeps placeholder
+        // prompts (no handle yet) from collapsing to their raw cuid.
+        map.set(prompt.id, prompt.handle ?? prompt.name ?? prompt.id);
       }
     }
     return map;

--- a/specs/evaluations-v3/experiment-runs-sidebar.feature
+++ b/specs/evaluations-v3/experiment-runs-sidebar.feature
@@ -1,0 +1,34 @@
+Feature: Experiment runs sidebar display
+  As a user comparing experiment runs
+  I want run names to use the available width and read cleanly
+  So that I can tell runs apart at a glance
+
+  Background:
+    Given I am viewing the experiment results page
+    And the sidebar lists multiple experiment runs
+
+  # ============================================================================
+  # Run name formatting
+  # ============================================================================
+
+  @integration
+  Scenario: A run without a commit message shows index then a middle-dot separator
+    Given a run has no commit message and a generated run id "snobbish-otter-1f2a3b"
+    And the run is the 10th run chronologically
+    When the run is shown in the sidebar
+    Then it shows "Run #10" followed by a gray "·" separator and the run id
+    And the run id is not wrapped in parentheses
+
+  @integration
+  Scenario: The run id uses the available width instead of an early hard truncation
+    Given a run has no commit message and a long generated run id
+    When the run is shown in the sidebar
+    Then the run id is not pre-truncated to eight characters
+    And overflow is clipped to a single line by the layout, with the full name in a tooltip
+
+  @integration
+  Scenario: A run with a commit message still shows the commit message
+    Given a run has a commit message "fix prompt temperature"
+    When the run is shown in the sidebar
+    Then it shows "fix prompt temperature"
+    And it does not show a generated run id suffix

--- a/specs/evaluations-v3/mapping-source-display.feature
+++ b/specs/evaluations-v3/mapping-source-display.feature
@@ -22,8 +22,9 @@ Feature: Mapping source display names
   @integration
   Scenario: Source name falls back to the ID when no friendly name is known
     Given I have an evaluator that maps "output" from a target whose name has not loaded yet
+    And the target's internal ID is "target_1778838627724"
     When I view the evaluator's variable mappings
-    Then the "output" mapping still renders a stable label using the source identifier
+    Then the "output" mapping shows the exact label "target_1778838627724.l3"
 
   @integration
   Scenario: Chaining one target into another shows the upstream target name

--- a/specs/evaluations-v3/mapping-source-display.feature
+++ b/specs/evaluations-v3/mapping-source-display.feature
@@ -1,0 +1,33 @@
+Feature: Mapping source display names
+  As a user mapping variables in Evaluations V3
+  I want mapping sources to show the human-readable target name
+  So that I can understand where a value comes from without decoding internal IDs
+
+  Background:
+    Given I have an evaluation workbench open
+    And I have a prompt target named "category_classifier"
+    And the prompt target produces an output field "l3"
+
+  # ============================================================================
+  # Source label resolution
+  # ============================================================================
+
+  @integration
+  Scenario: Mapping a value from another target shows the target name not its ID
+    Given I have an evaluator that maps "output" from the "category_classifier" target
+    When I view the evaluator's variable mappings
+    Then the "output" mapping shows "category_classifier.l3"
+    And the "output" mapping does not show the raw target ID
+
+  @integration
+  Scenario: Source name falls back to the ID when no friendly name is known
+    Given I have an evaluator that maps "output" from a target whose name has not loaded yet
+    When I view the evaluator's variable mappings
+    Then the "output" mapping still renders a stable label using the source identifier
+
+  @integration
+  Scenario: Chaining one target into another shows the upstream target name
+    Given I have a second prompt target that maps an input from "category_classifier"
+    When I open the second target's variables panel
+    Then the available source for that input is labelled "category_classifier"
+    And it is not labelled with the internal target ID

--- a/specs/evaluations-v3/mapping-validation.feature
+++ b/specs/evaluations-v3/mapping-validation.feature
@@ -113,3 +113,23 @@ Feature: Mapping Validation and Missing Mapping Detection
     When I click the evaluator chip on a runner cell
     Then the evaluator drawer opens
     And the missing mappings are highlighted
+
+  # ============================================================================
+  # Declared-but-unused prompt variables
+  # ============================================================================
+
+  @regression
+  Scenario: A declared prompt variable not referenced by any message is not required
+    Given I have a prompt target with an explicit user message
+    And the message content does not reference "{{input}}"
+    And "input" is still a declared variable on the prompt
+    And the prompt target follows the latest version with no local edits
+    Then "input" is not reported as a missing required mapping
+    And the experiment can run without mapping "input"
+
+  @regression
+  Scenario: A declared prompt variable that IS referenced still requires a mapping
+    Given I have a prompt target whose user message references "{{product_name}}"
+    And "product_name" is a declared variable on the prompt
+    And "product_name" is not mapped for the active dataset
+    Then "product_name" is reported as a missing required mapping

--- a/specs/evaluations-v3/prompt-editor-drawer-display.feature
+++ b/specs/evaluations-v3/prompt-editor-drawer-display.feature
@@ -1,0 +1,30 @@
+Feature: Prompt editor drawer display
+  As a user editing a prompt inside the Evaluations V3 drawer
+  I want the drawer chrome to stay readable while I scroll
+  So that controls and content never visually collide
+
+  Background:
+    Given I have an evaluation workbench open
+    And I open the prompt editor drawer for a prompt target
+
+  # ============================================================================
+  # Sticky header / model selector stacking
+  # ============================================================================
+
+  @integration
+  Scenario: The model selector header stays opaque above scrolling messages
+    Given the prompt has long message content that scrolls
+    When I scroll the messages in the drawer
+    Then the model selector header keeps a solid background
+    And the scrolling message text does not show through or over the header
+
+  # ============================================================================
+  # Add logic / Add variable buttons
+  # ============================================================================
+
+  @integration
+  Scenario: The add-variable and add-logic buttons sit on a solid background
+    Given I hover over a message editor that shows the add buttons
+    When the "Add logic" and "Add variable" buttons appear
+    Then the buttons render on a solid (non-transparent) background
+    And the message text behind them does not bleed through the button labels


### PR DESCRIPTION
Five Evaluations V3 UX bugs from the May 15 report. Each is provable via the BDD scenarios, the integration tests they bind, and the dogfood QA screenshots at the bottom.

## Bugs fixed (lines 163-185 of the report)

### C1 — Variable mappings show the target name, not its internal id
**Before:** `output = target_1778838627724.l3` (raw id) in the **evaluator drawer** when an input is mapped from a target's output.
**After:** `output = category_classifier.l3` (the prompt handle, falling back to the prompt's plain `name`, then `"New Prompt"`, then the target id).

- `VariableMappingInput` now renders `source.name || source.id` for the selected source tag (the dropdown already showed names; the tag was inconsistent).
- New `useResolveTargetName` hook centralises target → display-name resolution on top of the existing `useTargetNameMap`.
- Wired into `TargetVariablesPanel.buildAvailableSources` (target → target chaining) and `RunEvaluationButton` (validation-failure drawer open). `TargetCell` already resolved the name correctly.
- Follow-up fix from rchaves's QA pass: `useTargetName` and `useTargetNameMap` collapsed to an empty string when a prompt had no handle yet, leaving target headers blank and the evaluator mapping tag falling back to the raw `target_<id>`. Both now prefer `handle`, then `name` (always present on `LlmPromptConfig`), then a stable last-resort fallback. Verified live in the browser: target headers render `New Prompt v1` and the evaluator drawer mapping reads `output = New Prompt.answer`.
- Specs: `specs/evaluations-v3/mapping-source-display.feature` (3 scenarios, all bound).

### C2 — Experiment Runs sidebar truncated names too soon, with ugly parentheses
**Before:** `Run #10 (snobbish…)` (8-char hard truncation, parens).
**After:** `Run #10 · snobbish-otter-1f2a3b` (full id, gray middle-dot separator, layout-driven clipping with the full name in the tooltip).

- `getRunDisplayName` drops the parens and the hard truncation; uses a ` · ` separator.
- New `RunDisplayName` rich component renders the run-id suffix in `fg.muted` gray.
- Sidebar's inner `HStack` now uses `flex={1} minWidth={0}` so the run name uses the available width; overflow is clipped by `lineClamp={1}` and the tooltip stays accurate.
- Specs: `specs/evaluations-v3/experiment-runs-sidebar.feature` (3 scenarios, all bound).

### C3 — Prompt editor drawer's sticky header was transparent, so scrolling messages painted over the model selector
**Fix:** Added `bg="bg"` to the sticky header (matching the drawer surface) and bumped its `zIndex` so messages always scroll cleanly under it.
- File: `src/components/prompts/PromptEditorDrawer.tsx`.
- Specs: `specs/evaluations-v3/prompt-editor-drawer-display.feature` (header scenario, bound).
- Live verification (browser): `getComputedStyle(header)` returns `position: sticky`, `zIndex: 2`, `backgroundColor: rgb(255, 255, 255)`.

### C4 — "Add logic" / "Add variable" buttons were transparent and mixed with the textarea text
**Fix (after rchaves's QA feedback):** Two separate outlined buttons (originally I'd merged them in a single pill, which read as one button). Each `AddLogicButton` / `AddVariableButton` now carries its own solid `bg.panel` background, a border, and tighter `paddingX={2}`. The wrapping `HStack` just positions the pair (`gap={1.5}`, absolute).
- Files: `PromptTextAreaWithVariables.tsx`, `AddLogicButton.tsx`, `AddVariableButton.tsx`.
- Specs: `specs/evaluations-v3/prompt-editor-drawer-display.feature` (add-buttons scenario, bound).

### C5 — Declared-but-unreferenced prompt variables blocked the run (e.g. the default `input`)
**Before:** A prompt target that follows the latest version with no local edits would hard-block the run on any declared input that had no mapping — including a default `input` the prompt's messages never reference.
**After:** Without local config we cannot prove a declared variable is actually used by the template, so such fields surface as **advisory** missing mappings: the alert icon still shows, but the run is not blocked. Once the prompt is opened/edited (`localPromptConfig` present), accurate `{{var}}`-based detection makes referenced+unmapped fields hard-required again.

- File: `src/evaluations-v3/utils/mappingValidation.ts`.
  - `getTargetMissingMappings`: prompt-target standard branch now marks missing mappings as `isRequired: false` when `localPromptConfig` is absent.
  - `targetHasMissingMappings`: returns true on **any** missing mapping (advisory or required) so the alert UX is preserved.
- Specs: 2 new `@regression` scenarios in `specs/evaluations-v3/mapping-validation.feature` (both bound).
- Definitive proof is in the unit/integration tests: with `localPromptConfig: undefined` and an unmapped declared input, `getTargetMissingMappings(...).isValid` is now `true` (run not blocked) AND the missing mapping is still reported with `isRequired: false` (advisory alert still shows).

## Tests

- `src/evaluations-v3` + `src/components/variables` — **60 files / 942 tests / 8 skipped, all green**.
- `src/components/prompts` + `src/components/prompt-textarea` + `src/components/batch-evaluation-results` — **18 files / 321 tests, all green**.
- `pnpm check:feature-parity` — **all 1098 enforced scenarios bound** (10 new bindings added across the 5 bugs).

## CI

`test-integration (3)` shows a pre-existing flake in `src/server/nlpgo/__tests__/traceparent-roundtrip.integration.test.ts` ("no spans landed in CH under the inbound trace_id — the 2026-05-14 bug"). The exact same job + test failed on `main` commit `0b2328a2` (today) and passed on the two `main` runs surrounding it, so this is a known intermittent in the NLP-Go / event-sourcing pipeline lane (Area D). The failure has zero overlap with the files this PR touches.

## QA screenshots (browser dogfood, `pnpm dev`)

**C1 — Evaluator drawer's VARIABLES section now shows friendly target names:**
![evaluator mapping](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4070/c1-evaluator-mapping-friendly-names.png)

`output = New Prompt.answer` (the target source label is the prompt's friendly name; before the fix this read `target_1769943494557.answer`). `expected_output = Test Data.expected_output` (dataset source with friendly name). This is exactly the surface rchaves flagged: evaluator input mapping from a target output.

**C1 (related) — Target column headers now display the prompt's friendly name:**
![target headers](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4070/c1-target-headers-named.png)

`New Prompt v1` instead of a blank header with only the version number.

**C3 — Prompt editor drawer with sticky model-selector header:**
![prompt drawer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4070/c1-c3-c4-prompt-drawer-fixed.png)

Sticky `New Prompt` + `gpt-4o-mini` header on a solid background — scrolling messages no longer show through.

**C4 — Two separate outlined buttons, each with its own solid background:**
![add buttons](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4070/c4-add-buttons-pill.png)

`Add logic` and `Add variable` are independent buttons with tighter padding; the textarea text behind no longer bleeds through their labels.

## Coordination

This PR is **Area C** of the May 15 bug-fix split. Area A (prompt sync fidelity, lines 3-146) is on #4068. No file overlap.
