### PR TITLE
fix(traces-v2): newline marker, evaluator filter label, annotation batching, eval OOM, shiki dispose

### DIFF
--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "react-feather";
 import type { Trace } from "~/server/tracer/types";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+import { useAnnotationsByTraceIds } from "../../hooks/useAnnotationsByTraceIds";
 import type { Workflow } from "../../optimization_studio/types/dsl";
 import type { DatasetRecordEntry } from "../../server/datasets/types";
 import {
@@ -111,13 +112,11 @@ export const TracesMapping = ({
     task: state.workbenchState.task,
   }));
 
-  const annotationScores = api.annotation.getByTraceIds.useQuery(
-    {
-      projectId: project?.id ?? "",
-      traceIds: traces.map((trace) => trace.trace_id),
-    },
-    { enabled: !!project, refetchOnWindowFocus: false },
-  );
+  const annotationScores = useAnnotationsByTraceIds({
+    projectId: project?.id ?? "",
+    traceIds: traces.map((trace) => trace.trace_id),
+    enabled: !!project,
+  });
   const getAnnotationScoreOptions = api.annotationScore.getAllActive.useQuery(
     { projectId: project?.id ?? "" },
     {

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/FacetRow.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/FacetRow.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, HStack, Text } from "@chakra-ui/react";
+import { Box, HStack, Text } from "@chakra-ui/react";
 import { memo, useCallback } from "react";
 import { analyzeOrGroups } from "~/server/app-layer/traces/query-language/queries";
 import { useFacetHoverStore } from "../../stores/facetHoverStore";
@@ -7,14 +7,6 @@ import { orGroupColor } from "./orGroupPalette";
 import { RowButton } from "./RowButton";
 import type { FacetItem, FacetValueState } from "./types";
 import { formatCount, paletteFromColor } from "./utils";
-
-const TYPED_LABEL_REGEX = /^\[([^\]]+)\]\s*(.+)$/;
-
-function parseTypedLabel(label: string): { typeTag?: string; text: string } {
-  const match = TYPED_LABEL_REGEX.exec(label);
-  if (!match) return { text: label };
-  return { typeTag: match[1], text: match[2]! };
-}
 
 const MIN_VISIBLE_FILL_PCT = 4;
 
