### PR TITLE
feat(feature-flags): per-org/per-project targeting rules in our own DB

### DIFF
--- a/langwatch/prisma/migrations/20260519120000_feature_flag_targeting_rules/migration.sql
+++ b/langwatch/prisma/migrations/20260519120000_feature_flag_targeting_rules/migration.sql
@@ -1,0 +1,7 @@
+-- Add a JSON column for per-flag targeting rules. Rules are evaluated
+-- in order; the first match decides; missing/empty rules fall through
+-- to the row's existing `enabled` boolean. Shape is owned by
+-- src/server/featureFlag/rules.ts so it can grow (percentage rollouts,
+-- email-domain matches, ...) without another migration.
+
+ALTER TABLE "FeatureFlag" ADD COLUMN "rules" JSONB;

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -1886,6 +1886,14 @@ model GatewayCacheRule {
 model FeatureFlag {
     key          String   @id
     enabled      Boolean
+    // Optional list of targeting rules evaluated before the `enabled`
+    // fallback. Each rule is `{ match: { projectId?, organizationId? },
+    // enabled: boolean }` — first match wins. Shape lives in
+    // `src/server/featureFlag/rules.ts` so it can grow over time
+    // (percentage rollouts, email-domain matches, etc.) without a
+    // migration. Storing as JSON keeps the surface flexible while
+    // postgres handles the row-level cache invalidation.
+    rules        Json?
     // Last operator to flip the value. Free-form string (user id), no FK
     // because the same table serves SaaS and self-hosted installs where
     // the User table is not guaranteed to share lifecycle with this row.

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
@@ -10,7 +10,7 @@ import {
   createListCollection,
 } from "@chakra-ui/react";
 import { Plus, Trash2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   DialogActionTrigger,
   DialogBody,
@@ -71,11 +71,12 @@ function rulesToUI(rules: FeatureFlagRules): UIRule[] {
 
 function uiToRules(rules: UIRule[]): FeatureFlagRules {
   return rules.map((r) => {
+    const scopeId = r.scopeId.trim();
     if (r.scopeKind === "ORGANIZATION") {
-      return { match: { organizationId: r.scopeId }, enabled: r.enabled };
+      return { match: { organizationId: scopeId }, enabled: r.enabled };
     }
     if (r.scopeKind === "PROJECT") {
-      return { match: { projectId: r.scopeId }, enabled: r.enabled };
+      return { match: { projectId: scopeId }, enabled: r.enabled };
     }
     return { match: {}, enabled: r.enabled };
   });
@@ -108,11 +109,16 @@ export function FeatureFlagRulesDialog({
     },
   });
 
-  // Re-seed the draft whenever the dialog is reopened or the upstream
-  // rules change, so a "Cancel" + reopen always starts from the saved
-  // server state and doesn't leak unsaved edits between sessions.
+  // Re-seed the draft only when the dialog transitions from closed to
+  // open, so a "Cancel" + reopen always starts from the saved server
+  // state and doesn't leak unsaved edits between sessions. We don't
+  // reset on every initialRules identity change, because a background
+  // refetch while the user is mid-edit would otherwise wipe their work.
+  const wasOpenRef = useRef(false);
   useEffect(() => {
-    if (open) setDraft(rulesToUI(initialRules));
+    const justOpened = open && !wasOpenRef.current;
+    if (justOpened) setDraft(rulesToUI(initialRules));
+    wasOpenRef.current = open;
   }, [open, initialRules]);
 
   const updateRule = (index: number, patch: Partial<UIRule>) => {

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
@@ -230,7 +230,11 @@ export function FeatureFlagRulesDialog({
               Cancel
             </Button>
           </DialogActionTrigger>
-          <Button onClick={handleSave} loading={setRules.isPending}>
+          <Button
+            onClick={handleSave}
+            loading={setRules.isPending}
+            colorPalette="blue"
+          >
             Save rules
           </Button>
         </DialogFooter>

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
@@ -49,7 +49,16 @@ const SCOPE_COLLECTION = createListCollection<{ value: ScopeKind; label: string 
   ],
 });
 
+const DEFAULT_NEW_RULE: UIRule = {
+  scopeKind: "ORGANIZATION",
+  scopeId: "",
+  enabled: true,
+};
+
 function rulesToUI(rules: FeatureFlagRules): UIRule[] {
+  // Empty input → seed the dialog with one org-scoped rule so operators
+  // see the shape they're about to fill in instead of an empty pane.
+  if (rules.length === 0) return [DEFAULT_NEW_RULE];
   return rules.map((r) => {
     if (r.match.organizationId) {
       return {

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
@@ -1,0 +1,315 @@
+import {
+  Box,
+  Button,
+  Field,
+  HStack,
+  IconButton,
+  Input,
+  Text,
+  VStack,
+  createListCollection,
+} from "@chakra-ui/react";
+import { Plus, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  DialogActionTrigger,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import {
+  SelectContent,
+  SelectItem,
+  SelectRoot,
+  SelectTrigger,
+  SelectValueText,
+} from "~/components/ui/select";
+import { Switch } from "~/components/ui/switch";
+import { toaster } from "~/components/ui/toaster";
+import { api } from "~/utils/api";
+import type { FeatureFlagRules } from "~/server/featureFlag";
+
+type ScopeKind = "EVERYONE" | "ORGANIZATION" | "PROJECT";
+
+interface UIRule {
+  scopeKind: ScopeKind;
+  scopeId: string;
+  enabled: boolean;
+}
+
+const SCOPE_COLLECTION = createListCollection<{ value: ScopeKind; label: string }>({
+  items: [
+    { value: "EVERYONE", label: "Everyone (default)" },
+    { value: "ORGANIZATION", label: "Organization" },
+    { value: "PROJECT", label: "Project" },
+  ],
+});
+
+function rulesToUI(rules: FeatureFlagRules): UIRule[] {
+  return rules.map((r) => {
+    if (r.match.organizationId) {
+      return {
+        scopeKind: "ORGANIZATION",
+        scopeId: r.match.organizationId,
+        enabled: r.enabled,
+      };
+    }
+    if (r.match.projectId) {
+      return {
+        scopeKind: "PROJECT",
+        scopeId: r.match.projectId,
+        enabled: r.enabled,
+      };
+    }
+    return { scopeKind: "EVERYONE", scopeId: "", enabled: r.enabled };
+  });
+}
+
+function uiToRules(rules: UIRule[]): FeatureFlagRules {
+  return rules.map((r) => {
+    if (r.scopeKind === "ORGANIZATION") {
+      return { match: { organizationId: r.scopeId }, enabled: r.enabled };
+    }
+    if (r.scopeKind === "PROJECT") {
+      return { match: { projectId: r.scopeId }, enabled: r.enabled };
+    }
+    return { match: {}, enabled: r.enabled };
+  });
+}
+
+export function FeatureFlagRulesDialog({
+  open,
+  onOpenChange,
+  flagKey,
+  initialRules,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  flagKey: string;
+  initialRules: FeatureFlagRules;
+}) {
+  const [draft, setDraft] = useState<UIRule[]>(() => rulesToUI(initialRules));
+  const utils = api.useUtils();
+  const setRules = api.ops.setFeatureFlagRules.useMutation({
+    onSuccess: async () => {
+      await utils.ops.listFeatureFlags.invalidate();
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      toaster.create({
+        title: "Failed to save rules",
+        description: error.message,
+        type: "error",
+      });
+    },
+  });
+
+  // Re-seed the draft whenever the dialog is reopened or the upstream
+  // rules change, so a "Cancel" + reopen always starts from the saved
+  // server state and doesn't leak unsaved edits between sessions.
+  useEffect(() => {
+    if (open) setDraft(rulesToUI(initialRules));
+  }, [open, initialRules]);
+
+  const updateRule = (index: number, patch: Partial<UIRule>) => {
+    setDraft((current) =>
+      current.map((r, i) => (i === index ? { ...r, ...patch } : r)),
+    );
+  };
+
+  const addRule = () => {
+    setDraft((current) => [
+      ...current,
+      { scopeKind: "ORGANIZATION", scopeId: "", enabled: true },
+    ]);
+  };
+
+  const removeRule = (index: number) => {
+    setDraft((current) => current.filter((_, i) => i !== index));
+  };
+
+  const handleSave = () => {
+    const invalid = draft.find(
+      (r) => r.scopeKind !== "EVERYONE" && r.scopeId.trim() === "",
+    );
+    if (invalid) {
+      toaster.create({
+        title: "Missing target",
+        description: `Every ${invalid.scopeKind.toLowerCase()} rule needs an ID.`,
+        type: "error",
+      });
+      return;
+    }
+    void setRules.mutateAsync({
+      key: flagKey,
+      rules: uiToRules(draft),
+    });
+  };
+
+  return (
+    <DialogRoot
+      open={open}
+      onOpenChange={(details) => onOpenChange(details.open)}
+      size="lg"
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Targeting rules</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <VStack align="stretch" gap={3}>
+            <Text fontSize="sm" color="fg.muted">
+              Rules are evaluated top-to-bottom; the first match wins. When
+              no rule matches, the row-level toggle is used as the
+              fallback. Once a row exists in postgres, PostHog is no
+              longer consulted for this flag.
+            </Text>
+            <Box>
+              <Text fontFamily="mono" fontSize="xs" color="fg.muted">
+                {flagKey}
+              </Text>
+            </Box>
+            {draft.length === 0 ? (
+              <Box
+                paddingY={6}
+                paddingX={4}
+                borderRadius="md"
+                borderWidth="1px"
+                borderStyle="dashed"
+                borderColor="border.muted"
+              >
+                <Text fontSize="sm" color="fg.muted" textAlign="center">
+                  No targeting rules. The row-level toggle decides the
+                  value for everyone.
+                </Text>
+              </Box>
+            ) : (
+              <VStack align="stretch" gap={2}>
+                {draft.map((rule, index) => (
+                  <RuleRow
+                    key={index}
+                    rule={rule}
+                    onChange={(patch) => updateRule(index, patch)}
+                    onRemove={() => removeRule(index)}
+                  />
+                ))}
+              </VStack>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              alignSelf="flex-start"
+              onClick={addRule}
+            >
+              <Plus size={14} /> Add rule
+            </Button>
+          </VStack>
+        </DialogBody>
+        <DialogFooter>
+          <DialogActionTrigger asChild>
+            <Button variant="outline" disabled={setRules.isPending}>
+              Cancel
+            </Button>
+          </DialogActionTrigger>
+          <Button onClick={handleSave} loading={setRules.isPending}>
+            Save rules
+          </Button>
+        </DialogFooter>
+        <DialogCloseTrigger />
+      </DialogContent>
+    </DialogRoot>
+  );
+}
+
+function RuleRow({
+  rule,
+  onChange,
+  onRemove,
+}: {
+  rule: UIRule;
+  onChange: (patch: Partial<UIRule>) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <HStack
+      align="flex-end"
+      gap={2}
+      padding={2}
+      borderRadius="md"
+      borderWidth="1px"
+      borderColor="border.muted"
+    >
+      <Field.Root flexBasis="180px" flexShrink={0}>
+        <Field.Label fontSize="xs">Scope</Field.Label>
+        <SelectRoot
+          collection={SCOPE_COLLECTION}
+          value={[rule.scopeKind]}
+          onValueChange={(details) => {
+            const next = details.value[0] as ScopeKind | undefined;
+            if (!next) return;
+            onChange({
+              scopeKind: next,
+              scopeId: next === "EVERYONE" ? "" : rule.scopeId,
+            });
+          }}
+          size="sm"
+        >
+          <SelectTrigger>
+            <SelectValueText placeholder="Pick scope" />
+          </SelectTrigger>
+          <SelectContent>
+            {SCOPE_COLLECTION.items.map((item) => (
+              <SelectItem key={item.value} item={item}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </SelectRoot>
+      </Field.Root>
+      <Field.Root flex={1}>
+        <Field.Label fontSize="xs">
+          {rule.scopeKind === "EVERYONE"
+            ? "Applies to every context"
+            : `${rule.scopeKind === "ORGANIZATION" ? "Organization" : "Project"} id`}
+        </Field.Label>
+        <Input
+          size="sm"
+          fontFamily="mono"
+          fontSize="xs"
+          placeholder={
+            rule.scopeKind === "ORGANIZATION"
+              ? "organization_xxxx"
+              : rule.scopeKind === "PROJECT"
+                ? "project_xxxx"
+                : ""
+          }
+          value={rule.scopeId}
+          disabled={rule.scopeKind === "EVERYONE"}
+          onChange={(e) => onChange({ scopeId: e.target.value })}
+        />
+      </Field.Root>
+      <Field.Root flexBasis="120px" flexShrink={0}>
+        <Field.Label fontSize="xs">Enabled</Field.Label>
+        <HStack height="32px" alignItems="center">
+          <Switch
+            checked={rule.enabled}
+            onCheckedChange={(details) => onChange({ enabled: details.checked })}
+          />
+          <Text fontSize="xs">{rule.enabled ? "on" : "off"}</Text>
+        </HStack>
+      </Field.Root>
+      <IconButton
+        aria-label="Remove rule"
+        size="sm"
+        variant="ghost"
+        onClick={onRemove}
+      >
+        <Trash2 size={14} />
+      </IconButton>
+    </HStack>
+  );
+}

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagRulesDialog.tsx
@@ -162,7 +162,7 @@ export function FeatureFlagRulesDialog({
       onOpenChange={(details) => onOpenChange(details.open)}
       size="lg"
     >
-      <DialogContent>
+      <DialogContent backdropProps={{ bg: "whiteAlpha.600" }}>
         <DialogHeader>
           <DialogTitle>Targeting rules</DialogTitle>
         </DialogHeader>

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -270,20 +270,37 @@ function FlagRowView({
         ? "postgres"
         : "registry default";
 
-  const enabledRules = row.rules.filter((r) => r.enabled);
+  // Walk rules honoring first-match-wins, so a disabled rule earlier in
+  // the list correctly shadows a later enabled rule for the same scope.
+  // An empty-match rule matches every context, so once one is seen, no
+  // later rule can ever fire and we stop.
+  let everyoneViaRule: boolean | null = null;
+  const orgDecisions = new Map<string, boolean>();
+  const projectDecisions = new Map<string, boolean>();
+  for (const r of row.rules) {
+    const isEveryone = !r.match.organizationId && !r.match.projectId;
+    if (isEveryone) {
+      everyoneViaRule = r.enabled;
+      break;
+    }
+    if (r.match.organizationId && !orgDecisions.has(r.match.organizationId)) {
+      orgDecisions.set(r.match.organizationId, r.enabled);
+    }
+    if (r.match.projectId && !projectDecisions.has(r.match.projectId)) {
+      projectDecisions.set(r.match.projectId, r.enabled);
+    }
+  }
   const enabledOrgIds = new Set(
-    enabledRules
-      .filter((r) => r.match.organizationId)
-      .map((r) => r.match.organizationId!),
+    Array.from(orgDecisions.entries())
+      .filter(([, v]) => v)
+      .map(([k]) => k),
   );
   const enabledProjectIds = new Set(
-    enabledRules
-      .filter((r) => r.match.projectId)
-      .map((r) => r.match.projectId!),
+    Array.from(projectDecisions.entries())
+      .filter(([, v]) => v)
+      .map(([k]) => k),
   );
-  const enabledEveryoneViaRule = enabledRules.some(
-    (r) => !r.match.organizationId && !r.match.projectId,
-  );
+  const enabledEveryoneViaRule = everyoneViaRule === true;
   const partialEnabled =
     !effective &&
     (enabledEveryoneViaRule ||

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -364,8 +364,16 @@ function FlagRowView({
             <Switch
               checked={effective || partialEnabled}
               disabled={!canManage || envLocked || pending}
-              colorPalette={partialEnabled ? "yellow" : "blue"}
               onCheckedChange={(details) => void onChange(details.checked)}
+              css={
+                partialEnabled
+                  ? {
+                      "& [data-part='control'][data-state='checked']": {
+                        background: "yellow.500",
+                      },
+                    }
+                  : undefined
+              }
             />
             {canManage && !envLocked && (
               <Tooltip
@@ -397,7 +405,7 @@ function FlagRowView({
             )}
           </HStack>
           {targetingLabel && (
-            <Text fontSize="xs" color="yellow.700">
+            <Text fontSize="xs" color="fg.muted">
               {targetingLabel}
             </Text>
           )}

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -217,7 +217,6 @@ function ScopeSection({
               <Table.ColumnHeader>Flag</Table.ColumnHeader>
               <Table.ColumnHeader>Effective</Table.ColumnHeader>
               <Table.ColumnHeader>Source</Table.ColumnHeader>
-              <Table.ColumnHeader>Targeting</Table.ColumnHeader>
               <Table.ColumnHeader>Default</Table.ColumnHeader>
               <Table.ColumnHeader>Last edit</Table.ColumnHeader>
             </Table.Row>
@@ -305,35 +304,23 @@ function FlagRowView({
         </VStack>
       </Table.Cell>
       <Table.Cell>
-        <HStack gap={3}>
-          <Switch
-            checked={effective}
-            disabled={!canManage || envLocked || pending}
-            onCheckedChange={(details) => void onChange(details.checked)}
-          />
-          {envLocked && (
-            <Tooltip
-              content={`Locked by env override (${row.envOverride ? "1" : "0"}). The toggle is disabled because the env var wins over postgres.`}
-            >
-              <Badge colorPalette="orange" size="sm" variant="subtle">
-                env override
-              </Badge>
-            </Tooltip>
-          )}
-        </HStack>
-      </Table.Cell>
-      <Table.Cell>
-        <Text fontSize="xs">{source}</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <HStack gap={2}>
-          <Text fontSize="xs" color={ruleCount > 0 ? "fg" : "fg.muted"}>
-            {ruleCount === 0
-              ? "no rules"
-              : ruleCount === 1
-                ? "1 rule"
-                : `${ruleCount} rules`}
-          </Text>
+        <VStack align="start" gap={1}>
+          <HStack gap={3}>
+            <Switch
+              checked={effective}
+              disabled={!canManage || envLocked || pending}
+              onCheckedChange={(details) => void onChange(details.checked)}
+            />
+            {envLocked && (
+              <Tooltip
+                content={`Locked by env override (${row.envOverride ? "1" : "0"}). The toggle is disabled because the env var wins over postgres.`}
+              >
+                <Badge colorPalette="orange" size="sm" variant="subtle">
+                  env override
+                </Badge>
+              </Tooltip>
+            )}
+          </HStack>
           {canManage && !envLocked && (
             <Button
               type="button"
@@ -347,16 +334,21 @@ function FlagRowView({
               minWidth="auto"
               onClick={() => setRulesDialogOpen(true)}
             >
-              {ruleCount === 0 ? "add" : "edit"}
+              {ruleCount === 0
+                ? "Specific targeting"
+                : `Specific targeting (${ruleCount})`}
             </Button>
           )}
-        </HStack>
+        </VStack>
         <FeatureFlagRulesDialog
           open={rulesDialogOpen}
           onOpenChange={setRulesDialogOpen}
           flagKey={row.key}
           initialRules={row.rules}
         />
+      </Table.Cell>
+      <Table.Cell>
+        <Text fontSize="xs">{source}</Text>
       </Table.Cell>
       <Table.Cell>
         <Text fontSize="xs">{row.defaultValue ? "on" : "off"}</Text>

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -369,7 +369,7 @@ function FlagRowView({
                 partialEnabled
                   ? {
                       "& [data-part='control'][data-state='checked']": {
-                        background: "yellow.500",
+                        background: "green.500",
                       },
                     }
                   : undefined

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -17,7 +17,9 @@ import { Tooltip } from "~/components/ui/tooltip";
 import { toaster } from "~/components/ui/toaster";
 import { useOpsPermission } from "~/hooks/useOpsPermission";
 import { usePublicEnv } from "~/hooks/usePublicEnv";
+import type { FeatureFlagRules } from "~/server/featureFlag";
 import { api } from "~/utils/api";
+import { FeatureFlagRulesDialog } from "./FeatureFlagRulesDialog";
 
 interface FlagRow {
   key: string;
@@ -26,6 +28,7 @@ interface FlagRow {
   description: string;
   family: string | null;
   storedValue: boolean | null;
+  rules: FeatureFlagRules;
   envOverride: boolean | null;
   effective: boolean;
   lastEditedBy: string | null;
@@ -214,6 +217,7 @@ function ScopeSection({
               <Table.ColumnHeader>Flag</Table.ColumnHeader>
               <Table.ColumnHeader>Effective</Table.ColumnHeader>
               <Table.ColumnHeader>Source</Table.ColumnHeader>
+              <Table.ColumnHeader>Targeting</Table.ColumnHeader>
               <Table.ColumnHeader>Default</Table.ColumnHeader>
               <Table.ColumnHeader>Last edit</Table.ColumnHeader>
             </Table.Row>
@@ -253,13 +257,17 @@ function FlagRowView({
   pending: boolean;
 }) {
   const [optimistic, setOptimistic] = useState<boolean | null>(null);
+  const [rulesDialogOpen, setRulesDialogOpen] = useState(false);
   const envLocked = row.envOverride !== null;
   const effective = optimistic ?? row.effective;
+  const ruleCount = row.rules.length;
   const source = envLocked
     ? "env override"
-    : row.storedValue !== null
-      ? "postgres"
-      : "registry default";
+    : ruleCount > 0
+      ? "postgres + rules"
+      : row.storedValue !== null
+        ? "postgres"
+        : "registry default";
 
   const onChange = async (next: boolean) => {
     setOptimistic(next);
@@ -316,6 +324,39 @@ function FlagRowView({
       </Table.Cell>
       <Table.Cell>
         <Text fontSize="xs">{source}</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <HStack gap={2}>
+          <Text fontSize="xs" color={ruleCount > 0 ? "fg" : "fg.muted"}>
+            {ruleCount === 0
+              ? "no rules"
+              : ruleCount === 1
+                ? "1 rule"
+                : `${ruleCount} rules`}
+          </Text>
+          {canManage && !envLocked && (
+            <Button
+              type="button"
+              variant="plain"
+              size="xs"
+              fontSize="xs"
+              color="blue.500"
+              textDecoration="underline"
+              paddingX={0}
+              height="auto"
+              minWidth="auto"
+              onClick={() => setRulesDialogOpen(true)}
+            >
+              {ruleCount === 0 ? "add" : "edit"}
+            </Button>
+          )}
+        </HStack>
+        <FeatureFlagRulesDialog
+          open={rulesDialogOpen}
+          onOpenChange={setRulesDialogOpen}
+          flagKey={row.key}
+          initialRules={row.rules}
+        />
       </Table.Cell>
       <Table.Cell>
         <Text fontSize="xs">{row.defaultValue ? "on" : "off"}</Text>

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -12,7 +12,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { Settings } from "lucide-react";
+import { Settings2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Switch } from "~/components/ui/switch";
 import { Tooltip } from "~/components/ui/tooltip";
@@ -270,6 +270,42 @@ function FlagRowView({
         ? "postgres"
         : "registry default";
 
+  const enabledRules = row.rules.filter((r) => r.enabled);
+  const enabledOrgIds = new Set(
+    enabledRules
+      .filter((r) => r.match.organizationId)
+      .map((r) => r.match.organizationId!),
+  );
+  const enabledProjectIds = new Set(
+    enabledRules
+      .filter((r) => r.match.projectId)
+      .map((r) => r.match.projectId!),
+  );
+  const enabledEveryoneViaRule = enabledRules.some(
+    (r) => !r.match.organizationId && !r.match.projectId,
+  );
+  const partialEnabled =
+    !effective &&
+    (enabledEveryoneViaRule ||
+      enabledOrgIds.size > 0 ||
+      enabledProjectIds.size > 0);
+  const targetingSummary = enabledEveryoneViaRule
+    ? "Enabled for everyone via rule"
+    : [
+        enabledOrgIds.size > 0 &&
+          `${enabledOrgIds.size} organization${enabledOrgIds.size === 1 ? "" : "s"}`,
+        enabledProjectIds.size > 0 &&
+          `${enabledProjectIds.size} project${enabledProjectIds.size === 1 ? "" : "s"}`,
+      ]
+        .filter(Boolean)
+        .join(", ");
+  const targetingLabel =
+    !effective && targetingSummary
+      ? enabledEveryoneViaRule
+        ? targetingSummary
+        : `Enabled for ${targetingSummary}`
+      : null;
+
   const onChange = async (next: boolean) => {
     setOptimistic(next);
     try {
@@ -306,41 +342,49 @@ function FlagRowView({
         </VStack>
       </Table.Cell>
       <Table.Cell>
-        <HStack gap={2}>
-          <Switch
-            checked={effective}
-            disabled={!canManage || envLocked || pending}
-            onCheckedChange={(details) => void onChange(details.checked)}
-          />
-          {canManage && !envLocked && (
-            <Tooltip
-              content={
-                ruleCount === 0
-                  ? "Specific targeting"
-                  : `Specific targeting (${ruleCount} rule${ruleCount === 1 ? "" : "s"})`
-              }
-            >
-              <IconButton
-                aria-label="Specific targeting"
-                size="xs"
-                variant="ghost"
-                onClick={() => setRulesDialogOpen(true)}
-                colorPalette={ruleCount > 0 ? "blue" : "gray"}
+        <VStack align="start" gap={1}>
+          <HStack gap={2}>
+            <Switch
+              checked={effective || partialEnabled}
+              disabled={!canManage || envLocked || pending}
+              colorPalette={partialEnabled ? "yellow" : "blue"}
+              onCheckedChange={(details) => void onChange(details.checked)}
+            />
+            {canManage && !envLocked && (
+              <Tooltip
+                content={
+                  ruleCount === 0
+                    ? "Specific targeting"
+                    : `Specific targeting (${ruleCount} rule${ruleCount === 1 ? "" : "s"})`
+                }
               >
-                <Settings size={14} />
-              </IconButton>
-            </Tooltip>
+                <IconButton
+                  aria-label="Specific targeting"
+                  size="xs"
+                  variant="ghost"
+                  onClick={() => setRulesDialogOpen(true)}
+                  color="gray.500"
+                >
+                  <Settings2 size={14} />
+                </IconButton>
+              </Tooltip>
+            )}
+            {envLocked && (
+              <Tooltip
+                content={`Locked by env override (${row.envOverride ? "1" : "0"}). The toggle is disabled because the env var wins over postgres.`}
+              >
+                <Badge colorPalette="orange" size="sm" variant="subtle">
+                  env override
+                </Badge>
+              </Tooltip>
+            )}
+          </HStack>
+          {targetingLabel && (
+            <Text fontSize="xs" color="yellow.700">
+              {targetingLabel}
+            </Text>
           )}
-          {envLocked && (
-            <Tooltip
-              content={`Locked by env override (${row.envOverride ? "1" : "0"}). The toggle is disabled because the env var wins over postgres.`}
-            >
-              <Badge colorPalette="orange" size="sm" variant="subtle">
-                env override
-              </Badge>
-            </Tooltip>
-          )}
-        </HStack>
+        </VStack>
         <FeatureFlagRulesDialog
           open={rulesDialogOpen}
           onOpenChange={setRulesDialogOpen}

--- a/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
+++ b/langwatch/src/components/ops/featureFlags/FeatureFlagsContent.tsx
@@ -5,12 +5,14 @@ import {
   Center,
   HStack,
   Heading,
+  IconButton,
   Spinner,
   Stack,
   Table,
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { Settings } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Switch } from "~/components/ui/switch";
 import { Tooltip } from "~/components/ui/tooltip";
@@ -304,42 +306,41 @@ function FlagRowView({
         </VStack>
       </Table.Cell>
       <Table.Cell>
-        <VStack align="start" gap={1}>
-          <HStack gap={3}>
-            <Switch
-              checked={effective}
-              disabled={!canManage || envLocked || pending}
-              onCheckedChange={(details) => void onChange(details.checked)}
-            />
-            {envLocked && (
-              <Tooltip
-                content={`Locked by env override (${row.envOverride ? "1" : "0"}). The toggle is disabled because the env var wins over postgres.`}
-              >
-                <Badge colorPalette="orange" size="sm" variant="subtle">
-                  env override
-                </Badge>
-              </Tooltip>
-            )}
-          </HStack>
+        <HStack gap={2}>
+          <Switch
+            checked={effective}
+            disabled={!canManage || envLocked || pending}
+            onCheckedChange={(details) => void onChange(details.checked)}
+          />
           {canManage && !envLocked && (
-            <Button
-              type="button"
-              variant="plain"
-              size="xs"
-              fontSize="xs"
-              color="blue.500"
-              textDecoration="underline"
-              paddingX={0}
-              height="auto"
-              minWidth="auto"
-              onClick={() => setRulesDialogOpen(true)}
+            <Tooltip
+              content={
+                ruleCount === 0
+                  ? "Specific targeting"
+                  : `Specific targeting (${ruleCount} rule${ruleCount === 1 ? "" : "s"})`
+              }
             >
-              {ruleCount === 0
-                ? "Specific targeting"
-                : `Specific targeting (${ruleCount})`}
-            </Button>
+              <IconButton
+                aria-label="Specific targeting"
+                size="xs"
+                variant="ghost"
+                onClick={() => setRulesDialogOpen(true)}
+                colorPalette={ruleCount > 0 ? "blue" : "gray"}
+              >
+                <Settings size={14} />
+              </IconButton>
+            </Tooltip>
           )}
-        </VStack>
+          {envLocked && (
+            <Tooltip
+              content={`Locked by env override (${row.envOverride ? "1" : "0"}). The toggle is disabled because the env var wins over postgres.`}
+            >
+              <Badge colorPalette="orange" size="sm" variant="subtle">
+                env override
+              </Badge>
+            </Tooltip>
+          )}
+        </HStack>
         <FeatureFlagRulesDialog
           open={rulesDialogOpen}
           onOpenChange={setRulesDialogOpen}

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -20,7 +20,10 @@ import {
   resolveFlagDefinition,
 } from "~/server/featureFlag";
 import { checkFlagEnvOverride } from "~/server/featureFlag/envOverride";
-import { featureFlagRulesSchema } from "~/server/featureFlag/rules";
+import {
+  featureFlagRulesSchema,
+  resolveEffectiveForListing,
+} from "~/server/featureFlag/rules";
 
 const opsViewPermission = checkOpsPermission({ permission: "ops:view" });
 
@@ -673,8 +676,12 @@ export const opsRouter = createTRPCRouter({
       const explicitRows = explicit.map((def) => {
         const row = stored.find((s) => s.key === def.key);
         const envOverride = checkFlagEnvOverride(def.key, def.legacyEnvVar);
-        const effective =
-          envOverride ?? row?.enabled ?? def.defaultValue;
+        const effective = resolveEffectiveForListing({
+          envOverride: envOverride ?? null,
+          rules: row?.rules ?? [],
+          rowEnabled: row?.enabled ?? null,
+          registryDefault: def.defaultValue,
+        });
         return {
           key: def.key,
           scope: def.scope,
@@ -705,8 +712,12 @@ export const opsRouter = createTRPCRouter({
         const row = stored.find((s) => s.key === desc.key);
         const def = resolveFlagDefinition(desc.key);
         const envOverride = checkFlagEnvOverride(desc.key, def?.legacyEnvVar);
-        const effective =
-          envOverride ?? row?.enabled ?? def?.defaultValue ?? false;
+        const effective = resolveEffectiveForListing({
+          envOverride: envOverride ?? null,
+          rules: row?.rules ?? [],
+          rowEnabled: row?.enabled ?? null,
+          registryDefault: def?.defaultValue ?? false,
+        });
         return {
           key: desc.key,
           scope: def?.scope ?? "SYSTEM",
@@ -738,8 +749,12 @@ export const opsRouter = createTRPCRouter({
             s.key,
             def?.legacyEnvVar,
           );
-          const effective =
-            envOverride ?? s.enabled ?? def?.defaultValue ?? false;
+          const effective = resolveEffectiveForListing({
+            envOverride: envOverride ?? null,
+            rules: s.rules,
+            rowEnabled: s.enabled,
+            registryDefault: def?.defaultValue ?? false,
+          });
           return {
             key: s.key,
             scope: def?.scope ?? "SYSTEM",

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -20,6 +20,7 @@ import {
   resolveFlagDefinition,
 } from "~/server/featureFlag";
 import { checkFlagEnvOverride } from "~/server/featureFlag/envOverride";
+import { featureFlagRulesSchema } from "~/server/featureFlag/rules";
 
 const opsViewPermission = checkOpsPermission({ permission: "ops:view" });
 
@@ -681,6 +682,7 @@ export const opsRouter = createTRPCRouter({
           description: def.description,
           family: def.family ?? null,
           storedValue: row?.enabled ?? null,
+          rules: row?.rules ?? [],
           envOverride: envOverride ?? null,
           effective,
           lastEditedBy: row?.lastEditedBy ?? null,
@@ -714,6 +716,7 @@ export const opsRouter = createTRPCRouter({
             : `Pipeline ${desc.pipelineName} ${desc.componentType} ${desc.componentName}.`,
           family: def?.family ?? null,
           storedValue: row?.enabled ?? null,
+          rules: row?.rules ?? [],
           envOverride: envOverride ?? null,
           effective,
           lastEditedBy: row?.lastEditedBy ?? null,
@@ -744,6 +747,7 @@ export const opsRouter = createTRPCRouter({
             description: def?.description ?? "Orphaned postgres flag row (no longer registered).",
             family: def?.family ?? null,
             storedValue: s.enabled,
+            rules: s.rules,
             envOverride: envOverride ?? null,
             effective,
             lastEditedBy: s.lastEditedBy,
@@ -794,6 +798,35 @@ export const opsRouter = createTRPCRouter({
       await getFeatureFlagStore().set(
         input.key,
         input.enabled,
+        ctx.session.user.id,
+      );
+      return { ok: true };
+    }),
+
+  setFeatureFlagRules: protectedProcedure
+    .use(opsManagePermission)
+    .input(
+      z.object({
+        key: z.string().min(1).max(200),
+        rules: featureFlagRulesSchema.max(50),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const isExplicitKey = listFeatureFlags().some(
+        (f) => f.key === input.key,
+      );
+      const isLiveKillSwitch = getKillSwitchDescriptors().some(
+        (d) => d.key === input.key,
+      );
+      if (!isExplicitKey && !isLiveKillSwitch) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Unknown feature flag key: ${input.key}`,
+        });
+      }
+      await getFeatureFlagStore().setRules(
+        input.key,
+        input.rules,
         ctx.session.user.id,
       );
       return { ok: true };

--- a/langwatch/src/server/featureFlag/__tests__/featureFlag.service.resolver.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/featureFlag.service.resolver.unit.test.ts
@@ -25,6 +25,11 @@ import {
 } from "vitest";
 import { FeatureFlagService } from "../featureFlag.service";
 import type { FeatureFlagStorePostgres } from "../featureFlagStore.postgres";
+import {
+  evaluateRules,
+  type FeatureFlagRules,
+  type RuleEvaluationContext,
+} from "../rules";
 import type { FeatureFlagServiceInterface } from "../types";
 
 const SYSTEM_FLAG = "ops_es_causality_loop_guard_disabled";
@@ -33,12 +38,26 @@ const PRODUCT_FLAG = "release_nlp_go_engine_enabled";
 const UNREGISTERED_FLAG = "experiment_some_adhoc_posthog_flag";
 
 class InMemoryStore {
-  private values = new Map<string, boolean>();
-  async get(key: string): Promise<boolean | null> {
-    return this.values.has(key) ? this.values.get(key)! : null;
+  private values = new Map<
+    string,
+    { enabled: boolean; rules: FeatureFlagRules }
+  >();
+  async get(
+    key: string,
+    ctx: RuleEvaluationContext = {},
+  ): Promise<boolean | null> {
+    const row = this.values.get(key);
+    if (!row) return null;
+    const ruleHit = evaluateRules(row.rules, ctx);
+    return ruleHit ?? row.enabled;
   }
   async set(key: string, enabled: boolean): Promise<void> {
-    this.values.set(key, enabled);
+    const existing = this.values.get(key);
+    this.values.set(key, { enabled, rules: existing?.rules ?? [] });
+  }
+  async setRules(key: string, rules: FeatureFlagRules): Promise<void> {
+    const existing = this.values.get(key);
+    this.values.set(key, { enabled: existing?.enabled ?? false, rules });
   }
   async clear(key: string): Promise<void> {
     this.values.delete(key);
@@ -175,6 +194,58 @@ describe("FeatureFlagService", () => {
           true,
         );
         const enabled = await service.isEnabled(PRODUCT_FLAG, { distinctId: "user-1", defaultValue: true });
+        expect(enabled).toBe(false);
+        expect(legacy.isEnabled).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the store row carries an org-scoped targeting rule", () => {
+      it("uses the rule for the matching org and skips PostHog", async () => {
+        const { service, store, legacy } = buildService();
+        await store.setRules(PRODUCT_FLAG, [
+          { match: { organizationId: "org_lw" }, enabled: true },
+        ]);
+        const enabled = await service.isEnabled(PRODUCT_FLAG, {
+          distinctId: "user-1",
+          organizationId: "org_lw",
+          defaultValue: false,
+        });
+        expect(enabled).toBe(true);
+        expect(legacy.isEnabled).not.toHaveBeenCalled();
+      });
+
+      it("uses the row-level default for a non-matching org without consulting PostHog", async () => {
+        // The store creates a row with row-level enabled=false when only
+        // rules are written, so the row counts as an explicit operator
+        // override and stops the PostHog fallthrough. To target an
+        // allowlist while still letting PostHog drive everyone else,
+        // operators must leave the row absent — that's by design.
+        const { service, store, legacy } = buildService();
+        await store.setRules(PRODUCT_FLAG, [
+          { match: { organizationId: "org_lw" }, enabled: true },
+        ]);
+        const enabled = await service.isEnabled(PRODUCT_FLAG, {
+          distinctId: "user-1",
+          organizationId: "org_other",
+          defaultValue: false,
+        });
+        expect(enabled).toBe(false);
+        expect(legacy.isEnabled).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the row carries both a row-level default and a non-matching rule", () => {
+      it("uses the row-level default (PostHog is not consulted because the row exists)", async () => {
+        const { service, store, legacy } = buildService();
+        await store.set(PRODUCT_FLAG, false);
+        await store.setRules(PRODUCT_FLAG, [
+          { match: { organizationId: "org_other" }, enabled: true },
+        ]);
+        const enabled = await service.isEnabled(PRODUCT_FLAG, {
+          distinctId: "user-1",
+          organizationId: "org_self",
+          defaultValue: true,
+        });
         expect(enabled).toBe(false);
         expect(legacy.isEnabled).not.toHaveBeenCalled();
       });

--- a/langwatch/src/server/featureFlag/__tests__/rules.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/rules.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   evaluateRules,
   parseRules,
+  resolveEffectiveForListing,
   type FeatureFlagRules,
 } from "../rules";
 
@@ -114,6 +115,68 @@ describe("parseRules", () => {
       expect(parsed).toHaveLength(1);
       expect(parsed[0]?.enabled).toBe(true);
       expect(parsed[0]?.match.organizationId).toBe("org_a");
+    });
+  });
+});
+
+describe("resolveEffectiveForListing", () => {
+  describe("when an env override is set", () => {
+    it("wins over rules, row default, and registry default", () => {
+      expect(
+        resolveEffectiveForListing({
+          envOverride: false,
+          rules: [{ match: {}, enabled: true }],
+          rowEnabled: true,
+          registryDefault: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("when an empty-match rule disables the flag", () => {
+    it("returns false even when the row toggle is on (regression: ops UI must not contradict the resolver)", () => {
+      // Resolver semantics: an empty-match rule matches every context
+      // and wins via first-match. Before this helper existed, the Ops
+      // table read `row.enabled` directly and showed "on" while the
+      // resolver returned false for every caller.
+      expect(
+        resolveEffectiveForListing({
+          envOverride: null,
+          rules: [{ match: {}, enabled: false }],
+          rowEnabled: true,
+          registryDefault: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("when only per-target rules are present", () => {
+    it("falls through to the row toggle because the listing has no context", () => {
+      // Per-org/per-project rules don't match the empty default context
+      // so the listing falls through to the row-level toggle, then to
+      // the registry default. The targeting UI surfaces those rules
+      // separately.
+      expect(
+        resolveEffectiveForListing({
+          envOverride: null,
+          rules: [{ match: { organizationId: "org_a" }, enabled: true }],
+          rowEnabled: false,
+          registryDefault: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("when nothing else applies", () => {
+    it("returns the registry default", () => {
+      expect(
+        resolveEffectiveForListing({
+          envOverride: null,
+          rules: [],
+          rowEnabled: null,
+          registryDefault: true,
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/langwatch/src/server/featureFlag/__tests__/rules.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/rules.unit.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateRules,
+  parseRules,
+  type FeatureFlagRules,
+} from "../rules";
+
+describe("evaluateRules", () => {
+  describe("when no rule matches", () => {
+    it("returns null so callers can fall back to the row default", () => {
+      const rules: FeatureFlagRules = [
+        { match: { organizationId: "org_other" }, enabled: true },
+      ];
+      expect(evaluateRules(rules, { organizationId: "org_self" })).toBeNull();
+    });
+  });
+
+  describe("when an organization-scoped rule matches the context", () => {
+    it("returns the rule's enabled value without consulting later rules", () => {
+      const rules: FeatureFlagRules = [
+        { match: { organizationId: "org_a" }, enabled: true },
+        { match: { organizationId: "org_a" }, enabled: false },
+      ];
+      expect(evaluateRules(rules, { organizationId: "org_a" })).toBe(true);
+    });
+  });
+
+  describe("when a project-scoped rule overrides a broader earlier rule", () => {
+    it("returns the first matching rule's value (order wins)", () => {
+      const rules: FeatureFlagRules = [
+        { match: { projectId: "proj_x" }, enabled: false },
+        { match: { organizationId: "org_a" }, enabled: true },
+      ];
+      const enabled = evaluateRules(rules, {
+        projectId: "proj_x",
+        organizationId: "org_a",
+      });
+      expect(enabled).toBe(false);
+    });
+  });
+
+  describe("when a rule has an empty match", () => {
+    it("matches every context so it acts as a default-rule", () => {
+      const rules: FeatureFlagRules = [
+        { match: { projectId: "proj_other" }, enabled: false },
+        { match: {}, enabled: true },
+      ];
+      expect(evaluateRules(rules, { projectId: "proj_self" })).toBe(true);
+    });
+  });
+
+  describe("when both projectId and organizationId are required", () => {
+    it("only matches when every specified field equals the context", () => {
+      const rules: FeatureFlagRules = [
+        {
+          match: { projectId: "proj_a", organizationId: "org_a" },
+          enabled: true,
+        },
+      ];
+      expect(
+        evaluateRules(rules, { projectId: "proj_a", organizationId: "org_b" }),
+      ).toBeNull();
+      expect(
+        evaluateRules(rules, { projectId: "proj_a", organizationId: "org_a" }),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("parseRules", () => {
+  describe("when given null or undefined", () => {
+    it("returns an empty list rather than throwing", () => {
+      expect(parseRules(null)).toEqual([]);
+      expect(parseRules(undefined)).toEqual([]);
+    });
+  });
+
+  describe("when given a malformed payload", () => {
+    it("returns an empty list so a bad row never 500s a flag check", () => {
+      expect(parseRules({ not: "an array" })).toEqual([]);
+      expect(parseRules([{ match: "wrong" }])).toEqual([]);
+    });
+  });
+
+  describe("when the payload carries unknown match fields", () => {
+    it("preserves them via passthrough so a newer writer's rule still parses", () => {
+      const parsed = parseRules([
+        {
+          match: { organizationId: "org_a", futureField: "x" },
+          enabled: true,
+        },
+      ]);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]?.enabled).toBe(true);
+      expect(parsed[0]?.match.organizationId).toBe("org_a");
+    });
+  });
+});

--- a/langwatch/src/server/featureFlag/__tests__/rules.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/rules.unit.test.ts
@@ -65,6 +65,27 @@ describe("evaluateRules", () => {
       ).toBe(true);
     });
   });
+
+  describe("when a rule carries an unknown match key (forward-compat)", () => {
+    it("fails closed so a newer writer's condition doesn't silently match everyone", () => {
+      // A future writer ships { match: { percentageRollout: 10 }, enabled: true }.
+      // An older reader doesn't know about percentageRollout — without
+      // the fail-closed guard this would degenerate to an empty match
+      // and turn into a global on-switch.
+      const rules: FeatureFlagRules = [
+        {
+          match: { percentageRollout: 10 } as unknown as FeatureFlagRules[number]["match"],
+          enabled: true,
+        },
+      ];
+      expect(
+        evaluateRules(rules, {
+          projectId: "proj_a",
+          organizationId: "org_a",
+        }),
+      ).toBeNull();
+    });
+  });
 });
 
 describe("parseRules", () => {

--- a/langwatch/src/server/featureFlag/featureFlag.service.ts
+++ b/langwatch/src/server/featureFlag/featureFlag.service.ts
@@ -87,21 +87,27 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
       return true;
     }
 
+    const storeCtx = {
+      projectId: opts.projectId,
+      organizationId: opts.organizationId,
+    };
+
     if (definition?.scope === "SYSTEM") {
-      const stored = await this.store.get(flagKey);
+      const stored = await this.store.get(flagKey, storeCtx);
       if (stored !== null) return stored;
       return definition.defaultValue;
     }
 
     if (definition?.scope === "PRODUCT") {
-      // Operator override via /ops/feature-flags wins. Both legacy
-      // backends (PostHog and memory) catch their own failures and
-      // return the registry default, so a try/catch around legacy
-      // never falls through to postgres on its own. Checking the
-      // store first keeps the Ops UI usable for self-hosted installs
-      // and during PostHog outages without losing PostHog's user
-      // targeting on flags that have no DB override.
-      const stored = await this.store.get(flagKey);
+      // Operator override via /ops/feature-flags wins. The store
+      // evaluates per-org/per-project targeting rules first; if any
+      // rule matches the calling context we use that result and never
+      // touch PostHog. With no rule match and no row, fall through to
+      // the legacy backend (PostHog when configured, memory otherwise).
+      // Both legacy backends catch their own failures and return the
+      // registry default, so checking the store first is also what
+      // keeps the Ops UI usable during PostHog outages or quota caps.
+      const stored = await this.store.get(flagKey, storeCtx);
       if (stored !== null) return stored;
 
       return await this.legacy.isEnabled(flagKey, {

--- a/langwatch/src/server/featureFlag/featureFlagStore.postgres.ts
+++ b/langwatch/src/server/featureFlag/featureFlagStore.postgres.ts
@@ -2,6 +2,12 @@ import { prisma } from "../db";
 import { createLogger } from "~/utils/logger/server";
 import { KILL_SWITCH_CACHE_TTL_MS } from "./constants";
 import { TtlCache } from "../utils/ttlCache";
+import {
+  evaluateRules,
+  parseRules,
+  type FeatureFlagRules,
+  type RuleEvaluationContext,
+} from "./rules";
 
 /**
  * Postgres-backed flag value store with a thin Redis/in-memory cache.
@@ -18,63 +24,82 @@ import { TtlCache } from "../utils/ttlCache";
  * minute per flag, orders of magnitude below the PostHog cost the
  * SYSTEM scope is replacing.
  *
- * "Not set" is a distinct state from "set to false": registry defaults
- * apply only when there is no row. We cache the tri-state explicitly so
- * a cache hit for an absent row doesn't shadow a registry default with
- * `false`.
+ * The cached value is the row itself ({ enabled, rules }), not a
+ * pre-evaluated boolean. Targeting-rule evaluation happens per call
+ * against the caller's `{ projectId, organizationId }` context, so a
+ * single cache entry serves every tenant — no per-context cache key
+ * fan-out (which is what drove the 2026-05 PostHog spike). "Not set"
+ * stays a distinct state (null row) so a cache hit for an absent row
+ * doesn't shadow a registry default with `false`.
  */
-type CachedValue = { enabled: boolean | null };
+type CachedRow = { enabled: boolean; rules: FeatureFlagRules } | null;
+type CacheSlot = { row: CachedRow };
 
-const CACHE_PREFIX = "feature_flag_store:";
-// Local in-process TTL: kept much shorter than the Redis TTL so a
-// killed flag still propagates within seconds, but long enough that
-// per-event reactor calls collapse to a Map lookup on the hot path.
+const CACHE_PREFIX = "feature_flag_store:v2:";
 const LOCAL_TTL_MS = 5_000;
-// Hard cap on the in-process map size so dynamically-named keys
-// (e.g. arbitrary unregistered flag lookups) can't grow memory
-// indefinitely. Expired entries are pruned lazily on writes; when
-// the cap is still exceeded after pruning, the oldest insertions
-// (Map iteration is insertion-ordered) are evicted to fit.
 const LOCAL_MAX_KEYS = 5_000;
 
 export class FeatureFlagStorePostgres {
   private readonly logger = createLogger("langwatch:feature-flag-store");
-  private readonly cache = new TtlCache<CachedValue>(
+  private readonly cache = new TtlCache<CacheSlot>(
     KILL_SWITCH_CACHE_TTL_MS,
     CACHE_PREFIX,
   );
   // Per-pod in-process cache. Sits in front of Redis so the trace-
   // processing reactor (called per event) does not generate a Redis GET
-  // per event. Map + timestamp is plenty; no LRU bound because the key
-  // space is bounded by the registry size.
-  private readonly local = new Map<string, { value: boolean | null; expiresAt: number }>();
+  // per event.
+  private readonly local = new Map<
+    string,
+    { row: CachedRow; expiresAt: number }
+  >();
 
   /**
-   * Read the operator-set value for `key`. Returns `null` when no row
-   * exists in postgres (caller should fall through to the registry
-   * default).
+   * Resolve `key` against the calling context. Returns `null` when no
+   * postgres row exists (caller should fall through to the registry
+   * default or PostHog). When a row exists, targeting rules are
+   * evaluated first; the row-level `enabled` is the fallback if no
+   * rule matches.
    */
-  async get(key: string): Promise<boolean | null> {
+  async get(
+    key: string,
+    ctx: RuleEvaluationContext = {},
+  ): Promise<boolean | null> {
+    const row = await this.getRow(key);
+    if (row === null) return null;
+    const ruleHit = evaluateRules(row.rules, ctx);
+    return ruleHit ?? row.enabled;
+  }
+
+  /**
+   * Bypass rule evaluation and return the raw row (or null when
+   * absent). Used by the Ops UI to render the row-level toggle and
+   * the rules editor against the same cache. Same TTLs as `get`.
+   */
+  async getRow(
+    key: string,
+  ): Promise<{ enabled: boolean; rules: FeatureFlagRules } | null> {
     const localHit = this.local.get(key);
     const now = Date.now();
     if (localHit) {
-      if (localHit.expiresAt > now) return localHit.value;
+      if (localHit.expiresAt > now) return localHit.row;
       this.local.delete(key);
     }
     const cached = await this.cache.get(key);
     if (cached !== undefined) {
-      this.writeLocal(key, cached.enabled, now);
-      return cached.enabled;
+      this.writeLocal(key, cached.row, now);
+      return cached.row;
     }
     try {
-      const row = await prisma.featureFlag.findUnique({
+      const dbRow = await prisma.featureFlag.findUnique({
         where: { key },
-        select: { enabled: true },
+        select: { enabled: true, rules: true },
       });
-      const value = row?.enabled ?? null;
-      await this.cache.set(key, { enabled: value });
-      this.writeLocal(key, value, now);
-      return value;
+      const row: CachedRow = dbRow
+        ? { enabled: dbRow.enabled, rules: parseRules(dbRow.rules) }
+        : null;
+      await this.cache.set(key, { row });
+      this.writeLocal(key, row, now);
+      return row;
     } catch (error) {
       this.logger.warn(
         { key, error: error instanceof Error ? error.message : error },
@@ -84,11 +109,9 @@ export class FeatureFlagStorePostgres {
     }
   }
 
-  private writeLocal(key: string, value: boolean | null, now: number): void {
-    this.local.set(key, { value, expiresAt: now + LOCAL_TTL_MS });
+  private writeLocal(key: string, row: CachedRow, now: number): void {
+    this.local.set(key, { row, expiresAt: now + LOCAL_TTL_MS });
     if (this.local.size <= LOCAL_MAX_KEYS) return;
-    // Cap exceeded: first prune expired entries; if still over cap,
-    // drop oldest insertions until we're back under.
     for (const [k, v] of this.local) {
       if (v.expiresAt <= now) this.local.delete(k);
     }
@@ -103,11 +126,8 @@ export class FeatureFlagStorePostgres {
   }
 
   /**
-   * Operator write: invalidates the per-pod cache entry immediately so
-   * subsequent reads on this pod see the new value. Other pods catch up
-   * within `KILL_SWITCH_CACHE_TTL_MS` via natural TTL expiry. No pub/sub
-   * channel by design (kept the Redis load minimal; the 60 s lag is
-   * acceptable for kill switches and operator UI ops).
+   * Operator write of the row-level enabled value (the rule-fallback
+   * default). Existing rules are preserved on update.
    */
   async set(
     key: string,
@@ -119,18 +139,36 @@ export class FeatureFlagStorePostgres {
       create: { key, enabled, lastEditedBy },
       update: { enabled, lastEditedBy },
     });
-    await this.cache.delete(key);
-    this.local.delete(key);
+    await this.invalidate(key);
+  }
+
+  /**
+   * Operator write of the targeting rules for a flag. Creates a row
+   * with rule-only semantics (no row-level true) when one doesn't
+   * already exist so an org-scoped enable doesn't accidentally flip
+   * the flag on cluster-wide.
+   */
+  async setRules(
+    key: string,
+    rules: FeatureFlagRules,
+    lastEditedBy: string | null,
+  ): Promise<void> {
+    await prisma.featureFlag.upsert({
+      where: { key },
+      create: {
+        key,
+        enabled: false,
+        rules: rules as unknown as object,
+        lastEditedBy,
+      },
+      update: { rules: rules as unknown as object, lastEditedBy },
+    });
+    await this.invalidate(key);
   }
 
   async clear(key: string, lastEditedBy: string | null): Promise<void> {
-    // `deleteMany` is idempotent (no-op when the row is absent) and
-    // bubbles real DB errors up to the caller, unlike the previous
-    // `.delete(...).catch(() => undefined)` which silently swallowed
-    // write failures and made the Ops UI report success on failure.
     await prisma.featureFlag.deleteMany({ where: { key } });
-    await this.cache.delete(key);
-    this.local.delete(key);
+    await this.invalidate(key);
     this.logger.debug({ key, lastEditedBy }, "feature flag cleared");
   }
 
@@ -140,13 +178,30 @@ export class FeatureFlagStorePostgres {
    * orphaned rows from removed flags and clean them up.
    */
   async listAll(): Promise<
-    Array<{ key: string; enabled: boolean; lastEditedBy: string | null; updatedAt: Date }>
+    Array<{
+      key: string;
+      enabled: boolean;
+      rules: FeatureFlagRules;
+      lastEditedBy: string | null;
+      updatedAt: Date;
+    }>
   > {
     const rows = await prisma.featureFlag.findMany({
-      select: { key: true, enabled: true, lastEditedBy: true, updatedAt: true },
+      select: {
+        key: true,
+        enabled: true,
+        rules: true,
+        lastEditedBy: true,
+        updatedAt: true,
+      },
       orderBy: { key: "asc" },
     });
-    return rows;
+    return rows.map((r) => ({ ...r, rules: parseRules(r.rules) }));
+  }
+
+  private async invalidate(key: string): Promise<void> {
+    await this.cache.delete(key);
+    this.local.delete(key);
   }
 }
 

--- a/langwatch/src/server/featureFlag/index.ts
+++ b/langwatch/src/server/featureFlag/index.ts
@@ -25,6 +25,18 @@ export type {
   FeatureFlagServiceInterface,
 } from "./types";
 export {
+  evaluateRules,
+  featureFlagRuleSchema,
+  featureFlagRulesSchema,
+  parseRules,
+} from "./rules";
+export type {
+  FeatureFlagRule,
+  FeatureFlagRuleMatch,
+  FeatureFlagRules,
+  RuleEvaluationContext,
+} from "./rules";
+export {
   FRONTEND_FEATURE_FLAGS,
   type FrontendFeatureFlag,
 } from "./frontendFeatureFlags";

--- a/langwatch/src/server/featureFlag/index.ts
+++ b/langwatch/src/server/featureFlag/index.ts
@@ -29,6 +29,7 @@ export {
   featureFlagRuleSchema,
   featureFlagRulesSchema,
   parseRules,
+  resolveEffectiveForListing,
 } from "./rules";
 export type {
   FeatureFlagRule,

--- a/langwatch/src/server/featureFlag/rules.ts
+++ b/langwatch/src/server/featureFlag/rules.ts
@@ -15,14 +15,20 @@ import { z } from "zod";
  * `percentageRollout`, etc., without a schema migration.
  */
 
+const KNOWN_MATCH_KEYS = ["projectId", "organizationId"] as const;
+type KnownMatchKey = (typeof KNOWN_MATCH_KEYS)[number];
+
 const featureFlagRuleMatchSchema = z
   .object({
     projectId: z.string().optional(),
     organizationId: z.string().optional(),
   })
-  // Future-proof: ignore extra fields rather than reject so a newer
-  // writer can ship a rule shape the running reader doesn't know yet,
-  // and old rows keep deserializing after we extend the schema.
+  // Future-proof: keep unknown fields on the parsed object rather than
+  // rejecting them, so a newer writer can ship a rule shape the running
+  // reader doesn't know yet and old rows keep deserializing after we
+  // extend the schema. The matcher itself fails closed on unknown keys
+  // (see matchesContext) so an unrecognized condition never silently
+  // matches every context.
   .passthrough();
 
 export const featureFlagRuleSchema = z.object({
@@ -72,6 +78,13 @@ function matchesContext(
   match: FeatureFlagRuleMatch,
   ctx: RuleEvaluationContext,
 ): boolean {
+  // Fail closed on unknown match keys: a newer writer might have added
+  // a condition (e.g. percentageRollout) that this reader doesn't
+  // understand. Treating it as "no constraint" would silently turn
+  // that rule into a global match for every context.
+  for (const key of Object.keys(match)) {
+    if (!KNOWN_MATCH_KEYS.includes(key as KnownMatchKey)) return false;
+  }
   // Every specified field must match the context. An entirely empty
   // match acts as a default-rule and matches every context.
   if (match.projectId !== undefined && match.projectId !== ctx.projectId) {

--- a/langwatch/src/server/featureFlag/rules.ts
+++ b/langwatch/src/server/featureFlag/rules.ts
@@ -74,6 +74,33 @@ export function evaluateRules(
   return null;
 }
 
+/**
+ * Compute the "default context" effective value for the Ops listing
+ * UI — what a feature-flag check would resolve to for a caller with no
+ * project/organization context. This mirrors the resolver chain so the
+ * table can't contradict runtime behavior: env override beats any
+ * empty-match rule, which beats the row-level toggle, which beats the
+ * registry default. Per-target rules (org/project) don't fire here
+ * because the listing has no specific tenant context.
+ */
+export function resolveEffectiveForListing({
+  envOverride,
+  rules,
+  rowEnabled,
+  registryDefault,
+}: {
+  envOverride: boolean | null;
+  rules: FeatureFlagRules;
+  rowEnabled: boolean | null;
+  registryDefault: boolean;
+}): boolean {
+  if (envOverride !== null) return envOverride;
+  const ruleHit = evaluateRules(rules, {});
+  if (ruleHit !== null) return ruleHit;
+  if (rowEnabled !== null) return rowEnabled;
+  return registryDefault;
+}
+
 function matchesContext(
   match: FeatureFlagRuleMatch,
   ctx: RuleEvaluationContext,

--- a/langwatch/src/server/featureFlag/rules.ts
+++ b/langwatch/src/server/featureFlag/rules.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+/**
+ * Targeting-rule contract for postgres-backed feature flags.
+ *
+ * Rules sit on `FeatureFlag.rules` as a JSON array. The store walks
+ * them in order at evaluation time; the first rule whose `match`
+ * conditions all hold against the calling context wins. When no rule
+ * matches, the row's `enabled` boolean is used as the row-level
+ * default. When the row itself is missing, the resolver falls
+ * through to PostHog (PRODUCT) or the registry default (SYSTEM).
+ *
+ * The shape is intentionally open-ended — today it carries `projectId`
+ * and `organizationId`, tomorrow it can grow `userEmail`,
+ * `percentageRollout`, etc., without a schema migration.
+ */
+
+const featureFlagRuleMatchSchema = z
+  .object({
+    projectId: z.string().optional(),
+    organizationId: z.string().optional(),
+  })
+  // Future-proof: ignore extra fields rather than reject so a newer
+  // writer can ship a rule shape the running reader doesn't know yet,
+  // and old rows keep deserializing after we extend the schema.
+  .passthrough();
+
+export const featureFlagRuleSchema = z.object({
+  match: featureFlagRuleMatchSchema,
+  enabled: z.boolean(),
+});
+
+export const featureFlagRulesSchema = z.array(featureFlagRuleSchema);
+
+export type FeatureFlagRuleMatch = z.infer<typeof featureFlagRuleMatchSchema>;
+export type FeatureFlagRule = z.infer<typeof featureFlagRuleSchema>;
+export type FeatureFlagRules = z.infer<typeof featureFlagRulesSchema>;
+
+export interface RuleEvaluationContext {
+  projectId?: string;
+  organizationId?: string;
+}
+
+/**
+ * Parses an unknown rules payload (typically straight off the JSONB
+ * column) into the typed shape. Returns an empty list when the input
+ * is null/undefined or fails validation — never throws — because a
+ * malformed rules blob must not turn a flag check into a 500.
+ */
+export function parseRules(input: unknown): FeatureFlagRules {
+  if (input == null) return [];
+  const result = featureFlagRulesSchema.safeParse(input);
+  return result.success ? result.data : [];
+}
+
+/**
+ * Walk rules in order and return the first match's `enabled`. When
+ * no rule matches, returns null so callers can fall back to the
+ * row-level default.
+ */
+export function evaluateRules(
+  rules: FeatureFlagRules,
+  ctx: RuleEvaluationContext,
+): boolean | null {
+  for (const rule of rules) {
+    if (matchesContext(rule.match, ctx)) return rule.enabled;
+  }
+  return null;
+}
+
+function matchesContext(
+  match: FeatureFlagRuleMatch,
+  ctx: RuleEvaluationContext,
+): boolean {
+  // Every specified field must match the context. An entirely empty
+  // match acts as a default-rule and matches every context.
+  if (match.projectId !== undefined && match.projectId !== ctx.projectId) {
+    return false;
+  }
+  if (
+    match.organizationId !== undefined &&
+    match.organizationId !== ctx.organizationId
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/specs/ops/internal-feature-flags.feature
+++ b/specs/ops/internal-feature-flags.feature
@@ -82,6 +82,7 @@ Feature: Internal feature flag system for system-level kill switches
     Scenario: PRODUCT flag with PostHog reachable consults PostHog for user targeting
       Given the registry has a PRODUCT-scoped UI flag
       And PostHog is configured and reachable
+      And the postgres flag store has no row or rule matching the calling context
       When the flag is checked for a known user
       Then PostHog evaluates the flag using the user's properties
       And the postgres store is not used as the source of truth for that result
@@ -99,6 +100,39 @@ Feature: Internal feature flag system for system-level kill switches
       And the per-flag env override forces the flag enabled
       When the flag is checked
       Then the flag resolves enabled
+
+  Rule: Postgres targeting rules win over PostHog
+
+    Scenario: org-scoped postgres rule enables a PRODUCT flag without touching PostHog
+      Given the postgres flag store has a row for the PRODUCT flag with
+            a targeting rule matching the calling organization and enabled true
+      And PostHog would return disabled for this flag and user
+      When the flag is checked with that organization in context
+      Then the flag resolves enabled from the postgres rule
+      And no PostHog call is attempted
+
+    Scenario: project-scoped postgres rule overrides the row-level default
+      Given the postgres flag store has a row for the PRODUCT flag with
+            a row-level enabled value of false
+      And the row carries a targeting rule that matches the calling project
+            with enabled true
+      When the flag is checked with that project in context
+      Then the flag resolves enabled from the targeting rule
+
+    Scenario: rule order wins on the first match
+      Given the postgres flag store has a row whose first rule matches the
+            calling organization with enabled true
+      And the row's second rule matches the same organization with enabled false
+      When the flag is checked with that organization in context
+      Then the flag resolves enabled because the first matching rule wins
+
+    Scenario: rules that do not match fall through to the row-level enabled value
+      Given the postgres flag store has a row whose only rule matches a
+            different organization than the calling one
+      And the row-level enabled value is false
+      When the flag is checked
+      Then the flag resolves disabled from the row-level enabled value
+      And PostHog is not consulted because the postgres row was present
 
   Rule: Operators manage flags from the Ops Feature Flags page
 


### PR DESCRIPTION
PostHog hit its feature-flag quota cap again ($14 → $16 → $20 bumps didn't free it). Decide endpoint has been returning `quotaLimited: ['feature_flags']` with an empty `featureFlags: {}`, which makes our PRODUCT resolver fall through to the registry default `false` for every user. Need our own targeting now.

## What's new

`FeatureFlag` table gets an optional `rules` JSON column. Each rule is:

```ts
{ match: { projectId?, organizationId? }, enabled: boolean }
```

First-match-wins. Empty `match` acts as a default-rule. When no rule matches, the row-level `enabled` is the fallback. When no row exists at all, the resolver falls back to PostHog (PRODUCT) or the registry default (SYSTEM) — unchanged.

Once any row exists, the resolver no longer consults PostHog. Operator override = explicit override.

`match` is `z.passthrough()` so a future field (e.g. `userEmail`, `percentageRollout`) can ship without breaking deserialization of older rows. `parseRules` swallows malformed payloads and returns `[]` so a bad row never 500s a flag check.

## Cache shape

Store caches the raw `{ enabled, rules }` row instead of a pre-evaluated boolean. Rule evaluation happens per call against the caller's `{ projectId, organizationId }`, so a single cache entry serves every tenant — no per-context cache-key fan-out (which is exactly what drove the original 2026-05 PostHog spike).

## Ops UI

`/ops/feature-flags` gets a Targeting column with the rule count + an add/edit link that opens a dialog. Each rule row: scope selector (Everyone / Organization / Project), id input, on/off switch. Empty match acts as default-rule; specific scopes require an ID.

## Immediately unblocks

Once merged + deployed, the LangWatch org can re-enable `release_nlp_go_engine_enabled` and `release_ui_ai_gateway_menu_enabled` via the Ops UI rule editor (organization rule -> enabled = true) without waiting for PostHog quota to clear.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` for feature-flag + ops surfaces passes (210/210)
- [ ] Post-deploy: add an org rule, confirm the flag flips for that org and stays unaffected for other tenants