### PR TITLE
ci: require explicit approval for privileged PR checks

### DIFF
--- a/.github/scripts/guard-pull-request-target.test.ts
+++ b/.github/scripts/guard-pull-request-target.test.ts
@@ -3,8 +3,10 @@ import { describe, it } from "node:test";
 
 import {
   hasSafeGate,
+  hasSensitivePermissions,
   jobBlocks,
   jobIfExpression,
+  usesNonGithubTokenSecret,
   usesPullRequestTarget,
 } from "./guard-pull-request-target.ts";
 
@@ -71,5 +73,14 @@ describe("pull_request_target workflow guard", () => {
     assert.ok(indentedJob);
     assert.equal(indentedJob.name, "build");
     assert.equal(hasSafeGate(indentedJob), true);
+  });
+
+  it("detects privileged pull_request_target risk signals", () => {
+    assert.equal(hasSensitivePermissions(["permissions:", "  contents: write"].join("\n")), true);
+    assert.equal(hasSensitivePermissions("permissions: write-all"), true);
+    assert.equal(hasSensitivePermissions("# contents: write"), false);
+
+    assert.equal(usesNonGithubTokenSecret("token: ${{ secrets.RELEASE_PLEASE_TOKEN }}"), true);
+    assert.equal(usesNonGithubTokenSecret("token: ${{ secrets.GITHUB_TOKEN }}"), false);
   });
 });

--- a/.github/scripts/guard-pull-request-target.test.ts
+++ b/.github/scripts/guard-pull-request-target.test.ts
@@ -52,4 +52,15 @@ describe("pull_request_target workflow guard", () => {
     );
     assert.equal(hasSafeGate(gatedJob), true);
   });
+
+  it("extracts commented jobs keys", () => {
+    const [job] = jobBlocks([
+      "jobs: # workflow jobs",
+      "  'build': # comment after job key",
+      "    runs-on: ubuntu-latest",
+    ]);
+
+    assert.ok(job);
+    assert.equal(job.name, "build");
+  });
 });

--- a/.github/scripts/guard-pull-request-target.test.ts
+++ b/.github/scripts/guard-pull-request-target.test.ts
@@ -53,14 +53,23 @@ describe("pull_request_target workflow guard", () => {
     assert.equal(hasSafeGate(gatedJob), true);
   });
 
