### PR TITLE
fix(trace-processing): cap oversized span attribute values at ingestion

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/__tests__/recordSpanCommand.test.ts
@@ -369,5 +369,44 @@ describe("RecordSpanCommand", () => {
         );
       });
     });
+
+    describe("when an attribute value is oversized", () => {
+      it("caps a multi-MB base64 image attribute on the emitted span", async () => {
+        const bigDataUrl = `data:image/png;base64,${"A".repeat(2 * 1024 * 1024)}`;
+        const command = createMockCommand("project-123", "trace-1", "span-1", [
+          { key: "langwatch.input", value: { stringValue: bigDataUrl } },
+        ]);
+
+        const events = await handler.handle(command);
+
+        const emittedSpan = events[0]!.data.span;
+        const inputAttr = emittedSpan.attributes.find(
+          (a) => a.key === "langwatch.input",
+        );
+        expect(inputAttr!.value.stringValue).toMatch(
+          /^\[truncated: \d+ bytes, image\/png\]$/,
+        );
+        // The huge payload must not survive into the folded event.
+        expect(inputAttr!.value.stringValue!.length).toBeLessThan(64);
+        // Original command data is left untouched (immutability contract).
+        expect(command.data.span.attributes[0]!.value.stringValue).toBe(
+          bigDataUrl,
+        );
+      });
+
+      it("leaves a normal small span attribute unchanged", async () => {
+        const command = createMockCommand("project-123", "trace-1", "span-1", [
+          { key: "langwatch.input", value: { stringValue: "what is 2+2?" } },
+        ]);
+
+        const events = await handler.handle(command);
+
+        const emittedSpan = events[0]!.data.span;
+        const inputAttr = emittedSpan.attributes.find(
+          (a) => a.key === "langwatch.input",
+        );
+        expect(inputAttr!.value.stringValue).toBe("what is 2+2?");
+      });
+    });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
@@ -26,6 +26,7 @@ import { OtlpSpanTokenEstimationService } from "~/server/app-layer/traces/span-t
 import { TiktokenClient } from "~/server/app-layer/clients/tokenizer/tiktoken.client";
 import { featureFlagService } from "~/server/featureFlag";
 import { TraceRequestUtils } from "../utils/traceRequest.utils";
