### PR TITLE
docs(skills): drop MCP install prerequisite note

### DIFF
--- a/docs/skills/directory.mdx
+++ b/docs/skills/directory.mdx
@@ -8,10 +8,6 @@ import { SkillAccordion } from "/snippets/skill-accordion.jsx"
 import { InfoBox } from "/snippets/info-box.jsx"
 import { PROMPTS } from "/snippets/prompts-data.jsx"
 
-<Note>
-For the best experience, [install the LangWatch MCP](/integration/mcp) before using skills — they work even better together.
-</Note>
-
 ## Core Skills
 
 <SkillAccordion title="Instrument my code with LangWatch" skill="langwatch/skills/tracing" slashCommand="/tracing" prompt={PROMPTS.tracing} />


### PR DESCRIPTION
## Summary
- Skills now use the CLI, not the MCP, so the "install the LangWatch MCP before using skills" note in the Skills Directory is no longer accurate.
- Removed the `<Note>` block from `docs/skills/directory.mdx`.

## Test plan
- [ ] Render `docs/skills/directory.mdx` and confirm the note is gone above "Core Skills".