### PR TITLE
feat(traces-v2): interactive error chip popover + blue glow on header-chip jumps

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceDrawer/ExceptionsContent.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/ExceptionsContent.tsx
@@ -1,0 +1,111 @@
+import { Button, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import { LuCircleX } from "react-icons/lu";
+import type { ErrorSpanRanked } from "../../utils/errorSpans";
+
+interface ExceptionsContentProps {
+  /** Trace-level error message rolled up from the failing span(s). */
+  error: string | null | undefined;
+  /** Spans flagged with status=error, deepest-first (use `rankedErrorSpans`). */
+  errorSpans: ErrorSpanRanked[];
+  /** Click handler for a span pill — jumps the drawer to that span. */
+  onSelectSpan?: (spanId: string) => void;
+  /**
+   * Compact mode tightens paddings + truncation widths so the same
+   * block fits comfortably inside a hover popover. The full-size
+   * variant is what the Exceptions accordion uses inline.
+   */
+  density?: "comfortable" | "compact";
+  /** Optional element rendered above the message block (e.g. a "preview" hint). */
+  header?: ReactNode;
+}
+
+/**
+ * Shared visual for the trace-level error summary + per-span jump
+ * buttons. The trace drawer surfaces this block in two places:
+ *
+ *   1. The `Exceptions` accordion on the Summary tab (comfortable).
+ *   2. A hover popover anchored to the header `Error` chip (compact).
+ *
+ * Keeping the two paths in one component means the popover stays in
+ * lockstep with the accordion: the same span ordering, the same red
+ * tone, the same chip shape. A second customer report that "the
+ * header link doesn't take me anywhere useful" stops being plausible
+ * once both surfaces share rendering.
+ */
+export function ExceptionsContent({
+  error,
+  errorSpans,
+  onSelectSpan,
+  density = "comfortable",
+  header,
+}: ExceptionsContentProps) {
+  const isCompact = density === "compact";
+  const spanNameMaxWidth = isCompact ? "160px" : "220px";
+  return (
+    <VStack align="stretch" gap={isCompact ? 1.5 : 2}>
+      {header}
+      {error && (
+        <HStack
+          gap={2}
+          paddingX={isCompact ? 2 : 3}
+          paddingY={isCompact ? 1.5 : 2}
+          borderRadius="sm"
+          bg="red.subtle"
+          align="flex-start"
+        >
+          <Icon
+            as={LuCircleX}
+            boxSize={isCompact ? 3.5 : 4}
+            color="red.fg"
+            flexShrink={0}
+            marginTop={0.5}
+          />
+          <Text
+            textStyle="xs"
+            color="red.fg"
+            whiteSpace="pre-wrap"
+            maxHeight={isCompact ? "5lh" : undefined}
+            overflow={isCompact ? "hidden" : undefined}
+          >
+            {error}
+          </Text>
+        </HStack>
+      )}
+      {errorSpans.length > 0 && (
+        <HStack gap={1.5} flexWrap="wrap" align="center">
+          <Text
+            textStyle="2xs"
+            color="fg.muted"
+            textTransform="uppercase"
+            letterSpacing="0.04em"
+          >
+            Spans with errors
+          </Text>
+          {errorSpans.map(({ span }) => (
+            <Button
+              key={span.spanId}
+              size="2xs"
+              variant="outline"
+              colorPalette="red"
+              onClick={(e) => {
+                // Stop propagation so the popover's outer hover/click
+                // capture (which would dismiss it before the handler
+                // ran) doesn't swallow the jump request.
+                e.stopPropagation();
+                onSelectSpan?.(span.spanId);
+              }}
+              paddingX={2}
+              height="22px"
+              fontWeight="medium"
+            >
+              <Text truncate maxWidth={spanNameMaxWidth}>
+                {span.name}
+              </Text>
+            </Button>
+          ))}
+        </HStack>
+      )}
+    </VStack>
+  );
+}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/ExceptionsContent.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/ExceptionsContent.tsx
@@ -11,6 +11,15 @@ interface ExceptionsContentProps {
   /** Click handler for a span pill — jumps the drawer to that span. */
   onSelectSpan?: (spanId: string) => void;
   /**
+   * Optional sibling-callback fired alongside `onSelectSpan` so the
+   * Exceptions section pulses + scrolls into view when the operator
+   * jumps via a pill. The chip popover wires this to re-fire the
+   * header chip's focus pipeline; the accordion-embedded variant wires
+   * it to re-pulse the section the operator is already viewing so the
+   * eye lands back on the row that owns the selected span.
+   */
+  onFocusSection?: () => void;
+  /**
    * Compact mode tightens paddings + truncation widths so the same
    * block fits comfortably inside a hover popover. The full-size
    * variant is what the Exceptions accordion uses inline.
@@ -37,6 +46,7 @@ export function ExceptionsContent({
   error,
   errorSpans,
   onSelectSpan,
+  onFocusSection,
   density = "comfortable",
   header,
 }: ExceptionsContentProps) {
@@ -94,6 +104,7 @@ export function ExceptionsContent({
                 // ran) doesn't swallow the jump request.
                 e.stopPropagation();
                 onSelectSpan?.(span.spanId);
+                onFocusSection?.();
               }}
               paddingX={2}
               height="22px"

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -214,13 +214,27 @@ function StatusChip({
     requestFocus({ traceId: trace.traceId, section: "exceptions" });
   }, [requestFocus, setActiveTab, setViewMode, trace.traceId]);
 
+  // Same focus request without the activeTab override, so a span pill
+  // inside the popover can flip to the span tab (via `selectSpan`)
+  // without our callback then yanking the operator back to summary.
+  // The pulse lands on whichever accordion stack is mounted next —
+  // `SpanAccordions` for span tab, `TraceSummaryAccordions` for
+  // summary — since both observe the same focus store.
+  const focusExceptionsKeepTab = useCallback(() => {
+    requestFocus({ traceId: trace.traceId, section: "exceptions" });
+  }, [requestFocus, trace.traceId]);
+
   const jumpToSpan = useCallback(
     (spanId: string) => {
+      // Land on the span detail tab — `selectSpan` flips activeTab to
+      // "span" internally, so we just ensure trace mode here. The
+      // accordion-side focus-glow observer on SpanAccordions will catch
+      // the follow-up `requestFocus({section: "exceptions"})` fired by
+      // ExceptionsContent and pulse the span's own Exceptions section.
       setViewMode("trace");
-      setActiveTab("summary");
       selectSpan(spanId);
     },
-    [selectSpan, setActiveTab, setViewMode],
+    [selectSpan, setViewMode],
   );
 
   // OK / non-error rendering keeps the existing static-tooltip recipe —
@@ -291,7 +305,7 @@ function StatusChip({
               error={trace.error}
               errorSpans={errorSpans}
               onSelectSpan={jumpToSpan}
-              onFocusSection={focusExceptions}
+              onFocusSection={focusExceptionsKeepTab}
               density="compact"
             />
             {/* Anchor row: nudges the operator that the popover is a

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -291,6 +291,7 @@ function StatusChip({
               error={trace.error}
               errorSpans={errorSpans}
               onSelectSpan={jumpToSpan}
+              onFocusSection={focusExceptions}
               density="compact"
             />
             {/* Anchor row: nudges the operator that the popover is a

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -2,8 +2,10 @@ import {
   Box,
   Button,
   Circle,
+  HoverCard,
   HStack,
   Icon,
+  Portal,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -39,6 +41,9 @@ import { useTraceRefresh } from "../../../hooks/useTraceRefresh";
 import { useTraceResources } from "../../../hooks/useTraceResources";
 import { useDrawerStore } from "../../../stores/drawerStore";
 import { useFilterStore } from "../../../stores/filterStore";
+import { useFocusSectionStore } from "../../../stores/focusSectionStore";
+import { rankedErrorSpans } from "../../../utils/errorSpans";
+import { ExceptionsContent } from "../ExceptionsContent";
 import type { PinnedAttribute } from "../../../stores/pinnedAttributesStore";
 import {
   abbreviateModel,
@@ -175,10 +180,13 @@ function TraceIdChip({ traceId }: { traceId: string }) {
 }
 
 /**
- * Trace status indicator. For error traces, the chip is clickable —
- * jumps to the first span with an error so the user can investigate
- * without having to scan the waterfall manually. OK traces render the
- * dot non-interactively (just the help tooltip).
+ * Trace status indicator. On error traces the chip is an interactive
+ * popover: hovering opens an inline preview of the Exceptions section
+ * (same trace-level message + same per-span pill row, sourced from
+ * the same `rankedErrorSpans` helper), and clicking the chip itself
+ * jumps the operator to the Summary tab's Exceptions accordion with
+ * a brief blue pulse so the eye lands. OK traces render the dot
+ * non-interactively (just the help tooltip).
  */
 function StatusChip({
   trace,
@@ -189,60 +197,121 @@ function StatusChip({
 }) {
   const selectSpan = useDrawerStore((s) => s.selectSpan);
   const setActiveTab = useDrawerStore((s) => s.setActiveTab);
+  const setViewMode = useDrawerStore((s) => s.setViewMode);
+  const requestFocus = useFocusSectionStore((s) => s.request);
   const spanTree = useSpanTree();
-  const firstErrorSpanId = useMemo(() => {
-    const spans = spanTree.data ?? [];
-    if (spans.length === 0) return null;
-    const errors = spans.filter((s) => s.status === "error");
-    if (errors.length === 0) return null;
-    errors.sort((a, b) => a.startTimeMs - b.startTimeMs);
-    return errors[0]!.spanId;
-  }, [spanTree.data]);
+  const errorSpans = useMemo(
+    () => rankedErrorSpans(spanTree.data ?? []),
+    [spanTree.data],
+  );
 
   const isError = trace.status === "error";
-  const canJump = isError && firstErrorSpanId != null;
-  const tooltipContent = isError
-    ? canJump
-      ? "Jump to the first span with an error"
-      : "At least one span on this trace recorded an error"
-    : trace.status === "ok"
-      ? "No errors recorded on any span in this trace"
-      : `Trace status: ${trace.status}`;
+  const hasErrorContent = isError && (!!trace.error || errorSpans.length > 0);
 
-  const handleClick = () => {
-    if (!canJump) return;
-    selectSpan(firstErrorSpanId);
+  const focusExceptions = useCallback(() => {
+    setViewMode("trace");
     setActiveTab("summary");
-  };
+    requestFocus({ traceId: trace.traceId, section: "exceptions" });
+  }, [requestFocus, setActiveTab, setViewMode, trace.traceId]);
+
+  const jumpToSpan = useCallback(
+    (spanId: string) => {
+      setViewMode("trace");
+      setActiveTab("summary");
+      selectSpan(spanId);
+    },
+    [selectSpan, setActiveTab, setViewMode],
+  );
+
+  // OK / non-error rendering keeps the existing static-tooltip recipe —
+  // there's nothing to preview, no jump to make.
+  if (!isError) {
+    const tooltipContent =
+      trace.status === "ok"
+        ? "No errors recorded on any span in this trace"
+        : `Trace status: ${trace.status}`;
+    return (
+      <Tooltip content={tooltipContent} positioning={{ placement: "bottom" }}>
+        <HStack gap={1} flexShrink={0} cursor="help">
+          <Circle size="8px" bg={statusColor} flexShrink={0} />
+        </HStack>
+      </Tooltip>
+    );
+  }
+
+  const chipBody = (
+    <HStack
+      as="button"
+      gap={1}
+      flexShrink={0}
+      cursor="pointer"
+      onClick={focusExceptions}
+      aria-label="Show exception details for this trace"
+      paddingX={1}
+      paddingY={0.5}
+      borderRadius="md"
+      _hover={{ bg: "red.fg/10" }}
+      transition="background 0.15s ease"
+    >
+      <Circle size="8px" bg={statusColor} flexShrink={0} />
+      <Text
+        textStyle="xs"
+        fontWeight="medium"
+        color={statusColor}
+        textTransform="capitalize"
+      >
+        {trace.status}
+      </Text>
+    </HStack>
+  );
+
+  // No content to preview — degrade to the plain clickable chip.
+  // Click still focuses the (empty) Exceptions section so the
+  // operator at least lands on the right tab.
+  if (!hasErrorContent) return chipBody;
 
   return (
-    <Tooltip content={tooltipContent} positioning={{ placement: "bottom" }}>
-      <HStack
-        as={canJump ? "button" : "div"}
-        gap={1}
-        flexShrink={0}
-        cursor={canJump ? "pointer" : "help"}
-        onClick={canJump ? handleClick : undefined}
-        aria-label={canJump ? "Jump to first error span" : undefined}
-        paddingX={canJump ? 1 : 0}
-        paddingY={canJump ? 0.5 : 0}
-        borderRadius={canJump ? "md" : undefined}
-        _hover={canJump ? { bg: "red.fg/10" } : undefined}
-        transition="background 0.15s ease"
-      >
-        <Circle size="8px" bg={statusColor} flexShrink={0} />
-        {trace.status !== "ok" && (
-          <Text
-            textStyle="xs"
-            fontWeight="medium"
-            color={statusColor}
-            textTransform="capitalize"
+    <HoverCard.Root
+      openDelay={150}
+      closeDelay={120}
+      positioning={{ placement: "bottom-start", gutter: 6 }}
+    >
+      <HoverCard.Trigger asChild>{chipBody}</HoverCard.Trigger>
+      <Portal>
+        <HoverCard.Positioner>
+          <HoverCard.Content
+            minWidth="280px"
+            maxWidth="420px"
+            padding={3}
+            borderRadius="lg"
+            background="bg.panel"
+            boxShadow="lg"
           >
-            {trace.status}
-          </Text>
-        )}
-      </HStack>
-    </Tooltip>
+            <ExceptionsContent
+              error={trace.error}
+              errorSpans={errorSpans}
+              onSelectSpan={jumpToSpan}
+              density="compact"
+            />
+            {/* Anchor row: nudges the operator that the popover is a
+                preview of the full Exceptions section, and clicking
+                the chip itself opens it. Matches the deep-link style
+                used on the eval header chips. */}
+            <HStack
+              gap={1}
+              paddingTop={2}
+              marginTop={2}
+              borderTopWidth="1px"
+              borderTopColor="border.muted"
+            >
+              <Text textStyle="2xs" color="fg.muted">
+                Click the chip to open the Exceptions section
+              </Text>
+            </HStack>
+          </HoverCard.Content>
+        </HoverCard.Positioner>
+      </Portal>
+    </HoverCard.Root>
   );
 }
 

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SectionFocusGlow.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SectionFocusGlow.tsx
@@ -1,72 +1,119 @@
-import type React from "react";
+import { Box, Portal } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 
 /**
- * One-shot blue pulse keyed off `data-section-focus="1"` on any
- * `Accordion.Item` rendered by `Section`. The header chips publish a
- * focus request to `useFocusSectionStore`; `TraceSummaryAccordions`
- * observes it, expands the matching section, scrolls it into view,
- * and toggles the data attribute long enough for the keyframe to
- * play. The keyframe self-clears via `forwards` so the section
- * settles back to its normal chrome without us having to remove the
- * attribute on a timer.
- *
- * Why a dedicated stylesheet rather than a Chakra `css={}` prop: the
- * `Accordion.Item` already binds `data-state` and `data-section`
- * attributes for its own state-recipe machinery, and layering another
- * inline-CSS prop fights the recipe's specificity. A document-level
- * keyframe definition + selector keeps the recipe untouched.
- *
- * The colour palette mirrors the existing onboarding `DrawerGlow`
- * recipe so the two glows read as the same affordance, with two
- * deliberate differences: this one runs once and fades, and the
- * outer halo is restricted (a section sits inside an `overflow: auto`
- * pane so a wide outer shadow would get clipped — keep it close to
- * the box).
+ * One-shot blue pulse painted as a Portal-rendered fixed-position overlay
+ * over a target accordion section. The overlay measures the target's
+ * bounding rect on mount and tracks it through scroll / resize for the
+ * duration of the animation. Because the overlay lives at the document
+ * body (via Portal) it sits outside every `overflow: hidden|auto`
+ * ancestor in the drawer chrome, so the full halo renders without
+ * getting cropped by the pane scroll viewport or the sticky section
+ * header. The target itself is left visually untouched — the glow
+ * doesn't paint border/shadow onto the section's own box, which avoided
+ * the prior split-look where the sticky header bg occluded the top
+ * edge of an inset shadow inside the body.
  */
-export const SectionFocusGlow: React.FC = () => (
-  <style>{`
-    @keyframes tracesV2SectionFocusGlow {
-      0% {
-        box-shadow:
-          inset 0 0 0 0 rgba(59, 130, 246, 0),
-          0 0 0 0 rgba(59, 130, 246, 0);
+const GLOW_DURATION_MS = 1500;
+const RECT_TRACK_FPS_INTERVAL_MS = 16;
+
+export function SectionFocusGlow({
+  target,
+  nonce,
+  onDone,
+}: {
+  target: HTMLElement;
+  nonce: number;
+  onDone: () => void;
+}) {
+  const [rect, setRect] = useState<DOMRect>(() => target.getBoundingClientRect());
+
+  useEffect(() => {
+    setRect(target.getBoundingClientRect());
+    let raf = 0;
+    let last = 0;
+    const update = () => {
+      const now = performance.now();
+      if (now - last >= RECT_TRACK_FPS_INTERVAL_MS) {
+        setRect(target.getBoundingClientRect());
+        last = now;
       }
-      18% {
-        box-shadow:
-          inset 0 0 0 2px rgba(59, 130, 246, 0.65),
-          0 0 22px rgba(59, 130, 246, 0.38);
-      }
-      100% {
-        box-shadow:
-          inset 0 0 0 0 rgba(59, 130, 246, 0),
-          0 0 0 0 rgba(59, 130, 246, 0);
-      }
-    }
-    @keyframes tracesV2SectionFocusGlowDark {
-      0% {
-        box-shadow:
-          inset 0 0 0 0 rgba(125, 211, 252, 0),
-          0 0 0 0 rgba(125, 211, 252, 0);
-      }
-      18% {
-        box-shadow:
-          inset 0 0 0 2px rgba(125, 211, 252, 0.55),
-          0 0 22px rgba(125, 211, 252, 0.36);
-      }
-      100% {
-        box-shadow:
-          inset 0 0 0 0 rgba(125, 211, 252, 0),
-          0 0 0 0 rgba(125, 211, 252, 0);
-      }
-    }
-    [data-section-focus="1"] {
-      animation: tracesV2SectionFocusGlow 1500ms ease-out 1;
-      border-radius: 4px;
-      position: relative;
-      z-index: 1;
-    }
-    html.dark [data-section-focus="1"] {
-      animation-name: tracesV2SectionFocusGlowDark;
-    }
-  `}</style>
-);
+      raf = requestAnimationFrame(update);
+    };
+    raf = requestAnimationFrame(update);
+    const done = window.setTimeout(onDone, GLOW_DURATION_MS);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.clearTimeout(done);
+    };
+  }, [target, nonce, onDone]);
+
+  return (
+    <Portal>
+      <style>{`
+        @keyframes tracesV2SectionFocusGlow {
+          0% {
+            box-shadow:
+              0 0 0 0 rgba(59, 130, 246, 0),
+              0 0 0 0 rgba(59, 130, 246, 0);
+            border-color: rgba(59, 130, 246, 0);
+          }
+          18% {
+            box-shadow:
+              0 0 0 2px rgba(59, 130, 246, 0.65),
+              0 0 28px 6px rgba(59, 130, 246, 0.42);
+            border-color: rgba(59, 130, 246, 0.85);
+          }
+          100% {
+            box-shadow:
+              0 0 0 0 rgba(59, 130, 246, 0),
+              0 0 0 0 rgba(59, 130, 246, 0);
+            border-color: rgba(59, 130, 246, 0);
+          }
+        }
+        @keyframes tracesV2SectionFocusGlowDark {
+          0% {
+            box-shadow:
+              0 0 0 0 rgba(125, 211, 252, 0),
+              0 0 0 0 rgba(125, 211, 252, 0);
+            border-color: rgba(125, 211, 252, 0);
+          }
+          18% {
+            box-shadow:
+              0 0 0 2px rgba(125, 211, 252, 0.55),
+              0 0 28px 6px rgba(125, 211, 252, 0.4);
+            border-color: rgba(125, 211, 252, 0.85);
+          }
+          100% {
+            box-shadow:
+              0 0 0 0 rgba(125, 211, 252, 0),
+              0 0 0 0 rgba(125, 211, 252, 0);
+            border-color: rgba(125, 211, 252, 0);
+          }
+        }
+        .tracesV2-section-focus-glow {
+          animation: tracesV2SectionFocusGlow ${GLOW_DURATION_MS}ms ease-out 1;
+        }
+        html.dark .tracesV2-section-focus-glow {
+          animation-name: tracesV2SectionFocusGlowDark;
+        }
+      `}</style>
+      <Box
+        key={nonce}
+        className="tracesV2-section-focus-glow"
+        position="fixed"
+        pointerEvents="none"
+        zIndex={1600}
+        borderWidth="1px"
+        borderStyle="solid"
+        borderRadius="6px"
+        style={{
+          top: `${rect.top}px`,
+          left: `${rect.left}px`,
+          width: `${rect.width}px`,
+          height: `${rect.height}px`,
+        }}
+      />
+    </Portal>
+  );
+}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SectionFocusGlow.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SectionFocusGlow.tsx
@@ -1,0 +1,72 @@
+import type React from "react";
+
+/**
+ * One-shot blue pulse keyed off `data-section-focus="1"` on any
+ * `Accordion.Item` rendered by `Section`. The header chips publish a
+ * focus request to `useFocusSectionStore`; `TraceSummaryAccordions`
+ * observes it, expands the matching section, scrolls it into view,
+ * and toggles the data attribute long enough for the keyframe to
+ * play. The keyframe self-clears via `forwards` so the section
+ * settles back to its normal chrome without us having to remove the
+ * attribute on a timer.
+ *
+ * Why a dedicated stylesheet rather than a Chakra `css={}` prop: the
+ * `Accordion.Item` already binds `data-state` and `data-section`
+ * attributes for its own state-recipe machinery, and layering another
+ * inline-CSS prop fights the recipe's specificity. A document-level
+ * keyframe definition + selector keeps the recipe untouched.
+ *
+ * The colour palette mirrors the existing onboarding `DrawerGlow`
+ * recipe so the two glows read as the same affordance, with two
+ * deliberate differences: this one runs once and fades, and the
+ * outer halo is restricted (a section sits inside an `overflow: auto`
+ * pane so a wide outer shadow would get clipped — keep it close to
+ * the box).
+ */
+export const SectionFocusGlow: React.FC = () => (
+  <style>{`
+    @keyframes tracesV2SectionFocusGlow {
+      0% {
+        box-shadow:
+          inset 0 0 0 0 rgba(59, 130, 246, 0),
+          0 0 0 0 rgba(59, 130, 246, 0);
+      }
+      18% {
+        box-shadow:
+          inset 0 0 0 2px rgba(59, 130, 246, 0.65),
+          0 0 22px rgba(59, 130, 246, 0.38);
+      }
+      100% {
+        box-shadow:
+          inset 0 0 0 0 rgba(59, 130, 246, 0),
+          0 0 0 0 rgba(59, 130, 246, 0);
+      }
+    }
+    @keyframes tracesV2SectionFocusGlowDark {
+      0% {
+        box-shadow:
+          inset 0 0 0 0 rgba(125, 211, 252, 0),
+          0 0 0 0 rgba(125, 211, 252, 0);
+      }
+      18% {
+        box-shadow:
+          inset 0 0 0 2px rgba(125, 211, 252, 0.55),
+          0 0 22px rgba(125, 211, 252, 0.36);
+      }
+      100% {
+        box-shadow:
+          inset 0 0 0 0 rgba(125, 211, 252, 0),
+          0 0 0 0 rgba(125, 211, 252, 0);
+      }
+    }
+    [data-section-focus="1"] {
+      animation: tracesV2SectionFocusGlow 1500ms ease-out 1;
+      border-radius: 4px;
+      position: relative;
+      z-index: 1;
+    }
+    html.dark [data-section-focus="1"] {
+      animation-name: tracesV2SectionFocusGlowDark;
+    }
+  `}</style>
+);

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { LuCircleX } from "react-icons/lu";
 import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
 import { useSpanDetail } from "../../../hooks/useSpanDetail";
