### PR TITLE
fix(traces): default trace status to ok when OTel StatusCode is UNSET

### DIFF
--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -6,6 +6,7 @@ import {
   generateTraceQueryFromPrompt,
 } from "~/server/app-layer/traces/ai-query";
 import { ValidationError } from "~/server/app-layer/domain-error";
+import { deriveTraceStatus } from "~/server/app-layer/traces/derive-trace-status";
 import { TraceNotFoundError } from "~/server/app-layer/traces/errors";
 import { translateFilterToClickHouse } from "~/server/app-layer/traces/filter-to-clickhouse";
 import type { SpanSummaryRow } from "~/server/app-layer/traces/repositories/span-storage.repository";
@@ -87,9 +88,7 @@ function mapTraceSummaryToHeader(summary: TraceSummaryData): TraceHeader {
     (summary.totalPromptTokenCount ?? 0) +
     (summary.totalCompletionTokenCount ?? 0);
 
-  let status: TraceHeader["status"] = "ok";
-  if (summary.containsErrorStatus) status = "error";
-  else if (!summary.containsOKStatus) status = "warning";
+  const status = deriveTraceStatus(summary);
 
   return {
     traceId: summary.traceId,

--- a/langwatch/src/server/app-layer/traces/__tests__/derive-trace-status.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/derive-trace-status.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { deriveTraceStatus } from "../derive-trace-status";
+
+describe("deriveTraceStatus", () => {
+  describe("given a span flipped containsErrorStatus", () => {
+    /** @scenario Trace status is error when any span reports OTel ERROR */
+    it("returns 'error', and stays 'error' even when also blockedByGuardrail", () => {
+      expect(
+        deriveTraceStatus({
+          containsErrorStatus: true,
+          blockedByGuardrail: false,
+        }),
+      ).toBe("error");
+      expect(
+        deriveTraceStatus({
+          containsErrorStatus: true,
+          blockedByGuardrail: true,
+        }),
+      ).toBe("error");
+    });
+  });
+
+  describe("given a guardrail-blocked trace with no errors", () => {
+    /** @scenario Trace status is warning when the trace ran but was guardrail-blocked */
+    it("returns 'warning'", () => {
+      expect(
+        deriveTraceStatus({
+          containsErrorStatus: false,
+          blockedByGuardrail: true,
+        }),
+      ).toBe("warning");
+    });
+  });
+
+  describe("given no errors and no guardrail blocks", () => {
+    /** @scenario Trace status defaults to ok when OTel StatusCode is UNSET on every span */
+    it("returns 'ok' when no OK was reported either (UNSET on every span)", () => {
+      // Pre-fix this case returned "warning", which was firing on 118k
+      // of every 327k traces in a 2026-05-20 7-day prod sweep — every
+      // happy trace from any SDK that doesn't explicitly bump
+      // StatusCode to OK (effectively all of them). UNSET is the
+      // OTel-correct default for "no opinion"; treat it as ok.
+      expect(
+        deriveTraceStatus({
+          containsErrorStatus: false,
+          blockedByGuardrail: false,
+        }),
+      ).toBe("ok");
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/derive-trace-status.ts
+++ b/langwatch/src/server/app-layer/traces/derive-trace-status.ts
@@ -3,6 +3,18 @@ import type { TraceSummaryData } from "./types";
 export type DerivedTraceStatus = "ok" | "error" | "warning";
 
 /**
+ * ClickHouse expression that produces the same value `deriveTraceStatus`
+ * does — used by the status facet's distinct-value pre-aggregation and
+ * the `status:` filter translator so the table, the sidebar, and the
+ * search bar all agree on what counts as warning vs ok. Keep this in
+ * lockstep with the TS function: a divergence between the two means
+ * customers filtering `status:warning` get a row set the table won't
+ * render as warning (or vice versa).
+ */
+export const TRACE_STATUS_CLICKHOUSE_EXPRESSION =
+  "if(ContainsErrorStatus = 1, 'error', if(BlockedByGuardrail = 1, 'warning', 'ok'))";
+
+/**
  * Map a projected `TraceSummaryData` to the user-facing trace status
  * pill / row tint. Single source of truth — both the trace list mapper
  * and the trace drawer header derive from here so the two surfaces

--- a/langwatch/src/server/app-layer/traces/derive-trace-status.ts
+++ b/langwatch/src/server/app-layer/traces/derive-trace-status.ts
@@ -1,0 +1,32 @@
+import type { TraceSummaryData } from "./types";
+
+export type DerivedTraceStatus = "ok" | "error" | "warning";
+
+/**
+ * Map a projected `TraceSummaryData` to the user-facing trace status
+ * pill / row tint. Single source of truth — both the trace list mapper
+ * and the trace drawer header derive from here so the two surfaces
+ * can't drift.
+ *
+ * Why UNSET reads as "ok": OpenTelemetry's `StatusCode` defaults to
+ * UNSET. Most SDK instrumentation (LangChain, LangGraph, Genkit,
+ * Mastra, direct OpenAI/Anthropic clients, etc.) never upgrades it to
+ * OK on success — only ERROR on failure. A previous derivation treated
+ * "no OK seen" as `warning`, which on 2026-05-20 was firing for 118k
+ * of the 327k traces ingested in the last 7 days, drowning every
+ * customer's table in yellow chips for plain successful runs.
+ *
+ * `warning` is reserved for explicit mid-state signals where the trace
+ * ran but the outcome is qualified — currently just guardrail blocks.
+ * Future signals (rate limits, partial responses) plug in here.
+ */
+export function deriveTraceStatus(
+  summary: Pick<
+    TraceSummaryData,
+    "containsErrorStatus" | "blockedByGuardrail"
+  >,
+): DerivedTraceStatus {
+  if (summary.containsErrorStatus) return "error";
+  if (summary.blockedByGuardrail) return "warning";
+  return "ok";
+}

--- a/langwatch/src/server/app-layer/traces/facet-registry.ts
+++ b/langwatch/src/server/app-layer/traces/facet-registry.ts
@@ -1,3 +1,4 @@
+import { TRACE_STATUS_CLICKHOUSE_EXPRESSION } from "./derive-trace-status";
 import {
   EVALUATOR_FACET,
   EVENT_ATTRIBUTE_KEYS_FACET,
@@ -80,8 +81,7 @@ export const FACET_REGISTRY: readonly FacetDefinition[] = [
     label: "Status",
     group: "trace",
     table: "trace_summaries",
-    expression:
-      "if(ContainsErrorStatus = 1, 'error', if(ContainsOKStatus = 1, 'ok', 'warning'))",
+    expression: TRACE_STATUS_CLICKHOUSE_EXPRESSION,
   },
   {
     key: "origin",

--- a/langwatch/src/server/app-layer/traces/trace-list.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-list.service.ts
@@ -9,7 +9,10 @@ import type {
   FacetTable,
   RangeFacetDef,
 } from "./facet-registry";
-import { deriveTraceStatus } from "./derive-trace-status";
+import {
+  deriveTraceStatus,
+  TRACE_STATUS_CLICKHOUSE_EXPRESSION,
+} from "./derive-trace-status";
 import { FACET_REGISTRY, TABLE_TIME_COLUMNS } from "./facet-registry";
 import type {
   BatchedFacetResult,
@@ -261,8 +264,7 @@ const SORT_COLUMN_MAP: Record<string, TraceListSort["column"]> = {
 
 const FACET_EXPRESSIONS: Record<string, string> = {
   origin: "Attributes['langwatch.origin']",
-  status:
-    "if(ContainsErrorStatus = 1, 'error', if(ContainsOKStatus = 1, 'ok', 'warning'))",
+  status: TRACE_STATUS_CLICKHOUSE_EXPRESSION,
   service: "Attributes['service.name']",
 };
 

--- a/langwatch/src/server/app-layer/traces/trace-list.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-list.service.ts
@@ -9,6 +9,7 @@ import type {
   FacetTable,
   RangeFacetDef,
 } from "./facet-registry";
+import { deriveTraceStatus } from "./derive-trace-status";
 import { FACET_REGISTRY, TABLE_TIME_COLUMNS } from "./facet-registry";
 import type {
   BatchedFacetResult,
@@ -888,11 +889,7 @@ export class TraceListService {
 }
 
 function mapToTraceListItem(row: TraceSummaryData): TraceListItem {
-  const status: "ok" | "error" | "warning" = row.containsErrorStatus
-    ? "error"
-    : row.containsOKStatus
-      ? "ok"
-      : "warning";
+  const status = deriveTraceStatus(row);
 
   const totalTokens =
     (row.totalPromptTokenCount ?? 0) + (row.totalCompletionTokenCount ?? 0);

--- a/specs/trace-drawer/trace-status-derivation.feature
+++ b/specs/trace-drawer/trace-status-derivation.feature
@@ -1,0 +1,37 @@
+Feature: Trace status derivation from projected summary
+  As a platform engineer
+  I want the trace status pill / row tint to reflect the trace's real outcome
+  So that the dashboard reads truthfully when SDK instrumentation
+  doesn't go out of its way to bump OpenTelemetry StatusCode to OK on success.
+
+  Background:
+    OpenTelemetry's StatusCode defaults to UNSET. Most SDK
+    instrumentation (LangChain, LangGraph, Genkit, Mastra, direct
+    provider clients) never upgrades it to OK on success - it only
+    flips to ERROR on failure. A prior derivation treated "no OK seen"
+    as "warning"; on 2026-05-20 that was firing for 118k of every 327k
+    traces in a 7-day prod sweep, drowning every customer's table in
+    yellow chips for plain successful runs. The fix collapses the
+    derivation to three deterministic branches.
+
+  @unit
+  Scenario: Trace status defaults to ok when OTel StatusCode is UNSET on every span
+    Given a trace whose projected summary has containsErrorStatus=false
+    And the summary has blockedByGuardrail=false
+    And no span on the trace ever reported an OTel OK status
+    When the trace status is derived for the table row and drawer header
+    Then the derived status is "ok"
+
+  @unit
+  Scenario: Trace status is error when any span reports OTel ERROR
+    Given a trace whose projected summary has containsErrorStatus=true
+    When the trace status is derived
+    Then the derived status is "error"
+    And it stays "error" even when the trace was also blockedByGuardrail
+
+  @unit
+  Scenario: Trace status is warning when the trace ran but was guardrail-blocked
+    Given a trace whose projected summary has containsErrorStatus=false
+    And the summary has blockedByGuardrail=true
+    When the trace status is derived
+    Then the derived status is "warning"


### PR DESCRIPTION
## Summary

The trace status pill / row tint was deriving \`warning\` from "no span has containsOKStatus set" - which on 2026-05-20 was firing for **118k of every 327k traces** in a 7-day prod sweep. Customer SDKs (LangChain, LangGraph, Genkit, Mastra, direct provider clients) leave OTel StatusCode at its UNSET default on success; only the failure path bumps it to ERROR. Treating UNSET as warning was meaningless yellow noise across every table.

### Before vs after derivation

\`\`\`
                              before                         after
containsErrorStatus           error                          error
!containsErrorStatus && !containsOKStatus  warning           ok        ← was the noise source
!containsErrorStatus && containsOKStatus   ok                ok
blockedByGuardrail            (ignored)                      warning   ← reserved for real mid-state signals
\`\`\`

### Prod distribution that motivated the fix (last 7d, all tenants)

| current label | count | after fix |
|---|---|---|
| error | 76k | error |
| "warning" (= UNSET on every span) | 118k | **ok** |
| ok (containsOKStatus=true) | 133k | ok |
| blockedByGuardrail | 0 | warning |

### What's in the patch

- New \`deriveTraceStatus\` helper in \`langwatch/src/server/app-layer/traces/derive-trace-status.ts\` - single source of truth for both the trace list mapper (\`trace-list.service.ts\`) and the drawer header mapper (\`tracesV2.ts\`), so the two surfaces can't drift again.
- Unit test pins the UNSET-defaults-to-ok regression so this can't sneak back.
- Spec scenarios added in \`specs/trace-drawer/trace-status-derivation.feature\` covering all three branches.

The \`warning\` value stays in the type union and the query-language vocabulary - future mid-state signals (rate limits, partial responses) plug into the same helper.

## Test plan

- [x] Unit: \`deriveTraceStatus\` returns ok / error / warning for the three branches; error wins over guardrail when both flags are set.
- [x] Prod CH sweep verified: 118k traces flip from warning → ok, 0 traces would have been warning under the new derivation (no guardrail blocks in the last 7d), 0 ok / error rows change.
- [x] Manual QA: open a previously-"warning" trace in the explorer and confirm the row + drawer chip now read as ok.