### PR TITLE
fix(groupQueue): disable evaluationEsSync no-op reactor

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationEsSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationEsSync.reactor.ts
@@ -31,6 +31,13 @@ export function createEvaluationEsSyncReactor(
 ): ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData> {
   return {
     name: "evaluationEsSync",
+    options: {
+      // ES writes fully disabled since LangWatch 3.0 (ClickHouse is the sole
+      // data store). Without this flag the reactor still goes through the full
+      // STAGE → DISPATCH → COMPLETE lifecycle (~25 Redis commands per
+      // evaluation run) only to execute an empty handler.
+      disabled: true,
+    },
 
     async handle(
       _event: EvaluationProcessingEvent,


### PR DESCRIPTION
## Summary

Adds `disabled: true` to the `evaluationEsSync` reactor, which has been a no-op since LangWatch 3.0 (commit `1bdf97f`, April 8).

## The Problem

The reactor handler is:
```typescript
async handle(): Promise<void> {
  // ES writes are fully disabled — ClickHouse is the sole data store.
  return;
}
```

But without the `disabled` flag, every evaluation run still stages the reactor into the group queue. Each run goes through the full lifecycle:

1. `dispatchToReactors()` → `send()` → STAGE_LUA (~8 Redis commands)
2. Dispatcher picks it up → DISPATCH_BATCH_LUA (~10 Redis commands)
3. Worker executes `return;`
4. Worker calls COMPLETE → COMPLETE_LUA (~8 Redis commands)

**~25 Redis commands per evaluation run, to execute nothing.**

For one high-volume tenant in the last 3 hours: 321 evaluationEsSync groups = ~8,000 wasted Redis commands. Platform-wide the waste scales with evaluation volume.

## The Fix

```typescript
options: {
  disabled: true,
}
```

`projectionRouter.ts:632` checks this flag and skips the `send()` call entirely — no staging, no dispatch, no complete. The reactor stays registered in the pipeline for compatibility but never fires.

This is the same mechanism used by `traceUpdateBroadcast` (`disabled: deps.hasRedis === false`).

## Test plan

- [x] `pnpm test:unit` evaluation-processing — 33/33 pass
- [ ] CI green