### PR TITLE
fix(groupQueue): check tenant cap before SISMEMBER in DISPATCH_BATCH

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1805,6 +1805,13 @@ describe("GroupStagingScripts", () => {
           jobDataJson: first.find((r) => r.groupId === "proj_noisy/g1")!.jobDataJson,
           errorMessage: "test",
         });
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "quiet-j2",
+            groupId: "proj_quiet/g2",
+            dispatchAfterMs: 3001,
+          }),
+        );
 
         const second = await scripts.dispatchBatch({
           nowMs: 4000,
@@ -1814,6 +1821,7 @@ describe("GroupStagingScripts", () => {
 
         expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g1");
         expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g2");
+        expect(second.map((r) => r.groupId)).toContain("proj_quiet/g2");
       });
 
       /** @scenario Drift cleanup runs for under-cap tenants in batch dispatch */
@@ -1840,7 +1848,9 @@ describe("GroupStagingScripts", () => {
           stagedJobId: batch1[0]!.stagedJobId,
         });
 
-        const readyBefore = await redis.zcard(`${keyPrefix()}ready`);
+        await redis.zadd(`${keyPrefix()}ready`, 2500, "proj_acme/g-zombie");
+        const readyBefore = await inspectReadySet();
+        expect(readyBefore).toContain("proj_acme/g-zombie");
 
         await scripts.dispatchBatch({
           nowMs: 3000,
@@ -1848,8 +1858,8 @@ describe("GroupStagingScripts", () => {
           maxJobs: 10,
         });
 
-        const readyAfter = await redis.zcard(`${keyPrefix()}ready`);
-        expect(readyAfter).toBeLessThanOrEqual(readyBefore);
+        const readyAfter = await inspectReadySet();
+        expect(readyAfter).not.toContain("proj_acme/g-zombie");
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1805,6 +1805,7 @@ describe("GroupStagingScripts", () => {
         });
         expect(first.map((r) => r.groupId)).toContain("proj_noisy/g1");
         expect(first.map((r) => r.groupId)).toContain("proj_noisy/g2");
+        expect(first.map((r) => r.groupId)).not.toContain("proj_noisy/g3");
         expect(first.map((r) => r.groupId)).toContain("proj_quiet/g1");
 
         // restageAndBlock frees g1's slot (counter 2→1). g2 still active

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1714,6 +1714,8 @@ describe("GroupStagingScripts", () => {
       expect(results[0]!.stagedJobId).toBe("j1");
     });
 
+    // Parity with specs/event-sourcing/tenant-soft-cap.feature
+    // @integration @tenant-cap @batch scenarios
     describe("when tenant cap interacts with dispatchBatch", () => {
       const TENANT_CAP_ENV = "LANGWATCH_DISPATCH_TENANT_CAP";
       let originalEnv: string | undefined;
@@ -1730,6 +1732,7 @@ describe("GroupStagingScripts", () => {
         }
       });
 
+      /** @scenario DISPATCH_BATCH skips over-cap groups and dispatches under-cap groups in one call */
       it("over-cap tenant groups are skipped, under-cap tenant groups dispatch", async () => {
         process.env[TENANT_CAP_ENV] = "1";
 
@@ -1762,6 +1765,7 @@ describe("GroupStagingScripts", () => {
         expect(dispatched).toHaveLength(2);
       });
 
+      /** @scenario Over-cap tenant with a blocked group does not affect other tenants */
       it("over-cap tenant blocked group is skipped without SISMEMBER affecting dispatch", async () => {
         process.env[TENANT_CAP_ENV] = "1";
 
@@ -1812,6 +1816,7 @@ describe("GroupStagingScripts", () => {
         expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g2");
       });
 
+      /** @scenario Drift cleanup runs for under-cap tenants in batch dispatch */
       it("drift cleanup still runs for under-cap tenants with empty job ZSETs", async () => {
         process.env[TENANT_CAP_ENV] = "10";
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1805,19 +1805,22 @@ describe("GroupStagingScripts", () => {
         });
         expect(first.map((r) => r.groupId)).toContain("proj_noisy/g1");
         expect(first.map((r) => r.groupId)).toContain("proj_noisy/g2");
+        expect(first.map((r) => r.groupId)).toContain("proj_quiet/g1");
 
-        // restageAndBlock frees g1's slot (counter 2→1), but g2 is still
-        // active so proj_noisy stays at cap (1 active, cap=2 → under cap?).
-        // No — we need tenant to remain AT cap after restage. With cap=2,
-        // first batch dispatches g1+g2 (counter=2). Restage g1 drops to 1.
-        // That's under cap=2, so g3 would dispatch. Set cap back to 1 so
-        // the remaining active g2 (counter=1) keeps tenant at cap.
+        // restageAndBlock frees g1's slot (counter 2→1). g2 still active
+        // so proj_noisy counter = 1. Complete proj_quiet/g1 so it frees
+        // its slot (counter 0). Now lower cap to 1: proj_noisy (counter=1)
+        // is at cap, proj_quiet (counter=0) is under cap.
         await scripts.restageAndBlock({
           groupId: "proj_noisy/g1",
           newStagedJobId: "j1-retry",
           score: 5000,
           jobDataJson: first.find((r) => r.groupId === "proj_noisy/g1")!.jobDataJson,
           errorMessage: "test",
+        });
+        await scripts.complete({
+          groupId: "proj_quiet/g1",
+          stagedJobId: first.find((r) => r.groupId === "proj_quiet/g1")!.stagedJobId,
         });
         process.env[TENANT_CAP_ENV] = "1";
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1767,7 +1767,7 @@ describe("GroupStagingScripts", () => {
 
       /** @scenario Over-cap tenant with a blocked group does not affect other tenants */
       it("over-cap tenant blocked group is skipped without SISMEMBER affecting dispatch", async () => {
-        process.env[TENANT_CAP_ENV] = "1";
+        process.env[TENANT_CAP_ENV] = "2";
 
         await scripts.stage(
           makeJob({
@@ -1785,6 +1785,13 @@ describe("GroupStagingScripts", () => {
         );
         await scripts.stage(
           makeJob({
+            stagedJobId: "j3",
+            groupId: "proj_noisy/g3",
+            dispatchAfterMs: 1000,
+          }),
+        );
+        await scripts.stage(
+          makeJob({
             stagedJobId: "quiet-j1",
             groupId: "proj_quiet/g1",
             dispatchAfterMs: 1001,
@@ -1797,14 +1804,23 @@ describe("GroupStagingScripts", () => {
           maxJobs: 10,
         });
         expect(first.map((r) => r.groupId)).toContain("proj_noisy/g1");
+        expect(first.map((r) => r.groupId)).toContain("proj_noisy/g2");
 
+        // restageAndBlock frees g1's slot (counter 2→1), but g2 is still
+        // active so proj_noisy stays at cap (1 active, cap=2 → under cap?).
+        // No — we need tenant to remain AT cap after restage. With cap=2,
+        // first batch dispatches g1+g2 (counter=2). Restage g1 drops to 1.
+        // That's under cap=2, so g3 would dispatch. Set cap back to 1 so
+        // the remaining active g2 (counter=1) keeps tenant at cap.
         await scripts.restageAndBlock({
           groupId: "proj_noisy/g1",
           newStagedJobId: "j1-retry",
-          score: 3000,
+          score: 5000,
           jobDataJson: first.find((r) => r.groupId === "proj_noisy/g1")!.jobDataJson,
           errorMessage: "test",
         });
+        process.env[TENANT_CAP_ENV] = "1";
+
         await scripts.stage(
           makeJob({
             stagedJobId: "quiet-j2",
@@ -1820,7 +1836,7 @@ describe("GroupStagingScripts", () => {
         });
 
         expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g1");
-        expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g2");
+        expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g3");
         expect(second.map((r) => r.groupId)).toContain("proj_quiet/g2");
       });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1713,6 +1713,140 @@ describe("GroupStagingScripts", () => {
       expect(results).toHaveLength(1);
       expect(results[0]!.stagedJobId).toBe("j1");
     });
+
+    describe("when tenant cap interacts with dispatchBatch", () => {
+      const TENANT_CAP_ENV = "LANGWATCH_DISPATCH_TENANT_CAP";
+      let originalEnv: string | undefined;
+
+      beforeEach(() => {
+        originalEnv = process.env[TENANT_CAP_ENV];
+      });
+
+      afterEach(() => {
+        if (originalEnv === undefined) {
+          delete process.env[TENANT_CAP_ENV];
+        } else {
+          process.env[TENANT_CAP_ENV] = originalEnv;
+        }
+      });
+
+      it("over-cap tenant groups are skipped, under-cap tenant groups dispatch", async () => {
+        process.env[TENANT_CAP_ENV] = "1";
+
+        for (let i = 0; i < 5; i++) {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: `noisy-j${i}`,
+              groupId: `proj_noisy/g${i}`,
+              dispatchAfterMs: 1000,
+            }),
+          );
+        }
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "quiet-j1",
+            groupId: "proj_quiet/g1",
+            dispatchAfterMs: 1001,
+          }),
+        );
+
+        const results = await scripts.dispatchBatch({
+          nowMs: 2000,
+          activeTtlSec: 60,
+          maxJobs: 10,
+        });
+
+        const dispatched = results.map((r) => r.groupId);
+        expect(dispatched).toContain("proj_noisy/g0");
+        expect(dispatched).toContain("proj_quiet/g1");
+        expect(dispatched).toHaveLength(2);
+      });
+
+      it("over-cap tenant blocked group is skipped without SISMEMBER affecting dispatch", async () => {
+        process.env[TENANT_CAP_ENV] = "1";
+
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "proj_noisy/g1",
+            dispatchAfterMs: 1000,
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j2",
+            groupId: "proj_noisy/g2",
+            dispatchAfterMs: 1000,
+          }),
+        );
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "quiet-j1",
+            groupId: "proj_quiet/g1",
+            dispatchAfterMs: 1001,
+          }),
+        );
+
+        const first = await scripts.dispatchBatch({
+          nowMs: 2000,
+          activeTtlSec: 60,
+          maxJobs: 10,
+        });
+        expect(first.map((r) => r.groupId)).toContain("proj_noisy/g1");
+
+        await scripts.restageAndBlock({
+          groupId: "proj_noisy/g1",
+          newStagedJobId: "j1-retry",
+          score: 3000,
+          jobDataJson: first.find((r) => r.groupId === "proj_noisy/g1")!.jobDataJson,
+          errorMessage: "test",
+        });
+
+        const second = await scripts.dispatchBatch({
+          nowMs: 4000,
+          activeTtlSec: 60,
+          maxJobs: 10,
+        });
+
+        expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g1");
+        expect(second.map((r) => r.groupId)).not.toContain("proj_noisy/g2");
+      });
+
+      it("drift cleanup still runs for under-cap tenants with empty job ZSETs", async () => {
+        process.env[TENANT_CAP_ENV] = "10";
+
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "proj_acme/g1",
+            dispatchAfterMs: 1000,
+          }),
+        );
+
+        const batch1 = await scripts.dispatchBatch({
+          nowMs: 2000,
+          activeTtlSec: 60,
+          maxJobs: 10,
+        });
+        expect(batch1).toHaveLength(1);
+
+        await scripts.complete({
+          groupId: "proj_acme/g1",
+          stagedJobId: batch1[0]!.stagedJobId,
+        });
+
+        const readyBefore = await redis.zcard(`${keyPrefix()}ready`);
+
+        await scripts.dispatchBatch({
+          nowMs: 3000,
+          activeTtlSec: 60,
+          maxJobs: 10,
+        });
+
+        const readyAfter = await redis.zcard(`${keyPrefix()}ready`);
+        expect(readyAfter).toBeLessThanOrEqual(readyBefore);
+      });
+    });
   });
   });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -362,26 +362,28 @@ while offset < scanBudget and dispatched < maxJobs do
   for _, groupId in ipairs(groups) do
     if dispatched >= maxJobs then break end
 
-    if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
-      -- Tenant soft-cap check (no-op when tenantCap == 0).
-      local tenantOverCap = false
-      local tenantCountKey = nil
-      if tenantCap > 0 then
-        local slashPos = string.find(groupId, "/", 1, true)
-        if slashPos and slashPos > 1 then
-          local tenantId = string.sub(groupId, 1, slashPos - 1)
-          tenantCountKey = keyPrefix .. "tenant_active:" .. tenantId
-          local cached = tenantCapCache[tenantId]
-          if cached == nil then
-            local n = tonumber(redis.call("GET", tenantCountKey)) or 0
-            cached = n >= tenantCap
-            tenantCapCache[tenantId] = cached
-          end
-          if cached then tenantOverCap = true end
+    -- Tenant soft-cap check (no-op when tenantCap == 0).
+    -- Checked before SISMEMBER so over-cap groups skip with 0 Redis commands
+    -- (the cap result is cached per-tenant in a Lua table).
+    local tenantOverCap = false
+    local tenantCountKey = nil
+    if tenantCap > 0 then
+      local slashPos = string.find(groupId, "/", 1, true)
+      if slashPos and slashPos > 1 then
+        local tenantId = string.sub(groupId, 1, slashPos - 1)
+        tenantCountKey = keyPrefix .. "tenant_active:" .. tenantId
+        local cached = tenantCapCache[tenantId]
+        if cached == nil then
+          local n = tonumber(redis.call("GET", tenantCountKey)) or 0
+          cached = n >= tenantCap
+          tenantCapCache[tenantId] = cached
         end
+        if cached then tenantOverCap = true end
       end
+    end
 
-      if not tenantOverCap then
+    if not tenantOverCap then
+      if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
         local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
         -- Defensive activeKey check — covers legacy state during migration
         -- and the small race between ZADD ready and ZADD active.
@@ -473,7 +475,7 @@ while offset < scanBudget and dispatched < maxJobs do
           end
         end
       end
-      end
+    end
     end
   end
 

--- a/specs/event-sourcing/tenant-soft-cap.feature
+++ b/specs/event-sourcing/tenant-soft-cap.feature
@@ -82,3 +82,29 @@ Feature: Per-tenant soft cap on in-flight dispatch
     Given the env var "LANGWATCH_DISPATCH_TENANT_CAP" is set to "0"
     When a full dispatch then completion lifecycle runs for any tenant
     Then no tenant counter keys are ever created in Redis
+
+  # DISPATCH_BATCH_LUA parity — the batch path shares the same cap logic
+  # but iterates multiple groups per EVAL. These scenarios guard against
+  # the batch branch drifting from the single-dispatch path above.
+
+  @integration @tenant-cap @batch @fairness
+  Scenario: DISPATCH_BATCH skips over-cap groups and dispatches under-cap groups in one call
+    Given a tenant "proj_noisy" with cap=1 and 5 groups on the ready zset
+    And a tenant "proj_quiet" with 1 group later in the zset
+    When DISPATCH_BATCH_LUA is invoked with maxJobs=10
+    Then "proj_noisy" dispatches exactly 1 group (hitting cap)
+    And "proj_quiet" dispatches its group in the same batch
+
+  @integration @tenant-cap @batch @blocked
+  Scenario: Over-cap tenant with a blocked group does not affect other tenants
+    Given a tenant "proj_noisy" at cap with a blocked group from a prior retry
+    And a tenant "proj_quiet" with dispatchable groups
+    When DISPATCH_BATCH_LUA is invoked
+    Then "proj_noisy"'s blocked group is not dispatched
+    And "proj_quiet"'s groups dispatch normally
+
+  @integration @tenant-cap @batch @cleanup
+  Scenario: Drift cleanup runs for under-cap tenants in batch dispatch
+    Given a tenant "proj_acme" with a zombie group (empty jobs zset) on the ready zset
+    When DISPATCH_BATCH_LUA is invoked
+    Then the zombie group is removed from the ready zset


### PR DESCRIPTION
## Summary

- Moves the tenant cap check above the SISMEMBER blocked check in `DISPATCH_BATCH_LUA`
- Over-cap groups now skip with **0 Redis commands** (Lua table lookup only) instead of 1 SISMEMBER each
- Projected: ~333K SISMEMBER/sec eliminated, main thread CPU from ~74% to ~5-10%

## Context

Follow-up to #4173 (which eliminated the GET waste). The SISMEMBER blocked check is the last remaining per-group Redis command for over-cap groups. The tenant cap result is already cached in a Lua table after the first lookup per tenant — moving it before the SISMEMBER means over-cap groups skip entirely at the Lua level with zero Redis commands.

Live data at time of fix: 11.7K ready groups, ~11.4K over-cap (97%), 333K SISMEMBER/sec, 74% main thread CPU. Under-cap tenants (~300 groups) still get full SISMEMBER + GET + dispatch as before.

## Test plan

- [x] All groupQueue unit tests pass (6/6)
- [x] Integration tests pass — hardened per CodeRabbit review:
  - Cross-tenant dispatch positively verified (quiet-tenant job dispatches in second batch)
  - Zombie ready-set cleanup tested with seeded stale entry
  - Over-cap test correctly keeps tenant at cap after restageAndBlock
- [ ] Monitor Redis SISMEMBER rate + main thread CPU after deploy — expect ~97% reduction in SISMEMBER, CPU to single digits