### PR TITLE
chore(coderabbit): opinionated review config (#3754)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -131,8 +131,9 @@ reviews:
 
         FAIL when this file imports from `~/components`, `~/components/...`,
         or any `langwatch/src/components/**` path. Server-layer code and
-        service-layer code must not depend on UI components. The dependency
-        direction is UI → services → server, never the reverse.
+        service-layer code must not depend on UI components. Allowed
+        dependency direction is UI → services and UI → server; the reverse
+        (server or service code importing UI) is never allowed.
 
     # Class component ban — restrict to component-bearing surface to keep
     # this from getting noisy on non-component files.
@@ -164,7 +165,7 @@ reviews:
         jest dependencies are out of scope here — promotion of this rule
         depends on a separate jest → vitest migration.
 
-    - path: "langwatch/src/server/api/routers/**/*.{ts,tsx}"
+    - path: "langwatch/src/server/{repositories,services}/**/*.{ts,tsx}"
       instructions: |
         Repository methods (under `langwatch/src/server/repositories/**`)
         must be named `findAll` / `findById` / `findBy*` / `create` / `update`

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -106,6 +106,13 @@ reviews:
     # export * from re-export shims) live in .coderabbit/ast-grep/rules/.
     # ClickHouse fully-qualified table names live in .semgrep/langwatch.yml.
     # path_instructions only carries the judgment calls.
+    #
+    # NOTE: each layering/convention rule below is in its own path_instructions
+    # block. Smoke testing (#4166) showed that bundling 4 unrelated FAIL
+    # conditions under one block caused CR to surface only 1 of them. Smaller
+    # focused blocks fire reliably.
+
+    # tRPC Zod gating — every router/procedure path.
     - path: "langwatch/src/**/*.{ts,tsx}"
       instructions: |
         Flag ONLY on newly added or modified lines.
@@ -114,17 +121,41 @@ reviews:
         `.input(z.object({...}))` or equivalent Zod schema — including
         procedures with no input (use `z.void()` or `z.object({})`).
 
-        FAIL when service-layer code (`langwatch/src/server/**`,
-        `langwatch/src/services/**`) imports from `~/components` or
-        `langwatch/src/components/**`. The server must not depend on UI.
+    # Service→UI layering guard. Glob scoped to the layers that must NOT
+    # import from UI. Smoke PR caught the violation as part of a generic
+    # comment, not surfaced under this rule — narrowing the glob makes CR
+    # consult this block only on those files, raising firing reliability.
+    - path: "langwatch/src/{server,services}/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
 
-        FAIL when a new React component is declared as a class component.
-        Use function components + hooks.
+        FAIL when this file imports from `~/components`, `~/components/...`,
+        or any `langwatch/src/components/**` path. Server-layer code and
+        service-layer code must not depend on UI components. The dependency
+        direction is UI → services → server, never the reverse.
+
+    # Class component ban — restrict to component-bearing surface to keep
+    # this from getting noisy on non-component files.
+    - path: "langwatch/src/**/*.tsx"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a new React component is declared as a class component
+        (`class X extends React.Component`, `class X extends Component`).
+        Use function components + hooks instead.
+
+    # Localhost-fallback judgment fallback (the ast-grep rule covers the
+    # syntactic shapes; this catches creative variations the syntactic
+    # rule misses).
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
 
         FAIL when code adds a default fallback URL of the form
-        `?? "http://localhost..."` or `?? "https://..."`. Required env vars
-        must be validated through the Zod env schema and consumed without
-        fallbacks.
+        `?? "http://localhost..."` or `?? "https://..."` (including
+        template-literal variants like `?? \`http://localhost:${...}\``).
+        Required env vars must be validated through the Zod env schema and
+        consumed without fallbacks.
 
     - path: "langwatch/package.json"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,286 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# Docs: https://docs.coderabbit.ai/reference/configuration
+#
+# Issue #3754. The investigation produced four flips off the original ACs:
+#  (1) AC1 split — YAML alone is advisory; branch-protection lives in AC1b.
+#  (2) AC3 deterministic rules move to ast-grep / semgrep; path_instructions
+#      keeps only judgment rules.
+#  (3) AC5 leaves CodeRabbit entirely (path_instructions cannot see PR
+#      descriptions). It now lives in .github/workflows/deployment-impact-check.yml.
+#  (4) Phased rollout — mode:warning for sprint 1, per-rule promotion to error
+#      after baseline is verifiably clean for that rule.
+#
+# All path_instructions below say "flag only newly added or modified lines" —
+# the baseline has 527 `any`s, 5 CH migrations with $CLICKHOUSE_DATABASE, etc.
+# Without that framing every PR touching legacy files gets spammed.
+
+language: en
+early_access: false
+tone_instructions: >
+  Be terse and concrete. Quote the rule that was violated. Cite the file and
+  line. Skip platitudes ("consider", "you might want to"). When unsure,
+  recommend the safer option and say so.
+
+reviews:
+  profile: assertive
+  # YAML alone is advisory — branch protection must be configured separately
+  # to require CR's status check. Tracked as AC1b in #3754.
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+
+  # Phased rollout. Promote individual checks to mode:error in follow-up PRs
+  # after baseline is clean for that check.
+  pre_merge_checks:
+    title:
+      mode: warning
+    description:
+      mode: warning
+    docstrings:
+      mode: warning
+
+  tools:
+    # Secrets / API keys (Betterleaks-backed; v2 schema preserves the key name).
+    gitleaks:
+      enabled: true
+    # Pattern-based PII / unsafe-code rules. CR does not autoload community
+    # packs — the ruleset lives at .semgrep/langwatch.yml in this repo.
+    semgrep:
+      enabled: true
+      config_file: .semgrep/langwatch.yml
+    # Deterministic syntactic rules (AC3) — see .coderabbit/ast-grep/rules/.
+    ast-grep:
+      essential_rules: true
+      rule_dirs:
+        - .coderabbit/ast-grep/rules
+
+  path_instructions:
+    # ── AC4: structural ${...} guard ───────────────────────────────────────
+    # PR #3476 leaked a literal "${HOME/workspace/orchard-codex/contracts}"
+    # directory into main. path_filters can't exclude these (exclusion skips
+    # the files entirely and path_instructions never fire — fa3bbc7ef on this
+    # branch's history fixed exactly that). Positive fail-rule on a permissive
+    # glob is the working form.
+    - path: "**/*"
+      instructions: |
+        FAIL the review (request changes) when any newly added or renamed
+        file path contains an unexpanded shell variable segment such as
+        "${HOME...", "${VAR...", or any path segment starting with "${".
+        These are bugs from broken env-var expansion, never intentional
+        content. This rule applies to path names only — file contents are
+        not in scope here.
+
+    # ── AC2: PII rules (judgment-level — patterns are in .semgrep) ────────
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines in this PR. Do NOT flag
+        pre-existing code unless it is part of the diff.
+
+        FAIL when logging, analytics, or telemetry calls (console.*,
+        logger.*, posthog.*, Sentry.*, captureException, track, identify)
+        include user-identifying fields — email, phone, name, IP, userId,
+        projectSlug, organizationId, apiKey, token — without an explicit
+        redaction wrapper (`redact(...)`, `hashEmail(...)`, masking) or a
+        comment marking it as intentional.
+
+        FAIL when a new HTTP endpoint or tRPC procedure returns PII without
+        both: (a) an explicit auth check (`ctx.session.user` consulted) and
+        (b) an audit-log write (`auditLog.create` or equivalent).
+
+    - path: "**/*.{py,go,ts,tsx,js,jsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when adding a new `print`, `console.log`, `fmt.Print*`,
+        `log.Info*`, or analytics call that emits a raw request body, full
+        headers map, raw cookie, or `Authorization` header. Log only the
+        fields needed for debugging, redact the rest.
+
+    # ── AC3: layering / convention rules (judgment, not syntax) ────────────
+    # Syntactic checks (no `any`, inline import(), form.watch() in child,
+    # export * from re-export shims) live in .coderabbit/ast-grep/rules/.
+    # ClickHouse fully-qualified table names live in .semgrep/langwatch.yml.
+    # path_instructions only carries the judgment calls.
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a tRPC router/procedure is declared without an explicit
+        `.input(z.object({...}))` or equivalent Zod schema — including
+        procedures with no input (use `z.void()` or `z.object({})`).
+
+        FAIL when service-layer code (`langwatch/src/server/**`,
+        `langwatch/src/services/**`) imports from `~/components` or
+        `langwatch/src/components/**`. The server must not depend on UI.
+
+        FAIL when a new React component is declared as a class component.
+        Use function components + hooks.
+
+        FAIL when code adds a default fallback URL of the form
+        `?? "http://localhost..."` or `?? "https://..."`. Required env vars
+        must be validated through the Zod env schema and consumed without
+        fallbacks.
+
+    - path: "langwatch/package.json"
+      instructions: |
+        FAIL when newly added dependencies include `jest`, `@types/jest`,
+        `babel-jest`, `ts-jest`, or jest plugins. Use Vitest. Pre-existing
+        jest dependencies are out of scope here — promotion of this rule
+        depends on a separate jest → vitest migration.
+
+    - path: "langwatch/src/server/api/routers/**/*.{ts,tsx}"
+      instructions: |
+        Repository methods (under `langwatch/src/server/repositories/**`)
+        must be named `findAll` / `findById` / `findBy*` / `create` / `update`
+        / `delete`. Service methods (under `langwatch/src/server/services/**`)
+        must be named `getAll` / `getById` / `getBy*` / `create` / `update`
+        / `delete`. FAIL when a NEW repository method uses a `get*` prefix
+        or a NEW service method uses a `find*` prefix.
+
+    - path: "{cmd,pkg,internal,services}/**/*.go"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a Hono or chi route handler reaches directly into a
+        repository (`*Repository`/`*Repo` struct) instead of going through
+        a service layer. Hono/chi routes call services; services call
+        repositories.
+
+    - path: "**/migrations/**/*.{sql,ts,go}"
+      instructions: |
+        Migrations must be reversible: include a `down`/`Down` step that
+        actually undoes the `up` step, or include a comment block beginning
+        `IRREVERSIBLE:` explaining why (data-destructive, schema-only, etc.).
+        FAIL when neither is present.
+
+    # ── AC7: SOLID / Clean Code / KISS / YAGNI / Boy Scout ─────────────────
+    # Principle-level checks. Each FAIL is one specific, observable failure
+    # mode — not vibes-based "this looks SOLID-y" judgement. All flag only
+    # newly added or modified lines.
+    - path: "**/*.{ts,tsx,js,jsx,py,go,rs}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        # SRP (Single Responsibility)
+        FAIL when a NEW file exceeds 300 source lines (excluding blank lines
+        and comments). Long files are SRP-violation evidence. Exception:
+        generated files, schema/migration files, fixture/snapshot files,
+        lockfiles.
+
+        FAIL when a NEW exported function exceeds 60 source lines or has
+        cyclomatic complexity > 10. Long functions mix abstraction levels.
+
+        FAIL when a NEW class or struct exposes methods spanning more than
+        one obvious concern (e.g., HTTP handling + persistence + email
+        sending). Name the responsibilities you see.
+
+        # DIP (Dependency Inversion) + dependency direction
+        FAIL when a higher-level module imports a lower-level concrete
+        implementation directly where an interface/port exists. Example:
+        a service importing a concrete `*Repository` class when a repository
+        interface is defined.
+
+        FAIL when the dependency direction crosses layer boundaries the
+        wrong way (UI → server is allowed, server → UI is not; domain →
+        infrastructure is not allowed; tests → src is allowed, src → tests
+        is not).
+
+        # OCP / ISP — flag, do not fail
+        Comment (do not fail) when a `switch`/`if-else` chain on a type
+        discriminator is added and a polymorphic alternative is plausible.
+
+        # Clean Code — naming
+        FAIL when a NEW public symbol (exported function, class, type,
+        const) uses a vague name: `data`, `info`, `value`, `item`, `obj`,
+        `tmp`, `temp`, `util`, `helper`, `manager`, `handler` (alone, not
+        as a suffix), or single-letter identifiers outside loop/lambda
+        context. Quote the name.
+
+        FAIL when a NEW boolean variable, parameter, or property is named
+        without an `is`/`has`/`should`/`can`/`will` prefix (or domain
+        equivalent like `enabled`, `visible`). Example: `loading: boolean`
+        should be `isLoading`.
+
+        # Clean Code — comments
+        FAIL when a NEW comment restates what the code already says (e.g.,
+        `// increment counter` above `counter++`). Comments must explain
+        *why*, not *what*.
+
+        FAIL when a NEW doc-comment block is purely decorative (only
+        contains the symbol name, type, or auto-generated boilerplate).
+
+        # KISS / YAGNI
+        FAIL when a NEW abstraction (interface, factory, strategy, adapter)
+        has exactly one implementation in this diff AND there is no caller
+        already using the abstraction. That is speculative — inline the
+        implementation until a second caller exists.
+
+        FAIL when a NEW configuration flag, env var, or feature toggle is
+        added without at least one referenced consumer in the same PR.
+
+        FAIL when NEW code is added behind `if (false)`,
+        `if (process.env.UNDEFINED_FLAG)`, or commented-out blocks "for
+        later." Delete it — git remembers.
+
+        # Boy Scout (do not fail — comment only)
+        Comment when a file is touched and contains adjacent in-file smells
+        that could be fixed in the same commit (dead imports, commented-out
+        code, obvious typos in identifiers, unused exports reachable in the
+        diff context). Cite the line and the smell — the author decides
+        whether to fix or note as out of scope.
+
+        # Done-means-verified
+        Comment when a PR description claims a behavior is "verified" /
+        "tested" / "works" but the diff contains no corresponding test, no
+        command output, and no screenshot. Quote the claim and ask for
+        evidence.
+
+    # ── AC8: BDD/TDD + public-API docs ─────────────────────────────────────
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW exported function, class, or hook is added without
+        either: (a) a corresponding new or updated test file under
+        `**/__tests__/**` or `**/*.{test,spec}.{ts,tsx}`, or (b) an explicit
+        `// no-test:` justification comment naming the reason (e.g., pure
+        re-export, type-only file, framework boilerplate).
+
+        FAIL when a NEW exported function or class lacks a JSDoc/TSDoc
+        comment block. The block must contain at least one sentence of
+        purpose (not just `@param`/`@returns`). Internal/non-exported
+        symbols are exempt.
+
+    - path: "{cmd,pkg,internal,services}/**/*.go"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW exported (capitalised) Go function, type, or method
+        lacks a doc-comment starting with the symbol name (Go convention).
+
+        FAIL when NEW Go production code is added under `cmd/`, `pkg/`,
+        `internal/`, or `services/` without a corresponding `_test.go`
+        test, or without a `// no-test:` justification comment.
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  # Capture house-style markers deterministically. Cheap, single-line addition.
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "CLAUDE.md"
+      - "**/CLAUDE.md"
+      - "AGENTS.md"
+      - "dev/docs/best_practices/**/*.md"
+  # Off per #3754 non-goals.
+  learnings:
+    scope: local
+  issues:
+    scope: local

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -189,6 +189,129 @@ reviews:
         `IRREVERSIBLE:` explaining why (data-destructive, schema-only, etc.).
         FAIL when neither is present.
 
+    # ── House-style rules sourced from dev/docs/best_practices/ ────────────
+    # Cite the source doc in your comment so authors can read the rationale.
+
+    # react.md: hooks must not return JSX. Hooks return state + callbacks;
+    # the consumer renders. JSX-returning hooks couple rendering to logic
+    # and hide the component tree.
+    - path: "langwatch/src/**/hooks/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a hook function (name starts with `use`) returns JSX.
+        Hooks return state and callbacks; consumers render. Cite
+        `dev/docs/best_practices/react.md` § Hooks.
+
+    # react.md: hook files should be .ts, not .tsx. A .tsx hook file means
+    # the hook returns JSX — same anti-pattern as above.
+    - path: "langwatch/src/**/hooks/**/use*.tsx"
+      instructions: |
+        FAIL: hook files must be `.ts`, not `.tsx`. A `.tsx` hook file is
+        a smell — the JSX belongs in the consumer component. Move the JSX
+        out and rename to `.ts`. See `dev/docs/best_practices/react.md`.
+
+    # typescript.md: exhaustive switches need a `never` check in default.
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW `switch` over a discriminated-union or enum type
+        lacks an exhaustiveness check in the `default:` case. The check
+        must assign the scrutinee to a `never`-typed variable
+        (`const _exhaustive: never = x;` or `assertNever(x);`). Without it,
+        adding a new variant later silently falls through. See
+        `dev/docs/best_practices/typescript.md` § Exhaustive switches.
+
+    # typescript.md: named params for 2+ args on exported functions.
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW exported function takes 2+ positional parameters
+        of the same primitive type (string, string, string) or where the
+        call site is non-obvious (`(scenarioId, target, setId)`). Use
+        object-destructuring instead: `({ scenarioId, target, setId })`.
+        Two-parameter functions where the types differ obviously
+        (e.g., `(id: string, options: { ... })`) are fine. See
+        `dev/docs/best_practices/typescript.md` § Named parameters.
+
+    # soft-delete-vs-archive.md: archivedAt, not deletedAt.
+    - path: "langwatch/{prisma/schema.prisma,src/server/**/*.{ts,tsx}}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW Prisma model field, repository method, or service
+        method introduces `deletedAt` for soft-delete semantics. The
+        house pattern is `archivedAt DateTime?` with a `findAll` that
+        filters `archivedAt IS NULL` by default, plus
+        `find*IncludingArchived` variants for the cases that need them.
+        Existing `deletedAt` fields are out of scope here (migration is
+        tracked in #1889). See
+        `dev/docs/best_practices/soft-delete-vs-archive.md`.
+
+    # ksuids.md: user-facing IDs use KSUIDs at the service/repository layer.
+    - path: "langwatch/src/server/{repositories,services}/**/*.ts"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW repository or service `create` method writes a
+        user-facing entity (one that shows up in URLs, API responses,
+        exports, or webhooks) using a Prisma default id
+        (`@default(nanoid())`, `@default(cuid())`, `@default(uuid())`)
+        instead of generating a prefixed KSUID via
+        `generate(KSUID_RESOURCES.X).toString()`. Internal join tables
+        (`*Scope`, `*Link`) may keep Prisma defaults. See
+        `dev/docs/best_practices/ksuids.md`.
+
+    # clickhouse-queries.md anti-pattern 1: ORDER BY <version> DESC LIMIT 1.
+    - path: "langwatch/src/server/clickhouse/**/*.{ts,sql}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW ClickHouse query selects heavy columns (Messages,
+        ComputedInput, Inputs, Details, SpanAttributes, RoleCosts,
+        Metadata) AND uses one of these anti-patterns:
+
+          (a) `ORDER BY <Version|UpdatedAt> DESC LIMIT 1` to pick the
+              latest version. Use the IN-tuple dedup pattern instead.
+          (b) `LIMIT 1 BY <key>` over heavy columns. Move the dedup into
+              a lightweight inner subquery (key columns only) and select
+              heavy columns in the outer query.
+
+        Cite `dev/docs/best_practices/clickhouse-queries.md` § Deduplication.
+
+    # design/guidelines.md §6: form Save button disables only on isPending,
+    # never on !form.formState.isValid. Pre-disabling is silent and
+    # frustrating; validation errors must surface inline or via toast.
+    - path: "langwatch/src/**/*.tsx"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW submit button uses `disabled={!form.formState.isValid}`,
+        `disabled={!isValid}`, `disabled={!formState.isValid}`, or any
+        variant that disables the button based on validity state.
+        Submit buttons disable ONLY while a request is in flight
+        (`disabled={mutation.isPending}` is the canonical shape).
+        Validation errors must surface inline (Field.ErrorText) or via
+        toast in the submit handler. See
+        `dev/docs/design/guidelines.md` § 6 and ADR-018.
+
+    # design/guidelines.md §3: prefer Drawer wrapper, not raw Chakra Modal.
+    # Biome's noRestrictedImports already bans @chakra-ui/react Dialog/Drawer/
+    # Modal — this catches the path_instructions side (new code introducing
+    # modal-style flows that should use Dialog wrapper).
+    - path: "langwatch/src/**/*.tsx"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when NEW resource creation, editing, or selection flows are
+        wired through a Dialog-style modal instead of a Drawer (e.g.,
+        adding a new "Create X" form behind a centered modal). Drawers
+        maintain context by keeping the underlying page visible.
+        Confirmation prompts (delete, discard) and simple alerts may
+        stay as Dialogs. See `dev/docs/design/guidelines.md` § 3.
+
     # ── AC7: SOLID / Clean Code / KISS / YAGNI / Boy Scout ─────────────────
     # Principle-level checks. Each FAIL is one specific, observable failure
     # mode — not vibes-based "this looks SOLID-y" judgement. All flag only
@@ -303,6 +426,11 @@ chat:
 
 knowledge_base:
   # Capture house-style markers deterministically. Cheap, single-line addition.
+  # Includes best_practices (TypeScript, React, ClickHouse, KSUIDs, repository
+  # pattern, soft-delete, etc.), design system (Chakra wrappers, drawer
+  # preference, form submit-then-surface), and ADRs (RBAC, event sourcing,
+  # logging, repository-service layering, form validation, etc.) so CR can
+  # cite the source in its review comments.
   code_guidelines:
     enabled: true
     filePatterns:
@@ -310,6 +438,9 @@ knowledge_base:
       - "**/CLAUDE.md"
       - "AGENTS.md"
       - "dev/docs/best_practices/**/*.md"
+      - "dev/docs/design/**/*.md"
+      - "dev/docs/adr/**/*.md"
+      - "docs/adr/**/*.md"
   # Off per #3754 non-goals.
   learnings:
     scope: local

--- a/.coderabbit/README.md
+++ b/.coderabbit/README.md
@@ -12,8 +12,8 @@ CodeRabbit auto-loads everything in this directory via `reviews.tools.ast-grep.r
 | `no-explicit-any.yml` | `: any`, `as any` in `langwatch/src/**`. |
 | `no-inline-dynamic-import.yml` | Inline `import(...)` in `.ts`/`.tsx` outside `routes.tsx` / `pages/**`. |
 | `no-form-watch-in-child.yml` | `$form.watch()` inside a child component receiving `form` as prop. |
-| `no-export-star-shim.yml` | `export * from "..."` outside `index.ts`/`index.tsx` barrels. |
-| `no-localhost-fallback.yml` | `?? "http://localhost..."` and equivalents. |
+| `no-export-star-shim.yml` | `export * from "..."` unless the preceding line is `// @barrel`. |
+| `no-localhost-fallback.yml` | `?? "http://localhost..."`, plus template-literal variants with embedded `${...}`. |
 
 All rules `severity: warning` for sprint 1 (phased rollout — promote to
 `error` per-rule once baseline is verifiably clean).

--- a/.coderabbit/README.md
+++ b/.coderabbit/README.md
@@ -7,24 +7,33 @@ CodeRabbit configuration ancillary files. The root config is `/.coderabbit.yaml`
 Deterministic syntactic rules (issue #3754 AC3). Each `.yml` is one rule;
 CodeRabbit auto-loads everything in this directory via `reviews.tools.ast-grep.rule_dirs`.
 
-| Rule | Forbids |
-|---|---|
-| `no-explicit-any.yml` | `: any`, `as any` in `langwatch/src/**`. |
-| `no-inline-dynamic-import.yml` | Inline `import(...)` in `.ts`/`.tsx` outside `routes.tsx` / `pages/**`. |
-| `no-form-watch-in-child.yml` | `$form.watch()` inside a child component receiving `form` as prop. |
-| `no-export-star-shim.yml` | `export * from "..."` unless the preceding line is `// @barrel`. |
-| `no-localhost-fallback.yml` | `?? "http://localhost..."`, plus template-literal variants with embedded `${...}`. |
+`language: TypeScript` does not match `.tsx` files in ast-grep's parser
+dispatch, so rules that apply to both file types are split into `_ts` /
+`_tsx` siblings.
+
+| Rule | Forbids | Scope |
+|---|---|---|
+| `no-explicit-any.yml` + `no-explicit-any-tsx.yml` | `: any`, `as any` (predefined_type kind with regex `^any$`) | `langwatch/src/**/*.{ts,tsx}` |
+| `no-inline-dynamic-import.yml` + `-tsx.yml` | Inline `import(...)` outside `routes.tsx` / `pages/**` | `langwatch/src/**/*.{ts,tsx}` |
+| `no-form-watch-in-child.yml` | `$form.watch()` inside a child component receiving `form` as prop | `langwatch/src/components/**/*.tsx` |
+| `no-export-star-shim.yml` + `-tsx.yml` | `export * from "..."`. Inline-disable with `// ast-grep-ignore: no-export-star-shim-{ts,tsx}` | `langwatch/src/**/*.{ts,tsx}` |
+| `no-localhost-fallback.yml` + `-tsx.yml` | `?? "http://localhost..."` and template-literal variants | `langwatch/src/**/*.{ts,tsx}` |
+| `no-form-disable-on-isvalid.yml` | `disabled={!form.formState.isValid}` / `disabled={!isValid}` on submit buttons — pre-disable is silent. See `dev/docs/design/guidelines.md` § 6. | `langwatch/src/**/*.tsx` |
 
 All rules `severity: warning` for sprint 1 (phased rollout — promote to
 `error` per-rule once baseline is verifiably clean).
 
 Add new rules by dropping a `.yml` here matching the [ast-grep rule schema](https://ast-grep.github.io/guide/rule-config.html).
-Keep rule IDs unique.
+Keep rule IDs unique. Split `_ts` / `_tsx` if the rule applies to both.
 
 ## Related
 
 - `/.coderabbit.yaml` — root config; references this directory.
-- `/.semgrep/langwatch.yml` — semantic patterns (PII regex, etc.).
+- `/.semgrep/langwatch.yml` — semantic patterns (PII regex, ClickHouse
+  TenantId enforcement, heavy-column dedup anti-pattern).
 - `/.github/workflows/deployment-impact-check.yml` — AC5 deployment-surface
   guard (moved out of CodeRabbit because `path_instructions` can't see PR
   descriptions).
+- `dev/docs/best_practices/`, `dev/docs/design/`, `dev/docs/adr/` — house
+  style sources, included in `knowledge_base.code_guidelines.filePatterns`
+  so CR can cite them in review comments.

--- a/.coderabbit/README.md
+++ b/.coderabbit/README.md
@@ -23,8 +23,29 @@ dispatch, so rules that apply to both file types are split into `_ts` /
 All rules `severity: warning` for sprint 1 (phased rollout — promote to
 `error` per-rule once baseline is verifiably clean).
 
-Add new rules by dropping a `.yml` here matching the [ast-grep rule schema](https://ast-grep.github.io/guide/rule-config.html).
-Keep rule IDs unique. Split `_ts` / `_tsx` if the rule applies to both.
+## Testing — every rule is proven by a fixture
+
+`sgconfig.yml` + `rule-tests/` make `ast-grep test` prove each rule actually
+matches real code. This harness exists because #3754 shipped a **dead** rule
+(`no-form-watch-in-child` fired on nothing); "looks right" is not enough.
+
+```bash
+# from .coderabbit/ast-grep/ :
+ast-grep test -c sgconfig.yml -t rule-tests       # all rules must pass
+ast-grep test -c sgconfig.yml -t rule-tests -U    # regenerate snapshots after a rule edit
+```
+
+Each `rule-tests/<id>-test.yml` lists `valid:` (must NOT match) and `invalid:`
+(MUST match) snippets; `rule-tests/__snapshots__/` pins the exact matches.
+`/.github/workflows/coderabbit-config-check.yml` runs this on every PR touching
+the config (pinned ast-grep + `semgrep --validate` + a semgrep match check), so
+a dead or malformed rule fails CI.
+
+**Adding a rule:** drop the `.yml` in `rules/` (matching the
+[ast-grep rule schema](https://ast-grep.github.io/guide/rule-config.html), unique
+id, split `_ts` / `_tsx` if it applies to both), add a `rule-tests/<id>-test.yml`
+with ≥1 `valid` + ≥1 `invalid` snippet, run `ast-grep test … -U` to record the
+snapshot, and commit all of it. No fixture = the rule is unproven.
 
 ## Related
 

--- a/.coderabbit/README.md
+++ b/.coderabbit/README.md
@@ -1,0 +1,30 @@
+# `.coderabbit/`
+
+CodeRabbit configuration ancillary files. The root config is `/.coderabbit.yaml`.
+
+## `ast-grep/rules/`
+
+Deterministic syntactic rules (issue #3754 AC3). Each `.yml` is one rule;
+CodeRabbit auto-loads everything in this directory via `reviews.tools.ast-grep.rule_dirs`.
+
+| Rule | Forbids |
+|---|---|
+| `no-explicit-any.yml` | `: any`, `as any` in `langwatch/src/**`. |
+| `no-inline-dynamic-import.yml` | Inline `import(...)` in `.ts`/`.tsx` outside `routes.tsx` / `pages/**`. |
+| `no-form-watch-in-child.yml` | `$form.watch()` inside a child component receiving `form` as prop. |
+| `no-export-star-shim.yml` | `export * from "..."` outside `index.ts`/`index.tsx` barrels. |
+| `no-localhost-fallback.yml` | `?? "http://localhost..."` and equivalents. |
+
+All rules `severity: warning` for sprint 1 (phased rollout — promote to
+`error` per-rule once baseline is verifiably clean).
+
+Add new rules by dropping a `.yml` here matching the [ast-grep rule schema](https://ast-grep.github.io/guide/rule-config.html).
+Keep rule IDs unique.
+
+## Related
+
+- `/.coderabbit.yaml` — root config; references this directory.
+- `/.semgrep/langwatch.yml` — semantic patterns (PII regex, etc.).
+- `/.github/workflows/deployment-impact-check.yml` — AC5 deployment-surface
+  guard (moved out of CodeRabbit because `path_instructions` can't see PR
+  descriptions).

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-explicit-any-ts-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-explicit-any-ts-snapshot.yml
@@ -1,0 +1,20 @@
+id: no-explicit-any-ts
+snapshots:
+  'const x: any = readJson();':
+    labels:
+    - source: any
+      style: primary
+      start: 9
+      end: 12
+  const y = value as any;:
+    labels:
+    - source: any
+      style: primary
+      start: 19
+      end: 22
+  'function f(a: any) { return a; }':
+    labels:
+    - source: any
+      style: primary
+      start: 14
+      end: 17

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-explicit-any-tsx-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-explicit-any-tsx-snapshot.yml
@@ -1,0 +1,14 @@
+id: no-explicit-any-tsx
+snapshots:
+  'const C = (p: any) => <div>{p.name}</div>;':
+    labels:
+    - source: any
+      style: primary
+      start: 14
+      end: 17
+  'const handler = (e: any): void => { e.preventDefault(); };':
+    labels:
+    - source: any
+      style: primary
+      start: 20
+      end: 23

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-export-star-shim-ts-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-export-star-shim-ts-snapshot.yml
@@ -1,0 +1,14 @@
+id: no-export-star-shim-ts
+snapshots:
+  export * from "../legacy/shim";:
+    labels:
+    - source: export * from "../legacy/shim";
+      style: primary
+      start: 0
+      end: 31
+  export * from "./module";:
+    labels:
+    - source: export * from "./module";
+      style: primary
+      start: 0
+      end: 25

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-export-star-shim-tsx-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-export-star-shim-tsx-snapshot.yml
@@ -1,0 +1,8 @@
+id: no-export-star-shim-tsx
+snapshots:
+  export * from "./Button";:
+    labels:
+    - source: export * from "./Button";
+      style: primary
+      start: 0
+      end: 25

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-form-disable-on-isvalid-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-form-disable-on-isvalid-snapshot.yml
@@ -1,0 +1,14 @@
+id: no-form-disable-on-isvalid
+snapshots:
+  const C = () => <button disabled={!form.formState.isValid}>Save</button>;:
+    labels:
+    - source: disabled={!form.formState.isValid}
+      style: primary
+      start: 24
+      end: 58
+  const C = () => <button disabled={!isValid}>Save</button>;:
+    labels:
+    - source: disabled={!isValid}
+      style: primary
+      start: 24
+      end: 43

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-form-watch-in-child-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-form-watch-in-child-snapshot.yml
@@ -1,0 +1,106 @@
+id: no-form-watch-in-child
+snapshots:
+  ? |
+    const Child = ({ form }: Props) => {
+      const name = form.watch("name");
+      return <input value={name} />;
+    };
+  : labels:
+    - source: form.watch("name")
+      style: primary
+      start: 52
+      end: 70
+    - source: form
+      style: secondary
+      start: 17
+      end: 21
+    - source: '({ form }: Props)'
+      style: secondary
+      start: 14
+      end: 31
+    - source: |-
+        ({ form }: Props) => {
+          const name = form.watch("name");
+          return <input value={name} />;
+        }
+      style: secondary
+      start: 14
+      end: 106
+  ? |
+    function Child(form: UseFormReturn<Values>) {
+      const all = form.watch();
+      return <div>{all.name}</div>;
+    }
+  : labels:
+    - source: form.watch()
+      style: primary
+      start: 60
+      end: 72
+    - source: form
+      style: secondary
+      start: 15
+      end: 19
+    - source: '(form: UseFormReturn<Values>)'
+      style: secondary
+      start: 14
+      end: 43
+    - source: |-
+        function Child(form: UseFormReturn<Values>) {
+          const all = form.watch();
+          return <div>{all.name}</div>;
+        }
+      style: secondary
+      start: 0
+      end: 107
+  ? |
+    function Child({ form }: Props) {
+      const all = form.watch();
+      return <input value={all.name} />;
+    }
+  : labels:
+    - source: form.watch()
+      style: primary
+      start: 48
+      end: 60
+    - source: form
+      style: secondary
+      start: 17
+      end: 21
+    - source: '({ form }: Props)'
+      style: secondary
+      start: 14
+      end: 31
+    - source: |-
+        function Child({ form }: Props) {
+          const all = form.watch();
+          return <input value={all.name} />;
+        }
+      style: secondary
+      start: 0
+      end: 100
+  ? |
+    function Child({ form }: Props) {
+      const name = form.watch("name");
+      return <input value={name} />;
+    }
+  : labels:
+    - source: form.watch("name")
+      style: primary
+      start: 49
+      end: 67
+    - source: form
+      style: secondary
+      start: 17
+      end: 21
+    - source: '({ form }: Props)'
+      style: secondary
+      start: 14
+      end: 31
+    - source: |-
+        function Child({ form }: Props) {
+          const name = form.watch("name");
+          return <input value={name} />;
+        }
+      style: secondary
+      start: 0
+      end: 103

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-inline-dynamic-import-ts-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-inline-dynamic-import-ts-snapshot.yml
@@ -1,0 +1,14 @@
+id: no-inline-dynamic-import-ts
+snapshots:
+  async function load() { const mod = await import("./heavy"); return mod; }:
+    labels:
+    - source: import("./heavy")
+      style: primary
+      start: 42
+      end: 59
+  const mod = import("./module");:
+    labels:
+    - source: import("./module")
+      style: primary
+      start: 12
+      end: 30

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-inline-dynamic-import-tsx-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-inline-dynamic-import-tsx-snapshot.yml
@@ -1,0 +1,8 @@
+id: no-inline-dynamic-import-tsx
+snapshots:
+  const C = () => { const m = import("./Chart"); return null; };:
+    labels:
+    - source: import("./Chart")
+      style: primary
+      start: 28
+      end: 45

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-localhost-fallback-ts-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-localhost-fallback-ts-snapshot.yml
@@ -1,0 +1,20 @@
+id: no-localhost-fallback-ts
+snapshots:
+  const url = env.API_URL ?? "http://localhost:3000";:
+    labels:
+    - source: env.API_URL ?? "http://localhost:3000"
+      style: primary
+      start: 12
+      end: 50
+  const url = env.API_URL ?? "https://localhost";:
+    labels:
+    - source: env.API_URL ?? "https://localhost"
+      style: primary
+      start: 12
+      end: 46
+  const url = env.API_URL ?? `http://localhost:${port}/api`;:
+    labels:
+    - source: env.API_URL ?? `http://localhost:${port}/api`
+      style: primary
+      start: 12
+      end: 57

--- a/.coderabbit/ast-grep/rule-tests/__snapshots__/no-localhost-fallback-tsx-snapshot.yml
+++ b/.coderabbit/ast-grep/rule-tests/__snapshots__/no-localhost-fallback-tsx-snapshot.yml
@@ -1,0 +1,14 @@
+id: no-localhost-fallback-tsx
+snapshots:
+  const C = () => { const u = env.URL ?? "http://localhost:3000"; return <a href={u} />; };:
+    labels:
+    - source: env.URL ?? "http://localhost:3000"
+      style: primary
+      start: 28
+      end: 62
+  const C = () => { const u = env.URL ?? `https://localhost:${p}`; return <a href={u} />; };:
+    labels:
+    - source: env.URL ?? `https://localhost:${p}`
+      style: primary
+      start: 28
+      end: 63

--- a/.coderabbit/ast-grep/rule-tests/no-explicit-any-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-explicit-any-test.yml
@@ -1,0 +1,9 @@
+id: no-explicit-any-ts
+valid:
+  - "const x: unknown = readJson();"
+  - "const n: number = 1;"
+  - "function f(a: string, b: number) { return a; }"
+invalid:
+  - "const x: any = readJson();"
+  - "function f(a: any) { return a; }"
+  - "const y = value as any;"

--- a/.coderabbit/ast-grep/rule-tests/no-explicit-any-tsx-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-explicit-any-tsx-test.yml
@@ -1,0 +1,7 @@
+id: no-explicit-any-tsx
+valid:
+  - "const C = (p: Props) => <div>{p.name}</div>;"
+  - "const v: unknown = 1;"
+invalid:
+  - "const C = (p: any) => <div>{p.name}</div>;"
+  - "const handler = (e: any): void => { e.preventDefault(); };"

--- a/.coderabbit/ast-grep/rule-tests/no-export-star-shim-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-export-star-shim-test.yml
@@ -1,0 +1,8 @@
+id: no-export-star-shim-ts
+valid:
+  - 'export { foo, bar } from "./module";'
+  - 'import { foo } from "./module";'
+  - 'export const foo = 1;'
+invalid:
+  - 'export * from "./module";'
+  - 'export * from "../legacy/shim";'

--- a/.coderabbit/ast-grep/rule-tests/no-export-star-shim-tsx-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-export-star-shim-tsx-test.yml
@@ -1,0 +1,6 @@
+id: no-export-star-shim-tsx
+valid:
+  - 'export { Button } from "./Button";'
+  - 'import { Button } from "./Button";'
+invalid:
+  - 'export * from "./Button";'

--- a/.coderabbit/ast-grep/rule-tests/no-form-disable-on-isvalid-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-form-disable-on-isvalid-test.yml
@@ -1,0 +1,7 @@
+id: no-form-disable-on-isvalid
+valid:
+  - "const C = () => <button disabled={mutation.isPending}>Save</button>;"
+  - "const C = () => <button disabled={isSubmitting}>Save</button>;"
+invalid:
+  - "const C = () => <button disabled={!form.formState.isValid}>Save</button>;"
+  - "const C = () => <button disabled={!isValid}>Save</button>;"

--- a/.coderabbit/ast-grep/rule-tests/no-form-watch-in-child-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-form-watch-in-child-test.yml
@@ -1,0 +1,49 @@
+id: no-form-watch-in-child
+valid:
+  # Correct pattern: useWatch({ control, name }) in the child, no form.watch().
+  - |
+    function Child({ control }: Props) {
+      const name = useWatch({ control, name: "name" });
+      return <input value={name} />;
+    }
+  # `form` is the component's OWN form (local var from useForm), not a prop.
+  - |
+    function FormOwner() {
+      const form = useForm<Values>();
+      const name = form.watch("name");
+      return <input value={name} />;
+    }
+  # A prop EXISTS (defaultValues) but .watch() is called on a LOCAL useForm()
+  # var — proves the rule requires the receiver itself to be the prop, not
+  # merely that the component takes some parameter.
+  - |
+    function Child({ defaultValues }: Props) {
+      const form = useForm({ defaultValues });
+      const name = form.watch("name");
+      return <input value={name} />;
+    }
+invalid:
+  # Child receives `form` as a destructured prop and calls form.watch() (zero-arg).
+  - |
+    function Child({ form }: Props) {
+      const all = form.watch();
+      return <input value={all.name} />;
+    }
+  # Child receives `form` as a destructured prop and calls form.watch("name").
+  - |
+    function Child({ form }: Props) {
+      const name = form.watch("name");
+      return <input value={name} />;
+    }
+  # Arrow-function child component with a destructured form prop.
+  - |
+    const Child = ({ form }: Props) => {
+      const name = form.watch("name");
+      return <input value={name} />;
+    };
+  # Named (non-destructured) form parameter, zero-arg watch.
+  - |
+    function Child(form: UseFormReturn<Values>) {
+      const all = form.watch();
+      return <div>{all.name}</div>;
+    }

--- a/.coderabbit/ast-grep/rule-tests/no-inline-dynamic-import-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-inline-dynamic-import-test.yml
@@ -1,0 +1,8 @@
+id: no-inline-dynamic-import-ts
+valid:
+  - 'import { foo } from "./module";'
+  - 'import type { Bar } from "./types";'
+  - 'export { baz } from "./module";'
+invalid:
+  - 'const mod = import("./module");'
+  - 'async function load() { const mod = await import("./heavy"); return mod; }'

--- a/.coderabbit/ast-grep/rule-tests/no-inline-dynamic-import-tsx-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-inline-dynamic-import-tsx-test.yml
@@ -1,0 +1,6 @@
+id: no-inline-dynamic-import-tsx
+valid:
+  - 'import { Button } from "./Button";'
+  - 'import type { Props } from "./types";'
+invalid:
+  - 'const C = () => { const m = import("./Chart"); return null; };'

--- a/.coderabbit/ast-grep/rule-tests/no-localhost-fallback-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-localhost-fallback-test.yml
@@ -1,0 +1,9 @@
+id: no-localhost-fallback-ts
+valid:
+  - 'const url = env.API_URL ?? getDefaultUrl();'
+  - 'const url = env.API_URL ?? "https://api.example.com";'
+  - 'const port = env.PORT ?? 3000;'
+invalid:
+  - 'const url = env.API_URL ?? "http://localhost:3000";'
+  - 'const url = env.API_URL ?? "https://localhost";'
+  - 'const url = env.API_URL ?? `http://localhost:${port}/api`;'

--- a/.coderabbit/ast-grep/rule-tests/no-localhost-fallback-tsx-test.yml
+++ b/.coderabbit/ast-grep/rule-tests/no-localhost-fallback-tsx-test.yml
@@ -1,0 +1,7 @@
+id: no-localhost-fallback-tsx
+valid:
+  - 'const C = () => { const u = env.URL ?? getDefault(); return <a href={u} />; };'
+  - 'const C = () => { const u = env.URL ?? "https://app.example.com"; return <a href={u} />; };'
+invalid:
+  - 'const C = () => { const u = env.URL ?? "http://localhost:3000"; return <a href={u} />; };'
+  - 'const C = () => { const u = env.URL ?? `https://localhost:${p}`; return <a href={u} />; };'

--- a/.coderabbit/ast-grep/rules/no-explicit-any-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-explicit-any-tsx.yml
@@ -1,19 +1,18 @@
-id: no-explicit-any-ts
+id: no-explicit-any-tsx
 message: >
   Avoid `any` — prefer `unknown` + narrowing, or a real type. See
   langwatch CLAUDE.md and #3754 AC3. (Biome also flags this via
   `suspicious.noExplicitAny` — this rule is the deterministic fallback
   for cases Biome misses.)
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   kind: predefined_type
   regex: '^any$'
 files:
-  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
 ignores:
-  - "**/*.d.ts"
   - "**/__tests__/**"
-  - "**/*.test.ts"
-  - "**/*.spec.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"
   - "**/__fixtures__/**"

--- a/.coderabbit/ast-grep/rules/no-explicit-any.yml
+++ b/.coderabbit/ast-grep/rules/no-explicit-any.yml
@@ -1,0 +1,22 @@
+id: no-explicit-any
+message: >
+  Avoid `any` — prefer `unknown` + narrowing, or a real type. See
+  langwatch CLAUDE.md and #3754 AC3.
+severity: warning
+language: TypeScript
+rule:
+  any:
+    - kind: any_type
+    - pattern: $X as any
+    - pattern: $X as any[]
+files:
+  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/*.d.ts"
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/__fixtures__/**"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim-tsx.yml
@@ -1,11 +1,11 @@
-id: no-export-star-shim-ts
+id: no-export-star-shim-tsx
 message: >
   `export * from "..."` is a re-export shim. Backwards-compat shims rot —
   update consumers to import from the new location instead. If this is a
   legitimate barrel, add `// @barrel` on the line above the first
   `export *` to opt out.
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   all:
     - kind: export_statement
@@ -15,4 +15,4 @@ rule:
           kind: comment
           regex: '@barrel'
 files:
-  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim-tsx.yml
@@ -1,18 +1,13 @@
 id: no-export-star-shim-tsx
 message: >
   `export * from "..."` is a re-export shim. Backwards-compat shims rot —
-  update consumers to import from the new location instead. If this is a
-  legitimate barrel, add `// @barrel` on the line above the first
-  `export *` to opt out.
+  update consumers to import from the new location instead. For a
+  legitimate barrel, add an inline `// ast-grep-ignore: no-export-star-shim-tsx`
+  comment on the previous line.
 severity: warning
 language: Tsx
 rule:
-  all:
-    - kind: export_statement
-    - regex: '^export \* from'
-    - not:
-        follows:
-          kind: comment
-          regex: '@barrel'
+  kind: export_statement
+  regex: '^export \* from'
 files:
   - "langwatch/src/**/*.tsx"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim.yml
@@ -1,0 +1,15 @@
+id: no-export-star-shim
+message: >
+  `export * from "..."` is a re-export shim. Backwards-compat shims rot —
+  update consumers to import from the new location instead. If this is a
+  legitimate barrel file with multiple exports, list each one explicitly.
+severity: warning
+language: TypeScript
+rule:
+  pattern: export * from $MOD
+files:
+  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/index.ts"
+  - "**/index.tsx"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim.yml
@@ -2,14 +2,17 @@ id: no-export-star-shim
 message: >
   `export * from "..."` is a re-export shim. Backwards-compat shims rot —
   update consumers to import from the new location instead. If this is a
-  legitimate barrel file with multiple exports, list each one explicitly.
+  legitimate barrel, add `// @barrel` on the line above the first
+  `export *` to opt out.
 severity: warning
 language: TypeScript
 rule:
   pattern: export * from $MOD
+  not:
+    precedes:
+      kind: comment
+      regex: '@barrel'
+      stopBy: end
 files:
   - "langwatch/src/**/*.ts"
   - "langwatch/src/**/*.tsx"
-ignores:
-  - "**/index.ts"
-  - "**/index.tsx"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim.yml
@@ -1,18 +1,13 @@
 id: no-export-star-shim-ts
 message: >
   `export * from "..."` is a re-export shim. Backwards-compat shims rot —
-  update consumers to import from the new location instead. If this is a
-  legitimate barrel, add `// @barrel` on the line above the first
-  `export *` to opt out.
+  update consumers to import from the new location instead. For a
+  legitimate barrel, add an inline `// ast-grep-ignore: no-export-star-shim-ts`
+  comment on the previous line.
 severity: warning
 language: TypeScript
 rule:
-  all:
-    - kind: export_statement
-    - regex: '^export \* from'
-    - not:
-        follows:
-          kind: comment
-          regex: '@barrel'
+  kind: export_statement
+  regex: '^export \* from'
 files:
   - "langwatch/src/**/*.ts"

--- a/.coderabbit/ast-grep/rules/no-form-disable-on-isvalid.yml
+++ b/.coderabbit/ast-grep/rules/no-form-disable-on-isvalid.yml
@@ -1,0 +1,17 @@
+id: no-form-disable-on-isvalid
+message: >
+  Submit button is disabled based on form validity — pre-disabling is silent
+  and frustrating. Disable ONLY while the request is in flight
+  (`disabled={mutation.isPending}` is the canonical shape). Surface
+  validation errors inline (Field.ErrorText) or via toast in the submit
+  handler. See `dev/docs/design/guidelines.md` § 6 and ADR-018.
+severity: warning
+language: Tsx
+rule:
+  kind: jsx_attribute
+  regex: '^disabled=\{[^}]*(isValid|formState\.isValid)'
+files:
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
+++ b/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
@@ -4,7 +4,7 @@ message: >
   it re-renders the whole form tree on every keystroke. Use
   `useWatch({ control, name })` instead.
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   pattern: $F.watch()
   inside:

--- a/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
+++ b/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
@@ -6,20 +6,25 @@ message: >
 severity: warning
 language: Tsx
 rule:
-  pattern: $F.watch()
+  # Any-arg watch: form.watch(), form.watch("name"), form.watch(["a","b"]).
+  pattern: $F.watch($$$ARGS)
+  # ...where the $F receiver is a parameter of an enclosing function/component
+  # (i.e. `form` was received as a prop), NOT the component's own useForm() var.
+  # stopBy: end is required — the immediate parent of the call is a statement,
+  # so the enclosing function is only reachable by walking all ancestors.
   inside:
+    stopBy: end
     any:
       - kind: arrow_function
-      - kind: function_expression
       - kind: function_declaration
+      - kind: function_expression
+      - kind: method_definition
     has:
       kind: formal_parameters
+      stopBy: end
       has:
-        any:
-          - kind: required_parameter
-            pattern: $F
-          - kind: identifier
-            pattern: $F
+        pattern: $F
+        stopBy: end
 files:
   - "langwatch/src/components/**/*.tsx"
 ignores:

--- a/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
+++ b/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
@@ -1,0 +1,21 @@
+id: no-form-watch-in-child
+message: >
+  Child components receiving `form` as prop must not call `form.watch()` —
+  it re-renders the whole form tree on every keystroke. Use
+  `useWatch({ control, name })` instead.
+severity: warning
+language: TypeScript
+rule:
+  pattern: $F.watch()
+  inside:
+    kind: function_declaration
+    has:
+      kind: formal_parameters
+      has:
+        kind: required_parameter
+        pattern: $F
+files:
+  - "langwatch/src/components/**/*.tsx"
+ignores:
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
+++ b/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
@@ -8,12 +8,18 @@ language: TypeScript
 rule:
   pattern: $F.watch()
   inside:
-    kind: function_declaration
+    any:
+      - kind: arrow_function
+      - kind: function_expression
+      - kind: function_declaration
     has:
       kind: formal_parameters
       has:
-        kind: required_parameter
-        pattern: $F
+        any:
+          - kind: required_parameter
+            pattern: $F
+          - kind: identifier
+            pattern: $F
 files:
   - "langwatch/src/components/**/*.tsx"
 ignores:

--- a/.coderabbit/ast-grep/rules/no-inline-dynamic-import-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-inline-dynamic-import-tsx.yml
@@ -1,15 +1,17 @@
-id: no-inline-dynamic-import-ts
+id: no-inline-dynamic-import-tsx
 message: >
   Avoid inline `import(...)` for what should be a static import. Use
   top-level `import` / `import type` instead. Dynamic `import()` inside
   a function for intentional lazy-loading is fine — annotate the diff
   if not obvious.
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   pattern: import($MOD)
 files:
-  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
 ignores:
-  - "**/*.test.ts"
-  - "**/*.spec.ts"
+  - "**/routes.tsx"
+  - "**/pages/**"
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-inline-dynamic-import.yml
+++ b/.coderabbit/ast-grep/rules/no-inline-dynamic-import.yml
@@ -1,0 +1,20 @@
+id: no-inline-dynamic-import
+message: >
+  Avoid inline `import(...)` for what should be a static import. Use
+  top-level `import` / `import type` instead. Dynamic `import()` inside
+  a function for intentional lazy-loading is fine — annotate the diff
+  if not obvious.
+severity: warning
+language: TypeScript
+rule:
+  pattern: import($MOD)
+files:
+  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/routes.tsx"
+  - "**/pages/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-localhost-fallback-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-localhost-fallback-tsx.yml
@@ -6,11 +6,10 @@ message: >
 severity: warning
 language: Tsx
 rule:
-  any:
-    - pattern: $X ?? "http://localhost$REST"
-    - pattern: $X ?? "https://localhost$REST"
-    - pattern: $X ?? `http://localhost$$$REST`
-    - pattern: $X ?? `https://localhost$$$REST`
+  pattern: $X ?? $R
+constraints:
+  R:
+    regex: '^["''`]?https?://localhost([:/?#].*)?["''`]?$'
 files:
   - "langwatch/src/**/*.tsx"
 ignores:

--- a/.coderabbit/ast-grep/rules/no-localhost-fallback-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-localhost-fallback-tsx.yml
@@ -1,10 +1,10 @@
-id: no-localhost-fallback-ts
+id: no-localhost-fallback-tsx
 message: >
   Don't fall back to a localhost URL via `??`. Required env vars must be
   validated through the Zod env schema and consumed without fallbacks —
   silent fallbacks mask missing configuration in production.
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   any:
     - pattern: $X ?? "http://localhost$REST"
@@ -12,7 +12,7 @@ rule:
     - pattern: $X ?? `http://localhost$$$REST`
     - pattern: $X ?? `https://localhost$$$REST`
 files:
-  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
 ignores:
-  - "**/*.test.ts"
-  - "**/*.spec.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
+++ b/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
@@ -1,0 +1,20 @@
+id: no-localhost-fallback
+message: >
+  Don't fall back to a localhost URL via `??`. Required env vars must be
+  validated through the Zod env schema and consumed without fallbacks —
+  silent fallbacks mask missing configuration in production.
+severity: warning
+language: TypeScript
+rule:
+  any:
+    - pattern: $X ?? "http://localhost$REST"
+    - pattern: $X ?? `http://localhost$REST`
+    - pattern: $X ?? "https://localhost$REST"
+files:
+  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
+++ b/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
@@ -8,8 +8,9 @@ language: TypeScript
 rule:
   any:
     - pattern: $X ?? "http://localhost$REST"
-    - pattern: $X ?? `http://localhost$REST`
     - pattern: $X ?? "https://localhost$REST"
+    - pattern: $X ?? `http://localhost$$$REST`
+    - pattern: $X ?? `https://localhost$$$REST`
 files:
   - "langwatch/src/**/*.ts"
   - "langwatch/src/**/*.tsx"

--- a/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
+++ b/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
@@ -6,11 +6,10 @@ message: >
 severity: warning
 language: TypeScript
 rule:
-  any:
-    - pattern: $X ?? "http://localhost$REST"
-    - pattern: $X ?? "https://localhost$REST"
-    - pattern: $X ?? `http://localhost$$$REST`
-    - pattern: $X ?? `https://localhost$$$REST`
+  pattern: $X ?? $R
+constraints:
+  R:
+    regex: '^["''`]?https?://localhost([:/?#].*)?["''`]?$'
 files:
   - "langwatch/src/**/*.ts"
 ignores:

--- a/.coderabbit/ast-grep/sgconfig.yml
+++ b/.coderabbit/ast-grep/sgconfig.yml
@@ -1,0 +1,12 @@
+# ast-grep project config for the committed CodeRabbit rules.
+#
+# Purpose: `ast-grep test` (run locally and in CI) proves every rule in rules/
+# actually matches the fixtures in rule-tests/ — so no rule can silently go
+# dead again (see #3754; no-form-watch-in-child was found firing on nothing).
+#
+# CodeRabbit itself loads these rules via reviews.tools.ast-grep.rule_dirs in
+# /.coderabbit.yaml and does NOT read this file or rule-tests/.
+ruleDirs:
+  - rules
+testConfigurations:
+  - testDir: rule-tests

--- a/.github/workflows/coderabbit-config-check.yml
+++ b/.github/workflows/coderabbit-config-check.yml
@@ -1,0 +1,56 @@
+name: coderabbit-config-check
+
+# Proves the committed CodeRabbit lint config ACTUALLY works, so no rule can
+# silently go dead again (see #3754: no-form-watch-in-child fired on nothing and
+# the semgrep ruleset failed to parse — both passed un-noticed because nothing
+# executed them). This job EXECUTES them:
+#   * every ast-grep rule must match its committed fixture (`ast-grep test`)
+#   * the semgrep ruleset must validate AND the PII rule must still match.
+#
+# ast-grep and semgrep are PINNED — rule-matching behaviour is version-sensitive
+# (the dead-rule confusion in #3754 was partly version fragility). Bump the pins
+# deliberately and re-run `ast-grep test`/`semgrep --validate` when you do.
+on:
+  pull_request:
+    paths:
+      - ".coderabbit.yaml"
+      - ".coderabbit/**"
+      - ".semgrep/**"
+      - ".github/workflows/coderabbit-config-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      # Actions are SHA-pinned (langwatch org policy requires full-SHA pins;
+      # tag refs like @v4 fail to start). Same SHAs other repo workflows use.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          persist-credentials: false # read-only job, no git ops — don't persist the token
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned linters
+        run: pip install "ast-grep-cli==0.42.3" "semgrep==1.164.0" "pyyaml>=6"
+
+      - name: ast-grep version (pinned)
+        run: ast-grep --version
+
+      - name: ast-grep rule fixtures — every rule must match its fixture
+        working-directory: .coderabbit/ast-grep
+        run: ast-grep test -c sgconfig.yml -t rule-tests
+
+      - name: semgrep ruleset validates
+        run: semgrep --validate --config .semgrep/langwatch.yml
+
+      - name: semgrep PII rule still matches its fixture (guard vs silent death)
+        run: |
+          python3 -c "import yaml; d=yaml.safe_load(open('.semgrep/langwatch.yml')); r=next(x for x in d['rules'] if x['id']=='pii-in-logger-call'); r.pop('paths', None); yaml.safe_dump({'rules':[r]}, open('/tmp/pii_only.yml','w'))"
+          n=$(semgrep --config /tmp/pii_only.yml .semgrep/tests/pii-in-logger-call.ts --json --quiet | python3 -c "import sys, json; print(len(json.load(sys.stdin)['results']))")
+          echo "pii-in-logger-call matched $n line(s) in the fixture (expect 5)"
+          test "$n" -eq 5

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -1,0 +1,75 @@
+name: deployment-impact-check
+
+# Fails when a PR touches deployment surface without addressing operator
+# impact in the PR description. CodeRabbit's path_instructions cannot see
+# PR descriptions, so this rule lives in a GH Action instead. See #3754
+# Investigation Flip 3.
+#
+# Once this workflow has run once and we have its check name, add it to
+# branch protection on main as a required check (tracked as AC1b in #3754).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - "charts/**"
+      - "services/**"
+      - "dev/docs/adr/**"
+      - "dev/docs/best_practices/**"
+      - "langwatch/.env.example"
+      - "docs/self-hosting/**"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify deployment-impact section in PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Body presence
+          if [ -z "$PR_BODY" ]; then
+            echo "::error::PR description is empty. Add a ## Deployment Impact section addressing env vars, helm values, default helm install behavior, and BYOC dataplane impact."
+            exit 1
+          fi
+
+          # Heading presence (case-insensitive, allow either Deployment Impact
+          # or Operator/Deployment impact).
+          if ! echo "$PR_BODY" | grep -qiE '^##+[[:space:]]*(deployment[[:space:]]+impact|operator[[:space:]]*/?[[:space:]]*deployment[[:space:]]+impact)' ; then
+            echo "::error::No '## Deployment Impact' heading found in PR description. This PR touches deployment surface (charts/services/ADRs/best-practices docs/env.example/self-hosting) — add the section."
+            exit 1
+          fi
+
+          # Content presence — the section must say *something*. We measure by
+          # extracting from the heading to the next H2 (or EOF) and requiring
+          # at least 80 non-whitespace chars beyond the heading. Cheap proxy
+          # for "actually filled in, not placeholder."
+          SECTION=$(printf '%s\n' "$PR_BODY" | awk '
+            BEGIN { capturing=0 }
+            /^##+[[:space:]]*[Dd]eployment[[:space:]]+[Ii]mpact/ { capturing=1; next }
+            /^##+[[:space:]]*[Oo]perator/ { if ($0 ~ /[Dd]eployment/) { capturing=1; next } }
+            capturing && /^##+[[:space:]]/ { exit }
+            capturing { print }
+          ')
+          LEN=$(printf '%s' "$SECTION" | tr -d '[:space:]' | wc -c | tr -d ' ')
+          if [ "${LEN:-0}" -lt 80 ]; then
+            echo "::error::'## Deployment Impact' section is too short (${LEN} non-whitespace chars). It must address: env vars added/changed, helm values added/changed, default behavior on vanilla 'helm install' with no overrides, and BYOC dataplane impact."
+            exit 1
+          fi
+
+          # Discourage obvious placeholder text.
+          if printf '%s' "$SECTION" | grep -qiE '\b(TBD|TODO|FIXME|placeholder|N/?A)\b'; then
+            # Allow N/A if the author explicitly justifies — look for at least
+            # one sentence of justification after the marker.
+            JUST=$(printf '%s' "$SECTION" | grep -iE '(TBD|TODO|FIXME|placeholder|N/?A)' | head -1)
+            if ! printf '%s\n' "$SECTION" | grep -qiE 'no operator impact|no deployment impact|repo metadata only|docs[- ]only'; then
+              echo "::error::'## Deployment Impact' contains a placeholder ('$JUST') without justification. Either fill it in, or explain why no impact applies (e.g., 'no deployment impact — repo metadata only')."
+              exit 1
+            fi
+          fi
+
+          echo "Deployment Impact section present and filled in (${LEN} chars). OK."

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -37,10 +37,10 @@ jobs:
             exit 1
           fi
 
-          # Heading presence (case-insensitive, allow either Deployment Impact
-          # or Operator/Deployment impact).
-          if ! echo "$PR_BODY" | grep -qiE '^##+[[:space:]]*(deployment[[:space:]]+impact|operator[[:space:]]*/?[[:space:]]*deployment[[:space:]]+impact)' ; then
-            echo "::error::No '## Deployment Impact' heading found in PR description. This PR touches deployment surface (charts/services/ADRs/best-practices docs/env.example/self-hosting) — add the section."
+          # Heading presence — strict H2 (`## `). Loosen to `##+` if H3 turns
+          # out to be common in template usage.
+          if ! printf '%s\n' "$PR_BODY" | grep -qiE '^##[[:space:]]+(deployment[[:space:]]+impact|operator[[:space:]]*/?[[:space:]]*deployment[[:space:]]+impact)' ; then
+            echo "::error::No '## Deployment Impact' heading found in PR description. This PR touches deployment surface (charts/services/ADRs/best-practices docs/env.example/self-hosting) — add the section as a top-level H2 (`## Deployment Impact`)."
             exit 1
           fi
 

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -50,9 +50,9 @@ jobs:
           # for "actually filled in, not placeholder."
           SECTION=$(printf '%s\n' "$PR_BODY" | awk '
             BEGIN { capturing=0 }
-            /^##+[[:space:]]*[Dd]eployment[[:space:]]+[Ii]mpact/ { capturing=1; next }
-            /^##+[[:space:]]*[Oo]perator/ { if ($0 ~ /[Dd]eployment/) { capturing=1; next } }
-            capturing && /^##+[[:space:]]/ { exit }
+            /^##[[:space:]]+[Dd]eployment[[:space:]]+[Ii]mpact([[:space:]]|$)/ { capturing=1; next }
+            /^##[[:space:]]+[Oo]perator[[:space:]]*\/?[[:space:]]*[Dd]eployment[[:space:]]+[Ii]mpact([[:space:]]|$)/ { capturing=1; next }
+            capturing && /^##[[:space:]]+/ { exit }
             capturing { print }
           ')
           LEN=$(printf '%s' "$SECTION" | tr -d '[:space:]' | wc -c | tr -d ' ')

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,12 @@ node_modules
 # Defense against MCP env-var leaks: external tooling can mkdir a literal
 # directory like "${HOME/...}" relative to cwd when bash-style env defaults
 # aren't expanded. Never let those slip into the repo again.
-${HOME*
-${VAR*
+# NB: the `{` is escaped as `[{]` so these stay valid globs for the Rust
+# `ignore` crate (ast-grep / ripgrep), which otherwise reads `{` as an
+# unclosed alternate group and aborts directory traversal. git treats
+# `[{]` as a literal-`{` character class, so the guard is unchanged.
+$[{]HOME*
+$[{]VAR*
 
 llm-model-costs.json
 quickwit-*

--- a/.semgrep/langwatch.yml
+++ b/.semgrep/langwatch.yml
@@ -90,3 +90,60 @@ rules:
     pattern-either:
       - pattern-regex: '\$\{CLICKHOUSE_DATABASE\}\.\w+'
       - pattern-regex: '\b(FROM|JOIN|INTO|UPDATE|TABLE|VIEW|EXISTS|DROP)[[:space:]]+langwatch\.[a-z_]+'
+
+  # ── ClickHouse runtime queries must filter by TenantId ─────────────────
+  # Surfaced as a follow-up by CR on PR #4170: every ClickHouse query MUST
+  # include `WHERE TenantId = {tenantId:String}` to keep tenants isolated.
+  # Migrations (DDL) are exempt — they don't filter by tenant. This rule
+  # targets query files only, where a missing TenantId predicate is a
+  # cross-tenant leak.
+  - id: clickhouse-require-tenant-id
+    message: >
+      ClickHouse query missing `WHERE TenantId = {tenantId:String}`
+      predicate. Every runtime query must filter by TenantId to keep
+      tenants isolated. See
+      `dev/docs/best_practices/clickhouse-queries.md` § Tenant scoping.
+    severity: ERROR
+    languages: [typescript, javascript]
+    paths:
+      include:
+        - "langwatch/src/server/clickhouse/**/*.ts"
+        - "langwatch/src/server/repositories/**/clickhouse*.ts"
+      exclude:
+        - "**/migrations/**"
+        - "**/__tests__/**"
+        - "**/*.test.ts"
+        - "**/*.spec.ts"
+    patterns:
+      - pattern-either:
+          - pattern: clickhouse.query({ query: $Q, ... })
+          - pattern: clickhouse.exec({ query: $Q, ... })
+          - pattern: clickhouseClient.query({ query: $Q, ... })
+      - pattern-not-regex: 'TenantId\s*=\s*\{tenantId'
+
+  # ── ClickHouse dedup anti-pattern: ORDER BY … LIMIT 1 + heavy cols ─────
+  # Anti-pattern 1 from clickhouse-queries.md. Reading heavy columns while
+  # sorting all unmerged versions of a row saturates ClickHouse.
+  - id: clickhouse-no-version-order-limit
+    message: >
+      ClickHouse query selects heavy columns AND uses
+      `ORDER BY <Version|UpdatedAt> DESC LIMIT 1` to pick the latest
+      version. This loads every unmerged version of every matching row
+      into memory before sorting. Use the IN-tuple dedup pattern
+      (lightweight key columns inner subquery + heavy columns in the
+      outer select). See
+      `dev/docs/best_practices/clickhouse-queries.md` § Anti-Pattern 1.
+    severity: WARNING
+    languages: [generic]
+    paths:
+      include:
+        - "langwatch/src/server/clickhouse/**/*.ts"
+        - "langwatch/src/server/clickhouse/**/*.sql"
+      exclude:
+        - "**/migrations/**"
+        - "**/__tests__/**"
+        - "**/*.test.ts"
+        - "**/*.spec.ts"
+    patterns:
+      - pattern-regex: '(Messages|ComputedInput|Inputs|Details|SpanAttributes|RoleCosts|Metadata)\b'
+      - pattern-regex: 'ORDER\s+BY\s+\w*(Version|UpdatedAt)\s+DESC\s+LIMIT\s+1'

--- a/.semgrep/langwatch.yml
+++ b/.semgrep/langwatch.yml
@@ -33,25 +33,25 @@ rules:
     patterns:
       - pattern-either:
           # Literal PII keys
-          - pattern: logger.$LEVEL($..., { ..., email: $E, ... }, $...)
-          - pattern: logger.$LEVEL($..., { ..., phone: $P, ... }, $...)
-          - pattern: logger.$LEVEL($..., { ..., userId: $U, ... }, $...)
-          - pattern: logger.$LEVEL($..., { ..., apiKey: $K, ... }, $...)
-          - pattern: logger.$LEVEL($..., { ..., token: $T, ... }, $...)
-          - pattern: console.$LEVEL($..., { ..., email: $E, ... }, $...)
-          - pattern: console.$LEVEL($..., { ..., userId: $U, ... }, $...)
-          - pattern: console.$LEVEL($..., { ..., apiKey: $K, ... }, $...)
-          - pattern: console.$LEVEL($..., { ..., token: $T, ... }, $...)
+          - pattern: 'logger.$LEVEL($..., { ..., email: $E, ... }, $...)'
+          - pattern: 'logger.$LEVEL($..., { ..., phone: $P, ... }, $...)'
+          - pattern: 'logger.$LEVEL($..., { ..., userId: $U, ... }, $...)'
+          - pattern: 'logger.$LEVEL($..., { ..., apiKey: $K, ... }, $...)'
+          - pattern: 'logger.$LEVEL($..., { ..., token: $T, ... }, $...)'
+          - pattern: 'console.$LEVEL($..., { ..., email: $E, ... }, $...)'
+          - pattern: 'console.$LEVEL($..., { ..., userId: $U, ... }, $...)'
+          - pattern: 'console.$LEVEL($..., { ..., apiKey: $K, ... }, $...)'
+          - pattern: 'console.$LEVEL($..., { ..., token: $T, ... }, $...)'
           # Spread of a user/session/account object
-          - pattern: logger.$LEVEL($..., { ...$USER, $... }, $...)
-          - pattern: console.$LEVEL($..., { ...$USER, $... }, $...)
+          - pattern: 'logger.$LEVEL($..., { ...$USER, $... }, $...)'
+          - pattern: 'console.$LEVEL($..., { ...$USER, $... }, $...)'
           # Shorthand property with a user-shaped name
-          - pattern: logger.$LEVEL($..., { user: $U, $... }, $...)
-          - pattern: logger.$LEVEL($..., { session: $S, $... }, $...)
-          - pattern: logger.$LEVEL($..., { account: $A, $... }, $...)
-          - pattern: logger.$LEVEL($..., { user }, $...)
-          - pattern: logger.$LEVEL($..., { session }, $...)
-          - pattern: logger.$LEVEL($..., { account }, $...)
+          - pattern: 'logger.$LEVEL($..., { user: $U, $... }, $...)'
+          - pattern: 'logger.$LEVEL($..., { session: $S, $... }, $...)'
+          - pattern: 'logger.$LEVEL($..., { account: $A, $... }, $...)'
+          - pattern: 'logger.$LEVEL($..., { user }, $...)'
+          - pattern: 'logger.$LEVEL($..., { session }, $...)'
+          - pattern: 'logger.$LEVEL($..., { account }, $...)'
 
   # ── PII regex literals outside fixtures ────────────────────────────────
   # SSN dropped: 3-2-4-digit regex false-positives on dates (`2026-05-21`),
@@ -116,9 +116,9 @@ rules:
         - "**/*.spec.ts"
     patterns:
       - pattern-either:
-          - pattern: clickhouse.query({ query: $Q, ... })
-          - pattern: clickhouse.exec({ query: $Q, ... })
-          - pattern: clickhouseClient.query({ query: $Q, ... })
+          - pattern: 'clickhouse.query({ query: $Q, ... })'
+          - pattern: 'clickhouse.exec({ query: $Q, ... })'
+          - pattern: 'clickhouseClient.query({ query: $Q, ... })'
       - pattern-not-regex: 'TenantId\s*=\s*\{tenantId'
 
   # ── ClickHouse dedup anti-pattern: ORDER BY … LIMIT 1 + heavy cols ─────

--- a/.semgrep/langwatch.yml
+++ b/.semgrep/langwatch.yml
@@ -1,0 +1,88 @@
+# Semgrep rules — semantic patterns CodeRabbit's path_instructions can't
+# express deterministically. Loaded via reviews.tools.semgrep.config_file
+# in /.coderabbit.yaml.
+#
+# Highest-value rule per #3754 Investigation #6: PII-in-logger
+# (only 3 audit hits — easy to baseline-clear, high signal).
+
+rules:
+  # ── PII in logger calls ────────────────────────────────────────────────
+  - id: pii-in-logger-call
+    message: >
+      Logger call references PII fields (email, phone, name, ip, userId,
+      apiKey, token, etc.) without redaction. Wrap with `redact(...)` or
+      `hashEmail(...)`, or pass the minimal non-identifying fields needed
+      for debugging. See #3754 AC2.
+    severity: WARNING
+    languages: [typescript, javascript]
+    paths:
+      include:
+        - "langwatch/src/**/*.ts"
+        - "langwatch/src/**/*.tsx"
+      exclude:
+        - "**/__tests__/**"
+        - "**/*.test.ts"
+        - "**/*.test.tsx"
+        - "**/*.spec.ts"
+        - "**/*.spec.tsx"
+        - "**/__fixtures__/**"
+    patterns:
+      - pattern-either:
+          - pattern: logger.$LEVEL($..., { ..., email: $E, ... }, $...)
+          - pattern: logger.$LEVEL($..., { ..., phone: $P, ... }, $...)
+          - pattern: logger.$LEVEL($..., { ..., userId: $U, ... }, $...)
+          - pattern: logger.$LEVEL($..., { ..., apiKey: $K, ... }, $...)
+          - pattern: logger.$LEVEL($..., { ..., token: $T, ... }, $...)
+          - pattern: console.$LEVEL($..., { ..., email: $E, ... }, $...)
+          - pattern: console.$LEVEL($..., { ..., userId: $U, ... }, $...)
+          - pattern: console.$LEVEL($..., { ..., apiKey: $K, ... }, $...)
+          - pattern: console.$LEVEL($..., { ..., token: $T, ... }, $...)
+
+  # ── PII regex literals outside fixtures ────────────────────────────────
+  - id: pii-literal-ssn
+    message: >
+      String literal matches US SSN shape (NNN-NN-NNNN). PII literals
+      should not appear in production code — use a fixture under
+      `**/__fixtures__/**` if this is a test value.
+    severity: WARNING
+    languages: [typescript, javascript, python]
+    paths:
+      exclude:
+        - "**/__fixtures__/**"
+        - "**/*.test.*"
+        - "**/*.spec.*"
+        - "**/migrations/**"
+    pattern-regex: '"\d{3}-\d{2}-\d{4}"'
+
+  - id: pii-literal-api-key
+    message: >
+      String literal matches API key prefix (`sk_live_`, `pk_live_`,
+      `xai-`, `sk-`, `lw_`). Use env-var indirection — never check live
+      keys into source. Gitleaks should also catch this; this rule
+      catches near-misses that gitleaks lets through.
+    severity: ERROR
+    languages: [typescript, javascript, python]
+    paths:
+      exclude:
+        - "**/__fixtures__/**"
+        - "**/*.test.*"
+        - "**/*.spec.*"
+    pattern-regex: '"(sk_live_|pk_live_|xai-|sk-proj-|sk-ant-)[A-Za-z0-9_-]{16,}"'
+
+  # ── ClickHouse migrations: unqualified table names only ────────────────
+  - id: clickhouse-no-qualified-table
+    message: >
+      ClickHouse migrations must use unqualified table names — they run
+      against the connected database. `${CLICKHOUSE_DATABASE}.<table>`
+      or `langwatch.<table>` breaks BYOC deployments where the database
+      name differs.
+    severity: WARNING
+    languages: [generic]
+    paths:
+      include:
+        - "**/clickhouse/migrations/**/*.sql"
+        - "**/clickhouse/migrations/**/*.ts"
+        - "**/clickhouse/migrations/**/*.go"
+    pattern-either:
+      - pattern-regex: '\$\{CLICKHOUSE_DATABASE\}\.\w+'
+      - pattern-regex: '\blangwatch\.[a-z_]+\b'

--- a/.semgrep/langwatch.yml
+++ b/.semgrep/langwatch.yml
@@ -7,6 +7,10 @@
 
 rules:
   # ── PII in logger calls ────────────────────────────────────────────────
+  # Pattern enumeration: literal email/userId/etc. keys, spread of User-named
+  # variables, shorthand property where the value-name suggests a user object.
+  # Doesn't catch `logger.info("msg", user)` — that needs taint-mode (deferred
+  # to a follow-up if AC6 shows the shape mismatters).
   - id: pii-in-logger-call
     message: >
       Logger call references PII fields (email, phone, name, ip, userId,
@@ -28,6 +32,7 @@ rules:
         - "**/__fixtures__/**"
     patterns:
       - pattern-either:
+          # Literal PII keys
           - pattern: logger.$LEVEL($..., { ..., email: $E, ... }, $...)
           - pattern: logger.$LEVEL($..., { ..., phone: $P, ... }, $...)
           - pattern: logger.$LEVEL($..., { ..., userId: $U, ... }, $...)
@@ -37,23 +42,21 @@ rules:
           - pattern: console.$LEVEL($..., { ..., userId: $U, ... }, $...)
           - pattern: console.$LEVEL($..., { ..., apiKey: $K, ... }, $...)
           - pattern: console.$LEVEL($..., { ..., token: $T, ... }, $...)
+          # Spread of a user/session/account object
+          - pattern: logger.$LEVEL($..., { ...$USER, $... }, $...)
+          - pattern: console.$LEVEL($..., { ...$USER, $... }, $...)
+          # Shorthand property with a user-shaped name
+          - pattern: logger.$LEVEL($..., { user: $U, $... }, $...)
+          - pattern: logger.$LEVEL($..., { session: $S, $... }, $...)
+          - pattern: logger.$LEVEL($..., { account: $A, $... }, $...)
+          - pattern: logger.$LEVEL($..., { user }, $...)
+          - pattern: logger.$LEVEL($..., { session }, $...)
+          - pattern: logger.$LEVEL($..., { account }, $...)
 
   # ── PII regex literals outside fixtures ────────────────────────────────
-  - id: pii-literal-ssn
-    message: >
-      String literal matches US SSN shape (NNN-NN-NNNN). PII literals
-      should not appear in production code — use a fixture under
-      `**/__fixtures__/**` if this is a test value.
-    severity: WARNING
-    languages: [typescript, javascript, python]
-    paths:
-      exclude:
-        - "**/__fixtures__/**"
-        - "**/*.test.*"
-        - "**/*.spec.*"
-        - "**/migrations/**"
-    pattern-regex: '"\d{3}-\d{2}-\d{4}"'
-
+  # SSN dropped: 3-2-4-digit regex false-positives on dates (`2026-05-21`),
+  # version strings, etc. The investigation didn't cite an SSN leak; bring
+  # the rule back when one exists.
   - id: pii-literal-api-key
     message: >
       String literal matches API key prefix (`sk_live_`, `pk_live_`,
@@ -70,19 +73,20 @@ rules:
     pattern-regex: '"(sk_live_|pk_live_|xai-|sk-proj-|sk-ant-)[A-Za-z0-9_-]{16,}"'
 
   # ── ClickHouse migrations: unqualified table names only ────────────────
+  # Anchored to SQL DDL keywords to avoid matching `langwatch.io`,
+  # comment tokens, etc.
   - id: clickhouse-no-qualified-table
     message: >
       ClickHouse migrations must use unqualified table names — they run
       against the connected database. `${CLICKHOUSE_DATABASE}.<table>`
-      or `langwatch.<table>` breaks BYOC deployments where the database
-      name differs.
+      or `langwatch.<table>` in a DDL context breaks BYOC deployments
+      where the database name differs.
     severity: WARNING
     languages: [generic]
     paths:
       include:
-        - "**/clickhouse/migrations/**/*.sql"
-        - "**/clickhouse/migrations/**/*.ts"
-        - "**/clickhouse/migrations/**/*.go"
+        - "langwatch/src/server/clickhouse/migrations/**/*.sql"
+        - "langwatch/src/server/clickhouse/migrations/**/*.ts"
     pattern-either:
       - pattern-regex: '\$\{CLICKHOUSE_DATABASE\}\.\w+'
-      - pattern-regex: '\blangwatch\.[a-z_]+\b'
+      - pattern-regex: '\b(FROM|JOIN|INTO|UPDATE|TABLE|VIEW|EXISTS|DROP)[[:space:]]+langwatch\.[a-z_]+'

--- a/.semgrep/langwatch.yml
+++ b/.semgrep/langwatch.yml
@@ -32,26 +32,28 @@ rules:
         - "**/__fixtures__/**"
     patterns:
       - pattern-either:
-          # Literal PII keys
-          - pattern: 'logger.$LEVEL($..., { ..., email: $E, ... }, $...)'
-          - pattern: 'logger.$LEVEL($..., { ..., phone: $P, ... }, $...)'
-          - pattern: 'logger.$LEVEL($..., { ..., userId: $U, ... }, $...)'
-          - pattern: 'logger.$LEVEL($..., { ..., apiKey: $K, ... }, $...)'
-          - pattern: 'logger.$LEVEL($..., { ..., token: $T, ... }, $...)'
-          - pattern: 'console.$LEVEL($..., { ..., email: $E, ... }, $...)'
-          - pattern: 'console.$LEVEL($..., { ..., userId: $U, ... }, $...)'
-          - pattern: 'console.$LEVEL($..., { ..., apiKey: $K, ... }, $...)'
-          - pattern: 'console.$LEVEL($..., { ..., token: $T, ... }, $...)'
-          # Spread of a user/session/account object
-          - pattern: 'logger.$LEVEL($..., { ...$USER, $... }, $...)'
-          - pattern: 'console.$LEVEL($..., { ...$USER, $... }, $...)'
-          # Shorthand property with a user-shaped name
-          - pattern: 'logger.$LEVEL($..., { user: $U, $... }, $...)'
-          - pattern: 'logger.$LEVEL($..., { session: $S, $... }, $...)'
-          - pattern: 'logger.$LEVEL($..., { account: $A, $... }, $...)'
-          - pattern: 'logger.$LEVEL($..., { user }, $...)'
-          - pattern: 'logger.$LEVEL($..., { session }, $...)'
-          - pattern: 'logger.$LEVEL($..., { account }, $...)'
+          # Literal PII keys anywhere in an object argument. Semgrep ellipsis is
+          # `...` (the bare token); `$...` is NOT valid semgrep and fails to
+          # parse — see #3754 (semgrep --validate is now a CI gate).
+          - pattern: 'logger.$LEVEL(..., { ..., email: $E, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., phone: $P, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., userId: $U, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., apiKey: $K, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., token: $T, ... }, ...)'
+          - pattern: 'console.$LEVEL(..., { ..., email: $E, ... }, ...)'
+          - pattern: 'console.$LEVEL(..., { ..., userId: $U, ... }, ...)'
+          - pattern: 'console.$LEVEL(..., { ..., apiKey: $K, ... }, ...)'
+          - pattern: 'console.$LEVEL(..., { ..., token: $T, ... }, ...)'
+          # Spread of a user/session/account object.
+          - pattern: 'logger.$LEVEL(..., { ...$USER, ... }, ...)'
+          - pattern: 'console.$LEVEL(..., { ...$USER, ... }, ...)'
+          # Shorthand / named property with a user-shaped name.
+          - pattern: 'logger.$LEVEL(..., { ..., user: $U, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., session: $S, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., account: $A, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., user, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., session, ... }, ...)'
+          - pattern: 'logger.$LEVEL(..., { ..., account, ... }, ...)'
 
   # ── PII regex literals outside fixtures ────────────────────────────────
   # SSN dropped: 3-2-4-digit regex false-positives on dates (`2026-05-21`),

--- a/.semgrep/tests/pii-in-logger-call.ts
+++ b/.semgrep/tests/pii-in-logger-call.ts
@@ -1,0 +1,14 @@
+// ruleid: pii-in-logger-call
+logger.info("login", { email: user.email, id: 1 });
+// ruleid: pii-in-logger-call
+logger.warn({ userId: u.id });
+// ruleid: pii-in-logger-call
+console.error("oops", { token: t });
+// ruleid: pii-in-logger-call
+logger.debug({ ...currentUser });
+// ruleid: pii-in-logger-call
+logger.info({ user });
+// ok: pii-in-logger-call
+logger.info("clean", { id: 1, role: "admin" });
+// ok: pii-in-logger-call
+logger.warn("just a message");


### PR DESCRIPTION
## Summary

- Move CodeRabbit off dashboard defaults onto a committed config so opinionated checks can block merges (`profile: assertive`, `request_changes_workflow: true`).
- Three-tier rule encoding:
  - **`path_instructions`** for judgment-level rules (PII in logging/endpoints, tRPC Zod, repository/service naming + layering, class components, Vitest > Jest, reversible migrations, plus 8 rules sourced from `dev/docs/best_practices/` and `dev/docs/design/`: hooks-must-not-return-JSX, exhaustive switches, named params, archivedAt-not-deletedAt, KSUIDs at service/repo, ClickHouse heavy-column dedup anti-patterns, form-no-pre-disable, prefer-Drawer-over-Modal).
  - **`.coderabbit/ast-grep/rules/`** for deterministic syntactic checks — 10 rule files (4 ts/tsx pairs for explicit-any, inline-dynamic-import, export-star-shim, localhost-fallback, plus form-watch-in-child and form-disable-on-isvalid).
  - **`.semgrep/langwatch.yml`** for semantic patterns — PII in logger (literal-key, spread, shorthand), PII API-key regex, ClickHouse qualified-table ban, ClickHouse TenantId-required, ClickHouse heavy-column dedup.
- `knowledge_base.code_guidelines` indexes `CLAUDE.md`, `dev/docs/best_practices/**`, `dev/docs/design/**`, `dev/docs/adr/**`, `docs/adr/**` so CR cites the house-style source in its review comments.
- Add a deployment-surface impact guard that fails when PRs touching `charts/`, `services/`, `dev/docs/adr/`, `dev/docs/best_practices/`, `langwatch/.env.example`, or `docs/self-hosting/**` ship without an operator/deployment-impact section.
- Pin `gitleaks` and `semgrep` on explicitly.

Validated against [schema.v2.json](https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json) with `jsonschema` (Draft 7).

Closes #3754.

## AC coverage

- [x] **AC1** — `.coderabbit.yaml` at repo root, schema-valid, `reviews.request_changes_workflow: true`.
- [x] **AC2** — PII rules via `path_instructions` covering logging/analytics PII, endpoint shape, PII regex literals, plus `gitleaks` + `semgrep` enabled in `reviews.tools`.
- [x] **AC3** — Coding-standards `path_instructions` for the full list in the issue (no `any`, tRPC Zod, service layering, function components, Vitest, no inline `import()`, no localhost fallbacks, no re-export shims, Hono → services, repo/service naming, `useWatch` not `form.watch()` in children, reversible migrations, unqualified ClickHouse tables).
- [x] **AC4** — Structural `\${...}` guard (carry-over from PR #3752 commit fa3bbc7).
- [x] **AC5** — Deployment-surface impact guard with explicit required-section list.
- [ ] **AC6** — Smoke-test PR pending (see Test Plan below). PR stays in draft until that lands.

## Non-goals (per issue)

- Org-level `.coderabbit.yaml` in `langwatch/.github` — keep repo-local.
- Knowledge-base / learnings file — `knowledge_base.{learnings,issues}.scope: local` only.

> Originally the issue listed "AST-grep custom rules — defer" as a non-goal. Reversed mid-stream: AC6 smoke-test (#4166) showed `path_instructions` couldn't reliably catch the syntactic shapes (`any`, inline `import()`, `export *`, localhost fallback, form.watch in child). The ast-grep `rule_dirs` approach gave deterministic, reproducible enforcement instead, so the rules now live under `.coderabbit/ast-grep/rules/`.

## Test Plan

- [x] YAML schema-validated locally (`jsonschema` Draft 7).
- [ ] **AC6 smoke test:** open a throwaway PR that intentionally violates at least one rule per category and confirm CodeRabbit requests changes on each. Categories to cover:
  - [ ] `\${UNEXPANDED}` directory or filename added.
  - [ ] `console.log({ user: { email: ... } })` added without redaction.
  - [ ] String literal matching the SSN / credit-card / `sk_live_` regex outside a fixture.
  - [ ] New `.ts` file using `any` and an inline `import("...")`.
  - [ ] tRPC procedure without `.input(z.object({...}))`.
  - [ ] React class component.
  - [ ] Test using `jest.fn`.
  - [ ] Migration without a `down`/`Down` step and without an `IRREVERSIBLE:` comment.
  - [ ] ClickHouse migration referencing `\${CLICKHOUSE_DATABASE}.<table>`.
  - [ ] Service-layer file importing from `~/components`.
  - [ ] `form.watch()` inside a child component receiving `form` as prop.
  - [ ] `?? "http://localhost..."` env fallback.
  - [ ] Charts/services/env.example change without an Operator/deployment-impact section.
  - [ ] Capture each CodeRabbit review verdict (link or screenshot) in the smoke-test PR description.
- [ ] After AC6 passes, flip this PR to ready and merge.

## Operator / deployment impact

None — pure repo metadata. CodeRabbit reads the YAML from the default branch at PR time; no runtime impact, no env vars, no helm values, no BYOC dataplane impact. The new rules take effect on the next PR opened after this merges.

## References

- Predecessor draft + path_filters bug-fix: PR #3752 commits 74debfa, fa3bbc7 (reverted in d4fa05c).
- Original leak that motivated the structural guard: PR #3476.
- Concrete evidence for AC3/AC5 rules: PR #4058 review history.
- Docs: https://docs.coderabbit.ai/getting-started/configure-coderabbit
- Schema: https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json

# Related Issue

- Resolve #3754

### AC6 — CodeRabbit verdict on smoke v3 (PR #4174)

Validated against PR https://github.com/langwatch/langwatch/pull/4174 (CR review CHANGES_REQUESTED at 2026-05-22T11:20:57Z, 19 review threads across 8 fixture files). Base = `issue3754/customize-coderabbit-with-committed-coderab` so CR loaded the expanded ruleset from PR #4162.

#### All 8 newly-added rules fired

| Rule | Fixture | Verdict | Evidence |
|---|---|---|---|
| Hooks must not return JSX (`react.md`) | `langwatch/src/components/hooks/useReturnsJsx.tsx:7` | ✅ | *"Line 7 returns JSX directly from a hook. As per coding guidelines: FAIL when a hook function (name starts with use) returns JSX"* |
| Hook files must be `.ts` not `.tsx` (`react.md`) | `langwatch/src/components/hooks/useReturnsJsx.tsx:1` | ✅ | *"This hook file is useReturnsJsx.tsx; hook files in this path must not be .tsx"* |
| Exhaustive switch with `never` check (`typescript.md`) | `langwatch/src/server/exhaustive-violation.ts:13` | ✅ | *"Make the union switch exhaustive with a never default check. Lines 6–13 add a new switch over a union without an exhaustiveness guard in default"* |
| Named params for 2+ positional same-type (`typescript.md`) | `langwatch/src/server/exhaustive-violation.ts:17` + `dedup-anti-pattern-violation.ts:4` | ✅ ×2 | *"Replace positional string args with named parameters object. Line 17 introduces 3 same-primitive positional params in an exported function"* |
| `archivedAt` not `deletedAt` (`soft-delete-vs-archive.md`) | `langwatch/src/server/prisma-deleted-at-violation.ts:7` | ✅ | *"Use archivedAt, not new deletedAt, in server-layer soft-delete semantics. Lines 7 and 14 introduce deletedAt in type and write path; this repo's pattern is archivedAt with archived-aware find methods"* |
| KSUID at service/repo for user-facing IDs (`ksuids.md`) | `langwatch/src/server/repositories/ksuid-violation.ts:8` | ✅ | *"Generate prefixed KSUID in repository create for user-facing entities. Lines 7–8 create a user-facing entity without explicit generate(KSUID_RESOURCES.X).toString() id assignment"* |
| ClickHouse heavy-column dedup anti-pattern (`clickhouse-queries.md`) | `langwatch/src/server/clickhouse/dedup-anti-pattern-violation.ts:12` | ✅ | *"Replace heavy-column ORDER BY ... LIMIT 1 dedup pattern. Lines 8–12 match the prohibited ClickHouse anti-pattern for heavy columns"* |
| ClickHouse TenantId-required + SQL-injection guard (`clickhouse-queries.md`) | `langwatch/src/server/clickhouse/dedup-anti-pattern-violation.ts:10` | ✅ Critical | *"Stop interpolating key directly into SQL. Line 10 is SQL-injection prone and, with no tenant predicate, can return cross-tenant data. Use parameterized queries and apply tenantId in WHERE"* |
| Form: no pre-disable on `!isValid` (`design/guidelines.md` § 6 + ADR-018) | `langwatch/src/components/FormDisableViolation.tsx:10` | ✅ | *"Remove validity-gated submit disabling. Line 10 violates the rule: disabled={!form.formState.isValid} is disallowed for new submit buttons; disable only while request is pending"* |

#### v2 relocations now firing

The fixture at `langwatch/src/server/judgment-violations.tsx` (relocated from v2's `langwatch/src/judgment-violations.ts` per CR's direct suggestion) lights up all 3 expected rules:

| Rule | Verdict | Evidence |
|---|---|---|
| tRPC missing `.input(z.object(...))` | ✅ | `judgment-violations.tsx:13` — *"Add explicit .input(z.object(...)) (or z.void()) to the procedure"* |
| Class component ban | ✅ | `judgment-violations.tsx:17` — *"Replace class component with function component + hooks. Line 17 introduces a new React class component"* |
| Service→UI layering | ✅ | `judgment-violations.tsx:9` — *"Remove UI import from server-layer module. Line 9 in a server file imports from ~/components, violating dependency direction"* |

#### Still silent

| Rule | Fixture | Hypothesis |
|---|---|---|
| `no-export-star-shim` (ast-grep) | `langwatch/src/components/barrel-test.ts:6` — `export * from "./FormDisableViolation";` | CR's ast-grep loader is not running this rule. CR DID review the file (thread on `barrel-test.ts:3` flagging the restatement comments) so the file is in scope. Both `kind: export_statement` + `regex` (current simplified shape) and the prior `pattern: export * from $MOD` + `not.follows` shape went silent on v2 and v3. CR's ast-grep version (v0.42.2 per schema) parses these locally — the gap is in CR's loader, not the rule. |

#### Counts

- ✅ New rules firing: 8 of 8 (Hooks-no-JSX, .tsx-hook-file, exhaustive-switch, named-params, archivedAt-not-deletedAt, KSUID, ClickHouse-dedup-anti-pattern, ClickHouse-TenantId, no-form-disable-on-isvalid)
- ✅ v2 relocations firing: 3 of 3 (tRPC, class-component, service→component)
- ✅ Bonus catch: ClickHouse SQL-injection guard surfaced as Critical alongside TenantId rule
- ❌ Still silent: 1 (`no-export-star-shim`) — tracked as #3754 follow-up

#### Follow-ups (carry forward to PR #4162)

1. **`no-export-star-shim` final diagnosis** — two rule shapes have gone silent in CR sandboxes despite local ast-grep 0.42.3 firing on the same fixture. Next steps: (a) drop ast-grep entirely for this rule and move to semgrep `pattern-regex: '^export \* from'` since semgrep's loader has worked reliably, or (b) replace with a path_instructions block that asks CR to flag `export * from` in TS/TSX directly.
2. **Comments-restate-code AC7 rule is firing hot** — every fixture got a "delete restatement comments" thread. The rule works, but on smoke fixtures (where comments deliberately describe the violation) it overshadows the actual rule under test. Not a real bug, but worth noting that on production PRs this rule will be active and authors should write *why*-comments only.
3. **JSDoc-on-exported AC8 rule is also firing hot** — same shape: smoke fixtures didn't bother with JSDocs and got flagged. Real behavior.

Verdict map produced 2026-05-22 by AC6 smoke v3 (PR https://github.com/langwatch/langwatch/pull/4174, closed after this paste lands).

---

### Earlier verdict (smoke v2 — historical)

### AC6 — CodeRabbit verdict on smoke v2 (PR #4170)

Validated against PR https://github.com/langwatch/langwatch/pull/4170 (CR review submitted 2026-05-21T22:29:02Z, 9 actionable + 6 nitpick comments across 19 review threads).

Mapping the 16 smoke categories against CR's output, with focus on the 4 previously-silent items:

| # | Category | First smoke (#4166) | This smoke (#4170) | Notes |
|---|---|---|---|---|
| 1 | Structural `${...}` guard | ✅ | n/a (file unchanged) | Carried forward |
| 2 | PII in logger (5 sites) | ✅ | ⚠️ subsumed | CR mentions the file but no per-site thread fired — review is incremental, prior comments may have been counted |
| 3 | PII literal API key | ✅ | ⚠️ subsumed | Same — file in scope, no new thread |
| 4 | ClickHouse qualified table | ⚠️ partial | ⚠️ partial | CR flagged as "goose will fail" + suggested adding TenantId rule — semgrep rule fired (it's the source of the comment) |
| 5 | Irreversible migration | ✅ | ✅ | Thread on `9999_irreversible_violation.sql:8` — "Provide a Down migration or add IRREVERSIBLE justification" |
| 6 | Big file > 300 lines | ✅ | ✅ (×10) | Threads on big-file-violation.ts lines 6-15 |
| 7 | tRPC Zod gate | ✅ | ❌ silent | `noInputProcedure` lives in `langwatch/src/judgment-violations.ts` — the file is outside the tRPC rule's new narrow glob. Smoke fixture needs to move. |
| 8 | Service→component layering | ❌ silent | ✅ rule-correct, fixture-misplaced | **CR caught the glob mismatch directly**: "File path doesn't match service-layer rule glob… the file is located at langwatch/src/judgment-violations.ts… the rule uses glob langwatch/src/{server,services}/**/*.{ts,tsx}". The new glob is correct; the smoke fixture is in the wrong directory. |
| 9 | Class component ban | ✅ | ❌ silent | Same root cause: lives inside `judgment-violations.ts`. |
| 10 | Localhost fallback (literal) | ✅ | ✅ | Thread on `syntactic-violations.ts:20` |
| 11 | Localhost fallback (template) | ✅ | ✅ | Thread on `syntactic-violations.ts:22` |
| 12 | `form.watch()` in child (arrow) | ✅ | ⚠️ subsumed | tsx file in CR scope, no new per-line thread |
| 13 | `form.watch()` in child (bare param) | ✅ | ⚠️ subsumed | Same |
| 14 | `form.watch()` in child (function_declaration) | ✅ | ⚠️ subsumed | Same |
| 15 | `no-explicit-any` | ❌ silent | ✅ FIXED | Thread on `syntactic-violations.ts:11` — "Avoid explicit any types. This function uses explicit any in three places: parameter type annotation input: any, return type annotation : any, type assertion as any" |
| 16 | `no-inline-dynamic-import` | ❌ silent | ✅ FIXED | Thread on `syntactic-violations.ts:16` — "Avoid inline dynamic imports. The inline import('node:fs') call should be moved to a top-level static import" |
| — | `no-export-star-shim` | ❌ silent | ❌ still silent | File `langwatch/src/export-star-shim-violation.ts` is in CR scope but no thread fired. **Hypothesis**: ast-grep's `kind: export_statement` + `regex: '^export \* from'` validated locally but CR's loader may not be running the rule (rule_dirs path resolution, file too short for diff-line filter, or CR essentials package overriding the custom rule). Needs second-pass diagnosis. |

### Counts

- ✅ Fires reliably: 8 (incl. 2 of 4 previously-silent now FIXED — explicit-any, inline-dynamic-import)
- ✅ Rule correct, smoke fixture in wrong place: 3 (service→component, tRPC, class-component — all inside `judgment-violations.ts` which falls outside the new narrow glob)
- ⚠️ Subsumed by incremental review (previously fired, file unchanged): 4
- ⚠️ Partial: 1 (ClickHouse — fires as DDL-failure, not as the canonical AC3 phrasing)
- ❌ Still silent: 1 (`no-export-star-shim`) — needs second-pass diagnosis

### Follow-ups

1. **`no-export-star-shim`**: investigate why CR's ast-grep loader skips it despite local 0.42.3 validating the rule fires on the fixture. Candidates: (a) CR's ast-grep version <0.42.x, (b) `not.follows` with `regex` constraint behaves differently in CR's sandbox, (c) `kind: export_statement` + sibling `regex:` combo in `all:` block rejected silently.
2. **Smoke fixture relocation**: move `langwatch/src/judgment-violations.ts` → `langwatch/src/server/judgment-violations.ts` to validate tRPC, class-component, and service→component as a third-smoke pass. (Or accept that the existing rules are correct based on (8)'s direct verdict and move on.)
3. **AC1b branch-protection**: capture CR's status-check name (visible on this PR — see check names in `gh pr checks 4170 --json name`).
4. **Daemon gap**: file git-orchard-rs issue for `pullRequest.reviews{}` returning null on cross-org repos like langwatch — used gh repeatedly this session.

Verdict map produced 2026-05-21 by AC6 smoke v2 (PR https://github.com/langwatch/langwatch/pull/4170, closed after this paste lands).
