### PR TITLE
fix(playground): persist latest assistant reply across browser refresh

### DIFF
--- a/langwatch/src/prompts/prompt-playground/components/chat/PromptPlaygroundChat.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/chat/PromptPlaygroundChat.tsx
@@ -27,6 +27,22 @@ interface PromptPlaygroundChatProps extends BoxProps {
 }
 
 /**
+ * Stable dedup key over the messages-to-persist projection. Encodes
+ * each entry's id, role, and content length so streaming content
+ * deltas trigger a re-persist (only ID-based dedup short-circuited
+ * the latest assistant's chunks and left it stuck at empty content
+ * across refreshes — see the effect comment in PromptPlaygroundChatInner).
+ * Exported for unit testing.
+ */
+export function persistedMessagesKey(
+  persisted: { id: string; role: ChatMessage["role"]; content: string }[],
+): string {
+  return persisted
+    .map((m) => `${m.id}:${m.role}:${m.content.length}`)
+    .join("|");
+}
+
+/**
  * PromptPlaygroundChatRef
  * Single Responsibility: Exposes imperative methods to control the chat instance (e.g., reset, focus).
  */
@@ -118,14 +134,35 @@ const PromptPlaygroundChatInner = forwardRef<PromptPlaygroundChatRef, object>(
     }, [setMessages, tabId, getTabById]);
 
     /**
-     * Sync the visible messages to the tab data.
+     * Sync the visible messages to the tab data so a browser refresh
+     * restores the running conversation. Deduping by message ID alone
+     * dropped the latest assistant reply: the assistant message gets a
+     * stable ID the moment streaming starts (when content is still
+     * empty), the ID-set never changes again for that turn, so the
+     * effect skipped every content delta. The persisted snapshot ended
+     * up with the most recent assistant message stuck at empty content
+     * — which `convertScenarioMessagesToCopilotKit` then dropped on
+     * reload via its `if (message.content && message.content !== "None")`
+     * guard. Keying on a content snapshot too means each streaming
+     * chunk re-persists the latest message; the per-turn writes are a
+     * few dozen small localStorage updates which is fine.
      */
-    const prevMessageIdsRef = useRef("");
+    const prevMessagesKeyRef = useRef("");
     useEffect(() => {
       if (!visibleMessages) return;
-      const messageIds = visibleMessages.map((m) => m.id).join(",");
-      if (messageIds === prevMessageIdsRef.current) return;
-      prevMessageIdsRef.current = messageIds;
+      const persisted = visibleMessages
+        .filter((message) => message.isTextMessage())
+        .map((message) => {
+          const textMessage = message as any; // Type assertion after isTextMessage() filter
+          return {
+            id: message.id,
+            role: textMessage.role as ChatMessage["role"],
+            content: textMessage.content?.toString() || "",
+          };
+        });
+      const messagesKey = persistedMessagesKey(persisted);
+      if (messagesKey === prevMessagesKeyRef.current) return;
+      prevMessagesKeyRef.current = messagesKey;
 
       const tab = getTabById(tabId);
       if (tab) {
@@ -135,16 +172,7 @@ const PromptPlaygroundChatInner = forwardRef<PromptPlaygroundChatRef, object>(
             ...(data || {}),
             chat: {
               ...(data?.chat || {}),
-              initialMessagesFromSpanData: visibleMessages
-                .filter((message) => message.isTextMessage())
-                .map((message) => {
-                  const textMessage = message as any; // Type assertion after isTextMessage() filter
-                  return {
-                    id: message.id,
-                    role: textMessage.role as ChatMessage["role"],
-                    content: textMessage.content?.toString() || "",
-                  };
-                }),
+              initialMessagesFromSpanData: persisted,
             },
           }),
         });

--- a/langwatch/src/prompts/prompt-playground/components/chat/__tests__/PromptPlaygroundChat.test.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/chat/__tests__/PromptPlaygroundChat.test.tsx
@@ -13,6 +13,7 @@ import {
   type TabData,
 } from "../../../prompt-playground-store/DraggableTabsBrowserStore";
 import { TabIdProvider } from "../../prompt-browser/ui/TabContext";
+import { persistedMessagesKey } from "../PromptPlaygroundChat";
 import { PromptPlaygroundChatProvider } from "../PromptPlaygroundChatContext";
 import { SyncedChatInput } from "../SyncedChatInput";
 
@@ -124,6 +125,50 @@ describe("PromptPlaygroundChat ref methods", () => {
 
       // This should not throw
       expect(() => foundTextarea?.focus()).not.toThrow();
+    });
+  });
+
+  // Regression: prior dedup keyed only on message IDs. The latest
+  // assistant message kept its ID stable across streaming chunks, so
+  // the persistence effect skipped every content delta and the snapshot
+  // saved to the tab store had its content stuck at empty. On refresh,
+  // `convertScenarioMessagesToCopilotKit` dropped empty-content rows
+  // and the latest assistant reply vanished from the chat. Key must
+  // include content length so streaming deltas re-trigger persistence.
+  describe("persistedMessagesKey (refresh persistence)", () => {
+    it("changes when a message's content grows even if IDs are unchanged", () => {
+      const placeholder = persistedMessagesKey([
+        { id: "u-1", role: "user", content: "hey there" },
+        { id: "a-1", role: "assistant", content: "" },
+      ]);
+      const streamed = persistedMessagesKey([
+        { id: "u-1", role: "user", content: "hey there" },
+        { id: "a-1", role: "assistant", content: "Your name is Bob." },
+      ]);
+      expect(placeholder).not.toBe(streamed);
+    });
+
+    it("is stable when nothing has changed", () => {
+      const messages = [
+        { id: "u-1", role: "user" as const, content: "hey" },
+        { id: "a-1", role: "assistant" as const, content: "hi" },
+      ];
+      expect(persistedMessagesKey(messages)).toBe(
+        persistedMessagesKey(messages),
+      );
+    });
+
+    it("changes when a new message is appended", () => {
+      const before = persistedMessagesKey([
+        { id: "u-1", role: "user", content: "hey" },
+        { id: "a-1", role: "assistant", content: "hi" },
+      ]);
+      const after = persistedMessagesKey([
+        { id: "u-1", role: "user", content: "hey" },
+        { id: "a-1", role: "assistant", content: "hi" },
+        { id: "u-2", role: "user", content: "ok" },
+      ]);
+      expect(before).not.toBe(after);
     });
   });
 


### PR DESCRIPTION
## Summary

In the prompt playground, the last assistant reply disappears from the chat after a browser refresh while every earlier turn survives.

Root cause: the chat-tab persistence effect in `PromptPlaygroundChat.tsx` deduped on message IDs only. The latest assistant message gets a stable ID the moment streaming starts (when content is still empty); the ID-set never changes again for that turn, so the effect skipped every content delta. The persisted snapshot ended up with the most recent assistant message stuck at empty content. On reload, `convertScenarioMessagesToCopilotKit` then dropped empty-content rows via its `if (message.content && message.content !== "None")` guard, and the latest assistant turn vanished.

Older turns survived because the next user-message arrival forced a re-persist after their content had finished streaming. The last turn never got that trigger.

Fix: key the dedup on `(id, role, content-length)` so each streaming chunk re-triggers persistence. Extracted the key function so the regression is unit-testable.

## Test plan

- [x] 3 new unit tests covering the dedup key (changes on content growth, stable on no-op, changes on appended message)
- [ ] Manual browser dogfood: send 3 turns, refresh, all replies (including the latest) still visible