### PR TITLE
fix(traces): open in playground everywhere + resizable attrs + eval chips in header

### DIFF
--- a/langwatch/scripts/seed-trace-evals.ts
+++ b/langwatch/scripts/seed-trace-evals.ts
@@ -11,9 +11,6 @@
  */
 import { EvaluationRunClickHouseRepository } from "../src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository";
 import { getClickHouseClientForProject } from "../src/server/clickhouse/clickhouseClient";
-import { randomBytes } from "crypto";
-
-const ulid = () => randomBytes(10).toString("hex");
 
 async function main() {
   const projectId = process.env.PROJECT_ID;

--- a/langwatch/scripts/seed-trace-evals.ts
+++ b/langwatch/scripts/seed-trace-evals.ts
@@ -1,0 +1,117 @@
+/**
+ * One-off: inject a handful of evaluation results directly into ClickHouse
+ * for an existing trace so the v2 drawer header chip can be screenshotted
+ * in every state (pass / score / fail / skipped). Bypasses the
+ * event-sourcing queue so it works in a plain `pnpm dev` setup where the
+ * worker pipeline isn't necessarily running.
+ *
+ * Usage:
+ *   PROJECT_ID=KAXYxPR8MUgTcP8CF193y TRACE_ID=c2481ff682fc54e912b7016a55db8153 \
+ *     npx tsx scripts/seed-trace-evals.ts
+ */
+import { EvaluationRunClickHouseRepository } from "../src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository";
+import { getClickHouseClientForProject } from "../src/server/clickhouse/clickhouseClient";
+import { randomBytes } from "crypto";
+
+const ulid = () => randomBytes(10).toString("hex");
+
+async function main() {
+  const projectId = process.env.PROJECT_ID;
+  const traceId = process.env.TRACE_ID;
+  if (!projectId || !traceId) {
+    throw new Error("PROJECT_ID and TRACE_ID required");
+  }
+
+  const repo = new EvaluationRunClickHouseRepository(async (tenantId: string) => {
+    const client = await getClickHouseClientForProject(tenantId);
+    if (!client) throw new Error(`No ClickHouse client for project ${tenantId}`);
+    return client;
+  });
+
+  const now = new Date();
+  const samples = [
+    {
+      evaluatorId: "presidio/pii_detection",
+      evaluatorType: "presidio/pii_detection",
+      evaluatorName: "PII Detection",
+      status: "processed" as const,
+      passed: true,
+      score: null,
+      label: null,
+      details: "No PII entities detected in the message.",
+    },
+    {
+      evaluatorId: "ragas/faithfulness",
+      evaluatorType: "ragas/faithfulness",
+      evaluatorName: "Faithfulness",
+      status: "processed" as const,
+      passed: false,
+      score: null,
+      label: null,
+      details: "Answer not grounded in retrieved context.",
+    },
+    {
+      evaluatorId: "lingua/language_detection",
+      evaluatorType: "lingua/language_detection",
+      evaluatorName: "Language Detection",
+      status: "processed" as const,
+      passed: null,
+      score: 0.92,
+      label: "English",
+      details: "Detected English with 92% confidence.",
+    },
+    {
+      evaluatorId: "ragas/answer_relevancy",
+      evaluatorType: "ragas/answer_relevancy",
+      evaluatorName: "Answer Relevancy",
+      status: "processed" as const,
+      passed: false,
+      score: 0.34,
+      label: "low relevancy",
+      details: "Answer is only weakly grounded in the retrieved context.",
+    },
+  ];
+
+  for (const s of samples) {
+    // Stable per-evaluator id so re-running the script replaces the row
+    // instead of stacking duplicates on the trace.
+    const evaluationId = `eval_seed_${s.evaluatorId.replace(/[^a-z0-9]/gi, "_")}_${traceId}`;
+    await repo.upsert(
+      {
+        evaluationId,
+        version: "1",
+        evaluatorId: s.evaluatorId,
+        evaluatorType: s.evaluatorType,
+        evaluatorName: s.evaluatorName,
+        traceId,
+        isGuardrail: false,
+        status: s.status,
+        score: s.score ?? null,
+        passed: s.passed,
+        label: s.label,
+        details: s.details,
+        inputs: null,
+        error: null,
+        errorDetails: null,
+        createdAt: now,
+        updatedAt: now,
+        archivedAt: null,
+        scheduledAt: now,
+        startedAt: now,
+        completedAt: now,
+        costId: null,
+        lastProcessedEventId: `manual:${evaluationId}`,
+        lastEventOccurredAt: now,
+      } as any,
+      projectId,
+    );
+    console.log(
+      `wrote ${s.evaluatorId} status=${s.status} score=${s.score} passed=${s.passed}`,
+    );
+  }
+}
+
+main().then(() => process.exit(0)).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/langwatch/scripts/seed-trace-evals.ts
+++ b/langwatch/scripts/seed-trace-evals.ts
@@ -26,46 +26,86 @@ async function main() {
   });
 
   const now = new Date();
