### PR TITLE
fix(traces-v2): drop outer box around rendered markdown in IO viewer

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/IOViewer.tsx
@@ -326,6 +326,14 @@ export const IOViewer = memo(function IOViewer({
   // gray box around the input, why does it exist?". Applies whether
   // we're rendering the input history or the output reply.
   const flushChatCard = format === "pretty" && isChat;
+  // Rendered markdown paints its own typography (headings, paragraphs,
+  // fenced code blocks, etc.) — the outer "bg.subtle + border" container
+  // makes the whole thing read as one giant code block, with the real
+  // fenced code blocks nested inside a near-identical box. Drop the
+  // outer chrome so prose looks like prose and code looks like code.
+  // Source mode (raw markdown text) keeps the box since it IS just text.
+  const flushMarkdown = format === "markdown" && markdownSubmode === "rendered";
+  const flushOuter = flushChatCard || flushMarkdown;
 
   // Track whether the preview box's content actually exceeds its visible
   // height. The "Click to interact" scrim only makes sense when there's
@@ -481,18 +489,18 @@ export const IOViewer = memo(function IOViewer({
                 the outer edge. */}
             <Box
               ref={previewBoxRef}
-              bg={flushChatCard ? "transparent" : "bg.subtle"}
-              borderRadius={flushChatCard ? "0" : "md"}
-              borderWidth={flushChatCard ? "0" : "1px"}
+              bg={flushOuter ? "transparent" : "bg.subtle"}
+              borderRadius={flushOuter ? "0" : "md"}
+              borderWidth={flushOuter ? "0" : "1px"}
               borderColor="border"
-              overflowX={flushChatCard ? "visible" : "auto"}
+              overflowX={flushOuter ? "visible" : "auto"}
               overflowY="visible"
               opacity={1}
               transition="opacity 120ms ease-out"
             >
               <Box
                 padding={
-                  flushChatCard
+                  flushOuter
                     ? 0
                     : format === "markdown" || isVirtualizingChat
                       ? 0


### PR DESCRIPTION
## Summary

When the operator picks **Markdown** in the input/output renderer, the rendered prose was wrapped in the same \`bg.subtle\` + bordered container used for the Pretty/Text views. With any fenced code block inside, the whole thing read as one giant code block nested inside another near-identical box, instead of prose + a single code block.

Extending the existing \`flushChatCard\` flag to also cover \`format === 'markdown' && markdownSubmode === 'rendered'\` drops the outer chrome only in that mode. Source submode keeps the box since the content there really is just raw text.

## Test plan
- [ ] Open a trace whose input or output contains markdown with a fenced code block.
- [ ] Switch to Markdown / Rendered: outer gray box and border disappear; prose and code block read as distinct elements.
- [ ] Switch to Markdown / Source: box stays (raw text needs the container).
- [ ] Pretty / Text / JSON: box unchanged from before.