### PR TITLE
fix(playground): live user turn placement + assistant reply on trace→playground resume

### DIFF
--- a/langwatch/scripts/dogfood-llm-span-messages.ts
+++ b/langwatch/scripts/dogfood-llm-span-messages.ts
@@ -1,0 +1,107 @@
+/**
+ * Replays an nlpgo-emitted LLM span's attribute shape through
+ * parseLLMSpanMessages() so the playground-resume output can be
+ * inspected without a browser session against a live trace.
+ *
+ * Input: the exact attribute shape nlpgo's endLLMSpan stamps —
+ *   - langwatch.input  = JSON-encoded []app.ChatMessage (bare array)
+ *   - langwatch.output = JSON-encoded single app.ChatMessage object
+ *     ({"role":"assistant","content":"<reply>"})
+ *
+ * Pre-fix output: only input messages (assistant reply silently
+ * dropped because the bare single-object shape fell through every
+ * branch of the CH extractor).
+ *
+ * Post-fix output (printed below): every input turn + the assistant
+ * reply at the end — exactly what the playground's chat panel needs
+ * to resume the conversation.
+ *
+ * Run: npx tsx scripts/dogfood-llm-span-messages.ts
+ */
+import { parseLLMSpanMessages } from "../src/server/traces/parseLLMSpanMessages";
+
+const attrs = {
+  // nlpgo serializes the LLM request prompt as a bare array of
+  // app.ChatMessage. Matches the 5-turn screenshot shape from
+  // rchaves's bug report: system + 4 chat turns.
+  "langwatch.input": JSON.stringify([
+    { role: "system", content: "Welcome to the LangWatch Prompt Playground" },
+    { role: "user", content: "how big is mars?" },
+    { role: "assistant", content: "Mars is about 6,779 km..." },
+    { role: "user", content: "thanks bro!" },
+  ]),
+  // nlpgo's endLLMSpan stamps a SINGLE app.ChatMessage struct
+  // (NOT wrapped in array, NOT wrapped in {type, value}).
+  // Pre-fix every CH extractor branch missed this shape.
+  "langwatch.output": JSON.stringify({
+    role: "assistant",
+    content: "You're welcome.",
+  }),
+  "langwatch.span.type": "llm",
+};
+
+const messages = parseLLMSpanMessages(attrs);
+
+console.log("=".repeat(72));
+console.log("INPUT — attribute shape nlpgo's endLLMSpan stamps");
+console.log("=".repeat(72));
+console.log("  langwatch.input  (bare array of app.ChatMessage):");
+console.log("    " + attrs["langwatch.input"]);
+console.log("  langwatch.output (single app.ChatMessage object):");
+console.log("    " + attrs["langwatch.output"]);
+console.log();
+console.log("=".repeat(72));
+console.log("OUTPUT — what useLoadSpanIntoPromptPlayground feeds the chat");
+console.log("=".repeat(72));
+console.log(JSON.stringify(messages, null, 2));
+console.log();
+console.log("=".repeat(72));
+console.log("VERIFICATION");
+console.log("=".repeat(72));
+const checks = [
+  {
+    name: "Conversation count: 4 input turns + 1 assistant reply = 5 total",
+    pass: messages.length === 5,
+    got: messages.length,
+  },
+  {
+    name: "First message is the system turn (verbatim from input)",
+    pass:
+      messages[0]?.role === "system" &&
+      messages[0]?.content === "Welcome to the LangWatch Prompt Playground",
+    got: messages[0],
+  },
+  {
+    name: "Last message is the assistant reply 'You're welcome.' (Bug B fix)",
+    pass:
+      messages[messages.length - 1]?.role === "assistant" &&
+      messages[messages.length - 1]?.content === "You're welcome.",
+    got: messages[messages.length - 1],
+  },
+  {
+    name: "Penultimate message is the latest user turn 'thanks bro!'",
+    pass:
+      messages[messages.length - 2]?.role === "user" &&
+      messages[messages.length - 2]?.content === "thanks bro!",
+    got: messages[messages.length - 2],
+  },
+  {
+    name: "Order preserved: input turns before output (chronological)",
+    pass:
+      messages.findIndex(
+        (m) => m.role === "user" && m.content === "thanks bro!",
+      ) <
+      messages.findIndex(
+        (m) => m.role === "assistant" && m.content === "You're welcome.",
+      ),
+    got: messages.map((m) => `${m.role}:${m.content.slice(0, 20)}`).join(" -> "),
+  },
+];
+for (const c of checks) {
+  console.log(`  ${c.pass ? "PASS" : "FAIL"}  ${c.name}`);
+  if (!c.pass) console.log(`        got: ${JSON.stringify(c.got)}`);
+}
+const allPass = checks.every((c) => c.pass);
+console.log();
+console.log(allPass ? "ALL CHECKS PASS" : "FAILURES PRESENT");
+process.exit(allPass ? 0 : 1);

