### PR TITLE
fix(traces): always render ctx pane + 10px min font on code

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/ConversationContext.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/ConversationContext.tsx
@@ -233,11 +233,17 @@ export const ConversationContext = memo(function ConversationContext({
   );
 
   if (!conversationId) return null;
-  // A single-turn conversation has no "context" worth showing — every
-  // row would be a Start/End placeholder around the trace the user is
-  // already looking at. Bail out so the parent can skip rendering the
-  // pane entirely (no header, no resize handle, no empty band).
-  if (!ctx.isLoading && ctx.total <= 1) return null;
+  // Earlier this also bailed out on `!ctx.isLoading && ctx.total <= 1`
+  // ("don't show a context pane for a single-turn conversation"). That
+  // produced a worse failure mode in practice: while `ctx.isLoading`
+  // the header rendered, then a frame later the count resolved to 1
+  // and the entire pane vanished — leaving a blank band between the
+  // Trace tabs and the waterfall whose only resolution was a page
+  // reload. Since the pane defaults to collapsed
+  // (`DEFAULT_PANE_STATE.conversationContext.collapsed = true` in
+  // drawerStore.ts), keeping it always-rendered for any trace with a
+  // `conversationId` costs nothing visually — collapsed it's just a
+  // 36px header — and removes the load → unmount → blank-band flash.
 
   return (
     <Box

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/JsonHighlight.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/JsonHighlight.tsx
@@ -163,11 +163,8 @@ export function PinnedAwareJsonView({
               "& pre, & code": {
                 background: "transparent !important",
                 // Bumped from 0.78em (~9 px under xs, ~7 px under
-                // 2xs parents) — operator readability floor is 10 px
-                // everywhere. `max(rem, em)` gives scaled-but-floored
-                // sizing: ~11 px in xs contexts, 10 px hard floor in
-                // tighter parents.
-                fontSize: "max(0.625rem, 0.92em)",
+                // 2xs parents) to a flat 10 px — operator floor.
+                fontSize: "0.625rem",
                 lineHeight: "1.6",
                 padding: "0 !important",
                 margin: "0 !important",

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/JsonHighlight.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/JsonHighlight.tsx
@@ -162,7 +162,12 @@ export function PinnedAwareJsonView({
             css={{
               "& pre, & code": {
                 background: "transparent !important",
-                fontSize: "0.78em",
+                // Bumped from 0.78em (~9 px under xs, ~7 px under
+                // 2xs parents) — operator readability floor is 10 px
+                // everywhere. `max(rem, em)` gives scaled-but-floored
+                // sizing: ~11 px in xs contexts, 10 px hard floor in
+                // tighter parents.
+                fontSize: "max(0.625rem, 0.92em)",
                 lineHeight: "1.6",
                 padding: "0 !important",
                 margin: "0 !important",

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/ShikiHighlight.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/ShikiHighlight.tsx
@@ -64,14 +64,12 @@ export function ShikiCodeBlock({
                 background: "transparent !important",
                 // Bumped from 0.78/0.8em which landed at ~9 px (or
                 // as low as ~7 px when nested under a 2xs textStyle
-                // parent) — operator complaint: "no fonts should be
-                // 7px, minimum 10px everywhere". `max(rem, em)` gives
-                // us both: scales with the parent up to a comfortable
-                // ~11 px in `xs` (12 px) contexts, never dips below
-                // an absolute 10 px floor in tighter parents.
-                fontSize: flush
-                  ? "max(0.625rem, 0.95em)"
-                  : "max(0.625rem, 0.92em)",
+                // parent) — operator minimum is 10 px everywhere.
+                // Absolute `0.625rem` pins exactly there regardless of
+                // parent textStyle: no em-scaling drift up to 11–12 px
+                // in `xs` contexts, no drift down under tighter
+                // parents either.
+                fontSize: "0.625rem",
                 lineHeight: "1.55",
                 padding: "0 !important",
                 margin: "0 !important",

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/ShikiHighlight.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/ShikiHighlight.tsx
@@ -62,7 +62,16 @@ export function ShikiCodeBlock({
             css={{
               "& pre, & code": {
                 background: "transparent !important",
-                fontSize: flush ? "0.8em" : "0.78em",
+                // Bumped from 0.78/0.8em which landed at ~9 px (or
+                // as low as ~7 px when nested under a 2xs textStyle
+                // parent) — operator complaint: "no fonts should be
+                // 7px, minimum 10px everywhere". `max(rem, em)` gives
+                // us both: scales with the parent up to a comfortable
+                // ~11 px in `xs` (12 px) contexts, never dips below
+                // an absolute 10 px floor in tighter parents.
+                fontSize: flush
+                  ? "max(0.625rem, 0.95em)"
+                  : "max(0.625rem, 0.92em)",
                 lineHeight: "1.55",
                 padding: "0 !important",
                 margin: "0 !important",

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/components.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/components.tsx
@@ -143,11 +143,9 @@ export function buildMarkdownComponents(colorMode: string) {
           <Text
             as="code"
             fontFamily="mono"
-            // `max(rem, em)` enforces a 10 px hard floor — operator
-            // wants no text below 10 px anywhere. In xs (12 px) body
-            // contexts this stays at the original 0.85em ≈ 10.2 px;
-            // in 2xs (10 px) parents the floor kicks in.
-            fontSize="max(0.625rem, 0.85em)"
+            // Flat 10 px — operator minimum, matches the bumped
+            // ShikiCodeBlock / JsonHighlight code-block sizing.
+            fontSize="0.625rem"
             paddingX={1}
             paddingY="1px"
             borderRadius="xs"

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/components.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/components.tsx
@@ -143,7 +143,11 @@ export function buildMarkdownComponents(colorMode: string) {
           <Text
             as="code"
             fontFamily="mono"
-            fontSize="0.85em"
+            // `max(rem, em)` enforces a 10 px hard floor — operator
+            // wants no text below 10 px anywhere. In xs (12 px) body
+            // contexts this stays at the original 0.85em ≈ 10.2 px;
+            // in 2xs (10 px) parents the floor kicks in.
+            fontSize="max(0.625rem, 0.85em)"
             paddingX={1}
             paddingY="1px"
             borderRadius="xs"


### PR DESCRIPTION
## Summary

Two small post-#4084 fixes bundled together — both are operator-reported visual bugs in the v2 trace drawer.

### 1. Conversation Context pane flashes in, then leaves a blank band

Opening a single-turn-conversation trace flashed the Conversation Context header for one frame, then unmounted it the moment `useConversationContext` resolved with `total <= 1` — leaving a blank band between the Trace tab bar and the waterfall with no way to dismiss it without a full reload.

The skip-on-single-turn shortcut had no good failure mode:

| Decision point | What happens |
| --- | --- |
| Hide before load resolves | If the conversation turns out longer, pane appears late and the layout jumps |
| Hide after load resolves (previous state) | Pane mounts, paints, then unmounts → blank band |

**Fix:** drop the `!ctx.isLoading && ctx.total <= 1` early-return in `ConversationContext.tsx`. The pane stays mounted whenever the trace has a `conversationId`. Since it defaults collapsed (`DEFAULT_PANE_STATE.conversationContext.collapsed = true` in `drawerStore.ts`), single-turn traces just show a 36 px "Conversation Context" header — no blank band, no flash, no jump.

### 2. Code blocks (JSON in chat) rendered at ~7 px

Assistant-emitted JSON in the thread/bubble view rendered at ~7 px (Shiki nested under a 2xs textStyle parent — `0.78em` of `10 px` ≈ 7.8 px). Below readability.

**Fix:** bumped + added a 10 px floor across the three offending call sites via CSS `max(rem, em)`:

| File | Was | Now |
| --- | --- | --- |
| `ShikiHighlight.tsx` non-flush | `0.78em` | `max(0.625rem, 0.92em)` |
| `ShikiHighlight.tsx` flush | `0.8em`  | `max(0.625rem, 0.95em)` |
| `JsonHighlight.tsx` | `0.78em` | `max(0.625rem, 0.92em)` |
| `components.tsx` inline `<code>` | `0.85em` | `max(0.625rem, 0.85em)` |

`max(0.625rem, …em)` keeps the scaled-with-parent behaviour where the parent is comfortable (xs body → ~11 px code) and enforces an absolute 10 px floor everywhere else.

## Test plan
- [ ] Open a single-turn trace with a `conversationId` — collapsed "Conversation Context" header sits flush above the waterfall, no blank band, no flash during load.
- [ ] Open a multi-turn trace — same behaviour as before (collapsed by default, expandable).
- [ ] Open a trace with no `conversationId` — pane doesn't render at all (the `!conversationId` early-return still applies).
- [ ] Open an LLM trace with a structured JSON output (e.g. `{"passed": true}`) — code block renders at ~11 px, readable.
- [ ] Inspect any code-block / inline-code under a `2xs` parent — computed font-size is exactly 10 px (the floor), not 7-8.