### PR TITLE
fix(groupQueue): add 25ms throttle between dispatch batch iterations

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/dispatcher.ts
@@ -40,6 +40,9 @@ export class GroupQueueDispatcher {
           let dispatched: number;
           do {
             dispatched = await this.dispatchBatch();
+            if (dispatched > 0) {
+              await new Promise((resolve) => setTimeout(resolve, 25));
+            }
           } while (dispatched > 0 && !this.shutdownRequested);
 
           // Drain signals that arrived during dispatch to prevent


### PR DESCRIPTION
## Summary

- Adds a 25ms `setTimeout` pause between successful `dispatchBatch()` iterations in the dispatcher loop to prevent back-to-back Lua EVAL scripts from saturating Redis CPU
- Follows up on #4161 (reduced scan budget per EVAL) — without a pause the dispatcher just runs more iterations, keeping Redis at 100% CPU across 4 pods
- The sleep only fires when `dispatched > 0`, so the loop exits immediately when there's nothing left

**Why 25ms is safe:** 4 pods × 40 batches/sec × 200 max batch size = 32,000 dispatches/sec capacity. Current throughput is ~300 completed/sec — orders of magnitude of headroom.

## Test plan

- [ ] Verify existing `groupQueue.integration.test.ts` and `scripts.integration.test.ts` pass (no behavior change, existing timeouts absorb the 25ms)
- [ ] Monitor Redis CPU in production after deploy — should drop well below 100%