### PR TITLE
fix(nlpgo): playground {{input}} auto-fill + structured-output gate parity

### DIFF
--- a/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.test.ts
+++ b/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.test.ts
@@ -73,6 +73,9 @@ import type {
   CopilotRuntimeChatCompletionResponse,
 } from "@copilotkit/runtime";
 import { beforeEach, describe, expect, it } from "vitest";
+import { studioBackendPostEvent } from "../../workflows/post_event/post-event";
+import { addEnvs } from "~/optimization_studio/server/addEnvs";
+import { loadDatasets } from "~/optimization_studio/server/loadDatasets";
 import { PromptStudioAdapter } from "./service-adapter";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -187,6 +190,198 @@ describe("PromptStudioAdapter", () => {
     generateOtelTraceIdMock.mockImplementation(() => {
       callCount++;
       return `trace-mock-${callCount}`;
+    });
+  });
+
+  // 2026-05-16 prompt-playground regression — the saved-prompt template
+  // carries `{{input}}` placeholders by default; the live chat turn must
+  // (a) bind to the `input` variable so those placeholders resolve, and
+  // (b) be ABSORBED by the template's user-message slot rather than
+  // duplicated as a separate live turn. Trace evidence from rchaves
+  // showed `{{input}}` rendering to empty AND the live turn appended
+  // alongside it.
+  describe("when the saved-prompt template references {{input}}", () => {
+    /** Build a fresh formValues blob matching what PromptPlaygroundChat
+     * forwards via `additionalParams.model`. */
+    function buildAdditionalParams({
+      messages: templateMessages,
+      variables,
+    }: {
+      messages: { role: string; content: string }[];
+      variables?: { identifier: string; value: string }[];
+    }): string {
+      return JSON.stringify({
+        formValues: {
+          version: {
+            configData: {
+              llm: { model: "openai/gpt-5-mini" },
+              messages: templateMessages,
+              inputs: [{ identifier: "input", type: "str" }],
+              outputs: [{ identifier: "output", type: "str" }],
+            },
+          },
+        },
+        variables: variables ?? [],
+      });
+    }
+
+    function buildRequestWithChat({
+      additionalParams,
+      chatMessages,
+      eventSource,
+    }: {
+      additionalParams: string;
+      chatMessages: { role: string; content: string }[];
+      eventSource: MockEventSource;
+    }): RequestForProcess {
+      return {
+        eventSource,
+        messages: chatMessages as any,
+        actions: [],
+        threadId: "thread-test-input-binding",
+        forwardedParameters: {
+          model: additionalParams,
+        } as CopilotRuntimeChatCompletionRequest["forwardedParameters"],
+      } as RequestForProcess;
+    }
+
+    function lastPostedEvent(): any {
+      const mocked = vi.mocked(studioBackendPostEvent);
+      expect(mocked, "studioBackendPostEvent must have been called").toHaveBeenCalled();
+      // The component_state_change consumer is async; we only need the
+      // envelope shape that was passed in.
+      return mocked.mock.calls[0][0].message;
+    }
+
+    beforeEach(() => {
+      vi.mocked(studioBackendPostEvent).mockReset();
+      vi.mocked(studioBackendPostEvent).mockResolvedValue(undefined as any);
+      vi.mocked(addEnvs).mockImplementation(async (event: any) => event);
+      vi.mocked(loadDatasets).mockImplementation(async (event: any) => event);
+    });
+
+    it("binds the latest live user-message content to inputs.input", async () => {
+      const { eventSource } = createMockEventSource();
+      await runProcess(
+        adapter,
+        buildRequestWithChat({
+          additionalParams: buildAdditionalParams({
+            messages: [
+              { role: "system", content: "Reply using {{input}} verbatim" },
+              { role: "user", content: "{{input}}" },
+            ],
+          }),
+          chatMessages: [{ role: "user", content: "test7" }],
+          eventSource,
+        }),
+      );
+
+      const envelope = lastPostedEvent();
+      expect(envelope.payload.inputs.input).toBe("test7");
+    });
+
+    it("absorbs the live user-message into the template slot (no duplicate turn)", async () => {
+      const { eventSource } = createMockEventSource();
+      await runProcess(
+        adapter,
+        buildRequestWithChat({
+          additionalParams: buildAdditionalParams({
+            messages: [
+              { role: "system", content: "system" },
+              { role: "user", content: "{{input}}" },
+            ],
+          }),
+          chatMessages: [{ role: "user", content: "test7" }],
+          eventSource,
+        }),
+      );
+
+      const envelope = lastPostedEvent();
+      const sent: { role: string; content: string }[] = envelope.payload.inputs.messages;
+      // Exactly one user turn — the template's `{{input}}` slot, NOT a
+      // duplicated live "test7" turn. Server-side render will resolve
+      // the placeholder against inputs.input.
+      const userTurns = sent.filter((m) => m.role === "user");
+      expect(userTurns).toHaveLength(1);
+      expect(userTurns[0].content).toBe("{{input}}");
+    });
+
+    it("keeps prior assistant + user turns when the template absorbs only the latest live turn", async () => {
+      const { eventSource } = createMockEventSource();
+      await runProcess(
+        adapter,
+        buildRequestWithChat({
+          additionalParams: buildAdditionalParams({
+            messages: [
+              { role: "system", content: "system" },
+              { role: "user", content: "{{input}}" },
+            ],
+          }),
+          chatMessages: [
+            { role: "user", content: "older question" },
+            { role: "assistant", content: "older reply" },
+            { role: "user", content: "test7" },
+          ],
+          eventSource,
+        }),
+      );
+
+      const envelope = lastPostedEvent();
+      const sent: { role: string; content: string }[] = envelope.payload.inputs.messages;
+      // Template's `{{input}}` turn + 2 prior live turns (older question
+      // + older reply). The latest "test7" turn is absorbed.
+      expect(sent.map((m) => m.content)).toEqual([
+        "{{input}}",
+        "older question",
+        "older reply",
+      ]);
+      expect(envelope.payload.inputs.input).toBe("test7");
+    });
+
+    it("appends the live turn normally when the template has no {{input}} user-slot", async () => {
+      const { eventSource } = createMockEventSource();
+      await runProcess(
+        adapter,
+        buildRequestWithChat({
+          additionalParams: buildAdditionalParams({
+            messages: [
+              // system references {{input}} for var binding, but there
+              // is NO template user turn to absorb the live message,
+              // so it must still appear as its own turn.
+              { role: "system", content: "Echo {{input}} back" },
+            ],
+          }),
+          chatMessages: [{ role: "user", content: "test7" }],
+          eventSource,
+        }),
+      );
+
+      const envelope = lastPostedEvent();
+      const sent: { role: string; content: string }[] = envelope.payload.inputs.messages;
+      expect(sent).toEqual([{ role: "user", content: "test7" }]);
+      // Still bind input so the system's {{input}} resolves.
+      expect(envelope.payload.inputs.input).toBe("test7");
+    });
+
+    it("does not override an explicit `input` value from the Variables panel", async () => {
+      const { eventSource } = createMockEventSource();
+      await runProcess(
+        adapter,
+        buildRequestWithChat({
+          additionalParams: buildAdditionalParams({
+            messages: [
+              { role: "system", content: "system" },
+              { role: "user", content: "{{input}}" },
+            ],
+            variables: [{ identifier: "input", value: "explicit-value" }],
+          }),
+          chatMessages: [{ role: "user", content: "test7" }],
+          eventSource,
+        }),
+      );
+
+      const envelope = lastPostedEvent();
+      expect(envelope.payload.inputs.input).toBe("explicit-value");
     });
   });
 

