### PR TITLE
chore(ci): sign release images with cosign and publish CycloneDX SBOMs

### DIFF
--- a/.github/workflows/publish-docker-app.yml
+++ b/.github/workflows/publish-docker-app.yml
@@ -213,6 +213,10 @@ jobs:
       - name: Sign manifests and attach per-platform CycloneDX SBOMs
         env:
           HASH: ${{ needs.extract-version.outputs.short_hash }}
+          IS_RELEASE: ${{ needs.extract-version.outputs.is_release }}
+          VERSION: ${{ needs.extract-version.outputs.version }}
+          CERT_IDENTITY_REGEX: ^https://github\.com/langwatch/langwatch/
+          CERT_OIDC_ISSUER: https://token.actions.githubusercontent.com
         run: |
           set -euo pipefail
           mkdir -p sboms
@@ -227,6 +231,33 @@ jobs:
             fi
             echo "Signing multi-arch index langwatch/${IMAGE}@${INDEX_DIGEST}"
             cosign sign "langwatch/${IMAGE}@${INDEX_DIGEST}"
+
+            echo "Verifying index signature for langwatch/${IMAGE}@${INDEX_DIGEST}"
+            cosign verify "langwatch/${IMAGE}@${INDEX_DIGEST}" \
+              --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+              --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
+
+            # Release tags (VERSION + optionally latest) and the HASH tag should all point
+            # at the same multi-arch manifest digest, but assert it explicitly so that any
+            # future registry-side normalization that produces a different digest is signed
+            # rather than silently leaving an unsigned tag.
+            EXTRA_TAGS=""
+            if [ "${IS_RELEASE}" = "true" ]; then
+              EXTRA_TAGS="${VERSION}"
+              if ! echo "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-.+'; then
+                EXTRA_TAGS="${EXTRA_TAGS} latest"
+              fi
+            fi
+            for TAG in ${EXTRA_TAGS}; do
+              TAG_DIGEST=$(docker buildx imagetools inspect "langwatch/${IMAGE}:${TAG}" --format '{{ json . }}' | jq -r '.manifest.digest')
+              if [ "${TAG_DIGEST}" != "${INDEX_DIGEST}" ]; then
+                echo "::warning::langwatch/${IMAGE}:${TAG} digest ${TAG_DIGEST} differs from :${HASH} digest ${INDEX_DIGEST}; signing separately"
+                cosign sign "langwatch/${IMAGE}@${TAG_DIGEST}"
+                cosign verify "langwatch/${IMAGE}@${TAG_DIGEST}" \
+                  --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+                  --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
+              fi
+            done
 
             PLATFORMS_JSON=$(echo "${INSPECT}" | jq -c '[.manifest.manifests[] | select(.platform.os != "unknown") | {digest: .digest, os: .platform.os, arch: .platform.architecture}]')
             COUNT=$(echo "${PLATFORMS_JSON}" | jq 'length')
@@ -251,6 +282,15 @@ jobs:
 
               echo "Attesting SBOM for ${PDREF}"
               cosign attest --predicate "${SBOM_FILE}" --type cyclonedx "${PDREF}"
+
+              echo "Verifying signature and SBOM attestation for ${PDREF}"
+              cosign verify "${PDREF}" \
+                --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+                --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
+              cosign verify-attestation "${PDREF}" \
+                --type cyclonedx \
+                --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+                --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
             done
           done
 

--- a/.github/workflows/publish-docker-app.yml
+++ b/.github/workflows/publish-docker-app.yml
@@ -186,6 +186,71 @@ jobs:
             done
           done
 
