### PR TITLE
fix(playground): absorb live chat when {{input}} is anywhere in template

### DIFF
--- a/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.test.ts
+++ b/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.test.ts
@@ -340,29 +340,71 @@ describe("PromptStudioAdapter", () => {
       expect(envelope.payload.inputs.input).toBe("test7");
     });
 
-    it("appends the live turn normally when the template has no {{input}} user-slot", async () => {
+    it("absorbs the live turn when the template references {{input}} only in the system message", async () => {
+      // 2026-05-17 dogfood (rchaves on a 'Messages mode' prompt): the
+      // template's USER message is plain text ('answer it') and only
+      // the SYSTEM contains `{{input}}`. The live chat must still be
+      // absorbed (bound to inputs.input) and NOT also appended as a
+      // duplicate user turn — Python parity is "absorb when {{input}}
+      // is ANYWHERE in the template", not "only when a user template
+      // contains it".
       const { eventSource } = createMockEventSource();
       await runProcess(
         adapter,
         buildRequestWithChat({
           additionalParams: buildAdditionalParams({
             messages: [
-              // system references {{input}} for var binding, but there
-              // is NO template user turn to absorb the live message,
-              // so it must still appear as its own turn.
-              { role: "system", content: "Echo {{input}} back" },
+              { role: "system", content: "Reply about {{input}}" },
+              { role: "user", content: "answer it" },
             ],
           }),
-          chatMessages: [{ role: "user", content: "test7" }],
+          chatMessages: [{ role: "user", content: "how much is 2+3" }],
           eventSource,
         }),
       );
 
       const envelope = lastPostedEvent();
       const sent: { role: string; content: string }[] = envelope.payload.inputs.messages;
-      expect(sent).toEqual([{ role: "user", content: "test7" }]);
-      // Still bind input so the system's {{input}} resolves.
-      expect(envelope.payload.inputs.input).toBe("test7");
+      // ONE user turn — the template's explicit "answer it". The
+      // live "how much is 2+3" is absorbed into inputs.input, not
+      // appended as a second user turn.
+      const userTurns = sent.filter((m) => m.role === "user");
+      expect(userTurns).toEqual([{ role: "user", content: "answer it" }]);
+      // The live chat is the value for {{input}} resolution.
+      expect(envelope.payload.inputs.input).toBe("how much is 2+3");
+    });
+
+    it("appends the live turn normally when the template doesn't reference {{input}} anywhere", async () => {
+      // Negative-direction guard for the absorb heuristic. When NO
+      // template message (system or user) references `{{input}}`,
+      // the live chat turn must still appear as its own user
+      // message — otherwise users in 'Messages mode' with no
+      // placeholder would have their chat silently dropped.
+      const { eventSource } = createMockEventSource();
+      await runProcess(
+        adapter,
+        buildRequestWithChat({
+          additionalParams: buildAdditionalParams({
+            messages: [
+              { role: "system", content: "Be terse" },
+              { role: "user", content: "answer it" },
+            ],
+          }),
+          chatMessages: [{ role: "user", content: "how much is 2+3" }],
+          eventSource,
+        }),
+      );
+
+      const envelope = lastPostedEvent();
+      const sent: { role: string; content: string }[] = envelope.payload.inputs.messages;
+      expect(sent).toEqual([
+        { role: "user", content: "answer it" },
+        { role: "user", content: "how much is 2+3" },
+      ]);
+      // No `{{input}}` placeholder anywhere → no need to bind, but
+      // bind still happens via the falsy-input fallback (kept for
+      // back-compat with prompts that consume `input` indirectly).
+      expect(envelope.payload.inputs.input).toBe("how much is 2+3");
     });
 
     it("does not override an explicit `input` value from the Variables panel", async () => {

--- a/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts
+++ b/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts
@@ -118,17 +118,28 @@ export class PromptStudioAdapter implements CopilotServiceAdapter {
       const lastLiveUserMsg = [...messages]
         .reverse()
         .find((m: any) => m.role === "user");
-      const templateUserMsgs = formMsgs.filter((m) => m.role === "user");
-      const templateUserReferencesInput = templateUserMsgs.some((m) =>
+      // Broaden the absorb-check to ANY template message (system +
+      // user templates), not just user-role templates. Old
+      // langwatch_nlp's playground heuristic was 'append the live
+      // turn only if `{{input}}` is not in the template' — i.e.
+      // ANYWHERE in the template. The 2026-05-17 follow-up to #4087
+      // (rchaves dogfood) hit the gap: switching the prompt editor to
+      // 'Messages' mode with `{{input}}` ONLY in the system message
+      // and a user template like 'answer it' caused the live chat
+      // input to be duplicated as a second user turn, because the
+      // narrower 'templateUserMsgs only' check returned false.
+      const allTemplateMsgs = formValues.version.configData.messages ?? [];
+      const templateReferencesInput = allTemplateMsgs.some((m) =>
         TEMPLATE_INPUT_PLACEHOLDER_RE.test(m.content ?? ""),
       );
-      // Drop the latest live user turn from the history when the
-      // template's user-message will render it (otherwise the user
-      // sees the same content twice — once rendered, once live).
-      // Earlier copilot turns (assistant replies + prior user turns)
-      // still belong in the history.
+      // Drop the latest live user turn from the history when ANY
+      // template message (system or user) will absorb it through
+      // `{{input}}` (otherwise the user sees the same content twice
+      // — once via `{{input}}` rendering, once live). Earlier copilot
+      // turns (assistant replies + prior user turns) still belong in
+      // the history.
       const liveMessagesForHistory =
-        templateUserReferencesInput && lastLiveUserMsg
+        templateReferencesInput && lastLiveUserMsg
           ? messages.filter((m: any) => m !== lastLiveUserMsg)
           : messages;
       const messagesHistory = [...formMsgs, ...liveMessagesForHistory]


### PR DESCRIPTION
## Summary

Follow-up to #4087 from rchaves's 2026-05-17 dogfood: switching the prompt editor to "Messages" mode with `{{input}}` ONLY in the system template (and an explicit plain-text user template like "answer it") caused the live chat turn to be duplicated as a second user message next to the explicit template turn.

Trace evidence: LLM input had two user turns — `[{user:"answer it"},{user:"how much is 2+3"}]` — where the second was the live chat that should have been absorbed into `inputs.input` for `{{input}}` resolution.

## Root cause

`#4087`'s absorb-check (`templateUserReferencesInput`) looked only at user-role template messages for the `{{input}}` placeholder. If the placeholder was only in the SYSTEM template, the check returned false and the live turn was appended verbatim.

Old `langwatch_nlp`'s playground heuristic absorbed the live turn when `{{input}}` was ANYWHERE in the template — not just in user-role messages. The narrower check in `#4087` missed that case.

## Fix

One-line change in `service-adapter.ts`: broaden the absorb-reference check to the full `configData.messages` array (system + user + any other role).

```diff
- const templateUserMsgs = formMsgs.filter((m) => m.role === "user");
- const templateUserReferencesInput = templateUserMsgs.some((m) =>
+ const allTemplateMsgs = formValues.version.configData.messages ?? [];
+ const templateReferencesInput = allTemplateMsgs.some((m) =>
    TEMPLATE_INPUT_PLACEHOLDER_RE.test(m.content ?? ""),
  );
```

## Tests

- **New**: `absorbs the live turn when the template references {{input}} only in the system message` — pins the exact dogfood shape (system with `{{input}}` + explicit user template + live chat). Would have FAILED #4087 pre-fix.
- **Rewritten** (was: `appends the live turn normally when the template has no {{input}} user-slot`): `appends the live turn normally when the template doesn't reference {{input}} anywhere` — negative-direction guard, prevents silent-drop when the template has no placeholder at all.

10/10 tests green. `pnpm typecheck` clean.

## Test plan

- [x] `pnpm test:unit src/app/api/copilotkit/[[...route]]/service-adapter.test.ts`
- [x] `pnpm typecheck`
- [x] Real browser dogfood: prompt editor in "Messages" mode, `{{input}}` in system + plain "answer it" user template, send "how much is 2+3" → single user turn (`answer it`) in trace LLM input, system has `how much is 2+3` interpolated, model answers `2 + 3 = 5`. Exact inversion of the rchaves repro.

## Browser dogfood

Messages-mode toggle reached via the `Prompt` section-title menu (`editing-mode-messages` testid). Configured the exact rchaves repro: system contains `{{input}}` and `{{test}}`, user template is plain `answer it`. Sent `how much is 2+3` in the chat.

Conversation (model now answers the math instead of rambling about the playground):

![messages-mode-clean-response](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4088/playground/messages-mode-clean-response.png)

LLM input + output in the trace — ONE user turn, `{{input}}` interpolated to `how much is 2+3` in the system, no duplicate:

![messages-mode-trace-single-user-turn](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4088/playground/messages-mode-trace-single-user-turn.png)

Before (rchaves screenshot in the kanban thread): two user turns `[{user:"answer it"},{user:"how much is 2+3"}]`, model rambled about how to use the playground.
