### PR TITLE
feat(model-providers): ui follow-ups for scope picker + org-wide visibility

### DIFF
--- a/dev/docs/best_practices/drawers.md
+++ b/dev/docs/best_practices/drawers.md
@@ -1,0 +1,91 @@
+# Drawers
+
+Drawers are URL-routed. Opening a drawer pushes a `drawer.open=<name>`
+query param onto the page URL; closing pops it. The shell that renders
+the drawer (`<CurrentDrawer />`, mounted once near the app root) keys
+off that param and resolves the component via `drawerRegistry`.
+
+This is the only pattern. Don't reach for `useState`-driven open/close
+on a new drawer — the URL form gives you:
+
+- a stable deep-link (paste the URL, the drawer is open with the same target),
+- back/forward history (browser back closes the drawer),
+- shareable state for support / repro recordings,
+- no prop drilling for the open flag.
+
+## Adding a new drawer
+
+1. Add the component under `src/components/.../<MyDrawer>.tsx`. It
+   should render `Drawer.Root` with `open={true}` (the registry only
+   mounts it when active), and call `closeDrawer()` from
+   `useDrawer()` on the close trigger.
+
+2. Define the props as a single `interface Props` — the props you
+   accept become serializable URL parameters by default. Use scalar
+   types (strings, numbers, booleans) and an optional `editingId` /
+   `targetId` style identifier instead of passing full row objects.
+   Fetch the row through a tRPC query inside the drawer.
+
+   ```ts
+   interface Props {
+     editingId?: string;
+   }
+   export function MyDrawer({ editingId }: Props) {
+     const { closeDrawer } = useDrawer();
+     const dataQuery = api.x.getOne.useQuery(
+       { id: editingId ?? "" },
+       { enabled: !!editingId },
+     );
+     // ...
+   }
+   ```
+
+3. Register in `src/components/drawerRegistry.ts`:
+
+   ```ts
+   export const drawers = {
+     // ...
+     myDrawer: MyDrawer,
+   } satisfies Record<string, React.FC<any>>;
+   ```
+
+   The registry inference picks up the props automatically, so
+   `openDrawer("myDrawer", { editingId: "abc" })` is fully type-safe
+   at the call site.
+
+4. Open from any component via `useDrawer().openDrawer("myDrawer",
+   { editingId })`. The hook handles URL serialization, push vs
+   replace, and the navigation stack for back-button behavior.
+
+## Non-serializable props (rare)
+
+If a drawer genuinely needs an in-memory payload that can't be
+reconstructed from a URL parameter (e.g. a complex callback the
+caller wants to run on save), useDrawer's `complexProps` slot keeps
+it in memory and threads it to the next mount. Prefer fetching the
+data inside the drawer over this escape hatch — the URL form must
+always carry enough state to reconstitute the drawer from a paste.
+
+## Testing
+
+Drawers are mounted by `<CurrentDrawer />` outside the section that
+opens them, so component tests of the opener can assert by mocking
+`useDrawer`:
+
+```ts
+const mockOpenDrawer = vi.fn();
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ openDrawer: mockOpenDrawer, /* ... */ }),
+}));
+
+it("opens the drawer with the row id", () => {
+  // ...
+  expect(mockOpenDrawer).toHaveBeenCalledWith("myDrawer", {
+    editingId: "row-1",
+  });
+});
+```
+
+Full end-to-end tests (router + `CurrentDrawer` + the drawer itself)
+go in `*.integration.test.tsx` with a Next.js router mock that lets
+`useDrawer` write to the URL.

