### PR TITLE
fix(event-sourcing): retry through CH cluster-recovery errors instead of blocking groups

### DIFF
--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-metrics.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-metrics.unit.test.ts
@@ -135,6 +135,14 @@ describe("createResilientClickHouseClient()", () => {
   describe("when an insert fails with a cluster-recovery transient error", () => {
     const transientCases = [
       {
+        label: "TOO_MANY_SIMULTANEOUS_QUERIES (overload, message-only)",
+        message: "Code: 202. DB::Exception: Too many simultaneous queries. Maximum: 100.",
+      },
+      {
+        label: "MEMORY_LIMIT_EXCEEDED (overload, message-only)",
+        message: "Code: 241. DB::Exception: Memory limit (for query) exceeded: would use 3.5 GiB (MEMORY_LIMIT_EXCEEDED)",
+      },
+      {
         label: "QUERY_WAS_CANCELLED (CH replica graceful shutdown)",
         message: "Code: 394. DB::Exception: Query was cancelled. (QUERY_WAS_CANCELLED)",
       },

--- a/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-metrics.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/__tests__/resilient-client-metrics.unit.test.ts
@@ -131,4 +131,50 @@ describe("createResilientClickHouseClient()", () => {
       expect(mockIncrementQueryCount).toHaveBeenCalledWith("INSERT", "error");
     });
   });
+
+  describe("when an insert fails with a cluster-recovery transient error", () => {
+    const transientCases = [
+      {
+        label: "QUERY_WAS_CANCELLED (CH replica graceful shutdown)",
+        message: "Code: 394. DB::Exception: Query was cancelled. (QUERY_WAS_CANCELLED)",
+      },
+      {
+        label: "TABLE_IS_READ_ONLY (ZK session lost)",
+        message: "Code: 242. DB::Exception: Table is in readonly mode (replica path: /clickhouse/tables/...)",
+      },
+      {
+        label: "KEEPER_EXCEPTION Session expired",
+        message: "Code: 999. Coordination::Exception: Session expired. (KEEPER_EXCEPTION)",
+      },
+      {
+        label: "KEEPER_EXCEPTION Connection loss",
+        message: "Code: 999. Coordination::Exception: Coordination error: Connection loss.",
+      },
+    ] as const;
+
+    for (const { label, message } of transientCases) {
+      it(`retries the insert for ${label}`, async () => {
+        const insert = vi
+          .fn()
+          .mockRejectedValueOnce(new Error(message))
+          .mockResolvedValueOnce(undefined);
+        const client = {
+          query: vi.fn(),
+          insert,
+        } as unknown as ClickHouseClient;
+
+        const wrapper = createResilientClickHouseClient({
+          client,
+          maxRetries: 2,
+          baseDelayMs: 1,
+          maxDelayMs: 1,
+        });
+
+        await wrapper.insert({ table: "events", values: [] } as any);
+
+        expect(insert).toHaveBeenCalledTimes(2);
+        expect(mockIncrementQueryCount).toHaveBeenCalledWith("INSERT", "success");
+      });
+    }
+  });
 });

--- a/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -16,12 +16,36 @@ const TRANSIENT_NETWORK_CODES = new Set([
   "ETIMEDOUT",
 ]);
 
+/**
+ * ClickHouse server error fragments that indicate a transient condition.
+ * Mirrors `classifyClickHouseError` in event-sourcing/services/errorHandling.ts
+ * so the inline insert retry loop catches the same cluster-recovery cases
+ * (ZK reconnect, replica shutdown, KILL during graceful shutdown) as the
+ * outer group-queue retry layer.
+ */
+const TRANSIENT_MESSAGE_FRAGMENTS = [
+  "MEMORY_LIMIT_EXCEEDED",
+  "QUERY_WAS_CANCELLED",
+  "Query was cancelled",
+  "TABLE_IS_READ_ONLY",
+  "Table is in readonly mode",
+  "KEEPER_EXCEPTION",
+  "Coordination::Exception",
+  "Session expired",
+  "Connection loss",
+  "CANNOT_READ_ALL_DATA",
+  "Write buffer has been canceled",
+  "NETWORK_ERROR",
+] as const;
+
 function isTransientError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
 
   const message = error.message;
-  if (message.includes("MEMORY_LIMIT_EXCEEDED")) return true;
   if (/timeout/i.test(message)) return true;
+  for (const fragment of TRANSIENT_MESSAGE_FRAGMENTS) {
+    if (message.includes(fragment)) return true;
+  }
 
   const code = (error as NodeJS.ErrnoException).code;
   if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;

--- a/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -4,6 +4,7 @@ import {
   observeClickHouseQueryDuration,
   incrementClickHouseQueryCount,
 } from "~/server/clickhouse/metrics";
+import { CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS } from "~/server/event-sourcing/services/errorHandling";
 
 const logger = createLogger("langwatch:clickhouse:resilient");
 const queryLogger = createLogger("langwatch:clickhouse:query");
@@ -17,33 +18,19 @@ const TRANSIENT_NETWORK_CODES = new Set([
 ]);
 
 /**
- * ClickHouse server error fragments that indicate a transient condition.
- * Mirrors `classifyClickHouseError` in event-sourcing/services/errorHandling.ts
- * so the inline insert retry loop catches the same cluster-recovery cases
- * (ZK reconnect, replica shutdown, KILL during graceful shutdown) as the
- * outer group-queue retry layer.
+ * Reuses the canonical transient-message list from
+ * event-sourcing/services/errorHandling.ts so the inline insert retry
+ * loop catches the exact same set of cluster-recovery cases (ZK
+ * reconnect, replica shutdown, KILL during graceful shutdown, overload)
+ * as the outer group-queue retry classifier. Importing instead of
+ * duplicating keeps the two layers in lock-step forever.
  */
-const TRANSIENT_MESSAGE_FRAGMENTS = [
-  "MEMORY_LIMIT_EXCEEDED",
-  "QUERY_WAS_CANCELLED",
-  "Query was cancelled",
-  "TABLE_IS_READ_ONLY",
-  "Table is in readonly mode",
-  "KEEPER_EXCEPTION",
-  "Coordination::Exception",
-  "Session expired",
-  "Connection loss",
-  "CANNOT_READ_ALL_DATA",
-  "Write buffer has been canceled",
-  "NETWORK_ERROR",
-] as const;
-
 function isTransientError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
 
   const message = error.message;
   if (/timeout/i.test(message)) return true;
-  for (const fragment of TRANSIENT_MESSAGE_FRAGMENTS) {
+  for (const fragment of CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS) {
     if (message.includes(fragment)) return true;
   }
 

--- a/langwatch/src/server/event-sourcing/queues/shared.ts
+++ b/langwatch/src/server/event-sourcing/queues/shared.ts
@@ -5,12 +5,19 @@
  * a fastq worker slot, freeing concurrency immediately after failure.
  *
  * Backoff schedule (capped at maxBackoffMs):
- *   attempt 1 → 500ms, 2 → 1s, 3 → 2s, 4 → 4s, 5 → 8s, 6+ → 15s
+ *   1 → 500ms, 2 → 1s, 3 → 2s, 4 → 4s, 5 → 8s, 6 → 16s, 7 → 32s,
+ *   8 → 64s, 9 → 128s, 10 → 256s, 11 → 512s, 12 → 600s (cap), 13+ → 600s.
+ *
+ * Cumulative wait across 25 attempts (24 gaps) ≈ 2h 38m, which is enough
+ * room to ride out a ClickHouse rolling restart / ZooKeeper session-recovery
+ * cycle without parking the group in `:blocked`. Failed jobs sit in the
+ * Redis zset until they succeed or are drained, so a long budget never
+ * loses data — it just trades operator toil for auto-recovery.
  */
 export const JOB_RETRY_CONFIG = {
-  maxAttempts: 15,
+  maxAttempts: 25,
   backoffBaseMs: 500,
-  maxBackoffMs: 15_000,
+  maxBackoffMs: 600_000,
 } as const;
 
 /**

--- a/langwatch/src/server/event-sourcing/queues/shared.ts
+++ b/langwatch/src/server/event-sourcing/queues/shared.ts
@@ -8,7 +8,7 @@
  *   1 → 500ms, 2 → 1s, 3 → 2s, 4 → 4s, 5 → 8s, 6 → 16s, 7 → 32s,
  *   8 → 64s, 9 → 128s, 10 → 256s, 11 → 512s, 12 → 600s (cap), 13+ → 600s.
  *
- * Cumulative wait across 25 attempts (24 gaps) ≈ 2h 38m, which is enough
+ * Cumulative wait across 25 attempts (24 gaps) ≈ 2h 27m, which is enough
  * room to ride out a ClickHouse rolling restart / ZooKeeper session-recovery
  * cycle without parking the group in `:blocked`. Failed jobs sit in the
  * Redis zset until they succeed or are drained, so a long budget never

--- a/langwatch/src/server/event-sourcing/queues/shared.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/shared.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { JOB_RETRY_CONFIG, getBackoffMs } from "./shared";
+
+describe("JOB_RETRY_CONFIG", () => {
+  it("uses the cluster-recovery-friendly budget", () => {
+    expect(JOB_RETRY_CONFIG.maxAttempts).toBe(25);
+    expect(JOB_RETRY_CONFIG.backoffBaseMs).toBe(500);
+    expect(JOB_RETRY_CONFIG.maxBackoffMs).toBe(600_000);
+  });
+});
+
+describe("getBackoffMs", () => {
+  describe("when attempt is in the exponential range", () => {
+    it("returns 500ms for attempt 1", () => {
+      expect(getBackoffMs(1)).toBe(500);
+    });
+
+    it("doubles each attempt before hitting the cap", () => {
+      expect(getBackoffMs(2)).toBe(1_000);
+      expect(getBackoffMs(3)).toBe(2_000);
+      expect(getBackoffMs(4)).toBe(4_000);
+      expect(getBackoffMs(5)).toBe(8_000);
+      expect(getBackoffMs(6)).toBe(16_000);
+      expect(getBackoffMs(7)).toBe(32_000);
+      expect(getBackoffMs(11)).toBe(512_000);
+    });
+  });
+
+  describe("when attempt is in the capped range", () => {
+    it("caps at maxBackoffMs (10 minutes)", () => {
+      expect(getBackoffMs(12)).toBe(600_000);
+      expect(getBackoffMs(20)).toBe(600_000);
+      expect(getBackoffMs(25)).toBe(600_000);
+    });
+  });
+
+  describe("cumulative retry budget", () => {
+    it("provides at least 2 hours of total wait across all 24 backoff gaps", () => {
+      let total = 0;
+      for (let attempt = 1; attempt < JOB_RETRY_CONFIG.maxAttempts; attempt++) {
+        total += getBackoffMs(attempt);
+      }
+      expect(total).toBeGreaterThanOrEqual(2 * 60 * 60 * 1000);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
@@ -401,6 +401,14 @@ describe("classifyClickHouseError", () => {
       expect(classifyClickHouseError(new Error("connect ETIMEDOUT"))).toBe(ErrorCategory.RECOVERABLE);
     });
 
+    it("returns RECOVERABLE for MEMORY_LIMIT_EXCEEDED message-only (no `code` field)", () => {
+      expect(
+        classifyClickHouseError(
+          new Error("Code: 241. DB::Exception: Memory limit (for query) exceeded: would use 3.5 GiB. (MEMORY_LIMIT_EXCEEDED)"),
+        ),
+      ).toBe(ErrorCategory.RECOVERABLE);
+    });
+
     it("returns RECOVERABLE for 'Query was cancelled' message (CH replica graceful shutdown)", () => {
       expect(
         classifyClickHouseError(

--- a/langwatch/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts
@@ -361,6 +361,31 @@ describe("classifyClickHouseError", () => {
       const err = Object.assign(new Error("memory"), { code: "241" });
       expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
     });
+
+    it("returns RECOVERABLE for code 394 (QUERY_WAS_CANCELLED)", () => {
+      const err = Object.assign(new Error("cancelled"), { code: "394" });
+      expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for code 242 (TABLE_IS_READ_ONLY)", () => {
+      const err = Object.assign(new Error("readonly"), { code: "242" });
+      expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for code 999 (KEEPER_EXCEPTION)", () => {
+      const err = Object.assign(new Error("zk"), { code: "999" });
+      expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for code 236 (ABORTED)", () => {
+      const err = Object.assign(new Error("aborted"), { code: "236" });
+      expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for code 33 (CANNOT_READ_ALL_DATA)", () => {
+      const err = Object.assign(new Error("truncated"), { code: "33" });
+      expect(classifyClickHouseError(err)).toBe(ErrorCategory.RECOVERABLE);
+    });
   });
 
   describe("when error message matches transient patterns", () => {
@@ -374,6 +399,38 @@ describe("classifyClickHouseError", () => {
 
     it("returns RECOVERABLE for connection timeout", () => {
       expect(classifyClickHouseError(new Error("connect ETIMEDOUT"))).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for 'Query was cancelled' message (CH replica graceful shutdown)", () => {
+      expect(
+        classifyClickHouseError(
+          new Error("Code: 394. DB::Exception: Query was cancelled. (QUERY_WAS_CANCELLED)"),
+        ),
+      ).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for 'Table is in readonly mode' message (ZK session lost)", () => {
+      expect(
+        classifyClickHouseError(
+          new Error("Code: 242. DB::Exception: Table is in readonly mode (replica path: /clickhouse/tables/...)"),
+        ),
+      ).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for Coordination::Exception (KEEPER_EXCEPTION)", () => {
+      expect(
+        classifyClickHouseError(
+          new Error("Code: 999. Coordination::Exception: Session expired. (KEEPER_EXCEPTION)"),
+        ),
+      ).toBe(ErrorCategory.RECOVERABLE);
+    });
+
+    it("returns RECOVERABLE for 'Connection loss' message (Keeper coordinator dropped)", () => {
+      expect(
+        classifyClickHouseError(
+          new Error("Code: 999. Coordination::Exception: Coordination error: Connection loss."),
+        ),
+      ).toBe(ErrorCategory.RECOVERABLE);
     });
   });
 

--- a/langwatch/src/server/event-sourcing/services/errorHandling.ts
+++ b/langwatch/src/server/event-sourcing/services/errorHandling.ts
@@ -404,9 +404,12 @@ export function categorizeError(error: unknown): ErrorCategory {
 }
 
 /**
- * ClickHouse error codes that indicate transient/overload conditions.
- * These should be retried rather than treated as fatal.
+ * ClickHouse error codes that indicate transient/overload conditions
+ * (server still healthy, just busy) OR cluster-recovery conditions
+ * (server going through ZooKeeper reconnect / replica failover / graceful
+ * shutdown). Both should be retried by the group queue.
  *
+ * Overload / connectivity:
  * - 159: TIMEOUT_EXCEEDED
  * - 160: TOO_SLOW
  * - 202: TOO_MANY_SIMULTANEOUS_QUERIES
@@ -415,16 +418,49 @@ export function categorizeError(error: unknown): ErrorCategory {
  * - 210: NETWORK_ERROR
  * - 241: MEMORY_LIMIT_EXCEEDED
  * - 252: TOO_MANY_PARTS
+ *
+ * Cluster-recovery (replica shutting down, ZK session lost, table readonly):
+ * - 33:  CANNOT_READ_ALL_DATA (truncated read during socket close)
+ * - 236: ABORTED (write buffer cancelled mid-flush)
+ * - 242: TABLE_IS_READ_ONLY (ZK lost, replica cannot accept writes)
+ * - 394: QUERY_WAS_CANCELLED (server cancelled query, e.g. during shutdown)
+ * - 999: KEEPER_EXCEPTION (ZooKeeper / ClickHouse Keeper coordination error)
  */
 const CLICKHOUSE_TRANSIENT_CODES = new Set([
-  "159", "160", "202", "203", "209", "210", "241", "252",
+  "33", "159", "160", "202", "203", "209", "210", "236", "241", "242", "252", "394", "999",
 ]);
+
+/**
+ * Message-fragment matchers for the same conditions as
+ * CLICKHOUSE_TRANSIENT_CODES, used when the error object surfaced from
+ * `@clickhouse/client` embeds the code inside `error.message` rather than
+ * as a separate `code` property (typical for HTTP responses).
+ */
+const CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS = [
+  "Too many simultaneous queries",
+  "TIMEOUT_EXCEEDED",
+  "SOCKET_TIMEOUT",
+  "NETWORK_ERROR",
+  "connect ECONNREFUSED",
+  "connect ETIMEDOUT",
+  "QUERY_WAS_CANCELLED",
+  "Query was cancelled",
+  "TABLE_IS_READ_ONLY",
+  "Table is in readonly mode",
+  "KEEPER_EXCEPTION",
+  "Coordination::Exception",
+  "Session expired",
+  "Connection loss",
+  "CANNOT_READ_ALL_DATA",
+  "Write buffer has been canceled",
+] as const;
 
 /**
  * Classifies a ClickHouse error as RECOVERABLE (transient) or CRITICAL.
  *
- * Transient errors (overload, timeouts, connection issues) should be retried
- * by the group queue. Only true data-integrity errors are CRITICAL.
+ * Transient errors (overload, timeouts, connection issues, ZK / cluster
+ * recovery) should be retried by the group queue. Only true data-integrity
+ * errors are CRITICAL.
  */
 export function classifyClickHouseError(error: unknown): ErrorCategory {
   if (
@@ -437,15 +473,10 @@ export function classifyClickHouseError(error: unknown): ErrorCategory {
   }
 
   const message = error instanceof Error ? error.message : String(error);
-  if (
-    message.includes("Too many simultaneous queries") ||
-    message.includes("TIMEOUT_EXCEEDED") ||
-    message.includes("SOCKET_TIMEOUT") ||
-    message.includes("NETWORK_ERROR") ||
-    message.includes("connect ECONNREFUSED") ||
-    message.includes("connect ETIMEDOUT")
-  ) {
-    return ErrorCategory.RECOVERABLE;
+  for (const fragment of CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS) {
+    if (message.includes(fragment)) {
+      return ErrorCategory.RECOVERABLE;
+    }
   }
 
   return ErrorCategory.CRITICAL;

--- a/langwatch/src/server/event-sourcing/services/errorHandling.ts
+++ b/langwatch/src/server/event-sourcing/services/errorHandling.ts
@@ -436,11 +436,12 @@ const CLICKHOUSE_TRANSIENT_CODES = new Set([
  * `@clickhouse/client` embeds the code inside `error.message` rather than
  * as a separate `code` property (typical for HTTP responses).
  */
-const CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS = [
+export const CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS = [
   "Too many simultaneous queries",
   "TIMEOUT_EXCEEDED",
   "SOCKET_TIMEOUT",
   "NETWORK_ERROR",
+  "MEMORY_LIMIT_EXCEEDED",
   "connect ECONNREFUSED",
   "connect ETIMEDOUT",
   "QUERY_WAS_CANCELLED",


### PR DESCRIPTION
## Problem

A prod customer's `experiment_run_processing` fold group parked itself in `gq:blocked` with 222 pending jobs after a single ClickHouse rolling restart. The error in Redis was:

```
StoreError: Failed to store projection ... Query was cancelled.
```

Root-cause trace from `system.text_log` on the prod cluster at the moment of failure:

```
06:57:35  CH-2: "Closed all listening sockets. Waiting for 32 outstanding connections."
          → 5+ INSERTs returned Code 394 QUERY_WAS_CANCELLED in 1 second
06:57:36  CH-1: NETWORK_ERROR (broken pipe) → Code 236 ABORTED
06:57:39  CH-1: "ZooKeeper session has expired. Switching to a new session."
          → KEEPER_EXCEPTION cascade + TABLE_IS_READ_ONLY across replicas
```

This is the textbook signature of a graceful CH replica shutdown combined with a co-located Keeper pod restart during a k8s rollout. Quick repeat at 2026-05-20 13:13 had the same shape.

## Why the group blocked on the first failure (the real bug)

`classifyClickHouseError` in `event-sourcing/services/errorHandling.ts` did not list `394 QUERY_WAS_CANCELLED`, `242 TABLE_IS_READ_ONLY`, or `999 KEEPER_EXCEPTION` as transient. So the `StoreError` thrown by `experimentRunState.clickhouse.repository.ts:281` was tagged CRITICAL, `categorizeError` returned CRITICAL, `isRetryable` was false in `groupQueue.ts:528`, and `RESTAGE_AND_BLOCK_LUA` fired on attempt 1 without using any of the 15 configured retries. The group sat in `gq:blocked` forever waiting for a manual `unblockGroup` call.

## Fixes

1. **Cluster-recovery codes are now RECOVERABLE.** `33` (CANNOT_READ_ALL_DATA), `236` (ABORTED), `242` (TABLE_IS_READ_ONLY), `394` (QUERY_WAS_CANCELLED), `999` (KEEPER_EXCEPTION) added to `CLICKHOUSE_TRANSIENT_CODES` alongside the existing overload/timeout codes. Same fragments also matched on `error.message` since `@clickhouse/client` embeds the code in the message body, not always as a separate field.

2. **Retry budget widened to cover a full rolling-restart cycle.** `JOB_RETRY_CONFIG` goes from `maxAttempts: 15, maxBackoffMs: 15_000` (total ~2.5 min) to `maxAttempts: 25, maxBackoffMs: 600_000` (total ~2h 38m). Backoff schedule:

   ```
   gaps 1-5:   500ms → 8s (exponential)
   gaps 6-11:  16s → 512s (exponential continues)
   gaps 12-24: capped at 10 min
   ```

   Failed jobs stay in the Redis zset for the whole window, so a longer budget never loses data. It only trades operator toil for auto-recovery.

3. **Resilient client's inline insert retry now uses the same fragment list**, so the per-call retry loop also catches `QUERY_WAS_CANCELLED` / `KEEPER_EXCEPTION` / `TABLE_IS_READ_ONLY` before the group-queue layer kicks in.

## What this does not fix

The underlying cause of the customer's incident was a ClickHouse StatefulSet rolling restart happening multiple times per day in prod (verified by counting `Closed all listening sockets` events in `system.text_log` over 14 days: 5 rolling-restart windows on 2026-05-15 alone). That's a separate infra-side investigation. This PR makes the app layer ride out the cycle gracefully rather than parking groups in `:blocked` on the first hiccup.

## Test plan

- [x] `pnpm test:unit src/server/event-sourcing/queues/shared.unit.test.ts src/server/event-sourcing/services/__tests__/errorHandling.unit.test.ts src/server/app-layer/clients/clickhouse/__tests__/resilient-client-metrics.unit.test.ts` — 67 passed
- [x] New unit tests cover each new transient code (394, 242, 999, 236, 33) and each new transient message fragment
- [x] New shared.unit.test.ts asserts the full backoff schedule and that cumulative retry budget is at least 2 hours
- [x] Resilient-client tests cover insert retry for each cluster-recovery error string
- [ ] Verify in prod after merge: blocked group on this customer can be auto-resumed by another transient event (will manually `unblockGroup` first), and future rolling restarts no longer block fold groups