### PR TITLE
fix(event-sourcing): stop runaway evaluation re-triggering and pause head-of-line blocking

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
@@ -13,7 +13,6 @@ import type { SingleEvaluationResult } from "~/server/evaluations/evaluators.gen
 import type { Trace } from "~/server/tracer/types";
 import type { LangEvalsClient } from "../../clients/langevals/langevals.client";
 import {
-  EvaluatorConfigError,
   EvaluatorNotFoundError,
   TraceNotEvaluatableError,
 } from "../errors";
@@ -467,6 +466,7 @@ describe("EvaluationExecutionService", () => {
           );
         });
 
+        /** @scenario a thread-based monitor still runs for a trace with a thread_id */
         it("includes evaluationThreadId in result", async () => {
           const { service } = createTestService({
             trace: threadTrace,
@@ -488,23 +488,30 @@ describe("EvaluationExecutionService", () => {
       });
 
       describe("when trace has no thread_id", () => {
-        it("throws EvaluatorConfigError", async () => {
-          const { service } = createTestService({
+        /** @scenario a thread-based monitor skips a trace without a thread_id */
+        it("returns skipped without calling the evaluator", async () => {
+          const { service, mockTraceService, mockClient } = createTestService({
             trace: buildTrace({ metadata: {} }),
           });
 
-          await expect(
-            service.executeForTrace({
-              ...defaultParams,
-              evaluatorType: "custom/thread-eval",
-              level: "thread",
-              mappings: {
-                mapping: {
-                  conversation: { source: "formatted_traces", type: "thread" },
-                },
-              } as any,
-            }),
-          ).rejects.toThrow(EvaluatorConfigError);
+          const result = await service.executeForTrace({
+            ...defaultParams,
+            evaluatorType: "custom/thread-eval",
+            level: "thread",
+            mappings: {
+              mapping: {
+                conversation: { source: "formatted_traces", type: "thread" },
+              },
+            } as any,
+          });
+
+          expect(result.status).toBe("skipped");
+          expect(result.skipReason).toBe("missing_thread_id");
+          // short-circuits before building thread data or calling the evaluator
+          expect(
+            mockTraceService.getTracesWithSpansByThreadIds,
+          ).not.toHaveBeenCalled();
+          expect(mockClient.evaluate).not.toHaveBeenCalled();
         });
       });
     });

--- a/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/__tests__/evaluation-execution.service.unit.test.ts
@@ -506,7 +506,7 @@ describe("EvaluationExecutionService", () => {
           });
 
           expect(result.status).toBe("skipped");
-          expect(result.skipReason).toBe("missing_thread_id");
+          expect(result.details).toContain("thread_id");
           // short-circuits before building thread data or calling the evaluator
           expect(
             mockTraceService.getTracesWithSpansByThreadIds,

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -235,6 +235,19 @@ export class EvaluationExecutionService {
         ? trace.metadata.thread_id
         : undefined;
 
+    // A thread-based evaluation needs a thread_id to group the conversation.
+    // A trace without one can never be thread-evaluated, so skip it here —
+    // before building thread data (which would throw) and before calling the
+    // evaluator. Callers drop this skip silently so a thread monitor running
+    // over non-thread traces stays cheap instead of erroring on every trace.
+    if (isThreadLevel && !trace.metadata?.thread_id) {
+      return {
+        status: "skipped",
+        skipReason: "missing_thread_id",
+        details: "Trace has no thread_id for thread-based evaluation",
+      };
+    }
+
     // 4. Build evaluation data
     const data = await this.buildDataForEvaluation({
       evaluatorType,

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.service.ts
@@ -238,12 +238,12 @@ export class EvaluationExecutionService {
     // A thread-based evaluation needs a thread_id to group the conversation.
     // A trace without one can never be thread-evaluated, so skip it here —
     // before building thread data (which would throw) and before calling the
-    // evaluator. Callers drop this skip silently so a thread monitor running
-    // over non-thread traces stays cheap instead of erroring on every trace.
+    // evaluator. Callers drop every skipped result silently so a thread monitor
+    // running over non-thread traces stays cheap instead of erroring on every
+    // trace.
     if (isThreadLevel && !trace.metadata?.thread_id) {
       return {
         status: "skipped",
-        skipReason: "missing_thread_id",
         details: "Trace has no thread_id for thread-based evaluation",
       };
     }

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.types.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.types.ts
@@ -29,6 +29,10 @@ export type EvaluationCost = z.infer<typeof evaluationCostSchema>;
 
 export const evaluationExecutionResultSchema = z.object({
   status: z.enum(["processed", "error", "skipped"]),
+  // Why a skipped result occurred. "missing_thread_id" marks a thread-based
+  // evaluation on a trace that carries no thread_id — it can never succeed, so
+  // callers drop it silently (no result event) rather than recording a skip.
+  skipReason: z.enum(["missing_thread_id"]).optional(),
   score: z.number().optional(),
   passed: z.boolean().optional(),
   label: z.string().optional(),

--- a/langwatch/src/server/app-layer/evaluations/evaluation-execution.types.ts
+++ b/langwatch/src/server/app-layer/evaluations/evaluation-execution.types.ts
@@ -29,10 +29,6 @@ export type EvaluationCost = z.infer<typeof evaluationCostSchema>;
 
 export const evaluationExecutionResultSchema = z.object({
   status: z.enum(["processed", "error", "skipped"]),
-  // Why a skipped result occurred. "missing_thread_id" marks a thread-based
-  // evaluation on a trace that carries no thread_id — it can never succeed, so
-  // callers drop it silently (no result event) rather than recording a skip.
-  skipReason: z.enum(["missing_thread_id"]).optional(),
   score: z.number().optional(),
   passed: z.boolean().optional(),
   label: z.string().optional(),

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -183,7 +183,7 @@ describe("deserializeAttributes", () => {
   });
 });
 
-describe("clampSpanReadLimit", () => {
+describe("given a requested span-read limit", () => {
   describe("when no limit is given", () => {
     it("defaults to the hard ceiling", () => {
       expect(clampSpanReadLimit(undefined)).toBe(MAX_DERIVATION_SPANS);
@@ -214,6 +214,13 @@ describe("clampSpanReadLimit", () => {
   describe("when the requested limit is fractional", () => {
     it("truncates toward zero", () => {
       expect(clampSpanReadLimit(10.9)).toBe(10);
+    });
+  });
+
+  describe("when the requested limit is not a finite number", () => {
+    it("defaults to the ceiling instead of propagating NaN/Infinity", () => {
+      expect(clampSpanReadLimit(NaN)).toBe(MAX_DERIVATION_SPANS);
+      expect(clampSpanReadLimit(Infinity)).toBe(MAX_DERIVATION_SPANS);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -3,6 +3,10 @@ import {
   deserializeAttributes,
   serializeAttributes,
 } from "../span-storage.clickhouse.repository";
+import {
+  clampSpanReadLimit,
+  MAX_DERIVATION_SPANS,
+} from "../span-storage.repository";
 
 describe("serializeAttributes", () => {
   describe("when given string values", () => {
@@ -175,6 +179,41 @@ describe("deserializeAttributes", () => {
       const serialized = serializeAttributes(original);
       const deserialized = deserializeAttributes(serialized);
       expect(deserialized).toEqual(original);
+    });
+  });
+});
+
+describe("clampSpanReadLimit", () => {
+  describe("when no limit is given", () => {
+    it("defaults to the hard ceiling", () => {
+      expect(clampSpanReadLimit(undefined)).toBe(MAX_DERIVATION_SPANS);
+    });
+  });
+
+  describe("when the requested limit is below the ceiling", () => {
+    it("keeps the requested limit", () => {
+      expect(clampSpanReadLimit(100)).toBe(100);
+    });
+  });
+
+  describe("when the requested limit exceeds the ceiling", () => {
+    it("clamps to the ceiling so a leaked trace_id cannot raise it", () => {
+      expect(clampSpanReadLimit(MAX_DERIVATION_SPANS + 50_000)).toBe(
+        MAX_DERIVATION_SPANS,
+      );
+    });
+  });
+
+  describe("when the requested limit is zero or negative", () => {
+    it("floors at 1", () => {
+      expect(clampSpanReadLimit(0)).toBe(1);
+      expect(clampSpanReadLimit(-10)).toBe(1);
+    });
+  });
+
+  describe("when the requested limit is fractional", () => {
+    it("truncates toward zero", () => {
+      expect(clampSpanReadLimit(10.9)).toBe(10);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -21,8 +21,8 @@ import type {
   SpanSummaryRow,
 } from "./span-storage.repository";
 import {
+  clampSpanReadLimit,
   LANGWATCH_SIGNAL_BUCKETS,
-  MAX_DERIVATION_SPANS,
 } from "./span-storage.repository";
 
 const TABLE_NAME = "stored_spans" as const;
@@ -614,15 +614,21 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
   async getSpansByTraceId({
     tenantId,
     traceId,
+    limit,
     occurredAtMs,
   }: {
     tenantId: string;
     traceId: string;
+    limit?: number;
   } & OccurredAtHint): Promise<Span[]> {
     EventUtils.validateTenantId(
       { tenantId },
       "SpanStorageClickHouseRepository.getSpansByTraceId",
     );
+
+    // Hard ceiling, applied unconditionally: a leaked trace_id with a huge span
+    // count can never load the pipeline through this path, regardless of caller.
+    const effectiveLimit = clampSpanReadLimit(limit);
 
     try {
       return await withPartitionHint<Span[]>(
@@ -640,8 +646,14 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
                 ${partition.sqlAnd}
                 AND ${dedupInTuple(partition.sqlAndInner)}
               ORDER BY StartTimeMs ASC
+              LIMIT {limit:UInt32}
             `,
-            query_params: { tenantId, traceId, ...partition.params },
+            query_params: {
+              tenantId,
+              traceId,
+              limit: effectiveLimit,
+              ...partition.params,
+            },
             format: "JSONEachRow",
           });
 
@@ -677,13 +689,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       "SpanStorageClickHouseRepository.getNormalizedSpansByTraceId",
     );
 
-    // MAX_DERIVATION_SPANS is a hard ceiling: a caller cannot raise it past the
-    // bounded-read guarantee, so even a leaked trace_id can never load the
-    // pipeline through this path.
-    const effectiveLimit = Math.min(
-      Math.max(1, Math.trunc(limit ?? MAX_DERIVATION_SPANS)),
-      MAX_DERIVATION_SPANS,
-    );
+    // Hard ceiling so even a leaked trace_id can never load the pipeline.
+    const effectiveLimit = clampSpanReadLimit(limit);
 
     // The ±window hint prunes partitions on the happy path; the empty-result
     // fallback covers a stale/wrong hint. The window (±2 days) dwarfs any real

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -19,13 +19,12 @@ export const MAX_DERIVATION_SPANS = 512;
  * Clamps a requested span-read limit to the `[1, MAX_DERIVATION_SPANS]` range.
  * `MAX_DERIVATION_SPANS` is a hard ceiling a caller can only lower, never raise,
  * so every full-span / derivation read is bounded even for a leaked trace_id.
- * Undefined defaults to the ceiling (read as many as allowed, but no more).
+ * A missing or non-finite limit (undefined, NaN, Infinity) defaults to the
+ * ceiling so the value never propagates into a ClickHouse `UInt32` param.
  */
 export function clampSpanReadLimit(limit?: number): number {
-  return Math.min(
-    Math.max(1, Math.trunc(limit ?? MAX_DERIVATION_SPANS)),
-    MAX_DERIVATION_SPANS,
-  );
+  const requested = Number.isFinite(limit) ? (limit as number) : MAX_DERIVATION_SPANS;
+  return Math.min(Math.max(1, Math.trunc(requested)), MAX_DERIVATION_SPANS);
 }
 
 export interface SpanSummaryRow {

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -15,6 +15,19 @@ import type { SpanInsertData } from "../types";
  */
 export const MAX_DERIVATION_SPANS = 512;
 
+/**
+ * Clamps a requested span-read limit to the `[1, MAX_DERIVATION_SPANS]` range.
+ * `MAX_DERIVATION_SPANS` is a hard ceiling a caller can only lower, never raise,
+ * so every full-span / derivation read is bounded even for a leaked trace_id.
+ * Undefined defaults to the ceiling (read as many as allowed, but no more).
+ */
+export function clampSpanReadLimit(limit?: number): number {
+  return Math.min(
+    Math.max(1, Math.trunc(limit ?? MAX_DERIVATION_SPANS)),
+    MAX_DERIVATION_SPANS,
+  );
+}
+
 export interface SpanSummaryRow {
   spanId: string;
   parentSpanId: string | null;
@@ -77,8 +90,13 @@ export interface OccurredAtHint {
 export interface SpanStorageRepository {
   insertSpan(span: SpanInsertData): Promise<void>;
   insertSpans(spans: SpanInsertData[]): Promise<void>;
+  /**
+   * Full spans for a trace. Bounded by `MAX_DERIVATION_SPANS` (hard ceiling,
+   * always applied) so no caller can make this read unbounded on a leaked
+   * trace_id. `limit` may only lower the bound.
+   */
   getSpansByTraceId(
-    params: { tenantId: string; traceId: string } & OccurredAtHint,
+    params: { tenantId: string; traceId: string; limit?: number } & OccurredAtHint,
   ): Promise<Span[]>;
   /**
    * Normalized spans for a trace, used by read-time derivations (trace events

--- a/langwatch/src/server/app-layer/traces/span-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-storage.service.ts
@@ -22,7 +22,7 @@ export class SpanStorageService {
     await this.repository.insertSpan(span);
   }
 
-  async getSpansByTraceId(params: ByTraceId): Promise<Span[]> {
+  async getSpansByTraceId(params: ByTraceId & { limit?: number }): Promise<Span[]> {
     return this.repository.getSpansByTraceId(params);
   }
 

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
@@ -43,7 +43,6 @@ function buildDeps(
     evaluationExecution: {
       executeForTrace: vi.fn().mockResolvedValue({
         status: "skipped",
-        skipReason: "missing_thread_id",
         details: "Trace has no thread_id for thread-based evaluation",
       }),
     } as unknown as ExecuteEvaluationCommandDeps["evaluationExecution"],

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
@@ -69,16 +69,22 @@ function buildCommand(): Command<ExecuteEvaluationCommandData> {
 }
 
 describe("ExecuteEvaluationCommand", () => {
-  describe("when a thread-based monitor runs on a trace with no thread_id", () => {
-    /** @scenario a skipped thread evaluation emits no result event */
-    it("emits no result event", async () => {
-      const deps = buildDeps();
-      const command = new ExecuteEvaluationCommand(deps);
+  describe("given a thread-based monitor", () => {
+    describe("when it runs on a trace with no thread_id", () => {
+      /** @scenario a skipped thread evaluation emits no result event */
+      it("emits no result event", async () => {
+        const deps = buildDeps();
+        const command = new ExecuteEvaluationCommand(deps);
 
-      const events = await command.handle(buildCommand());
+        const events = await command.handle(buildCommand());
 
-      expect(events).toEqual([]);
-      expect(deps.costRecorder.recordCost).not.toHaveBeenCalled();
+        // Pin the skip to the missing-thread-id branch: the command must reach
+        // executeForTrace (which returns the skip) rather than bailing out at an
+        // earlier guard, otherwise an empty event list would be a false positive.
+        expect(deps.evaluationExecution.executeForTrace).toHaveBeenCalledTimes(1);
+        expect(events).toEqual([]);
+        expect(deps.costRecorder.recordCost).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit test for ExecuteEvaluationCommand's thread_id skip behaviour.
+ * All deps injected via constructor — zero vi.mock calls.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createTenantId } from "../../../../";
+import type { Command } from "../../../../";
+import {
+  ExecuteEvaluationCommand,
+  type ExecuteEvaluationCommandDeps,
+} from "../executeEvaluation.command";
+import type { ExecuteEvaluationCommandData } from "../../schemas/commands";
+
+function buildDeps(
+  overrides: Partial<ExecuteEvaluationCommandDeps> = {},
+): ExecuteEvaluationCommandDeps {
+  return {
+    monitors: {
+      getMonitorById: vi.fn().mockResolvedValue({
+        id: "monitor_1",
+        checkType: "custom/thread-eval",
+        level: "thread",
+        sample: 1,
+        preconditions: [],
+        mappings: {
+          mapping: {
+            conversation: { source: "formatted_traces", type: "thread" },
+          },
+        },
+        parameters: {},
+        evaluator: null,
+      }),
+    } as unknown as ExecuteEvaluationCommandDeps["monitors"],
+    spanStorage: {
+      getSpansByTraceId: vi.fn().mockResolvedValue([]),
+    },
+    traceEvents: {
+      getEventsByTraceId: vi.fn().mockResolvedValue([]),
+    },
+    evaluationExecution: {
+      executeForTrace: vi.fn().mockResolvedValue({
+        status: "skipped",
+        skipReason: "missing_thread_id",
+        details: "Trace has no thread_id for thread-based evaluation",
+      }),
+    } as unknown as ExecuteEvaluationCommandDeps["evaluationExecution"],
+    costRecorder: {
+      recordCost: vi.fn(),
+    } as unknown as ExecuteEvaluationCommandDeps["costRecorder"],
+    ...overrides,
+  };
+}
+
+function buildCommand(): Command<ExecuteEvaluationCommandData> {
+  return {
+    tenantId: createTenantId("project_phwl"),
+    data: {
+      tenantId: "project_phwl",
+      traceId: "trace_no_thread",
+      evaluationId: "eval_1",
+      evaluatorId: "monitor_1",
+      evaluatorType: "custom/thread-eval",
+      occurredAt: Date.now(),
+    },
+  } as unknown as Command<ExecuteEvaluationCommandData>;
+}
+
+describe("ExecuteEvaluationCommand", () => {
+  describe("when a thread-based monitor runs on a trace with no thread_id", () => {
+    /** @scenario a skipped thread evaluation emits no result event */
+    it("emits no result event", async () => {
+      const deps = buildDeps();
+      const command = new ExecuteEvaluationCommand(deps);
+
+      const events = await command.handle(buildCommand());
+
+      expect(events).toEqual([]);
+      expect(deps.costRecorder.recordCost).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -251,19 +251,23 @@ export class ExecuteEvaluationCommand implements CommandHandler<
         workflowId,
       });
 
-      // A thread-based monitor on a trace without a thread_id can never run.
-      // Drop it with no event (like an unmet precondition) so it does not fold
-      // an evaluation result — a bulk re-evaluation over non-thread traces
-      // would otherwise emit thousands of error results, each paying the heavy
-      // evaluation-projection read.
-      if (result.status === "skipped" && result.skipReason === "missing_thread_id") {
+      // A trace the service could not evaluate (no thread_id for a thread-based
+      // monitor, errored trace with no I/O, etc.) comes back as "skipped". Drop
+      // it with no event, like an unmet precondition: a skipped run has no
+      // score to fold, and a bulk re-evaluation over non-evaluatable traces
+      // would otherwise emit thousands of results, each paying the heavy
+      // evaluation-projection read. Config skips (monitor not found, provider
+      // not configured) are emitted earlier via their own path and still
+      // surface in the UI.
+      if (result.status === "skipped") {
         logger.debug(
           {
             tenantId,
             evaluatorId: data.evaluatorId,
             traceId: data.traceId,
+            details: result.details,
           },
-          "Thread-based monitor on trace without thread_id — skipping",
+          "Trace not evaluatable — skipping with no result event",
         );
         return [];
       }

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -251,6 +251,23 @@ export class ExecuteEvaluationCommand implements CommandHandler<
         workflowId,
       });
 
+      // A thread-based monitor on a trace without a thread_id can never run.
+      // Drop it with no event (like an unmet precondition) so it does not fold
+      // an evaluation result — a bulk re-evaluation over non-thread traces
+      // would otherwise emit thousands of error results, each paying the heavy
+      // evaluation-projection read.
+      if (result.status === "skipped" && result.skipReason === "missing_thread_id") {
+        logger.debug(
+          {
+            tenantId,
+            evaluatorId: data.evaluatorId,
+            traceId: data.traceId,
+          },
+          "Thread-based monitor on trace without thread_id — skipping",
+        );
+        return [];
+      }
+
       // 5. Record cost via service
       let costId: string | null = null;
       if (result.status === "processed" && result.cost) {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/foldStateBounded.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/foldStateBounded.unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { applySpanToSummary } from "../traceSummary.foldProjection";
+import {
+  applySpanToSummary,
+  MAX_PROCESSED_SPANS,
+  TraceSummaryFoldProjection,
+} from "../traceSummary.foldProjection";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import { createInitState, createTestSpan } from "./fixtures/trace-summary-test.fixtures";
 
@@ -63,6 +67,32 @@ describe("trace summary fold state size", () => {
       expect(large).not.toHaveProperty("scenarioRoleSpans");
       expect(large).not.toHaveProperty("scenarioRoleCosts");
       expect(large).not.toHaveProperty("spanCosts");
+    });
+  });
+
+  describe("given a trace that exceeds the processing cap", () => {
+    it("keeps counting but stops deriving past MAX_PROCESSED_SPANS", () => {
+      const projection = new TraceSummaryFoldProjection({ store: {} as any });
+      const atCap: TraceSummaryData = {
+        ...createInitState(),
+        spanCount: MAX_PROCESSED_SPANS,
+        models: ["gpt-5-mini"],
+        totalCost: 1.23,
+      };
+      // The span body is intentionally minimal: past the cap the handler
+      // short-circuits before normalizing it.
+      const event = {
+        tenantId: "tenant-1",
+        data: { span: { name: "should-not-be-processed" } },
+      } as any;
+
+      const result = projection.handleTraceSpanReceived(event, atCap);
+
+      // Still counted, so the true magnitude stays visible.
+      expect(result.spanCount).toBe(MAX_PROCESSED_SPANS + 1);
+      // Derived fields frozen — the span was not folded in.
+      expect(result.models).toEqual(["gpt-5-mini"]);
+      expect(result.totalCost).toBe(1.23);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/foldStateBounded.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/foldStateBounded.unit.test.ts
@@ -71,28 +71,30 @@ describe("trace summary fold state size", () => {
   });
 
   describe("given a trace that exceeds the processing cap", () => {
-    it("keeps counting but stops deriving past MAX_PROCESSED_SPANS", () => {
-      const projection = new TraceSummaryFoldProjection({ store: {} as any });
-      const atCap: TraceSummaryData = {
-        ...createInitState(),
-        spanCount: MAX_PROCESSED_SPANS,
-        models: ["gpt-5-mini"],
-        totalCost: 1.23,
-      };
-      // The span body is intentionally minimal: past the cap the handler
-      // short-circuits before normalizing it.
-      const event = {
-        tenantId: "tenant-1",
-        data: { span: { name: "should-not-be-processed" } },
-      } as any;
+    describe("when another span is received past MAX_PROCESSED_SPANS", () => {
+      it("keeps counting but stops deriving", () => {
+        const projection = new TraceSummaryFoldProjection({ store: {} as any });
+        const atCap: TraceSummaryData = {
+          ...createInitState(),
+          spanCount: MAX_PROCESSED_SPANS,
+          models: ["gpt-5-mini"],
+          totalCost: 1.23,
+        };
+        // The span body is intentionally minimal: past the cap the handler
+        // short-circuits before normalizing it.
+        const event = {
+          tenantId: "tenant-1",
+          data: { span: { name: "should-not-be-processed" } },
+        } as any;
 
-      const result = projection.handleTraceSpanReceived(event, atCap);
+        const result = projection.handleTraceSpanReceived(event, atCap);
 
-      // Still counted, so the true magnitude stays visible.
-      expect(result.spanCount).toBe(MAX_PROCESSED_SPANS + 1);
-      // Derived fields frozen — the span was not folded in.
-      expect(result.models).toEqual(["gpt-5-mini"]);
-      expect(result.totalCost).toBe(1.23);
+        // Still counted, so the true magnitude stays visible.
+        expect(result.spanCount).toBe(MAX_PROCESSED_SPANS + 1);
+        // Derived fields frozen — the span was not folded in.
+        expect(result.models).toEqual(["gpt-5-mini"]);
+        expect(result.totalCost).toBe(1.23);
+      });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -78,6 +78,14 @@ const traceNameResolutionService = new TraceNameResolutionService();
 
 // ─── Main composition ───────────────────────────────────────────────
 
+/**
+ * Max spans we fully process (normalize + derive) into a trace summary. A
+ * handful of traces accumulate tens of thousands of spans (reused trace_id,
+ * runaway loops); deriving every one pays unbounded cost for no added value.
+ * Past the cap we only keep counting so the true magnitude stays visible.
+ */
+export const MAX_PROCESSED_SPANS = 512;
+
 /** @internal Exported for unit testing */
 export function applySpanToSummary({
   state,
@@ -255,6 +263,13 @@ export class TraceSummaryFoldProjection
     event: SpanReceivedEvent,
     state: TraceSummaryData,
   ): TraceSummaryData {
+    // Past the processing cap, keep counting but skip the expensive
+    // normalization + derivation — a runaway trace cannot keep growing the
+    // fold cost. Derived fields stay frozen at the first MAX_PROCESSED_SPANS.
+    if (state.spanCount >= MAX_PROCESSED_SPANS) {
+      return { ...state, spanCount: state.spanCount + 1 };
+    }
+
     const normalizedSpan =
       spanNormalizationPipelineService.normalizeSpanReceived(
         event.tenantId,

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -87,6 +87,21 @@ function createSpanEvent(opts: SpanEventOpts = {}): TraceProcessingEvent {
   } as unknown as TraceProcessingEvent;
 }
 
+function createTopicAssignedEvent(): TraceProcessingEvent {
+  return {
+    id: "event-1",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.topic_assigned",
+    version: 1,
+    data: { topicId: "topic-1", subtopicId: null },
+    metadata: { traceId: "trace-1" },
+  } as unknown as TraceProcessingEvent;
+}
+
 function createOriginEvent(origin = "application"): TraceProcessingEvent {
   return {
     id: "event-1",
@@ -196,6 +211,52 @@ describe("evaluationTrigger reactor", () => {
       await reactor.handle(createOriginEvent(), createContext(state));
 
       expect(deps.monitors.getEnabledOnMessageMonitors).toHaveBeenCalledWith("tenant-1");
+      expect(deps.evaluation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the event is a derived enrichment (topic assignment)", () => {
+    /** @scenario a topic assignment does not re-run evaluations */
+    it("does not dispatch evaluations", async () => {
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+      });
+
+      await reactor.handle(createTopicAssignedEvent(), createContext(state));
+
+      expect(deps.monitors.getEnabledOnMessageMonitors).not.toHaveBeenCalled();
+      expect(deps.evaluation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the trace is older than the evaluation cutoff", () => {
+    /** @scenario evaluations do not re-run for a trace older than the cutoff */
+    it("does not dispatch even on a genuine new span", async () => {
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+        occurredAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
+      });
+
+      await reactor.handle(createSpanEvent(), createContext(state));
+
+      expect(deps.evaluation).not.toHaveBeenCalled();
+    });
+
+    /** @scenario a new span on a recent trace re-runs evaluations */
+    it("dispatches for a recent trace", async () => {
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+        occurredAt: Date.now(),
+      });
+
+      await reactor.handle(createSpanEvent(), createContext(state));
+
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
     });
   });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.unit.test.ts
@@ -12,16 +12,19 @@ import { DEFERRED_CHECK_DELAY_MS } from "../originGate.reactor";
 function makeEvent(overrides: Partial<TraceProcessingEvent> = {}): TraceProcessingEvent {
   return {
     id: "evt-1",
-    type: "trace.span_received",
+    type: "lw.obs.trace.span_received",
     version: 1,
     aggregateType: "trace",
     aggregateId: "trace-1",
     tenantId: "project-1",
     createdAt: Date.now(),
     occurredAt: Date.now(),
-    data: {} as any,
+    data: {
+      span: { name: "openai.chat", spanId: "span-1", parentSpanId: null, attributes: [] },
+    },
+    metadata: { spanId: "span-1", traceId: "trace-1" },
     ...overrides,
-  } as TraceProcessingEvent;
+  } as unknown as TraceProcessingEvent;
 }
 
 function makeContext(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/_originGuardedReactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/_originGuardedReactor.ts
@@ -4,21 +4,49 @@ import type {
 } from "../../../reactors/reactor.types";
 import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
 import type { TraceProcessingEvent } from "../schemas/events";
+import {
+  ORIGIN_RESOLVED_EVENT_TYPE,
+  SPAN_RECEIVED_EVENT_TYPE,
+} from "../schemas/constants";
 
 const OLD_TRACE_THRESHOLD_MS = 60 * 60 * 1000;
 
 /**
+ * Never re-run an on-message reactor for a trace whose first span is older
+ * than this, even on a genuine new span. Re-evaluating / re-alerting days-old
+ * traces is never wanted, and bounds the blast radius of any path that
+ * re-touches historical traces. Distinct from `OLD_TRACE_THRESHOLD_MS` (which
+ * skips stale *events*); this bounds the *trace* age.
+ */
+const MAX_TRACE_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Trace-processing events that represent genuine new message content and so
+ * should (re-)run on-message reactors. Everything else (topic assignment,
+ * annotations, name changes, log/metric records) updates the fold projection
+ * but must NOT fan out to side-effecting reactors. `origin_resolved` is here
+ * so deferred-origin traces still dispatch once their origin lands.
+ */
+const MESSAGE_EVENT_TYPES = new Set<string>([
+  SPAN_RECEIVED_EVENT_TYPE,
+  ORIGIN_RESOLVED_EVENT_TYPE,
+]);
+
+/**
  * Defines a trace-processing reactor that fires only when:
  *   1. the event is recent (<1h old, skips replay/resync floods),
- *   2. the trace is not blocked by guardrail with no output, and
- *   3. `langwatch.origin` is resolved on the fold state.
+ *   2. the event is a message event (span_received / origin_resolved) — derived
+ *      enrichment events like topic_assigned do not re-run side effects,
+ *   3. the trace itself is not older than MAX_TRACE_AGE_MS,
+ *   4. the trace is not blocked by guardrail with no output, and
+ *   5. `langwatch.origin` is resolved on the fold state.
  *
  * The originGate reactor handles deferred resolution for traces that
  * arrive without a resolved origin, so other origin-dependent reactors
  * just no-op until the gate has fired.
  *
  * Wraps the reactor's `handle` with these guards so each call site
- * doesn't repeat the same five-line preamble.
+ * doesn't repeat the same preamble.
  */
 export function defineOriginGuardedTraceReactor(opts: {
   name: string;
@@ -40,9 +68,28 @@ export function defineOriginGuardedTraceReactor(opts: {
     },
 
     async handle(event, context) {
+      // 1. Skip stale events (replay/resync re-emit old-occurredAt events).
       if (event.occurredAt < Date.now() - OLD_TRACE_THRESHOLD_MS) return;
 
+      // 2. Only genuine message events re-run side-effecting reactors. A daily
+      //    topic-clustering pass re-emits topic_assigned for thousands of
+      //    historical traces; without this it would re-run every monitor/alert
+      //    over the whole backlog (2026-05-27 read-amp incident).
+      if (!MESSAGE_EVENT_TYPES.has(event.type)) return;
+
       const { foldState } = context;
+
+      // 3. Never re-run for a trace whose first span is older than the cutoff,
+      //    even on a genuine new span. Checks the TRACE START
+      //    (foldState.occurredAt), not event.occurredAt — a re-emitted or late
+      //    event is fresh, but the trace itself is days old.
+      if (
+        foldState.occurredAt > 0 &&
+        foldState.occurredAt < Date.now() - MAX_TRACE_AGE_MS
+      ) {
+        return;
+      }
+
       if (foldState.blockedByGuardrail && !foldState.computedOutput) return;
 
       const attrs = foldState.attributes ?? {};

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1433,7 +1433,7 @@ describe("GroupStagingScripts", () => {
     }
 
     /** @scenario Pausing a tenant halts dispatch for that tenant only */
-    it("skips a group whose tenantId-prefix is in paused-jobs as 'tenant:<id>'", async () => {
+    it("parks a paused tenant's group OUT of ready (not skip-in-place) and returns null", async () => {
       await scripts.stage(
         makeJob({
           stagedJobId: "j1",
@@ -1446,6 +1446,71 @@ describe("GroupStagingScripts", () => {
 
       const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
       expect(result).toBeNull();
+
+      // The group is moved OUT of the ready scan into the tenant's parked set, so a
+      // large paused backlog can never plug the bounded scan and starve other tenants.
+      const ready = await inspectReadySet();
+      expect(ready).not.toContain("project_A/command/recordSpan/trace:xyz");
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
+      expect(
+        await redis.sismember(`${keyPrefix()}parked-tenants`, "project_A"),
+      ).toBe(1);
+    });
+
+    /** @scenario A paused tenant's backlog does not block other tenants */
+    it("dispatches another tenant even when a paused tenant fills the front of ready", async () => {
+      // Paused tenant has several due groups at the FRONT of ready (lowest scores).
+      for (let i = 0; i < 5; i++) {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: `bad${i}`,
+            groupId: `project_A/command/recordSpan/trace:${i}`,
+            dispatchAfterMs: 100 + i,
+            jobDataJson: makeBenignJobData(),
+          }),
+        );
+      }
+      // Another tenant's group is staged later (higher score = behind the paused ones).
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "good",
+          groupId: "project_B/command/recordSpan/trace:b",
+          dispatchAfterMs: 200,
+          jobDataJson: makeBenignJobData(),
+        }),
+      );
+      await scripts.addPauseKey("tenant:project_A");
+
+      // Dispatch reaches project_B because project_A's groups are parked OUT of the
+      // scan as it walks past them, rather than re-skipped in place every poll.
+      const result = await scripts.dispatch({ nowMs: 300, activeTtlSec: 60 });
+      expect(result).not.toBeNull();
+      expect(result!.groupId).toBe("project_B/command/recordSpan/trace:b");
+
+      // All 5 paused groups were moved out of ready into parked.
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(5);
+    });
+
+    /** @scenario A still-paused tenant is not restored by the reconcile */
+    it("keeps groups parked across the reconcile while the tenant stays paused", async () => {
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          groupId: "project_A/command/recordSpan/trace:xyz",
+          dispatchAfterMs: 100,
+          jobDataJson: makeBenignJobData(),
+        }),
+      );
+      await scripts.addPauseKey("tenant:project_A");
+
+      // First poll parks it.
+      expect(await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 })).toBeNull();
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
+
+      // A later poll runs the reconcile (past the 2s gate), but the tenant is still
+      // paused so unparkUpTo refuses to restore: it stays parked, dispatch null.
+      expect(await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 })).toBeNull();
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
     });
 
     it("dispatches groups for non-paused tenants while paused tenant is skipped", async () => {
@@ -1474,7 +1539,7 @@ describe("GroupStagingScripts", () => {
     });
 
     /** @scenario Unpausing a tenant resumes dispatch immediately */
-    it("resumes dispatch immediately after the tenant pause key is removed", async () => {
+    it("restores the parked group and resumes dispatch after the tenant pause key is removed", async () => {
       await scripts.stage(
         makeJob({
           stagedJobId: "j1",
@@ -1487,12 +1552,18 @@ describe("GroupStagingScripts", () => {
 
       const blocked = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
       expect(blocked).toBeNull();
+      // Parked out of the ready scan while paused.
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(1);
 
       await scripts.removePauseKey("tenant:project_A");
 
-      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+      // Unpausing restores the parked group via the dispatch reconcile (time-gated
+      // ~2s): advance the clock past the gate so the next poll reconciles the
+      // now-unpaused tenant back into ready and dispatches it in the same call.
+      const result = await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 });
       expect(result).not.toBeNull();
       expect(result!.stagedJobId).toBe("j1");
+      expect(await redis.zcard(`${keyPrefix()}parked:project_A`)).toBe(0);
     });
 
     it("does not pause an unrelated tenant whose id is a prefix of the paused one", async () => {
@@ -1536,9 +1607,11 @@ describe("GroupStagingScripts", () => {
       result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
       expect(result).toBeNull();
 
-      // Remove tenant pause — now dispatches
+      // Remove tenant pause — the tenant-paused group was parked out of the scan,
+      // so resumption is via the dispatch reconcile (time-gated ~2s): advance the
+      // clock past the gate so the next poll restores and dispatches it.
       await scripts.removePauseKey("tenant:project_A");
-      result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+      result = await scripts.dispatch({ nowMs: 2300, activeTtlSec: 60 });
       expect(result).not.toBeNull();
       expect(result!.stagedJobId).toBe("j1");
     });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1616,9 +1616,11 @@ describe("GroupStagingScripts", () => {
       expect(result!.stagedJobId).toBe("j1");
     });
 
-    it("falls back gracefully when groupId has no '/' (single-segment id)", async () => {
+    it("parks a paused single-segment groupId (whole id is the tenant)", async () => {
       // Defensive: a groupId without "/" means the whole string is the tenant.
-      // This shouldn't happen in production but the Lua must not error.
+      // This shouldn't happen in production but the Lua must not error, and a
+      // paused single-segment tenant must still be parked out of the scan (via
+      // parkTenantOf), not left to skip-in-place.
       await scripts.stage(
         makeJob({
           stagedJobId: "j1",
@@ -1631,6 +1633,9 @@ describe("GroupStagingScripts", () => {
 
       const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
       expect(result).toBeNull();
+      expect(
+        await redis.zcard(`${keyPrefix()}parked:single_segment_group`),
+      ).toBe(1);
     });
   });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -424,12 +424,11 @@ while offset < scanBudget do
       -- pauses below stay skip-in-place (rarer, and need the job data to classify).
       local tenantPaused = false
       if hasPauses then
-        local pp = string.find(groupId, "/", 1, true)
-        if pp and pp > 1 then
-          if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. string.sub(groupId, 1, pp - 1)) == 1 then
-            tenantPaused = true
-            parkGroup(readyKey, groupId)
-          end
+        -- parkTenantOf handles both "tenant/..." and single-segment ids, so a
+        -- paused single-segment tenant is parked too, not left to skip-in-place.
+        if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. parkTenantOf(groupId)) == 1 then
+          tenantPaused = true
+          parkGroup(readyKey, groupId)
         end
       end
 
@@ -611,12 +610,10 @@ while offset < scanBudget and dispatched < maxJobs do
     -- to restore a still-paused tenant, the reconcile restores it on unpause.
     local tenantPaused = false
     if hasPauses then
-      local pp = string.find(groupId, "/", 1, true)
-      if pp and pp > 1 then
-        if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. string.sub(groupId, 1, pp - 1)) == 1 then
-          tenantPaused = true
-          parkGroup(readyKey, groupId)
-        end
+      -- parkTenantOf handles single-segment ids too (see DISPATCH_LUA).
+      if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. parkTenantOf(groupId)) == 1 then
+        tenantPaused = true
+        parkGroup(readyKey, groupId)
       end
     end
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -102,6 +102,14 @@ end
 -- so COMPLETE-unpark and the dispatch-tail reconcile can never over-unpark into
 -- a re-park churn (TRAP 3). Returns how many were moved.
 local function unparkUpTo(readyKey, tenantId, slots)
+  local kp = parkKeyPrefixOf(readyKey)
+  -- A paused tenant's groups stay parked OUT of the ready scan regardless of cap
+  -- headroom or the cap=0 drain: pause is an explicit operator hold and must win.
+  -- Otherwise COMPLETE-unpark / reconcile would restore them into ready and a large
+  -- paused backlog would plug the bounded dispatch scan for every other tenant again.
+  if redis.call("SISMEMBER", kp .. "paused-jobs", "tenant:" .. tenantId) == 1 then
+    return 0
+  end
   if slots <= 0 then return 0 end
   -- Bound the per-eval work so no single caller can ZRANGE + ZREM/ZADD an
   -- unbounded set and block the single Redis thread. The reconcile leaves the
@@ -109,7 +117,6 @@ local function unparkUpTo(readyKey, tenantId, slots)
   -- later cycles. (Normal cap>0 unparks pass slots = cap - active, far below
   -- this; the bound only bites the cap=0 kill-switch drain of a huge backlog.)
   if slots > ${PARK_RECONCILE_MAX_DRAIN} then slots = ${PARK_RECONCILE_MAX_DRAIN} end
-  local kp = parkKeyPrefixOf(readyKey)
   local parkedKey = kp .. "parked:" .. tenantId
   local members = redis.call("ZRANGE", parkedKey, 0, slots - 1, "WITHSCORES")
   local moved = 0
@@ -408,11 +415,29 @@ while offset < scanBudget do
         end
       end
 
+      -- Tenant-level pause: park the group OUT of ready (like over-cap) rather than
+      -- skip it in place. A paused tenant can hold a huge due-now backlog; left in
+      -- ready it sits at the front and the bounded scan burns its whole budget
+      -- skipping it, starving every other tenant (the 2026-05-27 head-of-line stall).
+      -- Parking moves it out so the scan reaches other tenants; the reconcile restores
+      -- it on unpause (unparkUpTo refuses to restore while still paused). Pipeline-level
+      -- pauses below stay skip-in-place (rarer, and need the job data to classify).
+      local tenantPaused = false
+      if hasPauses then
+        local pp = string.find(groupId, "/", 1, true)
+        if pp and pp > 1 then
+          if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. string.sub(groupId, 1, pp - 1)) == 1 then
+            tenantPaused = true
+            parkGroup(readyKey, groupId)
+          end
+        end
+      end
+
       local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
       -- Defensive activeKey check — covers legacy state during migration
       -- and the small race between ZADD ready and ZADD active.
       local activeJob = redis.call("GET", activeKey)
-      if (not activeJob) and (not tenantOverCap) then
+      if (not activeJob) and (not tenantOverCap) and (not tenantPaused) then
         local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
         local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
@@ -580,7 +605,22 @@ while offset < scanBudget and dispatched < maxJobs do
       end
     end
 
-    if not tenantOverCap then
+    -- Tenant-level pause: park OUT of ready instead of skip-in-place, so a large
+    -- paused backlog cannot plug the bounded scan and starve other tenants
+    -- (head-of-line). See DISPATCH_LUA for the full rationale; unparkUpTo refuses
+    -- to restore a still-paused tenant, the reconcile restores it on unpause.
+    local tenantPaused = false
+    if hasPauses then
+      local pp = string.find(groupId, "/", 1, true)
+      if pp and pp > 1 then
+        if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. string.sub(groupId, 1, pp - 1)) == 1 then
+          tenantPaused = true
+          parkGroup(readyKey, groupId)
+        end
+      end
+    end
+
+    if not tenantOverCap and not tenantPaused then
       if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
         local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
         -- Defensive activeKey check — covers legacy state during migration

--- a/specs/evaluators/thread-eval-skips-without-thread-id.feature
+++ b/specs/evaluators/thread-eval-skips-without-thread-id.feature
@@ -1,0 +1,29 @@
+Feature: Thread-based evaluations skip traces that have no thread_id
+  As the evaluation pipeline
+  I want a thread-based monitor to skip a trace that has no thread_id
+  So that a misconfigured thread monitor on non-thread traces cannot error or starve the queue with heavy reads
+
+  # Context: a bulk re-evaluation enabled thread-based monitors over historical
+  # traces that carry no thread_id. Every such evaluation used to fetch the
+  # trace, attempt thread-data building, throw, and emit an error result — each
+  # one paying heavy ClickHouse reads. Skipping a thread evaluation that can
+  # never succeed makes the whole class cheap and quiet.
+
+  Background:
+    Given a project with a thread-based monitor enabled
+
+  Scenario: a thread-based monitor skips a trace without a thread_id
+    Given a trace that has no thread_id
+    When the pipeline executes the thread-based monitor for that trace
+    Then the evaluation is skipped
+    And the evaluator is not called
+
+  Scenario: a skipped thread evaluation emits no result event
+    Given a trace that has no thread_id
+    When the pipeline executes the thread-based monitor for that trace
+    Then no evaluation result event is emitted
+
+  Scenario: a thread-based monitor still runs for a trace with a thread_id
+    Given a trace that has a thread_id
+    When the pipeline executes the thread-based monitor for that trace
+    Then the evaluation runs normally

--- a/specs/evaluators/thread-eval-skips-without-thread-id.feature
+++ b/specs/evaluators/thread-eval-skips-without-thread-id.feature
@@ -1,13 +1,15 @@
 Feature: Thread-based evaluations skip traces that have no thread_id
   As the evaluation pipeline
   I want a thread-based monitor to skip a trace that has no thread_id
-  So that a misconfigured thread monitor on non-thread traces cannot error or starve the queue with heavy reads
+  So that a misconfigured thread monitor on non-thread traces cannot error or fold doomed result events
 
   # Context: a bulk re-evaluation enabled thread-based monitors over historical
-  # traces that carry no thread_id. Every such evaluation used to fetch the
-  # trace, attempt thread-data building, throw, and emit an error result — each
-  # one paying heavy ClickHouse reads. Skipping a thread evaluation that can
-  # never succeed makes the whole class cheap and quiet.
+  # traces that carry no thread_id. Every such evaluation used to attempt
+  # thread-data building, throw, and emit an error result whose projection fold
+  # is expensive. Skipping a thread evaluation that can never succeed runs no
+  # evaluator and emits no event, so the whole class stays quiet. The span reads
+  # that precede the skip are separately bounded by a per-trace ceiling, so even
+  # a leaked trace_id cannot make them heavy.
 
   Background:
     Given a project with a thread-based monitor enabled

--- a/specs/monitors/evaluation-trigger-skips-derived-and-stale-traces.feature
+++ b/specs/monitors/evaluation-trigger-skips-derived-and-stale-traces.feature
@@ -1,0 +1,29 @@
+Feature: ON_MESSAGE evaluations only re-run on real, recent messages
+  As the evaluation pipeline
+  I want monitors to re-run only when a trace gains genuine new message content and only while the trace is recent
+  So that derived enrichments and re-touched historical traces cannot spray thousands of evaluations and starve the queue
+
+  # Context (2026-05-27 incident): the daily topic-clustering pass appends a
+  # topic_assigned event to thousands of historical traces. The trigger reactor
+  # treated every trace event as a reason to re-run all ON_MESSAGE monitors, so
+  # one clustering pass re-ran 12 monitors over ~863 old traces and saturated
+  # ClickHouse. Two guards close it: derived events do not trigger, and old
+  # traces are never re-evaluated.
+
+  Background:
+    Given a project with an enabled ON_MESSAGE monitor
+
+  Scenario: a topic assignment does not re-run evaluations
+    Given a trace that already has spans
+    When the topic-clustering pass assigns a topic to that trace
+    Then no evaluation is dispatched
+
+  Scenario: evaluations do not re-run for a trace older than the cutoff
+    Given a trace whose first span is older than the evaluation cutoff
+    When a new span arrives on that trace
+    Then no evaluation is dispatched
+
+  Scenario: a new span on a recent trace re-runs evaluations
+    Given a recent trace
+    When a new span arrives on that trace
+    Then an evaluation is dispatched

--- a/specs/queue-pausing/queue-pausing.feature
+++ b/specs/queue-pausing/queue-pausing.feature
@@ -58,6 +58,29 @@ Feature: Queue pipeline pausing
     When the operator unpauses tenant A
     Then tenant A's groups resume dispatching within the next scan
 
+  # ============================================================================
+  # Pause must not block OTHER tenants — added 2026-05-27 post-incident
+  # ============================================================================
+  # A paused tenant can hold a very large due-now backlog. The dispatcher scans
+  # the shared ready queue with a bounded budget per poll; if a huge paused
+  # backlog sits at the front, the scan exhausts its budget skipping it and never
+  # reaches other tenants. So a paused tenant's groups are held out of the
+  # dispatch scan entirely (not skipped in place), and restored when unpaused.
+
+  @integration @v1 @tenant-pause
+  Scenario: A paused tenant's backlog does not block other tenants
+    Given tenant A is paused with many pending groups at the front of the queue
+    And tenant B has a pending group behind them
+    When the dispatcher runs
+    Then tenant B's group is dispatched
+    And tenant A's groups are held out of the dispatch scan
+
+  @integration @v1 @tenant-pause
+  Scenario: A still-paused tenant is not restored by the reconcile
+    Given tenant A is paused and its groups are held out of the dispatch scan
+    When the dispatcher reconcile runs while tenant A is still paused
+    Then tenant A's groups remain held out of the scan
+
   # Note: scenarios "active jobs at pause-time complete normally" and
   # "Ops UI controls" are covered by integration tests + manual QA below
   # and are not added as separate @scenario-bound unit tests because the


### PR DESCRIPTION
## What happened

On 2026-05-27 the event-sourcing queue stalled with near-zero throughput while Redis CPU stayed low (the opposite signature of a write storm). Root cause: the daily topic-clustering pass re-assigns topics to thousands of historical traces. Each `topic_assigned` event was treated as a new message, so the evaluation trigger re-ran every ON_MESSAGE monitor over ~863 old traces, about 10k evaluations in one 0.4s burst. The thread-based monitors among them fail on traces with no `thread_id`, but only after heavy ClickHouse reads each, which saturated ClickHouse and starved every other tenant.

A second, independent bug made recovery worse: pausing the noisy tenant left its huge backlog inside the dispatch scan, head-of-line blocking 63 other tenants.

## Fixes (all in one PR)

Evaluation re-triggering:

1. On-message trace reactors (evaluation and alert triggers) only fire on real message events (`span_received`, `origin_resolved`), never on derived enrichment events like `topic_assigned`, annotations, name changes, or log/metric records. Enforced once in the shared `defineOriginGuardedTraceReactor` so no reactor can miss it.
2. Evaluations never re-trigger for a trace whose first span is older than 24h, even on a genuine new span. The check uses the trace start time from the fold state, not the event time, so a freshly re-emitted event on an old trace is still skipped. This guard alone would have prevented the incident.
3. A thread-based evaluation on a trace with no `thread_id` runs no evaluator and emits no result event, instead of erroring and folding a doomed result. The skip happens where `thread_id` is first known (after the trace read); the reads behind it are bounded by fix #5, so the skip stays cheap even at volume. More broadly, every skipped evaluation now emits no event, since a skipped run has no score to fold.

Processing bounds:

4. Fold processing is capped at 512 spans per trace. Past the cap the trace is still counted but not re-derived, so a runaway trace cannot grow per-trace processing cost without bound.
5. The per-trace full-span read (`getSpansByTraceId`) applies the same 512-span ceiling for every caller via a shared `clampSpanReadLimit` helper, so a leaked or looping trace_id cannot make any single read heavy. The trace-with-spans read was already bounded at 200 spans per trace.

Pause head-of-line blocking:

6. Paused-tenant groups move out of the dispatch scan into a parked side-set, so a paused tenant's backlog can never block other tenants. Reuses the over-cap parking path.

## Tests

- Unit: thread-id skip returns skipped and emits no event; every skipped evaluation emits no event; `topic_assigned` does not dispatch; old traces do not dispatch; a recent new span still dispatches; the 512-span fold cap freezes derivation while still counting; `clampSpanReadLimit` enforces the read ceiling.
- Integration: 130 group-queue tests on real Redis cover the pause-park path.
- BDD specs under `specs/evaluators` and `specs/monitors`, all scenarios bound; feature-parity passes.

Replaces #4220 (its pause-park commit is included here).