### PR TITLE
fix(python-sdk): scope disable_sending to trace lifetime (#3981 root cause, supersedes #3979)

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/offline-experiment-evaluations-joinability.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/offline-experiment-evaluations-joinability.integration.test.ts
@@ -1,32 +1,26 @@
 /**
- * Integration test for issue #3900 — Phase 1 fix.
+ * Integration test for issue #3900 / #3981 — analytics JOIN regression.
  *
- * Bug: Offline-experiment evaluation results produced by the orchestrator are
- * written to `evaluation_runs` (via reportEvaluation → EvaluationRunFoldProjection
- * → upsert) but the corresponding `trace_summaries` row is never written for
- * offline-cell trace IDs. Because the analytics read path JOINs (INNER) from
- * `trace_summaries` to `evaluation_runs` on (TenantId, TraceId), any evaluation
- * row whose TraceId has no matching trace_summary is silently dropped. The
- * Custom Graphs chart therefore shows an empty plot for offline experiments.
+ * The analytics read path INNER JOINs from `trace_summaries` to
+ * `evaluation_runs` on `(TenantId, TraceId)`. An evaluation row whose TraceId
+ * has no matching trace_summary is silently dropped, leaving Custom Graphs
+ * empty.
  *
- * Fix (Phase 1 / #3900): The orchestrator now dispatches a synthetic recordSpan
- * via `getApp().traces.recordSpan(...)` immediately after every `target_result`
- * event for an offline-experiment cell. This guarantees a `trace_summaries` row
- * exists for the cell's traceId, regardless of what langwatch_nlp's OTLP send
- * did or did not do at runtime.
+ * Originally tripped by #3981: the SDK silently dropped OTel spans for
+ * offline-experiment cells (singleton `disable_sending` flag leaked across
+ * reused nlp worker processes). The root cause is fixed in the python-sdk,
+ * but the analytics-layer JOIN is the load-bearing read path either way —
+ * if it ever breaks, offline experiments go invisible again.
  *
  * Test strategy:
- * - Seed `evaluation_runs` rows for synthetic offline-cell trace IDs.
- * - ALSO seed `trace_summaries` rows for those trace IDs — simulating what the
- *   orchestrator's new `recordSpan` dispatch creates at runtime via the
- *   trace processing pipeline.
+ * - Seed both `evaluation_runs` AND `trace_summaries` for synthetic
+ *   offline-cell trace IDs (the runtime state the SDK fix guarantees).
  * - Execute the real `buildTimeseriesQuery` for `evaluations.evaluation_score`
  *   and `evaluations.evaluation_pass_rate` against the test ClickHouse.
- * - Assert that the result contains at least one non-null / non-zero metric
- *   bucket — this proves the analytics JOIN succeeds once trace_summaries rows
- *   are present.
+ * - Assert non-null / non-zero metric buckets — proves the JOIN works.
  *
  * @see https://github.com/langwatch/langwatch/issues/3900
+ * @see https://github.com/langwatch/langwatch/issues/3981
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -44,8 +38,8 @@ const TENANT_ID = "test-offline-exp-3900-fixed";
 
 /**
  * Synthetic trace IDs that the offline-experiment orchestrator generates per
- * cell. With the Phase 1 fix, the orchestrator dispatches a recordSpan for
- * each, which writes a matching trace_summaries row.
+ * cell. The SDK fix in #3981 ensures the matching trace_summaries row is
+ * actually written by the OTel export path.
  */
 const OFFLINE_TRACE_ID_0 = `${TENANT_ID}-offline-cell-trace-0`;
 const OFFLINE_TRACE_ID_1 = `${TENANT_ID}-offline-cell-trace-1`;
@@ -76,18 +70,19 @@ describe("offline-experiment evaluations on Custom Graphs", () => {
       ch = wrapWithDefaultSettings(rawClient);
 
       /**
-       * Simulate the fixed runtime state:
+       * Simulate the runtime end-state:
        *
-       * The orchestrator generates a synthetic traceId per cell, calls
-       * reportEvaluation (writes evaluation_runs), and NOW ALSO dispatches a
-       * synthetic recordSpan via getApp().traces.recordSpan() — which ultimately
-       * writes a trace_summaries row. We simulate the end-result of that
-       * pipeline by inserting into both tables directly, as the full BullMQ
-       * pipeline is not available in this integration test environment.
+       * The orchestrator generates a traceId per cell, calls reportEvaluation
+       * (writes evaluation_runs), and langwatch_nlp exports OTel spans for the
+       * cell (writes trace_summaries via the trace-processing pipeline). We
+       * simulate the end-result of both pipelines by inserting into both
+       * tables directly, since the full BullMQ trace pipeline is not
+       * available in this integration test environment.
        */
 
-      // Seed trace_summaries — this is what the orchestrator's new recordSpan
-      // dispatch creates at runtime via the trace processing pipeline.
+      // Seed trace_summaries — represents what the OTel export pipeline
+      // writes at runtime for offline-experiment cells (now reliably, after
+      // the #3981 SDK fix removed the singleton disable_sending leak).
       const now = new Date("2025-06-01T10:00:00Z");
       await ch.insert({
         table: "trace_summaries",
@@ -259,21 +254,20 @@ describe("offline-experiment evaluations on Custom Graphs", () => {
     }
   });
 
-  describe("given the orchestrator dispatches a recordSpan for each offline-experiment cell", () => {
+  describe("given trace_summaries rows exist for each offline-experiment cell traceId", () => {
     describe("when the analytics layer queries evaluation_score for the experiment's evaluator", () => {
       /**
        * @scenario Offline experiment writes joinable evaluation_runs rows for boolean and numeric evaluators
        */
       it("renders non-empty evaluation_score buckets for the offline-experiment evaluator", async () => {
-        // With the Phase 1 fix, the orchestrator dispatches a synthetic
-        // recordSpan immediately after each target_result event. This creates a
-        // trace_summaries row for the cell's traceId via the trace processing
-        // pipeline. The analytics INNER JOIN trace_summaries → evaluation_runs
-        // on (TenantId, TraceId) therefore matches, and the metric is non-null.
+        // With the #3981 SDK fix, offline-experiment cell spans now reach
+        // `trace_summaries` reliably via the normal OTel export pipeline.
+        // The analytics INNER JOIN trace_summaries → evaluation_runs on
+        // (TenantId, TraceId) therefore matches, and the metric is non-null.
         //
-        // This test seeds both trace_summaries (simulating the recordSpan write)
-        // and evaluation_runs (seeded as before), then asserts the analytics
-        // query returns a non-zero value.
+        // This test seeds both trace_summaries (simulating the OTel export
+        // pipeline writing the cell's span) and evaluation_runs, then asserts
+        // the analytics query returns a non-zero value.
         resetParamCounter();
         const { sql, params } = buildTimeseriesQuery({
           ...baseInput,

--- a/langwatch/src/server/analytics/clickhouse/__tests__/offline-experiment-evaluations-joinability.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/offline-experiment-evaluations-joinability.integration.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Integration test for issue #3900 — Phase 1 fix.
+ *
+ * Bug: Offline-experiment evaluation results produced by the orchestrator are
+ * written to `evaluation_runs` (via reportEvaluation → EvaluationRunFoldProjection
+ * → upsert) but the corresponding `trace_summaries` row is never written for
+ * offline-cell trace IDs. Because the analytics read path JOINs (INNER) from
+ * `trace_summaries` to `evaluation_runs` on (TenantId, TraceId), any evaluation
+ * row whose TraceId has no matching trace_summary is silently dropped. The
+ * Custom Graphs chart therefore shows an empty plot for offline experiments.
+ *
+ * Fix (Phase 1 / #3900): The orchestrator now dispatches a synthetic recordSpan
+ * via `getApp().traces.recordSpan(...)` immediately after every `target_result`
+ * event for an offline-experiment cell. This guarantees a `trace_summaries` row
+ * exists for the cell's traceId, regardless of what langwatch_nlp's OTLP send
+ * did or did not do at runtime.
+ *
+ * Test strategy:
+ * - Seed `evaluation_runs` rows for synthetic offline-cell trace IDs.
+ * - ALSO seed `trace_summaries` rows for those trace IDs — simulating what the
+ *   orchestrator's new `recordSpan` dispatch creates at runtime via the
+ *   trace processing pipeline.
+ * - Execute the real `buildTimeseriesQuery` for `evaluations.evaluation_score`
+ *   and `evaluations.evaluation_pass_rate` against the test ClickHouse.
+ * - Assert that the result contains at least one non-null / non-zero metric
+ *   bucket — this proves the analytics JOIN succeeds once trace_summaries rows
+ *   are present.
+ *
+ * @see https://github.com/langwatch/langwatch/issues/3900
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  getTestClickHouseClient,
+  cleanupTestData,
+} from "../../../event-sourcing/__tests__/integration/testContainers";
+import { buildTimeseriesQuery } from "../aggregation-builder";
+import { resetParamCounter } from "../filter-translator";
+import type { FlattenAnalyticsMetricsEnum } from "../../registry";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+
+const TENANT_ID = "test-offline-exp-3900-fixed";
+
+/**
+ * Synthetic trace IDs that the offline-experiment orchestrator generates per
+ * cell. With the Phase 1 fix, the orchestrator dispatches a recordSpan for
+ * each, which writes a matching trace_summaries row.
+ */
+const OFFLINE_TRACE_ID_0 = `${TENANT_ID}-offline-cell-trace-0`;
+const OFFLINE_TRACE_ID_1 = `${TENANT_ID}-offline-cell-trace-1`;
+
+/**
+ * evaluatorA: numeric evaluator (produces Score values, no Passed)
+ * evaluatorB: boolean evaluator (produces Passed values, no Score)
+ */
+const NUMERIC_EVALUATOR_ID = "offline-3900-fixed-numeric-evaluator";
+const BOOL_EVALUATOR_ID = "offline-3900-fixed-bool-evaluator";
+
+/** Wide date range so rows are always inside the query window */
+const baseInput = {
+  projectId: TENANT_ID,
+  startDate: new Date("2020-01-01T00:00:00Z"),
+  endDate: new Date("2030-01-01T00:00:00Z"),
+  previousPeriodStartDate: new Date("2019-01-01T00:00:00Z"),
+  timeScale: "full" as const,
+};
+
+describe("offline-experiment evaluations on Custom Graphs", () => {
+  let ch: ClickHouseClient;
+
+  beforeAll(
+    async () => {
+      const rawClient = getTestClickHouseClient();
+      if (!rawClient) throw new Error("ClickHouse client not available");
+      ch = wrapWithDefaultSettings(rawClient);
+
+      /**
+       * Simulate the fixed runtime state:
+       *
+       * The orchestrator generates a synthetic traceId per cell, calls
+       * reportEvaluation (writes evaluation_runs), and NOW ALSO dispatches a
+       * synthetic recordSpan via getApp().traces.recordSpan() — which ultimately
+       * writes a trace_summaries row. We simulate the end-result of that
+       * pipeline by inserting into both tables directly, as the full BullMQ
+       * pipeline is not available in this integration test environment.
+       */
+
+      // Seed trace_summaries — this is what the orchestrator's new recordSpan
+      // dispatch creates at runtime via the trace processing pipeline.
+      const now = new Date("2025-06-01T10:00:00Z");
+      await ch.insert({
+        table: "trace_summaries",
+        values: [
+          {
+            ProjectionId: `proj-ts-3900-0`,
+            TenantId: TENANT_ID,
+            TraceId: OFFLINE_TRACE_ID_0,
+            Version: "1",
+            Attributes: {
+              "langwatch.origin": "evaluation",
+              "langwatch.experiment_id": "exp-offline-3900",
+              "langwatch.run_id": "run-offline-3900",
+            },
+            OccurredAt: now,
+            CreatedAt: now,
+            UpdatedAt: now,
+            ComputedIOSchemaVersion: "",
+            ComputedInput: "",
+            ComputedOutput: "",
+            TimeToFirstTokenMs: 0,
+            TimeToLastTokenMs: 0,
+            TotalDurationMs: 0,
+            TokensPerSecond: 0,
+            SpanCount: 1,
+            ContainsErrorStatus: 0,
+            ContainsOKStatus: 1,
+            ErrorMessage: null,
+            Models: [],
+            TotalCost: 0,
+            TokensEstimated: false,
+            TotalPromptTokenCount: 0,
+            TotalCompletionTokenCount: 0,
+            OutputFromRootSpan: 0,
+            OutputSpanEndTimeMs: 0,
+            BlockedByGuardrail: 0,
+            TopicId: null,
+            SubTopicId: null,
+            HasAnnotation: null,
+          },
+          {
+            ProjectionId: `proj-ts-3900-1`,
+            TenantId: TENANT_ID,
+            TraceId: OFFLINE_TRACE_ID_1,
+            Version: "1",
+            Attributes: {
+              "langwatch.origin": "evaluation",
+              "langwatch.experiment_id": "exp-offline-3900",
+              "langwatch.run_id": "run-offline-3900",
+            },
+            OccurredAt: now,
+            CreatedAt: now,
+            UpdatedAt: now,
+            ComputedIOSchemaVersion: "",
+            ComputedInput: "",
+            ComputedOutput: "",
+            TimeToFirstTokenMs: 0,
+            TimeToLastTokenMs: 0,
+            TotalDurationMs: 0,
+            TokensPerSecond: 0,
+            SpanCount: 1,
+            ContainsErrorStatus: 0,
+            ContainsOKStatus: 1,
+            ErrorMessage: null,
+            Models: [],
+            TotalCost: 0,
+            TokensEstimated: false,
+            TotalPromptTokenCount: 0,
+            TotalCompletionTokenCount: 0,
+            OutputFromRootSpan: 0,
+            OutputSpanEndTimeMs: 0,
+            BlockedByGuardrail: 0,
+            TopicId: null,
+            SubTopicId: null,
+            HasAnnotation: null,
+          },
+        ],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+
+      // Seed evaluation_runs — these are what the orchestrator's reportEvaluation
+      // call creates (unchanged from before the fix).
+      await ch.insert({
+        table: "evaluation_runs",
+        values: [
+          // Numeric evaluator, cell 0: score 0.75
+          {
+            ProjectionId: "proj-offline-3900-fixed-num-0",
+            TenantId: TENANT_ID,
+            EvaluationId: "eval-offline-3900-fixed-num-0",
+            Version: "1",
+            EvaluatorId: NUMERIC_EVALUATOR_ID,
+            EvaluatorType: "custom",
+            TraceId: OFFLINE_TRACE_ID_0,
+            Status: "processed",
+            Score: 0.75,
+            Passed: null,
+            Label: null,
+            LastProcessedEventId: "evt-offline-3900-fixed-num-0",
+            UpdatedAt: new Date("2025-06-01T10:00:00Z").toISOString(),
+          },
+          // Numeric evaluator, cell 1: score 0.25
+          {
+            ProjectionId: "proj-offline-3900-fixed-num-1",
+            TenantId: TENANT_ID,
+            EvaluationId: "eval-offline-3900-fixed-num-1",
+            Version: "1",
+            EvaluatorId: NUMERIC_EVALUATOR_ID,
+            EvaluatorType: "custom",
+            TraceId: OFFLINE_TRACE_ID_1,
+            Status: "processed",
+            Score: 0.25,
+            Passed: null,
+            Label: null,
+            LastProcessedEventId: "evt-offline-3900-fixed-num-1",
+            UpdatedAt: new Date("2025-06-01T10:00:01Z").toISOString(),
+          },
+          // Boolean evaluator, cell 0: passed
+          {
+            ProjectionId: "proj-offline-3900-fixed-bool-0",
+            TenantId: TENANT_ID,
+            EvaluationId: "eval-offline-3900-fixed-bool-0",
+            Version: "1",
+            EvaluatorId: BOOL_EVALUATOR_ID,
+            EvaluatorType: "custom",
+            TraceId: OFFLINE_TRACE_ID_0,
+            Status: "processed",
+            Score: null,
+            Passed: 1,
+            Label: null,
+            LastProcessedEventId: "evt-offline-3900-fixed-bool-0",
+            UpdatedAt: new Date("2025-06-01T10:00:02Z").toISOString(),
+          },
+          // Boolean evaluator, cell 1: failed
+          {
+            ProjectionId: "proj-offline-3900-fixed-bool-1",
+            TenantId: TENANT_ID,
+            EvaluationId: "eval-offline-3900-fixed-bool-1",
+            Version: "1",
+            EvaluatorId: BOOL_EVALUATOR_ID,
+            EvaluatorType: "custom",
+            TraceId: OFFLINE_TRACE_ID_1,
+            Status: "processed",
+            Score: null,
+            Passed: 0,
+            Label: null,
+            LastProcessedEventId: "evt-offline-3900-fixed-bool-1",
+            UpdatedAt: new Date("2025-06-01T10:00:03Z").toISOString(),
+          },
+        ],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+    },
+    60_000,
+  );
+
+  afterAll(async () => {
+    await cleanupTestData(TENANT_ID);
+
+    // cleanupTestData does not delete from evaluation_runs — clean up manually
+    const rawClient = getTestClickHouseClient();
+    if (rawClient) {
+      await rawClient.exec({
+        query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
+        query_params: { tenantId: TENANT_ID },
+      });
+    }
+  });
+
+  describe("given the orchestrator dispatches a recordSpan for each offline-experiment cell", () => {
+    describe("when the analytics layer queries evaluation_score for the experiment's evaluator", () => {
+      /**
+       * @scenario Offline experiment writes joinable evaluation_runs rows for boolean and numeric evaluators
+       */
+      it("renders non-empty evaluation_score buckets for the offline-experiment evaluator", async () => {
+        // With the Phase 1 fix, the orchestrator dispatches a synthetic
+        // recordSpan immediately after each target_result event. This creates a
+        // trace_summaries row for the cell's traceId via the trace processing
+        // pipeline. The analytics INNER JOIN trace_summaries → evaluation_runs
+        // on (TenantId, TraceId) therefore matches, and the metric is non-null.
+        //
+        // This test seeds both trace_summaries (simulating the recordSpan write)
+        // and evaluation_runs (seeded as before), then asserts the analytics
+        // query returns a non-zero value.
+        resetParamCounter();
+        const { sql, params } = buildTimeseriesQuery({
+          ...baseInput,
+          series: [
+            {
+              metric:
+                "evaluations.evaluation_score" as FlattenAnalyticsMetricsEnum,
+              aggregation: "avg",
+              key: NUMERIC_EVALUATOR_ID,
+            },
+          ],
+        });
+
+        const result = await ch.query({
+          query: sql,
+          query_params: params,
+          format: "JSONEachRow",
+        });
+
+        type Row = Record<string, unknown>;
+        const rows = (await result.json()) as Row[];
+
+        expect(Array.isArray(rows)).toBe(true);
+
+        const currentRows = rows.filter((r) => r["period"] === "current");
+
+        // At least one bucket must exist with a non-null numeric score.
+        // avg(0.75, 0.25) = 0.5 if both rows are visible via the JOIN.
+        const metricKey = Object.keys(currentRows[0] ?? {}).find(
+          (k) => k !== "date" && k !== "period" && k !== "group_key",
+        );
+
+        expect(
+          metricKey,
+          "No metric column found — query returned zero rows (trace_summaries rows missing for offline-experiment cells)",
+        ).toBeDefined();
+
+        const score = Number(currentRows[0]?.[metricKey!]);
+        expect(
+          isNaN(score) || score === 0,
+          `Metric value was ${score} — expected non-zero avg score (0.75 and 0.25 seeded)`,
+        ).toBe(false);
+      });
+
+      it("renders non-empty evaluation_pass_rate buckets for the offline-experiment evaluator", async () => {
+        // Same verification for boolean evaluator pass_rate.
+        // Passed=1 (cell 0) and Passed=0 (cell 1) → avg pass_rate = 0.5.
+        resetParamCounter();
+        const { sql, params } = buildTimeseriesQuery({
+          ...baseInput,
+          series: [
+            {
+              metric:
+                "evaluations.evaluation_pass_rate" as FlattenAnalyticsMetricsEnum,
+              aggregation: "avg",
+              key: BOOL_EVALUATOR_ID,
+            },
+          ],
+        });
+
+        const result = await ch.query({
+          query: sql,
+          query_params: params,
+          format: "JSONEachRow",
+        });
+
+        type Row = Record<string, unknown>;
+        const rows = (await result.json()) as Row[];
+
+        expect(Array.isArray(rows)).toBe(true);
+
+        const currentRows = rows.filter((r) => r["period"] === "current");
+
+        const metricKey = Object.keys(currentRows[0] ?? {}).find(
+          (k) => k !== "date" && k !== "period" && k !== "group_key",
+        );
+
+        expect(
+          metricKey,
+          "No metric column found — query returned zero rows (trace_summaries rows missing for offline-experiment cells)",
+        ).toBeDefined();
+
+        // avg(Passed) = (1 + 0) / 2 = 0.5 if both rows are visible.
+        // If rows are dropped by the JOIN, avg() of nothing returns 0 (not NaN)
+        // because the analytics SQL COALESCEs nulls to 0. The assertion must
+        // also reject 0 to detect the bug.
+        const passRate = Number(currentRows[0]?.[metricKey!]);
+        expect(
+          isNaN(passRate) || passRate === 0,
+          `Pass rate was ${passRate} — expected non-zero avg (Passed=1 and Passed=0 seeded)`,
+        ).toBe(false);
+      });
+    });
+  });
+});

--- a/python-sdk/src/langwatch/client.py
+++ b/python-sdk/src/langwatch/client.py
@@ -1,6 +1,7 @@
 import atexit
 import os
 import logging
+import threading
 from typing import List, Optional, Sequence, ClassVar
 
 from langwatch.__version__ import __version__
@@ -43,6 +44,19 @@ class Client(LangWatchClientProtocol):
     _base_attributes: ClassVar[BaseAttributes] = {}
     _instrumentors: ClassVar[Sequence[BaseInstrumentor]] = ()
     _disable_sending: ClassVar[bool] = False
+    # Refcount of currently-active traces that requested disable_sending=True.
+    # While >0, sending stays disabled even if the underlying user-set flag is
+    # False — this prevents one trace's disable_sending=True from poisoning
+    # subsequent traces (issue #3981) while also remaining correct under
+    # overlapping concurrent traces. The user-set flag (set via the
+    # `client.disable_sending` setter directly) is preserved separately.
+    _disable_sending_refcount: ClassVar[int] = 0
+    _disable_sending_lock: ClassVar[threading.Lock] = threading.Lock()
+    # Snapshot of the user-set disable_sending value at the moment the first
+    # disable_sending=True trace acquired the refcount. Restored when the
+    # last trace releases. Lets a user who set `client.disable_sending = True`
+    # explicitly keep that value across trace boundaries.
+    _disable_sending_user_baseline: ClassVar[bool] = False
     _flush_on_exit: ClassVar[bool] = True
     _span_exclude_rules: ClassVar[List[SpanProcessingExcludeRule]] = []  # type: ignore[misc]
     _ignore_global_tracer_provider_override_warning: ClassVar[bool] = False
@@ -361,6 +375,8 @@ class Client(LangWatchClientProtocol):
         cls._base_attributes = {}
         cls._instrumentors = ()
         cls._disable_sending = False
+        cls._disable_sending_refcount = 0
+        cls._disable_sending_user_baseline = False
         cls._flush_on_exit = True
         cls._span_exclude_rules = []
         cls._ignore_global_tracer_provider_override_warning = False
@@ -473,6 +489,44 @@ class Client(LangWatchClientProtocol):
             Client._tracer_provider.force_flush()
 
         Client._disable_sending = value
+
+    def acquire_disable_sending(self) -> None:
+        """Refcount-based gate used by `langwatch.trace(disable_sending=True)`.
+
+        Each call increments the refcount and forces sending disabled. Pairs
+        with `release_disable_sending`. Concurrency-safe (issue #3981): an
+        overlapping default-sending trace will not flip the flag back on
+        while another trace still holds the disable refcount.
+        """
+        with Client._disable_sending_lock:
+            if Client._disable_sending_refcount == 0:
+                Client._disable_sending_user_baseline = Client._disable_sending
+            Client._disable_sending_refcount += 1
+            if not Client._disable_sending:
+                # Bypass the public setter's force_flush — we want to start
+                # dropping spans immediately, not flush pending traffic that
+                # was queued under the prior baseline.
+                Client._disable_sending = True
+
+    def release_disable_sending(self) -> None:
+        """Pair with `acquire_disable_sending`. Decrement the refcount; when
+        it returns to zero, restore the user-set baseline value.
+        """
+        with Client._disable_sending_lock:
+            if Client._disable_sending_refcount == 0:
+                # Already released — defensive no-op; an unbalanced release
+                # should not corrupt the baseline.
+                return
+            Client._disable_sending_refcount -= 1
+            if Client._disable_sending_refcount == 0:
+                baseline = Client._disable_sending_user_baseline
+                if Client._disable_sending != baseline:
+                    if (
+                        Client._tracer_provider
+                        and not Client._skip_open_telemetry_setup
+                    ):
+                        Client._tracer_provider.force_flush()
+                    Client._disable_sending = baseline
 
     def __shutdown_tracer_provider(self) -> None:
         """Shuts down the current tracer provider, including flushing."""

--- a/python-sdk/src/langwatch/telemetry/tracing.py
+++ b/python-sdk/src/langwatch/telemetry/tracing.py
@@ -130,10 +130,12 @@ class LangWatchTrace:
             )
             self.metadata["deprecated.trace_id"] = str(trace_id)
 
-        if disable_sending:
-            client = get_instance()
-            if client:
-                client.disable_sending = True
+        # Per-trace flag. Applied to the singleton on __enter__ and restored
+        # on __exit__ so a `disable_sending=True` block cannot poison
+        # subsequent traces (issue #3981 — silent span loss for offline
+        # experiment cells when worker processes are reused across event types).
+        self._disable_sending_request = disable_sending
+        self._prev_disable_sending: Optional[bool] = None
 
         # Use the global tracer provider
         self._tracer_provider = tracer_provider
@@ -186,7 +188,7 @@ class LangWatchTrace:
             metadata=self.metadata,
             expected_output=self._expected_output,
             api_key=self.api_key,
-            disable_sending=self.disable_sending,
+            disable_sending=self._disable_sending_request,
             max_string_length=self.max_string_length,
             tracer_provider=self._tracer_provider,
             span_id=root_span_params.get("span_id", None),
@@ -250,6 +252,34 @@ class LangWatchTrace:
                 self._trace_id = context.trace_id
             return self.root_span
 
+    def _apply_disable_sending(self) -> None:
+        """Snapshot the client's disable_sending flag and apply this trace's
+        request. Paired with `_restore_disable_sending` in `_cleanup`.
+        """
+        client = get_instance()
+        if client is None:
+            return
+        self._prev_disable_sending = client.disable_sending
+        if self._disable_sending_request and not client.disable_sending:
+            client.disable_sending = True
+
+    def _restore_disable_sending(self) -> None:
+        """Restore the client's disable_sending flag to the value captured
+        on enter. Prevents one trace's `disable_sending=True` from poisoning
+        subsequent traces on a reused worker (issue #3981).
+        """
+        if self._prev_disable_sending is None:
+            return
+        client = get_instance()
+        if client is None:
+            self._prev_disable_sending = None
+            return
+        try:
+            if client.disable_sending != self._prev_disable_sending:
+                client.disable_sending = self._prev_disable_sending
+        finally:
+            self._prev_disable_sending = None
+
     def _cleanup(
         self,
         exc_type: Optional[type],
@@ -270,6 +300,8 @@ class LangWatchTrace:
             if self._context_token is not None:
                 langwatch.telemetry.context._reset_current_trace(self._context_token)
                 self._context_token = None
+
+            self._restore_disable_sending()
 
             self._cleaned_up = True
 
@@ -580,6 +612,7 @@ class LangWatchTrace:
     def __enter__(self) -> "LangWatchTrace":
         """Makes the trace usable as a context manager."""
         self._reset()
+        self._apply_disable_sending()
 
         # Store the old token and set the new one
         self._context_token = langwatch.telemetry.context._set_current_trace(self)
@@ -608,6 +641,7 @@ class LangWatchTrace:
     async def __aenter__(self) -> "LangWatchTrace":
         """Makes the trace usable as an async context manager."""
         self._reset()
+        self._apply_disable_sending()
 
         # Store the old token and set the new one
         self._context_token = langwatch.telemetry.context._set_current_trace(self)

--- a/python-sdk/src/langwatch/telemetry/tracing.py
+++ b/python-sdk/src/langwatch/telemetry/tracing.py
@@ -130,12 +130,13 @@ class LangWatchTrace:
             )
             self.metadata["deprecated.trace_id"] = str(trace_id)
 
-        # Per-trace flag. Applied to the singleton on __enter__ and restored
-        # on __exit__ so a `disable_sending=True` block cannot poison
-        # subsequent traces (issue #3981 — silent span loss for offline
-        # experiment cells when worker processes are reused across event types).
+        # Per-trace request. Refcounted on the client during __enter__ and
+        # released during _cleanup so a `disable_sending=True` block cannot
+        # poison subsequent traces (issue #3981 — silent span loss for offline
+        # experiment cells when worker processes are reused across event
+        # types) AND remains correct under overlapping concurrent traces.
         self._disable_sending_request = disable_sending
-        self._prev_disable_sending: Optional[bool] = None
+        self._disable_sending_acquired = False
 
         # Use the global tracer provider
         self._tracer_provider = tracer_provider
@@ -253,32 +254,34 @@ class LangWatchTrace:
             return self.root_span
 
     def _apply_disable_sending(self) -> None:
-        """Snapshot the client's disable_sending flag and apply this trace's
-        request. Paired with `_restore_disable_sending` in `_cleanup`.
+        """Acquire a refcount on the client's disable_sending gate if this
+        trace requested it. Idempotent: the matching `_release_disable_sending`
+        in `_cleanup` will only release if we actually acquired.
         """
-        client = get_instance()
-        if client is None:
+        if not self._disable_sending_request or self._disable_sending_acquired:
             return
-        self._prev_disable_sending = client.disable_sending
-        if self._disable_sending_request and not client.disable_sending:
-            client.disable_sending = True
+        client = get_instance()
+        if client is None or not hasattr(client, "acquire_disable_sending"):
+            return
+        client.acquire_disable_sending()
+        self._disable_sending_acquired = True
 
-    def _restore_disable_sending(self) -> None:
-        """Restore the client's disable_sending flag to the value captured
-        on enter. Prevents one trace's `disable_sending=True` from poisoning
-        subsequent traces on a reused worker (issue #3981).
+    def _release_disable_sending(self) -> None:
+        """Release the refcount acquired by `_apply_disable_sending`, if any.
+
+        Concurrency-safe (issue #3981): the refcount on the client means an
+        overlapping default-sending trace cannot flip the flag back on while
+        another trace still holds the disable refcount, and a `disable_sending`
+        block restores the user-set baseline only when the last holder exits.
         """
-        if self._prev_disable_sending is None:
+        if not self._disable_sending_acquired:
             return
         client = get_instance()
-        if client is None:
-            self._prev_disable_sending = None
-            return
         try:
-            if client.disable_sending != self._prev_disable_sending:
-                client.disable_sending = self._prev_disable_sending
+            if client is not None and hasattr(client, "release_disable_sending"):
+                client.release_disable_sending()
         finally:
-            self._prev_disable_sending = None
+            self._disable_sending_acquired = False
 
     def _cleanup(
         self,
@@ -301,7 +304,7 @@ class LangWatchTrace:
                 langwatch.telemetry.context._reset_current_trace(self._context_token)
                 self._context_token = None
 
-            self._restore_disable_sending()
+            self._release_disable_sending()
 
             self._cleaned_up = True
 

--- a/python-sdk/tests/test_disable_sending_singleton_poisoning.py
+++ b/python-sdk/tests/test_disable_sending_singleton_poisoning.py
@@ -1,0 +1,139 @@
+"""
+Regression test for #3981 — offline-experiment cell traces silently lost on OTLP path.
+
+Root cause: `langwatch.trace(disable_sending=True)` flips `Client._disable_sending`
+on the singleton classvar. When the trace block exits, the flag is NEVER restored.
+
+In `langwatch_nlp` the runtime reuses worker processes across event types:
+- `execute_evaluation` and `execute_optimization` explicitly set
+  `client.disable_sending = True`.
+- `execute_component` (used by offline-experiment cells) does not set it.
+
+Result: a worker that previously handled an evaluation/optimization keeps
+`_disable_sending = True`, and every subsequent `execute_component` from an
+offline-experiment cell has its spans dropped by `ConditionalSpanExporter`
+even though the caller never opted into disabling.
+
+PR #3979 papered over the symptom by synthesizing a stand-in `recordSpan` from
+the orchestrator. This test exercises the SDK-level bug directly, so the fix
+must restore the flag (or scope it per-trace) rather than mask it downstream.
+"""
+
+import langwatch
+from langwatch.client import Client
+from langwatch.state import get_instance
+
+
+def _make_setup(**overrides):
+    """Setup args matching what nlp's execute_event passes."""
+    defaults = {
+        "api_key": "test-key-3981",
+        "endpoint_url": "http://localhost:5560",
+        "skip_open_telemetry_setup": True,  # we don't need a real exporter
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+class TestDisableSendingSingletonPoisoning:
+    """
+    Reproduces the offline-experiment trace-loss bug from issue #3981.
+
+    The trigger is a worker process that handles an `execute_evaluation`
+    or `execute_optimization` first (sets `disable_sending=True`), then
+    handles an `execute_component` for an offline-experiment cell.
+    """
+
+    def setup_method(self):
+        Client.reset_for_testing()
+
+    def teardown_method(self):
+        Client.reset_for_testing()
+
+    def test_disable_sending_is_restored_after_trace_block_exits(self):
+        """
+        A `langwatch.trace(disable_sending=True)` block must not leave the
+        singleton flag flipped after it exits.
+
+        This is the minimum guarantee the SDK must provide so worker reuse
+        in `langwatch_nlp` cannot poison subsequent unrelated traces.
+        """
+        langwatch.setup(**_make_setup())
+
+        client = get_instance()
+        assert client is not None
+        assert client.disable_sending is False, (
+            "Precondition: client starts with sending enabled"
+        )
+
+        # Simulate an `execute_evaluation` invocation on this worker.
+        # nlp's `optional_langwatch_trace` ends up calling `langwatch.trace`
+        # with `disable_sending=True` for the duration of an evaluation block.
+        with langwatch.trace(name="evaluation-block", disable_sending=True):
+            assert client.disable_sending is True, (
+                "Sanity: inside the disable_sending block, flag is True"
+            )
+
+        # After the block exits, the worker process is returned to the pool.
+        # The next event handled by this worker may be an `execute_component`
+        # for an offline-experiment cell — its spans MUST be sent.
+        assert client.disable_sending is False, (
+            "After a `disable_sending=True` trace block exits, the singleton "
+            "flag must be restored. Otherwise subsequent unrelated traces on "
+            "the same worker silently drop spans (#3981)."
+        )
+
+    def test_subsequent_trace_without_disable_sending_actually_sends(self):
+        """
+        End-to-end shape of the poisoning bug: simulate the worker handling
+        an evaluation (disable_sending=True), then immediately handling an
+        offline-experiment cell's execute_component (default disable_sending).
+
+        The second trace's spans must reach the exporter.
+        """
+        langwatch.setup(**_make_setup())
+
+        client = get_instance()
+        assert client is not None
+
+        # First "event" — evaluation, sending disabled. Mirrors nlp's
+        # `execute_evaluation` and `execute_optimization` cases.
+        with langwatch.trace(name="prior-evaluation", disable_sending=True):
+            pass
+
+        # Second "event" — offline-experiment cell. nlp's `execute_component`
+        # creates a trace with disable_sending=False (the default).
+        with langwatch.trace(name="offline-experiment-cell"):
+            # During an offline-experiment cell, the exporter check
+            # (ConditionalSpanExporter.export) reads this flag at export
+            # time. It MUST be False or the span is dropped silently.
+            assert client.disable_sending is False, (
+                "After a prior `disable_sending=True` trace, a subsequent "
+                "default trace must NOT inherit the disabled flag. "
+                "ConditionalSpanExporter would otherwise drop every span "
+                "for offline-experiment cells (#3981)."
+            )
+
+    def test_nested_disable_sending_restores_outer_state(self):
+        """
+        Defense in depth: even when traces nest, exiting an inner block must
+        restore the state the outer block established — not the SDK default.
+        """
+        langwatch.setup(**_make_setup())
+
+        client = get_instance()
+        assert client is not None
+
+        with langwatch.trace(name="outer-default"):
+            assert client.disable_sending is False
+
+            with langwatch.trace(name="inner-disabled", disable_sending=True):
+                assert client.disable_sending is True
+
+            assert client.disable_sending is False, (
+                "Inner `disable_sending=True` block must restore the outer "
+                "state (False) on exit. Leaking the True flag to the outer "
+                "block silently drops the rest of the outer trace's spans."
+            )
+
+        assert client.disable_sending is False

--- a/python-sdk/tests/test_disable_sending_singleton_poisoning.py
+++ b/python-sdk/tests/test_disable_sending_singleton_poisoning.py
@@ -1,8 +1,8 @@
 """
 Regression test for #3981 — offline-experiment cell traces silently lost on OTLP path.
 
-Root cause: `langwatch.trace(disable_sending=True)` flips `Client._disable_sending`
-on the singleton classvar. When the trace block exits, the flag is NEVER restored.
+Root cause: `langwatch.trace(disable_sending=True)` flipped `Client._disable_sending`
+on the singleton classvar without restoring it.
 
 In `langwatch_nlp` the runtime reuses worker processes across event types:
 - `execute_evaluation` and `execute_optimization` explicitly set
@@ -16,8 +16,11 @@ even though the caller never opted into disabling.
 
 PR #3979 papered over the symptom by synthesizing a stand-in `recordSpan` from
 the orchestrator. This test exercises the SDK-level bug directly, so the fix
-must restore the flag (or scope it per-trace) rather than mask it downstream.
+must scope the flag per-trace lifetime — and remain correct under overlapping
+concurrent traces, not just sequential reuse.
 """
+
+import threading
 
 import langwatch
 from langwatch.client import Client
@@ -137,3 +140,82 @@ class TestDisableSendingSingletonPoisoning:
             )
 
         assert client.disable_sending is False
+
+    def test_user_set_disable_sending_baseline_is_preserved(self):
+        """
+        If the user explicitly set `client.disable_sending = True` outside of
+        any trace block, a `disable_sending=True` trace must NOT flip the
+        baseline back to False on exit.
+        """
+        langwatch.setup(**_make_setup())
+
+        client = get_instance()
+        assert client is not None
+        client.disable_sending = True
+        assert client.disable_sending is True
+
+        with langwatch.trace(name="inside-user-disabled", disable_sending=True):
+            assert client.disable_sending is True
+
+        assert client.disable_sending is True, (
+            "User-set baseline of `disable_sending=True` must survive a "
+            "trace block exit — only the refcount-acquired delta should be "
+            "released, not the user's intent."
+        )
+
+        client.disable_sending = False
+
+    def test_overlapping_concurrent_traces_do_not_corrupt_flag(self):
+        """
+        CodeRabbit critique: simple snapshot/restore is unsafe under
+        overlapping concurrent traces. Two threads start a
+        `disable_sending=True` trace each; while both are active the flag
+        must stay True; only when the last one exits does it return to the
+        baseline. A non-refcounted implementation can leak `True` to the
+        baseline or flip back to `False` too early.
+        """
+        langwatch.setup(**_make_setup())
+        client = get_instance()
+        assert client is not None
+
+        observations = []
+        gate_outer_entered = threading.Event()
+        gate_inner_done = threading.Event()
+        gate_release_outer = threading.Event()
+
+        def outer():
+            with langwatch.trace(name="outer-disabled", disable_sending=True):
+                gate_outer_entered.set()
+                gate_release_outer.wait(timeout=5)
+                observations.append(("outer.exit", client.disable_sending))
+
+        def inner():
+            gate_outer_entered.wait(timeout=5)
+            with langwatch.trace(name="inner-disabled", disable_sending=True):
+                observations.append(("inner.inside", client.disable_sending))
+            gate_inner_done.set()
+
+        t_outer = threading.Thread(target=outer)
+        t_inner = threading.Thread(target=inner)
+        t_outer.start()
+        t_inner.start()
+
+        gate_inner_done.wait(timeout=5)
+        # Inner has fully exited its `with` block; outer is still holding
+        # the disable refcount. Flag must remain True.
+        t_inner.join(timeout=5)
+        assert client.disable_sending is True, (
+            "After inner trace exits but outer still holds the disable "
+            "refcount, flag must remain True. Single-slot snapshot/restore "
+            "(pre-refcount fix) would have already flipped it to False here."
+        )
+
+        gate_release_outer.set()
+        t_outer.join(timeout=5)
+
+        assert client.disable_sending is False, (
+            "After ALL disable-requesting traces have exited, flag must "
+            "return to baseline (False)."
+        )
+        assert ("inner.inside", True) in observations
+        assert ("outer.exit", True) in observations


### PR DESCRIPTION
## Why

Closes #3981. Closes #3900. Replaces #3979 (closed).

The SDK's `Client._disable_sending` flag was a singleton classvar. `langwatch.trace(disable_sending=True)` flipped it to `True` and never restored. In `langwatch_nlp`, the worker pool reuses 4 processes across event types — `execute_evaluation` and `execute_optimization` legitimately disable sending, then `execute_component` (offline-experiment cells) inherits the disabled flag and its OTel spans are silently dropped by `ConditionalSpanExporter`.

End result: offline-experiment cell traces never landed in `trace_summaries`. The analytics `INNER JOIN evaluation_runs ON TraceId` dropped every row. Custom Graphs went empty.

#3979 attempted to work around this by synthesizing stand-in spans from the orchestrator. That made charts non-empty but the synthetic spans lacked real LLM/tool/RAG data — anyone clicking into a cell trace still saw stubs. This PR fixes the root cause in the SDK so the real OTel export path delivers actual spans. The orchestrator-side workaround is no longer needed.

## What changed

- **Refcount on `Client`** for `disable_sending`, guarded by `threading.Lock`. Each `acquire_disable_sending()` increments; `release_disable_sending()` decrements. Flag stays True while any holder is active; reverts to the user-set baseline when count hits zero.
- **`LangWatchTrace` calls acquire/release from `__enter__`/`_cleanup`** instead of mutating singleton state at construction. Per-trace request lives on the instance; release is idempotent.
- **Concurrent-overlap safety** (CodeRabbit's critique on PR v1): two threads each entering a disable trace keep the flag True until the last exits. User-set baseline (`client.disable_sending = True` set outside any trace) survives trace boundaries.

## Test plan

`python-sdk/tests/test_disable_sending_singleton_poisoning.py` — 5 cases covering the bug shape:

| # | Case | Catches |
|---|---|---|
| 1 | Flag restored after a disable trace exits | Original #3981 leak |
| 2 | Prior disable trace doesn't poison the next default trace | Worker-reuse shape from nlp's pool |
| 3 | Nested traces restore outer state | Inner-block leakage |
| 4 | User-set baseline survives a disable trace exit | Refcount must NOT clobber explicit user intent |
| 5 | Overlapping concurrent disable traces | CodeRabbit's threading concern |

```
$ .venv/bin/python -m pytest tests/test_disable_sending_singleton_poisoning.py tests/test_client.py tests/telemetry/ -v
51 passed in 0.27s
```

**Analytics JOIN regression test** (cherry-picked from #3979) at `langwatch/src/server/analytics/clickhouse/__tests__/offline-experiment-evaluations-joinability.integration.test.ts` — seeds both tables and asserts the read-path INNER JOIN produces non-null buckets. Catches future regressions in the analytics layer regardless of which mechanism populates `trace_summaries`.

All 15 CI runs green on the prior commit; new commit retriggers CI on the integration test.

## How I can prove I was successful

End-to-end browser QA on boxd VM with the patched SDK deployed into `langwatch-langwatch_nlp-1`. The load-bearing screenshot is **Cell trace — real LLM spans** below: an offline-experiment cell trace containing a real `openai/gpt-5.2` LLM span (329 tokens, $0.00419), not a synthetic stand-in.

**Signin / dashboard**
![](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4148/qa/01-signin-or-dashboard.png)

**Experiment evaluations populated**
![](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4148/qa/02-experiment-evaluations-populated.png)

**Custom graph with data**
![](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4148/qa/03-custom-graph-with-data.png)

**Cell trace — real LLM spans** ← load-bearing
![](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4148/qa/04-cell-trace-real-spans.png)

**Span attributes — real LLM data**
![](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4148/qa/05-span-attributes-real.png)

**Trace waterfall**
![](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4148/qa/06-trace-waterfall.png)

## Anything surprising?

A per-request `ContextVar` would be more correct than a refcount for fully isolated concurrent traces — a default-sending trace running concurrently with a disable trace still gets its spans dropped under the refcount approach. That's a follow-up if production traffic shows that shape; the refcount is equivalent to prior behavior for non-overlapping use and strictly better for the bug class #3981 covers.
