### PR TITLE
fix(feature-flags): build PostHog client lazily so SYSTEM-only processes don't poll

### DIFF
--- a/langwatch/src/server/__tests__/posthog-local-evaluation.unit.test.ts
+++ b/langwatch/src/server/__tests__/posthog-local-evaluation.unit.test.ts
@@ -8,6 +8,12 @@
  * definitions in the background and evaluates them in-process instead of
  * hitting the /flags endpoint per call.
  *
+ * Constructing the client with local evaluation starts that background poller,
+ * so the client is built lazily on first getPostHogInstance() call rather than
+ * at module load. A process that only reads SYSTEM flags from postgres (workers,
+ * the event-sourcing pipeline) imports this module but never requests the
+ * instance, so it never starts the poller and never burns the flags quota.
+ *
  * @see specs/analytics/posthog-cost-control.feature
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -42,26 +48,53 @@ describe("posthog-node initialization", () => {
     vi.resetModules();
   });
 
+  const mockLocalEvalEnv = () =>
+    vi.doMock("~/env.mjs", () => ({
+      env: {
+        POSTHOG_KEY: "phc_test_key",
+        POSTHOG_HOST: "https://us.i.posthog.com",
+        POSTHOG_FEATURE_FLAGS_KEY: "phx_personal_key",
+      },
+    }));
+
   describe("when POSTHOG_FEATURE_FLAGS_KEY is set", () => {
-    it("enables local evaluation with the configured personal API key", async () => {
-      vi.doMock("~/env.mjs", () => ({
-        env: {
-          POSTHOG_KEY: "phc_test_key",
-          POSTHOG_HOST: "https://us.i.posthog.com",
-          POSTHOG_FEATURE_FLAGS_KEY: "phx_personal_key",
-        },
-      }));
+    describe("when the module is imported but the instance is never requested", () => {
+      it("does not construct the client, so no background flag poller starts", async () => {
+        mockLocalEvalEnv();
 
-      await import("../posthog");
+        await import("../posthog");
 
-      expect(ctorSpy).toHaveBeenCalledWith(
-        "phc_test_key",
-        expect.objectContaining({
-          host: "https://us.i.posthog.com",
-          personalApiKey: "phx_personal_key",
-          featureFlagsPollingInterval: expect.any(Number),
-        }),
-      );
+        expect(ctorSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the instance is first requested", () => {
+      it("enables local evaluation with the configured personal API key", async () => {
+        mockLocalEvalEnv();
+
+        const { getPostHogInstance } = await import("../posthog");
+        getPostHogInstance();
+
+        expect(ctorSpy).toHaveBeenCalledWith(
+          "phc_test_key",
+          expect.objectContaining({
+            host: "https://us.i.posthog.com",
+            personalApiKey: "phx_personal_key",
+            featureFlagsPollingInterval: expect.any(Number),
+          }),
+        );
+      });
+
+      it("memoizes the instance so the poller is started only once", async () => {
+        mockLocalEvalEnv();
+
+        const { getPostHogInstance } = await import("../posthog");
+        const first = getPostHogInstance();
+        const second = getPostHogInstance();
+
+        expect(ctorSpy).toHaveBeenCalledTimes(1);
+        expect(first).toBe(second);
+      });
     });
 
     it("respects an explicit polling interval override", async () => {
@@ -74,7 +107,8 @@ describe("posthog-node initialization", () => {
         },
       }));
 
-      await import("../posthog");
+      const { getPostHogInstance } = await import("../posthog");
+      getPostHogInstance();
 
       expect(ctorSpy).toHaveBeenCalledWith(
         "phc_test_key",
@@ -94,7 +128,8 @@ describe("posthog-node initialization", () => {
         },
       }));
 
-      await import("../posthog");
+      const { getPostHogInstance } = await import("../posthog");
+      getPostHogInstance();
 
       expect(ctorSpy).toHaveBeenCalledWith(
         "phc_test_key",
@@ -112,9 +147,11 @@ describe("posthog-node initialization", () => {
         env: {},
       }));
 
-      await import("../posthog");
+      const { getPostHogInstance } = await import("../posthog");
+      const instance = getPostHogInstance();
 
       expect(ctorSpy).not.toHaveBeenCalled();
+      expect(instance).toBeNull();
     });
   });
 });