+  sign-and-attest:
+    runs-on: ubuntu-latest
+    needs: [extract-version, create-manifest]
+    permissions:
+      contents: write # upload SBOMs to GitHub release assets
+      id-token: write # keyless OIDC signing via Sigstore
+    env:
+      COSIGN_YES: "true"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Sign manifests and attach CycloneDX SBOMs
+        env:
+          HASH: ${{ needs.extract-version.outputs.short_hash }}
+        run: |
+          set -euo pipefail
+          mkdir -p sboms
+          for IMAGE in langwatch langwatch_nlp langevals ai-gateway; do
+            REF="langwatch/${IMAGE}:${HASH}"
+            DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{ json . }}' | jq -r '.manifest.digest')
+            if [ -z "${DIGEST}" ] || [ "${DIGEST}" = "null" ]; then
+              echo "::error::Could not resolve digest for ${REF}"
+              exit 1
+            fi
+            DIGEST_REF="langwatch/${IMAGE}@${DIGEST}"
+            echo "Signing ${DIGEST_REF}"
+            cosign sign "${DIGEST_REF}"
+
+            SBOM_FILE="sboms/${IMAGE}.cdx.json"
+            echo "Generating CycloneDX SBOM for ${DIGEST_REF}"
+            syft "registry:${DIGEST_REF}" -o cyclonedx-json="${SBOM_FILE}"
+
+            echo "Attesting SBOM for ${DIGEST_REF}"
+            cosign attest --predicate "${SBOM_FILE}" --type cyclonedx "${DIGEST_REF}"
+          done
+
+      - name: Upload SBOMs as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sboms-${{ needs.extract-version.outputs.short_hash }}
+          path: sboms/*.cdx.json
+          retention-days: 90
+
+      - name: Attach SBOMs to GitHub release
+        if: needs.extract-version.outputs.is_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" sboms/*.cdx.json --clobber --repo "${GITHUB_REPOSITORY}"
+
   notify:
     runs-on: ubuntu-latest
     needs: [extract-version, create-manifest]

--- a/.github/workflows/publish-docker-app.yml
+++ b/.github/workflows/publish-docker-app.yml
@@ -210,7 +210,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Sign manifests and attach CycloneDX SBOMs
+      - name: Sign manifests and attach per-platform CycloneDX SBOMs
         env:
           HASH: ${{ needs.extract-version.outputs.short_hash }}
         run: |
@@ -218,21 +218,40 @@ jobs:
           mkdir -p sboms
           for IMAGE in langwatch langwatch_nlp langevals ai-gateway; do
             REF="langwatch/${IMAGE}:${HASH}"
-            DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{ json . }}' | jq -r '.manifest.digest')
-            if [ -z "${DIGEST}" ] || [ "${DIGEST}" = "null" ]; then
-              echo "::error::Could not resolve digest for ${REF}"
+            INSPECT=$(docker buildx imagetools inspect "${REF}" --format '{{ json . }}')
+
+            INDEX_DIGEST=$(echo "${INSPECT}" | jq -r '.manifest.digest')
+            if [ -z "${INDEX_DIGEST}" ] || [ "${INDEX_DIGEST}" = "null" ]; then
+              echo "::error::Could not resolve index digest for ${REF}"
               exit 1
             fi
-            DIGEST_REF="langwatch/${IMAGE}@${DIGEST}"
-            echo "Signing ${DIGEST_REF}"
-            cosign sign "${DIGEST_REF}"
+            echo "Signing multi-arch index langwatch/${IMAGE}@${INDEX_DIGEST}"
+            cosign sign "langwatch/${IMAGE}@${INDEX_DIGEST}"
 
-            SBOM_FILE="sboms/${IMAGE}.cdx.json"
-            echo "Generating CycloneDX SBOM for ${DIGEST_REF}"
-            syft "registry:${DIGEST_REF}" -o cyclonedx-json="${SBOM_FILE}"
+            PLATFORMS_JSON=$(echo "${INSPECT}" | jq -c '[.manifest.manifests[] | select(.platform.os != "unknown") | {digest: .digest, os: .platform.os, arch: .platform.architecture}]')
+            COUNT=$(echo "${PLATFORMS_JSON}" | jq 'length')
+            if [ "${COUNT}" -eq 0 ]; then
+              echo "::error::No platform manifests found in index for ${REF}"
+              exit 1
+            fi
 
-            echo "Attesting SBOM for ${DIGEST_REF}"
-            cosign attest --predicate "${SBOM_FILE}" --type cyclonedx "${DIGEST_REF}"
+            for i in $(seq 0 $((COUNT - 1))); do
+              ENTRY=$(echo "${PLATFORMS_JSON}" | jq -c ".[$i]")
+              PDIGEST=$(echo "${ENTRY}" | jq -r '.digest')
+              POS=$(echo "${ENTRY}" | jq -r '.os')
+              PARCH=$(echo "${ENTRY}" | jq -r '.arch')
+              PDREF="langwatch/${IMAGE}@${PDIGEST}"
+              SBOM_FILE="sboms/${IMAGE}-${POS}-${PARCH}.cdx.json"
+
+              echo "Generating CycloneDX SBOM for ${PDREF} (${POS}/${PARCH})"
+              syft "registry:${PDREF}" -o cyclonedx-json="${SBOM_FILE}"
+
+              echo "Signing platform manifest ${PDREF}"
+              cosign sign "${PDREF}"
+
+              echo "Attesting SBOM for ${PDREF}"
+              cosign attest --predicate "${SBOM_FILE}" --type cyclonedx "${PDREF}"
+            done
           done
 
       - name: Upload SBOMs as workflow artifact
@@ -253,7 +272,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    needs: [extract-version, create-manifest]
+    needs: [extract-version, create-manifest, sign-and-attest]
     if: needs.extract-version.outputs.is_release == 'true'
 
     steps:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -27305,6 +27305,38 @@ LangWatch enforces tenant isolation at the application level:
 - API tokens are scoped to a specific project
 - Cross-tenant data access is prevented at the query layer
 
+## Supply Chain
+
+LangWatch container images and CLI packages are published with verifiable supply-chain attestations so operators can confirm an artifact was built by LangWatch CI from a specific source commit.
+
+### Container images (Docker Hub)
+
+Every release of `langwatch/langwatch`, `langwatch/langwatch_nlp`, `langwatch/langevals`, and `langwatch/ai-gateway` is signed with [Sigstore](https://www.sigstore.dev/) cosign using keyless OIDC. Both the multi-arch index manifest and each per-platform manifest (linux/amd64, linux/arm64) are signed by digest. A CycloneDX SBOM is generated per platform and attached as a cosign attestation against the matching platform manifest digest, so the SBOM you verify always corresponds to the architecture you actually pulled.
+
+Verify a signature with [cosign](https://github.com/sigstore/cosign):
+
+```bash
+cosign verify langwatch/langwatch:<tag> \
+  --certificate-identity-regexp '^https://github\.com/langwatch/langwatch/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Inspect the attached SBOM for the platform you pulled (cosign resolves the right per-platform manifest digest automatically when you pass a tag):
+
+```bash
+cosign download attestation \
+  --predicate-type https://cyclonedx.org/bom \
+  langwatch/langwatch:<tag> \
+  | jq -r '.payload | @base64d | fromjson | .predicate' \
+  > langwatch.cdx.json
+```
+
+The per-platform `*.cdx.json` files (e.g. `langwatch-linux-amd64.cdx.json`, `langwatch-linux-arm64.cdx.json`) are also attached to each `langwatch@vX.Y.Z` [GitHub release](https://github.com/langwatch/langwatch/releases).
+
+### npm CLI
+
+The `langwatch` npm package is published with [npm provenance attestations](https://docs.npmjs.com/generating-provenance-statements) via GitHub Actions OIDC, also backed by Sigstore. The provenance link is visible on the [package page](https://www.npmjs.com/package/langwatch) and can be verified with `npm audit signatures`.
+
 ## Production Hardening Checklist
 
 - [ ] `autogen.enabled: false` — use manually created secrets
@@ -27320,6 +27352,7 @@ LangWatch enforces tenant isolation at the application level:
 - [ ] Pod security contexts verified (non-root, read-only filesystem)
 - [ ] Ingress rate limiting configured
 - [ ] Audit logs enabled (Enterprise)
+- [ ] Image signatures verified at pull time (admission controller or `cosign verify` in CI)
 
 ---
 

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -173,6 +173,36 @@ LangWatch enforces tenant isolation at the application level:
 - API tokens are scoped to a specific project
 - Cross-tenant data access is prevented at the query layer
 
+## Supply Chain
+
+LangWatch container images and CLI packages are published with verifiable supply-chain attestations so operators can confirm an artifact was built by LangWatch CI from a specific source commit.
+
+### Container images (Docker Hub)
+
+Every release of `langwatch/langwatch`, `langwatch/langwatch_nlp`, `langwatch/langevals`, and `langwatch/ai-gateway` is signed with [Sigstore](https://www.sigstore.dev/) cosign using keyless OIDC, and a CycloneDX SBOM is attached as a cosign attestation.
+
+Verify a signature with [cosign](https://github.com/sigstore/cosign):
+
+```bash
+cosign verify langwatch/langwatch:<tag> \
+  --certificate-identity-regexp '^https://github\.com/langwatch/langwatch/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Inspect the attached SBOM:
+
+```bash
+cosign download attestation langwatch/langwatch:<tag> \
+  | jq -r '.payload | @base64d | fromjson | .predicate' \
+  > langwatch.cdx.json
+```
+
+The same `*.cdx.json` files are also attached to each `langwatch@vX.Y.Z` [GitHub release](https://github.com/langwatch/langwatch/releases).
+
+### npm CLI
+
+The `langwatch` npm package is published with [npm provenance attestations](https://docs.npmjs.com/generating-provenance-statements) via GitHub Actions OIDC, also backed by Sigstore. The provenance link is visible on the [package page](https://www.npmjs.com/package/langwatch) and can be verified with `npm audit signatures`.
+
 ## Production Hardening Checklist
 
 - [ ] `autogen.enabled: false` — use manually created secrets
@@ -188,3 +218,4 @@ LangWatch enforces tenant isolation at the application level:
 - [ ] Pod security contexts verified (non-root, read-only filesystem)
 - [ ] Ingress rate limiting configured
 - [ ] Audit logs enabled (Enterprise)
+- [ ] Image signatures verified at pull time (admission controller or `cosign verify` in CI)

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -179,7 +179,7 @@ LangWatch container images and CLI packages are published with verifiable supply
 
 ### Container images (Docker Hub)
 
-Every release of `langwatch/langwatch`, `langwatch/langwatch_nlp`, `langwatch/langevals`, and `langwatch/ai-gateway` is signed with [Sigstore](https://www.sigstore.dev/) cosign using keyless OIDC, and a CycloneDX SBOM is attached as a cosign attestation.
+Every release of `langwatch/langwatch`, `langwatch/langwatch_nlp`, `langwatch/langevals`, and `langwatch/ai-gateway` is signed with [Sigstore](https://www.sigstore.dev/) cosign using keyless OIDC. Both the multi-arch index manifest and each per-platform manifest (linux/amd64, linux/arm64) are signed by digest. A CycloneDX SBOM is generated per platform and attached as a cosign attestation against the matching platform manifest digest, so the SBOM you verify always corresponds to the architecture you actually pulled.
 
 Verify a signature with [cosign](https://github.com/sigstore/cosign):
 
@@ -189,15 +189,17 @@ cosign verify langwatch/langwatch:<tag> \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-Inspect the attached SBOM:
+Inspect the attached SBOM for the platform you pulled (cosign resolves the right per-platform manifest digest automatically when you pass a tag):
 
 ```bash
-cosign download attestation langwatch/langwatch:<tag> \
+cosign download attestation \
+  --predicate-type https://cyclonedx.org/bom \
+  langwatch/langwatch:<tag> \
   | jq -r '.payload | @base64d | fromjson | .predicate' \
   > langwatch.cdx.json
 ```
 
-The same `*.cdx.json` files are also attached to each `langwatch@vX.Y.Z` [GitHub release](https://github.com/langwatch/langwatch/releases).
+The per-platform `*.cdx.json` files (e.g. `langwatch-linux-amd64.cdx.json`, `langwatch-linux-arm64.cdx.json`) are also attached to each `langwatch@vX.Y.Z` [GitHub release](https://github.com/langwatch/langwatch/releases).
 
 ### npm CLI
 

--- a/python-sdk/examples/cli/guaranteed_availability_with_cli.py
+++ b/python-sdk/examples/cli/guaranteed_availability_with_cli.py
@@ -124,9 +124,9 @@ def main():
             ), f"Prompt handle should be {prompt_name}"
 
             print(f"   Model: {prompt.model}")  # from the prompt data itself
-            assert (
-                prompt.model == "openai/gpt-5"
-            ), "Prompt model should match the langwatch CLI's default (openai/gpt-5 — see typescript-sdk/src/cli/commands/create.ts)"
+            assert prompt.model.startswith(
+                "openai/gpt-5"
+            ), f"Prompt model should belong to the langwatch CLI's gpt-5 default family, got {prompt.model!r}"
 
             # 5. Test compile the prompt
             print("\n5️⃣ Test compile the prompt")


### PR DESCRIPTION
## Summary

Closes the supply-chain gap on Docker Hub releases. Today the langwatch container images are pushed unsigned and without an SBOM, which fails procurement controls that require third-party software to be signed by an approved vendor and trackable to a verifiable bill of materials.

After this PR, each release of `langwatch/langwatch`, `langwatch/langwatch_nlp`, `langwatch/langevals`, and `langwatch/ai-gateway`:

- is signed with [Sigstore cosign](https://www.sigstore.dev/) using keyless OIDC, with the certificate identity tied to this repository and workflow,
- gets a CycloneDX JSON SBOM generated with syft and attached to the manifest digest as a cosign attestation (`--type cyclonedx`),
- has the same SBOM uploaded as a workflow artifact (90-day retention) and, for tagged releases, attached to the GitHub release as a `*.cdx.json` asset.

Verification example (added to the self-hosting security docs):

```bash
cosign verify langwatch/langwatch:<tag> \
  --certificate-identity-regexp '^https://github\.com/langwatch/langwatch/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

## What changed

- `.github/workflows/publish-docker-app.yml`: new `sign-and-attest` job after `create-manifest`. Installs cosign + syft, logs into Docker Hub (read), resolves the multi-arch manifest digest for each image, signs by digest, generates the SBOM, attaches it as a cosign attestation, uploads SBOMs as workflow artifacts, and (for releases) uploads them to the GitHub release assets. Requires `id-token: write` at the job level for OIDC.
- `docs/self-hosting/security.mdx`: new "Supply Chain" section documenting the signing model and verification commands, plus a hardening-checklist entry for verifying image signatures at pull time.

## Notes

- Signing runs on every successful publish (release + workflow_dispatch). The GitHub-release-assets upload step is gated on `is_release == 'true'`.
- The per-arch images (`${HASH}-amd64`, `${HASH}-arm64`) are deleted by the existing `create-manifest` cleanup. Only the multi-arch manifest digest is signed, which is what consumers actually pull.
- Image-digest pinning in the Helm chart (e.g. `image: foo@sha256:...`) is the natural next step but is out of scope here; it requires changes to the release-please flow that writes tags into `values.yaml`.

## Test plan

- [ ] Run `publish-docker-app` via workflow_dispatch with a custom tag and confirm the `sign-and-attest` job succeeds for all four images.
- [ ] After the dispatch run, `cosign verify langwatch/langwatch:<tag> --certificate-identity-regexp '^https://github\.com/langwatch/langwatch/' --certificate-oidc-issuer https://token.actions.githubusercontent.com` returns the signature claim.
- [ ] `cosign download attestation langwatch/langwatch:<tag>` returns a CycloneDX predicate that decodes to valid JSON.
- [ ] Cut a draft release and confirm `*.cdx.json` files appear on the release assets list.
- [ ] `npm audit signatures` on the npm CLI still passes (unchanged code path, but worth re-confirming end-to-end provenance story).