### PR TITLE
refactor(api-keys): move direct Prisma queries in apiKey router to service layer

### DIFF
--- a/langwatch/src/server/api-key/__tests__/api-key.service.unit.test.ts
+++ b/langwatch/src/server/api-key/__tests__/api-key.service.unit.test.ts
@@ -67,6 +67,7 @@ function createMockPrisma() {
     $transaction: vi.fn((fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
     organizationUser: {
       findFirst: vi.fn().mockResolvedValue({ userId: "user_1" }),
+      findMany: vi.fn().mockResolvedValue([]),
     },
     apiKey: {
       findFirst: vi.fn(),
@@ -76,8 +77,24 @@ function createMockPrisma() {
     },
     roleBinding: {
       findFirst: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
       createMany: vi.fn(),
       deleteMany: vi.fn(),
+    },
+    organization: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    team: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    project: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    customRole: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    user: {
+      findMany: vi.fn().mockResolvedValue([]),
     },
     _mockTx: mockTx,
   } as any;
@@ -421,6 +438,177 @@ describe("ApiKeyService", () => {
             organizationId: "org_1",
           }),
         ).rejects.toThrow();
+      });
+    });
+  });
+
+  describe("getMyBindings()", () => {
+    describe("when user has active bindings", () => {
+      it("returns bindings with resolved scope names", async () => {
+        prisma.roleBinding.findMany.mockResolvedValue([
+          { id: "rb_1", role: "ADMIN", customRoleId: null, scopeType: "ORGANIZATION", scopeId: "org_1" },
+          { id: "rb_2", role: "MEMBER", customRoleId: null, scopeType: "PROJECT", scopeId: "proj_1" },
+        ]);
+        prisma.organization.findMany.mockResolvedValue([{ id: "org_1", name: "Acme Corp" }]);
+        prisma.project.findMany.mockResolvedValue([{ id: "proj_1", name: "My Project" }]);
+
+        const result = await service.getMyBindings({ userId: "user_1", organizationId: "org_1" });
+
+        expect(result).toEqual([
+          expect.objectContaining({ id: "rb_1", scopeName: "Acme Corp" }),
+          expect.objectContaining({ id: "rb_2", scopeName: "My Project" }),
+        ]);
+      });
+    });
+
+    describe("when user has archived project bindings", () => {
+      it("excludes archived project bindings", async () => {
+        prisma.roleBinding.findMany.mockResolvedValue([
+          { id: "rb_1", role: "ADMIN", customRoleId: null, scopeType: "ORGANIZATION", scopeId: "org_1" },
+          { id: "rb_2", role: "MEMBER", customRoleId: null, scopeType: "PROJECT", scopeId: "archived_proj" },
+        ]);
+        prisma.organization.findMany.mockResolvedValue([{ id: "org_1", name: "Acme Corp" }]);
+        prisma.project.findMany.mockResolvedValue([]);
+
+        const result = await service.getMyBindings({ userId: "user_1", organizationId: "org_1" });
+
+        expect(result).toHaveLength(1);
+      });
+    });
+
+    describe("when user has custom role bindings", () => {
+      it("includes custom role names", async () => {
+        prisma.roleBinding.findMany.mockResolvedValue([
+          { id: "rb_1", role: "CUSTOM", customRoleId: "cr_1", scopeType: "ORGANIZATION", scopeId: "org_1" },
+        ]);
+        prisma.organization.findMany.mockResolvedValue([{ id: "org_1", name: "Acme Corp" }]);
+        prisma.customRole.findMany.mockResolvedValue([{ id: "cr_1", name: "Deployer" }]);
+
+        const result = await service.getMyBindings({ userId: "user_1", organizationId: "org_1" });
+
+        expect(result[0]!.customRoleName).toBe("Deployer");
+      });
+    });
+
+    describe("when user is not an org member", () => {
+      it("throws scope violation error", async () => {
+        prisma.organizationUser.findFirst.mockResolvedValue(null);
+
+        await expect(
+          service.getMyBindings({ userId: "user_1", organizationId: "org_1" }),
+        ).rejects.toThrow("Not a member of this organization");
+      });
+    });
+  });
+
+  describe("getApiKeysWithNames()", () => {
+    describe("when caller is admin", () => {
+      it("returns all org keys with enriched names", async () => {
+        prisma.apiKey.findMany.mockResolvedValue([
+          {
+            id: "ak_1",
+            name: "Key 1",
+            description: null,
+            lookupId: "lookup1234567890",
+            permissionMode: "all",
+            userId: "user_1",
+            createdByUserId: "user_1",
+            organizationId: "org_1",
+            createdAt: new Date(),
+            expiresAt: null,
+            lastUsedAt: null,
+            revokedAt: null,
+            roleBindings: [
+              { id: "rb_1", role: "ADMIN", customRoleId: null, scopeType: "ORGANIZATION", scopeId: "org_1" },
+            ],
+          },
+        ]);
+        prisma.organization.findMany.mockResolvedValue([{ id: "org_1", name: "Acme Corp" }]);
+        prisma.user.findMany.mockResolvedValue([{ id: "user_1", name: "Alice", email: "alice@acme.com" }]);
+
+        const result = await service.getApiKeysWithNames({
+          userId: "user_1",
+          organizationId: "org_1",
+          isAdmin: true,
+        });
+
+        expect(result[0]!.userName).toBe("Alice");
+      });
+    });
+
+    describe("when caller is not admin", () => {
+      it("returns only user's own keys", async () => {
+        prisma.apiKey.findMany.mockResolvedValue([]);
+
+        const result = await service.getApiKeysWithNames({
+          userId: "user_1",
+          organizationId: "org_1",
+          isAdmin: false,
+        });
+
+        expect(prisma.apiKey.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({ organizationId: "org_1" }),
+          }),
+        );
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe("getOrgProjects()", () => {
+    describe("when org has active projects", () => {
+      it("returns non-archived projects ordered by name", async () => {
+        prisma.project.findMany.mockResolvedValue([
+          { id: "proj_1", name: "Alpha" },
+          { id: "proj_2", name: "Beta" },
+        ]);
+
+        const result = await service.getOrgProjects({ userId: "user_1", organizationId: "org_1" });
+
+        expect(result).toEqual([
+          { id: "proj_1", name: "Alpha" },
+          { id: "proj_2", name: "Beta" },
+        ]);
+      });
+    });
+
+    describe("when user is not an org member", () => {
+      it("throws scope violation error", async () => {
+        prisma.organizationUser.findFirst.mockResolvedValue(null);
+
+        await expect(
+          service.getOrgProjects({ userId: "user_1", organizationId: "org_1" }),
+        ).rejects.toThrow("Not a member of this organization");
+      });
+    });
+  });
+
+  describe("getOrgMembers()", () => {
+    describe("when caller is admin", () => {
+      it("returns org members with user details", async () => {
+        prisma.roleBinding.findFirst.mockResolvedValue({ id: "rb_admin" });
+        prisma.organizationUser.findMany.mockResolvedValue([
+          { user: { id: "user_1", name: "Alice", email: "alice@acme.com" } },
+          { user: { id: "user_2", name: null, email: "bob@acme.com" } },
+        ]);
+
+        const result = await service.getOrgMembers({ userId: "user_1", organizationId: "org_1" });
+
+        expect(result).toEqual([
+          { id: "user_1", name: "Alice", email: "alice@acme.com" },
+          { id: "user_2", name: null, email: "bob@acme.com" },
+        ]);
+      });
+    });
+
+    describe("when caller is not admin", () => {
+      it("returns empty array", async () => {
+        prisma.roleBinding.findFirst.mockResolvedValue(null);
+
+        const result = await service.getOrgMembers({ userId: "user_1", organizationId: "org_1" });
+
+        expect(result).toEqual([]);
       });
     });
   });

--- a/langwatch/src/server/api-key/api-key.service.ts
+++ b/langwatch/src/server/api-key/api-key.service.ts
@@ -217,10 +217,7 @@ export class ApiKeyService {
     });
   }
 
-  /**
-   * Verifies the creator is a member of the org before an API key can be minted.
-   */
-  private async assertOrgMembership({
+  async assertOrgMembership({
     userId,
     organizationId,
   }: {
@@ -547,10 +544,226 @@ export class ApiKeyService {
     return !!binding;
   }
 
+  async getMyBindings({
+    userId,
+    organizationId,
+  }: {
+    userId: string;
+    organizationId: string;
+  }) {
+    await this.assertOrgMembership({ userId, organizationId });
+
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: { userId, organizationId },
+      select: {
+        id: true,
+        role: true,
+        customRoleId: true,
+        scopeType: true,
+        scopeId: true,
+      },
+    });
+
+    const { orgNames, teamNames, projectNames, customRoleNames } =
+      await this.resolveScopeNames({ bindings });
+
+    const activeProjectIds = new Set(projectNames.keys());
+
+    return bindings
+      .filter(
+        (b) =>
+          b.scopeType !== RoleBindingScopeType.PROJECT ||
+          activeProjectIds.has(b.scopeId),
+      )
+      .map((b) => ({
+        ...b,
+        scopeName:
+          b.scopeType === RoleBindingScopeType.ORGANIZATION
+            ? orgNames.get(b.scopeId) ?? null
+            : b.scopeType === RoleBindingScopeType.TEAM
+              ? teamNames.get(b.scopeId) ?? null
+              : projectNames.get(b.scopeId) ?? null,
+        customRoleName: b.customRoleId
+          ? customRoleNames.get(b.customRoleId) ?? null
+          : null,
+      }));
+  }
+
+  async getApiKeysWithNames({
+    userId,
+    organizationId,
+    isAdmin,
+  }: {
+    userId: string;
+    organizationId: string;
+    isAdmin: boolean;
+  }) {
+    await this.assertOrgMembership({ userId, organizationId });
+
+    const apiKeys = isAdmin
+      ? await this.listAll({ organizationId })
+      : await this.list({ userId, organizationId });
+
+    const allBindings = apiKeys.flatMap((k) => k.roleBindings);
+    const { orgNames, teamNames, projectNames, customRoleNames } =
+      await this.resolveScopeNames({ bindings: allBindings });
+
+    const userIds = new Set<string>();
+    for (const k of apiKeys) {
+      if (k.userId) userIds.add(k.userId);
+      if (k.createdByUserId) userIds.add(k.createdByUserId);
+    }
+
+    const users = userIds.size
+      ? await this.prisma.user.findMany({
+          where: { id: { in: [...userIds] } },
+          select: { id: true, name: true, email: true },
+        })
+      : [];
+    const userName = new Map(users.map((u) => [u.id, u.name ?? u.email]));
+
+    return apiKeys.map((apiKey) => ({
+      id: apiKey.id,
+      lookupIdSuffix: apiKey.lookupId.slice(-4),
+      name: apiKey.name,
+      description: apiKey.description,
+      permissionMode: apiKey.permissionMode,
+      userId: apiKey.userId,
+      userName: apiKey.userId ? (userName.get(apiKey.userId) ?? null) : null,
+      createdByUserId: apiKey.createdByUserId,
+      createdByUserName: apiKey.createdByUserId
+        ? userName.get(apiKey.createdByUserId) ?? null
+        : null,
+      createdAt: apiKey.createdAt,
+      expiresAt: apiKey.expiresAt,
+      lastUsedAt: apiKey.lastUsedAt,
+      revokedAt: apiKey.revokedAt,
+      roleBindings: apiKey.roleBindings.map((rb) => ({
+        id: rb.id,
+        role: rb.role,
+        customRoleId: rb.customRoleId,
+        customRoleName: rb.customRoleId
+          ? customRoleNames.get(rb.customRoleId) ?? null
+          : null,
+        scopeType: rb.scopeType,
+        scopeId: rb.scopeId,
+        scopeName:
+          rb.scopeType === RoleBindingScopeType.ORGANIZATION
+            ? orgNames.get(rb.scopeId) ?? null
+            : rb.scopeType === RoleBindingScopeType.TEAM
+              ? teamNames.get(rb.scopeId) ?? null
+              : projectNames.get(rb.scopeId) ?? null,
+      })),
+    }));
+  }
+
+  async getOrgProjects({
+    userId,
+    organizationId,
+  }: {
+    userId: string;
+    organizationId: string;
+  }) {
+    await this.assertOrgMembership({ userId, organizationId });
+
+    return this.prisma.project.findMany({
+      where: {
+        team: { organizationId },
+        archivedAt: null,
+      },
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    });
+  }
+
+  async getOrgMembers({
+    userId,
+    organizationId,
+  }: {
+    userId: string;
+    organizationId: string;
+  }) {
+    await this.assertOrgMembership({ userId, organizationId });
+
+    const isAdmin = await this.isOrgAdmin({ userId, organizationId });
+    if (!isAdmin) return [];
+
+    const orgUsers = await this.prisma.organizationUser.findMany({
+      where: { organizationId },
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+      },
+    });
+    return orgUsers.map((ou) => ({
+      id: ou.user.id,
+      name: ou.user.name,
+      email: ou.user.email,
+    }));
+  }
+
   /**
    * Gets a single API key by ID (for display, not verification).
    */
   async getById({ id }: { id: string }): Promise<ApiKeyWithBindings | null> {
     return this.repo.findById({ id });
+  }
+
+  private async resolveScopeNames({
+    bindings,
+  }: {
+    bindings: Array<{
+      scopeType: string;
+      scopeId: string;
+      customRoleId?: string | null;
+    }>;
+  }) {
+    const orgIds = new Set<string>();
+    const teamIds = new Set<string>();
+    const projectIds = new Set<string>();
+    const customRoleIds = new Set<string>();
+
+    for (const b of bindings) {
+      if (b.scopeType === RoleBindingScopeType.ORGANIZATION)
+        orgIds.add(b.scopeId);
+      else if (b.scopeType === RoleBindingScopeType.TEAM)
+        teamIds.add(b.scopeId);
+      else if (b.scopeType === RoleBindingScopeType.PROJECT)
+        projectIds.add(b.scopeId);
+      if (b.customRoleId) customRoleIds.add(b.customRoleId);
+    }
+
+    const [orgs, teams, projects, customRoles] = await Promise.all([
+      orgIds.size
+        ? this.prisma.organization.findMany({
+            where: { id: { in: [...orgIds] } },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([]),
+      teamIds.size
+        ? this.prisma.team.findMany({
+            where: { id: { in: [...teamIds] } },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([]),
+      projectIds.size
+        ? this.prisma.project.findMany({
+            where: { id: { in: [...projectIds] }, archivedAt: null },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([]),
+      customRoleIds.size
+        ? this.prisma.customRole.findMany({
+            where: { id: { in: [...customRoleIds] } },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve([]),
+    ]);
+
+    return {
+      orgNames: new Map(orgs.map((o) => [o.id, o.name])),
+      teamNames: new Map(teams.map((t) => [t.id, t.name])),
+      projectNames: new Map(projects.map((p) => [p.id, p.name])),
+      customRoleNames: new Map(customRoles.map((r) => [r.id, r.name])),
+    };
   }
 }

--- a/langwatch/src/server/api/routers/apiKey.ts
+++ b/langwatch/src/server/api/routers/apiKey.ts
@@ -1,5 +1,4 @@
 import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
-import type { PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
@@ -8,10 +7,6 @@ import { ApiKeyService } from "~/server/api-key/api-key.service";
 import { auditLog } from "~/server/auditLog";
 import { skipPermissionCheck } from "../rbac";
 
-/**
- * Maps an API key domain error to a tRPCError. Re-throws anything
- * that isn't a handled DomainError.
- */
 function mapApiKeyDomainError(error: unknown): never {
   if (DomainError.isHandled(error)) {
     switch (error.kind) {
@@ -28,27 +23,6 @@ function mapApiKeyDomainError(error: unknown): never {
     }
   }
   throw error;
-}
-
-async function assertOrgMembership({
-  prisma,
-  userId,
-  organizationId,
-}: {
-  prisma: PrismaClient;
-  userId: string;
-  organizationId: string;
-}): Promise<void> {
-  const membership = await prisma.organizationUser.findFirst({
-    where: { userId, organizationId },
-    select: { userId: true },
-  });
-  if (!membership) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "Not a member of this organization",
-    });
-  }
 }
 
 const roleBindingSchema = z.object({
@@ -71,91 +45,15 @@ export const apiKeyRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      await assertOrgMembership({
-        prisma: ctx.prisma,
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-
-      const bindings = await ctx.prisma.roleBinding.findMany({
-        where: {
+      const apiKeyService = ApiKeyService.create(ctx.prisma);
+      try {
+        return await apiKeyService.getMyBindings({
           userId: ctx.session.user.id,
           organizationId: input.organizationId,
-        },
-        select: {
-          id: true,
-          role: true,
-          customRoleId: true,
-          scopeType: true,
-          scopeId: true,
-        },
-      });
-
-      const orgIds = new Set<string>();
-      const teamIds = new Set<string>();
-      const projectIds = new Set<string>();
-      const customRoleIds = new Set<string>();
-      for (const b of bindings) {
-        if (b.scopeType === RoleBindingScopeType.ORGANIZATION)
-          orgIds.add(b.scopeId);
-        else if (b.scopeType === RoleBindingScopeType.TEAM)
-          teamIds.add(b.scopeId);
-        else if (b.scopeType === RoleBindingScopeType.PROJECT)
-          projectIds.add(b.scopeId);
-        if (b.customRoleId) customRoleIds.add(b.customRoleId);
+        });
+      } catch (error) {
+        mapApiKeyDomainError(error);
       }
-
-      const [orgs, teams, projects, customRoles] = await Promise.all([
-        orgIds.size
-          ? ctx.prisma.organization.findMany({
-              where: { id: { in: [...orgIds] } },
-              select: { id: true, name: true },
-            })
-          : Promise.resolve([]),
-        teamIds.size
-          ? ctx.prisma.team.findMany({
-              where: { id: { in: [...teamIds] } },
-              select: { id: true, name: true },
-            })
-          : Promise.resolve([]),
-        projectIds.size
-          ? ctx.prisma.project.findMany({
-              where: { id: { in: [...projectIds] }, archivedAt: null },
-              select: { id: true, name: true },
-            })
-          : Promise.resolve([]),
-        customRoleIds.size
-          ? ctx.prisma.customRole.findMany({
-              where: { id: { in: [...customRoleIds] } },
-              select: { id: true, name: true },
-            })
-          : Promise.resolve([]),
-      ]);
-
-      const orgName = new Map(orgs.map((o) => [o.id, o.name]));
-      const teamName = new Map(teams.map((t) => [t.id, t.name]));
-      const activeProjectIds = new Set(projects.map((p) => p.id));
-      const projectName = new Map(projects.map((p) => [p.id, p.name]));
-      const customRoleName = new Map(customRoles.map((r) => [r.id, r.name]));
-
-      return bindings
-        .filter(
-          (b) =>
-            b.scopeType !== RoleBindingScopeType.PROJECT ||
-            activeProjectIds.has(b.scopeId),
-        )
-        .map((b) => ({
-          ...b,
-          scopeName:
-            b.scopeType === RoleBindingScopeType.ORGANIZATION
-              ? orgName.get(b.scopeId) ?? null
-              : b.scopeType === RoleBindingScopeType.TEAM
-                ? teamName.get(b.scopeId) ?? null
-                : projectName.get(b.scopeId) ?? null,
-          customRoleName: b.customRoleId
-            ? customRoleName.get(b.customRoleId) ?? null
-            : null,
-        }));
     }),
 
   /**
@@ -169,119 +67,20 @@ export const apiKeyRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      await assertOrgMembership({
-        prisma: ctx.prisma,
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-
       const apiKeyService = ApiKeyService.create(ctx.prisma);
-      const callerIsAdmin = await apiKeyService.isOrgAdmin({
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-
-      const apiKeys = callerIsAdmin
-        ? await apiKeyService.listAll({ organizationId: input.organizationId })
-        : await apiKeyService.list({
-            userId: ctx.session.user.id,
-            organizationId: input.organizationId,
-          });
-
-      // Resolve scope names and user names for display
-      const allBindings = apiKeys.flatMap((k) => k.roleBindings);
-      const orgIds = new Set<string>();
-      const teamIds = new Set<string>();
-      const projectIds = new Set<string>();
-      const customRoleIds = new Set<string>();
-      const userIds = new Set<string>();
-
-      for (const b of allBindings) {
-        if (b.scopeType === RoleBindingScopeType.ORGANIZATION)
-          orgIds.add(b.scopeId);
-        else if (b.scopeType === RoleBindingScopeType.TEAM)
-          teamIds.add(b.scopeId);
-        else if (b.scopeType === RoleBindingScopeType.PROJECT)
-          projectIds.add(b.scopeId);
-        if (b.customRoleId) customRoleIds.add(b.customRoleId);
+      try {
+        const callerIsAdmin = await apiKeyService.isOrgAdmin({
+          userId: ctx.session.user.id,
+          organizationId: input.organizationId,
+        });
+        return await apiKeyService.getApiKeysWithNames({
+          userId: ctx.session.user.id,
+          organizationId: input.organizationId,
+          isAdmin: callerIsAdmin,
+        });
+      } catch (error) {
+        mapApiKeyDomainError(error);
       }
-      for (const k of apiKeys) {
-        if (k.userId) userIds.add(k.userId);
-        if (k.createdByUserId) userIds.add(k.createdByUserId);
-      }
-
-      const [orgs, teams, projects, customRoles, users] = await Promise.all([
-        orgIds.size
-          ? ctx.prisma.organization.findMany({
-              where: { id: { in: [...orgIds] } },
-              select: { id: true, name: true },
-            })
-          : Promise.resolve([]),
-        teamIds.size
-          ? ctx.prisma.team.findMany({
-              where: { id: { in: [...teamIds] } },
-              select: { id: true, name: true },
-            })
-          : Promise.resolve([]),
-        projectIds.size
-          ? ctx.prisma.project.findMany({
-              where: { id: { in: [...projectIds] } },
-              select: { id: true, name: true },
-            })
-          : Promise.resolve([]),
-        customRoleIds.size
-          ? ctx.prisma.customRole.findMany({
-              where: { id: { in: [...customRoleIds] } },
-              select: { id: true, name: true },
-            })
-          : Promise.resolve([]),
-        userIds.size
-          ? ctx.prisma.user.findMany({
-              where: { id: { in: [...userIds] } },
-              select: { id: true, name: true, email: true },
-            })
-          : Promise.resolve([]),
-      ]);
-
-      const orgName = new Map(orgs.map((o) => [o.id, o.name]));
-      const teamName = new Map(teams.map((t) => [t.id, t.name]));
-      const projectName = new Map(projects.map((p) => [p.id, p.name]));
-      const customRoleName = new Map(customRoles.map((r) => [r.id, r.name]));
-      const userName = new Map(users.map((u) => [u.id, u.name ?? u.email]));
-
-      return apiKeys.map((apiKey) => ({
-        id: apiKey.id,
-        lookupIdSuffix: apiKey.lookupId.slice(-4),
-        name: apiKey.name,
-        description: apiKey.description,
-        permissionMode: apiKey.permissionMode,
-        userId: apiKey.userId,
-        userName: apiKey.userId ? (userName.get(apiKey.userId) ?? null) : null,
-        createdByUserId: apiKey.createdByUserId,
-        createdByUserName: apiKey.createdByUserId
-          ? userName.get(apiKey.createdByUserId) ?? null
-          : null,
-        createdAt: apiKey.createdAt,
-        expiresAt: apiKey.expiresAt,
-        lastUsedAt: apiKey.lastUsedAt,
-        revokedAt: apiKey.revokedAt,
-        roleBindings: apiKey.roleBindings.map((rb) => ({
-          id: rb.id,
-          role: rb.role,
-          customRoleId: rb.customRoleId,
-          customRoleName: rb.customRoleId
-            ? customRoleName.get(rb.customRoleId) ?? null
-            : null,
-          scopeType: rb.scopeType,
-          scopeId: rb.scopeId,
-          scopeName:
-            rb.scopeType === RoleBindingScopeType.ORGANIZATION
-              ? orgName.get(rb.scopeId) ?? null
-              : rb.scopeType === RoleBindingScopeType.TEAM
-                ? teamName.get(rb.scopeId) ?? null
-                : projectName.get(rb.scopeId) ?? null,
-        })),
-      }));
     }),
 
   create: protectedProcedure
@@ -303,13 +102,16 @@ export const apiKeyRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      await assertOrgMembership({
-        prisma: ctx.prisma,
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-
       const apiKeyService = ApiKeyService.create(ctx.prisma);
+      try {
+        await apiKeyService.assertOrgMembership({
+          userId: ctx.session.user.id,
+          organizationId: input.organizationId,
+        });
+      } catch (error) {
+        mapApiKeyDomainError(error);
+      }
+
       const isService = input.keyType === "service";
 
       // Service keys and assigning to another user both require admin
@@ -385,13 +187,16 @@ export const apiKeyRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      await assertOrgMembership({
-        prisma: ctx.prisma,
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-
       const apiKeyService = ApiKeyService.create(ctx.prisma);
+      try {
+        await apiKeyService.assertOrgMembership({
+          userId: ctx.session.user.id,
+          organizationId: input.organizationId,
+        });
+      } catch (error) {
+        mapApiKeyDomainError(error);
+      }
+
       const callerIsAdmin = await apiKeyService.isOrgAdmin({
         userId: ctx.session.user.id,
         organizationId: input.organizationId,
@@ -443,13 +248,16 @@ export const apiKeyRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      await assertOrgMembership({
-        prisma: ctx.prisma,
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-
       const apiKeyService = ApiKeyService.create(ctx.prisma);
+      try {
+        await apiKeyService.assertOrgMembership({
+          userId: ctx.session.user.id,
+          organizationId: input.organizationId,
+        });
+      } catch (error) {
+        mapApiKeyDomainError(error);
+      }
+
       const callerIsAdmin = await apiKeyService.isOrgAdmin({
         userId: ctx.session.user.id,
         organizationId: input.organizationId,
@@ -486,20 +294,15 @@ export const apiKeyRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      await assertOrgMembership({
-        prisma: ctx.prisma,
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-
-      return ctx.prisma.project.findMany({
-        where: {
-          team: { organizationId: input.organizationId },
-          archivedAt: null,
-        },
-        select: { id: true, name: true },
-        orderBy: { name: "asc" },
-      });
+      const apiKeyService = ApiKeyService.create(ctx.prisma);
+      try {
+        return await apiKeyService.getOrgProjects({
+          userId: ctx.session.user.id,
+          organizationId: input.organizationId,
+        });
+      } catch (error) {
+        mapApiKeyDomainError(error);
+      }
     }),
 
   /**
@@ -513,29 +316,14 @@ export const apiKeyRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      await assertOrgMembership({
-        prisma: ctx.prisma,
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-
       const apiKeyService = ApiKeyService.create(ctx.prisma);
-      const callerIsAdmin = await apiKeyService.isOrgAdmin({
-        userId: ctx.session.user.id,
-        organizationId: input.organizationId,
-      });
-      if (!callerIsAdmin) return [];
-
-      const orgUsers = await ctx.prisma.organizationUser.findMany({
-        where: { organizationId: input.organizationId },
-        include: {
-          user: { select: { id: true, name: true, email: true } },
-        },
-      });
-      return orgUsers.map((ou) => ({
-        id: ou.user.id,
-        name: ou.user.name,
-        email: ou.user.email,
-      }));
+      try {
+        return await apiKeyService.getOrgMembers({
+          userId: ctx.session.user.id,
+          organizationId: input.organizationId,
+        });
+      } catch (error) {
+        mapApiKeyDomainError(error);
+      }
     }),
 });


### PR DESCRIPTION
## Summary

Moves all direct `ctx.prisma` calls from the `apiKey.ts` tRPC router into `ApiKeyService`, following the project's service/repository layering rules.

- **`myBindings`** — new `ApiKeyService.getMyBindings()` handles role binding fetch, name resolution, and archived project filtering
- **`list`** — new `ApiKeyService.getApiKeysWithNames()` handles key listing with scope/user name enrichment
- **`orgProjects` / `orgMembers`** — new service methods replace direct Prisma queries
- Extracted shared `resolveScopeNames()` private helper to DRY the name-enrichment logic used by both `getMyBindings` and `getApiKeysWithNames`
- Made `assertOrgMembership()` public for router-level membership checks on create/update/revoke
- Router now only handles input validation, auth checks, and error mapping — zero `ctx.prisma` references remain (except `ApiKeyService.create(ctx.prisma)`)

## Test plan

- [x] All 32 existing tests pass without modification
- [x] 10 new BDD-style unit tests cover the extracted service methods
- [x] `pnpm typecheck` passes clean
- [x] `grep ctx.prisma` in router shows only `ApiKeyService.create()` calls

Closes #4067

# Related Issue

- Resolve #4067