### PR TITLE
fix(metrics): read backup status from system.backup_log

### DIFF
--- a/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
@@ -223,65 +223,71 @@ describe("ClickHouse metrics", () => {
       );
     });
 
-    it("queries system.backup_log for backup status", async () => {
-      const partsResult = {
-        json: vi.fn().mockResolvedValue({ data: [] }),
-      };
-      const backupResult = {
-        json: vi.fn().mockResolvedValue({
-          data: [
-            {
-              status: "BACKUP_CREATED",
-              cnt: "3",
-              last_success_time: "2024-01-15 10:00:00",
-              last_success_size: "1073741824",
-            },
-          ],
-        }),
-      };
-      const diskResult = {
-        json: vi.fn().mockResolvedValue({
-          data: [
-            { name: "default", total_space: "322122547200", free_space: "214748364800", used_space: "107374182400" },
-          ],
-        }),
-      };
-      const mockClient = {
-        query: vi.fn()
-          .mockResolvedValueOnce(partsResult)
-          .mockResolvedValueOnce(backupResult)
-          .mockResolvedValueOnce(diskResult),
-      } as unknown as ClickHouseClient;
+    describe("given backup status collection", () => {
+      describe("when system.backup_log returns data", () => {
+        it("queries system.backup_log for backup status", async () => {
+          const partsResult = {
+            json: vi.fn().mockResolvedValue({ data: [] }),
+          };
+          const backupResult = {
+            json: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  status: "BACKUP_CREATED",
+                  cnt: "3",
+                  last_success_time: "2024-01-15 10:00:00",
+                  last_success_size: "1073741824",
+                },
+              ],
+            }),
+          };
+          const diskResult = {
+            json: vi.fn().mockResolvedValue({
+              data: [
+                { name: "default", total_space: "322122547200", free_space: "214748364800", used_space: "107374182400" },
+              ],
+            }),
+          };
+          const mockClient = {
+            query: vi.fn()
+              .mockResolvedValueOnce(partsResult)
+              .mockResolvedValueOnce(backupResult)
+              .mockResolvedValueOnce(diskResult),
+          } as unknown as ClickHouseClient;
 
-      await metrics.collectStorageStats(mockClient);
+          await metrics.collectStorageStats(mockClient);
 
-      // Should have been called 3 times: parts, backups, disks
-      expect(mockClient.query).toHaveBeenCalledTimes(3);
-      expect(mockClient.query).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: expect.stringContaining("system.backup_log"),
-        })
-      );
-      expect(mockClient.query).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: expect.stringContaining("system.disks"),
-        })
-      );
-    });
+          // Should have been called 3 times: parts, backups, disks
+          expect(mockClient.query).toHaveBeenCalledTimes(3);
+          expect(mockClient.query).toHaveBeenCalledWith(
+            expect.objectContaining({
+              query: expect.stringContaining("system.backup_log"),
+            })
+          );
+          expect(mockClient.query).toHaveBeenCalledWith(
+            expect.objectContaining({
+              query: expect.stringContaining("system.disks"),
+            })
+          );
+        });
+      });
 
-    it("handles system.backup_log query failure gracefully", async () => {
-      const partsResult = {
-        json: vi.fn().mockResolvedValue({ data: [] }),
-      };
-      const mockClient = {
-        query: vi.fn()
-          .mockResolvedValueOnce(partsResult)
-          .mockRejectedValueOnce(new Error("system.backup_log not enabled"))
-          .mockResolvedValueOnce({ json: vi.fn().mockResolvedValue({ data: [] }) }),
-      } as unknown as ClickHouseClient;
+      describe("when system.backup_log query fails", () => {
+        it("handles system.backup_log query failure gracefully", async () => {
+          const partsResult = {
+            json: vi.fn().mockResolvedValue({ data: [] }),
+          };
+          const mockClient = {
+            query: vi.fn()
+              .mockResolvedValueOnce(partsResult)
+              .mockRejectedValueOnce(new Error("system.backup_log not enabled"))
+              .mockResolvedValueOnce({ json: vi.fn().mockResolvedValue({ data: [] }) }),
+          } as unknown as ClickHouseClient;
 
-      // Should not throw — backup errors are handled gracefully
-      await expect(metrics.collectStorageStats(mockClient)).resolves.toBeUndefined();
+          // Should not throw — backup errors are handled gracefully
+          await expect(metrics.collectStorageStats(mockClient)).resolves.toBeUndefined();
+        });
+      });
     });
 
     it("handles query errors gracefully", async () => {
@@ -394,7 +400,7 @@ describe("ClickHouse metrics", () => {
     });
   });
 
