### PR TITLE
fix(specs): bind deferral test scenarios to tenant-soft-cap feature file

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -2672,7 +2672,7 @@ describe("GroupStagingScripts", () => {
       expect(afterDefer).toBeNull(); // still over cap, but proves they're scannable again
     });
 
-    /** @scenario dispatchBatch defers over-cap groups the same way */
+    /** @scenario dispatchBatch defers over-cap groups to future scores */
     it("dispatchBatch defers over-cap groups to future scores", async () => {
       process.env[TENANT_CAP_ENV] = "1";
 

--- a/specs/event-sourcing/tenant-soft-cap.feature
+++ b/specs/event-sourcing/tenant-soft-cap.feature
@@ -109,23 +109,30 @@ Feature: Per-tenant soft cap on in-flight dispatch
     When DISPATCH_BATCH_LUA is invoked
     Then the zombie group is removed from the ready zset
 
-  # Over-cap groups are pushed to a future score instead of being left at the
-  # head of ready, so repeated polls don't keep scanning past them every time.
-  # A quiet tenant deeper in the zset is reached immediately, and a follow-up
-  # poll returns nothing instead of re-walking the deferred groups; they become
-  # eligible again after the defer window.
-  @integration @tenant-cap @fairness
-  Scenario: Over-cap groups are deferred so they don't starve other tenants on repeated polls
-    Given a tenant "proj_noisy" over cap with many groups at the head of ready
-    And a tenant "proj_quiet" with one group later in the zset
-    When dispatch is polled repeatedly at the same time
-    Then "proj_quiet"'s group is dispatched
-    And the over-cap groups are pushed to a future score so the next poll skips them
-    And they become eligible again only after the defer window
+  # Deferral — post-2026-05-27 incident follow-up
+  #
+  # When over-cap groups dominate the head of the ready zset (e.g.
+  # assignTopic backfill from a topic clustering fix), the scan budget
+  # (10K entries) can be exhausted re-scanning groups that will always
+  # be skipped — starving other tenants entirely. Deferring over-cap
+  # groups to a future score pushes them past the dispatch window so
+  # subsequent polls reach other tenants immediately.
 
-  @integration @tenant-cap @batch @fairness
-  Scenario: dispatchBatch defers over-cap groups the same way
-    Given a tenant over cap with groups on the ready zset
-    When DISPATCH_BATCH_LUA is invoked
-    Then the over-cap groups are deferred to a future score
-    And under-cap tenants are still served in the same batch
+  @integration @tenant-cap @deferral
+  Scenario: Over-cap groups are deferred so they don't starve other tenants on repeated polls
+    Given a tenant "proj_noisy" with cap=1 and 50 groups at the head of the ready zset
+    And a tenant "proj_quiet" with 1 group later in the zset
+    When DISPATCH_LUA dispatches once (proj_noisy wins)
+    And DISPATCH_LUA dispatches again (proj_quiet wins, noisy groups deferred)
+    Then a third DISPATCH_LUA at the same timestamp returns nil immediately
+    And the deferred groups remain in the ready set with future scores
+    And the deferred groups become eligible again after the defer window
+
+  @integration @tenant-cap @batch @deferral
+  Scenario: dispatchBatch defers over-cap groups to future scores
+    Given a tenant "proj_noisy" with cap=1 and 20 groups at the head of the ready zset
+    And a tenant "proj_quiet" with 1 group later in the zset
+    When DISPATCH_BATCH_LUA is invoked with maxJobs=10
+    Then proj_noisy dispatches exactly 1 group and proj_quiet dispatches its group
+    And a second DISPATCH_BATCH_LUA returns zero results
+    And all remaining noisy groups have future scores past the dispatch window


### PR DESCRIPTION
## Summary

- The two `@scenario` annotations added in #4209 weren't bound to any feature file, causing the `check:feature-parity` CI step to fail with "2 unknown annotation(s)"
- Added the corresponding deferral scenarios to `specs/event-sourcing/tenant-soft-cap.feature` with detailed incident context and specific step definitions
- Fixed the batch test annotation to match the feature scenario name exactly (`"dispatchBatch defers over-cap groups to future scores"`)

## Test plan

- [x] `pnpm check:feature-parity` passes locally (14/14 scenarios bound, 0 unknown annotations)
- [x] CI fully green after rebase on main and conflict resolution