--- a/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.test.ts
+++ b/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.test.ts
@@ -249,8 +249,10 @@ describe("PromptStudioAdapter", () => {
       const mocked = vi.mocked(studioBackendPostEvent);
       expect(mocked, "studioBackendPostEvent must have been called").toHaveBeenCalled();
       // The component_state_change consumer is async; we only need the
-      // envelope shape that was passed in.
-      return mocked.mock.calls[0][0].message;
+      // envelope shape that was passed in. The `!` propagates the
+      // toHaveBeenCalled guarantee past TS's noUncheckedIndexedAccess.
+      const firstCall = mocked.mock.calls[0]!;
+      return (firstCall[0] as any).message;
     }
 
     beforeEach(() => {
@@ -303,7 +305,7 @@ describe("PromptStudioAdapter", () => {
       // the placeholder against inputs.input.
       const userTurns = sent.filter((m) => m.role === "user");
       expect(userTurns).toHaveLength(1);
-      expect(userTurns[0].content).toBe("{{input}}");
+      expect(userTurns[0]!.content).toBe("{{input}}");
     });
 
     it("keeps prior assistant + user turns when the template absorbs only the latest live turn", async () => {

--- a/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts
+++ b/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts
@@ -28,6 +28,11 @@ import { extractStreamableOutput, type OutputConfig } from "./output-formatter";
 
 const logger = createLogger("PromptStudioAdapter");
 
+// Matches a `{{ input }}` Liquid placeholder (whitespace tolerated).
+// Used to detect whether a saved-prompt template message will absorb
+// the live chat turn or needs it appended separately.
+const TEMPLATE_INPUT_PLACEHOLDER_RE = /\{\{\s*input\s*\}\}/;
+
 type PromptStudioAdapterParams = {
   projectId: string;
 };
@@ -96,7 +101,37 @@ export class PromptStudioAdapter implements CopilotServiceAdapter {
       const formMsgs = (formValues.version.configData.messages ?? []).filter(
         (m) => m.role !== "system",
       );
-      const messagesHistory = [...formMsgs, ...messages]
+
+      // 2026-05-16 prompt-playground regression: the saved-prompt
+      // template carries `{{input}}` placeholders by default
+      // (llm-config.repository.ts:872), but PromptStudioAdapter never
+      // bound the live chat turn to the `input` variable — so
+      // `{{input}}` rendered to empty and the live user message was
+      // appended as a SEPARATE turn next to the template turn. Old
+      // langwatch_nlp's playground path treated the latest live user
+      // message as the `input` value; the new live turn was only
+      // appended when the template did NOT already reference
+      // `{{input}}`. Reproducing that heuristic here keeps the wire
+      // shape (`inputs.input` + `inputs.messages`) consistent with
+      // what nlpgo's buildMessages expects and what the saved prompt
+      // template assumes.
+      const lastLiveUserMsg = [...messages]
+        .reverse()
+        .find((m: any) => m.role === "user");
+      const templateUserMsgs = formMsgs.filter((m) => m.role === "user");
+      const templateUserReferencesInput = templateUserMsgs.some((m) =>
+        TEMPLATE_INPUT_PLACEHOLDER_RE.test(m.content ?? ""),
+      );
+      // Drop the latest live user turn from the history when the
+      // template's user-message will render it (otherwise the user
+      // sees the same content twice — once rendered, once live).
+      // Earlier copilot turns (assistant replies + prior user turns)
+      // still belong in the history.
+      const liveMessagesForHistory =
+        templateUserReferencesInput && lastLiveUserMsg
+          ? messages.filter((m: any) => m !== lastLiveUserMsg)
+          : messages;
+      const messagesHistory = [...formMsgs, ...liveMessagesForHistory]
         .map((message: any) => ({
           role: message.role,
           content: message.content,
@@ -121,6 +156,18 @@ export class PromptStudioAdapter implements CopilotServiceAdapter {
         },
         {} as Record<string, unknown>,
       );
+      // Bind the latest live user message's content to the `input`
+      // variable so saved-prompt `{{input}}` placeholders (in system
+      // OR template user messages) resolve to what the user actually
+      // typed. An explicit value from the Variables panel always
+      // wins — typing-then-overriding is the user's choice.
+      const lastLiveUserContent =
+        lastLiveUserMsg && typeof (lastLiveUserMsg as any).content === "string"
+          ? ((lastLiveUserMsg as any).content as string)
+          : undefined;
+      if (lastLiveUserContent !== undefined && variablesDict.input === undefined) {
+        variablesDict.input = lastLiveUserContent;
+      }
 
       // Build execute_flow event (inputs must be a dict)
       const rawEvent: StudioClientEvent = {

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -449,20 +449,39 @@ func (e *Engine) runSignature(ctx context.Context, execReq ExecuteRequest, node 
 }
 
 // signatureNeedsStructuredOutput returns true when the engine should
-// ask the LLM for a JSON-shaped response and parse it across multiple
-// outputs. True iff any output is typed json_schema OR there are 2+
-// outputs (multi-output requires field separation — assigning the raw
-// content to every declared output loses signal).
+// ask the LLM for a JSON-shaped response and parse it across one or
+// more typed outputs.
+//
+// Python parity — langwatch_nlp/langwatch_nlp/studio/dspy/template_
+// adapter.py:228-232 `_use_text_only_completion`: text-only iff there
+// are zero outputs OR a single output whose annotation is `str`.
+// Everything else (single bool, single float, single json_schema, OR
+// 2+ outputs) needs response_format on the LLM request so the model
+// returns a parseable JSON object the engine can coerce back into the
+// declared field types.
+//
+// Earlier revision (PR #4062 baseline) only triggered structured
+// outputs for json_schema-typed OR 2+ outputs. That missed single
+// `bool` / `float` outputs entirely: the engine sent no response_format,
+// the LLM replied with prose, and engine.go's fallback shoved that prose
+// into a typed slot as a raw string — manifesting as a blank chat bubble
+// in the playground (rchaves dogfood 2026-05-16) because the TS output-
+// formatter silently rejects type-mismatched values.
 func signatureNeedsStructuredOutput(outputs []dsl.Field) bool {
-	if len(outputs) >= 2 {
-		return true
+	if len(outputs) == 0 {
+		return false
 	}
 	for _, f := range outputs {
-		if f.Type == dsl.FieldTypeJSONSchema {
+		if f.Type != dsl.FieldTypeStr {
 			return true
 		}
 	}
-	return false
+	// All outputs are `str`: when there's exactly one, use the text-
+	// only fast path (Python's _use_text_only_completion). When there
+	// are multiple `str` outputs, we still need structured output —
+	// otherwise the same response text would be assigned to every
+	// declared output, losing signal.
+	return len(outputs) >= 2
 }
 
 // sanitizeSchemaName normalizes a string to OpenAI's

--- a/services/nlpgo/app/engine/signature_outputs_test.go
+++ b/services/nlpgo/app/engine/signature_outputs_test.go
@@ -11,21 +11,41 @@ import (
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
 )
 
-// TestSignatureNeedsStructuredOutput pins the policy: structured
-// response_format is requested when (a) any output is json_schema-typed
-// or (b) there are 2+ outputs (multi-output requires field separation).
+// TestSignatureNeedsStructuredOutput pins the Python-parity policy
+// (_use_text_only_completion at langwatch_nlp/langwatch_nlp/studio/dspy/
+// template_adapter.py:228-232): text-only fast path is taken iff there
+// are zero outputs OR a single output whose type is `str`. Everything
+// else needs response_format — including single `bool`, single `float`,
+// single `json_schema`, and any multi-output signature.
+//
+// Pre-fix this gate only fired for json_schema-typed or 2+ outputs;
+// single `bool` / single `float` slipped through, the LLM replied with
+// prose, and the engine shoved that prose into a typed slot. Manifested
+// as a blank chat bubble in the playground (rchaves dogfood 2026-05-16)
+// because the TS output-formatter silently rejects type-mismatched
+// values.
 func TestSignatureNeedsStructuredOutput(t *testing.T) {
 	cases := []struct {
 		name string
 		out  []dsl.Field
 		want bool
 	}{
-		{"single str", []dsl.Field{{Identifier: "a", Type: dsl.FieldTypeStr}}, false},
-		{"single int", []dsl.Field{{Identifier: "n", Type: dsl.FieldTypeInt}}, false},
-		{"single json_schema", []dsl.Field{{Identifier: "o", Type: dsl.FieldTypeJSONSchema}}, true},
-		{"two str", []dsl.Field{{Identifier: "a"}, {Identifier: "b"}}, true},
-		{"three mixed", []dsl.Field{{Identifier: "a"}, {Identifier: "b"}, {Identifier: "c"}}, true},
+		// Text-only fast path (Python parity).
 		{"empty", []dsl.Field{}, false},
+		{"single str", []dsl.Field{{Identifier: "a", Type: dsl.FieldTypeStr}}, false},
+
+		// Single non-str — was the gap, now correctly structured.
+		{"single bool", []dsl.Field{{Identifier: "passed", Type: dsl.FieldTypeBool}}, true},
+		{"single float", []dsl.Field{{Identifier: "score", Type: dsl.FieldTypeFloat}}, true},
+		{"single int", []dsl.Field{{Identifier: "n", Type: dsl.FieldTypeInt}}, true},
+		{"single json_schema", []dsl.Field{{Identifier: "o", Type: dsl.FieldTypeJSONSchema}}, true},
+		{"single list[str]", []dsl.Field{{Identifier: "tags", Type: dsl.FieldTypeListStr}}, true},
+		{"single dict", []dsl.Field{{Identifier: "meta", Type: dsl.FieldTypeDict}}, true},
+
+		// Multi-output always structured (assigning the same response
+		// to every declared output loses signal).
+		{"two str", []dsl.Field{{Identifier: "a", Type: dsl.FieldTypeStr}, {Identifier: "b", Type: dsl.FieldTypeStr}}, true},
+		{"three mixed", []dsl.Field{{Identifier: "a"}, {Identifier: "b"}, {Identifier: "c"}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -52,6 +72,31 @@ func TestComposeSignatureResponseFormat_TwoStringOutputs(t *testing.T) {
 	assert.Equal(t, map[string]any{"type": "number"}, props["confidence"])
 	required := schema["required"].([]string)
 	assert.ElementsMatch(t, []string{"label", "confidence"}, required)
+}
+
+// TestComposeSignatureResponseFormat_SingleBool pins the rchaves
+// dogfood case (2026-05-16): a prompt with Structured Outputs ON and a
+// single output `passed: bool` must produce a response_format with a
+// boolean property so the LLM returns `{"passed": true}` instead of
+// prose. Pre-fix the gate predicate skipped this entirely and the
+// engine never sent response_format.
+func TestComposeSignatureResponseFormat_SingleBool(t *testing.T) {
+	rf := composeSignatureResponseFormat("Verifier", []dsl.Field{
+		{Identifier: "passed", Type: dsl.FieldTypeBool},
+	})
+	require.NotNil(t, rf, "single-bool output must produce a response_format (Python parity)")
+	assert.Equal(t, "json_schema", rf.Type)
+	js := rf.JSONSchema
+	assert.Equal(t, "Verifier", js["name"])
+	assert.Equal(t, true, js["strict"])
+	schema := js["schema"].(map[string]any)
+	assert.Equal(t, "object", schema["type"])
+	assert.Equal(t, false, schema["additionalProperties"])
+	props := schema["properties"].(map[string]any)
+	assert.Equal(t, map[string]any{"type": "boolean"}, props["passed"],
+		"the bool field must declare type:boolean so the LLM returns a JSON bool, not prose")
+	required := schema["required"].([]string)
+	assert.ElementsMatch(t, []string{"passed"}, required)
 }
 
 // TestComposeSignatureResponseFormat_JSONSchemaPassthrough proves a

--- a/services/nlpgo/tests/integration/dsl_patterns_test.go
+++ b/services/nlpgo/tests/integration/dsl_patterns_test.go
@@ -761,6 +761,117 @@ func TestPattern007_MultiOutputSignatureParseAndSplit(t *testing.T) {
 	assert.InDelta(t, 0.93, res.Result["confidence"], 1e-9)
 }
 
+// TestPattern_StructuredOutput_SingleBool is the B5 regression pin.
+// A prompt-playground-style signature node with a single `passed: bool`
+// output must trigger structured response_format on the LLM request and
+// parse the JSON reply back into a Go bool — exactly Python's
+// `_use_text_only_completion` parity at langwatch_nlp/.../template_adapter
+// .py:228-232.
+//
+// Pre-fix this slipped through: signatureNeedsStructuredOutput only
+// fired for json_schema-typed or 2+ outputs, so a single-bool signature
+// sent no response_format, the LLM returned prose, and the engine
+// shoved that prose into the typed bool slot as a raw string. In the
+// playground that surfaced as a blank chat bubble because the TS
+// output-formatter silently rejects type-mismatched values (rchaves
+// dogfood 2026-05-16, three tabs of `customer-care-prompt` with
+// Structured Outputs ON).
+//
+// What this test proves end-to-end:
+//
+//  1. The signature node with a single `bool` output sends
+//     response_format = json_schema in the LLMRequest (was nil
+//     pre-fix). Verified at the LLM boundary via fakeLLMClient.
+//  2. The composed JSON Schema declares `passed: {"type": "boolean"}`
+//     so the provider enforces a JSON bool reply, not prose.
+//  3. The engine parses the JSON `{"passed": true}` reply and the
+//     downstream end node receives a real Go bool — no longer a raw
+//     string.
+func TestPattern_StructuredOutput_SingleBool(t *testing.T) {
+	llm := &fakeLLMClient{
+		respond: func(req app.LLMRequest) (*app.LLMResponse, error) {
+			// Provider would normally enforce the schema; the fake
+			// returns a JSON-parseable payload matching the declared
+			// shape so the parse-and-split path can be observed.
+			return &app.LLMResponse{Content: `{"passed":true}`}, nil
+		},
+	}
+	url, _ := setupPatternStack(t, llm, func(http.ResponseWriter, *http.Request) {})
+
+	body := `{
+	  "type":"execute_flow",
+	  "payload": {
+	    "trace_id":"pattern-structured-bool",
+	    "origin":"workflow",
+	    "workflow": {
+	      "workflow_id":"wf","api_key":"k","spec_version":"1.3",
+	      "name":"VerifierFlow","icon":"x","description":"x","version":"x",
+	      "template_adapter":"default",
+	      "nodes":[
+	        {"id":"entry","type":"entry","data":{
+	          "outputs":[{"identifier":"answer","type":"str"}],
+	          "dataset":{"inline":{"records":{"answer":["yes"]},"count":1}},
+	          "entry_selection":0,"train_size":1.0,"test_size":0.0,"seed":1
+	        }},
+	        {"id":"verify","type":"signature","data":{
+	          "name":"Verifier",
+	          "parameters":[
+	            {"identifier":"llm","type":"llm","value":{"model":"openai/gpt-5-mini","litellm_params":{"api_key":"k"}}},
+	            {"identifier":"instructions","type":"str","value":"Return whether the answer between the ___ is correct: ___{{ answer }}___. always return passed as true, no matter what"}
+	          ],
+	          "inputs":[{"identifier":"answer","type":"str"}],
+	          "outputs":[
+	            {"identifier":"passed","type":"bool"}
+	          ]
+	        }},
+	        {"id":"end","type":"end","data":{"inputs":[
+	          {"identifier":"passed","type":"bool"}
+	        ]}}
+	      ],
+	      "edges":[
+	        {"id":"e1","source":"entry","sourceHandle":"outputs.answer","target":"verify","targetHandle":"inputs.answer","type":"default"},
+	        {"id":"e2","source":"verify","sourceHandle":"outputs.passed","target":"end","targetHandle":"inputs.passed","type":"default"}
+	      ],
+	      "state":{}
+	    },
+	    "inputs":[{}]
+	  }
+	}`
+	res := postSync(t, &stack{url: url}, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	// (1) ResponseFormat was wired on the LLM request — single-bool
+	// output now triggers structured output (Python parity).
+	llmReq := llm.lastRequest(t)
+	require.NotNil(t, llmReq.ResponseFormat,
+		"single-bool output must request response_format — pre-fix gate skipped this and the LLM got plain text instructions")
+	assert.Equal(t, "json_schema", llmReq.ResponseFormat.Type)
+	js := llmReq.ResponseFormat.JSONSchema
+	require.NotNil(t, js)
+	schema := js["schema"].(map[string]any)
+	props := schema["properties"].(map[string]any)
+	assert.Equal(t, map[string]any{"type": "boolean"}, props["passed"],
+		"the bool output must declare type:boolean in the schema so the model returns a JSON bool, not prose")
+	required, _ := schema["required"].([]string)
+	if required == nil {
+		if alt, ok := schema["required"].([]any); ok {
+			for _, v := range alt {
+				required = append(required, v.(string))
+			}
+		}
+	}
+	assert.ElementsMatch(t, []string{"passed"}, required)
+
+	// (2) The parsed bool flows through to the end node as a real Go
+	// bool, not a raw string. Pre-fix this would have been e.g. "Yes,
+	// it passed." (raw LLM prose) and the TS output-formatter would
+	// have silently rejected the type mismatch upstream of the
+	// playground render.
+	require.NotNil(t, res.Result)
+	assert.Equal(t, true, res.Result["passed"],
+		"end node must receive a Go bool — proves parse-and-split happened, not the pre-fix 'shove raw content into typed slot' bug")
+}
+
 // stringContains is a tiny case-sensitive substring helper to avoid
 // pulling strings just for these branch discriminators.
 func stringContains(s, sub string) bool {


### PR DESCRIPTION
## Summary

Two follow-up regressions from the 2026-05-16 prod dogfood after PR #4062 merged.

### B4 — `{{input}}` not auto-filled from the live chat message

Template: `{{test}}` + `{{input}}`. Variables panel: `test=test`. User sends "test7". Trace shows the system rendered `{{test}}`→"test" but `{{input}}`→"" with "test7" appended as a separate user turn. The old Python playground path bound the latest live user-message content to the `input` variable before rendering; PR #4062's `buildMessages` rewrite restored template_adapter format() parity but skipped that input-binding step.

Fix in `langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts` (playground-only — workflow signature nodes still get `input` from upstream edges):
- bind `inputs.input = lastLiveUser.content` when the Variables panel has no explicit value (explicit wins)
- drop the latest live user turn from messages history iff the template has a user-message containing `{{input}}` (template absorbs it; otherwise the live turn stays as a separate turn)
- prior live turns (assistant + earlier user) preserved either way

5 new unit tests in `service-adapter.test.ts` cover: bind, absorb, prior-turns-survive, system-only-ref still appends, explicit-var wins.

### B5 — Structured outputs gate too narrow (single non-`str`)

`services/nlpgo/app/engine/engine.go` `signatureNeedsStructuredOutput` only triggered structured outputs for `json_schema`-typed or 2+ outputs. Python parity (`langwatch_nlp/langwatch_nlp/studio/dspy/template_adapter.py:228-232` `_use_text_only_completion`) is "text-only iff zero outputs OR a single output of type `str`". Any single non-`str` output needs `response_format` so the LLM returns parseable JSON. A prompt with Structured Outputs ON and a single `passed: bool` output slipped through: no `response_format` was sent, the LLM replied with prose, and the engine shoved that prose into the typed bool slot as a raw string. In the playground this surfaced as a blank chat bubble because the TS output-formatter silently rejects type-mismatched values upstream of the render path (B6, observation-only — once B5 is fixed, the type matches and the bubble renders).

Fix: gate returns true for any non-`str` output (matches Python exactly). Existing scenarios (single-`json_schema`, multi-output) unchanged.

Comprehensive coverage in `signature_outputs_test.go`: `bool` / `float` / `int` / `list[*]` / `dict` / `json_schema` single-output cases, plus empty + single-`str` + multi-output edges. New `TestComposeSignatureResponseFormat_SingleBool` pins the exact dogfood case ("Verifier" prompt with `passed: bool` → response_format with `passed: {type: boolean}`).

End-to-end integration proof in `dsl_patterns_test.go` (`TestPattern_StructuredOutput_SingleBool`): drives the real router → engine → fakeLLM boundary with a single-`bool` signature workflow, asserts (1) `response_format` reaches the LLM as `json_schema` (was nil pre-fix), (2) schema declares `passed: {type: boolean}`, (3) the parsed JSON `{"passed": true}` flows through to the end node as a real Go bool.

## Tests / proof

- **B4**: 5 new unit tests + existing 3 still green; `pnpm typecheck` clean (Sarah, locally).
- **B5**: comprehensive unit coverage in `signature_outputs_test.go` + full router-through-LLM-boundary integration test in `dsl_patterns_test.go`. Full nlpgo Go suite green.

## Commits

- `831c342c0` fix(nlpgo): broaden structured-output gate to match Python parity (B5)
- `e64829d69` fix(playground): bind live chat to inputs.input + absorb the absorbed live turn (B4)
- `5f9f490b9` test(nlpgo): integration proof for B5 single-bool structured output

Browser dogfood of both fixes (live prompt playground + structured-output prompt) in progress; screenshots to follow.
