### PR TITLE
fix(experiments): stop API-key guard from 401ing session-driven /execute

### DIFF
--- a/langwatch/src/server/api-router.ts
+++ b/langwatch/src/server/api-router.ts
@@ -80,6 +80,15 @@ export function createApiRouter() {
   api.route("/", dashboardsApp);
   api.route("/", datasetApp);
   api.route("/", evaluatorsApp);
+  // experimentsV3App owns the session-authenticated execute/abort endpoints and
+  // the API-key-authenticated run/runs endpoints. It must mount before
+  // experimentsApp, whose project-API-key auth middleware spans the whole
+  // /api/experiments/* namespace. Mounted first, that middleware would run on
+  // POST /api/experiments/execute (a session-cookie request that carries no
+  // API key) and reject it before the session is ever checked. Mounting v3
+  // first lets its own handlers match and respond, short-circuiting the guard.
+  api.route("/", experimentsV3App);
+  api.route("/", experimentsV3LegacyAliasApp);  // /api/evaluations/v3/... → /api/experiments/...
   api.route("/", experimentsApp);
   api.route("/", filesApp);
   api.route("/", exportTracesApp);
@@ -101,8 +110,6 @@ export function createApiRouter() {
   api.route("/", triggersApp);
   api.route("/", workflowsCrudApp);      // CRUD — complements workflowsApp (code-completion, post_event)
 
-  api.route("/", experimentsV3App);
-  api.route("/", experimentsV3LegacyAliasApp);  // /api/evaluations/v3/... → /api/experiments/...
   api.route("/", gatewayInternalApp);
   api.route("/", otelApp);
   api.route("/", playgroundApp);

--- a/langwatch/src/server/routes/__tests__/experiments-route-auth.test.ts
+++ b/langwatch/src/server/routes/__tests__/experiments-route-auth.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment node
+ *
+ * @see specs/experiments-v3/execution-backend.feature - Hono SSE Endpoint auth
+ *
+ * Regression guard for the prod incident where the browser workbench got
+ * 401 "Authentication required. Use Authorization: Basic ..." on
+ * POST /api/experiments/execute.
+ *
+ * Root cause: the public experiments REST API (GET /api/experiments) and the
+ * session-driven execute/abort endpoints share the /api/experiments path but
+ * live in two separate Hono apps. The public app applies a project-API-key
+ * auth middleware across the whole /api/experiments/* namespace. When it is
+ * composed ahead of the execute app, that API-key guard runs first on
+ * POST /api/experiments/execute (a request that carries only a browser session
+ * cookie, never an API key) and rejects it before the session is checked.
+ *
+ * This test exercises the real router composition (createApiRouter) so a
+ * future reordering or re-introduction of a namespace-wide API-key guard that
+ * shadows the session routes fails here.
+ */
+import { Hono } from "hono";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// The execute endpoint authenticates by user session. Force "no session" so
+// the request, once it reaches the endpoint, returns the session-layer 401
+// ("You must be logged in") rather than proceeding into prisma/orchestrator.
+// If the API-key guard wrongly intercepts, we get the API-key 401 instead,
+// which is exactly what this test asserts must NOT happen.
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: vi.fn().mockResolvedValue(null),
+}));
+
+const API_KEY_GUARD_MESSAGE =
+  "Authentication required. Use Authorization: Basic base64(projectId:token), Authorization: Bearer <token>, or X-Auth-Token header.";
+const SESSION_GUARD_MESSAGE = "You must be logged in to access this endpoint.";
+
+// Minimal body that passes the execute endpoint's zod validation, so routing
+// reaches the auth layer rather than short-circuiting at body validation.
+const validExecuteBody = {
+  projectId: "project_test",
+  name: "regression-test",
+  dataset: { id: "dataset-1", name: "ds", type: "inline" as const, columns: [] },
+  targets: [],
+  evaluators: [],
+  scope: { type: "full" as const },
+};
+
+let router: Hono;
+
+beforeAll(async () => {
+  const { createApiRouter } = await import("~/server/api-router");
+  router = createApiRouter();
+}, 120_000);
+
+describe("POST /api/experiments/execute auth", () => {
+  describe("when the request carries a user session but no project API key", () => {
+    /** @scenario Browser execution authenticates by user session */
+    it("is not rejected by the project API-key guard", async () => {
+      const res = await router.request(
+        "http://localhost/api/experiments/execute",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(validExecuteBody),
+        },
+      );
+
+      const body = (await res.json()) as { error?: string; message?: string };
+
+      // The API-key guard from the public experiments REST app must never be
+      // the thing that answers this request.
+      expect(body.message).not.toBe(API_KEY_GUARD_MESSAGE);
+      expect(body.error).not.toBe("Unauthorized");
+    });
+  });
+
+  describe("when the request has neither a session nor an API key", () => {
+    /** @scenario Execution endpoint rejects requests with no session */
+    it("returns 401 from the session guard telling the user to log in", async () => {
+      const res = await router.request(
+        "http://localhost/api/experiments/execute",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(validExecuteBody),
+        },
+      );
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error?: string };
+      expect(body.error).toBe(SESSION_GUARD_MESSAGE);
+    });
+  });
+});
+
+// Mounting the session app first must not steal the public REST list endpoint
+// (GET /api/experiments) from the API-key-authenticated experiments app.
+describe("GET /api/experiments (public REST list)", () => {
+  describe("when the request has no project API key", () => {
+    it("is still answered by the project API-key guard", async () => {
+      const res = await router.request("http://localhost/api/experiments", {
+        method: "GET",
+      });
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error?: string; message?: string };
+      expect(body.error).toBe("Unauthorized");
+      expect(body.message).toBe(API_KEY_GUARD_MESSAGE);
+    });
+  });
+});

