### PR TITLE
fix(event-sourcing): park paused-tenant groups out of the dispatch scan

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1433,7 +1433,7 @@ describe("GroupStagingScripts", () => {
     }
 
     /** @scenario Pausing a tenant halts dispatch for that tenant only */
-    it("skips a group whose tenantId-prefix is in paused-jobs as 'tenant:<id>'", async () => {
+    it("parks a paused tenant's group OUT of ready (not skip-in-place) and returns null", async () => {
       await scripts.stage(
         makeJob({
           stagedJobId: "j1",
@@ -1446,6 +1446,71 @@ describe("GroupStagingScripts", () => {
 
       const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
       expect(result).toBeNull();
+
+      // The group is moved OUT of the ready scan into the tenant's parked set, so a
+      // large paused backlog can never plug the bounded scan and starve other tenants.
+      const ready = await inspectReadySet();
+      expect(ready).not.toContain("project_A/command/recordSpan/trace:xyz");
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
+      expect(
+        await redis.sismember(`${keyPrefix()}parked-tenants`, "project_A"),
+      ).toBe(1);
+    });
+
+    /** @scenario A paused tenant's backlog does not block other tenants */
+    it("dispatches another tenant even when a paused tenant fills the front of ready", async () => {
+      // Paused tenant has several due groups at the FRONT of ready (lowest scores).
+      for (let i = 0; i < 5; i++) {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: `bad${i}`,
+            groupId: `project_A/command/recordSpan/trace:${i}`,
+            dispatchAfterMs: 100 + i,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+      }
+      // Another tenant's group is staged later (higher score = behind the paused ones).
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "good",
+          groupId: "project_B/command/recordSpan/trace:b",
+          dispatchAfterMs: 200,
+          jobDataJson: makeBenignJobData(),
+        }),
+      );
+      await scripts.addPauseKey("tenant:project_A");
+
+      // Dispatch reaches project_B because project_A's groups are parked OUT of the
+      // scan as it walks past them, rather than re-skipped in place every poll.
+      const result = await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
+      expect(result).not.toBeNull();
+      expect(result!.groupId).toBe("project_B/command/recordSpan/trace:b");
+
+      // All 5 paused groups were moved out of ready into parked.
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(5);
+    });
+
+    /** @scenario A still-paused tenant is not restored by the reconcile */
+    it("keeps groups parked across the reconcile while the tenant stays paused", async () => {
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          groupId: "project_A/command/recordSpan/trace:xyz",
+          dispatchAfterMs: 100,
+          jobDataJson: makeBenignJobData(),
+        }),
+      );
+      await scripts.addPauseKey("tenant:project_A");
+
+      // First poll parks it.
+      expect(await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 })).toBeNull();
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
+
+      // A later poll runs the reconcile (past the 2s gate), but the tenant is still
+      // paused so unparkUpTo refuses to restore: it stays parked, dispatch null.
+      expect(await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 })).toBeNull();
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
     });
 
     it("dispatches groups for non-paused tenants while paused tenant is skipped", async () => {
@@ -1474,7 +1539,7 @@ describe("GroupStagingScripts", () => {
     });
 
     /** @scenario Unpausing a tenant resumes dispatch immediately */
-    it("resumes dispatch immediately after the tenant pause key is removed", async () => {
+    it("restores the parked group and resumes dispatch after the tenant pause key is removed", async () => {
       await scripts.stage(
         makeJob({
           stagedJobId: "j1",
@@ -1487,12 +1552,18 @@ describe("GroupStagingScripts", () => {
 
       const blocked = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
       expect(blocked).toBeNull();
+      // Parked out of the ready scan while paused.
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
 
       await scripts.removePauseKey("tenant:project_A");
 
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+      // Unpausing restores the parked group via the dispatch reconcile (time-gated
+      // ~2s): advance the clock past the gate so the next poll reconciles the
+      // now-unpaused tenant back into ready and dispatches it in the same call.
+      const result = await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 });
       expect(result).not.toBeNull();
       expect(result!.stagedJobId).toBe("j1");
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(0);
     });
 
     it("does not pause an unrelated tenant whose id is a prefix of the paused one", async () => {
@@ -1536,9 +1607,11 @@ describe("GroupStagingScripts", () => {
       result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
       expect(result).toBeNull();
 
-      // Remove tenant pause — now dispatches
+      // Remove tenant pause — the tenant-paused group was parked out of the scan,
+      // so resumption is via the dispatch reconcile (time-gated ~2s): advance the
+      // clock past the gate so the next poll restores and dispatches it.
       await scripts.removePauseKey("tenant:project_A");
-      result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+      result = await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 });
       expect(result).not.toBeNull();
       expect(result!.stagedJobId).toBe("j1");
     });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -102,6 +102,14 @@ end
 -- so COMPLETE-unpark and the dispatch-tail reconcile can never over-unpark into
 -- a re-park churn (TRAP 3). Returns how many were moved.
 local function unparkUpTo(readyKey, tenantId, slots)
+  local kp = parkKeyPrefixOf(readyKey)
+  -- A paused tenant's groups stay parked OUT of the ready scan regardless of cap
+  -- headroom or the cap=0 drain: pause is an explicit operator hold and must win.
+  -- Otherwise COMPLETE-unpark / reconcile would restore them into ready and a large
+  -- paused backlog would plug the bounded dispatch scan for every other tenant again.
+  if redis.call("SISMEMBER", kp .. "paused-jobs", "tenant:" .. tenantId) == 1 then
+    return 0
+  end
   if slots <= 0 then return 0 end
   -- Bound the per-eval work so no single caller can ZRANGE + ZREM/ZADD an
   -- unbounded set and block the single Redis thread. The reconcile leaves the
@@ -109,7 +117,6 @@ local function unparkUpTo(readyKey, tenantId, slots)
   -- later cycles. (Normal cap>0 unparks pass slots = cap - active, far below
   -- this; the bound only bites the cap=0 kill-switch drain of a huge backlog.)
   if slots > ${PARK_RECONCILE_MAX_DRAIN} then slots = ${PARK_RECONCILE_MAX_DRAIN} end
-  local kp = parkKeyPrefixOf(readyKey)
   local parkedKey = kp .. "parked:" .. tenantId
   local members = redis.call("ZRANGE", parkedKey, 0, slots - 1, "WITHSCORES")
   local moved = 0
@@ -408,11 +415,29 @@ while offset < scanBudget do
         end
       end
 
+      -- Tenant-level pause: park the group OUT of ready (like over-cap) rather than
+      -- skip it in place. A paused tenant can hold a huge due-now backlog; left in
+      -- ready it sits at the front and the bounded scan burns its whole budget
+      -- skipping it, starving every other tenant (the 2026-05-27 head-of-line stall).
+      -- Parking moves it out so the scan reaches other tenants; the reconcile restores
+      -- it on unpause (unparkUpTo refuses to restore while still paused). Pipeline-level
+      -- pauses below stay skip-in-place (rarer, and need the job data to classify).
+      local tenantPaused = false
+      if hasPauses then
+        local pp = string.find(groupId, "/", 1, true)
+        if pp and pp > 1 then
+          if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. string.sub(groupId, 1, pp - 1)) == 1 then
+            tenantPaused = true
+            parkGroup(readyKey, groupId)
+          end
+        end
+      end
+
       local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
       -- Defensive activeKey check — covers legacy state during migration
       -- and the small race between ZADD ready and ZADD active.
       local activeJob = redis.call("GET", activeKey)
-      if (not activeJob) and (not tenantOverCap) then
+      if (not activeJob) and (not tenantOverCap) and (not tenantPaused) then
         local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
         local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
@@ -580,7 +605,22 @@ while offset < scanBudget and dispatched < maxJobs do
       end
     end
 
-    if not tenantOverCap then
+    -- Tenant-level pause: park OUT of ready instead of skip-in-place, so a large
+    -- paused backlog cannot plug the bounded scan and starve other tenants
+    -- (head-of-line). See DISPATCH_LUA for the full rationale; unparkUpTo refuses
+    -- to restore a still-paused tenant, the reconcile restores it on unpause.
+    local tenantPaused = false
+    if hasPauses then
+      local pp = string.find(groupId, "/", 1, true)
+      if pp and pp > 1 then
+        if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. string.sub(groupId, 1, pp - 1)) == 1 then
+          tenantPaused = true
+          parkGroup(readyKey, groupId)
+        end
+      end
+    end
+
+    if not tenantOverCap and not tenantPaused then
       if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
         local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
         -- Defensive activeKey check — covers legacy state during migration

--- a/specs/queue-pausing/queue-pausing.feature
+++ b/specs/queue-pausing/queue-pausing.feature
@@ -58,6 +58,29 @@ Feature: Queue pipeline pausing
     When the operator unpauses tenant A
     Then tenant A's groups resume dispatching within the next scan
 
+  # ============================================================================
+  # Pause must not block OTHER tenants — added 2026-05-27 post-incident
+  # ============================================================================
+  # A paused tenant can hold a very large due-now backlog. The dispatcher scans
+  # the shared ready queue with a bounded budget per poll; if a huge paused
+  # backlog sits at the front, the scan exhausts its budget skipping it and never
+  # reaches other tenants. So a paused tenant's groups are held out of the
+  # dispatch scan entirely (not skipped in place), and restored when unpaused.
+
+  @integration @v1 @tenant-pause
+  Scenario: A paused tenant's backlog does not block other tenants
+    Given tenant A is paused with many pending groups at the front of the queue
+    And tenant B has a pending group behind them
+    When the dispatcher runs
+    Then tenant B's group is dispatched
+    And tenant A's groups are held out of the dispatch scan
+
+  @integration @v1 @tenant-pause
+  Scenario: A still-paused tenant is not restored by the reconcile
+    Given tenant A is paused and its groups are held out of the dispatch scan
+    When the dispatcher reconcile runs while tenant A is still paused
+    Then tenant A's groups remain held out of the scan
+
   # Note: scenarios "active jobs at pause-time complete normally" and
   # "Ops UI controls" are covered by integration tests + manual QA below
   # and are not added as separate @scenario-bound unit tests because the


### PR DESCRIPTION
## Problem

A tenant pause left the tenant's groups in the `ready` zset and skipped them in place during the dispatch scan. The dispatch scan is bounded (scanBudget 10000 with the cap on). When a paused tenant has a large due-now backlog at the front of the shared ready zset, the scan exhausts its entire budget skipping that one tenant and never reaches groups for other tenants deeper in the zset, so the whole queue stalls.

This is the head-of-line half of the 2026-05-27 incident: pausing a runaway tenant (the operator mitigation lever itself) plugged dispatch for all other tenants. Live prod read during the incident: `ready` held 33k groups across 64 tenants, the first non-paused group sat at rank 15001 (beyond the 10000 scan budget), so 63 tenants saw zero throughput.

## Fix

Park paused-tenant groups OUT of `ready`, reusing the over-cap parking path that already exists:

- **Dispatch** (`DISPATCH_LUA` + `DISPATCH_BATCH_LUA`): when a group's tenant is paused, `parkGroup` it out of the scan instead of skipping in place, so the scan reaches other tenants. Pipeline-level pauses stay skip-in-place (rarer, and need the job data to classify).
- **`unparkUpTo`**: refuses to restore a still-paused tenant. This one guard covers COMPLETE-unpark, the dispatch reconcile, and the cap=0 drain, so paused groups stay parked until the pause is lifted (pause wins over cap headroom and the kill-switch).
- **Unpause**: the existing reconcile restores the tenant's parked groups on the next poll once the pause clears. Resumption is via the reconcile (time-gated, within a couple seconds) rather than in-place, bounded by cap so a huge backlog cannot re-clog the scan in one shot.

The existing `addToReadyOrParked` invariant already keeps a parked group parked when STAGE / UNBLOCK / RETRY / COMPLETE write to it, so no other writer needs changing.

## Tests

`scripts.integration.test.ts` (real Redis, testcontainers), 130/130 green:
- a paused tenant's group is parked out of ready (not skip-in-place)
- a paused tenant's backlog does not block another tenant
- a still-paused tenant is not restored by the reconcile
- unpause restores the parked group and resumes dispatch

Specs added to `specs/queue-pausing/queue-pausing.feature`.

## Scope

This is the head-of-line half. The root cause of the eval storm itself (the scheduled topic-clustering worker appending `topic_assigned` events that re-fire the `evaluationTrigger` reactor over historical traces) is fixed separately on the eval-trigger PR.