### PR TITLE
fix(event-sourcing): keep in-flight trace-read memo entries shareable past the window

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/trace-read-derivation.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-read-derivation.service.unit.test.ts
@@ -137,6 +137,38 @@ describe("TraceReadDerivationService", () => {
     });
   });
 
+  describe("given a read slower than the window", () => {
+    describe("when a concurrent caller arrives after the window would have elapsed", () => {
+      it("shares the still-in-flight read instead of firing a duplicate", async () => {
+        vi.useFakeTimers();
+        let reads = 0;
+        let resolveRead!: (value: never[]) => void;
+        const reader: NormalizedSpanReader = {
+          async getNormalizedSpansByTraceId() {
+            return [];
+          },
+          getTraceEventsByTraceId() {
+            reads++;
+            return new Promise((resolve) => {
+              resolveRead = resolve;
+            });
+          },
+        };
+        const service = new TraceReadDerivationService(reader);
+
+        const first = service.deriveEvents(BATCH_PARAMS);
+        // The window elapses while the read is still in flight.
+        vi.setSystemTime(Date.now() + 31_000);
+        const second = service.deriveEvents(BATCH_PARAMS);
+
+        expect(reads).toBe(1);
+
+        resolveRead([]);
+        await Promise.all([first, second]);
+      });
+    });
+  });
+
   describe("given a read that rejects", () => {
     describe("when the same derivation is retried", () => {
       it("does not cache the failure", async () => {

--- a/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-read-derivation.service.ts
@@ -137,12 +137,26 @@ export class TraceReadDerivationService {
     // eviction drop a just-read entry as the "oldest". Re-inserting keeps the
     // insertion order tracking last read.
     cache.delete(key);
-    cache.set(key, { value, expiresAt: now + DERIVATION_READ_WINDOW_MS });
-    // Never cache a failed read: drop the entry so the next caller retries
-    // instead of replaying the rejection for the whole window.
-    value.catch(() => {
-      if (cache.get(key)?.value === value) cache.delete(key);
-    });
+    // Keep an in-flight read shareable no matter how long it takes: start the
+    // freshness window only once the read resolves. Stamping expiresAt up front
+    // would let a read slower than the window expire mid-flight, so concurrent
+    // callers would miss the memo and fire duplicate reads — defeating
+    // single-flight exactly on the slow heavy-trace paths this exists for.
+    const entry: MemoEntry<T> = {
+      value,
+      expiresAt: Number.POSITIVE_INFINITY,
+    };
+    cache.set(key, entry);
+    value.then(
+      () => {
+        entry.expiresAt = Date.now() + DERIVATION_READ_WINDOW_MS;
+      },
+      // Never cache a failed read: drop the entry so the next caller retries
+      // instead of replaying the rejection.
+      () => {
+        if (cache.get(key) === entry) cache.delete(key);
+      },
+    );
     this.evict(cache, now);
     return value;
   }


### PR DESCRIPTION
## What

Follow-up to #4211. Keep an in-flight trace-read memo entry shareable no matter how long the read takes, by starting the 30s freshness window only once the read resolves.

## Why

CodeRabbit flagged it on #4211 (Major): `expiresAt` was stamped when the read *started* (`now + window`). A read slower than the window therefore expires while still in flight, so a concurrent caller arriving after the window misses the memo and fires a duplicate read. That breaks single-flight on exactly the slow, heavy-trace reads the memo exists to collapse, which is where the original read-amplification incident lived.

## Fix

While the read is pending the entry holds `expiresAt = +Infinity`, so concurrent callers always share it. On resolve, `expiresAt` is set to `Date.now() + window`, so the freshness window measures the age of the result, not the start of the read. The reject path still drops the entry (no caching of failures). In-flight entries sit at the back of the insertion order, so the front-anchored expiry sweep is unaffected.

## Tests

Added a regression test: with a read held in flight and the system clock advanced past the window, a second concurrent derivation shares the in-flight read (one underlying read, not two). 9/9 unit tests green.
