### PR TITLE
feat(ops): show Completed/s peak alongside the running total

### DIFF
--- a/langwatch/specs/ops/redis-pressure.feature
+++ b/langwatch/specs/ops/redis-pressure.feature
@@ -113,3 +113,15 @@ Feature: Redis pressure visibility on the Ops dashboard
     Given Redis reports 24 connected clients
     When the dashboard loads
     Then the Redis conns tile shows "24" with a "clients" sublabel
+
+  # ---------------------------------------------------------------------------
+  # Throughput: Completed/s shows its peak, mirroring Staged/s, without losing
+  # the running total operators rely on.
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Completed/s tile shows the per-second peak alongside the running total
+    Given the dashboard reports a Completed/s peak and a running total
+    When the dashboard loads
+    Then the Completed/s tile sublabel shows the peak per second
+    And it keeps showing the running total

--- a/langwatch/src/components/ops/dashboard/OpsDashboardContent.tsx
+++ b/langwatch/src/components/ops/dashboard/OpsDashboardContent.tsx
@@ -13,25 +13,19 @@ import { BlockedCard } from "~/components/ops/queues/BlockedCard";
 import { DlqCard } from "~/components/ops/queues/DlqCard";
 import { GroupsCard } from "~/components/ops/queues/GroupsCard";
 import { PipelineTreeCard } from "~/components/ops/queues/PipelineTreeCard";
-import {
-  formatCount,
-  formatMs,
-  formatRate,
-} from "~/components/ops/shared/formatters";
 import type { DashboardData } from "~/server/app-layer/ops/types";
 import { api } from "~/utils/api";
 import { ActiveOperationsSection } from "./ActiveOperationsSection";
-import { LinkedStat } from "./LinkedStat";
 import { RedisStatTiles } from "./RedisStatTiles";
 import { ReplayHistorySection } from "./ReplayHistorySection";
 import { ThroughputChart } from "./ThroughputChart";
