### PR TITLE
fix(evaluations): accept custom models in setupModelEnv validation

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.factories.unit.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for setupModelEnv in evaluation-execution.factories.
+ *
+ * Mocks getProjectModelProviders and prepareLitellmParams so we can
+ * test validation logic in isolation without DB or external calls.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { MaybeStoredModelProvider } from "~/server/modelProviders/registry";
+
+vi.mock("~/server/api/routers/modelProviders.utils", () => ({
+  getProjectModelProviders: vi.fn(),
+  prepareLitellmParams: vi.fn().mockResolvedValue({ model: "gemini/gemini-1.5-pro", api_key: "test-key" }),
+  prepareEnvKeys: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("~/server/modelProviders/resolveMaxTokensCeiling", () => ({
+  resolveMaxTokensCeiling: vi.fn().mockReturnValue(null),
+}));
+
+import { setupModelEnv } from "../evaluation-execution.factories";
+import { getProjectModelProviders } from "~/server/api/routers/modelProviders.utils";
+import { EvaluatorConfigError } from "../errors";
+
+function buildProvider(overrides: Partial<MaybeStoredModelProvider> = {}): MaybeStoredModelProvider {
+  return {
+    provider: "gemini",
+    enabled: true,
+    customKeys: null,
+    models: ["gemini-2.5-pro", "gemini-2.5-flash"],
+    embeddingsModels: ["gemini-embedding-001"],
+    customModels: null,
+    customEmbeddingsModels: null,
+    deploymentMapping: null,
+    extraHeaders: null,
+    ...overrides,
+  };
+}
+
+describe("setupModelEnv", () => {
+  describe("when model is in the registry list", () => {
+    it("resolves without error", async () => {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        gemini: buildProvider(),
+      });
+
+      await expect(
+        setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1"),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("when model is NOT in registry but IS a custom model", () => {
+    it("resolves without error for chat custom models", async () => {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        gemini: buildProvider({
+          customModels: [
+            { modelId: "gemini-1.5-pro", displayName: "gemini-1.5-pro", mode: "chat" },
+          ],
+        }),
+      });
+
+      await expect(
+        setupModelEnv("gemini/gemini-1.5-pro", false, "proj-1"),
+      ).resolves.toBeDefined();
+    });
+
+    it("resolves without error for embedding custom models", async () => {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        gemini: buildProvider({
+          customEmbeddingsModels: [
+            { modelId: "custom-embed", displayName: "custom-embed", mode: "embedding" },
+          ],
+        }),
+      });
+
+      await expect(
+        setupModelEnv("gemini/custom-embed", true, "proj-1"),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("when model is NOT in registry AND NOT a custom model", () => {
+    it("throws EvaluatorConfigError", async () => {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        gemini: buildProvider(),
+      });
+
+      await expect(
+        setupModelEnv("gemini/nonexistent-model", false, "proj-1"),
+      ).rejects.toThrow(EvaluatorConfigError);
+    });
+  });
+
+  describe("when provider has no registry models", () => {
+    it("allows any model (no whitelist to check against)", async () => {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        gemini: buildProvider({ models: null }),
+      });
+
+      await expect(
+        setupModelEnv("gemini/any-model", false, "proj-1"),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("when provider is not configured", () => {
+    it("throws EvaluatorConfigError", async () => {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({});
+
+      await expect(
+        setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1"),
+      ).rejects.toThrow("Provider gemini is not configured");
+    });
+  });
+
+  describe("when provider is disabled", () => {
+    it("throws EvaluatorConfigError", async () => {
+      vi.mocked(getProjectModelProviders).mockResolvedValue({
+        gemini: buildProvider({ enabled: false }),
+      });
+
+      await expect(
+        setupModelEnv("gemini/gemini-2.5-pro", false, "proj-1"),
+      ).rejects.toThrow("Provider gemini is not enabled");
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.factories.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.factories.ts
@@ -92,7 +92,17 @@ export async function setupModelEnv(
     ? modelProvider.embeddingsModels
     : modelProvider.models;
 
-  if (modelList && modelList.length > 0 && !modelList.includes(modelName)) {
+  const customModelList = embeddings
+    ? modelProvider.customEmbeddingsModels
+    : modelProvider.customModels;
+  const isCustomModel = customModelList?.some((m) => m.modelId === modelName);
+
+  if (
+    modelList &&
+    modelList.length > 0 &&
+    !modelList.includes(modelName) &&
+    !isCustomModel
+  ) {
     throw new EvaluatorConfigError(
       `Model ${modelName} is not in the ${
         embeddings ? "embedding models" : "models"


### PR DESCRIPTION
## Summary

Fixes #4076

- `setupModelEnv` only validated models against `modelProvider.models` (registry-computed list), rejecting custom models users added via provider settings
- Extended the validation to also check `customModels` / `customEmbeddingsModels` before throwing `EvaluatorConfigError`

## Root Cause

`modelProvider.models` is dynamically computed from the static registry (`llmModels.json`) on every read — it never includes user-defined custom models. When a user adds a custom model (e.g. `gemini-1.5-pro`) to a provider and selects it for an evaluator, the runtime validation rejected it because `customModels` was never consulted.

## Test plan

- [x] Regression test reproduces the bug (custom chat model rejected → `EvaluatorConfigError`)
- [x] Regression test for custom embedding model
- [x] Fix: validation now checks `customModels`/`customEmbeddingsModels` before rejecting
- [x] All 7 new tests pass, all 28 existing evaluator service tests pass
- [x] Typecheck passes
- [x] Direct proof: called `setupModelEnv("gemini/gemini-1.5-pro", ...)` against a real project with custom model configured — previously threw, now resolves