### PR TITLE
feat(posthog): additive instrumentation for "the truth" dashboard

### DIFF
--- a/langwatch/specs/ops/uncaught-error-reporting.feature
+++ b/langwatch/specs/ops/uncaught-error-reporting.feature
@@ -1,0 +1,39 @@
+Feature: Uncaught backend errors are reported to PostHog
+  As an operator watching the "users hitting an error per week" quality metric
+  I want process-level crashes in the server and worker processes to reach PostHog
+  So that the error metric reflects real backend failures, not just client + handled errors
+
+  Context: the global crash handlers in start.ts and workers.ts only called
+  logger.fatal and exited, so uncaught exceptions and unhandled promise
+  rejections — the most severe, process-killing errors — were written to logs
+  but never sent to PostHog. The "the truth" dashboard error tile (insight
+  fNE339yg) therefore silently under-reported backend errors. PostHog's
+  posthog-node client batches events, so an event captured in a dying process
+  is lost unless the buffer is flushed (shutdownPostHog) before exit.
+
+  @integration
+  Scenario: An uncaught exception in the server process is captured and flushed before exit
+    Given the server process has a configured PostHog client
+    When an uncaught exception is thrown
+    Then a "$exception" event is captured tagged source=uncaughtException, process=server
+    And the PostHog buffer is flushed before the process exits
+
+  @integration
+  Scenario: An uncaught exception in a worker process is captured and flushed before exit
+    Given a worker process has a configured PostHog client
+    When an uncaught exception is thrown
+    Then a "$exception" event is captured tagged source=uncaughtException, process=worker
+    And the PostHog buffer is flushed as part of graceful shutdown
+
+  @integration
+  Scenario: An unhandled rejection is captured without changing exit behavior
+    Given the server or worker process has a configured PostHog client
+    When a promise rejection goes unhandled
+    Then a "$exception" event is captured tagged source=unhandledRejection
+    And the process keeps running, relying on the normal batch flush to deliver it
+
+  @unit
+  Scenario: Capturing a crash never throws even when PostHog is not configured
+    Given no POSTHOG_KEY is set
+    When the crash handler captures an error
+    Then no error is raised and the shutdown sequence still completes

--- a/langwatch/specs/toaster-error-reporting.feature
+++ b/langwatch/specs/toaster-error-reporting.feature
@@ -1,0 +1,32 @@
+Feature: Handled client errors reach PostHog via the toaster
+  As an operator watching the client error-rate quality metric
+  I want handled failures that show an error toast to also report to PostHog
+  So that the metric reflects real user pain, not only uncaught crashes
+
+  Context: audit of the "the truth" dashboard found that ~150 client catch
+  blocks showed an error toast but never reported the error, so handled
+  failures (failed uploads, saves, billing actions) were invisible to the
+  $exception metric. The shared toaster now accepts an opt-in `error` field:
+  passing the caught error forwards it to PostHog as a $exception. Validation
+  toasts pass no error and stay silent — the presence of a real error is the
+  signal, so we never report plain "field required" messages.
+
+  @unit
+  Scenario: An error toast that carries a caught error reports to PostHog
+    Given a catch block calls toaster.create with type "error" and the caught error
+    When the toast is created
+    Then a "$exception" event is captured tagged source=toaster
+    And the toast still renders unchanged
+
+  @unit
+  Scenario: A validation toast without an error stays silent
+    Given a toaster.create call with type "error" and no error field
+    When the toast is created
+    Then no "$exception" event is captured
+    And the toast renders normally
+
+  @unit
+  Scenario: Non-error toasts never report
+    Given a toaster.create call with type "success", "info", or "loading"
+    When the toast is created
+    Then no "$exception" event is captured

--- a/langwatch/src/components/TraceDetailsDrawer.tsx
+++ b/langwatch/src/components/TraceDetailsDrawer.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useDrawer } from "~/hooks/useDrawer";
+import { useTrackTraceOpened } from "~/hooks/useTrackTraceOpened";
 import { Drawer } from "../components/ui/drawer";
 import { useAnnotationCommentStore } from "../hooks/useAnnotationCommentStore";
 import { LegacyTracesDeprecationBanner } from "./messages/LegacyTracesDeprecationBanner";
@@ -14,6 +15,8 @@ interface TraceDetailsDrawerProps {
 export const TraceDetailsDrawer = (props: TraceDetailsDrawerProps) => {
   const { goBack } = useDrawer();
   const commentState = useAnnotationCommentStore();
+
+  useTrackTraceOpened(props.traceId, "v1");
 
   const [traceView, setTraceView] = useState<"span" | "full">("span");
 

--- a/langwatch/src/components/agents/WorkflowSelectorDrawer.tsx
+++ b/langwatch/src/components/agents/WorkflowSelectorDrawer.tsx
@@ -164,6 +164,7 @@ export function WorkflowSelectorDrawer(props: WorkflowSelectorDrawerProps) {
           title: "Error",
           description: "Failed to create workflow agent",
           type: "error",
+          error: error,
         });
       }
     },

--- a/langwatch/src/components/checks/TryItOut.tsx
+++ b/langwatch/src/components/checks/TryItOut.tsx
@@ -190,6 +190,7 @@ export function TryItOut({
           meta: {
             closable: true,
           },
+          error: e,
         });
         console.error(e);
         return;

--- a/langwatch/src/components/datasets/AddRowsFromCSVModal.tsx
+++ b/langwatch/src/components/datasets/AddRowsFromCSVModal.tsx
@@ -117,6 +117,7 @@ export function AddRowsFromCSVModal({
         meta: {
           closable: true,
         },
+        error: error,
       });
 
       return;

--- a/langwatch/src/components/datasets/CopyDatasetDialog.tsx
+++ b/langwatch/src/components/datasets/CopyDatasetDialog.tsx
@@ -99,6 +99,7 @@ export const CopyDatasetDialog = ({
         title: "Error replicating dataset",
         description: error instanceof Error ? error.message : "Unknown error",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/evaluators/WorkflowSelectorForEvaluatorDrawer.tsx
+++ b/langwatch/src/components/evaluators/WorkflowSelectorForEvaluatorDrawer.tsx
@@ -168,6 +168,7 @@ export function WorkflowSelectorForEvaluatorDrawer(
           title: "Error",
           description: "Failed to create workflow evaluator",
           type: "error",
+          error: error,
         });
       }
     },

--- a/langwatch/src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx
+++ b/langwatch/src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx
@@ -197,6 +197,7 @@ export const useBatchEvaluationDownloadCSV = ({
         meta: {
           closable: true,
         },
+        error: error,
       });
       console.error(error);
     }

--- a/langwatch/src/components/experiments/CopyExperimentDialog.tsx
+++ b/langwatch/src/components/experiments/CopyExperimentDialog.tsx
@@ -116,6 +116,7 @@ export const CopyExperimentDialog = ({
         title: "Error replicating experiment",
         description: error instanceof Error ? error.message : "Unknown error",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/gateway/BudgetCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/BudgetCreateDrawer.tsx
@@ -137,7 +137,7 @@ export function BudgetCreateDrawer({
       if (scopeKind === "PRINCIPAL") {
         setSubmitError(message);
       } else {
-        toaster.create({ title: message, type: "error" });
+        toaster.create({ title: message, type: "error", error });
       }
     }
   };

--- a/langwatch/src/components/gateway/BudgetEditDrawer.tsx
+++ b/langwatch/src/components/gateway/BudgetEditDrawer.tsx
@@ -96,6 +96,7 @@ export function BudgetEditDrawer({
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to update budget",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/gateway/CacheRuleCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/CacheRuleCreateDrawer.tsx
@@ -55,6 +55,7 @@ export function CacheRuleCreateDrawer({ open, onOpenChange, onCreated }: Props) 
       toaster.create({
         title: e instanceof Error ? e.message : "Failed to create cache rule",
         type: "error",
+        error: e,
       });
     }
   };

--- a/langwatch/src/components/gateway/CacheRuleEditDrawer.tsx
+++ b/langwatch/src/components/gateway/CacheRuleEditDrawer.tsx
@@ -86,6 +86,7 @@ export function CacheRuleEditDrawer({ rule, onOpenChange, onSaved }: Props) {
       toaster.create({
         title: e instanceof Error ? e.message : "Failed to save cache rule",
         type: "error",
+        error: e,
       });
     }
   };

--- a/langwatch/src/components/gateway/VirtualKeyCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyCreateDrawer.tsx
@@ -162,6 +162,7 @@ export function VirtualKeyCreateDrawer({
         title:
           error instanceof Error ? error.message : "Failed to create virtual key",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/gateway/VirtualKeyEditDrawer.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyEditDrawer.tsx
@@ -174,6 +174,7 @@ export function VirtualKeyEditDrawer({
             ? error.message
             : "Failed to update virtual key",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/me/SignInMethodsSection.tsx
+++ b/langwatch/src/components/me/SignInMethodsSection.tsx
@@ -122,6 +122,7 @@ export function SignInMethodsSection() {
           error instanceof Error ? error.message : "Please try again",
         type: "error",
         meta: { closable: true },
+        error,
       });
     }
   };

--- a/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
+++ b/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
@@ -209,6 +209,7 @@ export function ScenarioAIGeneration({ form }: ScenarioAIGenerationProps) {
             }
           : undefined,
         meta: { closable: true },
+        error: error,
       });
     }
   }, [

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -374,6 +374,7 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
           error instanceof Error ? error.message : "An error occurred",
         type: "error",
         meta: { closable: true },
+        error,
       });
     }
   }, [

--- a/langwatch/src/components/settings/ChangePasswordDialog.tsx
+++ b/langwatch/src/components/settings/ChangePasswordDialog.tsx
@@ -72,6 +72,7 @@ export function ChangePasswordDialog({
           error instanceof Error ? error.message : "Please try again",
         type: "error",
         meta: { closable: true },
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/settings/CreateGroupDialog.tsx
+++ b/langwatch/src/components/settings/CreateGroupDialog.tsx
@@ -73,7 +73,7 @@ export function CreateGroupDialog({
       reset();
       onClose();
     } catch (e: any) {
-      toaster.create({ title: e.message ?? "Failed to create group", type: "error" });
+      toaster.create({ title: e.message ?? "Failed to create group", type: "error", error: e });
     }
   }
 

--- a/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -367,6 +367,7 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
         type: "error",
         duration: 6000,
         meta: { closable: true },
+        error: err,
       });
     } finally {
       setBusy(false);

--- a/langwatch/src/components/settings/DefaultModelsSection.tsx
+++ b/langwatch/src/components/settings/DefaultModelsSection.tsx
@@ -151,6 +151,7 @@ export function DefaultModelsSection({
         type: "error",
         duration: 6000,
         meta: { closable: true },
+        error: err,
       });
     }
   };

