### PR TITLE
fix(groupQueue): skip GET activeKey for over-cap groups in dispatch Lua

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -228,13 +228,14 @@ while offset < scanBudget do
         end
       end
 
-      local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-      -- Defensive activeKey check — covers legacy state during migration
-      -- and the small race between ZADD ready and ZADD active.
-      local activeJob = redis.call("GET", activeKey)
-      if (not activeJob) and (not tenantOverCap) then
-        local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
-        local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
+      if not tenantOverCap then
+        local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+        -- Defensive activeKey check — covers legacy state during migration
+        -- and the small race between ZADD ready and ZADD active.
+        local activeJob = redis.call("GET", activeKey)
+        if not activeJob then
+          local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
+          local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
         if #results >= 2 then
           local stagedJobId = results[1]
@@ -310,6 +311,7 @@ while offset < scanBudget do
           end
         end
       end
+      end
     end
   end
 
@@ -381,12 +383,13 @@ while offset < scanBudget and dispatched < maxJobs do
         end
       end
 
-      local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-      -- Defensive activeKey check — covers legacy state during migration
-      -- and the small race between ZADD ready and ZADD active.
-      local activeJob = redis.call("GET", activeKey)
+      if not tenantOverCap then
+        local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+        -- Defensive activeKey check — covers legacy state during migration
+        -- and the small race between ZADD ready and ZADD active.
+        local activeJob = redis.call("GET", activeKey)
 
-      if (not activeJob) and (not tenantOverCap) then
+        if not activeJob then
         local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
         local jobResults = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
@@ -471,6 +474,7 @@ while offset < scanBudget and dispatched < maxJobs do
             end
           end
         end
+      end
       end
     end
   end

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -228,14 +228,13 @@ while offset < scanBudget do
         end
       end
 
-      if not tenantOverCap then
-        local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-        -- Defensive activeKey check — covers legacy state during migration
-        -- and the small race between ZADD ready and ZADD active.
-        local activeJob = redis.call("GET", activeKey)
-        if not activeJob then
-          local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
-          local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
+      local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+      -- Defensive activeKey check — covers legacy state during migration
+      -- and the small race between ZADD ready and ZADD active.
+      local activeJob = redis.call("GET", activeKey)
+      if (not activeJob) and (not tenantOverCap) then
+        local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
+        local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
         if #results >= 2 then
           local stagedJobId = results[1]
@@ -310,7 +309,6 @@ while offset < scanBudget do
             end
           end
         end
-      end
       end
     end
   end


### PR DESCRIPTION
## Summary

- Hoists the `tenantOverCap` check above the `GET activeKey` in `DISPATCH_BATCH_LUA` (the hot dispatch path)
- Over-cap groups are already skipped — this avoids a wasted `GET` per group that the dispatch loop never uses
- Live measurement: ~355K unnecessary `GET` commands/sec eliminated when the ready ZSET is dominated by over-cap tenants (~50% reduction in wasted dispatch commands)

## Context

During morning burst peaks, over-cap tenants accumulate ~10K groups in the ready ZSET. The dispatcher scans through all of them (necessary to reach under-cap tenants deeper in the ZSET), doing `SISMEMBER` (blocked check) + `GET` (activeKey) per group. The `GET` result is unused because `tenantOverCap` short-circuits the condition on the next line. This saves the `GET` + string concat per over-cap group.

## Test plan

- [x] All 36 groupQueue unit tests pass
- [ ] Integration tests
- [ ] Monitor Redis `GET` command rate after deploy — expect ~50% reduction during over-cap scanning