-  describe("system.backup_log failure logging", () => {
+  describe("given system.backup_log failure logging", () => {
     const buildMockClient = (backupShouldFail: () => boolean) => {
       const partsResult = { json: vi.fn().mockResolvedValue({ data: [] }) };
       const successfulBackupResult = {
@@ -426,39 +432,43 @@ describe("ClickHouse metrics", () => {
         return typeof arg === "string" && arg.includes(needle);
       }).length;
 
-    it("emits exactly one warn for repeated failures until recovery", async () => {
-      const client = buildMockClient(() => true);
+    describe("when system.backup_log fails repeatedly", () => {
+      it("emits exactly one warn for repeated failures until recovery", async () => {
+        const client = buildMockClient(() => true);
 
-      await metrics.collectStorageStats(client);
-      await metrics.collectStorageStats(client);
-      await metrics.collectStorageStats(client);
+        await metrics.collectStorageStats(client);
+        await metrics.collectStorageStats(client);
+        await metrics.collectStorageStats(client);
 
-      // logger.warn signature is (obj, msg). First failure warns;
-      // subsequent failures fall through to debug.
-      expect(
-        countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backup_log"),
-      ).toBe(1);
+        // logger.warn signature is (obj, msg). First failure warns;
+        // subsequent failures fall through to debug.
+        expect(
+          countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backup_log"),
+        ).toBe(1);
+      });
     });
 
-    it("warns again on a fresh failure after recovering", async () => {
-      let shouldFail = true;
-      const client = buildMockClient(() => shouldFail);
+    describe("when system.backup_log recovers then fails again", () => {
+      it("warns again on a fresh failure after recovering", async () => {
+        let shouldFail = true;
+        const client = buildMockClient(() => shouldFail);
 
-      await metrics.collectStorageStats(client); // fail → warn (#1)
-      await metrics.collectStorageStats(client); // fail → debug (suppressed)
-      shouldFail = false;
-      await metrics.collectStorageStats(client); // recover → info
-      shouldFail = true;
-      await metrics.collectStorageStats(client); // fail → warn (#2)
+        await metrics.collectStorageStats(client); // fail → warn (#1)
+        await metrics.collectStorageStats(client); // fail → debug (suppressed)
+        shouldFail = false;
+        await metrics.collectStorageStats(client); // recover → info
+        shouldFail = true;
+        await metrics.collectStorageStats(client); // fail → warn (#2)
 
-      expect(
-        countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backup_log"),
-      ).toBe(2);
-      // logger.info("ClickHouse backup stats collection recovered ...")
-      // is called with the message as the first arg.
-      expect(
-        countCallsMatching(loggerMocks.info.mock.calls, 0, "recovered"),
-      ).toBe(1);
+        expect(
+          countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backup_log"),
+        ).toBe(2);
+        // logger.info("ClickHouse backup stats collection recovered ...")
+        // is called with the message as the first arg.
+        expect(
+          countCallsMatching(loggerMocks.info.mock.calls, 0, "recovered"),
+        ).toBe(1);
+      });
     });
   });
 });

--- a/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/metrics.unit.test.ts
@@ -223,7 +223,7 @@ describe("ClickHouse metrics", () => {
       );
     });
 
-    it("queries system.backups for backup status", async () => {
+    it("queries system.backup_log for backup status", async () => {
       const partsResult = {
         json: vi.fn().mockResolvedValue({ data: [] }),
       };
@@ -259,7 +259,7 @@ describe("ClickHouse metrics", () => {
       expect(mockClient.query).toHaveBeenCalledTimes(3);
       expect(mockClient.query).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: expect.stringContaining("system.backups"),
+          query: expect.stringContaining("system.backup_log"),
         })
       );
       expect(mockClient.query).toHaveBeenCalledWith(
@@ -269,14 +269,14 @@ describe("ClickHouse metrics", () => {
       );
     });
 
-    it("handles system.backups query failure gracefully", async () => {
+    it("handles system.backup_log query failure gracefully", async () => {
       const partsResult = {
         json: vi.fn().mockResolvedValue({ data: [] }),
       };
       const mockClient = {
         query: vi.fn()
           .mockResolvedValueOnce(partsResult)
-          .mockRejectedValueOnce(new Error("system.backups not found"))
+          .mockRejectedValueOnce(new Error("system.backup_log not enabled"))
           .mockResolvedValueOnce({ json: vi.fn().mockResolvedValue({ data: [] }) }),
       } as unknown as ClickHouseClient;
 
@@ -394,7 +394,7 @@ describe("ClickHouse metrics", () => {
     });
   });
 
-  describe("system.backups failure logging", () => {
+  describe("system.backup_log failure logging", () => {
     const buildMockClient = (backupShouldFail: () => boolean) => {
       const partsResult = { json: vi.fn().mockResolvedValue({ data: [] }) };
       const successfulBackupResult = {
@@ -404,9 +404,9 @@ describe("ClickHouse metrics", () => {
       return {
         query: vi.fn(async ({ query }: { query: string }) => {
           if (query.includes("system.parts")) return partsResult;
-          if (query.includes("system.backups")) {
+          if (query.includes("system.backup_log")) {
             if (backupShouldFail()) {
-              throw new Error("system.backups not found");
+              throw new Error("system.backup_log not enabled");
             }
             return successfulBackupResult;
           }
@@ -436,7 +436,7 @@ describe("ClickHouse metrics", () => {
       // logger.warn signature is (obj, msg). First failure warns;
       // subsequent failures fall through to debug.
       expect(
-        countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backups"),
+        countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backup_log"),
       ).toBe(1);
     });
 
@@ -452,7 +452,7 @@ describe("ClickHouse metrics", () => {
       await metrics.collectStorageStats(client); // fail → warn (#2)
 
       expect(
-        countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backups"),
+        countCallsMatching(loggerMocks.warn.mock.calls, 1, "system.backup_log"),
       ).toBe(2);
       // logger.info("ClickHouse backup stats collection recovered ...")
       // is called with the message as the first arg.

--- a/langwatch/src/server/clickhouse/metrics.ts
+++ b/langwatch/src/server/clickhouse/metrics.ts
@@ -267,7 +267,15 @@ export async function collectStorageStats(
       setClickHouseTableParts(row.table, parseInt(row.parts_count, 10));
     }
 
-    // Collect backup status metrics
+    // Collect backup status metrics from system.backup_log (persistent).
+    // We deliberately query system.backup_log instead of system.backups:
+    // system.backups is an in-memory table that gets wiped on CH restart,
+    // which happens on every app deploy (the CH image tag is bumped by the
+    // build pipeline). After a restart the in-memory table is empty until
+    // the next scheduled backup runs, so a freshly-rolled worker pod sees
+    // zero rows and never emits the gauge, tripping the "Backup Reporting
+    // Absent" alert despite backups being healthy. system.backup_log is a
+    // persistent system table that retains entries across restarts.
     try {
       interface BackupStats {
         status: string;
@@ -283,7 +291,7 @@ export async function collectStorageStats(
             count() as cnt,
             maxIf(end_time, status = 'BACKUP_CREATED') as last_success_time,
             argMaxIf(total_size, end_time, status = 'BACKUP_CREATED') as last_success_size
-          FROM system.backups
+          FROM system.backup_log
           GROUP BY status
         `,
       });
@@ -316,13 +324,13 @@ export async function collectStorageStats(
       if (!backupStatsCollectionFailing) {
         logger.warn(
           { error: backupError },
-          "Failed to collect ClickHouse backup stats from system.backups (further failures suppressed until recovery)",
+          "Failed to collect ClickHouse backup stats from system.backup_log (further failures suppressed until recovery)",
         );
         backupStatsCollectionFailing = true;
       } else {
         logger.debug(
           { error: backupError },
-          "Failed to collect ClickHouse backup stats from system.backups",
+          "Failed to collect ClickHouse backup stats from system.backup_log",
         );
       }
     }


### PR DESCRIPTION
## Summary

Today an alert fired in lw-prod: **"ClickHouse Backup Reporting Absent"** stayed firing for 2h10m after a deploy + IAM-rotation rollout, even though backups themselves were running fine. Root cause is in `metrics.ts`:

- The collector queries `system.backups` to populate `clickhouse_backup_last_success_timestamp_seconds`.
- `system.backups` is an **in-memory** CH table — it gets wiped on every CH restart.
- CH restarts on every app deploy (the image tag in SSM bumps on every build), so the table is empty for ~1h between restart and the next scheduled backup.
- During that window a freshly-rolled worker pod sees zero rows and never calls `setClickHouseBackupLastSuccessTimestamp`. The gauge is lazy-registered (intentional — see the existing comment), so the metric stays absent entirely until a backup row appears, tripping the absent-gauge alert.

The fix swaps to `system.backup_log`, the persistent equivalent. Same columns we care about (`status`, `end_time`, `total_size`), survives CH restarts, has months of history available.

Validated on lw-prod: `system.backup_log` is enabled with 3539 rows back to 2026-01-29.

## Test plan

- [x] `pnpm test:unit src/server/clickhouse/__tests__/metrics.unit.test.ts` — 31/31 pass
- [ ] After merge, watch `clickhouse_backup_last_success_timestamp_seconds` in Grafana through the next prod deploy: gauge should remain present across the CH/worker rollout instead of disappearing for ~1-2h
- [ ] Confirm the "ClickHouse Backup Reporting Absent" alert no longer flaps on deploy