-  it("extracts commented jobs keys", () => {
-    const [job] = jobBlocks([
+  it("extracts commented and wider-indented jobs keys", () => {
+    const [commentedJob] = jobBlocks([
       "jobs: # workflow jobs",
       "  'build': # comment after job key",
       "    runs-on: ubuntu-latest",
     ]);
+    const [indentedJob] = jobBlocks([
+      "jobs:",
+      "    build: # indented job key",
+      "      if: github.event.label.name == 'approved-ci'",
+      "      runs-on: ubuntu-latest",
+    ]);
 
-    assert.ok(job);
-    assert.equal(job.name, "build");
+    assert.ok(commentedJob);
+    assert.equal(commentedJob.name, "build");
+    assert.ok(indentedJob);
+    assert.equal(indentedJob.name, "build");
+    assert.equal(hasSafeGate(indentedJob), true);
   });
 });

--- a/.github/scripts/guard-pull-request-target.test.ts
+++ b/.github/scripts/guard-pull-request-target.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  hasSafeGate,
+  jobBlocks,
+  jobIfExpression,
+  usesPullRequestTarget,
+} from "./guard-pull-request-target.ts";
+
+const unsafeCheckoutJob = (ifLines: string[]): string[] => [
+  "jobs:",
+  "  test:",
+  "    runs-on: ubuntu-latest",
+  ...ifLines,
+  "    steps:",
+  "      - uses: actions/checkout@v6",
+  "        with:",
+  "          ref: ${{ github.event.pull_request.head.sha }}",
+];
+
+describe("pull_request_target workflow guard", () => {
+  it("detects pull_request_target trigger forms with values", () => {
+    assert.equal(usesPullRequestTarget(["  pull_request_target: # labeled"]), true);
+    assert.equal(
+      usesPullRequestTarget(["on: { pull_request_target: { types: [labeled] } }"]),
+      true,
+    );
+  });
+
+  it("reads safe gates only from a job-level if field", () => {
+    const [commentSpoofedJob] = jobBlocks(
+      unsafeCheckoutJob([
+        "    # github.event.label.name == 'approved-ci'",
+        "    if: always()",
+      ]),
+    );
+    assert.ok(commentSpoofedJob);
+    assert.equal(hasSafeGate(commentSpoofedJob), false);
+
+    const [gatedJob] = jobBlocks(
+      unsafeCheckoutJob([
+        "    if: >",
+        "      github.event_name != 'pull_request_target'",
+        "      || github.event.label.name == 'approved-ci'",
+      ]),
+    );
+    assert.ok(gatedJob);
+    assert.equal(
+      jobIfExpression(gatedJob),
+      "github.event_name != 'pull_request_target'\n|| github.event.label.name == 'approved-ci'",
+    );
+    assert.equal(hasSafeGate(gatedJob), true);
+  });
+});

--- a/.github/scripts/guard-pull-request-target.ts
+++ b/.github/scripts/guard-pull-request-target.ts
@@ -94,6 +94,22 @@ const hasUnsafeCheckout = (jobText: string): boolean =>
   jobText.includes("actions/checkout") &&
   unsafeHeadRefPatterns.some((pattern) => jobText.includes(pattern));
 
+export const hasSensitivePermissions = (text: string): boolean => {
+  const uncommentedText = text
+    .split(/\r?\n/)
+    .map(stripYamlComment)
+    .join("\n");
+
+  return [
+    /(^|\n)permissions:\s*write-all\b/,
+    /(^|\n)contents:\s*write\b/,
+    /(^|\n)pull-requests:\s*write\b/,
+  ].some((pattern) => pattern.test(uncommentedText));
+};
+
+export const usesNonGithubTokenSecret = (text: string): boolean =>
+  /secrets\.(?!GITHUB_TOKEN\b)[A-Za-z0-9_]+/.test(text);
+
 export const jobIfExpression = (job: JobBlock): string | undefined => {
   const fieldPattern = new RegExp(
     `^(\\s{${job.indent + 1},})([A-Za-z0-9_-]+):\\s*`,
@@ -177,11 +193,25 @@ const main = (): number => {
       continue;
     }
 
+    const workflowHasSensitivePermissions = hasSensitivePermissions(
+      lines.join("\n"),
+    );
+
     for (const job of jobBlocks(lines)) {
       const jobText = job.lines.join("\n");
-      if (hasUnsafeCheckout(jobText) && !hasSafeGate(job)) {
+      const risks = [
+        hasUnsafeCheckout(jobText) ? "checks out PR-head code" : undefined,
+        workflowHasSensitivePermissions || hasSensitivePermissions(jobText)
+          ? "has write permissions"
+          : undefined,
+        usesNonGithubTokenSecret(jobText)
+          ? "uses non-GITHUB_TOKEN secrets"
+          : undefined,
+      ].filter((risk) => risk !== undefined);
+
+      if (risks.length > 0 && !hasSafeGate(job)) {
         errors.push(
-          `${displayPath(repoRoot, path)}:${job.startLine}: job \`${job.name}\` checks out PR-head code ` +
+          `${displayPath(repoRoot, path)}:${job.startLine}: job \`${job.name}\` ${risks.join(", ")} ` +
             "from pull_request_target without an `approved-ci` or same-repo gate",
         );
       }

--- a/.github/scripts/guard-pull-request-target.ts
+++ b/.github/scripts/guard-pull-request-target.ts
@@ -33,7 +33,9 @@ const workflowFiles = (repoRoot: string): string[] => {
 };
 
 export const jobBlocks = (lines: string[]): JobBlock[] => {
-  const jobsStart = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  const jobsStart = lines.findIndex((line) =>
+    /^jobs:\s*(?:#.*)?$/.test(line),
+  );
   if (jobsStart === -1) {
     return [];
   }
@@ -47,7 +49,7 @@ export const jobBlocks = (lines: string[]): JobBlock[] => {
       break;
     }
 
-    const match = /^  ([A-Za-z0-9_-]+):\s*$/.exec(line);
+    const match = /^  ["']?([A-Za-z0-9_-]+)["']?:\s*(?:#.*)?$/.exec(line);
     if (match?.[1]) {
       if (current) {
         jobs.push(current);

--- a/.github/scripts/guard-pull-request-target.ts
+++ b/.github/scripts/guard-pull-request-target.ts
@@ -21,6 +21,7 @@ const safeGatePatterns = [
 type JobBlock = {
   name: string;
   startLine: number;
+  indent: number;
   lines: string[];
 };
 
@@ -42,6 +43,7 @@ export const jobBlocks = (lines: string[]): JobBlock[] => {
 
   const jobs: JobBlock[] = [];
   let current: JobBlock | undefined;
+  let jobIndent: number | undefined;
 
   for (let index = jobsStart + 1; index < lines.length; index++) {
     const line = lines[index] ?? "";
@@ -49,12 +51,18 @@ export const jobBlocks = (lines: string[]): JobBlock[] => {
       break;
     }
 
-    const match = /^  ["']?([A-Za-z0-9_-]+)["']?:\s*(?:#.*)?$/.exec(line);
-    if (match?.[1]) {
+    const match = /^(\s+)["']?([A-Za-z0-9_-]+)["']?:\s*(?:#.*)?$/.exec(line);
+    const indent = match?.[1]?.length;
+    if (
+      match?.[2] &&
+      indent !== undefined &&
+      (jobIndent === undefined || indent === jobIndent)
+    ) {
+      jobIndent ??= indent;
       if (current) {
         jobs.push(current);
       }
-      current = { name: match[1], startLine: index + 1, lines: [line] };
+      current = { name: match[2], startLine: index + 1, indent, lines: [line] };
       continue;
     }
 
@@ -87,13 +95,29 @@ const hasUnsafeCheckout = (jobText: string): boolean =>
   unsafeHeadRefPatterns.some((pattern) => jobText.includes(pattern));
 
 export const jobIfExpression = (job: JobBlock): string | undefined => {
-  const ifStart = job.lines.findIndex((line) => /^    if:\s*/.test(line));
+  const fieldPattern = new RegExp(
+    `^(\\s{${job.indent + 1},})([A-Za-z0-9_-]+):\\s*`,
+  );
+  const fieldIndent = job.lines.reduce<number | undefined>((minimum, line) => {
+    const match = fieldPattern.exec(line);
+    const indent = match?.[1]?.length;
+    return indent === undefined || (minimum !== undefined && minimum <= indent)
+      ? minimum
+      : indent;
+  }, undefined);
+  if (fieldIndent === undefined) {
+    return undefined;
+  }
+
+  const ifPattern = new RegExp(`^\\s{${fieldIndent}}if:\\s*`);
+  const fieldBoundaryPattern = new RegExp(`^\\s{${fieldIndent}}\\S`);
+  const ifStart = job.lines.findIndex((line) => ifPattern.test(line));
   if (ifStart === -1) {
     return undefined;
   }
 
   const firstLine = job.lines[ifStart] ?? "";
-  const firstValue = stripYamlComment(firstLine.replace(/^    if:\s*/, ""));
+  const firstValue = stripYamlComment(firstLine.replace(ifPattern, ""));
   const ifLines =
     /^(?:[>|][+-]?)?$/.test(firstValue) || firstValue === ""
       ? []
@@ -101,7 +125,7 @@ export const jobIfExpression = (job: JobBlock): string | undefined => {
 
   for (let index = ifStart + 1; index < job.lines.length; index++) {
     const line = job.lines[index] ?? "";
-    if (/^    \S/.test(line)) {
+    if (fieldBoundaryPattern.test(line)) {
       break;
     }
 

--- a/.github/scripts/guard-pull-request-target.ts
+++ b/.github/scripts/guard-pull-request-target.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readdirSync, readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const defaultRepoRoot = ".";
 const guardWorkflow = ".github/workflows/workflow-security-guard.yml";
@@ -31,7 +32,7 @@ const workflowFiles = (repoRoot: string): string[] => {
     .map((file) => resolve(workflowDir, file));
 };
 
-const jobBlocks = (lines: string[]): JobBlock[] => {
+export const jobBlocks = (lines: string[]): JobBlock[] => {
   const jobsStart = lines.findIndex((line) => /^jobs:\s*$/.test(line));
   if (jobsStart === -1) {
     return [];
@@ -65,15 +66,58 @@ const jobBlocks = (lines: string[]): JobBlock[] => {
   return jobs;
 };
 
-const usesPullRequestTarget = (lines: string[]): boolean =>
-  lines.some((line) => /^\s*pull_request_target:\s*$/.test(line));
+const stripYamlComment = (line: string): string => {
+  const trimmed = line.trim();
+  if (trimmed.startsWith("#")) {
+    return "";
+  }
+
+  return trimmed.replace(/\s+#.*$/, "").trim();
+};
+
+export const usesPullRequestTarget = (lines: string[]): boolean =>
+  lines.some((line) =>
+    /(^|[{,\s])pull_request_target\s*:/.test(stripYamlComment(line)),
+  );
 
 const hasUnsafeCheckout = (jobText: string): boolean =>
   jobText.includes("actions/checkout") &&
   unsafeHeadRefPatterns.some((pattern) => jobText.includes(pattern));
 
-const hasSafeGate = (jobText: string): boolean =>
-  safeGatePatterns.some((pattern) => pattern.test(jobText));
+export const jobIfExpression = (job: JobBlock): string | undefined => {
+  const ifStart = job.lines.findIndex((line) => /^    if:\s*/.test(line));
+  if (ifStart === -1) {
+    return undefined;
+  }
+
+  const firstLine = job.lines[ifStart] ?? "";
+  const firstValue = stripYamlComment(firstLine.replace(/^    if:\s*/, ""));
+  const ifLines =
+    /^(?:[>|][+-]?)?$/.test(firstValue) || firstValue === ""
+      ? []
+      : [firstValue];
+
+  for (let index = ifStart + 1; index < job.lines.length; index++) {
+    const line = job.lines[index] ?? "";
+    if (/^    \S/.test(line)) {
+      break;
+    }
+
+    const value = stripYamlComment(line);
+    if (value) {
+      ifLines.push(value);
+    }
+  }
+
+  return ifLines.join("\n");
+};
+
+export const hasSafeGate = (job: JobBlock): boolean => {
+  const ifExpression = jobIfExpression(job);
+  return ifExpression !== undefined
+    ? safeGatePatterns.some((pattern) => pattern.test(ifExpression))
+    : false;
+};
 
 const validateGuardWorkflow = (repoRoot: string, errors: string[]): void => {
   const path = resolve(repoRoot, guardWorkflow);
@@ -109,7 +153,7 @@ const main = (): number => {
 
     for (const job of jobBlocks(lines)) {
       const jobText = job.lines.join("\n");
-      if (hasUnsafeCheckout(jobText) && !hasSafeGate(jobText)) {
+      if (hasUnsafeCheckout(jobText) && !hasSafeGate(job)) {
         errors.push(
           `${displayPath(repoRoot, path)}:${job.startLine}: job \`${job.name}\` checks out PR-head code ` +
             "from pull_request_target without an `approved-ci` or same-repo gate",
@@ -130,4 +174,10 @@ const main = (): number => {
   return 0;
 };
 
-process.exitCode = main();
+const isEntrypoint = (): boolean =>
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isEntrypoint()) {
+  process.exitCode = main();
+}

--- a/.github/scripts/guard-pull-request-target.ts
+++ b/.github/scripts/guard-pull-request-target.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+const defaultRepoRoot = ".";
+const guardWorkflow = ".github/workflows/workflow-security-guard.yml";
+
+const unsafeHeadRefPatterns = [
+  "github.event.pull_request.head.sha",
+  "github.event.pull_request.head.ref",
+  "github.head_ref",
+];
+
+const safeGatePatterns = [
+  /github\.event\.label\.name\s*==\s*['"]approved-ci['"]/,
+  /github\.event\.pull_request\.head\.repo\.full_name\s*==\s*github\.repository/,
+  /github\.event\.pull_request\.head\.repo\.fork\s*==\s*false/,
+];
+
+type JobBlock = {
+  name: string;
+  startLine: number;
+  lines: string[];
+};
+
+const workflowFiles = (repoRoot: string): string[] => {
+  const workflowDir = resolve(repoRoot, ".github/workflows");
+  return readdirSync(workflowDir)
+    .filter((file) => file.endsWith(".yml") || file.endsWith(".yaml"))
+    .sort()
+    .map((file) => resolve(workflowDir, file));
+};
+
+const jobBlocks = (lines: string[]): JobBlock[] => {
+  const jobsStart = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  if (jobsStart === -1) {
+    return [];
+  }
+
+  const jobs: JobBlock[] = [];
+  let current: JobBlock | undefined;
+
+  for (let index = jobsStart + 1; index < lines.length; index++) {
+    const line = lines[index] ?? "";
+    if (line && !line.startsWith(" ")) {
+      break;
+    }
+
+    const match = /^  ([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (match?.[1]) {
+      if (current) {
+        jobs.push(current);
+      }
+      current = { name: match[1], startLine: index + 1, lines: [line] };
+      continue;
+    }
+
+    current?.lines.push(line);
+  }
+
+  if (current) {
+    jobs.push(current);
+  }
+
+  return jobs;
+};
+
+const usesPullRequestTarget = (lines: string[]): boolean =>
+  lines.some((line) => /^\s*pull_request_target:\s*$/.test(line));
+
+const hasUnsafeCheckout = (jobText: string): boolean =>
+  jobText.includes("actions/checkout") &&
+  unsafeHeadRefPatterns.some((pattern) => jobText.includes(pattern));
+
+const hasSafeGate = (jobText: string): boolean =>
+  safeGatePatterns.some((pattern) => pattern.test(jobText));
+
+const validateGuardWorkflow = (repoRoot: string, errors: string[]): void => {
+  const path = resolve(repoRoot, guardWorkflow);
+  const text = readFileSync(path, "utf8");
+  const requiredSnippets = [
+    "pull_request:",
+    '".github/workflows/*.yml"',
+    '".github/workflows/*.yaml"',
+    ".github/scripts/guard-pull-request-target.ts",
+  ];
+
+  for (const snippet of requiredSnippets) {
+    if (!text.includes(snippet)) {
+      errors.push(`${guardWorkflow}: missing required guard trigger \`${snippet}\``);
+    }
+  }
+};
+
+const displayPath = (repoRoot: string, path: string): string =>
+  relative(resolve(repoRoot), path) || path;
+
+const main = (): number => {
+  const repoRoot = process.argv[2] ?? defaultRepoRoot;
+  const errors: string[] = [];
+
+  validateGuardWorkflow(repoRoot, errors);
+
+  for (const path of workflowFiles(repoRoot)) {
+    const lines = readFileSync(path, "utf8").split(/\r?\n/);
+    if (!usesPullRequestTarget(lines)) {
+      continue;
+    }
+
+    for (const job of jobBlocks(lines)) {
+      const jobText = job.lines.join("\n");
+      if (hasUnsafeCheckout(jobText) && !hasSafeGate(jobText)) {
+        errors.push(
+          `${displayPath(repoRoot, path)}:${job.startLine}: job \`${job.name}\` checks out PR-head code ` +
+            "from pull_request_target without an `approved-ci` or same-repo gate",
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("Unsafe pull_request_target workflow pattern found:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    return 1;
+  }
+
+  console.log("pull_request_target workflow guard passed");
+  return 0;
+};
+
+process.exitCode = main();

--- a/.github/workflows/clickhouse-serverless-chart.yml
+++ b/.github/workflows/clickhouse-serverless-chart.yml
@@ -23,8 +23,8 @@ jobs:
       run:
         working-directory: charts/clickhouse-serverless
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
       - run: make template
@@ -37,14 +37,14 @@ jobs:
       run:
         working-directory: charts/clickhouse-serverless
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
       - name: Build Docker image for Kind
         run: |
           docker build -t langwatch/clickhouse-serverless:next ../../clickhouse-serverless/
-      - uses: helm/kind-action@v1
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: ch-test
       - name: Load image into Kind

--- a/.github/workflows/clickhouse-serverless.yml
+++ b/.github/workflows/clickhouse-serverless.yml
@@ -41,12 +41,12 @@ jobs:
       run:
         working-directory: clickhouse-serverless
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.26"
           cache-dependency-path: clickhouse-serverless/go.sum
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
       - run: make test
@@ -61,12 +61,12 @@ jobs:
       run:
         working-directory: clickhouse-serverless
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.26"
           cache-dependency-path: clickhouse-serverless/go.sum
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - run: make e2e
       - run: make e2e-cold
       - run: make e2e-cold-move

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check for broken links
         run: |
@@ -57,15 +57,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.RELEASE_DOCS_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/langevals-ci.yml
+++ b/.github/workflows/langevals-ci.yml
@@ -1,7 +1,7 @@
 # Always-run workflow with internal path gating + aggregator. See #3223.
 # Branch protection requires `langevals-complete` (includes docker-build).
-# `pull_request_target` runs real tests on `approved-ci` labeled dependabot
-# PRs (per-job `if:` guards); that event forces `relevant=true`.
+# `pull_request_target` runs real tests only after an `approved-ci` label
+# is applied (per-job `if:` guards); that event forces `relevant=true`.
 name: langevals-ci
 
 on:
@@ -38,8 +38,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -67,8 +66,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -112,8 +110,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -123,7 +123,7 @@ jobs:
         run: bash ../.github/scripts/notify-slack-test-failure.sh test-unit
 
       - name: Upload unit test coverage to Codecov
-        if: always()
+        if: always() && hashFiles('langwatch/coverage/lcov.info') != ''
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           files: langwatch/coverage/lcov.info
@@ -245,7 +245,7 @@ jobs:
         run: bash ../.github/scripts/notify-slack-test-failure.sh test-integration
 
       - name: Upload integration test coverage to Codecov
-        if: always()
+        if: always() && hashFiles('langwatch/coverage/lcov.info') != ''
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           files: langwatch/coverage/lcov.info

--- a/.github/workflows/langwatch-chart.yml
+++ b/.github/workflows/langwatch-chart.yml
@@ -51,8 +51,8 @@ jobs:
           - name: scalable-prod
             flags: "-f examples/values-scalable-prod.yaml"
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
       - run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
@@ -81,8 +81,8 @@ jobs:
       run:
         working-directory: charts/langwatch
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
       - name: Build clickhouse-serverless image
@@ -95,7 +95,7 @@ jobs:
       # gateway.image.{repository,tag,pullPolicy} to match.
       - name: Build gateway image
         run: docker build -t langwatch/ai-gateway:e2e -f ../../Dockerfile.go_service ../..
-      - uses: helm/kind-action@v1
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: ${{ matrix.cluster }}
       - name: Load images into Kind

--- a/.github/workflows/langwatch-nlp-ci.yml
+++ b/.github/workflows/langwatch-nlp-ci.yml
@@ -1,7 +1,7 @@
 # Always-run workflow with internal path gating + aggregator. See #3223.
 # Branch protection requires `langwatch-nlp-complete` (includes docker-build).
-# `pull_request_target` runs real tests on `approved-ci` labeled dependabot
-# PRs (per-job `if:` guards); that event forces `relevant=true`.
+# `pull_request_target` runs real tests only after an `approved-ci` label
+# is applied (per-job `if:` guards); that event forces `relevant=true`.
 name: langwatch-nlp-ci
 
 on:
@@ -51,8 +51,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -81,8 +80,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -110,8 +108,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -144,8 +141,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -183,8 +179,7 @@ jobs:
     if: >
       needs.changes.outputs.lambda-image == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/mcp-javascript-ci.yml
+++ b/.github/workflows/mcp-javascript-ci.yml
@@ -39,8 +39,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,8 +61,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-auto-approve.yml
+++ b/.github/workflows/pr-auto-approve.yml
@@ -99,6 +99,7 @@ jobs:
   firefighting:
     needs: preflight
     if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
       needs.preflight.outputs.short_circuit != 'true' &&
       contains(needs.preflight.outputs.labels, ',firefighting,')
     runs-on: ubuntu-latest
@@ -209,6 +210,7 @@ jobs:
   evaluate:
     needs: preflight
     if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
       needs.preflight.outputs.short_circuit != 'true' &&
       !contains(needs.preflight.outputs.labels, ',firefighting,')
     runs-on: ubuntu-latest

--- a/.github/workflows/release-clickhouse-serverless-chart.yml
+++ b/.github/workflows/release-clickhouse-serverless-chart.yml
@@ -14,8 +14,8 @@ jobs:
       run:
         working-directory: charts/clickhouse-serverless
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
       - name: Lint and template
@@ -26,7 +26,7 @@ jobs:
     needs: validate
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
 

--- a/.github/workflows/release-langwatch-chart.yml
+++ b/.github/workflows/release-langwatch-chart.yml
@@ -19,7 +19,7 @@ jobs:
           && github.event.workflow_run.event == 'release')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -29,7 +29,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
 

--- a/.github/workflows/release-please-chart-lock-sync.yml
+++ b/.github/workflows/release-please-chart-lock-sync.yml
@@ -42,7 +42,7 @@ jobs:
       startsWith(github.head_ref, 'release-please--branches--main--components--langwatch')
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
           # PAT — pushes by GITHUB_TOKEN don't retrigger downstream workflows,
@@ -50,7 +50,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: v3.12.0
 

--- a/.github/workflows/sdk-go-ci.yml
+++ b/.github/workflows/sdk-go-ci.yml
@@ -38,8 +38,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -85,8 +84,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     steps:
       - run: echo "no typechecking is needed for go"
@@ -96,8 +94,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/sdk-javascript-ci.yml
+++ b/.github/workflows/sdk-javascript-ci.yml
@@ -42,8 +42,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     # Run lint, typecheck, tests, and build for TypeScript SDK
     defaults:
@@ -82,8 +81,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -44,8 +44,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -93,8 +92,7 @@ jobs:
     if: >
       needs.changes.outputs.relevant == 'true'
       && (github.event_name != 'pull_request_target'
-          || (github.event.label.name == 'approved-ci'
-              && github.event.pull_request.user.login == 'dependabot[bot]'))
+          || github.event.label.name == 'approved-ci')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/workflow-security-guard.yml
+++ b/.github/workflows/workflow-security-guard.yml
@@ -1,0 +1,60 @@
+name: workflow-security-guard
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+      - ".github/actions/**"
+      - ".github/scripts/guard-pull-request-target.ts"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+      - ".github/actions/**"
+      - ".github/scripts/guard-pull-request-target.ts"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pull-request-target-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head for scanning
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          persist-credentials: false
+
+      - name: Checkout trusted guard script
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+
+      - name: Check privileged workflow gates on PR
+        if: github.event_name == 'pull_request'
+        run: node --experimental-strip-types base/.github/scripts/guard-pull-request-target.ts pr
+
+      - name: Checkout repository
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Check privileged workflow gates
+        if: github.event_name != 'pull_request'
+        run: node --experimental-strip-types .github/scripts/guard-pull-request-target.ts

--- a/.github/workflows/workflow-security-guard.yml
+++ b/.github/workflows/workflow-security-guard.yml
@@ -40,6 +40,18 @@ jobs:
           path: base
           persist-credentials: false
 
+      # The base branch has no guard script during the initial rollout.
+      # After merge, future workflow PRs use the trusted base copy.
+      - name: Resolve guard script path
+        if: github.event_name == 'pull_request'
+        id: guard-script
+        run: |
+          if [ -f base/.github/scripts/guard-pull-request-target.ts ]; then
+            echo "path=base/.github/scripts/guard-pull-request-target.ts" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=pr/.github/scripts/guard-pull-request-target.ts" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -47,7 +59,7 @@ jobs:
 
       - name: Check privileged workflow gates on PR
         if: github.event_name == 'pull_request'
-        run: node --experimental-strip-types base/.github/scripts/guard-pull-request-target.ts pr
+        run: node --experimental-strip-types "${{ steps.guard-script.outputs.path }}" pr
 
       - name: Checkout repository
         if: github.event_name != 'pull_request'

--- a/.github/workflows/workflow-security-guard.yml
+++ b/.github/workflows/workflow-security-guard.yml
@@ -6,7 +6,7 @@ on:
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
       - ".github/actions/**"
-      - ".github/scripts/guard-pull-request-target.ts"
+      - ".github/scripts/guard-pull-request-target*.ts"
   push:
     branches:
       - main
@@ -14,7 +14,7 @@ on:
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
       - ".github/actions/**"
-      - ".github/scripts/guard-pull-request-target.ts"
+      - ".github/scripts/guard-pull-request-target*.ts"
   workflow_dispatch:
 
 permissions:
@@ -61,6 +61,10 @@ jobs:
         if: github.event_name == 'pull_request'
         run: node --experimental-strip-types "${{ steps.guard-script.outputs.path }}" pr
 
+      - name: Check guard tests on PR
+        if: github.event_name == 'pull_request'
+        run: node --test --experimental-strip-types pr/.github/scripts/guard-pull-request-target.test.ts
+
       - name: Checkout repository
         if: github.event_name != 'pull_request'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -70,3 +74,7 @@ jobs:
       - name: Check privileged workflow gates
         if: github.event_name != 'pull_request'
         run: node --experimental-strip-types .github/scripts/guard-pull-request-target.ts
+
+      - name: Check guard tests
+        if: github.event_name != 'pull_request'
+        run: node --test --experimental-strip-types .github/scripts/guard-pull-request-target.test.ts

--- a/langwatch/src/utils/testUtils.ts
+++ b/langwatch/src/utils/testUtils.ts
@@ -1,18 +1,23 @@
 import {
+  type Organization,
   OrganizationUserRole,
   PIIRedactionLevel,
   Prisma,
   type Project,
   ProjectSensitiveDataVisibilityLevel,
+  type Team,
   TeamUserRole,
+  type User,
 } from "@prisma/client";
 import { nanoid } from "nanoid";
-import type { NextApiRequest, NextApiResponse } from "~/types/next-stubs";
 import { createMocks, type RequestMethod } from "node-mocks-http";
-import { prisma } from "../server/db";
+import type { NextApiRequest, NextApiResponse } from "~/types/next-stubs";
 import { ENTERPRISE_LICENSE_KEY } from "../../ee/licensing/__tests__/fixtures/testLicenses";
+import { prisma } from "../server/db";
 
-async function ignoreUniqueViolation<T>(promise: Promise<T>): Promise<T | null> {
+async function ignoreUniqueViolation<T>(
+  promise: Promise<T>,
+): Promise<T | null> {
   try {
     return await promise;
   } catch (error) {
@@ -26,49 +31,85 @@ async function ignoreUniqueViolation<T>(promise: Promise<T>): Promise<T | null> 
   }
 }
 
+async function readAfterUniqueViolation<T>(
+  promise: Promise<T>,
+  readExisting: () => Promise<T | null>,
+): Promise<T> {
+  try {
+    return await promise;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      const existing = await readExisting();
+      if (existing) {
+        return existing;
+      }
+    }
+    throw error;
+  }
+}
+
 export async function getTestUser() {
-  const user = await prisma.user.upsert({
-    where: { email: "test-user@example.com" },
-    update: {},
-    create: {
-      name: "Test User",
-      email: "test-user@example.com",
-    },
-  });
+  const user = await readAfterUniqueViolation<User>(
+    prisma.user.upsert({
+      where: { email: "test-user@example.com" },
+      update: {},
+      create: {
+        name: "Test User",
+        email: "test-user@example.com",
+      },
+    }),
+    () => prisma.user.findUnique({ where: { email: "test-user@example.com" } }),
+  );
 
-  const organization = await prisma.organization.upsert({
-    where: { slug: "test-organization" },
-    update: { license: ENTERPRISE_LICENSE_KEY },
-    create: {
-      name: "Test Organization",
-      slug: "test-organization",
-      license: ENTERPRISE_LICENSE_KEY,
-    },
-  });
+  const organization = await readAfterUniqueViolation<Organization>(
+    prisma.organization.upsert({
+      where: { slug: "test-organization" },
+      update: { license: ENTERPRISE_LICENSE_KEY },
+      create: {
+        name: "Test Organization",
+        slug: "test-organization",
+        license: ENTERPRISE_LICENSE_KEY,
+      },
+    }),
+    () =>
+      prisma.organization.findUnique({ where: { slug: "test-organization" } }),
+  );
 
-  const team = await prisma.team.upsert({
-    where: { slug: "test-team", organizationId: organization.id },
-    update: {},
-    create: {
-      name: "Test Team",
-      slug: "test-team",
-      organizationId: organization.id,
-    },
-  });
+  const team = await readAfterUniqueViolation<Team>(
+    prisma.team.upsert({
+      where: { slug: "test-team", organizationId: organization.id },
+      update: {},
+      create: {
+        name: "Test Team",
+        slug: "test-team",
+        organizationId: organization.id,
+      },
+    }),
+    () =>
+      prisma.team.findUnique({
+        where: { slug: "test-team", organizationId: organization.id },
+      }),
+  );
 
-  await prisma.project.upsert({
-    where: { id: "test-project-id" },
-    update: {},
-    create: {
-      id: "test-project-id",
-      name: "Test Project",
-      slug: "test-project",
-      apiKey: "test-api-key",
-      teamId: team.id,
-      language: "en",
-      framework: "test-framework",
-    },
-  });
+  await readAfterUniqueViolation<Project>(
+    prisma.project.upsert({
+      where: { id: "test-project-id" },
+      update: {},
+      create: {
+        id: "test-project-id",
+        name: "Test Project",
+        slug: "test-project",
+        apiKey: "test-api-key",
+        teamId: team.id,
+        language: "en",
+        framework: "test-framework",
+      },
+    }),
+    () => prisma.project.findUnique({ where: { id: "test-project-id" } }),
+  );
 
   await ignoreUniqueViolation(
     prisma.teamUser.create({


### PR DESCRIPTION
## Summary

- remove the Dependabot-author trust condition from privileged `pull_request_target` CI gates
- keep `approved-ci` as the explicit human approval switch for running PR-head code with secrets
- add a TypeScript workflow guard that scans `pull_request_target` workflows for PR-head checkouts without an `approved-ci` or same-repo gate
- run the guard from the trusted base checkout while scanning PR-head workflow files

## GitHub-side follow-up

After this lands, make `workflow-security-guard / pull-request-target-guard` a required branch protection check for PRs that touch workflow files. GitHub-side, the strongest secret-leak controls are: keep repository Actions permissions least-privileged, avoid sharing sensitive org/repo secrets with untrusted PR workflows, use environments with required reviewers for secrets that must be accessed manually, and keep privileged `pull_request_target` jobs from executing PR-head code unless explicitly reviewed.

## Validation

- `node --experimental-strip-types .github/scripts/guard-pull-request-target.ts`