### PR TITLE
feat(feature-flags): named-opts isEnabled + close type-safety hole

### DIFF
--- a/dev/docs/adr/005-feature-flags.md
+++ b/dev/docs/adr/005-feature-flags.md
@@ -47,7 +47,7 @@ PostHog is **never** called on the SYSTEM path. PRODUCT keeps PostHog as the sou
 ### Adding a new flag
 
 1. Add a `FEATURE_FLAGS` entry with `scope: "SYSTEM" | "PRODUCT"`, `defaultValue`, `description`. For SYSTEM flags migrated from an existing env variable, set `legacyEnvVar` so the old name keeps working.
-2. Call `featureFlagService.isEnabled("your_new_flag_key", distinctId, defaultValue?, options?)`. The key is type-checked against `FeatureFlagKey`.
+2. Call `featureFlagService.isEnabled("your_new_flag_key", { distinctId, defaultValue?, projectId?, organizationId?, cacheTtlMs? })`. The key is type-checked against `FeatureFlagKey` via the shared `FeatureFlagServiceInterface`, so unregistered keys fail at compile time even when the service is dependency-injected.
 3. Flip from `/ops/feature-flags` at runtime without a redeploy. For PRODUCT flags, prefer flipping in PostHog directly so user targeting rules apply.
 
 ### Adding a new family
@@ -91,15 +91,15 @@ FeatureFlagService                                 env override
 PRODUCT flags target users / projects / orgs through PostHog `personProperties`:
 
 ```typescript
-await featureFlagService.isEnabled(
-  "release_ui_simulations_menu_enabled",
-  userId,
-  false,
-  { projectId: "proj_123", organizationId: "org_456" },
-);
+await featureFlagService.isEnabled("release_ui_simulations_menu_enabled", {
+  distinctId: userId,
+  defaultValue: false,
+  projectId: "proj_123",
+  organizationId: "org_456",
+});
 ```
 
-PostHog receives these as `personProperties.project_id` and `personProperties.organization_id` for release condition evaluation. SYSTEM flags ignore `options` since they're cluster-wide.
+PostHog receives these as `personProperties.project_id` and `personProperties.organization_id` for release condition evaluation. SYSTEM flags ignore `projectId` / `organizationId` since they're cluster-wide.
 
 ## Environment Overrides
 

--- a/langwatch/src/components/filters/FilterToggle.tsx
+++ b/langwatch/src/components/filters/FilterToggle.tsx
@@ -3,8 +3,6 @@ import { useRouter } from "~/utils/compat/next-router";
 import qs from "qs";
 import { X } from "react-feather";
 import { type FilterParam, useFilterParams } from "../../hooks/useFilterParams";
-import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
-import { useFeatureFlag } from "../../hooks/useFeatureFlag";
 import { filterOutEmptyFilters } from "../../server/analytics/utils";
 import type { FilterField } from "../../server/filters/types";
 import { Tooltip } from "../ui/tooltip";
