### PR TITLE
fix(traces): flat default drawer width, grey flame text, ↵ glyph clamp

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
@@ -276,11 +276,13 @@ export const IOViewer = memo(function IOViewer({
   // with nested scroll containers.
   const isVirtualizingChat =
     format === "pretty" && isChat && conversationTurns.length >= VIRTUALIZE_AT;
-  // Output mode + chat = a single AssistantTurnCard. That card already has
-  // its own purple-bordered chrome; wrapping it in the IOViewer's outer
-  // card makes a card-in-card. Drop the outer chrome there so the
-  // assistant card sits flush at the root of the section.
-  const flushChatCard = format === "pretty" && isChat && mode === "output";
+  // Pretty + chat: every individual turn already paints its own role
+  // chrome (bubble, card, or thread row with an avatar header). The
+  // outer IOViewer "bg.subtle + border" box around them just looks
+  // like a redundant container — operator complaint: "remove this
+  // gray box around the input, why does it exist?". Applies whether
+  // we're rendering the input history or the output reply.
+  const flushChatCard = format === "pretty" && isChat;
 
   // Track whether the preview box's content actually exceeds its visible
   // height. The "Click to interact" scrim only makes sense when there's

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
@@ -4,6 +4,7 @@ import { useColorMode } from "~/components/ui/color-mode";
 import { Drawer } from "~/components/ui/drawer";
 import { IsolatedErrorBoundary } from "~/components/ui/IsolatedErrorBoundary";
 import {
+  DRAWER_DEFAULT_WIDTH_PX,
   DRAWER_MIN_WIDTH_PX,
   useDrawerStore,
 } from "../../stores/drawerStore";
@@ -105,26 +106,28 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
   }
 
   // The drawer width is driven by the operator's drag (persisted in
-  // drawerStore.widthPx). When `null`, we fall back to the legacy 45%
-  // viewport rule. Below the `md` breakpoint (~768px) there isn't
-  // useful underlying surface to peek at — the drawer goes full
-  // viewport so the chrome stays usable on phones. We also skip the
-  // inline override if the persisted width is wider than the current
-  // viewport, so a width remembered on a wide monitor never overflows
-  // a narrower window.
+  // drawerStore.widthPx). Until they drag, we use a flat
+  // `DRAWER_DEFAULT_WIDTH_PX` (920) instead of the previous 45% rule
+  // — a deterministic first-paint width that doesn't visibly shift
+  // when the user later drags and the persisted px replaces the %.
+  // Below the `md` breakpoint (~768px) the drawer goes full viewport
+  // so the chrome stays usable on phones. We also cap any
+  // persisted/default width against the current viewport so a width
+  // remembered on a wide monitor never overflows a narrower window.
   const viewportWidth =
     typeof window !== "undefined" ? window.innerWidth : Infinity;
   const isCompactViewport = viewportWidth < 768;
-  const widthFitsViewport =
-    widthPx !== null && widthPx <= viewportWidth;
-  const contentWidthStyle =
-    widthPx !== null && !isCompactViewport && widthFitsViewport
-      ? {
-          width: `${widthPx}px`,
-          maxWidth: `${widthPx}px`,
-          minWidth: `${DRAWER_MIN_WIDTH_PX}px`,
-        }
-      : undefined;
+  const effectiveWidthPx = Math.min(
+    widthPx ?? DRAWER_DEFAULT_WIDTH_PX,
+    viewportWidth,
+  );
+  const contentWidthStyle = isCompactViewport
+    ? undefined
+    : {
+        width: `${effectiveWidthPx}px`,
+        maxWidth: `${effectiveWidthPx}px`,
+        minWidth: `${DRAWER_MIN_WIDTH_PX}px`,
+      };
 
   return (
     <Drawer.Root
@@ -153,16 +156,13 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
           bg="transparent"
           ref={drawerContentRef}
           paddingX={0}
-          maxWidth={
-            contentWidthStyle
-              ? undefined
-              : { base: "100vw", md: "45%" }
-          }
-          width={
-            contentWidthStyle
-              ? undefined
-              : { base: "100vw", md: "auto" }
-          }
+          // When `contentWidthStyle` is set (non-compact viewports) the
+          // inline style below owns width/maxWidth. The fallback here
+          // only matters on compact viewports (<md), where we want
+          // the drawer full-bleed — the operator can't drag on a
+          // phone-sized window anyway.
+          maxWidth={contentWidthStyle ? undefined : "100vw"}
+          width={contentWidthStyle ? undefined : "100vw"}
           // The ResizeRail renders the visible pill in a 10px gutter
           // *outside* the drawer's left edge. Allow horizontal overflow
           // so that bit isn't clipped; the body itself still clips its

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/flameView/FlameBlock.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/flameView/FlameBlock.tsx
@@ -65,6 +65,15 @@ export function FlameBlock({
 
   const color =
     (SPAN_TYPE_COLORS[span.type ?? "span"] as string) ?? "gray.solid";
+  // `gray.solid` is too low-saturation for the white-on-fill recipe
+  // every other palette uses — at 85% alpha on a white canvas the
+  // result is a pale grey that white text dissolves into (operator
+  // report: "can't read the letters" on Scenario Turn / module /
+  // execute_event_loop_cycle bars). Dark mode is fine because the
+  // canvas is already dark. So flip text to `fg` only for grey
+  // palettes in light mode; everything else stays the saturated
+  // white-on-colour treatment.
+  const isLowContrastPalette = color === "gray.solid";
   const depthAlpha = Math.max(
     DEPTH_FADE_FLOOR,
     1 - depth * DEPTH_FADE_STEP,
@@ -196,18 +205,24 @@ export function FlameBlock({
       >
         <Text
           textStyle="xs"
-          // White text in both modes. Light mode's `lightBgAlphaPct`
-          // floor (see above) keeps every block saturated enough that
-          // white reads cleanly — no more dark-on-light fights when the
-          // alpha rolled into pastel territory. The text-shadow gives a
-          // half-pixel of lift against the saturated background so the
-          // glyphs don't melt into the colour. Even at the dimmed-state
-          // alpha (~55%), white over a `.solid` blue/purple/teal still
-          // beats the legibility of dark text on a pale tint.
-          color="white"
+          // White text in both modes for the saturated palettes
+          // (blue/green/purple/teal/orange/pink/cyan) — `lightBgAlphaPct`
+          // keeps the fill saturated enough that white reads cleanly.
+          // Grey-palette spans (span/module) get `fg` in light mode
+          // instead because grey.solid at 85% alpha is too pale for
+          // white text — dark mode stays white because the canvas
+          // already pushes the fill into a dark band.
+          color={isLowContrastPalette ? { base: "fg", _dark: "white" } : "white"}
           truncate
           lineHeight={1}
-          textShadow="0 1px 1px rgba(0,0,0,0.45)"
+          // Dark drop-shadow lifts white text off the saturated fills.
+          // On the grey-palette light-mode path we render dark text
+          // instead, where this same shadow would double-print the
+          // glyphs into bold-ish noise — drop it on that branch.
+          textShadow={{
+            base: isLowContrastPalette ? "none" : "0 1px 1px rgba(0,0,0,0.45)",
+            _dark: "0 1px 1px rgba(0,0,0,0.45)",
+          }}
         >
           <BlockLabel
             name={span.name}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/panes/ResizeRail.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/panes/ResizeRail.tsx
@@ -1,6 +1,7 @@
 import { Box } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef } from "react";
 import {
+  DRAWER_DEFAULT_WIDTH_PX,
   DRAWER_MAXIMIZE_EDGE_PX,
   DRAWER_MIN_WIDTH_PX,
   useDrawerStore,
@@ -36,8 +37,10 @@ export function ResizeRail() {
 
   const resolveCurrentWidth = useCallback(() => {
     if (widthPx !== null) return widthPx;
-    if (typeof window === "undefined") return DRAWER_MIN_WIDTH_PX;
-    return Math.round(window.innerWidth * 0.45);
+    if (typeof window === "undefined") return DRAWER_DEFAULT_WIDTH_PX;
+    // Cap at the viewport so a default wider than the window doesn't
+    // start the drag from off-screen.
+    return Math.min(DRAWER_DEFAULT_WIDTH_PX, window.innerWidth);
   }, [widthPx]);
 
   const handlePointerDown = useCallback(
@@ -133,9 +136,9 @@ export function ResizeRail() {
 
   // Determine whether the drawer is at the max-snap width. When it is,
   // we hide the pill — the rail is invisible chrome that only re-appears
-  // on hover for the operator to grab the edge back. The default 45%
-  // fallback (`widthPx === null`) is never "at max" so the pill is
-  // always visible there.
+  // on hover for the operator to grab the edge back. The default flat
+  // `DRAWER_DEFAULT_WIDTH_PX` fallback (`widthPx === null`) is never
+  // "at max" so the pill is always visible there.
   const atMaxSnap = (() => {
     if (typeof window === "undefined" || widthPx === null) return false;
     const max = window.innerWidth - DRAWER_MAXIMIZE_EDGE_PX;

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/scenarioRoles.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/scenarioRoles.tsx
@@ -89,8 +89,8 @@ export function getDisplayRoleVisuals(
   return role === "user"
     ? {
         displayRole: "assistant",
-        label: "SIMULATOR",
-        bubbleLabel: "Simulator",
+        label: "USER SIMULATOR",
+        bubbleLabel: "User Simulator",
         Icon: LuFlaskConical,
       }
     : {

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/AssistantTurnCard.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/AssistantTurnCard.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import { LuBot } from "react-icons/lu";
 import type { DisplayRoleVisuals } from "../scenarioRoles";
 import { BlockStack } from "./BlockStack";
+import { getRolePalette } from "./RoleChip";
 import { TurnCollapseChevron } from "./TurnCollapseChevron";
 import type { ChatMessage, ContentBlock } from "./types";
 
@@ -54,12 +55,18 @@ export function AssistantTurnCard({
   );
   const visibleToolCalls = opsHidden && hasOutputText ? [] : toolCalls;
 
+  // Assistant-side bubble: always sourced from `ROLE_PALETTES.assistant`
+  // (purple). This is the canonical "assistant side" colour; thread
+  // layout reads the same palette via `getRolePalette("assistant")`,
+  // so a scenario simulator (displayRole=assistant) renders purple
+  // here AND in the thread chip.
+  const palette = getRolePalette("assistant");
   return (
     <Box
       mb="4"
       pl="4"
       borderStartWidth="2px"
-      borderStartColor="purple.muted"
+      borderStartColor={palette.muted}
       bg="bg.panel"
       py="3"
       pr="3"
@@ -72,16 +79,16 @@ export function AssistantTurnCard({
           w="4"
           h="4"
           borderRadius="full"
-          bg="purple.muted"
+          bg={palette.muted}
           align="center"
           justify="center"
           flexShrink={0}
         >
-          <Icon as={visuals?.Icon ?? LuBot} boxSize={2.5} color="purple.fg" />
+          <Icon as={visuals?.Icon ?? LuBot} boxSize={2.5} color={palette.fg} />
         </Flex>
         <Text
           textStyle="2xs"
-          color="purple.fg"
+          color={palette.fg}
           fontWeight="600"
           textTransform="uppercase"
           letterSpacing="0.06em"

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/FlatTurnView.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/FlatTurnView.tsx
@@ -1,4 +1,4 @@
-import { Box, chakra, Flex, HStack, Icon, Text } from "@chakra-ui/react";
+import { Box, chakra, Flex, Icon, Text } from "@chakra-ui/react";
 import { LuBot, LuChevronUp, LuUser } from "react-icons/lu";
 import { getDisplayRoleVisuals, useIsScenarioRole } from "../scenarioRoles";
 import { BlockStack } from "./BlockStack";

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/FlatTurnView.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/FlatTurnView.tsx
@@ -1,10 +1,14 @@
-import { Box, Flex, HStack, Icon, Text } from "@chakra-ui/react";
-import { LuBot, LuUser } from "react-icons/lu";
+import { Box, chakra, Flex, HStack, Icon, Text } from "@chakra-ui/react";
+import { LuBot, LuChevronUp, LuUser } from "react-icons/lu";
 import { getDisplayRoleVisuals, useIsScenarioRole } from "../scenarioRoles";
 import { BlockStack } from "./BlockStack";
-import { ROLE_COLORS, ROLE_ICONS, ROLE_LABELS } from "./RoleChip";
-import { TurnCollapseChevron } from "./TurnCollapseChevron";
-import type { ConversationTurn } from "./types";
+import {
+  getRolePalette,
+  ROLE_ICONS,
+  ROLE_LABELS,
+  type RolePalette,
+} from "./RoleChip";
+import type { ContentBlock, ConversationTurn } from "./types";
 
 /**
  * Flat, ChatGPT-style turn body. Renders the role chip on its own row
@@ -28,30 +32,35 @@ export function FlatTurnView({
   if (turn.kind === "system") {
     const sourceRole = turn.role;
     const RoleIcon = ROLE_ICONS[sourceRole] ?? LuUser;
-    const color = ROLE_COLORS[sourceRole] ?? "fg.muted";
+    const palette = getRolePalette(sourceRole);
     const label = ROLE_LABELS[sourceRole] ?? sourceRole.toUpperCase();
     return (
       <FlatBody
         Icon={RoleIcon}
-        color={color}
+        palette={palette}
         label={label}
         onCollapse={onCollapse}
       >
-        <BlockStack
-          blocks={turn.blocks}
-          toolCalls={[]}
-          collapseTools={collapseTools}
-        />
+        {/* System prompts in thread layout render as plain text instead
+            of the asMarkdownBody → fenced-code-block path used elsewhere.
+            The latter detects pseudo-XML markers like `<role>`/`<goal>`
+            and wraps the WHOLE message in a Shiki ```xml block, which
+            then renders at 0.78em — visibly tiny vs neighbouring user
+            and assistant turns. Plain `<pre>`-style rendering keeps the
+            same baseline font size (textStyle="xs") as every other
+            turn body. */}
+        <SystemPlainText blocks={turn.blocks} />
       </FlatBody>
     );
   }
 
   const visuals = getDisplayRoleVisuals(turn.kind, { isScenario });
-  // Same colour key resolution as ThreadedTurnView's collapsed header so
-  // the chip carries through scenario role-swaps consistently.
+  // Key the palette on the *display* role so scenario role-swap lands
+  // on the same colour the bubble layout uses (simulator = assistant
+  // displayRole = purple, agent = user displayRole = blue).
   const sourceRole = turn.kind === "user" ? "user" : "assistant";
   const colorKey = visuals.displayRole ?? sourceRole;
-  const color = ROLE_COLORS[colorKey] ?? "fg.muted";
+  const palette = getRolePalette(colorKey);
   const RoleIcon =
     visuals.Icon ??
     ROLE_ICONS[sourceRole] ??
@@ -64,7 +73,7 @@ export function FlatTurnView({
   return (
     <FlatBody
       Icon={RoleIcon}
-      color={color}
+      palette={palette}
       label={label}
       onCollapse={onCollapse}
     >
@@ -77,38 +86,90 @@ export function FlatTurnView({
   );
 }
 
+/**
+ * Plain-text renderer for system prompts in thread layout. Sidesteps
+ * the markdown / code-fence pipeline so the operator sees the prompt
+ * at the same size as every other turn. `whiteSpace="pre-wrap"`
+ * preserves the original line breaks + indentation.
+ */
+function SystemPlainText({ blocks }: { blocks: ContentBlock[] }) {
+  const text = blocks
+    .filter(
+      (b): b is Extract<ContentBlock, { kind: "text" }> => b.kind === "text",
+    )
+    .map((b) => b.text)
+    .join("\n");
+  if (!text) {
+    return (
+      <Text textStyle="xs" color="fg.subtle" fontStyle="italic">
+        No content
+      </Text>
+    );
+  }
+  return (
+    <Box
+      textStyle="xs"
+      color="fg"
+      lineHeight={1.6}
+      whiteSpace="pre-wrap"
+      wordBreak="break-word"
+      fontFamily="mono"
+    >
+      {text}
+    </Box>
+  );
+}
+
 function FlatBody({
   Icon: RoleIcon,
-  color,
+  palette,
   label,
   onCollapse,
   children,
 }: {
   Icon: typeof LuUser;
-  color: string;
+  palette: RolePalette;
   label: string;
   onCollapse?: () => void;
   children: React.ReactNode;
 }) {
+  // Header always renders the same row chrome regardless of collapsed
+  // state — operator complaint: "why when its not expanded the
+  // system/agent/simulator/user header becomes smaller padded to the
+  // middle?". Same padding + avatar size in both states. The whole
+  // header is the click target when expanded (so clicking anywhere on
+  // it collapses the turn), not just the chevron.
   return (
     <Box paddingY={1.5}>
-      <HStack gap={1.5} marginBottom={1.5}>
+      <chakra.button
+        type="button"
+        onClick={onCollapse}
+        disabled={!onCollapse}
+        display="flex"
+        alignItems="center"
+        gap={2}
+        width="full"
+        paddingY={0.5}
+        paddingX={1.5}
+        borderRadius="sm"
+        cursor={onCollapse ? "pointer" : "default"}
+        _hover={onCollapse ? { bg: "bg.muted" } : undefined}
+        textAlign="left"
+      >
         <Flex
-          width="14px"
-          height="14px"
+          width="24px"
+          height="24px"
           borderRadius="full"
-          bg="bg.subtle"
-          borderWidth="1px"
-          borderColor="border.subtle"
+          bg={palette.solid}
           align="center"
           justify="center"
           flexShrink={0}
         >
-          <Icon as={RoleIcon} boxSize="8px" color={color} />
+          <Icon as={RoleIcon} boxSize="13px" color={palette.contrast} />
         </Flex>
         <Text
           textStyle="2xs"
-          color={color}
+          color={palette.fg}
           fontWeight="600"
           textTransform="uppercase"
           letterSpacing="0.06em"
@@ -119,11 +180,19 @@ function FlatBody({
         {onCollapse && (
           <>
             <Box flex={1} />
-            <TurnCollapseChevron onClick={onCollapse} />
+            {/* Caret direction matches operator spec:
+                collapsed (expandable) → ↓, expanded (collapsible) → ↑.
+                ThreadedTurnView's collapsed state shows ↓; here we're
+                always rendering the expanded body, so always ↑. */}
+            <Icon as={LuChevronUp} boxSize={3.5} color="fg.subtle" />
           </>
         )}
-      </HStack>
-      <Box paddingLeft="20px">{children}</Box>
+      </chakra.button>
+      {/* Padding-left aligns the body with the role text, not the
+          avatar circle. 32px ≈ 24px avatar + 8px gap. */}
+      <Box paddingLeft="32px" paddingTop={1.5}>
+        {children}
+      </Box>
     </Box>
   );
 }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/RoleChip.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/RoleChip.tsx
@@ -11,13 +11,79 @@ export const ROLE_LABELS: Record<string, string> = {
   developer: "DEVELOPER",
 };
 
-export const ROLE_COLORS: Record<string, string> = {
-  system: "fg.muted",
-  user: "blue.fg",
-  assistant: "green.fg",
-  tool: "orange.fg",
-  developer: "purple.fg",
+/**
+ * Canonical per-role palette. Every chrome surface that renders a role
+ * (chip, thread-layout avatar, bubble-layout container, system marker,
+ * etc.) sources its colours from here so the same role reads the same
+ * across the drawer.
+ *
+ * Keyed by **display role** (the one users see after scenario role-swap
+ * has been applied) so a scenario simulator (`displayRole=assistant`)
+ * picks up the same purple the bubble layout uses for assistant cards.
+ *
+ *  - `fg`     — text + icon colour on the page's neutral surface
+ *  - `muted`  — small avatar circle background + accent strips
+ *  - `solid`  — saturated background for ChatGPT-style filled avatars
+ *  - `contrast` — text/icon colour to use on top of a `solid` fill
+ */
+export interface RolePalette {
+  fg: string;
+  muted: string;
+  solid: string;
+  contrast: string;
+}
+
+export const ROLE_PALETTES: Record<string, RolePalette> = {
+  system: {
+    fg: "fg.muted",
+    muted: "bg.subtle",
+    solid: "gray.solid",
+    contrast: "white",
+  },
+  user: {
+    fg: "blue.fg",
+    muted: "blue.muted",
+    solid: "blue.solid",
+    contrast: "white",
+  },
+  // Assistant tracks the bubble layout's purple (AssistantTurnCard uses
+  // purple.muted/purple.fg). When scenario mode flips a source-user turn
+  // into displayRole=assistant ("User Simulator"), this palette gives it
+  // the same purple — matching the bubble side instead of drifting to a
+  // different colour per layout.
+  assistant: {
+    fg: "purple.fg",
+    muted: "purple.muted",
+    solid: "purple.solid",
+    contrast: "white",
+  },
+  tool: {
+    fg: "orange.fg",
+    muted: "orange.muted",
+    solid: "orange.solid",
+    contrast: "white",
+  },
+  developer: {
+    fg: "purple.fg",
+    muted: "purple.muted",
+    solid: "purple.solid",
+    contrast: "white",
+  },
 };
+
+export function getRolePalette(role: string): RolePalette {
+  return ROLE_PALETTES[role] ?? ROLE_PALETTES.system!;
+}
+
+/**
+ * Back-compat shim. New code should consume `ROLE_PALETTES` /
+ * `getRolePalette` directly; this object preserves the previous
+ * `Record<string, string>` `.fg`-only API for the handful of older
+ * sites that aren't worth a full refactor.
+ */
+export const ROLE_COLORS: Record<string, string> = Object.fromEntries(
+  Object.entries(ROLE_PALETTES).map(([role, palette]) => [role, palette.fg]),
+);
 
 export const ROLE_ICONS: Record<string, IconType> = {
   system: LuSettings,
@@ -35,19 +101,18 @@ export function RoleChip({ role }: { role: string }) {
       : null;
   const label =
     scenarioVisuals?.label ?? ROLE_LABELS[role] ?? role.toUpperCase();
-  // Reuse the existing role palette by keying on the *display* role under
-  // scenario, so the swap matches whatever color the bubble/card around it
-  // is using.
+  // Key on the *display* role under scenario so the chip carries through
+  // the same purple/blue the surrounding bubble/card is using.
   const colorKey = scenarioVisuals?.displayRole ?? role;
-  const color = ROLE_COLORS[colorKey] ?? "fg.muted";
+  const palette = getRolePalette(colorKey);
   const RoleIcon = scenarioVisuals?.Icon ?? ROLE_ICONS[role];
   return (
     <HStack gap={1} marginBottom={1}>
-      {RoleIcon && <Icon as={RoleIcon} boxSize={3} color={color} />}
+      {RoleIcon && <Icon as={RoleIcon} boxSize={3} color={palette.fg} />}
       <Text
         textStyle="2xs"
         fontWeight="600"
-        color={color}
+        color={palette.fg}
         textTransform="uppercase"
         letterSpacing="0.06em"
       >

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/ThreadedTurnView.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/ThreadedTurnView.tsx
@@ -1,9 +1,9 @@
 import { Box, chakra, Flex, HStack, Icon, Text } from "@chakra-ui/react";
 import { useMemo, useState } from "react";
-import { LuChevronRight, LuUser } from "react-icons/lu";
+import { LuChevronDown, LuUser } from "react-icons/lu";
 import { getDisplayRoleVisuals, useIsScenarioRole } from "../scenarioRoles";
 import { FlatTurnView } from "./FlatTurnView";
-import { ROLE_COLORS, ROLE_ICONS, ROLE_LABELS } from "./RoleChip";
+import { getRolePalette, ROLE_ICONS, ROLE_LABELS } from "./RoleChip";
 import { TurnView } from "./TurnView";
 import { summarizeTurn } from "./turns";
 import type { ChatLayout, ConversationTurn } from "./types";
@@ -65,7 +65,7 @@ export function ThreadedTurnView({
       ? getDisplayRoleVisuals(turn.kind, { isScenario: true })
       : null;
   const colorKey = scenarioVisuals?.displayRole ?? sourceRole;
-  const color = ROLE_COLORS[colorKey] ?? "fg.muted";
+  const palette = getRolePalette(colorKey);
   const RoleIcon = scenarioVisuals?.Icon ?? ROLE_ICONS[sourceRole] ?? LuUser;
   const label =
     scenarioVisuals?.label ??
@@ -73,8 +73,12 @@ export function ThreadedTurnView({
     sourceRole.toUpperCase();
 
   if (expanded) {
+    // Expanded body — FlatTurnView (or TurnView for bubble layout)
+    // owns its own header (whole-row clickable to collapse, same
+    // avatar size as below). No extra paddingY here so the expanded
+    // and collapsed rows occupy the same vertical rhythm.
     return (
-      <Box paddingY={0.5}>
+      <Box paddingY={1.5}>
         {layout === "thread" ? (
           <FlatTurnView
             turn={turn}
@@ -92,57 +96,63 @@ export function ThreadedTurnView({
     );
   }
 
+  // Collapsed row — chrome MUST match the expanded header so the row
+  // height doesn't jump when toggling. Same 24px solid avatar, same
+  // paddingY={1.5}, same paddingX={1.5}, same text style. Caret points
+  // ↓ to signal "click to open downward". (Operator complaint: collapsed
+  // version was visibly smaller / more centred than the expanded one.)
   return (
-    <chakra.button
-      type="button"
-      onClick={() => setExpanded(true)}
-      display="flex"
-      alignItems="center"
-      gap={1.5}
-      paddingY={0.5}
-      paddingX={1.5}
-      borderRadius="sm"
-      cursor="pointer"
-      _hover={{ bg: "bg.muted" }}
-      textAlign="left"
-      width="full"
-    >
-      <HStack gap={1.5} flexShrink={0}>
+    <Box paddingY={1.5}>
+      <chakra.button
+        type="button"
+        onClick={() => setExpanded(true)}
+        display="flex"
+        alignItems="center"
+        gap={2}
+        width="full"
+        paddingY={0.5}
+        paddingX={1.5}
+        borderRadius="sm"
+        cursor="pointer"
+        _hover={{ bg: "bg.muted" }}
+        textAlign="left"
+      >
         <Flex
-          width="14px"
-          height="14px"
+          width="24px"
+          height="24px"
           borderRadius="full"
-          bg="bg.subtle"
-          borderWidth="1px"
-          borderColor="border.subtle"
+          bg={palette.solid}
           align="center"
           justify="center"
           flexShrink={0}
         >
-          <Icon as={RoleIcon} boxSize="8px" color={color} />
+          <Icon as={RoleIcon} boxSize="13px" color={palette.contrast} />
         </Flex>
-        <Text
-          textStyle="2xs"
-          color={color}
-          fontWeight="600"
-          textTransform="uppercase"
-          letterSpacing="0.06em"
-          lineHeight={1.4}
-        >
-          {label}
-        </Text>
-      </HStack>
-      <Text
-        textStyle="xs"
-        color="fg.default"
-        truncate
-        flex={1}
-        minWidth={0}
-        lineHeight={1.4}
-      >
-        {summary}
-      </Text>
-      <Icon as={LuChevronRight} boxSize={2.5} color="fg.subtle" flexShrink={0} />
-    </chakra.button>
+        <HStack gap={2} flex={1} minWidth={0}>
+          <Text
+            textStyle="2xs"
+            color={palette.fg}
+            fontWeight="600"
+            textTransform="uppercase"
+            letterSpacing="0.06em"
+            lineHeight={1.4}
+            flexShrink={0}
+          >
+            {label}
+          </Text>
+          <Text
+            textStyle="xs"
+            color="fg.default"
+            truncate
+            flex={1}
+            minWidth={0}
+            lineHeight={1.4}
+          >
+            {summary}
+          </Text>
+        </HStack>
+        <Icon as={LuChevronDown} boxSize={3.5} color="fg.subtle" flexShrink={0} />
+      </chakra.button>
+    </Box>
   );
 }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/TurnCollapseChevron.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/TurnCollapseChevron.tsx
@@ -1,11 +1,14 @@
 import { chakra, Icon } from "@chakra-ui/react";
-import { LuChevronDown } from "react-icons/lu";
+import { LuChevronUp } from "react-icons/lu";
 
 /**
  * Caret used by expanded turn rows to collapse the turn back to its
- * one-line summary. Sits inline with the role chip inside the turn's own
- * header so we don't need to render a duplicate header row above the
- * body just to host a collapse affordance.
+ * one-line summary. Sits inline with the role chip inside the turn's
+ * own header so we don't need to render a duplicate header row above
+ * the body just to host a collapse affordance.
+ *
+ * Points ↑ per operator spec — collapsed rows render ↓ ("click to open
+ * downward"), expanded rows render ↑ ("click to close upward").
  */
 export function TurnCollapseChevron({ onClick }: { onClick: () => void }) {
   return (
@@ -27,7 +30,7 @@ export function TurnCollapseChevron({ onClick }: { onClick: () => void }) {
       aria-label="Collapse turn"
       flexShrink={0}
     >
-      <Icon as={LuChevronDown} boxSize={3} />
+      <Icon as={LuChevronUp} boxSize={3} />
     </chakra.button>
   );
 }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/UserTurnBubble.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/transcript/UserTurnBubble.tsx
@@ -3,6 +3,7 @@ import { LuUser } from "react-icons/lu";
 import { RenderedMarkdown } from "../markdownView";
 import type { DisplayRoleVisuals } from "../scenarioRoles";
 import { BlockStack } from "./BlockStack";
+import { getRolePalette } from "./RoleChip";
 import { TurnCollapseChevron } from "./TurnCollapseChevron";
 import { asMarkdownBody } from "./parsing";
 import type { ChatMessage, ContentBlock } from "./types";
@@ -36,6 +37,10 @@ export function UserTurnBubble({
   const HeaderIcon = visuals?.Icon ?? LuUser;
   const headerLabel = visuals?.bubbleLabel ?? "User";
   const onlyText = blocks.length > 0 && blocks.every((b) => b.kind === "text");
+  // The user-side bubble is always rendered for `displayRole=user` —
+  // sourced from `ROLE_PALETTES.user` so every surface that paints
+  // "the user side" lands on the same blue.
+  const palette = getRolePalette("user");
 
   // Pure-prose user message → classic chat bubble layout.
   if (onlyText) {
@@ -60,16 +65,16 @@ export function UserTurnBubble({
               width="16px"
               height="16px"
               borderRadius="full"
-              bg="blue.muted"
+              bg={palette.muted}
               align="center"
               justify="center"
               flexShrink={0}
             >
-              <Icon as={HeaderIcon} boxSize="10px" color="blue.fg" />
+              <Icon as={HeaderIcon} boxSize="10px" color={palette.fg} />
             </Flex>
             <Text
               textStyle="2xs"
-              color="blue.fg"
+              color={palette.fg}
               fontWeight="600"
               textTransform="uppercase"
               letterSpacing="0.06em"
@@ -106,23 +111,23 @@ export function UserTurnBubble({
       marginBottom={4}
       paddingLeft={4}
       borderLeftWidth="2px"
-      borderLeftColor="blue.muted"
+      borderLeftColor={palette.muted}
     >
       <HStack gap={1.5} marginBottom={1.5}>
         <Flex
           width="16px"
           height="16px"
           borderRadius="full"
-          bg="blue.muted"
+          bg={palette.muted}
           align="center"
           justify="center"
           flexShrink={0}
         >
-          <Icon as={HeaderIcon} boxSize="10px" color="blue.fg" />
+          <Icon as={HeaderIcon} boxSize="10px" color={palette.fg} />
         </Flex>
         <Text
           textStyle="2xs"
-          color="blue.fg"
+          color={palette.fg}
           fontWeight="600"
           textTransform="uppercase"
           letterSpacing="0.06em"

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/useIOViewerState.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/useIOViewerState.ts
@@ -62,19 +62,22 @@ export function useIOViewerState({
 }: UseIOViewerStateArgs): IOViewerState {
   const [format, setFormat] = useState<ViewFormat>("pretty");
   const chatLayout = useChatLayoutPref((s) => s.chatLayout);
-  const setChatLayoutRaw = useChatLayoutPref((s) => s.setChatLayout);
   // Wrap the store setter as a `SetStateAction` so the existing IOViewer
   // call sites (`setChatLayout(v as ChatLayout)`, etc.) keep typechecking
-  // without churn.
+  // without churn. The functional-updater branch evaluates against the
+  // LATEST store state (not the render-time `chatLayout` closure), so
+  // concurrent updates from multiple subscribers compose correctly
+  // (CodeRabbit suggestion, PR #4084).
   const setChatLayout = useCallback<Dispatch<SetStateAction<ChatLayout>>>(
     (value) => {
-      const next =
-        typeof value === "function"
-          ? (value as (prev: ChatLayout) => ChatLayout)(chatLayout)
-          : value;
-      setChatLayoutRaw(next);
+      useChatLayoutPref.setState((state) => ({
+        chatLayout:
+          typeof value === "function"
+            ? (value as (prev: ChatLayout) => ChatLayout)(state.chatLayout)
+            : value,
+      }));
     },
-    [chatLayout, setChatLayoutRaw],
+    [],
   );
   // `mode` is retained on the API for future per-mode defaults but no
   // longer drives the initial layout.

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/useIOViewerState.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/useIOViewerState.ts
@@ -2,9 +2,11 @@ import {
   type Dispatch,
   type RefObject,
   type SetStateAction,
+  useCallback,
   useRef,
   useState,
 } from "react";
+import { create } from "zustand";
 import type { ChatLayout } from "./transcript";
 
 export type ViewFormat = "pretty" | "text" | "json" | "markdown";
@@ -31,6 +33,26 @@ interface IOViewerState {
 }
 
 /**
+ * Shared chat-layout preference across every IOViewer instance.
+ *
+ * Operator complaint: toggling thread↔bubbles in INPUT didn't affect
+ * OUTPUT (and vice-versa), even though they're two halves of the
+ * same conversation. The toggle now lives in a tiny module-level
+ * store so both panels read and write the same value.
+ *
+ * Thread is the default — flat ChatGPT-style stack reads naturally
+ * for both the full input history and the single assistant reply.
+ */
+interface ChatLayoutPrefState {
+  chatLayout: ChatLayout;
+  setChatLayout: (next: ChatLayout) => void;
+}
+const useChatLayoutPref = create<ChatLayoutPrefState>((set) => ({
+  chatLayout: "thread",
+  setChatLayout: (next) => set({ chatLayout: next }),
+}));
+
+/**
  * State + outside-click bookkeeping for the IOViewer panel. Engaged mode
  * dismisses on a `mousedown` outside the engaged ref so the panel never
  * traps wheel scroll once the user moves on.
@@ -39,12 +61,21 @@ export function useIOViewerState({
   mode,
 }: UseIOViewerStateArgs): IOViewerState {
   const [format, setFormat] = useState<ViewFormat>("pretty");
-  // Thread layout is the default everywhere — it's the flat
-  // ChatGPT-style stack (role label + content stacked, no boxes), which
-  // reads naturally for both the full input history and the single
-  // assistant reply in output mode. Bubbles remain available as the
-  // alternative for operators who prefer the boxed card visual.
-  const [chatLayout, setChatLayout] = useState<ChatLayout>("thread");
+  const chatLayout = useChatLayoutPref((s) => s.chatLayout);
+  const setChatLayoutRaw = useChatLayoutPref((s) => s.setChatLayout);
+  // Wrap the store setter as a `SetStateAction` so the existing IOViewer
+  // call sites (`setChatLayout(v as ChatLayout)`, etc.) keep typechecking
+  // without churn.
+  const setChatLayout = useCallback<Dispatch<SetStateAction<ChatLayout>>>(
+    (value) => {
+      const next =
+        typeof value === "function"
+          ? (value as (prev: ChatLayout) => ChatLayout)(chatLayout)
+          : value;
+      setChatLayoutRaw(next);
+    },
+    [chatLayout, setChatLayoutRaw],
+  );
   // `mode` is retained on the API for future per-mode defaults but no
   // longer drives the initial layout.
   void mode;

--- a/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
@@ -27,11 +27,40 @@ export const IOPreview: React.FC<IOPreviewProps> = ({ input, output }) => {
  * isChat/isTool flags that drive the role icon. Both are cheap (each does
  * one JSON.parse attempt on the same input).
  */
-/** Inject the `↵` glyph just before each real newline so the reader
- * sees both: the symbol marks the soft break, the `\n` lets CSS render
- * the actual line wrap. */
+/**
+ * Render line breaks for the 2-line clamped preview cell.
+ *
+ * Trade-offs we're navigating:
+ *  - We want the `↵` glyph as an explicit "there was a break here"
+ *    marker, so wrapped text doesn't look like one continuous string.
+ *  - CSS `-webkit-line-clamp` can truncate anywhere — including right
+ *    after a glyph, which then renders as the ugly "…↵..." or pure
+ *    "↵..." (an empty line whose only content is the glyph followed
+ *    by the clamp ellipsis). Operator complaint, with screenshots.
+ *
+ * Strategy:
+ *  - Strip trailing whitespace/blank lines so the text never ends on
+ *    a break.
+ *  - Collapse runs of blank lines to a single break (no more "↵\n↵\n"
+ *    that renders as an empty middle line whose only character is the
+ *    glyph).
+ *  - Put the glyph at the START of every continuation line, not at
+ *    the END of the previous one. That way the clamp ellipsis lands
+ *    on real text content (or replaces it mid-word with "…"), never
+ *    on the glyph itself. Reads as "↳ continuation" rather than
+ *    "ends with ↵...".
+ */
 function withGlyphBreaks(text: string): string {
-  return text.replace(/\n/g, " ↵\n");
+  // 1. Normalise: trim trailing whitespace/newlines so we never end
+  //    on a hard break.
+  const trimmed = text.replace(/\s+$/u, "");
+  // 2. Split on newline runs (one or more), so consecutive blanks
+  //    collapse to a single break point.
+  const lines = trimmed.split(/\n+/);
+  if (lines.length <= 1) return trimmed;
+  // 3. Re-join with `\n↵ ` — leading-glyph style. The first line
+  //    has no prefix; every subsequent line is "↵ <content>".
+  return lines.join("\n↵ ");
 }
 
 function buildRow(raw: string | null): {

--- a/langwatch/src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts
+++ b/langwatch/src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  DRAWER_DEFAULT_WIDTH_PX,
   DRAWER_MAXIMIZE_EDGE_PX,
   DRAWER_MIN_WIDTH_PX,
   useDrawerStore,
@@ -98,11 +99,18 @@ describe("drawerStore.toggleSnapMaximize", () => {
 
   describe("given no prior width", () => {
     describe("when toggleSnapMaximize fires then restores", () => {
-      it("restores to 45% of the viewport as a sensible default", () => {
+      it("restores to DRAWER_DEFAULT_WIDTH_PX as a sensible default", () => {
         useDrawerStore.getState().toggleSnapMaximize(VIEWPORT_WIDTH);
         useDrawerStore.getState().toggleSnapMaximize(VIEWPORT_WIDTH);
         const state = useDrawerStore.getState();
-        expect(state.widthPx).toBe(Math.round(VIEWPORT_WIDTH * 0.45));
+        // Default is a flat px (deterministic first paint) instead of
+        // the previous 45% rule. Capped at the snap width on viewports
+        // narrower than the default so restore never lands wider than
+        // the snap target.
+        const snapWidth = VIEWPORT_WIDTH - DRAWER_MAXIMIZE_EDGE_PX;
+        expect(state.widthPx).toBe(
+          Math.min(DRAWER_DEFAULT_WIDTH_PX, snapWidth),
+        );
       });
     });
   });

--- a/langwatch/src/features/traces-v2/stores/drawerStore.ts
+++ b/langwatch/src/features/traces-v2/stores/drawerStore.ts
@@ -227,6 +227,17 @@ export const DRAWER_MIN_WIDTH_PX = 360;
 export const DRAWER_MAXIMIZE_EDGE_PX = 10;
 export const DRAWER_RESTORE_EDGE_PX = 80;
 
+/**
+ * Initial drawer width before the operator has dragged it once.
+ * Flat px (no viewport % math) so first-paint is deterministic — the
+ * previous `45%` fallback meant the drawer width visibly shifted
+ * after the user first dragged because the persisted px and the
+ * computed % rarely matched. Once the operator drags, the chosen
+ * width is persisted to localStorage and this default no longer
+ * applies. Clamped at the call sites against the current viewport.
+ */
+export const DRAWER_DEFAULT_WIDTH_PX = 920;
+
 const DEFAULT_PANE_STATE: Record<PaneId, PaneState> = {
   // Conversation context starts collapsed by default — most traces are
   // single-turn anyway, and the user can flip it open per-session via
@@ -420,7 +431,8 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
         s.widthPx !== null && Math.abs(s.widthPx - snapWidth) < 2;
       if (isAtSnap) {
         const restore =
-          s.preMaximizeWidthPx ?? Math.round(viewportWidth * 0.45);
+          s.preMaximizeWidthPx ??
+          Math.min(DRAWER_DEFAULT_WIDTH_PX, snapWidth);
         persistWidth(restore);
         return {
           widthPx: restore,
@@ -430,7 +442,8 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
       }
       persistWidth(snapWidth);
       return {
-        preMaximizeWidthPx: s.widthPx ?? Math.round(viewportWidth * 0.45),
+        preMaximizeWidthPx:
+          s.widthPx ?? Math.min(DRAWER_DEFAULT_WIDTH_PX, snapWidth),
         widthPx: snapWidth,
         isMaximized: true,
       };


### PR DESCRIPTION
## Summary

Three post-merge operator reports against the new traces v2 drawer, rolled into one fix-pass.

### 1. v2 drawer initial width was variable
The `widthPx === null` fallback computed `45%` of the viewport — first paint width then visibly shifted the moment the operator dragged (the persisted px replaced the %). Replaced with a flat `DRAWER_DEFAULT_WIDTH_PX = 920` constant (clamped at the viewport on small screens). Once the operator drags, the persisted localStorage value wins as before.

Touches: `drawerStore.ts` (new constant + restore paths), `TraceDrawerShell.tsx` (always-defined width style), `ResizeRail.tsx` (drag-start fallback), `drawerStore.unit.test.ts` (expected restore value).

### 2. Grey flame-chart bars unreadable in light mode
Every `*.solid` palette except grey is saturated enough at 85% alpha on a white canvas for white text to read. `gray.solid` blends to a pale grey that dissolves white text — operator report: "can't read the letters" on Scenario Turn / module / execute_event_loop_cycle bars. Flip text to `fg` for grey palettes in light mode only (dark mode is fine; canvas is dark). Drop the dark drop-shadow on that branch too (would double-print dark glyphs).

Touches: `FlameBlock.tsx`.

### 3. `↵` glyph rendered as ugly trailing `↵...` under line-clamp
The previous "append `↵` to end of every line, then `\n`" recipe meant CSS `-webkit-line-clamp` could truncate exactly after the glyph — produced blank visible lines that were just `↵...` or non-empty lines ending in `↵...`. Switched to **leading-glyph** style: every continuation line is prefixed with `↵ ` instead of suffixing the previous one. Also trim trailing whitespace and collapse runs of blank lines, so the preview never ends on a break and never has empty middle lines. The clamp ellipsis now lands on actual content (or `…`) rather than the glyph.

Touches: `IOPreview.tsx`.

## Test plan
- [ ] Open a trace via the new drawer cold (no localStorage width) — drawer is 920 px wide, not 45 % of viewport.
- [ ] Drag the drawer narrower; reload — width persists.
- [ ] Drag on a narrow window (<920 px viewport) — drawer caps at viewport, no horizontal scroll.
- [ ] Open the Flame view on a trace with framework spans (Scenario Turn, execute_event_loop_cycle, etc.) in light mode — labels are readable.
- [ ] Same in dark mode — still white text on grey bars, no regression.
- [ ] In the traces list, look at rows with multi-line output (`Here are the results:\n\n- bullet`-style content) — preview never ends in `↵...` and never has a blank `↵`-only line.

## Screenshots <!-- dogfood-fdb1d1d -->

Local dogfood, single LLM span with system + user + assistant + user turns. Demonstrates the canonical role palette, the ChatGPT-style 24px solid avatars, the system prompt at normal font size, and the no-gray-box treatment for chat content.

### Thread layout — system / user / assistant turns
![thread layout](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4084/thread-layout/thread-system-user-assistant.png)

### Bubble layout — same trace, same palette
Toggling Bubbles on one side flips both INPUT and OUTPUT (shared `chatLayout` store).
![bubble layout](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4084/thread-layout/bubbles-layout.png)

> Note: "USER SIMULATOR"-purple is only visible on traces with `Attributes['scenario.run_id']` (scenario role-swap). Local dogfood didn't have one handy; the rename is verifiable in `scenarioRoles.tsx` and the palette flows through the canonical `ROLE_PALETTES` map so it'll land correctly the moment a real scenario trace opens.