--- a/langwatch/src/components/settings/GroupDetailDialog.tsx
+++ b/langwatch/src/components/settings/GroupDetailDialog.tsx
@@ -133,7 +133,7 @@ export function GroupDetailDialog({
       onClose();
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to save";
-      toaster.create({ title: message, type: "error" });
+      toaster.create({ title: message, type: "error", error: e });
     } finally {
       setIsSaving(false);
     }

--- a/langwatch/src/components/settings/MemberDetailDialog.tsx
+++ b/langwatch/src/components/settings/MemberDetailDialog.tsx
@@ -133,7 +133,7 @@ export function MemberDetailDialog({
       onClose();
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to save";
-      toaster.create({ title: message, type: "error" });
+      toaster.create({ title: message, type: "error", error: e });
     } finally {
       setIsSaving(false);
     }

--- a/langwatch/src/components/subscription/useSubscriptionActions.ts
+++ b/langwatch/src/components/subscription/useSubscriptionActions.ts
@@ -94,6 +94,7 @@ export function useSubscriptionActions({
           err instanceof Error ? err.message : "An unexpected error occurred",
         type: "error",
         meta: { closable: true },
+        error: err,
       });
     }
   };
@@ -134,6 +135,7 @@ export function useSubscriptionActions({
               err instanceof Error ? err.message : "An unexpected error occurred",
             type: "error",
             meta: { closable: true },
+            error: err,
           });
         }
       },
@@ -159,6 +161,7 @@ export function useSubscriptionActions({
           err instanceof Error ? err.message : "An unexpected error occurred",
         type: "error",
         meta: { closable: true },
+        error: err,
       });
     }
   };

--- a/langwatch/src/components/ui/PushToCopiesDialog.tsx
+++ b/langwatch/src/components/ui/PushToCopiesDialog.tsx
@@ -75,6 +75,7 @@ export function PushToCopiesDialog({
             ? String((err as { message: unknown }).message)
             : "Unknown error",
         type: "error",
+        error: err,
       });
     }
   };

--- a/langwatch/src/components/ui/ReplicateToProjectDialog.tsx
+++ b/langwatch/src/components/ui/ReplicateToProjectDialog.tsx
@@ -91,6 +91,7 @@ export function ReplicateToProjectDialog({
         title: `Error replicating ${entityLabel.toLowerCase()}`,
         description: error instanceof Error ? error.message : "Unknown error",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/ui/toaster.tsx
+++ b/langwatch/src/components/ui/toaster.tsx
@@ -9,6 +9,7 @@ import {
   Toast,
 } from "@chakra-ui/react";
 import { Info } from "react-feather";
+import { captureException } from "~/utils/posthogErrorCapture";
 
 const toaster_ = createToaster({
   placement: "top-end",
@@ -18,12 +19,23 @@ const toaster_ = createToaster({
 // Workaround for https://github.com/chakra-ui/chakra-ui/issues/9490#issuecomment-2601014577
 export const toaster = {
   ...toaster_,
-  create: (args: Parameters<typeof toaster_.create>[0]) => {
+  // Opt-in error reporting: pass the caught `error` and it's forwarded to
+  // PostHog as a $exception, so handled failures (not just uncaught crashes)
+  // reach the error/quality metrics. Validation toasts pass no `error` and
+  // stay silent — the presence of a real error is the signal, so we never
+  // report plain "field required" messages.
+  create: (
+    args: Parameters<typeof toaster_.create>[0] & { error?: unknown },
+  ) => {
+    const { error, ...toastArgs } = args;
+    if (error !== undefined) {
+      captureException(error, { tags: { source: "toaster" } });
+    }
     return toaster_.create({
       duration: 5000,
-      ...args,
+      ...toastArgs,
       meta: {
-        ...args.meta,
+        ...toastArgs.meta,
         placement: "top-end",
       },
     });

--- a/langwatch/src/components/ui/toaster.tsx
+++ b/langwatch/src/components/ui/toaster.tsx
@@ -9,7 +9,7 @@ import {
   Toast,
 } from "@chakra-ui/react";
 import { Info } from "react-feather";
-import { captureException } from "~/utils/posthogErrorCapture";
+import { captureException, toError } from "~/utils/posthogErrorCapture";
 
 const toaster_ = createToaster({
   placement: "top-end",
@@ -29,7 +29,7 @@ export const toaster = {
   ) => {
     const { error, ...toastArgs } = args;
     if (error !== undefined) {
-      captureException(error, { tags: { source: "toaster" } });
+      captureException(toError(error), { tags: { source: "toaster" } });
     }
     return toaster_.create({
       duration: 5000,

--- a/langwatch/src/components/upgrade-modal/SeatsContent.tsx
+++ b/langwatch/src/components/upgrade-modal/SeatsContent.tsx
@@ -135,6 +135,7 @@ export function SeatsContent({
           err instanceof Error ? err.message : "An unexpected error occurred",
         type: "error",
         meta: { closable: true },
+        error: err,
       });
     } finally {
       setIsConfirming(false);

--- a/langwatch/src/experiments-v3/hooks/useAutosaveEvaluationsV3.ts
+++ b/langwatch/src/experiments-v3/hooks/useAutosaveEvaluationsV3.ts
@@ -261,7 +261,6 @@ export const useAutosaveEvaluationsV3 = () => {
             meta: {
               closable: true,
             },
-            error: error,
           });
           captureException(
             toError(error),

--- a/langwatch/src/experiments-v3/hooks/useAutosaveEvaluationsV3.ts
+++ b/langwatch/src/experiments-v3/hooks/useAutosaveEvaluationsV3.ts
@@ -261,6 +261,7 @@ export const useAutosaveEvaluationsV3 = () => {
             meta: {
               closable: true,
             },
+            error: error,
           });
           captureException(
             toError(error),

--- a/langwatch/src/experiments-v3/hooks/useExecuteEvaluation.ts
+++ b/langwatch/src/experiments-v3/hooks/useExecuteEvaluation.ts
@@ -787,6 +787,7 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
         title: "Abort Failed",
         description: message,
         type: "error",
+        error: err,
       });
     }
     // Note: No finally block - isAborting stays true until `stopped` event

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
@@ -42,7 +42,9 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
     drawerContentRef,
   } = useTraceDrawerScaffold();
 
-  useTrackTraceOpened(traceId, "v2");
+  // Only count a view once the trace has actually loaded — firing on the
+  // raw traceId would also count failed/empty fetches as `trace_opened`.
+  useTrackTraceOpened(trace ? trace.traceId : undefined, "v2");
 
   const widthPx = useDrawerStore((s) => s.widthPx);
   const shortcutsOpen = useDrawerStore((s) => s.shortcutsOpen);

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
@@ -1,3 +1,4 @@
+import { useTrackTraceOpened } from "~/hooks/useTrackTraceOpened";
 import { Drawer } from "~/components/ui/drawer";
 import { DrawerSpotlights } from "../../onboarding/spotlights/DrawerSpotlights";
 import {
@@ -40,6 +41,8 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
     handleClose,
     drawerContentRef,
   } = useTraceDrawerScaffold();
+
+  useTrackTraceOpened(traceId, "v2");
 
   const widthPx = useDrawerStore((s) => s.widthPx);
   const shortcutsOpen = useDrawerStore((s) => s.shortcutsOpen);

--- a/langwatch/src/hooks/useInviteActions.ts
+++ b/langwatch/src/hooks/useInviteActions.ts
@@ -251,6 +251,7 @@ export function useInviteActions({
               type: "error",
               duration: 5000,
               meta: { closable: true },
+              error: err,
             });
           }
         },

--- a/langwatch/src/hooks/useProviderFormSubmit.ts
+++ b/langwatch/src/hooks/useProviderFormSubmit.ts
@@ -130,6 +130,7 @@ export function useProviderFormSubmit({
           type: "error",
           duration: 4000,
           meta: { closable: true },
+          error: err,
         });
       }
     },
@@ -469,6 +470,7 @@ export function useProviderFormSubmit({
         type: "error",
         duration: 4000,
         meta: { closable: true },
+        error: err,
       });
     } finally {
       setIsSaving(false);

--- a/langwatch/src/hooks/useRunScenario.tsx
+++ b/langwatch/src/hooks/useRunScenario.tsx
@@ -121,6 +121,7 @@ export function useRunScenario({
           description: message,
           type: "error",
           meta: { closable: true },
+          error: error,
         });
       } finally {
         setIsPolling(false);

--- a/langwatch/src/hooks/useTrackTraceOpened.ts
+++ b/langwatch/src/hooks/useTrackTraceOpened.ts
@@ -1,0 +1,25 @@
+import posthog from "posthog-js";
+import { useEffect } from "react";
+
+/**
+ * Fires a `trace_opened` PostHog event once per opened trace.
+ *
+ * Trace viewing is one of the actions that counts toward the active-user
+ * KPI (alongside the run/create events), so every place that renders a
+ * trace detail drawer — both the v1 drawer and the v2 shell — calls this
+ * so the signal is captured regardless of which UI the operator lands on
+ * or whether they arrived via an in-app click or a deep link.
+ *
+ * Client-side capture inherits the identified user and `$groups.organization`
+ * set in usePostHogIdentify, so this attributes to a real person (and org)
+ * without threading any identity or project context through.
+ */
+export function useTrackTraceOpened(
+  traceId: string | undefined,
+  version: "v1" | "v2",
+): void {
+  useEffect(() => {
+    if (!traceId) return;
+    posthog.capture("trace_opened", { traceId, version });
+  }, [traceId, version]);
+}

--- a/langwatch/src/optimization_studio/components/Evaluate.tsx
+++ b/langwatch/src/optimization_studio/components/Evaluate.tsx
@@ -287,6 +287,7 @@ export function EvaluateModalContent({
               type: "error",
               duration: 5000,
               meta: { closable: true },
+              error: error,
             });
             throw error;
           }

--- a/langwatch/src/optimization_studio/components/Optimize.tsx
+++ b/langwatch/src/optimization_studio/components/Optimize.tsx
@@ -282,6 +282,7 @@ export function OptimizeModalContent({
             title: "Error",
             description: "Failed to save version",
             type: "error",
+            error: error,
           });
           throw error;
         }

--- a/langwatch/src/optimization_studio/components/Publish.tsx
+++ b/langwatch/src/optimization_studio/components/Publish.tsx
@@ -512,6 +512,7 @@ function PublishModalContent({
             meta: {
               closable: true,
             },
+            error: error,
           });
           throw error;
         }

--- a/langwatch/src/optimization_studio/components/properties/llm-configs/signature-properties-panel/hooks/useResetFormWithLatestDatabaseVersion.ts
+++ b/langwatch/src/optimization_studio/components/properties/llm-configs/signature-properties-panel/hooks/useResetFormWithLatestDatabaseVersion.ts
@@ -55,6 +55,7 @@ export function useResetFormWithLatestDatabaseVersion(params: {
         title: "Failed to load latest version",
         description: "Please try again",
         type: "error",
+        error: error,
       });
     }
   }, [getPromptById, formProps, configId]);