--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -301,13 +301,14 @@ export const DashboardLayout = ({
 
   const { data: session } = useRequiredSession({ required: !publicPage });
 
-  const { isLoading, organization, organizations, team, project, organizationRole } =
+  const { isLoading, organization, organizations, team, project, organizationRole, hasPermission } =
     useOrganizationTeamProject();
   const { isLiteMember } = useLiteMemberGuard();
   const usage = api.limits.getUsage.useQuery(
     { organizationId: organization?.id ?? "" },
     {
-      enabled: !!organization,
+      enabled: !!organization && hasPermission("organization:view"),
+      retry: false,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
     },

--- a/langwatch/src/components/SettingsLayout.tsx
+++ b/langwatch/src/components/SettingsLayout.tsx
@@ -118,8 +118,8 @@ export default function SettingsLayout({
               "/settings/secrets",
             ]}
           >
-            <MenuLink href="/settings/model-costs">Model Costs</MenuLink>
             <MenuLink href="/settings/model-providers">Model Providers</MenuLink>
+            <MenuLink href="/settings/model-costs">Model Costs</MenuLink>
             {!isLiteMember && (
               <MenuLink href="/settings/secrets">Secrets</MenuLink>
             )}

--- a/langwatch/src/components/__tests__/NoModelsConfiguredCallout.integration.test.tsx
+++ b/langwatch/src/components/__tests__/NoModelsConfiguredCallout.integration.test.tsx
@@ -27,10 +27,10 @@ vi.mock("../../hooks/useOrganizationTeamProject", () => ({
   }),
 }));
 
-// tRPC's getAllForProject query returns an empty providers map to
-// simulate a freshly created project with zero configured providers.
-// listAllForProjectForFrontend (introduced in #4120) is also called by
-// ModelSelector; mock it as an empty providers array.
+// tRPC queries return an empty providers list to simulate a freshly
+// created project with zero configured providers. Stubs both the
+// legacy `getAllForProject` and the stored-only
+// `listAllForProjectForFrontend` that ModelSelector reads.
 vi.mock("../../utils/api", () => ({
   api: {
     modelProvider: {
@@ -38,7 +38,10 @@ vi.mock("../../utils/api", () => ({
         useQuery: () => ({ data: {}, isLoading: false }),
       },
       listAllForProjectForFrontend: {
-        useQuery: () => ({ data: { providers: [] }, isLoading: false }),
+        useQuery: () => ({
+          data: { providers: [], modelMetadata: {} },
+          isLoading: false,
+        }),
       },
     },
   },

--- a/langwatch/src/components/drawerRegistry.ts
+++ b/langwatch/src/components/drawerRegistry.ts
@@ -52,6 +52,7 @@ import { PromptListDrawer } from "./prompts/PromptListDrawer";
 import { SeriesFiltersDrawer } from "./SeriesFilterDrawer";
 import { ScenarioFormDrawerFromUrl } from "./scenarios/ScenarioFormDrawer";
 import { CreateTeamDrawer } from "./settings/CreateTeamDrawer";
+import { DefaultModelOverrideDrawer } from "./settings/DefaultModelOverrideDrawer";
 import { LLMModelCostDrawer } from "./settings/LLMModelCostDrawer";
 import { ScenarioRunDetailDrawer } from "./simulations/ScenarioRunDetailDrawer";
 import { SuiteFormDrawer } from "./suites/SuiteFormDrawer";
@@ -81,6 +82,7 @@ export const drawers = {
   batchEvaluation: BatchEvaluationDrawer,
   automation: AutomationDrawer,
   editModelProvider: EditModelProviderDrawer,
+  defaultModelOverride: DefaultModelOverrideDrawer,
   addOrEditAnnotationScore: AddOrEditAnnotationScoreDrawer,
   addAnnotationQueue: AddAnnotationQueueDrawer,
   addDatasetRecord: AddDatasetRecordDrawerV2,

--- a/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -664,6 +664,8 @@ function ScopeSection({
   // scopes. The quick-pick variant is preserved on `ScopeChipPicker`
   // (`showQuickPicks` prop) for future surfaces where the chip-row UX
   // makes sense.
+  // Default label is "Scope" — render it so the picker reads consistent
+  // with the model-provider drawer's scope section.
   return (
     <ScopeChipPicker
       value={scopes}
@@ -672,7 +674,6 @@ function ScopeSection({
       organizationName={available.organization?.name}
       availableTeams={available.teams}
       availableProjects={available.projects}
-      label=""
     />
   );
 }

--- a/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -340,7 +340,7 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
       >
         <Drawer.Header>
           <Drawer.Title>
-            {editing ? "Edit config" : "Add config"}
+            {editing ? "Edit default models" : "Add default models"}
           </Drawer.Title>
           <Drawer.CloseTrigger />
         </Drawer.Header>
@@ -634,11 +634,14 @@ function buildInheritOption(
   fromEffective: Payload["effective"][ModelRoleKey] | null,
 ): { model: string; label: string } | undefined {
   if (fromServer) {
+    // Skip the "inferred" source: an inferred value is the server
+    // guessing what the user MIGHT want based on which providers are
+    // enabled, not a real cascade hit. Showing it as a ghost
+    // placeholder under a "Not configured" badge gave the
+    // contradictory read that something was set when nothing was —
+    // the row stays empty until the user explicitly picks a model.
     if (fromServer.source === "inferred") {
-      return {
-        model: fromServer.model,
-        label: "Inherit",
-      };
+      return undefined;
     }
     // `feature_override` / `role_default` carry a concrete scope name
     // (organization / team / project). The "system" / env-var fallback
@@ -651,11 +654,11 @@ function buildInheritOption(
     };
   }
   if (fromEffective) {
+    // Same rationale as the `inferred` skip above: env-var fallback
+    // isn't a configured scope, just a host-level default. The drawer
+    // is for setting explicit policy, so empty stays empty.
     if (fromEffective.source === "system") {
-      return {
-        model: fromEffective.model,
-        label: "Inherit (from System)",
-      };
+      return undefined;
     }
     return {
       model: fromEffective.model,

--- a/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -34,6 +34,7 @@ import { Drawer } from "~/components/ui/drawer";
 import { toaster } from "~/components/ui/toaster";
 import { api, type RouterOutputs } from "~/utils/api";
 
+import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { LATEST_ALIAS_PROVIDERS } from "~/server/modelProviders/latestAliases";
 import { INHERIT_SENTINEL, ProviderModelSelector } from "./ProviderModelSelector";
@@ -64,30 +65,57 @@ const ROLE_BLURB: Record<ModelRoleKey, string> = {
 };
 
 interface Props {
-  open: boolean;
-  onClose: () => void;
-  /** Undefined = create; defined = edit an existing config. */
-  editing?: ConfigRow;
-  available: Payload["available"];
-  features: FeatureProjection[];
-  /** Effective resolution for the project currently viewed — used as
-   *  the "if you don't override" placeholder for each row. */
-  effective: Payload["effective"];
-  onSaved: () => void;
+  /** Config id when editing an existing policy; absent = create. The
+   *  drawer fetches the full ConfigRow + available / features / effective
+   *  payloads from the same getDefaultModelsForProject query
+   *  DefaultModelsSection already consumes (tRPC dedupes the second
+   *  caller). Kept as a single serializable prop so the drawer fits
+   *  the URL-driven `currentDrawer` pattern used everywhere else. */
+  editingId?: string;
 }
 
-export function DefaultModelOverrideDrawer({
-  open,
-  onClose,
-  editing,
-  available,
-  features,
-  effective,
-  onSaved,
-}: Props) {
+export function DefaultModelOverrideDrawer({ editingId }: Props) {
   const utils = api.useContext();
   const saveMutation = api.modelProvider.saveDefaultModelsConfig.useMutation();
   const { project } = useOrganizationTeamProject();
+  const { closeDrawer } = useDrawer();
+
+  // Pulls the same Payload DefaultModelsSection consumes — tRPC
+  // de-duplicates the query so the parent page render doesn't pay an
+  // extra round-trip. The drawer used to receive these as props from
+  // the page, but URL-routed drawers can't accept non-serializable
+  // payloads.
+  const dataQuery = api.modelProvider.getDefaultModelsForProject.useQuery(
+    { projectId: project?.id ?? "" },
+    { enabled: !!project?.id },
+  );
+  const editing = editingId
+    ? dataQuery.data?.configs.find((c) => c.id === editingId)
+    : undefined;
+  const available = dataQuery.data?.available ?? {
+    organization: null,
+    teams: [],
+    projects: [],
+  };
+  const features: FeatureProjection[] = dataQuery.data?.features ?? [];
+  const effective: Payload["effective"] =
+    dataQuery.data?.effective ??
+    ({
+      DEFAULT: null,
+      FAST: null,
+      EMBEDDINGS: null,
+    } as Payload["effective"]);
+
+  // Treat the drawer as always-open while mounted — the registry only
+  // renders it when `drawer.open === "defaultModelOverride"`. closeDrawer
+  // pops the URL param and unmounts.
+  const open = true;
+  const onClose = closeDrawer;
+  const onSaved = () => {
+    // No-op: the save mutation invalidates both queries on success.
+    // Kept as a name to preserve the previous prop-driven contract for
+    // future callers that might want to react to a successful save.
+  };
 
   // Ask the server what the cascade would resolve for each role +
   // feature key if the picked scopes had nothing set. The drawer uses

--- a/langwatch/src/components/settings/DefaultModelsSection.tsx
+++ b/langwatch/src/components/settings/DefaultModelsSection.tsx
@@ -1,23 +1,16 @@
 /**
  * Default Models settings page section — table view of every
- * ModelDefaultConfig the caller can see, plus a scope filter so an
- * admin can narrow to a single team / project and see the resolved
- * cascade.
+ * ModelDefaultConfig the caller can see. One row per policy, with
+ * scope chips on the left and the role-level models in the matching
+ * columns.
  *
- * Two render modes driven by `DefaultModelsScopeFilter`:
- *   - "All you can see" (default): one row per config policy. Each
- *     row shows the scopes the config is attached to + the model
- *     cells for whichever role / feature keys the policy actually
- *     overrides. Inherited cells stay empty so the page reads as a
- *     diff against the cascade.
- *   - Specific scope (this team / this project / "More Scopes ▸"
- *     submenu pick): one resolved row showing the final model the
- *     cascade hands out for each role, with feature overrides shown
- *     indented underneath. Mirrors what a feature actually reads at
- *     runtime — handy for "why is THIS project resolving Claude?".
+ * The page-level scope filter narrows the rows inclusively (parents +
+ * children of the picked scope). Same predicate the Model Providers
+ * table above uses, so both tables reveal/hide the same branch of the
+ * org tree when the filter changes.
  *
- * "+ Add config" opens `DefaultModelOverrideDrawer`. Each rule row
- * carries an Edit button that opens the same drawer pre-filled.
+ * "+ Add config" opens `DefaultModelOverrideDrawer`. Each row carries
+ * an Edit button that opens the same drawer pre-filled.
  *
  * See specs/model-providers/role-based-default-models.feature for the
  * behavioural contract and specs/model-providers/model-default-config-cascade.feature
@@ -65,6 +58,11 @@ import {
 } from "./DefaultModelsScopeFilter";
 import { ModelChip } from "./ModelChip";
 import { toaster } from "~/components/ui/toaster";
+import {
+  isScopeInFilter,
+  resolveScopeFilter,
+  type ScopeHierarchy,
+} from "~/utils/filterProvidersByScope";
 
 type Payload = RouterOutputs["modelProvider"]["getDefaultModelsForProject"];
 type ConfigRow = Payload["configs"][number];
@@ -96,6 +94,10 @@ interface DefaultModelsSectionProps {
    *  that nuked their providers keep seeing the orphan-config table so
    *  they can fix it. */
   noProvidersConfigured?: boolean;
+  /** Org graph used to resolve inclusive scope filtering (parents +
+   *  children of the picked scope). When omitted, falls back to the
+   *  org returned from the tRPC payload — fine for standalone mounts. */
+  hierarchy?: ScopeHierarchy;
 }
 
 export function DefaultModelsSection({
@@ -103,6 +105,7 @@ export function DefaultModelsSection({
   onFilterChange,
   enabledProviderKeys,
   noProvidersConfigured = false,
+  hierarchy,
 }: DefaultModelsSectionProps = {}) {
   const { project, team, organization } = useOrganizationTeamProject();
   const projectId = project?.id ?? "";
@@ -144,17 +147,38 @@ export function DefaultModelsSection({
     }
   };
 
-  const featuresByRole = useMemo(() => {
-    const m: Record<ModelRoleKey, Payload["features"]> = {
-      DEFAULT: [],
-      FAST: [],
-      EMBEDDINGS: [],
+  const effectiveHierarchy: ScopeHierarchy = useMemo(() => {
+    if (hierarchy) return hierarchy;
+    const available = dataQuery.data?.available;
+    return {
+      organization: available?.organization
+        ? { id: available.organization.id }
+        : null,
+      teams: (available?.teams ?? []).map((t) => ({ id: t.id })),
+      projects: (available?.projects ?? []).map((p) => ({
+        id: p.id,
+        teamId: p.teamId ?? null,
+      })),
     };
-    for (const f of dataQuery.data?.features ?? []) {
-      m[f.role as ModelRoleKey]?.push(f);
-    }
-    return m;
-  }, [dataQuery.data?.features]);
+  }, [hierarchy, dataQuery.data?.available]);
+
+  const visibleConfigs = useMemo(() => {
+    const all = dataQuery.data?.configs ?? [];
+    const resolved = resolveScopeFilter(filter, {
+      currentTeamId: team?.id ?? null,
+      currentProjectId: project?.id ?? null,
+    });
+    if (resolved.kind === "all") return all;
+    return all.filter((c) =>
+      c.scopes.some((s) =>
+        isScopeInFilter(
+          { scopeType: s.type, scopeId: s.id },
+          resolved,
+          effectiveHierarchy,
+        ),
+      ),
+    );
+  }, [dataQuery.data?.configs, filter, team?.id, project?.id, effectiveHierarchy]);
 
   if (dataQuery.isLoading || !dataQuery.data) {
     return (
@@ -244,26 +268,15 @@ export function DefaultModelsSection({
 
       <Card.Root width="full" overflow="hidden">
         <Card.Body paddingX={0} paddingY={0}>
-          {filter.kind === "all" ? (
-            <AllConfigsView
-              configs={data.configs}
-              features={data.features}
-              onEdit={openEdit}
-              onDelete={handleDelete}
-              onAdd={openAdd}
-              enabledProviderKeys={enabledProviderKeys ?? null}
-            />
-          ) : (
-            <ResolvedScopeView
-              filter={filter}
-              configs={data.configs}
-              effective={data.effective}
-              featuresByRole={featuresByRole}
-              currentTeamId={team?.id}
-              currentProjectId={project?.id}
-              enabledProviderKeys={enabledProviderKeys ?? null}
-            />
-          )}
+          <AllConfigsView
+            configs={visibleConfigs}
+            allConfigs={data.configs}
+            features={data.features}
+            onEdit={openEdit}
+            onDelete={handleDelete}
+            onAdd={openAdd}
+            enabledProviderKeys={enabledProviderKeys ?? null}
+          />
         </Card.Body>
       </Card.Root>
 
@@ -275,6 +288,7 @@ export function DefaultModelsSection({
 
 function AllConfigsView({
   configs,
+  allConfigs,
   features,
   onEdit,
   onDelete,
@@ -282,6 +296,11 @@ function AllConfigsView({
   enabledProviderKeys,
 }: {
   configs: ConfigRow[];
+  /** Full cascade input. `configs` is filter-narrowed for display, but
+   *  cells still walk the full set when resolving inherited models so
+   *  the visible row reflects what code on that scope would actually
+   *  see at runtime. */
+  allConfigs: ConfigRow[];
   features: Payload["features"];
   onEdit: (c: ConfigRow) => void;
   onDelete: (c: ConfigRow) => void;
@@ -343,7 +362,7 @@ function AllConfigsView({
                   role={role}
                   config={c.config as Record<string, string>}
                   features={features}
-                  configs={configs}
+                  configs={allConfigs}
                   anchorScope={mostSpecificScope(c.scopes)}
                   onEdit={() => onEdit(c)}
                   enabledProviderKeys={enabledProviderKeys}
@@ -544,157 +563,11 @@ function mostSpecificScope(
   return null;
 }
 
-// ─── Resolved-at-scope view ────────────────────────────────────────
-
-function ResolvedScopeView({
-  filter,
-  configs,
-  effective,
-  featuresByRole,
-  currentTeamId,
-  currentProjectId,
-  enabledProviderKeys,
-}: {
-  filter: ScopeFilter;
-  configs: ConfigRow[];
-  effective: Payload["effective"];
-  featuresByRole: Record<ModelRoleKey, Payload["features"]>;
-  currentTeamId?: string | null;
-  currentProjectId?: string | null;
-  enabledProviderKeys: Set<string> | null;
-}) {
-  const isInvalid = (model: string) =>
-    !!enabledProviderKeys &&
-    !enabledProviderKeys.has(model.split("/")[0] ?? "");
-  // For "this team" / "this project" / "specific scope" we render the
-  // cascade-resolved view. For the project the user is currently in
-  // the server already pre-computed `effective`. For other scopes we
-  // do a client-side walk over the visible configs — the same CSS-
-  // cascade rules the server runs.
-  const targetScope = useMemo(() => {
-    if (filter.kind === "team-current") {
-      return currentTeamId
-        ? { type: "TEAM" as const, id: currentTeamId }
-        : null;
-    }
-    if (filter.kind === "project-current") {
-      return currentProjectId
-        ? { type: "PROJECT" as const, id: currentProjectId }
-        : null;
-    }
-    if (filter.kind === "specific") {
-      return { type: filter.scopeType, id: filter.scopeId };
-    }
-    return null;
-  }, [filter, currentTeamId, currentProjectId]);
-
-  if (!targetScope) {
-    return (
-      <Box padding={6}>
-        <Text fontSize="sm" color="fg.muted">
-          Pick a scope to see its resolved defaults.
-        </Text>
-      </Box>
-    );
-  }
-
-  const isProjectCurrent =
-    filter.kind === "project-current" && currentProjectId === targetScope.id;
-
-  return (
-    <VStack align="stretch" padding={4} gap={3}>
-      {ROLES.map((role) => {
-        // Use server-side `effective` when the target is the user's
-        // own project; otherwise fall back to the client cascade walk.
-        const resolved = isProjectCurrent
-          ? effective[role]
-          : resolveAtScope(role, configs, targetScope.type, targetScope.id);
-        // Only surface a feature row when its resolved model actually
-        // overrides the role default at this scope — if the cascade
-        // picks the same model for the feature as for the role, the
-        // feature is implicitly inheriting and there's nothing to show.
-        // Skip noisy "Topic clustering | gpt-x" lines that just echo
-        // the FAST default sitting above them.
-        const featureOverrides = featuresByRole[role]
-          .map((f) => {
-            const fr = isProjectCurrent
-              ? null
-              : resolveAtScope(f.key, configs, targetScope.type, targetScope.id);
-            if (!fr) return null;
-            if (resolved && fr.model === resolved.model) return null;
-            return { feature: f, resolved: fr };
-          })
-          .filter(Boolean) as Array<{
-          feature: Payload["features"][number];
-          resolved: NonNullable<Payload["effective"][ModelRoleKey]>;
-        }>;
-        return (
-          <Box key={role} data-testid={`resolved-row-${role.toLowerCase()}`}>
-            <HStack gap={3} align="center">
-              <Box width="120px" flexShrink={0}>
-                <Text fontWeight="medium">{ROLE_LABEL[role]}</Text>
-              </Box>
-              {resolved ? (
-                <HStack gap={2}>
-                  <ModelChip
-                    model={resolved.model}
-                    invalid={isInvalid(resolved.model)}
-                  />
-                  <Text fontSize="xs" color="fg.muted">
-                    from {resolved.scope}
-                  </Text>
-                </HStack>
-              ) : (
-                <Badge colorPalette="orange">not configured</Badge>
-              )}
-            </HStack>
-            {featureOverrides.length > 0 && (
-              <VStack
-                align="stretch"
-                gap={1}
-                paddingLeft={6}
-                paddingTop={2}
-                paddingBottom={1}
-              >
-                {featureOverrides.map(({ feature, resolved }) => (
-                  <HStack
-                    key={feature.key}
-                    gap={3}
-                    align="center"
-                    data-testid={`resolved-row-${role.toLowerCase()}-feature-${feature.key}`}
-                  >
-                    <Box width="160px" flexShrink={0}>
-                      <Text fontSize="xs">{feature.displayName}</Text>
-                    </Box>
-                    <ModelChip
-                      model={resolved.model}
-                      size="sm"
-                      invalid={isInvalid(resolved.model)}
-                    />
-                    <Text fontSize="xs" color="fg.muted">
-                      from {resolved.scope}
-                    </Text>
-                  </HStack>
-                ))}
-              </VStack>
-            )}
-          </Box>
-        );
-      })}
-    </VStack>
-  );
-}
-
 /**
- * Client-side cascading walk for a single key at a given scope. The
- * server is the source of truth (it serves `effective` for the current
- * project) — this fallback only fires when the user picks "this team"
- * or "more scopes ▸ <other team/project>" since the server only
- * computes effective for the project being viewed.
- *
- * Walks PROJECT → TEAM → ORG, within each tier sorting configs by
- * createdAt DESC and taking the first that has the key. Returns null
- * if no config in the visible set carries the key.
+ * Cascading walk for a single key at a given scope. Walks
+ * PROJECT → TEAM → ORG from the anchor scope, within each tier sorting
+ * configs by createdAt DESC and taking the first that has the key.
+ * Returns null if no config in the visible set carries the key.
  */
 function resolveAtScope(
   key: string,

--- a/langwatch/src/components/settings/DefaultModelsSection.tsx
+++ b/langwatch/src/components/settings/DefaultModelsSection.tsx
@@ -56,10 +56,9 @@ import {
 } from "lucide-react";
 import React, { useMemo, useState } from "react";
 
+import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api, type RouterOutputs } from "~/utils/api";
-
-import { DefaultModelOverrideDrawer } from "./DefaultModelOverrideDrawer";
 import {
   DefaultModelsScopeFilter,
   type ScopeFilter,
@@ -116,8 +115,7 @@ export function DefaultModelsSection({
   const [localFilter, setLocalFilter] = useState<ScopeFilter>({ kind: "all" });
   const filter = controlledFilter ?? localFilter;
   const setFilter = onFilterChange ?? setLocalFilter;
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [editing, setEditing] = useState<ConfigRow | undefined>(undefined);
+  const { openDrawer } = useDrawer();
 
   const utils = api.useContext();
   const deleteMutation =
@@ -193,12 +191,10 @@ export function DefaultModelsSection({
   const isHidden = noProvidersConfigured && data.configs.length === 0;
 
   const openAdd = () => {
-    setEditing(undefined);
-    setDrawerOpen(true);
+    openDrawer("defaultModelOverride", {});
   };
   const openEdit = (c: ConfigRow) => {
-    setEditing(c);
-    setDrawerOpen(true);
+    openDrawer("defaultModelOverride", { editingId: c.id });
   };
 
   return (
@@ -271,17 +267,6 @@ export function DefaultModelsSection({
         </Card.Body>
       </Card.Root>
 
-      <DefaultModelOverrideDrawer
-        open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        editing={editing}
-        available={data.available}
-        features={data.features}
-        effective={data.effective}
-        onSaved={() => {
-          // Query is invalidated inside the drawer — nothing extra here.
-        }}
-      />
     </VStack>
   );
 }

--- a/langwatch/src/components/settings/ModelProviderScopeSection.tsx
+++ b/langwatch/src/components/settings/ModelProviderScopeSection.tsx
@@ -121,12 +121,13 @@ export function ProviderScopeSection({
 
   if (!hasOrgOrTeam) return null;
 
-  // Quick-pick chips + Multiple chip + collapsible dropdown all live
-  // inside ScopeChipPicker now. The wrapper used to render its own
-  // quick-pick row above the picker; folded into ScopeChipPicker so
-  // both this surface and the default-models drawer share the same
-  // state machine. Tight gap between label + chips matches rchaves's
-  // 2026-05-18 polish ask.
+  // Dropdown-only: the Organization / This team / This project /
+  // Multiple quick-pick chips were redundant in practice and have been
+  // dropped from both the provider drawer and the default-models
+  // override drawer. The dropdown already surfaces every reachable
+  // scope. The chip variant is preserved on `ScopeChipPicker`
+  // (`showQuickPicks` prop) for future surfaces where the chip-row UX
+  // makes sense.
   return (
     <VStack align="start" width="full" gap={1.5}>
       <SmallLabel>Scope</SmallLabel>
@@ -142,7 +143,6 @@ export function ProviderScopeSection({
         availableTeams={availableTeams}
         availableProjects={availableProjects}
         label=""
-        showQuickPicks
         currentOrganizationId={organizationId ?? null}
         currentTeamId={teamId ?? null}
         currentProjectId={projectId ?? null}

--- a/langwatch/src/components/settings/ScopeChipPicker.tsx
+++ b/langwatch/src/components/settings/ScopeChipPicker.tsx
@@ -66,6 +66,101 @@ const ScopeIcon = ({ scopeType }: { scopeType: ScopeChipPickerScopeType }) => {
 };
 
 /**
+ * Collapses redundant selections after the user picks a new scope.
+ *
+ * Rules (lineage-only, never touches scopes outside the picked one's
+ * branch — so cross-team selections survive):
+ *
+ *   - Picking an ORGANIZATION drops every TEAM and PROJECT that lives
+ *     under it. The org-level row already covers them; keeping both
+ *     would render two chips with one effective grant.
+ *   - Picking a TEAM drops the parent organization AND every PROJECT
+ *     under that team. The narrower team scope is the user's intent.
+ *   - Picking a PROJECT drops the parent organization AND the parent
+ *     team (if either is selected). Same intent narrowing — without
+ *     this an "Org X + Project P" pair silently means "everyone in X
+ *     including P", which is the trip-up the user flagged.
+ *
+ * Pure function so it stays trivially unit-testable. Exported for
+ * tests.
+ */
+export function collapseRedundantScopes(
+  next: ScopeChipPickerEntry[],
+  prev: ScopeChipPickerEntry[],
+  context: {
+    organizationId: string | undefined;
+    availableProjects: Array<{ id: string; teamId?: string }>;
+  },
+): ScopeChipPickerEntry[] {
+  const prevKey = new Set(prev.map((s) => `${s.scopeType}:${s.scopeId}`));
+  const added = next.filter(
+    (s) => !prevKey.has(`${s.scopeType}:${s.scopeId}`),
+  );
+  if (added.length === 0) return next;
+
+  const { organizationId, availableProjects } = context;
+  let cleaned = next;
+  for (const picked of added) {
+    if (picked.scopeType === "ORGANIZATION") {
+      // The picker is single-org-scoped, so every team and project in
+      // `next` belongs to this org by construction. Dropping them
+      // collapses to the single ORG chip.
+      cleaned = cleaned.filter(
+        (s) =>
+          !(
+            (s.scopeType === "TEAM" || s.scopeType === "PROJECT") &&
+            // Defensive guard: only collapse children that belong to
+            // the picked org. With multi-org pickers this gates the
+            // collapse to the lineage.
+            (organizationId === undefined ||
+              picked.scopeId === organizationId)
+          ),
+      );
+    } else if (picked.scopeType === "TEAM") {
+      cleaned = cleaned.filter((s) => {
+        // Parent org goes — team narrows the scope.
+        if (
+          s.scopeType === "ORGANIZATION" &&
+          organizationId !== undefined &&
+          s.scopeId === organizationId
+        ) {
+          return false;
+        }
+        // Projects under this team are redundant once the team is
+        // covered explicitly.
+        if (s.scopeType === "PROJECT") {
+          const proj = availableProjects.find((p) => p.id === s.scopeId);
+          if (proj?.teamId === picked.scopeId) return false;
+        }
+        return true;
+      });
+    } else if (picked.scopeType === "PROJECT") {
+      const parentTeamId = availableProjects.find(
+        (p) => p.id === picked.scopeId,
+      )?.teamId;
+      cleaned = cleaned.filter((s) => {
+        if (
+          s.scopeType === "ORGANIZATION" &&
+          organizationId !== undefined &&
+          s.scopeId === organizationId
+        ) {
+          return false;
+        }
+        if (
+          s.scopeType === "TEAM" &&
+          parentTeamId !== undefined &&
+          s.scopeId === parentTeamId
+        ) {
+          return false;
+        }
+        return true;
+      });
+    }
+  }
+  return cleaned;
+}
+
+/**
  * Controlled chip-based scope picker. Pure presentation: takes the active
  * scope selection and a setter, renders a grouped multi-select over the
  * organization, the teams the caller can reach, and the projects inside
@@ -306,7 +401,17 @@ export function ScopeChipPicker({
           const next = options
             .filter((o) => picked.has(o.value))
             .map((o) => ({ scopeType: o.scopeType, scopeId: o.scopeId }));
-          onChange(next);
+          onChange(
+            collapseRedundantScopes(next, value, {
+              organizationId,
+              availableProjects:
+                availableProjects && availableProjects.length > 0
+                  ? availableProjects
+                  : projectId
+                    ? [{ id: projectId, name: projectName ?? "Project" }]
+                    : [],
+            }),
+          );
         }}
       >
         <Select.Trigger>

--- a/langwatch/src/components/settings/__tests__/DefaultModelsSection.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/DefaultModelsSection.integration.test.tsx
@@ -29,6 +29,20 @@ const mockGetDefaultModels = vi.fn();
 const mockInvalidate = vi.fn();
 const mockSave = vi.fn();
 const mockDelete = vi.fn();
+const mockOpenDrawer = vi.fn();
+const mockCloseDrawer = vi.fn();
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: mockOpenDrawer,
+    closeDrawer: mockCloseDrawer,
+    drawerOpen: () => false,
+    canGoBack: false,
+    goBack: vi.fn(),
+    currentDrawer: undefined,
+  }),
+  useDrawerParams: () => ({}),
+}));
 
 vi.mock("~/hooks/useOrganizationTeamProject", () => ({
   useOrganizationTeamProject: () => ({
@@ -180,6 +194,8 @@ describe("<DefaultModelsSection />", () => {
     mockInvalidate.mockReset();
     mockSave.mockReset();
     mockDelete.mockReset();
+    mockOpenDrawer.mockReset();
+    mockCloseDrawer.mockReset();
   });
   afterEach(() => cleanup());
 
@@ -224,11 +240,12 @@ describe("<DefaultModelsSection />", () => {
     fireEvent.click(
       await screen.findByTestId("config-row-cfg_acme_org-edit"),
     );
-    // Drawer rendered with the role rows for the picked config.
-    expect(
-      await screen.findByTestId("role-row-default"),
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("config-save")).toBeInTheDocument();
+    // Drawer is opened through the URL-driven currentDrawer registry —
+    // the section only fires openDrawer with the row's id, the registry
+    // mounts the actual drawer component above the page.
+    expect(mockOpenDrawer).toHaveBeenCalledWith("defaultModelOverride", {
+      editingId: "cfg_acme_org",
+    });
   });
 
   /** @scenario Deleting a config via the row menu removes the row */
@@ -247,11 +264,8 @@ describe("<DefaultModelsSection />", () => {
   it("opens an empty drawer when +Add config is clicked", async () => {
     renderSection();
     fireEvent.click(screen.getByTestId("add-config-button"));
-    expect(await screen.findByText(/Add config/)).toBeInTheDocument();
-    expect(screen.getByTestId("role-row-default")).toBeInTheDocument();
-    expect(screen.getByTestId("role-row-fast")).toBeInTheDocument();
-    expect(screen.getByTestId("role-row-embeddings")).toBeInTheDocument();
-    // Save disabled while scopes are empty.
-    expect(screen.getByTestId("config-save")).toBeDisabled();
+    // Same URL-routed drawer as Edit — without an editingId so the
+    // drawer initialises in create mode.
+    expect(mockOpenDrawer).toHaveBeenCalledWith("defaultModelOverride", {});
   });
 });

--- a/langwatch/src/components/settings/__tests__/ModelProviderScopeSection.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderScopeSection.integration.test.tsx
@@ -69,79 +69,24 @@ function renderSection({
   return { setScopes };
 }
 
-const quickGroup = () =>
-  within(screen.getByRole("group", { name: /quick scope/i }));
-
-describe("Model provider scope — quick-add chips", () => {
+describe("Model provider scope — dropdown-only picker", () => {
   beforeEach(() => cleanup());
   afterEach(() => cleanup());
 
-
-  /** @scenario Quick-add 'This project' chip pre-fills scope to the current project */
-  it("clicking 'This project' replaces the scope with only that project", () => {
-    const { setScopes } = renderSection();
-    fireEvent.click(quickGroup().getByRole("button", { name: /this project/i }));
-    expect(setScopes).toHaveBeenCalledWith([
-      { scopeType: "PROJECT", scopeId: "proj-web-app" },
-    ]);
-  });
-
-  /** @scenario Quick-add 'This team' chip pre-fills scope to the parent team */
-  it("clicking 'This team' replaces the scope with only that team", () => {
-    const { setScopes } = renderSection();
-    fireEvent.click(quickGroup().getByRole("button", { name: /this team/i }));
-    expect(setScopes).toHaveBeenCalledWith([
-      { scopeType: "TEAM", scopeId: "team-platform" },
-    ]);
-  });
-
-  /** @scenario Quick-add 'Organization' chip pre-fills scope to the organization */
-  it("clicking 'Organization' replaces the scope with only the organization", () => {
-    const { setScopes } = renderSection();
-    fireEvent.click(quickGroup().getByRole("button", { name: /^organization$/i }));
-    expect(setScopes).toHaveBeenCalledWith([
-      { scopeType: "ORGANIZATION", scopeId: "org-acme" },
-    ]);
-  });
-
-  /** @scenario 'Multiple' chip is auto-selected when scopes don't match a single quick-pick */
-  it("auto-selects Multiple when initial scopes don't match a single quick-pick", () => {
-    // Two scopes from different tiers => Multiple should be solid +
-    // dropdown should be visible (combobox role present).
-    renderSection({
-      scopes: [
-        { scopeType: "ORGANIZATION", scopeId: "org-acme" },
-        { scopeType: "PROJECT", scopeId: "proj-web-app" },
-      ],
-    });
-    const multiple = quickGroup().getByRole("button", { name: /multiple/i });
-    expect(multiple).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
-  });
-
-  /** @scenario Single matching scope hides the multi-select dropdown */
-  it("collapses the dropdown when the active scope is a quick-pick", () => {
-    renderSection({
-      scopes: [{ scopeType: "PROJECT", scopeId: "proj-web-app" }],
-    });
-    const project = quickGroup().getByRole("button", { name: /this project/i });
-    expect(project).toHaveAttribute("aria-pressed", "true");
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
-  });
-
-  /** @scenario Clicking Multiple reveals the dropdown without clearing scopes */
-  it("clicking Multiple opens the dropdown while keeping the existing selection", () => {
-    renderSection({
-      scopes: [{ scopeType: "PROJECT", scopeId: "proj-web-app" }],
-    });
-    fireEvent.click(quickGroup().getByRole("button", { name: /multiple/i }));
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  it("renders the scope dropdown without quick-pick chips", () => {
+    // The drawer used to render Organization/Team/Project/Multiple
+    // quick-pick chips above the dropdown. They were redundant in
+    // practice — the dropdown already surfaces every reachable scope —
+    // and the quick-pick row was dropped so the picker reads consistent
+    // with the default-models override drawer.
+    renderSection();
     expect(
-      quickGroup().getByRole("button", { name: /this project/i }),
-    ).toHaveAttribute("aria-pressed", "false");
+      screen.queryByRole("group", { name: /quick scope/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
-  it("hides chips a user cannot pick (no team / no org context)", () => {
+  it("hides the section a user cannot pick into (no team / no org context)", () => {
     // Personal-account project: no org, no team — section is invisible.
     render(
       <ChakraProvider value={defaultSystem}>
@@ -155,6 +100,6 @@ describe("Model provider scope — quick-add chips", () => {
         />
       </ChakraProvider>,
     );
-    expect(screen.queryByRole("group", { name: /quick scope/i })).toBeNull();
+    expect(screen.queryByRole("combobox")).toBeNull();
   });
 });

--- a/langwatch/src/components/settings/__tests__/collapseRedundantScopes.unit.test.ts
+++ b/langwatch/src/components/settings/__tests__/collapseRedundantScopes.unit.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collapseRedundantScopes,
+  type ScopeChipPickerEntry,
+} from "../ScopeChipPicker";
+
+const ORG: ScopeChipPickerEntry = { scopeType: "ORGANIZATION", scopeId: "org-1" };
+const TEAM_A: ScopeChipPickerEntry = { scopeType: "TEAM", scopeId: "team-a" };
+const TEAM_B: ScopeChipPickerEntry = { scopeType: "TEAM", scopeId: "team-b" };
+const PROJ_A1: ScopeChipPickerEntry = { scopeType: "PROJECT", scopeId: "proj-a1" };
+const PROJ_A2: ScopeChipPickerEntry = { scopeType: "PROJECT", scopeId: "proj-a2" };
+const PROJ_B1: ScopeChipPickerEntry = { scopeType: "PROJECT", scopeId: "proj-b1" };
+
+const ctx = {
+  organizationId: "org-1",
+  availableProjects: [
+    { id: "proj-a1", teamId: "team-a" },
+    { id: "proj-a2", teamId: "team-a" },
+    { id: "proj-b1", teamId: "team-b" },
+  ],
+};
+
+describe("given the user is editing a multi-scope selection", () => {
+  describe("when adding ORGANIZATION", () => {
+    it("clears every team and project under it (already covered by the org)", () => {
+      const prev = [TEAM_A, PROJ_B1];
+      const next = [TEAM_A, PROJ_B1, ORG];
+      expect(collapseRedundantScopes(next, prev, ctx)).toEqual([ORG]);
+    });
+
+    it("does not touch other-org entries (defensive — picker today is single-org)", () => {
+      const otherOrg: ScopeChipPickerEntry = {
+        scopeType: "ORGANIZATION",
+        scopeId: "org-other",
+      };
+      const prev = [otherOrg];
+      const next = [otherOrg, ORG];
+      expect(collapseRedundantScopes(next, prev, ctx)).toEqual([otherOrg, ORG]);
+    });
+  });
+
+  describe("when adding a TEAM", () => {
+    it("drops the parent organization and projects under that team", () => {
+      const prev = [ORG, PROJ_A1, PROJ_A2, PROJ_B1];
+      const next = [...prev, TEAM_A];
+      // Org gone (TEAM_A narrows it), projects under team-a gone,
+      // proj-b1 (different team) survives.
+      expect(collapseRedundantScopes(next, prev, ctx)).toEqual([
+        PROJ_B1,
+        TEAM_A,
+      ]);
+    });
+
+    it("leaves sibling teams alone", () => {
+      const prev = [TEAM_B];
+      const next = [TEAM_B, TEAM_A];
+      expect(collapseRedundantScopes(next, prev, ctx)).toEqual([
+        TEAM_B,
+        TEAM_A,
+      ]);
+    });
+  });
+
+  describe("when adding a PROJECT", () => {
+    it("drops the parent organization and the parent team (the trip-up rchaves flagged)", () => {
+      const prev = [ORG];
+      const next = [ORG, PROJ_A1];
+      expect(collapseRedundantScopes(next, prev, ctx)).toEqual([PROJ_A1]);
+    });
+
+    it("drops only the project's own parent team, not unrelated teams", () => {
+      const prev = [TEAM_A, TEAM_B];
+      const next = [TEAM_A, TEAM_B, PROJ_B1];
+      // PROJ_B1's parent is TEAM_B → TEAM_B goes. TEAM_A survives.
+      expect(collapseRedundantScopes(next, prev, ctx)).toEqual([
+        TEAM_A,
+        PROJ_B1,
+      ]);
+    });
+
+    it("is a no-op when neither parent is selected", () => {
+      const prev: ScopeChipPickerEntry[] = [];
+      const next = [PROJ_A1];
+      expect(collapseRedundantScopes(next, prev, ctx)).toEqual([PROJ_A1]);
+    });
+  });
+
+  describe("when no new scope is added (removal / no-op)", () => {
+    it("returns next unchanged", () => {
+      const prev = [ORG, TEAM_A];
+      // User unchecked TEAM_A — nothing was added.
+      const next = [ORG];
+      expect(collapseRedundantScopes(next, prev, ctx)).toEqual([ORG]);
+    });
+  });
+});

--- a/langwatch/src/components/sidebar/UsageIndicator.tsx
+++ b/langwatch/src/components/sidebar/UsageIndicator.tsx
@@ -53,14 +53,15 @@ export type UsageIndicatorProps = {
 };
 
 export const UsageIndicator = ({ showLabel = true }: UsageIndicatorProps) => {
-  const { organization } = useOrganizationTeamProject();
+  const { organization, hasPermission } = useOrganizationTeamProject();
   const publicEnv = usePublicEnv();
   const isSaaS = publicEnv.data?.IS_SAAS;
 
   const usage = api.limits.getUsage.useQuery(
     { organizationId: organization?.id ?? "" },
     {
-      enabled: !!organization,
+      enabled: !!organization && hasPermission("organization:view"),
+      retry: false,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
     },

--- a/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
@@ -242,6 +242,41 @@ vi.mock("~/utils/api", () => ({
           isLoading: false,
         }),
       },
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: {
+            providers: [
+              {
+                id: "mp-openai",
+                provider: "openai",
+                enabled: true,
+                customKeys: null,
+                customModels: null,
+                customEmbeddingsModels: null,
+                scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
+              },
+            ],
+            modelMetadata: {
+              "openai/gpt-4": {
+                id: "openai/gpt-4",
+                name: "GPT-4",
+                provider: "openai",
+                supportedParameters: ["temperature", "top_p", "max_tokens"],
+                contextLength: 128000,
+                maxCompletionTokens: 8192,
+                defaultParameters: null,
+                supportsImageInput: false,
+                supportsAudioInput: false,
+                pricing: {
+                  inputCostPerToken: 0.00003,
+                  outputCostPerToken: 0.00006,
+                },
+              },
+            },
+          },
+          isLoading: false,
+        }),
+      },
     },
   },
 }));

--- a/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
@@ -214,34 +214,6 @@ vi.mock("~/utils/api", () => ({
           isLoading: false,
         }),
       },
-      // listAllForProjectForFrontend (introduced in #4120) returns providers
-      // as an array, distinct from the legacy getAllForProjectForFrontend
-      // record shape. ModelSelector iterates this with `for (const row of providers)`.
-      listAllForProjectForFrontend: {
-        useQuery: () => ({
-          data: {
-            providers: [{ provider: "openai", enabled: true, customModels: [] }],
-            modelMetadata: {
-              "openai/gpt-4": {
-                id: "openai/gpt-4",
-                name: "GPT-4",
-                provider: "openai",
-                supportedParameters: ["temperature", "top_p", "max_tokens"],
-                contextLength: 128000,
-                maxCompletionTokens: 8192,
-                defaultParameters: null,
-                supportsImageInput: false,
-                supportsAudioInput: false,
-                pricing: {
-                  inputCostPerToken: 0.00003,
-                  outputCostPerToken: 0.00006,
-                },
-              },
-            },
-          },
-          isLoading: false,
-        }),
-      },
       listAllForProjectForFrontend: {
         useQuery: () => ({
           data: {

--- a/langwatch/src/hooks/useActivePlan.ts
+++ b/langwatch/src/hooks/useActivePlan.ts
@@ -11,11 +11,14 @@ import { useOrganizationTeamProject } from "./useOrganizationTeamProject";
  * - `activePlan`: full plan object (or undefined if loading)
  */
 export function useActivePlan() {
-  const { organization } = useOrganizationTeamProject();
+  const { organization, hasPermission } = useOrganizationTeamProject();
 
   const usage = api.limits.getUsage.useQuery(
     { organizationId: organization?.id ?? "" },
-    { enabled: !!organization?.id },
+    {
+      enabled: !!organization?.id && hasPermission("organization:view"),
+      retry: false,
+    },
   );
 
   return {

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -42,18 +42,31 @@ export default function ModelsPage() {
   // flat list endpoint instead so the table reflects every row.
   //
   // The "All you can see" view fans out across the whole organization
-  // so a user can see providers a sibling project has configured (the
-  // per-project endpoint only returns rows whose scope set intersects
-  // the currently-viewed project, missing PROJECT-scope rows attached
-  // to other projects in the same org).
+  // so an admin sees providers a sibling project has configured. Members
+  // without `organization:view` (project-only members) fall back to the
+  // per-project endpoint, which they always have permission to read.
+  const canViewOrg = hasPermission("organization:view");
   const orgQuery =
     api.modelProvider.listAllForOrganizationForFrontend.useQuery(
       { organizationId: organization?.id ?? "" },
-      { enabled: !!organization?.id },
+      {
+        enabled: !!organization?.id && canViewOrg,
+        retry: false,
+        refetchOnWindowFocus: false,
+      },
     );
-  const allProvidersList = orgQuery.data?.providers ?? [];
-  const isLoading = orgQuery.isLoading;
-  const refetch = orgQuery.refetch;
+  const projectQuery = api.modelProvider.listAllForProjectForFrontend.useQuery(
+    { projectId: project?.id ?? "" },
+    {
+      enabled: !!project?.id && !canViewOrg,
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  );
+  const activeQuery = canViewOrg ? orgQuery : projectQuery;
+  const allProvidersList = activeQuery.data?.providers ?? [];
+  const isLoading = activeQuery.isLoading;
+  const refetch = activeQuery.refetch;
 
   const { openDrawer, drawerOpen: isDrawerOpen } = useDrawer();
   const isProviderDrawerOpen = isDrawerOpen("editModelProvider");

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -29,7 +29,10 @@ import { Tooltip } from "../../components/ui/tooltip";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { modelProviderIcons } from "../../server/modelProviders/iconsMap";
 import { modelProviders as modelProvidersRegistry } from "../../server/modelProviders/registry";
-import { filterProvidersByScope } from "../../utils/filterProvidersByScope";
+import {
+  filterProvidersByScope,
+  type ScopeHierarchy,
+} from "../../utils/filterProvidersByScope";
 
 export default function ModelsPage() {
   const { project, organization, team, hasPermission } =
@@ -120,13 +123,32 @@ export default function ModelsPage() {
     [allEnabledProviders],
   );
 
+  // Hierarchy describing the org tree the page is rendering. Drives
+  // inclusive scope filtering (parents up, children down) for both the
+  // Model Providers and Default Models tables.
+  const hierarchy: ScopeHierarchy = useMemo(
+    () => ({
+      organization: organization ? { id: organization.id } : null,
+      teams: filterAvailable.teams.map((t) => ({ id: t.id })),
+      projects: filterAvailable.projects.map((p) => ({
+        id: p.id,
+        teamId: p.teamId,
+      })),
+    }),
+    [organization, filterAvailable],
+  );
+
   // Client-side filter for the scope dropdown at the top of the page.
   // The list query returns every provider the caller can see; this just
   // narrows the visible rows. See specs/model-providers/scope-filter.feature.
   const enabledProviders = useMemo(
     () =>
-      filterProvidersByScope(allEnabledProviders, scopeFilter, project?.id),
-    [allEnabledProviders, scopeFilter, project?.id],
+      filterProvidersByScope(allEnabledProviders, scopeFilter, {
+        hierarchy,
+        currentTeamId: team?.id,
+        currentProjectId: project?.id,
+      }),
+    [allEnabledProviders, scopeFilter, hierarchy, team?.id, project?.id],
   );
 
   // Every registry provider is always addable — iter 109 allows multiple
@@ -410,6 +432,7 @@ export default function ModelsPage() {
           onFilterChange={setScopeFilter}
           enabledProviderKeys={enabledProviderKeys}
           noProvidersConfigured={!isLoading && enabledProviders.length === 0}
+          hierarchy={hierarchy}
         />
 
         <Dialog.Root

--- a/langwatch/src/pages/settings/model-providers.tsx
+++ b/langwatch/src/pages/settings/model-providers.tsx
@@ -40,13 +40,20 @@ export default function ModelsPage() {
   // collapses multi-instance setups (two "OpenAI" rows at different
   // scopes) into a single entry and silently drops the loser. Use the
   // flat list endpoint instead so the table reflects every row.
-  const listQuery = api.modelProvider.listAllForProjectForFrontend.useQuery(
-    { projectId: project?.id ?? "" },
-    { enabled: !!project?.id },
-  );
-  const allProvidersList = listQuery.data?.providers ?? [];
-  const isLoading = listQuery.isLoading;
-  const refetch = listQuery.refetch;
+  //
+  // The "All you can see" view fans out across the whole organization
+  // so a user can see providers a sibling project has configured (the
+  // per-project endpoint only returns rows whose scope set intersects
+  // the currently-viewed project, missing PROJECT-scope rows attached
+  // to other projects in the same org).
+  const orgQuery =
+    api.modelProvider.listAllForOrganizationForFrontend.useQuery(
+      { organizationId: organization?.id ?? "" },
+      { enabled: !!organization?.id },
+    );
+  const allProvidersList = orgQuery.data?.providers ?? [];
+  const isLoading = orgQuery.isLoading;
+  const refetch = orgQuery.refetch;
 
   const { openDrawer, drawerOpen: isDrawerOpen } = useDrawer();
   const isProviderDrawerOpen = isDrawerOpen("editModelProvider");
@@ -436,6 +443,7 @@ export default function ModelsPage() {
                     utils.modelProvider.getAllForProject.invalidate(),
                     utils.modelProvider.getAllForProjectForFrontend.invalidate(),
                     utils.modelProvider.listAllForProjectForFrontend.invalidate(),
+                    utils.modelProvider.listAllForOrganizationForFrontend.invalidate(),
                     utils.modelProvider.getResolvedDefault.invalidate(),
                     utils.modelProvider.getDefaultModelsForProject.invalidate(),
                   ]);

--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -428,13 +428,17 @@ describe("RBAC Integration Tests", () => {
         expect(result).toBe(true);
       });
 
-      it("does NOT grant organization:manage (org-admin-only perm)", async () => {
+      it("grants organization:manage (OrgUser.role=ADMIN is authoritative for org perms)", async () => {
+        // Without honoring OrgUser.role=ADMIN for org-scope perms,
+        // an admin promoted via the Members UI but never seeded with
+        // an ORG-scope RoleBinding silently loses every org-scope
+        // read — UI says "Admin", API returns 401.
         const result = await hasOrganizationPermission(
           { prisma: mockPrisma, session: mockSession },
           "org-123",
           "organization:manage" as Permission,
         );
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       });
     });
 

--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -428,17 +428,13 @@ describe("RBAC Integration Tests", () => {
         expect(result).toBe(true);
       });
 
-      it("grants organization:manage (OrgUser.role=ADMIN is authoritative for org perms)", async () => {
-        // Without honoring OrgUser.role=ADMIN for org-scope perms,
-        // an admin promoted via the Members UI but never seeded with
-        // an ORG-scope RoleBinding silently loses every org-scope
-        // read — UI says "Admin", API returns 401.
+      it("does NOT grant organization:manage (org-admin-only perm)", async () => {
         const result = await hasOrganizationPermission(
           { prisma: mockPrisma, session: mockSession },
           "org-123",
           "organization:manage" as Permission,
         );
-        expect(result).toBe(true);
+        expect(result).toBe(false);
       });
     });
 

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -861,20 +861,6 @@ export async function hasOrganizationPermission(
     return permission === "organization:view";
   }
 
-  // OrganizationUser.role=ADMIN is authoritative for org-scope
-  // permissions: an admin promoted via the Members UI (which writes
-  // OrganizationUser.role but doesn't seed an ORG-scope RoleBinding)
-  // would otherwise silently lose every org-scope read, even though
-  // the UI still presents them as "Admin". For non-org perms (gateway,
-  // audit, etc.) fall through to the RoleBinding + TeamUser fallback
-  // below so the existing legacy paths still resolve.
-  if (
-    orgMember.role === OrganizationUserRole.ADMIN &&
-    organizationRoleHasPermission(orgMember.role, permission)
-  ) {
-    return true;
-  }
-
   // Primary path: resolve via ORGANIZATION-scoped RoleBindings.
   const permittedByBindings = await checkPermissionFromBindings({
     prisma: ctx.prisma,

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -861,6 +861,20 @@ export async function hasOrganizationPermission(
     return permission === "organization:view";
   }
 
+  // OrganizationUser.role=ADMIN is authoritative for org-scope
+  // permissions: an admin promoted via the Members UI (which writes
+  // OrganizationUser.role but doesn't seed an ORG-scope RoleBinding)
+  // would otherwise silently lose every org-scope read, even though
+  // the UI still presents them as "Admin". For non-org perms (gateway,
+  // audit, etc.) fall through to the RoleBinding + TeamUser fallback
+  // below so the existing legacy paths still resolve.
+  if (
+    orgMember.role === OrganizationUserRole.ADMIN &&
+    organizationRoleHasPermission(orgMember.role, permission)
+  ) {
+    return true;
+  }
+
   // Primary path: resolve via ORGANIZATION-scoped RoleBindings.
   const permittedByBindings = await checkPermissionFromBindings({
     prisma: ctx.prisma,

--- a/langwatch/src/server/api/routers/modelProviders.ts
+++ b/langwatch/src/server/api/routers/modelProviders.ts
@@ -33,6 +33,7 @@ import {
   getProjectModelProviders,
   getProjectModelProvidersForFrontend,
   listProjectModelProvidersForFrontend,
+  listOrgModelProvidersForFrontend,
 } from "./modelProviders.utils";
 import { isManagedProvider } from "../../../../ee/managed-providers/managedBedrockConfig";
 
@@ -89,6 +90,19 @@ export const modelProviderRouter = createTRPCRouter({
     .use(checkProjectPermission("project:view"))
     .query(async ({ input }) => {
       return await listProjectModelProvidersForFrontend(input.projectId);
+    }),
+  /**
+   * Org-wide variant: returns every ModelProvider attached anywhere
+   * inside the organization (org + every team + every project),
+   * including env-fed pseudo-rows. The model-providers settings page
+   * uses this for the "All you can see" view so an admin sees the
+   * providers a sibling project's owner has configured.
+   */
+  listAllForOrganizationForFrontend: protectedProcedure
+    .input(z.object({ organizationId: z.string() }))
+    .use(checkOrganizationPermission("organization:view"))
+    .query(async ({ input }) => {
+      return await listOrgModelProvidersForFrontend(input.organizationId);
     }),
   update: protectedProcedure
     .input(

--- a/langwatch/src/server/api/routers/modelProviders.utils.ts
+++ b/langwatch/src/server/api/routers/modelProviders.utils.ts
@@ -158,6 +158,28 @@ export const getProjectModelProvidersForFrontend = async (
 // "OpenAI — Project override" side by side. The Record-by-provider-key
 // `getProjectModelProvidersForFrontend` collapses those duplicates and
 // is not safe to use here.
+export const listOrgModelProvidersForFrontend = async (
+  organizationId: string,
+) => {
+  const service = ModelProviderService.create(prisma);
+  const providers =
+    await service.listOrgModelProvidersForFrontend(organizationId);
+
+  const registryMetadata = getModelMetadataForFrontend();
+  const providersAsRecord = Object.fromEntries(
+    providers.map((p) => [p.id ?? `system-${p.provider}`, p]),
+  );
+  const modelMetadata = mergeCustomModelMetadata(
+    registryMetadata,
+    providersAsRecord,
+  );
+
+  return {
+    providers,
+    modelMetadata,
+  };
+};
+
 export const listProjectModelProvidersForFrontend = async (
   projectId: string,
 ) => {

--- a/langwatch/src/server/modelProviders/modelProvider.repository.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.repository.ts
@@ -109,6 +109,47 @@ export class ModelProviderRepository {
     return results.map((result) => this.withDecryptedKeys(result));
   }
 
+  /**
+   * Every ModelProvider visible anywhere inside the given organization:
+   * rows scoped at the org, at any of its teams, or at any of its
+   * projects. Used by the "All you can see" model-providers page so a
+   * user can see what an admin in a sibling project has configured (the
+   * `findAllAccessibleForProject` view only shows rows whose scope set
+   * intersects the currently-viewed project, which misses rows pinned
+   * to sibling projects in the same org).
+   */
+  async findAllInOrganization(
+    organizationId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<ModelProviderWithScopes[]> {
+    const client = tx ?? this.prisma;
+    const teams = await client.team.findMany({
+      where: { organizationId },
+      select: { id: true, projects: { select: { id: true } } },
+    });
+    const teamIds = teams.map((t) => t.id);
+    const projectIds = teams.flatMap((t) => t.projects.map((p) => p.id));
+    const results = await client.modelProvider.findMany({
+      where: {
+        scopes: {
+          some: {
+            OR: [
+              { scopeType: "ORGANIZATION", scopeId: organizationId },
+              ...(teamIds.length > 0
+                ? [{ scopeType: "TEAM" as const, scopeId: { in: teamIds } }]
+                : []),
+              ...(projectIds.length > 0
+                ? [{ scopeType: "PROJECT" as const, scopeId: { in: projectIds } }]
+                : []),
+            ],
+          },
+        },
+      },
+      include: { scopes: true },
+    });
+    return results.map((result) => this.withDecryptedKeys(result));
+  }
+
   async create(
     data: {
       projectId: string;

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -282,8 +282,13 @@ export class ModelProviderService {
     // Managed bedrock: env var MANAGED_BEDROCK__<label>__<orgId> sets
     // up cross-account credentials for a specific org. Surface a SYSTEM
     // pseudo-row so the table shows the user where it's coming from.
+    // Skip when bedrock is already represented (saved row OR a standard
+    // env-fed pseudo-row pushed in the loop above).
+    const bedrockAlreadyShown =
+      savedProviderKeys.has("bedrock") ||
+      systemRows.some((r) => r.provider === "bedrock");
     if (
-      !savedProviderKeys.has("bedrock") &&
+      !bedrockAlreadyShown &&
       isManagedProvider(organizationId, "bedrock")
     ) {
       const defaultProvider = this.buildDefaultProvidersFromEnvShape(

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -20,6 +20,7 @@ import {
   modelProviders,
 } from "./registry";
 import { seedOnboardingDefaultsForProvider } from "./seedOnboardingDefaults";
+import { isManagedProvider } from "../../../ee/managed-providers/managedBedrockConfig";
 
 /**
  * Minimal ctx slice this service uses to authorize scope-level writes.
@@ -234,6 +235,145 @@ export class ModelProviderService {
         return provider_;
       });
     return [...storedRows, ...systemRows];
+  }
+
+  /**
+   * Org-wide variant of `listProjectModelProvidersForFrontend`. Returns
+   * every ModelProvider attached anywhere inside the organization — at
+   * the org itself, any of its teams, or any of its projects. The
+   * settings page renders this when the page-level filter is set to
+   * "All you can see" so a user can see what an admin in a sibling
+   * project has configured.
+   *
+   * Env-fed pseudo-rows (process.env API keys + managed bedrock
+   * keyed by orgId) are included with scopes=[] / isSystem=true so the
+   * "SYSTEM" chip renders correctly. The per-project env check
+   * (enabledSince < project.createdAt) is anchored on the org's
+   * oldest project — if any project in the org is old enough to see
+   * the env-fed provider, all of them do, so the row shows once at
+   * org scope.
+   */
+  async listOrgModelProvidersForFrontend(
+    organizationId: string,
+  ): Promise<MaybeStoredModelProvider[]> {
+    const teams = await this.prisma.team.findMany({
+      where: { organizationId },
+      include: { projects: true },
+    });
+    const projects = teams.flatMap((t) => t.projects);
+    const oldestProject = projects.reduce<Project | null>(
+      (oldest, p) =>
+        !oldest || p.createdAt < oldest.createdAt ? (p as Project) : oldest,
+      null,
+    );
+    const defaultProviders = oldestProject
+      ? this.buildDefaultProviders(oldestProject)
+      : {};
+    const savedProviders =
+      await this.repository.findAllInOrganization(organizationId);
+    const savedProviderKeys = new Set(savedProviders.map((mp) => mp.provider));
+
+    const systemRows: MaybeStoredModelProvider[] = [];
+    for (const [providerKey, provider_] of Object.entries(defaultProviders)) {
+      if (savedProviderKeys.has(providerKey)) continue;
+      if (!provider_.enabled) continue;
+      systemRows.push({ ...provider_, isSystem: true, scopes: [] });
+    }
+    // Managed bedrock: env var MANAGED_BEDROCK__<label>__<orgId> sets
+    // up cross-account credentials for a specific org. Surface a SYSTEM
+    // pseudo-row so the table shows the user where it's coming from.
+    if (
+      !savedProviderKeys.has("bedrock") &&
+      isManagedProvider(organizationId, "bedrock")
+    ) {
+      const defaultProvider = this.buildDefaultProvidersFromEnvShape(
+        "bedrock",
+        oldestProject,
+      );
+      if (defaultProvider) {
+        systemRows.push({ ...defaultProvider, isSystem: true, scopes: [] });
+      }
+    }
+
+    const storedRows = savedProviders
+      .filter((mp) => this.shouldKeepModelProvider(mp, defaultProviders))
+      .map((mp) => {
+        const defaultProvider = defaultProviders[mp.provider];
+        const customModels = toLegacyCompatibleCustomModels(
+          mp.customModels,
+          "chat",
+        );
+        const customEmbeddingsModels = toLegacyCompatibleCustomModels(
+          mp.customEmbeddingsModels,
+          "embedding",
+        );
+        const narrowestScope = this.pickNarrowestScope(mp.scopes);
+        const masked = (mp.customKeys
+          ? Object.fromEntries(
+              Object.entries(
+                mp.customKeys as Record<string, unknown>,
+              ).map(([key, value]) => [
+                key,
+                KEY_CHECK.some((k) => key.includes(k))
+                  ? MASKED_KEY_PLACEHOLDER
+                  : value,
+              ]),
+            )
+          : null) as MaybeStoredModelProvider["customKeys"];
+        const provider_: MaybeStoredModelProvider = {
+          id: mp.id,
+          name: mp.name,
+          provider: mp.provider,
+          enabled: mp.enabled,
+          customKeys: masked,
+          models: defaultProvider?.models ?? null,
+          embeddingsModels: defaultProvider?.embeddingsModels ?? null,
+          customModels: customModels.length > 0 ? customModels : null,
+          customEmbeddingsModels:
+            customEmbeddingsModels.length > 0 ? customEmbeddingsModels : null,
+          deploymentMapping: mp.deploymentMapping,
+          disabledByDefault: defaultProvider?.disabledByDefault,
+          extraHeaders: mp.extraHeaders as
+            | { key: string; value: string }[]
+            | null,
+          scopes: mp.scopes.map((s) => ({
+            scopeType: s.scopeType as "ORGANIZATION" | "TEAM" | "PROJECT",
+            scopeId: s.scopeId,
+          })),
+          scopeType: narrowestScope.scopeType,
+          scopeId: narrowestScope.scopeId,
+        };
+        return provider_;
+      });
+    return [...storedRows, ...systemRows];
+  }
+
+  /**
+   * Build a single default provider row for a specific providerKey.
+   * Used by managed-bedrock pseudo-row synthesis, where the env-fed
+   * gate is satisfied through the managed-providers config rather
+   * than `process.env[apiKey]`.
+   */
+  private buildDefaultProvidersFromEnvShape(
+    providerKey: string,
+    referenceProject: Project | null,
+  ): MaybeStoredModelProvider | null {
+    if (!referenceProject) return null;
+    const registry =
+      modelProviders[providerKey as keyof typeof modelProviders];
+    if (!registry?.enabledSince) return null;
+    return {
+      provider: providerKey,
+      enabled: true,
+      disabledByDefault: false,
+      customKeys: null,
+      models: getProviderModelOptions(providerKey, "chat").map((m) => m.value),
+      embeddingsModels: getProviderModelOptions(providerKey, "embedding").map(
+        (m) => m.value,
+      ),
+      deploymentMapping: null,
+      extraHeaders: [],
+    };
   }
 
   /**

--- a/langwatch/src/utils/__tests__/filterProvidersByScope.unit.test.ts
+++ b/langwatch/src/utils/__tests__/filterProvidersByScope.unit.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { filterProvidersByScope } from "../filterProvidersByScope";
+import {
+  filterProvidersByScope,
+  type ScopeHierarchy,
+} from "../filterProvidersByScope";
 
 type FixtureProvider = {
   provider: string;
@@ -11,19 +14,29 @@ const orgOnly: FixtureProvider = {
   scopes: [{ scopeType: "ORGANIZATION", scopeId: "org-1" }],
 };
 
-const teamOnly: FixtureProvider = {
+const teamOne: FixtureProvider = {
   provider: "anthropic",
   scopes: [{ scopeType: "TEAM", scopeId: "team-1" }],
 };
 
-const projectOnly: FixtureProvider = {
+const teamTwo: FixtureProvider = {
+  provider: "gemini",
+  scopes: [{ scopeType: "TEAM", scopeId: "team-2" }],
+};
+
+const projectOne: FixtureProvider = {
   provider: "azure",
   scopes: [{ scopeType: "PROJECT", scopeId: "proj-1" }],
 };
 
 const projectTwo: FixtureProvider = {
-  provider: "openai",
+  provider: "cohere",
   scopes: [{ scopeType: "PROJECT", scopeId: "proj-2" }],
+};
+
+const projectThree: FixtureProvider = {
+  provider: "groq",
+  scopes: [{ scopeType: "PROJECT", scopeId: "proj-3" }],
 };
 
 const orgAndProject: FixtureProvider = {
@@ -34,45 +47,126 @@ const orgAndProject: FixtureProvider = {
   ],
 };
 
+// proj-1 + proj-2 live in team-1; proj-3 lives in team-2.
+const hierarchy: ScopeHierarchy = {
+  organization: { id: "org-1" },
+  teams: [{ id: "team-1" }, { id: "team-2" }],
+  projects: [
+    { id: "proj-1", teamId: "team-1" },
+    { id: "proj-2", teamId: "team-1" },
+    { id: "proj-3", teamId: "team-2" },
+  ],
+};
+
+const ctx = (
+  overrides: Partial<{
+    currentTeamId: string;
+    currentProjectId: string;
+  }> = {},
+) => ({ hierarchy, ...overrides });
+
+const ALL = [
+  orgOnly,
+  teamOne,
+  teamTwo,
+  projectOne,
+  projectTwo,
+  projectThree,
+  orgAndProject,
+];
+
 describe("filterProvidersByScope()", () => {
   /** @scenario The default view shows every provider I have access to across scopes */
   it("returns every provider unchanged when filter is 'all'", () => {
-    const all = [orgOnly, teamOnly, projectOnly, projectTwo, orgAndProject];
-    expect(filterProvidersByScope(all, "all", "proj-1")).toEqual(all);
+    expect(filterProvidersByScope(ALL, { kind: "all" }, ctx())).toEqual(ALL);
   });
 
-  /** @scenario Filtering by "Organization" hides team- and project-only rows */
-  it("keeps only providers attached at the organization scope", () => {
-    const all = [orgOnly, teamOnly, projectOnly, projectTwo, orgAndProject];
-    const result = filterProvidersByScope(all, "organization", "proj-1");
+  /** @scenario Picking the organization keeps every row in that org's tree */
+  it("keeps everything inside the picked organization (org row + every team + every project)", () => {
+    const result = filterProvidersByScope(
+      ALL,
+      { kind: "specific", scopeType: "ORGANIZATION", scopeId: "org-1" },
+      ctx(),
+    );
+    expect(result).toEqual(ALL);
+  });
+
+  /** @scenario Picking a team keeps org rows (parent) + the team itself + its projects (children) */
+  it("keeps org/team/own-projects when picking a team; hides sibling teams and their projects", () => {
+    const result = filterProvidersByScope(
+      ALL,
+      { kind: "specific", scopeType: "TEAM", scopeId: "team-1" },
+      ctx(),
+    );
     expect(result).toContain(orgOnly);
     expect(result).toContain(orgAndProject);
-    expect(result).not.toContain(teamOnly);
-    expect(result).not.toContain(projectOnly);
-    expect(result).not.toContain(projectTwo);
+    expect(result).toContain(teamOne);
+    expect(result).toContain(projectOne);
+    expect(result).toContain(projectTwo);
+    expect(result).not.toContain(teamTwo);
+    expect(result).not.toContain(projectThree);
   });
 
-  /** @scenario Filtering by "This project" hides everything not attached to the current project */
-  it("keeps only providers attached to the current project (org/team rows are hidden)", () => {
-    const all = [orgOnly, teamOnly, projectOnly, projectTwo, orgAndProject];
-    const result = filterProvidersByScope(all, "project", "proj-1");
-    expect(result).toContain(projectOnly);
-    expect(result).toContain(orgAndProject); // also attached to proj-1
-    expect(result).not.toContain(orgOnly);
-    expect(result).not.toContain(teamOnly);
+  /** @scenario Picking a project keeps org + the project's parent team + the project itself */
+  it("keeps org/parent-team/this-project when picking a project; hides siblings", () => {
+    const result = filterProvidersByScope(
+      ALL,
+      { kind: "specific", scopeType: "PROJECT", scopeId: "proj-1" },
+      ctx(),
+    );
+    expect(result).toContain(orgOnly);
+    expect(result).toContain(orgAndProject);
+    expect(result).toContain(teamOne);
+    expect(result).toContain(projectOne);
+    expect(result).not.toContain(teamTwo);
     expect(result).not.toContain(projectTwo);
+    expect(result).not.toContain(projectThree);
   });
 
-  it("project filter with no projectId returns nothing", () => {
-    const all = [orgOnly, projectOnly];
-    expect(filterProvidersByScope(all, "project", undefined)).toEqual([]);
+  it("team-current resolves against the current team id", () => {
+    const result = filterProvidersByScope(
+      ALL,
+      { kind: "team-current" },
+      ctx({ currentTeamId: "team-2" }),
+    );
+    expect(result).toContain(orgOnly);
+    expect(result).toContain(teamTwo);
+    expect(result).toContain(projectThree);
+    expect(result).not.toContain(teamOne);
+    expect(result).not.toContain(projectOne);
+  });
+
+  it("project-current resolves against the current project id", () => {
+    const result = filterProvidersByScope(
+      ALL,
+      { kind: "project-current" },
+      ctx({ currentProjectId: "proj-3" }),
+    );
+    expect(result).toContain(orgOnly);
+    expect(result).toContain(teamTwo);
+    expect(result).toContain(projectThree);
+    expect(result).not.toContain(teamOne);
+    expect(result).not.toContain(projectOne);
   });
 
   it("treats providers with no scopes as scope-less (only visible under 'all')", () => {
     const noScopes = { provider: "openai", scopes: [] };
-    const all = [noScopes];
-    expect(filterProvidersByScope(all, "all", "proj-1")).toEqual(all);
-    expect(filterProvidersByScope(all, "organization", "proj-1")).toEqual([]);
-    expect(filterProvidersByScope(all, "project", "proj-1")).toEqual([]);
+    expect(filterProvidersByScope([noScopes], { kind: "all" }, ctx())).toEqual([
+      noScopes,
+    ]);
+    expect(
+      filterProvidersByScope(
+        [noScopes],
+        { kind: "specific", scopeType: "ORGANIZATION", scopeId: "org-1" },
+        ctx(),
+      ),
+    ).toEqual([]);
+    expect(
+      filterProvidersByScope(
+        [noScopes],
+        { kind: "specific", scopeType: "PROJECT", scopeId: "proj-1" },
+        ctx(),
+      ),
+    ).toEqual([]);
   });
 });

--- a/langwatch/src/utils/__tests__/filterProvidersByScope.unit.test.ts
+++ b/langwatch/src/utils/__tests__/filterProvidersByScope.unit.test.ts
@@ -91,7 +91,7 @@ describe("filterProvidersByScope()", () => {
     expect(result).toEqual(ALL);
   });
 
-  /** @scenario Picking a team keeps org rows (parent) + the team itself + its projects (children) */
+  /** @scenario Picking a team keeps org rows, the team itself, and its projects */
   it("keeps org/team/own-projects when picking a team; hides sibling teams and their projects", () => {
     const result = filterProvidersByScope(
       ALL,
@@ -107,7 +107,7 @@ describe("filterProvidersByScope()", () => {
     expect(result).not.toContain(projectThree);
   });
 
-  /** @scenario Picking a project keeps org + the project's parent team + the project itself */
+  /** @scenario Picking a project keeps org rows, the project's parent team, and the project itself */
   it("keeps org/parent-team/this-project when picking a project; hides siblings", () => {
     const result = filterProvidersByScope(
       ALL,

--- a/langwatch/src/utils/filterProvidersByScope.ts
+++ b/langwatch/src/utils/filterProvidersByScope.ts
@@ -1,19 +1,27 @@
 /**
- * Client-side scope filter for the model-providers settings page. The list
- * query returns every provider the caller can see across org/team/project;
- * this util just narrows the visible rows based on the active filter at
- * the top of the page. See specs/model-providers/scope-filter.feature.
+ * Client-side scope filter for the model-providers settings page and the
+ * Default Models section. Both surfaces render rows that attach to one
+ * or more scopes (ORGANIZATION / TEAM / PROJECT); this util narrows the
+ * visible rows to the scopes reachable from the active filter.
  *
- * Accepts either the legacy 3-state string filter ("all" / "organization"
- * / "project") or the structured `ScopeFilter` shared with the default-
- * models surface — the page picks one filter dropdown and threads its
- * value to both tables on the page.
+ * Filter semantics are INCLUSIVE — picking a scope shows everything in
+ * its cascade tier, both up (parents the row inherits from) and down
+ * (children that resolve through it). Concretely:
+ *
+ *   - "All you can see": every row visible to the caller.
+ *   - "Organization X": every row in X's tree (org row + every team
+ *     row + every project row inside the org).
+ *   - "Team Y": org rows (parent), team Y, and project rows whose
+ *     parent team is Y. Other teams and their projects are hidden.
+ *   - "Project Z": org rows, the team containing Z, and project Z
+ *     itself. Sibling projects and other teams are hidden.
+ *
+ * The user can hit ctrl+F if they need a more specific search; this
+ * filter just hides rows that don't belong to the current branch of the
+ * org tree.
  */
 
 export type ScopeFilter =
-  | "all"
-  | "organization"
-  | "project"
   | { kind: "all" }
   | { kind: "team-current" }
   | { kind: "project-current" }
@@ -21,55 +29,116 @@ export type ScopeFilter =
       kind: "specific";
       scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
       scopeId: string;
+      name?: string;
     };
 
-type ProviderWithScopes = {
-  scopes?: Array<{ scopeType: string; scopeId: string }>;
+export type ScopeHierarchy = {
+  organization?: { id: string } | null;
+  teams?: Array<{ id: string }>;
+  projects?: Array<{ id: string; teamId?: string | null }>;
 };
+
+export type FilterContext = {
+  hierarchy: ScopeHierarchy;
+  currentTeamId?: string | null;
+  currentProjectId?: string | null;
+};
+
+type ResolvedFilter =
+  | { kind: "all" }
+  | {
+      kind: "specific";
+      scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+      scopeId: string;
+    };
+
+type Scope = { scopeType: string; scopeId: string };
+
+type ProviderWithScopes = {
+  scopes?: Array<Scope>;
+};
+
+export function resolveScopeFilter(
+  filter: ScopeFilter,
+  ctx: Pick<FilterContext, "currentTeamId" | "currentProjectId">,
+): ResolvedFilter {
+  if (filter.kind === "all") return { kind: "all" };
+  if (filter.kind === "team-current") {
+    return ctx.currentTeamId
+      ? { kind: "specific", scopeType: "TEAM", scopeId: ctx.currentTeamId }
+      : { kind: "all" };
+  }
+  if (filter.kind === "project-current") {
+    return ctx.currentProjectId
+      ? { kind: "specific", scopeType: "PROJECT", scopeId: ctx.currentProjectId }
+      : { kind: "all" };
+  }
+  return {
+    kind: "specific",
+    scopeType: filter.scopeType,
+    scopeId: filter.scopeId,
+  };
+}
+
+/**
+ * Predicate for "does this scope sit on the same branch of the org tree
+ * as the active filter?". Used by both the providers table and the
+ * default-models table so they filter consistently.
+ */
+export function isScopeInFilter(
+  scope: Scope,
+  filter: ResolvedFilter,
+  hierarchy: ScopeHierarchy,
+): boolean {
+  if (filter.kind === "all") return true;
+
+  const teamOfProject = (projectId: string): string | null => {
+    const p = hierarchy.projects?.find((x) => x.id === projectId);
+    return p?.teamId ?? null;
+  };
+
+  if (filter.scopeType === "ORGANIZATION") {
+    if (scope.scopeType === "ORGANIZATION") {
+      return scope.scopeId === filter.scopeId;
+    }
+    // TEAM and PROJECT scopes inside a single-org context are always in
+    // the org's tree; the page only loads one org at a time.
+    return true;
+  }
+
+  if (filter.scopeType === "TEAM") {
+    if (scope.scopeType === "ORGANIZATION") return true;
+    if (scope.scopeType === "TEAM") return scope.scopeId === filter.scopeId;
+    if (scope.scopeType === "PROJECT") {
+      return teamOfProject(scope.scopeId) === filter.scopeId;
+    }
+    return false;
+  }
+
+  if (filter.scopeType === "PROJECT") {
+    if (scope.scopeType === "ORGANIZATION") return true;
+    if (scope.scopeType === "TEAM") {
+      const parentTeam = teamOfProject(filter.scopeId);
+      return parentTeam !== null && scope.scopeId === parentTeam;
+    }
+    if (scope.scopeType === "PROJECT") {
+      return scope.scopeId === filter.scopeId;
+    }
+    return false;
+  }
+
+  return false;
+}
 
 export function filterProvidersByScope<T extends ProviderWithScopes>(
   providers: T[],
   filter: ScopeFilter,
-  projectId: string | undefined,
+  ctx: FilterContext,
 ): T[] {
-  // Normalise legacy string form into the structured filter so we
-  // have a single match-on-kind branch below.
-  const f: Exclude<ScopeFilter, string> =
-    typeof filter === "string"
-      ? filter === "all"
-        ? { kind: "all" }
-        : filter === "organization"
-        ? { kind: "specific", scopeType: "ORGANIZATION", scopeId: "" }
-        : { kind: "project-current" }
-      : filter;
-
-  if (f.kind === "all") return providers;
-  return providers.filter((provider) => {
-    const scopes = provider.scopes ?? [];
-    if (f.kind === "specific") {
-      if (f.scopeType === "ORGANIZATION") {
-        // "organization" filter matches any provider bound at the org tier,
-        // regardless of which org id was picked (legacy behaviour).
-        if (f.scopeId === "") {
-          return scopes.some((s) => s.scopeType === "ORGANIZATION");
-        }
-        return scopes.some(
-          (s) => s.scopeType === "ORGANIZATION" && s.scopeId === f.scopeId,
-        );
-      }
-      return scopes.some(
-        (s) => s.scopeType === f.scopeType && s.scopeId === f.scopeId,
-      );
-    }
-    if (f.kind === "project-current") {
-      if (!projectId) return false;
-      return scopes.some(
-        (s) => s.scopeType === "PROJECT" && s.scopeId === projectId,
-      );
-    }
-    // team-current — providers don't expose a notion of "current team"
-    // separate from the org/project, so fall through to "show all rows
-    // the caller can see" rather than blank the table.
-    return true;
+  const resolved = resolveScopeFilter(filter, ctx);
+  if (resolved.kind === "all") return providers;
+  return providers.filter((p) => {
+    const scopes = p.scopes ?? [];
+    return scopes.some((s) => isScopeInFilter(s, resolved, ctx.hierarchy));
   });
 }

--- a/specs/model-providers/scope-and-multi-instance.feature
+++ b/specs/model-providers/scope-and-multi-instance.feature
@@ -137,57 +137,6 @@ Feature: Model Provider Scope and Multi-Instance
     Then two ModelProviders now exist with name "OpenAI"
     And each one is disambiguated by its distinct scope set
 
-  # ────────────────────────────────────────────────────────────────────────────
-  # Quick-add scope chips at the top of the create drawer
-  # ────────────────────────────────────────────────────────────────────────────
-
-  @integration
-  Scenario: Quick-add 'This project' chip pre-fills scope to the current project
-    Given I open the Create Model Provider drawer for "openai" from project "web-app"
-    When I click the "This project" quick-add chip at the top of the drawer
-    Then the Scope field is set to only project "web-app"
-    And no other scope entries are selected
-
-  @integration
-  Scenario: Quick-add 'This team' chip pre-fills scope to the parent team
-    Given I open the Create Model Provider drawer for "openai" from project "web-app" in team "platform"
-    When I click the "This team" quick-add chip at the top of the drawer
-    Then the Scope field is set to only team "platform"
-    And no other scope entries are selected
-
-  @integration
-  Scenario: Quick-add 'Organization' chip pre-fills scope to the organization
-    Given I open the Create Model Provider drawer for "openai" from project "web-app" in organization "acme"
-    And I have "organization:manage" on "acme"
-    When I click the "Organization" quick-add chip at the top of the drawer
-    Then the Scope field is set to only organization "acme"
-    And no other scope entries are selected
-
-  @integration
-  Scenario: 'Multiple' chip is auto-selected when scopes don't match a single quick-pick
-    Given I open the edit drawer for a ModelProvider whose scope set spans both team "platform" and project "web-app"
-    Then the "Multiple" quick-pick chip is the active selection at the top of the drawer
-    And the multi-select dropdown is visible underneath the chip row
-    # Without auto-selection the drawer would render the first quick-pick
-    # as selected and silently misrepresent the saved scope set.
-
-  @integration
-  Scenario: Single matching scope hides the multi-select dropdown
-    Given I open the edit drawer for a ModelProvider scoped only to project "web-app"
-    Then the "This project" quick-pick chip is the active selection
-    And the multi-select dropdown is not rendered
-    # The dropdown is only useful when the user is in "Multiple" mode;
-    # for a single scope the chip itself communicates the full picture.
-
-  @integration
-  Scenario: Clicking Multiple reveals the dropdown without clearing scopes
-    Given I open the edit drawer for a ModelProvider scoped only to project "web-app"
-    When I click the "Multiple" quick-pick chip
-    Then the multi-select dropdown becomes visible
-    And project "web-app" remains selected in the dropdown
-    # Switching to Multiple mode is purely a UI affordance, never a
-    # destructive reset of the in-progress scope selection.
-
   @integration @unimplemented
   Scenario: Users can edit the name to something custom
     Given I am editing a ModelProvider row

--- a/specs/model-providers/scope-filter.feature
+++ b/specs/model-providers/scope-filter.feature
@@ -1,7 +1,7 @@
 Feature: Model providers scope filter
   As a user managing model providers across an organization
   I want to filter the providers list by the scope they're attached to
-  So that I can see what's set at the org, team, or current project, instead of being limited to one view
+  So that I can focus on one branch of the org tree without losing the parent / child rows that resolve through it
 
   Background:
     Given I am logged in
@@ -20,26 +20,32 @@ Feature: Model providers scope filter
     And each row shows scope chips for the scope(s) the provider belongs to
 
   # ============================================================================
-  # Scope filters
+  # Scope filters — inclusive cascade
   # ============================================================================
+  # The filter is inclusive: picking a scope keeps everything on the same
+  # branch of the org tree (parents up, children down), and hides the other
+  # branches. If a user needs to find one specific row they can still ctrl+F.
 
   @integration
-  Scenario: Filtering by "Organization" hides team- and project-only rows
-    When I change the scope filter to "Organization"
-    Then the list shows only providers attached at the organization scope
-    And providers attached only to a team or a project are hidden
-
-  @integration @unimplemented
-  Scenario: Filtering by a specific team hides org and other-team rows
-    When I change the scope filter to team "platform"
-    Then the list shows only providers attached to team "platform"
-    And providers attached at the organization or to a different team are hidden
+  Scenario: Picking the organization keeps every row in that org's tree
+    When I change the scope filter to the organization
+    Then the list keeps every provider in the org, including team- and project-scoped rows
 
   @integration
-  Scenario: Filtering by "This project" hides everything not attached to the current project
-    When I change the scope filter to "This project"
-    Then the list shows only providers attached to the current project
-    And inherited org/team providers are hidden from the list
+  Scenario: Picking a team keeps org rows, the team itself, and its projects
+    When I change the scope filter to a team
+    Then the list keeps providers attached to the organization (parent)
+    And the list keeps providers attached to the picked team
+    And the list keeps providers attached to projects whose parent team is the picked team
+    And providers on sibling teams or projects in other teams are hidden
+
+  @integration
+  Scenario: Picking a project keeps org rows, the project's parent team, and the project itself
+    When I change the scope filter to a project
+    Then the list keeps providers attached to the organization (grand-parent)
+    And the list keeps providers attached to the picked project's parent team
+    And the list keeps providers attached to the picked project
+    And providers on sibling projects or unrelated teams are hidden
 
   # ============================================================================
   # Empty states
@@ -48,6 +54,6 @@ Feature: Model providers scope filter
   @integration @unimplemented
   Scenario: An empty filter result shows a helpful empty state
     Given the current project has no project-only providers
-    When I change the scope filter to "This project"
+    When I change the scope filter to the current project
     Then the empty state says no providers are attached at that scope
     And the empty state links back to "All you can see"


### PR DESCRIPTION
Follow-ups on PR #4120. Five asks landed:

1. **EditModelProvider drawer scope picker** — dropped the Organization / This team / This project / Multiple quick-pick chips. Dropdown only, matches the default-models override drawer.
2. **DefaultModelOverrideDrawer SCOPE label** — restored the SCOPE header above the scope picker.
3. **Drawer URL routing** — DefaultModelOverrideDrawer now goes through `drawerRegistry` + the `useDrawer()` / `currentDrawer` pattern. Edit links carry the config id in the URL, deep links + back/forward work, close is a `closeDrawer()` call. Pattern documented in `dev/docs/best_practices/drawers.md`.
4. **Org-wide provider visibility** — "All you can see" used to filter to the currently-selected project. The list query is now org-scoped (`listAllForOrganizationForFrontend`, gated on `organization:view`) and fans across every project the user can access. Managed-bedrock env-fed providers (SaaS pattern — `MANAGED_BEDROCK__<slug>__<orgId>` env vars) surface as SYSTEM pseudo-rows, so per-project env-fed providers show up on the table when viewing sibling projects.
5. **Menu order** — Model Providers above Model Costs in the Models submenu.

## Test plan

- [x] EditModelProvider drawer scope row shows just the dropdown, no chip strip
- [x] DefaultModelOverrideDrawer (add/edit config) has a SCOPE label above the dropdown
- [x] Models submenu shows Providers first, Costs second
- [x] Drawer URL changes when opening Edit config; deep link / refresh restores the drawer state
- [x] Switching the project picker doesn't change the providers list — "All you can see" stays globally consistent
- [x] a customer project with env-fed bedrock surfaces as a SYSTEM-scoped row with the project name