--- a/specs/experiments-v3/execution-backend.feature
+++ b/specs/experiments-v3/execution-backend.feature
@@ -239,11 +239,24 @@ Feature: Evaluation execution - Backend
   # Hono SSE Endpoint
   # ==========================================================================
 
-  @unimplemented
-  Scenario: Endpoint requires authentication
-    Given no auth token
+  # The execute and abort endpoints are driven by the browser workbench, so
+  # they authenticate by the logged-in user session, not by a project API key.
+  # The public experiments REST API (list endpoint) lives under the same
+  # /api/experiments path and authenticates by API key. These two auth models
+  # must not collide: the API-key guard must never intercept a session-driven
+  # execute request and reject it before the session is checked.
+
+  Scenario: Browser execution authenticates by user session
+    Given a logged-in user running an evaluation from the workbench
+    And the request carries the user session but no project API key
     When I POST to /api/experiments/execute
-    Then I receive 401 Unauthorized
+    Then the request reaches the session-authenticated execute endpoint
+    And it is not rejected by the project API-key guard
+
+  Scenario: Execution endpoint rejects requests with no session
+    Given a request with neither a user session nor a project API key
+    When I POST to /api/experiments/execute
+    Then I receive 401 Unauthorized telling me to log in
 
   @unimplemented
   Scenario: Endpoint validates request body


### PR DESCRIPTION
## What was happening

Clicking **Run** in the evaluations-v3 Experiments Workbench failed with an "Execution Failed" toast. The browser's `POST /api/experiments/execute` came back `401 Unauthorized`:

```
error    "Unauthorized"
message  "Authentication required. Use Authorization: Basic base64(projectId:token), Authorization: Bearer <token>, or X-Auth-Token header."
```

That message comes from the project-API-key auth middleware, but the workbench authenticates by the logged-in user session, not by an API key. The request never should have hit that middleware.

## Root cause

Two Hono apps share the `/api/experiments` base path:

- `experimentsApp` (`app/api/experiments/[[...route]]/app.ts`): the public REST list endpoint `GET /api/experiments`, which applies `.use(authMiddleware)` (project API key) across the whole `/api/experiments/*` namespace.
- `experimentsV3App` (`server/routes/experiments-v3.ts`): the session-authenticated `POST /execute` and `/abort`, plus the API-key-authenticated `/:slug/run` and `/runs` endpoints.

In `createApiRouter`, `experimentsApp` was mounted before `experimentsV3App`. Hono merges a mounted app's `.use()` middleware into the parent router keyed by path, so the API-key guard registered for `/api/experiments/*` ran first on every request in that namespace. For `POST /api/experiments/execute`, which carries only a session cookie and no API key, the guard returned 401 before the session was ever checked.

API-key routes (`/runs`, `/:slug/run`) survived because they do send a key, so the guard let them through. Only the session-cookie routes (`/execute`, `/abort`) broke. This shipped with the evaluations-v3 to experiments rename in #3893, when `/execute` moved under the `/api/experiments` namespace.

I reproduced the exact behavior at the framework level (Hono 4.12.16): mounting the public app first returns the API-key 401 on `/execute`; mounting the v3 app first returns 200 and reaches the handler.

## The fix

Mount `experimentsV3App` (and its legacy alias) before `experimentsApp`. The session-authenticated handlers now match first and return their response, short-circuiting the namespace-wide API-key guard. This mirrors the existing `workflowsApp` / `workflowsCrudApp` ordering, where the specific handlers are mounted ahead of the API-key-guarded CRUD app for the same reason.

The public `GET /api/experiments` list endpoint is unaffected: no v3 route matches it, so it still falls through to the API-key-guarded list handler.

## Tests

New `experiments-route-auth.test.ts` runs against the real `createApiRouter()` composition and asserts:

1. `POST /api/experiments/execute` with no API key is no longer answered by the API-key guard.
2. An unauthenticated execute request reaches the session guard and gets "You must be logged in to access this endpoint."
3. `GET /api/experiments` with no API key is still answered by the API-key guard (no collateral damage to the public REST list).

The test fails on the pre-fix mount order and passes after, so a future reorder or a re-introduced namespace-wide guard that shadows the session routes is caught here.

Specs updated in `specs/experiments-v3/execution-backend.feature` to describe the session-vs-API-key auth distinction for the execute endpoint.

## QA (real browser, my fix running locally against dev infra)

Dogfooded with `pnpm dev` on this branch, signed in as a real user (browser session, no API key), and issued the exact request the workbench Run button makes. Before/after on the actual Experiments Workbench surface:

![execute auth before/after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4212/auth-fix/execute-auth-proof.png)

The live response is `HTTP 400 "Invalid dataset configuration"` (an empty test payload). The point is what it is NOT: it is no longer the `401 "Authentication required. Use Authorization: Basic ..."` the user reported. The request now passes session auth plus the project-permission check and reaches the execution data-loading logic.

The Experiments Workbench surface where the report came from:

![experiments workbench](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4212/auth-fix/workbench.png)