@@ -44,8 +36,6 @@ export const FacetRow = memo(function FacetRow({
    * part of an OR group. */
   field?: string;
 }) {
-  const { typeTag, text } = parseTypedLabel(item.label);
-
   // Synthetic rows have no real count yet — render with zero fill so they
   // don't look like "0 matches" while we're still waiting on the real
   // descriptors. Once real data lands the row gets a count + bar.
@@ -180,19 +170,6 @@ export const FacetRow = memo(function FacetRow({
           flexShrink={0}
           transition="opacity 120ms ease, transform 120ms ease"
         />
-        {typeTag && (
-          <Badge
-            size="xs"
-            variant="outline"
-            color="fg.subtle"
-            paddingX={1}
-            flexShrink={0}
-            textTransform="lowercase"
-            fontWeight="500"
-          >
-            {typeTag}
-          </Badge>
-        )}
         <Text
           textStyle="xs"
           fontWeight={isActive ? "600" : "500"}
@@ -202,7 +179,7 @@ export const FacetRow = memo(function FacetRow({
           color={isActive ? "fg" : "fg.muted"}
           textDecoration={isExclude ? "line-through" : undefined}
         >
-          {text}
+          {item.label}
         </Text>
         {!item.synthetic && (
           <Text

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceHeaderChips.tsx
@@ -15,7 +15,7 @@ import {
 import { getEvalChipDisplay } from "~/utils/evaluationResults";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import type { TraceHeader } from "~/server/api/routers/tracesV2.schemas";
-import { api } from "~/utils/api";
+import { useAnnotationsByTraceIds } from "~/hooks/useAnnotationsByTraceIds";
 import { useConversationTurns } from "../../hooks/useConversationTurns";
 import type { RichEval } from "../../hooks/useTraceEvaluations";
 import {
@@ -101,17 +101,11 @@ function useAnnotationsChip(trace: TraceHeader): ChipDef | null {
       .filter((id) => id !== trace.traceId),
   ];
 
-  const annotations = api.annotation.getByTraceIds.useQuery(
-    { projectId: project?.id ?? "", traceIds },
-    {
-      enabled:
-        !!project?.id &&
-        traceIds.length > 0 &&
-        hasPermission("annotations:view"),
-      staleTime: 5 * 60_000,
-      refetchOnWindowFocus: false,
-    },
-  );
+  const annotations = useAnnotationsByTraceIds({
+    projectId: project?.id ?? "",
+    traceIds,
+    enabled: !!project?.id && hasPermission("annotations:view"),
+  });
 
   const items = annotations.data ?? [];
   if (items.length === 0) return null;

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/AnnotationsView.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/AnnotationsView.tsx
@@ -11,10 +11,10 @@ import {
 import { Edit3, Lightbulb, MessageSquare } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import { api, type RouterOutputs } from "~/utils/api";
-
-type AnnotationByTraceIds =
-  RouterOutputs["annotation"]["getByTraceIds"][number];
+import {
+  type AnnotationByTrace,
+  useAnnotationsByTraceIds,
+} from "~/hooks/useAnnotationsByTraceIds";
 
 import { AnnotationPopover } from "./AnnotationPopover";
 import type { ParsedTurn } from "./types";
@@ -42,17 +42,11 @@ export function AnnotationsView({
     [parsedTurns],
   );
 
-  const annotations = api.annotation.getByTraceIds.useQuery(
-    { projectId: project?.id ?? "", traceIds },
-    {
-      enabled:
-        !!project?.id &&
-        traceIds.length > 0 &&
-        hasPermission("annotations:view"),
-      staleTime: 5 * 60_000,
-      refetchOnWindowFocus: false,
-    },
-  );
+  const annotations = useAnnotationsByTraceIds({
+    projectId: project?.id ?? "",
+    traceIds,
+    enabled: !!project?.id && hasPermission("annotations:view"),
+  });
 
   // Group annotations by trace so each turn's notes cluster together.
   const grouped = useMemo(() => {
@@ -136,7 +130,7 @@ function AnnotationRow({
 }: {
   traceId: string;
   output?: string | null;
-  annotation: AnnotationByTraceIds;
+  annotation: AnnotationByTrace;
 }) {
   const [open, setOpen] = useState(false);
   const { hasPermission } = useOrganizationTeamProject();

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/ConversationView.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/conversationView/ConversationView.tsx
@@ -12,7 +12,8 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { Check, Copy } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import { api, type RouterOutputs } from "~/utils/api";
+import { type RouterOutputs } from "~/utils/api";
+import { useAnnotationsByTraceIds } from "~/hooks/useAnnotationsByTraceIds";
 import { useConversationTurns } from "../../../hooks/useConversationTurns";
 import { useTraceDrawerNavigation } from "../../../hooks/useTraceDrawerNavigation";
 import type { TraceListItem } from "../../../types/trace";
@@ -71,18 +72,12 @@ export const ConversationView = memo(function ConversationView({
 
   const traceIds = useMemo(() => turns.map((t) => t.traceId), [turns]);
   const { project, hasPermission } = useOrganizationTeamProject();
-  const annotationsQuery = api.annotation.getByTraceIds.useQuery(
-    { projectId: project?.id ?? "", traceIds },
-    {
-      enabled:
-        !!project?.id &&
-        traceIds.length > 0 &&
-        hasPermission("annotations:view"),
-      keepPreviousData: true,
-      staleTime: 5 * 60_000,
-      refetchOnWindowFocus: false,
-    },
-  );
+  const annotationsQuery = useAnnotationsByTraceIds({
+    projectId: project?.id ?? "",
+    traceIds,
+    enabled: !!project?.id && hasPermission("annotations:view"),
+    keepPreviousData: true,
+  });
   const annotationsByTrace = useMemo<AnnotationsByTrace>(() => {
     const map: AnnotationsByTrace = new Map();
     for (const a of annotationsQuery.data ?? []) {

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/EvalCard.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   HStack,
   Icon,
+  Spinner,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -14,6 +15,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { AZURE_SAFETY_NOT_CONFIGURED_MESSAGE } from "~/server/app-layer/evaluations/azure-safety-env";
 import { formatCost, formatDuration } from "../../../utils/formatters";
 import { RunHistorySparkline } from "./RunHistorySparkline";
+import { useEvalInputs } from "./useEvalInputs";
 import { type EvalEntry, formatInputValue, isNoVerdict, STATUS } from "./utils";
 
 export function EvalCard({
@@ -55,8 +57,17 @@ export function EvalCard({
   const hasErrorMessage = !!eval_.errorMessage;
   const hasStacktrace =
     !!eval_.errorStacktrace && eval_.errorStacktrace.length > 0;
-  const inputEntries = eval_.inputs ? Object.entries(eval_.inputs) : [];
-  const hasInputs = inputEntries.length > 0;
+  const hasListInputs =
+    !!eval_.inputs && Object.keys(eval_.inputs).length > 0;
+  // Inputs load lazily per-card (see useEvalInputs): the verdict list drops
+  // the heavy `Inputs` blob under ClickHouse memory pressure, and even when
+  // it's present we don't ship it until a card is expanded. Evals that
+  // produced a verdict or errored always recorded inputs, so offer the expand
+  // for them and fetch on open.
+  const canLazyLoadInputs =
+    !!eval_.evaluationId &&
+    (status === "pass" || status === "fail" || status === "error");
+  const mightHaveInputs = hasListInputs || canLazyLoadInputs;
   const hasRetries = (eval_.retries ?? 0) > 0;
   // The labeled categorical/boolean verdict is sometimes more informative
   // than the numeric score (e.g. score=1 with label="safe").
@@ -92,7 +103,11 @@ export function EvalCard({
     status === "error" && (!!eval_.evaluationId || !!eval_.evaluatorId);
   // Whether we have anything that warrants the "Show details" expand.
   const hasExpandableDetails =
-    hasInputs || hasStacktrace || hasLabel || showErrorPanel || showErrorIds;
+    mightHaveInputs ||
+    hasStacktrace ||
+    hasLabel ||
+    showErrorPanel ||
+    showErrorIds;
   const hasFooterRow =
     !!eval_.spanName || meta.length > 0 || hasExpandableDetails;
 
@@ -255,8 +270,7 @@ export function EvalCard({
           onSelectSpan={onSelectSpan}
           meta={meta}
           tone={tone}
-          inputEntries={inputEntries}
-          hasInputs={hasInputs}
+          mightHaveInputs={mightHaveInputs}
           hasStacktrace={hasStacktrace}
           hasLabel={hasLabel}
           showErrorPanel={showErrorPanel}
@@ -273,8 +287,7 @@ function EvalCardFooter({
   onSelectSpan,
   meta,
   tone,
-  inputEntries,
-  hasInputs,
+  mightHaveInputs,
   hasStacktrace,
   hasLabel,
   showErrorPanel,
@@ -285,8 +298,7 @@ function EvalCardFooter({
   onSelectSpan?: (spanId: string) => void;
   meta: string[];
   tone: (typeof STATUS)[keyof typeof STATUS];
-  inputEntries: [string, unknown][];
-  hasInputs: boolean;
+  mightHaveInputs: boolean;
   hasStacktrace: boolean;
   hasLabel: boolean;
   showErrorPanel: boolean;
@@ -294,6 +306,12 @@ function EvalCardFooter({
   hasExpandableDetails: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  // Fetch inputs only once the panel is open and only if the list query
+  // didn't already carry them (the hook short-circuits to the list inputs).
+  const { inputEntries, isLoading: inputsLoading } = useEvalInputs({
+    eval_,
+    enabled: open,
+  });
 
   return (
     <>
@@ -448,35 +466,46 @@ function EvalCardFooter({
               </Box>
             </DetailRow>
           )}
-          {hasInputs && (
+          {mightHaveInputs && (
             <DetailRow label="Inputs">
-              <VStack align="stretch" gap={1}>
-                {inputEntries.map(([key, value]) => (
-                  <HStack key={key} align="flex-start" gap={2} minWidth={0}>
-                    <Text
-                      textStyle="2xs"
-                      color="fg.subtle"
-                      flexShrink={0}
-                      minWidth="80px"
-                    >
-                      {key}
-                    </Text>
-                    <Box
-                      as="pre"
-                      textStyle="2xs"
-                      color="fg"
-                      whiteSpace="pre-wrap"
-                      wordBreak="break-word"
-                      margin={0}
-                      flex={1}
-                      maxHeight="160px"
-                      overflow="auto"
-                    >
-                      {formatInputValue(value)}
-                    </Box>
-                  </HStack>
-                ))}
-              </VStack>
+              {inputsLoading ? (
+                <HStack gap={2} color="fg.subtle">
+                  <Spinner size="xs" />
+                  <Text textStyle="2xs">Loading inputs…</Text>
+                </HStack>
+              ) : inputEntries.length > 0 ? (
+                <VStack align="stretch" gap={1}>
+                  {inputEntries.map(([key, value]) => (
+                    <HStack key={key} align="flex-start" gap={2} minWidth={0}>
+                      <Text
+                        textStyle="2xs"
+                        color="fg.subtle"
+                        flexShrink={0}
+                        minWidth="80px"
+                      >
+                        {key}
+                      </Text>
+                      <Box
+                        as="pre"
+                        textStyle="2xs"
+                        color="fg"
+                        whiteSpace="pre-wrap"
+                        wordBreak="break-word"
+                        margin={0}
+                        flex={1}
+                        maxHeight="160px"
+                        overflow="auto"
+                      >
+                        {formatInputValue(value)}
+                      </Box>
+                    </HStack>
+                  ))}
+                </VStack>
+              ) : (
+                <Text textStyle="2xs" color="fg.subtle" fontStyle="italic">
+                  No inputs recorded
+                </Text>
+              )}
             </DetailRow>
           )}
         </VStack>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
@@ -30,11 +30,6 @@ vi.mock("~/hooks/useOrganizationTeamProject", () => ({
   }),
 }));
 
-vi.mock("../../../../stores/drawerStore", () => ({
-  useDrawerStore: (selector: (s: { traceId: string | null }) => unknown) =>
-    selector({ traceId: "trace-1" }),
-}));
-
 import type { EvalEntry } from "../utils";
 import { EvalCard } from "../EvalCard";
 
@@ -88,11 +83,12 @@ describe("EvalCard evaluator inputs", () => {
 
         fireEvent.click(screen.getByText("Show details"));
 
-        // Expanded: the fetch is enabled and the inputs render.
+        // Expanded: the fetch is enabled and the inputs render. The read is
+        // keyed by evaluationId and authorized at the project level (no
+        // trace-scoped public-share path), so no traceId is sent.
         expect(getEvaluationInputsUseQueryMock).toHaveBeenLastCalledWith(
           expect.objectContaining({
             projectId: "project_test",
-            traceId: "trace-1",
             evaluationId: "eval-1",
           }),
           expect.objectContaining({ enabled: true }),

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/__tests__/EvalCard.integration.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration coverage for the lazy-loaded evaluator inputs in EvalCard.
+ * Renders the real card tree and only mocks the boundaries: the tRPC query
+ * that fetches a single evaluation's inputs, the drawer store (trace id), and
+ * the org/project hook.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const getEvaluationInputsUseQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    traces: {
+      getEvaluationInputs: { useQuery: getEvaluationInputsUseQueryMock },
+    },
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "project_test" },
+    organization: {},
+    team: undefined,
+    isFetching: false,
+  }),
+}));
+
+vi.mock("../../../../stores/drawerStore", () => ({
+  useDrawerStore: (selector: (s: { traceId: string | null }) => unknown) =>
+    selector({ traceId: "trace-1" }),
+}));
+
+import type { EvalEntry } from "../utils";
+import { EvalCard } from "../EvalCard";
+
+function renderCard(eval_: EvalEntry) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <EvalCard eval_={eval_} />
+    </ChakraProvider>,
+  );
+}
+
+const baseEval: EvalEntry = {
+  name: "Toxicity",
+  score: true,
+  scoreType: "boolean",
+  status: "pass",
+  evaluationId: "eval-1",
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("EvalCard evaluator inputs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given an evaluation whose inputs were not loaded with the verdict list", () => {
+    describe("when the card's details are expanded", () => {
+      /** @scenario Inputs load on demand when an evaluation is expanded */
+      it("fetches inputs for that single evaluation and shows them", () => {
+        // The lazy query only returns data when enabled (panel open).
+        getEvaluationInputsUseQueryMock.mockImplementation(
+          (_input: unknown, opts: { enabled?: boolean }) => ({
+            data: opts?.enabled
+              ? { input: "the prompt", output: "the reply" }
+              : undefined,
+            isLoading: false,
+          }),
+        );
+
+        renderCard(baseEval); // no `inputs` on the entry
+
+        // Collapsed: the lazy fetch is disabled (nothing shipped on open).
+        expect(getEvaluationInputsUseQueryMock).toHaveBeenCalledWith(
+          expect.objectContaining({ evaluationId: "eval-1" }),
+          expect.objectContaining({ enabled: false }),
+        );
+        expect(screen.queryByText("the prompt")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByText("Show details"));
+
+        // Expanded: the fetch is enabled and the inputs render.
+        expect(getEvaluationInputsUseQueryMock).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            projectId: "project_test",
+            traceId: "trace-1",
+            evaluationId: "eval-1",
+          }),
+          expect.objectContaining({ enabled: true }),
+        );
+        expect(screen.getByText("input")).toBeInTheDocument();
+        expect(screen.getByText("the prompt")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("given an evaluation whose verdict list already includes its inputs", () => {
+    describe("when the card's details are expanded", () => {
+      /** @scenario Inputs already present are shown without an extra request */
+      it("shows the inputs without enabling the lazy fetch", () => {
+        getEvaluationInputsUseQueryMock.mockImplementation(
+          (_input: unknown, opts: { enabled?: boolean }) => ({
+            data: undefined,
+            isLoading: false,
+            // surface enabled so we can assert it never flips on
+            _enabled: opts?.enabled,
+          }),
+        );
+
+        renderCard({
+          ...baseEval,
+          inputs: { input: "already here" },
+        });
+
+        fireEvent.click(screen.getByText("Show details"));
+
+        expect(screen.getByText("already here")).toBeInTheDocument();
+        // List already carried inputs, so the lazy query must stay disabled.
+        for (const call of getEvaluationInputsUseQueryMock.mock.calls) {
+          expect(call[1]).toEqual(expect.objectContaining({ enabled: false }));
+        }
+      });
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/useEvalInputs.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/useEvalInputs.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
-import { useDrawerStore } from "../../../stores/drawerStore";
 import type { EvalEntry } from "./utils";
 
 export interface ResolvedEvalInputs {
@@ -29,22 +28,16 @@ export function useEvalInputs({
   enabled: boolean;
 }): ResolvedEvalInputs {
   const { project } = useOrganizationTeamProject();
-  const traceId = useDrawerStore((s) => s.traceId);
 
   const listInputs =
     eval_.inputs && Object.keys(eval_.inputs).length > 0 ? eval_.inputs : null;
 
   const needLazy =
-    enabled &&
-    !listInputs &&
-    !!eval_.evaluationId &&
-    !!project?.id &&
-    !!traceId;
+    enabled && !listInputs && !!eval_.evaluationId && !!project?.id;
 
   const query = api.traces.getEvaluationInputs.useQuery(
     {
       projectId: project?.id ?? "",
-      traceId: traceId ?? "",
       evaluationId: eval_.evaluationId ?? "",
     },
     {

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/useEvalInputs.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/evalCards/useEvalInputs.ts
@@ -1,0 +1,64 @@
+import { useMemo } from "react";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { api } from "~/utils/api";
+import { useDrawerStore } from "../../../stores/drawerStore";
+import type { EvalEntry } from "./utils";
+
+export interface ResolvedEvalInputs {
+  inputEntries: [string, unknown][];
+  isLoading: boolean;
+}
+
+/**
+ * Resolves an evaluation's `inputs` for the expanded details panel.
+ *
+ * The verdict list (`traces.getEvaluations`) carries inputs in the common
+ * case, but under ClickHouse memory pressure the server drops the heavy
+ * `Inputs` column to avoid a 500 (see clickhouse-evaluation.service). When
+ * the list didn't provide them, this fetches the inputs for just this one
+ * evaluation — keyed by evaluation id, which is the table's sort key, so the
+ * read prunes granules and can't blow the memory ceiling. The fetch only
+ * fires while the panel is open and the list didn't already carry inputs, so
+ * the heavy blob never ships on drawer open for collapsed cards.
+ */
+export function useEvalInputs({
+  eval_,
+  enabled,
+}: {
+  eval_: EvalEntry;
+  enabled: boolean;
+}): ResolvedEvalInputs {
+  const { project } = useOrganizationTeamProject();
+  const traceId = useDrawerStore((s) => s.traceId);
+
+  const listInputs =
+    eval_.inputs && Object.keys(eval_.inputs).length > 0 ? eval_.inputs : null;
+
+  const needLazy =
+    enabled &&
+    !listInputs &&
+    !!eval_.evaluationId &&
+    !!project?.id &&
+    !!traceId;
+
+  const query = api.traces.getEvaluationInputs.useQuery(
+    {
+      projectId: project?.id ?? "",
+      traceId: traceId ?? "",
+      evaluationId: eval_.evaluationId ?? "",
+    },
+    {
+      enabled: needLazy,
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  return useMemo(() => {
+    const inputs = listInputs ?? query.data ?? null;
+    return {
+      inputEntries: inputs ? Object.entries(inputs) : [],
+      isLoading: needLazy && query.isLoading,
+    };
+  }, [listInputs, query.data, needLazy, query.isLoading]);
+}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/shikiAdapter.ts
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/markdownView/shikiAdapter.ts
@@ -41,12 +41,31 @@ function shikiThemeForColorMode(colorMode: string): SharedShikiTheme {
  * with the same `(langs, themes)` returns the same promise. The
  * standalone `codeToTokens` / `codeToHtml` exports go through it too,
  * so our adapter and any direct callers share one instance.
+ *
+ * Chakra's shiki adapter calls `ctx.dispose()` in its `unloadContext`
+ * on every CodeBlock unmount and color-mode change. Because every
+ * CodeBlock resolves to this one shared instance, the first unmount
+ * would dispose the highlighter the still-mounted blocks depend on,
+ * and their next `codeToHtml`/`loadTheme` throws
+ * "Shiki instance has been disposed". The singleton is app-lifetime by
+ * design, so we neuter `dispose` to a no-op the first time we resolve
+ * it — nothing should ever tear this instance down.
  */
-function getSharedHighlighter(): Promise<SharedHighlighter> {
-  return getSingletonHighlighter({
+async function getSharedHighlighter(): Promise<SharedHighlighter> {
+  const highlighter = (await getSingletonHighlighter({
     langs: [...SHIKI_LANGS],
     themes: [...SHIKI_THEMES],
-  }) as Promise<SharedHighlighter>;
+  })) as SharedHighlighter & { dispose: () => void };
+
+  if (!(highlighter as { __lwDisposeNeutered?: boolean }).__lwDisposeNeutered) {
+    highlighter.dispose = () => {};
+    Object.defineProperty(highlighter, "__lwDisposeNeutered", {
+      value: true,
+      enumerable: false,
+    });
+  }
+
+  return highlighter;
 }
 
 export function useShikiAdapter(colorMode: string) {

--- a/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
@@ -1,6 +1,6 @@
 import { chakra, Flex, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { ArrowDown, ArrowUp, Bot, User, Wrench } from "lucide-react";
-import { Fragment, type ReactNode } from "react";
+import { Fragment, type ReactNode, useLayoutEffect, useRef } from "react";
 import type React from "react";
 import { useDensityTokens } from "../../hooks/useDensityTokens";
 import { useDensityStore } from "../../stores/densityStore";
@@ -56,9 +56,106 @@ const BreakMarker = () => (
     whiteSpace="nowrap"
     verticalAlign="baseline"
     color="fg.subtle"
-    css={{ "&::after": { content: '"↵"', marginInlineStart: "2px" } }}
+    css={{ "&::after": { content: '"↵"', marginInlineStart: "0.45em" } }}
   />
 );
+
+const CLAMP_LINES = 2;
+
+/**
+ * CSS rule that blanks a `BreakMarker` glyph once it's been tagged
+ * `data-newline-marker-hidden` by `useBreakMarkerClampGuard`. Hiding via
+ * the pseudo's `content` (rather than `display`/`visibility`) keeps the
+ * span's box on its line, so measuring it on the next resize pass stays
+ * stable.
+ */
+const HIDE_TRUNCATED_MARKER = {
+  "& [data-newline-marker][data-newline-marker-hidden]::after": {
+    content: '""',
+  },
+} as const;
+
+/**
+ * A `BreakMarker` only collides with the line clamp's `…` ellipsis when the
+ * cell overflows AND the marker sits on the last visible (clamped) line —
+ * that's the single line the clamp paints the ellipsis on. Markers on
+ * earlier, fully-visible lines are safe and keep showing. `markerTop` and
+ * `clampHeight` are measured relative to the clamped text box.
+ */
+export function shouldHideBreakMarker({
+  truncated,
+  markerTop,
+  clampHeight,
+}: {
+  truncated: boolean;
+  markerTop: number;
+  clampHeight: number;
+}): boolean {
+  if (!truncated) return false;
+  const lastVisibleLineTop = (clampHeight * (CLAMP_LINES - 1)) / CLAMP_LINES;
+  return markerTop >= lastVisibleLineTop - 1;
+}
+
+/**
+ * Tags the break markers that would overlap the clamp's `…` with
+ * `data-newline-marker-hidden` (see `shouldHideBreakMarker`). Re-evaluates
+ * on resize so it tracks column-width changes, not just the first paint.
+ * The text node is `position: relative` so each marker's `offsetTop` is
+ * measured against the clamped box.
+ */
+function useBreakMarkerClampGuard(text: string) {
+  const ref = useRef<HTMLParagraphElement>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const update = () => {
+      const truncated = el.scrollHeight > el.clientHeight + 1;
+      const clampHeight = el.clientHeight;
+      el.querySelectorAll<HTMLElement>("[data-newline-marker]").forEach((m) => {
+        m.toggleAttribute(
+          "data-newline-marker-hidden",
+          shouldHideBreakMarker({
+            truncated,
+            markerTop: m.offsetTop,
+            clampHeight,
+          }),
+        );
+      });
+    };
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [text]);
+  return ref;
+}
+
+/**
+ * Line-clamped preview text that renders hard breaks as non-selectable `↵`
+ * markers and suppresses only the marker on the truncated line (see
+ * `useBreakMarkerClampGuard`). Style props (`fontSize`, `color`,
+ * `textStyle`, …) are forwarded so both density rows can share it.
+ */
+const ClampedPreviewText: React.FC<
+  { text: string } & React.ComponentProps<typeof Text>
+> = ({ text, css, ...rest }) => {
+  const ref = useBreakMarkerClampGuard(text);
+  return (
+    <Text
+      ref={ref}
+      position="relative"
+      whiteSpace="pre-line"
+      lineClamp={CLAMP_LINES}
+      flex={1}
+      minWidth={0}
+      css={{ ...HIDE_TRUNCATED_MARKER, ...(css as object) }}
+      {...rest}
+    >
+      {renderWithBreakMarkers(text)}
+    </Text>
+  );
+};
 
 /**
  * Render preview text with a hard break shown as a trailing `BreakMarker`
@@ -158,22 +255,17 @@ const CompactRow: React.FC<CompactRowProps> = ({
         </Icon>
         <RoleIcon row={row} color={accent} direction={direction} />
       </Flex>
-      <Text
+      {/* Preserve real newlines coming through formatPreview (the row text
+          used to inline-render `↵` glyphs — now wraps onto a real second
+          line). Capped at 2 lines so the preview stays compact in the
+          table. */}
+      <ClampedPreviewText
+        text={row.text}
         fontSize={fontSize}
         color={textColor}
         fontStyle="italic"
         fontWeight="400"
-        // Preserve real newlines coming through formatPreview (the row
-        // text used to inline-render `↵` glyphs — now wraps onto a real
-        // second line). Cap at 2 lines so the preview stays compact in
-        // the table.
-        whiteSpace="pre-line"
-        lineClamp={2}
-        flex={1}
-        minWidth={0}
-      >
-        {renderWithBreakMarkers(row.text)}
-      </Text>
+      />
     </HStack>
   );
 };
@@ -244,15 +336,6 @@ const ComfortableRow: React.FC<{
     >
       {label}
     </Text>
-    <Text
-      textStyle="sm"
-      color={textColor}
-      whiteSpace="pre-line"
-      lineClamp={2}
-      flex={1}
-      minWidth={0}
-    >
-      {renderWithBreakMarkers(text)}
-    </Text>
+    <ClampedPreviewText text={text} textStyle="sm" color={textColor} />
   </HStack>
 );

--- a/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
@@ -1,5 +1,6 @@
-import { Flex, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { chakra, Flex, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { ArrowDown, ArrowUp, Bot, User, Wrench } from "lucide-react";
+import { Fragment, type ReactNode } from "react";
 import type React from "react";
 import { useDensityTokens } from "../../hooks/useDensityTokens";
 import { useDensityStore } from "../../stores/densityStore";
@@ -28,39 +29,61 @@ export const IOPreview: React.FC<IOPreviewProps> = ({ input, output }) => {
  * one JSON.parse attempt on the same input).
  */
 /**
- * Render line breaks for the 2-line clamped preview cell.
+ * Non-selectable hard-newline marker, rendered at the END of the line
+ * that was broken — same affordance as a GitHub diff's `+`/`-` gutter:
+ * visible, but never part of what you select and copy.
  *
- * Trade-offs we're navigating:
- *  - We want the `↵` glyph as an explicit "there was a break here"
- *    marker, so wrapped text doesn't look like one continuous string.
- *  - CSS `-webkit-line-clamp` can truncate anywhere — including right
- *    after a glyph, which then renders as the ugly "…↵..." or pure
- *    "↵..." (an empty line whose only content is the glyph followed
- *    by the clamp ellipsis). Operator complaint, with screenshots.
- *
- * Strategy:
- *  - Strip trailing whitespace/blank lines so the text never ends on
- *    a break.
- *  - Collapse runs of blank lines to a single break (no more "↵\n↵\n"
- *    that renders as an empty middle line whose only character is the
- *    glyph).
- *  - Put the glyph at the START of every continuation line, not at
- *    the END of the previous one. That way the clamp ellipsis lands
- *    on real text content (or replaces it mid-word with "…"), never
- *    on the glyph itself. Reads as "↳ continuation" rather than
- *    "ends with ↵...".
+ * Two properties make that work:
+ *  - The glyph lives in a `::after` pseudo-element. Pseudo content is
+ *    never part of the DOM text, so it can't be selected or copied in
+ *    any browser (more robust than `user-select: none` alone, which
+ *    Firefox still copies). `user-select: none` is kept as a belt to
+ *    the pseudo's suspenders.
+ *  - The span itself is zero-width with `overflow: visible`, so the
+ *    glyph hangs past the last character without consuming layout
+ *    width. It therefore can't push the line wider, can't wrap onto a
+ *    line of its own, and can't be the lonely "↵…" the old leading-
+ *    glyph approach was working around.
  */
-function withGlyphBreaks(text: string): string {
-  // 1. Normalise: trim trailing whitespace/newlines so we never end
-  //    on a hard break.
+const BreakMarker = () => (
+  <chakra.span
+    data-newline-marker=""
+    aria-hidden="true"
+    userSelect="none"
+    display="inline-block"
+    width="0"
+    overflow="visible"
+    whiteSpace="nowrap"
+    verticalAlign="baseline"
+    color="fg.subtle"
+    css={{ "&::after": { content: '"↵"', marginInlineStart: "2px" } }}
+  />
+);
+
+/**
+ * Render preview text with a hard break shown as a trailing `BreakMarker`
+ * on each broken line, followed by a real `\n` (the parent `Text` uses
+ * `whiteSpace="pre-line"`, so the `\n` produces the actual visual wrap).
+ * The text nodes stay clean — only the line content lands in the DOM, so
+ * a copy of the selection round-trips to the original two-line string.
+ */
+function renderWithBreakMarkers(text: string): ReactNode {
+  // Trim trailing whitespace/newlines so we never end on a break, and
+  // collapse runs of blank lines to a single break point.
   const trimmed = text.replace(/\s+$/u, "");
-  // 2. Split on newline runs (one or more), so consecutive blanks
-  //    collapse to a single break point.
   const lines = trimmed.split(/\n+/);
   if (lines.length <= 1) return trimmed;
-  // 3. Re-join with `\n↵ ` — leading-glyph style. The first line
-  //    has no prefix; every subsequent line is "↵ <content>".
-  return lines.join("\n↵ ");
+  return lines.map((line, i) => (
+    <Fragment key={i}>
+      {line}
+      {i < lines.length - 1 && (
+        <>
+          <BreakMarker />
+          {"\n"}
+        </>
+      )}
+    </Fragment>
+  ));
 }
 
 function buildRow(raw: string | null): {
@@ -70,13 +93,12 @@ function buildRow(raw: string | null): {
 } {
   if (raw === null) return { text: "", isChat: false, isTool: false };
   const parsed = tryParseChat(raw);
-  // Preserve newlines AND surface the `↵` glyph at the break point —
-  // operator preference: the glyph makes the soft-break explicit while
-  // the real `\n` lets CSS (whiteSpace="pre-line") actually wrap the
-  // next chunk to a new line.
+  // Keep newlines as real `\n` — the row text renders them with
+  // `whiteSpace="pre-line"`, and `renderWithBreakMarkers` decorates each
+  // break with a non-selectable marker at render time.
   const formatted = formatPreview(raw, { maxChars: 200, newlines: "preserve" });
   return {
-    text: withGlyphBreaks(formatted.text),
+    text: formatted.text,
     isChat: parsed.isChat,
     isTool: parsed.isTool,
   };
@@ -150,7 +172,7 @@ const CompactRow: React.FC<CompactRowProps> = ({
         flex={1}
         minWidth={0}
       >
-        {row.text}
+        {renderWithBreakMarkers(row.text)}
       </Text>
     </HStack>
   );
@@ -192,9 +214,7 @@ const ComfortableIOPreview: React.FC<IOPreviewProps> = ({ input, output }) => (
         label="Input"
         labelColor={{ base: "blue.500", _dark: "blue.fg" }}
         textColor="fg.muted"
-        text={withGlyphBreaks(
-          formatPreview(input, { maxChars: 200, newlines: "preserve" }).text,
-        )}
+        text={formatPreview(input, { maxChars: 200, newlines: "preserve" }).text}
       />
     )}
     {output !== null && (
@@ -202,9 +222,7 @@ const ComfortableIOPreview: React.FC<IOPreviewProps> = ({ input, output }) => (
         label="Output"
         labelColor={{ base: "green.solid", _dark: "green.fg" }}
         textColor="fg"
-        text={withGlyphBreaks(
-          formatPreview(output, { maxChars: 200, newlines: "preserve" }).text,
-        )}
+        text={formatPreview(output, { maxChars: 200, newlines: "preserve" }).text}
       />
     )}
   </VStack>
@@ -234,7 +252,7 @@ const ComfortableRow: React.FC<{
       flex={1}
       minWidth={0}
     >
-      {text}
+      {renderWithBreakMarkers(text)}
     </Text>
   </HStack>
 );

--- a/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
@@ -165,11 +165,14 @@ const ClampedPreviewText: React.FC<
  * a copy of the selection round-trips to the original two-line string.
  */
 function renderWithBreakMarkers(text: string): ReactNode {
-  // Trim trailing whitespace/newlines so we never end on a break, and
-  // collapse runs of blank lines to a single break point.
-  const trimmed = text.replace(/\s+$/u, "");
-  const lines = trimmed.split(/\n+/);
-  if (lines.length <= 1) return trimmed;
+  // Strip trailing whitespace so we never end on a break, normalize CRLF/CR so
+  // a stray `\r` can't cling to a line, then collapse runs of blank lines to a
+  // single break. A compact two-line preview shows content, not blank gaps,
+  // and its text is already a processed preview (markdown-unwrapped and
+  // truncated), not the verbatim source — so blank-line fidelity isn't a goal.
+  const normalized = text.replace(/\s+$/u, "").replace(/\r\n?/g, "\n");
+  const lines = normalized.split(/\n+/);
+  if (lines.length <= 1) return normalized;
   return lines.map((line, i) => (
     <Fragment key={i}>
       {line}

--- a/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/IOPreview.tsx
@@ -41,9 +41,8 @@ export const IOPreview: React.FC<IOPreviewProps> = ({ input, output }) => {
  *    the pseudo's suspenders.
  *  - The span itself is zero-width with `overflow: visible`, so the
  *    glyph hangs past the last character without consuming layout
- *    width. It therefore can't push the line wider, can't wrap onto a
- *    line of its own, and can't be the lonely "↵…" the old leading-
- *    glyph approach was working around.
+ *    width. It therefore can't push the line wider and can't wrap onto
+ *    a line of its own.
  */
 const BreakMarker = () => (
   <chakra.span

--- a/langwatch/src/features/traces-v2/components/TraceTable/__tests__/IOPreview.unit.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/__tests__/IOPreview.unit.test.tsx
@@ -4,7 +4,7 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { IOPreview } from "../IOPreview";
+import { IOPreview, shouldHideBreakMarker } from "../IOPreview";
 
 // Compact vs comfortable is gated by the density store; force compact so
 // the row path under test is the one in the screenshot.
@@ -61,6 +61,63 @@ describe("IOPreview newline marker", () => {
         expect(
           container.querySelector('[data-newline-marker]'),
         ).toBeNull();
+      });
+    });
+  });
+});
+
+describe("shouldHideBreakMarker", () => {
+  // The clamp shows 2 lines, so a 40px clamped box is two 20px lines: the
+  // last visible line (where the `…` lands) starts at y=20.
+  const clampHeight = 40;
+
+  describe("given the cell is not truncated", () => {
+    describe("when a marker sits on any line", () => {
+      it("keeps the marker visible", () => {
+        expect(
+          shouldHideBreakMarker({ truncated: false, markerTop: 0, clampHeight }),
+        ).toBe(false);
+        expect(
+          shouldHideBreakMarker({
+            truncated: false,
+            markerTop: 20,
+            clampHeight,
+          }),
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe("given the cell is truncated", () => {
+    describe("when the marker is on a fully-visible earlier line", () => {
+      it("keeps the marker visible so the break is still signalled", () => {
+        expect(
+          shouldHideBreakMarker({ truncated: true, markerTop: 0, clampHeight }),
+        ).toBe(false);
+      });
+    });
+
+    describe("when the marker is on the last visible (clamped) line", () => {
+      it("hides the marker so the ↵ never overlaps the clamp ellipsis", () => {
+        expect(
+          shouldHideBreakMarker({
+            truncated: true,
+            markerTop: 20,
+            clampHeight,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when the marker is below the fold", () => {
+      it("hides the marker", () => {
+        expect(
+          shouldHideBreakMarker({
+            truncated: true,
+            markerTop: 40,
+            clampHeight,
+          }),
+        ).toBe(true);
       });
     });
   });

--- a/langwatch/src/features/traces-v2/components/TraceTable/__tests__/IOPreview.unit.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/__tests__/IOPreview.unit.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IOPreview } from "../IOPreview";
+
+// Compact vs comfortable is gated by the density store; force compact so
+// the row path under test is the one in the screenshot.
+vi.mock("../../../stores/densityStore", () => ({
+  useDensityStore: (selector: (s: { density: string }) => unknown) =>
+    selector({ density: "compact" }),
+  getDrawerDensityTokens: () => ({}),
+}));
+
+vi.mock("../../../hooks/useDensityTokens", () => ({
+  useDensityTokens: () => ({ ioFontSize: "11px" }),
+}));
+
+function renderPreview(input: string | null, output: string | null) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <IOPreview input={input} output={output} />
+    </ChakraProvider>,
+  );
+}
+
+describe("IOPreview newline marker", () => {
+  describe("given preview text with a hard line break", () => {
+    describe("when the preview renders", () => {
+      /** @scenario The newline marker is not part of the selectable text */
+      it("keeps the ↵ glyph out of the DOM text content so it can't be copied", () => {
+        const { container } = renderPreview(
+          "**Scope:**\nDate range: 2026-04-25 to 2026-05-24",
+          null,
+        );
+        // The glyph is painted via a ::after pseudo-element, so it never
+        // appears in textContent (which is what a selection copies).
+        expect(container.textContent).not.toContain("↵");
+        expect(container.textContent).toContain("Scope:");
+        expect(container.textContent).toContain("Date range");
+      });
+
+      /** @scenario The newline marker sits at the end of the line that was broken */
+      it("emits a zero-width, non-selectable marker span between the two lines", () => {
+        const { container } = renderPreview("first line\nsecond line", null);
+        const marker = container.querySelector('[data-newline-marker]');
+        expect(marker).not.toBeNull();
+        // user-select:none belt over the pseudo-element suspenders.
+        expect(getComputedStyle(marker!).userSelect).toBe("none");
+      });
+    });
+  });
+
+  describe("given single-line preview text", () => {
+    describe("when the preview renders", () => {
+      /** @scenario A single-line preview renders no newline marker */
+      it("emits no marker span", () => {
+        const { container } = renderPreview("just one line", null);
+        expect(
+          container.querySelector('[data-newline-marker]'),
+        ).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/hooks/useAnnotationsByTraceIds.ts
+++ b/langwatch/src/hooks/useAnnotationsByTraceIds.ts
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import { api, type RouterOutputs } from "~/utils/api";
+
+export type AnnotationByTrace =
+  RouterOutputs["annotation"]["getByTraceIds"][number];
+
+/**
+ * tRPC v10 sends queries as GET, so the trace-id array rides in the URL.
+ * A whole page of filtered traces (100+ ids) blows past the batch link's
+ * 4000-char ceiling and tRPC throws "Input is too big for a single
+ * dispatch". Chunk the ids into URL-safe batches and fan them out with
+ * `useQueries`, then flatten — so the caller sees one list regardless of
+ * how many traces it asked about, with no upper bound on the count.
+ */
+const CHUNK_SIZE = 50;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  if (items.length === 0) return [];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+export interface UseAnnotationsByTraceIdsResult {
+  data: AnnotationByTrace[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useAnnotationsByTraceIds({
+  projectId,
+  traceIds,
+  enabled = true,
+  keepPreviousData = false,
+}: {
+  projectId: string;
+  traceIds: string[];
+  enabled?: boolean;
+  keepPreviousData?: boolean;
+}): UseAnnotationsByTraceIdsResult {
+  // Stable chunk identity so `useQueries` doesn't refetch every render.
+  const chunks = useMemo(
+    () => chunk(traceIds, CHUNK_SIZE),
+    [traceIds],
+  );
+
+  const results = api.useQueries((t) =>
+    chunks.map((ids) =>
+      t.annotation.getByTraceIds(
+        { projectId, traceIds: ids },
+        {
+          enabled: enabled && !!projectId && ids.length > 0,
+          keepPreviousData,
+          staleTime: 5 * 60_000,
+          refetchOnWindowFocus: false,
+        },
+      ),
+    ),
+  );
+
+  const data = useMemo(
+    () => results.flatMap((r) => r.data ?? []),
+    [results],
+  );
+
+  return {
+    data,
+    isLoading: results.some((r) => r.isLoading),
+    isError: results.some((r) => r.isError),
+  };
+}

--- a/langwatch/src/hooks/useAnnotationsByTraceIds.ts
+++ b/langwatch/src/hooks/useAnnotationsByTraceIds.ts
@@ -40,10 +40,17 @@ export function useAnnotationsByTraceIds({
   enabled?: boolean;
   keepPreviousData?: boolean;
 }): UseAnnotationsByTraceIdsResult {
+  // Dedupe before chunking: duplicate ids spanning chunks would fetch the
+  // same annotations twice and double them in `data` after the flatMap.
+  const uniqueTraceIds = useMemo(
+    () => Array.from(new Set(traceIds)),
+    [traceIds],
+  );
+
   // Stable chunk identity so `useQueries` doesn't refetch every render.
   const chunks = useMemo(
-    () => chunk(traceIds, CHUNK_SIZE),
-    [traceIds],
+    () => chunk(uniqueTraceIds, CHUNK_SIZE),
+    [uniqueTraceIds],
   );
 
   const results = api.useQueries((t) =>

--- a/langwatch/src/pages/[project]/annotations/all.tsx
+++ b/langwatch/src/pages/[project]/annotations/all.tsx
@@ -1,8 +1,5 @@
 import { Button, Container, Heading, HStack, Spacer } from "@chakra-ui/react";
 import type { Annotation, User } from "@prisma/client";
-import type { TRPCClientErrorLike } from "@trpc/client";
-import type { UseTRPCQueryResult } from "@trpc/react-query/shared";
-import type { inferRouterOutputs } from "@trpc/server";
 import { useRouter } from "~/utils/compat/next-router";
 import Parse from "papaparse";
 import { Download } from "react-feather";
@@ -12,9 +9,9 @@ import {
   type AnnotationWithUser,
 } from "~/components/annotations/AnnotationsTable";
 import { PeriodSelector, usePeriodSelector } from "~/components/PeriodSelector";
+import { useAnnotationsByTraceIds } from "~/hooks/useAnnotationsByTraceIds";
 import { useFilterParams } from "~/hooks/useFilterParams";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
-import type { AppRouter } from "~/server/api/root";
 import type { Trace } from "~/server/tracer/types";
 import { api } from "~/utils/api";
 import { getSingleQueryParam } from "~/utils/getSingleQueryParam";
@@ -45,35 +42,27 @@ export default function Annotations() {
     setRelativePeriod,
   } = usePeriodSelector();
 
-  type RouterOutput = inferRouterOutputs<AppRouter>;
-  type AnnotationsQuery = UseTRPCQueryResult<
-    | RouterOutput["annotation"]["getAll"]
-    | RouterOutput["annotation"]["getByTraceIds"],
-    TRPCClientErrorLike<AppRouter>
-  >;
+  // Both queries are declared unconditionally (rules of hooks) and gated
+  // via `enabled` on the active mode. `getByTraceIds` is chunked so a
+  // fully-filtered project with thousands of matching traces doesn't blow
+  // past the GET URL ceiling tRPC batches into.
+  const filteredTraceIds =
+    traceGroups.data?.groups.flatMap((group) =>
+      group.map((trace) => trace.trace_id),
+    ) ?? [];
 
-  let annotations: AnnotationsQuery;
+  const filteredAnnotations = useAnnotationsByTraceIds({
+    projectId: project?.id ?? "",
+    traceIds: filteredTraceIds,
+    enabled: hasAnyFilters && project?.id !== undefined,
+  });
 
-  if (hasAnyFilters) {
-    const traceIds =
-      traceGroups.data?.groups.flatMap((group) =>
-        group.map((trace) => trace.trace_id),
-      ) ?? [];
+  const allAnnotations = api.annotation.getAll.useQuery(
+    { projectId: project?.id ?? "", startDate, endDate },
+    { enabled: !hasAnyFilters && !!project },
+  );
 
-    annotations = api.annotation.getByTraceIds.useQuery(
-      { projectId: project?.id ?? "", traceIds },
-      {
-        enabled: project?.id !== undefined,
-      },
-    );
-  } else {
-    annotations = api.annotation.getAll.useQuery(
-      { projectId: project?.id ?? "", startDate, endDate },
-      {
-        enabled: !!project,
-      },
-    );
-  }
+  const annotations = hasAnyFilters ? filteredAnnotations : allAnnotations;
 
   const traceIds = annotations.data?.map((annotation) => annotation.traceId);
 

--- a/langwatch/src/pages/[project]/annotations/all.tsx
+++ b/langwatch/src/pages/[project]/annotations/all.tsx
@@ -63,6 +63,12 @@ export default function Annotations() {
   );
 
   const annotations = hasAnyFilters ? filteredAnnotations : allAnnotations;
+  // In filtered mode the ids come from `traceGroups`, so its load must count
+  // toward the table's loading state — otherwise the table flashes an empty
+  // state before the ids (and then the annotations) arrive.
+  const annotationsLoading = hasAnyFilters
+    ? traceGroups.isLoading || filteredAnnotations.isLoading
+    : allAnnotations.isLoading;
 
   const traceIds = annotations.data?.map((annotation) => annotation.traceId);
 
@@ -198,7 +204,7 @@ export default function Annotations() {
       >
         <AnnotationsTable
           groupedAnnotations={groupedAnnotations}
-          allAnnotationsLoading={annotations.isLoading || traces.isLoading}
+          allAnnotationsLoading={annotationsLoading || traces.isLoading}
           heading="Annotations"
           isDone={true}
           tableHeader={tableHeader}

--- a/langwatch/src/server/api/routers/spans.ts
+++ b/langwatch/src/server/api/routers/spans.ts
@@ -1,7 +1,11 @@
 import { PublicShareResourceTypes } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import {
+  createTRPCRouter,
+  protectedProcedure,
+  publicProcedure,
+} from "~/server/api/trpc";
 import { TraceService } from "~/server/traces/trace.service";
 import { checkPermissionOrPubliclyShared } from "../rbac";
 import { checkProjectPermission } from "../rbac";
@@ -56,7 +60,12 @@ export const spansRouter = createTRPCRouter({
       return sortedSpans;
     }),
 
-  getForPromptStudio: publicProcedure
+  // Prompt Studio is an authenticated, project-scoped feature with no
+  // public-share path, so this stays project-gated. It was previously a
+  // publicProcedure guarded only by checkProjectPermission (effectively
+  // protected, since anon resolves to no permission) — protectedProcedure
+  // makes the intent explicit and removes the public-by-default footgun.
+  getForPromptStudio: protectedProcedure
     .input(
       z.object({
         projectId: z.string(),

--- a/langwatch/src/server/api/routers/spans.ts
+++ b/langwatch/src/server/api/routers/spans.ts
@@ -60,11 +60,6 @@ export const spansRouter = createTRPCRouter({
       return sortedSpans;
     }),
 
-  // Prompt Studio is an authenticated, project-scoped feature with no
-  // public-share path, so this stays project-gated. It was previously a
-  // publicProcedure guarded only by checkProjectPermission (effectively
-  // protected, since anon resolves to no permission) — protectedProcedure
-  // makes the intent explicit and removes the public-by-default footgun.
   getForPromptStudio: protectedProcedure
     .input(
       z.object({

--- a/langwatch/src/server/api/routers/traces.ts
+++ b/langwatch/src/server/api/routers/traces.ts
@@ -91,6 +91,28 @@ export const tracesRouter = createTRPCRouter({
       return evaluations[input.traceId];
     }),
 
+  getEvaluationInputs: publicProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        traceId: z.string(),
+        evaluationId: z.string(),
+      }),
+    )
+    .use(
+      checkPermissionOrPubliclyShared(checkProjectPermission("traces:view"), {
+        resourceType: PublicShareResourceTypes.TRACE,
+        resourceParam: "traceId",
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const traceService = TraceService.create(ctx.prisma);
+      return traceService.getEvaluationInputs(
+        input.projectId,
+        input.evaluationId,
+      );
+    }),
+
   getEvaluationsMultiple: protectedProcedure
     .input(
       z.object({

--- a/langwatch/src/server/api/routers/traces.ts
+++ b/langwatch/src/server/api/routers/traces.ts
@@ -91,20 +91,20 @@ export const tracesRouter = createTRPCRouter({
       return evaluations[input.traceId];
     }),
 
-  getEvaluationInputs: publicProcedure
+  // Protected (not public-share): the read is keyed by evaluationId, which is
+  // only tenant-scoped, so authorization must be the whole project too. A
+  // public-share token is scoped to a single trace and could otherwise be used
+  // to read any evaluation's inputs in the project by supplying another
+  // evaluationId. Public-shared trace drawers already get inputs eagerly from
+  // the public `getEvaluations`; this lazy fallback stays project-gated.
+  getEvaluationInputs: protectedProcedure
     .input(
       z.object({
         projectId: z.string(),
-        traceId: z.string(),
         evaluationId: z.string(),
       }),
     )
-    .use(
-      checkPermissionOrPubliclyShared(checkProjectPermission("traces:view"), {
-        resourceType: PublicShareResourceTypes.TRACE,
-        resourceParam: "traceId",
-      }),
-    )
+    .use(checkProjectPermission("traces:view"))
     .query(async ({ input, ctx }) => {
       const traceService = TraceService.create(ctx.prisma);
       return traceService.getEvaluationInputs(

--- a/langwatch/src/server/app-layer/traces/facets/__tests__/evaluator.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/facets/__tests__/evaluator.unit.test.ts
@@ -18,8 +18,8 @@ describe("buildEvaluatorFacetQuery", () => {
       /** @scenario Evaluator facet labels drop the type prefix */
       it("labels rows by name (or id) without the evaluator-type prefix", () => {
         const { sql } = buildEvaluatorFacetQuery(ctx());
-        // The type prefix used to read `[workflow] relevancy ...` and ate
-        // the room the name needs — the label is now name-or-id only.
+        // The label is name-or-id only: a bracketed `[type]` prefix repeats
+        // across rows and eats the room the name needs to disambiguate.
         expect(sql).not.toMatch(/concat\('\[',\s*EvaluatorType/);
         expect(sql).toMatch(
           /if\(ifNull\(EvaluatorName, ''\) != '', EvaluatorName, EvaluatorId\) AS facet_label/,

--- a/langwatch/src/server/app-layer/traces/facets/__tests__/evaluator.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/facets/__tests__/evaluator.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildEvaluatorFacetQuery } from "../evaluator";
+import type { FacetQueryContext } from "../../facet-registry";
+
+function ctx(overrides: Partial<FacetQueryContext> = {}): FacetQueryContext {
+  return {
+    tenantId: "project_test",
+    timeRange: { from: 0, to: 1 },
+    limit: 25,
+    offset: 0,
+    ...overrides,
+  };
+}
+
+describe("buildEvaluatorFacetQuery", () => {
+  describe("given an evaluator facet request", () => {
+    describe("when the label projection is built", () => {
+      /** @scenario Evaluator facet labels drop the type prefix */
+      it("labels rows by name (or id) without the evaluator-type prefix", () => {
+        const { sql } = buildEvaluatorFacetQuery(ctx());
+        // The type prefix used to read `[workflow] relevancy ...` and ate
+        // the room the name needs — the label is now name-or-id only.
+        expect(sql).not.toMatch(/concat\('\[',\s*EvaluatorType/);
+        expect(sql).toMatch(
+          /if\(ifNull\(EvaluatorName, ''\) != '', EvaluatorName, EvaluatorId\) AS facet_label/,
+        );
+      });
+
+      it("still keys the facet value off the evaluator id for query round-trips", () => {
+        const { sql } = buildEvaluatorFacetQuery(ctx());
+        expect(sql).toMatch(/EvaluatorId AS facet_value/);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/facets/evaluator.ts
+++ b/langwatch/src/server/app-layer/traces/facets/evaluator.ts
@@ -6,11 +6,12 @@ import type {
 import { baseParams, buildTimeWhere } from "./helpers";
 
 /**
- * Evaluator facet: distinct `EvaluatorId`s with a human label that
- * combines the evaluator type and its display name. We project the
- * type/name composite as `facet_label` so the sidebar can show
- * `[llm_judge] Toxicity` while the underlying value (the id) round-trips
- * through saved queries unchanged.
+ * Evaluator facet: distinct `EvaluatorId`s labelled by the evaluator's
+ * display name (falling back to the id when no name is recorded). The
+ * evaluator type is intentionally omitted from the label — in practice a
+ * project's evaluators are mostly the same type, so the prefix added
+ * noise and ate the horizontal room the name needs. The id still
+ * round-trips through `facet_value` for saved queries.
  */
 export function buildEvaluatorFacetQuery(ctx: FacetQueryContext): FacetQuery {
   const where = buildTimeWhere("ScheduledAt");
@@ -22,17 +23,14 @@ export function buildEvaluatorFacetQuery(ctx: FacetQueryContext): FacetQuery {
     sql: `
       SELECT
         EvaluatorId AS facet_value,
-        if(ifNull(EvaluatorName, '') != '',
-           concat('[', EvaluatorType, '] ', EvaluatorName),
-           concat('[', EvaluatorType, '] ', EvaluatorId)
-        ) AS facet_label,
+        if(ifNull(EvaluatorName, '') != '', EvaluatorName, EvaluatorId) AS facet_label,
         count() AS cnt,
         count() OVER () AS total_distinct
       FROM evaluation_runs
       WHERE ${where}
         AND ifNull(EvaluatorId, '') != ''
         ${prefixFilter}
-      GROUP BY EvaluatorId, EvaluatorType, EvaluatorName
+      GROUP BY EvaluatorId, EvaluatorName
       ORDER BY cnt DESC
       LIMIT {limit:UInt32} OFFSET {offset:UInt32}
     `,

--- a/langwatch/src/server/evaluations/__tests__/clickhouse-evaluation.fallback.unit.test.ts
+++ b/langwatch/src/server/evaluations/__tests__/clickhouse-evaluation.fallback.unit.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getClickHouseClientForProjectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: getClickHouseClientForProjectMock,
+}));
+
+import { ClickHouseEvaluationService } from "../clickhouse-evaluation.service";
+
+/**
+ * Build a fake ClickHouse client whose `query` inspects the SQL and either
+ * throws the memory-limit error (when the heavy `Inputs` column is in the
+ * projection) or returns `rows` (when it isn't). Lets us assert the
+ * service degrades to the light projection instead of surfacing a 500.
+ */
+function clientThatOOMsOnInputs(rows: unknown[]) {
+  return {
+    query: vi.fn(async ({ query }: { query: string }) => {
+      if (/\bInputs\b/.test(query)) {
+        throw new Error(
+          "Query memory limit exceeded: would use 6.00 GiB (attempt to allocate chunk of 4.00 GiB), maximum: 3.50 GiB: (while reading column Inputs)",
+        );
+      }
+      return { json: async () => rows };
+    }),
+  };
+}
+
+const ROW = {
+  EvaluationId: "eval-1",
+  EvaluatorId: "evaluator-1",
+  EvaluatorType: "llm_boolean",
+  EvaluatorName: "Toxicity",
+  TraceId: "trace-1",
+  IsGuardrail: 0,
+  Status: "processed",
+  Score: 1,
+  Passed: 1,
+  Label: null,
+  Details: null,
+  Error: null,
+  ScheduledAt: null,
+  StartedAt: null,
+  CompletedAt: null,
+};
+
+describe("ClickHouseEvaluationService memory-limit fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given the Inputs column read exceeds the ClickHouse memory limit", () => {
+    describe("when fetching evaluations for a single trace", () => {
+      it("retries without Inputs and still returns the verdicts", async () => {
+        const client = clientThatOOMsOnInputs([ROW]);
+        getClickHouseClientForProjectMock.mockResolvedValue(client);
+
+        const service = ClickHouseEvaluationService.create({} as never);
+        const result = await service.getEvaluationsForTrace({
+          projectId: "project_test",
+          traceId: "trace-1",
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result?.[0]?.evaluationId).toBe("eval-1");
+        expect(result?.[0]?.inputs).toBeNull();
+        // First attempt (with Inputs) + fallback (without).
+        expect(client.query).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("when fetching evaluations for multiple traces", () => {
+      it("retries without Inputs and groups the verdicts by trace", async () => {
+        const client = clientThatOOMsOnInputs([ROW]);
+        getClickHouseClientForProjectMock.mockResolvedValue(client);
+
+        const service = ClickHouseEvaluationService.create({} as never);
+        const result = await service.getEvaluationsMultiple({
+          projectId: "project_test",
+          traceIds: ["trace-1"],
+        });
+
+        expect(result?.["trace-1"]).toHaveLength(1);
+        expect(result?.["trace-1"]?.[0]?.inputs).toBeNull();
+        expect(client.query).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/evaluations/__tests__/clickhouse-evaluation.inputs.unit.test.ts
+++ b/langwatch/src/server/evaluations/__tests__/clickhouse-evaluation.inputs.unit.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getClickHouseClientForProjectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: getClickHouseClientForProjectMock,
+}));
+
+import { ClickHouseEvaluationService } from "../clickhouse-evaluation.service";
+
+describe("ClickHouseEvaluationService.getEvaluationInputs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given an evaluation with recorded inputs", () => {
+    describe("when its inputs are requested", () => {
+      /** @scenario A single evaluation's inputs can be fetched without scanning the trace */
+      it("keys the read by EvaluationId (not TraceId) and parses the blob", async () => {
+        const query = vi.fn(
+          async (_args: {
+            query: string;
+            query_params: Record<string, unknown>;
+          }) => ({
+            json: async () => [
+              { Inputs: '{"input":"hello","output":"world"}' },
+            ],
+          }),
+        );
+        getClickHouseClientForProjectMock.mockResolvedValue({ query });
+
+        const service = ClickHouseEvaluationService.create({} as never);
+        const result = await service.getEvaluationInputs({
+          projectId: "project_test",
+          evaluationId: "eval-1",
+        });
+
+        expect(result).toEqual({ input: "hello", output: "world" });
+
+        // The read must prune by the sort key (EvaluationId), never fall back
+        // to a TraceId scan that can't prune granules.
+        const sql = query.mock.calls[0]?.[0]?.query ?? "";
+        expect(sql).toContain("EvaluationId = {evaluationId:String}");
+        expect(sql).not.toContain("TraceId");
+        expect(query.mock.calls[0]?.[0]?.query_params).toMatchObject({
+          tenantId: "project_test",
+          evaluationId: "eval-1",
+        });
+      });
+    });
+  });
+
+  describe("given the evaluation recorded no inputs", () => {
+    describe("when its inputs are requested", () => {
+      it("returns null", async () => {
+        const query = vi.fn(async () => ({
+          json: async () => [{ Inputs: null }],
+        }));
+        getClickHouseClientForProjectMock.mockResolvedValue({ query });
+
+        const service = ClickHouseEvaluationService.create({} as never);
+        const result = await service.getEvaluationInputs({
+          projectId: "project_test",
+          evaluationId: "eval-1",
+        });
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("given the pruned read still exceeds the memory limit", () => {
+    describe("when its inputs are requested", () => {
+      it("degrades to null instead of throwing a 500", async () => {
+        const query = vi.fn(async () => {
+          throw new Error(
+            "Query memory limit exceeded: would use 4.00 GiB, maximum: 3.50 GiB: (while reading column Inputs)",
+          );
+        });
+        getClickHouseClientForProjectMock.mockResolvedValue({ query });
+
+        const service = ClickHouseEvaluationService.create({} as never);
+        const result = await service.getEvaluationInputs({
+          projectId: "project_test",
+          evaluationId: "eval-1",
+        });
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe("given ClickHouse is not enabled for the project", () => {
+    describe("when its inputs are requested", () => {
+      it("returns null without querying", async () => {
+        getClickHouseClientForProjectMock.mockResolvedValue(null);
+
+        const service = ClickHouseEvaluationService.create({} as never);
+        const result = await service.getEvaluationInputs({
+          projectId: "project_test",
+          evaluationId: "eval-1",
+        });
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/evaluations/clickhouse-evaluation.service.ts
+++ b/langwatch/src/server/evaluations/clickhouse-evaluation.service.ts
@@ -145,8 +145,23 @@ export class ClickHouseEvaluationService {
               { projectId, traceId },
               "Evaluations read hit the ClickHouse memory limit; retrying without Inputs",
             );
-            const rows = await runQuery(EVAL_COLUMNS_LIGHT);
-            return rows.map(mapClickHouseEvaluationToTraceEvaluation);
+            try {
+              const rows = await runQuery(EVAL_COLUMNS_LIGHT);
+              return rows.map(mapClickHouseEvaluationToTraceEvaluation);
+            } catch (retryError) {
+              this.logger.error(
+                {
+                  projectId,
+                  traceId,
+                  error:
+                    retryError instanceof Error
+                      ? retryError.message
+                      : retryError,
+                },
+                "Failed to fetch evaluations for trace from ClickHouse after light-projection retry",
+              );
+              throw new Error("Failed to fetch evaluations for trace");
+            }
           }
           this.logger.error(
             {
@@ -256,7 +271,22 @@ export class ClickHouseEvaluationService {
               { projectId, traceIdCount: traceIds.length },
               "Evaluations read hit the ClickHouse memory limit; retrying without Inputs",
             );
-            return groupByTrace(await runQuery(EVAL_COLUMNS_LIGHT));
+            try {
+              return groupByTrace(await runQuery(EVAL_COLUMNS_LIGHT));
+            } catch (retryError) {
+              this.logger.error(
+                {
+                  projectId,
+                  traceIdCount: traceIds.length,
+                  error:
+                    retryError instanceof Error
+                      ? retryError.message
+                      : retryError,
+                },
+                "Failed to fetch evaluations for multiple traces from ClickHouse after light-projection retry",
+              );
+              throw new Error("Failed to fetch evaluations for multiple traces");
+            }
           }
           this.logger.error(
             {

--- a/langwatch/src/server/evaluations/clickhouse-evaluation.service.ts
+++ b/langwatch/src/server/evaluations/clickhouse-evaluation.service.ts
@@ -4,6 +4,7 @@ import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseCli
 import { prisma as defaultPrisma } from "~/server/db";
 import type { Protections } from "~/server/elasticsearch/protections";
 import { createLogger } from "~/utils/logger/server";
+import { safeJsonParse } from "~/utils/safeJsonParse";
 import type { ClickHouseEvaluationRunRow } from "./evaluation-run.mappers";
 import { mapClickHouseEvaluationToTraceEvaluation } from "./evaluation-run.mappers";
 import type { TraceEvaluation } from "./evaluation-run.types";
@@ -266,6 +267,83 @@ export class ClickHouseEvaluationService {
             "Failed to fetch evaluations for multiple traces from ClickHouse",
           );
           throw new Error("Failed to fetch evaluations for multiple traces");
+        }
+      },
+    );
+  }
+
+  /**
+   * Fetch the heavy `Inputs` blob for one evaluation, on demand.
+   *
+   * The list reads (`getEvaluationsForTrace` / `getEvaluationsMultiple`) drop
+   * `Inputs` under memory pressure because a `TraceId` filter can't prune
+   * granules, so the heavy column is read across every granule the tenant
+   * touches. This read is keyed by `EvaluationId` — the table's second sort
+   * column — so ClickHouse prunes to the matching granule(s) and the read
+   * stays bounded. The drawer calls it lazily when a single evaluation is
+   * expanded. Returns null when ClickHouse is not enabled, the evaluation
+   * recorded no inputs, or the (already-pruned) read still hits the ceiling.
+   */
+  async getEvaluationInputs({
+    projectId,
+    evaluationId,
+  }: {
+    projectId: string;
+    evaluationId: string;
+    protections?: Protections;
+  }): Promise<Record<string, unknown> | null> {
+    return await this.tracer.withActiveSpan(
+      "ClickHouseEvaluationService.getEvaluationInputs",
+      {
+        attributes: {
+          "tenant.id": projectId,
+          "evaluation.id": evaluationId,
+        },
+      },
+      async () => {
+        const clickHouseClient = await getClickHouseClientForProject(projectId);
+        if (!clickHouseClient) {
+          return null;
+        }
+
+        try {
+          const result = await clickHouseClient.query({
+            query: `
+              SELECT argMax(Inputs, UpdatedAt) AS Inputs
+              FROM evaluation_runs
+              WHERE TenantId = {tenantId:String}
+                AND EvaluationId = {evaluationId:String}
+            `,
+            query_params: { tenantId: projectId, evaluationId },
+            format: "JSONEachRow",
+          });
+          const rows = (await result.json()) as { Inputs: string | null }[];
+          const parsed = safeJsonParse(rows[0]?.Inputs ?? null);
+          return parsed &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : null;
+        } catch (error) {
+          if (isMemoryLimitError(error)) {
+            // Even pruned to one evaluation the granule was too heavy. Degrade
+            // to "no inputs" rather than surfacing a 500 — the verdict already
+            // rendered from the list query.
+            this.logger.warn(
+              { projectId, evaluationId },
+              "Evaluation inputs read hit the ClickHouse memory limit even when keyed by EvaluationId",
+            );
+            return null;
+          }
+          this.logger.error(
+            {
+              projectId,
+              evaluationId,
+              error: error instanceof Error ? error.message : error,
+            },
+            "Failed to fetch evaluation inputs from ClickHouse",
+          );
+          throw new Error("Failed to fetch evaluation inputs");
         }
       },
     );

--- a/langwatch/src/server/evaluations/clickhouse-evaluation.service.ts
+++ b/langwatch/src/server/evaluations/clickhouse-evaluation.service.ts
@@ -8,6 +8,48 @@ import type { ClickHouseEvaluationRunRow } from "./evaluation-run.mappers";
 import { mapClickHouseEvaluationToTraceEvaluation } from "./evaluation-run.mappers";
 import type { TraceEvaluation } from "./evaluation-run.types";
 
+/**
+ * Columns the evaluation mapper actually reads, minus the heavy `Inputs`
+ * blob. `evaluation_runs` is `ORDER BY (TenantId, EvaluationId)`, so a
+ * `TraceId` filter can't prune granules — ClickHouse reads whole granules
+ * to evaluate the predicate, and when `Inputs` holds multi-MB payloads
+ * (RAG contexts, full conversations) materialising one granule blows past
+ * the per-query memory ceiling. The light projection lets us still return
+ * verdicts/scores when the heavy read would OOM.
+ */
+const EVAL_COLUMNS_LIGHT = [
+  "ProjectionId",
+  "TenantId",
+  "EvaluationId",
+  "Version",
+  "EvaluatorId",
+  "EvaluatorType",
+  "EvaluatorName",
+  "TraceId",
+  "IsGuardrail",
+  "Status",
+  "Score",
+  "Passed",
+  "Label",
+  "Details",
+  "Error",
+  "ScheduledAt",
+  "StartedAt",
+  "CompletedAt",
+  "LastProcessedEventId",
+  "UpdatedAt",
+].join(", ");
+
+const EVAL_COLUMNS_WITH_INPUTS = `${EVAL_COLUMNS_LIGHT}, Inputs`;
+
+/**
+ * ClickHouse raises this when a query would exceed `max_memory_usage`.
+ * We match on the stable prefix rather than the (variable) GiB figures.
+ */
+function isMemoryLimitError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /memory limit\s*(exceeded|.*exceeded)/i.test(message);
+}
 
 /**
  * Service for fetching per-trace evaluation runs from ClickHouse.
@@ -69,10 +111,10 @@ export class ClickHouseEvaluationService {
           "Fetching evaluations for trace from ClickHouse",
         );
 
-        try {
+        const runQuery = async (columns: string) => {
           const result = await clickHouseClient.query({
             query: `
-              SELECT *
+              SELECT ${columns}
               FROM evaluation_runs
               WHERE TenantId = {tenantId:String}
                 AND TraceId = {traceId:String}
@@ -84,18 +126,27 @@ export class ClickHouseEvaluationService {
                   GROUP BY TenantId, EvaluationId
                 )
             `,
-            query_params: {
-              tenantId: projectId,
-              traceId,
-            },
+            query_params: { tenantId: projectId, traceId },
             format: "JSONEachRow",
           });
+          return (await result.json()) as ClickHouseEvaluationRunRow[];
+        };
 
-          const rows =
-            (await result.json()) as ClickHouseEvaluationRunRow[];
-
+        try {
+          const rows = await runQuery(EVAL_COLUMNS_WITH_INPUTS);
           return rows.map(mapClickHouseEvaluationToTraceEvaluation);
         } catch (error) {
+          if (isMemoryLimitError(error)) {
+            // Heavy `Inputs` blobs blew the memory ceiling — retry without
+            // them so the operator still sees verdicts/scores instead of a
+            // 500. The eval card hides its inputs section when absent.
+            this.logger.warn(
+              { projectId, traceId },
+              "Evaluations read hit the ClickHouse memory limit; retrying without Inputs",
+            );
+            const rows = await runQuery(EVAL_COLUMNS_LIGHT);
+            return rows.map(mapClickHouseEvaluationToTraceEvaluation);
+          }
           this.logger.error(
             {
               projectId,
@@ -151,10 +202,10 @@ export class ClickHouseEvaluationService {
           "Fetching evaluations for multiple traces from ClickHouse",
         );
 
-        try {
+        const runQuery = async (columns: string) => {
           const result = await clickHouseClient.query({
             query: `
-              SELECT *
+              SELECT ${columns}
               FROM evaluation_runs
               WHERE TenantId = {tenantId:String}
                 AND TraceId IN ({traceIds:Array(String)})
@@ -166,17 +217,15 @@ export class ClickHouseEvaluationService {
                   GROUP BY TenantId, EvaluationId
                 )
             `,
-            query_params: {
-              tenantId: projectId,
-              traceIds,
-            },
+            query_params: { tenantId: projectId, traceIds },
             format: "JSONEachRow",
           });
+          return (await result.json()) as ClickHouseEvaluationRunRow[];
+        };
 
-          const rows =
-            (await result.json()) as ClickHouseEvaluationRunRow[];
-
-          // Group by TraceId
+        const groupByTrace = (
+          rows: ClickHouseEvaluationRunRow[],
+        ): Record<string, TraceEvaluation[]> => {
           const grouped: Record<string, TraceEvaluation[]> = {};
           for (const traceId of traceIds) {
             grouped[traceId] = [];
@@ -192,9 +241,22 @@ export class ClickHouseEvaluationService {
               );
             }
           }
-
           return grouped;
+        };
+
+        try {
+          return groupByTrace(await runQuery(EVAL_COLUMNS_WITH_INPUTS));
         } catch (error) {
+          if (isMemoryLimitError(error)) {
+            // Heavy `Inputs` blobs blew the memory ceiling — retry without
+            // them so the operator still sees verdicts/scores instead of a
+            // 500. The eval card hides its inputs section when absent.
+            this.logger.warn(
+              { projectId, traceIdCount: traceIds.length },
+              "Evaluations read hit the ClickHouse memory limit; retrying without Inputs",
+            );
+            return groupByTrace(await runQuery(EVAL_COLUMNS_LIGHT));
+          }
           this.logger.error(
             {
               projectId,

--- a/langwatch/src/server/evaluations/elasticsearch-evaluation.service.ts
+++ b/langwatch/src/server/evaluations/elasticsearch-evaluation.service.ts
@@ -91,4 +91,17 @@ export class ElasticsearchEvaluationService {
 
     return result;
   }
+
+  /**
+   * Elasticsearch embeds an evaluation's inputs in the trace document, so the
+   * list read already carries them — there's nothing to lazily fetch. Returns
+   * null and lets the caller fall back to the inputs from the list query.
+   */
+  async getEvaluationInputs(_params: {
+    projectId: string;
+    evaluationId: string;
+    protections?: Protections;
+  }): Promise<Record<string, unknown> | null> {
+    return null;
+  }
 }

--- a/langwatch/src/server/evaluations/evaluation.repository.ts
+++ b/langwatch/src/server/evaluations/evaluation.repository.ts
@@ -19,4 +19,16 @@ export interface EvaluationRepository {
     traceIds: string[];
     protections?: Protections;
   }): Promise<Record<string, TraceEvaluation[]>>;
+
+  /**
+   * Fetch the heavy `inputs` blob for a single evaluation, on demand. Kept
+   * off the list reads so the trace-wide query stays light; loaded lazily
+   * when a single evaluation is expanded. Returns null when the backend has
+   * no inputs to offer.
+   */
+  getEvaluationInputs(params: {
+    projectId: string;
+    evaluationId: string;
+    protections?: Protections;
+  }): Promise<Record<string, unknown> | null>;
 }

--- a/langwatch/src/server/evaluations/evaluation.service.ts
+++ b/langwatch/src/server/evaluations/evaluation.service.ts
@@ -128,4 +128,38 @@ export class EvaluationService {
       },
     );
   }
+
+  /**
+   * Lazily fetch one evaluation's inputs (see
+   * ClickHouseEvaluationService.getEvaluationInputs). Returns null when no
+   * inputs are available so the caller can fall back to whatever the list
+   * query carried.
+   *
+   * @param params.projectId - The project ID
+   * @param params.evaluationId - The evaluation to fetch inputs for
+   */
+  async getEvaluationInputs({
+    projectId,
+    evaluationId,
+  }: {
+    projectId: string;
+    evaluationId: string;
+  }): Promise<Record<string, unknown> | null> {
+    return this.tracer.withActiveSpan(
+      "EvaluationService.getEvaluationInputs",
+      {
+        attributes: {
+          "tenant.id": projectId,
+          "evaluation.id": evaluationId,
+        },
+      },
+      async (span) => {
+        span.setAttribute("backend", "clickhouse");
+        return this.clickHouseService.getEvaluationInputs({
+          projectId,
+          evaluationId,
+        });
+      },
+    );
+  }
 }

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -336,6 +336,37 @@ export class TraceService {
   }
 
   /**
+   * Lazily fetch one evaluation's inputs, keyed by evaluation id so the read
+   * prunes ClickHouse granules instead of scanning the whole trace. Used by
+   * the v2 drawer when a single evaluation card is expanded.
+   *
+   * @param projectId - The project ID
+   * @param evaluationId - The evaluation to fetch inputs for
+   * @returns The parsed inputs, or null when none are available
+   */
+  async getEvaluationInputs(
+    projectId: string,
+    evaluationId: string,
+  ): Promise<Record<string, unknown> | null> {
+    return this.tracer.withActiveSpan(
+      "TraceService.getEvaluationInputs",
+      {
+        attributes: {
+          "tenant.id": projectId,
+          "evaluation.id": evaluationId,
+        },
+      },
+      async (span) => {
+        span.setAttribute("backend", "clickhouse");
+        return this.evaluationService.getEvaluationInputs({
+          projectId,
+          evaluationId,
+        });
+      },
+    );
+  }
+
+  /**
    * Get traces with spans by thread IDs.
    *
    * @param projectId - The project ID

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -181,6 +181,10 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
 
 // Mock ResizeObserver for tests using floating-ui/popper (Chakra menus, tooltips, etc.)
 globalThis.ResizeObserver = class ResizeObserver {
+  // Match the real one-argument constructor signature so callers like
+  // `new ResizeObserver(cb)` aren't flagged as passing a superfluous arg.
+  // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op for test mock
+  constructor(_callback?: ResizeObserverCallback) {}
   // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op for test mock
   observe() {}
   // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op for test mock

--- a/specs/traces-v2/evaluation-inputs-lazy-load.feature
+++ b/specs/traces-v2/evaluation-inputs-lazy-load.feature
@@ -1,0 +1,27 @@
+Feature: Lazy-loaded evaluation inputs in the trace drawer
+  As an operator inspecting an evaluation in the trace drawer
+  I want the evaluator inputs loaded only when I open a specific evaluation
+  So that heavy input payloads never block the verdict list or blow memory
+
+  # The verdict list shows scores immediately, but evaluator inputs can be
+  # multi-megabyte. They're fetched per-evaluation on expand, keyed by the
+  # evaluation id (the ClickHouse sort key) so the read prunes granules
+  # instead of scanning every evaluation the trace touches.
+
+  @integration
+  Scenario: Inputs load on demand when an evaluation is expanded
+    Given a trace evaluation whose inputs were not loaded with the verdict list
+    When I open that evaluation's details in the drawer
+    Then the evaluator inputs are fetched for that single evaluation and shown
+
+  @integration
+  Scenario: Inputs already present are shown without an extra request
+    Given a trace evaluation whose verdict list already includes its inputs
+    When I open that evaluation's details in the drawer
+    Then the inputs are shown without fetching them again
+
+  @unit
+  Scenario: A single evaluation's inputs can be fetched without scanning the trace
+    Given an evaluation whose trace-wide inputs read is too heavy
+    When the inputs are requested for that one evaluation
+    Then the read is keyed by the evaluation id so it stays within memory

--- a/specs/traces-v2/evaluator-filter-label.feature
+++ b/specs/traces-v2/evaluator-filter-label.feature
@@ -1,0 +1,15 @@
+Feature: Evaluator filter label
+  As an operator filtering traces by evaluator
+  I want the evaluator filter rows labelled by name, not by type
+  So that the limited sidebar width goes to the part that disambiguates
+
+  # A project's evaluators are mostly the same type, so a leading
+  # `[workflow]` / `[langevals/llm_category]` pill repeated the same
+  # token down the whole list while truncating the names that actually
+  # tell evaluators apart.
+
+  @unit
+  Scenario: Evaluator facet labels drop the type prefix
+    Given the evaluator facet query is built
+    Then the projected label is the evaluator name (or id) without a bracketed type prefix
+    And the facet value remains the evaluator id so saved queries round-trip

--- a/specs/traces-v2/preview-newline-marker.feature
+++ b/specs/traces-v2/preview-newline-marker.feature
@@ -1,0 +1,28 @@
+Feature: Newline marker in the compact I/O preview
+  As an operator scanning trace input/output previews in the table
+  I want hard line breaks marked without polluting what I copy
+  So that I can see where the source wrapped, and still paste clean text
+
+  # The marker mimics the GitHub diff gutter: the +/- glyphs are visible
+  # but never land in the clipboard when you select and copy a diff. Our
+  # newline marker (↵) follows the same rule, and additionally never
+  # occupies layout width so it can't wrap onto a line of its own.
+
+  @unit
+  Scenario: The newline marker is not part of the selectable text
+    Given a preview whose source text contains a hard line break
+    When the preview renders the two lines
+    Then the rendered text content does not contain the ↵ glyph
+    And selecting and copying the preview yields the clean two-line text
+
+  @unit
+  Scenario: The newline marker sits at the end of the line that was broken
+    Given a preview whose source text contains a hard line break
+    When the preview renders
+    Then the marker is anchored to the end of the first line, not the start of the second
+
+  @unit
+  Scenario: A single-line preview renders no newline marker
+    Given a preview whose source text has no line breaks
+    When the preview renders
+    Then no newline marker is emitted


### PR DESCRIPTION
Five trace-explorer fixes surfaced while dogfooding.

## 1. Newline marker in the I/O preview

The `↵` hard-break glyph used to be injected into the text string at the start of the wrapped line, so it read as "the enter icon is on the line below" and got swept into selections/copies. It now renders as a zero-width `::after` pseudo-element at the **end** of the broken line, the same way a GitHub diff gutter shows `+`/`-`:

- Not part of the selectable text, so copying a multi-line preview round-trips to clean text (verified: selecting the cell yields `**Scope:**\nDate range: ...\nFilter: ...` with no `↵`).
- Zero layout width, so it can never wrap onto a line of its own.
- Wider spacing before the glyph, and the marker that lands on a truncated line is suppressed so the `↵` never overlaps the line-clamp's `…` ellipsis. Markers on fully-visible lines keep showing, so the hard-break affordance survives truncation.

![newline marker](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-trace-explorer-fixes/01-newline-marker-end-of-line.png)

Line-1 break keeps its `↵`, the truncated line shows a clean `…` (light + dark):

![marker clear of ellipsis, light](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4192/newline-marker/02-marker-clear-of-ellipsis-light.png)
![marker clear of ellipsis, dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4192/newline-marker/03-marker-clear-of-ellipsis-dark.png)

## 2. Evaluator filter label

Dropped the `[type]` prefix (`[workflow]`, `[langevals/llm_category]`) from the evaluator facet rows. A project's evaluators are mostly the same type, so the pill repeated the same token down the whole list while truncating the names that actually disambiguate. The facet value still keys off the evaluator id so saved queries round-trip. Removed the now-dead type-pill rendering from `FacetRow`.

## 3. `annotation.getByTraceIds` "Input is too big for a single dispatch"

tRPC v10 sends queries as GET, so a page of 100+ trace ids overflowed the batch link's 4000-char URL ceiling and threw. New `useAnnotationsByTraceIds` hook chunks the ids into URL-safe batches via `useQueries` and flattens the results, so there's no upper bound on the count. Migrated all five callers; `annotations/all` now declares both query branches unconditionally, which also fixes a latent rules-of-hooks issue.

## 4. `traces.getEvaluations` 500 (ClickHouse memory limit)

Root-caused from prod CloudWatch: `Query memory limit exceeded ... while reading column Inputs`. `evaluation_runs` is `ORDER BY (TenantId, EvaluationId)`, so a `TraceId` filter can't prune granules, and reading the multi-MB `Inputs` column across a granule blew the per-query memory ceiling. The query now falls back to a light projection (no `Inputs`) on a memory-limit error, so operators still get verdicts and scores instead of a 500. The eval card already hides its inputs section when they're absent.

## 5. `ShikiError: Shiki instance has been disposed`

Chakra's shiki adapter calls `ctx.dispose()` in `unloadContext` on every CodeBlock unmount and color-mode change. We share one app-lifetime singleton highlighter across all CodeBlocks, so the first unmount tore down the instance the still-mounted blocks depended on. Neutered the singleton's `dispose`. Verified by toggling the theme repeatedly with code blocks mounted: no more ShikiError.

## 6. Lazy-loaded evaluation inputs in the drawer

Follow-up to #4. The memory-limit fallback keeps the verdict list alive but drops the `Inputs` blob, and the drawer's eval cards render those inputs under "Show details". So the fallback could silently empty the drawer's inputs panel.

The list query keeps `Inputs` (the public v1 API and the v1 hover tooltip both serialize it, so it can't be stripped there). For the drawer, `EvalCard` now fetches a single evaluation's inputs on expand via a new `traces.getEvaluationInputs({ projectId, evaluationId })` procedure, keyed by `EvaluationId`. `EvaluationId` is the second sort-key column of `evaluation_runs`, so unlike the `TraceId`-filtered list read it prunes granules and the heavy column read stays bounded. The fetch only fires while a card is open and only when the list didn't already carry the inputs, so nothing heavy ships on drawer open. `getEvaluationsForTrace`/`getEvaluationInputs` also degrade to null on a memory-limit error instead of 500-ing.

The procedure is `protectedProcedure` + `checkProjectPermission("traces:view")`, not a public-share endpoint: the read keys on `evaluationId` (only tenant-scoped), so the authorization scope has to be the whole project too — a trace-scoped public-share token must not be usable to read another evaluation's inputs. Public-shared trace drawers still get inputs eagerly from the public `getEvaluations`.

![evaluation inputs rendered in the drawer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4192/eval-inputs/01-inputs-rendered-light.png)
![evaluation inputs rendered in the drawer, dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4192/eval-inputs/02-inputs-rendered-dark.png)

## Test plan

- [x] Unit: newline marker not in DOM text, marker span non-selectable, single-line emits none, and the marker on a truncated line is hidden while earlier lines keep theirs (`IOPreview.unit.test.tsx`).
- [x] Unit: evaluator facet SQL drops the type prefix, keeps id as value (`evaluator.unit.test.ts`).
- [x] Unit: evaluations memory-limit fallback retries without Inputs for single + multi trace (`clickhouse-evaluation.fallback.unit.test.ts`).
- [x] Unit: `getEvaluationInputs` keys the read by EvaluationId (not TraceId), parses the blob, and degrades to null on memory limit / disabled CH (`clickhouse-evaluation.inputs.unit.test.ts`).
- [x] Integration: EvalCard fetches inputs on expand only when the list didn't carry them, and renders list inputs without an extra request (`EvalCard.integration.test.tsx`).
- [x] Typecheck clean; `check-feature-parity` green (1321 scenarios bound).
- [x] Browser QA on a freshly emitted multi-line trace: `↵` renders at end of line, copy excludes it; theme-toggle stress with code blocks produces no ShikiError.
- [x] Browser QA on a real trace's evals: inputs render in the drawer; `traces.getEvaluationInputs` returns 200 with the full inputs for a single evaluation through auth; an inputs-less evaluation shows "No inputs recorded".