### PR TITLE
fix(traces): full trace id in toast + prompt section on llm spans

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
@@ -18,8 +18,10 @@ import {
   LuList,
   LuMessageSquare,
   LuPencil,
+  LuPlay,
 } from "react-icons/lu";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { useGoToSpanInPlaygroundTabUrlBuilder } from "~/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground";
 import { AnnotationPopover } from "./conversationView/AnnotationPopover";
 import { IOViewerBody } from "./IOViewerBody";
 import { safePrettyJson } from "./JsonHighlight";
@@ -62,6 +64,15 @@ interface IOViewerProps {
    * span), so per-span IOViewers leave this undefined.
    */
   traceId?: string;
+  /**
+   * Span this IOViewer is rendering. When set on an `llm` span the header
+   * surfaces an "Open in Playground" affordance — the chat history is the
+   * natural place to pick the conversation back up, especially for
+   * third-party traces with no managed prompt tied to the call.
+   */
+  spanId?: string;
+  /** Span type — `llm` enables the Playground affordance. */
+  spanType?: string;
 }
 
 const ActionButton = forwardRef<
@@ -88,6 +99,33 @@ const ActionButton = forwardRef<
     </Button>
   );
 });
+
+function PlaygroundButton({ spanId }: { spanId: string }) {
+  const { buildUrl } = useGoToSpanInPlaygroundTabUrlBuilder();
+  const href = buildUrl(spanId, "create-new")?.toString() ?? "";
+  if (!href) return null;
+  return (
+    <Button
+      asChild
+      size="xs"
+      variant="ghost"
+      color="fg.muted"
+      gap={1.5}
+      paddingX={2}
+      height="22px"
+    >
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer noopener"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Icon as={LuPlay} boxSize={3} />
+        Open in Playground
+      </a>
+    </Button>
+  );
+}
 
 function AnnotateButton({ traceId }: { traceId: string }) {
   const { hasPermission } = useOrganizationTeamProject();
@@ -160,6 +198,8 @@ export const IOViewer = memo(function IOViewer({
   content,
   mode = "input",
   traceId,
+  spanId,
+  spanType,
 }: IOViewerProps) {
   const parsed = useMemo(() => tryParseJSON(content), [content]);
   // Coerce parsed into a chat message array — handles top-level arrays,
@@ -419,6 +459,9 @@ export const IOViewer = memo(function IOViewer({
         {!collapsed && traceId && <AnnotateButton traceId={traceId} />}
         {!collapsed && traceId && mode === "output" && (
           <SuggestCorrectionButton traceId={traceId} output={content} />
+        )}
+        {!collapsed && spanType === "llm" && spanId && mode === "input" && (
+          <PlaygroundButton spanId={spanId} />
         )}
         <CopyButton text={content} />
       </HStack>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
@@ -102,7 +102,10 @@ const ActionButton = forwardRef<
 
 function PlaygroundButton({ spanId }: { spanId: string }) {
   const { buildUrl } = useGoToSpanInPlaygroundTabUrlBuilder();
-  const href = buildUrl(spanId, "create-new")?.toString() ?? "";
+  // No explicit action — the playground loader auto-detects: opens the
+  // existing managed prompt at the traced version when one is linked,
+  // creates a fresh tab when not. One button, smart default.
+  const href = buildUrl(spanId)?.toString() ?? "";
   if (!href) return null;
   return (
     <Button

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/PromptAccordion.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/PromptAccordion.tsx
@@ -8,13 +8,23 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useMemo } from "react";
-import { LuCopy, LuExternalLink, LuPencil } from "react-icons/lu";
+import {
+  LuChevronDown,
+  LuCopy,
+  LuExternalLink,
+  LuPencil,
+  LuPlay,
+} from "react-icons/lu";
 import { useDrawer } from "~/hooks/useDrawer";
+import { Link } from "~/components/ui/link";
+import { Menu } from "~/components/ui/menu";
+import { useGoToSpanInPlaygroundTabUrlBuilder } from "~/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground";
 import type { SpanDetail } from "~/server/api/routers/tracesV2.schemas";
 import {
   extractPromptReference,
   hasPromptMetadata,
 } from "../../utils/promptAttributes";
+import { usePromptByHandle } from "../../hooks/usePromptByHandle";
 
 export { hasPromptMetadata };
 
@@ -27,21 +37,65 @@ interface PromptAccordionProps {
  * pulls its weight even when only some `langwatch.prompt.*` keys made it
  * onto the span. The trace-level Prompts tab is the rollup view; this is
  * the per-span deep dive.
+ *
+ * Always renders on `llm` spans, even when no prompt metadata exists —
+ * the "Open in Playground" action still works (it creates a brand-new
+ * playground tab from the LLM span's input/output) so operators can
+ * continue any LLM call regardless of whether a managed prompt was tied
+ * to it. Mirrors the old SpanDetails behaviour.
  */
 export function PromptAccordion({ span }: PromptAccordionProps) {
   const { openDrawer } = useDrawer();
   const ref = useMemo(() => extractPromptReference(span.params), [span]);
+  const { buildUrl } = useGoToSpanInPlaygroundTabUrlBuilder();
+  // SDK sometimes emits the opaque slug-id (`prompt_xxx`) instead of the
+  // human handle (`pizza-prompt`) on `langwatch.prompt.id`. Resolve to the
+  // friendlier handle for display while keeping the raw value for the
+  // playground deep-link.
+  const { resolvedHandle } = usePromptByHandle(ref?.handle ?? null);
 
   const variableEntries = ref?.variables
     ? Object.entries(ref.variables).sort(([a], [b]) => a.localeCompare(b))
     : [];
 
-  // Section visibility is gated upstream by `hasPromptMetadata`, so we
-  // get here whenever any `langwatch.prompt.*` key exists. When the
-  // reference itself didn't parse (variables-only, or a bare slug we
-  // can't parse without a handle key) we still surface the variables —
-  // partial info beats an empty section.
+  const rawHandle = ref?.handle ?? null;
+  const displayHandle = resolvedHandle ?? rawHandle;
+  const isLlmSpan = span.type === "llm";
+  const promptRefLabel =
+    rawHandle && ref?.versionNumber != null
+      ? `${rawHandle}:${ref.versionNumber}`
+      : rawHandle && ref?.tag
+        ? `${rawHandle}:${ref.tag}`
+        : rawHandle;
+
+  // The accordion is mounted in two situations:
+  //   (a) span has prompt metadata of its own (handle/variables) — render
+  //       the full pane with the Open-in-Prompts menu.
+  //   (b) span is an `llm` with no metadata — surface only the "Open in
+  //       Playground" affordance so operators can still continue the
+  //       conversation; nothing else to show.
   if (!ref && variableEntries.length === 0) {
+    if (isLlmSpan) {
+      return (
+        <VStack align="stretch" gap={2} paddingY={2}>
+          <Text textStyle="xs" color="fg.muted" paddingX={2}>
+            No managed prompt detected on this LLM call. You can still open
+            it in the Playground to continue the conversation.
+          </Text>
+          <HStack gap={1} paddingX={2}>
+            <Link
+              href={buildUrl(span.spanId, "create-new")?.toString() ?? ""}
+              isExternal
+            >
+              <Button size="xs" variant="ghost" gap={1}>
+                <Icon as={LuPlay} boxSize={3} />
+                Open in Playground
+              </Button>
+            </Link>
+          </HStack>
+        </VStack>
+      );
+    }
     return (
       <Box paddingX={2} paddingY={3}>
         <Text textStyle="xs" color="fg.muted">
@@ -52,8 +106,6 @@ export function PromptAccordion({ span }: PromptAccordionProps) {
     );
   }
 
-  const handle = ref?.handle ?? null;
-
   return (
     <VStack align="stretch" gap={3} paddingY={2}>
       {/* Header */}
@@ -61,9 +113,9 @@ export function PromptAccordion({ span }: PromptAccordionProps) {
         <Text
           textStyle="sm"
           fontWeight="bold"
-          color={handle ? "fg" : "fg.muted"}
+          color={displayHandle ? "fg" : "fg.muted"}
         >
-          {handle ?? "Prompt (no handle on span)"}
+          {displayHandle ?? "Prompt (no handle on span)"}
         </Text>
         {ref?.versionNumber != null && (
           <Badge size="sm" variant="subtle">
@@ -155,23 +207,50 @@ export function PromptAccordion({ span }: PromptAccordionProps) {
       )}
 
       {/* Actions */}
-      {handle && (
+      {rawHandle && (
         <HStack gap={1} paddingX={2}>
           <Button
             size="xs"
             variant="ghost"
             gap={1}
-            onClick={() => openDrawer("promptEditor", { promptId: handle })}
+            onClick={() => openDrawer("promptEditor", { promptId: rawHandle })}
           >
             <Icon as={LuPencil} boxSize={3} />
             Open prompt
           </Button>
-          {/* Playground action stays disabled until the playground drawer
-              accepts span input + variables as deep-link params. */}
-          <Button size="xs" variant="ghost" gap={1} disabled>
-            <Icon as={LuExternalLink} boxSize={3} />
-            Open in Playground
-          </Button>
+          {isLlmSpan && (
+            <Menu.Root>
+              <Menu.Trigger asChild>
+                <Button size="xs" variant="ghost" gap={1}>
+                  <Icon as={LuExternalLink} boxSize={3} />
+                  Open in Playground
+                  <Icon as={LuChevronDown} boxSize={2.5} />
+                </Button>
+              </Menu.Trigger>
+              <Menu.Content>
+                <Menu.Item value="open-existing" asChild>
+                  <Link
+                    href={
+                      buildUrl(span.spanId, "open-existing")?.toString() ?? ""
+                    }
+                    isExternal
+                  >
+                    Open {promptRefLabel ?? "prompt"}
+                  </Link>
+                </Menu.Item>
+                <Menu.Item value="create-new" asChild>
+                  <Link
+                    href={
+                      buildUrl(span.spanId, "create-new")?.toString() ?? ""
+                    }
+                    isExternal
+                  >
+                    Create new prompt
+                  </Link>
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Root>
+          )}
         </HStack>
       )}
     </VStack>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/PromptAccordion.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/PromptAccordion.tsx
@@ -13,7 +13,6 @@ import {
   LuCopy,
   LuExternalLink,
   LuPencil,
-  LuPlay,
 } from "react-icons/lu";
 import { useDrawer } from "~/hooks/useDrawer";
 import { Link } from "~/components/ui/link";
@@ -68,34 +67,11 @@ export function PromptAccordion({ span }: PromptAccordionProps) {
         ? `${rawHandle}:${ref.tag}`
         : rawHandle;
 
-  // The accordion is mounted in two situations:
-  //   (a) span has prompt metadata of its own (handle/variables) — render
-  //       the full pane with the Open-in-Prompts menu.
-  //   (b) span is an `llm` with no metadata — surface only the "Open in
-  //       Playground" affordance so operators can still continue the
-  //       conversation; nothing else to show.
+  // No-prompt llm spans don't reach this component anymore (the IOViewer
+  // header carries the Playground affordance for that case). When we do
+  // render and only partial metadata is present, fall back to a hint
+  // instead of an empty section.
   if (!ref && variableEntries.length === 0) {
-    if (isLlmSpan) {
-      return (
-        <VStack align="stretch" gap={2} paddingY={2}>
-          <Text textStyle="xs" color="fg.muted" paddingX={2}>
-            No managed prompt detected on this LLM call. You can still open
-            it in the Playground to continue the conversation.
-          </Text>
-          <HStack gap={1} paddingX={2}>
-            <Link
-              href={buildUrl(span.spanId, "create-new")?.toString() ?? ""}
-              isExternal
-            >
-              <Button size="xs" variant="ghost" gap={1}>
-                <Icon as={LuPlay} boxSize={3} />
-                Open in Playground
-              </Button>
-            </Link>
-          </HStack>
-        </VStack>
-      );
-    }
     return (
       <Box paddingX={2} paddingY={3}>
         <Text textStyle="xs" color="fg.muted">

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -110,7 +110,12 @@ function TraceIdChip({ traceId }: { traceId: string }) {
         await navigator.clipboard.writeText(traceId);
         toaster.create({
           title: "Trace ID copied",
-          description: short + "…",
+          // Show the full id so the operator can verify what landed on
+          // their clipboard at a glance. The chip shows a short id by
+          // design (git-SHA convention) but the toast has the real
+          // estate — operator report: the previous "<8 chars>…" felt
+          // truncated for no benefit.
+          description: traceId,
           type: "success",
           duration: 2500,
         });

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -44,13 +44,10 @@ export function SpanAccordions({
     !!detail?.params && Object.keys(detail.params).length > 0;
   const hasAttributes = hasSpanAttrs || hasResourceAttrs;
   const hasScope = !!spanScope?.name;
-  // LLM spans always get a Prompt section even without metadata — the
-  // accordion still surfaces "Open in Playground" so operators can pick
-  // up the conversation regardless of whether a managed prompt was tied
-  // to the call. Matches the legacy SpanDetails behaviour.
-  const isLlmSpan = span.type === "llm";
-  const hasPrompt =
-    isLlmSpan || (!!detail && hasPromptMetadata(detail.params));
+  // Prompt section only when there's actual prompt metadata. The no-prompt
+  // case is covered by the "Open in Playground" affordance on the IOViewer
+  // header — no value in rendering an empty Prompt accordion next to it.
+  const hasPrompt = !!detail && hasPromptMetadata(detail.params);
   const hasError = span.status === "error" || !!detail?.error;
   const hasEvents = !!detail?.events && detail.events.length > 0;
 
@@ -139,6 +136,8 @@ export function SpanAccordions({
                           label="Input"
                           content={detail.input}
                           mode="input"
+                          spanId={detail.spanId}
+                          spanType={detail.type}
                         />
                       )}
                       {detail?.output && (
@@ -146,6 +145,8 @@ export function SpanAccordions({
                           label="Output"
                           content={detail.output}
                           mode="output"
+                          spanId={detail.spanId}
+                          spanType={detail.type}
                         />
                       )}
                     </VStack>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -44,7 +44,13 @@ export function SpanAccordions({
     !!detail?.params && Object.keys(detail.params).length > 0;
   const hasAttributes = hasSpanAttrs || hasResourceAttrs;
   const hasScope = !!spanScope?.name;
-  const hasPrompt = !!detail && hasPromptMetadata(detail.params);
+  // LLM spans always get a Prompt section even without metadata — the
+  // accordion still surfaces "Open in Playground" so operators can pick
+  // up the conversation regardless of whether a managed prompt was tied
+  // to the call. Matches the legacy SpanDetails behaviour.
+  const isLlmSpan = span.type === "llm";
+  const hasPrompt =
+    isLlmSpan || (!!detail && hasPromptMetadata(detail.params));
   const hasError = span.status === "error" || !!detail?.error;
   const hasEvents = !!detail?.events && detail.events.length > 0;
 

--- a/langwatch/src/features/traces-v2/hooks/usePromptByHandle.ts
+++ b/langwatch/src/features/traces-v2/hooks/usePromptByHandle.ts
@@ -24,6 +24,10 @@ export function usePromptByHandle(handle: string | null | undefined) {
   return {
     ...lookup,
     latestVersion: lookup.data?.version ?? null,
+    // Friendly human-readable handle (e.g. "pizza-prompt") when the SDK
+    // emitted the opaque slug-id form (`prompt_xxx`). Null when the prompt
+    // never had a handle or the lookup hasn't resolved yet.
+    resolvedHandle: lookup.data?.handle ?? null,
     missing: !!handle && lookup.isError,
   };
 }

--- a/langwatch/src/features/traces-v2/hooks/useTraceHeaderChips.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceHeaderChips.ts
@@ -100,7 +100,18 @@ export function useTraceHeaderChips(
   });
 
   const lastUsedHandle = trace.lastUsedPromptId;
-  const { latestVersion, missing } = usePromptByHandle(lastUsedHandle);
+  const { latestVersion, missing, resolvedHandle: lastUsedResolvedHandle } =
+    usePromptByHandle(lastUsedHandle);
+  // SDKs sometimes emit the opaque slug-id (`prompt_xxx`) instead of the
+  // human handle (`pizza-prompt`). When the live prompt config resolves a
+  // friendlier handle, prefer it in the chip — fall back to the raw id so
+  // we still surface *something* while the lookup is in flight or for
+  // unmanaged prompts.
+  const lastUsedDisplayHandle = lastUsedResolvedHandle ?? lastUsedHandle;
+  const { resolvedHandle: selectedResolvedHandle } = usePromptByHandle(
+    trace.selectedPromptId,
+  );
+  const selectedDisplayId = selectedResolvedHandle ?? trace.selectedPromptId;
   const lastUsedState: PromptChipState = { latestVersion, missing };
 
   const driftFromSelection =
@@ -142,7 +153,7 @@ export function useTraceHeaderChips(
   if (trace.selectedPromptId && driftFromSelection) {
     chips.push({
       kind: "promptSelected",
-      selectedId: trace.selectedPromptId,
+      selectedId: selectedDisplayId ?? trace.selectedPromptId,
       spanId: trace.selectedPromptSpanId,
     });
   }
@@ -150,7 +161,7 @@ export function useTraceHeaderChips(
   if (trace.lastUsedPromptId) {
     chips.push({
       kind: "promptLastUsed",
-      handle: trace.lastUsedPromptId,
+      handle: lastUsedDisplayHandle ?? trace.lastUsedPromptId,
       versionNumber: trace.lastUsedPromptVersionNumber,
       spanId: trace.lastUsedPromptSpanId,
       state: lastUsedState,

--- a/langwatch/src/features/traces-v2/utils/promptAttributes.ts
+++ b/langwatch/src/features/traces-v2/utils/promptAttributes.ts
@@ -176,6 +176,20 @@ export function extractPromptReference(
     return { handle, versionNumber: null, tag: null, variables };
   }
 
+  // Bare-slug `prompt.id` (no colon, no separate handle attribute) — the
+  // ingestion-side `parsePromptReference` accepts this; mirror it here so
+  // the v2 accordion lights up on llm spans that the server enriched
+  // via ancestor lookup (which writes nested `langwatch.prompt.id` only).
+  if (typeof promptId === "string" && promptId.length > 0) {
+    if (versionRaw != null) {
+      const version = Number(versionRaw);
+      if (Number.isInteger(version) && version > 0) {
+        return { handle: promptId, versionNumber: version, tag: null, variables };
+      }
+    }
+    return { handle: promptId, versionNumber: null, tag: null, variables };
+  }
+
   return null;
 }
 

--- a/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptBrowserWindowContent.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/prompt-browser/prompt-browser-window/PromptBrowserWindowContent.tsx
@@ -53,12 +53,11 @@ export function PromptBrowserWindowContent() {
     },
   );
 
-  // Show loading skeleton while tab data is being fetched — no form initialization
-  if (tab?.data.loading) {
-    const layoutMode: LayoutMode = isSingleWindow ? "horizontal" : "vertical";
-    return <PromptTabLoadingSkeleton layoutMode={layoutMode} />;
-  }
-
+  // All hooks must run on every render — `useMemo` below used to sit
+  // after an early-return for `tab?.data.loading`, which crashed React
+  // with "Rendered more hooks than during the previous render" the
+  // moment the loading flag flipped to false (one extra hook in the
+  // next render).
   const currentValues = tab?.data.form.currentValues;
   const versionNumber = tab?.data.meta.versionNumber;
   const initialConfigValues = useMemo(
@@ -66,10 +65,15 @@ export function PromptBrowserWindowContent() {
     [currentValues],
   );
 
-  if (!initialConfigValues) return null;
-
   // Use horizontal layout when there's only one window
   const layoutMode: LayoutMode = isSingleWindow ? "horizontal" : "vertical";
+
+  // Show loading skeleton while tab data is being fetched — no form initialization
+  if (tab?.data.loading) {
+    return <PromptTabLoadingSkeleton layoutMode={layoutMode} />;
+  }
+
+  if (!initialConfigValues) return null;
 
   // Key includes version to force remount when version changes externally (e.g., upgrade clicked)
   // This ensures react-hook-form gets fresh defaultValues

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -15,6 +15,11 @@ import {
   TRACE_NAME_MAX_LENGTH,
   TRACE_NAME_MIN_LENGTH,
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import {
+  findPromptReferenceInAncestors,
+  flattenParamsToPromptAttributes,
+  type PromptLookupSpan,
+} from "~/server/traces/findPromptReferenceInAncestors";
 import type { Span, SpanInputOutput } from "~/server/tracer/types";
 import { checkProjectPermission } from "../rbac";
 import type {
@@ -210,6 +215,83 @@ function mapSpanToDetail(
       attributes: e.attributes,
     })),
   };
+}
+
+const PROMPT_ATTR_KEYS = [
+  "langwatch.prompt.id",
+  "langwatch.prompt.handle",
+  "langwatch.prompt.version.number",
+  "langwatch.prompt.variables",
+] as const;
+
+function hasOwnPromptAttrs(
+  params: Record<string, unknown> | null,
+): boolean {
+  if (!params) return false;
+  const flat = flattenParamsToPromptAttributes(params);
+  return PROMPT_ATTR_KEYS.some((k) => flat[k] !== undefined);
+}
+
+/**
+ * Resolves the closest preceding `langwatch.prompt.*` reference for an llm
+ * span by walking the trace's ancestor / sibling chain — same heuristic
+ * `getSpanForPromptStudio` uses on the legacy path. Returns the llm span's
+ * params merged with the resolved prompt attributes (in nested-object form
+ * matching the rest of `params`), or null when nothing was found so the
+ * caller can skip the assignment.
+ */
+async function enrichLlmSpanWithAncestorPrompt({
+  tenantId,
+  traceId,
+  targetSpanId,
+  occurredAtMs,
+  currentParams,
+}: {
+  tenantId: string;
+  traceId: string;
+  targetSpanId: string;
+  occurredAtMs?: number;
+  currentParams: Record<string, unknown> | null;
+}): Promise<Record<string, unknown> | null> {
+  const app = getApp();
+  const allSpans = await app.traces.spans.getSpansByTraceId({
+    tenantId,
+    traceId,
+    occurredAtMs,
+  });
+
+  const lookupSpans: PromptLookupSpan[] = allSpans.map((s) => ({
+    spanId: s.span_id,
+    parentSpanId: s.parent_id ?? null,
+    startTime: s.timestamps.started_at,
+    attributes: flattenParamsToPromptAttributes(
+      s.params as Record<string, unknown> | null,
+    ),
+  }));
+
+  const ref = findPromptReferenceInAncestors({
+    targetSpanId,
+    spans: lookupSpans,
+  });
+  if (!ref?.promptHandle) return null;
+
+  const promptNode: Record<string, unknown> = {
+    id: ref.promptHandle,
+  };
+  if (ref.promptVersionNumber != null) {
+    promptNode.version = { number: ref.promptVersionNumber };
+  }
+  if (ref.promptVariables) {
+    promptNode.variables = ref.promptVariables;
+  }
+
+  const next: Record<string, unknown> = { ...(currentParams ?? {}) };
+  const langwatch =
+    next.langwatch && typeof next.langwatch === "object"
+      ? (next.langwatch as Record<string, unknown>)
+      : {};
+  next.langwatch = { ...langwatch, prompt: promptNode };
+  return next;
 }
 
 // ---------------------------------------------------------------------------
@@ -717,7 +799,7 @@ export const tracesV2Router = createTRPCRouter({
         throw new TraceNotFoundError(input.spanId);
       }
 
-      return mapSpanToDetail(
+      const detail = mapSpanToDetail(
         span,
         rawEvents.map((e) => ({
           name: e.event_type,
@@ -731,6 +813,30 @@ export const tracesV2Router = createTRPCRouter({
           ]),
         })),
       );
+
+      // SDK pattern: `Prompt.compile` / `PromptApiService.get` siblings
+      // carry `langwatch.prompt.*` while the actual `llm` span next door
+      // does not. Walk ancestors/siblings here so the v2 drawer's prompt
+      // accordion lights up on the llm span too (matches legacy
+      // SpanDetails). One extra trace-scoped read, only when the llm
+      // span has no own prompt attrs.
+      if (
+        detail.type === "llm" &&
+        !hasOwnPromptAttrs(detail.params as Record<string, unknown> | null)
+      ) {
+        const enriched = await enrichLlmSpanWithAncestorPrompt({
+          tenantId: input.projectId,
+          traceId: input.traceId,
+          targetSpanId: input.spanId,
+          occurredAtMs: hint.occurredAtMs,
+          currentParams: detail.params as Record<string, unknown> | null,
+        });
+        if (enriched) {
+          detail.params = enriched;
+        }
+      }
+
+      return detail;
     }),
 
   /**

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -71,10 +71,20 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
     userId: string;
     teamId: string;
   }): Promise<OrganizationUserRole | null> {
+    // The Prisma multitenancy middleware rejects `OrganizationUser`
+    // queries that don't pin an `organizationId` in the where clause.
+    // Resolve teamId -> organizationId first, then look up the
+    // membership directly — keeps the middleware happy without
+    // exempting the model.
+    const team = await this.prisma.team.findUnique({
+      where: { id: teamId },
+      select: { organizationId: true },
+    });
+    if (!team) return null;
     const orgUser = await this.prisma.organizationUser.findFirst({
       where: {
         userId,
-        organization: { teams: { some: { id: teamId } } },
+        organizationId: team.organizationId,
       },
       select: { role: true },
     });

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1058,9 +1058,13 @@ export class ClickHouseTraceService {
     const attrs = row.SpanAttributes;
     const messages: PromptStudioSpanResult["messages"] = [];
 
-    // Extract input messages from gen_ai.prompt or langwatch.input
-    // Note: langwatch.input includes system messages; gen_ai.input.messages does not
+    // Extract input messages from gen_ai.input.messages (OTel GenAI
+    // semantic convention — what newer SDKs emit, including the system
+    // message), or fall back to legacy gen_ai.prompt / langwatch.input.
+    // Without gen_ai.input.messages the system prompt was being dropped
+    // from the playground form on third-party-traced spans.
     const inputStr =
+      (attrs["gen_ai.input.messages"] as string) ??
       (attrs["gen_ai.prompt"] as string) ??
       (attrs["langwatch.input"] as string);
     if (inputStr) {

--- a/langwatch/src/server/traces/findPromptReferenceInAncestors.ts
+++ b/langwatch/src/server/traces/findPromptReferenceInAncestors.ts
@@ -43,6 +43,13 @@ export function flattenParamsToPromptAttributes(
   const attrs: Record<string, unknown> = {};
 
   for (const key of PROMPT_ATTRIBUTE_KEYS) {
+    // Flat-keyed shape first (`params["langwatch.prompt.id"]`) — that's
+    // how OTel attributes land before ingestion un-flattens them, and
+    // some SDK paths leave them as-is. Fall back to nested walk after.
+    if (params[key] !== undefined) {
+      attrs[key] = params[key];
+      continue;
+    }
     const segments = key.split(".");
     let current: unknown = params;
     for (const segment of segments) {


### PR DESCRIPTION
## Summary

Follow-up to the v2 trace drawer polish work.

- **Trace ID toast** shows the full id, not `<8 chars>…`. The chip stays short by design; the toast has the real estate.
- **Prompt header chip** resolves SDK-emitted opaque slug ids (`prompt_xxx`) back to the friendly handle (`pizza-prompt`) by reading the live prompt config. Falls back to the raw id while the lookup is in flight or for unmanaged prompts.
- **Prompt accordion on llm spans**: always renders on llm spans, even when no managed prompt is tied to the call. Surfaces a single "Open in Playground" affordance so the operator can continue the conversation regardless.
- **"Open in Playground" menu** (Open existing / Create new) replaces the disabled placeholder. Same affordance the legacy SpanDetails had, wired to `useGoToSpanInPlaygroundTabUrlBuilder`.
- **Server-side ancestor lookup**: when an llm span has no own `langwatch.prompt.*` attrs, `tracesV2.spanDetail` walks siblings (`Prompt.compile`, `PromptApiService.get`) and injects the resolved prompt attrs into `params`. The accordion lights up exactly like the legacy drawer.

## Test plan

- [ ] toast on trace-id copy shows the full id
- [ ] header chip on a managed-prompt trace shows the handle, not the slug-id
- [ ] llm span with a sibling `Prompt.compile` renders the prompt accordion (handle, variables, Open in Playground menu)
- [ ] llm span with no prompt anywhere still renders the Prompt section with "Open in Playground"
- [ ] "Open in Playground → Open <handle>" lands on the playground with that prompt
- [ ] "Open in Playground → Create new prompt" lands on a fresh playground tab

## Screenshot

Multi-prompt trace from local dogfood (`inbox-narrator/3f32ff...`):

![multi-prompt-header](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4095/multi-prompt-header.png)

The chip strip shows three prompt chips at once (`prompt-managed-app`, `prompt-managed-app`, `prompt-managed`) — one trace, multiple managed prompts driving sibling spans (`classify-intent`, `sentiment-detect`, `urgency-rank`, `summarize-thread`, `drafter`).

### llm span prompt accordion (ancestor walk in action)

Selected `intent-llm` (an llm span whose only prompt metadata lives on its sibling `classify-intent` Prompt.compile). The accordion shows the resolved `intent-classifier` handle plus `Open prompt` / `Open in Playground` actions:

![llm-span-ancestor-prompt](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4095/llm-span-ancestor-prompt.png)

Also fixed two adjacent gaps surfaced while dogfooding:
- v2 `extractPromptReference` now accepts a bare-slug `langwatch.prompt.id` (no colon, no separate `handle` attr) — the legacy server-side parser already did this; mirroring it here lights up traces that only carry the id.
- `flattenParamsToPromptAttributes` (used by the ancestor walk) reads flat dot-notation keys first, then falls back to nested. Before, traces where `params["langwatch.prompt.id"]` was a flat string silently dropped out of the lookup.

### Playground affordance on the chat header

The chat history is the natural place to continue an llm call. The IOViewer's INPUT panel header now carries an "Open in Playground" trailing action whenever the span is `type=llm`:

![ioviewer-playground-button](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4095/ioviewer-playground-button.png)

Works regardless of whether a managed prompt was tied to the call — covers the third-party-tracing case the Prompt accordion previously couldn't reach. The redundant no-prompt empty state inside the Prompt accordion is gone; that section only renders when there's actual prompt metadata, same as before.

### Playground load works end-to-end

Two crashes were blocking the chat-header "Open in Playground" flow from a trace span: a Prisma multitenancy guard on `OrganizationUser` (queried via a nested team relation without `organizationId` pinned) and a React hook-order violation in `PromptBrowserWindowContent` (`useMemo` after an early-return on the loading flag). Both fixed.

**Existing managed prompt** (smart-default opens the linked prompt at the traced version with the trace's chat history pre-filled):

![playground-existing-prompt](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4095/playground-existing-prompt.png)

**No managed prompt** (third-party-traced llm span — smart-default creates a fresh tab populated with the span's input/output):

![playground-new-prompt-from-llm-span](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4095/playground-new-prompt-from-llm-span.png?v=3)