### PR TITLE
fix(docs): unquote @-bearing YAML scalars in third-party-integrations (#3996)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -24945,7 +24945,7 @@ Email is used for alerts, team invitations, and system notifications.
 app:
   email:
     enabled: true
-    defaultFrom: "langwatch@yourcompany.com"
+    defaultFrom: langwatch@yourcompany.com
     provider: sendgrid
     providers:
       sendgrid:
@@ -24985,7 +24985,7 @@ Capture application errors and exceptions for debugging.
 app:
   extraEnvs:
     - name: SENTRY_DSN
-      value: "https://examplePublicKey@o0.ingest.sentry.io/0"
+      value: https://examplePublicKey@o0.ingest.sentry.io/0
 ```
 
 ## Usage Analytics

--- a/docs/self-hosting/configuration/third-party-integrations.mdx
+++ b/docs/self-hosting/configuration/third-party-integrations.mdx
@@ -15,7 +15,7 @@ Email is used for alerts, team invitations, and system notifications.
 app:
   email:
     enabled: true
-    defaultFrom: "langwatch@yourcompany.com"
+    defaultFrom: langwatch@yourcompany.com
     provider: sendgrid
     providers:
       sendgrid:
@@ -55,7 +55,7 @@ Capture application errors and exceptions for debugging.
 app:
   extraEnvs:
     - name: SENTRY_DSN
-      value: "https://examplePublicKey@o0.ingest.sentry.io/0"
+      value: https://examplePublicKey@o0.ingest.sentry.io/0
 ```
 
 ## Usage Analytics


### PR DESCRIPTION
## Problem

Resolves #3996 (sibling of #3107, #3995). Same root cause as #3104.

`docs/self-hosting/configuration/third-party-integrations.mdx` contains two YAML config snippets that wrap an `@`-bearing value in double quotes:

```yaml
defaultFrom: "langwatch@yourcompany.com"
...
value: "https://examplePublicKey@o0.ingest.sentry.io/0"
```

Gemini CLI's chat-input `atCommandProcessor` extracts `@`-prefixed runs as potential file paths and calls `fs.lstatSync()` on each one. Its regex `AT_COMMAND_PATH_REGEX_SOURCE` has a `"[^"]*"` alternative that matches across newlines — so the closing quote of `"langwatch@yourcompany.com"` opens a match that eats through the rest of the YAML block, the Setup Steps section, and most of the Sentry section until the next `"` 40 lines later.

Running Gemini's exact regex against the file pre-fix:

```
longest component: 495 bytes (NAME_MAX = 255 on macOS/Linux)
```

`lstat()` throws `ENAMETOOLONG` and Gemini crashes with an unhandled rejection on paste.

## Solution

Drop the double quotes around the two `@`-bearing values. Both remain valid YAML plain scalars (no `": "` or other YAML indicators present), and the rendered docs are visually identical. Verified the values still round-trip correctly through PyYAML:

```json
{
  "defaultFrom": "langwatch@yourcompany.com",
  "value": "https://examplePublicKey@o0.ingest.sentry.io/0"
}
```

Post-fix, the longest `@`-token Gemini extracts from this file drops from **495 bytes to 20 bytes** (`@o0.ingest.sentry.io`).

`docs/llms-full.txt` regenerated via `node docs/llms.txt.cjs` to mirror the change in the aggregated corpus.

## Testing

```bash
node -e '
const re = new RegExp(String.raw`(?<!\\)@` + String.raw`(?:(?:"(?:[^"]*)")|(?:\\.|[^ \t\n\r,;!?()\[\]{}.]|\.(?!$|[ \t\n\r])))+`, "g");
const text = require("fs").readFileSync("docs/self-hosting/configuration/third-party-integrations.mdx", "utf-8");
let max = "";
for (const m of text.matchAll(re)) for (const c of m[0].split("/")) if (c.length > max.length) max = c;
console.log(max.length, JSON.stringify(max));
'
# Before: 495  "@yourcompany.com\"\n    provider: sendgrid\n..."
# After:   20  "@o0.ingest.sentry.io"
```

A repo-wide regression test for `docs/**/*.mdx` (analogous to the one added in #3107 for onboarding prompts) would prevent this footgun from creeping back in — left for a follow-up to keep this PR focused on the file the issue calls out.