### PR TITLE
refactor(traces-v2): remove dead tracesV2.events procedure

### DIFF
--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -880,24 +880,6 @@ export const tracesV2Router = createTRPCRouter({
       };
     }),
 
-  events: protectedProcedure
-    .input(
-      z.object({
-        projectId: z.string(),
-        traceId: z.string(),
-        ...spanReadHintShape,
-      }),
-    )
-    .use(checkProjectPermission("traces:view"))
-    .query(async ({ input }) => {
-      const app = getApp();
-      return app.traces.spans.getEventsByTraceId({
-        tenantId: input.projectId,
-        traceId: input.traceId,
-        ...occurredAtFromInput(input),
-      });
-    }),
-
   /**
    * Trace-level events ({spanId, timestamp, name, attributes}) for the drawer.
    * Split off the header so the header stays a pure summary read; the drawer


### PR DESCRIPTION
## What

Removes the now-dead `tracesV2.events` tRPC procedure.

## Why

PR #4205 split trace-level events off the drawer header into a dedicated `tracesV2.traceEvents` query (returning the `{spanId, timestamp, name, attributes}` shape the v2 `EventCard` renders, read from an events-only ClickHouse query). The drawer was rewired onto `traceEvents`, leaving the older `events` procedure with no consumers.

That older procedure returned the ElasticSearch event shape (`metrics`/`event_details` split, raw attributes dropped, exceptions filtered), which never fit the v2 drawer. Nothing reads it anymore, so it is dead code.

## Scope

- Removes only the `events` procedure from `tracesV2.ts`.
- The `getEventsByTraceId` repository and service method stay: evaluation execution still reads trace events through it.

Typecheck green.