### PR TITLE
fix(traces): handle large traces in search — batch ClickHouse on OOM + stream response

### DIFF
--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -234,24 +234,8 @@ describe("POST /search", () => {
     });
   });
 
-  describe("when response is streamed", () => {
-    it("produces valid JSON with correct structure", async () => {
-      const res = await searchRequest({
-        startDate: 1000,
-        endDate: 5000,
-      });
-
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toBe("application/json");
-
-      const body = await res.json();
-      expect(body).toHaveProperty("traces");
-      expect(body).toHaveProperty("pagination");
-      expect(body.pagination).toHaveProperty("totalHits", 2);
-      expect(body.traces).toHaveLength(2);
-    });
-
-    it("handles many traces with correct comma separation", async () => {
+  describe("when result set is large", () => {
+    it("serializes many traces with correct comma separation", async () => {
       const manyTraces = Array.from({ length: 50 }, (_, i) => ({
         trace_id: `trace-${i}`,
         project_id: "project-123",
@@ -281,7 +265,7 @@ describe("POST /search", () => {
       expect(body.pagination.scrollId).toBe("next-page-token");
     });
 
-    it("handles empty result set", async () => {
+    it("returns valid JSON for empty result set", async () => {
       mockGetAllTracesForProject.mockResolvedValue({
         groups: [[]],
         totalHits: 0,

--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -233,4 +233,70 @@ describe("POST /search", () => {
       expect(body.traces[1].evaluations).toEqual([]);
     });
   });
+
+  describe("when response is streamed", () => {
+    it("produces valid JSON with correct structure", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/json");
+
+      const body = await res.json();
+      expect(body).toHaveProperty("traces");
+      expect(body).toHaveProperty("pagination");
+      expect(body.pagination).toHaveProperty("totalHits", 2);
+      expect(body.traces).toHaveLength(2);
+    });
+
+    it("handles many traces with correct comma separation", async () => {
+      const manyTraces = Array.from({ length: 50 }, (_, i) => ({
+        trace_id: `trace-${i}`,
+        project_id: "project-123",
+        input: { value: `input-${i}` },
+        output: { value: `output-${i}` },
+        timestamps: { started_at: i * 100, inserted_at: i * 100, updated_at: i * 100 },
+        metadata: {},
+        spans: [],
+      }));
+
+      mockGetAllTracesForProject.mockResolvedValue({
+        groups: [manyTraces],
+        totalHits: 50,
+        traceChecks: Object.fromEntries(manyTraces.map((t) => [t.trace_id, []])),
+        scrollId: "next-page-token",
+      });
+
+      const res = await searchRequest({
+        startDate: 0,
+        endDate: 10000,
+      });
+
+      const body = await res.json();
+      expect(body.traces).toHaveLength(50);
+      expect(body.traces[0].trace_id).toBe("trace-0");
+      expect(body.traces[49].trace_id).toBe("trace-49");
+      expect(body.pagination.scrollId).toBe("next-page-token");
+    });
+
+    it("handles empty result set", async () => {
+      mockGetAllTracesForProject.mockResolvedValue({
+        groups: [[]],
+        totalHits: 0,
+        traceChecks: {},
+        scrollId: undefined,
+      });
+
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+      });
+
+      const body = await res.json();
+      expect(body.traces).toHaveLength(0);
+      expect(body.pagination.totalHits).toBe(0);
+    });
+  });
 });

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -152,13 +152,31 @@ app.post(
       }));
     }
 
-    return c.json({
+    const responseBody = {
       traces,
       pagination: {
         totalHits: results.totalHits,
         scrollId: results.scrollId,
       },
-    });
+    };
+
+    try {
+      return c.json(responseBody);
+    } catch (err) {
+      if (err instanceof RangeError) {
+        return c.json(
+          {
+            error: "Response too large",
+            message:
+              `The response for the requested date range exceeds serialization limits ` +
+              `(${rawTraces.length} traces). Use a smaller "pageSize" (e.g. 50 or 100) ` +
+              `and paginate with the "scrollId" returned in each response.`,
+          },
+          413,
+        );
+      }
+      throw err;
+    }
   },
 );
 

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -157,16 +157,26 @@ app.post(
       scrollId: results.scrollId,
     });
 
+    const serializedTraces: string[] = [];
+    for (const trace of enrichedTraces) {
+      try {
+        serializedTraces.push(JSON.stringify(formatTrace(trace)));
+      } catch (err) {
+        logger.error(
+          { traceId: trace.trace_id, error: err instanceof Error ? err.message : err },
+          "Failed to serialize trace, skipping",
+        );
+      }
+    }
+
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       start(controller) {
         controller.enqueue(encoder.encode('{"traces":['));
 
-        for (let i = 0; i < enrichedTraces.length; i++) {
+        for (let i = 0; i < serializedTraces.length; i++) {
           const prefix = i > 0 ? "," : "";
-          controller.enqueue(
-            encoder.encode(prefix + JSON.stringify(formatTrace(enrichedTraces[i]!)))
-          );
+          controller.enqueue(encoder.encode(prefix + serializedTraces[i]!));
         }
 
         controller.enqueue(

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -126,57 +126,59 @@ app.post(
       traceChecks: results.traceChecks,
     });
 
-    let traces: unknown[];
-    if (format === "digest") {
-      traces = enrichedTraces.map((trace) => ({
-        trace_id: trace.trace_id,
-        formatted_trace: formatTraceSummaryDigest(trace),
-        input: trace.input,
-        output: trace.output,
-        timestamps: trace.timestamps,
-        metadata: trace.metadata,
-        error: trace.error,
-        evaluations: trace.evaluations,
-        platformUrl: platformUrl({
-          projectSlug: project.slug,
-          path: `/messages/${trace.trace_id}`,
-        }),
-      }));
-    } else {
-      traces = enrichedTraces.map((trace) => ({
+    const formatTrace = (trace: Trace) => {
+      if (format === "digest") {
+        return {
+          trace_id: trace.trace_id,
+          formatted_trace: formatTraceSummaryDigest(trace),
+          input: trace.input,
+          output: trace.output,
+          timestamps: trace.timestamps,
+          metadata: trace.metadata,
+          error: trace.error,
+          evaluations: trace.evaluations,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/messages/${trace.trace_id}`,
+          }),
+        };
+      }
+      return {
         ...trace,
         platformUrl: platformUrl({
           projectSlug: project.slug,
           path: `/messages/${trace.trace_id}`,
         }),
-      }));
-    }
-
-    const responseBody = {
-      traces,
-      pagination: {
-        totalHits: results.totalHits,
-        scrollId: results.scrollId,
-      },
+      };
     };
 
-    try {
-      return c.json(responseBody);
-    } catch (err) {
-      if (err instanceof RangeError) {
-        return c.json(
-          {
-            error: "Response too large",
-            message:
-              `The response for the requested date range exceeds serialization limits ` +
-              `(${rawTraces.length} traces). Use a smaller "pageSize" (e.g. 50 or 100) ` +
-              `and paginate with the "scrollId" returned in each response.`,
-          },
-          413,
+    const pagination = JSON.stringify({
+      totalHits: results.totalHits,
+      scrollId: results.scrollId,
+    });
+
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"traces":['));
+
+        for (let i = 0; i < enrichedTraces.length; i++) {
+          const prefix = i > 0 ? "," : "";
+          controller.enqueue(
+            encoder.encode(prefix + JSON.stringify(formatTrace(enrichedTraces[i]!)))
+          );
+        }
+
+        controller.enqueue(
+          encoder.encode(`],"pagination":${pagination}}`)
         );
-      }
-      throw err;
-    }
+        controller.close();
+      },
+    });
+
+    return new Response(stream, {
+      headers: { "Content-Type": "application/json" },
+    });
   },
 );
 

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -765,10 +765,6 @@ describe("ClickHouseTraceService", () => {
 
     describe("when ClickHouse MEMORY_LIMIT_EXCEEDED on evaluations query", () => {
       it("retries evaluations in batches and returns traces", async () => {
-        setupStandardMocks(["trace-1"]);
-
-        // Override the evaluations mock (4th call) — make it OOM then succeed
-        mockClickHouseQuery.mockReset();
         const summaryRows = [makeSummaryRow("trace-1")];
         mockClickHouseQuery
           // count

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -687,6 +687,60 @@ describe("ClickHouseTraceService", () => {
         expect(traces).toHaveLength(4);
       });
 
+      it("splits into 25-ID batches when retrying with >25 traces", async () => {
+        const traceIds = Array.from({ length: 30 }, (_, i) => `trace-${i}`);
+        const summaryRows = traceIds.map((id, i) => ({
+          ...makeSummaryRow(id),
+          ts_OccurredAt: Date.now() - i * 1000,
+        }));
+        const idRows = traceIds.map((id) => ({ TraceId: id }));
+
+        mockClickHouseQuery
+          // count
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          // IDs
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          // summary — OOM
+          .mockRejectedValueOnce(
+            new Error("MEMORY_LIMIT_EXCEEDED"),
+          )
+          // retry batch 1: traces 0-24
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows.slice(0, 25)),
+          })
+          // retry batch 2: traces 25-29
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows.slice(25)),
+          })
+          // evaluations
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          { ...baseInput, pageSize: 30 } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        const traces = result!.groups.flat();
+        expect(traces).toHaveLength(30);
+
+        // Verify batch split: call 0=count, 1=IDs, 2=OOM, 3=batch1, 4=batch2
+        const batch1Params = mockClickHouseQuery.mock.calls[3]![0];
+        const batch2Params = mockClickHouseQuery.mock.calls[4]![0];
+        expect(batch1Params.query_params.pageTraceIds).toHaveLength(25);
+        expect(batch2Params.query_params.pageTraceIds).toHaveLength(5);
+      });
+
       it("re-throws non-OOM errors from summary query", async () => {
         const idRows = [{ TraceId: "trace-1" }];
 

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -763,6 +763,52 @@ describe("ClickHouseTraceService", () => {
       });
     });
 
+    describe("when ClickHouse MEMORY_LIMIT_EXCEEDED on evaluations query", () => {
+      it("retries evaluations in batches and returns traces", async () => {
+        setupStandardMocks(["trace-1"]);
+
+        // Override the evaluations mock (4th call) — make it OOM then succeed
+        mockClickHouseQuery.mockReset();
+        const summaryRows = [makeSummaryRow("trace-1")];
+        mockClickHouseQuery
+          // count
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: "1" }]),
+          })
+          // IDs
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ TraceId: "trace-1" }]),
+          })
+          // summary
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows),
+          })
+          // evaluations — OOM
+          .mockRejectedValueOnce(
+            Object.assign(
+              new Error("Query memory limit exceeded"),
+              { type: "MEMORY_LIMIT_EXCEEDED" },
+            ),
+          )
+          // evaluations retry batch
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          baseInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.groups.flat()).toHaveLength(1);
+      });
+    });
+
     describe("when includeSpans is true", () => {
       it("fetches and attaches spans to traces", async () => {
         const summaryRow = makeSummaryRow("trace-1");

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace.service.unit.test.ts
@@ -638,6 +638,77 @@ describe("ClickHouseTraceService", () => {
       });
     });
 
+    describe("when ClickHouse MEMORY_LIMIT_EXCEEDED on summary query", () => {
+      it("retries in smaller batches and returns all traces", async () => {
+        const traceIds = Array.from({ length: 4 }, (_, i) => `trace-${i}`);
+        const summaryRows = traceIds.map((id, i) => ({
+          ...makeSummaryRow(id),
+          ts_OccurredAt: Date.now() - i * 1000,
+        }));
+        const idRows = traceIds.map((id) => ({ TraceId: id }));
+
+        // Batch size is 25, so 4 traces fit in one retry batch
+        mockClickHouseQuery
+          // count
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: String(traceIds.length) }]),
+          })
+          // IDs
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          // summary — OOM
+          .mockRejectedValueOnce(
+            new Error(
+              "Query memory limit exceeded: would use 3.50 GiB, " +
+                "maximum: 3.50 GiB: MEMORY_LIMIT_EXCEEDED",
+            ),
+          )
+          // retry batch (all 4 fit in one batch of 25)
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(summaryRows),
+          })
+          // evaluations
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([]),
+          });
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        const result = await service.getAllTracesForProject(
+          { ...baseInput, pageSize: 4 } as GetAllTracesForProjectInput,
+          protections,
+        );
+
+        expect(result).not.toBeNull();
+        const traces = result!.groups.flat();
+        expect(traces).toHaveLength(4);
+      });
+
+      it("re-throws non-OOM errors from summary query", async () => {
+        const idRows = [{ TraceId: "trace-1" }];
+
+        mockClickHouseQuery
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve([{ total: "1" }]),
+          })
+          .mockResolvedValueOnce({
+            json: () => Promise.resolve(idRows),
+          })
+          .mockRejectedValueOnce(new Error("SYNTAX_ERROR: bad query"));
+
+        const service = new ClickHouseTraceService({
+          project: { findUnique: mockPrismaFindUnique },
+        } as never);
+
+        await expect(
+          service.getAllTracesForProject(baseInput, protections),
+        ).rejects.toThrow("SYNTAX_ERROR");
+      });
+    });
+
     describe("when includeSpans is true", () => {
       it("fetches and attaches spans to traces", async () => {
         const summaryRow = makeSummaryRow("trace-1");

--- a/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
@@ -77,13 +77,18 @@ describe("trace dedup OOM safety", () => {
   const topicClusteringSource = fs.readFileSync(topicClusteringPath, "utf-8");
 
   // ---------------------------------------------------------------------------
-  // clickhouse-trace.service.ts: fetchTracesWithPagination
+  // clickhouse-trace.service.ts: fetchTracesWithPagination + fetchTraceSummaryRows
   // ---------------------------------------------------------------------------
   describe("fetchTracesWithPagination()", () => {
-    const body = extractMethodBody(
+    const paginationBody = extractMethodBody(
       traceServiceSource,
       "fetchTracesWithPagination",
     );
+    const summaryBody = extractMethodBody(
+      traceServiceSource,
+      "fetchTraceSummaryRows",
+    );
+    const body = paginationBody + summaryBody;
 
     describe("when the pagination query SQL is inspected", () => {
       it("does not use LIMIT 1 BY for deduplication", () => {

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -609,29 +609,11 @@ export class ClickHouseTraceService {
           const traceIds = groups.flat().map((t) => t.trace_id);
           let traceChecks: TracesForProjectResult["traceChecks"] = {};
           if (traceIds.length > 0 && clickHouseClient) {
-            const evalResult = await clickHouseClient.query({
-              query: `
-                SELECT *
-                FROM evaluation_runs
-                WHERE TenantId = {tenantId:String}
-                  AND TraceId IN ({traceIds:Array(String)})
-                  AND (TenantId, EvaluationId, UpdatedAt) IN (
-                    SELECT TenantId, EvaluationId, max(UpdatedAt)
-                    FROM evaluation_runs
-                    WHERE TenantId = {tenantId:String}
-                      AND TraceId IN ({traceIds:Array(String)})
-                    GROUP BY TenantId, EvaluationId
-                  )
-              `,
-              query_params: {
-                tenantId: input.projectId,
-                traceIds,
-              },
-              format: "JSONEachRow",
+            const evalRows = await this.fetchEvaluationRows({
+              clickHouseClient,
+              projectId: input.projectId,
+              traceIds,
             });
-
-            const evalRows =
-              (await evalResult.json()) as ClickHouseEvaluationRunRow[];
 
             const grouped: Record<
               string,
@@ -1522,10 +1504,7 @@ export class ClickHouseTraceService {
     try {
       return await runQuery(traceIds);
     } catch (error) {
-      if (
-        !(error instanceof Error) ||
-        !error.message.includes("MEMORY_LIMIT_EXCEEDED")
-      ) {
+      if (!isClickHouseMemoryLimitError(error)) {
         throw error;
       }
 
@@ -1554,6 +1533,72 @@ export class ClickHouseTraceService {
         if (a.ts_TraceId === b.ts_TraceId) return 0;
         return a.ts_TraceId < b.ts_TraceId ? -dir : dir;
       });
+
+      return allRows;
+    }
+  }
+
+  /**
+   * Fetch evaluation rows for a set of trace IDs.
+   * Same OOM-resilient pattern as fetchTraceSummaryRows.
+   */
+  private async fetchEvaluationRows({
+    clickHouseClient,
+    projectId,
+    traceIds,
+  }: {
+    clickHouseClient: ClickHouseClient;
+    projectId: string;
+    traceIds: string[];
+  }): Promise<ClickHouseEvaluationRunRow[]> {
+    const runQuery = async (ids: string[]) => {
+      const result = await clickHouseClient.query({
+        query: `
+          SELECT *
+          FROM evaluation_runs
+          WHERE TenantId = {tenantId:String}
+            AND TraceId IN ({traceIds:Array(String)})
+            AND (TenantId, EvaluationId, UpdatedAt) IN (
+              SELECT TenantId, EvaluationId, max(UpdatedAt)
+              FROM evaluation_runs
+              WHERE TenantId = {tenantId:String}
+                AND TraceId IN ({traceIds:Array(String)})
+              GROUP BY TenantId, EvaluationId
+            )
+        `,
+        query_params: {
+          tenantId: projectId,
+          traceIds: ids,
+        },
+        format: "JSONEachRow",
+      });
+      return result.json() as Promise<ClickHouseEvaluationRunRow[]>;
+    };
+
+    try {
+      return await runQuery(traceIds);
+    } catch (error) {
+      if (!isClickHouseMemoryLimitError(error)) {
+        throw error;
+      }
+
+      this.logger.warn(
+        `Evaluations query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
+      );
+
+      const allRows: ClickHouseEvaluationRunRow[] = [];
+      for (
+        let i = 0;
+        i < traceIds.length;
+        i += ClickHouseTraceService.SUMMARY_BATCH_SIZE
+      ) {
+        const batch = traceIds.slice(
+          i,
+          i + ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+        );
+        const batchRows = await runQuery(batch);
+        allRows.push(...batchRows);
+      }
 
       return allRows;
     }
@@ -2169,6 +2214,15 @@ interface PromptStudioCandidateRow {
  *   3. First llm in the trace by start time as a last resort.
  * Returns null when the trace genuinely has no llm spans.
  */
+function isClickHouseMemoryLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes("MEMORY_LIMIT_EXCEEDED") ||
+    error.message.toLowerCase().includes("memory limit exceeded") ||
+    (error as { type?: string }).type === "MEMORY_LIMIT_EXCEEDED"
+  );
+}
+
 function findNearestLlm<T extends PromptStudioCandidateRow>(
   rows: T[],
   requested: T,

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1416,62 +1416,14 @@ export class ClickHouseTraceService {
         // Step 2: Fetch full data for just the page's trace IDs.
         // The dedup subquery is scoped to pageTraceIds so it only reads
         // N traces instead of the entire table.
-        const summaryResult = await clickHouseClient.query({
-          query: `
-            SELECT
-              ts.TraceId AS ts_TraceId,
-              ts.SpanCount AS ts_SpanCount,
-              ts.TotalDurationMs AS ts_TotalDurationMs,
-              ts.ComputedIOSchemaVersion AS ts_ComputedIOSchemaVersion,
-              ts.TimeToFirstTokenMs AS ts_TimeToFirstTokenMs,
-              ts.TimeToLastTokenMs AS ts_TimeToLastTokenMs,
-              ts.TokensPerSecond AS ts_TokensPerSecond,
-              ts.ContainsErrorStatus AS ts_ContainsErrorStatus,
-              ts.ContainsOKStatus AS ts_ContainsOKStatus,
-              ts.ErrorMessage AS ts_ErrorMessage,
-              ts.Models AS ts_Models,
-              ts.TotalCost AS ts_TotalCost,
-              ts.TokensEstimated AS ts_TokensEstimated,
-              ts.TotalPromptTokenCount AS ts_TotalPromptTokenCount,
-              ts.TotalCompletionTokenCount AS ts_TotalCompletionTokenCount,
-              ts.TopicId AS ts_TopicId,
-              ts.SubTopicId AS ts_SubTopicId,
-              ts.HasAnnotation AS ts_HasAnnotation,
-              ts.AnnotationIds AS ts_AnnotationIds,
-              ts.ComputedInput AS ts_ComputedInput,
-              ts.ComputedOutput AS ts_ComputedOutput,
-              ts.Attributes AS ts_Attributes,
-              ts.TraceName AS ts_TraceName,
-              toUnixTimestamp64Milli(ts.OccurredAt) AS ts_OccurredAt,
-              toUnixTimestamp64Milli(ts.CreatedAt) AS ts_CreatedAt,
-              toUnixTimestamp64Milli(ts.UpdatedAt) AS ts_UpdatedAt
-            FROM trace_summaries ts
-            WHERE ts.TenantId = {tenantId:String}
-              AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-              AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
-              AND ts.TraceId IN ({pageTraceIds:Array(String)})
-              AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
-                SELECT TenantId, TraceId, max(UpdatedAt)
-                FROM trace_summaries
-                WHERE TenantId = {tenantId:String}
-                  AND OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-                  AND OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
-                  AND TraceId IN ({pageTraceIds:Array(String)})
-                GROUP BY TenantId, TraceId
-              )
-            ORDER BY ts.OccurredAt ${orderDirection}, ts.TraceId ${orderDirection}
-          `,
-          query_params: {
-            tenantId: projectId,
-            startDate: startDate ?? 0,
-            endDate: endDate ?? Date.now(),
-            pageTraceIds,
-          },
-          format: "JSONEachRow",
+        const summaryRows = await this.fetchTraceSummaryRows({
+          clickHouseClient,
+          projectId,
+          startDate: startDate ?? 0,
+          endDate: endDate ?? Date.now(),
+          traceIds: pageTraceIds,
+          orderDirection,
         });
-
-        const summaryRows =
-          await summaryResult.json() as TraceSummaryRow[];
 
         const traces: Trace[] = summaryRows.map((row) => {
           const summary = this.rowToTraceSummaryData(row);
@@ -1485,6 +1437,125 @@ export class ClickHouseTraceService {
         return { traces, totalHits, lastTrace };
       },
     );
+  }
+
+  private static readonly SUMMARY_BATCH_SIZE = 25;
+
+  /**
+   * Fetch full trace summary rows for a set of trace IDs.
+   * On ClickHouse MEMORY_LIMIT_EXCEEDED, retries in smaller batches
+   * so that heavy ComputedInput/ComputedOutput columns don't blow the
+   * per-query memory cap.
+   */
+  private async fetchTraceSummaryRows({
+    clickHouseClient,
+    projectId,
+    startDate,
+    endDate,
+    traceIds,
+    orderDirection,
+  }: {
+    clickHouseClient: ClickHouseClient;
+    projectId: string;
+    startDate: number;
+    endDate: number;
+    traceIds: string[];
+    orderDirection: string;
+  }): Promise<TraceSummaryRow[]> {
+    const runQuery = async (ids: string[]) => {
+      const result = await clickHouseClient.query({
+        query: `
+          SELECT
+            ts.TraceId AS ts_TraceId,
+            ts.SpanCount AS ts_SpanCount,
+            ts.TotalDurationMs AS ts_TotalDurationMs,
+            ts.ComputedIOSchemaVersion AS ts_ComputedIOSchemaVersion,
+            ts.TimeToFirstTokenMs AS ts_TimeToFirstTokenMs,
+            ts.TimeToLastTokenMs AS ts_TimeToLastTokenMs,
+            ts.TokensPerSecond AS ts_TokensPerSecond,
+            ts.ContainsErrorStatus AS ts_ContainsErrorStatus,
+            ts.ContainsOKStatus AS ts_ContainsOKStatus,
+            ts.ErrorMessage AS ts_ErrorMessage,
+            ts.Models AS ts_Models,
+            ts.TotalCost AS ts_TotalCost,
+            ts.TokensEstimated AS ts_TokensEstimated,
+            ts.TotalPromptTokenCount AS ts_TotalPromptTokenCount,
+            ts.TotalCompletionTokenCount AS ts_TotalCompletionTokenCount,
+            ts.TopicId AS ts_TopicId,
+            ts.SubTopicId AS ts_SubTopicId,
+            ts.HasAnnotation AS ts_HasAnnotation,
+            ts.AnnotationIds AS ts_AnnotationIds,
+            ts.ComputedInput AS ts_ComputedInput,
+            ts.ComputedOutput AS ts_ComputedOutput,
+            ts.Attributes AS ts_Attributes,
+            ts.TraceName AS ts_TraceName,
+            toUnixTimestamp64Milli(ts.OccurredAt) AS ts_OccurredAt,
+            toUnixTimestamp64Milli(ts.CreatedAt) AS ts_CreatedAt,
+            toUnixTimestamp64Milli(ts.UpdatedAt) AS ts_UpdatedAt
+          FROM trace_summaries ts
+          WHERE ts.TenantId = {tenantId:String}
+            AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+            AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+            AND ts.TraceId IN ({pageTraceIds:Array(String)})
+            AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
+              SELECT TenantId, TraceId, max(UpdatedAt)
+              FROM trace_summaries
+              WHERE TenantId = {tenantId:String}
+                AND OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+                AND OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+                AND TraceId IN ({pageTraceIds:Array(String)})
+              GROUP BY TenantId, TraceId
+            )
+          ORDER BY ts.OccurredAt ${orderDirection}, ts.TraceId ${orderDirection}
+        `,
+        query_params: {
+          tenantId: projectId,
+          startDate,
+          endDate,
+          pageTraceIds: ids,
+        },
+        format: "JSONEachRow",
+      });
+      return result.json() as Promise<TraceSummaryRow[]>;
+    };
+
+    try {
+      return await runQuery(traceIds);
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes("MEMORY_LIMIT_EXCEEDED")
+      ) {
+        throw error;
+      }
+
+      this.logger.warn(
+        `Summary query OOM for ${traceIds.length} traces, retrying in batches of ${ClickHouseTraceService.SUMMARY_BATCH_SIZE}`,
+      );
+
+      const allRows: TraceSummaryRow[] = [];
+      for (
+        let i = 0;
+        i < traceIds.length;
+        i += ClickHouseTraceService.SUMMARY_BATCH_SIZE
+      ) {
+        const batch = traceIds.slice(
+          i,
+          i + ClickHouseTraceService.SUMMARY_BATCH_SIZE,
+        );
+        const batchRows = await runQuery(batch);
+        allRows.push(...batchRows);
+      }
+
+      const dir = orderDirection === "DESC" ? -1 : 1;
+      allRows.sort((a, b) => {
+        const timeDiff = a.ts_OccurredAt - b.ts_OccurredAt;
+        if (timeDiff !== 0) return timeDiff * dir;
+        return a.ts_TraceId < b.ts_TraceId ? -dir : dir;
+      });
+
+      return allRows;
+    }
   }
 
   /**

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1427,7 +1427,7 @@ export class ClickHouseTraceService {
    * Fetch full trace summary rows for a set of trace IDs.
    * On ClickHouse MEMORY_LIMIT_EXCEEDED, retries in smaller batches
    * so that heavy ComputedInput/ComputedOutput columns don't blow the
-   * per-query memory cap.
+   * per-query memory cap. If a single batch still OOMs the error propagates.
    */
   private async fetchTraceSummaryRows({
     clickHouseClient,

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2203,6 +2203,15 @@ interface PromptStudioCandidateRow {
   StartTime: number;
 }
 
+function isClickHouseMemoryLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes("MEMORY_LIMIT_EXCEEDED") ||
+    error.message.toLowerCase().includes("memory limit exceeded") ||
+    (error as { type?: string }).type === "MEMORY_LIMIT_EXCEEDED"
+  );
+}
+
 /**
  * Given a non-llm span the operator clicked "Open in Playground" from
  * (typically `Prompt.compile` or `PromptApiService.get`), find the
@@ -2214,15 +2223,6 @@ interface PromptStudioCandidateRow {
  *   3. First llm in the trace by start time as a last resort.
  * Returns null when the trace genuinely has no llm spans.
  */
-function isClickHouseMemoryLimitError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return (
-    error.message.includes("MEMORY_LIMIT_EXCEEDED") ||
-    error.message.toLowerCase().includes("memory limit exceeded") ||
-    (error as { type?: string }).type === "MEMORY_LIMIT_EXCEEDED"
-  );
-}
-
 function findNearestLlm<T extends PromptStudioCandidateRow>(
   rows: T[],
   requested: T,

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1551,6 +1551,7 @@ export class ClickHouseTraceService {
       allRows.sort((a, b) => {
         const timeDiff = a.ts_OccurredAt - b.ts_OccurredAt;
         if (timeDiff !== 0) return timeDiff * dir;
+        if (a.ts_TraceId === b.ts_TraceId) return 0;
         return a.ts_TraceId < b.ts_TraceId ? -dir : dir;
       });
 


### PR DESCRIPTION
## Summary

- On ClickHouse `MEMORY_LIMIT_EXCEEDED`, retries both the trace summary and evaluations queries in batches of 25 IDs — zero overhead for normal cases
- Streams the JSON response incrementally so V8's ~512MB string limit applies per-trace, not the aggregate
- Fixes error detection: `ClickHouseError` sets `.type = "MEMORY_LIMIT_EXCEEDED"` but `.message` is human-readable — now checks both

## Context

Customer report: `/api/traces/search` returns 500 after paginating through ~800 traces with large payloads (RAG contexts, long conversations) using `pageSize: 200`. Two failure modes:

1. **ClickHouse OOM** — queries fetch heavy `ComputedInput`/`ComputedOutput` columns (or `SELECT *` from `evaluation_runs`) for all page trace IDs in one shot, exceeding the 3.5 GiB per-query memory cap
2. **V8 RangeError** — `JSON.stringify()` on 200 traces with multi-MB payloads exceeds the ~512MB hard string limit

Reproduced against production with the customer's exact request (`pageSize: 200`, 891 traces over one day).

## Test plan

- [x] Reproduced: `pageSize: 200` fails on page 3 with ClickHouse OOM (pre-fix)
- [x] Verified: `pageSize: 200` fetches all 891 traces across 5 pages with zero errors (post-fix)
- [x] OOM triggers batched retry and returns all traces
- [x] >25 trace IDs split into correct batch sizes on retry
- [x] Non-OOM errors re-throw without retry
- [x] Streaming produces valid JSON with correct structure
- [x] Structural regression: dedup still uses `max(UpdatedAt) GROUP BY`, no `LIMIT 1 BY`
- [x] All 63 tests pass (trace service + API + regression)

Closes #3919