--- a/langwatch/src/server/featureFlag/__tests__/featureFlag.service.lazy-legacy.unit.test.ts
+++ b/langwatch/src/server/featureFlag/__tests__/featureFlag.service.lazy-legacy.unit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment node
+ *
+ * The legacy backend (PostHog when configured) is built lazily, on the first
+ * PRODUCT/unregistered flag evaluation. Constructing the PostHog backend calls
+ * getPostHogInstance(), which starts posthog-node's background flag-definition
+ * poller. A process that only ever reads SYSTEM flags (the workers and the
+ * event-sourcing pipeline — those resolve from postgres and never touch
+ * PostHog) must therefore never construct it, so it never polls PostHog and
+ * never trips the feature-flags billing quota.
+ *
+ * @see specs/analytics/posthog-cost-control.feature
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FeatureFlagService } from "../featureFlag.service";
+import type { FeatureFlagStorePostgres } from "../featureFlagStore.postgres";
+
+const { posthogCreateSpy, memoryCreateSpy } = vi.hoisted(() => ({
+  posthogCreateSpy: vi.fn(),
+  memoryCreateSpy: vi.fn(),
+}));
+
+vi.mock("~/env.mjs", () => ({
+  env: { POSTHOG_KEY: "phc_test_key" },
+}));
+
+vi.mock("../featureFlagService.posthog", () => ({
+  FeatureFlagServicePostHog: {
+    create: () => {
+      posthogCreateSpy();
+      return { isEnabled: vi.fn().mockResolvedValue(false), isAvailable: () => true };
+    },
+  },
+}));
+
+vi.mock("../featureFlagService.memory", () => ({
+  FeatureFlagServiceMemory: {
+    create: () => {
+      memoryCreateSpy();
+      return { isEnabled: vi.fn().mockResolvedValue(false), isAvailable: () => true };
+    },
+  },
+}));
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const SYSTEM_FLAG = "ops_es_causality_loop_guard_disabled";
+const PRODUCT_FLAG = "release_nlp_go_engine_enabled";
+
+const emptyStore = {
+  get: vi.fn().mockResolvedValue(null),
+} as unknown as FeatureFlagStorePostgres;
+
+function buildService() {
+  // No `legacy` injected: exercises the real lazy createLegacyService path.
+  return new FeatureFlagService({ store: emptyStore });
+}
+
+describe("FeatureFlagService legacy backend construction", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The dev .env force-enables this PRODUCT flag, which would short-circuit
+    // before the legacy path. Clear the overrides so the resolver actually
+    // reaches the lazily-built legacy backend.
+    process.env = { ...originalEnv };
+    delete process.env.RELEASE_NLP_GO_ENGINE_ENABLED;
+    delete process.env.FEATURE_FLAG_FORCE_ENABLE;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("given a process that only evaluates SYSTEM flags", () => {
+    describe("when a SYSTEM flag is evaluated", () => {
+      /** @scenario Processes that only read SYSTEM flags never start the local-evaluation poller */
+      it("never constructs the PostHog legacy backend, so no poller starts", async () => {
+        const service = buildService();
+
+        await service.isEnabled(SYSTEM_FLAG, {
+          distinctId: "tenant-a",
+          defaultValue: false,
+        });
+
+        expect(posthogCreateSpy).not.toHaveBeenCalled();
+        expect(memoryCreateSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when constructing the service alone", () => {
+      it("does not eagerly construct the legacy backend", () => {
+        buildService();
+
+        expect(posthogCreateSpy).not.toHaveBeenCalled();
+        expect(memoryCreateSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a PRODUCT flag with no store override", () => {
+    describe("when the flag is evaluated", () => {
+      /** @scenario A PostHog-backed flag builds the client lazily on first evaluation */
+      it("constructs the PostHog legacy backend on demand", async () => {
+        const service = buildService();
+
+        await service.isEnabled(PRODUCT_FLAG, {
+          distinctId: "user-1",
+          defaultValue: false,
+        });
+
+        expect(posthogCreateSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it("constructs it only once across repeated evaluations", async () => {
+        const service = buildService();
+
+        await service.isEnabled(PRODUCT_FLAG, { distinctId: "user-1", defaultValue: false });
+        await service.isEnabled(PRODUCT_FLAG, { distinctId: "user-2", defaultValue: false });
+
+        expect(posthogCreateSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/featureFlag/featureFlag.service.ts
+++ b/langwatch/src/server/featureFlag/featureFlag.service.ts
@@ -42,7 +42,8 @@ import type {
  * @see registry.ts for the list of registered flags
  */
 export class FeatureFlagService implements FeatureFlagServiceInterface {
-  private readonly legacy: FeatureFlagServiceInterface;
+  private readonly legacyOverride?: FeatureFlagServiceInterface;
+  private legacyInstance?: FeatureFlagServiceInterface;
   private readonly store: FeatureFlagStorePostgres;
   private readonly logger = createLogger("langwatch:feature-flag-service");
 
@@ -52,8 +53,22 @@ export class FeatureFlagService implements FeatureFlagServiceInterface {
       store?: FeatureFlagStorePostgres;
     } = {},
   ) {
-    this.legacy = deps.legacy ?? this.createLegacyService();
+    this.legacyOverride = deps.legacy;
     this.store = deps.store ?? getFeatureFlagStore();
+  }
+
+  /**
+   * The legacy backend (PostHog when configured, memory otherwise) is built on
+   * first use, not in the constructor. Constructing the PostHog backend starts
+   * its background flag-definition poller, so a process that only ever
+   * evaluates SYSTEM flags (workers, the event-sourcing pipeline) never builds
+   * it and never polls PostHog. Only a PRODUCT/unregistered flag evaluation
+   * reaches here.
+   */
+  private get legacy(): FeatureFlagServiceInterface {
+    if (this.legacyOverride) return this.legacyOverride;
+    this.legacyInstance ??= this.createLegacyService();
+    return this.legacyInstance;
   }
 
   static create(): FeatureFlagService {

--- a/langwatch/src/server/posthog.ts
+++ b/langwatch/src/server/posthog.ts
@@ -11,32 +11,49 @@ const logger = createLogger("langwatch:posthog:client");
 // cheaper. Override via POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS.
 const DEFAULT_FLAGS_POLLING_INTERVAL_MS = 5 * 60 * 1000;
 
-// Create a private singleton instance.
 // When POSTHOG_FEATURE_FLAGS_KEY is set (Feature Flags Secure API key, phs_*,
 // or a legacy Personal API key, phx_*), posthog-node enables local
 // evaluation: flag definitions are polled in the background and
 // `isFeatureEnabled` resolves in-process without a /flags request per call.
 // The SDK option is named `personalApiKey` for historical reasons but accepts
 // both key types.
-const _posthogInstance = env.POSTHOG_KEY
-  ? new PostHog(env.POSTHOG_KEY, {
-      host: env.POSTHOG_HOST,
-      ...(env.POSTHOG_FEATURE_FLAGS_KEY
-        ? {
-            personalApiKey: env.POSTHOG_FEATURE_FLAGS_KEY,
-            featureFlagsPollingInterval:
-              env.POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS ??
-              DEFAULT_FLAGS_POLLING_INTERVAL_MS,
-          }
-        : {}),
-    })
-  : null;
+//
+// Constructing the client with local evaluation starts that background poller
+// immediately, regardless of whether any flag is ever evaluated. So the client
+// is built lazily on first use rather than at module load: a process that only
+// reads SYSTEM flags (workers, the event-sourcing pipeline — those resolve from
+// postgres and never touch PostHog) imports this module but never calls
+// getPostHogInstance, so it never starts the poller and never burns the
+// feature-flags quota. The web/API process builds it on its first PostHog flag
+// evaluation or analytics capture.
+//
+// `undefined` = not yet initialized, `null` = initialized with no POSTHOG_KEY.
+let _posthogInstance: PostHog | null | undefined;
+
+function createPostHogInstance(): PostHog | null {
+  if (!env.POSTHOG_KEY) return null;
+  return new PostHog(env.POSTHOG_KEY, {
+    host: env.POSTHOG_HOST,
+    ...(env.POSTHOG_FEATURE_FLAGS_KEY
+      ? {
+          personalApiKey: env.POSTHOG_FEATURE_FLAGS_KEY,
+          featureFlagsPollingInterval:
+            env.POSTHOG_FEATURE_FLAGS_POLLING_INTERVAL_MS ??
+            DEFAULT_FLAGS_POLLING_INTERVAL_MS,
+        }
+      : {}),
+  });
+}
 
 /**
- * Returns the PostHog instance if it exists, null otherwise.
- * The instance is immutable and should not be modified.
+ * Returns the PostHog instance if POSTHOG_KEY is configured, null otherwise.
+ * Constructs it on first call. The instance is immutable and should not be
+ * modified.
  */
 export function getPostHogInstance(): PostHog | null {
+  if (_posthogInstance === undefined) {
+    _posthogInstance = createPostHogInstance();
+  }
   return _posthogInstance;
 }
 

--- a/specs/analytics/posthog-cost-control.feature
+++ b/specs/analytics/posthog-cost-control.feature
@@ -45,6 +45,19 @@ Feature: PostHog cost control
     Then the flag is evaluated locally without calling the PostHog /flags endpoint
     And no /flags request is made for that evaluation
 
+  Scenario: Processes that only read SYSTEM flags never start the local-evaluation poller
+    Given local evaluation is enabled
+    And a process imports the feature flag service but only ever evaluates SYSTEM-scoped flags
+    When those SYSTEM flags are evaluated
+    Then the PostHog client is never constructed in that process
+    And no background flag-definition polling runs in that process
+    And the flag values come from postgres
+
+  Scenario: A PostHog-backed flag builds the client lazily on first evaluation
+    Given local evaluation is enabled
+    When a PRODUCT flag with no operator override is first evaluated
+    Then the PostHog client is constructed once and reused for later evaluations
+
   Scenario: Backend falls back to remote evaluation when no personal API key is configured
     Given POSTHOG_KEY is configured but POSTHOG_FEATURE_FLAGS_KEY is not
     When the backend evaluates a feature flag


### PR DESCRIPTION
## What

The workers and event-sourcing pipeline were logging `[FEATURE FLAGS] Feature flags quota limit exceeded - unsetting all local flags`, even though those processes only ever evaluate SYSTEM-scoped flags, which resolve from postgres and never call PostHog.

## Why it happened

The warning was not from a flag check. It was from posthog-node's background flag-definition poller, which starts the moment the client is constructed:

1. The workers and the event-sourcing reactors statically import `featureFlagService`.
2. That transitively imports `server/posthog.ts`, whose module-level `_posthogInstance = new PostHog(...)` ran at import time.
3. Because `POSTHOG_FEATURE_FLAGS_KEY` is set, the client was built with local evaluation enabled, which spins up a timer that fetches all flag definitions every 5 minutes, in every process, regardless of whether any flag is ever evaluated.
4. On top of that, the `featureFlagService` singleton constructor eagerly built the PostHog legacy backend, which also constructed the client.

So every workers pod ran that 5-minute poll forever, for flags it never reads. Across replicas, that tripped the PostHog feature-flags billing quota.

The polling was originally justified by per-span killswitch checks, but those killswitches moved to postgres, so on the workers the poller had no remaining purpose.

## The fix

- `server/posthog.ts`: construct the client on the first `getPostHogInstance()` call instead of at module load. Importing the module no longer starts the poller.
- `FeatureFlagService`: build the legacy backend (PostHog when configured, memory otherwise) lazily on the first PRODUCT or unregistered flag evaluation, not in the constructor.

A process that only reads SYSTEM flags now never constructs the PostHog client and never polls. The web and API process still builds it on its first PostHog-backed flag evaluation or analytics capture, where the local-evaluation cost tradeoff still applies.

## Tests

- `posthog-local-evaluation.unit.test.ts`: importing the module alone no longer constructs the client; construction happens on first `getPostHogInstance()` and is memoized.
- `featureFlag.service.lazy-legacy.unit.test.ts`: evaluating a SYSTEM flag never constructs the PostHog backend; a PRODUCT flag builds it once on demand.
- Added two scenarios to `specs/analytics/posthog-cost-control.feature` covering both paths.