### PR TITLE
[DO NOT MERGE] AC6 smoke v3: 8 new rules + relocated v2 misses (#3754)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -106,6 +106,13 @@ reviews:
     # export * from re-export shims) live in .coderabbit/ast-grep/rules/.
     # ClickHouse fully-qualified table names live in .semgrep/langwatch.yml.
     # path_instructions only carries the judgment calls.
+    #
+    # NOTE: each layering/convention rule below is in its own path_instructions
+    # block. Smoke testing (#4166) showed that bundling 4 unrelated FAIL
+    # conditions under one block caused CR to surface only 1 of them. Smaller
+    # focused blocks fire reliably.
+
+    # tRPC Zod gating — every router/procedure path.
     - path: "langwatch/src/**/*.{ts,tsx}"
       instructions: |
         Flag ONLY on newly added or modified lines.
@@ -114,17 +121,41 @@ reviews:
         `.input(z.object({...}))` or equivalent Zod schema — including
         procedures with no input (use `z.void()` or `z.object({})`).
 
-        FAIL when service-layer code (`langwatch/src/server/**`,
-        `langwatch/src/services/**`) imports from `~/components` or
-        `langwatch/src/components/**`. The server must not depend on UI.
+    # Service→UI layering guard. Glob scoped to the layers that must NOT
+    # import from UI. Smoke PR caught the violation as part of a generic
+    # comment, not surfaced under this rule — narrowing the glob makes CR
+    # consult this block only on those files, raising firing reliability.
+    - path: "langwatch/src/{server,services}/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
 
-        FAIL when a new React component is declared as a class component.
-        Use function components + hooks.
+        FAIL when this file imports from `~/components`, `~/components/...`,
+        or any `langwatch/src/components/**` path. Server-layer code and
+        service-layer code must not depend on UI components. The dependency
+        direction is UI → services → server, never the reverse.
+
+    # Class component ban — restrict to component-bearing surface to keep
+    # this from getting noisy on non-component files.
+    - path: "langwatch/src/**/*.tsx"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a new React component is declared as a class component
+        (`class X extends React.Component`, `class X extends Component`).
+        Use function components + hooks instead.
+
+    # Localhost-fallback judgment fallback (the ast-grep rule covers the
+    # syntactic shapes; this catches creative variations the syntactic
+    # rule misses).
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
 
         FAIL when code adds a default fallback URL of the form
-        `?? "http://localhost..."` or `?? "https://..."`. Required env vars
-        must be validated through the Zod env schema and consumed without
-        fallbacks.
+        `?? "http://localhost..."` or `?? "https://..."` (including
+        template-literal variants like `?? \`http://localhost:${...}\``).
+        Required env vars must be validated through the Zod env schema and
+        consumed without fallbacks.
 
     - path: "langwatch/package.json"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,286 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# Docs: https://docs.coderabbit.ai/reference/configuration
+#
+# Issue #3754. The investigation produced four flips off the original ACs:
+#  (1) AC1 split — YAML alone is advisory; branch-protection lives in AC1b.
+#  (2) AC3 deterministic rules move to ast-grep / semgrep; path_instructions
+#      keeps only judgment rules.
+#  (3) AC5 leaves CodeRabbit entirely (path_instructions cannot see PR
+#      descriptions). It now lives in .github/workflows/deployment-impact-check.yml.
+#  (4) Phased rollout — mode:warning for sprint 1, per-rule promotion to error
+#      after baseline is verifiably clean for that rule.
+#
+# All path_instructions below say "flag only newly added or modified lines" —
+# the baseline has 527 `any`s, 5 CH migrations with $CLICKHOUSE_DATABASE, etc.
+# Without that framing every PR touching legacy files gets spammed.
+
+language: en
+early_access: false
+tone_instructions: >
+  Be terse and concrete. Quote the rule that was violated. Cite the file and
+  line. Skip platitudes ("consider", "you might want to"). When unsure,
+  recommend the safer option and say so.
+
+reviews:
+  profile: assertive
+  # YAML alone is advisory — branch protection must be configured separately
+  # to require CR's status check. Tracked as AC1b in #3754.
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+
+  # Phased rollout. Promote individual checks to mode:error in follow-up PRs
+  # after baseline is clean for that check.
+  pre_merge_checks:
+    title:
+      mode: warning
+    description:
+      mode: warning
+    docstrings:
+      mode: warning
+
+  tools:
+    # Secrets / API keys (Betterleaks-backed; v2 schema preserves the key name).
+    gitleaks:
+      enabled: true
+    # Pattern-based PII / unsafe-code rules. CR does not autoload community
+    # packs — the ruleset lives at .semgrep/langwatch.yml in this repo.
+    semgrep:
+      enabled: true
+      config_file: .semgrep/langwatch.yml
+    # Deterministic syntactic rules (AC3) — see .coderabbit/ast-grep/rules/.
+    ast-grep:
+      essential_rules: true
+      rule_dirs:
+        - .coderabbit/ast-grep/rules
+
+  path_instructions:
+    # ── AC4: structural ${...} guard ───────────────────────────────────────
+    # PR #3476 leaked a literal "${HOME/workspace/orchard-codex/contracts}"
+    # directory into main. path_filters can't exclude these (exclusion skips
+    # the files entirely and path_instructions never fire — fa3bbc7ef on this
+    # branch's history fixed exactly that). Positive fail-rule on a permissive
+    # glob is the working form.
+    - path: "**/*"
+      instructions: |
+        FAIL the review (request changes) when any newly added or renamed
+        file path contains an unexpanded shell variable segment such as
+        "${HOME...", "${VAR...", or any path segment starting with "${".
+        These are bugs from broken env-var expansion, never intentional
+        content. This rule applies to path names only — file contents are
+        not in scope here.
+
+    # ── AC2: PII rules (judgment-level — patterns are in .semgrep) ────────
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines in this PR. Do NOT flag
+        pre-existing code unless it is part of the diff.
+
+        FAIL when logging, analytics, or telemetry calls (console.*,
+        logger.*, posthog.*, Sentry.*, captureException, track, identify)
+        include user-identifying fields — email, phone, name, IP, userId,
+        projectSlug, organizationId, apiKey, token — without an explicit
+        redaction wrapper (`redact(...)`, `hashEmail(...)`, masking) or a
+        comment marking it as intentional.
+
+        FAIL when a new HTTP endpoint or tRPC procedure returns PII without
+        both: (a) an explicit auth check (`ctx.session.user` consulted) and
+        (b) an audit-log write (`auditLog.create` or equivalent).
+
+    - path: "**/*.{py,go,ts,tsx,js,jsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when adding a new `print`, `console.log`, `fmt.Print*`,
+        `log.Info*`, or analytics call that emits a raw request body, full
+        headers map, raw cookie, or `Authorization` header. Log only the
+        fields needed for debugging, redact the rest.
+
+    # ── AC3: layering / convention rules (judgment, not syntax) ────────────
+    # Syntactic checks (no `any`, inline import(), form.watch() in child,
+    # export * from re-export shims) live in .coderabbit/ast-grep/rules/.
+    # ClickHouse fully-qualified table names live in .semgrep/langwatch.yml.
+    # path_instructions only carries the judgment calls.
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a tRPC router/procedure is declared without an explicit
+        `.input(z.object({...}))` or equivalent Zod schema — including
+        procedures with no input (use `z.void()` or `z.object({})`).
+
+        FAIL when service-layer code (`langwatch/src/server/**`,
+        `langwatch/src/services/**`) imports from `~/components` or
+        `langwatch/src/components/**`. The server must not depend on UI.
+
+        FAIL when a new React component is declared as a class component.
+        Use function components + hooks.
+
+        FAIL when code adds a default fallback URL of the form
+        `?? "http://localhost..."` or `?? "https://..."`. Required env vars
+        must be validated through the Zod env schema and consumed without
+        fallbacks.
+
+    - path: "langwatch/package.json"
+      instructions: |
+        FAIL when newly added dependencies include `jest`, `@types/jest`,
+        `babel-jest`, `ts-jest`, or jest plugins. Use Vitest. Pre-existing
+        jest dependencies are out of scope here — promotion of this rule
+        depends on a separate jest → vitest migration.
+
+    - path: "langwatch/src/server/api/routers/**/*.{ts,tsx}"
+      instructions: |
+        Repository methods (under `langwatch/src/server/repositories/**`)
+        must be named `findAll` / `findById` / `findBy*` / `create` / `update`
+        / `delete`. Service methods (under `langwatch/src/server/services/**`)
+        must be named `getAll` / `getById` / `getBy*` / `create` / `update`
+        / `delete`. FAIL when a NEW repository method uses a `get*` prefix
+        or a NEW service method uses a `find*` prefix.
+
+    - path: "{cmd,pkg,internal,services}/**/*.go"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a Hono or chi route handler reaches directly into a
+        repository (`*Repository`/`*Repo` struct) instead of going through
+        a service layer. Hono/chi routes call services; services call
+        repositories.
+
+    - path: "**/migrations/**/*.{sql,ts,go}"
+      instructions: |
+        Migrations must be reversible: include a `down`/`Down` step that
+        actually undoes the `up` step, or include a comment block beginning
+        `IRREVERSIBLE:` explaining why (data-destructive, schema-only, etc.).
+        FAIL when neither is present.
+
+    # ── AC7: SOLID / Clean Code / KISS / YAGNI / Boy Scout ─────────────────
+    # Principle-level checks. Each FAIL is one specific, observable failure
+    # mode — not vibes-based "this looks SOLID-y" judgement. All flag only
+    # newly added or modified lines.
+    - path: "**/*.{ts,tsx,js,jsx,py,go,rs}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        # SRP (Single Responsibility)
+        FAIL when a NEW file exceeds 300 source lines (excluding blank lines
+        and comments). Long files are SRP-violation evidence. Exception:
+        generated files, schema/migration files, fixture/snapshot files,
+        lockfiles.
+
+        FAIL when a NEW exported function exceeds 60 source lines or has
+        cyclomatic complexity > 10. Long functions mix abstraction levels.
+
+        FAIL when a NEW class or struct exposes methods spanning more than
+        one obvious concern (e.g., HTTP handling + persistence + email
+        sending). Name the responsibilities you see.
+
+        # DIP (Dependency Inversion) + dependency direction
+        FAIL when a higher-level module imports a lower-level concrete
+        implementation directly where an interface/port exists. Example:
+        a service importing a concrete `*Repository` class when a repository
+        interface is defined.
+
+        FAIL when the dependency direction crosses layer boundaries the
+        wrong way (UI → server is allowed, server → UI is not; domain →
+        infrastructure is not allowed; tests → src is allowed, src → tests
+        is not).
+
+        # OCP / ISP — flag, do not fail
+        Comment (do not fail) when a `switch`/`if-else` chain on a type
+        discriminator is added and a polymorphic alternative is plausible.
+
+        # Clean Code — naming
+        FAIL when a NEW public symbol (exported function, class, type,
+        const) uses a vague name: `data`, `info`, `value`, `item`, `obj`,
+        `tmp`, `temp`, `util`, `helper`, `manager`, `handler` (alone, not
+        as a suffix), or single-letter identifiers outside loop/lambda
+        context. Quote the name.
+
+        FAIL when a NEW boolean variable, parameter, or property is named
+        without an `is`/`has`/`should`/`can`/`will` prefix (or domain
+        equivalent like `enabled`, `visible`). Example: `loading: boolean`
+        should be `isLoading`.
+
+        # Clean Code — comments
+        FAIL when a NEW comment restates what the code already says (e.g.,
+        `// increment counter` above `counter++`). Comments must explain
+        *why*, not *what*.
+
+        FAIL when a NEW doc-comment block is purely decorative (only
+        contains the symbol name, type, or auto-generated boilerplate).
+
+        # KISS / YAGNI
+        FAIL when a NEW abstraction (interface, factory, strategy, adapter)
+        has exactly one implementation in this diff AND there is no caller
+        already using the abstraction. That is speculative — inline the
+        implementation until a second caller exists.
+
+        FAIL when a NEW configuration flag, env var, or feature toggle is
+        added without at least one referenced consumer in the same PR.
+
+        FAIL when NEW code is added behind `if (false)`,
+        `if (process.env.UNDEFINED_FLAG)`, or commented-out blocks "for
+        later." Delete it — git remembers.
+
+        # Boy Scout (do not fail — comment only)
+        Comment when a file is touched and contains adjacent in-file smells
+        that could be fixed in the same commit (dead imports, commented-out
+        code, obvious typos in identifiers, unused exports reachable in the
+        diff context). Cite the line and the smell — the author decides
+        whether to fix or note as out of scope.
+
+        # Done-means-verified
+        Comment when a PR description claims a behavior is "verified" /
+        "tested" / "works" but the diff contains no corresponding test, no
+        command output, and no screenshot. Quote the claim and ask for
+        evidence.
+
+    # ── AC8: BDD/TDD + public-API docs ─────────────────────────────────────
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW exported function, class, or hook is added without
+        either: (a) a corresponding new or updated test file under
+        `**/__tests__/**` or `**/*.{test,spec}.{ts,tsx}`, or (b) an explicit
+        `// no-test:` justification comment naming the reason (e.g., pure
+        re-export, type-only file, framework boilerplate).
+
+        FAIL when a NEW exported function or class lacks a JSDoc/TSDoc
+        comment block. The block must contain at least one sentence of
+        purpose (not just `@param`/`@returns`). Internal/non-exported
+        symbols are exempt.
+
+    - path: "{cmd,pkg,internal,services}/**/*.go"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW exported (capitalised) Go function, type, or method
+        lacks a doc-comment starting with the symbol name (Go convention).
+
+        FAIL when NEW Go production code is added under `cmd/`, `pkg/`,
+        `internal/`, or `services/` without a corresponding `_test.go`
+        test, or without a `// no-test:` justification comment.
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  # Capture house-style markers deterministically. Cheap, single-line addition.
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "CLAUDE.md"
+      - "**/CLAUDE.md"
+      - "AGENTS.md"
+      - "dev/docs/best_practices/**/*.md"
+  # Off per #3754 non-goals.
+  learnings:
+    scope: local
+  issues:
+    scope: local

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -189,6 +189,129 @@ reviews:
         `IRREVERSIBLE:` explaining why (data-destructive, schema-only, etc.).
         FAIL when neither is present.
 
+    # ── House-style rules sourced from dev/docs/best_practices/ ────────────
+    # Cite the source doc in your comment so authors can read the rationale.
+
+    # react.md: hooks must not return JSX. Hooks return state + callbacks;
+    # the consumer renders. JSX-returning hooks couple rendering to logic
+    # and hide the component tree.
+    - path: "langwatch/src/**/hooks/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a hook function (name starts with `use`) returns JSX.
+        Hooks return state and callbacks; consumers render. Cite
+        `dev/docs/best_practices/react.md` § Hooks.
+
+    # react.md: hook files should be .ts, not .tsx. A .tsx hook file means
+    # the hook returns JSX — same anti-pattern as above.
+    - path: "langwatch/src/**/hooks/**/use*.tsx"
+      instructions: |
+        FAIL: hook files must be `.ts`, not `.tsx`. A `.tsx` hook file is
+        a smell — the JSX belongs in the consumer component. Move the JSX
+        out and rename to `.ts`. See `dev/docs/best_practices/react.md`.
+
+    # typescript.md: exhaustive switches need a `never` check in default.
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW `switch` over a discriminated-union or enum type
+        lacks an exhaustiveness check in the `default:` case. The check
+        must assign the scrutinee to a `never`-typed variable
+        (`const _exhaustive: never = x;` or `assertNever(x);`). Without it,
+        adding a new variant later silently falls through. See
+        `dev/docs/best_practices/typescript.md` § Exhaustive switches.
+
+    # typescript.md: named params for 2+ args on exported functions.
+    - path: "langwatch/src/**/*.{ts,tsx}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW exported function takes 2+ positional parameters
+        of the same primitive type (string, string, string) or where the
+        call site is non-obvious (`(scenarioId, target, setId)`). Use
+        object-destructuring instead: `({ scenarioId, target, setId })`.
+        Two-parameter functions where the types differ obviously
+        (e.g., `(id: string, options: { ... })`) are fine. See
+        `dev/docs/best_practices/typescript.md` § Named parameters.
+
+    # soft-delete-vs-archive.md: archivedAt, not deletedAt.
+    - path: "langwatch/{prisma/schema.prisma,src/server/**/*.{ts,tsx}}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW Prisma model field, repository method, or service
+        method introduces `deletedAt` for soft-delete semantics. The
+        house pattern is `archivedAt DateTime?` with a `findAll` that
+        filters `archivedAt IS NULL` by default, plus
+        `find*IncludingArchived` variants for the cases that need them.
+        Existing `deletedAt` fields are out of scope here (migration is
+        tracked in #1889). See
+        `dev/docs/best_practices/soft-delete-vs-archive.md`.
+
+    # ksuids.md: user-facing IDs use KSUIDs at the service/repository layer.
+    - path: "langwatch/src/server/{repositories,services}/**/*.ts"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW repository or service `create` method writes a
+        user-facing entity (one that shows up in URLs, API responses,
+        exports, or webhooks) using a Prisma default id
+        (`@default(nanoid())`, `@default(cuid())`, `@default(uuid())`)
+        instead of generating a prefixed KSUID via
+        `generate(KSUID_RESOURCES.X).toString()`. Internal join tables
+        (`*Scope`, `*Link`) may keep Prisma defaults. See
+        `dev/docs/best_practices/ksuids.md`.
+
+    # clickhouse-queries.md anti-pattern 1: ORDER BY <version> DESC LIMIT 1.
+    - path: "langwatch/src/server/clickhouse/**/*.{ts,sql}"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW ClickHouse query selects heavy columns (Messages,
+        ComputedInput, Inputs, Details, SpanAttributes, RoleCosts,
+        Metadata) AND uses one of these anti-patterns:
+
+          (a) `ORDER BY <Version|UpdatedAt> DESC LIMIT 1` to pick the
+              latest version. Use the IN-tuple dedup pattern instead.
+          (b) `LIMIT 1 BY <key>` over heavy columns. Move the dedup into
+              a lightweight inner subquery (key columns only) and select
+              heavy columns in the outer query.
+
+        Cite `dev/docs/best_practices/clickhouse-queries.md` § Deduplication.
+
+    # design/guidelines.md §6: form Save button disables only on isPending,
+    # never on !form.formState.isValid. Pre-disabling is silent and
+    # frustrating; validation errors must surface inline or via toast.
+    - path: "langwatch/src/**/*.tsx"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when a NEW submit button uses `disabled={!form.formState.isValid}`,
+        `disabled={!isValid}`, `disabled={!formState.isValid}`, or any
+        variant that disables the button based on validity state.
+        Submit buttons disable ONLY while a request is in flight
+        (`disabled={mutation.isPending}` is the canonical shape).
+        Validation errors must surface inline (Field.ErrorText) or via
+        toast in the submit handler. See
+        `dev/docs/design/guidelines.md` § 6 and ADR-018.
+
+    # design/guidelines.md §3: prefer Drawer wrapper, not raw Chakra Modal.
+    # Biome's noRestrictedImports already bans @chakra-ui/react Dialog/Drawer/
+    # Modal — this catches the path_instructions side (new code introducing
+    # modal-style flows that should use Dialog wrapper).
+    - path: "langwatch/src/**/*.tsx"
+      instructions: |
+        Flag ONLY on newly added or modified lines.
+
+        FAIL when NEW resource creation, editing, or selection flows are
+        wired through a Dialog-style modal instead of a Drawer (e.g.,
+        adding a new "Create X" form behind a centered modal). Drawers
+        maintain context by keeping the underlying page visible.
+        Confirmation prompts (delete, discard) and simple alerts may
+        stay as Dialogs. See `dev/docs/design/guidelines.md` § 3.
+
     # ── AC7: SOLID / Clean Code / KISS / YAGNI / Boy Scout ─────────────────
     # Principle-level checks. Each FAIL is one specific, observable failure
     # mode — not vibes-based "this looks SOLID-y" judgement. All flag only
@@ -303,6 +426,11 @@ chat:
 
 knowledge_base:
   # Capture house-style markers deterministically. Cheap, single-line addition.
+  # Includes best_practices (TypeScript, React, ClickHouse, KSUIDs, repository
+  # pattern, soft-delete, etc.), design system (Chakra wrappers, drawer
+  # preference, form submit-then-surface), and ADRs (RBAC, event sourcing,
+  # logging, repository-service layering, form validation, etc.) so CR can
+  # cite the source in its review comments.
   code_guidelines:
     enabled: true
     filePatterns:
@@ -310,6 +438,9 @@ knowledge_base:
       - "**/CLAUDE.md"
       - "AGENTS.md"
       - "dev/docs/best_practices/**/*.md"
+      - "dev/docs/design/**/*.md"
+      - "dev/docs/adr/**/*.md"
+      - "docs/adr/**/*.md"
   # Off per #3754 non-goals.
   learnings:
     scope: local

--- a/.coderabbit/README.md
+++ b/.coderabbit/README.md
@@ -12,8 +12,8 @@ CodeRabbit auto-loads everything in this directory via `reviews.tools.ast-grep.r
 | `no-explicit-any.yml` | `: any`, `as any` in `langwatch/src/**`. |
 | `no-inline-dynamic-import.yml` | Inline `import(...)` in `.ts`/`.tsx` outside `routes.tsx` / `pages/**`. |
 | `no-form-watch-in-child.yml` | `$form.watch()` inside a child component receiving `form` as prop. |
-| `no-export-star-shim.yml` | `export * from "..."` outside `index.ts`/`index.tsx` barrels. |
-| `no-localhost-fallback.yml` | `?? "http://localhost..."` and equivalents. |
+| `no-export-star-shim.yml` | `export * from "..."` unless the preceding line is `// @barrel`. |
+| `no-localhost-fallback.yml` | `?? "http://localhost..."`, plus template-literal variants with embedded `${...}`. |
 
 All rules `severity: warning` for sprint 1 (phased rollout — promote to
 `error` per-rule once baseline is verifiably clean).

--- a/.coderabbit/README.md
+++ b/.coderabbit/README.md
@@ -7,24 +7,33 @@ CodeRabbit configuration ancillary files. The root config is `/.coderabbit.yaml`
 Deterministic syntactic rules (issue #3754 AC3). Each `.yml` is one rule;
 CodeRabbit auto-loads everything in this directory via `reviews.tools.ast-grep.rule_dirs`.
 
-| Rule | Forbids |
-|---|---|
-| `no-explicit-any.yml` | `: any`, `as any` in `langwatch/src/**`. |
-| `no-inline-dynamic-import.yml` | Inline `import(...)` in `.ts`/`.tsx` outside `routes.tsx` / `pages/**`. |
-| `no-form-watch-in-child.yml` | `$form.watch()` inside a child component receiving `form` as prop. |
-| `no-export-star-shim.yml` | `export * from "..."` unless the preceding line is `// @barrel`. |
-| `no-localhost-fallback.yml` | `?? "http://localhost..."`, plus template-literal variants with embedded `${...}`. |
+`language: TypeScript` does not match `.tsx` files in ast-grep's parser
+dispatch, so rules that apply to both file types are split into `_ts` /
+`_tsx` siblings.
+
+| Rule | Forbids | Scope |
+|---|---|---|
+| `no-explicit-any.yml` + `no-explicit-any-tsx.yml` | `: any`, `as any` (predefined_type kind with regex `^any$`) | `langwatch/src/**/*.{ts,tsx}` |
+| `no-inline-dynamic-import.yml` + `-tsx.yml` | Inline `import(...)` outside `routes.tsx` / `pages/**` | `langwatch/src/**/*.{ts,tsx}` |
+| `no-form-watch-in-child.yml` | `$form.watch()` inside a child component receiving `form` as prop | `langwatch/src/components/**/*.tsx` |
+| `no-export-star-shim.yml` + `-tsx.yml` | `export * from "..."`. Inline-disable with `// ast-grep-ignore: no-export-star-shim-{ts,tsx}` | `langwatch/src/**/*.{ts,tsx}` |
+| `no-localhost-fallback.yml` + `-tsx.yml` | `?? "http://localhost..."` and template-literal variants | `langwatch/src/**/*.{ts,tsx}` |
+| `no-form-disable-on-isvalid.yml` | `disabled={!form.formState.isValid}` / `disabled={!isValid}` on submit buttons — pre-disable is silent. See `dev/docs/design/guidelines.md` § 6. | `langwatch/src/**/*.tsx` |
 
 All rules `severity: warning` for sprint 1 (phased rollout — promote to
 `error` per-rule once baseline is verifiably clean).
 
 Add new rules by dropping a `.yml` here matching the [ast-grep rule schema](https://ast-grep.github.io/guide/rule-config.html).
-Keep rule IDs unique.
+Keep rule IDs unique. Split `_ts` / `_tsx` if the rule applies to both.
 
 ## Related
 
 - `/.coderabbit.yaml` — root config; references this directory.
-- `/.semgrep/langwatch.yml` — semantic patterns (PII regex, etc.).
+- `/.semgrep/langwatch.yml` — semantic patterns (PII regex, ClickHouse
+  TenantId enforcement, heavy-column dedup anti-pattern).
 - `/.github/workflows/deployment-impact-check.yml` — AC5 deployment-surface
   guard (moved out of CodeRabbit because `path_instructions` can't see PR
   descriptions).
+- `dev/docs/best_practices/`, `dev/docs/design/`, `dev/docs/adr/` — house
+  style sources, included in `knowledge_base.code_guidelines.filePatterns`
+  so CR can cite them in review comments.

--- a/.coderabbit/README.md
+++ b/.coderabbit/README.md
@@ -1,0 +1,30 @@
+# `.coderabbit/`
+
+CodeRabbit configuration ancillary files. The root config is `/.coderabbit.yaml`.
+
+## `ast-grep/rules/`
+
+Deterministic syntactic rules (issue #3754 AC3). Each `.yml` is one rule;
+CodeRabbit auto-loads everything in this directory via `reviews.tools.ast-grep.rule_dirs`.
+
+| Rule | Forbids |
+|---|---|
+| `no-explicit-any.yml` | `: any`, `as any` in `langwatch/src/**`. |
+| `no-inline-dynamic-import.yml` | Inline `import(...)` in `.ts`/`.tsx` outside `routes.tsx` / `pages/**`. |
+| `no-form-watch-in-child.yml` | `$form.watch()` inside a child component receiving `form` as prop. |
+| `no-export-star-shim.yml` | `export * from "..."` outside `index.ts`/`index.tsx` barrels. |
+| `no-localhost-fallback.yml` | `?? "http://localhost..."` and equivalents. |
+
+All rules `severity: warning` for sprint 1 (phased rollout — promote to
+`error` per-rule once baseline is verifiably clean).
+
+Add new rules by dropping a `.yml` here matching the [ast-grep rule schema](https://ast-grep.github.io/guide/rule-config.html).
+Keep rule IDs unique.
+
+## Related
+
+- `/.coderabbit.yaml` — root config; references this directory.
+- `/.semgrep/langwatch.yml` — semantic patterns (PII regex, etc.).
+- `/.github/workflows/deployment-impact-check.yml` — AC5 deployment-surface
+  guard (moved out of CodeRabbit because `path_instructions` can't see PR
+  descriptions).

--- a/.coderabbit/ast-grep/rules/no-explicit-any-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-explicit-any-tsx.yml
@@ -1,19 +1,18 @@
-id: no-explicit-any-ts
+id: no-explicit-any-tsx
 message: >
   Avoid `any` — prefer `unknown` + narrowing, or a real type. See
   langwatch CLAUDE.md and #3754 AC3. (Biome also flags this via
   `suspicious.noExplicitAny` — this rule is the deterministic fallback
   for cases Biome misses.)
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   kind: predefined_type
   regex: '^any$'
 files:
-  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
 ignores:
-  - "**/*.d.ts"
   - "**/__tests__/**"
-  - "**/*.test.ts"
-  - "**/*.spec.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"
   - "**/__fixtures__/**"

--- a/.coderabbit/ast-grep/rules/no-explicit-any.yml
+++ b/.coderabbit/ast-grep/rules/no-explicit-any.yml
@@ -1,0 +1,22 @@
+id: no-explicit-any
+message: >
+  Avoid `any` — prefer `unknown` + narrowing, or a real type. See
+  langwatch CLAUDE.md and #3754 AC3.
+severity: warning
+language: TypeScript
+rule:
+  any:
+    - kind: any_type
+    - pattern: $X as any
+    - pattern: $X as any[]
+files:
+  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/*.d.ts"
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/__fixtures__/**"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim-tsx.yml
@@ -1,11 +1,11 @@
-id: no-export-star-shim-ts
+id: no-export-star-shim-tsx
 message: >
   `export * from "..."` is a re-export shim. Backwards-compat shims rot —
   update consumers to import from the new location instead. If this is a
   legitimate barrel, add `// @barrel` on the line above the first
   `export *` to opt out.
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   all:
     - kind: export_statement
@@ -15,4 +15,4 @@ rule:
           kind: comment
           regex: '@barrel'
 files:
-  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim-tsx.yml
@@ -1,18 +1,13 @@
 id: no-export-star-shim-tsx
 message: >
   `export * from "..."` is a re-export shim. Backwards-compat shims rot —
-  update consumers to import from the new location instead. If this is a
-  legitimate barrel, add `// @barrel` on the line above the first
-  `export *` to opt out.
+  update consumers to import from the new location instead. For a
+  legitimate barrel, add an inline `// ast-grep-ignore: no-export-star-shim-tsx`
+  comment on the previous line.
 severity: warning
 language: Tsx
 rule:
-  all:
-    - kind: export_statement
-    - regex: '^export \* from'
-    - not:
-        follows:
-          kind: comment
-          regex: '@barrel'
+  kind: export_statement
+  regex: '^export \* from'
 files:
   - "langwatch/src/**/*.tsx"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim.yml
@@ -1,0 +1,15 @@
+id: no-export-star-shim
+message: >
+  `export * from "..."` is a re-export shim. Backwards-compat shims rot —
+  update consumers to import from the new location instead. If this is a
+  legitimate barrel file with multiple exports, list each one explicitly.
+severity: warning
+language: TypeScript
+rule:
+  pattern: export * from $MOD
+files:
+  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/index.ts"
+  - "**/index.tsx"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim.yml
@@ -2,14 +2,17 @@ id: no-export-star-shim
 message: >
   `export * from "..."` is a re-export shim. Backwards-compat shims rot —
   update consumers to import from the new location instead. If this is a
-  legitimate barrel file with multiple exports, list each one explicitly.
+  legitimate barrel, add `// @barrel` on the line above the first
+  `export *` to opt out.
 severity: warning
 language: TypeScript
 rule:
   pattern: export * from $MOD
+  not:
+    precedes:
+      kind: comment
+      regex: '@barrel'
+      stopBy: end
 files:
   - "langwatch/src/**/*.ts"
   - "langwatch/src/**/*.tsx"
-ignores:
-  - "**/index.ts"
-  - "**/index.tsx"

--- a/.coderabbit/ast-grep/rules/no-export-star-shim.yml
+++ b/.coderabbit/ast-grep/rules/no-export-star-shim.yml
@@ -1,18 +1,13 @@
 id: no-export-star-shim-ts
 message: >
   `export * from "..."` is a re-export shim. Backwards-compat shims rot —
-  update consumers to import from the new location instead. If this is a
-  legitimate barrel, add `// @barrel` on the line above the first
-  `export *` to opt out.
+  update consumers to import from the new location instead. For a
+  legitimate barrel, add an inline `// ast-grep-ignore: no-export-star-shim-ts`
+  comment on the previous line.
 severity: warning
 language: TypeScript
 rule:
-  all:
-    - kind: export_statement
-    - regex: '^export \* from'
-    - not:
-        follows:
-          kind: comment
-          regex: '@barrel'
+  kind: export_statement
+  regex: '^export \* from'
 files:
   - "langwatch/src/**/*.ts"

--- a/.coderabbit/ast-grep/rules/no-form-disable-on-isvalid.yml
+++ b/.coderabbit/ast-grep/rules/no-form-disable-on-isvalid.yml
@@ -1,0 +1,17 @@
+id: no-form-disable-on-isvalid
+message: >
+  Submit button is disabled based on form validity — pre-disabling is silent
+  and frustrating. Disable ONLY while the request is in flight
+  (`disabled={mutation.isPending}` is the canonical shape). Surface
+  validation errors inline (Field.ErrorText) or via toast in the submit
+  handler. See `dev/docs/design/guidelines.md` § 6 and ADR-018.
+severity: warning
+language: Tsx
+rule:
+  kind: jsx_attribute
+  regex: '^disabled=\{[^}]*(isValid|formState\.isValid)'
+files:
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
+++ b/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
@@ -4,7 +4,7 @@ message: >
   it re-renders the whole form tree on every keystroke. Use
   `useWatch({ control, name })` instead.
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   pattern: $F.watch()
   inside:

--- a/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
+++ b/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
@@ -1,0 +1,21 @@
+id: no-form-watch-in-child
+message: >
+  Child components receiving `form` as prop must not call `form.watch()` —
+  it re-renders the whole form tree on every keystroke. Use
+  `useWatch({ control, name })` instead.
+severity: warning
+language: TypeScript
+rule:
+  pattern: $F.watch()
+  inside:
+    kind: function_declaration
+    has:
+      kind: formal_parameters
+      has:
+        kind: required_parameter
+        pattern: $F
+files:
+  - "langwatch/src/components/**/*.tsx"
+ignores:
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
+++ b/.coderabbit/ast-grep/rules/no-form-watch-in-child.yml
@@ -8,12 +8,18 @@ language: TypeScript
 rule:
   pattern: $F.watch()
   inside:
-    kind: function_declaration
+    any:
+      - kind: arrow_function
+      - kind: function_expression
+      - kind: function_declaration
     has:
       kind: formal_parameters
       has:
-        kind: required_parameter
-        pattern: $F
+        any:
+          - kind: required_parameter
+            pattern: $F
+          - kind: identifier
+            pattern: $F
 files:
   - "langwatch/src/components/**/*.tsx"
 ignores:

--- a/.coderabbit/ast-grep/rules/no-inline-dynamic-import-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-inline-dynamic-import-tsx.yml
@@ -1,15 +1,17 @@
-id: no-inline-dynamic-import-ts
+id: no-inline-dynamic-import-tsx
 message: >
   Avoid inline `import(...)` for what should be a static import. Use
   top-level `import` / `import type` instead. Dynamic `import()` inside
   a function for intentional lazy-loading is fine — annotate the diff
   if not obvious.
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   pattern: import($MOD)
 files:
-  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
 ignores:
-  - "**/*.test.ts"
-  - "**/*.spec.ts"
+  - "**/routes.tsx"
+  - "**/pages/**"
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-inline-dynamic-import.yml
+++ b/.coderabbit/ast-grep/rules/no-inline-dynamic-import.yml
@@ -1,0 +1,20 @@
+id: no-inline-dynamic-import
+message: >
+  Avoid inline `import(...)` for what should be a static import. Use
+  top-level `import` / `import type` instead. Dynamic `import()` inside
+  a function for intentional lazy-loading is fine — annotate the diff
+  if not obvious.
+severity: warning
+language: TypeScript
+rule:
+  pattern: import($MOD)
+files:
+  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/routes.tsx"
+  - "**/pages/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-localhost-fallback-tsx.yml
+++ b/.coderabbit/ast-grep/rules/no-localhost-fallback-tsx.yml
@@ -1,10 +1,10 @@
-id: no-localhost-fallback-ts
+id: no-localhost-fallback-tsx
 message: >
   Don't fall back to a localhost URL via `??`. Required env vars must be
   validated through the Zod env schema and consumed without fallbacks —
   silent fallbacks mask missing configuration in production.
 severity: warning
-language: TypeScript
+language: Tsx
 rule:
   any:
     - pattern: $X ?? "http://localhost$REST"
@@ -12,7 +12,7 @@ rule:
     - pattern: $X ?? `http://localhost$$$REST`
     - pattern: $X ?? `https://localhost$$$REST`
 files:
-  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
 ignores:
-  - "**/*.test.ts"
-  - "**/*.spec.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
+++ b/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
@@ -1,0 +1,20 @@
+id: no-localhost-fallback
+message: >
+  Don't fall back to a localhost URL via `??`. Required env vars must be
+  validated through the Zod env schema and consumed without fallbacks —
+  silent fallbacks mask missing configuration in production.
+severity: warning
+language: TypeScript
+rule:
+  any:
+    - pattern: $X ?? "http://localhost$REST"
+    - pattern: $X ?? `http://localhost$REST`
+    - pattern: $X ?? "https://localhost$REST"
+files:
+  - "langwatch/src/**/*.ts"
+  - "langwatch/src/**/*.tsx"
+ignores:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"

--- a/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
+++ b/.coderabbit/ast-grep/rules/no-localhost-fallback.yml
@@ -8,8 +8,9 @@ language: TypeScript
 rule:
   any:
     - pattern: $X ?? "http://localhost$REST"
-    - pattern: $X ?? `http://localhost$REST`
     - pattern: $X ?? "https://localhost$REST"
+    - pattern: $X ?? `http://localhost$$$REST`
+    - pattern: $X ?? `https://localhost$$$REST`
 files:
   - "langwatch/src/**/*.ts"
   - "langwatch/src/**/*.tsx"

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -1,0 +1,75 @@
+name: deployment-impact-check
+
+# Fails when a PR touches deployment surface without addressing operator
+# impact in the PR description. CodeRabbit's path_instructions cannot see
+# PR descriptions, so this rule lives in a GH Action instead. See #3754
+# Investigation Flip 3.
+#
+# Once this workflow has run once and we have its check name, add it to
+# branch protection on main as a required check (tracked as AC1b in #3754).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - "charts/**"
+      - "services/**"
+      - "dev/docs/adr/**"
+      - "dev/docs/best_practices/**"
+      - "langwatch/.env.example"
+      - "docs/self-hosting/**"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify deployment-impact section in PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Body presence
+          if [ -z "$PR_BODY" ]; then
+            echo "::error::PR description is empty. Add a ## Deployment Impact section addressing env vars, helm values, default helm install behavior, and BYOC dataplane impact."
+            exit 1
+          fi
+
+          # Heading presence (case-insensitive, allow either Deployment Impact
+          # or Operator/Deployment impact).
+          if ! echo "$PR_BODY" | grep -qiE '^##+[[:space:]]*(deployment[[:space:]]+impact|operator[[:space:]]*/?[[:space:]]*deployment[[:space:]]+impact)' ; then
+            echo "::error::No '## Deployment Impact' heading found in PR description. This PR touches deployment surface (charts/services/ADRs/best-practices docs/env.example/self-hosting) — add the section."
+            exit 1
+          fi
+
+          # Content presence — the section must say *something*. We measure by
+          # extracting from the heading to the next H2 (or EOF) and requiring
+          # at least 80 non-whitespace chars beyond the heading. Cheap proxy
+          # for "actually filled in, not placeholder."
+          SECTION=$(printf '%s\n' "$PR_BODY" | awk '
+            BEGIN { capturing=0 }
+            /^##+[[:space:]]*[Dd]eployment[[:space:]]+[Ii]mpact/ { capturing=1; next }
+            /^##+[[:space:]]*[Oo]perator/ { if ($0 ~ /[Dd]eployment/) { capturing=1; next } }
+            capturing && /^##+[[:space:]]/ { exit }
+            capturing { print }
+          ')
+          LEN=$(printf '%s' "$SECTION" | tr -d '[:space:]' | wc -c | tr -d ' ')
+          if [ "${LEN:-0}" -lt 80 ]; then
+            echo "::error::'## Deployment Impact' section is too short (${LEN} non-whitespace chars). It must address: env vars added/changed, helm values added/changed, default behavior on vanilla 'helm install' with no overrides, and BYOC dataplane impact."
+            exit 1
+          fi
+
+          # Discourage obvious placeholder text.
+          if printf '%s' "$SECTION" | grep -qiE '\b(TBD|TODO|FIXME|placeholder|N/?A)\b'; then
+            # Allow N/A if the author explicitly justifies — look for at least
+            # one sentence of justification after the marker.
+            JUST=$(printf '%s' "$SECTION" | grep -iE '(TBD|TODO|FIXME|placeholder|N/?A)' | head -1)
+            if ! printf '%s\n' "$SECTION" | grep -qiE 'no operator impact|no deployment impact|repo metadata only|docs[- ]only'; then
+              echo "::error::'## Deployment Impact' contains a placeholder ('$JUST') without justification. Either fill it in, or explain why no impact applies (e.g., 'no deployment impact — repo metadata only')."
+              exit 1
+            fi
+          fi
+
+          echo "Deployment Impact section present and filled in (${LEN} chars). OK."

--- a/.github/workflows/deployment-impact-check.yml
+++ b/.github/workflows/deployment-impact-check.yml
@@ -37,10 +37,10 @@ jobs:
             exit 1
           fi
 
-          # Heading presence (case-insensitive, allow either Deployment Impact
-          # or Operator/Deployment impact).
-          if ! echo "$PR_BODY" | grep -qiE '^##+[[:space:]]*(deployment[[:space:]]+impact|operator[[:space:]]*/?[[:space:]]*deployment[[:space:]]+impact)' ; then
-            echo "::error::No '## Deployment Impact' heading found in PR description. This PR touches deployment surface (charts/services/ADRs/best-practices docs/env.example/self-hosting) — add the section."
+          # Heading presence — strict H2 (`## `). Loosen to `##+` if H3 turns
+          # out to be common in template usage.
+          if ! printf '%s\n' "$PR_BODY" | grep -qiE '^##[[:space:]]+(deployment[[:space:]]+impact|operator[[:space:]]*/?[[:space:]]*deployment[[:space:]]+impact)' ; then
+            echo "::error::No '## Deployment Impact' heading found in PR description. This PR touches deployment surface (charts/services/ADRs/best-practices docs/env.example/self-hosting) — add the section as a top-level H2 (`## Deployment Impact`)."
             exit 1
           fi
 

--- a/.semgrep/langwatch.yml
+++ b/.semgrep/langwatch.yml
@@ -90,3 +90,60 @@ rules:
     pattern-either:
       - pattern-regex: '\$\{CLICKHOUSE_DATABASE\}\.\w+'
       - pattern-regex: '\b(FROM|JOIN|INTO|UPDATE|TABLE|VIEW|EXISTS|DROP)[[:space:]]+langwatch\.[a-z_]+'
+
+  # ── ClickHouse runtime queries must filter by TenantId ─────────────────
+  # Surfaced as a follow-up by CR on PR #4170: every ClickHouse query MUST
+  # include `WHERE TenantId = {tenantId:String}` to keep tenants isolated.
+  # Migrations (DDL) are exempt — they don't filter by tenant. This rule
+  # targets query files only, where a missing TenantId predicate is a
+  # cross-tenant leak.
+  - id: clickhouse-require-tenant-id
+    message: >
+      ClickHouse query missing `WHERE TenantId = {tenantId:String}`
+      predicate. Every runtime query must filter by TenantId to keep
+      tenants isolated. See
+      `dev/docs/best_practices/clickhouse-queries.md` § Tenant scoping.
+    severity: ERROR
+    languages: [typescript, javascript]
+    paths:
+      include:
+        - "langwatch/src/server/clickhouse/**/*.ts"
+        - "langwatch/src/server/repositories/**/clickhouse*.ts"
+      exclude:
+        - "**/migrations/**"
+        - "**/__tests__/**"
+        - "**/*.test.ts"
+        - "**/*.spec.ts"
+    patterns:
+      - pattern-either:
+          - pattern: clickhouse.query({ query: $Q, ... })
+          - pattern: clickhouse.exec({ query: $Q, ... })
+          - pattern: clickhouseClient.query({ query: $Q, ... })
+      - pattern-not-regex: 'TenantId\s*=\s*\{tenantId'
+
+  # ── ClickHouse dedup anti-pattern: ORDER BY … LIMIT 1 + heavy cols ─────
+  # Anti-pattern 1 from clickhouse-queries.md. Reading heavy columns while
+  # sorting all unmerged versions of a row saturates ClickHouse.
+  - id: clickhouse-no-version-order-limit
+    message: >
+      ClickHouse query selects heavy columns AND uses
+      `ORDER BY <Version|UpdatedAt> DESC LIMIT 1` to pick the latest
+      version. This loads every unmerged version of every matching row
+      into memory before sorting. Use the IN-tuple dedup pattern
+      (lightweight key columns inner subquery + heavy columns in the
+      outer select). See
+      `dev/docs/best_practices/clickhouse-queries.md` § Anti-Pattern 1.
+    severity: WARNING
+    languages: [generic]
+    paths:
+      include:
+        - "langwatch/src/server/clickhouse/**/*.ts"
+        - "langwatch/src/server/clickhouse/**/*.sql"
+      exclude:
+        - "**/migrations/**"
+        - "**/__tests__/**"
+        - "**/*.test.ts"
+        - "**/*.spec.ts"
+    patterns:
+      - pattern-regex: '(Messages|ComputedInput|Inputs|Details|SpanAttributes|RoleCosts|Metadata)\b'
+      - pattern-regex: 'ORDER\s+BY\s+\w*(Version|UpdatedAt)\s+DESC\s+LIMIT\s+1'

--- a/.semgrep/langwatch.yml
+++ b/.semgrep/langwatch.yml
@@ -1,0 +1,88 @@
+# Semgrep rules — semantic patterns CodeRabbit's path_instructions can't
+# express deterministically. Loaded via reviews.tools.semgrep.config_file
+# in /.coderabbit.yaml.
+#
+# Highest-value rule per #3754 Investigation #6: PII-in-logger
+# (only 3 audit hits — easy to baseline-clear, high signal).
+
+rules:
+  # ── PII in logger calls ────────────────────────────────────────────────
+  - id: pii-in-logger-call
+    message: >
+      Logger call references PII fields (email, phone, name, ip, userId,
+      apiKey, token, etc.) without redaction. Wrap with `redact(...)` or
+      `hashEmail(...)`, or pass the minimal non-identifying fields needed
+      for debugging. See #3754 AC2.
+    severity: WARNING
+    languages: [typescript, javascript]
+    paths:
+      include:
+        - "langwatch/src/**/*.ts"
+        - "langwatch/src/**/*.tsx"
+      exclude:
+        - "**/__tests__/**"
+        - "**/*.test.ts"
+        - "**/*.test.tsx"
+        - "**/*.spec.ts"
+        - "**/*.spec.tsx"
+        - "**/__fixtures__/**"
+    patterns:
+      - pattern-either:
+          - pattern: logger.$LEVEL($..., { ..., email: $E, ... }, $...)
+          - pattern: logger.$LEVEL($..., { ..., phone: $P, ... }, $...)
+          - pattern: logger.$LEVEL($..., { ..., userId: $U, ... }, $...)
+          - pattern: logger.$LEVEL($..., { ..., apiKey: $K, ... }, $...)
+          - pattern: logger.$LEVEL($..., { ..., token: $T, ... }, $...)
+          - pattern: console.$LEVEL($..., { ..., email: $E, ... }, $...)
+          - pattern: console.$LEVEL($..., { ..., userId: $U, ... }, $...)
+          - pattern: console.$LEVEL($..., { ..., apiKey: $K, ... }, $...)
+          - pattern: console.$LEVEL($..., { ..., token: $T, ... }, $...)
+
+  # ── PII regex literals outside fixtures ────────────────────────────────
+  - id: pii-literal-ssn
+    message: >
+      String literal matches US SSN shape (NNN-NN-NNNN). PII literals
+      should not appear in production code — use a fixture under
+      `**/__fixtures__/**` if this is a test value.
+    severity: WARNING
+    languages: [typescript, javascript, python]
+    paths:
+      exclude:
+        - "**/__fixtures__/**"
+        - "**/*.test.*"
+        - "**/*.spec.*"
+        - "**/migrations/**"
+    pattern-regex: '"\d{3}-\d{2}-\d{4}"'
+
+  - id: pii-literal-api-key
+    message: >
+      String literal matches API key prefix (`sk_live_`, `pk_live_`,
+      `xai-`, `sk-`, `lw_`). Use env-var indirection — never check live
+      keys into source. Gitleaks should also catch this; this rule
+      catches near-misses that gitleaks lets through.
+    severity: ERROR
+    languages: [typescript, javascript, python]
+    paths:
+      exclude:
+        - "**/__fixtures__/**"
+        - "**/*.test.*"
+        - "**/*.spec.*"
+    pattern-regex: '"(sk_live_|pk_live_|xai-|sk-proj-|sk-ant-)[A-Za-z0-9_-]{16,}"'
+
+  # ── ClickHouse migrations: unqualified table names only ────────────────
+  - id: clickhouse-no-qualified-table
+    message: >
+      ClickHouse migrations must use unqualified table names — they run
+      against the connected database. `${CLICKHOUSE_DATABASE}.<table>`
+      or `langwatch.<table>` breaks BYOC deployments where the database
+      name differs.
+    severity: WARNING
+    languages: [generic]
+    paths:
+      include:
+        - "**/clickhouse/migrations/**/*.sql"
+        - "**/clickhouse/migrations/**/*.ts"
+        - "**/clickhouse/migrations/**/*.go"
+    pattern-either:
+      - pattern-regex: '\$\{CLICKHOUSE_DATABASE\}\.\w+'
+      - pattern-regex: '\blangwatch\.[a-z_]+\b'

--- a/.semgrep/langwatch.yml
+++ b/.semgrep/langwatch.yml
@@ -7,6 +7,10 @@
 
 rules:
   # ── PII in logger calls ────────────────────────────────────────────────
+  # Pattern enumeration: literal email/userId/etc. keys, spread of User-named
+  # variables, shorthand property where the value-name suggests a user object.
+  # Doesn't catch `logger.info("msg", user)` — that needs taint-mode (deferred
+  # to a follow-up if AC6 shows the shape mismatters).
   - id: pii-in-logger-call
     message: >
       Logger call references PII fields (email, phone, name, ip, userId,
@@ -28,6 +32,7 @@ rules:
         - "**/__fixtures__/**"
     patterns:
       - pattern-either:
+          # Literal PII keys
           - pattern: logger.$LEVEL($..., { ..., email: $E, ... }, $...)
           - pattern: logger.$LEVEL($..., { ..., phone: $P, ... }, $...)
           - pattern: logger.$LEVEL($..., { ..., userId: $U, ... }, $...)
@@ -37,23 +42,21 @@ rules:
           - pattern: console.$LEVEL($..., { ..., userId: $U, ... }, $...)
           - pattern: console.$LEVEL($..., { ..., apiKey: $K, ... }, $...)
           - pattern: console.$LEVEL($..., { ..., token: $T, ... }, $...)
+          # Spread of a user/session/account object
+          - pattern: logger.$LEVEL($..., { ...$USER, $... }, $...)
+          - pattern: console.$LEVEL($..., { ...$USER, $... }, $...)
+          # Shorthand property with a user-shaped name
+          - pattern: logger.$LEVEL($..., { user: $U, $... }, $...)
+          - pattern: logger.$LEVEL($..., { session: $S, $... }, $...)
+          - pattern: logger.$LEVEL($..., { account: $A, $... }, $...)
+          - pattern: logger.$LEVEL($..., { user }, $...)
+          - pattern: logger.$LEVEL($..., { session }, $...)
+          - pattern: logger.$LEVEL($..., { account }, $...)
 
   # ── PII regex literals outside fixtures ────────────────────────────────
-  - id: pii-literal-ssn
-    message: >
-      String literal matches US SSN shape (NNN-NN-NNNN). PII literals
-      should not appear in production code — use a fixture under
-      `**/__fixtures__/**` if this is a test value.
-    severity: WARNING
-    languages: [typescript, javascript, python]
-    paths:
-      exclude:
-        - "**/__fixtures__/**"
-        - "**/*.test.*"
-        - "**/*.spec.*"
-        - "**/migrations/**"
-    pattern-regex: '"\d{3}-\d{2}-\d{4}"'
-
+  # SSN dropped: 3-2-4-digit regex false-positives on dates (`2026-05-21`),
+  # version strings, etc. The investigation didn't cite an SSN leak; bring
+  # the rule back when one exists.
   - id: pii-literal-api-key
     message: >
       String literal matches API key prefix (`sk_live_`, `pk_live_`,
@@ -70,19 +73,20 @@ rules:
     pattern-regex: '"(sk_live_|pk_live_|xai-|sk-proj-|sk-ant-)[A-Za-z0-9_-]{16,}"'
 
   # ── ClickHouse migrations: unqualified table names only ────────────────
+  # Anchored to SQL DDL keywords to avoid matching `langwatch.io`,
+  # comment tokens, etc.
   - id: clickhouse-no-qualified-table
     message: >
       ClickHouse migrations must use unqualified table names — they run
       against the connected database. `${CLICKHOUSE_DATABASE}.<table>`
-      or `langwatch.<table>` breaks BYOC deployments where the database
-      name differs.
+      or `langwatch.<table>` in a DDL context breaks BYOC deployments
+      where the database name differs.
     severity: WARNING
     languages: [generic]
     paths:
       include:
-        - "**/clickhouse/migrations/**/*.sql"
-        - "**/clickhouse/migrations/**/*.ts"
-        - "**/clickhouse/migrations/**/*.go"
+        - "langwatch/src/server/clickhouse/migrations/**/*.sql"
+        - "langwatch/src/server/clickhouse/migrations/**/*.ts"
     pattern-either:
       - pattern-regex: '\$\{CLICKHOUSE_DATABASE\}\.\w+'
-      - pattern-regex: '\blangwatch\.[a-z_]+\b'
+      - pattern-regex: '\b(FROM|JOIN|INTO|UPDATE|TABLE|VIEW|EXISTS|DROP)[[:space:]]+langwatch\.[a-z_]+'

--- a/langwatch/src/components/FormDisableViolation.tsx
+++ b/langwatch/src/components/FormDisableViolation.tsx
@@ -1,0 +1,13 @@
+// Smoke-test v3 — DO NOT MERGE. Save button disabled on !isValid
+// (design/guidelines.md § 6 + ADR-018).
+
+import React from "react";
+
+export function CreateThing({ form, mutation }: { form: { formState: { isValid: boolean } }; mutation: { isPending: boolean } }) {
+  return (
+    <form>
+      {/* VIOLATION: disable on !form.formState.isValid. */}
+      <button type="submit" disabled={!form.formState.isValid}>Save</button>
+    </form>
+  );
+}

--- a/langwatch/src/components/barrel-test.ts
+++ b/langwatch/src/components/barrel-test.ts
@@ -1,0 +1,5 @@
+// Smoke-test v3 — DO NOT MERGE. export * from re-export shim
+// (no-export-star-shim rule). This file does NOT have the
+// `// ast-grep-ignore: no-export-star-shim-ts` opt-out, so it should fire.
+
+export * from "./FormDisableViolation";

--- a/langwatch/src/components/hooks/useReturnsJsx.tsx
+++ b/langwatch/src/components/hooks/useReturnsJsx.tsx
@@ -1,0 +1,8 @@
+// Smoke-test v3 — DO NOT MERGE. Hook that returns JSX (react.md violation).
+// Also: filename is .tsx, which the rule itself flags as a smell.
+
+import React from "react";
+
+export function useReturnsJsx() {
+  return <div>nope</div>;
+}

--- a/langwatch/src/server/clickhouse/dedup-anti-pattern-violation.ts
+++ b/langwatch/src/server/clickhouse/dedup-anti-pattern-violation.ts
@@ -1,0 +1,17 @@
+// Smoke-test v3 — DO NOT MERGE. ClickHouse heavy-column dedup anti-pattern
+// (clickhouse-queries.md anti-pattern 1).
+
+export async function getLatestRow(tenantId: string, key: string): Promise<unknown> {
+  // VIOLATION: heavy columns (Messages, ComputedInput) + ORDER BY UpdatedAt DESC LIMIT 1.
+  // Also VIOLATION: missing TenantId filter shape `{tenantId:String}`.
+  const sql = `
+    SELECT Messages, ComputedInput, Inputs
+    FROM trace_events
+    WHERE Key = '${key}'
+    ORDER BY UpdatedAt DESC
+    LIMIT 1
+  `;
+  return await clickhouse.query({ query: sql });
+}
+
+declare const clickhouse: { query: (args: { query: string }) => Promise<unknown> };

--- a/langwatch/src/server/exhaustive-violation.ts
+++ b/langwatch/src/server/exhaustive-violation.ts
@@ -1,0 +1,19 @@
+// Smoke-test v3 — DO NOT MERGE. Non-exhaustive switch (typescript.md).
+
+type Color = "red" | "green" | "blue";
+
+export function colorName(c: Color): string {
+  switch (c) {
+    case "red":
+      return "Red";
+    case "green":
+      return "Green";
+    // Missing "blue" + missing never check in default — VIOLATION.
+  }
+  return "unknown";
+}
+
+// Named-params violation: 3+ positional same-type args (typescript.md).
+export function runFooBar(scenarioId: string, target: string, setId: string): string {
+  return `${scenarioId}/${target}/${setId}`;
+}

--- a/langwatch/src/server/judgment-violations.tsx
+++ b/langwatch/src/server/judgment-violations.tsx
@@ -1,0 +1,21 @@
+// Smoke-test v3 for issue #3754 — DO NOT MERGE.
+// Located under langwatch/src/server/ so the layering + tRPC + class-component
+// rules' globs actually match (v2 had this at langwatch/src/judgment-violations.ts
+// which was outside the service-layer glob).
+
+import React from "react";
+import { router, publicProcedure } from "./trpc-stub";
+// SERVICE-LAYER importing UI — VIOLATION (service→component layering rule).
+import { SomeButton } from "~/components/SomeButton";
+
+// tRPC procedure missing .input(...) — VIOLATION.
+export const noInputProcedure = router({
+  ping: publicProcedure.query(() => ({ ok: true })),
+});
+
+// React class component — VIOLATION (class-component ban).
+export class ClassComponentViolation extends React.Component {
+  render() {
+    return <SomeButton />;
+  }
+}

--- a/langwatch/src/server/prisma-deleted-at-violation.ts
+++ b/langwatch/src/server/prisma-deleted-at-violation.ts
@@ -1,0 +1,18 @@
+// Smoke-test v3 — DO NOT MERGE. Soft-delete instead of archive (soft-delete-vs-archive.md).
+// House pattern is archivedAt, not deletedAt.
+
+export type SoftDeletedResource = {
+  id: string;
+  name: string;
+  deletedAt: Date | null;  // VIOLATION — should be archivedAt.
+};
+
+export async function softDelete(id: string): Promise<void> {
+  // Simulated repository call writing deletedAt.
+  await fakePrisma.resource.update({
+    where: { id },
+    data: { deletedAt: new Date() },  // VIOLATION.
+  });
+}
+
+declare const fakePrisma: { resource: { update: (args: unknown) => Promise<unknown> } };

--- a/langwatch/src/server/repositories/ksuid-violation.ts
+++ b/langwatch/src/server/repositories/ksuid-violation.ts
@@ -1,0 +1,12 @@
+// Smoke-test v3 — DO NOT MERGE. User-facing resource using Prisma default
+// instead of generate(KSUID_RESOURCES.X) (ksuids.md).
+
+export class ProviderRepository {
+  // VIOLATION: user-facing entity (Provider has a URL) created without
+  // an explicit KSUID. Prisma default would be nanoid/cuid — wrong shape.
+  async create(input: { name: string }): Promise<{ id: string; name: string }> {
+    return await fakePrisma.provider.create({ data: input });
+  }
+}
+
+declare const fakePrisma: { provider: { create: (args: unknown) => Promise<{ id: string; name: string }> } };


### PR DESCRIPTION
## What

Validates 8 new rules added in commit 87263d2bb on PR #4162, plus the relocated v2 misses (tRPC / class-component / service→component, all now in `langwatch/src/server/`).

**Base is `issue3754/customize-coderabbit-with-committed-coderab`** (not main) — CR reads `.coderabbit.yaml` from the base branch at PR-creation time, so this PR's CR review will use the expanded ruleset from #4162.

## Fixtures + expected verdicts

| Fixture | Expected rule(s) | Source doc |
|---|---|---|
| `langwatch/src/server/judgment-violations.tsx` | tRPC no .input + class component + service→UI layering | `dev/docs/best_practices/repository-service.md` + #3754 AC3 |
| `langwatch/src/components/hooks/useReturnsJsx.tsx` | hooks-no-JSX + .tsx-hook-file | `dev/docs/best_practices/react.md` |
| `langwatch/src/server/exhaustive-violation.ts` | non-exhaustive switch + named-params | `dev/docs/best_practices/typescript.md` |
| `langwatch/src/server/prisma-deleted-at-violation.ts` | archivedAt-not-deletedAt | `dev/docs/best_practices/soft-delete-vs-archive.md` |
| `langwatch/src/server/repositories/ksuid-violation.ts` | KSUID at service/repo | `dev/docs/best_practices/ksuids.md` |
| `langwatch/src/server/clickhouse/dedup-anti-pattern-violation.ts` | heavy-col + ORDER BY LIMIT 1 + missing TenantId | `dev/docs/best_practices/clickhouse-queries.md` |
| `langwatch/src/components/FormDisableViolation.tsx` | no-form-disable-on-isvalid (ast-grep) + path_instructions | `dev/docs/design/guidelines.md` § 6 + ADR-018 |
| `langwatch/src/components/barrel-test.ts` | no-export-star-shim (v2 silent — now expected to fire) | #3754 AC3 |

## After CR review lands

Map verdicts back to PR #4162 body, close this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases for form validation, React component patterns, database queries, and repository implementations.

---

**Note:** This release contains internal test files only. No user-facing features or changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langwatch/langwatch/pull/4174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->