### PR TITLE
chore(feature-flags): drop POSTHOG_KEY-missing warn on boot

### DIFF
--- a/langwatch/src/server/featureFlag/featureFlag.service.ts
+++ b/langwatch/src/server/featureFlag/featureFlag.service.ts
@@ -124,9 +124,6 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
       this.logger.info("Using PostHog feature flag service for PRODUCT flags");
       return FeatureFlagServicePostHog.create();
     }
-    this.logger.warn(
-      "POSTHOG_KEY not set; PRODUCT flags fall back to postgres/memory only.",
-    );
     return FeatureFlagServiceMemory.create();
   }
 


### PR DESCRIPTION
PostHog is optional. Self-hosted installs run without `POSTHOG_KEY` by design and would otherwise see this warn on every pod start.

Kept the positive `Using PostHog feature flag service for PRODUCT flags` info log so the active path is still visible when configured.

## Test plan
- [x] `pnpm test:unit src/server/featureFlag` passes (31 tests)