### PR TITLE
fix(deps): move mcp-server pnpm.overrides to workspace root

### DIFF
--- a/langwatch/pnpm-workspace.yaml
+++ b/langwatch/pnpm-workspace.yaml
@@ -21,6 +21,8 @@ overrides:
   "@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3": "1.26.0"
   # Security: langchain serialization injection (#223)
   "langchain@<0.3.37": "0.3.37"
+  # Security: langsmith SDK floor (from mcp-server)
+  "langsmith@<0.6.0": "0.6.0"
   # Security: merge prototype pollution (#194) via exec-sh
   "merge@<2.1.1": "2.1.1"
   # Security: validator incomplete filtering (#216) via class-validator

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -75,12 +75,5 @@
   },
   "bin": {
     "langwatch-mcp-server": "./dist/index.js"
-  },
-  "pnpm": {
-    "overrides": {
-      "protobufjs": ">=7.5.6 <8.0.0 || >=8.0.2",
-      "langsmith@<0.6.0": "0.6.0",
-      "fast-uri@<3.1.2": "3.1.2"
-    }
   }
 }

--- a/mcp-server/pnpm-workspace.yaml
+++ b/mcp-server/pnpm-workspace.yaml
@@ -1,4 +1,9 @@
 minimumReleaseAge: 10080
 
+overrides:
+  "protobufjs": ">=7.5.6 <8.0.0 || >=8.0.2"
+  "langsmith@<0.6.0": "0.6.0"
+  "fast-uri@<3.1.2": "3.1.2"
+
 onlyBuiltDependencies:
   - node-pty


### PR DESCRIPTION
## Summary

`pnpm install` warns that `pnpm.overrides` in `mcp-server/package.json` is ignored:

> The field "pnpm.overrides" was found in mcp-server/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.

mcp-server is a workspace member of `langwatch/` (declared via `../mcp-server` in `langwatch/pnpm-workspace.yaml`), so overrides must live in the workspace root file. `protobufjs` and `fast-uri` floors were already in the workspace overrides. The only missing entry was `langsmith@<0.6.0`, which is now added there. The dead `pnpm` block in `mcp-server/package.json` is removed.

## Test plan

- [x] `pnpm install` in `langwatch/` no longer prints the overrides warning
- [x] `pnpm run start:prepare:files` runs clean