### PR TITLE
fix(tests): mock new listAllForProjectForFrontend tRPC method

### DIFF
--- a/langwatch/src/components/__tests__/NoModelsConfiguredCallout.integration.test.tsx
+++ b/langwatch/src/components/__tests__/NoModelsConfiguredCallout.integration.test.tsx
@@ -29,11 +29,16 @@ vi.mock("../../hooks/useOrganizationTeamProject", () => ({
 
 // tRPC's getAllForProject query returns an empty providers map to
 // simulate a freshly created project with zero configured providers.
+// listAllForProjectForFrontend (introduced in #4120) is also called by
+// ModelSelector; mock it as an empty providers array.
 vi.mock("../../utils/api", () => ({
   api: {
     modelProvider: {
       getAllForProject: {
         useQuery: () => ({ data: {}, isLoading: false }),
+      },
+      listAllForProjectForFrontend: {
+        useQuery: () => ({ data: { providers: [] }, isLoading: false }),
       },
     },
   },

--- a/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
+++ b/langwatch/src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
@@ -208,6 +208,24 @@ vi.mock("~/utils/api", () => ({
                 id: "openai/gpt-4",
                 name: "GPT-4",
                 provider: "openai",
+              },
+            },
+          },
+          isLoading: false,
+        }),
+      },
+      // listAllForProjectForFrontend (introduced in #4120) returns providers
+      // as an array, distinct from the legacy getAllForProjectForFrontend
+      // record shape. ModelSelector iterates this with `for (const row of providers)`.
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: {
+            providers: [{ provider: "openai", enabled: true, customModels: [] }],
+            modelMetadata: {
+              "openai/gpt-4": {
+                id: "openai/gpt-4",
+                name: "GPT-4",
+                provider: "openai",
                 supportedParameters: ["temperature", "top_p", "max_tokens"],
                 contextLength: 128000,
                 maxCompletionTokens: 8192,


### PR DESCRIPTION
## Summary

Unblock CI on `main`.

After #4120 landed (`feat(model-defaults): latest/latest-mini aliases + topic-clustering lift`), two integration tests started failing on every push — `langwatch-app-complete` / `test-unit (3)` / `test-integration (3)` have been red on `main` since.

Root cause: `ModelSelector` now calls the new `api.modelProvider.listAllForProjectForFrontend.useQuery` (introduced in #4120) alongside the legacy `getAllForProjectForFrontend`. Two `vi.mock("~/utils/api", ...)` blocks weren't updated to mock the new method, so reads returned `undefined.useQuery` and the renders threw.

## What changed

- `NoModelsConfiguredCallout.integration.test.tsx`: add the new method to the api mock, returning `{ providers: [] }` for the empty-state contract.
- `PromptEditorLocalChanges.integration.test.tsx`: add the new method, noting the array-vs-record shape difference from the legacy procedure. Kept the legacy `getAllForProjectForFrontend` mock too because some code paths still call it.

## Test plan

```bash
pnpm test:unit src/components/__tests__/NoModelsConfiguredCallout.integration.test.tsx
pnpm test:unit src/evaluations-v3/__tests__/PromptEditorLocalChanges.integration.test.tsx
```

Both pass locally (3/3 + 6/6+1 skipped).

## How I can prove I was successful

Before this PR: `gh run list --branch main --workflow=langwatch-app-ci.yml` shows the two most recent main runs failing.
After this PR merges: re-run of the same workflow on main will be green.

## Anything surprising?

`api.modelProvider.useQuery` mocks live on the consumer side (per-test `vi.mock`) rather than in a shared fixture, so every new tRPC procedure under `modelProvider.*` will silently break unrelated integration tests until they're individually patched. Worth a follow-up to centralise the mock, but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)