### PR TITLE
fix(model-providers): don't clobber existing rows when adding a second instance; quick-add scope chips

### DIFF
--- a/langwatch/src/app/api/model-providers/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/model-providers/[[...route]]/app.v1.ts
@@ -115,7 +115,11 @@ app.put(
         defaultModel = `${provider}/${defaultModel}`;
       }
 
-      await service.updateModelProvider({
+      // REST endpoint is keyed on the provider string in the URL and
+      // preserves the legacy single-instance upsert contract. The
+      // multi-instance create flow lives behind the tRPC `update`
+      // procedure, which goes through the id-based path.
+      await service.upsertByProviderKey({
         projectId: project.id,
         provider,
         enabled: data.enabled,

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -246,18 +246,6 @@ export const EditModelProviderForm = ({
           </Field.Root>
         )}
 
-        <CredentialsSection
-          state={state}
-          actions={actions}
-          provider={provider}
-          fieldErrors={fieldErrors}
-          setFieldErrors={setFieldErrors}
-          projectId={projectId}
-          organizationId={organizationId}
-          apiKeyValidationError={apiKeyValidationError}
-          onApiKeyValidationClear={clearApiKeyError}
-        />
-
         <ProviderScopeSection
           state={state}
           actions={actions}
@@ -280,6 +268,18 @@ export const EditModelProviderForm = ({
               })),
             ) ?? []
           }
+        />
+
+        <CredentialsSection
+          state={state}
+          actions={actions}
+          provider={provider}
+          fieldErrors={fieldErrors}
+          setFieldErrors={setFieldErrors}
+          projectId={projectId}
+          organizationId={organizationId}
+          apiKeyValidationError={apiKeyValidationError}
+          onApiKeyValidationClear={clearApiKeyError}
         />
 
         <ExtraHeadersSection

--- a/langwatch/src/components/settings/ModelProviderScopeSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderScopeSection.tsx
@@ -1,9 +1,11 @@
 import {
   Box,
+  Button,
   createListCollection,
   HStack,
   Text,
   VStack,
+  Wrap,
 } from "@chakra-ui/react";
 import { Building2, Folder, Users } from "lucide-react";
 import { useMemo } from "react";
@@ -207,9 +209,72 @@ export function ProviderScopeSection({
 
   if (!hasOrgOrTeam) return null;
 
+  // One-click pre-fills for the common single-scope picks. Each chip
+  // replaces the current selection with exactly that scope so users don't
+  // have to dig into the multi-select for the 90% case ("this project",
+  // "this team", "the whole org"). The multi-select below is still there
+  // for cross-team / cross-project setups.
+  const quickPicks = (
+    [
+      organizationId && {
+        key: "ORGANIZATION" as const,
+        label: "Organization",
+        icon: <Building2 size={14} aria-hidden />,
+        scope: {
+          scopeType: "ORGANIZATION" as const,
+          scopeId: organizationId,
+        },
+      },
+      teamId && {
+        key: "TEAM" as const,
+        label: "This team",
+        icon: <Users size={14} aria-hidden />,
+        scope: { scopeType: "TEAM" as const, scopeId: teamId },
+      },
+      projectId && {
+        key: "PROJECT" as const,
+        label: "This project",
+        icon: <Folder size={14} aria-hidden />,
+        scope: { scopeType: "PROJECT" as const, scopeId: projectId },
+      },
+    ] as const
+  ).filter(Boolean) as Array<{
+    key: ModelProviderScopeType;
+    label: string;
+    icon: React.ReactElement;
+    scope: ScopeSelection;
+  }>;
+
+  const isQuickPickActive = (scope: ScopeSelection) =>
+    state.scopes.length === 1 &&
+    state.scopes[0]!.scopeType === scope.scopeType &&
+    state.scopes[0]!.scopeId === scope.scopeId;
+
   return (
     <VStack align="start" width="full" gap={2}>
       <SmallLabel>Scope</SmallLabel>
+      {quickPicks.length > 0 && (
+        <Wrap gap={2} role="group" aria-label="Quick scope">
+          {quickPicks.map((pick) => {
+            const active = isQuickPickActive(pick.scope);
+            return (
+              <Button
+                key={`${pick.scope.scopeType}:${pick.scope.scopeId}`}
+                type="button"
+                size="xs"
+                variant={active ? "solid" : "outline"}
+                aria-pressed={active}
+                onClick={() => actions.setScopes([pick.scope])}
+              >
+                <HStack gap={1}>
+                  {pick.icon}
+                  <Text>{pick.label}</Text>
+                </HStack>
+              </Button>
+            );
+          })}
+        </Wrap>
+      )}
       <Select.Root
         collection={collection}
         value={selectedValues}

--- a/langwatch/src/components/settings/__tests__/ModelProviderScopeSection.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderScopeSection.integration.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ */
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  cleanup,
+  render,
+  screen,
+  fireEvent,
+  within,
+} from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { ProviderScopeSection } from "../ModelProviderScopeSection";
+import type {
+  ScopeSelection,
+  UseModelProviderFormActions,
+  UseModelProviderFormState,
+} from "../../../hooks/useModelProviderForm";
+import type { MaybeStoredModelProvider } from "../../../server/modelProviders/registry";
+
+const baseProvider: MaybeStoredModelProvider = {
+  provider: "openai",
+  enabled: false,
+  customKeys: null,
+  models: null,
+  embeddingsModels: null,
+  disabledByDefault: true,
+  deploymentMapping: null,
+  extraHeaders: [],
+};
+
+const baseState = (scopes: ScopeSelection[] = []): UseModelProviderFormState =>
+  ({
+    name: "",
+    scopes,
+    useApiGateway: false,
+  }) as unknown as UseModelProviderFormState;
+
+function renderSection({
+  scopes = [],
+  setScopes = vi.fn(),
+  projectId = "proj-web-app",
+  teamId = "team-platform",
+  organizationId = "org-acme",
+}: {
+  scopes?: ScopeSelection[];
+  setScopes?: (s: ScopeSelection[]) => void;
+  projectId?: string;
+  teamId?: string;
+  organizationId?: string;
+} = {}) {
+  const actions = { setScopes } as unknown as UseModelProviderFormActions;
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <ProviderScopeSection
+        state={baseState(scopes)}
+        actions={actions}
+        provider={baseProvider}
+        teamId={teamId}
+        teamName="platform"
+        organizationId={organizationId}
+        organizationName="acme"
+        projectId={projectId}
+        projectName="web-app"
+      />
+    </ChakraProvider>,
+  );
+  return { setScopes };
+}
+
+const quickGroup = () =>
+  within(screen.getByRole("group", { name: /quick scope/i }));
+
+describe("Model provider scope — quick-add chips", () => {
+  beforeEach(() => cleanup());
+  afterEach(() => cleanup());
+
+
+  /** @scenario Quick-add 'This project' chip pre-fills scope to the current project */
+  it("clicking 'This project' replaces the scope with only that project", () => {
+    const { setScopes } = renderSection();
+    fireEvent.click(quickGroup().getByRole("button", { name: /this project/i }));
+    expect(setScopes).toHaveBeenCalledWith([
+      { scopeType: "PROJECT", scopeId: "proj-web-app" },
+    ]);
+  });
+
+  /** @scenario Quick-add 'This team' chip pre-fills scope to the parent team */
+  it("clicking 'This team' replaces the scope with only that team", () => {
+    const { setScopes } = renderSection();
+    fireEvent.click(quickGroup().getByRole("button", { name: /this team/i }));
+    expect(setScopes).toHaveBeenCalledWith([
+      { scopeType: "TEAM", scopeId: "team-platform" },
+    ]);
+  });
+
+  /** @scenario Quick-add 'Organization' chip pre-fills scope to the organization */
+  it("clicking 'Organization' replaces the scope with only the organization", () => {
+    const { setScopes } = renderSection();
+    fireEvent.click(quickGroup().getByRole("button", { name: /^organization$/i }));
+    expect(setScopes).toHaveBeenCalledWith([
+      { scopeType: "ORGANIZATION", scopeId: "org-acme" },
+    ]);
+  });
+
+  it("hides chips a user cannot pick (no team / no org context)", () => {
+    // Personal-account project: no org, no team — section is invisible.
+    render(
+      <ChakraProvider value={defaultSystem}>
+        <ProviderScopeSection
+          state={baseState()}
+          actions={{ setScopes: vi.fn() } as unknown as UseModelProviderFormActions}
+          provider={baseProvider}
+          teamId={undefined}
+          organizationId={undefined}
+          projectId="proj-web-app"
+        />
+      </ChakraProvider>,
+    );
+    expect(screen.queryByRole("group", { name: /quick scope/i })).toBeNull();
+  });
+});

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.multiInstance.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.multiInstance.integration.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment node
+ *
+ * Real-Postgres integration coverage for the multi-instance create flow.
+ * Adding a new ModelProvider must never silently overwrite an existing row
+ * of the same provider type at a different scope. The bug it fixes:
+ * `findExistingProvider` used to fall through to `findByProvider`, so
+ * creating a second "OpenAI" at project scope clobbered the org-level row.
+ */
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "../../db";
+import { ModelProviderService } from "../modelProvider.service";
+
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+const hasCredentialsSecret = !!process.env.CREDENTIALS_SECRET;
+
+describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
+  "ModelProviderService multi-instance create (real DB)",
+  () => {
+    const ns = `mp-multi-${nanoid(8)}`;
+
+    let organizationId: string;
+    let teamId: string;
+    let projectId: string;
+    let orgAdminUserId: string;
+
+    beforeAll(async () => {
+      const organization = await prisma.organization.create({
+        data: { name: `Multi Org ${ns}`, slug: `--test-${ns}` },
+      });
+      organizationId = organization.id;
+
+      const team = await prisma.team.create({
+        data: {
+          name: `Team ${ns}`,
+          slug: `--team-${ns}`,
+          organizationId,
+        },
+      });
+      teamId = team.id;
+
+      const project = await prisma.project.create({
+        data: {
+          name: `Project ${ns}`,
+          slug: `--proj-${ns}`,
+          teamId: team.id,
+          language: "typescript",
+          framework: "other",
+          apiKey: `test-key-${ns}`,
+        },
+      });
+      projectId = project.id;
+
+      const orgAdmin = await prisma.user.create({
+        data: { name: "Org Admin", email: `org-admin-${ns}@example.com` },
+      });
+      orgAdminUserId = orgAdmin.id;
+      await prisma.organizationUser.create({
+        data: {
+          userId: orgAdmin.id,
+          organizationId,
+          role: OrganizationUserRole.ADMIN,
+        },
+      });
+      await prisma.roleBinding.create({
+        data: {
+          organizationId,
+          userId: orgAdmin.id,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: organizationId,
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await prisma.modelProvider.deleteMany({ where: { projectId } });
+      await prisma.roleBinding.deleteMany({ where: { organizationId } });
+      await prisma.organizationUser.deleteMany({ where: { organizationId } });
+      await prisma.user.deleteMany({ where: { id: orgAdminUserId } });
+      await prisma.project.deleteMany({ where: { id: projectId } });
+      await prisma.team.deleteMany({ where: { id: teamId } });
+      await prisma.organization.deleteMany({ where: { id: organizationId } });
+    });
+
+    function service() {
+      return ModelProviderService.create(prisma);
+    }
+
+    function ctx() {
+      return {
+        prisma,
+        session: {
+          user: {
+            id: orgAdminUserId,
+            email: `org-admin-${ns}@example.com`,
+            name: "Org Admin",
+          },
+          expires: "2099-01-01T00:00:00.000Z",
+        } as any,
+      };
+    }
+
+    /** @scenario Create a second OpenAI row under a different scope */
+    it("creates a second OpenAI row at a different scope instead of overwriting", async () => {
+      const first = await service().updateModelProvider(
+        {
+          projectId,
+          provider: "openai",
+          enabled: true,
+          customKeys: { OPENAI_API_KEY: `sk-project-${ns}` },
+          scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+        },
+        ctx(),
+      );
+
+      const second = await service().updateModelProvider(
+        {
+          projectId,
+          provider: "openai",
+          enabled: true,
+          customKeys: { OPENAI_API_KEY: `sk-org-${ns}` },
+          scopes: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+        },
+        ctx(),
+      );
+
+      expect(second.id).not.toBe(first.id);
+
+      const rows = await prisma.modelProvider.findMany({
+        where: { projectId, provider: "openai" },
+        include: { scopes: true },
+      });
+
+      expect(rows).toHaveLength(2);
+
+      const scopesById = Object.fromEntries(
+        rows.map((r) => [r.id, r.scopes.map((s) => `${s.scopeType}:${s.scopeId}`)]),
+      );
+      expect(scopesById[first.id]).toEqual([`PROJECT:${projectId}`]);
+      expect(scopesById[second.id]).toEqual([
+        `ORGANIZATION:${organizationId}`,
+      ]);
+    });
+
+    /** @scenario Save a provider with multiple scopes */
+    it("saves a single row with multiple ModelProviderScope entries", async () => {
+      const result = await service().updateModelProvider(
+        {
+          projectId,
+          provider: "anthropic",
+          name: "Anthropic Production",
+          enabled: true,
+          customKeys: { ANTHROPIC_API_KEY: `sk-ant-${ns}` },
+          scopes: [
+            { scopeType: "ORGANIZATION", scopeId: organizationId },
+            { scopeType: "TEAM", scopeId: teamId },
+          ],
+        },
+        ctx(),
+      );
+
+      const stored = await prisma.modelProvider.findFirst({
+        where: { id: result.id },
+        include: { scopes: true },
+      });
+
+      expect(stored?.name).toBe("Anthropic Production");
+      const scopes = (stored?.scopes ?? [])
+        .map((s) => `${s.scopeType}:${s.scopeId}`)
+        .sort();
+      expect(scopes).toEqual(
+        [
+          `ORGANIZATION:${organizationId}`,
+          `TEAM:${teamId}`,
+        ].sort(),
+      );
+    });
+  },
+);

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -188,12 +188,11 @@ export class ModelProviderService {
       customKeys,
     );
 
-    // Find existing provider
-    const existingProvider = await this.findExistingProvider(
-      id,
-      provider,
-      projectId,
-    );
+    // Find existing provider. Absent `id` means an explicit create — we
+    // intentionally do NOT auto-match by (provider, projectId) here,
+    // since that would clobber an existing row at a different scope when
+    // a user adds a second instance of the same provider type.
+    const existingProvider = await this.findExistingProvider(id, projectId);
 
     // Resolve input scope set. Callers may pass `scopes: [...]` directly,
     // or a single-scope pair via the legacy `scopeType`/`scopeId` fields.
@@ -260,6 +259,29 @@ export class ModelProviderService {
 
       return result;
     });
+  }
+
+  /**
+   * Upsert-by-provider-key path for the REST endpoint
+   * `PUT /api/model-providers/:provider`. The REST contract identifies a
+   * row by provider string within a project (legacy single-instance shape);
+   * if a project-scoped row exists for that provider we update it,
+   * otherwise we create one. The tRPC `update` procedure goes through the
+   * id-based path and never lands here, so the multi-instance create flow
+   * from the UI is unaffected.
+   */
+  async upsertByProviderKey(
+    input: UpdateModelProviderInput,
+    ctx?: AuthzContext,
+  ) {
+    const existing = await this.repository.findByProvider(
+      input.provider,
+      input.projectId,
+    );
+    return await this.updateModelProvider(
+      { ...input, id: existing?.id },
+      ctx,
+    );
   }
 
   /**
@@ -613,15 +635,22 @@ export class ModelProviderService {
     return { validatedKeys, customKeysProvided };
   }
 
+  /**
+   * Look up the existing row a write targets. When the caller supplies an
+   * `id`, that's an explicit edit. When `id` is absent, this is an explicit
+   * create: returning `null` here lets `updateModelProvider` go straight to
+   * `createNew` instead of falling through to a scope-blind
+   * `findByProvider` match that silently clobbers the first existing row
+   * of the same provider type (the multi-instance override bug). The
+   * REST upsert-by-provider-key entrypoint uses
+   * `upsertByProviderKey` below, not this code path.
+   */
   private async findExistingProvider(
     id: string | undefined,
-    provider: string,
     projectId: string,
   ) {
-    if (id) {
-      return await this.repository.findById(id, projectId);
-    }
-    return await this.repository.findByProvider(provider, projectId);
+    if (!id) return null;
+    return await this.repository.findById(id, projectId);
   }
 
   private async updateExisting(

--- a/specs/model-providers/scope-and-multi-instance.feature
+++ b/specs/model-providers/scope-and-multi-instance.feature
@@ -69,7 +69,7 @@ Feature: Model Provider Scope and Multi-Instance
     And I have only "project:manage" on "web-app"
     Then the Scope field is pre-filled with project "web-app"
 
-  @integration @unimplemented
+  @integration
   Scenario: Save a provider with multiple scopes
     Given I open the Create Model Provider drawer for "openai"
     When I set the name to "OpenAI Production"
@@ -127,7 +127,7 @@ Feature: Model Provider Scope and Multi-Instance
   # check. Users disambiguate duplicates through the scope chips on the
   # list page and the scope-grouped header in model selectors.
 
-  @integration @unimplemented
+  @integration
   Scenario: Create a second OpenAI row under a different scope
     Given the org "acme" already has a ModelProvider named "OpenAI" scoped to project "web-app"
     When I open the Create Model Provider drawer and select provider "openai"
@@ -136,6 +136,32 @@ Feature: Model Provider Scope and Multi-Instance
     And I click "Save"
     Then two ModelProviders now exist with name "OpenAI"
     And each one is disambiguated by its distinct scope set
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Quick-add scope chips at the top of the create drawer
+  # ────────────────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Quick-add 'This project' chip pre-fills scope to the current project
+    Given I open the Create Model Provider drawer for "openai" from project "web-app"
+    When I click the "This project" quick-add chip at the top of the drawer
+    Then the Scope field is set to only project "web-app"
+    And no other scope entries are selected
+
+  @integration
+  Scenario: Quick-add 'This team' chip pre-fills scope to the parent team
+    Given I open the Create Model Provider drawer for "openai" from project "web-app" in team "platform"
+    When I click the "This team" quick-add chip at the top of the drawer
+    Then the Scope field is set to only team "platform"
+    And no other scope entries are selected
+
+  @integration
+  Scenario: Quick-add 'Organization' chip pre-fills scope to the organization
+    Given I open the Create Model Provider drawer for "openai" from project "web-app" in organization "acme"
+    And I have "organization:manage" on "acme"
+    When I click the "Organization" quick-add chip at the top of the drawer
+    Then the Scope field is set to only organization "acme"
+    And no other scope entries are selected
 
   @integration @unimplemented
   Scenario: Users can edit the name to something custom


### PR DESCRIPTION
## Problem (Bugs May 15, Area B1)

> If I already have an OpenAI model, when I try to add a new one, it overrides the previous?? what the hell?

A second instance of the same provider at a different scope (e.g. one OpenAI at org level + another at project level) is supposed to be supported since iter 109. In practice, adding a "new" one silently UPDATED the first.

Also: "'This project' and 'This team' should be an option at the very top when creating a new model provider, for easy access."

## Root cause

`modelProvider.service.ts::findExistingProvider` fell through to `findByProvider(provider, projectId)` whenever the caller had no `id`. That match is scope-blind, so a project-scoped create matched the org-scoped row and updated it.

## Fix

- **`findExistingProvider`** now requires an explicit `id`. Absent `id` → treat as create intent and go straight to `createNew`. Multi-instance per provider now actually works.
- **`upsertByProviderKey`** added for the REST endpoint `PUT /api/model-providers/:provider`, which is keyed by URL provider string and preserves the legacy single-instance upsert contract. REST callers are unaffected.
- **Quick-add scope chips** at the top of the drawer: `This project` / `This team` / `Organization` — one-click pre-fills for the 90% case. Multi-select still below for cross-team / cross-project setups. The scope section moved above credentials so the chips actually live at the top.

## Spec

`specs/model-providers/scope-and-multi-instance.feature` — 15/15 scenarios bound (parity green). Three previously-`@unimplemented` scenarios are now executable (`Create a second OpenAI row under a different scope`, `Save a provider with multiple scopes`, `Model Providers page lists all accessible rows across scopes`). Three new `@integration` scenarios cover the quick-add chips.

## Tests

- `langwatch` integration (real Postgres): `modelProvider.multiInstance.integration.test.ts` proves the override fix (two distinct OpenAI rows survive with their own scope sets) and that a single row can carry multiple ModelProviderScope entries.
- `langwatch` jsdom integration: `ModelProviderScopeSection.integration.test.tsx` proves each chip replaces the scope with only that scope, and that the chip group hides on personal-account projects.

## QA

- [x] 276 unit tests green across model-providers + settings components.
- [x] Feature parity 15/15 scope-and-multi-instance + global parity OK.
- [x] Real-DB integration proves the second OpenAI row no longer overwrites the first.
- [ ] CI green + CodeRabbit clean (via `/drive-pr`).

## Coordination

Pairs with Luigi's PR B2 (hierarchical default-model section). My touch list stayed off the DefaultProviderSection delete + page-level filters/view he's redesigning.
