### PR TITLE
fix(dev): eliminate redundant init work in Docker Compose startup

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -71,9 +71,9 @@ services:
       - db-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U prisma -d mydb"]
-      interval: 10s
+      interval: 3s
       timeout: 5s
-      retries: 5
+      retries: 10
     deploy:
       resources:
         limits:
@@ -97,9 +97,9 @@ services:
       - redis-data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
+      interval: 3s
       timeout: 5s
-      retries: 5
+      retries: 10
     deploy:
       resources:
         limits:
@@ -115,10 +115,10 @@ services:
       - clickhouse-data:/var/lib/clickhouse
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8123/ping || exit 1"]
-      interval: 10s
+      interval: 5s
       timeout: 5s
       retries: 10
-      start_period: 30s
+      start_period: 10s
     deploy:
       resources:
         limits:
@@ -158,10 +158,9 @@ services:
           chmod +x /opt/goose-bin/goose &&
           printf '%s' \"$$GOOSE_MARKER\" > /opt/goose-bin/.goose-meta;
         fi &&
-        (cd /mcp-server && pnpm install --ignore-scripts && pnpm run build) &&
+        (cd /mcp-server && pnpm install --ignore-scripts) &&
         pnpm -w install &&
-        pnpm -w exec prisma generate &&
-        pnpm run types:zod:generate
+        pnpm run start:prepare:files
       "
     environment:
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
@@ -189,10 +188,8 @@ services:
       sh -c "
         export PATH=/opt/goose-bin:$$PATH &&
         corepack enable &&
-        pnpm -w exec prisma generate &&
-        pnpm run types:zod:generate &&
         pnpm run start:prepare:db &&
-        pnpm run dev
+        START_WORKERS=true FORCE_COLOR=1 SKIP_PREPARE_DB=true pnpm start 2>&1 | tee server.log
       "
     ports:
       - "${APP_PORT:-5560}:5560"

--- a/langwatch/scripts/start.sh
+++ b/langwatch/scripts/start.sh
@@ -58,7 +58,9 @@ if [[ "$NODE_ENV" = "development" ]]; then
   START_VITE_COMMAND="pnpm run dev:vite"
 fi
 
-pnpm run start:prepare:db
+if [ "$SKIP_PREPARE_DB" != "true" ]; then
+  pnpm run start:prepare:db
+fi
 
 COMMANDS=()
 NAMES=()


### PR DESCRIPTION
## Summary

- Docker Compose init was running prisma generate **4x**, zod types **4x**, mcp-server build **3x**, and `start:prepare:db` **2x** per startup due to overlapping responsibilities between the init container, app container, and `pnpm dev`/`start.sh` scripts
- Init container now runs the full `start:prepare:files` script, and the app container bypasses `pnpm run dev` to call `pnpm start` directly — eliminating all duplicate file preparation
- Healthcheck intervals tightened (postgres/redis 10s→3s, clickhouse start_period 30s→10s) for faster infrastructure readiness

## Root Cause

Two execution paths share the same scripts:
1. **Host-side `pnpm dev`** (no Docker) — needs `start:prepare:files` + `start:prepare:db`
2. **Docker Compose** — init container prepares files, then app runs `pnpm dev` which re-does everything

The app container was: (a) explicitly running `prisma generate` + `types:zod:generate`, then (b) calling `pnpm run dev` which runs `start:prepare:files` (doing them again + mcp build), then (c) `start.sh` inside `pnpm start` was running `start:prepare:db` a second time.

## Changes

| File | Change |
|------|--------|
| `compose.dev.yml` (init) | Replace individual `prisma generate` + `types:zod:generate` with full `start:prepare:files`; skip separate mcp-server build (handled by `start:prepare:files`) |
| `compose.dev.yml` (app) | Remove duplicate `prisma generate` + `types:zod:generate`; bypass `pnpm run dev` and call `pnpm start` directly with `SKIP_PREPARE_DB=true` |
| `compose.dev.yml` (infra) | Postgres/Redis healthcheck interval 10s→3s; ClickHouse start_period 30s→10s, interval 10s→5s |
| `langwatch/scripts/start.sh` | Respect `SKIP_PREPARE_DB` env var to skip duplicate migration run |

## Before/After

| Operation | Before | After |
|-----------|--------|-------|
| `prisma generate` | 4x (init + app explicit + app via dev + app via start:prepare:files) | 1x (init via start:prepare:files) |
| `types:zod:generate` | 4x | 1x |
| `build:mcp-server` | 3x (init explicit + app via dev + app via start:prepare:files) | 1x (init via start:prepare:files) |
| `start:prepare:db` | 2x (app explicit + start.sh) | 1x (app explicit, start.sh skipped) |
| ClickHouse ready wait | 30s start_period + 10s intervals | 10s start_period + 5s intervals |

Estimated savings: **~30-60s** per Docker Compose cold start.

## Test plan

- [ ] `make quickstart backend-shared` starts successfully and app is reachable
- [ ] `make quickstart full-local` with workers profile works
- [ ] Host-side `pnpm dev` (no Docker) still works as before (no env vars set = same behavior)
- [ ] Fresh clone with empty volumes: init installs deps and prepares files, app boots cleanly
- [ ] Prisma migrations and ClickHouse migrations run exactly once