### PR TITLE
fix(queue): eliminate pending counter drift

### DIFF
--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -53,15 +53,14 @@ local errorKey        = KEYS[7]
 local totalPendingKey = KEYS[8]
 local groupId         = ARGV[1]
 
--- Total dropped = staged jobs (ZCARD) + the active job if one exists.
--- The active job is in flight on a worker; once that worker calls
--- COMPLETE_LUA it will be a no-op because the activeKey is gone, so the
--- total-pending counter would otherwise leak forever. We must account
--- for it here. Added post-2026-05-11 incident — bulk drain at 500K
--- scale would otherwise leave the stat permanently overstated.
+-- Total dropped = staged jobs (ZCARD) only. Previously this also counted
+-- the active job (+hadActive), but since the counter DECR moved from
+-- COMPLETE_LUA to DISPATCH (PR #4181), the active job's INCR is already
+-- compensated at dispatch time. Counting it again here would double-DECR.
+-- Added post-2026-05-11 incident — bulk drain at 500K scale would
+-- otherwise leave the stat permanently overstated.
 local pendingCount = redis.call("ZCARD", jobsKey)
-local hadActive    = redis.call("EXISTS", activeKey)
-local totalDropped = pendingCount + hadActive
+local totalDropped = pendingCount
 
 redis.call("DEL", jobsKey)
 redis.call("DEL", dataKey)

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1733,6 +1733,7 @@ describe("GroupStagingScripts", () => {
     });
 
     describe("when the happy path completes normally", () => {
+      /** @scenario Counter tracks jobs in :jobs ZSETs through happy path */
       it("total-pending returns to 0 after stage → dispatch → complete", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g1", dispatchAfterMs: 100 }));
         await scripts.stage(makeJob({ stagedJobId: "j2", groupId: "g2", dispatchAfterMs: 100 }));
@@ -1753,6 +1754,7 @@ describe("GroupStagingScripts", () => {
     });
 
     describe("when active key expires before COMPLETE", () => {
+      /** @scenario Counter stays accurate when activeKey expires before COMPLETE */
       it("counter stays accurate — DECR happened at dispatch, not complete", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-leak", dispatchAfterMs: 100 }));
         expect(await inspectTotalPending()).toBe(1);
@@ -1776,6 +1778,7 @@ describe("GroupStagingScripts", () => {
     });
 
     describe("when a job is retried via retryRestage", () => {
+      /** @scenario Counter tracks retry restage as a new pending job */
       it("total-pending returns to 0 after stage → dispatch → retryRestage → dispatch → complete", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-retry", dispatchAfterMs: 100 }));
         expect(await inspectTotalPending()).toBe(1);
@@ -1810,6 +1813,7 @@ describe("GroupStagingScripts", () => {
     });
 
     describe("when a job exhausts retries via restageAndBlock", () => {
+      /** @scenario Counter tracks restage-and-block as a new pending job */
       it("total-pending returns to 0 after stage → dispatch → restageAndBlock → unblock → dispatch → complete", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-block", dispatchAfterMs: 100 }));
         expect(await inspectTotalPending()).toBe(1);
@@ -1934,6 +1938,7 @@ describe("GroupStagingScripts", () => {
     });
 
     describe("counter reconciliation invariant", () => {
+      /** @scenario Counter equals sum of all :jobs ZSET cardinalities */
       it("total-pending equals sum of ZCARD(:jobs) across all groups", async () => {
         await scripts.stage(makeJob({ stagedJobId: "a1", groupId: "g-recon-a", dispatchAfterMs: 100 }));
         await scripts.stage(makeJob({ stagedJobId: "a2", groupId: "g-recon-a", dispatchAfterMs: 200 }));

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1753,11 +1753,13 @@ describe("GroupStagingScripts", () => {
     });
 
     describe("when active key expires before COMPLETE", () => {
-      it("leaks the counter — documents the current drift bug", async () => {
+      it("counter stays accurate — DECR happened at dispatch, not complete", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-leak", dispatchAfterMs: 100 }));
         expect(await inspectTotalPending()).toBe(1);
 
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        // DECR happened at dispatch time (ZREM from :jobs). Counter is now 0.
+        expect(await inspectTotalPending()).toBe(0);
 
         // Simulate active key expiry (Redis TTL fires or saturation delays heartbeat)
         await redis.del(`${keyPrefix()}group:g-leak:active`);
@@ -1765,11 +1767,11 @@ describe("GroupStagingScripts", () => {
         const completed = await scripts.complete({ groupId: "g-leak", stagedJobId: "j1" });
         expect(completed).toBe(false);
 
-        // BUG: counter is still 1 — the DECR was skipped because active key didn't match.
-        // The job was already removed from :jobs at dispatch time (ZREM),
-        // and its data was HDEL'd. It can never be re-processed.
-        // This is the root cause of the 826K phantom counter in production.
-        expect(await inspectTotalPending()).toBe(1);
+        // FIX: counter is 0 — DECR already happened at dispatch time.
+        // COMPLETE_LUA no longer touches the counter, so active key
+        // expiry can't cause drift. This was the root cause of the
+        // 826K phantom counter in production.
+        expect(await inspectTotalPending()).toBe(0);
       });
     });
 
@@ -1894,47 +1896,45 @@ describe("GroupStagingScripts", () => {
       });
     });
 
-    describe("proposed fix validation", () => {
-      it("DECR at dispatch without compensating INCR in retryRestage causes negative drift", async () => {
-        // This test simulates the NAIVE 2-script fix proposed in the post-mortem
-        // (move DECR from COMPLETE to DISPATCH) to PROVE it's incomplete.
-        // It manually applies DECR at dispatch points without adding the
-        // compensating INCR in retryRestage.
-
-        const pendingKey = `${keyPrefix()}stats:total-pending`;
+    describe("4-script fix validation (DECR at dispatch + compensating INCRs)", () => {
+      it("dispatch→retry→dispatch cycle stays balanced with real scripts", async () => {
+        // Previously this test simulated the NAIVE 2-script fix manually
+        // to prove it was incomplete (negative drift). Now the real scripts
+        // implement the full 4-script fix: DECR at dispatch + INCR at
+        // retryRestage/restageAndBlock. No manual counter manipulation needed.
 
         // Stage: INCR → counter = 1
-        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-naive", dispatchAfterMs: 100 }));
+        await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-balanced", dispatchAfterMs: 100 }));
         expect(await inspectTotalPending()).toBe(1);
 
-        // Dispatch: the real script doesn't DECR, so we simulate it manually
+        // Dispatch: DECR at ZREM → counter = 0
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
-        await redis.decr(pendingKey);
         expect(await inspectTotalPending()).toBe(0);
 
-        // retryRestage: adds new job to :jobs but NO compensating INCR
+        // retryRestage: INCR (job re-enters :jobs) → counter = 1
         await scripts.retryRestage({
-          groupId: "g-naive",
+          groupId: "g-balanced",
           stagedJobId: "j1",
           newStagedJobId: "j1/r/1",
           dispatchAfterMs: 300,
           jobDataJson: JSON.stringify({ attempt: 2 }),
           backoffMs: 500,
         });
+        expect(await inspectTotalPending()).toBe(1);
+
+        // Active key expires, dispatch retry: DECR → counter = 0
+        await redis.del(`${keyPrefix()}group:g-balanced:active`);
+        await scripts.dispatch({ nowMs: 400, activeTtlSec: 60 });
         expect(await inspectTotalPending()).toBe(0);
 
-        // Active key expires, dispatch retry: again simulate DECR-at-dispatch
-        await redis.del(`${keyPrefix()}group:g-naive:active`);
-        await scripts.dispatch({ nowMs: 400, activeTtlSec: 60 });
-        await redis.decr(pendingKey);
-
-        // Counter is now -1. This proves the naive fix creates NEGATIVE drift.
-        expect(await inspectTotalPending()).toBe(-1);
+        // Complete: no counter change → counter = 0
+        await scripts.complete({ groupId: "g-balanced", stagedJobId: "j1/r/1" });
+        expect(await inspectTotalPending()).toBe(0);
       });
     });
 
     describe("counter reconciliation invariant", () => {
-      it("total-pending equals sum of ZCARD(:jobs) + EXISTS(:active) across all groups", async () => {
+      it("total-pending equals sum of ZCARD(:jobs) across all groups", async () => {
         await scripts.stage(makeJob({ stagedJobId: "a1", groupId: "g-recon-a", dispatchAfterMs: 100 }));
         await scripts.stage(makeJob({ stagedJobId: "a2", groupId: "g-recon-a", dispatchAfterMs: 200 }));
         await scripts.stage(makeJob({ stagedJobId: "b1", groupId: "g-recon-b", dispatchAfterMs: 100 }));
@@ -1945,24 +1945,27 @@ describe("GroupStagingScripts", () => {
         await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
         await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
 
-        // Reconcile: counter should equal actual state
+        // Reconcile: counter should equal jobs in :jobs ZSETs only.
+        // Active (in-flight) jobs were already DECRed at dispatch time.
         const groups = ["g-recon-a", "g-recon-b", "g-recon-c"];
         let actualPending = 0;
         for (const g of groups) {
           const jobCount = await redis.zcard(`${keyPrefix()}group:${g}:jobs`);
-          const hasActive = await redis.exists(`${keyPrefix()}group:${g}:active`);
-          actualPending += jobCount + hasActive;
+          actualPending += jobCount;
         }
 
         expect(await inspectTotalPending()).toBe(actualPending);
       });
 
-      it("retryRestage breaks the invariant — retry adds a job without INCR", async () => {
+      it("retryRestage preserves the invariant — retry INCRs when job re-enters :jobs", async () => {
         await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-recon-retry", dispatchAfterMs: 100 }));
         expect(await inspectTotalPending()).toBe(1);
 
+        // Dispatch: DECR → counter = 0
         await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+        expect(await inspectTotalPending()).toBe(0);
 
+        // retryRestage: INCR → counter = 1
         await scripts.retryRestage({
           groupId: "g-recon-retry",
           stagedJobId: "j1",
@@ -1972,18 +1975,12 @@ describe("GroupStagingScripts", () => {
           backoffMs: 500,
         });
 
-        // retryRestage ZADD'd a new job to :jobs without INCR.
-        // ZCARD(:jobs) = 1 (retry job) + EXISTS(:active) = 1 = actual 2
-        // But total-pending = 1 (only the original STAGE INCR'd).
-        // This is BY DESIGN in the current system: the counter tracks
-        // "original work the system owes", not "total jobs in Redis."
+        // retryRestage ZADD'd a new job AND INCR'd the counter.
+        // ZCARD(:jobs) = 1 (retry job), counter = 1. Invariant holds.
         const jobCount = await redis.zcard(`${keyPrefix()}group:g-recon-retry:jobs`);
-        const hasActive = await redis.exists(`${keyPrefix()}group:g-recon-retry:active`);
-        const actualInRedis = jobCount + hasActive;
-
+        expect(jobCount).toBe(1);
         expect(await inspectTotalPending()).toBe(1);
-        expect(actualInRedis).toBe(2);
-        expect(await inspectTotalPending()).not.toBe(actualInRedis);
+        expect(await inspectTotalPending()).toBe(jobCount);
       });
     });
   });
@@ -2016,48 +2013,48 @@ describe("GroupStagingScripts", () => {
       expect(after).toBe(0);
     });
 
-    it("also decrements for an active in-flight job (active key is dropped, COMPLETE_LUA would no-op)", async () => {
+    it("decrements only staged jobs — active job was already DECRed at dispatch", async () => {
       // Stage two, dispatch one (now active), then drain. Total dropped
-      // should be 2: 1 staged + 1 active. total-pending must drop by 2,
-      // not 1, otherwise the active job's eventual COMPLETE_LUA call —
-      // which now no-ops because the active key is gone — would leak the
-      // counter forever.
+      // should be 1 (just j2 in :jobs). j1's INCR was already compensated
+      // by DECR at dispatch time. Drain must NOT count the active job
+      // again or the counter goes negative.
       await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-active", dispatchAfterMs: 100 }));
       await scripts.stage(makeJob({ stagedJobId: "j2", groupId: "g-active", dispatchAfterMs: 200 }));
 
-      const before = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
-      expect(before).toBe(2);
+      const afterStage = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      expect(afterStage).toBe(2);
 
-      // Move j1 from staged → active
+      // Move j1 from staged → active (DECR at dispatch → counter = 1)
       const dispatched = await scripts.dispatch({ nowMs: 150, activeTtlSec: 60 });
       expect(dispatched).not.toBeNull();
       expect(dispatched!.stagedJobId).toBe("j1");
-      // Sanity: active key exists, only j2 left in staged jobsKey
       expect(await inspectActiveKey("g-active")).toBe("j1");
-      const staged = await inspectGroupJobs("g-active");
-      expect(staged.filter((s) => !s.match(/^\d+$/))).toEqual(["j2"]);
+
+      const afterDispatch = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      expect(afterDispatch).toBe(1); // j2 still in :jobs
 
       const result = await repo.drainGroup({ queueName: QUEUE_NAME, groupId: "g-active" });
-      expect(result.jobsRemoved).toBe(2); // 1 staged (j2) + 1 active (j1)
+      expect(result.jobsRemoved).toBe(1); // only j2 (staged), not j1 (active)
 
       const after = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
-      expect(after).toBe(0); // started at 2, dropped 2
+      expect(after).toBe(0);
     });
 
-    it("decrements only the active count when no jobs are staged", async () => {
-      // Edge case: ZCARD=0 but activeKey exists. Drop must still account for 1.
+    it("drain on a fully-dispatched group drops 0 jobs", async () => {
+      // Edge case: ZCARD=0 because the only job was dispatched (DECRed).
+      // activeKey exists but drain must NOT count it — already DECRed.
       await scripts.stage(makeJob({ stagedJobId: "j1", groupId: "g-only-active", dispatchAfterMs: 100 }));
       await scripts.dispatch({ nowMs: 150, activeTtlSec: 60 });
-      const beforeStaged = await inspectGroupJobs("g-only-active");
-      expect(beforeStaged.filter((s) => !s.match(/^\d+$/))).toEqual([]);
       expect(await inspectActiveKey("g-only-active")).toBe("j1");
 
       const before = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
+      expect(before).toBe(0); // dispatch already DECRed
+
       const result = await repo.drainGroup({ queueName: QUEUE_NAME, groupId: "g-only-active" });
-      expect(result.jobsRemoved).toBe(1);
+      expect(result.jobsRemoved).toBe(0); // no staged jobs to drop
 
       const after = Number(await redis.get(`${keyPrefix()}stats:total-pending`));
-      expect(after).toBe(before - 1);
+      expect(after).toBe(0);
     });
 
     it("returns 0 and does not touch total-pending when the group is empty", async () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -624,9 +624,11 @@ local activeKey    = keyPrefix .. "group:" .. groupId .. ":active"
 redis.call("SADD", blockedKey, groupId)
 
 -- 2. Re-stage the failed job with a new ID
-redis.call("ZADD", groupJobsKey, score, newStagedJobId)
+local inserted = redis.call("ZADD", groupJobsKey, score, newStagedJobId)
 redis.call("HSET", groupDataKey, newStagedJobId, jobDataJson)
-redis.call("INCR", totalPendingKey)
+if inserted == 1 then
+  redis.call("INCR", totalPendingKey)
+end
 
 -- 3. Remove from ready set — blocked groups should not be scanned by dispatch.
 --    UNBLOCK_LUA re-adds the group when it is unblocked.
@@ -697,9 +699,11 @@ end
 -- 2. Re-stage job with future score (backoff delay)
 local groupJobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
 local groupDataKey = keyPrefix .. "group:" .. groupId .. ":data"
-redis.call("ZADD", groupJobsKey, dispatchAfterMs, newStagedJobId)
+local inserted = redis.call("ZADD", groupJobsKey, dispatchAfterMs, newStagedJobId)
 redis.call("HSET", groupDataKey, newStagedJobId, jobDataJson)
-redis.call("INCR", totalPendingKey)
+if inserted == 1 then
+  redis.call("INCR", totalPendingKey)
+end
 
 -- 3. Update ready set score = future dispatch time so the group becomes
 --    eligible exactly when the backoff window expires.

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -168,9 +168,10 @@ return newStagedCount
 `;
 
 const DISPATCH_LUA = `
-local readyKey     = KEYS[1]
-local blockedKey   = KEYS[2]
-local pausedJobKey = KEYS[3]
+local readyKey         = KEYS[1]
+local blockedKey       = KEYS[2]
+local pausedJobKey     = KEYS[3]
+local totalPendingKey  = KEYS[4]
 
 local keyPrefix    = ARGV[1]
 local nowMs        = tonumber(ARGV[2])
@@ -278,6 +279,7 @@ while offset < scanBudget do
 
           if not paused then
             redis.call("ZREM", jobsKey, stagedJobId)
+            redis.call("DECR", totalPendingKey)
             redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
 
             -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
@@ -321,9 +323,10 @@ return nil
 `;
 
 const DISPATCH_BATCH_LUA = `
-local readyKey     = KEYS[1]
-local blockedKey   = KEYS[2]
-local pausedJobKey = KEYS[3]
+local readyKey         = KEYS[1]
+local blockedKey       = KEYS[2]
+local pausedJobKey     = KEYS[3]
+local totalPendingKey  = KEYS[4]
 
 local keyPrefix      = ARGV[1]
 local nowMs          = tonumber(ARGV[2])
@@ -433,6 +436,7 @@ while offset < scanBudget and dispatched < maxJobs do
 
           if not paused then
             redis.call("ZREM", jobsKey, stagedJobId)
+            redis.call("DECR", totalPendingKey)
             redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
 
             -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
@@ -491,7 +495,6 @@ local readyKey        = KEYS[3]
 local signalKey       = KEYS[4]
 local statsKey        = KEYS[5]
 local errorKey        = KEYS[6]
-local totalPendingKey = KEYS[7]
 
 local groupId      = ARGV[1]
 local stagedJobId  = ARGV[2]
@@ -550,9 +553,6 @@ if jobName and jobName ~= "" then
   redis.call("INCR", statsKey .. ":" .. jobName)
 end
 
--- Decrement total pending counter
-redis.call("DECR", totalPendingKey)
-
 -- Clear any leftover error from previous failures now that the job succeeded
 redis.call("DEL", errorKey)
 
@@ -598,9 +598,10 @@ return 0
 `;
 
 const RESTAGE_AND_BLOCK_LUA = `
-local blockedKey = KEYS[1]
-local readyKey   = KEYS[2]
-local statsKey   = KEYS[3]
+local blockedKey      = KEYS[1]
+local readyKey        = KEYS[2]
+local statsKey        = KEYS[3]
+local totalPendingKey = KEYS[4]
 
 local keyPrefix             = ARGV[1]
 local groupId               = ARGV[2]
@@ -625,6 +626,7 @@ redis.call("SADD", blockedKey, groupId)
 -- 2. Re-stage the failed job with a new ID
 redis.call("ZADD", groupJobsKey, score, newStagedJobId)
 redis.call("HSET", groupDataKey, newStagedJobId, jobDataJson)
+redis.call("INCR", totalPendingKey)
 
 -- 3. Remove from ready set — blocked groups should not be scanned by dispatch.
 --    UNBLOCK_LUA re-adds the group when it is unblocked.
@@ -671,7 +673,8 @@ return 1
 `;
 
 const RETRY_RESTAGE_LUA = `
-local activeKey = KEYS[1]
+local activeKey       = KEYS[1]
+local totalPendingKey = KEYS[2]
 
 local keyPrefix             = ARGV[1]
 local groupId               = ARGV[2]
@@ -696,6 +699,7 @@ local groupJobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
 local groupDataKey = keyPrefix .. "group:" .. groupId .. ":data"
 redis.call("ZADD", groupJobsKey, dispatchAfterMs, newStagedJobId)
 redis.call("HSET", groupDataKey, newStagedJobId, jobDataJson)
+redis.call("INCR", totalPendingKey)
 
 -- 3. Update ready set score = future dispatch time so the group becomes
 --    eligible exactly when the backoff window expires.
@@ -918,6 +922,7 @@ export class GroupStagingScripts {
     const readyKey = `${this.keyPrefix}ready`;
     const blockedKey = `${this.keyPrefix}blocked`;
     const pausedJobKey = `${this.keyPrefix}paused-jobs`;
+    const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
 
     // Tenant soft-cap (post-2026-05-11 follow-up). 0 = disabled.
     // Env var lets operators flip on per-environment without redeploy.
@@ -925,10 +930,11 @@ export class GroupStagingScripts {
 
     const result = await this.redis.eval(
       DISPATCH_LUA,
-      3,
+      4,
       readyKey,
       blockedKey,
       pausedJobKey,
+      totalPendingKey,
       this.keyPrefix,
       String(nowMs),
       String(activeTtlSec),
@@ -963,15 +969,17 @@ export class GroupStagingScripts {
     const readyKey = `${this.keyPrefix}ready`;
     const blockedKey = `${this.keyPrefix}blocked`;
     const pausedJobKey = `${this.keyPrefix}paused-jobs`;
+    const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
 
     const tenantCap = readTenantCap();
 
     const result = await this.redis.eval(
       DISPATCH_BATCH_LUA,
-      3,
+      4,
       readyKey,
       blockedKey,
       pausedJobKey,
+      totalPendingKey,
       this.keyPrefix,
       String(nowMs),
       String(activeTtlSec),
@@ -1016,18 +1024,16 @@ export class GroupStagingScripts {
     const signalKey = `${this.keyPrefix}signal`;
     const statsKey = `${this.keyPrefix}stats:completed`;
     const errorKey = `${this.keyPrefix}group:${groupId}:error`;
-    const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
 
     const result = await this.redis.eval(
       COMPLETE_LUA,
-      7,
+      6,
       activeKey,
       jobsKey,
       readyKey,
       signalKey,
       statsKey,
       errorKey,
-      totalPendingKey,
       groupId,
       stagedJobId,
       jobName ?? "",
@@ -1091,13 +1097,15 @@ export class GroupStagingScripts {
     const blockedKey = `${this.keyPrefix}blocked`;
     const readyKey = `${this.keyPrefix}ready`;
     const statsKey = `${this.keyPrefix}stats:failed`;
+    const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
 
     await this.redis.eval(
       RESTAGE_AND_BLOCK_LUA,
-      3,
+      4,
       blockedKey,
       readyKey,
       statsKey,
+      totalPendingKey,
       this.keyPrefix,
       groupId,
       newStagedJobId,
@@ -1136,13 +1144,15 @@ export class GroupStagingScripts {
     backoffMs: number;
   }): Promise<boolean> {
     const activeKey = `${this.keyPrefix}group:${groupId}:active`;
+    const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
     // TTL = backoff + 2s buffer so the key expires just after the job becomes eligible
     const retryTtlSec = Math.ceil(backoffMs / 1000) + 2;
 
     const result = await this.redis.eval(
       RETRY_RESTAGE_LUA,
-      1,
+      2,
       activeKey,
+      totalPendingKey,
       this.keyPrefix,
       groupId,
       stagedJobId,

--- a/specs/event-sourcing/pending-counter-conservation.feature
+++ b/specs/event-sourcing/pending-counter-conservation.feature
@@ -1,0 +1,55 @@
+Feature: Pending counter conservation across job lifecycle
+  As an operator monitoring the ops dashboard
+  I want the total-pending counter to accurately reflect jobs in :jobs ZSETs
+  So that the dashboard shows real queue depth, not phantom drift.
+
+  # Why this exists — incident 2026-05-21
+  #
+  # The total-pending counter drifted to 827K (real pending was ~1,300).
+  # Root cause: COMPLETE_LUA only DECRs the counter when the activeKey
+  # matches the stagedJobId. When the activeKey expires before the worker
+  # calls COMPLETE, the DECR is silently skipped. The INCR at stage time
+  # has no compensating DECR, so the counter only ever goes up.
+  #
+  # Fix: move DECR to DISPATCH (job leaves :jobs ZSET — always succeeds)
+  # and add compensating INCRs in RETRY_RESTAGE and RESTAGE_AND_BLOCK
+  # (job re-enters :jobs ZSET). COMPLETE no longer touches the counter.
+
+  Background:
+    Given the GroupQueue is running with Lua scripts deployed
+
+  @integration @counter @lifecycle
+  Scenario: Counter tracks jobs in :jobs ZSETs through happy path
+    Given a staged job for tenant "proj_acme" (INCR at stage)
+    When DISPATCH removes the job from :jobs
+    Then the counter is decremented (DECR at dispatch)
+    When COMPLETE runs successfully
+    Then the counter is unchanged (no DECR in COMPLETE)
+
+  @integration @counter @active-expiry
+  Scenario: Counter stays accurate when activeKey expires before COMPLETE
+    Given a staged job for tenant "proj_acme" (INCR at stage)
+    When DISPATCH removes the job from :jobs (DECR at dispatch)
+    And the activeKey expires before the worker completes
+    And COMPLETE returns 0 (stale active key)
+    Then the counter is still accurate (DECR already happened at dispatch)
+
+  @integration @counter @retry
+  Scenario: Counter tracks retry restage as a new pending job
+    Given a dispatched job (counter was decremented at dispatch)
+    When RETRY_RESTAGE re-stages the job with a future score
+    Then the counter is incremented (job re-enters :jobs ZSET)
+    When DISPATCH picks up the retried job
+    Then the counter is decremented again
+
+  @integration @counter @block
+  Scenario: Counter tracks restage-and-block as a new pending job
+    Given a dispatched job (counter was decremented at dispatch)
+    When RESTAGE_AND_BLOCK re-stages with a new ID and blocks the group
+    Then the counter is incremented (job re-enters :jobs ZSET)
+
+  @integration @counter @invariant
+  Scenario: Counter equals sum of all :jobs ZSET cardinalities
+    Given multiple tenants with staged, dispatched, and retried jobs
+    When the system reaches a quiescent state
+    Then total-pending equals the sum of ZCARD across all group :jobs ZSETs


### PR DESCRIPTION
## Summary

- Move `total-pending` counter DECR from COMPLETE_LUA to DISPATCH (ZREM from `:jobs` — always succeeds)
- Add compensating INCRs in RETRY_RESTAGE and RESTAGE_AND_BLOCK (job re-enters `:jobs`)
- Remove DECR + `totalPendingKey` from COMPLETE_LUA entirely

## Problem

The ops dashboard showed 827K pending jobs when real pending was ~1,300. The `total-pending` counter only goes up because COMPLETE_LUA skips the DECR when the activeKey doesn't match the stagedJobId (line 507 early return). This happens whenever the active key expires before the worker calls COMPLETE — the INCR from stage time has no compensating DECR.

## Root cause

```
STAGE:    INCR  (job enters :jobs ZSET)
DISPATCH: —     (job removed from :jobs, no counter change)
COMPLETE: DECR  ← but ONLY if activeKey matches (skipped on expiry)
```

Every active key expiry = +1 permanent drift. At scale, hundreds of expirations per hour compound into 827K phantom pending.

## Fix

```
STAGE:              INCR  (job enters :jobs)
DISPATCH:           DECR  (job leaves :jobs via ZREM — always succeeds)
COMPLETE:           —     (no counter change needed)
RETRY_RESTAGE:      INCR  (job re-enters :jobs via ZADD)
RESTAGE_AND_BLOCK:  INCR  (job re-enters :jobs via ZADD)
```

Every INCR has a guaranteed DECR. No conditional paths. Counter semantic changes from "staged but not completed" to "jobs in :jobs ZSETs" — which is what the dashboard actually wants to show.

## 4 Lua script changes

| Script | Change |
|--------|--------|
| DISPATCH_LUA | Add `DECR totalPendingKey` after ZREM |
| DISPATCH_BATCH_LUA | Add `DECR totalPendingKey` after ZREM |
| COMPLETE_LUA | Remove DECR + `totalPendingKey` from KEYS |
| RETRY_RESTAGE_LUA | Add `INCR totalPendingKey` after ZADD |
| RESTAGE_AND_BLOCK_LUA | Add `INCR totalPendingKey` after ZADD |

## Risk

- **No data loss** — counter is read-only metadata for the ops dashboard
- **No behavior change** — no processing logic depends on this counter
- **Rolling deploy safe** — Lua scripts are embedded in TS, both deploy together
- After deploy, the counter will still show the stale 827K value until reset. A one-time `SET {event-sourcing/jobs}:gq:stats:total-pending <real-value>` on the primary is needed.

## Test plan

- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] Existing unit tests pass (tenantCap)
- [ ] Integration tests pass (scripts.integration.test.ts — requires Docker)
- [ ] After deploy: reset counter to real pending count
- [ ] Monitor dashboard — counter should track real pending without drift