### PR TITLE
fix(ui): always-transparent Dialog backdrop + Biome guard

### DIFF
--- a/langwatch/biome.json
+++ b/langwatch/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -24,6 +24,7 @@
 				"useOptionalChain": "error"
 			},
 			"correctness": {
+				"noNextAsyncClientComponent": "warn",
 				"noPrecisionLoss": "error",
 				"noUnusedVariables": "warn"
 			},
@@ -31,7 +32,6 @@
 				"noFloatingPromises": "error",
 				"noForIn": "error",
 				"noMisusedPromises": "error",
-				"noNextAsyncClientComponent": "warn",
 				"noSyncScripts": "error"
 			},
 			"performance": {
@@ -43,7 +43,17 @@
 				"noHeadElement": "warn",
 				"noInferrableTypes": "error",
 				"noNamespace": "error",
-				"noRestrictedImports": "error",
+				"noRestrictedImports": {
+					"level": "error",
+					"options": {
+						"paths": {
+							"@chakra-ui/react": {
+								"importNames": ["Dialog", "Drawer", "Modal"],
+								"message": "Import Dialog/Drawer from ~/components/ui/dialog or ~/components/ui/drawer instead. The wrappers force a transparent backdrop (no dark grey overlay), wire focus/scroll defaults, and add an inline error boundary. Raw Chakra primitives reintroduce the dark backdrop we explicitly do not want."
+							}
+						}
+					}
+				},
 				"useArrayLiterals": "error",
 				"useAsConstAssertion": "error",
 				"useConsistentArrayType": "off",
@@ -128,6 +138,19 @@
 				"rules": {
 					"suspicious": {
 						"noEmptyBlockStatements": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": [
+				"src/components/ui/dialog.tsx",
+				"src/components/ui/drawer.tsx"
+			],
+			"linter": {
+				"rules": {
+					"style": {
+						"noRestrictedImports": "off"
 					}
 				}
 			}

--- a/langwatch/biome.json
+++ b/langwatch/biome.json
@@ -49,7 +49,7 @@
 						"paths": {
 							"@chakra-ui/react": {
 								"importNames": ["Dialog", "Drawer", "Modal"],
-								"message": "Import Dialog/Drawer from ~/components/ui/dialog or ~/components/ui/drawer instead. The wrappers force a transparent backdrop (no dark grey overlay), wire focus/scroll defaults, and add an inline error boundary. Raw Chakra primitives reintroduce the dark backdrop we explicitly do not want."
+								"message": "Import Dialog or Drawer from ~/components/ui/dialog and ~/components/ui/drawer instead. Modal-style flows also use the Dialog wrapper (see AICreateModal, RunScenarioModal, etc.) — there is no Modal wrapper. The wrappers force a transparent backdrop (no dark grey overlay), wire focus/scroll defaults, and add an inline error boundary. Raw Chakra primitives reintroduce the dark backdrop we explicitly do not want."
 							}
 						}
 					}

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
@@ -171,7 +171,7 @@ export function FeatureFlagRulesDialog({
       onOpenChange={(details) => onOpenChange(details.open)}
       size="lg"
     >
-      <DialogContent backdropProps={{ bg: "whiteAlpha.600" }}>
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>Targeting rules</DialogTitle>
         </DialogHeader>

--- a/langwatch/src/components/ui/__tests__/dialog-backdrop.integration.test.tsx
+++ b/langwatch/src/components/ui/__tests__/dialog-backdrop.integration.test.tsx
@@ -84,6 +84,25 @@ describe("Dialog backdrop", () => {
     });
   });
 
+  describe("when a caller tries to set a dark background via inline style", () => {
+    it("forces style.background and style.backgroundColor to transparent and warns", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      renderOpenDialog({
+        backdropProps: {
+          style: { backgroundColor: "black" },
+        } as unknown as Parameters<typeof Dialog.Content>[0]["backdropProps"],
+      });
+      const backdrop = getBackdrop();
+      expect(backdrop.style.backgroundColor).toBe("transparent");
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "backdropProps.bg/background/backgroundColor is ignored",
+        ),
+      );
+      warn.mockRestore();
+    });
+  });
+
   describe("when consumers reach for the Dialog namespace", () => {
     /** @scenario Dialog.Backdrop is not exposed as a public sub-component */
     it("does not expose a Backdrop sub-component", () => {

--- a/langwatch/src/components/ui/__tests__/dialog-backdrop.integration.test.tsx
+++ b/langwatch/src/components/ui/__tests__/dialog-backdrop.integration.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the Dialog backdrop styling.
+ *
+ * The base Dialog wrapper at src/components/ui/dialog.tsx must keep the
+ * backdrop transparent (blur-only). Chakra's default backdrop ships with
+ * `bg: blackAlpha.500` — the dark grey overlay we explicitly do not want.
+ *
+ * @see specs/features/dialog-backdrop-transparency-blur.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Dialog } from "../dialog";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderOpenDialog(
+  extra?: Parameters<typeof Dialog.Content>[0],
+) {
+  render(
+    <Dialog.Root open={true}>
+      <Dialog.Content bg="bg" {...extra}>
+        <Dialog.Body>content</Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>,
+    { wrapper: Wrapper },
+  );
+}
+
+function getBackdrop(): HTMLElement {
+  const backdrop = document.querySelector<HTMLElement>(
+    "[data-part='backdrop']",
+  );
+  if (!backdrop) throw new Error("backdrop not found");
+  return backdrop;
+}
+
+describe("Dialog backdrop", () => {
+  afterEach(cleanup);
+
+  describe("when a dialog opens", () => {
+    /** @scenario Dialog backdrop renders with blur and no dark fill */
+    it("renders a backdrop and does not inject a dark inline fill", () => {
+      renderOpenDialog();
+      const backdrop = getBackdrop();
+
+      // Chakra resolves the `bg` prop through its recipe to a CSS class
+      // rather than an inline style, so we can't read the colour value
+      // from jsdom. What we CAN assert is that the wrapper does not put a
+      // dark colour as an inline style on the backdrop element, since
+      // Chakra's default (blackAlpha.500) only renders through the class.
+      // Visual confirmation lives in pr-screenshots from QA.
+      const inlineBg =
+        backdrop.style.background || backdrop.style.backgroundColor;
+      expect(inlineBg).not.toMatch(/blackalpha|rgba\(0,\s*0,\s*0,/i);
+    });
+  });
+
+  describe("when a caller tries to set a dark background via backdropProps", () => {
+    /** @scenario Caller cannot override the backdrop with a dark fill */
+    it("strips bg/background/backgroundColor and warns in dev", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      renderOpenDialog({
+        // Cast to widen the type so we exercise the runtime guard, since
+        // the type-level Omit already forbids these keys at compile time.
+        backdropProps: { bg: "blackAlpha.700" } as unknown as Parameters<
+          typeof Dialog.Content
+        >[0]["backdropProps"],
+      });
+      const backdrop = getBackdrop();
+      const inlineBg =
+        backdrop.style.background || backdrop.style.backgroundColor;
+      expect(inlineBg).not.toMatch(/blackalpha|rgba\(0,\s*0,\s*0,/i);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "backdropProps.bg/background/backgroundColor is ignored",
+        ),
+      );
+      warn.mockRestore();
+    });
+  });
+
+  describe("when consumers reach for the Dialog namespace", () => {
+    /** @scenario Dialog.Backdrop is not exposed as a public sub-component */
+    it("does not expose a Backdrop sub-component", () => {
+      expect((Dialog as unknown as Record<string, unknown>).Backdrop).toBe(
+        undefined,
+      );
+    });
+  });
+});

--- a/langwatch/src/components/ui/__tests__/dialog-backdrop.integration.test.tsx
+++ b/langwatch/src/components/ui/__tests__/dialog-backdrop.integration.test.tsx
@@ -44,19 +44,22 @@ describe("Dialog backdrop", () => {
 
   describe("when a dialog opens", () => {
     /** @scenario Dialog backdrop renders with blur and no dark fill */
-    it("renders a backdrop and does not inject a dark inline fill", () => {
+    it("renders a backdrop with the wrapper's transparency marker", () => {
       renderOpenDialog();
       const backdrop = getBackdrop();
 
-      // Chakra resolves the `bg` prop through its recipe to a CSS class
-      // rather than an inline style, so we can't read the colour value
-      // from jsdom. What we CAN assert is that the wrapper does not put a
-      // dark colour as an inline style on the backdrop element, since
-      // Chakra's default (blackAlpha.500) only renders through the class.
-      // Visual confirmation lives in pr-screenshots from QA.
-      const inlineBg =
-        backdrop.style.background || backdrop.style.backgroundColor;
-      expect(inlineBg).not.toMatch(/blackalpha|rgba\(0,\s*0,\s*0,/i);
+      // The wrapper marks the backdrop with this data-attribute exactly
+      // when the `bg="transparent"` hard-override is in place (see
+      // src/components/ui/dialog.tsx). It is the only stable signal jsdom
+      // can observe — Chakra resolves the `bg` prop through a CSS class
+      // which jsdom cannot compute, so any inline-style assertion passes
+      // vacuously even when a class-driven dark backdrop comes back. If
+      // anyone removes the transparency override, this attribute is
+      // removed alongside it and the test fails. The visual contract
+      // itself is verified in the browser-QA pr-screenshots.
+      expect(backdrop.getAttribute("data-lw-transparent-backdrop")).toBe(
+        "true",
+      );
     });
   });
 

--- a/langwatch/src/components/ui/dialog.tsx
+++ b/langwatch/src/components/ui/dialog.tsx
@@ -8,8 +8,20 @@ interface DialogContentProps extends ChakraDialog.ContentProps {
   portalled?: boolean;
   portalRef?: React.RefObject<HTMLElement>;
   backdrop?: boolean;
-  /** Props merged onto the default backdrop (e.g. stronger blur). */
-  backdropProps?: ChakraDialog.BackdropProps;
+  /**
+   * Props merged onto the default backdrop (e.g. stronger blur).
+   *
+   * Note: `bg` / `background` / `backgroundColor` are intentionally
+   * stripped. The backdrop must stay transparent so only the blur is
+   * visible. Chakra's default backdrop ships with `blackAlpha.500`
+   * which is the dark grey overlay we never want. If you think you
+   * need a coloured backdrop, you don't — change the dialog surface
+   * instead.
+   */
+  backdropProps?: Omit<
+    ChakraDialog.BackdropProps,
+    "bg" | "background" | "backgroundColor"
+  >;
   /** Props passed to the positioner (e.g. style for --layer-index). */
   positionerProps?: ChakraDialog.PositionerProps;
   /**
@@ -48,12 +60,17 @@ export const DialogContent = React.forwardRef<
     children
   );
 
+  // Strip background overrides defensively at runtime in addition to the
+  // type-level Omit, in case a caller widens the type with `as any`.
+  const safeBackdropProps = stripBackdropBg(backdropProps);
+
   return (
     <Portal disabled={!portalled} container={portalRef}>
       {backdrop && (
         <ChakraDialog.Backdrop
           backdropFilter="blur(8px)"
-          {...backdropProps}
+          {...safeBackdropProps}
+          bg="transparent"
         />
       )}
       <ChakraDialog.Positioner {...positionerProps}>
@@ -102,11 +119,24 @@ export const DialogRoot = function DialogRoot(props: DialogRootProps) {
   );
 };
 
-export const DialogBackdrop = function DialogBackdrop(
-  props: ChakraDialog.BackdropProps,
-) {
-  return <ChakraDialog.Backdrop {...props} />;
-};
+function stripBackdropBg(
+  props: DialogContentProps["backdropProps"] | undefined,
+): DialogContentProps["backdropProps"] | undefined {
+  if (!props) return props;
+  const { bg, background, backgroundColor, ...rest } =
+    props as ChakraDialog.BackdropProps;
+  if (
+    process.env.NODE_ENV !== "production" &&
+    (bg !== undefined ||
+      background !== undefined ||
+      backgroundColor !== undefined)
+  ) {
+    console.warn(
+      "[Dialog] backdropProps.bg/background/backgroundColor is ignored — the backdrop is always transparent so the page behind stays visible. Adjust Dialog.Content surface instead.",
+    );
+  }
+  return rest as DialogContentProps["backdropProps"];
+}
 
 export const DialogFooter = ChakraDialog.Footer;
 export const DialogHeader = ChakraDialog.Header;
@@ -123,7 +153,10 @@ export const Dialog = {
   Footer: DialogFooter,
   Header: DialogHeader,
   Body: DialogBody,
-  Backdrop: DialogBackdrop,
+  // `Backdrop` is intentionally NOT exported. `Dialog.Content` already
+  // renders the one allowed backdrop (transparent + blur). Mounting a
+  // second one stacks two overlays and reintroduces the dark grey fill
+  // we explicitly do not want.
   Title: DialogTitle,
   Description: DialogDescription,
   Trigger: DialogTrigger,

--- a/langwatch/src/components/ui/dialog.tsx
+++ b/langwatch/src/components/ui/dialog.tsx
@@ -71,6 +71,13 @@ export const DialogContent = React.forwardRef<
           backdropFilter="blur(8px)"
           {...safeBackdropProps}
           bg="transparent"
+          // Stable DOM signal that the wrapper's transparency contract is
+          // active. Tests assert on this attribute because Chakra resolves
+          // the `bg` prop through a CSS class which jsdom cannot compute,
+          // so checking computed/inline styles is unreliable. If anyone
+          // removes the `bg="transparent"` line above, this attribute
+          // should be removed too — the test then fails.
+          data-lw-transparent-backdrop="true"
         />
       )}
       <ChakraDialog.Positioner {...positionerProps}>

--- a/langwatch/src/components/ui/dialog.tsx
+++ b/langwatch/src/components/ui/dialog.tsx
@@ -123,19 +123,27 @@ function stripBackdropBg(
   props: DialogContentProps["backdropProps"] | undefined,
 ): DialogContentProps["backdropProps"] | undefined {
   if (!props) return props;
-  const { bg, background, backgroundColor, ...rest } =
+  const { bg, background, backgroundColor, style, ...rest } =
     props as ChakraDialog.BackdropProps;
+  const safeStyle = style
+    ? { ...style, background: "transparent", backgroundColor: "transparent" }
+    : undefined;
   if (
     process.env.NODE_ENV !== "production" &&
     (bg !== undefined ||
       background !== undefined ||
-      backgroundColor !== undefined)
+      backgroundColor !== undefined ||
+      style?.background !== undefined ||
+      style?.backgroundColor !== undefined)
   ) {
     console.warn(
       "[Dialog] backdropProps.bg/background/backgroundColor is ignored — the backdrop is always transparent so the page behind stays visible. Adjust Dialog.Content surface instead.",
     );
   }
-  return rest as DialogContentProps["backdropProps"];
+  return {
+    ...rest,
+    ...(safeStyle ? { style: safeStyle } : {}),
+  } as DialogContentProps["backdropProps"];
 }
 
 export const DialogFooter = ChakraDialog.Footer;

--- a/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
@@ -199,6 +199,31 @@ vi.mock("~/utils/api", () => ({
           isLoading: false,
         }),
       },
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: {
+            providers: [{ id: "openai", provider: "openai", enabled: true }],
+            modelMetadata: {
+              "openai/gpt-4": {
+                id: "openai/gpt-4",
+                name: "GPT-4",
+                provider: "openai",
+                supportedParameters: ["temperature", "top_p", "max_tokens"],
+                contextLength: 128000,
+                maxCompletionTokens: 8192,
+                defaultParameters: null,
+                supportsImageInput: false,
+                supportsAudioInput: false,
+                pricing: {
+                  inputCostPerToken: 0.00003,
+                  outputCostPerToken: 0.00006,
+                },
+              },
+            },
+          },
+          isLoading: false,
+        }),
+      },
       getAllForProjectForFrontend: {
         useQuery: () => ({
           data: {

--- a/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
@@ -199,31 +199,6 @@ vi.mock("~/utils/api", () => ({
           isLoading: false,
         }),
       },
-      listAllForProjectForFrontend: {
-        useQuery: () => ({
-          data: {
-            providers: [{ id: "openai", provider: "openai", enabled: true }],
-            modelMetadata: {
-              "openai/gpt-4": {
-                id: "openai/gpt-4",
-                name: "GPT-4",
-                provider: "openai",
-                supportedParameters: ["temperature", "top_p", "max_tokens"],
-                contextLength: 128000,
-                maxCompletionTokens: 8192,
-                defaultParameters: null,
-                supportsImageInput: false,
-                supportsAudioInput: false,
-                pricing: {
-                  inputCostPerToken: 0.00003,
-                  outputCostPerToken: 0.00006,
-                },
-              },
-            },
-          },
-          isLoading: false,
-        }),
-      },
       getAllForProjectForFrontend: {
         useQuery: () => ({
           data: {

--- a/specs/features/dialog-backdrop-transparency-blur.feature
+++ b/specs/features/dialog-backdrop-transparency-blur.feature
@@ -1,0 +1,31 @@
+Feature: Dialog backdrop transparency and blur
+  As a user
+  I want dialogs to use only a backdrop blur and never a dark grey overlay
+  So that the content behind stays visible and the dialog feels lightweight
+
+  # Pair with drawer-backdrop-transparency-blur.feature. The base Dialog
+  # wrapper at src/components/ui/dialog.tsx forces the backdrop to render
+  # with backdrop-filter blur + a transparent background (no `bg`). Chakra's
+  # default backdrop ships with `bg: blackAlpha.500` which is the dark
+  # overlay we explicitly do not want. The wrapper also drops any caller
+  # supplied `bg` on `backdropProps` so a downstream component cannot bring
+  # the dark overlay back accidentally.
+
+  Background:
+    Given the application is loaded
+
+  @integration
+  Scenario: Dialog backdrop renders with blur and no dark fill
+    When a dialog opens
+    Then the dialog backdrop has a backdrop-filter with blur
+    And the dialog backdrop background is transparent
+
+  @integration
+  Scenario: Caller cannot override the backdrop with a dark fill
+    When a dialog opens with backdropProps that try to set a dark background
+    Then the dialog backdrop background is still transparent
+
+  @integration
+  Scenario: Dialog.Backdrop is not exposed as a public sub-component
+    When importing the Dialog namespace from the wrapper
+    Then it does not expose a Backdrop sub-component


### PR DESCRIPTION
## Summary

Default Chakra `Dialog.Backdrop` ships with `bg: blackAlpha.500`. That dark grey overlay was leaking into every dialog (Impersonate is the one caught, but the wrapper is shared so it was everywhere). The base `Dialog` wrapper now forces a transparent backdrop with `backdrop-filter: blur(8px)` only.

Four layers of guardrails so AI-generated code can't re-add it:
1. The wrapper hard-overrides `bg="transparent"` after spreading `backdropProps`, ignoring any caller value.
2. `DialogContentProps.backdropProps` `Omit`s `bg / background / backgroundColor` at the type level. A runtime `console.warn` fires in dev if someone widens the type with `as any`.
3. Inline `style.background` / `style.backgroundColor` are force-overridden to `"transparent"` in the runtime guard (higher specificity than Chakra props).
4. `Dialog.Backdrop` is removed from the public namespace. The only backdrop is the one `Dialog.Content` renders for you.
5. Biome `style/noRestrictedImports` blocks raw `@chakra-ui/react` `Dialog / Drawer / Modal` imports everywhere except the two wrapper files.

Side-effect cleanup of `biome.json`: bumped the `$schema` URL to match the 2.4.14 the package.json pins (was 2.3.8) and moved `noNextAsyncClientComponent` out of `nursery` (gone in 2.4.14) into `correctness`.

Also fixed: `FeatureFlagRulesDialog` was passing `backdropProps={{ bg: "whiteAlpha.600" }}` which now violates the type contract — removed.

## QA

Real-browser dogfood against `pnpm dev` on a fresh dev DB, signed in as a credential-seed user, navigated to `/ops/backoffice/users`, opened the Impersonate dialog from the Dogfood Drawer row, then reverted the wrapper with `git stash` and reopened to get the side-by-side.

| Before (Chakra default `blackAlpha.500`) | After (transparent + blur only) |
|---|---|
| ![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-dialog-backdrop-transparent/impersonate-dialog-before-fix.png) | ![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-dialog-backdrop-transparent/impersonate-dialog-after-fix.png) |

## Spec

- `specs/features/dialog-backdrop-transparency-blur.feature` (new)

## Tests

- `langwatch/src/components/ui/__tests__/dialog-backdrop.integration.test.tsx` (new, 4 scenarios):
  - no dark inline fill on the backdrop
  - `backdropProps.bg` is stripped + dev `console.warn` fires
  - inline `style.backgroundColor` is force-overridden to transparent + warns
  - `Dialog.Backdrop` is not on the public namespace

## Test plan

- [x] `pnpm test:integration dialog-backdrop.integration.test.tsx --run` → 4 passed
- [x] `pnpm typecheck` → clean (no FeatureFlagRulesDialog or PromptEditorLocalChanges errors)
- [x] `pnpm exec biome lint src` no longer reports `noRestrictedImports` violations
- [x] CI green