### PR TITLE
fix(groupQueue): update tenant cap test to match new default of 50

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tenantCap.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tenantCap.unit.test.ts
@@ -4,7 +4,7 @@ import { DEFAULT_TENANT_CAP, readTenantCap } from "../scripts";
 /**
  * The tenant soft-cap is a defense added post-2026-05-11 incident.
  * As of the noisy-neighbour follow-up it ships ON by default
- * (DEFAULT_TENANT_CAP = 100) so every install gets baseline protection
+ * (DEFAULT_TENANT_CAP = 50) so every install gets baseline protection
  * without explicit configuration. Operators retune or kill via
  * LANGWATCH_DISPATCH_TENANT_CAP — these tests pin that contract so a
  * future refactor cannot silently change the default.
@@ -25,10 +25,10 @@ describe("readTenantCap", () => {
     }
   });
 
-  /** @scenario Tenant cap defaults to 100 when env var is unset */
+  /** @scenario Tenant cap defaults to 50 when env var is unset */
   it("defaults to DEFAULT_TENANT_CAP when env var is unset", () => {
     expect(readTenantCap()).toBe(DEFAULT_TENANT_CAP);
-    expect(DEFAULT_TENANT_CAP).toBe(100);
+    expect(DEFAULT_TENANT_CAP).toBe(50);
   });
 
   it("falls back to the default for empty string", () => {

--- a/specs/event-sourcing/tenant-soft-cap.feature
+++ b/specs/event-sourcing/tenant-soft-cap.feature
@@ -14,7 +14,7 @@ Feature: Per-tenant soft cap on in-flight dispatch
   # cluster capacity; the scheduler scans past its over-cap groups and
   # serves the rest of the fleet.
   #
-  # Ships ON by default (LANGWATCH_DISPATCH_TENANT_CAP unset → 100).
+  # Ships ON by default (LANGWATCH_DISPATCH_TENANT_CAP unset → 50).
   # Operators set =0 as an explicit kill switch, or =N to retune.
   # Sized at ≈ GLOBAL_QUEUE_CONCURRENCY so a tenant tops out at one
   # pod's worth of slots — strong protection on multi-pod clusters,
@@ -24,10 +24,10 @@ Feature: Per-tenant soft cap on in-flight dispatch
     Given the GroupQueue is running with Lua scripts deployed
 
   @unit @tenant-cap @env
-  Scenario: Tenant cap defaults to 100 when env var is unset
+  Scenario: Tenant cap defaults to 50 when env var is unset
     Given the env var "LANGWATCH_DISPATCH_TENANT_CAP" is not set
     When readTenantCap() is invoked
-    Then it returns 100
+    Then it returns 50
 
   @unit @tenant-cap @env
   Scenario: Explicit env=0 disables the tenant cap entirely (kill switch)


### PR DESCRIPTION
## Summary

- Update `tenantCap.unit.test.ts` assertion from `100` to `50` to match the `DEFAULT_TENANT_CAP` change in #4161

## Test plan

- [ ] `tenantCap.unit.test.ts` passes