### PR TITLE
fix(event-sourcing): coalesce backed-up fold groups into one apply/store cycle

### DIFF
--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -456,6 +456,30 @@ export class EventSourcing {
         }
         await result.entry.process(result.clean);
       },
+      coalesceMaxBatch: (payload: Record<string, unknown>) => {
+        const result = this.lookupEntry(payload);
+        return result?.entry.coalesceMaxBatch ?? 1;
+      },
+      processBatch: async (payloads: Record<string, unknown>[]) => {
+        if (payloads.length === 0) return;
+        // A coalesced batch is always one group → one registry entry. Resolve it
+        // from the first payload and hand the batch handler the clean payloads
+        // (routing metadata stripped).
+        const first = this.lookupEntry(payloads[0]!);
+        if (!first?.entry.processBatch) {
+          // No batch handler for this job type — process each individually.
+          for (const payload of payloads) {
+            const result = this.lookupEntry(payload);
+            if (result) await result.entry.process(result.clean);
+          }
+          return;
+        }
+        const cleanPayloads = payloads.map((payload) => {
+          const result = this.lookupEntry(payload);
+          return result ? result.clean : payload;
+        });
+        await first.entry.processBatch(cleanPayloads);
+      },
     };
 
     const effectiveRedis = this._redis;

--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -462,23 +462,23 @@ export class EventSourcing {
       },
       processBatch: async (payloads: Record<string, unknown>[]) => {
         if (payloads.length === 0) return;
-        // A coalesced batch is always one group → one registry entry. Resolve it
-        // from the first payload and hand the batch handler the clean payloads
-        // (routing metadata stripped).
+        // A coalesced batch is always one group → one registry entry. Resolve
+        // every payload and guard against a mixed/unknown batch (should never
+        // happen — the GroupQueue only coalesces same-group jobs — but a stray
+        // payload must never be misrouted to the wrong handler). On any mismatch
+        // fall back to per-item processing.
         const first = this.lookupEntry(payloads[0]!);
-        if (!first?.entry.processBatch) {
-          // No batch handler for this job type — process each individually.
-          for (const payload of payloads) {
-            const result = this.lookupEntry(payload);
+        const resolved = payloads.map((payload) => this.lookupEntry(payload));
+        const homogeneous =
+          !!first?.entry.processBatch &&
+          resolved.every((r) => r?.entry === first.entry);
+        if (!homogeneous) {
+          for (const result of resolved) {
             if (result) await result.entry.process(result.clean);
           }
           return;
         }
-        const cleanPayloads = payloads.map((payload) => {
-          const result = this.lookupEntry(payload);
-          return result ? result.clean : payload;
-        });
-        await first.entry.processBatch(cleanPayloads);
+        await first.entry.processBatch!(resolved.map((r) => r!.clean));
       },
     };
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/traceProcessing.coalescing.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/traceProcessing.coalescing.integration.test.ts
@@ -120,7 +120,7 @@ describe.skipIf(!hasTestcontainers)(
 
         const executor = new FoldProjectionExecutor();
         const fold = new TraceSummaryFoldProjection({ store: traceSummaryStore });
-        const context = { aggregateId: traceId, tenantId: tenantIdString, key: traceId };
+        const context = { aggregateId: traceId, tenantId, key: traceId };
 
         const folded = (await executor.executeBatch(
           fold as never,

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/traceProcessing.coalescing.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/traceProcessing.coalescing.integration.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
+import { SpanStorageClickHouseRepository } from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
+import { TraceSummaryService } from "~/server/app-layer/traces/trace-summary.service";
+import { TraceSummaryClickHouseRepository } from "~/server/app-layer/traces/repositories/trace-summary.clickhouse.repository";
+import { getTestClickHouseClient } from "../../../__tests__/integration/testContainers";
+import {
+  cleanupTestDataForTenant,
+  createTestTenantId,
+  getTenantIdString,
+} from "../../../__tests__/integration/testHelpers";
+import { FoldProjectionExecutor } from "../../../projections/foldProjectionExecutor";
+import { RecordSpanCommand } from "../commands/recordSpanCommand";
+import { RECORD_SPAN_COMMAND_TYPE } from "../schemas/constants";
+import type { SpanReceivedEvent } from "../schemas/events";
+import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
+import { TraceSummaryFoldProjection } from "../projections/traceSummary.foldProjection";
+import type { OtlpSpan } from "../schemas/otlp";
+import { TraceSummaryStore } from "../projections/traceSummary.store";
+
+// Subclass that injects no-op span-enrichment deps so the production
+// `require("~/server/db")` default-dependency path never runs (that require
+// can't be resolved at runtime under vitest). Mirrors the pattern in
+// metricsSync.convergence.integration.test.ts.
+class TestRecordSpanCommand extends RecordSpanCommand {
+  static override readonly schema = RecordSpanCommand.schema;
+  constructor() {
+    super({
+      piiRedactionService: { redactSpan: async () => {} },
+      costEnrichmentService: { enrichSpan: async () => {} },
+      tokenEstimationService: { estimateSpanTokens: async () => {} },
+    } as never);
+  }
+}
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+}
+
+function buildRawSpan(traceId: string, spanId: string, startTimeMs: number): OtlpSpan {
+  const startNano = BigInt(startTimeMs) * 1_000_000n;
+  const endNano = startNano + BigInt(10) * 1_000_000n;
+  return {
+    traceId,
+    spanId,
+    parentSpanId: null,
+    name: `span-${spanId}`,
+    kind: 1,
+    startTimeUnixNano: startNano.toString(),
+    endTimeUnixNano: endNano.toString(),
+    attributes: [],
+    events: [],
+    links: [],
+    status: { code: 1, message: null },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  } as unknown as OtlpSpan;
+}
+
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+);
+
+describe.skipIf(!hasTestcontainers)(
+  "Trace summary fold coalescing -> ClickHouse",
+  () => {
+    let tenantId: ReturnType<typeof createTestTenantId>;
+    let tenantIdString: string;
+    let traceSummaryStore: TraceSummaryStore;
+
+    beforeEach(() => {
+      const clickHouseClient = getTestClickHouseClient();
+      if (!clickHouseClient) throw new Error("ClickHouse required.");
+      tenantId = createTestTenantId();
+      tenantIdString = getTenantIdString(tenantId);
+      traceSummaryStore = new TraceSummaryStore(
+        new TraceSummaryService(
+          new TraceSummaryClickHouseRepository(async () => clickHouseClient),
+        ).repository,
+      );
+      // Touch span-storage wiring too, to keep the import surface honest.
+      void new SpanStorageService(
+        new SpanStorageClickHouseRepository(async () => clickHouseClient),
+      );
+    });
+
+    afterEach(async () => {
+      await cleanupTestDataForTenant(tenantIdString);
+    });
+
+    describe("given many spans for one trace folded as one coalesced batch", () => {
+      /** @scenario 'Coalesced folding produces the correct accumulated state through the pipeline' */
+      it("folds every span into the exact accumulated count persisted in ClickHouse", async () => {
+        const traceId = generateId("trace");
+        const SPAN_COUNT = 40;
+        const base = Date.now();
+
+        // Build valid normalized span events via the real command (no queue), so
+        // this is deterministic. executeBatch then folds them in ONE
+        // load/apply/store cycle — the coalescing path — straight to ClickHouse.
+        const command = new TestRecordSpanCommand();
+        const events: SpanReceivedEvent[] = [];
+        for (let i = 0; i < SPAN_COUNT; i++) {
+          const produced = await command.handle({
+            type: RECORD_SPAN_COMMAND_TYPE,
+            aggregateId: traceId,
+            tenantId: tenantIdString,
+            data: {
+              span: buildRawSpan(traceId, `${generateId("span")}-${i}`, base + i),
+              resource: null,
+              instrumentationScope: null,
+              piiRedactionLevel: "DISABLED",
+              occurredAt: base + i,
+            },
+          } as never);
+          events.push(...produced);
+        }
+        expect(events).toHaveLength(SPAN_COUNT);
+
+        const executor = new FoldProjectionExecutor();
+        const fold = new TraceSummaryFoldProjection({ store: traceSummaryStore });
+        const context = { aggregateId: traceId, tenantId: tenantIdString, key: traceId };
+
+        const folded = (await executor.executeBatch(
+          fold as never,
+          events as never,
+          context,
+        )) as TraceSummaryData;
+
+        // In-memory result: every span folded, no double-count, no loss.
+        expect(folded.spanCount).toBe(SPAN_COUNT);
+
+        // Persisted in ClickHouse: read the single stored summary back.
+        const persisted = (await traceSummaryStore.get(traceId, context)) as TraceSummaryData | null;
+        expect(persisted?.spanCount).toBe(SPAN_COUNT);
+      }, 45000);
+    });
+  },
+);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/traceProcessing.coalescing.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/traceProcessing.coalescing.integration.test.ts
@@ -131,8 +131,15 @@ describe.skipIf(!hasTestcontainers)(
         // In-memory result: every span folded, no double-count, no loss.
         expect(folded.spanCount).toBe(SPAN_COUNT);
 
-        // Persisted in ClickHouse: read the single stored summary back.
-        const persisted = (await traceSummaryStore.get(traceId, context)) as TraceSummaryData | null;
+        // Persisted in ClickHouse: read the single stored summary back. Poll to
+        // tolerate ClickHouse insert visibility lag (the row is written once).
+        let persisted: TraceSummaryData | null = null;
+        const deadline = Date.now() + 10000;
+        while (Date.now() < deadline) {
+          persisted = (await traceSummaryStore.get(traceId, context)) as TraceSummaryData | null;
+          if (persisted?.spanCount === SPAN_COUNT) break;
+          await new Promise((r) => setTimeout(r, 200));
+        }
         expect(persisted?.spanCount).toBe(SPAN_COUNT);
       }, 45000);
     });

