### PR TITLE
fix(traces): fix broken links from traces UI to old messages view

### DIFF
--- a/langwatch/src/features/command-bar/__tests__/useCommandSearch.test.ts
+++ b/langwatch/src/features/command-bar/__tests__/useCommandSearch.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "vitest";
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach } from "vitest";
 import { detectEntityId } from "../useCommandSearch";
 
 /**
@@ -7,6 +10,10 @@ import { detectEntityId } from "../useCommandSearch";
  */
 describe("detectEntityId", () => {
   const PROJECT_SLUG = "test-project";
+
+  afterEach(() => {
+    window.localStorage.removeItem("langwatch:traces-v2-preferred");
+  });
 
   /**
    * Helper to extract the type from detectEntityId result.
@@ -81,7 +88,19 @@ describe("detectEntityId", () => {
       expect(detectIdType("0123456789ABCDEF0123456789ABCDEF")).toBe("trace");
     });
 
-    it("navigates to v2 /traces with drawer params (no in-place drawerAction)", () => {
+    it("navigates to v1 /messages when v2 preference is off", () => {
+      const result = detectEntityId({
+        query: "trace_abc123",
+        projectSlug: PROJECT_SLUG,
+      });
+      expect(result?.path).toBe(
+        "/test-project/messages?drawer.open=traceDetails&drawer.traceId=trace_abc123"
+      );
+      expect(result?.drawerAction).toBeUndefined();
+    });
+
+    it("navigates to v2 /traces when v2 preference is on", () => {
+      window.localStorage.setItem("langwatch:traces-v2-preferred", "1");
       const result = detectEntityId({
         query: "trace_abc123",
         projectSlug: PROJECT_SLUG,

--- a/langwatch/src/features/command-bar/useCommandSearch.ts
+++ b/langwatch/src/features/command-bar/useCommandSearch.ts
@@ -11,6 +11,7 @@ import {
   isSpanId,
   traceIcon,
 } from "./entityRegistry";
+import { getTracesV2Preferred } from "~/features/traces-v2/hooks/useTracesV2Preference";
 
 /**
  * Detect if the query is an entity ID and return navigation info.
@@ -43,17 +44,17 @@ export function detectEntityId({
     };
   }
 
-  // Check for trace ID patterns. v2 drawer hydrates from `drawer.*` URL
-  // params on the /traces page. We navigate (rather than `openDrawer`
-  // in place) so the underlying page context matches what the drawer
-  // was designed against.
   if (isTraceId(trimmedQuery)) {
+    const prefersV2 = getTracesV2Preferred();
+    const path = prefersV2
+      ? `/${projectSlug}/traces?drawer.open=traceV2Details&drawer.traceId=${trimmedQuery}`
+      : `/${projectSlug}/messages?drawer.open=traceDetails&drawer.traceId=${trimmedQuery}`;
     return {
       id: `trace-${trimmedQuery}`,
       label: "Open trace",
       description: trimmedQuery,
       icon: traceIcon,
-      path: `/${projectSlug}/traces?drawer.open=traceV2Details&drawer.traceId=${trimmedQuery}`,
+      path,
       type: "trace",
     };
   }

--- a/langwatch/src/features/traces-v2/components/Toolbar/AutomateButton.tsx
+++ b/langwatch/src/features/traces-v2/components/Toolbar/AutomateButton.tsx
@@ -93,7 +93,7 @@ export const AutomateButton: React.FC = () => {
                 <Icon boxSize={3.5}>
                   <ArrowUpRight />
                 </Icon>
-                Open original trace view
+                Set up automations (original view)
               </Button>
             </NextLink>
           </VStack>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/TraceOverflowMenu.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/TraceOverflowMenu.tsx
@@ -18,6 +18,7 @@ import {
 import { resetTracesV2PromoSnooze } from "~/components/messages/NewTracesPromo";
 import { Menu } from "~/components/ui/menu";
 import { useDrawer } from "~/hooks/useDrawer";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useConversationTurns } from "../../../hooks/useConversationTurns";
 import { setTracesV2Preferred } from "../../../hooks/useTracesV2Preference";
 
@@ -52,6 +53,7 @@ export function TraceOverflowMenu({
   onTogglePinned,
 }: TraceOverflowMenuProps) {
   const { openDrawer } = useDrawer();
+  const { project } = useOrganizationTeamProject();
 
   const conversationTurns = useConversationTurns(conversationId);
   const conversationTraceIds =
@@ -82,22 +84,18 @@ export function TraceOverflowMenu({
       surface: "drawer_overflow_menu",
       traceId,
     });
-    // Hard-nav for symmetry with the v1→v2 opt-in (and the same
-    // reasoning — soft-swap races against Chakra's unmount-fired
-    // onOpenChange). Preserve non-drawer params (`span`, etc.).
-    if (typeof window !== "undefined") {
-      const url = new URL(window.location.href);
-      const drawerKeys: string[] = [];
-      url.searchParams.forEach((_, key) => {
-        if (key.startsWith("drawer.")) drawerKeys.push(key);
-      });
-      for (const key of drawerKeys) url.searchParams.delete(key);
-      url.searchParams.set("drawer.open", "traceDetails");
-      url.searchParams.set("drawer.traceId", traceId);
-      url.searchParams.set("drawer.selectedTab", "traceDetails");
-      window.location.href = url.toString();
+    // Hard-nav to /messages where the v1 traceDetails drawer is
+    // registered. Previously this rewrote params on the current URL
+    // (/traces), but the v2 hydrator ignores traceDetails — so the
+    // drawer never opened.
+    if (typeof window !== "undefined" && project?.slug) {
+      const params = new URLSearchParams();
+      params.set("drawer.open", "traceDetails");
+      params.set("drawer.traceId", traceId);
+      params.set("drawer.selectedTab", "traceDetails");
+      window.location.href = `/${project.slug}/messages?${params.toString()}`;
     }
-  }, [traceId]);
+  }, [traceId, project?.slug]);
 
   return (
     <Menu.Root positioning={{ placement: "bottom-end" }}>


### PR DESCRIPTION
## Summary
- **Command bar search** now respects the user's v1/v2 trace viewer preference instead of always forcing v2. Users who haven't opted into v2 get routed to `/messages` with the correct drawer.
- **TraceOverflowMenu "Go back to old trace visualization"** now navigates to `/messages` where the v1 drawer actually renders, instead of rewriting params on `/traces` where they were silently ignored.
- **AutomateButton** label clarified from "Open original trace view" to "Set up automations (original view)" so users understand why they're being sent to a different page.

## Context
Customer report: searching for a trace via command bar always redirected to the new trace explorer, and the "go back to old view" escape hatch didn't work because it stayed on `/traces` where the v1 drawer doesn't hydrate.

## Test plan
- [ ] Search for a trace ID in the command bar with v2 preference OFF — should open on `/messages`
- [ ] Search for a trace ID in the command bar with v2 preference ON — should open on `/traces`
- [ ] Open a trace in v2 drawer → overflow menu → "Go back to old trace visualization" — should navigate to `/messages` and open the v1 drawer
- [ ] In traces v2, click Automate button — popover should say "Set up automations (original view)"