--- a/langwatch/src/optimization_studio/components/workflow/NewWorkflowModal.tsx
+++ b/langwatch/src/optimization_studio/components/workflow/NewWorkflowModal.tsx
@@ -120,6 +120,7 @@ export const NewWorkflowModal = ({
               error instanceof Error ? error.message : "Unknown error occurred",
             type: "error",
             meta: { closable: true },
+            error: error,
           });
         }
       };

--- a/langwatch/src/optimization_studio/hooks/useRunEvalution.ts
+++ b/langwatch/src/optimization_studio/hooks/useRunEvalution.ts
@@ -195,6 +195,7 @@ export const useRunEvalution = () => {
             type: "error",
             duration: 5000,
             meta: { closable: true },
+            error: err,
           });
           return;
         }

--- a/langwatch/src/pages/settings/gateway/budgets.tsx
+++ b/langwatch/src/pages/settings/gateway/budgets.tsx
@@ -86,6 +86,7 @@ function BudgetsPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to archive",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/pages/settings/gateway/budgets/[id].tsx
+++ b/langwatch/src/pages/settings/gateway/budgets/[id].tsx
@@ -75,6 +75,7 @@ function BudgetDetailPage() {
       toaster.create({
         title: err instanceof Error ? err.message : "Failed to archive",
         type: "error",
+        error: err,
       });
     }
   };

--- a/langwatch/src/pages/settings/gateway/cache-rules.tsx
+++ b/langwatch/src/pages/settings/gateway/cache-rules.tsx
@@ -96,6 +96,7 @@ function CacheRulesPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to archive",
         type: "error",
+        error: error,
       });
     }
   };
@@ -112,6 +113,7 @@ function CacheRulesPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to toggle rule",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/pages/settings/gateway/virtual-keys/[id].tsx
+++ b/langwatch/src/pages/settings/gateway/virtual-keys/[id].tsx
@@ -196,6 +196,7 @@ function VirtualKeyDetailPage() {
       toaster.create({
         title: err instanceof Error ? err.message : "Failed to rotate key",
         type: "error",
+        error: err,
       });
     }
   };
@@ -209,6 +210,7 @@ function VirtualKeyDetailPage() {
       toaster.create({
         title: err instanceof Error ? err.message : "Failed to revoke key",
         type: "error",
+        error: err,
       });
     }
   };

--- a/langwatch/src/pages/settings/secrets.tsx
+++ b/langwatch/src/pages/settings/secrets.tsx
@@ -71,6 +71,7 @@ export default function SecretsPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to create secret",
         type: "error",
+        error: error,
       });
     }
   };
@@ -88,6 +89,7 @@ export default function SecretsPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to delete secret",
         type: "error",
+        error: error,
       });
     }
   };
@@ -107,6 +109,7 @@ export default function SecretsPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to update secret",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/prompts/prompt-playground/components/sidebar/PublishedPromptActions.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/sidebar/PublishedPromptActions.tsx
@@ -95,6 +95,7 @@ export function PublishedPromptActions({
         meta: {
           closable: true,
         },
+        error: error,
       });
     }
   }, [syncFromSource, project, utils, promptId, promptHandle]);