@@ -20,6 +20,8 @@ import { AccordionShell, Section } from "./AccordionShell";
 import { EmptyEventsState, EmptyHint } from "./EmptyStates";
 import { EventCard } from "./EventCard";
 import { useAutoOpenSections } from "./sectionPresence";
+import { SectionFocusGlow } from "./SectionFocusGlow";
+import { useSectionFocusGlow } from "./useSectionFocusGlow";
 import { countFlatLeaves } from "./utils";
 
 export function SpanAccordions({
@@ -75,8 +77,17 @@ export function SpanAccordions({
     events: hasEvents,
   });
 
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { glow, handleGlowDone } = useSectionFocusGlow({
+    traceId,
+    sections,
+    openSections,
+    setOpenSections,
+    containerRef,
+  });
+
   return (
-    <Box>
+    <Box ref={containerRef}>
       {/* Span-switch loading banner — makes it explicit that the panel
         below is still resolving, instead of letting the user stare at
         an empty accordion stack and wonder if anything's happening. */}
@@ -106,6 +117,14 @@ export function SpanAccordions({
         detail. The tab-bar chip already covers the same trace-level
         attribution; nothing else to add here.
       */}
+      {glow ? (
+        <SectionFocusGlow
+          key={glow.nonce}
+          target={glow.target}
+          nonce={glow.nonce}
+          onDone={handleGlowDone}
+        />
+      ) : null}
       {detailQuery.isLoading ? (
         <VStack align="stretch" gap={2} padding={4}>
           <Skeleton height="32px" borderRadius="md" />

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
@@ -1,6 +1,5 @@
-import { Box, Button, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { Box, HStack, Text, VStack } from "@chakra-ui/react";
 import { useEffect, useMemo, useRef } from "react";
-import { LuCircleX } from "react-icons/lu";
 import { useFocusSectionStore } from "../../../stores/focusSectionStore";
 import type {
   SpanTreeNode,
@@ -8,15 +7,20 @@ import type {
 } from "~/server/api/routers/tracesV2.schemas";
 import { useTraceEvaluations } from "../../../hooks/useTraceEvaluations";
 import { useTraceResources } from "../../../hooks/useTraceResources";
+import { rankedErrorSpans } from "../../../utils/errorSpans";
 import { AttributeTable } from "../AttributeTable";
 import { EvalsList } from "../evalCards";
+import { ExceptionsContent } from "../ExceptionsContent";
 import { IOViewer } from "../IOViewer";
 import { ScopeBlock } from "../ScopeChip";
 import { AccordionShell, Section } from "./AccordionShell";
 import { EmptyEventsState, EmptyHint } from "./EmptyStates";
 import { EventCard } from "./EventCard";
 import { useAutoOpenSections } from "./sectionPresence";
+import { SectionFocusGlow } from "./SectionFocusGlow";
 import { countFlatLeaves } from "./utils";
+
+const SECTION_GLOW_DURATION_MS = 1500;
 
 export function TraceSummaryAccordions({
   trace,
@@ -59,30 +63,15 @@ export function TraceSummaryAccordions({
     [richEvals, spans],
   );
 
-  // Spans flagged with status=error, sorted deepest-first so the most
+  // Spans flagged with status=error, deepest-first so the most
   // specific failure (the leaf that actually threw) leads the pill row.
-  // The trace's `error` summary covers the *what*; these pills cover the
-  // *where* — clicking one jumps to the span's details. If span data
-  // hasn't loaded yet we fall back to the summary-only layout.
-  const errorSpans = useMemo(() => {
-    if (!hasError || spans.length === 0) return [];
-    const byId = new Map(spans.map((s) => [s.spanId, s]));
-    const depthOf = (spanId: string): number => {
-      let depth = 0;
-      let cur: SpanTreeNode | undefined = byId.get(spanId);
-      while (cur?.parentSpanId) {
-        const parent = byId.get(cur.parentSpanId);
-        if (!parent) break;
-        depth += 1;
-        cur = parent;
-      }
-      return depth;
-    };
-    return spans
-      .filter((s) => s.status === "error")
-      .map((s) => ({ span: s, depth: depthOf(s.spanId) }))
-      .sort((a, b) => b.depth - a.depth);
-  }, [spans, hasError]);
+  // Same ranking is reused by the StatusChip's interactive tooltip so
+  // the operator sees the same span order whether they're scanning
+  // the popover or the expanded accordion.
+  const errorSpans = useMemo(
+    () => (hasError ? rankedErrorSpans(spans) : []),
+    [spans, hasError],
+  );
 
   const sections = useMemo(() => {
     const list: Array<
@@ -134,15 +123,35 @@ export function TraceSummaryAccordions({
     // Wait one frame so the accordion has actually expanded before we
     // measure + scroll. Two rAFs because the first only flushes the
     // open-state setState; layout commits on the second.
+    const glowSection = pendingFocus.section;
+    const root = containerRef.current;
+    const fadeTimer = window.setTimeout(() => {
+      root
+        ?.querySelector<HTMLElement>(`[data-section="${glowSection}"]`)
+        ?.removeAttribute("data-section-focus");
+    }, SECTION_GLOW_DURATION_MS);
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        const el = containerRef.current?.querySelector<HTMLElement>(
-          `[data-section="${pendingFocus.section}"]`,
+        const el = root?.querySelector<HTMLElement>(
+          `[data-section="${glowSection}"]`,
         );
         el?.scrollIntoView({ behavior: "smooth", block: "start" });
+        // Set the focus attribute AFTER the scroll so the keyframe's
+        // initial transparent frame doesn't elapse mid-scroll — the
+        // operator sees the pulse on the section already in view.
+        // Clear-then-set so re-clicking the same chip restarts the
+        // animation instead of getting swallowed by the running one.
+        if (el) {
+          el.removeAttribute("data-section-focus");
+          // Force a style flush so the re-applied attribute restarts
+          // the keyframe even when the previous run was still in-flight.
+          void el.offsetWidth;
+          el.setAttribute("data-section-focus", "1");
+        }
       });
     });
     clearFocus();
+    return () => window.clearTimeout(fadeTimer);
   }, [
     pendingFocus,
     trace.traceId,
@@ -158,6 +167,7 @@ export function TraceSummaryAccordions({
           attribution row at the top of the summary panel. It's now
           pinned to the right of the SpanTabBar so it stays visible
           when the user scrolls the summary content. */}
+      <SectionFocusGlow />
       <AccordionShell value={openSections} onValueChange={setOpenSections}>
         {sections.map((id, idx) => {
           const isFirst = idx === 0;
@@ -254,59 +264,11 @@ export function TraceSummaryAccordions({
                 isFirst={isFirst}
                 open={isOpen}
               >
-                <VStack align="stretch" gap={2}>
-                  <HStack
-                    gap={2}
-                    paddingX={3}
-                    paddingY={2}
-                    borderRadius="sm"
-                    bg="red.subtle"
-                    align="flex-start"
-                  >
-                    <Icon
-                      as={LuCircleX}
-                      boxSize={4}
-                      color="red.fg"
-                      flexShrink={0}
-                      marginTop={0.5}
-                    />
-                    <Text textStyle="xs" color="red.fg" whiteSpace="pre-wrap">
-                      {trace.error}
-                    </Text>
-                  </HStack>
-                  {/* Pills for spans flagged with status=error, deepest
-                      first. The summary up top tells you *what* broke;
-                      these tell you *where* — click to jump to the span
-                      and see the per-span exception payload. */}
-                  {errorSpans.length > 0 && (
-                    <HStack gap={1.5} flexWrap="wrap" align="center">
-                      <Text
-                        textStyle="2xs"
-                        color="fg.muted"
-                        textTransform="uppercase"
-                        letterSpacing="0.04em"
-                      >
-                        Spans with errors
-                      </Text>
-                      {errorSpans.map(({ span }) => (
-                        <Button
-                          key={span.spanId}
-                          size="2xs"
-                          variant="outline"
-                          colorPalette="red"
-                          onClick={() => onSelectSpan?.(span.spanId)}
-                          paddingX={2}
-                          height="22px"
-                          fontWeight="medium"
-                        >
-                          <Text truncate maxWidth="220px">
-                            {span.name}
-                          </Text>
-                        </Button>
-                      ))}
-                    </HStack>
-                  )}
-                </VStack>
+                <ExceptionsContent
+                  error={trace.error}
+                  errorSpans={errorSpans}
+                  onSelectSpan={onSelectSpan}
+                />
               </Section>
             );
           }

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
@@ -1,5 +1,5 @@
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFocusSectionStore } from "../../../stores/focusSectionStore";
 import type {
   SpanTreeNode,
@@ -19,8 +19,6 @@ import { EventCard } from "./EventCard";
 import { useAutoOpenSections } from "./sectionPresence";
 import { SectionFocusGlow } from "./SectionFocusGlow";
 import { countFlatLeaves } from "./utils";
-
-const SECTION_GLOW_DURATION_MS = 1500;
 
 export function TraceSummaryAccordions({
   trace,
@@ -111,6 +109,11 @@ export function TraceSummaryAccordions({
   const containerRef = useRef<HTMLDivElement>(null);
   const pendingFocus = useFocusSectionStore((s) => s.pending);
   const clearFocus = useFocusSectionStore((s) => s.clear);
+  const [glow, setGlow] = useState<{
+    target: HTMLElement;
+    nonce: number;
+  } | null>(null);
+  const handleGlowDone = useCallback(() => setGlow(null), []);
   useEffect(() => {
     if (!pendingFocus) return;
     if (pendingFocus.traceId !== trace.traceId) return;
@@ -120,38 +123,27 @@ export function TraceSummaryAccordions({
         ? openSections
         : [...openSections, pendingFocus.section],
     );
-    // Wait one frame so the accordion has actually expanded before we
-    // measure + scroll. Two rAFs because the first only flushes the
-    // open-state setState; layout commits on the second.
     const glowSection = pendingFocus.section;
+    const glowNonce = pendingFocus.nonce;
     const root = containerRef.current;
-    const fadeTimer = window.setTimeout(() => {
-      root
-        ?.querySelector<HTMLElement>(`[data-section="${glowSection}"]`)
-        ?.removeAttribute("data-section-focus");
-    }, SECTION_GLOW_DURATION_MS);
+    // Two rAFs so the accordion has actually expanded before we measure
+    // + scroll. The first flushes the open-state setState; layout
+    // commits on the second.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         const el = root?.querySelector<HTMLElement>(
           `[data-section="${glowSection}"]`,
         );
-        el?.scrollIntoView({ behavior: "smooth", block: "start" });
-        // Set the focus attribute AFTER the scroll so the keyframe's
-        // initial transparent frame doesn't elapse mid-scroll — the
-        // operator sees the pulse on the section already in view.
-        // Clear-then-set so re-clicking the same chip restarts the
-        // animation instead of getting swallowed by the running one.
-        if (el) {
-          el.removeAttribute("data-section-focus");
-          // Force a style flush so the re-applied attribute restarts
-          // the keyframe even when the previous run was still in-flight.
-          void el.offsetWidth;
-          el.setAttribute("data-section-focus", "1");
-        }
+        if (!el) return;
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+        // Mount the overlay AFTER the scroll starts so the pulse lands
+        // on the section already in view rather than ticking out
+        // mid-scroll. The nonce keys the overlay so a re-click
+        // remounts + restarts the keyframe.
+        setGlow({ target: el, nonce: glowNonce });
       });
     });
     clearFocus();
-    return () => window.clearTimeout(fadeTimer);
   }, [
     pendingFocus,
     trace.traceId,
@@ -167,7 +159,14 @@ export function TraceSummaryAccordions({
           attribution row at the top of the summary panel. It's now
           pinned to the right of the SpanTabBar so it stays visible
           when the user scrolls the summary content. */}
-      <SectionFocusGlow />
+      {glow ? (
+        <SectionFocusGlow
+          key={glow.nonce}
+          target={glow.target}
+          nonce={glow.nonce}
+          onDone={handleGlowDone}
+        />
+      ) : null}
       <AccordionShell value={openSections} onValueChange={setOpenSections}>
         {sections.map((id, idx) => {
           const isFirst = idx === 0;

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
@@ -109,6 +109,7 @@ export function TraceSummaryAccordions({
   const containerRef = useRef<HTMLDivElement>(null);
   const pendingFocus = useFocusSectionStore((s) => s.pending);
   const clearFocus = useFocusSectionStore((s) => s.clear);
+  const requestFocus = useFocusSectionStore((s) => s.request);
   const [glow, setGlow] = useState<{
     target: HTMLElement;
     nonce: number;
@@ -267,6 +268,12 @@ export function TraceSummaryAccordions({
                   error={trace.error}
                   errorSpans={errorSpans}
                   onSelectSpan={onSelectSpan}
+                  onFocusSection={() =>
+                    requestFocus({
+                      traceId: trace.traceId,
+                      section: "exceptions",
+                    })
+                  }
                 />
               </Section>
             );

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
@@ -1,5 +1,5 @@
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef } from "react";
 import { useFocusSectionStore } from "../../../stores/focusSectionStore";
 import type {
   SpanTreeNode,
@@ -18,6 +18,7 @@ import { EmptyEventsState, EmptyHint } from "./EmptyStates";
 import { EventCard } from "./EventCard";
 import { useAutoOpenSections } from "./sectionPresence";
 import { SectionFocusGlow } from "./SectionFocusGlow";
+import { useSectionFocusGlow } from "./useSectionFocusGlow";
 import { countFlatLeaves } from "./utils";
 
 export function TraceSummaryAccordions({
@@ -107,52 +108,14 @@ export function TraceSummaryAccordions({
   // overflow menus, …). When a request matches this trace, ensure the
   // requested section is in `openSections` and scroll it into view.
   const containerRef = useRef<HTMLDivElement>(null);
-  const pendingFocus = useFocusSectionStore((s) => s.pending);
-  const clearFocus = useFocusSectionStore((s) => s.clear);
   const requestFocus = useFocusSectionStore((s) => s.request);
-  const [glow, setGlow] = useState<{
-    target: HTMLElement;
-    nonce: number;
-  } | null>(null);
-  const handleGlowDone = useCallback(() => setGlow(null), []);
-  useEffect(() => {
-    if (!pendingFocus) return;
-    if (pendingFocus.traceId !== trace.traceId) return;
-    if (!sections.includes(pendingFocus.section as never)) return;
-    setOpenSections(
-      openSections.includes(pendingFocus.section)
-        ? openSections
-        : [...openSections, pendingFocus.section],
-    );
-    const glowSection = pendingFocus.section;
-    const glowNonce = pendingFocus.nonce;
-    const root = containerRef.current;
-    // Two rAFs so the accordion has actually expanded before we measure
-    // + scroll. The first flushes the open-state setState; layout
-    // commits on the second.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const el = root?.querySelector<HTMLElement>(
-          `[data-section="${glowSection}"]`,
-        );
-        if (!el) return;
-        el.scrollIntoView({ behavior: "smooth", block: "start" });
-        // Mount the overlay AFTER the scroll starts so the pulse lands
-        // on the section already in view rather than ticking out
-        // mid-scroll. The nonce keys the overlay so a re-click
-        // remounts + restarts the keyframe.
-        setGlow({ target: el, nonce: glowNonce });
-      });
-    });
-    clearFocus();
-  }, [
-    pendingFocus,
-    trace.traceId,
+  const { glow, handleGlowDone } = useSectionFocusGlow({
+    traceId: trace.traceId,
     sections,
     openSections,
     setOpenSections,
-    clearFocus,
-  ]);
+    containerRef,
+  });
 
   return (
     <Box ref={containerRef}>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/useSectionFocusGlow.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/useSectionFocusGlow.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { useFocusSectionStore } from "../../../stores/focusSectionStore";
+
+/**
+ * Wires an accordion stack to the cross-component focus pipeline:
+ *
+ *   1. Subscribes to `useFocusSectionStore.pending`.
+ *   2. When a request matches `traceId` AND the requested section is
+ *      one this stack renders, expands the section, scrolls it into
+ *      view, then publishes a `glow` payload that the caller renders
+ *      via `<SectionFocusGlow>`.
+ *
+ * Returning the glow payload (instead of mounting the overlay here)
+ * lets the caller control where the overlay lives in the JSX tree —
+ * the summary accordions render their own overlay sibling, and the
+ * span-detail accordions render theirs. The hook is the brain; the
+ * overlay is the visual.
+ */
+export function useSectionFocusGlow({
+  traceId,
+  sections,
+  openSections,
+  setOpenSections,
+  containerRef,
+}: {
+  traceId: string;
+  sections: readonly string[];
+  openSections: string[];
+  setOpenSections: (next: string[]) => void;
+  containerRef: RefObject<HTMLElement | null>;
+}) {
+  const pendingFocus = useFocusSectionStore((s) => s.pending);
+  const clearFocus = useFocusSectionStore((s) => s.clear);
+  const [glow, setGlow] = useState<{
+    target: HTMLElement;
+    nonce: number;
+  } | null>(null);
+  const handleGlowDone = useCallback(() => setGlow(null), []);
+  // Refs so the effect can read latest open-state without re-running
+  // (and thus retriggering scroll) every time the list reference changes.
+  const openSectionsRef = useRef(openSections);
+  openSectionsRef.current = openSections;
+  const setOpenSectionsRef = useRef(setOpenSections);
+  setOpenSectionsRef.current = setOpenSections;
+
+  useEffect(() => {
+    if (!pendingFocus) return;
+    if (pendingFocus.traceId !== traceId) return;
+    if (!sections.includes(pendingFocus.section)) return;
+    const currentOpen = openSectionsRef.current;
+    setOpenSectionsRef.current(
+      currentOpen.includes(pendingFocus.section)
+        ? currentOpen
+        : [...currentOpen, pendingFocus.section],
+    );
+    const glowSection = pendingFocus.section;
+    const glowNonce = pendingFocus.nonce;
+    const root = containerRef.current;
+    if (!root) return;
+    let observer: MutationObserver | null = null;
+    let bailTimer = 0;
+    const tryScrollAndGlow = () => {
+      const el = root.querySelector<HTMLElement>(
+        `[data-section="${glowSection}"]`,
+      );
+      if (!el) return false;
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      // Mount the overlay AFTER the scroll starts so the pulse lands
+      // on the section already in view rather than ticking out
+      // mid-scroll. The nonce keys the overlay so a re-click
+      // remounts + restarts the keyframe.
+      setGlow({ target: el, nonce: glowNonce });
+      clearFocus();
+      return true;
+    };
+    // Two rAFs so the accordion has actually expanded before we measure
+    // + scroll. The first flushes the open-state setState; layout
+    // commits on the second.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (tryScrollAndGlow()) return;
+        // The target section isn't in the DOM yet — common when the
+        // span tab just mounted and `useSpanDetail` is still loading
+        // (the skeleton renders instead of the accordion stack). Watch
+        // for the section to appear, then run the same scroll+glow.
+        observer = new MutationObserver(() => {
+          if (tryScrollAndGlow()) {
+            observer?.disconnect();
+            window.clearTimeout(bailTimer);
+          }
+        });
+        observer.observe(root, { childList: true, subtree: true });
+        // Safety net so we don't keep observing forever if the section
+        // never shows up (wrong trace, focus request to a section this
+        // stack doesn't render, etc.). 5s is generous for slow detail
+        // queries on dev infra.
+        bailTimer = window.setTimeout(() => {
+          observer?.disconnect();
+          clearFocus();
+        }, 5000);
+      });
+    });
+    return () => {
+      observer?.disconnect();
+      window.clearTimeout(bailTimer);
+    };
+  }, [pendingFocus, traceId, sections, containerRef, clearFocus]);
+
+  return { glow, handleGlowDone };
+}

--- a/langwatch/src/features/traces-v2/stores/__tests__/focusSectionStore.unit.test.ts
+++ b/langwatch/src/features/traces-v2/stores/__tests__/focusSectionStore.unit.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useFocusSectionStore } from "../focusSectionStore";
+
+describe("useFocusSectionStore", () => {
+  beforeEach(() => {
+    useFocusSectionStore.setState({ pending: null });
+  });
+
+  describe("given a focus request for the exceptions section", () => {
+    /** @scenario Clicking the error status chip focuses the Exceptions section */
+    it("publishes a pending focus payload the trace-summary observer consumes", () => {
+      // The status chip's onClick funnels through this store — the
+      // accordion observer reads `pending`, expands the section,
+      // scrolls + triggers the glow. Testing the store directly keeps
+      // the chip's click handler decoupled from the accordion's DOM.
+      useFocusSectionStore
+        .getState()
+        .request({ traceId: "trace-abc", section: "exceptions" });
+      const pending = useFocusSectionStore.getState().pending;
+      expect(pending?.traceId).toBe("trace-abc");
+      expect(pending?.section).toBe("exceptions");
+    });
+  });
+
+  describe("given a focus request for the evals section", () => {
+    /** @scenario Clicking an evaluation chip focuses the Evals section */
+    it("publishes a pending focus payload for the evals section", () => {
+      useFocusSectionStore
+        .getState()
+        .request({ traceId: "trace-xyz", section: "evals" });
+      const pending = useFocusSectionStore.getState().pending;
+      expect(pending?.traceId).toBe("trace-xyz");
+      expect(pending?.section).toBe("evals");
+    });
+  });
+
+  describe("given the same chip is re-clicked while the previous request is still pending", () => {
+    /** @scenario The focus glow runs a single short pulse so the eye lands without distracting */
+    it("bumps the nonce so the observer re-fires the glow + scroll", () => {
+      // Without the nonce bump, a second click during the ~1.5s glow
+      // window would set the same {traceId, section} state and the
+      // observer's effect dep array wouldn't trigger again — the
+      // operator would feel like the chip stopped responding. Nonce
+      // is the cheap way to make every click distinct in observer
+      // identity terms.
+      useFocusSectionStore
+        .getState()
+        .request({ traceId: "trace-abc", section: "exceptions" });
+      const first = useFocusSectionStore.getState().pending!.nonce;
+      useFocusSectionStore
+        .getState()
+        .request({ traceId: "trace-abc", section: "exceptions" });
+      const second = useFocusSectionStore.getState().pending!.nonce;
+      expect(second).toBeGreaterThan(first);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/stores/focusSectionStore.ts
+++ b/langwatch/src/features/traces-v2/stores/focusSectionStore.ts
@@ -7,7 +7,7 @@ import { create } from "zustand";
  * triggering a no-op at runtime when `TraceSummaryAccordions` fails to
  * find a matching `data-section` element.
  */
-const FOCUS_SECTIONS = ["evals", "events"] as const;
+const FOCUS_SECTIONS = ["evals", "events", "exceptions"] as const;
 export type FocusSection = (typeof FOCUS_SECTIONS)[number];
 
 interface PendingFocus {

--- a/langwatch/src/features/traces-v2/utils/__tests__/errorSpans.unit.test.ts
+++ b/langwatch/src/features/traces-v2/utils/__tests__/errorSpans.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
+import { rankedErrorSpans } from "../errorSpans";
+
+function span(partial: Partial<SpanTreeNode>): SpanTreeNode {
+  return {
+    spanId: "s",
+    parentSpanId: null,
+    name: "span",
+    type: null,
+    startTimeMs: 0,
+    endTimeMs: 1,
+    durationMs: 1,
+    status: "ok",
+    model: null,
+    ...partial,
+  };
+}
+
+describe("rankedErrorSpans", () => {
+  describe("given a flat list of spans with no errors", () => {
+    it("returns an empty array", () => {
+      const spans = [
+        span({ spanId: "a", status: "ok" }),
+        span({ spanId: "b", status: "ok" }),
+      ];
+      expect(rankedErrorSpans(spans)).toEqual([]);
+    });
+  });
+
+  describe("given mixed error / ok spans across a tree", () => {
+    it("ranks deepest-first, then by startTimeMs as a tiebreaker", () => {
+      // Tree:
+      //   root (ok)
+      //     ├── m1 (error, depth=1, start=20)
+      //     │     └── leaf-late (error, depth=2, start=40)
+      //     └── m2 (error, depth=1, start=10)
+      const spans = [
+        span({ spanId: "root", status: "ok", parentSpanId: null }),
+        span({
+          spanId: "m1",
+          status: "error",
+          parentSpanId: "root",
+          startTimeMs: 20,
+          name: "m1",
+        }),
+        span({
+          spanId: "leaf-late",
+          status: "error",
+          parentSpanId: "m1",
+          startTimeMs: 40,
+          name: "leaf-late",
+        }),
+        span({
+          spanId: "m2",
+          status: "error",
+          parentSpanId: "root",
+          startTimeMs: 10,
+          name: "m2",
+        }),
+      ];
+
+      const out = rankedErrorSpans(spans).map((r) => ({
+        id: r.span.spanId,
+        depth: r.depth,
+      }));
+
+      expect(out).toEqual([
+        // Deepest-first.
+        { id: "leaf-late", depth: 2 },
+        // Equal depth — earlier start wins.
+        { id: "m2", depth: 1 },
+        { id: "m1", depth: 1 },
+      ]);
+    });
+  });
+
+  describe("given a span whose parent isn't in the trace", () => {
+    it("treats the missing parent as depth 0 and keeps the span in the list", () => {
+      const spans = [
+        span({
+          spanId: "orphan",
+          status: "error",
+          parentSpanId: "phantom-id-not-in-trace",
+          name: "orphan",
+        }),
+      ];
+      expect(rankedErrorSpans(spans)).toEqual([
+        { span: spans[0], depth: 0 },
+      ]);
+    });
+  });
+
+  describe("given an empty span list", () => {
+    it("returns an empty array without throwing", () => {
+      expect(rankedErrorSpans([])).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/utils/errorSpans.ts
+++ b/langwatch/src/features/traces-v2/utils/errorSpans.ts
@@ -1,0 +1,39 @@
+import type { SpanTreeNode } from "~/server/api/routers/tracesV2.schemas";
+
+export interface ErrorSpanRanked {
+  span: SpanTreeNode;
+  depth: number;
+}
+
+/**
+ * Return every span whose status is `"error"`, ranked deepest-first
+ * (the leaf that actually threw leads), then by start time as a
+ * stable tiebreaker. Matches the ordering the trace-summary
+ * Exceptions accordion uses so the header chip's tooltip and the
+ * full accordion list can't drift apart.
+ *
+ * Returns an empty array when there are no error spans — caller code
+ * should treat that as "fall back to trace-level error message only".
+ */
+export function rankedErrorSpans(spans: SpanTreeNode[]): ErrorSpanRanked[] {
+  if (spans.length === 0) return [];
+  const byId = new Map(spans.map((s) => [s.spanId, s]));
+  const depthOf = (spanId: string): number => {
+    let depth = 0;
+    let cur: SpanTreeNode | undefined = byId.get(spanId);
+    while (cur?.parentSpanId) {
+      const parent = byId.get(cur.parentSpanId);
+      if (!parent) break;
+      depth += 1;
+      cur = parent;
+    }
+    return depth;
+  };
+  return spans
+    .filter((s) => s.status === "error")
+    .map((s) => ({ span: s, depth: depthOf(s.spanId) }))
+    .sort((a, b) => {
+      if (a.depth !== b.depth) return b.depth - a.depth;
+      return a.span.startTimeMs - b.span.startTimeMs;
+    });
+}

--- a/scripts/dogfood-error-trace.ts
+++ b/scripts/dogfood-error-trace.ts
@@ -1,0 +1,195 @@
+/* eslint-disable */
+/**
+ * Emit one OTLP trace with a chain of error spans, intended for the
+ * StatusChip interactive-tooltip dogfood. Mirrors the screenshot the
+ * customer report used to motivate the work — a top-level workflow
+ * span errors with "Connection error.", and a couple of llm + chain
+ * leaf spans error underneath so the popover has multiple chips.
+ *
+ * Usage:
+ *   LW_API_KEY=sk-lw-... LW_ENDPOINT=http://localhost:5560 \
+ *     npx tsx scripts/dogfood-error-trace.ts
+ */
+import { randomBytes } from "node:crypto";
+
+const ENDPOINT =
+  process.env.LW_ENDPOINT ?? "http://localhost:5560";
+const API_KEY = process.env.LW_API_KEY;
+if (!API_KEY) {
+  console.error("LW_API_KEY is required");
+  process.exit(1);
+}
+
+const NOW_NS = BigInt(Date.now()) * 1_000_000n;
+const SEC_NS = 1_000_000_000n;
+
+function id(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+const traceId = id(16);
+const root = id(8);
+const llmChat = id(8);
+const llmRetry = id(8);
+const chain = id(8);
+const chainInner = id(8);
+
+interface SpanInput {
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  startOffsetSec: number;
+  durationSec: number;
+  attrs?: Record<string, string | number | boolean>;
+  errorMessage?: string;
+}
+
+const spans: SpanInput[] = [
+  {
+    spanId: root,
+    name: "Deliverables Checklist",
+    startOffsetSec: 0,
+    durationSec: 6,
+    errorMessage: "Connection error.",
+    attrs: { "langwatch.span.type": "workflow" },
+  },
+  {
+    spanId: chain,
+    parentSpanId: root,
+    name: "RunnableSequence",
+    startOffsetSec: 0.2,
+    durationSec: 5.5,
+    errorMessage: "Connection error.",
+    attrs: { "langwatch.span.type": "chain" },
+  },
+  {
+    spanId: chainInner,
+    parentSpanId: chain,
+    name: "RunnableSequence",
+    startOffsetSec: 0.4,
+    durationSec: 5,
+    errorMessage: "Connection error.",
+    attrs: { "langwatch.span.type": "chain" },
+  },
+  {
+    spanId: llmChat,
+    parentSpanId: chainInner,
+    name: "llm",
+    startOffsetSec: 0.6,
+    durationSec: 2,
+    errorMessage:
+      "Connection error.\n  at OpenAIClient.request (node_modules/openai/src/client.ts:312:23)",
+    attrs: {
+      "langwatch.span.type": "llm",
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+    },
+  },
+  {
+    spanId: llmRetry,
+    parentSpanId: chainInner,
+    name: "llm",
+    startOffsetSec: 3,
+    durationSec: 2,
+    errorMessage:
+      "Connection error.\n  at OpenAIClient.request (node_modules/openai/src/client.ts:312:23)",
+    attrs: {
+      "langwatch.span.type": "llm",
+      "gen_ai.system": "openai",
+      "gen_ai.request.model": "gpt-4o",
+    },
+  },
+];
+
+function toAttrValue(v: string | number | boolean) {
+  if (typeof v === "string") return { stringValue: v };
+  if (typeof v === "number") return Number.isInteger(v) ? { intValue: v } : { doubleValue: v };
+  return { boolValue: v };
+}
+
+const otlpSpans = spans.map((s) => {
+  const start = NOW_NS + BigInt(Math.floor(s.startOffsetSec * 1e9));
+  const end = start + BigInt(Math.floor(s.durationSec * 1e9));
+  return {
+    traceId,
+    spanId: s.spanId,
+    parentSpanId: s.parentSpanId,
+    name: s.name,
+    kind: 1,
+    startTimeUnixNano: start.toString(),
+    endTimeUnixNano: end.toString(),
+    attributes: Object.entries(s.attrs ?? {}).map(([key, value]) => ({
+      key,
+      value: toAttrValue(value),
+    })),
+    status: s.errorMessage
+      ? { code: 2, message: s.errorMessage }
+      : undefined,
+    events: s.errorMessage
+      ? [
+          {
+            name: "exception",
+            timeUnixNano: end.toString(),
+            attributes: [
+              {
+                key: "exception.type",
+                value: { stringValue: "ConnectionError" },
+              },
+              {
+                key: "exception.message",
+                value: { stringValue: s.errorMessage },
+              },
+              {
+                key: "exception.stacktrace",
+                value: {
+                  stringValue:
+                    s.errorMessage +
+                    "\n  at Loop.tick (node_modules/openai/src/loop.ts:84:10)",
+                },
+              },
+            ],
+          },
+        ]
+      : [],
+  };
+});
+
+const payload = {
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "deliverables-api" } },
+          { key: "service.version", value: { stringValue: "0.4.7" } },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: { name: "@langwatch/dogfood-error-trace", version: "1.0.0" },
+          spans: otlpSpans,
+        },
+      ],
+    },
+  ],
+};
+
+async function main() {
+  const url = `${ENDPOINT}/api/otel/v1/traces`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  const text = await res.text();
+  console.log(`POST ${url} -> ${res.status}`);
+  if (text) console.log(text);
+  console.log(`\nTrace id: ${traceId}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/specs/trace-drawer/header-chip-deeplinks.feature
+++ b/specs/trace-drawer/header-chip-deeplinks.feature
@@ -1,0 +1,66 @@
+Feature: Trace drawer header chips deep-link into summary sections with a blue glow
+
+  As an operator triaging a trace in the v2 explorer drawer
+  I want the error status pill and evaluation chips in the header to take me
+  directly to the relevant accordion section on the Summary tab,
+  with a brief blue glow on arrival so I don't lose the section in a busy panel.
+
+  Background:
+    The drawer header surfaces a compact strip of chips (status, evals,
+    pinned attributes). When an operator clicks one of these chips it
+    publishes a one-shot focus request through `useFocusSectionStore`.
+    The `TraceSummaryAccordions` observer expands the matching section,
+    scrolls it into view, and the section briefly pulses with a blue
+    ring so the eye lands on it. The same observer wires the
+    "Exceptions", "Evals", and "Events" sections.
+
+  # ---------------------------------------------------------------------------
+  # Error status chip
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Clicking the error status chip focuses the Exceptions section
+    Given a trace whose status is "error" and at least one span recorded an exception
+    And the drawer header is visible with the red "Error" status chip
+    When the operator clicks the status chip
+    Then the drawer switches to the Summary tab
+    And the Exceptions accordion expands if it was collapsed
+    And the Exceptions accordion is scrolled into view
+    And the Exceptions accordion briefly pulses with the shared trace-drawer focus glow
+
+  @integration @unimplemented
+  Scenario: Hovering the error status chip surfaces an interactive exceptions preview
+    Given a trace whose status is "error" and four spans recorded errors
+    And the drawer header is visible
+    When the operator hovers over the status chip
+    Then a popover opens showing the trace-level error message in the same red treatment as the Exceptions section
+    And the popover lists one button per error span, in the same deepest-first order the Exceptions section uses
+    When the operator clicks one of the span buttons inside the popover
+    Then the drawer switches to the span detail tab for that span
+    And the popover closes
+
+  # ---------------------------------------------------------------------------
+  # Evaluation chip
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Clicking an evaluation chip focuses the Evals section
+    Given a trace with at least one completed evaluation
+    And the drawer header is visible with an evaluation chip
+    When the operator clicks the evaluation chip
+    Then the drawer switches to the Summary tab
+    And the Evals accordion expands if it was collapsed
+    And the Evals accordion is scrolled into view
+    And the Evals accordion briefly pulses with the shared trace-drawer focus glow
+
+  # ---------------------------------------------------------------------------
+  # Glow shape contract — keeps light/dark variants from drifting
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: The focus glow runs a single short pulse so the eye lands without distracting
+    Given a section is targeted via a focus request
+    When the glow plays
+    Then it runs for roughly one and a half seconds before fading out
+    And it does not loop forever like the onboarding tour glow
+    And it never blocks subsequent focus requests for the same section


### PR DESCRIPTION
## Summary

Customer report on the trace drawer: clicking the red \`Error\` chip in the header "doesn't really take you anywhere". It actually did switch to the Summary tab and select the first error span, but:

1. The Exceptions accordion sat lower in the panel so the operator landed on whatever was already in view (usually IO / Metadata).
2. Nothing visually pointed at the section that just opened.
3. The static tooltip said "Jump to the first span with an error" which wasn't what the chip actually did.

Same complaint applied to the Eval chip: it scrolled the Evals section into view but the operator's eye didn't track the change in a busy panel.

### What changed

- **Interactive popover on the Error chip.** Hovering opens a HoverCard mirroring the full Exceptions accordion - same red error block + same per-span pill row sourced from the new shared \`rankedErrorSpans\` helper. Click a span inside the popover to jump directly to it; click the chip itself to open the full Exceptions section.
- **Blue glow on header-chip jumps.** Extended \`useFocusSectionStore\` with an \`exceptions\` target so the error chip uses the same focus pipeline as the eval chips. After the auto-scroll lands, the targeted section briefly pulses with a 1.5s blue ring (\`SectionFocusGlow\`) that mirrors the onboarding \`DrawerGlow\` palette - same affordance, shorter run, scoped inside the section box.
- **Shared exceptions block.** Extracted \`ExceptionsContent\` so the accordion section and the chip popover render from one component. The two surfaces can't drift on span order, copy, or red treatment.
- **Dogfood emitter.** \`scripts/dogfood-error-trace.ts\` posts one trace via OTLP with a workflow + chain + 2 retry LLM spans all flagged \`status=error\` - enough surface area to exercise the popover + glow.

## Screenshots

Interactive popover anchored to the Error chip (matches the Exceptions section content):
![popover](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4123-followup-error-chip-glow/01-error-chip-interactive-popover.png)

Click the chip and the Exceptions section pulses blue once the auto-scroll lands. The glow is painted as a fixed-position overlay through a Portal so the drawer's scroll-viewport overflow and the sticky section header can't crop it on any edge:
![exceptions-glow](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4179-overlay-glow/01-exceptions-overlay-glow.png)

Same pipeline pulses the Evals section when an eval chip is clicked:
![evals-glow](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4179-overlay-glow/02-evals-overlay-glow.png)

## Test plan

- [x] Unit: \`rankedErrorSpans\` ranks deepest-first, breaks ties by startTimeMs, treats out-of-trace parents as depth 0, returns empty for non-error inputs.
- [x] Unit: \`useFocusSectionStore.request\` publishes the right pending payload for both \`exceptions\` and \`evals\`, and bumps the nonce on repeat clicks so the observer effect re-fires.
- [x] Spec: \`specs/trace-drawer/header-chip-deeplinks.feature\` covers click-to-focus for both chips and the glow shape contract (~1.5s, single pulse, doesn't loop).
- [x] Manual QA on a freshly-emitted dogfood trace (\`scripts/dogfood-error-trace.ts\`):
  - Hover the red Error chip opens the popover with 5 span buttons.
  - Click the chip - the Summary tab opens, Exceptions accordion expands, and the section pulses blue.
  - Click an eval chip - the Evals accordion expands and pulses blue.
- [x] Spec parity check (\`pnpm tsx scripts/check-feature-parity.ts\`) green: 1303 enforced scenarios bound.
