### PR TITLE
fix(traces-v2): coderabbit + reviewer follow-ups for #4179

### DIFF
--- a/langwatch/scripts/dogfood/traces/error-trace.ts
+++ b/langwatch/scripts/dogfood/traces/error-trace.ts
@@ -1,19 +1,17 @@
-/* eslint-disable */
 /**
  * Emit one OTLP trace with a chain of error spans, intended for the
  * StatusChip interactive-tooltip dogfood. Mirrors the screenshot the
- * customer report used to motivate the work — a top-level workflow
+ * customer report used to motivate the work, a top-level workflow
  * span errors with "Connection error.", and a couple of llm + chain
  * leaf spans error underneath so the popover has multiple chips.
  *
  * Usage:
  *   LW_API_KEY=sk-lw-... LW_ENDPOINT=http://localhost:5560 \
- *     npx tsx scripts/dogfood-error-trace.ts
+ *     npx tsx langwatch/scripts/dogfood/traces/error-trace.ts
  */
 import { randomBytes } from "node:crypto";
 
-const ENDPOINT =
-  process.env.LW_ENDPOINT ?? "http://localhost:5560";
+const ENDPOINT = process.env.LW_ENDPOINT ?? "http://localhost:5560";
 const API_KEY = process.env.LW_API_KEY;
 if (!API_KEY) {
   console.error("LW_API_KEY is required");
@@ -21,7 +19,6 @@ if (!API_KEY) {
 }
 
 const NOW_NS = BigInt(Date.now()) * 1_000_000n;
-const SEC_NS = 1_000_000_000n;
 
 function id(bytes: number): string {
   return randomBytes(bytes).toString("hex");

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/TraceSummaryAccordions.tsx
@@ -43,7 +43,6 @@ export function TraceSummaryAccordions({
   const hasTraceAttributes = Object.keys(traceAttributes).length > 0;
   const hasAttributes = hasTraceAttributes || hasResourceAttributes;
   const hasScope = !!resources.scope?.name;
-  const hasError = trace.status === "error" && !!trace.error;
 
   const {
     rich: richEvals,
@@ -68,9 +67,16 @@ export function TraceSummaryAccordions({
   // the operator sees the same span order whether they're scanning
   // the popover or the expanded accordion.
   const errorSpans = useMemo(
-    () => (hasError ? rankedErrorSpans(spans) : []),
-    [spans, hasError],
+    () => (trace.status === "error" ? rankedErrorSpans(spans) : []),
+    [spans, trace.status],
   );
+  // Surface the Exceptions section whenever an error trace has either
+  // a trace-level error string or at least one errored span. The latter
+  // matters for traces that only have span-level failures (no rolled
+  // up trace.error), where the header chip would otherwise list pills
+  // that lead to a section gate that never opens.
+  const hasError =
+    trace.status === "error" && (!!trace.error || errorSpans.length > 0);
 
   const sections = useMemo(() => {
     const list: Array<

--- a/langwatch/src/features/traces-v2/stores/__tests__/focusSectionStore.unit.test.ts
+++ b/langwatch/src/features/traces-v2/stores/__tests__/focusSectionStore.unit.test.ts
@@ -7,51 +7,57 @@ describe("useFocusSectionStore", () => {
   });
 
   describe("given a focus request for the exceptions section", () => {
-    /** @scenario Clicking the error status chip focuses the Exceptions section */
-    it("publishes a pending focus payload the trace-summary observer consumes", () => {
-      // The status chip's onClick funnels through this store — the
-      // accordion observer reads `pending`, expands the section,
-      // scrolls + triggers the glow. Testing the store directly keeps
-      // the chip's click handler decoupled from the accordion's DOM.
-      useFocusSectionStore
-        .getState()
-        .request({ traceId: "trace-abc", section: "exceptions" });
-      const pending = useFocusSectionStore.getState().pending;
-      expect(pending?.traceId).toBe("trace-abc");
-      expect(pending?.section).toBe("exceptions");
+    describe("when the status chip is clicked", () => {
+      /** @scenario Clicking the error status chip focuses the Exceptions section */
+      it("publishes a pending focus payload the trace-summary observer consumes", () => {
+        // The status chip's onClick funnels through this store, the
+        // accordion observer reads `pending`, expands the section,
+        // scrolls + triggers the glow. Testing the store directly keeps
+        // the chip's click handler decoupled from the accordion's DOM.
+        useFocusSectionStore
+          .getState()
+          .request({ traceId: "trace-abc", section: "exceptions" });
+        const pending = useFocusSectionStore.getState().pending;
+        expect(pending?.traceId).toBe("trace-abc");
+        expect(pending?.section).toBe("exceptions");
+      });
     });
   });
 
   describe("given a focus request for the evals section", () => {
-    /** @scenario Clicking an evaluation chip focuses the Evals section */
-    it("publishes a pending focus payload for the evals section", () => {
-      useFocusSectionStore
-        .getState()
-        .request({ traceId: "trace-xyz", section: "evals" });
-      const pending = useFocusSectionStore.getState().pending;
-      expect(pending?.traceId).toBe("trace-xyz");
-      expect(pending?.section).toBe("evals");
+    describe("when an evaluation chip is clicked", () => {
+      /** @scenario Clicking an evaluation chip focuses the Evals section */
+      it("publishes a pending focus payload for the evals section", () => {
+        useFocusSectionStore
+          .getState()
+          .request({ traceId: "trace-xyz", section: "evals" });
+        const pending = useFocusSectionStore.getState().pending;
+        expect(pending?.traceId).toBe("trace-xyz");
+        expect(pending?.section).toBe("evals");
+      });
     });
   });
 
   describe("given the same chip is re-clicked while the previous request is still pending", () => {
-    /** @scenario The focus glow runs a single short pulse so the eye lands without distracting */
-    it("bumps the nonce so the observer re-fires the glow + scroll", () => {
-      // Without the nonce bump, a second click during the ~1.5s glow
-      // window would set the same {traceId, section} state and the
-      // observer's effect dep array wouldn't trigger again — the
-      // operator would feel like the chip stopped responding. Nonce
-      // is the cheap way to make every click distinct in observer
-      // identity terms.
-      useFocusSectionStore
-        .getState()
-        .request({ traceId: "trace-abc", section: "exceptions" });
-      const first = useFocusSectionStore.getState().pending!.nonce;
-      useFocusSectionStore
-        .getState()
-        .request({ traceId: "trace-abc", section: "exceptions" });
-      const second = useFocusSectionStore.getState().pending!.nonce;
-      expect(second).toBeGreaterThan(first);
+    describe("when the chip is clicked a second time", () => {
+      /** @scenario The focus glow runs a single short pulse so the eye lands without distracting */
+      it("bumps the nonce so the observer re-fires the glow + scroll", () => {
+        // Without the nonce bump, a second click during the ~1.5s glow
+        // window would set the same {traceId, section} state and the
+        // observer's effect dep array wouldn't trigger again, the
+        // operator would feel like the chip stopped responding. Nonce
+        // is the cheap way to make every click distinct in observer
+        // identity terms.
+        useFocusSectionStore
+          .getState()
+          .request({ traceId: "trace-abc", section: "exceptions" });
+        const first = useFocusSectionStore.getState().pending!.nonce;
+        useFocusSectionStore
+          .getState()
+          .request({ traceId: "trace-abc", section: "exceptions" });
+        const second = useFocusSectionStore.getState().pending!.nonce;
+        expect(second).toBeGreaterThan(first);
+      });
     });
   });
 });

--- a/langwatch/src/features/traces-v2/utils/__tests__/errorSpans.unit.test.ts
+++ b/langwatch/src/features/traces-v2/utils/__tests__/errorSpans.unit.test.ts
@@ -19,81 +19,114 @@ function span(partial: Partial<SpanTreeNode>): SpanTreeNode {
 
 describe("rankedErrorSpans", () => {
   describe("given a flat list of spans with no errors", () => {
-    it("returns an empty array", () => {
-      const spans = [
-        span({ spanId: "a", status: "ok" }),
-        span({ spanId: "b", status: "ok" }),
-      ];
-      expect(rankedErrorSpans(spans)).toEqual([]);
+    describe("when ranking is requested", () => {
+      it("returns an empty array", () => {
+        const spans = [
+          span({ spanId: "a", status: "ok" }),
+          span({ spanId: "b", status: "ok" }),
+        ];
+        expect(rankedErrorSpans(spans)).toEqual([]);
+      });
     });
   });
 
   describe("given mixed error / ok spans across a tree", () => {
-    it("ranks deepest-first, then by startTimeMs as a tiebreaker", () => {
-      // Tree:
-      //   root (ok)
-      //     ├── m1 (error, depth=1, start=20)
-      //     │     └── leaf-late (error, depth=2, start=40)
-      //     └── m2 (error, depth=1, start=10)
-      const spans = [
-        span({ spanId: "root", status: "ok", parentSpanId: null }),
-        span({
-          spanId: "m1",
-          status: "error",
-          parentSpanId: "root",
-          startTimeMs: 20,
-          name: "m1",
-        }),
-        span({
-          spanId: "leaf-late",
-          status: "error",
-          parentSpanId: "m1",
-          startTimeMs: 40,
-          name: "leaf-late",
-        }),
-        span({
-          spanId: "m2",
-          status: "error",
-          parentSpanId: "root",
-          startTimeMs: 10,
-          name: "m2",
-        }),
-      ];
+    describe("when ranking is requested", () => {
+      it("ranks deepest-first, then by startTimeMs as a tiebreaker", () => {
+        // Tree:
+        //   root (ok)
+        //     ├── m1 (error, depth=1, start=20)
+        //     │     └── leaf-late (error, depth=2, start=40)
+        //     └── m2 (error, depth=1, start=10)
+        const spans = [
+          span({ spanId: "root", status: "ok", parentSpanId: null }),
+          span({
+            spanId: "m1",
+            status: "error",
+            parentSpanId: "root",
+            startTimeMs: 20,
+            name: "m1",
+          }),
+          span({
+            spanId: "leaf-late",
+            status: "error",
+            parentSpanId: "m1",
+            startTimeMs: 40,
+            name: "leaf-late",
+          }),
+          span({
+            spanId: "m2",
+            status: "error",
+            parentSpanId: "root",
+            startTimeMs: 10,
+            name: "m2",
+          }),
+        ];
 
-      const out = rankedErrorSpans(spans).map((r) => ({
-        id: r.span.spanId,
-        depth: r.depth,
-      }));
+        const out = rankedErrorSpans(spans).map((r) => ({
+          id: r.span.spanId,
+          depth: r.depth,
+        }));
 
-      expect(out).toEqual([
-        // Deepest-first.
-        { id: "leaf-late", depth: 2 },
-        // Equal depth — earlier start wins.
-        { id: "m2", depth: 1 },
-        { id: "m1", depth: 1 },
-      ]);
+        expect(out).toEqual([
+          // Deepest-first.
+          { id: "leaf-late", depth: 2 },
+          // Equal depth, earlier start wins.
+          { id: "m2", depth: 1 },
+          { id: "m1", depth: 1 },
+        ]);
+      });
     });
   });
 
   describe("given a span whose parent isn't in the trace", () => {
-    it("treats the missing parent as depth 0 and keeps the span in the list", () => {
-      const spans = [
-        span({
-          spanId: "orphan",
-          status: "error",
-          parentSpanId: "phantom-id-not-in-trace",
-          name: "orphan",
-        }),
-      ];
-      expect(rankedErrorSpans(spans)).toEqual([
-        { span: spans[0], depth: 0 },
-      ]);
+    describe("when ranking is requested", () => {
+      it("treats the missing parent as depth 0 and keeps the span in the list", () => {
+        const spans = [
+          span({
+            spanId: "orphan",
+            status: "error",
+            parentSpanId: "phantom-id-not-in-trace",
+            name: "orphan",
+          }),
+        ];
+        expect(rankedErrorSpans(spans)).toEqual([
+          { span: spans[0], depth: 0 },
+        ]);
+      });
     });
   });
 
   describe("given an empty span list", () => {
-    it("returns an empty array without throwing", () => {
-      expect(rankedErrorSpans([])).toEqual([]);
+    describe("when ranking is requested", () => {
+      it("returns an empty array without throwing", () => {
+        expect(rankedErrorSpans([])).toEqual([]);
+      });
+    });
+  });
+
+  describe("given spans with cyclic parent links", () => {
+    describe("when ranking is requested", () => {
+      it("bails out of the depth walk instead of looping forever", () => {
+        // a → b → a (cycle). Both are error spans so they enter ranking.
+        const spans = [
+          span({
+            spanId: "a",
+            status: "error",
+            parentSpanId: "b",
+            name: "a",
+          }),
+          span({
+            spanId: "b",
+            status: "error",
+            parentSpanId: "a",
+            name: "b",
+          }),
+        ];
+        const out = rankedErrorSpans(spans).map((r) => r.span.spanId);
+        // Order isn't load-bearing here, only that the call returns.
+        expect(out.sort()).toEqual(["a", "b"]);
+      });
     });
   });
 });

--- a/langwatch/src/features/traces-v2/utils/errorSpans.ts
+++ b/langwatch/src/features/traces-v2/utils/errorSpans.ts
@@ -21,7 +21,13 @@ export function rankedErrorSpans(spans: SpanTreeNode[]): ErrorSpanRanked[] {
   const depthOf = (spanId: string): number => {
     let depth = 0;
     let cur: SpanTreeNode | undefined = byId.get(spanId);
+    // Track visited ids so a malformed graph with cyclic parent links
+    // (e.g. an OTel exporter that mis-attributes parents) bails out
+    // instead of hanging the ranker.
+    const visited = new Set<string>();
     while (cur?.parentSpanId) {
+      if (visited.has(cur.spanId)) break;
+      visited.add(cur.spanId);
       const parent = byId.get(cur.parentSpanId);
       if (!parent) break;
       depth += 1;


### PR DESCRIPTION
## Summary

Quick follow-ups on the trace-drawer error chip PR #4179 that landed before review comments could be addressed:

- **Scripts layout (reviewer):** moved `scripts/dogfood-error-trace.ts` to `langwatch/scripts/dogfood/traces/error-trace.ts` so the dogfood folder stays organised by feature (matches the existing `langwatch/scripts/dogfood/prompts/` shape). Also dropped the blanket `/* eslint-disable */` and the unused `SEC_NS` constant.
- **Cycle guard (CodeRabbit, major):** `rankedErrorSpans.depthOf` now tracks visited span ids while walking parents, so a malformed graph with cyclic parents can't hang the ranker. New unit case covers the cycle path.
- **Exceptions gating (CodeRabbit, outside-diff major):** `TraceSummaryAccordions` was gating `hasError` on `trace.status === "error" && !!trace.error`, which hid the Exceptions accordion (and broke the new focus pipeline) for traces whose only error signal is at the span level. `hasError` now also activates when there are ranked error spans, so the chip popover's pills always have a section to land on.
- **BDD nesting (CodeRabbit, nits):** wrapped the two new unit suites' `it` blocks in inner `describe("when ...")` blocks to match the repo's BDD convention.

## Test plan

- [x] `pnpm test:unit src/features/traces-v2/utils/__tests__/errorSpans.unit.test.ts src/features/traces-v2/stores/__tests__/focusSectionStore.unit.test.ts` (8/8 pass, includes the new cycle case).
- [x] `pnpm tsx scripts/check-feature-parity.ts` clean (1303 enforced scenarios bound).
- [x] Targeted typecheck on touched files clean.