@@ -168,6 +169,7 @@ export function PublishedPromptActions({
         description:
           error instanceof Error ? error.message : "An unknown error occurred",
         type: "error",
+        error: error,
       });
     } finally {
       setIsDeleteDialogOpen(false);

--- a/langwatch/src/server/api/routers/agents.ts
+++ b/langwatch/src/server/api/routers/agents.ts
@@ -15,6 +15,7 @@ import {
 } from "../../agents/agent.repository";
 import { AgentService } from "../../agents/agent.service";
 import { enforceLicenseLimit } from "../../license-enforcement";
+import { trackProjectEvent } from "../../posthog";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import {
@@ -119,7 +120,7 @@ export const agentsRouter = createTRPCRouter({
 
       const agentService = AgentService.create(ctx.prisma);
       // Config is validated by the refine above, safe to cast
-      return await agentService.create({
+      const created = await agentService.create({
         id: input.id,
         projectId: input.projectId,
         name: input.name,
@@ -127,6 +128,24 @@ export const agentsRouter = createTRPCRouter({
         config: input.config as AgentComponentConfig,
         workflowId: input.workflowId,
       });
+
+      // Feature-adoption breakdown driver. The `type` property powers
+      // the "which agent types are most created" insight on "the truth"
+      // — signature vs code vs workflow vs http tells us where users
+      // actually live in the agent product.
+      trackProjectEvent({
+        prisma: ctx.prisma,
+        userId: ctx.session.user.id,
+        event: "agent_created",
+        projectId: input.projectId,
+        properties: {
+          agentId: input.id,
+          type: input.type,
+          hasWorkflow: Boolean(input.workflowId),
+        },
+      });
+
+      return created;
     }),
 
   /**

--- a/langwatch/src/server/api/routers/annotation.ts
+++ b/langwatch/src/server/api/routers/annotation.ts
@@ -4,6 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { AnnotationService } from "~/server/annotations/annotation.service";
+import { trackProjectEvent } from "~/server/posthog";
 import { getApp } from "~/server/app-layer/app";
 import type { Session } from "~/server/auth";
 import { TraceService } from "~/server/traces/trace.service";
@@ -184,6 +185,24 @@ export const annotationRouter = createTRPCRouter({
           "Failed to sync annotation to ClickHouse",
         );
       }
+
+      // Annotations are a leading indicator of "this team is using
+      // LangWatch as a feedback loop" — usually power-user behavior.
+      // Properties capture the SHAPE of annotation (thumbs/score/comment)
+      // so we can see which feedback mechanism users actually pick.
+      trackProjectEvent({
+        prisma: ctx.prisma,
+        userId: ctx.session.user.id,
+        event: "annotation_created",
+        projectId: input.projectId,
+        properties: {
+          annotationId: createdAnnotation.id,
+          hasComment: Boolean(input.comment),
+          hasThumbsUp: input.isThumbsUp != null,
+          scoreOptionsCount: Object.keys(input.scoreOptions ?? {}).length,
+          hasExpectedOutput: Boolean(input.expectedOutput),
+        },
+      });
 
       return createdAnnotation;
     }),

--- a/langwatch/src/server/api/routers/apiKey.ts
+++ b/langwatch/src/server/api/routers/apiKey.ts
@@ -5,6 +5,7 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { HandledError } from "@langwatch/handled-error";
 import { ApiKeyService } from "~/server/api-key/api-key.service";
 import { auditLog } from "~/server/auditLog";
+import { trackServerEvent } from "~/server/posthog";
 import { skipPermissionCheck } from "../rbac";
 import { permissionFormatSchema } from "~/server/rbac/custom-role-permissions";
 
@@ -282,6 +283,27 @@ export const apiKeyRouter = createTRPCRouter({
             keyType: input.keyType,
             permissionMode: input.permissionMode,
             assignedToUserId: targetUserId,
+          },
+        });
+
+        // Critical activation step: a project API key is what unblocks SDK
+        // integration. Without this event we can't measure the lag from
+        // project_created → api_key_created → first_trace_received, which
+        // is the biggest gap to close on TTV (time to value).
+        trackServerEvent({
+          userId: ctx.session.user.id,
+          event: "api_key_created",
+          organizationId: input.organizationId,
+          properties: {
+            apiKeyId: apiKey.id,
+            keyType: input.keyType,
+            permissionMode: input.permissionMode,
+            isService,
+            assignedToOther: Boolean(
+              input.assignedToUserId &&
+                input.assignedToUserId !== ctx.session.user.id,
+            ),
+            hasExpiry: Boolean(input.expiresAt),
           },
         });
 

--- a/langwatch/src/server/api/routers/dataset.ts
+++ b/langwatch/src/server/api/routers/dataset.ts
@@ -10,6 +10,7 @@ import {
   datasetRecordInputSchema,
 } from "../../datasets/types";
 import { enforceLicenseLimit } from "../../license-enforcement";
+import { trackProjectEvent } from "../../posthog";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
@@ -65,7 +66,7 @@ export const datasetRouter = createTRPCRouter({
       const datasetService = DatasetService.create(ctx.prisma);
 
       // Delegate all business logic to service
-      return await datasetService.upsertDataset({
+      const result = await datasetService.upsertDataset({
         projectId: input.projectId,
         name: "name" in input ? input.name : undefined,
         experimentId: "experimentId" in input ? input.experimentId : undefined,
@@ -73,6 +74,29 @@ export const datasetRouter = createTRPCRouter({
         datasetId: "datasetId" in input ? input.datasetId : undefined,
         datasetRecords: input.datasetRecords,
       });
+
+      // Gate to first-time creates: this is an upsert procedure, but the
+      // adoption metric we care about is "did the user CREATE a new
+      // dataset", not "did they update an existing one". Updates are
+      // implied by dataset_records_added on datasetRecord.create.
+      if (isNewDataset) {
+        trackProjectEvent({
+          prisma: ctx.prisma,
+          userId: ctx.session.user.id,
+          event: "dataset_created",
+          projectId: input.projectId,
+          properties: {
+            datasetId: result.id,
+            columnCount: input.columnTypes
+              ? Object.keys(input.columnTypes).length
+              : 0,
+            initialRecordCount: input.datasetRecords?.length ?? 0,
+            fromExperiment: "experimentId" in input,
+          },
+        });
+      }
+
+      return result;
     }),
 
   /**

--- a/langwatch/src/server/api/routers/datasetRecord.ts
+++ b/langwatch/src/server/api/routers/datasetRecord.ts
@@ -17,6 +17,7 @@ import {
 import { stripNullBytes } from "../../datasets/sanitize";
 import { newDatasetEntriesSchema } from "../../datasets/types";
 import { prisma } from "../../db";
+import { trackProjectEvent } from "../../posthog";
 import { StorageService } from "../../storage";
 import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
@@ -104,8 +105,9 @@ export const datasetRecordRouter = createTRPCRouter({
         });
       }
 
+      let created;
       try {
-        return await createManyDatasetRecords({
+        created = await createManyDatasetRecords({
           datasetId: input.datasetId,
           projectId: input.projectId,
           datasetRecords: input.entries,
@@ -115,6 +117,22 @@ export const datasetRecordRouter = createTRPCRouter({
       } catch (error) {
         return rethrowDatasetNotReadyAsTRPC(error);
       }
+
+      // Batched per request — we capture once per add call regardless of
+      // how many records were appended, with `count` as a property. Per-
+      // record capture would explode event volume for large CSV uploads.
+      trackProjectEvent({
+        prisma: ctx.prisma,
+        userId: ctx.session.user.id,
+        event: "dataset_records_added",
+        projectId: input.projectId,
+        properties: {
+          datasetId: input.datasetId,
+          count: input.entries.length,
+        },
+      });
+
+      return created;
     }),
   update: protectedProcedure
     .input(

--- a/langwatch/src/server/api/routers/evaluators.ts
+++ b/langwatch/src/server/api/routers/evaluators.ts
@@ -7,6 +7,7 @@ import { getWorkflowEntryOutputs } from "../../../optimization_studio/utils/work
 import { codeEvaluatorConfigSchema } from "../../evaluators/codeEvaluator";
 import { EvaluatorService } from "../../evaluators/evaluator.service";
 import { enforceLicenseLimit } from "../../license-enforcement";
+import { trackProjectEvent } from "../../posthog";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { copyEvaluatorToProject } from "./copyEvaluatorToProject";
@@ -138,7 +139,7 @@ export const evaluatorsRouter = createTRPCRouter({
       }
 
       const evaluatorService = EvaluatorService.create(ctx.prisma);
-      return await evaluatorService.create({
+      const created = await evaluatorService.create({
         id: input.id,
         projectId: input.projectId,
         name: input.name,
@@ -146,6 +147,24 @@ export const evaluatorsRouter = createTRPCRouter({
         config: input.config as Prisma.InputJsonValue,
         workflowId: input.workflowId,
       });
+
+      // Feature-adoption signal. We already have `evaluation_ran` (the
+      // RUN event), but creation is the leading indicator — a user can
+      // create an evaluator and not run it for days, and that gap is
+      // exactly the friction worth measuring.
+      trackProjectEvent({
+        prisma: ctx.prisma,
+        userId: ctx.session.user.id,
+        event: "evaluator_created",
+        projectId: input.projectId,
+        properties: {
+          evaluatorId: input.id,
+          type: input.type,
+          hasWorkflow: Boolean(input.workflowId),
+        },
+      });
+
+      return created;
     }),
 
   /**

--- a/langwatch/src/server/api/routers/modelProviders.ts
+++ b/langwatch/src/server/api/routers/modelProviders.ts
@@ -221,7 +221,12 @@ export const modelProviderRouter = createTRPCRouter({
             isUpdate: Boolean(input.id),
             hasCustomModels: Boolean(input.customModels),
             hasDefaultModel: Boolean(input.defaultModel),
-            scopeCount: input.scopes?.length ?? (input.scopeId ? 1 : 0),
+            // Only report scopeCount when the caller actually supplied scope
+            // input; a scope-preserving update omits it, and emitting 0 there
+            // would misclassify it as "scopes cleared".
+            ...(input.scopes !== undefined || input.scopeId !== undefined
+              ? { scopeCount: input.scopes?.length ?? (input.scopeId ? 1 : 0) }
+              : {}),
           },
         });
       }

--- a/langwatch/src/server/api/routers/modelProviders.ts
+++ b/langwatch/src/server/api/routers/modelProviders.ts
@@ -27,6 +27,7 @@ import {
   updateConfig,
 } from "../../modelProviders/modelDefaults.service";
 import { ModelProviderService } from "../../modelProviders/modelProvider.service";
+import { trackProjectEvent } from "~/server/posthog";
 import {
   checkOrganizationPermission,
   checkProjectPermission,
@@ -119,6 +120,12 @@ export const modelProviderRouter = createTRPCRouter({
       return await listOrgModelProvidersForFrontend(input.organizationId);
     }),
   update: protectedProcedure
+    // PostHog instrumentation: model_provider_configured fires on the
+    // first time keys are set (or on each rekey), gating on enabled +
+    // customKeys presence. This is the moment a user has actually given
+    // the platform credentials to talk to an LLM — without it, evaluators
+    // and prompts can't run, so it's a hard activation gate worth tracking
+    // distinctly from this generic "update" name.
     .input(
       z.object({
         id: z.string().optional(),
@@ -195,6 +202,29 @@ export const modelProviderRouter = createTRPCRouter({
         },
         { prisma: ctx.prisma, session: ctx.session },
       );
+
+      // Fire only when this looks like a "credentials supplied" event
+      // (enabled + customKeys present). A pure toggle or unset wouldn't
+      // count as setup — those would inflate adoption metrics.
+      const customKeysProvided =
+        input.customKeys != null &&
+        typeof input.customKeys === "object" &&
+        Object.keys(input.customKeys).length > 0;
+      if (input.enabled && customKeysProvided) {
+        trackProjectEvent({
+          prisma: ctx.prisma,
+          userId: ctx.session.user.id,
+          event: "model_provider_configured",
+          projectId: input.projectId,
+          properties: {
+            provider: input.provider,
+            isUpdate: Boolean(input.id),
+            hasCustomModels: Boolean(input.customModels),
+            hasDefaultModel: Boolean(input.defaultModel),
+            scopeCount: input.scopes?.length ?? (input.scopeId ? 1 : 0),
+          },
+        });
+      }
 
       return result;
     }),

--- a/langwatch/src/server/api/routers/monitors.ts
+++ b/langwatch/src/server/api/routers/monitors.ts
@@ -14,6 +14,7 @@ import {
 import { getEvaluatorDefinitions } from "../../evaluations/getEvaluator";
 import { validatedPreconditionsSchema } from "../../evaluations/preconditionValidation";
 import { enforceLicenseLimit } from "../../license-enforcement";
+import { trackProjectEvent } from "../../posthog";
 import { coerceMonitorMappings } from "../../tracer/tracesMapping";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
@@ -242,6 +243,29 @@ export const monitorsRouter = createTRPCRouter({
           evaluatorId,
           level: level ?? "trace",
           threadIdleTimeout,
+        },
+      });
+
+      // Monitor creation is the highest-leverage adoption event: it sets
+      // up continuous online evaluation, which is the LangWatch "always-on"
+      // value proposition. `executionMode` (ON_MESSAGE vs AS_GUARDRAIL vs
+      // MANUALLY) is the key breakdown — guardrails are a leading
+      // indicator of production usage.
+      trackProjectEvent({
+        prisma,
+        userId: ctx.session.user.id,
+        event: "monitor_created",
+        projectId,
+        properties: {
+          monitorId: newCheck.id,
+          checkType,
+          executionMode,
+          level: level ?? "trace",
+          sample,
+          hasEvaluator: Boolean(evaluatorId),
+          preconditionCount: Array.isArray(preconditions)
+            ? preconditions.length
+            : 0,
         },
       });
 

--- a/langwatch/src/server/api/routers/organization.ts
+++ b/langwatch/src/server/api/routers/organization.ts
@@ -91,6 +91,20 @@ export const organizationRouter = createTRPCRouter({
         userDisplayName: ctx.session.user.name,
       });
 
+      // Activation funnel step 2 on "the truth": user → org. Carries
+      // organizationId both as a property and via $groups so org-level
+      // breakdowns (plan distribution, org-count-by-week) work.
+      trackServerEvent({
+        userId: ctx.session.user.id,
+        event: "organization_created",
+        organizationId: result.organization.id,
+        properties: {
+          teamId: result.team.id,
+          hasPhoneNumber: Boolean(input.phoneNumber),
+          orgNameProvided: Boolean(input.orgName),
+        },
+      });
+
       return {
         success: true,
         organization: result.organization,
@@ -1191,6 +1205,20 @@ export const organizationRouter = createTRPCRouter({
           },
         });
       }
+
+      // Pairs with the existing `team_member_invited` event (which fires
+      // when the invite is SENT). Together they form the invite-acceptance
+      // funnel: invited → accepted. The gap is the expansion-conversion
+      // metric the founders track for collaboration features.
+      trackServerEvent({
+        userId: session.user.id,
+        event: "team_invite_accepted",
+        organizationId: invite.organization.id,
+        properties: {
+          inviteId: invite.id,
+          role: invite.role,
+        },
+      });
 
       void getApp()
         .notifications.sendSlackSignupEvent({

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -23,6 +23,7 @@ import {
   createLicenseEnforcementService,
   LimitExceededError,
 } from "../../license-enforcement";
+import { trackServerEvent } from "~/server/posthog";
 import { generateApiKey } from "../../utils/apiKeyGenerator";
 import {
   checkOrganizationPermission,
@@ -191,6 +192,22 @@ export const projectRouter = createTRPCRouter({
           },
         });
       }
+
+      // Activation funnel step 3 on "the truth": org → project. The
+      // `language`/`framework` properties drive the "which SDKs are most
+      // chosen" breakdown — a roadmap signal for which integrations to
+      // invest in next.
+      trackServerEvent({
+        userId,
+        event: "project_created",
+        projectId: project.id,
+        organizationId: input.organizationId,
+        properties: {
+          language: input.language,
+          framework: input.framework,
+          teamCreatedInline: !input.teamId,
+        },
+      });
 
       return { success: true, projectSlug: project.slug };
     }),

--- a/langwatch/src/server/api/routers/prompts/prompts.trpc-router.ts
+++ b/langwatch/src/server/api/routers/prompts/prompts.trpc-router.ts
@@ -13,6 +13,7 @@ import {
 } from "~/prompts/schemas";
 import { afterPromptCreated } from "~/../ee/billing/nurturing/hooks/promptCreation";
 import { enforceLicenseLimit } from "~/server/license-enforcement";
+import { trackProjectEvent } from "~/server/posthog";
 import { hoistSystemMessage, PromptService } from "~/server/prompt-config";
 import { NotFoundError } from "~/server/prompt-config/errors";
 import { TagValidationError } from "~/server/prompt-config/repositories/llm-config-tag.repository";
@@ -203,6 +204,27 @@ export const promptsRouter = createTRPCRouter({
         projectId: input.projectId,
         userId: authorId,
       });
+
+      // Prompt creation is the bread-and-butter adoption event for the
+      // Prompts product. `source: "created"` distinguishes this from the
+      // copy path below — duplicated prompts inflate adoption but aren't
+      // true new authorship, so we split them.
+      if (authorId) {
+        trackProjectEvent({
+          prisma: ctx.prisma,
+          userId: authorId,
+          event: "prompt_created",
+          projectId: input.projectId,
+          properties: {
+            source: "created",
+            scope: input.data.scope ?? null,
+            hasMessages: Boolean(input.data.messages?.length),
+            hasInputs: Boolean(input.data.inputs?.length),
+            model: input.data.model ?? null,
+            hasDemonstrations: Boolean(input.data.demonstrations),
+          },
+        });
+      }
 
       return result;
     }),
@@ -436,6 +458,22 @@ export const promptsRouter = createTRPCRouter({
         projectId: input.projectId,
         userId: authorId,
       });
+
+      // Counterpart to the `prompt_created` event in the create() path —
+      // `source: "copied"` so dashboards can split "original authorship"
+      // from "duplication" without conflating them.
+      if (authorId) {
+        trackProjectEvent({
+          prisma: ctx.prisma,
+          userId: authorId,
+          event: "prompt_created",
+          projectId: input.projectId,
+          properties: {
+            source: "copied",
+            sourcePromptId: copiedPrompt.copiedFromPromptId,
+          },
+        });
+      }
 
       return copiedPrompt;
     }),

--- a/langwatch/src/server/api/routers/scenarios/simulation-runner.router.ts
+++ b/langwatch/src/server/api/routers/scenarios/simulation-runner.router.ts
@@ -14,6 +14,7 @@ import {
 } from "~/server/scenarios/execution/data-prefetcher";
 import { getOnPlatformSetId } from "~/server/scenarios/internal-set-id";
 import { generateBatchRunId } from "~/server/scenarios/scenario.ids";
+import { trackProjectEvent } from "~/server/posthog";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { checkProjectPermission } from "../../rbac";
 import { projectSchema } from "./schemas";
@@ -54,7 +55,7 @@ export const simulationRunnerRouter = createTRPCRouter({
   run: protectedProcedure
     .input(runScenarioSchema)
     .use(checkProjectPermission("scenarios:manage"))
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       const setId = input.setId ?? getOnPlatformSetId(input.projectId);
       const batchRunId = input.batchRunId ?? generateBatchRunId();
 
@@ -126,6 +127,22 @@ export const simulationRunnerRouter = createTRPCRouter({
       // No explicit job scheduling — the execution reactor picks up the queued
       // event via the GroupQueue and spawns the child process.
       logger.info({ batchRunId, scenarioRunId }, "Scenario queued via event-sourcing");
+
+      // Active-user signal. The SDK ingest path (/api/scenario-events) is
+      // API-key authed and has no user, so platform-triggered runs are the
+      // only ones attributable to a person — track them here.
+      trackProjectEvent({
+        prisma: ctx.prisma,
+        userId: ctx.session.user.id,
+        event: "scenario_run",
+        projectId: input.projectId,
+        properties: {
+          scenarioId: input.scenarioId,
+          scenarioRunId,
+          batchRunId,
+          targetType: input.target.type,
+        },
+      });
 
       return {
         scheduled: true,

--- a/langwatch/src/server/api/routers/suites/suite.router.ts
+++ b/langwatch/src/server/api/routers/suites/suite.router.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { enforceLicenseLimit } from "~/server/license-enforcement";
+import { trackProjectEvent } from "~/server/posthog";
 import { ProjectRepository } from "~/server/projects/project.repository";
 import type { SuiteRunSummary } from "~/server/scenarios/scenario-event.types";
 import { SuiteDomainError } from "~/server/suites/errors";
@@ -37,7 +38,24 @@ export const suiteRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       await enforceLicenseLimit(ctx, input.projectId, "experiments");
       const service = createSuiteService(ctx.prisma);
-      return service.create(input);
+      const suite = await service.create(input);
+
+      // Simulation suites are a key Scenarios-product adoption signal.
+      // Pairs with the existing `scenario_created` event: scenarios live
+      // inside suites, so suite_created is the "container" adoption while
+      // scenario_created is the "content" adoption. Both together give
+      // us creation→usage of the simulations product.
+      trackProjectEvent({
+        prisma: ctx.prisma,
+        userId: ctx.session.user.id,
+        event: "suite_created",
+        projectId: input.projectId,
+        properties: {
+          suiteId: suite.id,
+        },
+      });
+
+      return suite;
     }),
 
   getAll: protectedProcedure

--- a/langwatch/src/server/api/routers/workflows.ts
+++ b/langwatch/src/server/api/routers/workflows.ts
@@ -31,6 +31,7 @@ import { pMapLimited } from "../../event-sourcing/replay/pMapLimited";
 import { materializeNodeLlmConfigs } from "../../workflows/materializeNodeLlmConfigs";
 import { checkProjectPermission, hasProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { trackProjectEvent } from "~/server/posthog";
 
 const autoComputeLogger = createLogger("langwatch:workflows:auto-compute");
 
@@ -113,6 +114,22 @@ export const workflowRouter = createTRPCRouter({
           });
         })
         .catch(captureException);
+
+      // Studio adoption signal. `autoPublished` lets us split "exploratory"
+      // workflows (saved but not published) from "production" workflows
+      // (published on first save, e.g. evaluator-shaped workflows). The
+      // ratio of those is a quality-of-use signal.
+      trackProjectEvent({
+        prisma: ctx.prisma,
+        userId: ctx.session.user.id,
+        event: "workflow_created",
+        projectId: input.projectId,
+        properties: {
+          workflowId: workflow.id,
+          autoPublished: Boolean(input.publish),
+          name: input.dsl.name,
+        },
+      });
 
       return { workflow, version };
     }),

--- a/langwatch/src/server/better-auth/hooks.ts
+++ b/langwatch/src/server/better-auth/hooks.ts
@@ -4,6 +4,7 @@ import { type Organization, Prisma, type PrismaClient, RoleBindingScopeType, Tea
 import { APIError } from "better-auth/api";
 import { getApp } from "~/server/app-layer/app";
 import { InviteService } from "~/server/invites/invite.service";
+import { trackServerEvent } from "~/server/posthog";
 import { KSUID_RESOURCES } from "~/utils/constants";
 import { fireSsoAutoAddNurturingCalls } from "../../../ee/billing/nurturing/hooks/ssoAutoAdd";
 import { captureException } from "../../utils/posthogErrorCapture";
@@ -107,6 +108,20 @@ export const afterUserCreate = async ({
   prisma: PrismaClient;
   user: { id: string; email: string; name: string };
 }): Promise<void> => {
+  // Top of the activation funnel on "the truth" dashboard. Fires once per
+  // brand-new user regardless of signup path (OAuth, SSO, credential),
+  // because this hook runs after the User row commits and before any of
+  // the SSO-auto-add branching below. Without this anchor, the activation
+  // funnel has no origin and TTV (time-to-first-trace) can't be measured.
+  trackServerEvent({
+    userId: user.id,
+    event: "signup_completed",
+    properties: {
+      emailDomain: extractEmailDomain(user.email),
+      hasDisplayName: Boolean(user.name),
+    },
+  });
+
   const domain = extractEmailDomain(user.email);
   if (!domain) return;
 

--- a/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -297,9 +297,10 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
         id: { in: [MONITOR_ID, MONITOR_NOT_GUARDRAIL_ID] },
       },
     });
-    await prisma.routingPolicyScope.deleteMany({
-      where: { routingPolicyId: RP_ID },
-    });
+    // RoutingPolicyScope rows cascade-delete with their RoutingPolicy
+    // (onDelete: Cascade), so deleting the policy below is enough — an
+    // explicit deleteMany here also trips the multi-tenancy guard, which
+    // has no RoutingPolicyScope predicate.
     await prisma.routingPolicy.deleteMany({ where: { id: RP_ID } });
     await prisma.modelProviderScope.deleteMany({
       where: {

--- a/langwatch/src/server/posthog.ts
+++ b/langwatch/src/server/posthog.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@langwatch/observability";
+import type { PrismaClient } from "@prisma/client";
 import { PostHog } from "posthog-node";
 import { env } from "../env.mjs";
 
@@ -60,17 +61,27 @@ export function getPostHogInstance(): PostHog | null {
 /**
  * Fire-and-forget server-side event tracking.
  * Silently no-ops when POSTHOG_KEY is not set (self-hosted without PostHog).
+ *
+ * Pass `organizationId` whenever it's in scope: it sets PostHog's `$groups`
+ * payload, which is the only way the "organization" group_type aggregations
+ * (org-level retention, plan breakdowns, WAU-by-org) on dashboards like
+ * "the truth" and "Langwatch Growth" can attribute server-side events to an
+ * org. Client-side capture inherits group context from `posthog.group()`
+ * called in usePostHogIdentify, but server-side captures don't — they must
+ * supply it explicitly per call.
  */
 export function trackServerEvent({
   userId,
   event,
   properties,
   projectId,
+  organizationId,
 }: {
   userId: string;
   event: string;
   properties?: Record<string, unknown>;
   projectId?: string;
+  organizationId?: string;
 }) {
   const posthog = getPostHogInstance();
   if (!posthog) return;
@@ -80,7 +91,65 @@ export function trackServerEvent({
     properties: {
       ...properties,
       ...(projectId ? { projectId } : {}),
+      ...(organizationId ? { organizationId } : {}),
     },
+    ...(organizationId
+      ? { groups: { organization: organizationId } }
+      : {}),
+  });
+}
+
+// Per-process cache. Project → org mapping is set at project creation and
+// never moves, so a single Prisma lookup per project per server lifetime
+// is enough to enrich every subsequent event with $groups.organization.
+const projectOrgCache = new Map<string, string>();
+
+/**
+ * Fire-and-forget tracking for project-scoped server events (a feature
+ * was created inside a project). Looks up the project's organization the
+ * first time we see a projectId and caches it, so every subsequent event
+ * for that project carries $groups.organization with zero extra Prisma
+ * calls.
+ *
+ * Use this for any "<resource>_created" event captured from a tRPC mutation
+ * scoped to a project. It's the server-side equivalent of the client-side
+ * posthog.group() call in usePostHogIdentify, and it's what unlocks
+ * per-org cohort/retention/breakdown analysis on dashboards like
+ * "the truth" and "Langwatch Growth".
+ */
+export function trackProjectEvent({
+  prisma,
+  userId,
+  event,
+  projectId,
+  properties,
+}: {
+  prisma: PrismaClient;
+  userId: string;
+  event: string;
+  projectId: string;
+  properties?: Record<string, unknown>;
+}): void {
+  void (async () => {
+    let organizationId = projectOrgCache.get(projectId);
+    if (!organizationId) {
+      const project = await prisma.project.findFirst({
+        where: { id: projectId },
+        select: { team: { select: { organizationId: true } } },
+      });
+      organizationId = project?.team.organizationId;
+      if (organizationId) projectOrgCache.set(projectId, organizationId);
+    }
+    trackServerEvent({
+      userId,
+      event,
+      projectId,
+      ...(organizationId ? { organizationId } : {}),
+      properties,
+    });
+  })().catch((err) => {
+    // Tracking must never break a write path. Log and swallow.
+    logger.warn({ err, event, projectId }, "trackProjectEvent failed");
   });
 }
 

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -89,7 +89,7 @@ import { verifyRedisReady } from "./server/redis";
 import { serveStaticOrFallback } from "./server/static-handler";
 import { setupTRPCWebSocket } from "./server/websockets/trpc-ws";
 import { startWorkers, type WorkerHandle } from "./server/workers/startWorkers";
-import { captureException } from "./utils/posthogErrorCapture";
+import { captureException, toError } from "./utils/posthogErrorCapture";
 
 const logger = createLogger("langwatch:start");
 
@@ -409,7 +409,7 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
       { reason: reason instanceof Error ? reason : { value: reason }, promise },
       "unhandled rejection detected"
     );
-    captureException(reason, {
+    captureException(toError(reason), {
       level: "error",
       tags: { source: "unhandledRejection", process: "server" },
     });

--- a/langwatch/src/start.ts
+++ b/langwatch/src/start.ts
@@ -89,6 +89,7 @@ import { verifyRedisReady } from "./server/redis";
 import { serveStaticOrFallback } from "./server/static-handler";
 import { setupTRPCWebSocket } from "./server/websockets/trpc-ws";
 import { startWorkers, type WorkerHandle } from "./server/workers/startWorkers";
+import { captureException } from "./utils/posthogErrorCapture";
 
 const logger = createLogger("langwatch:start");
 
@@ -392,7 +393,14 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
 
   process.on("uncaughtException", (err) => {
     logger.fatal({ error: err }, "uncaught exception detected");
-    server.close(() => process.exit(1));
+    captureException(err, {
+      level: "error",
+      tags: { source: "uncaughtException", process: "server" },
+    });
+    // Flush the buffered $exception before exiting — posthog-node batches
+    // events, so without this the event dies with the process. The 1s abort
+    // below is the hard backstop if the flush hangs.
+    void shutdownPostHog().finally(() => server.close(() => process.exit(1)));
     setTimeout(() => process.abort(), 1000).unref();
   });
 
@@ -401,6 +409,10 @@ export const startApp = async (dir = path.dirname(__dirname)) => {
       { reason: reason instanceof Error ? reason : { value: reason }, promise },
       "unhandled rejection detected"
     );
+    captureException(reason, {
+      level: "error",
+      tags: { source: "unhandledRejection", process: "server" },
+    });
   });
 
   // In-process worker stack (dev opt-in via WORKERS_IN_PROCESS=1). Booted last —

--- a/langwatch/src/workers.ts
+++ b/langwatch/src/workers.ts
@@ -85,11 +85,14 @@ process.on("uncaughtException", (err) => {
     tags: { source: "uncaughtException", process: "worker" },
   });
 
-  // Attempt graceful shutdown, abort if it takes too long. shutdownPostHog
-  // flushes the buffered $exception above — posthog-node batches events, so
-  // it would otherwise die with the process. Both run inside the 3s race.
+  // Attempt graceful shutdown, abort if it takes too long. Both run in
+  // parallel — gracefulShutdown() no longer exits internally (see its
+  // definition above), so nothing here races an internal process.exit()
+  // against the flush. shutdownPostHog()'s own error is swallowed so a
+  // slow/unreachable PostHog can never skip the job drain; the whole
+  // sequence is still bounded by the 3s race.
   Promise.race([
-    Promise.all([gracefulShutdown(), shutdownPostHog()]),
+    Promise.all([gracefulShutdown(), shutdownPostHog().catch(() => {})]),
     new Promise((_, reject) => setTimeout(() => reject(new Error("Shutdown timeout")), 3000)),
   ])
     .catch(() => process.abort())

--- a/langwatch/src/workers.ts
+++ b/langwatch/src/workers.ts
@@ -22,7 +22,9 @@ import "./instrumentation.node";
 import "./server/handled-error-wiring";
 import { setEnvironment } from "@langwatch/ksuid";
 import { createLogger } from "@langwatch/observability";
+import { shutdownPostHog } from "./server/posthog";
 import { startWorkers, type WorkerHandle } from "./server/workers/startWorkers";
+import { captureException } from "./utils/posthogErrorCapture";
 
 setEnvironment(process.env.ENVIRONMENT ?? "local");
 
@@ -57,11 +59,15 @@ async function gracefulShutdown(): Promise<void> {
   } catch (error) {
     logger.error({ error }, "error closing app during shutdown");
   }
-  process.exit(0);
+  // Exiting is left to the caller (rather than done here) so the
+  // uncaughtException handler below can race this against shutdownPostHog()
+  // and pick the exit code — an internal process.exit() here would fire the
+  // instant this function's own work settled, killing the process before the
+  // PostHog flush it's racing against ever completes.
 }
 
-process.on("SIGINT", () => void gracefulShutdown());
-process.on("SIGTERM", () => void gracefulShutdown());
+process.on("SIGINT", () => void gracefulShutdown().then(() => process.exit(0)));
+process.on("SIGTERM", () => void gracefulShutdown().then(() => process.exit(0)));
 
 void startWorkers({ shouldStartMetricsServer: true })
   .then((handle) => {
@@ -74,7 +80,20 @@ void startWorkers({ shouldStartMetricsServer: true })
 
 process.on("uncaughtException", (err) => {
   logger.fatal({ error: err }, "uncaught exception detected");
-  process.exit(1);
+  captureException(err, {
+    level: "error",
+    tags: { source: "uncaughtException", process: "worker" },
+  });
+
+  // Attempt graceful shutdown, abort if it takes too long. shutdownPostHog
+  // flushes the buffered $exception above — posthog-node batches events, so
+  // it would otherwise die with the process. Both run inside the 3s race.
+  Promise.race([
+    Promise.all([gracefulShutdown(), shutdownPostHog()]),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("Shutdown timeout")), 3000)),
+  ])
+    .catch(() => process.abort())
+    .finally(() => process.exit(1));
 });
 
 process.on("unhandledRejection", (reason, promise) => {
@@ -82,4 +101,8 @@ process.on("unhandledRejection", (reason, promise) => {
     { reason: reason instanceof Error ? reason : { value: reason }, promise },
     "unhandled rejection detected",
   );
+  captureException(reason, {
+    level: "error",
+    tags: { source: "unhandledRejection", process: "worker" },
+  });
 });

--- a/langwatch/src/workers.ts
+++ b/langwatch/src/workers.ts
@@ -24,7 +24,7 @@ import { setEnvironment } from "@langwatch/ksuid";
 import { createLogger } from "@langwatch/observability";
 import { shutdownPostHog } from "./server/posthog";
 import { startWorkers, type WorkerHandle } from "./server/workers/startWorkers";
-import { captureException } from "./utils/posthogErrorCapture";
+import { captureException, toError } from "./utils/posthogErrorCapture";
 
 setEnvironment(process.env.ENVIRONMENT ?? "local");
 
@@ -104,7 +104,7 @@ process.on("unhandledRejection", (reason, promise) => {
     { reason: reason instanceof Error ? reason : { value: reason }, promise },
     "unhandled rejection detected",
   );
-  captureException(reason, {
+  captureException(toError(reason), {
     level: "error",
     tags: { source: "unhandledRejection", process: "worker" },
   });


### PR DESCRIPTION
## Summary

Closes the biggest blind spots in our PostHog instrumentation by adding **16 additive events** across every major create-path in the Next.js app, plus a helper upgrade that makes server-side events org-aware. Pairs with **6 new tiles** added to the existing PostHog "[the truth](https://eu.posthog.com/project/66212/dashboard/651303)" dashboard (id `651303`).

**No existing event names changed**, no DB migrations, no client-side renames. Existing dashboards (`Langwatch Growth`, `Paying customer retention`) keep working exactly as-is.

## Why this PR exists

Before: the only product-action events firing reliably were `evaluation_ran`, `scenario_created`, `team_member_invited`, `subscription_created`, `limit_blocked`, and the onboarding-screen views. That means we could not answer:

- _How many users actually made it from signup to their first product action?_ (no `signup_completed`, no `project_created`, no `api_key_created`)
- _Which products do users adopt — and which do they ignore?_ (no `dataset_created`, `prompt_created`, `agent_created`, `monitor_created`, `workflow_created`, `annotation_created`, `suite_created`)
- _Where do users churn or get stuck?_ (no `feature_locked_attempted` distinct from rate-limit, no `model_provider_configured` to see who has unblocked themselves)
- _How long does TTV take?_ (no signup anchor, no first-feature-use anchor)
- _Which orgs are using what?_ (server events fired without `$groups.organization`, so cohort/retention rollups were structurally broken)

This PR fixes all of the above by piggy-backing on the existing `trackServerEvent` helper, plus a small new `trackProjectEvent` wrapper that auto-attaches `$groups.organization` for project-scoped events.

## Helper changes (`src/server/posthog.ts`)

1. **`trackServerEvent`** now accepts an optional `organizationId`. When provided, it sets PostHog's `groups: { organization: organizationId }` so the event attributes to the org cohort. Existing callers (which omit it) keep working unchanged.
2. **`trackProjectEvent({ prisma, ... })`** is new — looks up `project.team.organizationId` once per process and caches it (`projectOrgCache`). Every project-scoped capture site uses it so we don't sprinkle org-lookups across 12 routers.

The cache is per-process and grows lazily; project→org mappings never move so a single SELECT per project per server lifetime is enough.

## New events (16) — per-event What / How / Why

### Activation funnel (top of "the truth")

| Event | Fires from | Why we track it |
|---|---|---|
| `signup_completed` | `better-auth/hooks.ts:afterUserCreate` (very top, before SSO branching) | Anchor of the activation funnel. Without it we can only proxy signups via `onboarding_welcome.viewed`, which misses users who bounce before opening onboarding. Fires once per User row commit regardless of auth path (OAuth/SSO/credential). |
| `organization_created` | `routers/organization.ts:createAndAssign` after `scheduleUsageStatsForOrganization` | Carries `organizationId` both as property AND `$groups.organization`. Unblocks org-count-by-week, plan distribution, and any per-org retention. |
| `project_created` | `routers/project.ts:create` after `prisma.project.create` | Properties `language` + `framework` drive the "which SDKs are most chosen" breakdown — a roadmap signal for which integrations to invest in next. |
| `api_key_created` | `routers/apiKey.ts:create` after `apiKeyService.create` + audit log | An API key is what unblocks SDK integration. Without it, we can't measure the lag `project_created → api_key_created → first feature use`, which is the biggest gap on TTV (time to value). |
| `model_provider_configured` | `routers/modelProviders.ts:update` after `service.updateModelProvider`, gated to `enabled && customKeys provided` | Gated to avoid firing on pure toggles — only when credentials are actually supplied. This is the gate before any evaluator/prompt can RUN. |

### Feature-adoption events

| Event | Fires from | Why we track it |
|---|---|---|
| `evaluator_created` | `routers/evaluators.ts:create` after `evaluatorService.create` | Pairs with existing `evaluation_ran`. Creation is the LEADING indicator — users often create an evaluator and don't run it for days; that gap is the friction worth measuring. |
| `monitor_created` | `routers/monitors.ts:create` after `prisma.monitor.create` | Highest-leverage adoption event: continuous online evaluation is the "always-on" LangWatch value proposition. `executionMode` breakdown (ON_MESSAGE vs AS_GUARDRAIL vs MANUALLY) tells us whether the monitor is production-grade. |
| `dataset_created` | `routers/dataset.ts:upsert` (gated to `isNewDataset` only) | Upsert procedure — gated so updates don't inflate adoption metrics. |
| `dataset_records_added` | `routers/datasetRecord.ts:create` after `createManyDatasetRecords` | Captured per request (not per-record) with `count` as a property. Per-record capture would explode event volume on large CSV uploads. |
| `prompt_created` | `routers/prompts/prompts.trpc-router.ts:create` (`source: "created"`) and the copy path (`source: "copied"`) | Two emit sites with `source` to distinguish original authorship vs duplication. Copies inflate raw adoption but aren't true new authorship. |
| `agent_created` | `routers/agents.ts:create` after `agentService.create` | `type` property powers "which agent types are most created" — signature vs code vs workflow vs http tells us where users actually live in the agent product. |
| `workflow_created` | `routers/workflows.ts:create` after the workflow + version creation | `autoPublished` splits "exploratory" workflows from "production" ones (e.g., evaluator-shaped workflows that publish on first save). The ratio is a quality-of-use signal. |
| `annotation_created` | `routers/annotation.ts:create` after the ClickHouse sync block | Annotations are a leading indicator of "team uses LangWatch as a feedback loop" — usually power-user behavior. Properties capture the SHAPE (thumbs/score/comment). |
| `suite_created` | `routers/suites/suite.router.ts:create` after `service.create` | Counterpart to the existing `scenario_created` event. Scenarios live inside suites — suite = container adoption, scenario = content adoption. Both together give create→usage of the simulations product. |

### Collaboration / expansion

| Event | Fires from | Why we track it |
|---|---|---|
| `team_invite_accepted` | `routers/organization.ts:acceptInvite` after `applyInvite` transaction | Pairs with existing `team_member_invited` (which fires when invite is SENT). Together they form the invite-acceptance funnel — the expansion-conversion metric. |

## Dashboard changes — "[the truth](https://eu.posthog.com/project/66212/dashboard/651303)" (id 651303)

6 new tiles added (now 9 total). Tiles referencing new events show empty until this PR ships and starts emitting — that's expected and documented in each tile's description.

| # | Tile | Built on | Status at merge |
|---|---|---|---|
| 1 | **Activation funnel — full (signup → first eval)** | new events | empty → fills on merge |
| 2 | **Feature adoption — WAU per product** (8 series) | new events | empty → fills on merge |
| 3 | **WAU — users vs orgs (`evaluation_ran`)** | existing event + group_type | **has data now** |
| 4 | **TTV — signup → first API key (time to convert)** | new events | empty → fills on merge |
| 5 | **Friction signals — `limit_blocked` & `upgrade_modal_shown`** | existing events | **has data now** |
| 6 | **First-time use per product** (`first_time_for_user` math) | new events | empty → fills on merge |

The existing 3 tiles (W4 Retention org/user-level on `evaluation_ran`, WAU rolling 7-day on `evaluation_ran` + `scenario_created`) are unchanged.

## What's intentionally deferred to follow-up PRs

These aren't in this PR because they're shaped differently and deserve their own review:

- **`first_trace_received`** — needs a Prisma migration adding `firstTraceReceivedAt DateTime?` to `Project` plus a gated capture in the collector ingestion path. This is THE central activation event for an LLM-observability platform and the next thing to add.
- **`subscription_updated` / `subscription_canceled`** — billing-side churn signals. Belongs in a billing-focused PR alongside MRR / dunning instrumentation.
- **Client-side `pricing_page_viewed` / `upgrade_clicked`** — requires deciding which CTA/page surfaces count.
- **`feature_locked_attempted`** distinct from `limit_blocked` — needs a survey of the plan-gate middleware sites first.

## Test plan

- [ ] CI typecheck passes
- [ ] After merge & deploy: confirm `signup_completed` fires on a fresh signup
- [ ] After merge & deploy: confirm `project_created` fires and carries `$groups.organization` in the PostHog Activity feed
- [ ] After merge & deploy: re-open "[the truth](https://eu.posthog.com/project/66212/dashboard/651303)" and confirm the empty tiles start populating within a day

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Additional commit — report uncaught backend errors to PostHog (`6fa2d5003`)

Bundled observability follow-up. The global `uncaughtException` / `unhandledRejection` handlers in `src/start.ts` and `src/workers.ts` previously only called `logger.fatal` and exited, so process-killing backend errors (the most severe kind) never reached PostHog — the dashboard error tile silently under-reported them. They now `captureException` and **flush** (`shutdownPostHog`) before exit, because `posthog-node` batches events and an unflushed event dies with the process. Adds `specs/ops/uncaught-error-reporting.feature`.

This complements the new error tile by widening what the `$exception` metric can see on the backend. Note: the **authoritative** backend-reliability signal is Prometheus request/job error rate (all the series already exist via `express-prom-bundle` + `job_processing_counter`), tracked separately in #4229 — no app code needed there.


---

## Update — `scenario_run` + `trace_opened` (active-users KPI)

The "Active users (30d)" KPI was keyed off `evaluation_ran` alone, which undercounts: a user who ran scenarios or just opened traces all month but never clicked "run eval" showed as inactive. Two more action events make the KPI count **distinct people who did *any* meaningful action — run / create / open**:

| Event | Fires from | Attribution | Notes |
|---|---|---|---|
| `scenario_run` | `routers/scenarios/simulation-runner.router.ts` `run` mutation (after queueRun) | server-side `trackProjectEvent`, real `userId` + org | The SDK ingest path (`/api/scenario-events`) is API-key authed with no user, so platform-triggered runs are the only scenario runs attributable to a person — tracked here. |
| `trace_opened` | new `useTrackTraceOpened` hook, called from the v1 `TraceDetailsDrawer` and the v2 `TraceDrawerShell` | client-side `posthog.capture` (inherits identified user + `$groups.organization`) | Fires once per opened trace, covering both drawer UIs and every open path (in-app click or deep link). |

**Resulting active-user definition** (built on the PostHog side as a combined Action, distinct-person count):

```
ACTIVE USER = a unique person who, in the last 30d, did ANY of:
  RUN     → scenario_run | evaluation_ran
  CREATE  → evaluator/monitor/dataset/prompt/agent/workflow/annotation/suite/scenario _created
  OPEN    → trace_opened
```

No backfill — both new events start at zero and the 30d KPI reflects them ~30 days post-deploy.