@@ -149,16 +147,7 @@ export function FilterToggleButton({
   negateFiltersToggled?: boolean;
   setNegateFilters?: (negateFilters: boolean) => void;
 }) {
-  const { project, organization } = useOrganizationTeamProject();
   const { filterCount, hasAnyFilters } = getFilterCount(filters);
-
-  const { enabled: hasNegateFilters } = useFeatureFlag(
-    "release_ui_negate_filters_enabled",
-    {
-      projectId: project?.id,
-      organizationId: organization?.id,
-    },
-  );
 
   return (
     <HStack gap={2}>
@@ -194,7 +183,7 @@ export function FilterToggleButton({
           )}
         </HStack>
       </Button>
-      {hasNegateFilters && setNegateFilters && (
+      {setNegateFilters && (
         <Tooltip content="Negate filters" positioning={{ gutter: 0 }}>
           <Button
             variant="plain"

--- a/langwatch/src/features/command-bar/command-registry.ts
+++ b/langwatch/src/features/command-bar/command-registry.ts
@@ -590,7 +590,7 @@ export const supportCommands: Command[] = [
 ];
 
 /**
- * Theme switching commands (only shown when dark mode feature flag is enabled).
+ * Theme switching commands.
  */
 export const themeCommands: Command[] = [
   {

--- a/langwatch/src/features/command-bar/hooks/useFilteredCommands.ts
+++ b/langwatch/src/features/command-bar/hooks/useFilteredCommands.ts
@@ -38,9 +38,6 @@ export function useFilteredCommands(
   projectId: string | undefined,
   isDevMode: boolean,
 ): FilteredCommands {
-  const { enabled: isDarkModeEnabled } = useFeatureFlag(
-    "release_ui_dark_mode_enabled",
-  );
   const { enabled: isTracesV2Enabled } = useFeatureFlag(
     "release_ui_traces_v2_enabled",
     { projectId, enabled: !!projectId },
@@ -171,9 +168,9 @@ export function useFilteredCommands(
     return filterCommands(availableCommands, query);
   }, [query, isSaas]);
 
-  // Filter theme commands based on query (only when dark mode flag is enabled)
+  // Filter theme commands based on query
   const filteredTheme = useMemo(() => {
-    if (!isDarkModeEnabled || !query.trim()) return [];
+    if (!query.trim()) return [];
 
     const lowerQuery = query.toLowerCase().trim();
 
@@ -189,7 +186,7 @@ export function useFilteredCommands(
     }
 
     return filterCommands(themeCommands, query);
-  }, [query, isDarkModeEnabled]);
+  }, [query]);
 
   // Filter page-specific commands based on current route
   const router = useRouter();

--- a/langwatch/src/hooks/__tests__/useFeatureFlag.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/useFeatureFlag.unit.test.ts
@@ -34,7 +34,7 @@ describe("useFeatureFlag()", () => {
 
     it("returns isLoading true", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled"),
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled"),
       );
 
       expect(result.current.isLoading).toBe(true);
@@ -42,7 +42,7 @@ describe("useFeatureFlag()", () => {
 
     it("returns enabled false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled"),
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled"),
       );
 
       expect(result.current.enabled).toBe(false);
@@ -59,7 +59,7 @@ describe("useFeatureFlag()", () => {
 
     it("returns enabled false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled"),
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled"),
       );
 
       expect(result.current.enabled).toBe(false);
@@ -67,7 +67,7 @@ describe("useFeatureFlag()", () => {
 
     it("returns isLoading false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled"),
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled"),
       );
 
       expect(result.current.isLoading).toBe(false);
@@ -84,7 +84,7 @@ describe("useFeatureFlag()", () => {
 
     it("returns enabled true", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled"),
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled"),
       );
 
       expect(result.current.enabled).toBe(true);
@@ -92,7 +92,7 @@ describe("useFeatureFlag()", () => {
 
     it("returns isLoading false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled"),
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled"),
       );
 
       expect(result.current.isLoading).toBe(false);
@@ -109,7 +109,7 @@ describe("useFeatureFlag()", () => {
 
     it("passes projectId and organizationId to query", () => {
       renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled", {
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled", {
           projectId: "proj-123",
           organizationId: "org-456",
         }),
@@ -117,7 +117,7 @@ describe("useFeatureFlag()", () => {
 
       expect(mockUseQuery).toHaveBeenCalledWith(
         {
-          flag: "release_ui_dark_mode_enabled",
+          flag: "release_ui_sdk_radar_banner_card_enabled",
           projectId: "proj-123",
           organizationId: "org-456",
         },
@@ -140,11 +140,11 @@ describe("useFeatureFlag()", () => {
     });
 
     it("passes undefined for optional params", () => {
-      renderHook(() => useFeatureFlag("release_ui_dark_mode_enabled"));
+      renderHook(() => useFeatureFlag("release_ui_sdk_radar_banner_card_enabled"));
 
       expect(mockUseQuery).toHaveBeenCalledWith(
         {
-          flag: "release_ui_dark_mode_enabled",
+          flag: "release_ui_sdk_radar_banner_card_enabled",
           projectId: undefined,
           organizationId: undefined,
         },
@@ -168,7 +168,7 @@ describe("useFeatureFlag()", () => {
 
     it("disables the query", () => {
       renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled", {
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled", {
           projectId: undefined,
           enabled: false,
         }),
@@ -184,7 +184,7 @@ describe("useFeatureFlag()", () => {
 
     it("returns enabled false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled", {
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled", {
           enabled: false,
         }),
       );
@@ -194,7 +194,7 @@ describe("useFeatureFlag()", () => {
 
     it("returns isLoading false", () => {
       const { result } = renderHook(() =>
-        useFeatureFlag("release_ui_dark_mode_enabled", {
+        useFeatureFlag("release_ui_sdk_radar_banner_card_enabled", {
           enabled: false,
         }),
       );

--- a/langwatch/src/server/api/routers/featureFlag.ts
+++ b/langwatch/src/server/api/routers/featureFlag.ts
@@ -65,9 +65,9 @@ export const featureFlagRouter = createTRPCRouter({
       // type, hence the explicit FeatureFlagKey narrowing.
       const enabled = await featureFlagService.isEnabled(
         input.flag as FeatureFlagKey,
-        userId,
-        false,
         {
+          distinctId: userId,
+          defaultValue: false,
           projectId: input.projectId,
           organizationId: input.organizationId,
         },

--- a/langwatch/src/server/app-layer/traces/__tests__/span-token-estimation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/span-token-estimation.service.unit.test.ts
@@ -480,9 +480,11 @@ describe("OtlpSpanTokenEstimationService", () => {
         expect(deps.tokenizer.countTokens).not.toHaveBeenCalled();
         expect(featureFlagService.isEnabled).toHaveBeenCalledWith(
           "token-estimation-killswitch",
-          "global",
-          false,
-          expect.objectContaining({ cacheTtlMs: expect.any(Number) }),
+          expect.objectContaining({
+            distinctId: "global",
+            defaultValue: false,
+            cacheTtlMs: expect.any(Number),
+          }),
         );
       });
     });
@@ -526,9 +528,9 @@ describe("OtlpSpanTokenEstimationService", () => {
         expect(deps.tokenizer.countTokens).not.toHaveBeenCalled();
         expect(featureFlagService.isEnabled).toHaveBeenCalledWith(
           "token-estimation-project-killswitch",
-          "project-456",
-          false,
           expect.objectContaining({
+            distinctId: "project-456",
+            defaultValue: false,
             projectId: "project-456",
             cacheTtlMs: expect.any(Number),
           }),

--- a/langwatch/src/server/app-layer/traces/span-pii-redaction.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-pii-redaction.service.ts
@@ -288,8 +288,7 @@ export class OtlpSpanPiiRedactionService {
   ): Promise<PIICheckOptions | null> {
     const disabled = await featureFlagService.isEnabled(
       "ops_pii_redaction_disabled",
-      "span-pii-service",
-      false,
+      { distinctId: "span-pii-service", defaultValue: false },
     );
     if (disabled) return null;
     if (piiRedactionLevel === "DISABLED") return null;

--- a/langwatch/src/server/app-layer/traces/span-token-estimation.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-token-estimation.service.ts
@@ -151,9 +151,11 @@ export class OtlpSpanTokenEstimationService {
     // hot path and a cache miss = one billable PostHog /flags request.
     const globalDisabled = await this.deps.featureFlagService.isEnabled(
       GLOBAL_KILL_SWITCH_KEY,
-      "global",
-      false,
-      { cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS },
+      {
+        distinctId: "global",
+        defaultValue: false,
+        cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
+      },
     );
     if (globalDisabled) return true;
 
@@ -161,9 +163,12 @@ export class OtlpSpanTokenEstimationService {
     if (tenantId) {
       const projectDisabled = await this.deps.featureFlagService.isEnabled(
         PROJECT_KILL_SWITCH_KEY,
-        tenantId,
-        false,
-        { projectId: tenantId, cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS },
+        {
+          distinctId: tenantId,
+          defaultValue: false,
+          projectId: tenantId,
+          cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
+        },
       );
       if (projectDisabled) return true;
     }

--- a/langwatch/src/server/background/workers/collectorWorker.ts
+++ b/langwatch/src/server/background/workers/collectorWorker.ts
@@ -451,8 +451,7 @@ const processCollectorJob_ = async (
 
   const piiRedactionDisabled = await featureFlagService.isEnabled(
     "ops_pii_redaction_disabled",
-    project.id,
-    false,
+    { distinctId: project.id, defaultValue: false },
   );
   if (!piiRedactionDisabled && project.piiRedactionLevel !== "DISABLED") {
     const piiEnforced = env.NODE_ENV === "production";

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -75,8 +75,7 @@ export function createEvaluationTriggerReactor(
       // via the standard env-override path (uppercased flag key).
       const guardDisabled = await featureFlagService.isEnabled(
         CAUSALITY_LOOP_GUARD_DISABLED_FLAG,
-        tenantId,
-        false,
+        { distinctId: tenantId, defaultValue: false },
       );
 
       if (!guardDisabled && isSpanReceivedEvent(event)) {

--- a/langwatch/src/server/event-sourcing/utils/__tests__/killSwitch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/utils/__tests__/killSwitch.unit.test.ts
@@ -81,9 +81,11 @@ describe("isComponentDisabled", () => {
       expect(result).toBe(true);
       expect(ffs.isEnabled).toHaveBeenCalledWith(
         "es-trace-command-recordSpan-killswitch",
-        "tenant-1",
-        false,
-        expect.objectContaining({ cacheTtlMs: expect.any(Number) }),
+        expect.objectContaining({
+          distinctId: "tenant-1",
+          defaultValue: false,
+          cacheTtlMs: expect.any(Number),
+        }),
       );
     });
 
@@ -140,9 +142,11 @@ describe("isComponentDisabled", () => {
 
       expect(ffs.isEnabled).toHaveBeenCalledWith(
         "my-custom-flag",
-        "tenant-1",
-        false,
-        expect.objectContaining({ cacheTtlMs: expect.any(Number) }),
+        expect.objectContaining({
+          distinctId: "tenant-1",
+          defaultValue: false,
+          cacheTtlMs: expect.any(Number),
+        }),
       );
     });
   });

--- a/langwatch/src/server/event-sourcing/utils/killSwitch.ts
+++ b/langwatch/src/server/event-sourcing/utils/killSwitch.ts
@@ -54,12 +54,11 @@ export async function isComponentDisabled({
     customKey ?? generateKillSwitchKey(aggregateType, componentType, componentName);
 
   try {
-    const isDisabled = await featureFlagService.isEnabled(
-      flagKey,
-      tenantId,
-      false,
-      { cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS },
-    );
+    const isDisabled = await featureFlagService.isEnabled(flagKey, {
+      distinctId: tenantId,
+      defaultValue: false,
+      cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
+    });
     if (isDisabled && logger) {
       logger.debug(
         { componentName, componentType, tenantId, flagKey },

--- a/langwatch/src/server/featureFlag/__tests__/featureFlag.service.resolver.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/featureFlag.service.resolver.unit.test.ts
@@ -79,7 +79,7 @@ describe("FeatureFlagService", () => {
     describe("when nothing overrides it", () => {
       it("resolves to the registry default and never calls the legacy service", async () => {
         const { service, legacy } = buildService();
-        const enabled = await service.isEnabled(SYSTEM_FLAG, "tenant-a", true);
+        const enabled = await service.isEnabled(SYSTEM_FLAG, { distinctId: "tenant-a", defaultValue: true });
         expect(enabled).toBe(false);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });
@@ -89,7 +89,7 @@ describe("FeatureFlagService", () => {
       it("uses the store value and never calls the legacy service", async () => {
         const { service, store, legacy } = buildService();
         await store.set(SYSTEM_FLAG, true);
-        const enabled = await service.isEnabled(SYSTEM_FLAG, "tenant-a", false);
+        const enabled = await service.isEnabled(SYSTEM_FLAG, { distinctId: "tenant-a", defaultValue: false });
         expect(enabled).toBe(true);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });
@@ -100,7 +100,7 @@ describe("FeatureFlagService", () => {
         const { service, store, legacy } = buildService();
         await store.set(SYSTEM_FLAG, false);
         process.env.OPS_ES_CAUSALITY_LOOP_GUARD_DISABLED = "1";
-        const enabled = await service.isEnabled(SYSTEM_FLAG, "tenant-a", false);
+        const enabled = await service.isEnabled(SYSTEM_FLAG, { distinctId: "tenant-a", defaultValue: false });
         expect(enabled).toBe(true);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });
@@ -110,7 +110,7 @@ describe("FeatureFlagService", () => {
       it("honors LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD for back-compat", async () => {
         const { service, legacy } = buildService();
         process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD = "1";
-        const enabled = await service.isEnabled(SYSTEM_FLAG, "tenant-a", false);
+        const enabled = await service.isEnabled(SYSTEM_FLAG, { distinctId: "tenant-a", defaultValue: false });
         expect(enabled).toBe(true);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });
@@ -121,7 +121,7 @@ describe("FeatureFlagService", () => {
     describe("when no store row exists", () => {
       it("resolves to family default off and skips the legacy service", async () => {
         const { service, legacy } = buildService();
-        const enabled = await service.isEnabled(FAMILY_FLAG, "tenant-a", false);
+        const enabled = await service.isEnabled(FAMILY_FLAG, { distinctId: "tenant-a", defaultValue: false });
         expect(enabled).toBe(false);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });
@@ -131,7 +131,7 @@ describe("FeatureFlagService", () => {
       it("returns true and still skips the legacy service", async () => {
         const { service, store, legacy } = buildService();
         await store.set(FAMILY_FLAG, true);
-        const enabled = await service.isEnabled(FAMILY_FLAG, "tenant-a", false);
+        const enabled = await service.isEnabled(FAMILY_FLAG, { distinctId: "tenant-a", defaultValue: false });
         expect(enabled).toBe(true);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });
@@ -145,14 +145,15 @@ describe("FeatureFlagService", () => {
         (legacy.isEnabled as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
           true,
         );
-        const enabled = await service.isEnabled(PRODUCT_FLAG, "user-1", false);
+        const enabled = await service.isEnabled(PRODUCT_FLAG, {
+          distinctId: "user-1",
+          defaultValue: false,
+        });
         expect(enabled).toBe(true);
-        expect(legacy.isEnabled).toHaveBeenCalledWith(
-          PRODUCT_FLAG,
-          "user-1",
-          false,
-          undefined,
-        );
+        expect(legacy.isEnabled).toHaveBeenCalledWith(PRODUCT_FLAG, {
+          distinctId: "user-1",
+          defaultValue: false,
+        });
       });
     });
 
@@ -160,7 +161,7 @@ describe("FeatureFlagService", () => {
       it("uses the store value without touching the legacy service", async () => {
         const { service, store, legacy } = buildService();
         await store.set(PRODUCT_FLAG, true);
-        const enabled = await service.isEnabled(PRODUCT_FLAG, "user-1", false);
+        const enabled = await service.isEnabled(PRODUCT_FLAG, { distinctId: "user-1", defaultValue: false });
         expect(enabled).toBe(true);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });
@@ -173,7 +174,7 @@ describe("FeatureFlagService", () => {
         (legacy.isEnabled as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
           true,
         );
-        const enabled = await service.isEnabled(PRODUCT_FLAG, "user-1", true);
+        const enabled = await service.isEnabled(PRODUCT_FLAG, { distinctId: "user-1", defaultValue: true });
         expect(enabled).toBe(false);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });
@@ -189,11 +190,10 @@ describe("FeatureFlagService", () => {
       // Cast: deliberately a non-registered flag to assert the
       // legacy-fallback path. Production callers can't reach this branch
       // because the FeatureFlagKey signature wouldn't accept the key.
-      const enabled = await service.isEnabled(
-        UNREGISTERED_FLAG as never,
-        "user-1",
-        false,
-      );
+      const enabled = await service.isEnabled(UNREGISTERED_FLAG as never, {
+        distinctId: "user-1",
+        defaultValue: false,
+      });
       expect(enabled).toBe(true);
       expect(legacy.isEnabled).toHaveBeenCalled();
     });

--- a/langwatch/src/server/featureFlag/__tests__/featureFlag.service.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/featureFlag.service.test.ts
@@ -59,15 +59,16 @@ describe("FeatureFlagService", () => {
           store: buildNoopStore(),
         });
 
-        const result = await service.isEnabled("some-flag" as never, "user-1", false);
+        const result = await service.isEnabled("some-flag" as never, {
+          distinctId: "user-1",
+          defaultValue: false,
+        });
 
         expect(result).toBe(true);
-        expect(legacy.isEnabled).toHaveBeenCalledWith(
-          "some-flag",
-          "user-1",
-          false,
-          undefined,
-        );
+        expect(legacy.isEnabled).toHaveBeenCalledWith("some-flag", {
+          distinctId: "user-1",
+          defaultValue: false,
+        });
       });
 
       it("forwards projectId to the legacy service", async () => {
@@ -77,15 +78,17 @@ describe("FeatureFlagService", () => {
           store: buildNoopStore(),
         });
 
-        const options = { projectId: "proj-123" };
-        await service.isEnabled("some-flag" as never, "user-1", true, options);
+        await service.isEnabled("some-flag" as never, {
+          distinctId: "user-1",
+          defaultValue: true,
+          projectId: "proj-123",
+        });
 
-        expect(legacy.isEnabled).toHaveBeenCalledWith(
-          "some-flag",
-          "user-1",
-          true,
-          options,
-        );
+        expect(legacy.isEnabled).toHaveBeenCalledWith("some-flag", {
+          distinctId: "user-1",
+          defaultValue: true,
+          projectId: "proj-123",
+        });
       });
 
       it("forwards organizationId to the legacy service", async () => {
@@ -95,15 +98,17 @@ describe("FeatureFlagService", () => {
           store: buildNoopStore(),
         });
 
-        const options = { organizationId: "org-456" };
-        await service.isEnabled("some-flag" as never, "user-1", false, options);
+        await service.isEnabled("some-flag" as never, {
+          distinctId: "user-1",
+          defaultValue: false,
+          organizationId: "org-456",
+        });
 
-        expect(legacy.isEnabled).toHaveBeenCalledWith(
-          "some-flag",
-          "user-1",
-          false,
-          options,
-        );
+        expect(legacy.isEnabled).toHaveBeenCalledWith("some-flag", {
+          distinctId: "user-1",
+          defaultValue: false,
+          organizationId: "org-456",
+        });
       });
     });
 
@@ -125,8 +130,7 @@ describe("FeatureFlagService", () => {
 
           const result = await service.isEnabled(
             "release_ui_simulations_menu_enabled" as never,
-            "user-123",
-            false,
+            { distinctId: "user-123", defaultValue: false },
           );
 
           expect(result).toBe(true);
@@ -140,8 +144,7 @@ describe("FeatureFlagService", () => {
 
           const result = await service.isEnabled(
             "release_ui_simulations_menu_enabled" as never,
-            "user-123",
-            true,
+            { distinctId: "user-123", defaultValue: true },
           );
 
           expect(result).toBe(false);
@@ -168,7 +171,10 @@ describe("FeatureFlagService", () => {
           store: buildNoopStore(),
         });
 
-        const result = await service.isEnabled("some_flag" as never, "user-1", false);
+        const result = await service.isEnabled("some_flag" as never, {
+          distinctId: "user-1",
+          defaultValue: false,
+        });
 
         expect(result).toBe(true);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
@@ -182,7 +188,10 @@ describe("FeatureFlagService", () => {
           store: buildNoopStore(),
         });
 
-        const result = await service.isEnabled("different_flag" as never, "u", false);
+        const result = await service.isEnabled("different_flag" as never, {
+          distinctId: "u",
+          defaultValue: false,
+        });
 
         expect(result).toBe(false);
         expect(legacy.isEnabled).toHaveBeenCalled();
@@ -196,7 +205,10 @@ describe("FeatureFlagService", () => {
           store: buildNoopStore(),
         });
 
-        const result = await service.isEnabled("spaced_flag" as never, "u", false);
+        const result = await service.isEnabled("spaced_flag" as never, {
+          distinctId: "u",
+          defaultValue: false,
+        });
 
         expect(result).toBe(true);
       });
@@ -212,8 +224,7 @@ describe("FeatureFlagService", () => {
 
         const result = await service.isEnabled(
           "release_ui_ai_gateway_menu_enabled",
-          "u",
-          false,
+          { distinctId: "u", defaultValue: false },
         );
 
         expect(result).toBe(true);
@@ -227,8 +238,7 @@ describe("FeatureFlagService", () => {
 
         const result = await service.isEnabled(
           "release_ui_simulations_menu_enabled" as never,
-          "u",
-          true,
+          { distinctId: "u", defaultValue: true },
         );
 
         expect(result).toBe(false);

--- a/langwatch/src/server/featureFlag/featureFlag.service.ts
+++ b/langwatch/src/server/featureFlag/featureFlag.service.ts
@@ -9,7 +9,10 @@ import {
 } from "./featureFlagStore.postgres";
 import type { FeatureFlagKey } from "./registry";
 import { resolveFlagDefinition } from "./registry";
-import type { FeatureFlagOptions, FeatureFlagServiceInterface } from "./types";
+import type {
+  FeatureFlagEvaluateOptions,
+  FeatureFlagServiceInterface,
+} from "./types";
 
 /**
  * Main feature flag service.
@@ -58,25 +61,18 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
   }
 
   /**
-   * Type-checked overload. `flagKey` is constrained to the union of
-   * registered flag keys plus the `es-*-killswitch` family template
-   * literal, so unregistered string literals fail at compile time.
-   * Internally still accepts arbitrary strings via the implementation
-   * signature so the legacy PostHog and memory backends keep working
-   * with flags that pre-date the registry.
+   * `flagKey` is constrained to the union of registered flag keys plus
+   * the `es-*-killswitch` family template literal, so unregistered
+   * string literals fail at compile time. Callers pass everything else
+   * (distinctId, defaultValue, projectId/organizationId for PostHog
+   * targeting, cacheTtlMs for hot-path TTL overrides) via the options
+   * object.
    */
   async isEnabled(
     flagKey: FeatureFlagKey,
-    distinctId: string,
-    defaultValue?: boolean,
-    options?: FeatureFlagOptions,
-  ): Promise<boolean>;
-  async isEnabled(
-    flagKey: string,
-    distinctId: string,
-    defaultValue = false,
-    options?: FeatureFlagOptions,
+    opts: FeatureFlagEvaluateOptions,
   ): Promise<boolean> {
+    const { distinctId, defaultValue = false } = opts;
     const definition = resolveFlagDefinition(flagKey);
 
     const envOverride = checkFlagEnvOverride(flagKey, definition?.legacyEnvVar);
@@ -108,15 +104,19 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
       const stored = await this.store.get(flagKey);
       if (stored !== null) return stored;
 
-      return await this.legacy.isEnabled(
-        flagKey,
+      return await this.legacy.isEnabled(flagKey, {
+        ...opts,
         distinctId,
-        definition.defaultValue,
-        options,
-      );
+        defaultValue: definition.defaultValue,
+      });
     }
 
-    return this.legacy.isEnabled(flagKey, distinctId, defaultValue, options);
+    // Unregistered keys reach the legacy backend for back-compat with
+    // ad-hoc PostHog flags. The legacy memory/PostHog services widen
+    // the param to `string` in their own implementations, so the
+    // interface-level `FeatureFlagKey` constraint still gates new
+    // callers without blocking runtime back-compat.
+    return this.legacy.isEnabled(flagKey, { ...opts, defaultValue });
   }
 
   private createLegacyService(): FeatureFlagServiceInterface {

--- a/langwatch/src/server/featureFlag/featureFlagService.memory.ts
+++ b/langwatch/src/server/featureFlag/featureFlagService.memory.ts
@@ -120,7 +120,6 @@ export class FeatureFlagServiceMemory implements FeatureFlagServiceInterface {
   private initializeFlags(): void {
     // Flags that should default to enabled in local dev (no PostHog)
     this.flags["release_ui_sdk_radar_banner_card_enabled"] = true;
-    this.flags["release_ui_dark_mode_enabled"] = true;
 
     this.logger.debug("Initialized in-memory feature flags");
   }

--- a/langwatch/src/server/featureFlag/featureFlagService.memory.ts
+++ b/langwatch/src/server/featureFlag/featureFlagService.memory.ts
@@ -1,6 +1,9 @@
 import { getLangWatchTracer } from "langwatch";
 import { createLogger } from "~/utils/logger/server";
-import type { FeatureFlagOptions, FeatureFlagServiceInterface } from "./types";
+import type {
+  FeatureFlagEvaluateOptions,
+  FeatureFlagServiceInterface,
+} from "./types";
 
 /**
  * In-memory feature flag service with default values.
@@ -29,14 +32,14 @@ export class FeatureFlagServiceMemory implements FeatureFlagServiceInterface {
 
   /**
    * Check if a feature flag is enabled.
-   * Note: options parameter is accepted for interface compatibility but ignored.
+   * Note: extra fields on opts (projectId, organizationId, cacheTtlMs)
+   * are accepted for interface compatibility but ignored.
    */
   async isEnabled(
     flagKey: string,
-    distinctId: string,
-    defaultValue = true,
-    _options?: FeatureFlagOptions,
+    opts: FeatureFlagEvaluateOptions,
   ): Promise<boolean> {
+    const { distinctId, defaultValue = true } = opts;
     return await this.tracer.withActiveSpan(
       "FeatureFlagServiceMemory.isEnabled",
       {

--- a/langwatch/src/server/featureFlag/featureFlagService.posthog.ts
+++ b/langwatch/src/server/featureFlag/featureFlagService.posthog.ts
@@ -6,7 +6,10 @@ import {
   KILL_SWITCH_CACHE_TTL_MS,
 } from "./constants";
 import { StaleWhileRevalidateCache } from "./staleWhileRevalidateCache.redis";
-import type { FeatureFlagOptions, FeatureFlagServiceInterface } from "./types";
+import type {
+  FeatureFlagEvaluateOptions,
+  FeatureFlagServiceInterface,
+} from "./types";
 
 /**
  * PostHog-based feature flag service with hybrid Redis/in-memory caching.
@@ -67,10 +70,15 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
    */
   async isEnabled(
     flagKey: string,
-    distinctId: string,
-    defaultValue = true,
-    options?: FeatureFlagOptions,
+    opts: FeatureFlagEvaluateOptions,
   ): Promise<boolean> {
+    const {
+      distinctId,
+      defaultValue = true,
+      projectId,
+      organizationId: orgId,
+      cacheTtlMs,
+    } = opts;
     return await this.tracer.withActiveSpan(
       "FeatureFlagServicePostHog.isEnabled",
       {
@@ -78,9 +86,9 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
           "feature.flag.key": flagKey,
           "feature.flag.distinct_id": distinctId,
           "feature.flag.default": defaultValue,
-          "feature.flag.project_id": options?.projectId ?? "",
-          "feature.flag.organization_id": options?.organizationId ?? "",
-          "tenant.id": options?.projectId ?? "",
+          "feature.flag.project_id": projectId ?? "",
+          "feature.flag.organization_id": orgId ?? "",
+          "tenant.id": projectId ?? "",
           "cache.backend": "redis",
         },
       },
@@ -90,13 +98,11 @@ export class FeatureFlagServicePostHog implements FeatureFlagServiceInterface {
           return defaultValue;
         }
 
-        const projectId = options?.projectId;
-        const orgId = options?.organizationId;
         const cacheKey = `${flagKey}:${distinctId}:${projectId ?? ""}:${orgId ?? ""}`;
 
         // Check hybrid cache first. Hot-path callers may pass a longer
         // cacheTtlMs to extend the staleness window without hitting PostHog.
-        const cachedResult = await this.cache.get(cacheKey, options?.cacheTtlMs);
+        const cachedResult = await this.cache.get(cacheKey, cacheTtlMs);
         if (cachedResult !== undefined) {
           span.setAttribute("feature.flag.source", "posthog-cached");
           span.setAttribute("feature.flag.enabled", cachedResult.value);

--- a/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
@@ -51,8 +51,6 @@
  */
 export const FRONTEND_FEATURE_FLAGS = [
   "release_ui_sdk_radar_banner_card_enabled",
-  "release_ui_dark_mode_enabled",
-  "release_ui_negate_filters_enabled",
   "release_ui_ai_gateway_menu_enabled",
   "release_ui_traces_v2_enabled",
 ] as const;

--- a/langwatch/src/server/featureFlag/index.ts
+++ b/langwatch/src/server/featureFlag/index.ts
@@ -21,7 +21,7 @@ export {
   resolveFlagDefinition,
 } from "./registry";
 export type {
-  FeatureFlagOptions,
+  FeatureFlagEvaluateOptions,
   FeatureFlagServiceInterface,
 } from "./types";
 export {

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -93,6 +93,27 @@ export const FEATURE_FLAGS = [
     family: "Collector",
     legacyEnvVar: "DISABLE_PII_REDACTION",
   },
+  // Per-span token estimation kill switches. Hardcoded raw keys before;
+  // each `record_span` job was a PostHog /flags call for the global key
+  // plus another for the project key (~5k calls/day in dogfood at modest
+  // traffic). Registering them moves the hot path to env + postgres so
+  // the only PostHog traffic is the Ops UI toggle.
+  {
+    key: "token-estimation-killswitch",
+    scope: "SYSTEM",
+    defaultValue: false,
+    description:
+      "Globally disables OTLP span token estimation in the collector. Emergency operator override; enabling skips the model-based token-count fill for spans missing usage metrics.",
+    family: "Collector",
+  },
+  {
+    key: "token-estimation-project-killswitch",
+    scope: "SYSTEM",
+    defaultValue: false,
+    description:
+      "Per-project (distinctId = project id) disable for OTLP span token estimation. Operators can opt a single tenant out before reaching for the global switch.",
+    family: "Collector",
+  },
 
   // ----- PRODUCT -----
   // Hot-ish per-project gate, but only checked on workflow execution

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -134,18 +134,6 @@ export const FEATURE_FLAGS = [
     description: "Shows the SDK radar banner card on the home page.",
   },
   {
-    key: "release_ui_dark_mode_enabled",
-    scope: "PRODUCT",
-    defaultValue: false,
-    description: "Enables the dark-mode toggle in the user profile menu.",
-  },
-  {
-    key: "release_ui_negate_filters_enabled",
-    scope: "PRODUCT",
-    defaultValue: false,
-    description: "Enables negate-filter chips on the messages / traces filters.",
-  },
-  {
     key: "release_ui_ai_gateway_menu_enabled",
     scope: "PRODUCT",
     defaultValue: false,

--- a/langwatch/src/server/featureFlag/types.ts
+++ b/langwatch/src/server/featureFlag/types.ts
@@ -1,14 +1,27 @@
+import type { FeatureFlagKey } from "./registry";
+
 /**
- * Options for feature flag evaluation.
+ * Options for evaluating a single feature flag.
+ *
+ * `distinctId` is the only required field — every flag resolution
+ * needs an identity to evaluate against (PostHog user targeting,
+ * audit log, cache key salting). The rest are optional knobs.
  */
-export interface FeatureFlagOptions {
+export interface FeatureFlagEvaluateOptions {
+  distinctId: string;
+  /**
+   * Overrides the registry default for unregistered keys (registered
+   * flags always use their `defaultValue` from `registry.ts`).
+   */
+  defaultValue?: boolean;
   projectId?: string;
   organizationId?: string;
   /**
    * Override the cache TTL (ms) for this evaluation. Used by hot-path
    * callers (kill switches checked per span/event) to avoid stampeding
-   * PostHog with one /flags request per cache key per 5 seconds when local
-   * evaluation is unavailable. Falls back to the service default when omitted.
+   * PostHog with one /flags request per cache key per 5 seconds when
+   * local evaluation is unavailable. Falls back to the service default
+   * when omitted.
    */
   cacheTtlMs?: number;
 }
@@ -16,18 +29,17 @@ export interface FeatureFlagOptions {
 /**
  * Common interface for feature flag services.
  *
- * `flagKey` is intentionally typed as `string` here rather than
- * `FeatureFlagKey`: this interface is also implemented by the legacy
- * PostHog and memory backends which must accept arbitrary keys for
- * back-compat with flags that pre-date the registry. The public
- * `FeatureFlagService.isEnabled` overload below tightens the key type
- * to `FeatureFlagKey` so new call sites get the type guarantee.
+ * `flagKey` is `FeatureFlagKey` so every call site is forced to use a
+ * registered key — the whole point of moving flags off PostHog onto
+ * env + postgres. The legacy PostHog and memory implementations widen
+ * the parameter to `string` internally to keep handling arbitrary keys
+ * at runtime (back-compat fallback for flags not yet migrated), which
+ * is allowed because method parameters are bivariant in class
+ * implementations. New callers must register the flag first.
  */
 export interface FeatureFlagServiceInterface {
   isEnabled(
-    flagKey: string,
-    distinctId: string,
-    defaultValue?: boolean,
-    options?: FeatureFlagOptions,
+    flagKey: FeatureFlagKey,
+    opts: FeatureFlagEvaluateOptions,
   ): Promise<boolean>;
 }

--- a/langwatch/src/server/nlpgo/nlpgoFetch.ts
+++ b/langwatch/src/server/nlpgo/nlpgoFetch.ts
@@ -210,7 +210,9 @@ export async function isNlpGoEnabled(
 ): Promise<boolean> {
   const organizationId =
     opts.organizationId ?? (await resolveOrganizationId(opts.projectId));
-  return featureFlagService.isEnabled(NLP_GO_FLAG, opts.projectId, false, {
+  return featureFlagService.isEnabled(NLP_GO_FLAG, {
+    distinctId: opts.projectId,
+    defaultValue: false,
     projectId: opts.projectId,
     organizationId,
   });

--- a/langwatch/src/server/observability/__tests__/anomalyDetector.unit.test.ts
+++ b/langwatch/src/server/observability/__tests__/anomalyDetector.unit.test.ts
@@ -224,8 +224,9 @@ describe("AnomalyDetector.tick", () => {
       const featureFlagService = {
         isEnabled: vi
           .fn()
-          .mockImplementation(async (_flag: string, distinctId: string) =>
-            distinctId === "proj_killed",
+          .mockImplementation(
+            async (_flag: string, opts: { distinctId: string }) =>
+              opts.distinctId === "proj_killed",
           ),
       };
 

--- a/langwatch/src/server/observability/anomalyDetector.ts
+++ b/langwatch/src/server/observability/anomalyDetector.ts
@@ -99,9 +99,11 @@ export class AnomalyDetector {
     try {
       return await this.deps.featureFlagService.isEnabled(
         ANOMALY_DETECTION_KILL_SWITCH_FLAG,
-        tenantId,
-        false,
-        { cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS },
+        {
+          distinctId: tenantId,
+          defaultValue: false,
+          cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
+        },
       );
     } catch {
       return false;

--- a/langwatch/src/server/observability/tenantRateTracker.ts
+++ b/langwatch/src/server/observability/tenantRateTracker.ts
@@ -81,9 +81,11 @@ export class TenantRateTracker {
     try {
       return await this.featureFlagService.isEnabled(
         ANOMALY_DETECTION_KILL_SWITCH_FLAG,
-        tenantId,
-        false,
-        { cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS },
+        {
+          distinctId: tenantId,
+          defaultValue: false,
+          cacheTtlMs: KILL_SWITCH_CACHE_TTL_MS,
+        },
       );
     } catch {
       return false;


### PR DESCRIPTION
## Context

Two follow-ups after merging #4097, surfaced when investigating yesterday's PostHog Feature Flag Calls spike chart:

| Flag | Calls last 2 days | Status |
|------|---|---|
| `es-observability-anomaly-detection-killswitch` | 69,081 | Fixed by #4097 — drops to **zero** after deploy ~20:30 UTC May 17 |
| `token-estimation-project-killswitch` | 7,948 | Still on PostHog (hardcoded raw key, outside `es-*-killswitch` family) |
| `token-estimation-killswitch` | 757 | Same |
| `release_nlp_go_engine_enabled` | 2,058 | Expected (PRODUCT, per-project rollout) |

## What's in this PR

1. **Close the type-safety hole.** `FeatureFlagServiceInterface.isEnabled` was typed as `flagKey: string`, so every dependency-injected caller bypassed the `FeatureFlagKey` overload on the concrete class. Tighten the interface so the rule applies everywhere. Class implementations keep widening to `string` internally (bivariant method params) which preserves runtime back-compat for unregistered ad-hoc PostHog keys without weakening the typecheck. **Unregistered keys now fail at compile time across the codebase, not just at the singleton call site.**

2. **Switch `isEnabled` to named opts**, per CodeRabbit's earlier feedback and the repo convention banning positional args for multi-arg functions:

```ts
// before
await featureFlagService.isEnabled(flag, distinctId, false, { projectId, cacheTtlMs });
// after
await featureFlagService.isEnabled(flag, { distinctId, defaultValue: false, projectId, cacheTtlMs });
```

3. **Register the two token-estimation kill switches** (`token-estimation-killswitch`, `token-estimation-project-killswitch`) as SYSTEM flags so the per-span hot path resolves from env + postgres instead of PostHog. Estimated ~8.7k/day of `posthog-node` traffic gone after deploy.

Updated all 9 call sites + 5 test files + ADR-005.

## Test plan
- [x] `pnpm typecheck` clean (catches any remaining unregistered call sites)
- [x] `pnpm test:unit` — 823/823 pass across featureFlag, observability, traces, event-sourcing
- [ ] Post-deploy: verify `token-estimation-*-killswitch` calls in PostHog go to zero for posthog-node library