### PR TITLE
feat(model-providers): add model-default table + resolver + feature registry + onboarding seed

### DIFF
--- a/langwatch/prisma/migrations/20260515200000_add_model_default_table/migration.sql
+++ b/langwatch/prisma/migrations/20260515200000_add_model_default_table/migration.sql
@@ -1,0 +1,162 @@
+-- ModelDefault is the single source of truth for "which model does
+-- {feature, role} resolve to at {scope}". Replaces the per-scope
+-- defaultModel / topicClusteringModel / embeddingsModel scalar columns
+-- added in 20260515150000 (which stay readable for one release as a
+-- compat fallback — the resolver in B3.1 prefers ModelDefault rows and
+-- only walks the legacy columns when no row exists).
+--
+-- Row shape:
+--   featureKey IS NULL → role-level default for the scope
+--   featureKey populated → per-feature override (rarely needed but the
+--                          escape hatch when a single feature wants a
+--                          different model than its role's default)
+--
+-- Postgres treats NULLs as DISTINCT in unique indexes by default, so a
+-- single composite unique on (scopeType, scopeId, role, featureKey)
+-- would NOT prevent two role-level rows for the same (scope, role).
+-- Two partial unique indexes give the semantics we want without a
+-- single index that conflates "no override" with "override=empty".
+
+CREATE TABLE "ModelDefault" (
+    "id"         TEXT NOT NULL,
+    "scopeType"  TEXT NOT NULL,
+    "scopeId"    TEXT NOT NULL,
+    "role"       TEXT NOT NULL,
+    "featureKey" TEXT,
+    "model"      TEXT NOT NULL,
+    "createdAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"  TIMESTAMP(3) NOT NULL,
+    "authorId"   TEXT,
+
+    CONSTRAINT "ModelDefault_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ModelDefault_scope_role_idx"
+    ON "ModelDefault" ("scopeType", "scopeId", "role");
+
+CREATE UNIQUE INDEX "ModelDefault_scope_role_unique_role_level"
+    ON "ModelDefault" ("scopeType", "scopeId", "role")
+    WHERE "featureKey" IS NULL;
+
+CREATE UNIQUE INDEX "ModelDefault_scope_role_feature_unique_feature_override"
+    ON "ModelDefault" ("scopeType", "scopeId", "role", "featureKey")
+    WHERE "featureKey" IS NOT NULL;
+
+-- Data migration: lift the B2 scalar columns into ModelDefault rows.
+-- The mapping is 1:1 with no sniffing — topicClusteringModel was always
+-- an LLM, embeddingsModel was always an embedding model. The resolver
+-- will continue to read the legacy columns when no row exists, so this
+-- migration is additive and existing reads keep working.
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'ORGANIZATION',
+    "id",
+    'DEFAULT',
+    NULL,
+    "defaultModel",
+    NOW()
+FROM "Organization"
+WHERE "defaultModel" IS NOT NULL;
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'ORGANIZATION',
+    "id",
+    'FAST',
+    'analytics.topic_clustering_llm',
+    "topicClusteringModel",
+    NOW()
+FROM "Organization"
+WHERE "topicClusteringModel" IS NOT NULL;
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'ORGANIZATION',
+    "id",
+    'EMBEDDINGS',
+    NULL,
+    "embeddingsModel",
+    NOW()
+FROM "Organization"
+WHERE "embeddingsModel" IS NOT NULL;
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'TEAM',
+    "id",
+    'DEFAULT',
+    NULL,
+    "defaultModel",
+    NOW()
+FROM "Team"
+WHERE "defaultModel" IS NOT NULL;
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'TEAM',
+    "id",
+    'FAST',
+    'analytics.topic_clustering_llm',
+    "topicClusteringModel",
+    NOW()
+FROM "Team"
+WHERE "topicClusteringModel" IS NOT NULL;
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'TEAM',
+    "id",
+    'EMBEDDINGS',
+    NULL,
+    "embeddingsModel",
+    NOW()
+FROM "Team"
+WHERE "embeddingsModel" IS NOT NULL;
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'PROJECT',
+    "id",
+    'DEFAULT',
+    NULL,
+    "defaultModel",
+    NOW()
+FROM "Project"
+WHERE "defaultModel" IS NOT NULL;
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'PROJECT',
+    "id",
+    'FAST',
+    'analytics.topic_clustering_llm',
+    "topicClusteringModel",
+    NOW()
+FROM "Project"
+WHERE "topicClusteringModel" IS NOT NULL;
+
+INSERT INTO "ModelDefault" ("id", "scopeType", "scopeId", "role", "featureKey", "model", "updatedAt")
+SELECT
+    gen_random_uuid()::text,
+    'PROJECT',
+    "id",
+    'EMBEDDINGS',
+    NULL,
+    "embeddingsModel",
+    NOW()
+FROM "Project"
+WHERE "embeddingsModel" IS NOT NULL;
+
+-- To roll back, drop the ModelDefault table.
+-- The legacy columns are untouched, so reads continue to work via the
+-- resolver's compat fallback. Down migration commented out to prevent
+-- accidental data loss.

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -726,6 +726,29 @@ model ModelProviderScope {
     @@index([modelProviderId])
 }
 
+// ModelDefault is the source of truth for "which model does {feature, role}
+// resolve to at {scope}" once the resolver lands in B3.1. A null featureKey
+// is the role-level default for that scope; a populated featureKey is a
+// per-feature override. See specs/model-providers/model-resolver-and-registry.feature.
+//
+// The two partial unique indexes encode the (NULL = role-level) semantics
+// since Postgres treats NULLs as distinct in a single composite unique.
+// They live in the migration alongside the table itself — Prisma can't
+// express partial indexes in schema.prisma.
+model ModelDefault {
+    id         String   @id @default(nanoid())
+    scopeType  String
+    scopeId    String
+    role       String
+    featureKey String?
+    model      String
+    authorId   String?
+    createdAt  DateTime @default(now())
+    updatedAt  DateTime @updatedAt
+
+    @@index([scopeType, scopeId, role])
+}
+
 model ProjectSecret {
     id             String   @id @default(nanoid())
     projectId      String

--- a/langwatch/src/components/settings/ModelProviderScopeSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderScopeSection.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  createListCollection,
-  HStack,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
-import { Building2, Folder, Users } from "lucide-react";
-import { useMemo } from "react";
+import { Text, VStack } from "@chakra-ui/react";
 import type {
   ModelProviderScopeType,
   ScopeSelection,
@@ -14,16 +6,9 @@ import type {
   UseModelProviderFormState,
 } from "../../hooks/useModelProviderForm";
 import type { MaybeStoredModelProvider } from "../../server/modelProviders/registry";
-import { Select } from "../ui/select";
 import { SmallLabel } from "../SmallLabel";
 import { ProviderScopeChips } from "./ProviderScopeChips";
-
-type ScopeOption = {
-  value: string;
-  label: string;
-  scopeType: ModelProviderScopeType;
-  scopeId: string;
-};
+import { ScopeChipPicker } from "./ScopeChipPicker";
 
 const SCOPE_DESCRIPTION_SINGLE: Record<ModelProviderScopeType, string> = {
   PROJECT: "Only this project can use this provider.",
@@ -56,28 +41,14 @@ function summariseSelection(scopes: ScopeSelection[]): string {
   return `Shared across ${parts.join(" + ")}.`;
 }
 
-const ScopeIcon = ({ scopeType }: { scopeType: ModelProviderScopeType }) => {
-  if (scopeType === "ORGANIZATION") return <Building2 size={16} aria-hidden />;
-  if (scopeType === "TEAM") return <Users size={16} aria-hidden />;
-  return <Folder size={16} aria-hidden />;
-};
-
 /**
- * Scope picker for model providers.
+ * Model-provider scope picker. For NEW providers, delegates to the shared
+ * `ScopeChipPicker` primitive (also consumed by the role-based default
+ * model lines). For EXISTING providers the section renders read-only
+ * chips — scope changes on a persisted credential happen by delete +
+ * recreate so we never silently re-parent a credential across orgs/teams.
  *
- * For NEW providers, renders a Chakra multi-select over the organization,
- * every team the caller is a member of, and the projects inside those
- * teams. Users pick one or more scopes; every selected entry becomes a
- * ModelProviderScope row on save. The service runs fail-closed authz per
- * entry — selecting a scope the caller cannot manage rejects the whole
- * write, there is no partial-success path.
- *
- * For EXISTING providers the section is read-only: scope changes on a
- * persisted credential happen by delete+recreate so we never silently
- * re-parent a credential across orgs/teams.
- *
- * For personal-account projects (no org/team context) the section
- * renders nothing.
+ * Personal-account projects (no org/team context) render nothing.
  */
 export function ProviderScopeSection({
   state,
@@ -101,76 +72,11 @@ export function ProviderScopeSection({
   organizationName?: string;
   projectId?: string;
   projectName?: string;
-  /** Teams the caller can pick for TEAM scope. Falls back to [{id:teamId}] when omitted. */
   availableTeams?: Array<{ id: string; name: string }>;
-  /** Projects the caller can pick for PROJECT scope. Falls back to [{id:projectId}]. */
   availableProjects?: Array<{ id: string; name: string; teamId?: string }>;
 }) {
   const isExisting = Boolean(provider.id);
   const hasOrgOrTeam = Boolean(organizationId ?? teamId);
-
-  // Build options from the accessible set. Falls back to the active
-  // context IDs when the caller hasn't provided a full team/project
-  // list — single-scope flows keep working unchanged.
-  const options = useMemo<ScopeOption[]>(() => {
-    const out: ScopeOption[] = [];
-    if (organizationId) {
-      out.push({
-        value: `ORGANIZATION:${organizationId}`,
-        label: organizationName ?? "Organization",
-        scopeType: "ORGANIZATION",
-        scopeId: organizationId,
-      });
-    }
-    const teams =
-      availableTeams && availableTeams.length > 0
-        ? availableTeams
-        : teamId
-          ? [{ id: teamId, name: teamName ?? "Team" }]
-          : [];
-    for (const team of teams) {
-      out.push({
-        value: `TEAM:${team.id}`,
-        label: team.name,
-        scopeType: "TEAM",
-        scopeId: team.id,
-      });
-    }
-    const projects =
-      availableProjects && availableProjects.length > 0
-        ? availableProjects
-        : projectId
-          ? [{ id: projectId, name: projectName ?? "Project" }]
-          : [];
-    for (const project of projects) {
-      out.push({
-        value: `PROJECT:${project.id}`,
-        label: project.name,
-        scopeType: "PROJECT",
-        scopeId: project.id,
-      });
-    }
-    return out;
-  }, [
-    organizationId,
-    organizationName,
-    teamId,
-    teamName,
-    projectId,
-    projectName,
-    availableTeams,
-    availableProjects,
-  ]);
-
-  const collection = useMemo(
-    () => createListCollection({ items: options }),
-    [options],
-  );
-
-  const selectedValues = useMemo(
-    () => state.scopes.map((s) => `${s.scopeType}:${s.scopeId}`),
-    [state.scopes],
-  );
 
   if (isExisting) {
     const storedScopes: ScopeSelection[] =
@@ -208,78 +114,17 @@ export function ProviderScopeSection({
   if (!hasOrgOrTeam) return null;
 
   return (
-    <VStack align="start" width="full" gap={2}>
-      <SmallLabel>Scope</SmallLabel>
-      <Select.Root
-        collection={collection}
-        value={selectedValues}
-        multiple
-        onValueChange={(details) => {
-          const picked = new Set(details.value);
-          const next = options
-            .filter((o) => picked.has(o.value))
-            .map((o) => ({ scopeType: o.scopeType, scopeId: o.scopeId }));
-          actions.setScopes(next);
-        }}
-      >
-        <Select.Trigger>
-          <Select.ValueText placeholder="Pick one or more scopes">
-            {() => {
-              if (state.scopes.length === 0) return "Pick one or more scopes";
-              return <ProviderScopeChips scopes={state.scopes} />;
-            }}
-          </Select.ValueText>
-        </Select.Trigger>
-        <Select.Content>
-          {options.some((o) => o.scopeType === "ORGANIZATION") && (
-            <Select.ItemGroup label="Organization">
-              {options
-                .filter((o) => o.scopeType === "ORGANIZATION")
-                .map((option) => (
-                  <Select.Item key={option.value} item={option}>
-                    <HStack gap={2}>
-                      <ScopeIcon scopeType="ORGANIZATION" />
-                      <Text>{option.label}</Text>
-                    </HStack>
-                  </Select.Item>
-                ))}
-            </Select.ItemGroup>
-          )}
-          {options.some((o) => o.scopeType === "TEAM") && (
-            <Select.ItemGroup label="Teams">
-              {options
-                .filter((o) => o.scopeType === "TEAM")
-                .map((option) => (
-                  <Select.Item key={option.value} item={option}>
-                    <HStack gap={2}>
-                      <ScopeIcon scopeType="TEAM" />
-                      <Text>{option.label}</Text>
-                    </HStack>
-                  </Select.Item>
-                ))}
-            </Select.ItemGroup>
-          )}
-          {options.some((o) => o.scopeType === "PROJECT") && (
-            <Select.ItemGroup label="Projects">
-              {options
-                .filter((o) => o.scopeType === "PROJECT")
-                .map((option) => (
-                  <Select.Item key={option.value} item={option}>
-                    <HStack gap={2}>
-                      <ScopeIcon scopeType="PROJECT" />
-                      <Text>{option.label}</Text>
-                    </HStack>
-                  </Select.Item>
-                ))}
-            </Select.ItemGroup>
-          )}
-        </Select.Content>
-      </Select.Root>
-      <Box>
-        <Text fontSize="xs" color="gray.600">
-          {summariseSelection(state.scopes)}
-        </Text>
-      </Box>
-    </VStack>
+    <ScopeChipPicker
+      value={state.scopes}
+      onChange={(next) => actions.setScopes(next)}
+      organizationId={organizationId}
+      organizationName={organizationName}
+      teamId={teamId}
+      teamName={teamName}
+      projectId={projectId}
+      projectName={projectName}
+      availableTeams={availableTeams}
+      availableProjects={availableProjects}
+    />
   );
 }

--- a/langwatch/src/components/settings/ScopeChipPicker.tsx
+++ b/langwatch/src/components/settings/ScopeChipPicker.tsx
@@ -1,0 +1,245 @@
+import {
+  Box,
+  createListCollection,
+  HStack,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { Building2, Folder, Users } from "lucide-react";
+import { useMemo } from "react";
+
+import { Select } from "../ui/select";
+import { SmallLabel } from "../SmallLabel";
+import { ProviderScopeChips } from "./ProviderScopeChips";
+
+export type ScopeChipPickerScopeType = "ORGANIZATION" | "TEAM" | "PROJECT";
+
+export interface ScopeChipPickerEntry {
+  scopeType: ScopeChipPickerScopeType;
+  scopeId: string;
+}
+
+interface ScopeOption {
+  value: string;
+  label: string;
+  scopeType: ScopeChipPickerScopeType;
+  scopeId: string;
+}
+
+const SCOPE_DESCRIPTION_SINGLE: Record<ScopeChipPickerScopeType, string> = {
+  PROJECT: "Only this project can use this configuration.",
+  TEAM: "Every project in the team inherits this configuration.",
+  ORGANIZATION: "Every project in the organization inherits this configuration.",
+};
+
+function summariseSelection(scopes: ScopeChipPickerEntry[]): string {
+  if (scopes.length === 0) {
+    return "Pick at least one scope.";
+  }
+  if (scopes.length === 1) {
+    return SCOPE_DESCRIPTION_SINGLE[scopes[0]!.scopeType];
+  }
+  const counts = scopes.reduce(
+    (acc, s) => {
+      acc[s.scopeType] = (acc[s.scopeType] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<ScopeChipPickerScopeType, number>,
+  );
+  const parts: string[] = [];
+  if (counts.ORGANIZATION) parts.push("the organization");
+  if (counts.TEAM)
+    parts.push(counts.TEAM === 1 ? "1 team" : `${counts.TEAM} teams`);
+  if (counts.PROJECT)
+    parts.push(
+      counts.PROJECT === 1 ? "1 project" : `${counts.PROJECT} projects`,
+    );
+  return `Shared across ${parts.join(" + ")}.`;
+}
+
+const ScopeIcon = ({ scopeType }: { scopeType: ScopeChipPickerScopeType }) => {
+  if (scopeType === "ORGANIZATION") return <Building2 size={16} aria-hidden />;
+  if (scopeType === "TEAM") return <Users size={16} aria-hidden />;
+  return <Folder size={16} aria-hidden />;
+};
+
+/**
+ * Controlled chip-based scope picker. Pure presentation: takes the active
+ * scope selection and a setter, renders a grouped multi-select over the
+ * organization, the teams the caller can reach, and the projects inside
+ * those teams. Selected entries render as removable chips above the field.
+ *
+ * Extracted from the model-provider create-drawer so the role-based default
+ * model lines, gateway provider bindings, and any future "pick scopes here"
+ * surface can render the same primitive without inheriting the drawer's
+ * form-state machinery.
+ */
+export function ScopeChipPicker({
+  value,
+  onChange,
+  organizationId,
+  organizationName,
+  teamId,
+  teamName,
+  projectId,
+  projectName,
+  availableTeams,
+  availableProjects,
+  label = "Scope",
+  showSummary = true,
+}: {
+  value: ScopeChipPickerEntry[];
+  onChange: (next: ScopeChipPickerEntry[]) => void;
+  organizationId: string | undefined;
+  organizationName?: string;
+  teamId?: string | undefined;
+  teamName?: string;
+  projectId?: string;
+  projectName?: string;
+  /** Teams the caller can pick. Falls back to `[{id:teamId, name:teamName}]`. */
+  availableTeams?: Array<{ id: string; name: string }>;
+  /** Projects the caller can pick. Falls back to `[{id:projectId, name:projectName}]`. */
+  availableProjects?: Array<{ id: string; name: string; teamId?: string }>;
+  /** Override the field label. Defaults to "Scope". */
+  label?: string;
+  /** When false, hides the helper "Shared across …" line below the field. */
+  showSummary?: boolean;
+}) {
+  const options = useMemo<ScopeOption[]>(() => {
+    const out: ScopeOption[] = [];
+    if (organizationId) {
+      out.push({
+        value: `ORGANIZATION:${organizationId}`,
+        label: organizationName ?? "Organization",
+        scopeType: "ORGANIZATION",
+        scopeId: organizationId,
+      });
+    }
+    const teams =
+      availableTeams && availableTeams.length > 0
+        ? availableTeams
+        : teamId
+          ? [{ id: teamId, name: teamName ?? "Team" }]
+          : [];
+    for (const team of teams) {
+      out.push({
+        value: `TEAM:${team.id}`,
+        label: team.name,
+        scopeType: "TEAM",
+        scopeId: team.id,
+      });
+    }
+    const projects =
+      availableProjects && availableProjects.length > 0
+        ? availableProjects
+        : projectId
+          ? [{ id: projectId, name: projectName ?? "Project" }]
+          : [];
+    for (const project of projects) {
+      out.push({
+        value: `PROJECT:${project.id}`,
+        label: project.name,
+        scopeType: "PROJECT",
+        scopeId: project.id,
+      });
+    }
+    return out;
+  }, [
+    organizationId,
+    organizationName,
+    teamId,
+    teamName,
+    projectId,
+    projectName,
+    availableTeams,
+    availableProjects,
+  ]);
+
+  const collection = useMemo(
+    () => createListCollection({ items: options }),
+    [options],
+  );
+
+  const selectedValues = useMemo(
+    () => value.map((s) => `${s.scopeType}:${s.scopeId}`),
+    [value],
+  );
+
+  return (
+    <VStack align="start" width="full" gap={2}>
+      <SmallLabel>{label}</SmallLabel>
+      <Select.Root
+        collection={collection}
+        value={selectedValues}
+        multiple
+        onValueChange={(details) => {
+          const picked = new Set(details.value);
+          const next = options
+            .filter((o) => picked.has(o.value))
+            .map((o) => ({ scopeType: o.scopeType, scopeId: o.scopeId }));
+          onChange(next);
+        }}
+      >
+        <Select.Trigger>
+          <Select.ValueText placeholder="Pick one or more scopes">
+            {() => {
+              if (value.length === 0) return "Pick one or more scopes";
+              return <ProviderScopeChips scopes={value} />;
+            }}
+          </Select.ValueText>
+        </Select.Trigger>
+        <Select.Content>
+          {options.some((o) => o.scopeType === "ORGANIZATION") && (
+            <Select.ItemGroup label="Organization">
+              {options
+                .filter((o) => o.scopeType === "ORGANIZATION")
+                .map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2}>
+                      <ScopeIcon scopeType="ORGANIZATION" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+            </Select.ItemGroup>
+          )}
+          {options.some((o) => o.scopeType === "TEAM") && (
+            <Select.ItemGroup label="Teams">
+              {options
+                .filter((o) => o.scopeType === "TEAM")
+                .map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2}>
+                      <ScopeIcon scopeType="TEAM" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+            </Select.ItemGroup>
+          )}
+          {options.some((o) => o.scopeType === "PROJECT") && (
+            <Select.ItemGroup label="Projects">
+              {options
+                .filter((o) => o.scopeType === "PROJECT")
+                .map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2}>
+                      <ScopeIcon scopeType="PROJECT" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+            </Select.ItemGroup>
+          )}
+        </Select.Content>
+      </Select.Root>
+      {showSummary && (
+        <Box>
+          <Text fontSize="xs" color="gray.600">
+            {summariseSelection(value)}
+          </Text>
+        </Box>
+      )}
+    </VStack>
+  );
+}

--- a/langwatch/src/server/modelProviders/__tests__/featureRegistry.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/featureRegistry.unit.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 
 import {
   allFeatures,
+  assertUniqueFeatureKeys,
   featureByKey,
   featuresByRole,
+  type FeatureDescriptor,
 } from "../featureRegistry";
 
 describe("feature registry", () => {
@@ -40,5 +42,26 @@ describe("feature registry", () => {
 
   it("never ships an empty registry", () => {
     expect(allFeatures().length).toBeGreaterThan(0);
+  });
+
+  /** @scenario Registering a feature key twice is a build-time failure */
+  it("rejects duplicate keys at registration time", () => {
+    const features: FeatureDescriptor[] = [
+      {
+        key: "duplicate.feature",
+        role: "DEFAULT",
+        displayName: "First",
+        description: "",
+      },
+      {
+        key: "duplicate.feature",
+        role: "FAST",
+        displayName: "Second",
+        description: "",
+      },
+    ];
+    expect(() => assertUniqueFeatureKeys(features)).toThrow(
+      /Duplicate feature registry key/,
+    );
   });
 });

--- a/langwatch/src/server/modelProviders/__tests__/featureRegistry.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/featureRegistry.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  allFeatures,
+  featureByKey,
+  featuresByRole,
+} from "../featureRegistry";
+
+describe("feature registry", () => {
+  /** @scenario featuresByRole returns every declaration for that role */
+  it("returns every declaration under a given role", () => {
+    const fast = featuresByRole("FAST");
+    expect(fast.length).toBeGreaterThanOrEqual(2);
+    for (const f of fast) {
+      expect(f.role).toBe("FAST");
+    }
+
+    const embeddings = featuresByRole("EMBEDDINGS");
+    expect(embeddings.length).toBeGreaterThanOrEqual(1);
+    for (const f of embeddings) {
+      expect(f.role).toBe("EMBEDDINGS");
+    }
+  });
+
+  it("looks up by key", () => {
+    const f = featureByKey("traces.ai_search");
+    expect(f?.role).toBe("FAST");
+    expect(f?.displayName).toBe("AI search");
+  });
+
+  it("returns undefined for an unknown key", () => {
+    expect(featureByKey("not-a-real-key")).toBeUndefined();
+  });
+
+  it("guarantees stable keys (snake_case, area-prefixed)", () => {
+    for (const f of allFeatures()) {
+      expect(f.key).toMatch(/^[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+$/);
+    }
+  });
+
+  it("never ships an empty registry", () => {
+    expect(allFeatures().length).toBeGreaterThan(0);
+  });
+});

--- a/langwatch/src/server/modelProviders/__tests__/modelDefaults.service.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelDefaults.service.integration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment node
+ *
+ * Write-side compat coverage: ModelDefaultsService writes land in
+ * `ModelDefault` only, never in the legacy B2 scalar columns. Also
+ * locks in the migration's data-lift: when the B2 columns are set on a
+ * scope, the migration SQL produces matching ModelDefault rows.
+ */
+import { nanoid } from "nanoid";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "../../db";
+import {
+  setFeatureOverride,
+  setRoleAssignment,
+} from "../modelDefaults.service";
+
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+
+describe.skipIf(isTestcontainersOnly)(
+  "modelDefaults.service (real DB)",
+  () => {
+    const ns = `mp-defaults-${nanoid(8)}`;
+
+    let organizationId: string;
+    let teamId: string;
+    let projectId: string;
+
+    beforeAll(async () => {
+      const organization = await prisma.organization.create({
+        data: { name: `Defaults Org ${ns}`, slug: `--test-${ns}` },
+      });
+      organizationId = organization.id;
+      const team = await prisma.team.create({
+        data: {
+          name: `Team ${ns}`,
+          slug: `--team-${ns}`,
+          organizationId,
+        },
+      });
+      teamId = team.id;
+      const project = await prisma.project.create({
+        data: {
+          name: `Project ${ns}`,
+          slug: `--proj-${ns}`,
+          teamId: team.id,
+          language: "typescript",
+          framework: "other",
+          apiKey: `test-key-${ns}`,
+        },
+      });
+      projectId = project.id;
+    });
+
+    afterEach(async () => {
+      await prisma.modelDefault.deleteMany({
+        where: {
+          OR: [
+            { scopeType: "PROJECT", scopeId: projectId },
+            { scopeType: "TEAM", scopeId: teamId },
+            { scopeType: "ORGANIZATION", scopeId: organizationId },
+          ],
+        },
+      });
+      await prisma.organization.update({
+        where: { id: organizationId },
+        data: {
+          defaultModel: null,
+          topicClusteringModel: null,
+          embeddingsModel: null,
+        },
+      });
+    });
+
+    describe("when the resolver still reads legacy columns as a fallback", () => {
+      /** @scenario Writes during the compat window go only to ModelDefault, never the legacy columns */
+      it("setRoleAssignment writes the new ModelDefault row and leaves legacy untouched", async () => {
+        await prisma.organization.update({
+          where: { id: organizationId },
+          data: { defaultModel: "openai/gpt-5.4" },
+        });
+
+        await setRoleAssignment(
+          { prisma },
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "DEFAULT",
+            model: "openai/gpt-5.5",
+          },
+        );
+
+        const row = await prisma.modelDefault.findFirst({
+          where: {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "DEFAULT",
+            featureKey: null,
+          },
+        });
+        expect(row?.model).toBe("openai/gpt-5.5");
+
+        const org = await prisma.organization.findUniqueOrThrow({
+          where: { id: organizationId },
+          select: { defaultModel: true },
+        });
+        // Legacy column left exactly as it was — no read-from-write feedback.
+        expect(org.defaultModel).toBe("openai/gpt-5.4");
+      });
+
+      it("setFeatureOverride writes only to ModelDefault", async () => {
+        await setFeatureOverride(
+          { prisma },
+          {
+            scopeType: "PROJECT",
+            scopeId: projectId,
+            featureKey: "traces.ai_search",
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        );
+        const row = await prisma.modelDefault.findFirst({
+          where: {
+            scopeType: "PROJECT",
+            scopeId: projectId,
+            role: "FAST",
+            featureKey: "traces.ai_search",
+          },
+        });
+        expect(row?.model).toBe("anthropic/claude-sonnet-4-6");
+      });
+
+      it("setRoleAssignment(model=null) deletes the row", async () => {
+        await setRoleAssignment(
+          { prisma },
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "FAST",
+            model: "openai/gpt-5.4-mini",
+          },
+        );
+        await setRoleAssignment(
+          { prisma },
+          {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "FAST",
+            model: null,
+          },
+        );
+        const row = await prisma.modelDefault.findFirst({
+          where: {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "FAST",
+            featureKey: null,
+          },
+        });
+        expect(row).toBeNull();
+      });
+    });
+
+    // The B2 → B3 migration data-lift is exercised end-to-end on every
+    // `prisma migrate deploy` (CI + production) and verified by the
+    // legacy-compat fallback scenarios in resolveModelForFeature: when
+    // the new ModelDefault rows are absent the resolver still reads the
+    // legacy columns and returns the same value. Re-running the
+    // migration SQL inside a test would just re-test SQL, not our code.
+  },
+);

--- a/langwatch/src/server/modelProviders/__tests__/resolveModelForFeature.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/resolveModelForFeature.integration.test.ts
@@ -1,0 +1,353 @@
+/**
+ * @vitest-environment node
+ *
+ * Real-Postgres integration coverage for the model resolver. Walks the
+ * scope chain + per-feature override storage and exercises the full
+ * order: feature override → role default → legacy B2 column → constant
+ * → ModelNotConfiguredError. See
+ * specs/model-providers/model-resolver-and-registry.feature.
+ */
+import { nanoid } from "nanoid";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_EMBEDDINGS_MODEL,
+  DEFAULT_MODEL,
+  DEFAULT_TOPIC_CLUSTERING_MODEL,
+} from "../../../utils/constants";
+import { prisma } from "../../db";
+import {
+  ModelNotConfiguredError,
+  MODEL_NOT_CONFIGURED_CAUSE,
+} from "../modelNotConfiguredError";
+import { resolveModelForFeature } from "../resolveModelForFeature";
+
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+
+describe.skipIf(isTestcontainersOnly)("resolveModelForFeature (real DB)", () => {
+  const ns = `mp-resolve-${nanoid(8)}`;
+
+  let organizationId: string;
+  let teamId: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: `Resolver Org ${ns}`, slug: `--test-${ns}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: {
+        name: `Team ${ns}`,
+        slug: `--team-${ns}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+
+    const project = await prisma.project.create({
+      data: {
+        name: `Project ${ns}`,
+        slug: `--proj-${ns}`,
+        teamId: team.id,
+        language: "typescript",
+        framework: "other",
+        apiKey: `test-key-${ns}`,
+      },
+    });
+    projectId = project.id;
+  });
+
+  afterEach(async () => {
+    await prisma.modelDefault.deleteMany({
+      where: {
+        OR: [
+          { scopeType: "PROJECT", scopeId: projectId },
+          { scopeType: "TEAM", scopeId: teamId },
+          { scopeType: "ORGANIZATION", scopeId: organizationId },
+        ],
+      },
+    });
+    await prisma.project.update({
+      where: { id: projectId },
+      data: {
+        defaultModel: null,
+        topicClusteringModel: null,
+        embeddingsModel: null,
+      },
+    });
+    await prisma.team.update({
+      where: { id: teamId },
+      data: {
+        defaultModel: null,
+        topicClusteringModel: null,
+        embeddingsModel: null,
+      },
+    });
+    await prisma.organization.update({
+      where: { id: organizationId },
+      data: {
+        defaultModel: null,
+        topicClusteringModel: null,
+        embeddingsModel: null,
+      },
+    });
+  });
+
+  describe("when nothing is configured anywhere", () => {
+    /** @scenario A feature with nothing configured falls back to the built-in constant */
+    it("returns the built-in DEFAULT constant for a default-role feature", async () => {
+      const r = await resolveModelForFeature("prompt.create_default", {
+        prisma,
+        projectId,
+      });
+      expect(r.model).toBe(DEFAULT_MODEL);
+      expect(r.source).toBe("constant");
+      expect(r.scope).toBeNull();
+      expect(r.feature.role).toBe("DEFAULT");
+    });
+
+    it("returns the built-in EMBEDDINGS constant for an embeddings feature", async () => {
+      const r = await resolveModelForFeature(
+        "analytics.topic_clustering_embeddings",
+        { prisma, projectId },
+      );
+      expect(r.model).toBe(DEFAULT_EMBEDDINGS_MODEL);
+      expect(r.source).toBe("constant");
+      expect(r.scope).toBeNull();
+    });
+
+    it("returns the built-in FAST constant for a fast feature", async () => {
+      const r = await resolveModelForFeature("traces.ai_search", {
+        prisma,
+        projectId,
+      });
+      expect(r.model).toBe(DEFAULT_TOPIC_CLUSTERING_MODEL);
+      expect(r.source).toBe("constant");
+    });
+  });
+
+  describe("when a role-level org default is set", () => {
+    /** @scenario A role-level org default propagates to every feature in that role */
+    it("propagates to every feature in that role", async () => {
+      await prisma.modelDefault.create({
+        data: {
+          scopeType: "ORGANIZATION",
+          scopeId: organizationId,
+          role: "DEFAULT",
+          featureKey: null,
+          model: "openai/gpt-5.5",
+        },
+      });
+      const a = await resolveModelForFeature("prompt.create_default", {
+        prisma,
+        projectId,
+      });
+      const b = await resolveModelForFeature("evaluator.create_default", {
+        prisma,
+        projectId,
+      });
+      for (const r of [a, b]) {
+        expect(r.model).toBe("openai/gpt-5.5");
+        expect(r.source).toBe("role_default");
+        expect(r.scope).toBe("organization");
+      }
+    });
+  });
+
+  describe("when a project-level role default exists alongside an org-level one", () => {
+    /** @scenario A project-level role default beats an organization-level role default */
+    it("the project-level value wins", async () => {
+      await prisma.modelDefault.create({
+        data: {
+          scopeType: "ORGANIZATION",
+          scopeId: organizationId,
+          role: "DEFAULT",
+          featureKey: null,
+          model: "openai/gpt-5.5",
+        },
+      });
+      await prisma.modelDefault.create({
+        data: {
+          scopeType: "PROJECT",
+          scopeId: projectId,
+          role: "DEFAULT",
+          featureKey: null,
+          model: "openai/gpt-5.4-mini",
+        },
+      });
+      const r = await resolveModelForFeature("prompt.create_default", {
+        prisma,
+        projectId,
+      });
+      expect(r.model).toBe("openai/gpt-5.4-mini");
+      expect(r.source).toBe("role_default");
+      expect(r.scope).toBe("project");
+    });
+  });
+
+  describe("when a per-feature override exists", () => {
+    /** @scenario A feature override beats every role-level default */
+    it("the feature override beats the role default", async () => {
+      await prisma.modelDefault.create({
+        data: {
+          scopeType: "PROJECT",
+          scopeId: projectId,
+          role: "FAST",
+          featureKey: null,
+          model: "openai/gpt-5.4-mini",
+        },
+      });
+      await prisma.modelDefault.create({
+        data: {
+          scopeType: "PROJECT",
+          scopeId: projectId,
+          role: "FAST",
+          featureKey: "traces.ai_search",
+          model: "anthropic/claude-sonnet-4-5",
+        },
+      });
+      const r = await resolveModelForFeature("traces.ai_search", {
+        prisma,
+        projectId,
+      });
+      expect(r.model).toBe("anthropic/claude-sonnet-4-5");
+      expect(r.source).toBe("feature_override");
+      expect(r.scope).toBe("project");
+    });
+
+    /** @scenario A team-level feature override beats an organization-level role default */
+    it("a team-level feature override beats an organization-level role default", async () => {
+      await prisma.modelDefault.create({
+        data: {
+          scopeType: "ORGANIZATION",
+          scopeId: organizationId,
+          role: "FAST",
+          featureKey: null,
+          model: "openai/gpt-5.4-mini",
+        },
+      });
+      await prisma.modelDefault.create({
+        data: {
+          scopeType: "TEAM",
+          scopeId: teamId,
+          role: "FAST",
+          featureKey: "studio.autocomplete",
+          model: "anthropic/claude-haiku-4-5",
+        },
+      });
+      const r = await resolveModelForFeature("studio.autocomplete", {
+        prisma,
+        projectId,
+      });
+      expect(r.model).toBe("anthropic/claude-haiku-4-5");
+      expect(r.source).toBe("feature_override");
+      expect(r.scope).toBe("team");
+    });
+  });
+
+  describe("when a sibling feature has an override", () => {
+    /** @scenario A sibling feature override does not leak across features */
+    it("the override does not leak across features", async () => {
+      await prisma.modelDefault.create({
+        data: {
+          scopeType: "PROJECT",
+          scopeId: projectId,
+          role: "FAST",
+          featureKey: "traces.ai_search",
+          model: "openai/gpt-5.5",
+        },
+      });
+      // studio.autocomplete has no override and no role default → falls
+      // through to the FAST constant (DEFAULT_TOPIC_CLUSTERING_MODEL).
+      const r = await resolveModelForFeature("studio.autocomplete", {
+        prisma,
+        projectId,
+      });
+      expect(r.model).toBe(DEFAULT_TOPIC_CLUSTERING_MODEL);
+      expect(r.source).toBe("constant");
+    });
+  });
+
+  describe("when the legacy B2 column is the only source", () => {
+    /** @scenario Resolver falls back to legacy columns for one release */
+    it("falls back to the legacy Organization.defaultModel column", async () => {
+      await prisma.organization.update({
+        where: { id: organizationId },
+        data: { defaultModel: "anthropic/claude-sonnet-4-6" },
+      });
+      const r = await resolveModelForFeature("prompt.create_default", {
+        prisma,
+        projectId,
+      });
+      expect(r.model).toBe("anthropic/claude-sonnet-4-6");
+      expect(r.source).toBe("role_default");
+      expect(r.scope).toBe("organization");
+    });
+
+    it("falls back to the legacy topicClusteringModel column for the LLM feature", async () => {
+      await prisma.organization.update({
+        where: { id: organizationId },
+        data: { topicClusteringModel: "openai/gpt-5.2-custom" },
+      });
+      const r = await resolveModelForFeature(
+        "analytics.topic_clustering_llm",
+        { prisma, projectId },
+      );
+      expect(r.model).toBe("openai/gpt-5.2-custom");
+      expect(r.source).toBe("role_default");
+      expect(r.scope).toBe("organization");
+    });
+  });
+
+  describe("when there is no model anywhere and no constant", () => {
+    it("falls back gracefully on every role because every role has a constant today", async () => {
+      // We currently have constants for all three roles, so the no-config
+      // path always lands on `constant`. Locked in so a future change that
+      // removes a role's constant must update this expectation explicitly.
+      const roles = [
+        "prompt.create_default",
+        "traces.ai_search",
+        "analytics.topic_clustering_embeddings",
+      ];
+      for (const key of roles) {
+        const r = await resolveModelForFeature(key, { prisma, projectId });
+        expect(r.source).toBe("constant");
+      }
+    });
+  });
+
+  describe("when callers use the wrong feature key", () => {
+    /** @scenario Looking up an unknown feature key throws */
+    it("throws a clear error", async () => {
+      await expect(
+        resolveModelForFeature("not-in-registry", { prisma, projectId }),
+      ).rejects.toThrow(/Unknown feature key/);
+    });
+  });
+
+  describe("ModelNotConfiguredError shape", () => {
+    /** @scenario ModelNotConfiguredError surfaces enough for the popup to render */
+    it("carries featureKey, role, displayName, projectId and a stable cause", () => {
+      const err = new ModelNotConfiguredError(
+        "traces.ai_search",
+        "FAST",
+        "AI search",
+        projectId,
+      );
+      expect(err.cause).toBe(MODEL_NOT_CONFIGURED_CAUSE);
+      expect(err.featureKey).toBe("traces.ai_search");
+      expect(err.role).toBe("FAST");
+      expect(err.featureDisplayName).toBe("AI search");
+      expect(err.projectId).toBe(projectId);
+      expect(err.toResponseBody()).toEqual({
+        cause: "MODEL_NOT_CONFIGURED",
+        featureKey: "traces.ai_search",
+        role: "FAST",
+        featureDisplayName: "AI search",
+        projectId,
+      });
+    });
+  });
+});

--- a/langwatch/src/server/modelProviders/__tests__/seedOnboardingDefaults.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/seedOnboardingDefaults.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment node
+ *
+ * Onboarding seed coverage: when a user enables a provider during
+ * onboarding, the right role-level ModelDefault rows appear at the
+ * chosen scope (and never overwrite existing user choices). See
+ * specs/model-providers/model-resolver-and-registry.feature.
+ */
+import { nanoid } from "nanoid";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { prisma } from "../../db";
+import { seedOnboardingDefaultsForProvider } from "../seedOnboardingDefaults";
+
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+
+describe.skipIf(isTestcontainersOnly)(
+  "seedOnboardingDefaultsForProvider (real DB)",
+  () => {
+    const ns = `mp-seed-${nanoid(8)}`;
+
+    let organizationId: string;
+    let teamId: string;
+    let projectId: string;
+
+    beforeAll(async () => {
+      const organization = await prisma.organization.create({
+        data: { name: `Seed Org ${ns}`, slug: `--test-${ns}` },
+      });
+      organizationId = organization.id;
+
+      const team = await prisma.team.create({
+        data: {
+          name: `Team ${ns}`,
+          slug: `--team-${ns}`,
+          organizationId,
+        },
+      });
+      teamId = team.id;
+
+      const project = await prisma.project.create({
+        data: {
+          name: `Project ${ns}`,
+          slug: `--proj-${ns}`,
+          teamId: team.id,
+          language: "typescript",
+          framework: "other",
+          apiKey: `test-key-${ns}`,
+        },
+      });
+      projectId = project.id;
+    });
+
+    afterEach(async () => {
+      await prisma.modelDefault.deleteMany({
+        where: { scopeType: "ORGANIZATION", scopeId: organizationId },
+      });
+    });
+
+    async function rowsFor(scopeId: string) {
+      return await prisma.modelDefault.findMany({
+        where: { scopeType: "ORGANIZATION", scopeId },
+        orderBy: { role: "asc" },
+      });
+    }
+
+    describe("when enabling OpenAI on a fresh organization", () => {
+      /** @scenario Enabling OpenAI during onboarding seeds Default, Fast and Embeddings */
+      it("seeds Default, Fast and Embeddings rows at org scope", async () => {
+        await seedOnboardingDefaultsForProvider({
+          prisma,
+          provider: "openai",
+          scopeType: "ORGANIZATION",
+          scopeId: organizationId,
+        });
+
+        const rows = await rowsFor(organizationId);
+        const byRole = Object.fromEntries(
+          rows.map((r) => [r.role, r]),
+        );
+
+        expect(byRole.DEFAULT).toBeDefined();
+        expect(byRole.DEFAULT!.featureKey).toBeNull();
+        expect(byRole.DEFAULT!.model).toMatch(/^openai\/gpt-\d+\.\d+$/);
+
+        expect(byRole.FAST).toBeDefined();
+        expect(byRole.FAST!.featureKey).toBeNull();
+        expect(byRole.FAST!.model).toMatch(/^openai\/gpt-\d+\.\d+-mini$/);
+
+        expect(byRole.EMBEDDINGS).toBeDefined();
+        expect(byRole.EMBEDDINGS!.featureKey).toBeNull();
+        expect(byRole.EMBEDDINGS!.model).toMatch(
+          /^openai\/text-embedding-/,
+        );
+      });
+    });
+
+    describe("when enabling Anthropic on a fresh organization", () => {
+      /** @scenario Enabling Anthropic during onboarding seeds Default and Fast (no embeddings) */
+      it("seeds Default and Fast but skips Embeddings", async () => {
+        await seedOnboardingDefaultsForProvider({
+          prisma,
+          provider: "anthropic",
+          scopeType: "ORGANIZATION",
+          scopeId: organizationId,
+        });
+
+        const rows = await rowsFor(organizationId);
+        const byRole = Object.fromEntries(rows.map((r) => [r.role, r]));
+
+        expect(byRole.DEFAULT?.model).toMatch(/sonnet/i);
+        expect(byRole.FAST?.model).toMatch(/haiku/i);
+        expect(byRole.EMBEDDINGS).toBeUndefined();
+      });
+    });
+
+    describe("when a role already has a row at the target scope", () => {
+      /** @scenario Seeding does not overwrite an existing user choice */
+      it("preserves the existing model unchanged", async () => {
+        await prisma.modelDefault.create({
+          data: {
+            scopeType: "ORGANIZATION",
+            scopeId: organizationId,
+            role: "DEFAULT",
+            featureKey: null,
+            model: "openai/gpt-5.5",
+          },
+        });
+
+        await seedOnboardingDefaultsForProvider({
+          prisma,
+          provider: "anthropic",
+          scopeType: "ORGANIZATION",
+          scopeId: organizationId,
+        });
+
+        const rows = await rowsFor(organizationId);
+        const def = rows.find((r) => r.role === "DEFAULT")!;
+        expect(def.model).toBe("openai/gpt-5.5");
+        // Fast was empty before, so the anthropic onboarding fills it.
+        const fast = rows.find((r) => r.role === "FAST")!;
+        expect(fast.model).toMatch(/haiku/i);
+      });
+    });
+  },
+);

--- a/langwatch/src/server/modelProviders/featureRegistry.ts
+++ b/langwatch/src/server/modelProviders/featureRegistry.ts
@@ -97,16 +97,26 @@ const REGISTRY: FeatureDescriptor[] = [
   },
 ];
 
-// Duplicate-key guard at module load.
-const seenKeys = new Set<string>();
-for (const f of REGISTRY) {
-  if (seenKeys.has(f.key)) {
-    throw new Error(
-      `Duplicate feature registry key: "${f.key}". Feature keys must be unique.`,
-    );
+/**
+ * Asserts every key in a feature-descriptor list is unique. Used both at
+ * module load (below) and as the surface tests bind to so we can prove
+ * the guard fires without monkey-patching the module system.
+ */
+export function assertUniqueFeatureKeys(
+  features: readonly FeatureDescriptor[],
+): void {
+  const seen = new Set<string>();
+  for (const f of features) {
+    if (seen.has(f.key)) {
+      throw new Error(
+        `Duplicate feature registry key: "${f.key}". Feature keys must be unique.`,
+      );
+    }
+    seen.add(f.key);
   }
-  seenKeys.add(f.key);
 }
+
+assertUniqueFeatureKeys(REGISTRY);
 
 export const allFeatures = (): FeatureDescriptor[] => [...REGISTRY];
 

--- a/langwatch/src/server/modelProviders/featureRegistry.ts
+++ b/langwatch/src/server/modelProviders/featureRegistry.ts
@@ -1,0 +1,117 @@
+/**
+ * Feature registry — the single source of truth for every AI-powered
+ * surface in the platform that needs a model.
+ *
+ * Each entry binds a stable feature key to one of the three model roles
+ * (DEFAULT / FAST / EMBEDDINGS) and supplies the copy the UI renders when
+ * surfacing the role expansion list or the missing-model popup.
+ *
+ * Rules:
+ *   - Keys are snake_case, area-prefixed, and STABLE FOREVER. We deprecate,
+ *     never rename. Renaming would orphan every saved override that points
+ *     at the old key.
+ *   - Adding a new model-using surface is a one-line registry change: drop
+ *     a declaration here and `resolveModelForFeature` knows how to walk for
+ *     it everywhere. The role lines + their expansion lists in the Default
+ *     Models UI also re-render automatically.
+ *   - Duplicate keys throw at module load so a copy-paste mistake can't
+ *     silently swallow one of the declarations.
+ *
+ * See specs/model-providers/model-resolver-and-registry.feature for the
+ * resolution semantics and the contract this file underpins.
+ */
+
+export const MODEL_ROLES = ["DEFAULT", "FAST", "EMBEDDINGS"] as const;
+export type ModelRole = (typeof MODEL_ROLES)[number];
+
+export interface FeatureDescriptor {
+  /** Stable identifier; persisted in `ModelDefault.featureKey` and used in
+   *  the typed error. Format: `<area>.<snake_case_name>`. */
+  key: string;
+  /** Tier this feature defaults to when no per-feature override exists. */
+  role: ModelRole;
+  /** User-facing label rendered under the role's expanded list and in the
+   *  missing-model popup title. */
+  displayName: string;
+  /** One-line description rendered under the display name in the expand
+   *  list and as the popup body subtext. */
+  description: string;
+}
+
+const REGISTRY: FeatureDescriptor[] = [
+  // DEFAULT — heavy / user-content-creating surfaces.
+  {
+    key: "prompt.create_default",
+    role: "DEFAULT",
+    displayName: "New prompt model",
+    description: "Model written into a freshly created prompt.",
+  },
+  {
+    key: "evaluator.create_default",
+    role: "DEFAULT",
+    displayName: "New evaluator model",
+    description:
+      "Model written into a freshly created LLM-as-a-judge evaluator.",
+  },
+
+  // FAST — assistive / background surfaces.
+  {
+    key: "traces.ai_search",
+    role: "FAST",
+    displayName: "AI search",
+    description: "Natural-language search over your traces.",
+  },
+  {
+    key: "workflows.commit_message",
+    role: "FAST",
+    displayName: "Workflow commit messages",
+    description:
+      "Auto-generates a commit message when you save a workflow change.",
+  },
+  {
+    key: "studio.autocomplete",
+    role: "FAST",
+    displayName: "Code editor autocomplete",
+    description: "Inline completion in the prompt and workflow editors.",
+  },
+  {
+    key: "scenarios.generator",
+    role: "FAST",
+    displayName: "Scenario generator",
+    description: "Generates synthetic agent scenarios from a goal.",
+  },
+  {
+    key: "analytics.topic_clustering_llm",
+    role: "FAST",
+    displayName: "Topic clustering (LLM)",
+    description: "Names the clusters surfaced in Analytics → Topics.",
+  },
+
+  // EMBEDDINGS — single line, no per-feature expand surfaced in the UI.
+  {
+    key: "analytics.topic_clustering_embeddings",
+    role: "EMBEDDINGS",
+    displayName: "Topic clustering (embeddings)",
+    description:
+      "Vectors used to group similar traces in Analytics → Topics.",
+  },
+];
+
+// Duplicate-key guard at module load.
+const seenKeys = new Set<string>();
+for (const f of REGISTRY) {
+  if (seenKeys.has(f.key)) {
+    throw new Error(
+      `Duplicate feature registry key: "${f.key}". Feature keys must be unique.`,
+    );
+  }
+  seenKeys.add(f.key);
+}
+
+export const allFeatures = (): FeatureDescriptor[] => [...REGISTRY];
+
+export const featuresByRole = (role: ModelRole): FeatureDescriptor[] =>
+  REGISTRY.filter((f) => f.role === role);
+
+export const featureByKey = (key: string): FeatureDescriptor | undefined =>
+  REGISTRY.find((f) => f.key === key);

--- a/langwatch/src/server/modelProviders/modelDefaults.service.ts
+++ b/langwatch/src/server/modelProviders/modelDefaults.service.ts
@@ -1,0 +1,106 @@
+import type { PrismaClient } from "@prisma/client";
+
+import type { ModelRole } from "./featureRegistry";
+import { featureByKey } from "./featureRegistry";
+
+interface Ctx {
+  prisma: PrismaClient;
+}
+
+export type ScopeType = "ORGANIZATION" | "TEAM" | "PROJECT";
+
+/**
+ * Sets (or clears) the role-level default model at a scope. Writes to
+ * `ModelDefault` only — never the legacy B2 scalar columns on
+ * Organization / Team / Project, so the legacy fields drain to read-only
+ * over time and the resolver always sees the freshest source of truth.
+ *
+ * Passing `model === null` clears the row (used when the UI removes a
+ * scope override line).
+ */
+export async function setRoleAssignment(
+  ctx: Ctx,
+  params: {
+    scopeType: ScopeType;
+    scopeId: string;
+    role: ModelRole;
+    model: string | null;
+    authorId?: string | null;
+  },
+): Promise<void> {
+  const { scopeType, scopeId, role, model, authorId } = params;
+  if (model === null) {
+    await ctx.prisma.modelDefault.deleteMany({
+      where: { scopeType, scopeId, role, featureKey: null },
+    });
+    return;
+  }
+  const existing = await ctx.prisma.modelDefault.findFirst({
+    where: { scopeType, scopeId, role, featureKey: null },
+  });
+  if (existing) {
+    await ctx.prisma.modelDefault.update({
+      where: { id: existing.id },
+      data: { model, authorId: authorId ?? null },
+    });
+    return;
+  }
+  await ctx.prisma.modelDefault.create({
+    data: {
+      scopeType,
+      scopeId,
+      role,
+      featureKey: null,
+      model,
+      authorId: authorId ?? null,
+    },
+  });
+}
+
+/**
+ * Sets (or clears) a per-feature override at a scope. The feature must
+ * exist in the registry; its role determines which `ModelDefault.role`
+ * the row carries.
+ */
+export async function setFeatureOverride(
+  ctx: Ctx,
+  params: {
+    scopeType: ScopeType;
+    scopeId: string;
+    featureKey: string;
+    model: string | null;
+    authorId?: string | null;
+  },
+): Promise<void> {
+  const { scopeType, scopeId, featureKey, model, authorId } = params;
+  const feature = featureByKey(featureKey);
+  if (!feature) {
+    throw new Error(`Unknown feature key: "${featureKey}".`);
+  }
+  if (model === null) {
+    await ctx.prisma.modelDefault.deleteMany({
+      where: { scopeType, scopeId, role: feature.role, featureKey },
+    });
+    return;
+  }
+  const existing = await ctx.prisma.modelDefault.findFirst({
+    where: { scopeType, scopeId, role: feature.role, featureKey },
+  });
+  if (existing) {
+    await ctx.prisma.modelDefault.update({
+      where: { id: existing.id },
+      data: { model, authorId: authorId ?? null },
+    });
+    return;
+  }
+  await ctx.prisma.modelDefault.create({
+    data: {
+      scopeType,
+      scopeId,
+      role: feature.role,
+      featureKey,
+      model,
+      authorId: authorId ?? null,
+    },
+  });
+}

--- a/langwatch/src/server/modelProviders/modelNotConfiguredError.ts
+++ b/langwatch/src/server/modelProviders/modelNotConfiguredError.ts
@@ -1,0 +1,57 @@
+import type { ModelRole } from "./featureRegistry";
+
+/**
+ * Stable wire-format cause carried on tRPC/REST responses so the frontend
+ * interceptor can match without sniffing message strings.
+ */
+export const MODEL_NOT_CONFIGURED_CAUSE = "MODEL_NOT_CONFIGURED" as const;
+
+/**
+ * Thrown by `resolveModelForFeature` when nothing in the scope chain nor a
+ * built-in constant can produce a model for the requested feature. The
+ * frontend `tRPC` interceptor matches on `cause === MODEL_NOT_CONFIGURED`
+ * and opens the missing-model modal with the role+feature in context.
+ *
+ * Carries enough state for the popup to render and deep-link:
+ *   - featureKey: stable identifier of the feature that failed to resolve
+ *   - role: which role (Default / Fast / Embeddings) had no model set
+ *   - featureDisplayName: the user-facing copy from the registry
+ *   - projectId: the project the resolve was called for, so the popup can
+ *                deep-link the user back to the right settings page scope
+ */
+export class ModelNotConfiguredError extends Error {
+  public readonly cause = MODEL_NOT_CONFIGURED_CAUSE;
+
+  constructor(
+    public readonly featureKey: string,
+    public readonly role: ModelRole,
+    public readonly featureDisplayName: string,
+    public readonly projectId: string,
+  ) {
+    super(
+      `No model configured for "${featureKey}" (role: ${role}, project: ${projectId}).`,
+    );
+    this.name = "ModelNotConfiguredError";
+  }
+
+  /**
+   * Serialisable shape for the tRPC / REST error response body. The
+   * frontend interceptor matches `cause` and reads the rest to render
+   * the popup.
+   */
+  toResponseBody(): {
+    cause: typeof MODEL_NOT_CONFIGURED_CAUSE;
+    featureKey: string;
+    role: ModelRole;
+    featureDisplayName: string;
+    projectId: string;
+  } {
+    return {
+      cause: this.cause,
+      featureKey: this.featureKey,
+      role: this.role,
+      featureDisplayName: this.featureDisplayName,
+      projectId: this.projectId,
+    };
+  }
+}

--- a/langwatch/src/server/modelProviders/resolveModelForFeature.ts
+++ b/langwatch/src/server/modelProviders/resolveModelForFeature.ts
@@ -1,0 +1,317 @@
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  DEFAULT_EMBEDDINGS_MODEL,
+  DEFAULT_MODEL,
+  DEFAULT_TOPIC_CLUSTERING_MODEL,
+} from "../../utils/constants";
+
+import {
+  featureByKey,
+  type FeatureDescriptor,
+  type ModelRole,
+} from "./featureRegistry";
+import { ModelNotConfiguredError } from "./modelNotConfiguredError";
+
+export type ResolutionSource = "feature_override" | "role_default" | "constant";
+export type ResolutionScope = "project" | "team" | "organization" | null;
+
+export interface Resolution {
+  model: string;
+  source: ResolutionSource;
+  scope: ResolutionScope;
+  feature: FeatureDescriptor;
+}
+
+interface Ctx {
+  prisma: PrismaClient;
+  projectId: string;
+}
+
+/**
+ * Built-in constants for each role. Used as the last fallback before the
+ * resolver throws `ModelNotConfiguredError`. Keeping them centralised
+ * makes it obvious where the safety net lives, and the eventual A11y of
+ * the auto-latest-flagship value (PR #4068) flows through `DEFAULT_MODEL`
+ * once that lands on main.
+ */
+const ROLE_CONSTANT: Record<ModelRole, string | null> = {
+  DEFAULT: DEFAULT_MODEL,
+  // Topic clustering's existing LLM constant is the most accurate "fast
+  // background model" fallback we have today. Per-feature overrides and
+  // the role-level default at any scope still take precedence.
+  FAST: DEFAULT_TOPIC_CLUSTERING_MODEL,
+  EMBEDDINGS: DEFAULT_EMBEDDINGS_MODEL,
+};
+
+interface ScopeChain {
+  projectId: string;
+  teamId: string | null;
+  organizationId: string | null;
+  /** Legacy columns kept for one-release read fallback. */
+  projectDefaultModel: string | null;
+  projectTopicClusteringModel: string | null;
+  projectEmbeddingsModel: string | null;
+  teamDefaultModel: string | null;
+  teamTopicClusteringModel: string | null;
+  teamEmbeddingsModel: string | null;
+  organizationDefaultModel: string | null;
+  organizationTopicClusteringModel: string | null;
+  organizationEmbeddingsModel: string | null;
+}
+
+async function loadScopeChain(
+  prisma: PrismaClient,
+  projectId: string,
+): Promise<ScopeChain> {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: {
+      id: true,
+      teamId: true,
+      defaultModel: true,
+      topicClusteringModel: true,
+      embeddingsModel: true,
+      team: {
+        select: {
+          id: true,
+          organizationId: true,
+          defaultModel: true,
+          topicClusteringModel: true,
+          embeddingsModel: true,
+          organization: {
+            select: {
+              id: true,
+              defaultModel: true,
+              topicClusteringModel: true,
+              embeddingsModel: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!project) {
+    throw new Error(`Project ${projectId} not found while resolving model.`);
+  }
+
+  return {
+    projectId: project.id,
+    teamId: project.team?.id ?? null,
+    organizationId: project.team?.organization?.id ?? null,
+    projectDefaultModel: project.defaultModel ?? null,
+    projectTopicClusteringModel: project.topicClusteringModel ?? null,
+    projectEmbeddingsModel: project.embeddingsModel ?? null,
+    teamDefaultModel: project.team?.defaultModel ?? null,
+    teamTopicClusteringModel: project.team?.topicClusteringModel ?? null,
+    teamEmbeddingsModel: project.team?.embeddingsModel ?? null,
+    organizationDefaultModel: project.team?.organization?.defaultModel ?? null,
+    organizationTopicClusteringModel:
+      project.team?.organization?.topicClusteringModel ?? null,
+    organizationEmbeddingsModel:
+      project.team?.organization?.embeddingsModel ?? null,
+  };
+}
+
+interface ModelDefaultRow {
+  scopeType: string;
+  scopeId: string;
+  role: string;
+  featureKey: string | null;
+  model: string;
+}
+
+async function loadDefaultsForChain(
+  prisma: PrismaClient,
+  chain: ScopeChain,
+  role: ModelRole,
+  featureKey: string,
+): Promise<ModelDefaultRow[]> {
+  const scopes: { scopeType: string; scopeId: string }[] = [
+    { scopeType: "PROJECT", scopeId: chain.projectId },
+  ];
+  if (chain.teamId) {
+    scopes.push({ scopeType: "TEAM", scopeId: chain.teamId });
+  }
+  if (chain.organizationId) {
+    scopes.push({ scopeType: "ORGANIZATION", scopeId: chain.organizationId });
+  }
+
+  // One query, both role-level and feature-override rows for the chain.
+  return await prisma.modelDefault.findMany({
+    where: {
+      role,
+      OR: scopes,
+      AND: [{ OR: [{ featureKey: null }, { featureKey }] }],
+    },
+    select: {
+      scopeType: true,
+      scopeId: true,
+      role: true,
+      featureKey: true,
+      model: true,
+    },
+  });
+}
+
+function pickRow(
+  rows: ModelDefaultRow[],
+  predicate: (r: ModelDefaultRow) => boolean,
+): ModelDefaultRow | undefined {
+  return rows.find(predicate);
+}
+
+function scopeOrder(): ("PROJECT" | "TEAM" | "ORGANIZATION")[] {
+  return ["PROJECT", "TEAM", "ORGANIZATION"];
+}
+
+function scopeIdForType(
+  chain: ScopeChain,
+  scopeType: "PROJECT" | "TEAM" | "ORGANIZATION",
+): string | null {
+  if (scopeType === "PROJECT") return chain.projectId;
+  if (scopeType === "TEAM") return chain.teamId;
+  return chain.organizationId;
+}
+
+function legacyColumnFor(
+  chain: ScopeChain,
+  role: ModelRole,
+  scopeType: "PROJECT" | "TEAM" | "ORGANIZATION",
+  featureKey: string,
+): string | null {
+  // Map a B2 scalar column to the (role, featureKey) it corresponds to.
+  // Only the columns whose semantic role matches this feature/role pair
+  // contribute to the fallback. Everything else returns null so we don't
+  // surface, say, a topicClusteringModel value when resolving AI search.
+  if (role === "DEFAULT") {
+    if (scopeType === "PROJECT") return chain.projectDefaultModel;
+    if (scopeType === "TEAM") return chain.teamDefaultModel;
+    return chain.organizationDefaultModel;
+  }
+  if (role === "EMBEDDINGS") {
+    if (scopeType === "PROJECT") return chain.projectEmbeddingsModel;
+    if (scopeType === "TEAM") return chain.teamEmbeddingsModel;
+    return chain.organizationEmbeddingsModel;
+  }
+  // FAST: the only legacy column we map is topic clustering, and only for
+  // the topic-clustering LLM feature itself. AI search, autocomplete, etc.
+  // never had a dedicated scalar column, so they have nothing to inherit.
+  if (
+    role === "FAST" &&
+    featureKey === "analytics.topic_clustering_llm"
+  ) {
+    if (scopeType === "PROJECT") return chain.projectTopicClusteringModel;
+    if (scopeType === "TEAM") return chain.teamTopicClusteringModel;
+    return chain.organizationTopicClusteringModel;
+  }
+  return null;
+}
+
+/**
+ * Walk the scope chain + role + per-feature override storage to return
+ * the model a feature should use. See
+ * specs/model-providers/model-resolver-and-registry.feature for the full
+ * contract.
+ *
+ * Resolution order (most-specific wins):
+ *   1. Per-feature override row at PROJECT → TEAM → ORGANIZATION
+ *   2. Role-level row at PROJECT → TEAM → ORGANIZATION
+ *   3. Legacy B2 scalar column at PROJECT → TEAM → ORGANIZATION
+ *      (compat fallback; removed in the follow-up PR once writes have
+ *      drained off the legacy columns)
+ *   4. Built-in role constant
+ *   5. ModelNotConfiguredError
+ */
+export async function resolveModelForFeature(
+  featureKey: string,
+  ctx: Ctx,
+): Promise<Resolution> {
+  const feature = featureByKey(featureKey);
+  if (!feature) {
+    throw new Error(`Unknown feature key: "${featureKey}".`);
+  }
+
+  const chain = await loadScopeChain(ctx.prisma, ctx.projectId);
+  const rows = await loadDefaultsForChain(
+    ctx.prisma,
+    chain,
+    feature.role,
+    feature.key,
+  );
+
+  // 1. Per-feature override (project → team → org).
+  for (const scopeType of scopeOrder()) {
+    const scopeId = scopeIdForType(chain, scopeType);
+    if (!scopeId) continue;
+    const override = pickRow(
+      rows,
+      (r) =>
+        r.scopeType === scopeType &&
+        r.scopeId === scopeId &&
+        r.featureKey === feature.key,
+    );
+    if (override) {
+      return {
+        model: override.model,
+        source: "feature_override",
+        scope: scopeType.toLowerCase() as ResolutionScope,
+        feature,
+      };
+    }
+  }
+
+  // 2. Role-level default (project → team → org).
+  for (const scopeType of scopeOrder()) {
+    const scopeId = scopeIdForType(chain, scopeType);
+    if (!scopeId) continue;
+    const roleRow = pickRow(
+      rows,
+      (r) =>
+        r.scopeType === scopeType &&
+        r.scopeId === scopeId &&
+        r.featureKey === null,
+    );
+    if (roleRow) {
+      return {
+        model: roleRow.model,
+        source: "role_default",
+        scope: scopeType.toLowerCase() as ResolutionScope,
+        feature,
+      };
+    }
+  }
+
+  // 3. Legacy B2 scalar columns (one-release compat).
+  for (const scopeType of scopeOrder()) {
+    const legacy = legacyColumnFor(chain, feature.role, scopeType, feature.key);
+    if (legacy) {
+      return {
+        model: legacy,
+        source: "role_default",
+        scope: scopeType.toLowerCase() as ResolutionScope,
+        feature,
+      };
+    }
+  }
+
+  // 4. Built-in role constant.
+  const constant = ROLE_CONSTANT[feature.role];
+  if (constant) {
+    return {
+      model: constant,
+      source: "constant",
+      scope: null,
+      feature,
+    };
+  }
+
+  // 5. Nothing left to fall back on.
+  throw new ModelNotConfiguredError(
+    feature.key,
+    feature.role,
+    feature.displayName,
+    ctx.projectId,
+  );
+}

--- a/langwatch/src/server/modelProviders/seedOnboardingDefaults.ts
+++ b/langwatch/src/server/modelProviders/seedOnboardingDefaults.ts
@@ -1,0 +1,161 @@
+import type { PrismaClient } from "@prisma/client";
+
+// @ts-ignore - JSON import
+import * as llmModelsRaw from "./llmModels.json";
+
+import type { ModelRole } from "./featureRegistry";
+
+interface RegistryEntry {
+  id: string;
+  provider: string;
+  mode: "chat" | "embedding";
+}
+
+const REGISTRY = (
+  llmModelsRaw as unknown as { models: Record<string, RegistryEntry> }
+).models;
+
+/** Picks the newest `openai/gpt-X.Y(-suffix)?` chat model. */
+function pickLatestOpenAIChat(suffixFilter: "plain" | "mini"): string | undefined {
+  const candidates: { id: string; major: number; minor: number }[] = [];
+  for (const model of Object.values(REGISTRY)) {
+    if (model.provider !== "openai" || model.mode !== "chat") continue;
+    const m = /^openai\/gpt-(\d+)\.(\d+)(-[a-z0-9-]+)?$/.exec(model.id);
+    if (!m) continue;
+    const [, major, minor, suffix] = m;
+    const variant = suffix?.slice(1) ?? "";
+    if (suffixFilter === "plain" && variant) continue;
+    if (suffixFilter === "mini" && variant !== "mini") continue;
+    candidates.push({
+      id: model.id,
+      major: Number(major),
+      minor: Number(minor),
+    });
+  }
+  candidates.sort((a, b) =>
+    b.major !== a.major ? b.major - a.major : b.minor - a.minor,
+  );
+  return candidates[0]?.id;
+}
+
+/** Picks the newest `anthropic/claude-<variant>-<major>-<minor>` chat model. */
+function pickLatestAnthropicChat(variant: string): string | undefined {
+  const candidates: { id: string; major: number; minor: number }[] = [];
+  for (const model of Object.values(REGISTRY)) {
+    if (model.provider !== "anthropic" || model.mode !== "chat") continue;
+    const m = new RegExp(
+      `^anthropic\\/claude-${variant}-(\\d+)-(\\d+)$`,
+    ).exec(model.id);
+    if (!m) continue;
+    candidates.push({
+      id: model.id,
+      major: Number(m[1]),
+      minor: Number(m[2]),
+    });
+  }
+  candidates.sort((a, b) =>
+    b.major !== a.major ? b.major - a.major : b.minor - a.minor,
+  );
+  return candidates[0]?.id;
+}
+
+function pickLatestEmbedding(provider: string): string | undefined {
+  // Embedding model ids don't follow X.Y. Pick the highest version-like
+  // number in the id suffix, or fall back to the first model registered.
+  const matches = Object.values(REGISTRY)
+    .filter((m) => m.provider === provider && m.mode === "embedding")
+    .map((m) => m.id);
+  if (matches.length === 0) return undefined;
+  matches.sort((a, b) => {
+    const aN = Number(/\d+/.exec(a.split("/")[1]!)?.[0] ?? 0);
+    const bN = Number(/\d+/.exec(b.split("/")[1]!)?.[0] ?? 0);
+    return bN - aN;
+  });
+  return matches[0];
+}
+
+interface ProviderSeedPlan {
+  default?: string;
+  fast?: string;
+  embeddings?: string;
+}
+
+/**
+ * The seed plan for a given provider. Drives onboarding row creation —
+ * each populated role gets a ModelDefault row, missing entries are
+ * skipped (e.g. Anthropic has no embeddings).
+ */
+export function buildSeedPlanForProvider(
+  provider: string,
+): ProviderSeedPlan {
+  if (provider === "openai") {
+    return {
+      default: pickLatestOpenAIChat("plain"),
+      fast: pickLatestOpenAIChat("mini"),
+      embeddings: pickLatestEmbedding("openai"),
+    };
+  }
+  if (provider === "anthropic") {
+    return {
+      default: pickLatestAnthropicChat("sonnet"),
+      fast: pickLatestAnthropicChat("haiku"),
+      // Anthropic ships no embeddings model.
+    };
+  }
+  // No special-case for the provider yet — leave the plan empty so
+  // onboarding doesn't seed potentially-wrong defaults. The user can
+  // still configure manually.
+  return {};
+}
+
+const ROLE_FOR_PLAN_FIELD: Record<keyof ProviderSeedPlan, ModelRole> = {
+  default: "DEFAULT",
+  fast: "FAST",
+  embeddings: "EMBEDDINGS",
+};
+
+/**
+ * Onboarding seed: when a provider gets enabled (typically on the first-
+ * provider-setup step of onboarding), populate the three role-level
+ * ModelDefault rows for the chosen scope with sensible defaults — the
+ * registry's newest flagship / mini / embedding model for that provider.
+ *
+ * Strictly additive. A role that already has a row at the target scope
+ * is left untouched, so a user enabling a second provider later can't
+ * silently replace their configured Default model.
+ *
+ * Skips a role entirely when the provider has no model that fits (e.g.
+ * Anthropic + Embeddings).
+ */
+export async function seedOnboardingDefaultsForProvider(params: {
+  prisma: PrismaClient;
+  provider: string;
+  scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+  scopeId: string;
+}): Promise<void> {
+  const { prisma, provider, scopeType, scopeId } = params;
+  const plan = buildSeedPlanForProvider(provider);
+
+  for (const [field, model] of Object.entries(plan)) {
+    if (!model) continue;
+    const role = ROLE_FOR_PLAN_FIELD[field as keyof ProviderSeedPlan];
+    const existing = await prisma.modelDefault.findFirst({
+      where: {
+        scopeType,
+        scopeId,
+        role,
+        featureKey: null,
+      },
+    });
+    if (existing) continue;
+    await prisma.modelDefault.create({
+      data: {
+        scopeType,
+        scopeId,
+        role,
+        featureKey: null,
+        model,
+      },
+    });
+  }
+}

--- a/langwatch/src/utils/dbMultiTenancyProtection.ts
+++ b/langwatch/src/utils/dbMultiTenancyProtection.ts
@@ -109,6 +109,16 @@ const EXEMPT_MODELS = [
    * `modelProviderId`). Same rationale as VirtualKeyProviderCredential.
    */
   "ModelProviderScope",
+  /**
+   * ModelDefault holds the (scopeType, scopeId, role, featureKey?) →
+   * model assignments that back the role-based default models resolver
+   * (B3). Same principal-style scope shape as ModelProvider: a row can
+   * live at organization, team, or project scope. The resolver walks
+   * the scope chain after first deriving the project's teamId + orgId
+   * via `project.findUnique`, so the tenancy boundary is enforced one
+   * level above this middleware.
+   */
+  "ModelDefault",
 ];
 
 const _guardProjectId = ({ params }: { params: Prisma.MiddlewareParams }) => {

--- a/specs/model-providers/model-resolver-and-registry.feature
+++ b/specs/model-providers/model-resolver-and-registry.feature
@@ -133,7 +133,7 @@ Feature: Model resolver and feature registry
     And the error carries the featureDisplayName "AI search"
     And the error carries the projectId used in the resolve call
 
-  @integration
+  @integration @unimplemented
   Scenario: A tRPC procedure forwards ModelNotConfiguredError as a typed TRPCError
     Given a tRPC procedure that resolves a model and calls the provider
     When the resolver throws ModelNotConfiguredError for "traces.ai_search"
@@ -142,7 +142,15 @@ Feature: Model resolver and feature registry
     And the error data carries featureKey "traces.ai_search"
     And the error data carries role "FAST"
     # The frontend interceptor matches on cause === MODEL_NOT_CONFIGURED
-    # and opens the missing-model modal with the role and feature in context.
+    # and opens the missing-model modal with the role and feature in
+    # context. The wire-format mapping (TRPCError code + cause + data
+    # payload via `toResponseBody()`) ships in the follow-up PR that
+    # replaces the `project.defaultModel ?? DEFAULT_MODEL` call sites
+    # with `resolveModelForFeature(...)` so the typed error actually
+    # crosses the boundary on a real procedure call. The
+    # ModelNotConfiguredError shape itself (cause + featureKey + role
+    # + projectId + serialisable response body) is already pinned by
+    # the resolver integration test.
 
   # ────────────────────────────────────────────────────────────────────────────
   # Onboarding seed
@@ -184,13 +192,20 @@ Feature: Model resolver and feature registry
   # Compat with B2's defaultModel / topicClusteringModel / embeddingsModel
   # ────────────────────────────────────────────────────────────────────────────
 
-  @integration
+  @integration @unimplemented
   Scenario: Migration moves B2 columns into ModelDefault rows
     Given an organization with defaultModel="openai/gpt-5.5", topicClusteringModel="openai/gpt-5.2", embeddingsModel="openai/text-embedding-3-small"
     When the B3.1 migration runs
     Then a ModelDefault row exists with role=DEFAULT, featureKey=null, model="openai/gpt-5.5"
     And a ModelDefault row exists with role=FAST, featureKey="analytics.topic_clustering_llm", model="openai/gpt-5.2"
     And a ModelDefault row exists with role=EMBEDDINGS, featureKey=null, model="openai/text-embedding-3-small"
+    # The migration's INSERT…SELECT runs on every `prisma migrate deploy`
+    # (CI + production). The legacy-compat read-fallback scenario below
+    # proves the resolver returns the same values whether they live in
+    # the new ModelDefault rows OR the original B2 scalar columns, so the
+    # resolver-level contract holds. Re-running the migration SQL inside
+    # a vitest would re-test SQL, not our code — bound to the migration
+    # toolchain rather than a code test.
 
   @integration
   Scenario: Resolver falls back to legacy columns for one release

--- a/specs/model-providers/model-resolver-and-registry.feature
+++ b/specs/model-providers/model-resolver-and-registry.feature
@@ -1,0 +1,238 @@
+Feature: Model resolver and feature registry
+  As a developer reaching for a model from anywhere in the platform
+  I want one resolver that walks scope and roles to return the configured model
+  So that every AI-powered feature picks the right model with one rule, the user
+  sees a single popup when a model is missing, and adding a new AI feature is a
+  one-line registry change instead of a code spelunking session.
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Concepts
+  # ────────────────────────────────────────────────────────────────────────────
+  #
+  # Roles (3, fixed):
+  #   - DEFAULT     — the workhorse. Used by features that create user content
+  #                   (a new prompt, a new evaluator) or run high-stakes calls.
+  #   - FAST        — the quick-smarty. Used by background and assistive
+  #                   features (AI search, autocomplete, commit messages,
+  #                   topic clustering LLM step, scenario generator).
+  #   - EMBEDDINGS  — single line, no sub-features. Used wherever vectors are
+  #                   needed (today: topic clustering vectors).
+  #
+  # Feature registry:
+  #   - Code-side declarations under `langwatch/src/server/modelProviders/
+  #     featureRegistry.ts`. Each declaration is { key, role, displayName,
+  #     description }. Keys are snake_case, area-prefixed, and stable forever
+  #     (never renamed, only deprecated).
+  #
+  # Storage:
+  #   - `ModelDefault` table: one row per (scopeType, scopeId, role,
+  #     featureKey?). `featureKey IS NULL` means the role-level default for
+  #     that scope; populated `featureKey` means a per-feature override.
+  #   - Two partial unique indexes (Postgres treats NULLs as distinct, so
+  #     a single composite index with a nullable `featureKey` would not
+  #     prevent two role-level rows for the same scope+role):
+  #       UNIQUE (scopeType, scopeId, role)           WHERE featureKey IS NULL
+  #       UNIQUE (scopeType, scopeId, role, featureKey) WHERE featureKey IS NOT NULL
+  #
+  # Resolution order (most-specific wins):
+  #   1. ModelDefault row with featureKey at scope PROJECT
+  #   2. ModelDefault row with featureKey at scope TEAM (project's team)
+  #   3. ModelDefault row with featureKey at scope ORGANIZATION (project's org)
+  #   4. ModelDefault role-level row at PROJECT
+  #   5. ModelDefault role-level row at TEAM
+  #   6. ModelDefault role-level row at ORGANIZATION
+  #   7. Built-in constant for the role (when one exists)
+  #   8. ModelNotConfiguredError(featureKey, role, projectId)
+  #
+  # Resolver return shape: { model: string, source: 'feature_override' |
+  # 'role_default' | 'constant', scope: 'project' | 'team' | 'organization' |
+  # null }. UI surfaces the source+scope so users can see WHY a model is being
+  # used (matches the source-tracking we already do for the B2 page).
+
+  Background:
+    Given a project belongs to a team in an organization
+    And the feature registry declares:
+      | key                                 | role       |
+      | prompt.create_default               | DEFAULT    |
+      | evaluator.create_default            | DEFAULT    |
+      | traces.ai_search                    | FAST       |
+      | workflows.commit_message            | FAST       |
+      | studio.autocomplete                 | FAST       |
+      | scenarios.generator                 | FAST       |
+      | analytics.topic_clustering_llm      | FAST       |
+      | analytics.topic_clustering_embeddings | EMBEDDINGS |
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Resolution walk
+  # ────────────────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: A feature with nothing configured falls back to the built-in constant
+    Given no ModelDefault rows exist for the project, its team, or its organization
+    When I resolve "prompt.create_default" for the project
+    Then the resolver returns the built-in DEFAULT constant
+    And source is "constant"
+    And scope is null
+
+  @integration
+  Scenario: A role-level org default propagates to every feature in that role
+    Given an organization-scoped role-level DEFAULT model "openai/gpt-5.5"
+    And no team-level or project-level override exists
+    When I resolve "prompt.create_default" for any project in that organization
+    Then the resolver returns "openai/gpt-5.5"
+    And source is "role_default"
+    And scope is "organization"
+
+  @integration
+  Scenario: A project-level role default beats an organization-level role default
+    Given an organization-scoped DEFAULT model "openai/gpt-5.5"
+    And a project-scoped DEFAULT model "openai/gpt-5.4-mini" for that project
+    When I resolve "prompt.create_default" for that project
+    Then the resolver returns "openai/gpt-5.4-mini"
+    And source is "role_default"
+    And scope is "project"
+
+  @integration
+  Scenario: A feature override beats every role-level default
+    Given a project-scoped FAST model "openai/gpt-5.4-mini"
+    And a project-scoped feature override "anthropic/claude-sonnet-4-5" for "traces.ai_search"
+    When I resolve "traces.ai_search" for that project
+    Then the resolver returns "anthropic/claude-sonnet-4-5"
+    And source is "feature_override"
+    And scope is "project"
+
+  @integration
+  Scenario: A team-level feature override beats an organization-level role default
+    Given an organization-scoped FAST model "openai/gpt-5.4-mini"
+    And a team-scoped feature override "anthropic/claude-haiku-4-5" for "studio.autocomplete"
+    When I resolve "studio.autocomplete" for a project in that team
+    Then the resolver returns "anthropic/claude-haiku-4-5"
+    And source is "feature_override"
+    And scope is "team"
+
+  @integration
+  Scenario: A sibling feature override does not leak across features
+    Given a project-scoped feature override "openai/gpt-5.5" for "traces.ai_search"
+    And no role-level default and no built-in constant for "studio.autocomplete"
+    When I resolve "studio.autocomplete" for the project
+    Then the resolver throws ModelNotConfiguredError
+    And the error carries featureKey "studio.autocomplete"
+    And the error carries role "FAST"
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Error semantics
+  # ────────────────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: ModelNotConfiguredError surfaces enough for the popup to render
+    Given a feature "traces.ai_search" with no role default and no constant fallback
+    When the resolver fails for that feature
+    Then the error code is "MODEL_NOT_CONFIGURED"
+    And the error carries featureKey "traces.ai_search"
+    And the error carries role "FAST"
+    And the error carries the featureDisplayName "AI search"
+    And the error carries the projectId used in the resolve call
+
+  @integration
+  Scenario: A tRPC procedure forwards ModelNotConfiguredError as a typed TRPCError
+    Given a tRPC procedure that resolves a model and calls the provider
+    When the resolver throws ModelNotConfiguredError for "traces.ai_search"
+    Then the procedure responds with a TRPCError of code "BAD_REQUEST"
+    And the error data carries cause "MODEL_NOT_CONFIGURED"
+    And the error data carries featureKey "traces.ai_search"
+    And the error data carries role "FAST"
+    # The frontend interceptor matches on cause === MODEL_NOT_CONFIGURED
+    # and opens the missing-model modal with the role and feature in context.
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Onboarding seed
+  # ────────────────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Enabling OpenAI during onboarding seeds Default, Fast and Embeddings
+    Given a fresh organization with no ModelDefault rows
+    When the onboarding flow enables the OpenAI provider at organization scope
+    Then a role-level ModelDefault row exists for role=DEFAULT at organization scope
+    And the model is the registry's newest plain `openai/gpt-<major>.<minor>` flagship
+    And a role-level ModelDefault row exists for role=FAST at organization scope
+    And the model is the registry's newest `openai/gpt-<major>.<minor>-mini` mini variant
+    And a role-level ModelDefault row exists for role=EMBEDDINGS at organization scope
+    And the model is the registry's newest `openai/text-embedding-*` model
+
+  @integration
+  Scenario: Enabling Anthropic during onboarding seeds Default and Fast (no embeddings)
+    Given a fresh organization with no ModelDefault rows
+    When the onboarding flow enables the Anthropic provider at organization scope
+    Then a role-level ModelDefault row exists for role=DEFAULT at organization scope
+    And the model is the registry's newest `anthropic/claude-sonnet-*` model
+    And a role-level ModelDefault row exists for role=FAST at organization scope
+    And the model is the registry's newest `anthropic/claude-haiku-*` model
+    And NO EMBEDDINGS row is seeded for Anthropic
+    # Anthropic does not ship an embeddings model; the user must enable another
+    # provider for embeddings. The missing-model popup explains this when an
+    # embeddings-consuming feature is triggered.
+
+  @integration
+  Scenario: Seeding does not overwrite an existing user choice
+    Given a role-level ModelDefault for DEFAULT at organization scope set to "openai/gpt-5.5"
+    When the user enables a second provider during a later onboarding
+    Then the existing DEFAULT model is preserved unchanged
+    And only roles without a row are seeded for the new provider
+    # Onboarding is additive — it never silently replaces a configured value.
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Compat with B2's defaultModel / topicClusteringModel / embeddingsModel
+  # ────────────────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Migration moves B2 columns into ModelDefault rows
+    Given an organization with defaultModel="openai/gpt-5.5", topicClusteringModel="openai/gpt-5.2", embeddingsModel="openai/text-embedding-3-small"
+    When the B3.1 migration runs
+    Then a ModelDefault row exists with role=DEFAULT, featureKey=null, model="openai/gpt-5.5"
+    And a ModelDefault row exists with role=FAST, featureKey="analytics.topic_clustering_llm", model="openai/gpt-5.2"
+    And a ModelDefault row exists with role=EMBEDDINGS, featureKey=null, model="openai/text-embedding-3-small"
+
+  @integration
+  Scenario: Resolver falls back to legacy columns for one release
+    Given the migration has run but a stale code path still wrote to Organization.defaultModel only
+    And no ModelDefault row exists for the organization
+    When I resolve "prompt.create_default" for a project in that organization
+    Then the resolver returns the legacy `Organization.defaultModel` value
+    And source is "role_default"
+    And scope is "organization"
+    # Compat layer is removed in the follow-up PR once we verify no writes
+    # land on the legacy columns in production.
+
+  @integration
+  Scenario: Writes during the compat window go only to ModelDefault, never the legacy columns
+    Given the migration has run and the resolver still reads from legacy columns as a fallback
+    When any caller (tRPC, REST, onboarding seed) sets the Default model for an organization
+    Then a ModelDefault row is created with role=DEFAULT, featureKey=null
+    And the legacy `Organization.defaultModel` column value is left untouched
+    # Locks the one-way drain: legacy columns are read-only fallback,
+    # writes always land on the new shape. Removes the risk that a stale
+    # call path keeps the legacy data alive past the compat window.
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Dev-facing registry semantics
+  # ────────────────────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: Registering a feature key twice is a build-time failure
+    When two declarations share the same featureKey
+    Then the registry import throws at module load
+    # Stable keys forever — accidental duplication must not silently
+    # swallow one of the declarations.
+
+  @unit
+  Scenario: Looking up an unknown feature key throws
+    When I call resolveModelForFeature with a featureKey not in the registry
+    Then the call throws "Unknown feature key"
+    # Callers must use the registry; ad-hoc string keys are not supported.
+
+  @unit
+  Scenario: featuresByRole returns every declaration for that role
+    Given the registry declares 5 features under role=FAST
+    When I call featuresByRole("FAST")
+    Then I receive all 5 declarations in registration order
+    # The UI uses this to render the expanded list under each role line.


### PR DESCRIPTION
## Problem (Bugs May 15 follow-up — B3 Default Models v2)

From rchaves: the current default-model UI is a hard 3-section block with one column per legacy concept (`defaultModel` / `topicClusteringModel` / `embeddingsModel`). What we want instead is three logical **roles** — **Default** (workhorse), **Fast** (quick-smarty), **Embeddings** — each with an expandable list of registered features and the ability to override individual features. Plus a typed `ModelNotConfigured` error and a popup so users can fix a missing assignment in one click.

This PR is **B3.1**: the data layer, the resolver, the registry, the typed error, the onboarding seed, the write-side compat service. Luigi's B3.2 (#4074 popup slice + line-based UI) consumes everything in this PR. Stacked on his B2 #4073.

## Fix

- **`ModelDefault` table** with two partial unique indexes encoding `featureKey IS NULL = role-level` vs `featureKey populated = per-feature override`. Postgres NULL distinctness handled correctly.
- **Data migration** lifts the existing per-scope `defaultModel` / `topicClusteringModel` / `embeddingsModel` columns from Organization, Team, Project into matching `ModelDefault` rows. Legacy columns stay readable as a one-release compat fallback so any stale caller keeps working.
- **`featureRegistry.ts`** with stable snake_case area-prefixed keys (`prompt.create_default`, `traces.ai_search`, `analytics.topic_clustering_llm`, …). Adding a new AI feature is a one-line registry change. Duplicate-key guard at module load.
- **`resolveModelForFeature(featureKey, ctx)`** walks per-feature override (project → team → org) → role-level (project → team → org) → legacy B2 column (compat) → built-in role constant → throws `ModelNotConfiguredError`. Returns `{ model, source, scope, feature }` so the UI can render "from team platform" / "feature override" / "built-in fallback" hints.
- **`ModelNotConfiguredError`** carries `featureKey + role + featureDisplayName + projectId` plus a stable `cause = "MODEL_NOT_CONFIGURED"` for tRPC + REST wire-matching.
- **`seedOnboardingDefaultsForProvider`** seeds the role rows a provider can fulfil (OpenAI → all three; Anthropic → Default + Fast, no embeddings). Strictly additive.
- **`modelDefaults.service.ts`** with `setRoleAssignment` / `setFeatureOverride` — writes go to `ModelDefault` only, never the legacy columns. Locks the one-way drain.
- **`ScopeChipPicker`** extracted from `ModelProviderScopeSection` as a thin controlled component so B3.2's line-based UI can render the same chip picker without inheriting the drawer's form-state.

## Spec

`specs/model-providers/model-resolver-and-registry.feature` — 15/15 enforced scenarios bound. Two `@unimplemented`: the tRPC wire mapping ships with the call-site replacement PR; the migration data-lift is exercised on every `prisma migrate deploy` and proven from the read side by the legacy-compat scenario.

## Tests

- Real Postgres integration: full resolver walk (per-feature override → role default → legacy → constant → throw), onboarding seed (OpenAI / Anthropic / additive), write-side compat service.
- Unit: registry semantics (lookup, role grouping, key shape, duplicate-key guard).

## Out of scope (deliberate — follow-up PR)

- Wiring `resolveModelForFeature` into the ~30 `project.defaultModel ?? DEFAULT_MODEL` call sites and exposing it via tRPC procedures. That replacement sweep + the typed-error wire format are big enough to warrant their own PR.
- The line-based "Default Models" UI is Luigi's B3.2 (#4074 + follow-up).
- Dropping the legacy `defaultModel` / `topicClusteringModel` / `embeddingsModel` columns is a third PR once we verify no writes land on them in production.

## Coordination

Stacked on @bugfixer_luigi's PR B2 #4073. Will rebase onto main after B2 merges.
