### PR TITLE
fix(event-sourcing): memoize trace read-derivation to stop per-event read amplification

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/trace-read-derivation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-read-derivation.service.unit.test.ts
@@ -24,21 +24,28 @@ class CountingReader implements NormalizedSpanReader {
   }
 }
 
-const CUTOFF_PARAMS = { tenantId: "t1", traceId: "trace-1", occurredAtMs: 1000 };
+// One coalesced batch: every per-event reactor observes the same final fold
+// state, so foldVersion (spanCount) is identical across the batch.
+const BATCH_PARAMS = {
+  tenantId: "t1",
+  traceId: "trace-1",
+  occurredAtMs: 1000,
+  foldVersion: 5,
+};
 
 afterEach(() => {
   vi.useRealTimers();
 });
 
 describe("TraceReadDerivationService", () => {
-  describe("given several reactor invocations derive trace data for the same trace at one fold cutoff", () => {
-    describe("when they run within one coalesced batch window", () => {
-      /** @scenario Repeated trace-level derivations for one trace read stored spans once */
+  describe("given several reactor invocations derive trace data for the same trace at one fold version", () => {
+    describe("when they run within one coalesced batch", () => {
+      /** @scenario Repeated trace-level derivations within one fold version read stored spans once */
       it("reads the stored events once, not once per invocation", async () => {
         const reader = new CountingReader();
         const service = new TraceReadDerivationService(reader);
 
-        for (let i = 0; i < 10; i++) await service.deriveEvents(CUTOFF_PARAMS);
+        for (let i = 0; i < 10; i++) await service.deriveEvents(BATCH_PARAMS);
 
         expect(reader.eventReads).toBe(1);
       });
@@ -48,7 +55,7 @@ describe("TraceReadDerivationService", () => {
         const service = new TraceReadDerivationService(reader);
 
         for (let i = 0; i < 10; i++) {
-          await service.deriveScenarioRoleMetrics(CUTOFF_PARAMS);
+          await service.deriveScenarioRoleMetrics(BATCH_PARAMS);
         }
 
         expect(reader.spanReads).toBe(1);
@@ -59,9 +66,9 @@ describe("TraceReadDerivationService", () => {
         const service = new TraceReadDerivationService(reader);
 
         await Promise.all([
-          service.deriveEvents(CUTOFF_PARAMS),
-          service.deriveEvents(CUTOFF_PARAMS),
-          service.deriveEvents(CUTOFF_PARAMS),
+          service.deriveEvents(BATCH_PARAMS),
+          service.deriveEvents(BATCH_PARAMS),
+          service.deriveEvents(BATCH_PARAMS),
         ]);
 
         expect(reader.eventReads).toBe(1);
@@ -69,27 +76,42 @@ describe("TraceReadDerivationService", () => {
     });
   });
 
-  describe("given trace data already derived at one fold cutoff", () => {
-    describe("when trace data is derived again at a later cutoff", () => {
-      /** @scenario A later fold cutoff derives from stored spans again */
-      it("reads the stored spans again for the newer cutoff", async () => {
+  describe("given trace data already derived at one fold version", () => {
+    describe("when the fold advances with newer spans", () => {
+      /** @scenario A derivation re-reads once the fold has advanced with new spans */
+      it("reads the stored spans again rather than serving the earlier result", async () => {
         const reader = new CountingReader();
         const service = new TraceReadDerivationService(reader);
 
-        await service.deriveEvents(CUTOFF_PARAMS);
-        await service.deriveEvents({ ...CUTOFF_PARAMS, occurredAtMs: 2000 });
+        await service.deriveEvents(BATCH_PARAMS);
+        await service.deriveEvents({ ...BATCH_PARAMS, foldVersion: 6 });
+
+        expect(reader.eventReads).toBe(2);
+      });
+    });
+
+    describe("when more spans arrive but the partition hint stays the same", () => {
+      // occurredAtMs is the trace's earliest span time and only a partition
+      // hint, so it does not change as the trace grows; keying on it would
+      // serve stale spans. The advancing foldVersion is what forces a re-read.
+      it("re-reads on the advanced fold version even with an unchanged occurredAtMs", async () => {
+        const reader = new CountingReader();
+        const service = new TraceReadDerivationService(reader);
+
+        await service.deriveEvents({ ...BATCH_PARAMS, occurredAtMs: 1000, foldVersion: 5 });
+        await service.deriveEvents({ ...BATCH_PARAMS, occurredAtMs: 1000, foldVersion: 7 });
 
         expect(reader.eventReads).toBe(2);
       });
     });
   });
 
-  describe("given a live derivation with no fold cutoff", () => {
+  describe("given a live derivation with no fold version", () => {
     describe("when it is derived repeatedly", () => {
       it("reads every time because a live read is non-deterministic", async () => {
         const reader = new CountingReader();
         const service = new TraceReadDerivationService(reader);
-        const live = { tenantId: "t1", traceId: "trace-1" };
+        const live = { tenantId: "t1", traceId: "trace-1", occurredAtMs: 1000 };
 
         await service.deriveEvents(live);
         await service.deriveEvents(live);
@@ -100,15 +122,15 @@ describe("TraceReadDerivationService", () => {
   });
 
   describe("given the read window has elapsed", () => {
-    describe("when the same derivation runs again", () => {
+    describe("when the same fold version is derived again", () => {
       it("reads the stored events again", async () => {
         vi.useFakeTimers();
         const reader = new CountingReader();
         const service = new TraceReadDerivationService(reader);
 
-        await service.deriveEvents(CUTOFF_PARAMS);
+        await service.deriveEvents(BATCH_PARAMS);
         vi.setSystemTime(Date.now() + 31_000);
-        await service.deriveEvents(CUTOFF_PARAMS);
+        await service.deriveEvents(BATCH_PARAMS);
 
         expect(reader.eventReads).toBe(2);
       });
@@ -131,10 +153,10 @@ describe("TraceReadDerivationService", () => {
         };
         const service = new TraceReadDerivationService(reader);
 
-        await expect(service.deriveEvents(CUTOFF_PARAMS)).rejects.toThrow(
+        await expect(service.deriveEvents(BATCH_PARAMS)).rejects.toThrow(
           "clickhouse blip",
         );
-        await expect(service.deriveEvents(CUTOFF_PARAMS)).resolves.toEqual([]);
+        await expect(service.deriveEvents(BATCH_PARAMS)).resolves.toEqual([]);
         expect(attempts).toBe(2);
       });
     });

--- a/langwatch/src/server/app-layer/traces/__tests__/trace-read-derivation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-read-derivation.service.unit.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  TraceReadDerivationService,
+  type NormalizedSpanReader,
+} from "../trace-read-derivation.service";
+
+/**
+ * Counts how many times each underlying span read is issued. The derivations
+ * return empty results — the test only cares about read amplification, not the
+ * derived values (covered by scenario-role-metrics.derivation tests).
+ */
+class CountingReader implements NormalizedSpanReader {
+  spanReads = 0;
+  eventReads = 0;
+
+  async getNormalizedSpansByTraceId() {
+    this.spanReads++;
+    return [];
+  }
+
+  async getTraceEventsByTraceId() {
+    this.eventReads++;
+    return [];
+  }
+}
+
+const CUTOFF_PARAMS = { tenantId: "t1", traceId: "trace-1", occurredAtMs: 1000 };
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TraceReadDerivationService", () => {
+  describe("given several reactor invocations derive trace data for the same trace at one fold cutoff", () => {
+    describe("when they run within one coalesced batch window", () => {
+      /** @scenario Repeated trace-level derivations for one trace read stored spans once */
+      it("reads the stored events once, not once per invocation", async () => {
+        const reader = new CountingReader();
+        const service = new TraceReadDerivationService(reader);
+
+        for (let i = 0; i < 10; i++) await service.deriveEvents(CUTOFF_PARAMS);
+
+        expect(reader.eventReads).toBe(1);
+      });
+
+      it("shares the scenario-role-metrics read across invocations", async () => {
+        const reader = new CountingReader();
+        const service = new TraceReadDerivationService(reader);
+
+        for (let i = 0; i < 10; i++) {
+          await service.deriveScenarioRoleMetrics(CUTOFF_PARAMS);
+        }
+
+        expect(reader.spanReads).toBe(1);
+      });
+
+      it("collapses concurrent in-flight reads into one", async () => {
+        const reader = new CountingReader();
+        const service = new TraceReadDerivationService(reader);
+
+        await Promise.all([
+          service.deriveEvents(CUTOFF_PARAMS),
+          service.deriveEvents(CUTOFF_PARAMS),
+          service.deriveEvents(CUTOFF_PARAMS),
+        ]);
+
+        expect(reader.eventReads).toBe(1);
+      });
+    });
+  });
+
+  describe("given trace data already derived at one fold cutoff", () => {
+    describe("when trace data is derived again at a later cutoff", () => {
+      /** @scenario A later fold cutoff derives from stored spans again */
+      it("reads the stored spans again for the newer cutoff", async () => {
+        const reader = new CountingReader();
+        const service = new TraceReadDerivationService(reader);
+
+        await service.deriveEvents(CUTOFF_PARAMS);
+        await service.deriveEvents({ ...CUTOFF_PARAMS, occurredAtMs: 2000 });
+
+        expect(reader.eventReads).toBe(2);
+      });
+    });
+  });
+
+  describe("given a live derivation with no fold cutoff", () => {
+    describe("when it is derived repeatedly", () => {
+      it("reads every time because a live read is non-deterministic", async () => {
+        const reader = new CountingReader();
+        const service = new TraceReadDerivationService(reader);
+        const live = { tenantId: "t1", traceId: "trace-1" };
+
+        await service.deriveEvents(live);
+        await service.deriveEvents(live);
+
+        expect(reader.eventReads).toBe(2);
+      });
+    });
+  });
+
+  describe("given the read window has elapsed", () => {
+    describe("when the same derivation runs again", () => {
+      it("reads the stored events again", async () => {
+        vi.useFakeTimers();
+        const reader = new CountingReader();
+        const service = new TraceReadDerivationService(reader);
+
+        await service.deriveEvents(CUTOFF_PARAMS);
+        vi.setSystemTime(Date.now() + 31_000);
+        await service.deriveEvents(CUTOFF_PARAMS);
+
+        expect(reader.eventReads).toBe(2);
+      });
+    });
+  });
+
+  describe("given a read that rejects", () => {
+    describe("when the same derivation is retried", () => {
+      it("does not cache the failure", async () => {
+        let attempts = 0;
+        const reader: NormalizedSpanReader = {
+          async getNormalizedSpansByTraceId() {
+            return [];
+          },
+          async getTraceEventsByTraceId() {
+            attempts++;
+            if (attempts === 1) throw new Error("clickhouse blip");
+            return [];
+          },
+        };
+        const service = new TraceReadDerivationService(reader);
+
+        await expect(service.deriveEvents(CUTOFF_PARAMS)).rejects.toThrow(
+          "clickhouse blip",
+        );
+        await expect(service.deriveEvents(CUTOFF_PARAMS)).resolves.toEqual([]);
+        expect(attempts).toBe(2);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
@@ -148,11 +148,15 @@ export class TraceReadDerivationService {
   }
 
   private evict<T>(cache: Map<string, MemoEntry<T>>, now: number): void {
-    if (cache.size <= DERIVATION_MEMO_MAX_ENTRIES) return;
+    // Entries share a fixed TTL and are re-inserted at the back on each miss,
+    // so the front is always the soonest to expire. Sweep expired entries from
+    // the front and stop at the first live one (amortized O(1) per insert, not
+    // O(n) per call), so expired promises are released even when the cache
+    // never reaches the size cap. Then enforce the cap on whatever remains.
     for (const [k, entry] of cache) {
-      if (entry.expiresAt <= now) cache.delete(k);
+      if (entry.expiresAt > now) break;
+      cache.delete(k);
     }
-    // Map preserves insertion order, so the front is the oldest entry.
     while (cache.size > DERIVATION_MEMO_MAX_ENTRIES) {
       const oldest = cache.keys().next().value;
       if (oldest === undefined) break;

--- a/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
@@ -24,20 +24,31 @@ export interface NormalizedSpanReader {
 interface DeriveParams {
   tenantId: string;
   traceId: string;
+  /**
+   * ClickHouse partition hint (the trace's EARLIEST span time). It narrows the
+   * partitions scanned; it is NOT a freshness cutoff and does not bound which
+   * spans come back, so it must not key the memo.
+   */
   occurredAtMs?: number;
+  /**
+   * Monotonic fold watermark — the fold's `spanCount`, which increments every
+   * time a span is folded. The memo is keyed on it so a cached derivation is
+   * reused only within one fold version (all of a coalesced batch's per-event
+   * reactors observe the same final state, so they share one read) and is
+   * dropped the moment newer spans land. Omit it to bypass the memo (a live
+   * read with no watermark must always hit storage).
+   */
+  foldVersion?: number;
 }
 
 /**
- * Window during which a derivation for the same (tenant, trace, cutoff) reuses
- * the in-flight or just-resolved span read. A coalesced fold batch dispatches
- * its reactors per event but with one shared final fold state, so every
- * reactor derives at the same occurredAt cutoff back-to-back; this window
- * collapses those identical reads into one. Kept short because the cutoff makes
- * each read deterministic, so the only thing aging out matters for is rare
- * out-of-order late spans.
+ * Window after which a memo entry is dropped purely as a memory backstop —
+ * correctness comes from the fold-version key, not from aging. An entry for a
+ * superseded version is simply never read again, so this only bounds how long
+ * an unused entry lingers.
  */
 const DERIVATION_READ_WINDOW_MS = 30_000;
-/** Cap so a burst of distinct traces can't grow the memo without bound. */
+/** Cap so a burst of distinct traces/versions can't grow the memo without bound. */
 const DERIVATION_MEMO_MAX_ENTRIES = 2_000;
 
 interface MemoEntry<T> {
@@ -55,11 +66,11 @@ interface MemoEntry<T> {
  *
  * The all-spans read these derivations issue is multi-MB for large traces. A
  * coalesced fold batch fires its reactors once per event but at one shared
- * occurredAt cutoff, so without coalescing the same read would run once per
+ * final fold state, so without coalescing the same read would run once per
  * span in the backlog — the read-amplification that re-saturated Redis/ClickHouse
- * during a backlog drain. The derivations are memoized per (tenant, trace,
- * cutoff) so a batch reads stored spans once regardless of how many reactors or
- * events it dispatches.
+ * during a backlog drain. The derivations are memoized per (tenant, trace, fold
+ * version) so a batch reads stored spans once regardless of how many reactors or
+ * events it dispatches, while a fold that has advanced (new spans) re-reads.
  */
 export class TraceReadDerivationService {
   private readonly spanCostService = new SpanCostService();
@@ -75,7 +86,11 @@ export class TraceReadDerivationService {
     params: DeriveParams,
   ): Promise<ScenarioRoleMetrics> {
     return this.memoize(this.scenarioRoleMetricsMemo, params, async () => {
-      const spans = await this.spans.getNormalizedSpansByTraceId(params);
+      const spans = await this.spans.getNormalizedSpansByTraceId({
+        tenantId: params.tenantId,
+        traceId: params.traceId,
+        occurredAtMs: params.occurredAtMs,
+      });
       return deriveScenarioRoleMetricsFromSpans({
         spans,
         spanCostService: this.spanCostService,
@@ -85,18 +100,23 @@ export class TraceReadDerivationService {
 
   async deriveEvents(params: DeriveParams): Promise<DerivedTraceEvent[]> {
     return this.memoize(this.eventsMemo, params, () =>
-      this.spans.getTraceEventsByTraceId(params),
+      this.spans.getTraceEventsByTraceId({
+        tenantId: params.tenantId,
+        traceId: params.traceId,
+        occurredAtMs: params.occurredAtMs,
+      }),
     );
   }
 
   /**
-   * Only deterministic reads are memoized: a derivation with an occurredAt
-   * cutoff returns the same spans no matter when it runs, so sharing it across
-   * a batch is safe. A live read (no cutoff) is left to pass straight through.
+   * Only memoize when a fold watermark is supplied: the key is the fold's
+   * version (spanCount), so a cached read is reused within one fold version and
+   * re-issued as soon as the fold advances. Without a watermark the read is
+   * non-deterministic over time and is left to pass straight through.
    */
   private memoKey(params: DeriveParams): string | null {
-    if (params.occurredAtMs === undefined) return null;
-    return `${params.tenantId}:${params.traceId}:${params.occurredAtMs}`;
+    if (params.foldVersion === undefined) return null;
+    return `${params.tenantId}:${params.traceId}:${params.foldVersion}`;
   }
 
   private memoize<T>(

--- a/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
@@ -28,29 +28,110 @@ interface DeriveParams {
 }
 
 /**
+ * Window during which a derivation for the same (tenant, trace, cutoff) reuses
+ * the in-flight or just-resolved span read. A coalesced fold batch dispatches
+ * its reactors per event but with one shared final fold state, so every
+ * reactor derives at the same occurredAt cutoff back-to-back; this window
+ * collapses those identical reads into one. Kept short because the cutoff makes
+ * each read deterministic, so the only thing aging out matters for is rare
+ * out-of-order late spans.
+ */
+const DERIVATION_READ_WINDOW_MS = 30_000;
+/** Cap so a burst of distinct traces can't grow the memo without bound. */
+const DERIVATION_MEMO_MAX_ENTRIES = 2_000;
+
+interface MemoEntry<T> {
+  value: Promise<T>;
+  expiresAt: number;
+}
+
+/**
  * Derives trace-summary fields that used to be accumulated on the hot fold
  * path. Moving them here keeps the fold O(1) per span: scenario role
  * cost/latency are computed from stored_spans once, when simulation metrics
  * are needed, instead of being maintained per-span for every trace on the
  * platform. See scenario-role-metrics.derivation.ts for the aggregation logic
  * and its parity with the legacy incremental fold.
+ *
+ * The all-spans read these derivations issue is multi-MB for large traces. A
+ * coalesced fold batch fires its reactors once per event but at one shared
+ * occurredAt cutoff, so without coalescing the same read would run once per
+ * span in the backlog — the read-amplification that re-saturated Redis/ClickHouse
+ * during a backlog drain. The derivations are memoized per (tenant, trace,
+ * cutoff) so a batch reads stored spans once regardless of how many reactors or
+ * events it dispatches.
  */
 export class TraceReadDerivationService {
   private readonly spanCostService = new SpanCostService();
+  private readonly scenarioRoleMetricsMemo = new Map<
+    string,
+    MemoEntry<ScenarioRoleMetrics>
+  >();
+  private readonly eventsMemo = new Map<string, MemoEntry<DerivedTraceEvent[]>>();
 
   constructor(private readonly spans: NormalizedSpanReader) {}
 
   async deriveScenarioRoleMetrics(
     params: DeriveParams,
   ): Promise<ScenarioRoleMetrics> {
-    const spans = await this.spans.getNormalizedSpansByTraceId(params);
-    return deriveScenarioRoleMetricsFromSpans({
-      spans,
-      spanCostService: this.spanCostService,
+    return this.memoize(this.scenarioRoleMetricsMemo, params, async () => {
+      const spans = await this.spans.getNormalizedSpansByTraceId(params);
+      return deriveScenarioRoleMetricsFromSpans({
+        spans,
+        spanCostService: this.spanCostService,
+      });
     });
   }
 
   async deriveEvents(params: DeriveParams): Promise<DerivedTraceEvent[]> {
-    return this.spans.getTraceEventsByTraceId(params);
+    return this.memoize(this.eventsMemo, params, () =>
+      this.spans.getTraceEventsByTraceId(params),
+    );
+  }
+
+  /**
+   * Only deterministic reads are memoized: a derivation with an occurredAt
+   * cutoff returns the same spans no matter when it runs, so sharing it across
+   * a batch is safe. A live read (no cutoff) is left to pass straight through.
+   */
+  private memoKey(params: DeriveParams): string | null {
+    if (params.occurredAtMs === undefined) return null;
+    return `${params.tenantId}:${params.traceId}:${params.occurredAtMs}`;
+  }
+
+  private memoize<T>(
+    cache: Map<string, MemoEntry<T>>,
+    params: DeriveParams,
+    read: () => Promise<T>,
+  ): Promise<T> {
+    const key = this.memoKey(params);
+    if (key === null) return read();
+
+    const now = Date.now();
+    const hit = cache.get(key);
+    if (hit && hit.expiresAt > now) return hit.value;
+
+    const value = read();
+    cache.set(key, { value, expiresAt: now + DERIVATION_READ_WINDOW_MS });
+    // Never cache a failed read: drop the entry so the next caller retries
+    // instead of replaying the rejection for the whole window.
+    value.catch(() => {
+      if (cache.get(key)?.value === value) cache.delete(key);
+    });
+    this.evict(cache, now);
+    return value;
+  }
+
+  private evict<T>(cache: Map<string, MemoEntry<T>>, now: number): void {
+    if (cache.size <= DERIVATION_MEMO_MAX_ENTRIES) return;
+    for (const [k, entry] of cache) {
+      if (entry.expiresAt <= now) cache.delete(k);
+    }
+    // Map preserves insertion order, so the front is the oldest entry.
+    while (cache.size > DERIVATION_MEMO_MAX_ENTRIES) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined) break;
+      cache.delete(oldest);
+    }
   }
 }

--- a/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
@@ -112,6 +112,11 @@ export class TraceReadDerivationService {
     if (hit && hit.expiresAt > now) return hit.value;
 
     const value = read();
+    // Delete before set so a refreshed (expired) key re-inserts at the end:
+    // Map.set on an existing key keeps its original position, which would let
+    // eviction drop a just-read entry as the "oldest". Re-inserting keeps the
+    // insertion order tracking last read.
+    cache.delete(key);
     cache.set(key, { value, expiresAt: now + DERIVATION_READ_WINDOW_MS });
     // Never cache a failed read: drop the entry so the next caller retries
     // instead of replaying the rejection for the whole window.

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -217,6 +217,7 @@ export class PipelineRegistry {
       tenantId: string;
       traceId: string;
       occurredAtMs?: number;
+      foldVersion?: number;
     }) => Promise<DerivedTraceEvent[]>;
   } {
     const traceReadDerivation = new TraceReadDerivationService(

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTrigger.reactor.ts
@@ -43,6 +43,7 @@ export interface EvaluationAlertTriggerReactorDeps
     tenantId: string;
     traceId: string;
     occurredAtMs?: number;
+    foldVersion?: number;
   }) => Promise<DerivedTraceEvent[]>;
 }
 
@@ -144,6 +145,7 @@ export function createEvaluationAlertTriggerReactor(
             tenantId,
             traceId,
             occurredAtMs: traceSummary.occurredAt,
+            foldVersion: traceSummary.spanCount,
           })
         : null;
 

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/computeRunMetrics.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/commands/computeRunMetrics.command.ts
@@ -39,6 +39,7 @@ export interface ComputeRunMetricsDeps {
     tenantId: string;
     traceId: string;
     occurredAtMs?: number;
+    foldVersion?: number;
   }) => Promise<{
     scenarioRoleCosts: Record<string, number>;
     scenarioRoleLatencies: Record<string, number>;
@@ -124,6 +125,7 @@ export class ComputeRunMetricsCommand
           tenantId: tenantIdStr,
           traceId,
           occurredAtMs: traceSummary.occurredAt,
+          foldVersion: traceSummary.spanCount,
         });
 
       // Summary exists but not yet populated (cost enrichment still in progress).

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/alertTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/alertTrigger.reactor.ts
@@ -28,6 +28,7 @@ export type AlertTriggerReactorDeps = TriggerActionDispatchDeps & {
     tenantId: string;
     traceId: string;
     occurredAtMs?: number;
+    foldVersion?: number;
   }) => Promise<DerivedTraceEvent[]>;
 };
 
@@ -67,6 +68,7 @@ export function createAlertTriggerReactor(
             tenantId,
             traceId,
             occurredAtMs: foldState.occurredAt,
+            foldVersion: foldState.spanCount,
           })
         : null;
 

--- a/specs/event-sourcing/fold-coalescing.feature
+++ b/specs/event-sourcing/fold-coalescing.feature
@@ -50,19 +50,20 @@ Feature: Group-coalesced fold projections
   # The per-event reactor dispatch above keeps every span's work, but reactors
   # that read trace-level data derived from stored_spans (alert triggers,
   # scenario role metrics) would otherwise re-issue that multi-MB read once per
-  # event. Sharing it across the batch is what keeps the recovery path from
-  # re-amplifying reads on the single-threaded Redis/ClickHouse.
+  # event. Sharing it across one fold version is what keeps the recovery path
+  # from re-amplifying reads on the single-threaded Redis/ClickHouse, while a
+  # fold that has advanced with newer spans still re-reads (no stale data).
   @unit @coalescing @reactors
-  Scenario: Repeated trace-level derivations for one trace read stored spans once
-    Given several reactor invocations derive trace data for the same trace at one fold cutoff
-    When they run within one coalesced batch window
+  Scenario: Repeated trace-level derivations within one fold version read stored spans once
+    Given several reactor invocations derive trace data for the same trace at one fold version
+    When they run within one coalesced batch
     Then the stored spans are read once, not once per invocation
 
   @unit @coalescing @reactors
-  Scenario: A later fold cutoff derives from stored spans again
-    Given trace data already derived at one fold cutoff
-    When trace data is derived again at a later cutoff
-    Then the stored spans are read again for the newer cutoff
+  Scenario: A derivation re-reads once the fold has advanced with new spans
+    Given trace data already derived at one fold version
+    When trace data is derived again after the fold advances with newer spans
+    Then the stored spans are read again rather than serving the earlier result
 
   @integration @coalescing @queue
   Scenario: A backed-up group is folded in a single batch call

--- a/specs/event-sourcing/fold-coalescing.feature
+++ b/specs/event-sourcing/fold-coalescing.feature
@@ -47,6 +47,23 @@ Feature: Group-coalesced fold projections
     Then the fold state is loaded and stored once
     And reactors are dispatched once per event, in occurredAt order
 
+  # The per-event reactor dispatch above keeps every span's work, but reactors
+  # that read trace-level data derived from stored_spans (alert triggers,
+  # scenario role metrics) would otherwise re-issue that multi-MB read once per
+  # event. Sharing it across the batch is what keeps the recovery path from
+  # re-amplifying reads on the single-threaded Redis/ClickHouse.
+  @unit @coalescing @reactors
+  Scenario: Repeated trace-level derivations for one trace read stored spans once
+    Given several reactor invocations derive trace data for the same trace at one fold cutoff
+    When they run within one coalesced batch window
+    Then the stored spans are read once, not once per invocation
+
+  @unit @coalescing @reactors
+  Scenario: A later fold cutoff derives from stored spans again
+    Given trace data already derived at one fold cutoff
+    When trace data is derived again at a later cutoff
+    Then the stored spans are read again for the newer cutoff
+
   @integration @coalescing @queue
   Scenario: A backed-up group is folded in a single batch call
     Given a group with ten queued events

--- a/specs/event-sourcing/tenant-soft-cap.feature
+++ b/specs/event-sourcing/tenant-soft-cap.feature
@@ -108,3 +108,24 @@ Feature: Per-tenant soft cap on in-flight dispatch
     Given a tenant "proj_acme" with a zombie group (empty jobs zset) on the ready zset
     When DISPATCH_BATCH_LUA is invoked
     Then the zombie group is removed from the ready zset
+
+  # Over-cap groups are pushed to a future score instead of being left at the
+  # head of ready, so repeated polls don't keep scanning past them every time.
+  # A quiet tenant deeper in the zset is reached immediately, and a follow-up
+  # poll returns nothing instead of re-walking the deferred groups; they become
+  # eligible again after the defer window.
+  @integration @tenant-cap @fairness
+  Scenario: Over-cap groups are deferred so they don't starve other tenants on repeated polls
+    Given a tenant "proj_noisy" over cap with many groups at the head of ready
+    And a tenant "proj_quiet" with one group later in the zset
+    When dispatch is polled repeatedly at the same time
+    Then "proj_quiet"'s group is dispatched
+    And the over-cap groups are pushed to a future score so the next poll skips them
+    And they become eligible again only after the defer window
+
+  @integration @tenant-cap @batch @fairness
+  Scenario: dispatchBatch defers over-cap groups the same way
+    Given a tenant over cap with groups on the ready zset
+    When DISPATCH_BATCH_LUA is invoked
+    Then the over-cap groups are deferred to a future score
+    And under-cap tenants are still served in the same batch


### PR DESCRIPTION
## What

Memoize the trace read-derivation (`deriveEvents` / `deriveScenarioRoleMetrics`) per `(tenantId, traceId, occurredAtMs)` so a coalesced fold batch reads stored spans once, not once per dispatched reactor/event.

## Why

Live incident: `/api/health/processor` timed out and the GroupQueue stalled at ~226k groups in `ready` (not memory, zero Redis evictions). Root cause was read amplification on the recovery path:

- The fold coalesces a backed-up group into one load/apply/store cycle (O(1) per span), but `projectionRouter` still dispatches reactors once per event so per-span reactors keep their work.
- Reactors that read trace-level data derived from `stored_spans` (alert triggers, scenario role metrics) re-issue a multi-MB all-spans ClickHouse read on every event. All events in a coalesced batch carry the same final `foldState.occurredAt`, so for an N-span trace the identical read ran up to N times.
- During a backlog drain this multiplied both the big ClickHouse reads and the fold-state bandwidth on the single-threaded Redis. Adding workers made it worse (8 workers drove Redis to ~37.7k ops/sec and 98% engine CPU), so scaling was not viable until the per-job cost dropped.

## Fix

A bounded, short-window memo in `TraceReadDerivationService`:

- Keyed by `(tenantId, traceId, occurredAtMs)`. The cutoff makes each read deterministic, so sharing it across a batch is safe.
- Single-flight: concurrent callers share the in-flight read; callers within the window share the resolved result.
- Live reads (no cutoff) pass straight through, never cached.
- Failed reads are not cached, so the next caller retries instead of replaying the error.
- Bounded entry count with expiry-first eviction so a burst of distinct traces cannot grow it without bound.

The per-event reactor dispatch is unchanged, so per-span reactors still see every event.

## Tests

`trace-read-derivation.service.unit.test.ts` (7 tests): N derivations for one trace+cutoff read once, concurrent reads collapse to one, a later cutoff reads again, live reads are not memoized, the window expiring re-reads, and a failed read is not cached.

Scenarios added to `specs/event-sourcing/fold-coalescing.feature` and bound.

## Follow-ups (non-blocking, not in this hotfix)

- Unify the 3 per-pipeline `TraceReadDerivationService` instances (registry deriveEvents x2 + computeRunMetrics) into one shared instance so the memo also collapses cross-pipeline same-trace reads. The in-pipeline hot path (where the amplification lives) is already covered, so this is an optimization, not a correctness gap.
- The memo keys on `spanCount`, which does not increment when a span is re-exported with the same `spanId` (content change, same count). A derivation could then reuse the prior result within the 30s window. Far narrower than the old constant-key bug, bounded by the window, and tolerable for alert/scenario eventual consistency. A stronger watermark (an event/version counter that ticks on every applied event) would close it.