### PR TITLE
fix(groupQueue): cache tenant-over-cap lookups in dispatch Lua scripts

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -201,6 +201,9 @@ local scanBudget = 1000
 if tenantCap > 0 then scanBudget = 10000 end
 local offset = 0
 
+-- Cache tenant cap lookups within this EVAL to avoid redundant GETs.
+local tenantCapCache = {}
+
 while offset < scanBudget do
   local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", offset, pageSize)
   if #groups == 0 then return nil end
@@ -215,8 +218,13 @@ while offset < scanBudget do
         if slashPos and slashPos > 1 then
           local tenantId = string.sub(groupId, 1, slashPos - 1)
           tenantCountKey = keyPrefix .. "tenant_active:" .. tenantId
-          local n = tonumber(redis.call("GET", tenantCountKey)) or 0
-          if n >= tenantCap then tenantOverCap = true end
+          local cached = tenantCapCache[tenantId]
+          if cached == nil then
+            local n = tonumber(redis.call("GET", tenantCountKey)) or 0
+            cached = n >= tenantCap
+            tenantCapCache[tenantId] = cached
+          end
+          if cached then tenantOverCap = true end
         end
       end
 
@@ -342,6 +350,11 @@ local scanBudget = pageSize * 5
 if tenantCap > 0 then scanBudget = pageSize * 50 end
 local offset = 0
 
+-- Cache tenant cap lookups within this EVAL to avoid redundant GETs.
+-- When 1,800 groups belong to one over-cap tenant, this turns 1,800
+-- GET calls into 1 GET + 1,799 table lookups.
+local tenantCapCache = {}
+
 while offset < scanBudget and dispatched < maxJobs do
   local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", offset, pageSize)
   if #groups == 0 then break end
@@ -358,8 +371,13 @@ while offset < scanBudget and dispatched < maxJobs do
         if slashPos and slashPos > 1 then
           local tenantId = string.sub(groupId, 1, slashPos - 1)
           tenantCountKey = keyPrefix .. "tenant_active:" .. tenantId
-          local n = tonumber(redis.call("GET", tenantCountKey)) or 0
-          if n >= tenantCap then tenantOverCap = true end
+          local cached = tenantCapCache[tenantId]
+          if cached == nil then
+            local n = tonumber(redis.call("GET", tenantCountKey)) or 0
+            cached = n >= tenantCap
+            tenantCapCache[tenantId] = cached
+          end
+          if cached then tenantOverCap = true end
         end
       end
 
@@ -423,6 +441,11 @@ while offset < scanBudget and dispatched < maxJobs do
             if tenantCap > 0 and tenantCountKey then
               redis.call("INCR", tenantCountKey)
               redis.call("EXPIRE", tenantCountKey, activeTtlSec)
+              -- Invalidate cache — count changed, may now be at cap
+              local slashPos2 = string.find(groupId, "/", 1, true)
+              if slashPos2 then
+                tenantCapCache[string.sub(groupId, 1, slashPos2 - 1)] = nil
+              end
             end
 
             local dataKey = keyPrefix .. "group:" .. groupId .. ":data"


### PR DESCRIPTION
## Summary

Cache tenant cap check results within each dispatch EVAL call to eliminate redundant Redis GET commands when scanning over-cap tenant groups.

## The Problem

When one tenant has 1,800 queued groups and is at the 50-slot cap, the dispatcher scans all 1,800 groups per cycle. For each group it does:

```
SISMEMBER blocked     ← 1 Redis command
GET tenant_active:X   ← 1 Redis command (same answer every time for same tenant)
```

That's 1,800 identical `GET tenant_active` calls returning the same value. At 4 pods × continuous cycles = massive Redis command waste.

## The Fix

Add a Lua table cache (`tenantCapCache`) inside each EVAL. First lookup for a tenant does the GET and caches the result. Subsequent groups from the same tenant use the cached value — a Lua table lookup instead of a Redis command.

The cache is **invalidated after a successful dispatch** INCRs the tenant counter (the count changed, may now be at cap).

Applied to both `DISPATCH_LUA` and `DISPATCH_BATCH_LUA`.

## What This Does NOT Change

**Scan budget is unchanged** (`pageSize * 50`). Considered reducing it to `pageSize * 10` but investigation showed the over-cap tenant's groups cluster at the ZSET head — with a smaller budget, other tenants deeper in the ZSET would starve until the backlog clears. The wide budget ensures fairness at the cost of more Lua iterations, but each iteration is now cheaper thanks to the cache.

## Impact

Per EVAL cycle with 1,800 over-cap groups from one tenant:
- **Before**: 1,800 GET commands
- **After**: 1 GET command + 1,799 Lua table lookups

## Test plan

- [x] `pnpm test:integration` — 97/97 pass (includes tenant cap tests: INCRs, DECRs, widened scan budget, cap=0 kill switch)
- [ ] CI green
- [ ] Deploy and monitor Redis ops/sec reduction