--- a/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/foldProjectionExecutor.test.ts
@@ -185,3 +185,220 @@ describe("FoldProjectionExecutor.execute", () => {
     });
   });
 });
+
+/** Accumulating state used by the batch tests: tracks count, the order events
+ * were folded in, and the highest occurredAt (mirrors AbstractFoldProjection). */
+interface BatchState {
+  count: number;
+  seen: string[];
+  LastEventOccurredAt: number;
+}
+
+const batchInit = (): BatchState => ({ count: 0, seen: [], LastEventOccurredAt: 0 });
+const batchApply = (state: BatchState, event: Event): BatchState => ({
+  count: state.count + 1,
+  seen: [...state.seen, event.id],
+  LastEventOccurredAt: Math.max(state.LastEventOccurredAt, event.occurredAt ?? 0),
+});
+
+describe("FoldProjectionExecutor.executeBatch", () => {
+  const tenantId = createTestTenantId();
+  let executor: FoldProjectionExecutor;
+
+  const context: ProjectionStoreContext = {
+    aggregateId: TEST_CONSTANTS.AGGREGATE_ID,
+    tenantId,
+  };
+
+  const makeEvent = (occurredAt: number, id: string) =>
+    createTestEvent(
+      TEST_CONSTANTS.AGGREGATE_ID,
+      TEST_CONSTANTS.AGGREGATE_TYPE,
+      tenantId,
+      undefined,
+      occurredAt,
+      undefined,
+      {},
+      id,
+    );
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_CONSTANTS.BASE_TIMESTAMP);
+    executor = new FoldProjectionExecutor();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("when folding several in-order events", () => {
+    /** @scenario 'Folding several events reads once and stores once' */
+    it("reads once, folds all, and stores once", async () => {
+      const store = createMockFoldProjectionStore<BatchState>();
+      (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      const foldDef = createMockFoldProjectionDefinition("counter", {
+        store,
+        init: batchInit,
+        apply: batchApply,
+      });
+
+      const events = [
+        makeEvent(1000, "e1"),
+        makeEvent(2000, "e2"),
+        makeEvent(3000, "e3"),
+      ];
+
+      const result = await executor.executeBatch(foldDef, events, context);
+
+      expect(result.count).toBe(3);
+      expect(result.seen).toEqual(["e1", "e2", "e3"]);
+      expect(store.get).toHaveBeenCalledTimes(1);
+      expect(store.store).toHaveBeenCalledTimes(1);
+      expect((store.store as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe(result);
+    });
+
+    /** @scenario 'Coalesced fold equals sequential folding' */
+    it("produces the same final state as sequential execute() calls", async () => {
+      const events = [makeEvent(1000, "a"), makeEvent(2000, "b"), makeEvent(3000, "c")];
+
+      const batchStore = createMockFoldProjectionStore<BatchState>();
+      (batchStore.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      const batchDef = createMockFoldProjectionDefinition("counter", {
+        store: batchStore,
+        init: batchInit,
+        apply: batchApply,
+      });
+      const batched = await executor.executeBatch(batchDef, events, context);
+
+      // Sequential path: each execute() re-reads the latest stored state.
+      let current: BatchState | null = null;
+      const seqStore = createMockFoldProjectionStore<BatchState>();
+      (seqStore.get as ReturnType<typeof vi.fn>).mockImplementation(async () => current);
+      (seqStore.store as ReturnType<typeof vi.fn>).mockImplementation(async (s: BatchState) => {
+        current = s;
+      });
+      const seqDef = createMockFoldProjectionDefinition("counter", {
+        store: seqStore,
+        init: batchInit,
+        apply: batchApply,
+      });
+      for (const event of events) {
+        await executor.execute(seqDef, event, context);
+      }
+
+      expect(batched).toEqual(current);
+    });
+  });
+
+  describe("when events arrive out of occurredAt order", () => {
+    /** @scenario 'Out-of-order events are folded in occurredAt order' */
+    it("folds them in occurredAt order", async () => {
+      const store = createMockFoldProjectionStore<BatchState>();
+      (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      const foldDef = createMockFoldProjectionDefinition("counter", {
+        store,
+        init: batchInit,
+        apply: batchApply,
+      });
+
+      const events = [makeEvent(3000, "third"), makeEvent(1000, "first"), makeEvent(2000, "second")];
+
+      const result = await executor.executeBatch(foldDef, events, context);
+
+      expect(result.seen).toEqual(["first", "second", "third"]);
+    });
+  });
+
+  describe("when a single event matches", () => {
+    it("delegates to execute() and stores once", async () => {
+      const store = createMockFoldProjectionStore<BatchState>();
+      (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      const foldDef = createMockFoldProjectionDefinition("counter", {
+        store,
+        init: batchInit,
+        apply: batchApply,
+      });
+
+      const result = await executor.executeBatch(foldDef, [makeEvent(1000, "only")], context);
+
+      expect(result.count).toBe(1);
+      expect(store.get).toHaveBeenCalledTimes(1);
+      expect(store.store).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when no events match the projection's event types", () => {
+    it("returns init state without loading or storing", async () => {
+      const store = createMockFoldProjectionStore<BatchState>();
+      const foldDef = createMockFoldProjectionDefinition("counter", {
+        store,
+        init: batchInit,
+        apply: batchApply,
+        eventTypes: ["some.other.event"],
+      });
+
+      const events = [makeEvent(1000, "x"), makeEvent(2000, "y")];
+
+      const result = await executor.executeBatch(foldDef, events, context);
+
+      expect(result).toEqual(batchInit());
+      expect(store.get).not.toHaveBeenCalled();
+      expect(store.store).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the batch starts before the persisted checkpoint", () => {
+    it("re-folds from scratch via eventLoader", async () => {
+      const store = createMockFoldProjectionStore<BatchState>();
+      (store.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        count: 5,
+        seen: ["old"],
+        LastEventOccurredAt: 5000,
+      });
+      const foldDef = createMockFoldProjectionDefinition("counter", {
+        store,
+        init: batchInit,
+        apply: batchApply,
+      });
+      foldDef.eventLoader = vi
+        .fn()
+        .mockResolvedValue([makeEvent(1000, "r1"), makeEvent(2000, "r2"), makeEvent(3000, "r3")]);
+
+      // Batch's earliest occurredAt (1000) is before the checkpoint (5000).
+      const events = [makeEvent(1000, "b1"), makeEvent(2000, "b2")];
+
+      const result = await executor.executeBatch(foldDef, events, context);
+
+      expect(foldDef.eventLoader).toHaveBeenCalledOnce();
+      // Re-folded purely from the loaded history, not the stale checkpoint.
+      expect(result.count).toBe(3);
+      expect(result.seen).toEqual(["r1", "r2", "r3"]);
+      expect(store.store).toHaveBeenCalledTimes(1);
+    });
+
+    it("applies on top of the checkpoint when no eventLoader is available", async () => {
+      const store = createMockFoldProjectionStore<BatchState>();
+      (store.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+        count: 5,
+        seen: ["old"],
+        LastEventOccurredAt: 5000,
+      });
+      const foldDef = createMockFoldProjectionDefinition("counter", {
+        store,
+        init: batchInit,
+        apply: batchApply,
+      });
+
+      const events = [makeEvent(1000, "b1"), makeEvent(2000, "b2")];
+
+      const result = await executor.executeBatch(foldDef, events, context);
+
+      // Degraded path mirrors execute(): batch folded onto the existing state.
+      expect(result.count).toBe(7);
+      expect(result.seen).toEqual(["old", "b1", "b2"]);
+      expect(store.store).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
@@ -745,4 +745,100 @@ describe("ProjectionRouter", () => {
       });
     });
   });
+
+  describe("processFoldProjectionBatch (coalescing)", () => {
+    function makeBatchEvent(id: string, occurredAt: number): Event {
+      return createTestEvent(
+        TEST_CONSTANTS.AGGREGATE_ID,
+        TEST_CONSTANTS.AGGREGATE_TYPE,
+        tenantId,
+        TEST_CONSTANTS.EVENT_TYPE_1,
+        occurredAt,
+        undefined,
+        {},
+        id,
+      );
+    }
+
+    function batchFold(store: ReturnType<typeof createMockFoldProjectionStore>) {
+      return createMockFoldProjectionDefinition("my-fold", {
+        store,
+        eventTypes: [TEST_CONSTANTS.EVENT_TYPE_1],
+        init: () => ({ count: 0, LastEventOccurredAt: 0 }),
+        apply: (s: any, e: any) => ({
+          count: s.count + 1,
+          LastEventOccurredAt: Math.max(s.LastEventOccurredAt, e.occurredAt ?? 0),
+        }),
+      });
+    }
+
+    describe("when several events for one aggregate are coalesced", () => {
+      /** @scenario 'Coalescing still dispatches per-span reactors for every event' */
+      it("folds the batch once but fires reactors for every event", async () => {
+        const router = new ProjectionRouter(
+          TEST_CONSTANTS.AGGREGATE_TYPE,
+          TEST_CONSTANTS.PIPELINE_NAME,
+          createMockQueueManager(),
+        );
+        const store = createMockFoldProjectionStore();
+        (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        const fold = batchFold(store);
+        router.registerFoldProjection(fold);
+
+        const seen: string[] = [];
+        const reactor: ReactorDefinition<Event> = {
+          name: "per-span-spy",
+          handle: async (event) => {
+            seen.push(event.id);
+          },
+        };
+        router.registerReactor("my-fold", reactor);
+
+        const events = [
+          makeBatchEvent("e1", 1000),
+          makeBatchEvent("e2", 2000),
+          makeBatchEvent("e3", 3000),
+        ];
+
+        await (router as any).processFoldProjectionBatch("my-fold", fold, events, { tenantId });
+
+        // The expensive fold load/store happens once — the O(n) win.
+        expect(store.get).toHaveBeenCalledTimes(1);
+        expect(store.store).toHaveBeenCalledTimes(1);
+        // Per-span reactors (embedded-eval sync, evaluation triggers) must see
+        // EVERY event, not just the last — otherwise N-1 spans are dropped.
+        expect(seen).toEqual(["e1", "e2", "e3"]);
+      });
+
+      it("dispatches reactors in occurredAt order even when events arrive shuffled", async () => {
+        const router = new ProjectionRouter(
+          TEST_CONSTANTS.AGGREGATE_TYPE,
+          TEST_CONSTANTS.PIPELINE_NAME,
+          createMockQueueManager(),
+        );
+        const store = createMockFoldProjectionStore();
+        (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        const fold = batchFold(store);
+        router.registerFoldProjection(fold);
+
+        const seen: string[] = [];
+        router.registerReactor("my-fold", {
+          name: "spy",
+          handle: async (event) => {
+            seen.push(event.id);
+          },
+        });
+
+        const events = [
+          makeBatchEvent("third", 3000),
+          makeBatchEvent("first", 1000),
+          makeBatchEvent("second", 2000),
+        ];
+
+        await (router as any).processFoldProjectionBatch("my-fold", fold, events, { tenantId });
+
+        expect(seen).toEqual(["first", "second", "third"]);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/projections/foldProjection.types.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjection.types.ts
@@ -88,6 +88,13 @@ export interface FoldProjectionDefinition<
 export interface FoldProjectionOptions {
   /** Kill switch configuration. When enabled, the projection is disabled. */
   killSwitch?: KillSwitchOptions;
+  /**
+   * Maximum number of same-aggregate events to coalesce into a single
+   * load/apply/store cycle when the group is backed up. 1 (the default)
+   * disables coalescing. Higher values bound how much of a backed-up group
+   * is drained per dispatch — converting an O(n²) backlog into O(n).
+   */
+  coalesceMaxBatch?: number;
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -85,6 +85,93 @@ export class FoldProjectionExecutor {
     return state;
   }
 
+  /**
+   * Applies a batch of events for the same aggregate in a single load/store cycle.
+   *
+   * Equivalent to calling `execute()` once per event, but reads the existing
+   * state once, folds every event in occurredAt order, and writes the result
+   * once. This turns a backed-up group of N events from N load+store round-trips
+   * (O(n²) on growing fold state) into a single one (O(n)).
+   *
+   * Out-of-order handling matches `execute()`: if the earliest event in the
+   * batch occurred before the persisted checkpoint, the aggregate is re-folded
+   * from scratch via `eventLoader` (when available).
+   */
+  async executeBatch<State, E extends Event>(
+    projection: FoldProjectionDefinition<State, E>,
+    events: E[],
+    context: ProjectionStoreContext,
+  ): Promise<State> {
+    const matching = events.filter((event) => this.matchesEventTypes(projection, event));
+    if (matching.length === 0) {
+      return projection.init();
+    }
+    if (matching.length === 1) {
+      return this.execute(projection, matching[0]!, context);
+    }
+
+    // Process in occurredAt order so the fold sees events as they happened,
+    // regardless of the order they were dispatched/drained in.
+    const ordered = [...matching].sort(
+      (a, b) =>
+        (((a as Record<string, unknown>).occurredAt as number) ?? 0) -
+        (((b as Record<string, unknown>).occurredAt as number) ?? 0),
+    );
+
+    const key = context.key ?? context.aggregateId;
+    let state = (await projection.store.get(key, context)) ?? projection.init();
+
+    const prevLastOccurred =
+      (state as Record<string, unknown>)[projection.LastEventOccurredAtKey] ?? 0;
+    const earliestOccurredAt = (ordered[0] as Record<string, unknown>).occurredAt;
+
+    // Out-of-order vs the persisted checkpoint: the batch starts earlier than
+    // what we've already folded. Re-fold from scratch when we can load the full
+    // history; otherwise fall through and apply the batch on top (matches the
+    // single-event executor's degraded behavior when no eventLoader exists).
+    const outOfOrder =
+      typeof earliestOccurredAt === "number" &&
+      earliestOccurredAt > 0 &&
+      typeof prevLastOccurred === "number" &&
+      earliestOccurredAt < prevLastOccurred;
+
+    if (outOfOrder && projection.eventLoader) {
+      const allEvents = await projection.eventLoader({
+        tenantId: context.tenantId,
+        aggregateId: context.aggregateId,
+      });
+      logger.info(
+        {
+          projection: projection.name,
+          aggregateId: context.aggregateId,
+          tenantId: context.tenantId,
+          batchSize: ordered.length,
+          earliestOccurredAt,
+          prevLastOccurred,
+          refoldEventCount: allEvents.length,
+        },
+        "Out-of-order batch detected, re-folding from scratch",
+      );
+      state = projection.init();
+      for (const e of allEvents) {
+        state = projection.apply(state, e as E);
+      }
+    } else {
+      if (outOfOrder) {
+        logger.warn(
+          { projection: projection.name, aggregateId: context.aggregateId },
+          "Out-of-order batch detected but no eventLoader available — cannot re-fold",
+        );
+      }
+      for (const event of ordered) {
+        state = projection.apply(state, event);
+      }
+    }
+
+    await projection.store.store(state, context);
+    return state;
+  }
+
   private matchesEventTypes<State, E extends Event>(
     projection: FoldProjectionDefinition<State, E>,
     event: E,

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -37,8 +37,9 @@ import type { ReplayMarkerChecker } from "./replayMarkerCheck";
 
 /**
  * Default cap on how many same-aggregate fold events are coalesced into one
- * load/apply/store cycle. Bounds the drain + apply loop (and the re-stage loop
- * on failure) while still collapsing a backed-up group from O(n²) to O(n).
+ * load/apply/store cycle. Bounds the per-cycle drain + apply loop (and the
+ * re-stage loop on failure) while collapsing a backed-up group from O(n²) to
+ * O(n). A fold can opt out by setting options.coalesceMaxBatch = 1.
  */
 const DEFAULT_FOLD_COALESCE_MAX_BATCH = 100;
 
@@ -242,9 +243,19 @@ export class ProjectionRouter<
       projectionDefs[name] = {
         name,
         groupKeyFn: fold.key,
-        // Coalesce a backed-up group's events into one fold cycle. Defaults on
-        // for every fold (harmless at batch size 1 when keeping up); a fold can
-        // override or opt out via options.coalesceMaxBatch.
+        // Coalesce a backed-up group's events into one fold load/apply/store
+        // cycle. On for every fold (harmless at batch size 1 when the queue
+        // keeps up). Safe for all folds because: the final folded state is
+        // identical to applying events one at a time (pure left-fold, the
+        // intermediate stores never affect the result); processFoldProjectionBatch
+        // still dispatches reactors per event, so event-sensitive reactors
+        // (per-span eval sync, evaluation/scenario triggers keyed on event type)
+        // see every event; and out-of-order is handled identically to the
+        // single-event path (executeBatch sorts by occurredAt and uses the same
+        // checkpoint re-fold). The only difference is reactors observe the final
+        // batch fold-state, which is the correct "current state" for a
+        // react-after-fold side effect. A fold can opt out via
+        // options.coalesceMaxBatch = 1.
         coalesceMaxBatch: fold.options?.coalesceMaxBatch ?? DEFAULT_FOLD_COALESCE_MAX_BATCH,
         options: fold.options,
       };
@@ -698,6 +709,15 @@ export class ProjectionRouter<
         }
         if (toApply.length === 0) return;
 
+        // Apply (and dispatch reactors) in occurredAt order — the same order
+        // executeBatch folds in — so reactor metadata and the final state are
+        // consistent regardless of the order events were drained/dispatched in.
+        toApply = [...toApply].sort(
+          (a, b) =>
+            (((a as Record<string, unknown>).occurredAt as number) ?? 0) -
+            (((b as Record<string, unknown>).occurredAt as number) ?? 0),
+        );
+
         const first = toApply[0]!;
         const key = fold.key ? fold.key(first) : undefined;
         const storeContext: ProjectionStoreContext = {
@@ -712,15 +732,19 @@ export class ProjectionRouter<
           onFail: (ms) => { incrementEsFoldProjectionTotal(this.pipelineName, projectionName, "failed"); observeEsFoldProjectionDuration(this.pipelineName, projectionName, ms); },
         });
 
-        // Dispatch reactors once with the final state, using the last event.
+        // Dispatch reactors for EVERY folded event, with the final fold state.
+        // Fold-state reactors (broadcast, metadata, alerts) carry makeJobId
+        // dedup and collapse to one effective run, so firing per event is cheap.
+        // Per-span reactors must see every event: customEvaluationSync reads
+        // event.data.span to extract embedded SDK evals, and evaluationTrigger
+        // inspects each span's attributes — firing only once would silently
+        // drop N-1 spans' work, and only under backlog (the recovery path).
+        // The O(n²)->O(n) win lives in the single fold load/store, not here.
         const reactors = this.reactorsForFold.get(projectionName);
         if (reactors && reactors.length > 0) {
-          await this.dispatchToReactors(
-            projectionName,
-            reactors,
-            toApply[toApply.length - 1]!,
-            foldState,
-          );
+          for (const event of toApply) {
+            await this.dispatchToReactors(projectionName, reactors, event, foldState);
+          }
         }
       },
     );

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -36,6 +36,13 @@ import type { ProjectionStoreContext } from "./projectionStoreContext";
 import type { ReplayMarkerChecker } from "./replayMarkerCheck";
 
 /**
+ * Default cap on how many same-aggregate fold events are coalesced into one
+ * load/apply/store cycle. Bounds the drain + apply loop (and the re-stage loop
+ * on failure) while still collapsing a backed-up group from O(n²) to O(n).
+ */
+const DEFAULT_FOLD_COALESCE_MAX_BATCH = 100;
+
+/**
  * Central router that registers fold and map projections and dispatches events.
  *
  * - FoldProjections: enqueued to GroupQueue (per-aggregate ordering), incremental only
@@ -227,6 +234,7 @@ export class ProjectionRouter<
     const projectionDefs: Record<string, {
       name: string;
       groupKeyFn?: (event: EventType) => string;
+      coalesceMaxBatch?: number;
       options?: { killSwitch?: KillSwitchOptions };
     }> = {};
 
@@ -234,6 +242,10 @@ export class ProjectionRouter<
       projectionDefs[name] = {
         name,
         groupKeyFn: fold.key,
+        // Coalesce a backed-up group's events into one fold cycle. Defaults on
+        // for every fold (harmless at batch size 1 when keeping up); a fold can
+        // override or opt out via options.coalesceMaxBatch.
+        coalesceMaxBatch: fold.options?.coalesceMaxBatch ?? DEFAULT_FOLD_COALESCE_MAX_BATCH,
         options: fold.options,
       };
     }
@@ -255,6 +267,23 @@ export class ProjectionRouter<
           fold,
           triggerEvent,
           { tenantId: triggerEvent.tenantId },
+        );
+      },
+      async (projectionName, events, _context) => {
+        const fold = this.foldProjections.get(projectionName);
+        if (!fold) {
+          throw new ConfigurationError(
+            "ProjectionRouter",
+            `Fold projection "${projectionName}" not found`,
+            { projectionName },
+          );
+        }
+
+        await this.processFoldProjectionBatch(
+          projectionName,
+          fold,
+          events,
+          { tenantId: events[0]!.tenantId },
         );
       },
     );
@@ -610,6 +639,88 @@ export class ProjectionRouter<
         const reactors = this.reactorsForFold.get(projectionName);
         if (reactors && reactors.length > 0) {
           await this.dispatchToReactors(projectionName, reactors, event, foldState);
+        }
+      },
+    );
+  }
+
+  /**
+   * Processes a batch of same-aggregate events for a fold projection in a single
+   * load/apply/store cycle (see FoldProjectionExecutor.executeBatch). Used by the
+   * GroupQueue's coalescing path when a group is backed up. All events share the
+   * aggregate (and tenant), so kill-switch and store key are resolved once.
+   *
+   * Reactors fire once with the final folded state (using the last event), which
+   * is the correct coalesced behavior for the trace's debounced reactors.
+   */
+  private async processFoldProjectionBatch(
+    projectionName: string,
+    fold: FoldProjectionDefinition<any, EventType>,
+    events: EventType[],
+    context: EventStoreReadContext<EventType>,
+  ): Promise<void> {
+    if (events.length === 0) return;
+
+    await this.tracer.withActiveSpan(
+      "ProjectionRouter.processFoldProjectionBatch",
+      {
+        kind: SpanKind.INTERNAL,
+        attributes: {
+          "projection.name": projectionName,
+          "event.count": events.length,
+          "event.aggregate_id": String(events[0]!.aggregateId),
+        },
+      },
+      async () => {
+        EventUtils.validateTenantId(context, "processFoldProjectionBatch");
+
+        // Check kill switch (all events share the tenant)
+        const disabled = await isComponentDisabled({
+          featureFlagService: this.featureFlagService,
+          aggregateType: this.aggregateType,
+          componentType: "projection",
+          componentName: projectionName,
+          tenantId: events[0]!.tenantId,
+          customKey: fold.options?.killSwitch?.customKey,
+          logger: this.logger,
+        });
+        if (disabled) return;
+
+        // Defer or skip events for which projection-replay is active.
+        let toApply = events;
+        if (this.replayMarkerChecker) {
+          const kept: EventType[] = [];
+          for (const event of events) {
+            const decision = await this.replayMarkerChecker.check(projectionName, event);
+            if (decision !== "skip") kept.push(event);
+          }
+          toApply = kept;
+        }
+        if (toApply.length === 0) return;
+
+        const first = toApply[0]!;
+        const key = fold.key ? fold.key(first) : undefined;
+        const storeContext: ProjectionStoreContext = {
+          aggregateId: String(first.aggregateId),
+          tenantId: first.tenantId,
+          key,
+        };
+
+        const foldState = await withMetrics({
+          fn: () => this.foldExecutor.executeBatch(fold, toApply, storeContext),
+          onComplete: (ms) => { incrementEsFoldProjectionTotal(this.pipelineName, projectionName, "completed"); observeEsFoldProjectionDuration(this.pipelineName, projectionName, ms); },
+          onFail: (ms) => { incrementEsFoldProjectionTotal(this.pipelineName, projectionName, "failed"); observeEsFoldProjectionDuration(this.pipelineName, projectionName, ms); },
+        });
+
+        // Dispatch reactors once with the final state, using the last event.
+        const reactors = this.reactorsForFold.get(projectionName);
+        if (reactors && reactors.length > 0) {
+          await this.dispatchToReactors(
+            projectionName,
+            reactors,
+            toApply[toApply.length - 1]!,
+            foldState,
+          );
         }
       },
     );

--- a/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
+++ b/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
@@ -18,13 +18,27 @@ export interface RedisCachedFoldStoreOptions {
 }
 
 /**
- * Default cache TTL. Sized to outlast the processing of a single aggregate's
- * event stream so the fold state stays warm in Redis across consecutive
- * events, instead of expiring mid-stream and forcing a ClickHouse fallback
- * read of the (potentially large) state on every event. Matches the queue's
- * activeTtlSec — the upper bound on how long one aggregate stays in-flight.
+ * Default cache TTL, in seconds. Sized to outlast the processing of a single
+ * aggregate's event stream so the fold state stays warm in Redis across
+ * consecutive events instead of expiring mid-stream and forcing a ClickHouse
+ * fallback read of the (potentially large) state on every event. Matches the
+ * queue's activeTtlSec — the upper bound on how long one aggregate stays
+ * in-flight.
+ *
+ * Overridable via LANGWATCH_FOLD_CACHE_TTL_SECONDS (read at call time, like
+ * LANGWATCH_DISPATCH_TENANT_CAP) so operators can dial residency down without a
+ * redeploy: the fold-cache key set is one entry per aggregate touched within
+ * the TTL window, so a longer TTL trades Redis memory for fewer ClickHouse
+ * fallback reads. Group-coalescing already collapses an aggregate's in-flight
+ * reads to one per batch, so this is a secondary lever, not the primary fix.
  */
-const DEFAULT_FOLD_CACHE_TTL_SECONDS = 300;
+function defaultFoldCacheTtlSeconds(): number {
+  const raw = process.env.LANGWATCH_FOLD_CACHE_TTL_SECONDS;
+  if (raw === undefined || raw === "") return 300;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 300;
+  return parsed;
+}
 
 /**
  * Wraps any FoldProjectionStore with a Redis write-through cache.
@@ -48,7 +62,7 @@ export class RedisCachedFoldStore<State>
     options: RedisCachedFoldStoreOptions,
   ) {
     this.keyPrefix = options.keyPrefix;
-    this.ttlSeconds = options.ttlSeconds ?? DEFAULT_FOLD_CACHE_TTL_SECONDS;
+    this.ttlSeconds = options.ttlSeconds ?? defaultFoldCacheTtlSeconds();
   }
 
   async get(

--- a/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
+++ b/langwatch/src/server/event-sourcing/projections/redisCachedFoldStore.ts
@@ -18,6 +18,15 @@ export interface RedisCachedFoldStoreOptions {
 }
 
 /**
+ * Default cache TTL. Sized to outlast the processing of a single aggregate's
+ * event stream so the fold state stays warm in Redis across consecutive
+ * events, instead of expiring mid-stream and forcing a ClickHouse fallback
+ * read of the (potentially large) state on every event. Matches the queue's
+ * activeTtlSec — the upper bound on how long one aggregate stays in-flight.
+ */
+const DEFAULT_FOLD_CACHE_TTL_SECONDS = 300;
+
+/**
  * Wraps any FoldProjectionStore with a Redis write-through cache.
  *
  * - get(): Redis first, ClickHouse fallback on miss.
@@ -39,7 +48,7 @@ export class RedisCachedFoldStore<State>
     options: RedisCachedFoldStoreOptions,
   ) {
     this.keyPrefix = options.keyPrefix;
-    this.ttlSeconds = options.ttlSeconds ?? 30;
+    this.ttlSeconds = options.ttlSeconds ?? DEFAULT_FOLD_CACHE_TTL_SECONDS;
   }
 
   async get(

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -402,5 +402,183 @@ describe.skipIf(!hasTestcontainers)(
         });
       });
     });
+
+    describe("group coalescing", () => {
+      describe("when a group is backed up", () => {
+        /** @scenario 'A backed-up group is folded in a single batch call' */
+        it("folds the queued events into a single processBatch call", async () => {
+          const batches: TestPayload[][] = [];
+          const singles: TestPayload[] = [];
+          const queue = createQueue(
+            async (p) => {
+              singles.push(p);
+            },
+            {
+              processBatch: async (ps) => {
+                batches.push(ps as TestPayload[]);
+              },
+              coalesceMaxBatch: () => 50,
+              score: (p) => Number(p.value) * 1000,
+            },
+          );
+          await queue.waitUntilReady();
+
+          const payloads = Array.from({ length: 10 }, (_, i) => ({
+            id: `j${i}`,
+            groupId: "group-a",
+            value: String(i),
+          }));
+          await queue.sendBatch(payloads);
+
+          await vi.waitFor(
+            () => {
+              const total = batches.reduce((n, b) => n + b.length, 0) + singles.length;
+              expect(total).toBe(10);
+            },
+            { timeout: 10000, interval: 50 },
+          );
+
+          // Coalescing actually happened: at least one multi-event batch.
+          expect(batches.length).toBeGreaterThanOrEqual(1);
+          expect(Math.max(...batches.map((b) => b.length))).toBeGreaterThan(1);
+          // Every event processed exactly once across batches + singles.
+          const allIds = [...batches.flat(), ...singles].map((p) => p.id);
+          expect(new Set(allIds).size).toBe(10);
+        });
+
+        it("delivers a coalesced batch in ascending score order", async () => {
+          let largest: TestPayload[] = [];
+          const queue = createQueue(async () => {}, {
+            processBatch: async (ps) => {
+              if (ps.length > largest.length) largest = ps as TestPayload[];
+            },
+            coalesceMaxBatch: () => 50,
+            score: (p) => Number(p.value) * 1000,
+          });
+          await queue.waitUntilReady();
+
+          // Send shuffled; the queue must still fold them in score order.
+          await queue.sendBatch(
+            [4, 2, 0, 3, 1].map((n) => ({ id: `j${n}`, groupId: "group-a", value: String(n) })),
+          );
+
+          await vi.waitFor(
+            () => {
+              expect(largest.length).toBe(5);
+            },
+            { timeout: 10000, interval: 50 },
+          );
+          expect(largest.map((p) => Number(p.value))).toEqual([0, 1, 2, 3, 4]);
+        });
+
+        /** @scenario 'Coalescing respects the configured max batch size' */
+        it("never exceeds coalesceMaxBatch per call", async () => {
+          const batches: TestPayload[][] = [];
+          const singles: TestPayload[] = [];
+          const queue = createQueue(
+            async (p) => {
+              singles.push(p);
+            },
+            {
+              processBatch: async (ps) => {
+                batches.push(ps as TestPayload[]);
+              },
+              coalesceMaxBatch: () => 3,
+              score: (p) => Number(p.value) * 1000,
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 9 }, (_, i) => ({ id: `j${i}`, groupId: "group-a", value: String(i) })),
+          );
+
+          await vi.waitFor(
+            () => {
+              const total = batches.reduce((n, b) => n + b.length, 0) + singles.length;
+              expect(total).toBe(9);
+            },
+            { timeout: 10000, interval: 50 },
+          );
+
+          for (const batch of batches) {
+            expect(batch.length).toBeLessThanOrEqual(3);
+          }
+          const allIds = [...batches.flat(), ...singles].map((p) => p.id);
+          expect(new Set(allIds).size).toBe(9);
+        });
+      });
+
+      describe("when coalescing is disabled (maxBatch 1)", () => {
+        /** @scenario 'Coalescing is a no-op when disabled' */
+        it("processes each event individually and never calls processBatch", async () => {
+          const batches: TestPayload[][] = [];
+          const singles: TestPayload[] = [];
+          const queue = createQueue(
+            async (p) => {
+              singles.push(p);
+            },
+            {
+              processBatch: async (ps) => {
+                batches.push(ps as TestPayload[]);
+              },
+              coalesceMaxBatch: () => 1,
+              score: (p) => Number(p.value) * 1000,
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 5 }, (_, i) => ({ id: `j${i}`, groupId: "group-a", value: String(i) })),
+          );
+
+          await vi.waitFor(
+            () => {
+              expect(singles.length).toBe(5);
+            },
+            { timeout: 10000, interval: 50 },
+          );
+          expect(batches.length).toBe(0);
+        });
+      });
+
+      describe("when a coalesced batch fails", () => {
+        /** @scenario 'A failed coalesced batch re-stages its drained siblings' */
+        it("re-stages drained siblings so none are lost", async () => {
+          let attempts = 0;
+          const succeeded: TestPayload[] = [];
+          const queue = createQueue(
+            async (p) => {
+              succeeded.push(p);
+            },
+            {
+              processBatch: async (ps) => {
+                attempts++;
+                if (attempts === 1) {
+                  throw new Error("simulated batch failure");
+                }
+                for (const p of ps) succeeded.push(p as TestPayload);
+              },
+              coalesceMaxBatch: () => 50,
+              score: (p) => Number(p.value) * 1000,
+            },
+          );
+          await queue.waitUntilReady();
+
+          await queue.sendBatch(
+            Array.from({ length: 4 }, (_, i) => ({ id: `j${i}`, groupId: "group-a", value: String(i) })),
+          );
+
+          // Despite the first batch throwing, every event is eventually
+          // processed — the drained siblings were re-staged, not lost.
+          await vi.waitFor(
+            () => {
+              expect(new Set(succeeded.map((p) => p.id)).size).toBe(4);
+            },
+            { timeout: 20000, interval: 100 },
+          );
+        });
+      });
+    });
   },
 );

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -2702,3 +2702,104 @@ describe("GroupStagingScripts", () => {
     });
   });
 });
+
+async function inspectTotalPending() {
+  return redis.get(`${keyPrefix()}stats:total-pending`);
+}
+
+describe("GroupStagingScripts.drainGroupReady", () => {
+  describe("when a group has several due jobs", () => {
+    it("drains up to maxJobs in ascending score order with their data", async () => {
+      await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100, jobDataJson: '{"n":1}' }));
+      await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200, jobDataJson: '{"n":2}' }));
+      await scripts.stage(makeJob({ stagedJobId: "j3", dispatchAfterMs: 300, jobDataJson: '{"n":3}' }));
+
+      const drained = await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 10_000,
+        maxJobs: 2,
+      });
+
+      expect(drained.map((d) => d.stagedJobId)).toEqual(["j1", "j2"]);
+      expect(drained.map((d) => d.jobDataJson)).toEqual(['{"n":1}', '{"n":2}']);
+      expect(drained.map((d) => d.originalScore)).toEqual([100, 200]);
+    });
+
+    it("removes drained jobs from the group's jobs zset and data hash", async () => {
+      await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+      await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
+      await scripts.stage(makeJob({ stagedJobId: "j3", dispatchAfterMs: 300 }));
+
+      await scripts.drainGroupReady({ groupId: "group-a", nowMs: 10_000, maxJobs: 2 });
+
+      const jobs = await inspectGroupJobs("group-a");
+      expect(jobs).toEqual(["j3", "300"]);
+      const data = await inspectDataHash("group-a");
+      expect(Object.keys(data)).toEqual(["j3"]);
+    });
+
+    /** @scenario 'Draining siblings for coalescing decrements pending per job' */
+    it("decrements total-pending by the number drained", async () => {
+      await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+      await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
+      await scripts.stage(makeJob({ stagedJobId: "j3", dispatchAfterMs: 300 }));
+      expect(await inspectTotalPending()).toBe("3");
+
+      await scripts.drainGroupReady({ groupId: "group-a", nowMs: 10_000, maxJobs: 2 });
+
+      expect(await inspectTotalPending()).toBe("1");
+    });
+  });
+
+  describe("when the group has an active key and ready entry", () => {
+    it("leaves active, ready, and blocked state untouched", async () => {
+      await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+      await scripts.stage(makeJob({ stagedJobId: "j2", dispatchAfterMs: 200 }));
+      // Simulate the caller holding the active slot for the dispatched job.
+      await redis.set(`${keyPrefix()}group:group-a:active`, "dispatched-job");
+      const readyBefore = await inspectReadySet();
+
+      await scripts.drainGroupReady({ groupId: "group-a", nowMs: 10_000, maxJobs: 5 });
+
+      expect(await inspectActiveKey("group-a")).toBe("dispatched-job");
+      expect(await inspectReadySet()).toEqual(readyBefore);
+      expect(await inspectBlockedSet()).toEqual([]);
+    });
+  });
+
+  describe("when some jobs are future-scheduled", () => {
+    it("drains only the jobs due at nowMs", async () => {
+      await scripts.stage(makeJob({ stagedJobId: "due1", dispatchAfterMs: 100 }));
+      await scripts.stage(makeJob({ stagedJobId: "due2", dispatchAfterMs: 200 }));
+      await scripts.stage(makeJob({ stagedJobId: "future", dispatchAfterMs: 9_999 }));
+
+      const drained = await scripts.drainGroupReady({
+        groupId: "group-a",
+        nowMs: 1_000,
+        maxJobs: 10,
+      });
+
+      expect(drained.map((d) => d.stagedJobId)).toEqual(["due1", "due2"]);
+      const jobs = await inspectGroupJobs("group-a");
+      expect(jobs).toEqual(["future", "9999"]);
+    });
+  });
+
+  describe("when maxJobs is zero or negative", () => {
+    it("returns empty without touching the group", async () => {
+      await scripts.stage(makeJob({ stagedJobId: "j1", dispatchAfterMs: 100 }));
+
+      expect(await scripts.drainGroupReady({ groupId: "group-a", nowMs: 10_000, maxJobs: 0 })).toEqual([]);
+
+      const jobs = await inspectGroupJobs("group-a");
+      expect(jobs).toEqual(["j1", "100"]);
+      expect(await inspectTotalPending()).toBe("1");
+    });
+  });
+
+  describe("when the group is empty", () => {
+    it("returns empty", async () => {
+      expect(await scripts.drainGroupReady({ groupId: "nonexistent", nowMs: 10_000, maxJobs: 5 })).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -37,7 +37,7 @@ import {
   gqJobDurationMilliseconds,
 } from "./metrics";
 import { GroupQueueMetricsCollector } from "./metricsCollector";
-import { type DispatchResult, GroupStagingScripts } from "./scripts";
+import { type DispatchResult, type DrainedJob, GroupStagingScripts } from "./scripts";
 import {
   TenantRateTracker,
   tenantIdFromGroupId,
@@ -94,6 +94,8 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   private readonly queueName: string;
   private readonly jobName: string;
   private readonly process: (payload: Payload) => Promise<void>;
+  private readonly processBatch?: (payloads: Payload[]) => Promise<void>;
+  private readonly coalesceMaxBatch?: (payload: Payload) => number | undefined;
   private readonly spanAttributes?: (payload: Payload) => SemConvAttributes;
   private readonly processingQueue: fastq.queueAsPromised<DispatchResult, void>;
   private readonly delay?: number;
@@ -121,6 +123,8 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const {
       name,
       process,
+      processBatch,
+      coalesceMaxBatch,
       options: defOptions,
       delay,
       spanAttributes,
@@ -162,6 +166,8 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     this.queueName = name;
     this.jobName = "queue";
     this.process = process;
+    this.processBatch = processBatch;
+    this.coalesceMaxBatch = coalesceMaxBatch;
     this.globalConcurrency =
       defOptions?.globalConcurrency ??
       GROUP_QUEUE_CONFIG.defaultGlobalConcurrency;
@@ -443,6 +449,46 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const routingLabels = { queue_name: this.queueName, pipeline_name: pipelineName, job_type: jobType, job_name: jobName };
     const payload = this.stripInternalFields(jobData);
 
+    // Opt-in batch coalescing: if this job type supports it, drain additional
+    // already-staged DUE jobs from the same group and fold them alongside the
+    // dispatched one in a single handler call. The group's active key (held by
+    // this job) guarantees no other worker dequeues from the group meanwhile,
+    // so the drain is exclusive. Drained siblings are re-staged on failure so
+    // they are not lost. When disabled (maxBatch <= 1) this is a no-op and the
+    // per-job path below is unchanged.
+    const maxBatch = this.coalesceMaxBatch?.(payload) ?? 1;
+    let batchPayloads: Payload[] | null = null;
+    let drainedSiblings: DrainedJob[] = [];
+    if (maxBatch > 1 && this.processBatch) {
+      try {
+        drainedSiblings = await this.scripts.drainGroupReady({
+          groupId,
+          nowMs: Date.now(),
+          maxJobs: maxBatch - 1,
+        });
+      } catch (err) {
+        this.logger.warn(
+          {
+            queueName: this.queueName,
+            groupId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "Failed to drain group siblings for coalescing — processing single job",
+        );
+        drainedSiblings = [];
+      }
+      if (drainedSiblings.length > 0) {
+        const siblingPayloads: Payload[] = [];
+        for (const sibling of drainedSiblings) {
+          const parsed = this.parseDrainedPayload(sibling, groupId);
+          if (parsed) siblingPayloads.push(parsed);
+        }
+        if (siblingPayloads.length > 0) {
+          batchPayloads = [payload, ...siblingPayloads];
+        }
+      }
+    }
+
     const jobStartTime = performance.now();
     const heartbeat = this.startActiveKeyHeartbeat({ groupId, stagedJobId });
     this.activeJobCount++;
@@ -506,10 +552,17 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               // Run the actual handler with request context propagation
               const requestContext = createContextFromJobData(contextMetadata);
               await runWithContext(requestContext, async () => {
-                await this.process(payload);
+                if (batchPayloads && this.processBatch) {
+                  span.setAttribute("queue.coalesced_batch_size", batchPayloads.length);
+                  await this.processBatch(batchPayloads);
+                } else {
+                  await this.process(payload);
+                }
               });
 
-              // Success — complete the group slot
+              // Success — complete the group slot. Drained siblings were
+              // removed from staging during the drain, so completing the
+              // dispatched job is enough to free the group.
               await this.scripts.complete({ groupId, stagedJobId, jobName });
               gqJobsCompletedTotal.inc(routingLabels);
 
@@ -526,6 +579,14 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               const error = err instanceof Error ? err : new Error(String(err));
               const category = categorizeError(err);
               const isRetryable = category !== ErrorCategory.CRITICAL;
+
+              // The batch stores its fold state only once, at the very end, so a
+              // failure means nothing was persisted for the drained siblings.
+              // Re-stage them so they are re-dispatched (and re-coalesced) on the
+              // dispatched job's retry, rather than lost until an event replay.
+              if (drainedSiblings.length > 0) {
+                await this.restageDrainedSiblings(groupId, drainedSiblings);
+              }
 
               if (isRetryable && attempt < JOB_RETRY_CONFIG.maxAttempts) {
                 // Re-stage with backoff — frees the worker slot immediately
@@ -625,6 +686,59 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       delete clean[field];
     }
     return clean as Payload;
+  }
+
+  /**
+   * Parses a drained sibling's stored JSON into a clean payload. Returns null
+   * on parse failure (the job was already removed from staging; it is dropped
+   * here and recoverable via event replay, mirroring the dispatched job's own
+   * parse-failure handling).
+   */
+  private parseDrainedPayload(sibling: DrainedJob, groupId: string): Payload | null {
+    try {
+      const jobData = JSON.parse(sibling.jobDataJson) as Record<string, unknown>;
+      return this.stripInternalFields(jobData);
+    } catch {
+      this.logger.error(
+        { queueName: this.queueName, groupId, stagedJobId: sibling.stagedJobId },
+        "Failed to parse drained sibling job data — dropping (recoverable via replay)",
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Re-stages siblings drained for a batch that ultimately failed, so they are
+   * re-dispatched instead of lost. Each is staged with its original score and
+   * raw job data (context metadata preserved). Best-effort: a re-stage failure
+   * is logged, not thrown, so it never masks the original processing error.
+   */
+  private async restageDrainedSiblings(
+    groupId: string,
+    siblings: DrainedJob[],
+  ): Promise<void> {
+    for (const sibling of siblings) {
+      try {
+        await this.scripts.stage({
+          stagedJobId: sibling.stagedJobId,
+          groupId,
+          dispatchAfterMs: sibling.originalScore,
+          dedupId: "",
+          dedupTtlMs: 0,
+          jobDataJson: sibling.jobDataJson,
+        });
+      } catch (err) {
+        this.logger.error(
+          {
+            queueName: this.queueName,
+            groupId,
+            stagedJobId: sibling.stagedJobId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "Failed to re-stage drained sibling after batch failure (recoverable via replay)",
+        );
+      }
+    }
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -490,6 +490,53 @@ end
 return results
 `;
 
+/**
+ * Pop up to maxJobs additional DUE jobs from a single group's pending queue,
+ * WITHOUT touching the group's active/ready/blocked/signal state.
+ *
+ * Safe to call only while the caller already holds the group's active slot
+ * (dispatch sets group:<id>:active and excludes active groups from dispatch),
+ * so no other worker can concurrently dequeue from this group. Used to coalesce
+ * a backed-up group's queued events into a single fold load/apply/store cycle.
+ *
+ * Mirrors the per-job bookkeeping DISPATCH does for the jobs it removes:
+ * ZREM from the jobs zset, HDEL the job data, and DECR total-pending. It does
+ * NOT mark anything active and does NOT re-score ready — the caller's active
+ * job remains the one that frees the group on COMPLETE.
+ */
+const DRAIN_GROUP_LUA = `
+local jobsKey         = KEYS[1]
+local dataKey         = KEYS[2]
+local totalPendingKey = KEYS[3]
+
+local nowMs   = tonumber(ARGV[1])
+local maxJobs = tonumber(ARGV[2])
+
+local results = {}
+if maxJobs <= 0 then
+  return results
+end
+
+local entries = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, maxJobs)
+local i = 1
+while i < #entries do
+  local stagedJobId   = entries[i]
+  local originalScore = entries[i + 1]
+  i = i + 2
+
+  redis.call("ZREM", jobsKey, stagedJobId)
+  local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+  redis.call("HDEL", dataKey, stagedJobId)
+  redis.call("DECR", totalPendingKey)
+
+  results[#results + 1] = stagedJobId
+  results[#results + 1] = jobDataJson or ""
+  results[#results + 1] = tostring(originalScore)
+end
+
+return results
+`;
+
 const COMPLETE_LUA = `
 local activeKey       = KEYS[1]
 local jobsKey         = KEYS[2]
@@ -742,6 +789,17 @@ return 1
 export interface DispatchResult {
   stagedJobId: string;
   groupId: string;
+  jobDataJson: string;
+  originalScore: number;
+}
+
+/**
+ * A job drained from a group's pending queue for batch coalescing.
+ * Unlike a DispatchResult it carries no groupId (the caller already knows it)
+ * and is never marked active — it is folded alongside the active job.
+ */
+export interface DrainedJob {
+  stagedJobId: string;
   jobDataJson: string;
   originalScore: number;
 }
@@ -1047,6 +1105,52 @@ export class GroupStagingScripts {
     );
 
     return result === 1;
+  }
+
+  /**
+   * Drain up to maxJobs additional DUE jobs from a group's pending queue without
+   * altering the group's active/ready state. Only safe while the caller holds
+   * the group's active slot. Returns the drained jobs (may be empty).
+   */
+  async drainGroupReady({
+    groupId,
+    nowMs,
+    maxJobs,
+  }: {
+    groupId: string;
+    nowMs: number;
+    maxJobs: number;
+  }): Promise<DrainedJob[]> {
+    if (maxJobs <= 0) return [];
+
+    const jobsKey = `${this.keyPrefix}group:${groupId}:jobs`;
+    const dataKey = `${this.keyPrefix}group:${groupId}:data`;
+    const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
+
+    const result = await this.redis.eval(
+      DRAIN_GROUP_LUA,
+      3,
+      jobsKey,
+      dataKey,
+      totalPendingKey,
+      String(nowMs),
+      String(maxJobs),
+    );
+
+    if (!result || !Array.isArray(result) || result.length < 3) {
+      return [];
+    }
+
+    const drained: DrainedJob[] = [];
+    for (let i = 0; i + 3 <= result.length; i += 3) {
+      drained.push({
+        stagedJobId: String(result[i]),
+        jobDataJson: String(result[i + 1]),
+        originalScore: Number(result[i + 2]),
+      });
+    }
+
+    return drained;
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/queue.types.ts
+++ b/langwatch/src/server/event-sourcing/queues/queue.types.ts
@@ -101,6 +101,23 @@ export interface EventSourcedQueueDefinition<Payload extends Record<string, unkn
   process: (payload: Payload) => Promise<void>;
 
   /**
+   * Optional batch processor. When set together with `coalesceMaxBatch`, the
+   * GroupQueue may fold several queued jobs of the same group into a single
+   * invocation (the dispatched job plus drained siblings), in occurredAt order.
+   * Used by fold projections to collapse a backed-up group's events into one
+   * load/apply/store cycle. The first payload is always the dispatched job.
+   */
+  processBatch?: (payloads: Payload[]) => Promise<void>;
+
+  /**
+   * Optional per-payload resolver for the maximum number of same-group jobs to
+   * coalesce into one `processBatch` call (including the dispatched job).
+   * Returns 1 (or undefined) to disable coalescing for that payload — the
+   * default, which leaves the per-job path byte-for-byte unchanged.
+   */
+  coalesceMaxBatch?: (payload: Payload) => number | undefined;
+
+  /**
    * Optional options for the queue processor.
    */
   options?: EventSourcedQueueProcessorOptions;

--- a/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
+++ b/langwatch/src/server/event-sourcing/services/queues/queueManager.ts
@@ -35,6 +35,18 @@ export interface JobRegistryEntry {
   delay?: number;
   deduplication?: DeduplicationConfig<any>;
   spanAttributes?: (payload: any) => Record<string, string | number | boolean>;
+  /**
+   * Optional batch processor for group coalescing. When set together with
+   * `coalesceMaxBatch > 1`, the global queue may fold several same-group jobs
+   * into one call (the dispatched job plus drained siblings, in occurredAt
+   * order). The first payload is always the dispatched job.
+   */
+  processBatch?: (payloads: any[]) => Promise<void>;
+  /**
+   * Max number of same-group jobs to coalesce into one `processBatch` call
+   * (including the dispatched job). Defaults to 1 (no coalescing).
+   */
+  coalesceMaxBatch?: number;
 }
 
 /**
@@ -271,6 +283,7 @@ export class QueueManager<EventType extends Event = Event> {
     projections: Record<string, {
       name: string;
       groupKeyFn?: (event: EventType) => string;
+      coalesceMaxBatch?: number;
       options?: {
         killSwitch?: KillSwitchOptions;
       };
@@ -278,6 +291,11 @@ export class QueueManager<EventType extends Event = Event> {
     onEvent: (
       projectionName: string,
       event: EventType,
+      context: EventStoreReadContext<EventType>,
+    ) => Promise<void>,
+    onEventBatch?: (
+      projectionName: string,
+      events: EventType[],
       context: EventStoreReadContext<EventType>,
     ) => Promise<void>,
   ): void {
@@ -299,6 +317,7 @@ export class QueueManager<EventType extends Event = Event> {
           ? (event: any) => customGroupKeyFn(event)
           : (event: any) => `${event.aggregateType}:${String(event.aggregateId)}`,
       });
+      const coalesceMaxBatch = projectionDef.coalesceMaxBatch;
       const entry: JobRegistryEntry = {
         groupKeyFn,
         scoreFn: (event: any) => event.occurredAt ?? event.createdAt,
@@ -307,6 +326,18 @@ export class QueueManager<EventType extends Event = Event> {
             tenantId: event.tenantId,
           });
         },
+        // Same-group fold events are coalesced into one load/apply/store cycle.
+        // All events in a batch share the group (= same projection + aggregate),
+        // so the tenant is taken from the first event.
+        processBatch:
+          onEventBatch && coalesceMaxBatch && coalesceMaxBatch > 1
+            ? async (events: any[]) => {
+                await onEventBatch(projectionName, events, {
+                  tenantId: events[0]?.tenantId,
+                });
+              }
+            : undefined,
+        coalesceMaxBatch,
         spanAttributes: (event: any) => ({
           "projection.name": projectionName,
           "event.type": event.type,

--- a/specs/event-sourcing/fold-coalescing.feature
+++ b/specs/event-sourcing/fold-coalescing.feature
@@ -40,6 +40,13 @@ Feature: Group-coalesced fold projections
     When the batch is folded
     Then the events are applied in occurredAt order
 
+  @unit @coalescing @reactors
+  Scenario: Coalescing still dispatches per-span reactors for every event
+    Given a coalesced batch of several events for one aggregate
+    When the batch is folded
+    Then the fold state is loaded and stored once
+    And reactors are dispatched once per event, in occurredAt order
+
   @integration @coalescing @queue
   Scenario: A backed-up group is folded in a single batch call
     Given a group with ten queued events
@@ -66,3 +73,9 @@ Feature: Group-coalesced fold projections
     Given a group whose first batch attempt fails
     When the group is retried
     Then every event is eventually processed and none are lost
+
+  @integration @coalescing @pipeline
+  Scenario: Coalesced folding produces the correct accumulated state through the pipeline
+    Given many spans recorded for one trace in quick succession
+    When the trace summary fold catches up
+    Then the accumulated span count persisted in ClickHouse equals the number of spans recorded

--- a/specs/event-sourcing/fold-coalescing.feature
+++ b/specs/event-sourcing/fold-coalescing.feature
@@ -1,0 +1,68 @@
+Feature: Group-coalesced fold projections
+
+  Fold projections accumulate state by reading the previous state, applying one
+  event, and writing it back. Processed one event at a time, a single aggregate
+  with N queued events costs N load+store round-trips over a state that grows
+  with N — O(n²) on the accumulated state, which on a single-threaded Redis
+  command path stalls the whole queue once a group backs up.
+
+  # Why this exists — incident 2026-05-26
+  #
+  # A 233-span trace (a 50-turn red-team run, no media) backed its fold group
+  # up. Each queued span re-read and re-wrote the multi-MB accumulated state,
+  # 233 times, diverging instead of draining. Shrinking the payload only lowers
+  # the constant; the structural maps (events, span costs, per-role spans) grow
+  # with span count regardless. The fix is to drain a backed-up group's queued
+  # events and fold them in a single load/apply/store cycle: O(n) for the
+  # backlog, self-healing instead of diverging. When the queue keeps up, batches
+  # are size 1 and the per-event path is unchanged.
+
+  Background:
+    Given a fold projection registered on the GroupQueue with coalescing enabled
+
+  @unit @coalescing @fold
+  Scenario: Folding several events reads once and stores once
+    Given an aggregate with three queued events
+    When the events are folded as one batch
+    Then the store is read once and written once
+    And the result reflects all three events
+
+  @unit @coalescing @fold
+  Scenario: Coalesced fold equals sequential folding
+    Given the same three events for one aggregate
+    When they are folded as one batch
+    And separately folded one event at a time
+    Then both produce the same final state
+
+  @unit @coalescing @fold
+  Scenario: Out-of-order events are folded in occurredAt order
+    Given a batch of events received out of occurredAt order
+    When the batch is folded
+    Then the events are applied in occurredAt order
+
+  @integration @coalescing @queue
+  Scenario: A backed-up group is folded in a single batch call
+    Given a group with ten queued events
+    When the group is processed
+    Then the events are delivered to the batch handler in one call
+    And every event is processed exactly once
+
+  @integration @coalescing @queue
+  Scenario: Coalescing respects the configured max batch size
+    Given a group with nine queued events and a max batch size of three
+    When the group is processed
+    Then no batch handed to the handler exceeds three events
+    And every event is processed exactly once
+
+  @integration @coalescing @queue
+  Scenario: Coalescing is a no-op when disabled
+    Given a group with five queued events and coalescing disabled
+    When the group is processed
+    Then each event is processed individually
+    And the batch handler is never called
+
+  @integration @coalescing @queue
+  Scenario: A failed coalesced batch re-stages its drained siblings
+    Given a group whose first batch attempt fails
+    When the group is retried
+    Then every event is eventually processed and none are lost

--- a/specs/event-sourcing/pending-counter-conservation.feature
+++ b/specs/event-sourcing/pending-counter-conservation.feature
@@ -53,3 +53,9 @@ Feature: Pending counter conservation across job lifecycle
     Given multiple tenants with staged, dispatched, and retried jobs
     When the system reaches a quiescent state
     Then total-pending equals the sum of ZCARD across all group :jobs ZSETs
+
+  @integration @counter @coalescing
+  Scenario: Draining siblings for coalescing decrements pending per job
+    Given a group with several staged jobs (INCR at stage)
+    When the coalescing path drains some of them in one call
+    Then the counter is decremented once per drained job (same as dispatch)

--- a/specs/event-sourcing/redis-fold-cache.feature
+++ b/specs/event-sourcing/redis-fold-cache.feature
@@ -22,10 +22,10 @@ Feature: Redis write-through cache for fold projections
     When the fold reads state for "trace-1"
     Then the state is returned from ClickHouse
 
-  Scenario: Store commits to Redis first then fires ClickHouse write
+  Scenario: Store commits to ClickHouse first then updates the Redis cache
     When the fold stores new state for aggregate "trace-1"
-    Then the state is written to Redis with a 300-second TTL
-    And a ClickHouse INSERT is fired without waiting for the async flush
+    Then the state is written to ClickHouse first (throwing on failure so the event is retried)
+    And only then cached in Redis with a 300-second TTL
 
   Scenario: ClickHouse write failure triggers replay from event log
     Given the fold stores new state for aggregate "trace-1"

--- a/specs/event-sourcing/redis-fold-cache.feature
+++ b/specs/event-sourcing/redis-fold-cache.feature
@@ -24,7 +24,7 @@ Feature: Redis write-through cache for fold projections
 
   Scenario: Store commits to Redis first then fires ClickHouse write
     When the fold stores new state for aggregate "trace-1"
-    Then the state is written to Redis with a 30-second TTL
+    Then the state is written to Redis with a 300-second TTL
     And a ClickHouse INSERT is fired without waiting for the async flush
 
   Scenario: ClickHouse write failure triggers replay from event log
@@ -42,7 +42,7 @@ Feature: Redis write-through cache for fold projections
     And the final state is cached in Redis
 
   Scenario: TTL expiry causes graceful fallback to ClickHouse
-    Given the fold state for aggregate "trace-1" was cached 31 seconds ago
+    Given the fold state for aggregate "trace-1" was cached 301 seconds ago
     When the fold reads state for "trace-1"
     Then the state is returned from ClickHouse
 


### PR DESCRIPTION
## What

Fold projections process one event at a time: read the previous state, apply the event, write it back. For a single aggregate with N queued events that is N load+store round-trips over state that grows with N, which is O(n^2) on the accumulated state. The GroupQueue's per-group active gate dispatches one job per group at a time, so a backed-up group drains strictly one event per dispatch and the cost compounds.

When a trace's fold group backs up, this diverges instead of draining and stalls the single-threaded Redis command path for every tenant on the shared queue.

This adds opt-in per-group batch coalescing:

- While a worker holds a group's active slot (which already excludes the group from concurrent dispatch), it drains the group's remaining due jobs in one pop-only Lua call (`drainGroupReady`) and folds them in a single load/apply/store cycle, in occurredAt order (`FoldProjectionExecutor.executeBatch`).
- A backed-up group now drains in O(n) and self-heals. When the queue keeps up, batches are size 1 and the per-event path is byte-for-byte unchanged.
- Bounded by a per-fold max batch (default 100), enabled for all fold projections. Other queues (maps, reactors) are untouched.
- A failed batch re-stages its drained siblings so none are lost (same recovery profile as the existing per-event path).
- The drain decrements `total-pending` once per job, exactly as dispatch does, so the ops counter stays conserved.

Also raises the Redis fold-cache TTL from 30s to 300s so the accumulated state stays warm in Redis across an aggregate's event stream instead of expiring mid-stream and forcing a ClickHouse re-read of the full state on every event.

## Why

This is the read-side half of the fold-projection fix. The structural maps in the trace summary state (events, span costs, per-role spans) grow with span count regardless of payload size, so shrinking payloads alone does not remove the O(n^2). Coalescing collapses the backlog cost itself.

The store-side half (capping oversized span attributes at ingestion, which shrinks the per-event constant) landed separately in #4198. The two compose: #4198 keeps each event small, this keeps a backed-up group from re-reading and re-writing the growing state once per event.

## Scope and safety

- Coalescing is opt-in via `coalesceMaxBatch`; with it at 1 the dispatch, complete, and retry Lua paths are unchanged.
- `drainGroupReady` is pop-only: it never touches the group's active, ready, or blocked state, and is only ever called while the caller holds the group's active slot, so the drain is exclusive.
- The fold is applied in occurredAt order and stored once, which is all-or-nothing per batch: a mid-batch failure leaves the persisted checkpoint untouched and re-stages the siblings, so re-processing folds cleanly from the same checkpoint.
- The in-memory dev/test queue ignores coalescing and keeps the per-event path.

## Tests

- Unit: `executeBatch` reads once and stores once, equals sequential folding, folds out-of-order events in occurredAt order, re-folds via eventLoader when a batch precedes the checkpoint.
- Integration (real Redis): `drainGroupReady` semantics (ascending order, removal, due-only, pending-counter decrement, no-op guards); end-to-end coalescing of a backed-up group into one batch call, max-batch cap, disabled-passthrough, and failed-batch re-stage.

BDD specs: `specs/event-sourcing/fold-coalescing.feature`, plus a coalescing scenario in `pending-counter-conservation.feature` and the TTL update in `redis-fold-cache.feature`.