### PR TITLE
fix(storage): pass region:undefined for AWS-IRSA endpoints instead of 'auto'

### DIFF
--- a/langwatch/src/server/__tests__/storage.createS3Client.unit.test.ts
+++ b/langwatch/src/server/__tests__/storage.createS3Client.unit.test.ts
@@ -70,16 +70,18 @@ vi.mock("../../env.mjs", () => ({
   ),
 }));
 
+function resetS3Env() {
+  s3ClientConstructorCalls.length = 0;
+  delete process.env.S3_ENDPOINT;
+  delete process.env.S3_ACCESS_KEY_ID;
+  delete process.env.S3_SECRET_ACCESS_KEY;
+  delete process.env.S3_SESSION_TOKEN;
+  delete process.env.S3_REGION;
+  delete process.env.S3_BUCKET_NAME;
+}
+
 describe("createS3Client credential mode handling", () => {
-  beforeEach(() => {
-    s3ClientConstructorCalls.length = 0;
-    delete process.env.S3_ENDPOINT;
-    delete process.env.S3_ACCESS_KEY_ID;
-    delete process.env.S3_SECRET_ACCESS_KEY;
-    delete process.env.S3_SESSION_TOKEN;
-    delete process.env.S3_REGION;
-    delete process.env.S3_BUCKET_NAME;
-  });
+  beforeEach(resetS3Env);
 
   describe("given static IAM-user keys (AKIA + secret, no token)", () => {
     /** @scenario "S3 client uses explicit credentials when env keys are present" */
@@ -190,80 +192,77 @@ describe("createS3Client credential mode handling", () => {
 });
 
 describe("region resolution — AWS endpoint, keyless (IRSA path)", () => {
-  beforeEach(() => {
-    s3ClientConstructorCalls.length = 0;
-    delete process.env.S3_ENDPOINT;
-    delete process.env.S3_ACCESS_KEY_ID;
-    delete process.env.S3_SECRET_ACCESS_KEY;
-    delete process.env.S3_SESSION_TOKEN;
-    delete process.env.S3_REGION;
-    delete process.env.S3_BUCKET_NAME;
+  beforeEach(resetS3Env);
+
+  describe("when no endpoint is set and no keys are provided", () => {
+    it("omits region so SDK resolves from credential chain", async () => {
+      await createS3Client("test-project");
+      const call = s3ClientConstructorCalls[0];
+      expect(call).not.toHaveProperty("region");
+    });
   });
 
-  it("passes region: undefined to S3Client when endpoint is unset and no keys", async () => {
-    // Arrange: no S3_ENDPOINT, no S3_REGION, no credentials (IRSA path)
-    await createS3Client("test-project");
-    const call = s3ClientConstructorCalls[0];
-    expect(call).not.toHaveProperty("region");
+  describe("when endpoint is *.amazonaws.com and no keys are provided", () => {
+    it("omits region so SDK resolves from credential chain", async () => {
+      process.env.S3_ENDPOINT = "https://s3.eu-central-1.amazonaws.com";
+      await createS3Client("test-project");
+      const call = s3ClientConstructorCalls[0];
+      expect(call).not.toHaveProperty("region");
+    });
   });
 
-  it("passes region: undefined when endpoint is *.amazonaws.com and no keys", async () => {
-    process.env.S3_ENDPOINT = "https://s3.eu-central-1.amazonaws.com";
-    await createS3Client("test-project");
-    const call = s3ClientConstructorCalls[0];
-    expect(call).not.toHaveProperty("region");
+  describe("when endpoint is AWS and explicit keys are provided (pre-#4058 compatibility path)", () => {
+    it("falls back to 'auto' to preserve pre-#4058 ops-tooling behavior", async () => {
+      process.env.S3_ACCESS_KEY_ID = "AKIAEXAMPLE";
+      process.env.S3_SECRET_ACCESS_KEY = "secret-value";
+      await createS3Client("test-project");
+      const call = s3ClientConstructorCalls[0];
+      expect(call.region).toBe("auto");
+    });
   });
 });
 
 describe("region resolution — non-AWS endpoint (BYOC/R2/MinIO)", () => {
-  beforeEach(() => {
-    s3ClientConstructorCalls.length = 0;
-    delete process.env.S3_ENDPOINT;
-    delete process.env.S3_ACCESS_KEY_ID;
-    delete process.env.S3_SECRET_ACCESS_KEY;
-    delete process.env.S3_SESSION_TOKEN;
-    delete process.env.S3_REGION;
-    delete process.env.S3_BUCKET_NAME;
+  beforeEach(resetS3Env);
+
+  describe("when endpoint is Cloudflare R2", () => {
+    it("uses 'auto' region", async () => {
+      process.env.S3_ENDPOINT = "https://abc123.r2.cloudflarestorage.com";
+      await createS3Client("test-project");
+      const call = s3ClientConstructorCalls[0];
+      expect(call.region).toBe("auto");
+    });
   });
 
-  it("keeps region: 'auto' for R2 endpoint", async () => {
-    process.env.S3_ENDPOINT = "https://abc123.r2.cloudflarestorage.com";
-    await createS3Client("test-project");
-    const call = s3ClientConstructorCalls[0];
-    expect(call.region).toBe("auto");
-  });
-
-  it("keeps region: 'auto' for MinIO endpoint", async () => {
-    process.env.S3_ENDPOINT = "http://minio:9000";
-    await createS3Client("test-project");
-    const call = s3ClientConstructorCalls[0];
-    expect(call.region).toBe("auto");
+  describe("when endpoint is MinIO", () => {
+    it("uses 'auto' region", async () => {
+      process.env.S3_ENDPOINT = "http://minio:9000";
+      await createS3Client("test-project");
+      const call = s3ClientConstructorCalls[0];
+      expect(call.region).toBe("auto");
+    });
   });
 });
 
 describe("region resolution — explicit S3_REGION always wins", () => {
-  beforeEach(() => {
-    s3ClientConstructorCalls.length = 0;
-    delete process.env.S3_ENDPOINT;
-    delete process.env.S3_ACCESS_KEY_ID;
-    delete process.env.S3_SECRET_ACCESS_KEY;
-    delete process.env.S3_SESSION_TOKEN;
-    delete process.env.S3_REGION;
-    delete process.env.S3_BUCKET_NAME;
+  beforeEach(resetS3Env);
+
+  describe("when S3_REGION is set for AWS endpoint without keys", () => {
+    it("uses S3_REGION value", async () => {
+      process.env.S3_REGION = "eu-central-1";
+      await createS3Client("test-project");
+      const call = s3ClientConstructorCalls[0];
+      expect(call.region).toBe("eu-central-1");
+    });
   });
 
-  it("uses S3_REGION when set, even for AWS endpoint without keys", async () => {
-    process.env.S3_REGION = "eu-central-1";
-    await createS3Client("test-project");
-    const call = s3ClientConstructorCalls[0];
-    expect(call.region).toBe("eu-central-1");
-  });
-
-  it("uses S3_REGION when set, even for BYOC endpoint", async () => {
-    process.env.S3_REGION = "us-east-1";
-    process.env.S3_ENDPOINT = "http://minio:9000";
-    await createS3Client("test-project");
-    const call = s3ClientConstructorCalls[0];
-    expect(call.region).toBe("us-east-1");
+  describe("when S3_REGION is set for BYOC endpoint", () => {
+    it("uses S3_REGION value", async () => {
+      process.env.S3_REGION = "us-east-1";
+      process.env.S3_ENDPOINT = "http://minio:9000";
+      await createS3Client("test-project");
+      const call = s3ClientConstructorCalls[0];
+      expect(call.region).toBe("us-east-1");
+    });
   });
 });

--- a/langwatch/src/server/__tests__/storage.createS3Client.unit.test.ts
+++ b/langwatch/src/server/__tests__/storage.createS3Client.unit.test.ts
@@ -19,6 +19,7 @@
  * resolution from there.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createS3Client } from "../storage";
 
 const s3ClientConstructorCalls: any[] = [];
 
@@ -185,5 +186,84 @@ describe("createS3Client credential mode handling", () => {
       expect(config.credentials).toBeUndefined();
       expect("credentials" in config).toBe(false);
     });
+  });
+});
+
+describe("region resolution — AWS endpoint, keyless (IRSA path)", () => {
+  beforeEach(() => {
+    s3ClientConstructorCalls.length = 0;
+    delete process.env.S3_ENDPOINT;
+    delete process.env.S3_ACCESS_KEY_ID;
+    delete process.env.S3_SECRET_ACCESS_KEY;
+    delete process.env.S3_SESSION_TOKEN;
+    delete process.env.S3_REGION;
+    delete process.env.S3_BUCKET_NAME;
+  });
+
+  it("passes region: undefined to S3Client when endpoint is unset and no keys", async () => {
+    // Arrange: no S3_ENDPOINT, no S3_REGION, no credentials (IRSA path)
+    await createS3Client("test-project");
+    const call = s3ClientConstructorCalls[0];
+    expect(call).not.toHaveProperty("region");
+  });
+
+  it("passes region: undefined when endpoint is *.amazonaws.com and no keys", async () => {
+    process.env.S3_ENDPOINT = "https://s3.eu-central-1.amazonaws.com";
+    await createS3Client("test-project");
+    const call = s3ClientConstructorCalls[0];
+    expect(call).not.toHaveProperty("region");
+  });
+});
+
+describe("region resolution — non-AWS endpoint (BYOC/R2/MinIO)", () => {
+  beforeEach(() => {
+    s3ClientConstructorCalls.length = 0;
+    delete process.env.S3_ENDPOINT;
+    delete process.env.S3_ACCESS_KEY_ID;
+    delete process.env.S3_SECRET_ACCESS_KEY;
+    delete process.env.S3_SESSION_TOKEN;
+    delete process.env.S3_REGION;
+    delete process.env.S3_BUCKET_NAME;
+  });
+
+  it("keeps region: 'auto' for R2 endpoint", async () => {
+    process.env.S3_ENDPOINT = "https://abc123.r2.cloudflarestorage.com";
+    await createS3Client("test-project");
+    const call = s3ClientConstructorCalls[0];
+    expect(call.region).toBe("auto");
+  });
+
+  it("keeps region: 'auto' for MinIO endpoint", async () => {
+    process.env.S3_ENDPOINT = "http://minio:9000";
+    await createS3Client("test-project");
+    const call = s3ClientConstructorCalls[0];
+    expect(call.region).toBe("auto");
+  });
+});
+
+describe("region resolution — explicit S3_REGION always wins", () => {
+  beforeEach(() => {
+    s3ClientConstructorCalls.length = 0;
+    delete process.env.S3_ENDPOINT;
+    delete process.env.S3_ACCESS_KEY_ID;
+    delete process.env.S3_SECRET_ACCESS_KEY;
+    delete process.env.S3_SESSION_TOKEN;
+    delete process.env.S3_REGION;
+    delete process.env.S3_BUCKET_NAME;
+  });
+
+  it("uses S3_REGION when set, even for AWS endpoint without keys", async () => {
+    process.env.S3_REGION = "eu-central-1";
+    await createS3Client("test-project");
+    const call = s3ClientConstructorCalls[0];
+    expect(call.region).toBe("eu-central-1");
+  });
+
+  it("uses S3_REGION when set, even for BYOC endpoint", async () => {
+    process.env.S3_REGION = "us-east-1";
+    process.env.S3_ENDPOINT = "http://minio:9000";
+    await createS3Client("test-project");
+    const call = s3ClientConstructorCalls[0];
+    expect(call.region).toBe("us-east-1");
   });
 });

--- a/langwatch/src/server/storage.ts
+++ b/langwatch/src/server/storage.ts
@@ -141,15 +141,23 @@ export const createS3Client = async (projectId: string) => {
   const sessionToken = env.S3_SESSION_TOKEN;
   const hasExplicitKeys = !!(accessKeyId && secretAccessKey);
 
-  // Region resolution. "auto" is the R2 / MinIO convention and works for
-  // those + any S3-compatible endpoint that ignores region. Real AWS S3
-  // requires the actual bucket region for SigV4 to verify, so the
-  // S3_REGION env override is the escape hatch for AWS deployments.
-  const region = env.S3_REGION ?? "auto";
+  // Region resolution:
+  //   - If S3_REGION is explicitly set, use it.
+  //   - If endpoint is non-AWS (R2, MinIO, custom host), keep "auto" — those operators rely on it.
+  //   - If endpoint is AWS (absent or *.amazonaws.com) AND no explicit keys
+  //     (IRSA path) → pass undefined so the SDK resolves region from its
+  //     chain (IRSA injects AWS_REGION into the EKS pod env).
+  //   - If endpoint is AWS AND explicit keys → fall back to "auto" to preserve
+  //     the pre-PR-4058 behavior for ops tooling / local env with hardcoded keys.
+  const endpoint = privateConfig?.endpoint ?? env.S3_ENDPOINT;
+  const isAwsEndpoint = !endpoint || endpoint.endsWith(".amazonaws.com");
+  const region: string | undefined =
+    env.S3_REGION ??
+    (isAwsEndpoint && !hasExplicitKeys ? undefined : "auto");
 
   const s3Client = new S3Client({
-    region,
-    endpoint: privateConfig?.endpoint ?? env.S3_ENDPOINT,
+    ...(region !== undefined ? { region } : {}),
+    endpoint,
     ...(hasExplicitKeys
       ? {
           credentials: {


### PR DESCRIPTION
## Why

Closes #4139

IRSA (IAM Roles for Service Accounts) on EKS authenticates via a projected service-account token — no `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` in env. The previous code always passed `region: "auto"` to `S3Client`, which **breaks AWS SigV4 signature validation**: AWS S3 rejects requests with `sts.auto.amazonaws.com` (NXDOMAIN) when no explicit region is given.

On EKS with IRSA, the correct behavior is to pass `region: undefined` so the AWS SDK resolves it from its credential chain — specifically `AWS_REGION`, which EKS injects into every pod.

## What changed

- **`region: undefined` for keyless AWS endpoints** — when `S3_ENDPOINT` is absent or `*.amazonaws.com` and no explicit keys (IRSA path), `region` is omitted from `S3Client` config so the SDK resolves it from `AWS_REGION`
- **`region: "auto"` preserved for BYOC endpoints** — Cloudflare R2, MinIO, and any non-AWS `S3_ENDPOINT` keep `"auto"` (required by those providers)
- **`S3_REGION` always wins** — explicit env override takes precedence in all cases
- **Unit tests** — `resetS3Env` helper extracted, `describe("when...")` nesting added, and the previously-untested AWS+explicit-keys→`"auto"` backwards-compatibility path now covered

## How it works

Region resolution priority in `createS3Client`:

| Condition | `region` passed to S3Client |
|---|---|
| `S3_REGION` set | `S3_REGION` value |
| AWS endpoint (no endpoint or `*.amazonaws.com`) + no explicit keys (IRSA) | `undefined` — SDK resolves from `AWS_REGION` |
| AWS endpoint + explicit keys | `"auto"` (preserves pre-#4058 behavior for local/ops tooling) |
| Non-AWS endpoint (R2, MinIO, custom) | `"auto"` |

The spread `...(region !== undefined ? { region } : {})` keeps `region` out of the constructor config entirely when undefined — consistent with the existing `credentials` field pattern in the same function, where absent-vs-present-but-undefined has different SDK semantics.

## Test plan

```bash
cd langwatch && pnpm test:unit src/server/__tests__/storage.createS3Client.unit.test.ts
```

New `describe` blocks covering:
- AWS endpoint, no keys (IRSA path) → `region` absent from config
- AWS endpoint, explicit keys → `region: "auto"` (backwards-compatibility path)
- Non-AWS endpoint (R2, MinIO) → `region: "auto"`
- `S3_REGION` override → always wins regardless of endpoint type
