### PR TITLE
fix(otelsetup): drop self-loop in startup error handler

### DIFF
--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -67,6 +67,8 @@ const DEFAULT_BATS_TEST_ROOTS: string[] = [
  */
 const DEFAULT_GO_TEST_ROOTS: string[] = [
   "services/nlpgo",
+  "services/aigateway",
+  "pkg",
 ];
 
 /**

--- a/pkg/otelsetup/otelsetup.go
+++ b/pkg/otelsetup/otelsetup.go
@@ -8,6 +8,7 @@ package otelsetup
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -23,6 +24,23 @@ import (
 
 	"github.com/langwatch/langwatch/pkg/contexts"
 )
+
+// slogErrorHandler is the fallback delegate behind startupErrorHandler.
+// Using a concrete handler — rather than whatever otelapi.GetErrorHandler()
+// returns — is load-bearing: GetErrorHandler() returns the global
+// *ErrDelegator wrapper, which forwards to the latest handler registered
+// via SetErrorHandler. If we captured the delegator and then registered
+// startupErrorHandler globally, dispatching any OTel error would recurse
+// (startupErrorHandler.Handle → delegator → startupErrorHandler.Handle …)
+// until the goroutine stack overflowed and the process exited with code 2.
+type slogErrorHandler struct{}
+
+func (slogErrorHandler) Handle(err error) {
+	if err == nil {
+		return
+	}
+	slog.Warn("otel error", "err", err)
+}
 
 // startupErrorHandler silences OTLP export errors during the first few
 // seconds of startup. The gateway commonly races its OTel exporter
@@ -232,7 +250,7 @@ func New(ctx context.Context, opts Options) (*Provider, error) {
 	// once the healthyExporter wrapper sees a successful export, or after
 	// the 30s grace window elapses (whichever comes first).
 	startupFilter := newStartupErrorHandler(
-		otelapi.GetErrorHandler(),
+		slogErrorHandler{},
 		30*time.Second,
 	)
 	otelapi.SetErrorHandler(startupFilter)

--- a/pkg/otelsetup/otelsetup_test.go
+++ b/pkg/otelsetup/otelsetup_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	otelapi "go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -62,6 +63,44 @@ func TestStartupErrorHandler_PassesAuthErrorsAfterGraceWindowElapses(t *testing.
 
 	if len(captured.errs) != 1 || !errors.Is(captured.errs[0], authErr) {
 		t.Fatalf("expected post-grace auth error to surface, got: %v", captured.errs)
+	}
+}
+
+// TestNew_StartupErrorHandlerHasConcreteDelegate pins the fix for the
+// 2026-05-18 incident. Previous code captured otelapi.GetErrorHandler()
+// as the filter's delegate, then registered the filter as the global
+// handler. GetErrorHandler() returns the singleton *ErrDelegator which
+// forwards to whichever handler is currently registered — so the
+// delegate pointed back to the filter itself, and every dispatched OTel
+// error recursed (filter → delegator → filter → …) until the goroutine
+// stack overflowed at 1 GiB and the process exited with code 2. With a
+// flapping OTLP collector this took the gateway down within seconds.
+//
+// The fix in New() uses a concrete slogErrorHandler{} as the fallback,
+// so the recursion is impossible by construction. This test asserts the
+// wiring intent — the registered filter's delegate must be a leaf
+// handler that does not call back into OTel globals. Asserting on the
+// concrete type is the right granularity because the bug was a
+// structural mistake at construction time, not a behavioral mistake in
+// the filter's Handle code.
+//
+/** @scenario dispatched OTel error invokes the registered handler exactly once */
+func TestNew_StartupErrorHandlerHasConcreteDelegate(t *testing.T) {
+	ctx := context.Background()
+	// Endpoint just needs to parse — otlptracehttp.New is lazy and does
+	// not connect at construction time, so an unreachable host is fine.
+	p, err := New(ctx, Options{OTLPEndpoint: "http://localhost:1/v1/traces"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(ctx) })
+
+	h, ok := otelapi.GetErrorHandler().(*startupErrorHandler)
+	if !ok {
+		t.Fatalf("expected global handler to be *startupErrorHandler, got %T", otelapi.GetErrorHandler())
+	}
+	if _, ok := h.delegate.(slogErrorHandler); !ok {
+		t.Fatalf("startupErrorHandler.delegate must be the concrete slogErrorHandler{} to avoid the self-loop recursion bug, got %T", h.delegate)
 	}
 }
 

--- a/specs/ai-gateway/telemetry-resilience.feature
+++ b/specs/ai-gateway/telemetry-resilience.feature
@@ -1,0 +1,47 @@
+Feature: Gateway telemetry resilience
+
+  # Verified in the Go gateway via unit tests in pkg/otelsetup/.
+  # Out of scope for the TS parity check.
+
+  The gateway runs on the customer hot path and ships OTel spans to an
+  internal collector. The collector and its downstream backend (Tempo)
+  are *internal observability* — gateway availability must NEVER depend
+  on their health. Any failure mode in the trace pipeline that takes
+  the gateway down is a sev-1 bug.
+
+  Rule: Trace export errors never crash the process
+
+    # Regression for the 2026-05-18 incident: startupErrorHandler
+    # captured otelapi.GetErrorHandler() as its delegate, then registered
+    # itself as the global. Because GetErrorHandler() returns the singleton
+    # *ErrDelegator wrapper (not the previous concrete handler), the
+    # delegator pointed back to startupErrorHandler — every dispatched
+    # OTel error recursed until the goroutine stack hit 1 GiB and the
+    # runtime aborted with exit code 2. The recursion fired the first
+    # time the OTLP exporter saw the collector return any error, so a
+    # flapping collector took down every gateway pod within seconds.
+    @unit @regression
+    Scenario: dispatched OTel error invokes the registered handler exactly once
+      Given the gateway has installed its OTel error handler
+      When the SDK dispatches an exporter error via otel.Handle
+      Then the registered handler receives the error exactly once
+      And the call does not recurse into itself
+
+  Rule: Collector outage keeps the gateway serving traffic
+
+    @integration @unimplemented
+    Scenario: OTLP collector connection-refused does not crash the gateway
+      Given the OTLP collector at GATEWAY_OTEL_DEFAULT_ENDPOINT is unreachable
+      And the gateway is configured with the default batch span processor
+      When 1000 spans are exported over 60 seconds
+      Then the gateway process continues serving requests
+      And /healthz keeps returning 200 throughout
+      And no goroutine stack exceeds 1 MiB
+
+    @integration @unimplemented
+    Scenario: empty OTLP endpoint installs a noop tracer provider
+      Given GATEWAY_OTEL_DEFAULT_ENDPOINT is empty
+      When the gateway boots
+      Then otelsetup.New returns a noop Provider
+      And no global error handler is registered
+      And subsequent otel.Handle calls fall back to the SDK default


### PR DESCRIPTION
## Summary

- Captures `otelapi.GetErrorHandler()` as the startup filter's delegate, then registers the filter via `SetErrorHandler`. `GetErrorHandler` returns the singleton `*ErrDelegator` which forwards to the latest registered handler, so the delegate pointed back to the filter itself.
- Every dispatched OTel error recursed (filter → delegator → filter → …) until the goroutine stack hit 1 GiB and the process exited with code 2.
- With a flapping internal collector / Tempo this took every gateway pod down within ~30s of boot, surfacing as `OOMKilled` in `kubectl describe` (exit 137 at the pod level once the runtime aborted) and the cascade nuked customer traffic.

Use a concrete `slogErrorHandler{}` as the fallback so the recursion is impossible by construction. Filter still suppresses startup-race auth/transport noise within the grace window; once `markHealthy` fires (first successful export) every error flows through to `slog`.

## Test plan

- [x] `go test ./pkg/otelsetup/...` — new regression test (`TestNew_StartupErrorHandlerHasConcreteDelegate`) asserts the filter's delegate is the concrete `slogErrorHandler{}`, not `*ErrDelegator`. Test fails loud on the buggy wiring.
- [x] `go build ./services/aigateway/...` clean.
- [x] Spec added at `specs/ai-gateway/telemetry-resilience.feature` covering the regression scenario plus the collector-outage / empty-endpoint cases.
- [ ] Prod gateway pods stable after image redeploy with `GATEWAY_OTEL_DEFAULT_ENDPOINT` restored.