+import { capOversizedAttributes } from "../utils/capOversizedAttributes";
 
 /**
  * Dependencies for RecordSpanCommand that can be injected for testing.
@@ -135,6 +136,23 @@ export class RecordSpanCommand implements CommandHandler<
           resourceToProcess,
           this.logger,
         );
+
+        // Cap oversized attribute values (multi-MB base64 images, huge params)
+        // before this span becomes a folded event. The trace-processing fold
+        // state is read-modify-written in Redis per event; multi-MB values
+        // saturate the single-threaded command loop and collapse folding
+        // throughput. Capping here keeps the fold state small for every
+        // ingestion path that dispatches recordSpan (collector REST and OTLP).
+        const cappedAttributeCount = capOversizedAttributes(
+          spanToProcess,
+          resourceToProcess,
+        );
+        if (cappedAttributeCount > 0) {
+          this.logger.warn(
+            { tenantId, traceId, spanId, cappedAttributeCount },
+            "Capped oversized span attribute value(s) before ingestion",
+          );
+        }
 
         const piiRedactionLevel =
           commandData.piiRedactionLevel ?? DEFAULT_PII_REDACTION_LEVEL;

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/capOversizedAttributes.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/utils/__tests__/capOversizedAttributes.unit.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import type { OtlpSpan } from "../../schemas/otlp";
+import {
+  capOversizedAttributes,
+  DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES,
+} from "../capOversizedAttributes";
+
+function makeSpan(attributes: OtlpSpan["attributes"]): OtlpSpan {
+  return {
+    traceId: "trace-1",
+    spanId: "span-1",
+    name: "test-span",
+    kind: 1,
+    startTimeUnixNano: { low: 0, high: 0 },
+    endTimeUnixNano: { low: 1_000_000, high: 0 },
+    attributes,
+    events: [],
+    links: [],
+    status: { message: null, code: null },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  } as unknown as OtlpSpan;
+}
+
+/** Builds a `data:image/png;base64,...` URL whose byte size exceeds the cap. */
+function oversizedDataUrl(): string {
+  const payload = "A".repeat(DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES + 1024);
+  return `data:image/png;base64,${payload}`;
+}
+
+describe("capOversizedAttributes", () => {
+  it("caps an oversized base64 data-url attribute and names the mime type", () => {
+    const url = oversizedDataUrl();
+    const span = makeSpan([
+      { key: "langwatch.input", value: { stringValue: url } },
+    ]);
+
+    const cappedCount = capOversizedAttributes(span, null);
+
+    expect(cappedCount).toBe(1);
+    const value = span.attributes[0]!.value.stringValue!;
+    expect(value).not.toContain("AAAA");
+    expect(value).toMatch(/^\[truncated: \d+ bytes, image\/png\]$/);
+    // Placeholder must be tiny, not multi-MB.
+    expect(value.length).toBeLessThan(64);
+  });
+
+  it("leaves a normal small span completely unchanged", () => {
+    const span = makeSpan([
+      { key: "langwatch.input", value: { stringValue: "hello world" } },
+      {
+        key: "langwatch.output",
+        value: {
+          stringValue: JSON.stringify({ role: "assistant", content: "hi" }),
+        },
+      },
+    ]);
+    const before = structuredClone(span.attributes);
+
+    const cappedCount = capOversizedAttributes(span, null);
+
+    expect(cappedCount).toBe(0);
+    expect(span.attributes).toEqual(before);
+  });
+
+  it("caps oversized strings nested inside arrayValue and kvlistValue", () => {
+    const big = "x".repeat(DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES + 1);
+    const span = makeSpan([
+      {
+        key: "langwatch.params",
+        value: {
+          kvlistValue: {
+            values: [
+              { key: "image", value: { stringValue: big } },
+              { key: "small", value: { stringValue: "ok" } },
+            ],
+          },
+        },
+      },
+      {
+        key: "langwatch.input",
+        value: {
+          arrayValue: {
+            values: [{ stringValue: big }, { stringValue: "fine" }],
+          },
+        },
+      },
+    ]);
+
+    const cappedCount = capOversizedAttributes(span, null);
+
+    expect(cappedCount).toBe(2);
+    const kv = span.attributes[0]!.value.kvlistValue!.values;
+    expect(kv[0]!.value.stringValue).toMatch(/^\[truncated: \d+ bytes\]$/);
+    expect(kv[1]!.value.stringValue).toBe("ok");
+    const arr = span.attributes[1]!.value.arrayValue!.values;
+    expect(arr[0]!.stringValue).toMatch(/^\[truncated: \d+ bytes\]$/);
+    expect(arr[1]!.stringValue).toBe("fine");
+  });
+
+  it("caps oversized bytesValue payloads", () => {
+    const span = makeSpan([
+      {
+        key: "langwatch.input",
+        value: {
+          bytesValue: new Uint8Array(DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES + 1),
+        },
+      },
+    ]);
+
+    const cappedCount = capOversizedAttributes(span, null);
+
+    expect(cappedCount).toBe(1);
+    expect(span.attributes[0]!.value.bytesValue).toBeNull();
+    expect(span.attributes[0]!.value.stringValue).toMatch(
+      /^\[truncated: \d+ bytes\]$/,
+    );
+  });
+
+  it("caps oversized values in events, links, and the resource", () => {
+    const big = "y".repeat(DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES + 1);
+    const span = makeSpan([]);
+    span.events = [
+      {
+        timeUnixNano: { low: 0, high: 0 },
+        name: "evt",
+        attributes: [{ key: "big", value: { stringValue: big } }],
+      },
+    ] as unknown as OtlpSpan["events"];
+    span.links = [
+      {
+        traceId: "t",
+        spanId: "s",
+        attributes: [{ key: "big", value: { stringValue: big } }],
+        droppedAttributesCount: 0,
+      },
+    ] as unknown as OtlpSpan["links"];
+    const resource = {
+      attributes: [{ key: "big", value: { stringValue: big } }],
+    };
+
+    const cappedCount = capOversizedAttributes(span, resource as never);
+
+    expect(cappedCount).toBe(3);
+  });
+
+  it("does not throw on malformed attribute shapes", () => {
+    const span = makeSpan([
+      { key: "weird", value: null as never },
+      undefined as never,
+    ]);
+
+    expect(() => capOversizedAttributes(span, null)).not.toThrow();
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/utils/capOversizedAttributes.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/utils/capOversizedAttributes.ts
@@ -1,0 +1,173 @@
+/**
+ * capOversizedAttributes — bounds the byte-size of incoming span attribute
+ * values at ingestion, before a span enters the event-sourcing fold state.
+ *
+ * Why this exists
+ * ---------------
+ * A small number of pathological traces carry multi-megabyte attribute values:
+ * base64-encoded images (`data:image/...;base64,...` data URLs) embedded in
+ * multimodal LLM messages on `langwatch.input` / `langwatch.output`, or simply
+ * very large `langwatch.params`. The trace-processing pipeline is event
+ * sourced: every span becomes a SpanReceivedEvent that is folded into a
+ * per-trace fold STATE in Redis via a read-modify-write per event. When that
+ * state grows to multiple megabytes, each Redis op saturates the single-
+ * threaded command loop, folding throughput collapses, staging outpaces it,
+ * and the backlog (and Redis memory) diverges.
+ *
+ * Capping oversized values here keeps the fold state small (KB, not MB) so
+ * folding throughput stays high. This only needs to protect NEW traces.
+ *
+ * Why a size cap and not blob extraction
+ * --------------------------------------
+ * The existing `extractInlineMediaFromEvent` blob extractor walks the
+ * structured chat `message` / `messages` content-part vocabulary used by the
+ * scenario path. In the trace/OTLP path the equivalent payload is a flat,
+ * already-serialized JSON string inside an attribute's `stringValue` (or a
+ * `bytesValue`), not a structured content array. Reaching the extractor would
+ * require speculatively JSON-parsing arbitrary attribute strings in the hottest
+ * ingestion path and re-serializing them, which is fragile and CPU-heavy. It
+ * also depends on a configured storage driver, which self-hosted deployments
+ * may not have. So we cap by size instead: bounded, allocation-light, and
+ * never throwing.
+ *
+ * Behaviour
+ * ---------
+ * - Walks span / resource attribute values (recursively through arrayValue and
+ *   kvlistValue) and replaces any `stringValue` or `bytesValue` whose byte size
+ *   exceeds the threshold with a short placeholder describing what was cut.
+ * - Normal traces are untouched: only values over the (generous) threshold are
+ *   replaced. The walk is in place and degrades gracefully — a malformed value
+ *   is left as-is rather than throwing.
+ */
+import type { OtlpAnyValue, OtlpResource, OtlpSpan } from "../schemas/otlp";
+
+/**
+ * Generous threshold (256KB). Real-world text input/output is far smaller; this
+ * only trips on embedded binary blobs (base64 images/audio) and pathologically
+ * large payloads.
+ */
+export const DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES = 256 * 1024;
+
+/** UTF-8 byte length of a string, without allocating a Buffer copy. */
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+/**
+ * Pulls a mime type out of a `data:<mime>;base64,...` URL so the placeholder
+ * can name what was cut. Returns null for non-data-url strings.
+ */
+function dataUrlMimeType(value: string): string | null {
+  if (!value.startsWith("data:")) return null;
+  const commaIdx = value.indexOf(",");
+  if (commaIdx === -1) return null;
+  const header = value.slice(5, commaIdx); // strip "data:"
+  const semiIdx = header.indexOf(";");
+  const mimeType = semiIdx === -1 ? header : header.slice(0, semiIdx);
+  return mimeType || null;
+}
+
+function truncationPlaceholder(
+  byteSize: number,
+  mimeType: string | null,
+): string {
+  return mimeType
+    ? `[truncated: ${byteSize} bytes, ${mimeType}]`
+    : `[truncated: ${byteSize} bytes]`;
+}
+
+/**
+ * Caps a single OTLP AnyValue in place. Returns true when something was
+ * replaced (used only for bookkeeping / tests). Recurses into arrays and
+ * kvlists so blobs nested inside structured params are caught too.
+ */
+function capAnyValue(value: OtlpAnyValue, maxBytes: number): boolean {
+  if (value == null || typeof value !== "object") return false;
+
+  let capped = false;
+
+  if (typeof value.stringValue === "string") {
+    const byteSize = utf8ByteLength(value.stringValue);
+    if (byteSize > maxBytes) {
+      value.stringValue = truncationPlaceholder(
+        byteSize,
+        dataUrlMimeType(value.stringValue),
+      );
+      capped = true;
+    }
+  }
+
+  if (value.bytesValue != null) {
+    const byteSize =
+      value.bytesValue instanceof Uint8Array
+        ? value.bytesValue.byteLength
+        : // JSON-serialized bytes ({"0":1,...}) or unexpected shape: best-effort size.
+          utf8ByteLength(String(value.bytesValue));
+    if (byteSize > maxBytes) {
+      // Replace the binary payload with a text placeholder. Downstream
+      // consumers read this attribute as a value type, so a stringValue
+      // placeholder is the safe, readable substitute.
+      value.bytesValue = null;
+      value.stringValue = truncationPlaceholder(byteSize, null);
+      capped = true;
+    }
+  }
+
+  if (value.arrayValue && Array.isArray(value.arrayValue.values)) {
+    for (const item of value.arrayValue.values) {
+      if (capAnyValue(item, maxBytes)) capped = true;
+    }
+  }
+
+  if (value.kvlistValue && Array.isArray(value.kvlistValue.values)) {
+    for (const entry of value.kvlistValue.values) {
+      if (entry?.value && capAnyValue(entry.value, maxBytes)) capped = true;
+    }
+  }
+
+  return capped;
+}
+
+type AttributeList = OtlpSpan["attributes"];
+
+/** Caps every value in an attribute list in place. */
+function capAttributeList(attributes: AttributeList, maxBytes: number): number {
+  if (!Array.isArray(attributes)) return 0;
+  let count = 0;
+  for (const attr of attributes) {
+    if (attr?.value && capAnyValue(attr.value, maxBytes)) count++;
+  }
+  return count;
+}
+
+/**
+ * Walks a span (and its events, links, and the shared resource) and replaces
+ * any attribute value over `maxBytes` with a short placeholder, in place.
+ *
+ * Safe for the hot ingestion path: never throws, only touches values that
+ * exceed the threshold, and leaves normal spans byte-for-byte unchanged.
+ *
+ * Returns the number of values capped (for logging / tests).
+ */
+export function capOversizedAttributes(
+  span: OtlpSpan,
+  resource: OtlpResource | null,
+  maxBytes: number = DEFAULT_MAX_ATTRIBUTE_VALUE_BYTES,
+): number {
+  let count = 0;
+  try {
+    count += capAttributeList(span.attributes, maxBytes);
+    for (const event of span.events ?? []) {
+      count += capAttributeList(event.attributes, maxBytes);
+    }
+    for (const link of span.links ?? []) {
+      count += capAttributeList(link.attributes, maxBytes);
+    }
+    if (resource) {
+      count += capAttributeList(resource.attributes, maxBytes);
+    }
+  } catch {
+    // Degraded, not broken: never block ingestion on a malformed value.
+  }
+  return count;
+}


### PR DESCRIPTION
## Root cause

Prod Redis hit 100% memory then 100% CPU on its single command thread. A small number of pathological traces carried multi-megabyte span attribute values: base64-encoded images (\`data:image/...;base64,...\` data URLs) embedded in multimodal LLM messages on \`langwatch.input\` / \`langwatch.output\`, plus very large \`langwatch.params\` and large traces in general.

Trace processing is event sourced. Every span becomes a \`SpanReceivedEvent\` that is folded into a per-trace fold STATE in Redis, and the fold projection does a read-modify-write of that accumulated state per event. When the state is multi-MB, each Redis op saturates the single-threaded command loop, folding throughput collapses (observed ~27 jobs/s), staging outpaces folding, and the backlog and Redis memory diverge.

## What changed and where

Added \`capOversizedAttributes\` and wired it into \`RecordSpanCommand.handle\`, right after the span is cloned and reserved attributes are stripped, before the \`SpanReceivedEvent\` is emitted.

\`RecordSpanCommand\` is the **shared chokepoint** every trace ingestion path dispatches through:

- Collector REST (\`routes/collector.ts\`) calls \`getApp().traces.recordSpan(...)\` per span.
- OTLP (\`routes/otel.ts\`) calls \`traces.collection.handleOtlpTraceRequest(...)\`, which internally calls \`commands.traces.recordSpan\`.
- \`routes/misc.ts\` also calls \`getApp().traces.recordSpan(...)\`.

\`App.traces\` is \`{ ...deps.traces, ...deps.commands.traces }\`, so \`getApp().traces.recordSpan\` is the exact same \`commands.traces.recordSpan\` the OTLP collection service uses. That command emits the \`SpanReceivedEvent\` whose \`data.span\` is what gets persisted and folded. Capping there guarantees the value never enters the fold state on any ingestion path, which is the path that actually bloated Redis (capping only the collector to ElasticSearch path would not have helped, since the event-sourcing path receives the span independently).

Files:
- \`langwatch/src/server/event-sourcing/pipelines/trace-processing/utils/capOversizedAttributes.ts\` (new) — the walker.
- \`langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts\` — calls the cap, logs a warning with the count when it fires.
- Tests for both (below).

## Approach and tradeoff

Two options were considered:

1. **Preserve via blob extraction** (reuse \`extractInlineMediaFromEvent\`). Rejected for the trace path: that extractor walks the structured chat \`message\` / \`messages\` content-part vocabulary used by the scenario ingestion path. In the trace/OTLP path the equivalent payload is a flat, already-serialized JSON string inside an attribute \`stringValue\` (or a \`bytesValue\`), not a structured content array. Reaching the extractor would require speculatively JSON-parsing arbitrary attribute strings in the hottest ingestion path and re-serializing them, which is fragile and CPU-heavy, and it depends on a configured storage driver that self-hosted deployments may not have.

2. **Size-threshold cap** (chosen). Walk each incoming span's attribute values and replace any over 256KB with a short placeholder like \`[truncated: 2097174 bytes, image/png]\`. The walker recurses through \`arrayValue\` and \`kvlistValue\` so blobs nested inside structured params are caught, and handles oversized \`bytesValue\`. It never throws (degraded, not broken) and leaves normal spans byte-for-byte unchanged.

Tradeoff: the size cap is simpler, bounded, and safe for the hot path, but it does not preserve the original image bytes (the over-threshold value is replaced by a placeholder). Given the priority of keeping ingestion and folding healthy and the lack of a guaranteed storage driver in self-hosted, the cap is the safe deployable fix. A future enhancement could externalize the bytes to the blob store before truncating when a driver is configured.

Threshold: 256KB. Generous enough that real-world text input/output is untouched; it only trips on embedded binary blobs and pathologically large payloads.

## Scope

This protects NEW traces. The existing backlog is handled operationally and is out of scope here.

## Tests

- \`capOversizedAttributes.unit.test.ts\` (new): oversized base64 data-url is capped with the mime type named; a normal small span is unchanged; nested \`arrayValue\` / \`kvlistValue\` blobs are capped; oversized \`bytesValue\` is capped; events / links / resource attributes are capped; malformed shapes do not throw.
- \`recordSpanCommand.test.ts\`: a span with an oversized base64 \`langwatch.input\` attribute is capped on the emitted \`SpanReceivedEvent\` while the original command data stays intact; a normal small attribute passes through unchanged.

All 21 tests in the two files pass.