### PR TITLE
chore(feature-flags): retire release_ui_traces_v2_enabled (GA)

### DIFF
--- a/langwatch/src/components/MainMenu.tsx
+++ b/langwatch/src/components/MainMenu.tsx
@@ -46,11 +46,6 @@ export const MainMenu = React.memo(function MainMenu({
     useOrganizationTeamProject();
   const [isHovered, setIsHovered] = useState(false);
 
-  const { enabled: tracesV2Enabled } = useFeatureFlag(
-    "release_ui_traces_v2_enabled",
-    { projectId: project?.id, enabled: !!project },
-  );
-
   const pendingItemsCount = api.annotation.getPendingItemsCount.useQuery(
     { projectId: project?.id ?? "" },
     { enabled: !!project?.id },
@@ -158,18 +153,16 @@ export const MainMenu = React.memo(function MainMenu({
               isActive={router.pathname.includes("/messages")}
               showLabel={showExpanded}
             />
-            {tracesV2Enabled && (
-              <PageMenuLink
-                path={projectRoutes.traces_v2.path}
-                icon={featureIcons.traces_v2.icon}
-                label={projectRoutes.traces_v2.title}
-                project={project}
-                isActive={router.pathname.includes("/traces")}
-                showLabel={showExpanded}
-                beta="Trace Explorer is in beta — expect rough edges. Share feedback or report issues on Slack, or open one at https://github.com/langwatch/langwatch/issues/new/choose."
-                betaLabel="Beta"
-              />
-            )}
+            <PageMenuLink
+              path={projectRoutes.traces_v2.path}
+              icon={featureIcons.traces_v2.icon}
+              label={projectRoutes.traces_v2.title}
+              project={project}
+              isActive={router.pathname.includes("/traces")}
+              showLabel={showExpanded}
+              beta="Trace Explorer is in beta. Expect rough edges; share feedback or report issues on Slack, or open one at https://github.com/langwatch/langwatch/issues/new/choose."
+              betaLabel="Beta"
+            />
 
             <Text
               fontSize="11px"

--- a/langwatch/src/components/home/TracesV2HomeBanner.tsx
+++ b/langwatch/src/components/home/TracesV2HomeBanner.tsx
@@ -9,10 +9,12 @@ import {
 	VStack,
 } from "@chakra-ui/react";
 import { MeshGradient } from "@paper-design/shaders-react";
+import posthog from "posthog-js";
 import { useEffect, useState } from "react";
 import { LuArrowRight, LuSparkles, LuX } from "react-icons/lu";
 import { Link } from "~/components/ui/link";
 import { Tooltip } from "~/components/ui/tooltip";
+import { setTracesV2Preferred } from "~/features/traces-v2/hooks/useTracesV2Preference";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { useColorModeValue } from "../ui/color-mode";
@@ -82,6 +84,20 @@ export function TracesV2HomeBanner() {
 	const handleDismiss = () => {
 		if (projectId) snooze(projectId);
 		setDismissed(true);
+	};
+
+	// Flip the per-device preference so `useTraceDetailsDrawer` opens
+	// the v2 drawer everywhere else in the app after the user clicks
+	// through the home banner — without this, opening a trace from the
+	// messages table would still land on v1 even though they just opted
+	// in here.
+	const handleTryV2 = () => {
+		setTracesV2Preferred(true);
+		posthog.capture("traces_v2_opt_in", {
+			surface: "home_banner",
+			projectId,
+		});
+		if (projectId) snooze(projectId);
 	};
 
 	const v2Href = `/${projectSlug}/traces`;
@@ -177,7 +193,11 @@ export function TracesV2HomeBanner() {
 						A faster, friendlier tracing experience, built on everything we learned from v1. Take it for a spin and tell us what you think.
 					</Text>
 					<HStack gap={2} marginTop={1.5}>
-						<Link href={v2Href} aria-label="Open new Trace Explorer">
+						<Link
+							href={v2Href}
+							onClick={handleTryV2}
+							aria-label="Open new Trace Explorer"
+						>
 							<Button
 								size="sm"
 								bg="white"

--- a/langwatch/src/components/home/TracesV2HomeBanner.tsx
+++ b/langwatch/src/components/home/TracesV2HomeBanner.tsx
@@ -1,37 +1,32 @@
 import {
-  Box,
-  Button,
-  chakra,
-  Heading,
-  HStack,
-  Icon,
-  IconButton,
-  Text,
-  VStack,
+	Box,
+	Button,
+	Heading,
+	HStack,
+	Icon,
+	IconButton,
+	Text,
+	VStack,
 } from "@chakra-ui/react";
 import { MeshGradient } from "@paper-design/shaders-react";
 import { useEffect, useState } from "react";
-import { LuArrowRight, LuMessageCircle, LuSparkles, LuX } from "react-icons/lu";
+import { LuArrowRight, LuSparkles, LuX } from "react-icons/lu";
 import { Link } from "~/components/ui/link";
 import { Tooltip } from "~/components/ui/tooltip";
-import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { useColorModeValue } from "../ui/color-mode";
 
 const SNOOZE_DAYS = 7;
 const SNOOZE_MS = SNOOZE_DAYS * 24 * 60 * 60 * 1000;
-const STORAGE_PREFIX = "langwatch:tracesV2-home-banner-dismissed:v2:";
+const STORAGE_PREFIX = "langwatch:tracesV2-home-banner-dismissed:v2:try:";
 
-type PromoMode = "try" | "request";
+const storageKey = (projectId: string) => `${STORAGE_PREFIX}${projectId}`;
 
-const storageKey = (projectId: string, mode: PromoMode) =>
-	`${STORAGE_PREFIX}${mode}:${projectId}`;
-
-function isSnoozed(projectId: string, mode: PromoMode): boolean {
+function isSnoozed(projectId: string): boolean {
 	if (typeof window === "undefined") return false;
 	try {
-		const raw = localStorage.getItem(storageKey(projectId, mode));
+		const raw = localStorage.getItem(storageKey(projectId));
 		if (!raw) return false;
 		const expiresAt = Number(raw);
 		if (!Number.isFinite(expiresAt)) return false;
@@ -41,11 +36,11 @@ function isSnoozed(projectId: string, mode: PromoMode): boolean {
 	}
 }
 
-function snooze(projectId: string, mode: PromoMode) {
+function snooze(projectId: string) {
 	if (typeof window === "undefined") return;
 	try {
 		localStorage.setItem(
-			storageKey(projectId, mode),
+			storageKey(projectId),
 			String(Date.now() + SNOOZE_MS),
 		);
 	} catch {
@@ -53,94 +48,11 @@ function snooze(projectId: string, mode: PromoMode) {
 	}
 }
 
-function openCrispChat(): boolean {
-	if (typeof window === "undefined") return false;
-	const crisp = (
-		window as unknown as { $crisp?: { push: (args: unknown[]) => void } }
-	).$crisp;
-	if (!crisp) return false;
-	crisp.push(["do", "chat:show"]);
-	crisp.push(["do", "chat:toggle"]);
-	return true;
-}
-
 // Colours mirror the in-app NewTracesPromo banner so the two surfaces feel
 // like the same announcement. Resolved hex values are required because the
 // MeshGradient WebGL shader cannot read CSS variables.
 const MESH_COLORS_LIGHT = ["#6b21a8", "#a855f7", "#ec4899", "#fdf2f8"];
 const MESH_COLORS_DARK = ["#581c87", "#9333ea", "#db2777", "#1f0a2e"];
-
-const PREVIEW_VARIANTS = ["simple", "complex"] as const;
-const PREVIEW_THEMES = ["light", "dark"] as const;
-type PreviewVariant = (typeof PREVIEW_VARIANTS)[number];
-type PreviewTheme = (typeof PREVIEW_THEMES)[number];
-
-// How long each variant stays on screen before the cross-fade.
-const PREVIEW_CYCLE_MS = 6000;
-const PREVIEW_FADE_MS = 700;
-
-interface PreviewFrameProps {
-	href: string;
-	onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
-	ariaLabel: string;
-	children: React.ReactNode;
-}
-
-/**
- * Request-mode-only preview. Default state: small peek in the bottom-right
- * corner. On hover the screenshot scales up with a `top right` transform
- * origin and translates *up* — the top of the screenshot stays comfortably
- * inside the banner (no clipping at the banner's top edge), and the extra
- * height grows downward where it gets clipped by the banner's overflow.
- * Net effect: the user sees a much larger, clearer view of the toolbar /
- * trace list (the "top" of the product) without the preview spilling
- * awkwardly above the banner.
- */
-function PreviewFrame({
-	href,
-	onClick,
-	ariaLabel,
-	children,
-}: PreviewFrameProps) {
-	const hoverTransform = "translateY(5%) scale(1.85)";
-
-	return (
-		<Link
-			href={href}
-			onClick={onClick}
-			aria-label={ariaLabel}
-			style={{ display: "contents" }}
-		>
-			<Box
-				position="absolute"
-				right={{ base: 4, md: 8 }}
-				bottom={0}
-				width={{ base: "210px", md: "270px" }}
-				height={{ base: "123px", md: "158px" }}
-				display={{ base: "none", sm: "block" }}
-				zIndex={1}
-				cursor="pointer"
-				transformOrigin="top right"
-				transform="translateY(38%)"
-				transition="transform 380ms cubic-bezier(0.2, 0.8, 0.2, 1), filter 280ms ease"
-				_hover={{
-					transform: hoverTransform,
-					filter: "brightness(1.05)",
-					zIndex: 5,
-				}}
-				_focusVisible={{
-					transform: hoverTransform,
-					zIndex: 5,
-					outline: "2px solid white",
-					outlineOffset: "4px",
-					borderRadius: "lg",
-				}}
-			>
-				{children}
-			</Box>
-		</Link>
-	);
-}
 
 export function TracesV2HomeBanner() {
 	const { project } = useOrganizationTeamProject({
@@ -151,24 +63,6 @@ export function TracesV2HomeBanner() {
 	const projectSlug = project?.slug;
 	const reduceMotion = useReducedMotion();
 	const meshColors = useColorModeValue(MESH_COLORS_LIGHT, MESH_COLORS_DARK);
-	const previewTheme: PreviewTheme = useColorModeValue("light", "dark");
-	const [previewVariant, setPreviewVariant] =
-		useState<PreviewVariant>("simple");
-
-	useEffect(() => {
-		if (reduceMotion) return;
-		const id = setInterval(() => {
-			setPreviewVariant((v) => (v === "simple" ? "complex" : "simple"));
-		}, PREVIEW_CYCLE_MS);
-		return () => clearInterval(id);
-	}, [reduceMotion]);
-
-	const { enabled: tracesV2Enabled, isLoading: tracesV2FlagLoading } =
-		useFeatureFlag("release_ui_traces_v2_enabled", {
-			projectId,
-			enabled: !!projectId,
-		});
-	const mode: PromoMode = tracesV2Enabled ? "try" : "request";
 
 	const [dismissed, setDismissed] = useState(false);
 	const [hasMounted, setHasMounted] = useState(false);
@@ -178,33 +72,19 @@ export function TracesV2HomeBanner() {
 	}, []);
 
 	useEffect(() => {
-		if (projectId) setDismissed(isSnoozed(projectId, mode));
-	}, [projectId, mode]);
+		if (projectId) setDismissed(isSnoozed(projectId));
+	}, [projectId]);
 
-	if (!hasMounted || !projectSlug || tracesV2FlagLoading || dismissed) {
+	if (!hasMounted || !projectSlug || dismissed) {
 		return null;
 	}
 
 	const handleDismiss = () => {
-		if (projectId) snooze(projectId, mode);
+		if (projectId) snooze(projectId);
 		setDismissed(true);
 	};
 
 	const v2Href = `/${projectSlug}/traces`;
-
-	const requestAccessMailto = `mailto:support@langwatch.ai?subject=${encodeURIComponent(
-		"Early access to the new Trace Explorer",
-	)}&body=${encodeURIComponent(
-		"Hi! I'd like early access to the new Trace Explorer" +
-			(project?.slug ? ` for project "${project.slug}"` : "") +
-			".",
-	)}`;
-
-	const handleRequestAccess = (e: React.MouseEvent<HTMLAnchorElement>) => {
-		if (openCrispChat()) {
-			e.preventDefault();
-		}
-	};
 
 	return (
 		<Box
@@ -241,11 +121,7 @@ export function TracesV2HomeBanner() {
 				align="center"
 				gap={{ base: 4, md: 6 }}
 				paddingLeft={{ base: 5, md: 7 }}
-				paddingRight={
-					mode === "request"
-						? { base: 5, sm: "230px", md: "290px" }
-						: { base: 5, md: 7 }
-				}
+				paddingRight={{ base: 5, md: 7 }}
 				paddingY={{ base: 5, md: 6 }}
 				width="full"
 			>
@@ -271,9 +147,7 @@ export function TracesV2HomeBanner() {
 							letterSpacing="-0.01em"
 							lineHeight={1.2}
 						>
-							{mode === "try"
-								? "The new Trace Explorer is here"
-								: "A new Trace Explorer is on the way"}
+							The new Trace Explorer is here
 						</Heading>
 						<Box
 							paddingX={2}
@@ -290,7 +164,7 @@ export function TracesV2HomeBanner() {
 								textTransform="uppercase"
 								lineHeight={1.2}
 							>
-								{mode === "try" ? "Beta" : "Coming soon"}
+								Beta
 							</Text>
 						</Box>
 					</HStack>
@@ -300,94 +174,28 @@ export function TracesV2HomeBanner() {
 						lineHeight={1.5}
 						maxWidth={{ base: "full", md: "520px" }}
 					>
-						{mode === "try"
-							? "A faster, friendlier tracing experience — built on everything we learned from v1. Take it for a spin and tell us what you think."
-							: "We're rolling out a faster, friendlier tracing experience in private beta. Want in early? Get in touch and we'll switch it on for you."}
+						A faster, friendlier tracing experience, built on everything we learned from v1. Take it for a spin and tell us what you think.
 					</Text>
 					<HStack gap={2} marginTop={1.5}>
-						{mode === "try" ? (
-							<Link href={v2Href} aria-label="Open new Trace Explorer">
-								<Button
-									size="sm"
-									bg="white"
-									color="purple.700"
-									fontWeight="600"
-									paddingX={4}
-									boxShadow="0 1px 2px rgba(0,0,0,0.12)"
-									_hover={{ bg: "white/90", transform: "translateY(-1px)" }}
-									_active={{ bg: "white/80", transform: "translateY(0)" }}
-									transition="background-color 0.12s ease, transform 0.12s ease"
-								>
-									Try the new Trace Explorer
-									<Icon as={LuArrowRight} boxSize={3.5} marginLeft={1} />
-								</Button>
-							</Link>
-						) : (
-							<Link
-								href={requestAccessMailto}
-								onClick={handleRequestAccess}
-								aria-label="Request early access to the new Trace Explorer"
+						<Link href={v2Href} aria-label="Open new Trace Explorer">
+							<Button
+								size="sm"
+								bg="white"
+								color="purple.700"
+								fontWeight="600"
+								paddingX={4}
+								boxShadow="0 1px 2px rgba(0,0,0,0.12)"
+								_hover={{ bg: "white/90", transform: "translateY(-1px)" }}
+								_active={{ bg: "white/80", transform: "translateY(0)" }}
+								transition="background-color 0.12s ease, transform 0.12s ease"
 							>
-								<Button
-									size="sm"
-									bg="white"
-									color="purple.700"
-									fontWeight="600"
-									paddingX={4}
-									boxShadow="0 1px 2px rgba(0,0,0,0.12)"
-									_hover={{ bg: "white/90", transform: "translateY(-1px)" }}
-									_active={{ bg: "white/80", transform: "translateY(0)" }}
-									transition="background-color 0.12s ease, transform 0.12s ease"
-								>
-									<Icon as={LuMessageCircle} boxSize={3.5} marginRight={1} />
-									Request early access
-								</Button>
-							</Link>
-						)}
+								Try the new Trace Explorer
+								<Icon as={LuArrowRight} boxSize={3.5} marginLeft={1} />
+							</Button>
+						</Link>
 					</HStack>
 				</VStack>
 			</HStack>
-
-			{/*
-        Preview screenshot. Sits in the bottom-right corner and is pushed
-        below the banner edge so only its top portion is visible — the
-        SaaS "screenshot peeking up into the hero" pattern. Renders all
-        four light/dark × simple/complex variants stacked and toggles
-        opacity, so both the timed variant cycle and theme changes share
-        the same cross-fade. The screenshots already include their own
-        window chrome and drop shadow, so we don't add a frame here.
-      */}
-			{mode === "request" && (
-				<PreviewFrame
-					href={requestAccessMailto}
-					onClick={handleRequestAccess}
-					ariaLabel="Request early access to the new Trace Explorer"
-				>
-					{PREVIEW_VARIANTS.flatMap((variant) =>
-						PREVIEW_THEMES.map((theme) => {
-							const isActive =
-								variant === previewVariant && theme === previewTheme;
-							return (
-								<chakra.img
-									key={`${variant}-${theme}`}
-									src={`/images/traces-v2/traces-v2-${variant}.${theme}.webp`}
-									alt=""
-									aria-hidden="true"
-									draggable={false}
-									position="absolute"
-									inset={0}
-									width="100%"
-									height="100%"
-									objectFit="contain"
-									objectPosition="top right"
-									opacity={isActive ? 1 : 0}
-									transition={`opacity ${PREVIEW_FADE_MS}ms ease`}
-								/>
-							);
-						}),
-					)}
-				</PreviewFrame>
-			)}
 
 			<Tooltip
 				content={`Hide for ${SNOOZE_DAYS} days`}

--- a/langwatch/src/components/messages/NewTracesPromo.tsx
+++ b/langwatch/src/components/messages/NewTracesPromo.tsx
@@ -9,29 +9,25 @@ import {
 } from "@chakra-ui/react";
 import posthog from "posthog-js";
 import { useEffect, useState } from "react";
-import { LuArrowRight, LuMessageCircle, LuSparkles, LuX } from "react-icons/lu";
-import { Link } from "~/components/ui/link";
+import { LuArrowRight, LuSparkles, LuX } from "react-icons/lu";
 import { Tooltip } from "~/components/ui/tooltip";
 import { setTracesV2Preferred } from "~/features/traces-v2/hooks/useTracesV2Preference";
-import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 
 const SNOOZE_DAYS = 7;
 const SNOOZE_MS = SNOOZE_DAYS * 24 * 60 * 60 * 1000;
 // Versioned so prior dismissals from earlier copy/iterations don't keep the
 // banner permanently hidden. Bump when the message materially changes.
-const STORAGE_PREFIX = "langwatch:tracesV2-promo-dismissed:v9:";
+const STORAGE_PREFIX = "langwatch:tracesV2-promo-dismissed:v9:try:";
 
-type PromoMode = "try" | "request";
-
-function storageKey(projectId: string, mode: PromoMode): string {
-  return `${STORAGE_PREFIX}${mode}:${projectId}`;
+function storageKey(projectId: string): string {
+  return `${STORAGE_PREFIX}${projectId}`;
 }
 
-function isSnoozed(projectId: string, mode: PromoMode): boolean {
+function isSnoozed(projectId: string): boolean {
   if (typeof window === "undefined") return false;
   try {
-    const raw = localStorage.getItem(storageKey(projectId, mode));
+    const raw = localStorage.getItem(storageKey(projectId));
     if (!raw) return false;
     const expiresAt = Number(raw);
     if (!Number.isFinite(expiresAt)) return false;
@@ -41,11 +37,11 @@ function isSnoozed(projectId: string, mode: PromoMode): boolean {
   }
 }
 
-function snooze(projectId: string, mode: PromoMode): void {
+function snooze(projectId: string): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(
-      storageKey(projectId, mode),
+      storageKey(projectId),
       String(Date.now() + SNOOZE_MS),
     );
   } catch {
@@ -79,17 +75,6 @@ export function resetTracesV2PromoSnooze(): void {
   }
 }
 
-function openCrispChat(): boolean {
-  if (typeof window === "undefined") return false;
-  const crisp = (
-    window as unknown as { $crisp?: { push: (args: unknown[]) => void } }
-  ).$crisp;
-  if (!crisp) return false;
-  crisp.push(["do", "chat:show"]);
-  crisp.push(["do", "chat:toggle"]);
-  return true;
-}
-
 interface NewTracesPromoProps {
   variant?: "full" | "compact";
   /** When set, the CTA deep-links to this trace inside the v2 drawer. */
@@ -106,12 +91,6 @@ export function NewTracesPromo({
   });
   const projectId = project?.id;
   const projectSlug = project?.slug;
-  const { enabled: tracesV2Enabled, isLoading: tracesV2FlagLoading } =
-    useFeatureFlag("release_ui_traces_v2_enabled", {
-      projectId,
-      enabled: !!projectId,
-    });
-  const mode: PromoMode = tracesV2Enabled ? "try" : "request";
   const [dismissed, setDismissed] = useState(false);
   const [hasMounted, setHasMounted] = useState(false);
 
@@ -120,8 +99,8 @@ export function NewTracesPromo({
   }, []);
 
   useEffect(() => {
-    if (projectId) setDismissed(isSnoozed(projectId, mode));
-  }, [projectId, mode]);
+    if (projectId) setDismissed(isSnoozed(projectId));
+  }, [projectId]);
 
   // Re-evaluate dismissed when the operator opts out of v2 from the
   // new drawer (which calls `resetTracesV2PromoSnooze` and dispatches
@@ -129,19 +108,19 @@ export function NewTracesPromo({
   // hidden until the 7-day snooze expired or the page reloaded.
   useEffect(() => {
     const onReset = () => {
-      if (projectId) setDismissed(isSnoozed(projectId, mode));
+      if (projectId) setDismissed(isSnoozed(projectId));
     };
     window.addEventListener("langwatch:traces-v2-promo-reset", onReset);
     return () =>
       window.removeEventListener("langwatch:traces-v2-promo-reset", onReset);
-  }, [projectId, mode]);
+  }, [projectId]);
 
-  if (!hasMounted || !projectSlug || tracesV2FlagLoading || dismissed) {
+  if (!hasMounted || !projectSlug || dismissed) {
     return null;
   }
 
   const handleDismiss = () => {
-    if (projectId) snooze(projectId, mode);
+    if (projectId) snooze(projectId);
     setDismissed(true);
   };
 
@@ -168,7 +147,7 @@ export function NewTracesPromo({
       projectId,
       traceId,
     });
-    if (projectId) snooze(projectId, mode);
+    if (projectId) snooze(projectId);
     // Preserve every non-drawer query param (`span`, filters, time
     // range, …) so the underlying scenario / list view stays put;
     // only swap the drawer.* params.
@@ -181,20 +160,6 @@ export function NewTracesPromo({
     url.searchParams.set("drawer.open", "traceV2Details");
     url.searchParams.set("drawer.traceId", traceId);
     window.location.href = url.toString();
-  };
-
-  const requestAccessMailto = `mailto:support@langwatch.ai?subject=${encodeURIComponent(
-    "Early access to the new Trace Explorer",
-  )}&body=${encodeURIComponent(
-    "Hi! I'd like early access to the new Trace Explorer" +
-      (project?.slug ? ` for project "${project.slug}"` : "") +
-      ".",
-  )}`;
-
-  const handleRequestAccess = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (openCrispChat()) {
-      e.preventDefault();
-    }
   };
 
   const isCompact = variant === "compact";
@@ -237,9 +202,7 @@ export function NewTracesPromo({
             letterSpacing="-0.005em"
             truncate
           >
-            {mode === "try"
-              ? "Try the new Trace Explorer"
-              : "A new Trace Explorer is on the way"}
+            Try the new Trace Explorer
           </Text>
           <Box
             paddingX={1.5}
@@ -256,7 +219,7 @@ export function NewTracesPromo({
               textTransform="uppercase"
               lineHeight={1.2}
             >
-              {mode === "try" ? "Beta" : "Coming soon"}
+              Beta
             </Text>
           </Box>
         </HStack>
@@ -272,51 +235,26 @@ export function NewTracesPromo({
               overflow: "hidden",
             }}
           >
-            {mode === "try"
-              ? "A tracing experience you'd introduce to your family. We'd love to hear your feedback — tell us what you love, and what you hate."
-              : "A faster, friendlier tracing experience is in private beta. Want in early? Get in touch and we'll switch it on for you."}
+            A tracing experience you'd introduce to your family. We'd love to hear your feedback, tell us what you love, and what you hate.
           </Text>
         )}
       </VStack>
-      {mode === "try" ? (
-        <Button
-          size={isCompact ? "xs" : "sm"}
-          aria-label="Try the new Trace Explorer"
-          bg="white"
-          color="purple.700"
-          fontWeight="600"
-          paddingX={isCompact ? 3 : 4}
-          boxShadow="0 1px 2px rgba(0, 0, 0, 0.12)"
-          _hover={{ bg: "white/90", transform: "translateY(-1px)" }}
-          _active={{ bg: "white/80", transform: "translateY(0)" }}
-          transition="background-color 0.12s ease, transform 0.12s ease"
-          onClick={handleTryV2}
-        >
-          Try the new one
-          <Icon as={LuArrowRight} boxSize={3.5} marginLeft={1} />
-        </Button>
-      ) : (
-        <Link
-          href={requestAccessMailto}
-          onClick={handleRequestAccess}
-          aria-label="Request early access to the new Trace Explorer"
-        >
-          <Button
-            size={isCompact ? "xs" : "sm"}
-            bg="white"
-            color="purple.700"
-            fontWeight="600"
-            paddingX={isCompact ? 3 : 4}
-            boxShadow="0 1px 2px rgba(0, 0, 0, 0.12)"
-            _hover={{ bg: "white/90", transform: "translateY(-1px)" }}
-            _active={{ bg: "white/80", transform: "translateY(0)" }}
-            transition="background-color 0.12s ease, transform 0.12s ease"
-          >
-            <Icon as={LuMessageCircle} boxSize={3.5} marginRight={1} />
-            Request early access
-          </Button>
-        </Link>
-      )}
+      <Button
+        size={isCompact ? "xs" : "sm"}
+        aria-label="Try the new Trace Explorer"
+        bg="white"
+        color="purple.700"
+        fontWeight="600"
+        paddingX={isCompact ? 3 : 4}
+        boxShadow="0 1px 2px rgba(0, 0, 0, 0.12)"
+        _hover={{ bg: "white/90", transform: "translateY(-1px)" }}
+        _active={{ bg: "white/80", transform: "translateY(0)" }}
+        transition="background-color 0.12s ease, transform 0.12s ease"
+        onClick={handleTryV2}
+      >
+        Try the new one
+        <Icon as={LuArrowRight} boxSize={3.5} marginLeft={1} />
+      </Button>
       <Tooltip
         content={`Hide for ${SNOOZE_DAYS} days`}
         positioning={{ placement: "top" }}

--- a/langwatch/src/features/command-bar/CommandBar.tsx
+++ b/langwatch/src/features/command-bar/CommandBar.tsx
@@ -195,7 +195,6 @@ export function CommandBar() {
     idResult,
     groupedItems,
     project?.slug,
-    project?.id,
   );
 
   // Easter egg effects

--- a/langwatch/src/features/command-bar/__tests__/useCommandSearch.test.ts
+++ b/langwatch/src/features/command-bar/__tests__/useCommandSearch.test.ts
@@ -81,39 +81,15 @@ describe("detectEntityId", () => {
       expect(detectIdType("0123456789ABCDEF0123456789ABCDEF")).toBe("trace");
     });
 
-    describe("when traces v2 is disabled (default)", () => {
-      it("includes traceDetails drawerAction", () => {
-        const result = detectEntityId({
-          query: "trace_abc123",
-          projectSlug: PROJECT_SLUG,
-        });
-        expect(result?.drawerAction).toEqual({
-          drawer: "traceDetails",
-          params: { traceId: "trace_abc123" },
-        });
+    it("navigates to v2 /traces with drawer params (no in-place drawerAction)", () => {
+      const result = detectEntityId({
+        query: "trace_abc123",
+        projectSlug: PROJECT_SLUG,
       });
-
-      it("builds v1 /messages path", () => {
-        const result = detectEntityId({
-          query: "trace_abc123",
-          projectSlug: PROJECT_SLUG,
-        });
-        expect(result?.path).toBe("/test-project/messages/trace_abc123");
-      });
-    });
-
-    describe("when traces v2 is enabled", () => {
-      it("navigates to v2 /traces with drawer params (no in-place drawerAction)", () => {
-        const result = detectEntityId({
-          query: "trace_abc123",
-          projectSlug: PROJECT_SLUG,
-          tracesV2Enabled: true,
-        });
-        expect(result?.path).toBe(
-          "/test-project/traces?drawer.open=traceV2Details&drawer.traceId=trace_abc123"
-        );
-        expect(result?.drawerAction).toBeUndefined();
-      });
+      expect(result?.path).toBe(
+        "/test-project/traces?drawer.open=traceV2Details&drawer.traceId=trace_abc123"
+      );
+      expect(result?.drawerAction).toBeUndefined();
     });
   });
 
@@ -130,35 +106,15 @@ describe("detectEntityId", () => {
       expect(detectIdType("0123456789ABCDEF")).toBe("span");
     });
 
-    describe("when traces v2 is disabled (default)", () => {
-      it("builds v1 /messages search path", () => {
-        const result = detectEntityId({
-          query: "span_abc123",
-          projectSlug: PROJECT_SLUG,
-        });
-        expect(result?.path).toBe("/test-project/messages?query=span_abc123");
+    it("builds v2 /traces fragment path with spanId query-language clause", () => {
+      const result = detectEntityId({
+        query: "span_abc123",
+        projectSlug: PROJECT_SLUG,
       });
-
-      it("does not include drawerAction", () => {
-        const result = detectEntityId({
-          query: "span_abc123",
-          projectSlug: PROJECT_SLUG,
-        });
-        expect(result?.drawerAction).toBeUndefined();
-      });
-    });
-
-    describe("when traces v2 is enabled", () => {
-      it("builds v2 /traces fragment path with spanId query-language clause", () => {
-        const result = detectEntityId({
-          query: "span_abc123",
-          projectSlug: PROJECT_SLUG,
-          tracesV2Enabled: true,
-        });
-        expect(result?.path).toBe(
-          "/test-project/traces#all-traces?q=spanId%3Aspan_abc123"
-        );
-      });
+      expect(result?.path).toBe(
+        "/test-project/traces#all-traces?q=spanId%3Aspan_abc123"
+      );
+      expect(result?.drawerAction).toBeUndefined();
     });
   });
 

--- a/langwatch/src/features/command-bar/hooks/useCommandBarItems.ts
+++ b/langwatch/src/features/command-bar/hooks/useCommandBarItems.ts
@@ -11,7 +11,6 @@ import {
 } from "../constants";
 import type { GroupedRecentItems } from "../useRecentItems";
 import { findEasterEgg } from "../easterEggs";
-import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 
 /**
  * Hook that builds the flat list of all items for keyboard navigation and display.
@@ -24,7 +23,6 @@ export function useCommandBarItems(
   idResult: SearchResult | null,
   groupedItems: GroupedRecentItems,
   projectSlug: string | undefined,
-  projectId: string | undefined,
 ): {
   allItems: ListItem[];
   recentItemsLimited: RecentItem[];
@@ -32,20 +30,7 @@ export function useCommandBarItems(
   searchInDocsItem: ListItem | null;
   easterEggItem: ListItem | null;
 } {
-  const { enabled: isTracesV2Enabled } = useFeatureFlag(
-    "release_ui_traces_v2_enabled",
-    { projectId, enabled: !!projectId },
-  );
-
-  const availableTopLevelNav = useMemo(
-    () =>
-      isTracesV2Enabled
-        ? topLevelNavigationCommands
-        : topLevelNavigationCommands.filter(
-            (cmd) => cmd.id !== "nav-traces-v2",
-          ),
-    [isTracesV2Enabled],
-  );
+  const availableTopLevelNav = topLevelNavigationCommands;
 
   // Get top recent items across all time groups
   const recentItemsLimited = useMemo(() => {

--- a/langwatch/src/features/command-bar/hooks/useFilteredCommands.ts
+++ b/langwatch/src/features/command-bar/hooks/useFilteredCommands.ts
@@ -12,7 +12,6 @@ import {
 import { MIN_SEARCH_QUERY_LENGTH, MIN_CATEGORY_MATCH_LENGTH } from "../constants";
 import { getPlanManagementUrl } from "~/hooks/usePlanManagementUrl";
 import { getPageCommands } from "../pageCommands";
-import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import {
   setFeatureFlagOverride,
   useFeatureFlagOverrides,
@@ -38,21 +37,14 @@ export function useFilteredCommands(
   projectId: string | undefined,
   isDevMode: boolean,
 ): FilteredCommands {
-  const { enabled: isTracesV2Enabled } = useFeatureFlag(
-    "release_ui_traces_v2_enabled",
-    { projectId, enabled: !!projectId },
-  );
   const { hasAccess: hasOpsAccess } = useOpsPermission();
 
   const availableNavCommands = useMemo(() => {
-    let commands = hasOpsAccess
+    const commands = hasOpsAccess
       ? navigationCommands
       : navigationCommands.filter((cmd) => !cmd.id.startsWith("nav-ops"));
-    if (!isTracesV2Enabled) {
-      commands = commands.filter((cmd) => cmd.id !== "nav-traces-v2");
-    }
     return commands;
-  }, [hasOpsAccess, isTracesV2Enabled]);
+  }, [hasOpsAccess]);
 
   const filteredNavigation = useMemo(() => {
     if (!query.trim()) return [];

--- a/langwatch/src/features/command-bar/useCommandSearch.ts
+++ b/langwatch/src/features/command-bar/useCommandSearch.ts
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { useDebounceValue } from "usehooks-ts";
 import { Bot, BookText, Percent, Table, Workflow } from "lucide-react";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { api } from "~/utils/api";
 import type { SearchResult } from "./types";
 import { SEARCH_DEBOUNCE_MS, MIN_SEARCH_QUERY_LENGTH } from "./constants";
@@ -17,18 +16,16 @@ import {
  * Detect if the query is an entity ID and return navigation info.
  * Exported for testing.
  *
- * `tracesV2Enabled` routes trace/span hits to the v2 page so command-bar
- * destinations match whichever traces UI the user is actually using.
- * Direct in-app navigation (table click, menu) stays separate by design.
+ * Trace/span hits route to the v2 page so command-bar destinations
+ * match the v2 traces UI everyone is on. Direct in-app navigation
+ * (table click, menu) stays separate by design.
  */
 export function detectEntityId({
   query,
   projectSlug,
-  tracesV2Enabled = false,
 }: {
   query: string;
   projectSlug: string;
-  tracesV2Enabled?: boolean;
 }): SearchResult | null {
   const trimmedQuery = query.trim();
   if (!trimmedQuery || !projectSlug) return null;
@@ -46,49 +43,32 @@ export function detectEntityId({
     };
   }
 
-  // Check for trace ID patterns
+  // Check for trace ID patterns. v2 drawer hydrates from `drawer.*` URL
+  // params on the /traces page. We navigate (rather than `openDrawer`
+  // in place) so the underlying page context matches what the drawer
+  // was designed against.
   if (isTraceId(trimmedQuery)) {
-    if (tracesV2Enabled) {
-      // v2 drawer hydrates from `drawer.*` URL params on the /traces page.
-      // We navigate (rather than `openDrawer` in place) so the underlying
-      // page context matches what the drawer was designed against.
-      return {
-        id: `trace-${trimmedQuery}`,
-        label: "Open trace",
-        description: trimmedQuery,
-        icon: traceIcon,
-        path: `/${projectSlug}/traces?drawer.open=traceV2Details&drawer.traceId=${trimmedQuery}`,
-        type: "trace",
-      };
-    }
     return {
       id: `trace-${trimmedQuery}`,
       label: "Open trace",
       description: trimmedQuery,
       icon: traceIcon,
-      path: `/${projectSlug}/messages/${trimmedQuery}`,
+      path: `/${projectSlug}/traces?drawer.open=traceV2Details&drawer.traceId=${trimmedQuery}`,
       type: "trace",
-      drawerAction: {
-        drawer: "traceDetails",
-        params: { traceId: trimmedQuery },
-      },
     };
   }
 
-  // Check for span ID patterns
+  // Check for span ID patterns. v2 stores filter state in the URL
+  // fragment as `#<lensId>?q=<query>`, and uses a small query language
+  // (`spanId:<id>`) for field lookups. The default lens id matches
+  // `useURLSync`'s DEFAULT_LENS_ID.
   if (isSpanId(trimmedQuery)) {
-    // v2 stores filter state in the URL fragment as `#<lensId>?q=<query>`,
-    // and uses a small query language (`spanId:<id>`) for field lookups.
-    // The default lens id matches `useURLSync`'s DEFAULT_LENS_ID.
-    const path = tracesV2Enabled
-      ? `/${projectSlug}/traces#all-traces?q=${encodeURIComponent(`spanId:${trimmedQuery}`)}`
-      : `/${projectSlug}/messages?query=${encodeURIComponent(trimmedQuery)}`;
     return {
       id: `span-${trimmedQuery}`,
       label: "Find span in traces",
       description: trimmedQuery,
       icon: traceIcon,
-      path,
+      path: `/${projectSlug}/traces#all-traces?q=${encodeURIComponent(`spanId:${trimmedQuery}`)}`,
       type: "trace",
     };
   }
@@ -104,11 +84,6 @@ export function useCommandSearch(query: string, isOpen: boolean) {
   const { project } = useOrganizationTeamProject();
   const projectId = project?.id ?? "";
   const projectSlug = project?.slug ?? "";
-
-  const { enabled: tracesV2Enabled } = useFeatureFlag(
-    "release_ui_traces_v2_enabled",
-    { projectId, enabled: !!projectId },
-  );
 
   // Debounce the query to prevent excessive filtering
   const [debouncedQuery] = useDebounceValue(query, SEARCH_DEBOUNCE_MS);
@@ -147,8 +122,8 @@ export function useCommandSearch(query: string, isOpen: boolean) {
   // Detect ID-based navigation (immediate, no debounce needed)
   const idResult = useMemo<SearchResult | null>(() => {
     if (query.trim().length < MIN_SEARCH_QUERY_LENGTH) return null;
-    return detectEntityId({ query, projectSlug, tracesV2Enabled });
-  }, [query, projectSlug, tracesV2Enabled]);
+    return detectEntityId({ query, projectSlug });
+  }, [query, projectSlug]);
 
   // Filter and transform results
   const searchResults = useMemo<SearchResult[]>(() => {

--- a/langwatch/src/features/traces-v2/components/TraceIdPeek.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceIdPeek.tsx
@@ -13,7 +13,6 @@ import { Eye } from "lucide-react";
 import type React from "react";
 import { type ReactNode, useState } from "react";
 import { useDrawer } from "~/hooks/useDrawer";
-import { useFeatureFlag } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
 import {
@@ -46,21 +45,14 @@ interface TracePreviewHoverCardProps {
  * trigger you put inside it. Use it to add a hover-peek to any element
  * already mounted next to a trace — buttons, links, badges — without
  * needing a standalone trigger like the eye icon.
- *
- * Gated on the `release_ui_traces_v2_enabled` flag the same way the
- * old standalone `<TraceIdPeek>` was — without v2 there's nothing to
- * peek at, so we return the trigger unchanged.
  */
 export const TracePreviewHoverCard: React.FC<TracePreviewHoverCardProps> = ({
   traceId,
   children,
   placement = "bottom-start",
 }) => {
-  const { enabled } = useFeatureFlag("release_ui_traces_v2_enabled");
   const [hasHovered, setHasHovered] = useState(false);
   const [open, setOpen] = useState(false);
-
-  if (!enabled) return <>{children}</>;
 
   return (
     <HoverCard.Root
@@ -105,10 +97,7 @@ interface TraceIdPeekProps {
  * `<TracePreviewHoverCard>` directly so the eye doesn't crowd the row.
  */
 export const TraceIdPeek: React.FC<TraceIdPeekProps> = ({ traceId }) => {
-  const { enabled } = useFeatureFlag("release_ui_traces_v2_enabled");
   const { openDrawer } = useDrawer();
-
-  if (!enabled) return null;
 
   const handleOpenDrawer = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/langwatch/src/features/traces-v2/hooks/useTracesV2Preference.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTracesV2Preference.ts
@@ -1,12 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 
 /**
- * Per-browser opt-in flag for the new Trace Explorer drawer. Sits
- * alongside the server-side `release_ui_traces_v2_enabled` feature
- * flag — both must be on for v2 to actually open. The flag is set
- * the first time the operator clicks "Try the new one" on the v1
- * banner, and cleared when they choose "Go back to old trace
- * visualization" from the v2 drawer's overflow menu.
+ * Per-browser opt-in flag for the new Trace Explorer drawer. Set the
+ * first time the operator clicks "Try the new one" on the v1 banner,
+ * and cleared when they choose "Go back to old trace visualization"
+ * from the v2 drawer's overflow menu.
  *
  * Kept as plain localStorage rather than a server-side preference
  * because (a) we want the choice to stick instantly without a

--- a/langwatch/src/hooks/useTraceDetailsDrawer.ts
+++ b/langwatch/src/hooks/useTraceDetailsDrawer.ts
@@ -2,8 +2,6 @@ import { useCallback } from "react";
 import type { DrawerProps } from "../components/drawerRegistry";
 import { useTracesV2Preference } from "../features/traces-v2/hooks/useTracesV2Preference";
 import { useDrawer } from "./useDrawer";
-import { useFeatureFlag } from "./useFeatureFlag";
-import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
 
 /**
  * Convenience hook for opening the trace details drawer.
@@ -12,34 +10,24 @@ import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
  * any `openDrawer("traceDetails", ...)` call (whether through this hook
  * or directly) is automatically intercepted for EXTERNAL users.
  *
- * Routes to the v2 drawer when both (a) the project has the
- * `release_ui_traces_v2_enabled` rollout flag on, and (b) the operator
- * has clicked "Try the new one" at least once on this device (the
- * preference lives in localStorage — see `useTracesV2Preference`).
- * Either knob off → legacy v1 drawer.
+ * Routes to the v2 drawer when the operator has clicked "Try the new
+ * one" at least once on this device (the preference lives in
+ * localStorage; see `useTracesV2Preference`); otherwise the legacy v1
+ * drawer.
  */
 export function useTraceDetailsDrawer() {
   const { openDrawer } = useDrawer();
-  const { project } = useOrganizationTeamProject({
-    redirectToOnboarding: false,
-    redirectToProjectOnboarding: false,
-  });
-  const { enabled: tracesV2Released } = useFeatureFlag(
-    "release_ui_traces_v2_enabled",
-    { projectId: project?.id, enabled: !!project?.id },
-  );
   const { preferred: prefersV2 } = useTracesV2Preference();
-  const useV2 = tracesV2Released && prefersV2;
 
   const openTraceDetailsDrawer = useCallback(
     (props?: Partial<DrawerProps<"traceDetails">>) => {
-      if (useV2 && props?.traceId) {
+      if (prefersV2 && props?.traceId) {
         openDrawer("traceV2Details", { traceId: props.traceId });
         return;
       }
       openDrawer("traceDetails", props);
     },
-    [openDrawer, useV2],
+    [openDrawer, prefersV2],
   );
 
   return { openTraceDetailsDrawer };

--- a/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
+++ b/langwatch/src/server/featureFlag/frontendFeatureFlags.ts
@@ -52,7 +52,6 @@
 export const FRONTEND_FEATURE_FLAGS = [
   "release_ui_sdk_radar_banner_card_enabled",
   "release_ui_ai_gateway_menu_enabled",
-  "release_ui_traces_v2_enabled",
 ] as const;
 
 /**

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -139,12 +139,6 @@ export const FEATURE_FLAGS = [
     defaultValue: false,
     description: "Reveals the AI Gateway menu in the project sidebar.",
   },
-  {
-    key: "release_ui_traces_v2_enabled",
-    scope: "PRODUCT",
-    defaultValue: false,
-    description: "Routes the /messages and trace detail surfaces to the v2 UI.",
-  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 export const FEATURE_FLAG_FAMILIES = [


### PR DESCRIPTION
Trace Explorer v2 is on for everyone. Dropping the flag everywhere.

## Why now

The PostHog project hit its feature-flag quota cap this morning. The decide endpoint started returning \`{ quotaLimited: [\"feature_flags\"], featureFlags: {} }\`, which meant our PRODUCT-flag fallthrough sent every user the registry default of \`false\` for \`release_ui_traces_v2_enabled\` — i.e., v2 silently turned off cluster-wide. Cleanup was already due, this just made it urgent.

## What changed

- Removed the flag from the registry + frontend exposure list.
- **MainMenu**: v2 nav link always renders for any project.
- **Command bar** (\`useFilteredCommands\`, \`useCommandBarItems\`, \`useCommandSearch\`): v2 nav command always included; \`detectEntityId\` routes trace + span hits to \`/traces\` unconditionally (collapsed v1/v2 branches, dropped the \`tracesV2Enabled\` param).
- **TraceIdPeek + TracePreviewHoverCard**: always render; no flag short-circuit.
- **useTraceDetailsDrawer**: now gates on the per-device opt-in only.
- **NewTracesPromo + TracesV2HomeBanner**: \`request early access\` branch deleted. Both banners are pure \"Try the new one\" promos pushing the per-device opt-in. Removed the request-mode preview frame, preview-variant cycling state, mailto/Crisp paths.

PostHog flag row deleted separately (last_called_at timestamp will stop advancing).

## Net diff
13 files, +126 / -512.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test:unit\` for affected suites (52 files / 759 tests pass)
- [ ] Post-deploy: confirm v2 menu link visible without postgres override; \`release_ui_traces_v2_enabled\` no longer appears in PostHog Feature Flag Calls