+import { ThroughputStatTiles } from "./ThroughputStatTiles";
 
 export function OpsDashboardContent({ data }: { data: DashboardData }) {
   const totalBlocked = data.queues.reduce(
     (sum, q) => sum + q.blockedGroupCount,
     0,
   );
-  const totalDlq = data.queues.reduce((sum, q) => sum + q.dlqCount, 0);
 
   const queuesQuery = api.ops.listQueues.useQuery(undefined, {
     refetchInterval: 10000,
@@ -46,47 +40,7 @@ export function OpsDashboardContent({ data }: { data: DashboardData }) {
       <ActiveOperationsSection data={data} />
 
       <SimpleGrid columns={{ base: 2, md: 5, lg: 10 }} gap={1}>
-        <LinkedStat
-          label="Staged/s"
-          value={formatRate(data.throughputIngestedPerSec)}
-          sublabel={`peak ${formatRate(data.peakIngestedPerSec)}`}
-        />
-        <LinkedStat
-          label="Completed/s"
-          value={formatRate(data.completedPerSec)}
-          sublabel={`${formatCount(data.totalCompleted)} total`}
-        />
-        <LinkedStat
-          label="Failed/s"
-          value={formatRate(data.failedPerSec)}
-          sublabel={
-            data.totalFailed > 0
-              ? `${formatCount(data.totalFailed)} total`
-              : undefined
-          }
-          color={data.failedPerSec > 0 ? "red.500" : undefined}
-        />
-        <LinkedStat
-          label="Blocked"
-          value={totalBlocked.toString()}
-          sublabel={`${data.totalGroups} groups`}
-          color={totalBlocked > 0 ? "red.500" : undefined}
-        />
-        <LinkedStat
-          label="P50"
-          value={formatMs(data.latencyP50Ms)}
-          sublabel={`peak ${formatMs(data.peakLatencyP50Ms)}`}
-        />
-        <LinkedStat
-          label="P99"
-          value={formatMs(data.latencyP99Ms)}
-          sublabel={`peak ${formatMs(data.peakLatencyP99Ms)}`}
-        />
-        <LinkedStat
-          label="DLQ"
-          value={totalDlq.toString()}
-          color={totalDlq > 0 ? "orange.500" : undefined}
-        />
+        <ThroughputStatTiles data={data} />
         <RedisStatTiles data={data} />
       </SimpleGrid>
 

--- a/langwatch/src/components/ops/dashboard/ThroughputStatTiles.tsx
+++ b/langwatch/src/components/ops/dashboard/ThroughputStatTiles.tsx
@@ -1,0 +1,85 @@
+import {
+  formatCount,
+  formatMs,
+  formatRate,
+} from "~/components/ops/shared/formatters";
+import type { DashboardData } from "~/server/app-layer/ops/types";
+import { LinkedStat } from "./LinkedStat";
+
+/**
+ * The throughput / latency / backlog stat strip on the ops dashboard. Extracted
+ * from OpsDashboardContent so the per-second tiles can be rendered in isolation
+ * under test (mirrors RedisStatTiles). Returns a fragment of grid cells; the
+ * parent SimpleGrid owns the layout.
+ */
+type ThroughputStatData = Pick<
+  DashboardData,
+  | "throughputIngestedPerSec"
+  | "peakIngestedPerSec"
+  | "completedPerSec"
+  | "peakCompletedPerSec"
+  | "totalCompleted"
+  | "failedPerSec"
+  | "totalFailed"
+  | "totalGroups"
+  | "latencyP50Ms"
+  | "peakLatencyP50Ms"
+  | "latencyP99Ms"
+  | "peakLatencyP99Ms"
+  | "queues"
+>;
+
+export function ThroughputStatTiles({ data }: { data: ThroughputStatData }) {
+  const totalBlocked = data.queues.reduce(
+    (sum, q) => sum + q.blockedGroupCount,
+    0,
+  );
+  const totalDlq = data.queues.reduce((sum, q) => sum + q.dlqCount, 0);
+
+  return (
+    <>
+      <LinkedStat
+        label="Staged/s"
+        value={formatRate(data.throughputIngestedPerSec)}
+        sublabel={`peak ${formatRate(data.peakIngestedPerSec)}`}
+      />
+      <LinkedStat
+        label="Completed/s"
+        value={formatRate(data.completedPerSec)}
+        sublabel={`peak ${formatRate(data.peakCompletedPerSec)} · ${formatCount(data.totalCompleted)} total`}
+        testId="ops-completed-stat"
+      />
+      <LinkedStat
+        label="Failed/s"
+        value={formatRate(data.failedPerSec)}
+        sublabel={
+          data.totalFailed > 0
+            ? `${formatCount(data.totalFailed)} total`
+            : undefined
+        }
+        color={data.failedPerSec > 0 ? "red.500" : undefined}
+      />
+      <LinkedStat
+        label="Blocked"
+        value={totalBlocked.toString()}
+        sublabel={`${data.totalGroups} groups`}
+        color={totalBlocked > 0 ? "red.500" : undefined}
+      />
+      <LinkedStat
+        label="P50"
+        value={formatMs(data.latencyP50Ms)}
+        sublabel={`peak ${formatMs(data.peakLatencyP50Ms)}`}
+      />
+      <LinkedStat
+        label="P99"
+        value={formatMs(data.latencyP99Ms)}
+        sublabel={`peak ${formatMs(data.peakLatencyP99Ms)}`}
+      />
+      <LinkedStat
+        label="DLQ"
+        value={totalDlq.toString()}
+        color={totalDlq > 0 ? "orange.500" : undefined}
+      />
+    </>
+  );
+}

--- a/langwatch/src/components/ops/dashboard/ThroughputStatTiles.tsx
+++ b/langwatch/src/components/ops/dashboard/ThroughputStatTiles.tsx
@@ -6,12 +6,7 @@ import {
 import type { DashboardData } from "~/server/app-layer/ops/types";
 import { LinkedStat } from "./LinkedStat";
 
-/**
- * The throughput / latency / backlog stat strip on the ops dashboard. Extracted
- * from OpsDashboardContent so the per-second tiles can be rendered in isolation
- * under test (mirrors RedisStatTiles). Returns a fragment of grid cells; the
- * parent SimpleGrid owns the layout.
- */
+/** The subset of dashboard data the throughput stat strip reads. */
 type ThroughputStatData = Pick<
   DashboardData,
   | "throughputIngestedPerSec"
@@ -29,6 +24,12 @@ type ThroughputStatData = Pick<
   | "queues"
 >;
 
+/**
+ * The throughput / latency / backlog stat strip on the ops dashboard. Extracted
+ * from OpsDashboardContent so the per-second tiles can be rendered in isolation
+ * under test (mirrors RedisStatTiles). Returns a fragment of grid cells; the
+ * parent SimpleGrid owns the layout.
+ */
 export function ThroughputStatTiles({ data }: { data: ThroughputStatData }) {
   const totalBlocked = data.queues.reduce(
     (sum, q) => sum + q.blockedGroupCount,

--- a/langwatch/src/components/ops/dashboard/__tests__/ThroughputStatTiles.integration.test.tsx
+++ b/langwatch/src/components/ops/dashboard/__tests__/ThroughputStatTiles.integration.test.tsx
@@ -48,10 +48,12 @@ describe("ThroughputStatTiles", () => {
       expect(within(tile).getByText(/peak 7\.1k · 205\.7M total/)).toBeTruthy();
     });
 
-    it("still shows the total when there is no recorded peak yet", () => {
+    it("renders peak 0.00 with the total at cold start, mirroring Staged/s", () => {
       renderTiles({ peakCompletedPerSec: 0, totalCompleted: 1500 });
 
       const tile = screen.getByTestId("ops-completed-stat");
+      // Staged/s renders its peak unconditionally, so Completed/s matches: a
+      // zero peak shows "peak 0.00" rather than diverging from the sibling tile.
       expect(within(tile).getByText(/peak 0\.00 · 1\.5k total/)).toBeTruthy();
     });
   });

--- a/langwatch/src/components/ops/dashboard/__tests__/ThroughputStatTiles.integration.test.tsx
+++ b/langwatch/src/components/ops/dashboard/__tests__/ThroughputStatTiles.integration.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Renders the real ThroughputStatTiles via React Testing Library against an
+ * actual ChakraProvider — no shallow rendering, no module mocks.
+ */
+import { ChakraProvider, defaultSystem, SimpleGrid } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThroughputStatTiles } from "../ThroughputStatTiles";
+
+const renderTiles = (
+  overrides: Partial<React.ComponentProps<typeof ThroughputStatTiles>["data"]> = {},
+) => {
+  const defaults: React.ComponentProps<typeof ThroughputStatTiles>["data"] = {
+    throughputIngestedPerSec: 534,
+    peakIngestedPerSec: 7700,
+    completedPerSec: 379,
+    peakCompletedPerSec: 7100,
+    totalCompleted: 205_700_000,
+    failedPerSec: 0,
+    totalFailed: 0,
+    totalGroups: 0,
+    latencyP50Ms: 0,
+    peakLatencyP50Ms: 0,
+    latencyP99Ms: 0,
+    peakLatencyP99Ms: 0,
+    queues: [],
+  };
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <SimpleGrid columns={10}>
+        <ThroughputStatTiles data={{ ...defaults, ...overrides }} />
+      </SimpleGrid>
+    </ChakraProvider>,
+  );
+};
+
+afterEach(cleanup);
+
+describe("ThroughputStatTiles", () => {
+  describe("the Completed/s tile", () => {
+    it("shows the per-second peak alongside the running total", () => {
+      renderTiles({ peakCompletedPerSec: 7100, totalCompleted: 205_700_000 });
+
+      const tile = screen.getByTestId("ops-completed-stat");
+      // Peak mirrors the Staged/s tile; the total M is kept.
+      expect(within(tile).getByText(/peak 7\.1k · 205\.7M total/)).toBeTruthy();
+    });
+
+    it("still shows the total when there is no recorded peak yet", () => {
+      renderTiles({ peakCompletedPerSec: 0, totalCompleted: 1500 });
+
+      const tile = screen.getByTestId("ops-completed-stat");
+      expect(within(tile).getByText(/peak 0\.00 · 1\.5k total/)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Why

On the ops dashboard the Staged/s tile shows its per-second peak ("peak 7.7k") but the Completed/s tile only showed the lifetime total ("205.7M total"). Operators want the completed peak too, without losing the total.

## What

- Completed/s sublabel now reads `peak <X> · <Y> total`, surfacing `peakCompletedPerSec` (already tracked and exposed by the metrics collector) and keeping the running total.
- Extracted the throughput / latency / backlog stat strip out of `OpsDashboardContent` into a `ThroughputStatTiles` component, mirroring the existing `RedisStatTiles`, so the per-second tiles render in isolation under test (the full dashboard pulls in recharts + tRPC and is awkward to render).

## Tests

`ThroughputStatTiles.integration.test.tsx` (real ChakraProvider, no mocks): the Completed/s tile shows the peak alongside the total, and still shows the total when no peak has been recorded yet. Behavior documented in `specs/ops/redis-pressure.feature`.

## Screenshot contract

Before: `Completed/s 379 — 205.7M total`. After: `Completed/s 379 — peak 7.1k · 205.7M total`.