-  const samples = [
+  const samples: Array<{
+    evaluatorId: string;
+    evaluatorType: string;
+    evaluatorName: string;
+    status: "processed" | "skipped" | "error";
+    passed: boolean | null;
+    score: number | null;
+    label: string | null;
+    details: string;
+    error: string | null;
+  }> = [
     {
       evaluatorId: "presidio/pii_detection",
       evaluatorType: "presidio/pii_detection",
       evaluatorName: "PII Detection",
-      status: "processed" as const,
+      status: "processed",
       passed: true,
       score: null,
       label: null,
       details: "No PII entities detected in the message.",
+      error: null,
     },
     {
       evaluatorId: "ragas/faithfulness",
       evaluatorType: "ragas/faithfulness",
       evaluatorName: "Faithfulness",
-      status: "processed" as const,
+      status: "processed",
       passed: false,
       score: null,
       label: null,
       details: "Answer not grounded in retrieved context.",
+      error: null,
     },
     {
       evaluatorId: "lingua/language_detection",
       evaluatorType: "lingua/language_detection",
       evaluatorName: "Language Detection",
-      status: "processed" as const,
+      status: "processed",
       passed: null,
       score: 0.92,
       label: "English",
       details: "Detected English with 92% confidence.",
+      error: null,
     },
     {
       evaluatorId: "ragas/answer_relevancy",
       evaluatorType: "ragas/answer_relevancy",
       evaluatorName: "Answer Relevancy",
-      status: "processed" as const,
+      status: "processed",
       passed: false,
       score: 0.34,
       label: "low relevancy",
       details: "Answer is only weakly grounded in the retrieved context.",
+      error: null,
+    },
+    // No-verdict states — exercise the SKIPPED / ERROR chip badges
+    // without depending on whatever evaluations the seed trace already
+    // happens to carry.
+    {
+      evaluatorId: "azure/content_safety",
+      evaluatorType: "azure/content_safety",
+      evaluatorName: "Content Safety",
+      status: "skipped",
+      passed: null,
+      score: null,
+      label: null,
+      details:
+        "Azure Safety provider not configured. Configure it in Settings → Model Providers to run this evaluator.",
+      error: null,
+    },
+    {
+      evaluatorId: "openai/moderation",
+      evaluatorType: "openai/moderation",
+      evaluatorName: "Moderation",
+      status: "error",
+      passed: null,
+      score: null,
+      label: null,
+      details: "OpenAI moderation request timed out after 30s.",
+      error: "OpenAI moderation request timed out after 30s.",
     },
   ];
 
@@ -88,7 +128,7 @@ async function main() {
         label: s.label,
         details: s.details,
         inputs: null,
-        error: null,
+        error: s.error,
         errorDetails: null,
         createdAt: now,
         updatedAt: now,

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
@@ -142,7 +142,10 @@ function ColumnResizeHandle({
         position: "absolute",
         top: 0,
         bottom: 0,
-        left: "2px",
+        // Centre the 1px line on `labelWidth` so it lands exactly at the
+        // label cell's right edge — otherwise the gray cell bg bleeds
+        // a pixel past the line and looks like the divider is broken.
+        left: "3px",
         width: "1px",
         transition: "background 100ms ease, width 100ms ease",
         background: state === "idle" ? "border" : "blue.solid",

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
@@ -67,9 +67,19 @@ function useLabelColumnWidth() {
  * `data-resize-handle-state` attribute so styling matches the rest of
  * the v2 surface without a custom theme.
  */
-function LabelResizeHandle({
+/**
+ * Single full-height column divider that overlays the attribute table's
+ * flat container. Mirrors the resize affordance of the drawer's pane
+ * separator (`react-resizable-panels`): a 1px static line that lights up
+ * blue on hover/drag and spans the entire column rather than splitting
+ * per-row. Placement is absolute at `left: labelWidth - 1` so the
+ * underlying row layout stays untouched and no nested grid is needed.
+ */
+function ColumnResizeHandle({
+  labelWidth,
   onResize,
 }: {
+  labelWidth: number;
   onResize: (deltaPx: number) => void;
 }) {
   const [state, setState] = useState<"idle" | "hover" | "drag">("idle");
@@ -98,6 +108,9 @@ function LabelResizeHandle({
     }
   };
 
+  // The clickable / hit area is wider than the visible line so the
+  // affordance is easy to grab; the line itself stays at 1px so the
+  // table layout reads as "solid divider that gets a blue glow on hover".
   return (
     <Box
       role="separator"
@@ -114,21 +127,29 @@ function LabelResizeHandle({
       onPointerLeave={() => {
         if (state === "hover") setState("idle");
       }}
-      width="4px"
-      flexShrink={0}
+      position="absolute"
+      top={0}
+      bottom={0}
+      // The label cell's right border lands at `labelWidth`; center the
+      // 6px-wide hit area on that line so dragging feels like grabbing
+      // the divider itself instead of the cell next to it.
+      style={{ left: `${labelWidth - 3}px` }}
+      width="6px"
       cursor="col-resize"
-      alignSelf="stretch"
-      position="relative"
-      marginRight="-1px"
+      zIndex={1}
       _before={{
         content: '""',
         position: "absolute",
         top: 0,
         bottom: 0,
-        left: "1px",
-        right: "1px",
-        transition: "background 100ms ease",
-        background: state === "idle" ? "transparent" : "blue.solid",
+        left: "2px",
+        width: "1px",
+        transition: "background 100ms ease, width 100ms ease",
+        background: state === "idle" ? "border" : "blue.solid",
+        // Bloom to a slightly thicker line on hover/drag so the active
+        // state reads at a glance without overwhelming the calm idle.
+        boxShadow:
+          state === "drag" ? "0 0 0 1px var(--chakra-colors-blue-solid)" : "none",
       }}
     />
   );
@@ -303,7 +324,6 @@ function FlatRow({
   isLast,
   onTogglePin,
   labelWidth,
-  onLabelResize,
 }: {
   attrKey: string;
   value: unknown;
@@ -312,7 +332,6 @@ function FlatRow({
   isLast: boolean;
   onTogglePin: () => void;
   labelWidth: number;
-  onLabelResize: (deltaPx: number) => void;
 }) {
   const display = formatValue(value);
   return (
@@ -357,7 +376,6 @@ function FlatRow({
           {attrKey}
         </Text>
       </Tooltip>
-      <LabelResizeHandle onResize={onLabelResize} />
       {/* Pretty-print column. Heuristic format detection picks chat / json
           / text / leaf; non-leaf values render a `📋 format` pill that
           opens a popover with the prettified payload + an override row.
@@ -434,12 +452,20 @@ function AttrSection({
         </Text>
       )}
       {viewMode === "flat" ? (
+        // `position: relative` anchors the absolute-positioned column
+        // resize handle inside this card so the line spans the table's
+        // full height regardless of how many rows render.
         <Box
           borderRadius="md"
           borderWidth="1px"
           borderColor="border"
-          overflow="hidden"
+          // Drop `overflow: hidden` so the resize handle's thicker drag
+          // glow can bleed slightly outside the card without clipping —
+          // gives the affordance a touch of "this is grabbable" without
+          // breaking the card's rounded silhouette (rows still respect
+          // the border-radius via their own bg).
           bg="bg.panel"
+          position="relative"
         >
           {sortedEntries.map(([key, val], i) => (
             <FlatRow
@@ -451,9 +477,12 @@ function AttrSection({
               isLast={i === sortedEntries.length - 1}
               onTogglePin={() => togglePin({ source, key })}
               labelWidth={labelWidth}
-              onLabelResize={onLabelResize}
             />
           ))}
+          <ColumnResizeHandle
+            labelWidth={labelWidth}
+            onResize={onLabelResize}
+          />
         </Box>
       ) : (
         <Box

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, HStack, Icon, Input, Text } from "@chakra-ui/react";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LuCheck, LuCopy, LuPin, LuPinOff } from "react-icons/lu";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -11,6 +11,118 @@ import { SegmentedToggle } from "./SegmentedToggle";
 
 const EM_DASH = "\u2014";
 const COPY_FEEDBACK_MS = 1500;
+
+const LABEL_WIDTH_STORAGE_KEY = "langwatch:traces-v2:attribute-label-width";
+const LABEL_WIDTH_MIN = 120;
+const LABEL_WIDTH_MAX = 480;
+const LABEL_WIDTH_DEFAULT = 200;
+
+function clampLabelWidth(value: number): number {
+  if (!Number.isFinite(value)) return LABEL_WIDTH_DEFAULT;
+  return Math.min(LABEL_WIDTH_MAX, Math.max(LABEL_WIDTH_MIN, Math.round(value)));
+}
+
+/**
+ * Persisted width of the attribute-name column. Operators told us the
+ * truncated `langwatch.prompt.variab\u2026` lines on prompt-heavy traces were
+ * unreadable; the column is now dragable per-device so they can size it
+ * to whatever fits their attribute namespace.
+ */
+function useLabelColumnWidth() {
+  const [width, setWidth] = useState<number>(() => {
+    if (typeof window === "undefined") return LABEL_WIDTH_DEFAULT;
+    const raw = window.localStorage.getItem(LABEL_WIDTH_STORAGE_KEY);
+    const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+    return Number.isFinite(parsed)
+      ? clampLabelWidth(parsed)
+      : LABEL_WIDTH_DEFAULT;
+  });
+
+  const setAndPersist = useCallback((next: number) => {
+    const clamped = clampLabelWidth(next);
+    setWidth(clamped);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(LABEL_WIDTH_STORAGE_KEY, String(clamped));
+    }
+  }, []);
+
+  return [width, setAndPersist] as const;
+}
+
+/**
+ * 4px-wide drag handle that sits flush with the right border of the
+ * label cell. Idle state shows the existing 1px border; on hover/drag
+ * the bar turns blue, mirroring the resize affordance of the drawer's
+ * pane separator (`PaneLayout`). State is tracked via a
+ * `data-resize-handle-state` attribute so styling matches the rest of
+ * the v2 surface without a custom theme.
+ */
+function LabelResizeHandle({
+  onResize,
+}: {
+  onResize: (deltaPx: number) => void;
+}) {
+  const [state, setState] = useState<"idle" | "hover" | "drag">("idle");
+  const startXRef = useRef<number | null>(null);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    startXRef.current = e.clientX;
+    setState("drag");
+    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (state !== "drag" || startXRef.current === null) return;
+    const delta = e.clientX - startXRef.current;
+    startXRef.current = e.clientX;
+    onResize(delta);
+  };
+
+  const handlePointerEnd = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (state === "drag") {
+      startXRef.current = null;
+      (e.currentTarget as HTMLDivElement).releasePointerCapture(e.pointerId);
+      setState("idle");
+    }
+  };
+
+  return (
+    <Box
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize attribute name column"
+      data-resize-handle-state={state}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+      onPointerEnter={() => {
+        if (state === "idle") setState("hover");
+      }}
+      onPointerLeave={() => {
+        if (state === "hover") setState("idle");
+      }}
+      width="4px"
+      flexShrink={0}
+      cursor="col-resize"
+      alignSelf="stretch"
+      position="relative"
+      marginRight="-1px"
+      _before={{
+        content: '""',
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: "1px",
+        right: "1px",
+        transition: "background 100ms ease",
+        background: state === "idle" ? "transparent" : "blue.solid",
+      }}
+    />
+  );
+}
 
 interface AttributeTableProps {
   attributes: Record<string, unknown>;
@@ -180,6 +292,8 @@ function FlatRow({
   pinned,
   isLast,
   onTogglePin,
+  labelWidth,
+  onLabelResize,
 }: {
   attrKey: string;
   value: unknown;
@@ -187,6 +301,8 @@ function FlatRow({
   pinned: boolean;
   isLast: boolean;
   onTogglePin: () => void;
+  labelWidth: number;
+  onLabelResize: (deltaPx: number) => void;
 }) {
   const display = formatValue(value);
   return (
@@ -205,28 +321,33 @@ function FlatRow({
         attrKey={attrKey}
         onToggle={onTogglePin}
       />
-      <Text
-        width="200px"
-        flexShrink={0}
-        textStyle="xs"
-        fontFamily="mono"
-        color={pinned ? "fg" : "fg.muted"}
-        fontWeight={pinned ? "semibold" : "normal"}
-        truncate
-        paddingX={3}
-        paddingY={1.5}
-        bg="bg.subtle"
-        borderRightWidth="1px"
-        borderColor="border.muted"
-        transition="color 0.12s ease, font-weight 0.12s ease"
-        css={{
-          // Strengthen the key column when the row is hovered so the
-          // attribute name reads as the focus, not just a tint change.
-          ".attr-row:hover &": { color: "fg", fontWeight: "semibold" },
-        }}
+      <Tooltip
+        content={attrKey}
+        openDelay={250}
+        positioning={{ placement: "top-start" }}
       >
-        {attrKey}
-      </Text>
+        <Text
+          width={`${labelWidth}px`}
+          flexShrink={0}
+          textStyle="xs"
+          fontFamily="mono"
+          color={pinned ? "fg" : "fg.muted"}
+          fontWeight={pinned ? "semibold" : "normal"}
+          truncate
+          paddingX={3}
+          paddingY={1.5}
+          bg="bg.subtle"
+          transition="color 0.12s ease, font-weight 0.12s ease"
+          css={{
+            // Strengthen the key column when the row is hovered so the
+            // attribute name reads as the focus, not just a tint change.
+            ".attr-row:hover &": { color: "fg", fontWeight: "semibold" },
+          }}
+        >
+          {attrKey}
+        </Text>
+      </Tooltip>
+      <LabelResizeHandle onResize={onLabelResize} />
       {/* Pretty-print column. Heuristic format detection picks chat / json
           / text / leaf; non-leaf values render a `📋 format` pill that
           opens a popover with the prettified payload + an override row.
@@ -257,11 +378,15 @@ function AttrSection({
   attributes,
   viewMode,
   source,
+  labelWidth,
+  onLabelResize,
 }: {
   title: string;
   attributes: Record<string, unknown>;
   viewMode: AttrViewMode;
   source: PinnedAttributeSource;
+  labelWidth: number;
+  onLabelResize: (deltaPx: number) => void;
 }) {
   const { project } = useOrganizationTeamProject();
   const { pins, isPinned, togglePin } = usePinnedAttributes(project?.id);
@@ -315,6 +440,8 @@ function AttrSection({
               pinned={isPinned(source, key)}
               isLast={i === sortedEntries.length - 1}
               onTogglePin={() => togglePin({ source, key })}
+              labelWidth={labelWidth}
+              onLabelResize={onLabelResize}
             />
           ))}
         </Box>
@@ -345,6 +472,13 @@ export function AttributeTable({
 }: AttributeTableProps) {
   const [viewMode, setViewMode] = useState<AttrViewMode>("flat");
   const [searchTerm, setSearchTerm] = useState("");
+  const [labelWidth, setLabelWidth] = useLabelColumnWidth();
+  const handleLabelResize = useCallback(
+    (delta: number) => {
+      setLabelWidth(labelWidth + delta);
+    },
+    [labelWidth, setLabelWidth],
+  );
 
   const flatAttrs = useMemo(() => flattenAttributes(attributes), [attributes]);
   const flatResAttrs = useMemo(
@@ -406,6 +540,8 @@ export function AttributeTable({
         attributes={filterAttrs}
         viewMode={viewMode}
         source="attribute"
+        labelWidth={labelWidth}
+        onLabelResize={handleLabelResize}
       />
       {filterResAttrs && (
         <AttrSection
@@ -413,6 +549,8 @@ export function AttributeTable({
           attributes={filterResAttrs}
           viewMode={viewMode}
           source="resource"
+          labelWidth={labelWidth}
+          onLabelResize={handleLabelResize}
         />
       )}
     </Box>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
@@ -68,18 +68,16 @@ function useLabelColumnWidth() {
  * the v2 surface without a custom theme.
  */
 /**
- * Single full-height column divider that overlays the attribute table's
- * flat container. Mirrors the resize affordance of the drawer's pane
- * separator (`react-resizable-panels`): a 1px static line that lights up
- * blue on hover/drag and spans the entire column rather than splitting
- * per-row. Placement is absolute at `left: labelWidth - 1` so the
- * underlying row layout stays untouched and no nested grid is needed.
+ * Per-row 4px resize handle that sits flush with the right border of
+ * the label cell. Idle state is invisible; hover/drag lights up the
+ * blue stripe. Resize state lives on the shared `useLabelColumnWidth`
+ * hook so dragging any row's handle resizes the whole column in
+ * lockstep — visually scoped to the row the operator grabbed, but
+ * functionally global.
  */
-function ColumnResizeHandle({
-  labelWidth,
+function LabelResizeHandle({
   onResize,
 }: {
-  labelWidth: number;
   onResize: (deltaPx: number) => void;
 }) {
   const [state, setState] = useState<"idle" | "hover" | "drag">("idle");
@@ -108,9 +106,6 @@ function ColumnResizeHandle({
     }
   };
 
-  // The clickable / hit area is wider than the visible line so the
-  // affordance is easy to grab; the line itself stays at 1px so the
-  // table layout reads as "solid divider that gets a blue glow on hover".
   return (
     <Box
       role="separator"
@@ -127,32 +122,21 @@ function ColumnResizeHandle({
       onPointerLeave={() => {
         if (state === "hover") setState("idle");
       }}
-      position="absolute"
-      top={0}
-      bottom={0}
-      // The label cell's right border lands at `labelWidth`; center the
-      // 6px-wide hit area on that line so dragging feels like grabbing
-      // the divider itself instead of the cell next to it.
-      style={{ left: `${labelWidth - 3}px` }}
-      width="6px"
+      width="4px"
+      flexShrink={0}
       cursor="col-resize"
-      zIndex={1}
+      alignSelf="stretch"
+      position="relative"
+      marginRight="-1px"
       _before={{
         content: '""',
         position: "absolute",
         top: 0,
         bottom: 0,
-        // Centre the 1px line on `labelWidth` so it lands exactly at the
-        // label cell's right edge — otherwise the gray cell bg bleeds
-        // a pixel past the line and looks like the divider is broken.
-        left: "3px",
-        width: "1px",
-        transition: "background 100ms ease, width 100ms ease",
-        background: state === "idle" ? "border" : "blue.solid",
-        // Bloom to a slightly thicker line on hover/drag so the active
-        // state reads at a glance without overwhelming the calm idle.
-        boxShadow:
-          state === "drag" ? "0 0 0 1px var(--chakra-colors-blue-solid)" : "none",
+        left: "1px",
+        right: "1px",
+        transition: "background 100ms ease",
+        background: state === "idle" ? "transparent" : "blue.solid",
       }}
     />
   );
@@ -327,6 +311,7 @@ function FlatRow({
   isLast,
   onTogglePin,
   labelWidth,
+  onLabelResize,
 }: {
   attrKey: string;
   value: unknown;
@@ -335,6 +320,7 @@ function FlatRow({
   isLast: boolean;
   onTogglePin: () => void;
   labelWidth: number;
+  onLabelResize: (deltaPx: number) => void;
 }) {
   const display = formatValue(value);
   return (
@@ -379,6 +365,7 @@ function FlatRow({
           {attrKey}
         </Text>
       </Tooltip>
+      <LabelResizeHandle onResize={onLabelResize} />
       {/* Pretty-print column. Heuristic format detection picks chat / json
           / text / leaf; non-leaf values render a `📋 format` pill that
           opens a popover with the prettified payload + an override row.
@@ -462,13 +449,8 @@ function AttrSection({
           borderRadius="md"
           borderWidth="1px"
           borderColor="border"
-          // Drop `overflow: hidden` so the resize handle's thicker drag
-          // glow can bleed slightly outside the card without clipping —
-          // gives the affordance a touch of "this is grabbable" without
-          // breaking the card's rounded silhouette (rows still respect
-          // the border-radius via their own bg).
+            overflow="hidden"
           bg="bg.panel"
-          position="relative"
         >
           {sortedEntries.map(([key, val], i) => (
             <FlatRow
@@ -480,12 +462,9 @@ function AttrSection({
               isLast={i === sortedEntries.length - 1}
               onTogglePin={() => togglePin({ source, key })}
               labelWidth={labelWidth}
+              onLabelResize={onLabelResize}
             />
           ))}
-          <ColumnResizeHandle
-            labelWidth={labelWidth}
-            onResize={onLabelResize}
-          />
         </Box>
       ) : (
         <Box

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/AttributeTable.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, HStack, Icon, Input, Text } from "@chakra-ui/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { LuCheck, LuCopy, LuPin, LuPinOff } from "react-icons/lu";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
@@ -46,7 +46,17 @@ function useLabelColumnWidth() {
     }
   }, []);
 
-  return [width, setAndPersist] as const;
+  const applyDelta = useCallback((deltaPx: number) => {
+    setWidth((prev) => {
+      const clamped = clampLabelWidth(prev + deltaPx);
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(LABEL_WIDTH_STORAGE_KEY, String(clamped));
+      }
+      return clamped;
+    });
+  }, []);
+
+  return [width, setAndPersist, applyDelta] as const;
 }
 
 /**
@@ -472,13 +482,8 @@ export function AttributeTable({
 }: AttributeTableProps) {
   const [viewMode, setViewMode] = useState<AttrViewMode>("flat");
   const [searchTerm, setSearchTerm] = useState("");
-  const [labelWidth, setLabelWidth] = useLabelColumnWidth();
-  const handleLabelResize = useCallback(
-    (delta: number) => {
-      setLabelWidth(labelWidth + delta);
-    },
-    [labelWidth, setLabelWidth],
-  );
+  const [labelWidth, , applyLabelDelta] = useLabelColumnWidth();
+  const handleLabelResize = applyLabelDelta;
 
   const flatAttrs = useMemo(() => flattenAttributes(attributes), [attributes]);
   const flatResAttrs = useMemo(

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/Chip.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/Chip.tsx
@@ -140,7 +140,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(function Chip(
       minWidth={0}
       className="chip-root"
     >
-      {dot && <Circle size="6px" bg={dot} flexShrink={0} />}
+      {dot && <Circle size="8px" bg={dot} flexShrink={0} />}
       {icon && <Icon as={icon} boxSize={3} color={style.fg} flexShrink={0} />}
       {label && (
         <Text

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/PromptAccordion.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/PromptAccordion.tsx
@@ -9,14 +9,12 @@ import {
 } from "@chakra-ui/react";
 import { useMemo } from "react";
 import {
-  LuChevronDown,
   LuCopy,
   LuExternalLink,
   LuPencil,
 } from "react-icons/lu";
 import { useDrawer } from "~/hooks/useDrawer";
 import { Link } from "~/components/ui/link";
-import { Menu } from "~/components/ui/menu";
 import { useGoToSpanInPlaygroundTabUrlBuilder } from "~/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground";
 import type { SpanDetail } from "~/server/api/routers/tracesV2.schemas";
 import {
@@ -59,13 +57,6 @@ export function PromptAccordion({ span }: PromptAccordionProps) {
 
   const rawHandle = ref?.handle ?? null;
   const displayHandle = resolvedHandle ?? rawHandle;
-  const isLlmSpan = span.type === "llm";
-  const promptRefLabel =
-    rawHandle && ref?.versionNumber != null
-      ? `${rawHandle}:${ref.versionNumber}`
-      : rawHandle && ref?.tag
-        ? `${rawHandle}:${ref.tag}`
-        : rawHandle;
 
   // No-prompt llm spans don't reach this component anymore (the IOViewer
   // header carries the Playground affordance for that case). When we do
@@ -203,38 +194,25 @@ export function PromptAccordion({ span }: PromptAccordionProps) {
             <Icon as={LuPencil} boxSize={3} />
             Open prompt
           </Button>
-          {isLlmSpan && (
-            <Menu.Root>
-              <Menu.Trigger asChild>
-                <Button size="xs" variant="ghost" gap={1}>
-                  <Icon as={LuExternalLink} boxSize={3} />
-                  Open in Playground
-                  <Icon as={LuChevronDown} boxSize={2.5} />
-                </Button>
-              </Menu.Trigger>
-              <Menu.Content>
-                <Menu.Item value="open-existing" asChild>
-                  <Link
-                    href={
-                      buildUrl(span.spanId, "open-existing")?.toString() ?? ""
-                    }
-                    isExternal
-                  >
-                    Open {promptRefLabel ?? "prompt"}
-                  </Link>
-                </Menu.Item>
-                <Menu.Item value="create-new" asChild>
-                  <Link
-                    href={
-                      buildUrl(span.spanId, "create-new")?.toString() ?? ""
-                    }
-                    isExternal
-                  >
-                    Create new prompt
-                  </Link>
-                </Menu.Item>
-              </Menu.Content>
-            </Menu.Root>
+          {/* Single smart-default button: server resolves to the
+              linked llm when this span isn't an llm itself
+              (Prompt.compile, PromptApiService.get), opens the
+              existing prompt at the traced version when one is
+              linked, or creates a fresh tab otherwise. Same
+              affordance the IOViewer header carries on llm spans —
+              kept identical here so behavior is predictable
+              wherever a prompt is surfaced. */}
+          {buildUrl(span.spanId) && (
+            <Link
+              href={buildUrl(span.spanId)?.toString() ?? ""}
+              isExternal
+              variant="plain"
+            >
+              <Button size="xs" variant="ghost" gap={1}>
+                <Icon as={LuExternalLink} boxSize={3} />
+                Open in Playground
+              </Button>
+            </Link>
           )}
         </HStack>
       )}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/PromptsPanel.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/PromptsPanel.tsx
@@ -18,8 +18,10 @@ import {
   LuSparkles,
   LuTriangleAlert,
 } from "react-icons/lu";
+import { Link } from "~/components/ui/link";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useDrawer } from "~/hooks/useDrawer";
+import { useGoToSpanInPlaygroundTabUrlBuilder } from "~/prompts/prompt-playground/hooks/useLoadSpanIntoPromptPlayground";
 import type {
   SpanDetail,
   SpanTreeNode,
@@ -456,6 +458,14 @@ function PromptUsageCard({
   const variableEntries = Object.entries(variables).sort(([a], [b]) =>
     a.localeCompare(b),
   );
+  const { buildUrl } = useGoToSpanInPlaygroundTabUrlBuilder();
+  // Prefer the first emitting span (Prompt.compile / PromptApiService.get)
+  // — the server-side playground loader walks descendants/siblings to
+  // find the actual llm call for it.
+  const playgroundSpanId = spanIds[0] ?? null;
+  const playgroundHref = playgroundSpanId
+    ? (buildUrl(playgroundSpanId)?.toString() ?? "")
+    : "";
 
   return (
     <VStack align="stretch" gap={3} paddingX={4} paddingY={4}>
@@ -491,15 +501,25 @@ function PromptUsageCard({
             </Badge>
           )}
         </HStack>
-        <Button
-          size="xs"
-          variant="ghost"
-          gap={1}
-          onClick={() => onOpenPromptEditor(ref.handle)}
-        >
-          <Icon as={LuExternalLink} boxSize={3} />
-          Open prompt
-        </Button>
+        <HStack gap={1}>
+          <Button
+            size="xs"
+            variant="ghost"
+            gap={1}
+            onClick={() => onOpenPromptEditor(ref.handle)}
+          >
+            <Icon as={LuExternalLink} boxSize={3} />
+            Open prompt
+          </Button>
+          {playgroundHref && (
+            <Link href={playgroundHref} isExternal variant="plain">
+              <Button size="xs" variant="ghost" gap={1}>
+                <Icon as={LuExternalLink} boxSize={3} />
+                Open in Playground
+              </Button>
+            </Link>
+          )}
+        </HStack>
       </HStack>
 
       {/* Variables */}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -497,11 +497,11 @@ function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
     id: `eval:${ev.evaluationId}`,
     label: "Eval",
     value: valueNode,
-    // No leading icon — the colored status dot is the eval's identity.
-    // Even skipped/error keep the dot (in a muted color) so eval chips
-    // line up vertically with their siblings; the SKIPPED / ERROR badge
-    // sits at the trailing edge as the verdict.
-    dot: display.noVerdict ? "fg.muted" : display.color,
+    // No leading icon — the colored status dot is the eval's identity
+    // and reads from the shared `EVALUATION_STATUS_COLORS` map so it
+    // matches the v3 EvaluatorChip and the trace-list EvalChip exactly
+    // (skipped = yellow, error = red, etc.).
+    dot: display.color,
     tone,
     onClick,
     ariaLabel: `Eval ${display.displayName}: ${display.statusLabel}${display.scoreText ? ` ${display.scoreText}` : ""}`,

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -52,7 +52,12 @@ export function TraceHeaderChips({
     onSelectSpan,
     onOpenPromptsTab,
   });
-  return <ChipBar chips={chipDefs} endSlot={endSlot} />;
+  // Trace header has plenty of horizontal room and eval/prompt chips are
+  // load-bearing signal — let up to 10 chips ride the strip before
+  // collapsing into the "+N more" pill, otherwise the second & third
+  // eval verdicts (the most actionable ones in a multi-evaluator setup)
+  // get hidden by default.
+  return <ChipBar chips={chipDefs} maxVisible={10} endSlot={endSlot} />;
 }
 
 /**

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -447,25 +447,6 @@ function buildLastUsedPromptChipDef({
   };
 }
 
-function evalChipTone(
-  status: ReturnType<typeof getEvalChipDisplay>["status"],
-): "green" | "red" | "yellow" | "neutral" {
-  switch (status) {
-    case "passed":
-      return "green";
-    case "failed":
-      return "red";
-    case "error":
-      return "yellow";
-    case "skipped":
-    case "processed":
-    case "running":
-    case "pending":
-    default:
-      return "neutral";
-  }
-}
-
 function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
   // Single source of truth for color / status label / score formatting.
   // The trace-list `EvalChip`, the v3 EvaluatorChip, and this header
@@ -479,7 +460,12 @@ function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
     label: ev.label,
     passed: ev.passed,
   });
-  const tone = evalChipTone(display.status);
+  // Header eval chips always render on a neutral bg — colored backgrounds
+  // would turn the strip into a rainbow when several evaluators land on a
+  // trace. The status colour shows up in the leading dot + the
+  // pass/fail label text, matching the trace-table EvalChip and the v3
+  // EvaluatorChip exactly.
+  const tone = "neutral" as const;
   const valueNode = (
     <HStack gap={1} flexShrink={0} align="center">
       <Text textStyle="xs" color="fg" fontWeight="medium" truncate>
@@ -512,9 +498,10 @@ function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
     label: "Eval",
     value: valueNode,
     // No leading icon — the colored status dot is the eval's identity.
-    // Skipped/error swap the dot for the inline badge so the chip never
-    // shows both.
-    dot: display.noVerdict ? undefined : display.color,
+    // Even skipped/error keep the dot (in a muted color) so eval chips
+    // line up vertically with their siblings; the SKIPPED / ERROR badge
+    // sits at the trailing edge as the verdict.
+    dot: display.noVerdict ? "fg.muted" : display.color,
     tone,
     onClick,
     ariaLabel: `Eval ${display.displayName}: ${display.statusLabel}${display.scoreText ? ` ${display.scoreText}` : ""}`,

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -2,16 +2,17 @@ import { Avatar, Box, Circle, HStack, Icon, Text, VStack } from "@chakra-ui/reac
 import { Lightbulb } from "lucide-react";
 import {
   LuBookMarked,
+  LuCircleAlert,
   LuCircleDashed,
+  LuCircleSlash,
   LuCode,
-  LuGauge,
   LuGlobe,
-  LuHistory,
   LuMessageSquare,
   LuServer,
   LuSparkles,
   LuTriangleAlert,
 } from "react-icons/lu";
+import { getEvalChipDisplay } from "~/utils/evaluationResults";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { TraceHeader } from "~/server/api/routers/tracesV2.schemas";
 import { api } from "~/utils/api";
@@ -344,11 +345,16 @@ function buildLastUsedPromptChipDef({
     : driftFromSelection || outOfDate
       ? "yellow"
       : "blue";
+  // Drop the leading history glyph on the happy path — the purple status
+  // dot + the "Prompt" label already say what this chip is, and the icon
+  // was just visual noise next to the verbose handle. We do keep the
+  // warning glyph for drift / out-of-date so the chip's tone change isn't
+  // the only signal that something's off.
   const icon = state.missing
     ? LuCircleDashed
     : driftFromSelection || outOfDate
       ? LuTriangleAlert
-      : LuHistory;
+      : undefined;
 
   const onClick = () => {
     if (spanId) {
@@ -436,107 +442,100 @@ function buildLastUsedPromptChipDef({
   };
 }
 
-function evalStatusTone(
-  ev: RichEval,
+function evalChipTone(
+  status: ReturnType<typeof getEvalChipDisplay>["status"],
 ): "green" | "red" | "yellow" | "neutral" {
-  switch (ev.status) {
-    case "pass":
+  switch (status) {
+    case "passed":
       return "green";
-    case "fail":
+    case "failed":
       return "red";
     case "error":
-    case "warning":
       return "yellow";
     case "skipped":
+    case "processed":
+    case "running":
+    case "pending":
     default:
       return "neutral";
   }
 }
 
-function evalStatusDot(ev: RichEval): string {
-  switch (ev.status) {
-    case "pass":
-      return "green.solid";
-    case "fail":
-      return "red.solid";
-    case "error":
-    case "warning":
-      return "yellow.solid";
-    case "skipped":
-    default:
-      return "gray.solid";
-  }
-}
-
-function evalStatusLabel(ev: RichEval): string {
-  switch (ev.status) {
-    case "pass":
-      return "Pass";
-    case "fail":
-      return "Fail";
-    case "error":
-      return "Error";
-    case "skipped":
-      return "Skipped";
-    case "warning":
-      return "Warning";
-    default:
-      return "—";
-  }
-}
-
-function formatEvalScore(ev: RichEval): string | null {
-  if (typeof ev.score !== "number") return null;
-  return ev.score <= 1 ? ev.score.toFixed(2) : ev.score.toFixed(1);
-}
-
 function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
-  const tone = evalStatusTone(ev);
-  const dot = evalStatusDot(ev);
-  const score = formatEvalScore(ev);
-  const displayName = ev.name || ev.evaluatorId;
-  const statusLabel = evalStatusLabel(ev);
-  // For pass / fail we already show the colour-coded dot — the trailing
-  // value reads as the score (or the verdict label when there's no
-  // numeric score). For skipped / error use the status label so the
-  // chip is never just `<name>` with no signal.
-  const value = score
-    ? `${displayName} ${score}`
-    : ev.status === "pass" || ev.status === "fail"
-      ? `${displayName} ${statusLabel}`
-      : `${displayName} ${statusLabel}`;
+  // Single source of truth for color / status label / score formatting.
+  // The trace-list `EvalChip`, the v3 EvaluatorChip, and this header
+  // chip all derive their display from `getEvalChipDisplay` so the
+  // visuals never drift between surfaces.
+  const display = getEvalChipDisplay({
+    name: ev.name,
+    evaluatorId: ev.evaluatorId,
+    status: ev.status,
+    score: ev.score,
+    label: ev.label,
+    passed: ev.passed,
+  });
+  const tone = evalChipTone(display.status);
+  const valueNode = (
+    <HStack gap={1} flexShrink={0} align="center">
+      <Text textStyle="xs" color="fg" fontWeight="medium" truncate>
+        {display.displayName}
+      </Text>
+      {/* Trailing verdict — for skipped/error this is a tinted badge;
+          for boolean Pass/Fail it's colored text; for numeric it's
+          a muted-foreground numeral. Mirrors the trace-table EvalChip. */}
+      {display.status === "skipped" ? (
+        <NoVerdictMicroBadge icon={LuCircleSlash} label="SKIPPED" />
+      ) : display.status === "error" ? (
+        <NoVerdictMicroBadge icon={LuCircleAlert} label="ERROR" />
+      ) : display.scoreText ? (
+        <Text textStyle="2xs" fontWeight="semibold" color="fg.muted">
+          {display.scoreText}
+        </Text>
+      ) : display.passLabel ? (
+        <Text
+          textStyle="2xs"
+          fontWeight="semibold"
+          color={display.passLabel.color}
+        >
+          {display.passLabel.text}
+        </Text>
+      ) : null}
+    </HStack>
+  );
   return {
     id: `eval:${ev.evaluationId}`,
     label: "Eval",
-    value,
-    icon: LuGauge,
-    dot,
+    value: valueNode,
+    // No leading icon — the colored status dot is the eval's identity.
+    // Skipped/error swap the dot for the inline badge so the chip never
+    // shows both.
+    dot: display.noVerdict ? undefined : display.color,
     tone,
     onClick,
-    ariaLabel: `Eval ${displayName}: ${statusLabel}${score ? ` ${score}` : ""}`,
+    ariaLabel: `Eval ${display.displayName}: ${display.statusLabel}${display.scoreText ? ` ${display.scoreText}` : ""}`,
     tooltip: (
       <VStack align="stretch" gap={1.5} minWidth="240px" maxWidth="340px">
         <HStack gap={2}>
-          <Circle size="8px" bg={dot} flexShrink={0} />
+          <Circle size="10px" bg={display.color} flexShrink={0} />
           <Text textStyle="sm" fontWeight="semibold" truncate>
-            {displayName}
+            {display.displayName}
           </Text>
         </HStack>
         <HStack justify="space-between" gap={3}>
           <Text textStyle="2xs" color="fg.muted">
             Status
           </Text>
-          <Text textStyle="2xs" fontWeight="semibold">
-            {statusLabel}
+          <Text textStyle="2xs" fontWeight="semibold" color={display.color}>
+            {display.statusLabel}
           </Text>
         </HStack>
-        {score && (
+        {display.scoreText && (
           <HStack justify="space-between" gap={3}>
             <Text textStyle="2xs" color="fg.muted">
               Score
             </Text>
             <Text textStyle="2xs" fontWeight="semibold">
-              {score}
+              {display.scoreText}
             </Text>
           </HStack>
         )}
@@ -594,6 +593,43 @@ function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
       </VStack>
     ),
   };
+}
+
+/**
+ * Tiny inline "no verdict" badge for the eval chip's value slot. Matches
+ * the visual language of the EvalCard's status tag (tinted bg, leading
+ * icon, uppercase letter-spaced label) so the same status reads the same
+ * way at every scale: chip → list pill → card header.
+ */
+function NoVerdictMicroBadge({
+  icon,
+  label,
+}: {
+  icon: typeof LuCircleSlash;
+  label: string;
+}) {
+  return (
+    <HStack
+      gap={0.5}
+      paddingX={1}
+      borderRadius="sm"
+      borderWidth="1px"
+      borderColor="border.muted"
+      bg="bg.muted"
+      flexShrink={0}
+      lineHeight="1"
+    >
+      <Icon as={icon} boxSize={2.5} color="fg.muted" />
+      <Text
+        textStyle="2xs"
+        fontWeight="bold"
+        color="fg.muted"
+        letterSpacing="0.04em"
+      >
+        {label}
+      </Text>
+    </HStack>
+  );
 }
 
 function SdkRow({ label, value }: { label: string; value: string }) {

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -1,9 +1,10 @@
-import { Avatar, Box, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { Avatar, Box, Circle, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { Lightbulb } from "lucide-react";
 import {
   LuBookMarked,
   LuCircleDashed,
   LuCode,
+  LuGauge,
   LuGlobe,
   LuHistory,
   LuMessageSquare,
@@ -15,6 +16,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { TraceHeader } from "~/server/api/routers/tracesV2.schemas";
 import { api } from "~/utils/api";
 import { useConversationTurns } from "../../hooks/useConversationTurns";
+import type { RichEval } from "../../hooks/useTraceEvaluations";
 import {
   type PromptChipState,
   type SdkInfoLike,
@@ -215,6 +217,8 @@ function buildChipDef(
         }),
         priority,
       };
+    case "eval":
+      return { ...buildEvalChipDef(data.eval, data.onClick), priority };
   }
 }
 
@@ -429,6 +433,166 @@ function buildLastUsedPromptChipDef({
     ariaLabel: spanId
       ? `Jump to the span that ran prompt ${handle}`
       : `Open prompt ${handle} in the Prompts tab`,
+  };
+}
+
+function evalStatusTone(
+  ev: RichEval,
+): "green" | "red" | "yellow" | "neutral" {
+  switch (ev.status) {
+    case "pass":
+      return "green";
+    case "fail":
+      return "red";
+    case "error":
+    case "warning":
+      return "yellow";
+    case "skipped":
+    default:
+      return "neutral";
+  }
+}
+
+function evalStatusDot(ev: RichEval): string {
+  switch (ev.status) {
+    case "pass":
+      return "green.solid";
+    case "fail":
+      return "red.solid";
+    case "error":
+    case "warning":
+      return "yellow.solid";
+    case "skipped":
+    default:
+      return "gray.solid";
+  }
+}
+
+function evalStatusLabel(ev: RichEval): string {
+  switch (ev.status) {
+    case "pass":
+      return "Pass";
+    case "fail":
+      return "Fail";
+    case "error":
+      return "Error";
+    case "skipped":
+      return "Skipped";
+    case "warning":
+      return "Warning";
+    default:
+      return "—";
+  }
+}
+
+function formatEvalScore(ev: RichEval): string | null {
+  if (typeof ev.score !== "number") return null;
+  return ev.score <= 1 ? ev.score.toFixed(2) : ev.score.toFixed(1);
+}
+
+function buildEvalChipDef(ev: RichEval, onClick: () => void): ChipDef {
+  const tone = evalStatusTone(ev);
+  const dot = evalStatusDot(ev);
+  const score = formatEvalScore(ev);
+  const displayName = ev.name || ev.evaluatorId;
+  const statusLabel = evalStatusLabel(ev);
+  // For pass / fail we already show the colour-coded dot — the trailing
+  // value reads as the score (or the verdict label when there's no
+  // numeric score). For skipped / error use the status label so the
+  // chip is never just `<name>` with no signal.
+  const value = score
+    ? `${displayName} ${score}`
+    : ev.status === "pass" || ev.status === "fail"
+      ? `${displayName} ${statusLabel}`
+      : `${displayName} ${statusLabel}`;
+  return {
+    id: `eval:${ev.evaluationId}`,
+    label: "Eval",
+    value,
+    icon: LuGauge,
+    dot,
+    tone,
+    onClick,
+    ariaLabel: `Eval ${displayName}: ${statusLabel}${score ? ` ${score}` : ""}`,
+    tooltip: (
+      <VStack align="stretch" gap={1.5} minWidth="240px" maxWidth="340px">
+        <HStack gap={2}>
+          <Circle size="8px" bg={dot} flexShrink={0} />
+          <Text textStyle="sm" fontWeight="semibold" truncate>
+            {displayName}
+          </Text>
+        </HStack>
+        <HStack justify="space-between" gap={3}>
+          <Text textStyle="2xs" color="fg.muted">
+            Status
+          </Text>
+          <Text textStyle="2xs" fontWeight="semibold">
+            {statusLabel}
+          </Text>
+        </HStack>
+        {score && (
+          <HStack justify="space-between" gap={3}>
+            <Text textStyle="2xs" color="fg.muted">
+              Score
+            </Text>
+            <Text textStyle="2xs" fontWeight="semibold">
+              {score}
+            </Text>
+          </HStack>
+        )}
+        {ev.label && (
+          <HStack justify="space-between" gap={3}>
+            <Text textStyle="2xs" color="fg.muted">
+              Label
+            </Text>
+            <Text textStyle="2xs" fontWeight="semibold">
+              {ev.label}
+            </Text>
+          </HStack>
+        )}
+        {ev.reasoning && (
+          <VStack
+            align="stretch"
+            gap={0.5}
+            paddingTop={1.5}
+            borderTopWidth="1px"
+            borderColor="border.muted"
+          >
+            <Text textStyle="2xs" color="fg.muted">
+              Reasoning
+            </Text>
+            <Text textStyle="2xs" color="fg" whiteSpace="pre-wrap">
+              {ev.reasoning}
+            </Text>
+          </VStack>
+        )}
+        {ev.errorMessage && (
+          <VStack
+            align="stretch"
+            gap={0.5}
+            paddingTop={1.5}
+            borderTopWidth="1px"
+            borderColor="border.muted"
+          >
+            <Text textStyle="2xs" color="red.fg">
+              Error
+            </Text>
+            <Text textStyle="2xs" color="fg" whiteSpace="pre-wrap">
+              {ev.errorMessage}
+            </Text>
+          </VStack>
+        )}
+        <Text
+          textStyle="2xs"
+          color="fg.subtle"
+          paddingTop={1}
+          borderTopWidth="1px"
+          borderColor="border.muted"
+        >
+          Click to jump to the Evals section
+        </Text>
+      </VStack>
+    ),
   };
 }
 

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -637,10 +637,13 @@ export const DrawerHeader = memo(function DrawerHeader({
     onSelectSpan: selectSpan,
     onOpenPromptsTab: () => setActiveTab("prompts"),
   });
-  // Source chips: cap inline at 6 — anything beyond rolls into the "+N more"
-  // popover so the strip stays scannable for traces with many capabilities.
+  // Source chips: cap inline at 10 so multi-evaluator traces don't hide
+  // their second & third verdicts in the overflow popover by default —
+  // eval status is the highest-signal data on the strip, not something
+  // to bury after a half-dozen capabilities. Anything beyond 10 still
+  // rolls into "+N more" so the row stays scannable.
   const { primary: primaryChips, overflowChip: chipsOverflow } =
-    splitChipsForOverflow(chipDefs, 6);
+    splitChipsForOverflow(chipDefs, 10);
   // Pins: auto-pins (identity/run/tag) always inline, custom pins capped at
   // 3 inline with the rest in a "+N pinned" popover. Anyone can pin
   // arbitrary attributes, so this keeps the row from running away.

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
@@ -10,12 +10,8 @@ import {
 } from "@chakra-ui/react";
 import { type ReactNode, useState } from "react";
 import { LuCircleAlert, LuCircleSlash, LuQuote } from "react-icons/lu";
-import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import {
-  AZURE_SAFETY_NOT_CONFIGURED_MESSAGE,
-  AZURE_SAFETY_PROVIDER_KEY,
-} from "~/server/app-layer/evaluations/azure-safety-env";
+import { AZURE_SAFETY_NOT_CONFIGURED_MESSAGE } from "~/server/app-layer/evaluations/azure-safety-env";
 import { formatCost, formatDuration } from "../../../utils/formatters";
 import { RunHistorySparkline } from "./RunHistorySparkline";
 import { type EvalEntry, formatInputValue, isNoVerdict, STATUS } from "./utils";
@@ -30,7 +26,6 @@ export function EvalCard({
   const { name, score, scoreType, status } = eval_;
   const tone = STATUS[status] ?? STATUS.warning;
   const noVerdict = isNoVerdict(status);
-  const { openDrawer } = useDrawer();
   const { project, organization } = useOrganizationTeamProject();
 
   let scoreLabel = "";
@@ -230,22 +225,16 @@ export function EvalCard({
                 primaryStatusText === AZURE_SAFETY_NOT_CONFIGURED_MESSAGE ? (
                   <>
                     Azure Safety provider not configured. Configure it in{" "}
-                    <chakra.button
-                      type="button"
+                    <chakra.a
+                      href="/settings/model-providers"
+                      target="_blank"
+                      rel="noopener noreferrer"
                       color="blue.fg"
                       textDecoration="underline"
-                      onClick={() => {
-                        if (!project?.id) return;
-                        openDrawer("editModelProvider", {
-                          projectId: project.id,
-                          organizationId: organization?.id,
-                          providerKey: AZURE_SAFETY_PROVIDER_KEY,
-                          modelProviderId: "new",
-                        });
-                      }}
+                      onClick={(e) => e.stopPropagation()}
                     >
                       Settings → Model Providers
-                    </chakra.button>{" "}
+                    </chakra.a>{" "}
                     to run this evaluator.
                   </>
                 ) : (

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/utils.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/utils.ts
@@ -1,41 +1,43 @@
+import {
+  EVALUATION_STATUS_COLORS,
+  EVALUATION_STATUS_TONES,
+} from "~/utils/evaluationResults";
 import type { EvalSummary } from "../../../types/trace";
 
+/**
+ * Per-status tag rendering for the Evals accordion cards. Sourced from
+ * the shared evaluation-results maps so dot / tag colours can't drift
+ * out of step with the trace-list `EvalChip`, the v2 drawer header
+ * chip, or the v3 EvaluatorChip — three surfaces that all need to
+ * agree on "this verdict reads as X".
+ */
+function buildStatusTone(
+  parsed: keyof typeof EVALUATION_STATUS_COLORS,
+  label: string,
+) {
+  return {
+    color: EVALUATION_STATUS_COLORS[parsed],
+    fg: EVALUATION_STATUS_TONES[parsed].fg,
+    bg: EVALUATION_STATUS_TONES[parsed].bg,
+    label,
+  } as const;
+}
+
 export const STATUS = {
-  pass: {
-    color: "green.solid",
-    fg: "green.fg",
-    bg: "green.subtle",
-    label: "PASS",
-  },
-  warning: {
-    color: "yellow.solid",
-    fg: "yellow.fg",
-    bg: "yellow.subtle",
-    label: "WARN",
-  },
-  fail: {
-    color: "red.solid",
-    fg: "red.fg",
-    bg: "red.subtle",
-    label: "FAIL",
-  },
+  pass: buildStatusTone("passed", "PASS"),
+  // "Warning" is a legacy trace-summary status with no v3 equivalent;
+  // it reads as a not-quite-pass, so route it through the `failed` tone
+  // so the chip still turns red rather than picking up a bespoke yellow.
+  warning: buildStatusTone("failed", "WARN"),
+  fail: buildStatusTone("failed", "FAIL"),
   // Evaluator wasn't run — provider not configured, preconditions failed,
-  // etc. This is a setup state, not a verdict; rendering a 0.00/1.00 score
-  // alongside it (the old behavior) lied about what happened.
-  skipped: {
-    color: "fg.subtle",
-    fg: "fg.muted",
-    bg: "bg.muted",
-    label: "SKIPPED",
-  },
-  // Evaluator crashed. Distinct from a FAIL verdict — there is no score
-  // because the evaluator never produced one.
-  error: {
-    color: "orange.solid",
-    fg: "orange.fg",
-    bg: "orange.subtle",
-    label: "ERROR",
-  },
+  // etc. This is a setup state, not a verdict; gray-on-gray keeps it from
+  // competing for attention next to real pass/fail rows.
+  skipped: buildStatusTone("skipped", "SKIPPED"),
+  // Evaluator crashed. Distinct from a FAIL verdict — uses the deeper
+  // red.700 from the shared map so "the evaluator broke" reads as a
+  // separate failure mode from "the evaluator ran and said no".
+  error: buildStatusTone("error", "ERROR"),
 } as const;
 
 /**

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/AccordionShell.tsx
@@ -78,6 +78,7 @@ export function Section({
     <Accordion.Item
       value={value}
       border="0"
+      data-section={value}
       data-section-label={title}
       data-section-count={count ?? ""}
     >

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, HStack, Icon, Text, VStack } from "@chakra-ui/react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { LuCircleX } from "react-icons/lu";
+import { useFocusSectionStore } from "../../../stores/focusSectionStore";
 import type {
   SpanTreeNode,
   TraceHeader,
@@ -115,8 +116,44 @@ export function TraceSummaryAccordions({
     events: hasEventsContent,
   });
 
+  // Observe focus-section signals from external surfaces (header chips,
+  // overflow menus, …). When a request matches this trace, ensure the
+  // requested section is in `openSections` and scroll it into view.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const pendingFocus = useFocusSectionStore((s) => s.pending);
+  const clearFocus = useFocusSectionStore((s) => s.clear);
+  useEffect(() => {
+    if (!pendingFocus) return;
+    if (pendingFocus.traceId !== trace.traceId) return;
+    if (!sections.includes(pendingFocus.section as never)) return;
+    setOpenSections(
+      openSections.includes(pendingFocus.section)
+        ? openSections
+        : [...openSections, pendingFocus.section],
+    );
+    // Wait one frame so the accordion has actually expanded before we
+    // measure + scroll. Two rAFs because the first only flushes the
+    // open-state setState; layout commits on the second.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const el = containerRef.current?.querySelector<HTMLElement>(
+          `[data-section="${pendingFocus.section}"]`,
+        );
+        el?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    });
+    clearFocus();
+  }, [
+    pendingFocus,
+    trace.traceId,
+    sections,
+    openSections,
+    setOpenSections,
+    clearFocus,
+  ]);
+
   return (
-    <Box>
+    <Box ref={containerRef}>
       {/* The instrumentation scope used to render here as a small
           attribution row at the top of the summary panel. It's now
           pinned to the right of the SpanTabBar so it stays visible

--- a/langwatch/src/features/traces-v2/components/TraceTable/registry/sharedChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/registry/sharedChips.tsx
@@ -95,7 +95,6 @@ function NoVerdictBadge({ label, icon: Icon }: { label: string; icon: IconType }
 
 export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
   const display = getEvalChipDisplay(eval_);
-  const noVerdict = display.noVerdict;
 
   return (
     <HoverCard.Root
@@ -116,11 +115,10 @@ export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
           flexShrink={0}
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
         >
-          {/* The "no verdict" badge already carries its own icon + label
-              so the leading dot would just be noise. */}
-          {!noVerdict && (
-            <Circle size="10px" bg={display.color} flexShrink={0} />
-          )}
+          {/* Dot always renders so every chip lines up regardless of
+              whether the trailing slot is a score, a Pass/Fail label,
+              or a no-verdict badge. */}
+          <Circle size="10px" bg={display.color} flexShrink={0} />
           <Text
             textStyle="2xs"
             fontWeight="medium"

--- a/langwatch/src/features/traces-v2/components/TraceTable/registry/sharedChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/registry/sharedChips.tsx
@@ -7,50 +7,95 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import type React from "react";
+import type { IconType } from "react-icons";
+import { LuCircleSlash, LuCircleAlert } from "react-icons/lu";
+import {
+  getEvalChipDisplay,
+  type EvalChipDisplay,
+} from "~/utils/evaluationResults";
 import type { TraceEvalResult, TraceListEvent } from "../../../types/trace";
 
-const EVAL_CHIP_COLORS: Record<string, string> = {
-  processed_pass: "green.solid",
-  processed_fail: "red.solid",
-  processed_neutral: "blue.solid",
-  error: "red.solid",
-  skipped: "yellow.solid",
-  in_progress: "blue.solid",
-  scheduled: "gray.solid",
-};
+/**
+ * Re-exported for callers that already imported from this module — the
+ * canonical formatter now lives in `evaluationResults.ts` so the trace
+ * table, the drawer header and any future surface format scores
+ * identically.
+ */
+export function formatEvalScore(ev: TraceEvalResult): string | null {
+  return getEvalChipDisplay(ev).scoreText;
+}
 
 export function evalChipColor(ev: TraceEvalResult): string {
-  if (ev.status === "processed") {
-    if (ev.passed === true) return EVAL_CHIP_COLORS.processed_pass!;
-    if (ev.passed === false) return EVAL_CHIP_COLORS.processed_fail!;
-    return EVAL_CHIP_COLORS.processed_neutral!;
-  }
-  return EVAL_CHIP_COLORS[ev.status] ?? "gray.solid";
+  return getEvalChipDisplay(ev).color;
 }
 
-export function formatEvalScore(ev: TraceEvalResult): string | null {
-  if (ev.score == null) return null;
-  if (ev.score <= 1) return ev.score.toFixed(2);
-  return ev.score.toFixed(1);
+/**
+ * Render the trailing verdict slot. Skipped / error get a tinted-bg
+ * badge with a leading icon so they don't look like a real score; pure
+ * boolean verdicts get colored "Pass" / "Fail" text; numeric scores stay
+ * as muted-foreground numerals.
+ */
+function VerdictSlot({ display }: { display: EvalChipDisplay }) {
+  if (display.status === "skipped") return <NoVerdictBadge label="SKIPPED" icon={LuCircleSlash} />;
+  if (display.status === "error") return <NoVerdictBadge label="ERROR" icon={LuCircleAlert} />;
+  if (display.scoreText) {
+    return (
+      <Text
+        textStyle="2xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        whiteSpace="nowrap"
+        lineHeight="1.2"
+      >
+        {display.scoreText}
+      </Text>
+    );
+  }
+  if (display.passLabel) {
+    return (
+      <Text
+        textStyle="2xs"
+        fontWeight="semibold"
+        color={display.passLabel.color}
+        whiteSpace="nowrap"
+        lineHeight="1.2"
+      >
+        {display.passLabel.text}
+      </Text>
+    );
+  }
+  return null;
 }
 
-function getStatusLabel(ev: TraceEvalResult): string {
-  if (ev.status === "processed") {
-    if (ev.passed === true) return "Passed";
-    if (ev.passed === false) return "Failed";
-    return "Processed";
-  }
-  if (ev.status === "in_progress") return "Running";
-  if (ev.status === "scheduled") return "Pending";
-  if (ev.status === "error") return "Error";
-  if (ev.status === "skipped") return "Skipped";
-  return ev.status;
+function NoVerdictBadge({ label, icon: Icon }: { label: string; icon: IconType }) {
+  return (
+    <HStack
+      gap={1}
+      paddingX={1.5}
+      paddingY={0}
+      borderRadius="sm"
+      borderWidth="1px"
+      borderColor="border.muted"
+      bg="bg.muted"
+      flexShrink={0}
+    >
+      <Icon size={10} />
+      <Text
+        textStyle="2xs"
+        fontWeight="bold"
+        color="fg.muted"
+        letterSpacing="0.04em"
+        lineHeight="1.2"
+      >
+        {label}
+      </Text>
+    </HStack>
+  );
 }
 
 export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
-  const color = evalChipColor(eval_);
-  const scoreText = formatEvalScore(eval_);
-  const displayName = eval_.evaluatorName ?? eval_.evaluatorId;
+  const display = getEvalChipDisplay(eval_);
+  const noVerdict = display.noVerdict;
 
   return (
     <HoverCard.Root
@@ -71,7 +116,11 @@ export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
           flexShrink={0}
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
         >
-          <Circle size="8px" bg={color} flexShrink={0} />
+          {/* The "no verdict" badge already carries its own icon + label
+              so the leading dot would just be noise. */}
+          {!noVerdict && (
+            <Circle size="10px" bg={display.color} flexShrink={0} />
+          )}
           <Text
             textStyle="2xs"
             fontWeight="medium"
@@ -80,30 +129,9 @@ export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
             maxWidth="80px"
             lineHeight="1.2"
           >
-            {displayName}
+            {display.displayName}
           </Text>
-          {scoreText && (
-            <Text
-              textStyle="2xs"
-              fontWeight="semibold"
-              color="fg.muted"
-              whiteSpace="nowrap"
-              lineHeight="1.2"
-            >
-              {scoreText}
-            </Text>
-          )}
-          {eval_.passed != null && eval_.score == null && (
-            <Text
-              textStyle="2xs"
-              fontWeight="semibold"
-              color={eval_.passed ? "green.fg" : "red.fg"}
-              whiteSpace="nowrap"
-              lineHeight="1.2"
-            >
-              {eval_.passed ? "Pass" : "Fail"}
-            </Text>
-          )}
+          <VerdictSlot display={display} />
         </HStack>
       </HoverCard.Trigger>
       <Portal>
@@ -119,18 +147,18 @@ export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
           >
             <VStack align="stretch" gap={1.5}>
               <HStack gap={2}>
-                <Circle size="8px" bg={color} flexShrink={0} />
+                <Circle size="8px" bg={display.color} flexShrink={0} />
                 <Text textStyle="xs" fontWeight="semibold" color="fg" truncate>
-                  {displayName}
+                  {display.displayName}
                 </Text>
               </HStack>
-              {scoreText && (
+              {display.scoreText && (
                 <HStack justify="space-between" gap={3}>
                   <Text textStyle="2xs" color="fg.muted">
                     Score
                   </Text>
                   <Text textStyle="2xs" fontWeight="semibold" color="fg">
-                    {scoreText}
+                    {display.scoreText}
                   </Text>
                 </HStack>
               )}
@@ -144,7 +172,7 @@ export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
                   </Text>
                 </HStack>
               )}
-              {eval_.passed != null && (
+              {display.passLabel && (
                 <HStack justify="space-between" gap={3}>
                   <Text textStyle="2xs" color="fg.muted">
                     Result
@@ -152,9 +180,9 @@ export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
                   <Text
                     textStyle="2xs"
                     fontWeight="semibold"
-                    color={eval_.passed ? "green.fg" : "red.fg"}
+                    color={display.passLabel.color}
                   >
-                    {eval_.passed ? "Passed" : "Failed"}
+                    {display.statusLabel}
                   </Text>
                 </HStack>
               )}
@@ -162,8 +190,12 @@ export const EvalChip: React.FC<{ eval_: TraceEvalResult }> = ({ eval_ }) => {
                 <Text textStyle="2xs" color="fg.muted">
                   Status
                 </Text>
-                <Text textStyle="2xs" fontWeight="semibold" color={color}>
-                  {getStatusLabel(eval_)}
+                <Text
+                  textStyle="2xs"
+                  fontWeight="semibold"
+                  color={display.color}
+                >
+                  {display.statusLabel}
                 </Text>
               </HStack>
             </VStack>

--- a/langwatch/src/features/traces-v2/hooks/useTraceHeaderChips.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceHeaderChips.ts
@@ -4,8 +4,11 @@ import {
   type ScenarioChipData,
   useScenarioChipData,
 } from "../components/TraceDrawer/ScenarioChip";
+import { useDrawerStore } from "../stores/drawerStore";
 import { useFilterStore } from "../stores/filterStore";
+import { useFocusSectionStore } from "../stores/focusSectionStore";
 import { parseSdkInfo, type SdkInfo } from "../utils/sdkInfo";
+import { type RichEval, useTraceEvaluations } from "./useTraceEvaluations";
 import { usePromptByHandle } from "./usePromptByHandle";
 
 export interface SdkInfoLike {
@@ -55,6 +58,11 @@ export type TraceHeaderChipData =
       state: PromptChipState;
       driftFromSelection: boolean;
       outOfDate: boolean;
+    }
+  | {
+      kind: "eval";
+      eval: RichEval;
+      onClick: () => void;
     };
 
 interface UseTraceHeaderChipsOptions {
@@ -167,6 +175,26 @@ export function useTraceHeaderChips(
       state: lastUsedState,
       driftFromSelection,
       outOfDate: isOutOfDate,
+    });
+  }
+
+  // One chip per evaluation result. Click jumps to the trace Summary
+  // Evals accordion and scrolls it into view — operators previously had
+  // to expand the drawer past the metadata strip to see any eval
+  // signal, even on heavily-evaluated traces.
+  const { rich: evals } = useTraceEvaluations();
+  const setViewMode = useDrawerStore((s) => s.setViewMode);
+  const setActiveTab = useDrawerStore((s) => s.setActiveTab);
+  const requestFocus = useFocusSectionStore((s) => s.request);
+  for (const ev of evals) {
+    chips.push({
+      kind: "eval",
+      eval: ev,
+      onClick: () => {
+        setViewMode("trace");
+        setActiveTab("summary");
+        requestFocus({ traceId: trace.traceId, section: "evals" });
+      },
     });
   }
 

--- a/langwatch/src/features/traces-v2/stores/focusSectionStore.ts
+++ b/langwatch/src/features/traces-v2/stores/focusSectionStore.ts
@@ -1,10 +1,20 @@
 import { create } from "zustand";
 
+/**
+ * Closed set of section ids that header chips can deep-link into. Kept
+ * narrow on purpose — adding a new section here is intentional and the
+ * extra typing makes typos surface at the call site instead of silently
+ * triggering a no-op at runtime when `TraceSummaryAccordions` fails to
+ * find a matching `data-section` element.
+ */
+const FOCUS_SECTIONS = ["evals", "events"] as const;
+export type FocusSection = (typeof FOCUS_SECTIONS)[number];
+
 interface PendingFocus {
   /** Trace this focus request applies to — observers ignore other traces. */
   traceId: string;
   /** Section id to expand + scroll to (matches the `value` of a `<Section>`). */
-  section: string;
+  section: FocusSection;
   /**
    * Monotonic counter so re-clicking the same chip re-triggers the effect
    * even when traceId + section are identical to the prior request.
@@ -14,7 +24,7 @@ interface PendingFocus {
 
 interface FocusSectionState {
   pending: PendingFocus | null;
-  request: (params: { traceId: string; section: string }) => void;
+  request: (params: { traceId: string; section: FocusSection }) => void;
   clear: () => void;
 }
 

--- a/langwatch/src/features/traces-v2/stores/focusSectionStore.ts
+++ b/langwatch/src/features/traces-v2/stores/focusSectionStore.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+
+interface PendingFocus {
+  /** Trace this focus request applies to — observers ignore other traces. */
+  traceId: string;
+  /** Section id to expand + scroll to (matches the `value` of a `<Section>`). */
+  section: string;
+  /**
+   * Monotonic counter so re-clicking the same chip re-triggers the effect
+   * even when traceId + section are identical to the prior request.
+   */
+  nonce: number;
+}
+
+interface FocusSectionState {
+  pending: PendingFocus | null;
+  request: (params: { traceId: string; section: string }) => void;
+  clear: () => void;
+}
+
+/**
+ * One-shot signal store for "expand + scroll the trace summary section
+ * with id X". Used by header chips (eval chip, error chip, …) to deep-
+ * link operators from a compact metadata pill straight to the relevant
+ * accordion section without prop-drilling refs across the drawer.
+ *
+ * `TraceSummaryAccordions` observes `pending`; when it matches the
+ * mounted trace, it adds the section to its open list and scrolls the
+ * section into view, then calls `clear()`.
+ */
+export const useFocusSectionStore = create<FocusSectionState>((set, get) => ({
+  pending: null,
+  request: ({ traceId, section }) => {
+    const nonce = (get().pending?.nonce ?? 0) + 1;
+    set({ pending: { traceId, section, nonce } });
+  },
+  clear: () => set({ pending: null }),
+}));

--- a/langwatch/src/features/traces-v2/utils/promptAttributes.ts
+++ b/langwatch/src/features/traces-v2/utils/promptAttributes.ts
@@ -201,10 +201,10 @@ export function extractPromptReference(
     if (versionRaw != null) {
       const version = Number(versionRaw);
       if (Number.isInteger(version) && version > 0) {
-        return { handle: promptId, versionNumber: version, tag: null, variables };
+        return { handle: promptId, versionNumber: version, tag: null, variables, draft };
       }
     }
-    return { handle: promptId, versionNumber: null, tag: null, variables };
+    return { handle: promptId, versionNumber: null, tag: null, variables, draft };
   }
 
   return null;

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -964,16 +964,27 @@ export class ClickHouseTraceService {
             StatusMessage: string | null;
           }>;
 
-          const row = allRows.find((r) => r.SpanId === spanId);
-          if (!row) {
+          const requestedRow = allRows.find((r) => r.SpanId === spanId);
+          if (!requestedRow) {
             return null;
           }
 
-          // Check if this is an LLM span by looking at attributes
-          const spanType = row.SpanAttributes["langwatch.span.type"] as
-            | string
-            | undefined;
-          if (spanType !== "llm") {
+          // If the caller pointed us at a non-llm span (e.g. the user
+          // clicked "Open in Playground" from the Prompt.compile or
+          // PromptApiService.get span, or from the Prompts tab usage
+          // card), resolve to the nearest llm in the trace that the
+          // operator most likely meant: a descendant first, then a
+          // sibling that started at or after the requested span. The
+          // playground form needs an llm span's messages + llm config —
+          // anything else lands as "No prompts open".
+          const requestedType = requestedRow.SpanAttributes[
+            "langwatch.span.type"
+          ] as string | undefined;
+          const row =
+            requestedType === "llm"
+              ? requestedRow
+              : (findNearestLlm(allRows, requestedRow) ?? null);
+          if (!row) {
             return null;
           }
 
@@ -1010,7 +1021,7 @@ export class ClickHouseTraceService {
             });
 
             const ancestorRef = findPromptReferenceInAncestors({
-              targetSpanId: spanId,
+              targetSpanId: row.SpanId,
               spans: ancestorSpans,
             });
             if (ancestorRef?.promptHandle) {
@@ -2117,6 +2128,71 @@ interface JoinedTraceSpanRow extends TraceSummaryRow {
   ss_DroppedAttributesCount: number | null;
   ss_DroppedEventsCount: number | null;
   ss_DroppedLinksCount: number | null;
+}
+
+interface PromptStudioCandidateRow {
+  SpanId: string;
+  ParentSpanId: string | null;
+  SpanAttributes: Record<string, unknown>;
+  StartTime: number;
+}
+
+/**
+ * Given a non-llm span the operator clicked "Open in Playground" from
+ * (typically `Prompt.compile` or `PromptApiService.get`), find the
+ * nearest llm in the same trace to load instead. Preference order:
+ *   1. Closest descendant llm under the requested span — usually a child
+ *      llm call that consumed the just-compiled prompt.
+ *   2. Sibling llm under the same parent that started after the
+ *      requested span — the next llm call in the chain.
+ *   3. First llm in the trace by start time as a last resort.
+ * Returns null when the trace genuinely has no llm spans.
+ */
+function findNearestLlm<T extends PromptStudioCandidateRow>(
+  rows: T[],
+  requested: T,
+): T | null {
+  const isLlm = (r: T) =>
+    (r.SpanAttributes["langwatch.span.type"] as string | undefined) === "llm";
+
+  const llmRows = rows.filter(isLlm);
+  if (llmRows.length === 0) return null;
+
+  // 1. Descendant llm closest to the requested span (smallest depth diff).
+  const childrenByParent = new Map<string, T[]>();
+  for (const r of rows) {
+    if (!r.ParentSpanId) continue;
+    const list = childrenByParent.get(r.ParentSpanId);
+    if (list) list.push(r);
+    else childrenByParent.set(r.ParentSpanId, [r]);
+  }
+  const visited = new Set<string>();
+  const queue: T[] = [requested];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current.SpanId)) continue;
+    visited.add(current.SpanId);
+    const children = childrenByParent.get(current.SpanId) ?? [];
+    for (const child of children) {
+      if (isLlm(child)) return child;
+      queue.push(child);
+    }
+  }
+
+  // 2. Sibling llm under the same parent that started at/after the
+  //    requested span. Prefer earliest such, so we land on the *next*
+  //    call, not one further down the chain.
+  if (requested.ParentSpanId) {
+    const siblings = (childrenByParent.get(requested.ParentSpanId) ?? [])
+      .filter((s) => s.SpanId !== requested.SpanId && isLlm(s))
+      .sort((a, b) => a.StartTime - b.StartTime);
+    const nextOrSame = siblings.find((s) => s.StartTime >= requested.StartTime);
+    if (nextOrSame) return nextOrSame;
+    if (siblings.length > 0) return siblings[0] ?? null;
+  }
+
+  // 3. Earliest llm in the trace.
+  return llmRows.sort((a, b) => a.StartTime - b.StartTime)[0] ?? null;
 }
 
 /**

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2179,17 +2179,22 @@ function findNearestLlm<T extends PromptStudioCandidateRow>(
     }
   }
 
-  // 2. Sibling llm under the same parent that started at/after the
-  //    requested span. Prefer earliest such, so we land on the *next*
-  //    call, not one further down the chain.
-  if (requested.ParentSpanId) {
-    const siblings = (childrenByParent.get(requested.ParentSpanId) ?? [])
-      .filter((s) => s.SpanId !== requested.SpanId && isLlm(s))
-      .sort((a, b) => a.StartTime - b.StartTime);
-    const nextOrSame = siblings.find((s) => s.StartTime >= requested.StartTime);
-    if (nextOrSame) return nextOrSame;
-    if (siblings.length > 0) return siblings[0] ?? null;
-  }
+  // 2. Sibling llm under the same parent (or root-level peer if the
+  //    requested span has no parent) that started at/after the requested
+  //    span. Earliest qualifying sibling wins, so we land on the *next*
+  //    call rather than one further down the chain. Siblings that
+  //    started *before* the requested span do NOT count — those belong
+  //    to an earlier turn and would open an unrelated playground
+  //    context — so the search falls through to step 3 instead.
+  const siblingPool =
+    requested.ParentSpanId == null
+      ? rows.filter((r) => r.ParentSpanId == null)
+      : (childrenByParent.get(requested.ParentSpanId) ?? []);
+  const siblings = siblingPool
+    .filter((s) => s.SpanId !== requested.SpanId && isLlm(s))
+    .sort((a, b) => a.StartTime - b.StartTime);
+  const nextOrSame = siblings.find((s) => s.StartTime >= requested.StartTime);
+  if (nextOrSame) return nextOrSame;
 
   // 3. Earliest llm in the trace.
   return llmRows.sort((a, b) => a.StartTime - b.StartTime)[0] ?? null;

--- a/langwatch/src/utils/__tests__/evaluationResults.test.ts
+++ b/langwatch/src/utils/__tests__/evaluationResults.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   EVALUATION_STATUS_COLORS,
+  getEvalChipDisplay,
   getStatusLabel,
   parseEvaluationResult,
 } from "../evaluationResults";
@@ -358,5 +359,116 @@ describe("getStatusLabel", () => {
 
   it("returns 'Skipped' for skipped", () => {
     expect(getStatusLabel("skipped")).toBe("Skipped");
+  });
+});
+
+describe("getEvalChipDisplay", () => {
+  describe("when adapting the trace-list status enum", () => {
+    it("normalizes processed + passed=true to passed", () => {
+      const d = getEvalChipDisplay({
+        status: "processed",
+        passed: true,
+        score: null,
+      });
+      expect(d.status).toBe("passed");
+      expect(d.color).toBe(EVALUATION_STATUS_COLORS.passed);
+      expect(d.passLabel).toEqual({ text: "Pass", color: "green.fg" });
+    });
+
+    it("normalizes processed + passed=false to failed", () => {
+      const d = getEvalChipDisplay({
+        status: "processed",
+        passed: false,
+        score: null,
+      });
+      expect(d.status).toBe("failed");
+      expect(d.passLabel).toEqual({ text: "Fail", color: "red.fg" });
+    });
+
+    it("normalizes the v1 'pass' / 'fail' tokens", () => {
+      
+        
+      expect(getEvalChipDisplay({ status: "pass" }).status).toBe("passed");
+      expect(getEvalChipDisplay({ status: "fail" }).status).toBe("failed");
+    });
+
+    it("normalizes the trace-list 'in_progress' / 'scheduled' tokens", () => {
+      
+        
+      expect(getEvalChipDisplay({ status: "in_progress" }).status).toBe(
+        "running",
+      );
+      expect(getEvalChipDisplay({ status: "scheduled" }).status).toBe(
+        "pending",
+      );
+    });
+
+    it("maps the legacy 'warning' status to failed so the chip turns red", () => {
+      
+        
+      expect(getEvalChipDisplay({ status: "warning" }).status).toBe("failed");
+    });
+  });
+
+  describe("when rendering trailing verdict slot", () => {
+    it("yields numeric scoreText for numeric verdicts (<= 1)", () => {
+      
+        
+      expect(getEvalChipDisplay({ status: "processed", score: 0.75 }).scoreText).toBe(
+        "0.75",
+      );
+    });
+
+    it("yields one-decimal scoreText for verdicts > 1", () => {
+      
+        
+      expect(getEvalChipDisplay({ status: "processed", score: 5 }).scoreText).toBe(
+        "5.0",
+      );
+    });
+
+    it("suppresses the boolean Pass/Fail label when a numeric score exists", () => {
+      
+        
+      const d = getEvalChipDisplay({ status: "passed", score: 0.9 });
+      expect(d.scoreText).toBe("0.90");
+      expect(d.passLabel).toBeNull();
+    });
+
+    it("marks skipped + error as no-verdict so the dot is dropped", () => {
+      
+        
+      expect(getEvalChipDisplay({ status: "skipped" }).noVerdict).toBe(true);
+      expect(getEvalChipDisplay({ status: "error" }).noVerdict).toBe(true);
+    });
+  });
+
+  describe("when picking a display name", () => {
+    it("prefers explicit name over evaluatorId", () => {
+      
+        
+      expect(
+        getEvalChipDisplay({ name: "Safety", evaluatorId: "azure_safety" })
+          .displayName,
+      ).toBe("Safety");
+    });
+
+    it("falls back to evaluatorId when name missing", () => {
+      
+        
+      expect(getEvalChipDisplay({ evaluatorId: "azure_safety" }).displayName).toBe(
+        "azure_safety",
+      );
+    });
+  });
+
+  it("color tokens stay in lockstep with EVALUATION_STATUS_COLORS for every status", () => {
+    
+      
+    for (const [status, color] of Object.entries(EVALUATION_STATUS_COLORS)) {
+      const d = getEvalChipDisplay({ status });
+      expect(d.color).toBe(color);
+      expect(d.statusLabel).toBe(getStatusLabel(d.status));
+    }
   });
 });

--- a/langwatch/src/utils/__tests__/evaluationResults.test.ts
+++ b/langwatch/src/utils/__tests__/evaluationResults.test.ts
@@ -324,14 +324,14 @@ describe("EVALUATION_STATUS_COLORS", () => {
   });
 
   it("uses a deeper red for error than for fail so the two states stay distinct", () => {
-    expect(EVALUATION_STATUS_COLORS.error).toBe("red.700");
+    expect(EVALUATION_STATUS_COLORS.error).toBe("red.600");
     expect(EVALUATION_STATUS_COLORS.error).not.toBe(
       EVALUATION_STATUS_COLORS.failed,
     );
   });
 
-  it("renders skipped as gray — it's a setup state, not a verdict", () => {
-    expect(EVALUATION_STATUS_COLORS.skipped).toBe("gray.500");
+  it("renders skipped as a light bg-style gray — it's a setup state, not a verdict, so it shouldn't compete with real pass/fail", () => {
+    expect(EVALUATION_STATUS_COLORS.skipped).toBe("gray.300");
   });
 });
 

--- a/langwatch/src/utils/__tests__/evaluationResults.test.ts
+++ b/langwatch/src/utils/__tests__/evaluationResults.test.ts
@@ -323,12 +323,15 @@ describe("EVALUATION_STATUS_COLORS", () => {
     expect(EVALUATION_STATUS_COLORS.processed).toBe("blue.500");
   });
 
-  it("has correct color for error (red)", () => {
-    expect(EVALUATION_STATUS_COLORS.error).toBe("red.500");
+  it("uses a deeper red for error than for fail so the two states stay distinct", () => {
+    expect(EVALUATION_STATUS_COLORS.error).toBe("red.700");
+    expect(EVALUATION_STATUS_COLORS.error).not.toBe(
+      EVALUATION_STATUS_COLORS.failed,
+    );
   });
 
-  it("has correct color for skipped (yellow)", () => {
-    expect(EVALUATION_STATUS_COLORS.skipped).toBe("yellow.500");
+  it("renders skipped as gray — it's a setup state, not a verdict", () => {
+    expect(EVALUATION_STATUS_COLORS.skipped).toBe("gray.500");
   });
 });
 

--- a/langwatch/src/utils/evaluationResults.ts
+++ b/langwatch/src/utils/evaluationResults.ts
@@ -122,7 +122,11 @@ export const parseEvaluationResult = (
 };
 
 /**
- * Status indicator colors for evaluation results.
+ * Status indicator colors for evaluation results — single source of
+ * truth for dots, popover accents, score-bar fills, and any other
+ * "one colour per status" rendering across the trace list, the v2
+ * drawer header, the Evals accordion cards, and the v3 evaluator
+ * chips. Update here and every surface follows.
  */
 export const EVALUATION_STATUS_COLORS = {
   pending: "gray.400",
@@ -130,8 +134,32 @@ export const EVALUATION_STATUS_COLORS = {
   passed: "green.500",
   failed: "red.500",
   processed: "blue.500", // Neutral color for score-only evaluators (no pass/fail)
-  error: "red.500", // Errors should be red like failures
-  skipped: "yellow.500",
+  // Errors get a deeper red so they read as "the evaluator broke",
+  // distinct from a fail verdict (which is a clean red.500).
+  error: "red.700",
+  // Skipped is a setup state, not a verdict — render gray so it doesn't
+  // compete for attention next to real pass/fail rows.
+  skipped: "gray.500",
+} as const;
+
+/**
+ * Tag rendering pairs for evaluation statuses — bg / fg combinations
+ * tuned for readability on light surfaces, used by the Evals accordion
+ * card's status pill and any future "filled chip" surface. Always
+ * derived from the same enum as `EVALUATION_STATUS_COLORS` so the
+ * dot colour and the tag colour can't drift out of step.
+ */
+export const EVALUATION_STATUS_TONES = {
+  pending: { bg: "gray.subtle", fg: "fg.muted" },
+  running: { bg: "blue.subtle", fg: "blue.fg" },
+  passed: { bg: "green.subtle", fg: "green.fg" },
+  failed: { bg: "red.subtle", fg: "red.fg" },
+  processed: { bg: "blue.subtle", fg: "blue.fg" },
+  // Darker red foreground to match the deeper dot — keeps the
+  // "this broke" reading from collapsing into a plain fail.
+  error: { bg: "red.subtle", fg: "red.700" },
+  // Gray-on-gray skipped tone — neutral, low-attention.
+  skipped: { bg: "bg.muted", fg: "fg.muted" },
 } as const;
 
 /**

--- a/langwatch/src/utils/evaluationResults.ts
+++ b/langwatch/src/utils/evaluationResults.ts
@@ -134,12 +134,14 @@ export const EVALUATION_STATUS_COLORS = {
   passed: "green.500",
   failed: "red.500",
   processed: "blue.500", // Neutral color for score-only evaluators (no pass/fail)
-  // Errors get a deeper red so they read as "the evaluator broke",
-  // distinct from a fail verdict (which is a clean red.500).
-  error: "red.700",
-  // Skipped is a setup state, not a verdict — render gray so it doesn't
-  // compete for attention next to real pass/fail rows.
-  skipped: "gray.500",
+  // Errors get one step deeper red than a fail verdict — distinct
+  // enough to read as "the evaluator broke" without going so dark it
+  // looks like a different colour entirely.
+  error: "red.600",
+  // Skipped is a setup state, not a verdict — light grey (closer to
+  // the muted bg than to fg) keeps it from competing for attention
+  // next to real pass/fail rows.
+  skipped: "gray.300",
 } as const;
 
 /**
@@ -155,9 +157,9 @@ export const EVALUATION_STATUS_TONES = {
   passed: { bg: "green.subtle", fg: "green.fg" },
   failed: { bg: "red.subtle", fg: "red.fg" },
   processed: { bg: "blue.subtle", fg: "blue.fg" },
-  // Darker red foreground to match the deeper dot — keeps the
-  // "this broke" reading from collapsing into a plain fail.
-  error: { bg: "red.subtle", fg: "red.700" },
+  // Slightly deeper red foreground to match the dot, but a step
+  // lighter than red.700 so it still reads as red rather than maroon.
+  error: { bg: "red.subtle", fg: "red.600" },
   // Gray-on-gray skipped tone — neutral, low-attention.
   skipped: { bg: "bg.muted", fg: "fg.muted" },
 } as const;

--- a/langwatch/src/utils/evaluationResults.ts
+++ b/langwatch/src/utils/evaluationResults.ts
@@ -157,3 +157,139 @@ export const getStatusLabel = (
       return "Pending";
   }
 };
+
+/**
+ * Shape of any of the evaluation result variants we display as chips.
+ * Tolerates the slightly different status enums used by the legacy
+ * v1 trace summary (`pass`/`fail`/`warning`) and the v3 evaluator
+ * runner (`passed`/`failed`/`processed`/`running`/`pending`).
+ */
+export interface EvalChipInput {
+  name?: string | null;
+  evaluatorId?: string | null;
+  /** Normalized verdict tokens from any source. */
+  status?:
+    | "pass"
+    | "passed"
+    | "fail"
+    | "failed"
+    | "processed"
+    | "warning"
+    | "skipped"
+    | "error"
+    | "running"
+    | "in_progress"
+    | "scheduled"
+    | "pending"
+    | string;
+  /** Numeric verdict, when produced. Booleans collapse to passed/failed. */
+  score?: number | boolean | null;
+  /** Categorical label, when the evaluator produced one. */
+  label?: string | null;
+  /** Explicit pass flag from a numeric/categorical evaluator. */
+  passed?: boolean | null;
+}
+
+/** Normalized chip-display contract — single source of truth for both
+ *  the trace-list `EvalChip` and the v2 drawer header eval chips so
+ *  visuals never drift between surfaces. */
+export interface EvalChipDisplay {
+  /** Mapped onto the v3 status enum so consumers can reuse `EVALUATION_STATUS_COLORS` / `getStatusLabel`. */
+  status: ParsedEvaluationResult["status"];
+  /** Chakra color token for the status dot / accent. */
+  color: string;
+  /** "Pass" / "Fail" / "Skipped" / ... — short title-case label. */
+  statusLabel: string;
+  /** Best-effort display name (evaluator name → id). */
+  displayName: string;
+  /** Formatted numeric score when present, else null. */
+  scoreText: string | null;
+  /** Whether the verdict is "no real score" (skipped or error). */
+  noVerdict: boolean;
+  /**
+   * Color-coded pass/fail label when the evaluator returned an explicit
+   * boolean verdict (not a numeric score). `null` for numeric / skipped /
+   * error.
+   */
+  passLabel: { text: string; color: string } | null;
+}
+
+/** Map any source's status string onto the canonical v3 status enum. */
+function normalizeEvalStatus(
+  input: EvalChipInput,
+): ParsedEvaluationResult["status"] {
+  switch (input.status) {
+    case "passed":
+    case "pass":
+      return "passed";
+    case "failed":
+    case "fail":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    case "error":
+      return "error";
+    case "running":
+    case "in_progress":
+      return "running";
+    case "pending":
+    case "scheduled":
+      return "pending";
+    case "warning":
+      // Warning isn't a v3 status; nearest equivalent is a non-fatal
+      // verdict — surface as "failed" so the chip turns red and the
+      // operator sees something went sideways.
+      return "failed";
+    case "processed":
+      if (input.passed === true) return "passed";
+      if (input.passed === false) return "failed";
+      return "processed";
+    default:
+      if (input.passed === true) return "passed";
+      if (input.passed === false) return "failed";
+      return "pending";
+  }
+}
+
+/** Same score formatter used by the trace table EvalChip — share so the
+ *  drawer chip never disagrees on rounding. */
+export function formatEvalScoreText(score: number | boolean | null | undefined): string | null {
+  if (typeof score !== "number") return null;
+  return score <= 1 ? score.toFixed(2) : score.toFixed(1);
+}
+
+/**
+ * Resolve any evaluation result variant into the chip-display contract.
+ * Centralized so the trace-table chip, the drawer header chip and any
+ * future surface (Evals accordion list, etc.) render identical visuals
+ * for the same input.
+ */
+export function getEvalChipDisplay(input: EvalChipInput): EvalChipDisplay {
+  const status = normalizeEvalStatus(input);
+  const color = EVALUATION_STATUS_COLORS[status];
+  const statusLabel = getStatusLabel(status);
+  const displayName = input.name || input.evaluatorId || "Unknown";
+  const scoreText =
+    typeof input.score === "number" ? formatEvalScoreText(input.score) : null;
+  const noVerdict = status === "skipped" || status === "error";
+
+  // Surface a colored Pass/Fail label only when the evaluator produced a
+  // pure boolean verdict (no numeric score to show in its place).
+  let passLabel: EvalChipDisplay["passLabel"] = null;
+  if (scoreText == null && !noVerdict) {
+    if (status === "passed")
+      passLabel = { text: "Pass", color: "green.fg" };
+    else if (status === "failed")
+      passLabel = { text: "Fail", color: "red.fg" };
+  }
+
+  return {
+    status,
+    color,
+    statusLabel,
+    displayName,
+    scoreText,
+    noVerdict,
+    passLabel,
+  };
+}

--- a/specs/trace-drawer/attribute-table.feature
+++ b/specs/trace-drawer/attribute-table.feature
@@ -1,0 +1,30 @@
+Feature: Attribute table label column is resizable and tooltipped
+
+  Prompt-heavy traces (`langwatch.prompt.variables.<name>`, deep nested
+  attribute namespaces) routinely produce attribute keys that overflow
+  the fixed 200px label column and end up truncated to
+  `langwatch.prompt.variab…`. Operators need to see the full key without
+  navigating away from the row, so the label column is per-device
+  resizable and every truncated key reveals its full value on hover.
+
+  Scenario: Truncated attribute name reveals its full value on hover
+    Given an attribute key longer than the label column
+    When the user hovers over the truncated label
+    Then a tooltip appears with the full attribute name
+
+  Scenario: Operator drags the label column wider
+    Given the attribute table is rendered with the default label column width
+    When the user drags the right border of the label column to the right
+    Then the label column grows live with the drag
+    And the width is clamped between 120px and 480px
+
+  Scenario: Resize handle lights up blue on hover and drag
+    Given the operator hovers the right border of the label column
+    Then the border turns blue
+    And the cursor switches to col-resize
+
+  Scenario: Resized width persists across drawer reopens
+    Given the operator has resized the label column wider
+    When the operator closes the drawer and opens any span
+    Then the label column starts at the previously chosen width
+    And the width survives a page reload

--- a/specs/trace-drawer/eval-chips-in-header.feature
+++ b/specs/trace-drawer/eval-chips-in-header.feature
@@ -20,7 +20,7 @@ Feature: Eval chips in the trace drawer header
   Scenario: Hovering an eval chip shows its full detail popover
     Given the operator hovers an eval chip
     Then the same popover that the trace list table uses appears
-    With the eval's full name, score / pass-fail, and any error / explanation
+    And the popover shows the eval's full name, score / pass-fail, and any error / explanation
 
   Scenario: Clicking an eval chip jumps to the Evals accordion
     Given the operator clicks an eval chip

--- a/specs/trace-drawer/eval-chips-in-header.feature
+++ b/specs/trace-drawer/eval-chips-in-header.feature
@@ -1,0 +1,43 @@
+Feature: Eval chips in the trace drawer header
+
+  The trace drawer header already shows compact chips for service /
+  origin / SDK / scenario / prompt. Evaluations only show up far below in
+  the trace summary's Evals accordion, so a heavily-evaluated trace
+  often looks like nothing happened. Each evaluation result gets its own
+  chip in the same chip strip as the prompt chips, reusing the same
+  result-pill component the trace list table uses (status dot + name +
+  score / pass-fail), but with a styling variant that matches the rest
+  of the header chips. Clicking a chip jumps the operator to the Evals
+  section so they can read the details without scrolling.
+
+  Scenario: Each evaluation result renders as a header chip
+    Given the trace has evaluation results
+    When the trace drawer header chip strip renders
+    Then there is one chip per evaluation
+    And each chip shows the eval's status dot, name, and score / pass-fail
+    And the chip styling matches the prompt / SDK chips alongside it
+
+  Scenario: Hovering an eval chip shows its full detail popover
+    Given the operator hovers an eval chip
+    Then the same popover that the trace list table uses appears
+    With the eval's full name, score / pass-fail, and any error / explanation
+
+  Scenario: Clicking an eval chip jumps to the Evals accordion
+    Given the operator clicks an eval chip
+    When they are NOT already on the Trace tab
+    Then the drawer switches to the Trace tab
+    And the right pane switches to the trace Summary tab
+    And the Evals accordion expands
+    And the pane scrolls so the Evals section is in view
+
+  Scenario: Clicking an eval chip when already on the right tabs
+    Given the operator is already on the Trace tab and the Summary tab
+    When the operator clicks an eval chip
+    Then the Evals accordion expands if it was collapsed
+    And the pane scrolls so the Evals section is in view
+
+  Scenario: No eval chips render when the trace has no evaluations
+    Given the trace has zero evaluation results
+    When the trace drawer header chip strip renders
+    Then no eval chips are present
+    And the rest of the header is unchanged

--- a/specs/trace-drawer/playground-affordance.feature
+++ b/specs/trace-drawer/playground-affordance.feature
@@ -1,0 +1,54 @@
+Feature: Open in Playground from anywhere a prompt is shown in the trace drawer
+
+  Every surface in the v2 trace drawer that mentions a prompt — the chat
+  history on an llm span, the span-level Prompt accordion on a
+  Prompt.compile / PromptApiService.get span, and the Prompts tab usage
+  card — must offer a one-click "Open in Playground" affordance. Behind
+  the button the loader smart-defaults: open the linked managed prompt at
+  the traced version when one is linked, create a fresh tab from the
+  span's input/output otherwise. The chat-side button works even when no
+  managed prompt is tied to the call (third-party tracing). When the
+  caller points at a non-llm span (Prompt.compile / PromptApiService.get
+  / Prompts tab card), the server resolves to the nearest llm in the same
+  trace before loading.
+
+  Scenario: Open in Playground on the chat header of any llm span
+    Given the user is viewing an llm span in the v2 trace drawer
+    When the user looks at the Input panel header
+    Then there is an "Open in Playground" action next to Copy / Annotate
+    And clicking it opens the playground in a new tab populated with the span's chat history
+
+  Scenario: Smart default opens the linked managed prompt at the traced version
+    Given the llm span has langwatch.prompt.id pointing at a managed prompt
+    When the user clicks "Open in Playground" on the chat header
+    Then the playground tab loads the existing prompt
+    And the prompt's system message is in the PROMPT box
+    And the trace's chat history is in the Conversation panel
+    And the model is set to the model recorded on the span
+
+  Scenario: Smart default creates a fresh tab when no prompt is linked
+    Given the llm span has no langwatch.prompt.* attribute
+    And no sibling Prompt.compile in the trace exposes one either
+    When the user clicks "Open in Playground" on the chat header
+    Then the playground tab is labelled "New Prompt"
+    And the span's system message lands in the PROMPT box
+    And the user / assistant messages land in the Conversation panel
+    And the model is set to the model recorded on the span
+
+  Scenario: Open in Playground on a Prompt.compile span resolves to its llm
+    Given the user is viewing a Prompt.compile span in the v2 trace drawer
+    When the user clicks "Open in Playground" in the Prompt accordion
+    Then the playground loads using the nearest llm child or sibling
+    And the prompt accordion is populated as if the user had clicked from that llm directly
+
+  Scenario: Open in Playground on a Prompts tab usage card
+    Given the v2 trace drawer's Prompts tab lists at least one prompt usage
+    When the user clicks "Open in Playground" on a usage card
+    Then the playground loads using the first emitting span of that usage
+    And the server resolves the loader's span to the nearest llm in the trace
+
+  Scenario: Playground tab title reflects what was actually opened
+    Given the user clicked "Open in Playground" from a span
+    When the playground tab finishes loading
+    Then the tab title shows the prompt handle when an existing prompt was opened
+    And the tab title shows "New Prompt" with an unsaved dot when a fresh tab was created

--- a/specs/trace-drawer/playground-affordance.feature
+++ b/specs/trace-drawer/playground-affordance.feature
@@ -41,6 +41,13 @@ Feature: Open in Playground from anywhere a prompt is shown in the trace drawer
     Then the playground loads using the nearest llm child or sibling
     And the prompt accordion is populated as if the user had clicked from that llm directly
 
+  Scenario: Resolver falls back to the earliest trace llm when no child or sibling matches
+    Given the user is viewing a non-llm span with no llm descendants
+    And no sibling llm started at or after the requested span
+    When the user clicks "Open in Playground" in the Prompt accordion
+    Then the playground loads using the earliest llm in the trace
+    And the prompt accordion is populated from that earliest llm's data
+
   Scenario: Open in Playground on a Prompts tab usage card
     Given the v2 trace drawer's Prompts tab lists at least one prompt usage
     When the user clicks "Open in Playground" on a usage card


### PR DESCRIPTION
## Summary

Three pieces from continued dogfood of the v2 trace drawer.

### Open in Playground from every prompt surface
- `PromptUsageCard` (Prompts tab) — new "Open in Playground" link next to "Open prompt".
- `PromptAccordion` on `Prompt.compile` / `PromptApiService.get` spans — single smart-default button (drops the llm-only menu; chat-header already covers the create-new path).
- Server-side `getSpanForPromptStudio` resolves non-llm spanIds to the nearest llm in the trace (descendant → sibling started-at-or-after → earliest overall). Without this, the new buttons on prompt-emitter spans hit "No prompts open" because the playground form needs an llm's messages + llm config.

### Resizable + tooltipped attribute label column
- Hover any truncated attribute key → tooltip with the full name.
- Drag the right border of the label column → live resize, clamped 120-480px.
- Drag handle lights up blue on hover/drag (matches the drawer's pane separator).
- Width persists per-device via localStorage (`langwatch:traces-v2:attribute-label-width`).

### Eval chips in the trace header
- One chip per evaluation result, styled to match the existing service / SDK / prompt chips (dot + label + value + tone-aligned border).
- Hover → popover with status, score, label, reasoning, error if present.
- Click → switches to Trace tab + Summary right-pane tab, expands the Evals accordion, and `scrollIntoView`s it via a new lightweight `useFocusSectionStore` (any future "jump to section X from a header chip" can reuse it).

## Specs

- `specs/trace-drawer/playground-affordance.feature`
- `specs/trace-drawer/attribute-table.feature`
- `specs/trace-drawer/eval-chips-in-header.feature`

## Test plan

- [ ] Open in Playground from the Prompts tab's usage card opens the linked prompt with chat history + variables
- [ ] Open in Playground from a `Prompt.compile` span resolves to the sibling llm and loads that span's data
- [ ] Dragging the attribute label column grows live, persists across reloads, clamps at 120 / 480
- [ ] Hovering a truncated attribute key shows a tooltip
- [ ] Each evaluation renders as a chip in the header
- [ ] Hovering an eval chip shows its popover; clicking expands and scrolls to the Evals accordion

## Screenshots (dogfood)

### Attribute label column: drag-resize + tooltip
Hover any truncated attribute key to see the full name; drag the right border of the label column to resize.

![attribute label tooltip on hover](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/attr-tooltip-crop.png)
![attribute label column resized wider](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/attr-resize-crop.png)

### Eval chips in trace header
One chip per evaluation, hover for status/score/reasoning, click to jump to the Evals accordion.

![eval chip rendered in the trace header strip](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/v2-eval-chips-neutral.png)
![eval chip hover popover showing reasoning and score](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/v2-pii-pass-popover-crop.png)
![clicking the eval chip expands and scrolls to the Evals section](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/eval-jumped-crop.png)

### Open in Playground from non-llm prompt spans
Now also available on `Prompt.compile` / `PromptApiService.get` spans (single smart-default button) and on every card in the Prompts tab.

![Open in Playground button on a Prompt.compile span accordion](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/prompt-accordion-crop.png)
![playground tab loaded from a Prompt.compile span via the new server-side findNearestLlm resolver](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/playground-from-prompt-compile.png)
![Open in Playground link on each PromptUsageCard in the Prompts tab](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/prompts-tab-crop2.png)
![playground tab loaded from a Prompts tab usage card](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/playground-from-usage-card.png)

## Iteration 2: redesign per dogfood feedback

### Header chip strip — no icon, status-tinted badge for no-verdict, dropped prompt history glyph
- Eval chip drops the gauge icon and bumps the status dot to 8px so it matches the trace-list `EvalChip` exactly.
- Skipped / error verdicts now render an inline tinted badge instead of a misleading `0.00` score.
- Prompt "Last used" chip drops the history icon on the happy path; the purple dot + the word "Prompt" already say what the chip is.
- All visuals come from a single shared `getEvalChipDisplay` helper in `src/utils/evaluationResults.ts` so the trace-list chip, drawer header chip and any future surface render the same input the same way; unit tests pin the contract so it can't drift.

![redesigned header chips: prompt without history icon, eval Azure Content Safety with SKIPPED badge](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/v2-eval-chips-neutral.png)

### Attribute table — single full-height column divider
- The 4px per-row stripe is gone. A single 1px column divider (with a 6px hit area, blue-glow on hover/drag) overlays the table at the label column edge — same visual language as the drawer's `react-resizable-panels` pane separator.

![full-height column divider between attribute key and value columns](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4099/attr-per-row-revert.png)