### PR TITLE
fix(event-sourcing): park over-cap groups out of ready instead of re-deferring

### DIFF
--- a/langwatch/src/components/ops/dashboard/OpsDashboardContent.tsx
+++ b/langwatch/src/components/ops/dashboard/OpsDashboardContent.tsx
@@ -31,6 +31,10 @@ export function OpsDashboardContent({ data }: { data: DashboardData }) {
     (sum, q) => sum + q.blockedGroupCount,
     0,
   );
+  const totalParked = data.queues.reduce(
+    (sum, q) => sum + q.parkedGroupCount,
+    0,
+  );
   const totalDlq = data.queues.reduce((sum, q) => sum + q.dlqCount, 0);
 
   const queuesQuery = api.ops.listQueues.useQuery(undefined, {
@@ -71,6 +75,12 @@ export function OpsDashboardContent({ data }: { data: DashboardData }) {
           value={totalBlocked.toString()}
           sublabel={`${data.totalGroups} groups`}
           color={totalBlocked > 0 ? "red.500" : undefined}
+        />
+        <LinkedStat
+          label="Parked"
+          value={totalParked.toString()}
+          sublabel="over cap"
+          color={totalParked > 0 ? "orange.500" : undefined}
         />
         <LinkedStat
           label="P50"

--- a/langwatch/src/components/ops/dashboard/OpsDashboardContent.tsx
+++ b/langwatch/src/components/ops/dashboard/OpsDashboardContent.tsx
@@ -58,7 +58,9 @@ export function OpsDashboardContent({ data }: { data: DashboardData }) {
         <LinkedStat
           label="Completed/s"
           value={formatRate(data.completedPerSec)}
-          sublabel={`${formatCount(data.totalCompleted)} total`}
+          sublabel={`peak ${formatRate(data.peakCompletedPerSec)} · ${formatCount(
+            data.totalCompleted,
+          )} total`}
         />
         <LinkedStat
           label="Failed/s"

--- a/langwatch/src/components/ops/dashboard/ThroughputChart.tsx
+++ b/langwatch/src/components/ops/dashboard/ThroughputChart.tsx
@@ -18,6 +18,7 @@ const COLORS = {
   failed: { stroke: "#ef4444", fill: "#ef4444" },
   pending: "#a78bfa",
   blocked: "#f97316",
+  parked: "#eab308",
 };
 
 interface ChartPoint {
@@ -27,6 +28,7 @@ interface ChartPoint {
   failed: number;
   pending: number;
   blocked: number;
+  parked: number;
 }
 
 const BUCKET_OPTIONS = [
@@ -53,6 +55,7 @@ function downsample(
       failed: point.failedPerSec,
       pending: point.pendingCount,
       blocked: point.blockedCount,
+      parked: point.parkedCount,
     }));
   }
 
@@ -71,6 +74,7 @@ function downsample(
       existing.sum.failed += point.failedPerSec;
       existing.sum.pending += point.pendingCount;
       existing.sum.blocked += point.blockedCount;
+      existing.sum.parked += point.parkedCount;
       existing.count++;
     } else {
       buckets.set(bucketKey, {
@@ -81,6 +85,7 @@ function downsample(
           failed: point.failedPerSec,
           pending: point.pendingCount,
           blocked: point.blockedCount,
+          parked: point.parkedCount,
         },
         count: 1,
       });
@@ -96,6 +101,7 @@ function downsample(
       failed: sum.failed / count,
       pending: Math.round(sum.pending / count),
       blocked: Math.round(sum.blocked / count),
+      parked: Math.round(sum.parked / count),
     });
   }
 
@@ -169,10 +175,10 @@ function CustomTooltip({
   if (!active || !payload?.length || label == null) return null;
 
   const rates = payload.filter(
-    (p) => p.name !== "Pending" && p.name !== "Blocked",
+    (p) => p.name !== "Pending" && p.name !== "Blocked" && p.name !== "Parked",
   );
   const counts = payload.filter(
-    (p) => p.name === "Pending" || p.name === "Blocked",
+    (p) => p.name === "Pending" || p.name === "Blocked" || p.name === "Parked",
   );
 
   return (
@@ -237,6 +243,7 @@ function CustomLegend({ showCounts }: { showCounts: boolean }) {
       ? [
           { name: "Pending", color: COLORS.pending, type: "line" as const },
           { name: "Blocked", color: COLORS.blocked, type: "line" as const },
+          { name: "Parked", color: COLORS.parked, type: "line" as const },
         ]
       : []),
   ];
@@ -300,14 +307,14 @@ export function ThroughputChart({ data }: { data: DashboardData }) {
   }, [chartData]);
 
   const hasCountData = useMemo(() => {
-    return chartData.some((p) => p.pending > 0 || p.blocked > 0);
+    return chartData.some((p) => p.pending > 0 || p.blocked > 0 || p.parked > 0);
   }, [chartData]);
 
   const yMaxRight = useMemo(() => {
     if (!hasCountData) return 10;
     let max = 0;
     for (const p of chartData) {
-      max = Math.max(max, p.pending, p.blocked);
+      max = Math.max(max, p.pending, p.blocked, p.parked);
     }
     return max <= 0 ? 10 : niceMax(max * 1.3);
   }, [chartData, hasCountData]);
@@ -481,6 +488,19 @@ export function ThroughputChart({ data }: { data: DashboardData }) {
             dot={false}
             activeDot={{ r: 2, strokeWidth: 0 }}
             name="Blocked"
+            isAnimationActive={false}
+          />
+          <Line
+            yAxisId={hasCountData ? "count" : "rate"}
+            type="monotone"
+            dataKey="parked"
+            stroke={COLORS.parked}
+            strokeWidth={1}
+            strokeOpacity={0.6}
+            strokeDasharray="4 3"
+            dot={false}
+            activeDot={{ r: 2, strokeWidth: 0 }}
+            name="Parked"
             isAnimationActive={false}
           />
         </AreaChart>

--- a/langwatch/src/server/app-layer/ops/__tests__/build-pipeline-tree.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/build-pipeline-tree.unit.test.ts
@@ -35,6 +35,7 @@ function createQueue(overrides: Partial<QueueInfo> = {}): QueueInfo {
     activeGroupCount: 0,
     totalPendingJobs: 0,
     dlqCount: 0,
+    parkedGroupCount: 0,
     groups: [],
     ...overrides,
   };

--- a/langwatch/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -69,6 +69,7 @@ describe("QueueService", () => {
       activeGroupCount: 0,
       totalPendingJobs: 0,
       dlqCount: 0,
+      parkedGroupCount: 0,
       groups,
     };
 
@@ -143,6 +144,7 @@ describe("QueueService", () => {
           activeGroupCount: 0,
           totalPendingJobs: 0,
           dlqCount: 0,
+          parkedGroupCount: 0,
           groups: [createGroup({ groupId: "other" }), group],
         };
         const repo = createMockRepo({
@@ -166,6 +168,7 @@ describe("QueueService", () => {
           activeGroupCount: 0,
           totalPendingJobs: 0,
           dlqCount: 0,
+          parkedGroupCount: 0,
           groups: [createGroup({ groupId: "other" })],
         };
         const repo = createMockRepo({

--- a/langwatch/src/server/app-layer/ops/metrics-collector.ts
+++ b/langwatch/src/server/app-layer/ops/metrics-collector.ts
@@ -798,9 +798,17 @@ class OpsMetricsCollector {
 
       const cutoff =
         Date.now() - THROUGHPUT_BUFFER_SIZE * METRICS_COLLECT_INTERVAL_MS;
-      this.throughputBuffer = state.throughputBuffer.filter(
-        (p) => p.timestamp > cutoff,
-      );
+      // Backfill parkedCount on points persisted before the Parked series
+      // existed, so the chart never reads undefined/NaN for old history. The
+      // state version is intentionally not bumped: this keeps the rolling
+      // history AND the accumulated peaks across the deploy (a bump would zero
+      // them, including the freshly-added Completed/s peak tile).
+      this.throughputBuffer = state.throughputBuffer
+        .filter((p) => p.timestamp > cutoff)
+        .map((p) => ({
+          ...p,
+          parkedCount: (p as { parkedCount?: number }).parkedCount ?? 0,
+        }));
 
       this.latestTotalCompleted = state.latestTotalCompleted;
       this.latestTotalFailed = state.latestTotalFailed;

--- a/langwatch/src/server/app-layer/ops/metrics-collector.ts
+++ b/langwatch/src/server/app-layer/ops/metrics-collector.ts
@@ -418,11 +418,13 @@ class OpsMetricsCollector {
 
     let totalGroups = 0;
     let blockedGroups = 0;
+    let parkedGroups = 0;
     let totalPendingJobs = 0;
 
     for (const q of fullQueues) {
       totalGroups += q.groups.length;
       blockedGroups += q.blockedGroupCount;
+      parkedGroups += q.parkedGroupCount;
       totalPendingJobs += q.totalPendingJobs;
     }
 
@@ -482,6 +484,7 @@ class OpsMetricsCollector {
     return {
       totalGroups,
       blockedGroups,
+      parkedGroups,
       totalPendingJobs,
       throughputIngestedPerSec: this.currentIngestedPerSec,
       totalCompleted: this.latestTotalCompleted,
@@ -976,8 +979,10 @@ class OpsMetricsCollector {
       this.hasBaseline = true;
 
       let totalBlockedCount = 0;
+      let totalParkedCount = 0;
       for (const q of queues) {
         totalBlockedCount += q.blockedGroupCount;
+        totalParkedCount += q.parkedGroupCount;
       }
 
       this.throughputBuffer.push({
@@ -987,6 +992,7 @@ class OpsMetricsCollector {
         failedPerSec: this.currentFailedPerSec,
         pendingCount: totalPending,
         blockedCount: totalBlockedCount,
+        parkedCount: totalParkedCount,
       });
 
       if (this.throughputBuffer.length > THROUGHPUT_BUFFER_SIZE) {

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -9,11 +9,15 @@ import type {
   JobEntry,
 } from "./queue.repository";
 import { normalizeErrorMessage } from "../normalize-error-message";
-import { GROUP_QUEUE_REGISTRY_KEY, TTL_HELPER_LUA } from "~/server/event-sourcing/queues/groupQueue/scripts";
+import {
+  GROUP_QUEUE_REGISTRY_KEY,
+  TTL_HELPER_LUA,
+  PARK_HELPER_LUA,
+} from "~/server/event-sourcing/queues/groupQueue/scripts";
 
 // ── Lua Scripts ──────────────────────────────────────────────────────
 
-const UNBLOCK_LUA = TTL_HELPER_LUA + `
+const UNBLOCK_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
 local blockedKey = KEYS[1]
 local activeKey  = KEYS[2]
 local jobsKey    = KEYS[3]
@@ -32,7 +36,11 @@ if wasBlocked > 0 then
   local pendingCount = redis.call("ZCARD", jobsKey)
   if pendingCount > 0 then
     local score = 1
-    redis.call("ZADD", readyKey, score, groupId)
+    -- Route through the parked-aware write so unblock can't clobber a parked
+    -- group back into the dispatch scan (TRAP 1). A blocked group is never
+    -- itself parked, so this normally writes straight to ready; if the tenant
+    -- is over cap, the next dispatch parks it again.
+    addToReadyOrParked(readyKey, groupId, score, false)
     -- The block path PERSISTs the group keys; restore the safety-net TTL now
     -- that the group is live again (dataKey = jobsKey with the ":jobs" suffix
     -- swapped for ":data").
@@ -138,7 +146,7 @@ redis.call("LTRIM", signalKey, 0, 999)
 return count
 `;
 
-const REPLAY_FROM_DLQ_LUA = TTL_HELPER_LUA + `
+const REPLAY_FROM_DLQ_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
 local dlqJobsKey   = KEYS[1]
 local dlqDataKey   = KEYS[2]
 local dlqErrorKey  = KEYS[3]
@@ -169,7 +177,10 @@ redis.call("DEL", dlqErrorKey)
 redis.call("SREM", dlqIndexKey, groupId)
 
 if count > 0 then
-  redis.call("ZADD", readyKey, 1, groupId)
+  -- Route through the parked-aware write so a replay can't clobber a parked
+  -- group back into the dispatch scan (TRAP 1). A DLQ group is never itself
+  -- parked; if the tenant is over cap, the next dispatch parks it again.
+  addToReadyOrParked(readyKey, groupId, 1, false)
   -- Restore the safety-net TTL on the revived group keys (DLQ keys carry none).
   refreshGroupKeyTtl(dstJobsKey, dstDataKey, nowMs)
 end
@@ -280,15 +291,39 @@ export class QueueRedisRepository implements QueueRepository {
     const blockedKey = `${prefix}blocked`;
     const dlqKey = `${prefix}dlq`;
     const totalPendingKey = `${prefix}stats:total-pending`;
+    const parkedTenantsKey = `${prefix}parked-tenants`;
 
-    const [readyCount, blockedCount, dlqCount, topReadyMembers, totalPendingRaw] =
-      await Promise.all([
-        this.redis.zcard(readyKey),
-        this.redis.scard(blockedKey),
-        this.redis.scard(dlqKey),
-        this.redis.zrevrange(readyKey, offset, offset + limit - 1, "WITHSCORES"),
-        this.redis.get(totalPendingKey),
-      ]);
+    const [
+      readyCount,
+      blockedCount,
+      dlqCount,
+      topReadyMembers,
+      totalPendingRaw,
+      parkedTenants,
+    ] = await Promise.all([
+      this.redis.zcard(readyKey),
+      this.redis.scard(blockedKey),
+      this.redis.scard(dlqKey),
+      this.redis.zrevrange(readyKey, offset, offset + limit - 1, "WITHSCORES"),
+      this.redis.get(totalPendingKey),
+      this.redis.smembers(parkedTenantsKey),
+    ]);
+
+    // Sum parked depth across the tenants currently over cap. The registry set
+    // is tiny (one entry per over-cap tenant), so this is a single SMEMBERS plus
+    // one ZCARD per parked tenant — effectively free in the cap=0 steady state
+    // where the registry is empty.
+    let parkedGroupCount = 0;
+    if (parkedTenants.length > 0) {
+      const parkedPipeline = this.redis.pipeline();
+      for (const tenantId of parkedTenants) {
+        parkedPipeline.zcard(`${prefix}parked:${tenantId}`);
+      }
+      const parkedResults = await parkedPipeline.exec();
+      for (const [err, val] of parkedResults ?? []) {
+        if (!err) parkedGroupCount += Number(val) || 0;
+      }
+    }
 
     const groupIds: string[] = [];
     const readyScores = new Map<string, number>();
@@ -458,6 +493,7 @@ export class QueueRedisRepository implements QueueRepository {
       activeGroupCount,
       totalPendingJobs,
       dlqCount,
+      parkedGroupCount,
       groups,
     };
   }

--- a/langwatch/src/server/app-layer/ops/types.ts
+++ b/langwatch/src/server/app-layer/ops/types.ts
@@ -27,6 +27,10 @@ export interface QueueInfo {
   activeGroupCount: number;
   totalPendingJobs: number;
   dlqCount: number;
+  // Groups a tenant soft-cap parked OUT of the ready scan because the tenant is
+  // at its in-flight cap. Surfaced so a parking spike (the over-cap ZADD storm
+  // root) or a parked-group strand is visible instead of invisible backlog.
+  parkedGroupCount: number;
   groups: GroupInfo[];
 }
 
@@ -38,6 +42,7 @@ export interface QueueSummaryInfo {
   activeGroupCount: number;
   totalPendingJobs: number;
   dlqCount: number;
+  parkedGroupCount: number;
 }
 
 export interface ThroughputPoint {
@@ -47,6 +52,7 @@ export interface ThroughputPoint {
   failedPerSec: number;
   pendingCount: number;
   blockedCount: number;
+  parkedCount: number;
 }
 
 export interface PhaseMetrics {
@@ -113,6 +119,7 @@ export interface RedisInfo {
 export interface DashboardData {
   totalGroups: number;
   blockedGroups: number;
+  parkedGroups: number;
   totalPendingJobs: number;
   throughputIngestedPerSec: number;
   totalCompleted: number;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -9,6 +9,7 @@ import {
   GroupStagingScripts,
   GROUP_KEY_TTL_MS,
   GROUP_QUEUE_REGISTRY_KEY,
+  PARK_RECONCILE_MAX_DRAIN,
   type DispatchResult,
 } from "../scripts";
 import { QueueRedisRepository } from "../../../../app-layer/ops/repositories/queue.redis.repository";
@@ -2881,6 +2882,37 @@ describe("GroupStagingScripts", () => {
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(0);
         expect(
           await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_acme"),
+        ).toBe(0);
+      });
+
+      it("drains a large parked backlog in bounded chunks when the cap is set to 0", async () => {
+        process.env[TENANT_CAP_ENV] = "0";
+        // Seed a large parked backlog directly — the parking mechanism is
+        // covered by the tests above; here we isolate the cap=0 kill-switch
+        // drain, which must NOT do one unbounded ZRANGE+ZREM/ZADD eval over the
+        // whole set (the May-27 442K-scale single-thread block this fix avoids).
+        const total = PARK_RECONCILE_MAX_DRAIN + 50;
+        const members: (string | number)[] = [];
+        for (let i = 0; i < total; i++) members.push(1000 + i, `proj_big/g${i}`);
+        await redis.zadd(`${keyPrefix()}parked:proj_big`, ...members);
+        await redis.sadd(`${keyPrefix()}parked-tenants`, "proj_big");
+        expect(await redis.zcard(parkedKey("proj_big"))).toBe(total);
+
+        // First reconcile past the 2s time-gate drains at most one chunk and
+        // leaves the tenant registered.
+        await scripts.dispatch({ nowMs: 5000, activeTtlSec: 60 });
+        expect(await redis.zcard(parkedKey("proj_big"))).toBe(
+          total - PARK_RECONCILE_MAX_DRAIN,
+        );
+        expect(
+          await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_big"),
+        ).toBe(1);
+
+        // A later reconcile drains the remainder and clears the registry.
+        await scripts.dispatch({ nowMs: 8000, activeTtlSec: 60 });
+        expect(await redis.zcard(parkedKey("proj_big"))).toBe(0);
+        expect(
+          await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_big"),
         ).toBe(0);
       });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -2587,9 +2587,14 @@ describe("GroupStagingScripts", () => {
       expect(third).toBeNull();
       // Counter unchanged — over-cap groups don't INCR
       expect(await redis.get(tenantCounterKey("proj_noisy"))).toBe("2");
-      // g3 is still on ready zset waiting
+      // g3 was parked OUT of the ready scan (not left at the head to be
+      // re-walked on every poll) and registered for reconcile.
       const ready = await inspectReadySet();
-      expect(ready.some((s) => s === "proj_noisy/g3")).toBe(true);
+      expect(ready.some((s) => s === "proj_noisy/g3")).toBe(false);
+      expect(await redis.zcard(`${keyPrefix()}parked:proj_noisy`)).toBe(1);
+      expect(
+        await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_noisy"),
+      ).toBe(1);
     });
 
     /** @scenario Over-cap tenant at the head of the zset does not starve other tenants */
@@ -2627,8 +2632,8 @@ describe("GroupStagingScripts", () => {
       expect(await redis.get(tenantCounterKey("proj_quiet"))).toBe("1");
     });
 
-    /** @scenario Over-cap groups are deferred so they don't starve other tenants on repeated polls */
-    it("defers over-cap groups to a future score so the next dispatch reaches other tenants immediately", async () => {
+    /** @scenario Over-cap groups are parked out of ready so they don't starve other tenants on repeated polls */
+    it("parks over-cap groups out of ready so the next dispatch reaches other tenants immediately", async () => {
       process.env[TENANT_CAP_ENV] = "1";
 
       // proj_noisy stages 50 groups at score=1000 (head of zset)
@@ -2649,31 +2654,34 @@ describe("GroupStagingScripts", () => {
         dispatchAfterMs: 1001,
       });
 
-      // First dispatch: proj_noisy/g0 wins
+      // First dispatch: proj_noisy/g0 wins (under cap)
       const first = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
       expect(first?.groupId).toMatch(/^proj_noisy\//);
 
-      // Second dispatch: proj_quiet wins (walk past over-cap noisy)
+      // Second dispatch: proj_noisy is now at cap, so its remaining groups are
+      // parked OUT of ready as the scan walks past them, and proj_quiet wins.
       const second = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
       expect(second!.groupId).toBe("proj_quiet/only");
 
-      // Key assertion: over-cap noisy groups were deferred to future scores,
-      // so a third dispatch at the same nowMs returns null immediately
-      // instead of scanning through them again.
+      // Key assertion: the over-cap noisy groups are no longer in the ready
+      // scan (parked), so a third poll at the same nowMs returns null without
+      // re-walking them — write volume no longer scales with backlog size.
       const third = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
       expect(third).toBeNull();
 
-      // The deferred groups are still in the ready set with future scores
-      const readyCount = await redis.zcard(`${keyPrefix()}ready`);
-      expect(readyCount).toBeGreaterThan(0);
-
-      // After the defer window (5s), they become eligible again
-      const afterDefer = await scripts.dispatch({ nowMs: 8000, activeTtlSec: 60 });
-      expect(afterDefer).toBeNull(); // still over cap, but proves they're scannable again
+      // The 49 remaining noisy groups were moved OUT of ready into the parked
+      // set, and the tenant is registered so the reconcile can find it.
+      expect(await redis.zcard(`${keyPrefix()}parked:proj_noisy`)).toBe(49);
+      expect(
+        await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_noisy"),
+      ).toBe(1);
+      // Ready now holds only the two active groups (g0 + quiet), both at future
+      // active scores — nothing is due, the parked backlog isn't re-scanned.
+      expect(await redis.zcount(`${keyPrefix()}ready`, "-inf", "2000")).toBe(0);
     });
 
-    /** @scenario dispatchBatch defers over-cap groups to future scores */
-    it("dispatchBatch defers over-cap groups to future scores", async () => {
+    /** @scenario dispatchBatch parks over-cap groups the same way */
+    it("dispatchBatch parks over-cap groups out of ready", async () => {
       process.env[TENANT_CAP_ENV] = "1";
 
       const noisyJobs = Array.from({ length: 20 }, (_, i) =>
@@ -2698,13 +2706,14 @@ describe("GroupStagingScripts", () => {
       expect(groupIds).toContain("proj_quiet/only");
       expect(groupIds.filter((g) => g.startsWith("proj_noisy/"))).toHaveLength(1);
 
-      // Second batch: both tenants at cap, over-cap groups deferred
+      // Second batch: both tenants at cap, nothing left to dispatch
       const batch2 = await scripts.dispatchBatch({ nowMs: 2000, activeTtlSec: 60, maxJobs: 10 });
       expect(batch2).toHaveLength(0);
 
-      // Remaining noisy groups still in ready but with future scores
-      const dueNow = await redis.zcount(`${keyPrefix()}ready`, "-inf", "2000");
-      expect(dueNow).toBe(0);
+      // The 19 remaining noisy groups were parked out of ready, not re-deferred
+      // within it.
+      expect(await redis.zcard(`${keyPrefix()}parked:proj_noisy`)).toBe(19);
+      expect(await redis.zcount(`${keyPrefix()}ready`, "-inf", "2000")).toBe(0);
     });
 
     /** @scenario cap=0 produces zero tenant counter keys (back-compat regression) */
@@ -2755,6 +2764,241 @@ describe("GroupStagingScripts", () => {
         `${keyPrefix()}tenant_active:*`,
       );
       expect(keysAfterRestage).toEqual([]);
+
+      // The parking machinery is also fully inert at cap=0: no parked zsets and
+      // no parked-tenants registry entry are ever created (protects the live
+      // cap=0 mitigation path from any new per-op overhead).
+      expect(await redis.keys(`${keyPrefix()}parked:*`)).toEqual([]);
+      expect(await redis.exists(`${keyPrefix()}parked-tenants`)).toBe(0);
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Parking model: over-cap groups are moved OUT of ready into a per-tenant
+    // parked zset (once), restored when the tenant drops below cap. This is the
+    // durable fix for the 2026-05-27 over-cap ZADD storm, where re-deferring a
+    // 442K-deep ready set every 5s saturated single-threaded Redis. Mutual
+    // exclusivity (a group is in exactly one of ready/parked/blocked/active) is
+    // the load-bearing invariant: every ready-writer must respect parked.
+    // ────────────────────────────────────────────────────────────────────
+    describe("parking over-cap groups", () => {
+      function parkedKey(tenantId: string) {
+        return `${keyPrefix()}parked:${tenantId}`;
+      }
+
+      /** @scenario A freed in-flight slot restores a parked group on completion */
+      it("restores a parked group to ready on completion, preserving its score", async () => {
+        process.env[TENANT_CAP_ENV] = "1";
+        await stageOne({
+          tenantId: "proj_acme",
+          groupSuffix: "g1",
+          stagedJobId: "j1",
+          dispatchAfterMs: 1000,
+        });
+        await stageOne({
+          tenantId: "proj_acme",
+          groupSuffix: "g2",
+          stagedJobId: "j2",
+          dispatchAfterMs: 1500,
+        });
+
+        const d1 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
+        expect(d1!.groupId).toBe("proj_acme/g1");
+        // Second poll parks g2 (tenant at cap=1) at its original score.
+        expect(await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 })).toBeNull();
+        expect(await redis.zrange(parkedKey("proj_acme"), 0, -1, "WITHSCORES")).toEqual([
+          "proj_acme/g2",
+          "1500",
+        ]);
+
+        // Completing g1 frees the slot → COMPLETE unparks g2 back into ready
+        // at its preserved score, and clears the now-empty registry entry.
+        await scripts.complete({ groupId: d1!.groupId, stagedJobId: d1!.stagedJobId });
+        expect(await redis.zcard(parkedKey("proj_acme"))).toBe(0);
+        expect(
+          await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_acme"),
+        ).toBe(0);
+        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBe("1500");
+
+        // g2 is now dispatchable.
+        const d2 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
+        expect(d2!.groupId).toBe("proj_acme/g2");
+      });
+
+      /** @scenario A crashed tenant's parked groups are restored once its in-flight count expires */
+      it("reconciles parked groups back to ready when the tenant counter expires (orphan recovery)", async () => {
+        process.env[TENANT_CAP_ENV] = "1";
+        await stageOne({
+          tenantId: "proj_crash",
+          groupSuffix: "g1",
+          stagedJobId: "j1",
+          dispatchAfterMs: 1000,
+        });
+        await stageOne({
+          tenantId: "proj_crash",
+          groupSuffix: "g2",
+          stagedJobId: "j2",
+          dispatchAfterMs: 1001,
+        });
+
+        const d1 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }); // parks g2
+        expect(await redis.zcard(parkedKey("proj_crash"))).toBe(1);
+
+        // Simulate the worker crashing: the active job never completes and both
+        // the active key and the tenant_active counter TTL-expire. No COMPLETE
+        // fires, so without the dispatch reconcile g2 would strand forever.
+        await redis.del(`${keyPrefix()}tenant_active:proj_crash`);
+        await redis.del(`${keyPrefix()}group:${d1!.groupId}:active`);
+
+        // A later poll past the reconcile interval reads the missing counter as
+        // 0 (under cap) and restores g2 — even though dispatch was never idle in
+        // the way the return-nil path needs.
+        const recovered = await scripts.dispatch({ nowMs: 5000, activeTtlSec: 60 });
+        expect(recovered!.groupId).toBe("proj_crash/g2");
+        expect(await redis.zcard(parkedKey("proj_crash"))).toBe(0);
+      });
+
+      /** @scenario Disabling the cap restores all parked groups */
+      it("drains every parked group back to ready when the cap is set to 0", async () => {
+        process.env[TENANT_CAP_ENV] = "1";
+        for (let i = 1; i <= 3; i++) {
+          await stageOne({
+            tenantId: "proj_acme",
+            groupSuffix: `g${i}`,
+            stagedJobId: `j${i}`,
+            dispatchAfterMs: 1000 + i,
+          });
+        }
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }); // g1 active
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }); // parks g2, g3
+        expect(await redis.zcard(parkedKey("proj_acme"))).toBe(2);
+
+        // Operator flips the kill switch; a poll past the reconcile interval
+        // drains the whole parked set back into ready (cap disabled = nothing
+        // should stay parked out of the scan).
+        process.env[TENANT_CAP_ENV] = "0";
+        await scripts.dispatch({ nowMs: 5000, activeTtlSec: 60 });
+        expect(await redis.zcard(parkedKey("proj_acme"))).toBe(0);
+        expect(
+          await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_acme"),
+        ).toBe(0);
+      });
+
+      /** @scenario Restoring parked groups never exceeds the tenant cap */
+      it("unparks no more than (cap - active) groups, so one completion frees exactly one", async () => {
+        process.env[TENANT_CAP_ENV] = "2";
+        for (let i = 1; i <= 5; i++) {
+          await stageOne({
+            tenantId: "proj_acme",
+            groupSuffix: `g${i}`,
+            stagedJobId: `j${i}`,
+            dispatchAfterMs: 1000 + i,
+          });
+        }
+        const d1 = await scripts.dispatch({ nowMs: 3000, activeTtlSec: 60 });
+        await scripts.dispatch({ nowMs: 3000, activeTtlSec: 60 });
+        expect(await redis.get(tenantCounterKey("proj_acme"))).toBe("2");
+        // Next poll parks the remaining 3 (tenant at cap=2).
+        expect(await scripts.dispatch({ nowMs: 3000, activeTtlSec: 60 })).toBeNull();
+        expect(await redis.zcard(parkedKey("proj_acme"))).toBe(3);
+
+        // Completing ONE frees exactly one slot → exactly ONE group unparks.
+        await scripts.complete({ groupId: d1!.groupId, stagedJobId: d1!.stagedJobId });
+        expect(await redis.zcard(parkedKey("proj_acme"))).toBe(2);
+        // The single restored group is the only one due in ready.
+        expect(await redis.zcount(`${keyPrefix()}ready`, "-inf", "3000")).toBe(1);
+      });
+
+      /** @scenario Staging a new job for a parked group keeps it parked */
+      it("keeps a parked group parked when a new job is staged for it (STAGE respects parked)", async () => {
+        process.env[TENANT_CAP_ENV] = "1";
+        await stageOne({
+          tenantId: "proj_acme",
+          groupSuffix: "g1",
+          stagedJobId: "j1",
+          dispatchAfterMs: 1000,
+        });
+        await stageOne({
+          tenantId: "proj_acme",
+          groupSuffix: "g2",
+          stagedJobId: "j2",
+          dispatchAfterMs: 1001,
+        });
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }); // g1 active
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }); // g2 parked
+        expect(await redis.zcard(parkedKey("proj_acme"))).toBe(1);
+
+        // Stage a lower-score job into the already-parked g2.
+        await scripts.stage(
+          makeJob({ groupId: "proj_acme/g2", stagedJobId: "j2b", dispatchAfterMs: 900 }),
+        );
+
+        // g2 must stay parked (absorbing the lower score there via LT), NOT
+        // reappear in the ready scan.
+        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBeNull();
+        expect(await redis.zrange(parkedKey("proj_acme"), 0, -1, "WITHSCORES")).toEqual([
+          "proj_acme/g2",
+          "900",
+        ]);
+      });
+
+      // The remaining ready-writers (STAGE_BATCH, RETRY_RESTAGE, ops UNBLOCK and
+      // REPLAY_FROM_DLQ) share the same addToReadyOrParked guard. These are extra
+      // regression coverage for the mutual-exclusivity invariant beyond the one
+      // bound scenario above.
+      it("keeps a parked group parked when stageBatch touches it", async () => {
+        process.env[TENANT_CAP_ENV] = "1";
+        await stageOne({
+          tenantId: "proj_acme",
+          groupSuffix: "g1",
+          stagedJobId: "j1",
+          dispatchAfterMs: 1000,
+        });
+        await stageOne({
+          tenantId: "proj_acme",
+          groupSuffix: "g2",
+          stagedJobId: "j2",
+          dispatchAfterMs: 1001,
+        });
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }); // parks g2
+        expect(await redis.zcard(parkedKey("proj_acme"))).toBe(1);
+
+        await scripts.stageBatch([
+          makeJob({ groupId: "proj_acme/g2", stagedJobId: "j2b", dispatchAfterMs: 900 }),
+        ]);
+
+        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBeNull();
+        expect(await redis.zscore(parkedKey("proj_acme"), "proj_acme/g2")).toBe("900");
+      });
+
+      it("keeps a parked group parked when it is unblocked via the ops repo", async () => {
+        process.env[TENANT_CAP_ENV] = "1";
+        const repo = new QueueRedisRepository(redis);
+        await stageOne({
+          tenantId: "proj_acme",
+          groupSuffix: "g1",
+          stagedJobId: "j1",
+          dispatchAfterMs: 1000,
+        });
+        await stageOne({
+          tenantId: "proj_acme",
+          groupSuffix: "g2",
+          stagedJobId: "j2",
+          dispatchAfterMs: 1001,
+        });
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }); // parks g2
+
+        // g2 is parked. Force it into the blocked set as if it had been blocked,
+        // then unblock it: UNBLOCK must route through the parked-aware write so
+        // it does not clobber g2 back into ready.
+        await redis.sadd(`${keyPrefix()}blocked`, "proj_acme/g2");
+        await repo.unblockGroup({ queueName: QUEUE_NAME, groupId: "proj_acme/g2" });
+
+        expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBeNull();
+        expect(await redis.zcard(parkedKey("proj_acme"))).toBe(1);
+      });
     });
   });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -5,6 +5,7 @@ const metricNames = [
   "gq_active_groups",
   "gq_pending_groups",
   "gq_blocked_groups",
+  "gq_parked_groups",
   "gq_groups_blocked_total",
   "gq_jobs_staged_total",
   "gq_jobs_dispatched_total",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -51,6 +51,12 @@ export const gqBlockedGroups = new Gauge({
   labelNames: ["queue_name"] as const,
 });
 
+export const gqParkedGroups = new Gauge({
+  name: "gq_parked_groups",
+  help: "Number of groups parked out of the ready scan because their tenant is at the in-flight soft cap. A sustained spike is the over-cap signal that previously surfaced only as an invisible dispatch-write storm; a non-draining floor flags a parked-group strand.",
+  labelNames: ["queue_name"] as const,
+});
+
 export const gqJobsStagedTotal = new Counter({
   name: "gq_jobs_staged_total",
   help: "Total number of jobs staged into the group queue",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metricsCollector.ts
@@ -7,6 +7,7 @@ import {
   gqBlockedGroups,
   gqFastqActive,
   gqFastqPending,
+  gqParkedGroups,
   gqPendingGroups,
   gqOldestPendingAgeMilliseconds,
 } from "./metrics";
@@ -58,12 +59,25 @@ export class GroupQueueMetricsCollector {
       const keyPrefix = this.params.scripts.getKeyPrefix();
       const readyKey = `${keyPrefix}ready`;
       const blockedKey = `${keyPrefix}blocked`;
+      const parkedTenantsKey = `${keyPrefix}parked-tenants`;
 
       const pendingGroupCount = await this.params.redisConnection.zcard(
         readyKey,
       );
       const blockedGroupCount =
         await this.params.redisConnection.scard(blockedKey);
+
+      // Parked depth = sum of every over-cap tenant's parked zset. The registry
+      // set is tiny (one entry per over-cap tenant) and empty in the cap=0
+      // steady state, so this is effectively free when nothing is parked.
+      let parkedGroupCount = 0;
+      const parkedTenants =
+        await this.params.redisConnection.smembers(parkedTenantsKey);
+      for (const tenantId of parkedTenants) {
+        parkedGroupCount += await this.params.redisConnection.zcard(
+          `${keyPrefix}parked:${tenantId}`,
+        );
+      }
 
       gqPendingGroups.set(
         { queue_name: this.params.queueName },
@@ -72,6 +86,10 @@ export class GroupQueueMetricsCollector {
       gqBlockedGroups.set(
         { queue_name: this.params.queueName },
         blockedGroupCount,
+      );
+      gqParkedGroups.set(
+        { queue_name: this.params.queueName },
+        parkedGroupCount,
       );
       gqActiveGroups.set(
         { queue_name: this.params.queueName },

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -106,6 +106,29 @@ local function unparkUpTo(readyKey, tenantId, slots)
   end
   return moved
 end
+
+-- Safety-net reconcile, run by DISPATCH on a cadence (not the normal path —
+-- COMPLETE-unpark frees slots as jobs finish). Restores parked groups whose
+-- tenant has dropped below cap, covering two cases COMPLETE cannot:
+--   * orphan recovery (TRAP 2): a crashed/timed-out tenant never fires COMPLETE,
+--     so its tenant_active key TTL-expires; read missing as 0 = under cap = unpark,
+--     else the parked groups strand forever (a new stranding mode).
+--   * cap disabled: flipping LANGWATCH_DISPATCH_TENANT_CAP to 0 must not leave
+--     groups parked out of the dispatch scan, so drain the whole tenant.
+-- Self-limiting via unparkUpTo (bounded by cap - active), so it never over-unparks.
+local function reconcileParked(readyKey, keyPrefix, tenantCap)
+  local tenants = redis.call("SMEMBERS", keyPrefix .. "parked-tenants")
+  for _, tenantId in ipairs(tenants) do
+    local slots
+    if tenantCap > 0 then
+      local active = tonumber(redis.call("GET", keyPrefix .. "tenant_active:" .. tenantId)) or 0
+      slots = tenantCap - active
+    else
+      slots = redis.call("ZCARD", keyPrefix .. "parked:" .. tenantId)
+    end
+    unparkUpTo(readyKey, tenantId, slots)
+  end
+end
 `;
 
 const STAGE_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
@@ -175,7 +198,7 @@ end
 
 -- Score = earliest pending dispatchAfter (LT keeps the smallest score per group)
 if shouldUpdateReady() then
-  redis.call("ZADD", readyKey, "LT", dispatchAfter, groupId)
+  addToReadyOrParked(readyKey, groupId, dispatchAfter, true)
 end
 
 redis.call("LPUSH", signalKey, "1")
@@ -187,7 +210,7 @@ redis.call("INCR", totalPendingKey)
 return 1
 `;
 
-const STAGE_BATCH_LUA = TTL_HELPER_LUA + `
+const STAGE_BATCH_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
 local readyKey        = KEYS[1]
 local signalKey       = KEYS[2]
 local totalPendingKey = KEYS[3]
@@ -263,7 +286,7 @@ for groupId, minScore in pairs(affectedGroups) do
   -- here would re-expose the group to ZRANGEBYSCORE before the next refresh.
   local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
   if redis.call("EXISTS", activeKey) == 0 and redis.call("SISMEMBER", blockedKey, groupId) == 0 then
-    redis.call("ZADD", readyKey, "LT", minScore, groupId)
+    addToReadyOrParked(readyKey, groupId, minScore, true)
   end
 end
 
@@ -297,6 +320,23 @@ local tenantCap    = tonumber(ARGV[4]) or 0
 
 local hasPauses = redis.call("SCARD", pausedJobKey) > 0
 local activeUntil = nowMs + activeTtlSec * 1000
+
+-- Restore parked over-cap groups on a cadence (TRAP 2 orphan recovery + cap=0
+-- drain). COMPLETE-unpark handles the normal slot-freeing as jobs finish; this
+-- only backstops what it can't: a crashed/timed-out tenant that never fires
+-- COMPLETE (its tenant_active TTL-expires to 0 = under cap = unpark), and
+-- flipping the cap off (drain everything parked). Time-gated rather than
+-- per-poll so under sustained load (dispatch rarely idle) orphan recovery is
+-- not starved, while the cap=0 steady state pays only a GET + an occasional
+-- empty SMEMBERS. SCARD-gated so it is a true no-op when nothing is parked.
+local reconcileTsKey = keyPrefix .. "reconcile-ts"
+local lastReconcile = tonumber(redis.call("GET", reconcileTsKey)) or 0
+if (nowMs - lastReconcile) >= 2000 then
+  redis.call("SET", reconcileTsKey, nowMs)
+  if redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
+    reconcileParked(readyKey, keyPrefix, tenantCap)
+  end
+end
 
 -- Pull only groups whose earliest job is due now (legacy entries with score=1 also pass).
 -- Active groups carry future scores (nowMs + activeTtlSec*1000) and are excluded.
@@ -457,6 +497,19 @@ local hasPauses = redis.call("SCARD", pausedJobKey) > 0
 local activeUntil = nowMs + activeTtlSec * 1000
 local results = {}
 local dispatched = 0
+
+-- Restore parked over-cap groups on a cadence (TRAP 2 orphan recovery + cap=0
+-- drain) — see DISPATCH_LUA for the rationale. COMPLETE-unpark handles the
+-- normal slot-freeing; this backstops crashed tenants and cap-disable. Time-
+-- and SCARD-gated so it is a no-op at the cap=0 steady state.
+local reconcileTsKey = keyPrefix .. "reconcile-ts"
+local lastReconcile = tonumber(redis.call("GET", reconcileTsKey)) or 0
+if (nowMs - lastReconcile) >= 2000 then
+  redis.call("SET", reconcileTsKey, nowMs)
+  if redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
+    reconcileParked(readyKey, keyPrefix, tenantCap)
+  end
+end
 
 -- Pull only groups whose earliest job is due now. Active groups carry future
 -- scores so they are naturally excluded. Over-fetch by 3x (min 30) per page to
@@ -658,7 +711,7 @@ end
 return results
 `;
 
-const COMPLETE_LUA = `
+const COMPLETE_LUA = PARK_HELPER_LUA + `
 local activeKey       = KEYS[1]
 local jobsKey         = KEYS[2]
 local readyKey        = KEYS[3]
@@ -675,6 +728,10 @@ local jobName      = ARGV[3]
 -- prefix in (not a derived tenantId) lets us keep the cap optional
 -- without breaking back-compat with older call sites.
 local tenantCountKeyPrefix = ARGV[4]
+-- Tenant soft-cap (same value DISPATCH_LUA reads). When > 0, a completion
+-- frees a slot that may let one of the tenant's parked over-cap groups resume,
+-- so we unpark up to the freed headroom. 0 = cap disabled, no parking in play.
+local tenantCap = tonumber(ARGV[5]) or 0
 
 local currentActive = redis.call("GET", activeKey)
 if currentActive ~= stagedJobId then
@@ -698,13 +755,29 @@ if tenantCountKeyPrefix and tenantCountKeyPrefix ~= "" then
   end
 end
 
+-- Freed slot: restore up to (cap - now-active) of this tenant's parked groups
+-- so over-cap work deferred by DISPATCH resumes the moment capacity opens. This
+-- is the normal-case unpark; the dispatch reconcile only backstops orphans.
+-- Self-limiting (TRAP 3): bounded to current headroom so COMPLETE-unpark and the
+-- reconcile can't over-unpark into re-park churn. The LPUSH below wakes a waiter.
+if tenantCap > 0 then
+  local slashPos = string.find(groupId, "/", 1, true)
+  if slashPos and slashPos > 1 then
+    local tenantId = string.sub(groupId, 1, slashPos - 1)
+    local active = tonumber(redis.call("GET", tenantCountKeyPrefix .. tenantId)) or 0
+    unparkUpTo(readyKey, tenantId, tenantCap - active)
+  end
+end
+
 local pendingCount = redis.call("ZCARD", jobsKey)
 if pendingCount > 0 then
   -- Re-score ready with earliest pending job's dispatchAfter so dispatch sees
-  -- it again as soon as that job is due (could be past or future).
+  -- it again as soon as that job is due (could be past or future). Route through
+  -- the parked-aware write so the invariant holds even though a completing
+  -- (active) group is never itself parked.
   local nextJob = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
   if #nextJob >= 2 then
-    redis.call("ZADD", readyKey, tonumber(nextJob[2]), groupId)
+    addToReadyOrParked(readyKey, groupId, tonumber(nextJob[2]), false)
   else
     redis.call("ZREM", readyKey, groupId)
   end
@@ -856,7 +929,7 @@ end
 return 1
 `;
 
-const RETRY_RESTAGE_LUA = TTL_HELPER_LUA + `
+const RETRY_RESTAGE_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
 local activeKey       = KEYS[1]
 local totalPendingKey = KEYS[2]
 
@@ -890,9 +963,11 @@ end
 refreshGroupKeyTtl(groupJobsKey, groupDataKey, nowMs)
 
 -- 3. Update ready set score = future dispatch time so the group becomes
---    eligible exactly when the backoff window expires.
+--    eligible exactly when the backoff window expires. Route through the
+--    parked-aware write so the invariant holds (an active group entering retry
+--    is never itself parked, so this normally writes straight to ready).
 local readyKey = keyPrefix .. "ready"
-redis.call("ZADD", readyKey, dispatchAfterMs, groupId)
+addToReadyOrParked(readyKey, groupId, dispatchAfterMs, false)
 
 -- 4. Set active key TTL to match backoff period.
 --    While the key exists the group is locked (preserves FIFO ordering).
@@ -1260,6 +1335,7 @@ export class GroupStagingScripts {
       stagedJobId,
       jobName ?? "",
       `${this.keyPrefix}tenant_active:`,
+      String(readTenantCap()),
     );
 
     return result === 1;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -32,7 +32,83 @@ local function refreshGroupKeyTtl(jobsKey, dataKey, nowMs)
 end
 `;
 
-const STAGE_LUA = TTL_HELPER_LUA + `
+// Lua helper for the tenant soft-cap "parking" model, prepended to every script
+// that writes the ready set. Over-cap groups are moved OUT of ready into a
+// per-tenant parked zset ONCE (not re-scored every poll), so the dispatch scan
+// never re-sees them and the write volume no longer scales with backlog size.
+// They are restored when the tenant's in-flight count drops below the cap.
+//
+// Invariant: a group is in exactly one of {ready, parked, blocked, active}.
+// Every ready-writer routes through addToReadyOrParked so a stage/unblock/retry/
+// complete-restage can never clobber a parked group back into the dispatch scan
+// (which is what re-creates the over-cap ZADD storm). The parked set and the
+// parked-tenants registry share the same hash tag as ready (keyPrefix carries
+// it), so all keys stay in one Redis Cluster slot.
+export const PARK_HELPER_LUA = `
+-- Tenant segment of a groupId (everything before the first '/'), else the id.
+local function parkTenantOf(groupId)
+  local slashPos = string.find(groupId, "/", 1, true)
+  if slashPos and slashPos > 1 then return string.sub(groupId, 1, slashPos - 1) end
+  return groupId
+end
+
+-- readyKey is always keyPrefix .. "ready"; recover keyPrefix so the parked keys
+-- can be derived without threading an extra ARGV through every script.
+local function parkKeyPrefixOf(readyKey)
+  return string.sub(readyKey, 1, #readyKey - 5)
+end
+
+-- Route a ready-write to the parked set instead when the group is already
+-- parked, preserving the parked state (cap-free: only DISPATCH/COMPLETE decide
+-- to park/unpark). useLT mirrors the call site's ZADD semantics.
+local function addToReadyOrParked(readyKey, groupId, score, useLT)
+  local kp = parkKeyPrefixOf(readyKey)
+  local parkedKey = kp .. "parked:" .. parkTenantOf(groupId)
+  local target = readyKey
+  if redis.call("ZSCORE", parkedKey, groupId) then target = parkedKey end
+  if useLT then
+    redis.call("ZADD", target, "LT", score, groupId)
+  else
+    redis.call("ZADD", target, score, groupId)
+  end
+end
+
+-- Move an over-cap group out of ready into its tenant's parked set, preserving
+-- its ready score so it keeps priority when restored. Registers the tenant so
+-- the dispatch-tail reconcile can find it even if no COMPLETE ever fires.
+local function parkGroup(readyKey, groupId)
+  local score = redis.call("ZSCORE", readyKey, groupId)
+  if not score then return end
+  local kp = parkKeyPrefixOf(readyKey)
+  local tenantId = parkTenantOf(groupId)
+  redis.call("ZREM", readyKey, groupId)
+  redis.call("ZADD", kp .. "parked:" .. tenantId, score, groupId)
+  redis.call("SADD", kp .. "parked-tenants", tenantId)
+end
+
+-- Restore up to "slots" of a tenant's parked groups (lowest score = earliest
+-- due first) back into ready. Self-limiting: callers pass slots = cap - active
+-- so COMPLETE-unpark and the dispatch-tail reconcile can never over-unpark into
+-- a re-park churn (TRAP 3). Returns how many were moved.
+local function unparkUpTo(readyKey, tenantId, slots)
+  if slots <= 0 then return 0 end
+  local kp = parkKeyPrefixOf(readyKey)
+  local parkedKey = kp .. "parked:" .. tenantId
+  local members = redis.call("ZRANGE", parkedKey, 0, slots - 1, "WITHSCORES")
+  local moved = 0
+  for i = 1, #members, 2 do
+    redis.call("ZREM", parkedKey, members[i])
+    redis.call("ZADD", readyKey, tonumber(members[i + 1]), members[i])
+    moved = moved + 1
+  end
+  if redis.call("ZCARD", parkedKey) == 0 then
+    redis.call("SREM", kp .. "parked-tenants", tenantId)
+  end
+  return moved
+end
+`;
+
+const STAGE_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
 local groupJobsKey    = KEYS[1]
 local readyKey        = KEYS[2]
 local signalKey       = KEYS[3]
@@ -77,7 +153,7 @@ if dedupId ~= "" and dedupTtlMs > 0 then
       redis.call("SET", dedupKey, existingJobId, "PX", dedupTtlMs)
       -- Score = earliest pending dispatchAfter (LT keeps the smallest score per group)
       if shouldUpdateReady() then
-        redis.call("ZADD", readyKey, "LT", dispatchAfter, groupId)
+        addToReadyOrParked(readyKey, groupId, dispatchAfter, true)
       end
       refreshGroupKeyTtl(groupJobsKey, dataKey, nowMs)
       redis.call("LPUSH", signalKey, "1")

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -15,6 +15,17 @@ import type { Cluster } from "ioredis";
  */
 export const GROUP_KEY_TTL_MS = 6 * 60 * 60 * 1000;
 
+/**
+ * Max groups any single unpark moves in one Lua eval. The cap=0 kill switch
+ * drains a tenant's entire parked set; without a bound, flipping the cap off
+ * while a tenant has a huge parked backlog (the May 27 incident parked ~442K)
+ * would do one ZRANGE + per-group ZREM/ZADD over the whole set in a single eval
+ * and block the single Redis thread — recreating the stall the kill switch
+ * exists to stop. Bounding the per-eval work lets the 2s-gated reconcile drain
+ * gradually instead. Interpolated into the Lua for a single source of truth.
+ */
+export const PARK_RECONCILE_MAX_DRAIN = 1000;
+
 // Lua helper, prepended to every script that writes group keys. Refreshes the
 // safety-net TTL on a group's jobs/data keys, deriving expiry from the LATEST
 // pending dispatch score so a job legitimately delayed past the window (e.g. a
@@ -92,6 +103,12 @@ end
 -- a re-park churn (TRAP 3). Returns how many were moved.
 local function unparkUpTo(readyKey, tenantId, slots)
   if slots <= 0 then return 0 end
+  -- Bound the per-eval work so no single caller can ZRANGE + ZREM/ZADD an
+  -- unbounded set and block the single Redis thread. The reconcile leaves the
+  -- tenant registered until its parked set is empty, so the rest drains in
+  -- later cycles. (Normal cap>0 unparks pass slots = cap - active, far below
+  -- this; the bound only bites the cap=0 kill-switch drain of a huge backlog.)
+  if slots > ${PARK_RECONCILE_MAX_DRAIN} then slots = ${PARK_RECONCILE_MAX_DRAIN} end
   local kp = parkKeyPrefixOf(readyKey)
   local parkedKey = kp .. "parked:" .. tenantId
   local members = redis.call("ZRANGE", parkedKey, 0, slots - 1, "WITHSCORES")
@@ -124,7 +141,11 @@ local function reconcileParked(readyKey, keyPrefix, tenantCap)
       local active = tonumber(redis.call("GET", keyPrefix .. "tenant_active:" .. tenantId)) or 0
       slots = tenantCap - active
     else
-      slots = redis.call("ZCARD", keyPrefix .. "parked:" .. tenantId)
+      -- Cap disabled: drain the tenant, but in bounded chunks across reconciles
+      -- (unparkUpTo caps the per-eval work and keeps the tenant registered until
+      -- its parked set is empty), so flipping the kill switch with a huge parked
+      -- backlog can't block Redis in one eval.
+      slots = ${PARK_RECONCILE_MAX_DRAIN}
     end
     unparkUpTo(readyKey, tenantId, slots)
   end

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -761,12 +761,9 @@ end
 -- Self-limiting (TRAP 3): bounded to current headroom so COMPLETE-unpark and the
 -- reconcile can't over-unpark into re-park churn. The LPUSH below wakes a waiter.
 if tenantCap > 0 then
-  local slashPos = string.find(groupId, "/", 1, true)
-  if slashPos and slashPos > 1 then
-    local tenantId = string.sub(groupId, 1, slashPos - 1)
-    local active = tonumber(redis.call("GET", tenantCountKeyPrefix .. tenantId)) or 0
-    unparkUpTo(readyKey, tenantId, tenantCap - active)
-  end
+  local tenantId = parkTenantOf(groupId)
+  local active = tonumber(redis.call("GET", tenantCountKeyPrefix .. tenantId)) or 0
+  unparkUpTo(readyKey, tenantId, tenantCap - active)
 end
 
 local pendingCount = redis.call("ZCARD", jobsKey)

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -278,7 +278,7 @@ end
 return newStagedCount
 `;
 
-const DISPATCH_LUA = `
+const DISPATCH_LUA = PARK_HELPER_LUA + `
 local readyKey         = KEYS[1]
 local blockedKey       = KEYS[2]
 local pausedJobKey     = KEYS[3]
@@ -338,10 +338,11 @@ while offset < scanBudget do
           end
           if cached then
             tenantOverCap = true
-            -- Defer over-cap group past the dispatch window so subsequent
-            -- polls reach other tenants without re-scanning this group.
-            -- 5s ≈ one poll cycle; group becomes eligible again naturally.
-            redis.call("ZADD", readyKey, nowMs + 5000, groupId)
+            -- Park the over-cap group OUT of ready (once) so subsequent polls
+            -- reach other tenants without re-scanning it. Restored when the
+            -- tenant's in-flight count drops below cap (COMPLETE / reconcile).
+            -- Replaces the per-poll ZADD defer that scaled writes with backlog.
+            parkGroup(readyKey, groupId)
           end
         end
       end
@@ -439,7 +440,7 @@ end
 return nil
 `;
 
-const DISPATCH_BATCH_LUA = `
+const DISPATCH_BATCH_LUA = PARK_HELPER_LUA + `
 local readyKey         = KEYS[1]
 local blockedKey       = KEYS[2]
 local pausedJobKey     = KEYS[3]
@@ -500,7 +501,7 @@ while offset < scanBudget and dispatched < maxJobs do
         end
         if cached then
           tenantOverCap = true
-          redis.call("ZADD", readyKey, nowMs + 5000, groupId)
+          parkGroup(readyKey, groupId)
         end
       end
     end

--- a/specs/event-sourcing/tenant-soft-cap.feature
+++ b/specs/event-sourcing/tenant-soft-cap.feature
@@ -67,7 +67,7 @@ Feature: Per-tenant soft cap on in-flight dispatch
     And a third dispatchable group for the same tenant is on the ready zset
     When DISPATCH_LUA is invoked
     Then no group is dispatched for "proj_acme"
-    And the third group remains on the ready zset
+    And the third group is parked out of the ready scan
 
   @integration @tenant-cap @fairness
   Scenario: Over-cap tenant at the head of the zset does not starve other tenants
@@ -109,30 +109,68 @@ Feature: Per-tenant soft cap on in-flight dispatch
     When DISPATCH_BATCH_LUA is invoked
     Then the zombie group is removed from the ready zset
 
-  # Deferral — post-2026-05-27 incident follow-up
-  #
-  # When over-cap groups dominate the head of the ready zset (e.g.
-  # assignTopic backfill from a topic clustering fix), the scan budget
-  # (10K entries) can be exhausted re-scanning groups that will always
-  # be skipped — starving other tenants entirely. Deferring over-cap
-  # groups to a future score pushes them past the dispatch window so
-  # subsequent polls reach other tenants immediately.
+  # Over-cap groups are moved OUT of ready into a per-tenant parked set instead
+  # of being re-scored within ready on every poll, so dispatch write volume no
+  # longer scales with backlog size (the 2026-05-27 over-cap ZADD storm, where
+  # re-deferring a 442K-deep ready set every 5s saturated single-threaded Redis).
+  # A quiet tenant deeper in the zset is reached immediately, a follow-up poll
+  # returns nothing instead of re-walking the over-cap groups, and the parked
+  # groups are restored to ready once the tenant drops below cap.
+  @integration @tenant-cap @fairness
+  Scenario: Over-cap groups are parked out of ready so they don't starve other tenants on repeated polls
+    Given a tenant "proj_noisy" over cap with many groups at the head of ready
+    And a tenant "proj_quiet" with one group later in the zset
+    When dispatch is polled repeatedly at the same time
+    Then "proj_quiet"'s group is dispatched
+    And the over-cap groups are moved out of ready into the tenant's parked set so the next poll skips them
+    And they are restored to ready once the tenant drops below cap
 
-  @integration @tenant-cap @deferral
-  Scenario: Over-cap groups are deferred so they don't starve other tenants on repeated polls
-    Given a tenant "proj_noisy" with cap=1 and 50 groups at the head of the ready zset
-    And a tenant "proj_quiet" with 1 group later in the zset
-    When DISPATCH_LUA dispatches once (proj_noisy wins)
-    And DISPATCH_LUA dispatches again (proj_quiet wins, noisy groups deferred)
-    Then a third DISPATCH_LUA at the same timestamp returns nil immediately
-    And the deferred groups remain in the ready set with future scores
-    And the deferred groups become eligible again after the defer window
+  @integration @tenant-cap @batch @fairness
+  Scenario: dispatchBatch parks over-cap groups the same way
+    Given a tenant over cap with groups on the ready zset
+    When DISPATCH_BATCH_LUA is invoked
+    Then the over-cap groups are moved out of ready into the tenant's parked set
+    And under-cap tenants are still served in the same batch
 
-  @integration @tenant-cap @batch @deferral
-  Scenario: dispatchBatch defers over-cap groups to future scores
-    Given a tenant "proj_noisy" with cap=1 and 20 groups at the head of the ready zset
-    And a tenant "proj_quiet" with 1 group later in the zset
-    When DISPATCH_BATCH_LUA is invoked with maxJobs=10
-    Then proj_noisy dispatches exactly 1 group and proj_quiet dispatches its group
-    And a second DISPATCH_BATCH_LUA returns zero results
-    And all remaining noisy groups have future scores past the dispatch window
+  # Parked groups must come back. COMPLETE frees an in-flight slot and restores
+  # one parked group immediately (the normal path), preserving its priority.
+  @integration @tenant-cap @parking
+  Scenario: A freed in-flight slot restores a parked group on completion
+    Given a tenant over cap with a parked group
+    When one of the tenant's in-flight groups completes
+    Then the parked group is restored to ready and dispatchable
+    And it keeps the score it had before being parked
+
+  # COMPLETE covers the normal case; a crashed tenant never completes, so its
+  # in-flight counter TTL-expires. A later poll must read the missing counter as
+  # zero and restore the parked groups, or they strand out of the scan forever.
+  @integration @tenant-cap @parking
+  Scenario: A crashed tenant's parked groups are restored once its in-flight count expires
+    Given a tenant over cap with a parked group
+    And the tenant's in-flight counter has expired without a completion
+    When dispatch is next polled past the reconcile interval
+    Then the parked group is restored to ready and dispatched
+
+  # Disabling the cap must not leave work stranded out of the dispatch scan.
+  @integration @tenant-cap @parking @kill-switch
+  Scenario: Disabling the cap restores all parked groups
+    Given a tenant over cap with several parked groups
+    When the cap is set to 0 and dispatch is polled past the reconcile interval
+    Then all of the tenant's parked groups are restored to ready
+
+  # Restoring is bounded by the freed headroom so it can't overshoot the cap and
+  # churn groups back and forth between ready and parked.
+  @integration @tenant-cap @parking
+  Scenario: Restoring parked groups never exceeds the tenant cap
+    Given a tenant at cap=2 with three parked groups
+    When exactly one in-flight group completes
+    Then exactly one parked group is restored to ready
+    And the other two remain parked
+
+  # Every writer that returns a group to ready must respect parked membership,
+  # or it clobbers a parked group into the dispatch scan and re-creates the storm.
+  @integration @tenant-cap @parking
+  Scenario: Staging a new job for a parked group keeps it parked
+    Given a tenant over cap with a parked group
+    When a new job is staged for that parked group
+    Then the group stays in the parked set and does not reappear in ready


### PR DESCRIPTION
## Why

Over the 2026-05-27 incident the dispatch loop saturated single-threaded Redis. The root was the tenant soft-cap's over-cap handling: when a tenant was at its in-flight cap, DISPATCH re-scored each of its over-cap groups to a future score (`ZADD ready now+5s`) on every poll. With a 442K-deep ready set and several workers polling, that became ~90K ZADD/sec, most of the command throughput, while the actual backlog barely moved.

The defer was meant to stop repeated rescans starving other tenants, but the write volume scaled with backlog size, which is exactly what a backlog drain cannot afford.

## What

Move over-cap groups OUT of the ready set into a per-tenant parked zset, once, instead of re-scoring them in place every poll. The dispatch scan never sees them again until they are restored, so write volume decouples from backlog size.

- `parkGroup` moves an over-cap group from ready to `parked:<tenant>` (score preserved) and registers the tenant in a `parked-tenants` set. This replaces the per-poll defer in DISPATCH and DISPATCH_BATCH.
- COMPLETE frees an in-flight slot and restores up to `cap - active` of the tenant's parked groups. This is the normal path back.
- DISPATCH runs a time-gated reconcile (every 2s, skipped when nothing is parked) that restores parked groups for any tenant now under cap. It backstops two cases COMPLETE cannot: a crashed tenant whose in-flight counter TTL-expired without completing, and the operator setting the cap to 0 (drains everything parked).

### Mutual exclusivity

A group is in exactly one of ready, parked, blocked, or active. Every writer that returns a group to ready now routes through a shared `addToReadyOrParked` helper that keeps an already-parked group parked rather than clobbering it back into the scan: STAGE, STAGE_BATCH, RETRY_RESTAGE, COMPLETE re-stage, and the ops repo UNBLOCK and REPLAY_FROM_DLQ paths. Missing one would silently re-create the storm, so the test matrix covers each.

### Observability

We were blind to the storm while it happened. This adds a `gq_parked_groups` Prometheus gauge per queue, plus parked depth on the ops dashboard (a tile and a line on the throughput history). A sustained parked spike is the over-cap signal that previously surfaced only as an invisible write storm; a non-draining floor flags a parked-group strand.

### Safety

All cap logic stays gated behind `tenantCap > 0`, so the current `LANGWATCH_DISPATCH_TENANT_CAP=0` mitigation path is unchanged and creates zero parked keys. Restores are bounded by `cap - active` so COMPLETE-unpark and the reconcile cannot over-restore into churn. Parked keys share the queue hash tag, so they stay in one Redis Cluster slot.

## Tests

Testcontainer integration coverage for: park on over-cap, unpark on completion with score preservation, orphan reconcile when the in-flight counter expires, cap-to-0 drain, bounded restore, and every ready-writer respecting parked. The existing over-cap deferral scenarios are rewritten for parking in `specs/event-sourcing/tenant-soft-cap.feature`, and this supersedes the deferral introduced in #4209 and bound in #4210.
