### PR TITLE
fix(simulations): mount View Trace button on voice/audio messages

### DIFF
--- a/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -146,6 +146,9 @@ export function ScenarioMessageRenderer({
                     </Text>
                   )}
                 </VStack>
+                {!smallerView && item.traceId && item.role === "assistant" && (
+                  <TraceMessage traceId={item.traceId} />
+                )}
               </VStack>
             );
 

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -25,7 +25,9 @@ vi.mock("~/utils/api", () => ({
 }));
 
 vi.mock("../../copilot-kit/TraceMessage", () => ({
-  TraceMessage: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TraceMessage: ({ traceId }: { traceId: string }) => (
+    <button data-testid="trace-message" data-trace-id={traceId}>View Trace</button>
+  ),
 }));
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -42,6 +44,20 @@ const renderWith = (
       <ScenarioMessageRenderer
         messages={messages}
         variant="drawer"
+        projectId={PROJECT_ID}
+      />
+    </Wrapper>,
+  );
+};
+
+const renderWithGrid = (
+  messages: ScenarioMessageSnapshotEvent["messages"],
+): void => {
+  render(
+    <Wrapper>
+      <ScenarioMessageRenderer
+        messages={messages}
+        variant="grid"
         projectId={PROJECT_ID}
       />
     </Wrapper>,
@@ -122,6 +138,134 @@ describe("<ScenarioMessageRenderer/>", () => {
 
       expect(screen.getByText("hello there")).toBeInTheDocument();
       expect(document.querySelector("audio")).toBeNull();
+    });
+  });
+
+  // --- AC 1: assistant audio + traceId shows View Trace in drawer ---
+  describe("when an assistant audio message has a trace id in drawer variant", () => {
+    it("renders a View Trace button under the media bubble", () => {
+      renderWith([
+        {
+          id: "msg_audio_trace",
+          role: "assistant",
+          trace_id: "trace_abc123",
+          content:
+            '[{"type":"input_audio","input_audio":{"data":"UklGRg==","format":"wav"}}]',
+        } as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      const traceButton = screen.getByTestId("trace-message");
+      expect(traceButton).toBeInTheDocument();
+      expect(traceButton).toHaveAttribute("data-trace-id", "trace_abc123");
+      // Confirms it's the media branch rendering (not a text branch)
+      expect(document.querySelector("audio")).not.toBeNull();
+    });
+  });
+
+  // --- AC 2a: no traceId → no View Trace button ---
+  describe("when an assistant audio message has no trace id", () => {
+    it("does not render a View Trace button", () => {
+      renderWith([
+        {
+          id: "msg_audio_no_trace",
+          role: "assistant",
+          content:
+            '[{"type":"input_audio","input_audio":{"data":"UklGRg==","format":"wav"}}]',
+        } as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      expect(screen.queryByTestId("trace-message")).toBeNull();
+      expect(document.querySelector("audio")).not.toBeNull();
+    });
+  });
+
+  // --- AC 2b: user-role audio + traceId → no View Trace button ---
+  describe("when a user-role audio message has a trace id", () => {
+    it("does not render a View Trace button", () => {
+      renderWith([
+        {
+          id: "msg_audio_user_trace",
+          role: "user",
+          trace_id: "trace_xyz",
+          content:
+            '[{"type":"input_audio","input_audio":{"data":"UklGRg==","format":"wav"}}]',
+        } as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      expect(screen.queryByTestId("trace-message")).toBeNull();
+      expect(document.querySelector("audio")).not.toBeNull();
+    });
+  });
+
+  // --- AC 4: grid variant suppresses View Trace on audio ---
+  describe("when the renderer is mounted in grid variant", () => {
+    it("does not render a View Trace button on assistant audio messages", () => {
+      renderWithGrid([
+        {
+          id: "msg_audio_grid",
+          role: "assistant",
+          trace_id: "trace_grid",
+          content:
+            '[{"type":"input_audio","input_audio":{"data":"UklGRg==","format":"wav"}}]',
+        } as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      expect(screen.queryByTestId("trace-message")).toBeNull();
+    });
+  });
+
+  // --- AC 5: transcript-collapse — one bubble, one View Trace button ---
+  describe("when an assistant message has both audio and a sibling text transcript with one trace id", () => {
+    it("renders exactly one bubble with exactly one View Trace button", () => {
+      renderWith([
+        {
+          id: "msg_audio_transcript",
+          role: "assistant",
+          trace_id: "trace_collapse",
+          content:
+            '[{"type":"input_audio","input_audio":{"data":"UklGRg==","format":"wav"}},{"type":"text","text":"hello"}]',
+        } as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      expect(document.querySelectorAll("audio")).toHaveLength(1);
+      expect(screen.getAllByTestId("trace-message")).toHaveLength(1);
+    });
+  });
+
+  // --- AC 6: existing text / tool_call / tool_result branches render View Trace unchanged ---
+  describe("when assistant text, tool_call, and tool_result turns have trace ids", () => {
+    it("renders a View Trace button for each turn unchanged", () => {
+      renderWith([
+        {
+          id: "msg_text_turn",
+          role: "assistant",
+          trace_id: "trace_text",
+          content: "Here is the result",
+        } as ScenarioMessageSnapshotEvent["messages"][number],
+        {
+          id: "msg_tool_call_turn",
+          role: "assistant",
+          trace_id: "trace_tool_call",
+          content: "",
+          tool_calls: [{ function: { name: "search", arguments: "{}" } }],
+        } as ScenarioMessageSnapshotEvent["messages"][number],
+        {
+          id: "msg_tool_result_turn",
+          role: "tool",
+          trace_id: "trace_tool_result",
+          content: "ok",
+        } as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      const traceButtons = screen.getAllByTestId("trace-message");
+      expect(traceButtons).toHaveLength(3);
+
+      const traceIds = traceButtons.map((btn) =>
+        btn.getAttribute("data-trace-id"),
+      );
+      expect(traceIds).toContain("trace_text");
+      expect(traceIds).toContain("trace_tool_call");
+      expect(traceIds).toContain("trace_tool_result");
     });
   });
 });

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -142,7 +142,15 @@ describe("<ScenarioMessageRenderer/>", () => {
   });
 
   // --- AC 1: assistant audio + traceId shows View Trace in drawer ---
+  // AC 3 ("clicking View Trace opens the trace details drawer") is also bound
+  // to this test: the click handler is owned by TraceMessage (see
+  // langwatch/src/components/copilot-kit/TraceMessage.tsx — it calls
+  // useTraceDetailsDrawer().openTraceDetailsDrawer({ traceId })). This PR
+  // adds no new wiring; the renderer-side responsibility is to mount the
+  // component with the correct traceId, which is what this test asserts.
   describe("when an assistant audio message has a trace id in drawer variant", () => {
+    /** @scenario "Assistant audio turn with a trace id shows the View Trace button in drawer variant" */
+    /** @scenario "Clicking View Trace on an audio turn opens the trace details drawer" */
     it("renders a View Trace button under the media bubble", () => {
       renderWith([
         {
@@ -164,6 +172,7 @@ describe("<ScenarioMessageRenderer/>", () => {
 
   // --- AC 2a: no traceId → no View Trace button ---
   describe("when an assistant audio message has no trace id", () => {
+    /** @scenario "Assistant audio turn without a trace id does not show the button" */
     it("does not render a View Trace button", () => {
       renderWith([
         {
@@ -181,6 +190,7 @@ describe("<ScenarioMessageRenderer/>", () => {
 
   // --- AC 2b: user-role audio + traceId → no View Trace button ---
   describe("when a user-role audio message has a trace id", () => {
+    /** @scenario "User-role audio turn does not show the View Trace button" */
     it("does not render a View Trace button", () => {
       renderWith([
         {
@@ -199,6 +209,7 @@ describe("<ScenarioMessageRenderer/>", () => {
 
   // --- AC 4: grid variant suppresses View Trace on audio ---
   describe("when the renderer is mounted in grid variant", () => {
+    /** @scenario "Grid variant suppresses the View Trace button on audio turns" */
     it("does not render a View Trace button on assistant audio messages", () => {
       renderWithGrid([
         {
@@ -216,6 +227,7 @@ describe("<ScenarioMessageRenderer/>", () => {
 
   // --- AC 5: transcript-collapse — one bubble, one View Trace button ---
   describe("when an assistant message has both audio and a sibling text transcript with one trace id", () => {
+    /** @scenario "Transcript-collapse case renders one bubble with one View Trace button" */
     it("renders exactly one bubble with exactly one View Trace button", () => {
       renderWith([
         {
@@ -234,6 +246,7 @@ describe("<ScenarioMessageRenderer/>", () => {
 
   // --- AC 6: existing text / tool_call / tool_result branches render View Trace unchanged ---
   describe("when assistant text, tool_call, and tool_result turns have trace ids", () => {
+    /** @scenario "Existing trace-button behavior on text and tool turns is unchanged" */
     it("renders a View Trace button for each turn unchanged", () => {
       renderWith([
         {

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -141,13 +141,10 @@ describe("<ScenarioMessageRenderer/>", () => {
     });
   });
 
-  // --- AC 1: assistant audio + traceId shows View Trace in drawer ---
-  // AC 3 ("clicking View Trace opens the trace details drawer") is also bound
-  // to this test: the click handler is owned by TraceMessage (see
-  // langwatch/src/components/copilot-kit/TraceMessage.tsx — it calls
-  // useTraceDetailsDrawer().openTraceDetailsDrawer({ traceId })). This PR
-  // adds no new wiring; the renderer-side responsibility is to mount the
-  // component with the correct traceId, which is what this test asserts.
+  // The AC 3 binding below is partial: TraceMessage owns the click handler
+  // (useTraceDetailsDrawer().openTraceDetailsDrawer), so this jsdom test only
+  // asserts the renderer's responsibility — mounting TraceMessage with the
+  // correct traceId. The drawer-open behavior on click is browser-verified.
   describe("when an assistant audio message has a trace id in drawer variant", () => {
     /** @scenario "Assistant audio turn with a trace id shows the View Trace button in drawer variant" */
     /** @scenario "Clicking View Trace on an audio turn opens the trace details drawer" */
@@ -170,7 +167,6 @@ describe("<ScenarioMessageRenderer/>", () => {
     });
   });
 
-  // --- AC 2a: no traceId → no View Trace button ---
   describe("when an assistant audio message has no trace id", () => {
     /** @scenario "Assistant audio turn without a trace id does not show the button" */
     it("does not render a View Trace button", () => {
@@ -188,7 +184,6 @@ describe("<ScenarioMessageRenderer/>", () => {
     });
   });
 
-  // --- AC 2b: user-role audio + traceId → no View Trace button ---
   describe("when a user-role audio message has a trace id", () => {
     /** @scenario "User-role audio turn does not show the View Trace button" */
     it("does not render a View Trace button", () => {
@@ -207,7 +202,6 @@ describe("<ScenarioMessageRenderer/>", () => {
     });
   });
 
-  // --- AC 4: grid variant suppresses View Trace on audio ---
   describe("when the renderer is mounted in grid variant", () => {
     /** @scenario "Grid variant suppresses the View Trace button on audio turns" */
     it("does not render a View Trace button on assistant audio messages", () => {
@@ -225,7 +219,6 @@ describe("<ScenarioMessageRenderer/>", () => {
     });
   });
 
-  // --- AC 5: transcript-collapse — one bubble, one View Trace button ---
   describe("when an assistant message has both audio and a sibling text transcript with one trace id", () => {
     /** @scenario "Transcript-collapse case renders one bubble with one View Trace button" */
     it("renders exactly one bubble with exactly one View Trace button", () => {
@@ -244,7 +237,6 @@ describe("<ScenarioMessageRenderer/>", () => {
     });
   });
 
-  // --- AC 6: existing text / tool_call / tool_result branches render View Trace unchanged ---
   describe("when assistant text, tool_call, and tool_result turns have trace ids", () => {
     /** @scenario "Existing trace-button behavior on text and tool turns is unchanged" */
     it("renders a View Trace button for each turn unchanged", () => {

--- a/specs/features/scenarios/voice-message-view-trace-button.feature
+++ b/specs/features/scenarios/voice-message-view-trace-button.feature
@@ -1,0 +1,79 @@
+Feature: View Trace button on voice messages in simulation run UI
+  As a user reviewing a simulation run that includes voice (audio) turns
+  I want voice/audio messages to expose the same "View Trace" affordance as text and tool turns
+  So that I can jump from any model-generated turn — including voice — to its underlying trace
+
+  Background:
+    Given I am viewing a simulation run in the run detail drawer
+    And the run's conversation is rendered by ScenarioMessageRenderer
+
+  @integration
+  Scenario: Assistant audio turn with a trace id shows the View Trace button in drawer variant
+    Given the renderer is mounted in drawer variant (variant === "drawer", smallerView === false)
+    And the conversation contains an assistant message rendered as a media item with a non-empty traceId
+    When the renderer paints that turn
+    Then a "View Trace" button is shown under the media bubble
+    And the button has the same affordance (button + hover-peek) as the text / tool-call / tool-result branches
+
+  @integration
+  Scenario: Assistant audio turn without a trace id does not show the button
+    Given the renderer is mounted in drawer variant
+    And the conversation contains an assistant message rendered as a media item with no traceId
+    When the renderer paints that turn
+    Then no "View Trace" button is shown under the media bubble
+
+  @integration
+  Scenario: User-role audio turn does not show the View Trace button
+    Given the renderer is mounted in drawer variant
+    And the conversation contains a user message rendered as a media item with a non-empty traceId
+    When the renderer paints that turn
+    Then no "View Trace" button is shown under the media bubble
+    # Mirrors the role gate the text branch applies — only assistant turns get the affordance
+
+  @integration
+  Scenario: Clicking View Trace on an audio turn opens the trace details drawer
+    Given an assistant media turn in drawer variant has a "View Trace" button
+    When I click the button
+    Then the trace details drawer opens for that traceId
+    # Wiring is delegated to TraceMessage's existing click handler — no new wiring expected
+
+  @integration
+  Scenario: Grid variant suppresses the View Trace button on audio turns
+    Given the renderer is mounted in grid variant (variant === "grid", smallerView === true)
+    And the conversation contains an assistant message rendered as a media item with a non-empty traceId
+    When the renderer paints that turn
+    Then no "View Trace" button is shown under the media bubble
+    # Matches how the other kinds behave in grid view
+
+  @integration
+  Scenario: Transcript-collapse case renders one bubble with one View Trace button
+    Given the renderer is mounted in drawer variant
+    And an assistant message contains both an audio part and a text-transcript part with a shared non-empty traceId
+    When the renderer paints that turn
+    Then exactly one bubble is rendered for that turn
+    And exactly one "View Trace" button is shown under that bubble
+    # No duplication between the media branch and the (now-collapsed) text branch
+
+  @integration
+  Scenario: Existing trace-button behavior on text and tool turns is unchanged
+    Given the renderer is mounted in drawer variant
+    And the conversation contains assistant text, tool-call, and tool-result turns with non-empty traceIds
+    When the renderer paints those turns
+    Then each turn shows its existing "View Trace" affordance exactly as before
+    # Guards the existing test suite against regressions when the media branch is changed
+
+  # --- AC Coverage Map ---
+  # AC 1 ("drawer variant: assistant media + traceId shows View Trace, same affordance as other branches")
+  #   -> Scenario: Assistant audio turn with a trace id shows the View Trace button in drawer variant
+  # AC 2 ("media item with no traceId, or role !== assistant, does not show the button — same gate as text branch")
+  #   -> Scenario: Assistant audio turn without a trace id does not show the button
+  #   -> Scenario: User-role audio turn does not show the View Trace button
+  # AC 3 ("button opens the trace details drawer for that trace id — delegated to TraceMessage's existing click handler")
+  #   -> Scenario: Clicking View Trace on an audio turn opens the trace details drawer
+  # AC 4 ("grid variant continues to suppress the button on media, matching how other kinds behave in grid view")
+  #   -> Scenario: Grid variant suppresses the View Trace button on audio turns
+  # AC 5 ("transcript-collapse case still renders a single bubble and a single View Trace button — no duplication")
+  #   -> Scenario: Transcript-collapse case renders one bubble with one View Trace button
+  # AC 6 ("existing tests pass; a new test covers AC 1 and AC 2 in the renderer's test suite")
+  #   -> Scenarios covering AC 1 and AC 2 (above) supply the new coverage
+  #   -> Scenario: Existing trace-button behavior on text and tool turns is unchanged (guards "existing tests pass")


### PR DESCRIPTION
## Why

Closes #4146

Audio messages rendered in the simulation-run conversation UI did not show a "View Trace" button, while text and tool turns did. The bug was surfaced via dogfooding the newly shipped voice support on production.

## What changed

- `case "media"` in `ScenarioMessageRenderer.tsx` now mounts `<TraceMessage>` under the bubble using the **same gate the text branch uses** (`!smallerView && item.traceId && item.role === "assistant"`). One 3-line addition; no new imports, no abstractions.
- Mount sits in the outer VStack (sibling of the media bubble), not the inner 420px-constrained stack — matches the text branch's layout.
- Scoped to media only. Image kind also lacks the button but was left out of scope intentionally (see the Plan on the issue).

## Test plan

- New + existing tests live in `langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx`.
- The TraceMessage mock was upgraded to render a `data-testid="trace-message"` probe so the tests can assert presence/absence.
- Run: `pnpm test:unit src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx` → **10/10 passing**.
- **TDD audit trail**: the regression tests were committed in `79c7cc2` BEFORE the fix in `8891e81`. The bug-reveal tests (AC 1 and AC 5) failed against `79c7cc2` and pass against `8891e81`.

Coverage map (one scenario per AC):
- AC 1: assistant + traceId in drawer → button shown.
- AC 2: no traceId OR user-role → no button.
- AC 3: button delegates to `TraceMessage`'s existing click handler (no new wiring — covered by the spec, verified manually).
- AC 4: grid variant (`smallerView === true`) → no button.
- AC 5: transcript-collapse (audio + sibling text → single media item) → exactly one bubble + one button.
- AC 6: text / tool_call / tool_result branches unchanged → still render their buttons.

## How I can prove I was successful

End-to-end verified against a real LangWatch stack on a boxd fork running this branch — full setup detailed in [the verification comment](https://github.com/langwatch/langwatch/pull/4156#issuecomment-4517278507). Three screenshots covering the user-facing ACs:

**AC 1 + AC 5** — Drawer renders the audio bubble + italic transcript + exactly one `View Trace` button under it (transcript-collapse does not duplicate):

![AC1+AC5](https://raw.githubusercontent.com/langwatch/langwatch/pr-evidence/4156/pr4156-01-drawer-with-view-trace.png)

**AC 1 "same affordance"** — Hover shows the same `TracePreviewHoverCard` used on text/tool turns (span `voice.respond`, Duration 1.0s, trace id `voicetrcverifyaa...`, service `voice-verify`):

![Hover peek](https://raw.githubusercontent.com/langwatch/langwatch/pr-evidence/4156/pr4156-02-hover-peek.png)

**AC 3** — Clicking View Trace opens the Trace Details drawer to the correct trace + span (URL: `?drawer.open=traceDetails&drawer.traceId=voicetrcverifyaaaaaaaaaaaaaaaa01&...`):

![Trace drawer opens](https://raw.githubusercontent.com/langwatch/langwatch/pr-evidence/4156/pr4156-03-trace-drawer-opens.png)

Reviewer can also verify by:
1. Reading the 3-line diff in `langwatch/src/components/simulations/ScenarioMessageRenderer.tsx`.
2. Reading the test additions in `ScenarioMessageRenderer.integration.test.tsx` and `specs/features/scenarios/voice-message-view-trace-button.feature`.
3. Running `pnpm test:unit src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx` — should show `10/10 passed`.
4. (Optional) Checking out `79c7cc2` and running the same command — should show `2 failed` (AC 1 + AC 5) confirming TDD ordering.

Screenshots live on a throwaway `pr-evidence/4156` branch (not for merging into main).

# Related Issue

- Resolve #4146