--- a/langwatch/scripts/dogfood-llm-span-messages.ts
+++ b/langwatch/scripts/dogfood-llm-span-messages.ts
@@ -20,7 +20,7 @@
  */
 import { parseLLMSpanMessages } from "../src/server/traces/parseLLMSpanMessages";
 
-const attrs = {
+const attrs: Record<string, unknown> = {
   // nlpgo serializes the LLM request prompt as a bare array of
   // app.ChatMessage. Matches the 5-turn screenshot shape from
   // rchaves's bug report: system + 4 chat turns.
@@ -46,9 +46,9 @@ console.log("=".repeat(72));
 console.log("INPUT — attribute shape nlpgo's endLLMSpan stamps");
 console.log("=".repeat(72));
 console.log("  langwatch.input  (bare array of app.ChatMessage):");
-console.log("    " + attrs["langwatch.input"]);
+console.log("    " + String(attrs["langwatch.input"]));
 console.log("  langwatch.output (single app.ChatMessage object):");
-console.log("    " + attrs["langwatch.output"]);
+console.log("    " + String(attrs["langwatch.output"]));
 console.log();
 console.log("=".repeat(72));
 console.log("OUTPUT — what useLoadSpanIntoPromptPlayground feeds the chat");

--- a/langwatch/scripts/dogfood-llm-span-messages.ts
+++ b/langwatch/scripts/dogfood-llm-span-messages.ts
@@ -94,7 +94,9 @@ const checks = [
       messages.findIndex(
         (m) => m.role === "assistant" && m.content === "You're welcome.",
       ),
-    got: messages.map((m) => `${m.role}:${m.content.slice(0, 20)}`).join(" -> "),
+    got: messages
+      .map((m) => `${m.role}:${String(m.content ?? "").slice(0, 20)}`)
+      .join(" -> "),
   },
 ];
 for (const c of checks) {

--- a/langwatch/scripts/dogfood/prompts/llm-span-messages.ts
+++ b/langwatch/scripts/dogfood/prompts/llm-span-messages.ts
@@ -16,9 +16,9 @@
  * reply at the end — exactly what the playground's chat panel needs
  * to resume the conversation.
  *
- * Run: npx tsx scripts/dogfood-llm-span-messages.ts
+ * Run: npx tsx scripts/dogfood/prompts/llm-span-messages.ts
  */
-import { parseLLMSpanMessages } from "../src/server/traces/parseLLMSpanMessages";
+import { parseLLMSpanMessages } from "../../../src/server/traces/parseLLMSpanMessages";
 
 const attrs: Record<string, unknown> = {
   // nlpgo serializes the LLM request prompt as a bare array of

--- a/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.test.ts
+++ b/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.test.ts
@@ -330,14 +330,64 @@ describe("PromptStudioAdapter", () => {
 
       const envelope = lastPostedEvent();
       const sent: { role: string; content: string }[] = envelope.payload.inputs.messages;
-      // Template's `{{input}}` turn + 2 prior live turns (older question
-      // + older reply). The latest "test7" turn is absorbed.
+      // Prior live history (older question + older reply) FIRST, then
+      // the template's `{{input}}` slot which renders to the latest
+      // "test7" turn at the END. Pre-2026-05-17 the order was inverted
+      // — `{{input}}` shipped at index 0 and the live history trailed
+      // behind, so the LLM read the latest user input as if it came
+      // BEFORE every prior turn. The screenshot from rchaves caught
+      // this: 'huh?' (latest) landed at messages[1] right after the
+      // system prompt, with 'how big is mars?' (older) following.
       expect(sent.map((m) => m.content)).toEqual([
-        "{{input}}",
         "older question",
         "older reply",
+        "{{input}}",
       ]);
       expect(envelope.payload.inputs.input).toBe("test7");
+    });
+
+    // 2026-05-17 prod regression — caught after #4098 merged.
+    // rchaves: "huh?" was the LATEST user message in the playground,
+    // but the trace shows it injected at messages[1] right after the
+    // system slot, with the actual conversation history ("how big is
+    // mars?", assistant reply, "thanks bro!", assistant reply)
+    // following it. This test replays the exact multi-turn shape that
+    // surfaced the bug.
+    it("places the latest user turn at the END of the messages array, not after the system slot", async () => {
+      const { eventSource } = createMockEventSource();
+      await runProcess(
+        adapter,
+        buildRequestWithChat({
+          additionalParams: buildAdditionalParams({
+            messages: [
+              { role: "system", content: "Welcome" },
+              { role: "user", content: "{{input}}" },
+            ],
+          }),
+          chatMessages: [
+            { role: "user", content: "how big is mars?" },
+            { role: "assistant", content: "Mars is 6,779 km in diameter." },
+            { role: "user", content: "thanks bro!" },
+            { role: "assistant", content: "You're welcome." },
+            { role: "user", content: "huh?" },
+          ],
+          eventSource,
+        }),
+      );
+
+      const envelope = lastPostedEvent();
+      const sent: { role: string; content: string }[] = envelope.payload.inputs.messages;
+      // Chronological history (everything BEFORE the latest user turn)
+      // + template's `{{input}}` slot at the end, which the downstream
+      // render will resolve to "huh?".
+      expect(sent.map((m) => ({ role: m.role, content: m.content }))).toEqual([
+        { role: "user", content: "how big is mars?" },
+        { role: "assistant", content: "Mars is 6,779 km in diameter." },
+        { role: "user", content: "thanks bro!" },
+        { role: "assistant", content: "You're welcome." },
+        { role: "user", content: "{{input}}" },
+      ]);
+      expect(envelope.payload.inputs.input).toBe("huh?");
     });
 
     it("absorbs the live turn when the template references {{input}} only in the system message", async () => {

--- a/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts
+++ b/langwatch/src/app/api/copilotkit/[[...route]]/service-adapter.ts
@@ -143,7 +143,25 @@ export class PromptStudioAdapter implements CopilotServiceAdapter {
         templateReferencesInput && lastLiveUserMsg
           ? messages.filter((m: any) => m !== lastLiveUserMsg)
           : messages;
-      const messagesHistory = [...formMsgs, ...liveMessagesForHistory]
+      // Order matters: when the template absorbs the latest live
+      // turn via `{{input}}`, the template's `{{input}}`-bearing
+      // user slot must land at the END of the messages array so
+      // it represents the LATEST turn. Putting formMsgs first
+      // (the previous order) shipped `{{input}}` at index 1 right
+      // after system, with the actual conversation history pushed
+      // behind it — the LLM then saw the latest user turn as if
+      // it came BEFORE every prior turn (2026-05-17 prod
+      // regression caught by rchaves: 'how big is mars?' history
+      // ended up trailing a 'huh?' that the user had just sent).
+      // When the template does NOT reference `{{input}}`, formMsgs
+      // is preamble/scaffolding (e.g. a fixed `user("answer it")`
+      // role-instruction in 'Messages mode') and stays at the
+      // front — the live history then appends as normal.
+      const messagesHistory = (
+        templateReferencesInput && lastLiveUserMsg
+          ? [...liveMessagesForHistory, ...formMsgs]
+          : [...formMsgs, ...liveMessagesForHistory]
+      )
         .map((message: any) => ({
           role: message.role,
           content: message.content,

--- a/langwatch/src/server/traces/__tests__/parseLLMSpanMessages.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/parseLLMSpanMessages.unit.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+
+import { parseLLMSpanMessages } from "../parseLLMSpanMessages";
+
+describe("parseLLMSpanMessages()", () => {
+  describe("when input carries the TypedValueJson chat_messages wrapper", () => {
+    it("extracts every message in order", () => {
+      const attrs = {
+        "gen_ai.input.messages": JSON.stringify({
+          type: "chat_messages",
+          value: [
+            { role: "system", content: "Be helpful." },
+            { role: "user", content: "What is 2+2?" },
+          ],
+        }),
+      };
+      expect(parseLLMSpanMessages(attrs)).toEqual([
+        { role: "system", content: "Be helpful." },
+        { role: "user", content: "What is 2+2?" },
+      ]);
+    });
+  });
+
+  describe("when input carries a bare array of message objects (nlpgo langwatch.input shape)", () => {
+    it("extracts each entry with its embedded role", () => {
+      const attrs = {
+        "langwatch.input": JSON.stringify([
+          { role: "system", content: "Be terse." },
+          { role: "user", content: "thanks bro!" },
+        ]),
+      };
+      expect(parseLLMSpanMessages(attrs)).toEqual([
+        { role: "system", content: "Be terse." },
+        { role: "user", content: "thanks bro!" },
+      ]);
+    });
+  });
+
+  describe("when output carries the single-object app.ChatMessage shape (nlpgo langwatch.output)", () => {
+    // Real-world regression caught during dogfood: nlpgo's endLLMSpan
+    // stamps langwatch.output as a JSON-encoded single app.ChatMessage
+    // ({"role":"assistant","content":"You're welcome."}) — NOT an
+    // array, NOT wrapped in {type, value}. Pre-fix, every branch in
+    // extractPromptStudioDataFromClickHouse missed this shape and the
+    // assistant reply was silently dropped from the playground
+    // "Open in Prompts" resume even though the trace drawer's OUTPUT
+    // panel rendered it inline.
+    it("emits the assistant reply as a chat message", () => {
+      const attrs = {
+        "langwatch.output": JSON.stringify({
+          role: "assistant",
+          content: "You're welcome.",
+        }),
+      };
+      expect(parseLLMSpanMessages(attrs)).toEqual([
+        { role: "assistant", content: "You're welcome." },
+      ]);
+    });
+
+    it("defaults the role to 'assistant' when the object omits it", () => {
+      const attrs = {
+        "langwatch.output": JSON.stringify({ content: "hello" }),
+      };
+      expect(parseLLMSpanMessages(attrs)).toEqual([
+        { role: "assistant", content: "hello" },
+      ]);
+    });
+  });
+
+  describe("when input + output are both present (the playground LLM span shape)", () => {
+    it("input comes first, output appended at the end — preserving the chat order on resume", () => {
+      // Replays the exact shape rchaves's dogfood produced: nlpgo
+      // serialised the request prompt as a bare array on langwatch.input
+      // and the assistant reply as a single object on langwatch.output.
+      const attrs = {
+        "langwatch.input": JSON.stringify([
+          { role: "system", content: "Welcome to the playground" },
+          { role: "user", content: "how big is mars?" },
+          { role: "assistant", content: "Mars is about 6,779 km..." },
+          { role: "user", content: "thanks bro!" },
+        ]),
+        "langwatch.output": JSON.stringify({
+          role: "assistant",
+          content: "You're welcome.",
+        }),
+      };
+
+      expect(parseLLMSpanMessages(attrs)).toEqual([
+        { role: "system", content: "Welcome to the playground" },
+        { role: "user", content: "how big is mars?" },
+        { role: "assistant", content: "Mars is about 6,779 km..." },
+        { role: "user", content: "thanks bro!" },
+        { role: "assistant", content: "You're welcome." },
+      ]);
+    });
+  });
+
+  describe("when output carries a TypedValueJson string value", () => {
+    it("unwraps the string into a single assistant turn", () => {
+      const attrs = {
+        "langwatch.output": JSON.stringify({
+          type: "json",
+          value: "Mars is small.",
+        }),
+      };
+      expect(parseLLMSpanMessages(attrs)).toEqual([
+        { role: "assistant", content: "Mars is small." },
+      ]);
+    });
+  });
+
+  describe("when attributes are missing", () => {
+    it("returns an empty array", () => {
+      expect(parseLLMSpanMessages({})).toEqual([]);
+    });
+  });
+
+  describe("when input is unparseable JSON", () => {
+    it("wraps the raw string as a single user message instead of throwing", () => {
+      const attrs = { "langwatch.input": "not valid json {" };
+      expect(parseLLMSpanMessages(attrs)).toEqual([
+        { role: "user", content: "not valid json {" },
+      ]);
+    });
+  });
+
+  describe("when input has gen_ai.input.messages set and gen_ai.prompt also present", () => {
+    it("prefers gen_ai.input.messages (the newer-SDK key)", () => {
+      const attrs = {
+        "gen_ai.input.messages": JSON.stringify([
+          { role: "user", content: "newer" },
+        ]),
+        "gen_ai.prompt": JSON.stringify([{ role: "user", content: "older" }]),
+      };
+      expect(parseLLMSpanMessages(attrs)).toEqual([
+        { role: "user", content: "newer" },
+      ]);
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/parseLLMSpanMessages.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/parseLLMSpanMessages.unit.test.ts
@@ -21,6 +21,33 @@ describe("parseLLMSpanMessages()", () => {
     });
   });
 
+  describe("when chat_messages typed-wrapper items omit role (CR consistency)", () => {
+    // Pre-fix, the typed-wrapper branch trusted the ChatMessage type
+    // assertion and let `{content}` items through with `role` left
+    // `undefined`. The bare-array and single-object branches both
+    // default missing roles to `defaultRole` — the wrapper branch now
+    // matches them so the shape coming out is consistent regardless
+    // of which envelope carried the payload.
+    it("defaults missing role to defaultRole, matching the other branches", () => {
+      const attrs = {
+        "langwatch.input": JSON.stringify({
+          type: "chat_messages",
+          value: [
+            { content: "no role here" },
+            { role: "user", content: "explicit role" },
+            { role: 42, content: "non-string role" },
+          ],
+        }),
+      };
+      const result = parseLLMSpanMessages(attrs);
+      expect(result).toEqual([
+        { role: "user", content: "no role here" },
+        { role: "user", content: "explicit role" },
+        { role: "user", content: "non-string role" },
+      ]);
+    });
+  });
+
   describe("when input carries a bare array of message objects (nlpgo langwatch.input shape)", () => {
     it("extracts each entry with its embedded role", () => {
       const attrs = {

--- a/langwatch/src/server/traces/__tests__/parseLLMSpanMessages.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/parseLLMSpanMessages.unit.test.ts
@@ -124,6 +124,63 @@ describe("parseLLMSpanMessages()", () => {
     });
   });
 
+  describe("when a recognized envelope produces zero entries (CR fallback guard)", () => {
+    // Without the `before = out.length` guard added per the major CR
+    // on parseLLMSpanMessages.ts:87, these cases silently dropped the
+    // payload from the playground resume even though raw content was
+    // present on the attribute. Falling back to a single raw-content
+    // turn keeps something visible instead of pretending the LLM said
+    // nothing — visible-but-ugly beats invisible-and-lost.
+
+    it("falls back to raw content when chat_messages envelope has an empty value array", () => {
+      const attrs = {
+        "langwatch.output": JSON.stringify({
+          type: "chat_messages",
+          value: [],
+        }),
+      };
+      const result = parseLLMSpanMessages(attrs);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.role).toBe("assistant");
+      expect(result[0]?.content).toBe(attrs["langwatch.output"]);
+    });
+
+    it("falls back to raw content when chat_messages envelope value has only malformed items", () => {
+      const attrs = {
+        "langwatch.output": JSON.stringify({
+          type: "chat_messages",
+          value: [{ role: "assistant" }, { wrong: "shape" }],
+        }),
+      };
+      const result = parseLLMSpanMessages(attrs);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.role).toBe("assistant");
+      expect(result[0]?.content).toBe(attrs["langwatch.output"]);
+    });
+
+    it("falls back to raw content for a bare empty array", () => {
+      const attrs = {
+        "langwatch.input": JSON.stringify([]),
+      };
+      const result = parseLLMSpanMessages(attrs);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.role).toBe("user");
+      expect(result[0]?.content).toBe(attrs["langwatch.input"]);
+    });
+
+    it("falls back to raw content for an unrecognized object envelope", () => {
+      const attrs = {
+        "langwatch.output": JSON.stringify({
+          custom_envelope: { something: "weird" },
+        }),
+      };
+      const result = parseLLMSpanMessages(attrs);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.role).toBe("assistant");
+      expect(result[0]?.content).toBe(attrs["langwatch.output"]);
+    });
+  });
+
   describe("when input has gen_ai.input.messages set and gen_ai.prompt also present", () => {
     it("prefers gen_ai.input.messages (the newer-SDK key)", () => {
       const attrs = {

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -26,6 +26,7 @@ import {
   mapTraceSummaryToTrace,
 } from "./mappers";
 import { findPromptReferenceInAncestors } from "./findPromptReferenceInAncestors";
+import { parseLLMSpanMessages } from "./parseLLMSpanMessages";
 import { parsePromptReference } from "./parsePromptReference";
 import type {
   AggregationFiltersInput,
@@ -1067,65 +1068,13 @@ export class ClickHouseTraceService {
     _protections: Protections,
   ): PromptStudioSpanResult {
     const attrs = row.SpanAttributes;
-    const messages: PromptStudioSpanResult["messages"] = [];
-
-    // Extract input messages from gen_ai.input.messages (OTel GenAI
-    // semantic convention — what newer SDKs emit, including the system
-    // message), or fall back to legacy gen_ai.prompt / langwatch.input.
-    // Without gen_ai.input.messages the system prompt was being dropped
-    // from the playground form on third-party-traced spans.
-    const inputStr =
-      (attrs["gen_ai.input.messages"] as string) ??
-      (attrs["gen_ai.prompt"] as string) ??
-      (attrs["langwatch.input"] as string);
-    if (inputStr) {
-      try {
-        const parsed = JSON.parse(inputStr);
-        if (parsed.type === "chat_messages" && Array.isArray(parsed.value)) {
-          messages.push(...parsed.value);
-        } else if (Array.isArray(parsed)) {
-          // Raw array of message objects (without TypedValueJson wrapper)
-          for (const item of parsed) {
-            if (item && typeof item === "object" && typeof item.content === "string") {
-              messages.push({ role: item.role ?? "user", content: item.content });
-            }
-          }
-        } else if (typeof parsed.value === "string") {
-          messages.push({ role: "user", content: parsed.value });
-        } else if (typeof parsed === "string") {
-          messages.push({ role: "user", content: parsed });
-        }
-      } catch {
-        messages.push({ role: "user", content: inputStr });
-      }
-    }
-
-    // Extract output messages from gen_ai.completion, gen_ai.output.messages, or langwatch.output
-    const outputStr =
-      (attrs["gen_ai.completion"] as string) ??
-      (attrs["gen_ai.output.messages"] as string) ??
-      (attrs["langwatch.output"] as string);
-    if (outputStr) {
-      try {
-        const parsed = JSON.parse(outputStr);
-        if (parsed.type === "chat_messages" && Array.isArray(parsed.value)) {
-          messages.push(...parsed.value);
-        } else if (Array.isArray(parsed)) {
-          // Raw array of message objects (without TypedValueJson wrapper)
-          for (const item of parsed) {
-            if (item && typeof item === "object" && typeof item.content === "string") {
-              messages.push({ role: item.role ?? "assistant", content: item.content });
-            }
-          }
-        } else if (typeof parsed.value === "string") {
-          messages.push({ role: "assistant", content: parsed.value });
-        } else if (typeof parsed === "string") {
-          messages.push({ role: "assistant", content: parsed });
-        }
-      } catch {
-        messages.push({ role: "assistant", content: outputStr });
-      }
-    }
+    // Pure extraction of input + output messages from the span's
+    // attributes. Lives in parseLLMSpanMessages.ts so the wire-shape
+    // contract — including the single-message-object form nlpgo emits
+    // for langwatch.output — is unit-testable without standing up the
+    // full service. See that file's docstring for the shape catalog.
+    const messages: PromptStudioSpanResult["messages"] =
+      parseLLMSpanMessages(attrs);
 
     // Extract LLM config
     const model =

--- a/langwatch/src/server/traces/parseLLMSpanMessages.ts
+++ b/langwatch/src/server/traces/parseLLMSpanMessages.ts
@@ -72,6 +72,16 @@ function pushDecoded(
     return;
   }
 
+  // Track baseline so we can detect the "all branches matched a
+  // structure but produced zero entries" case — e.g. `{type:"chat_
+  // messages", value:[]}` or `{type:"chat_messages", value:[{bad}]}`
+  // where every item failed the filter. Without this guard the
+  // attribute would be silently dropped from the playground resume
+  // even though we had a payload to surface. Falling back to a single
+  // raw-content turn keeps something visible in the chat instead of
+  // pretending the LLM said nothing.
+  const before = out.length;
+
   if (
     parsed &&
     typeof parsed === "object" &&
@@ -84,10 +94,7 @@ function pushDecoded(
           !!m && typeof m === "object" && typeof m.content === "string",
       )),
     );
-    return;
-  }
-
-  if (Array.isArray(parsed)) {
+  } else if (Array.isArray(parsed)) {
     for (const item of parsed) {
       if (
         item &&
@@ -103,10 +110,7 @@ function pushDecoded(
         });
       }
     }
-    return;
-  }
-
-  if (
+  } else if (
     parsed &&
     typeof parsed === "object" &&
     typeof (parsed as { content?: unknown }).content === "string"
@@ -118,19 +122,23 @@ function pushDecoded(
         : defaultRole) as ChatMessage["role"],
       content: (parsed as { content: string }).content,
     });
-    return;
+  } else {
+    const wrapped =
+      parsed && typeof parsed === "object"
+        ? (parsed as { value?: unknown }).value
+        : undefined;
+    if (typeof wrapped === "string") {
+      out.push({ role: defaultRole, content: wrapped });
+    } else if (typeof parsed === "string") {
+      out.push({ role: defaultRole, content: parsed });
+    }
   }
 
-  const wrapped =
-    parsed && typeof parsed === "object"
-      ? (parsed as { value?: unknown }).value
-      : undefined;
-  if (typeof wrapped === "string") {
-    out.push({ role: defaultRole, content: wrapped });
-    return;
-  }
-  if (typeof parsed === "string") {
-    out.push({ role: defaultRole, content: parsed });
-    return;
+  // Last-resort fallback: a payload was present but every recognized
+  // shape produced zero entries (empty array, malformed items,
+  // unrecognized envelope). Surface the raw string so the trace is
+  // never silently empty — visible-but-ugly beats invisible-and-lost.
+  if (out.length === before) {
+    out.push({ role: defaultRole, content: raw });
   }
 }

--- a/langwatch/src/server/traces/parseLLMSpanMessages.ts
+++ b/langwatch/src/server/traces/parseLLMSpanMessages.ts
@@ -88,12 +88,26 @@ function pushDecoded(
     (parsed as { type?: unknown }).type === "chat_messages" &&
     Array.isArray((parsed as { value?: unknown }).value)
   ) {
-    out.push(
-      ...((parsed as { value: ChatMessage[] }).value.filter(
-        (m): m is ChatMessage =>
-          !!m && typeof m === "object" && typeof m.content === "string",
-      )),
-    );
+    // Normalize role for every entry the same way the bare-array and
+    // single-object branches do — an item with a missing or non-string
+    // role gets `defaultRole`. Pre-fix this branch trusted the typed-
+    // wrapper assertion and let invalid roles through, producing an
+    // inconsistent shape vs the sibling branches.
+    for (const item of (parsed as { value: unknown[] }).value) {
+      if (
+        item &&
+        typeof item === "object" &&
+        typeof (item as { content?: unknown }).content === "string"
+      ) {
+        const role = (item as { role?: unknown }).role;
+        out.push({
+          role: (typeof role === "string"
+            ? role
+            : defaultRole) as ChatMessage["role"],
+          content: (item as { content: string }).content,
+        });
+      }
+    }
   } else if (Array.isArray(parsed)) {
     for (const item of parsed) {
       if (

--- a/langwatch/src/server/traces/parseLLMSpanMessages.ts
+++ b/langwatch/src/server/traces/parseLLMSpanMessages.ts
@@ -1,0 +1,132 @@
+import type { PromptStudioSpanResult } from "./types";
+
+type ChatMessage = PromptStudioSpanResult["messages"][number];
+
+/**
+ * Parses the input (request prompt) + output (assistant reply) messages
+ * carried on an LLM-kind span's attributes into a flat ordered list, the
+ * shape the trace→playground "Open in Prompts" loader feeds into the chat.
+ *
+ * Reads, in fallback order:
+ *
+ *   - input:  `gen_ai.input.messages` → `gen_ai.prompt` → `langwatch.input`
+ *   - output: `gen_ai.completion` → `gen_ai.output.messages` → `langwatch.output`
+ *
+ * Each attribute is a JSON-encoded string emitted by the producing SDK.
+ * Three wire shapes are accepted because different SDKs serialize the
+ * same logical thing differently:
+ *
+ *   1. TypedValueJson wrapper: `{"type":"chat_messages","value":[...]}` —
+ *      the LangWatch python-sdk's canonical shape for explicit
+ *      input/output rendering on a span.
+ *   2. Bare array of `{role, content}` message objects — what nlpgo's
+ *      `langwatch.input` on an LLM span carries (`[]app.ChatMessage`
+ *      JSON-encoded).
+ *   3. Bare SINGLE message object `{role, content}` — what nlpgo's
+ *      `langwatch.output` on an LLM span carries (a single
+ *      `app.ChatMessage` JSON-encoded, NOT an array). This shape was
+ *      not handled pre-fix and the assistant reply was silently
+ *      dropped from the playground "Open in Prompts" resume.
+ *
+ * Falls back to wrapping the raw string as a single user/assistant turn
+ * when JSON parsing fails or the shape is unrecognized, so the resume
+ * never crashes on a stranger trace.
+ *
+ * Default role is `user` for input, `assistant` for output. Embedded
+ * roles always win when the shape carries them.
+ */
+export function parseLLMSpanMessages(
+  attrs: Record<string, unknown>,
+): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+
+  const inputStr =
+    (attrs["gen_ai.input.messages"] as string) ??
+    (attrs["gen_ai.prompt"] as string) ??
+    (attrs["langwatch.input"] as string);
+  if (inputStr) {
+    pushDecoded(messages, inputStr, "user");
+  }
+
+  const outputStr =
+    (attrs["gen_ai.completion"] as string) ??
+    (attrs["gen_ai.output.messages"] as string) ??
+    (attrs["langwatch.output"] as string);
+  if (outputStr) {
+    pushDecoded(messages, outputStr, "assistant");
+  }
+
+  return messages;
+}
+
+function pushDecoded(
+  out: ChatMessage[],
+  raw: string,
+  defaultRole: "user" | "assistant",
+): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    out.push({ role: defaultRole, content: raw });
+    return;
+  }
+
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    (parsed as { type?: unknown }).type === "chat_messages" &&
+    Array.isArray((parsed as { value?: unknown }).value)
+  ) {
+    out.push(
+      ...((parsed as { value: ChatMessage[] }).value.filter(
+        (m): m is ChatMessage =>
+          !!m && typeof m === "object" && typeof m.content === "string",
+      )),
+    );
+    return;
+  }
+
+  if (Array.isArray(parsed)) {
+    for (const item of parsed) {
+      if (
+        item &&
+        typeof item === "object" &&
+        typeof (item as { content?: unknown }).content === "string"
+      ) {
+        const role = (item as { role?: unknown }).role;
+        out.push({
+          role: typeof role === "string" ? role : defaultRole,
+          content: (item as { content: string }).content,
+        });
+      }
+    }
+    return;
+  }
+
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    typeof (parsed as { content?: unknown }).content === "string"
+  ) {
+    const role = (parsed as { role?: unknown }).role;
+    out.push({
+      role: typeof role === "string" ? role : defaultRole,
+      content: (parsed as { content: string }).content,
+    });
+    return;
+  }
+
+  const wrapped =
+    parsed && typeof parsed === "object"
+      ? (parsed as { value?: unknown }).value
+      : undefined;
+  if (typeof wrapped === "string") {
+    out.push({ role: defaultRole, content: wrapped });
+    return;
+  }
+  if (typeof parsed === "string") {
+    out.push({ role: defaultRole, content: parsed });
+    return;
+  }
+}

--- a/langwatch/src/server/traces/parseLLMSpanMessages.ts
+++ b/langwatch/src/server/traces/parseLLMSpanMessages.ts
@@ -96,7 +96,9 @@ function pushDecoded(
       ) {
         const role = (item as { role?: unknown }).role;
         out.push({
-          role: typeof role === "string" ? role : defaultRole,
+          role: (typeof role === "string"
+            ? role
+            : defaultRole) as ChatMessage["role"],
           content: (item as { content: string }).content,
         });
       }
@@ -111,7 +113,9 @@ function pushDecoded(
   ) {
     const role = (parsed as { role?: unknown }).role;
     out.push({
-      role: typeof role === "string" ? role : defaultRole,
+      role: (typeof role === "string"
+        ? role
+        : defaultRole) as ChatMessage["role"],
       content: (parsed as { content: string }).content,
     });
     return;


### PR DESCRIPTION
## Summary

Two regressions caught dogfooding the prompt playground after #4098 merged.

### Bug A — live user turn injected after `system`, not at the end (`589774ed3`, @ash)
When a saved prompt template contained `{{input}}`, `PromptStudioAdapter` concatenated `[formMsgs, ...liveMessagesForHistory]`. With the latest live user turn absorbed into the template's `{{input}}` placeholder, the rendered template message landed at index `[1]` (right after `system`) and the live chat history followed. The LLM saw the latest user message BEFORE the prior conversation — replies became non-sequiturs.

Fix: when the template absorbs the latest turn, place `formMsgs` at the END of the messages array so the wire becomes `[history → template-slot]`. When the template does not reference `{{input}}`, the previous `[formMsgs, history]` preamble shape is preserved.

### Bug B — assistant reply silently dropped on "Open in Playground" resume (`776da3d2b`, @sarah)
`nlpgo`'s `endLLMSpan` stamps `langwatch.output` as a JSON-encoded SINGLE `app.ChatMessage` (`{"role":"assistant","content":"..."}`). The CH extractor in `clickhouse-trace.service.ts` checked TypedValueJson wrapper / bare array / `parsed.value` string / bare string — every branch missed the bare single-object form, and `parsed` fell through. The assistant reply was dropped from the chat that loaded into the playground on "Open in Playground", even though the trace drawer's OUTPUT panel rendered it inline.

Fix: add the single-object branch (`{role?, content}`, role defaults to `assistant` for output / `user` for input). Refactor the input/output parsing out of the private `extractPromptStudioDataFromClickHouse` method into a pure `parseLLMSpanMessages(attrs)` function so the wire-shape contract is unit-testable without standing up the full service.

## Browser dogfood (Bug A)

5-turn chat in the prompt playground, populator-greeting prompt (template: `[system, user("{{input}}")]`), nlpgo on the workflow path:

| Turn | User | Assistant |
|------|------|-----------|
| 1 | how big is mars? | Short answer: Mars is a little over half the size of Earth... |
| 2 | thanks bro! | You're welcome! Glad it helped — want more Mars facts or anything else? |
| 3 | huh? | Sorry if my last reply sounded too casual. Do you want one more Mars fact?... |
| 4 | one more turn | One more turn — here's a neat Mars fact:... |
| 5 | final question | Sure — what's your final question? |

![multi-turn playground chat](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4101/playground/conv-multiturn-with-replies.png)

The assistant's "Sure — what's your final question?" reply on turn 5 proves the wire order is correct: it understood "final question" came AFTER the Mars conversation. Pre-fix, the latest turn was at index `[1]` and the LLM treated it as the opening message.

Captured `/api/copilotkit` request payload from the live session (`window.fetch` interception) confirms the messages array reached the adapter chronologically:

```
[0] system: "Please act as efficient, competent..."
[1] user: "how big is mars?"
[2] assistant: "Short answer: Mars is a little over half..."
[3] user: "thanks bro!"
[4] assistant: "You're welcome! Glad it helped..."
[5] user: "huh?"
[6] user: "one more turn"
[7] assistant: "Sorry if my last reply sounded too casual..."
[8] user: "one more turn pls"
[9] assistant: "One more turn — here's a neat Mars fact..."
[10] user: "final question"    ← LATEST
```

The adapter's job is to keep that order intact through to the wire it ships to nlpgo. Pre-fix `[formMsgs, ...history]` shoved the rendered `{{input}}` (latest user content) to index `[1]`; the new `[history, ...formMsgs]` ordering when the template absorbs `{{input}}` keeps the latest user turn at the end. The LLM responses match the new chronology.

## Test plan

- [x] 11 service-adapter tests pinning the new ordering, including a regression that replays the exact 5-turn screenshot shape (`how big is mars? → ... → huh?` at the end)
- [x] 9 `parseLLMSpanMessages` unit tests covering every wire shape (TypedValueJson wrapper, bare array, single object, bare string, missing attrs, unparseable JSON, gen_ai.* precedence)
- [x] Full trace suite green (156 tests)
- [x] Browser dogfood: 5-turn chat with latest user turn at the end of the wire array
- [ ] Browser dogfood: "Open in Playground" from a trace span — assistant reply present in resumed chat (Bug B — @sarah's lane)


## Bug B browser + data-layer evidence (@sarah)

**Trace drawer renders the assistant reply on the LLM span** (the data exists, just got dropped on resume pre-fix):

![LLM span detail with assistant reply](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4101/playground/llm-span-detail-with-assistant-reply.png)

The screenshot above is the trace drawer's LLM-span view: INPUT shows the system + user turns; OUTPUT shows the assistant reply ("Hello! How can I help you today?"). Pre-fix, clicking the "Open in Playground" link at the top right loaded only the INPUT turns into the playground chat — the OUTPUT reply was silently dropped.

**Data-layer replay** (`langwatch/scripts/dogfood-llm-span-messages.ts`) — replays the exact attribute shape nlpgo's `endLLMSpan` stamps (`langwatch.input` bare array + `langwatch.output` single `app.ChatMessage` object) through `parseLLMSpanMessages` and asserts what the playground chat panel sees:

```
INPUT — attribute shape nlpgo's endLLMSpan stamps
  langwatch.input  (bare array of app.ChatMessage):  [{...4 turns...}]
  langwatch.output (single app.ChatMessage object):  {"role":"assistant","content":"You're welcome."}

OUTPUT — what useLoadSpanIntoPromptPlayground feeds the chat
  [system → user → assistant → user → assistant("You're welcome.")]   ← 5 messages

VERIFICATION
  PASS  Conversation count: 4 input turns + 1 assistant reply = 5 total
  PASS  First message is the system turn (verbatim from input)
  PASS  Last message is the assistant reply 'You're welcome.' (Bug B fix)
  PASS  Penultimate message is the latest user turn 'thanks bro!'
  PASS  Order preserved: input turns before output (chronological)
```
