### PR TITLE
fix(event-sourcing): self-heal tenant soft-cap in-flight count on ungraceful worker death

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -2481,7 +2481,10 @@ describe("GroupStagingScripts", () => {
     // Live in-flight count for a tenant = ZSET members whose expiry score is
     // still in the future relative to nowMs (lapsed members no longer count).
     async function tenantLiveCount(tenantId: string, nowMs: number) {
-      return redis.zcount(tenantActiveZKey(tenantId), `(${nowMs}`, "+inf");
+      // Inclusive lower bound to mirror the Lua live-count contract: the script
+      // GCs only scores STRICTLY below nowMs (ZREMRANGEBYSCORE "-inf" "(nowMs")
+      // then ZCARDs, so a slot scored exactly nowMs is still live.
+      return redis.zcount(tenantActiveZKey(tenantId), `${nowMs}`, "+inf");
     }
 
     async function stageOne({

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -2438,18 +2438,21 @@ describe("GroupStagingScripts", () => {
   });
 
   /**
-   * Post-2026-05-11 tenant soft-cap integration coverage.
+   * Tenant soft-cap integration coverage.
    *
-   * These tests drive the new Lua paths against a real Redis (via
+   * These tests drive the Lua paths against a real Redis (via
    * testcontainers) and prove:
-   *   - the `tenant_active:<tenantId>` counter stays consistent across
-   *     DISPATCH (INCR) → COMPLETE / RESTAGE_AND_BLOCK (DECR/DEL) and
-   *     REFRESH / RETRY_RESTAGE (TTL renewal)
+   *   - the per-tenant in-flight ZSET `tenant_active_z:<tenantId>` stays
+   *     consistent across DISPATCH (ZADD), COMPLETE / RESTAGE_AND_BLOCK (ZREM)
+   *     and REFRESH / RETRY_RESTAGE (score renewal)
+   *   - a slot whose worker dies ungracefully lapses out of the live count once
+   *     its expiry score falls into the past, so the cap self-heals with no
+   *     operator reset
    *   - cap enforcement at the scheduler level
    *   - widened scan budget keeps cross-tenant fairness when an
    *     over-cap tenant dominates the head of the ready zset
-   *   - cap=0 (kill switch) leaves the counter machinery completely
-   *     inert — no `tenant_active:*` keys ever appear
+   *   - cap=0 (kill switch) leaves the ZSET machinery completely
+   *     inert: no `tenant_active_z:*` keys ever appear
    *
    * All scenarios mutate `LANGWATCH_DISPATCH_TENANT_CAP` per test
    * (readTenantCap reads process.env at call time on purpose) and
@@ -2471,8 +2474,14 @@ describe("GroupStagingScripts", () => {
       }
     });
 
-    function tenantCounterKey(tenantId: string) {
-      return `${keyPrefix()}tenant_active:${tenantId}`;
+    function tenantActiveZKey(tenantId: string) {
+      return `${keyPrefix()}tenant_active_z:${tenantId}`;
+    }
+
+    // Live in-flight count for a tenant = ZSET members whose expiry score is
+    // still in the future relative to nowMs (lapsed members no longer count).
+    async function tenantLiveCount(tenantId: string, nowMs: number) {
+      return redis.zcount(tenantActiveZKey(tenantId), `(${nowMs}`, "+inf");
     }
 
     async function stageOne({
@@ -2494,7 +2503,7 @@ describe("GroupStagingScripts", () => {
     }
 
     /** @scenario Counter increments on dispatch, decrements on completion */
-    it("INCRs the tenant counter on dispatch and DELs it on completion", async () => {
+    it("adds the group to the tenant ZSET on dispatch and removes it on completion", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       const groupId = await stageOne({
         tenantId: "proj_acme",
@@ -2508,24 +2517,22 @@ describe("GroupStagingScripts", () => {
       });
       expect(dispatched?.groupId).toBe(groupId);
 
-      // Counter at 1 after first dispatch
-      expect(await redis.get(tenantCounterKey("proj_acme"))).toBe("1");
-      // TTL is in lockstep with activeKey
-      const counterTtl = await redis.ttl(tenantCounterKey("proj_acme"));
-      const activeTtl = await redis.ttl(
-        `${keyPrefix()}group:${groupId}:active`,
-      );
-      expect(Math.abs(counterTtl - activeTtl)).toBeLessThanOrEqual(1);
+      // One live slot after first dispatch, scored at the slot's expiry
+      // (nowMs + activeTtlSec*1000 = 2000 + 60000 = 62000).
+      expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(1);
+      expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBe("62000");
 
-      // Completing the only in-flight group DELs the counter (n was 1)
+      // Completing the only in-flight group removes its slot, leaving the ZSET
+      // empty (Redis drops a ZSET key once its last member is removed).
       await scripts.complete({
         groupId,
         stagedJobId: dispatched!.stagedJobId,
       });
-      expect(await redis.exists(tenantCounterKey("proj_acme"))).toBe(0);
+      expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(0);
+      expect(await redis.exists(tenantActiveZKey("proj_acme"))).toBe(0);
     });
 
-    it("DECRs (does not DEL) when there are other in-flight groups for the same tenant", async () => {
+    it("removes only the completed group's slot when other groups are in flight for the same tenant", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       await stageOne({
         tenantId: "proj_acme",
@@ -2538,22 +2545,30 @@ describe("GroupStagingScripts", () => {
         stagedJobId: "j2",
       });
 
-      const d1 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
-      const d2 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
+      // Dispatch with a real wall-clock nowMs so the in-flight slot scores
+      // (nowMs + activeTtlSec*1000) are genuinely in the future when COMPLETE
+      // runs its lapsed-slot GC against Date.now(). A synthetic small nowMs
+      // would make every slot look already-expired and get GC'd at completion.
+      const now = Date.now();
+      const d1 = await scripts.dispatch({ nowMs: now, activeTtlSec: 60 });
+      const d2 = await scripts.dispatch({ nowMs: now, activeTtlSec: 60 });
       expect(d1).not.toBeNull();
       expect(d2).not.toBeNull();
-      expect(await redis.get(tenantCounterKey("proj_acme"))).toBe("2");
+      expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(2);
 
       // Complete only one
       await scripts.complete({
         groupId: d1!.groupId,
         stagedJobId: d1!.stagedJobId,
       });
-      expect(await redis.get(tenantCounterKey("proj_acme"))).toBe("1");
+      expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(1);
+      // The remaining slot belongs to the still-active group.
+      expect(await redis.zscore(tenantActiveZKey("proj_acme"), d2!.groupId)).not.toBeNull();
+      expect(await redis.zscore(tenantActiveZKey("proj_acme"), d1!.groupId)).toBeNull();
     });
 
     /** @scenario RESTAGE_AND_BLOCK decrements the counter on exhausted retries */
-    it("RESTAGE_AND_BLOCK_LUA decrements the tenant counter (preventing slot leak on terminal failures)", async () => {
+    it("RESTAGE_AND_BLOCK_LUA removes the tenant slot (preventing slot leak on terminal failures)", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       const groupId = await stageOne({
         tenantId: "proj_acme",
@@ -2561,7 +2576,7 @@ describe("GroupStagingScripts", () => {
         stagedJobId: "j1",
       });
       await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
-      expect(await redis.get(tenantCounterKey("proj_acme"))).toBe("1");
+      expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(1);
 
       await scripts.restageAndBlock({
         groupId,
@@ -2570,11 +2585,11 @@ describe("GroupStagingScripts", () => {
         jobDataJson: JSON.stringify({ hello: "world" }),
         errorMessage: "max retries",
       });
-      expect(await redis.exists(tenantCounterKey("proj_acme"))).toBe(0);
+      expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(0);
     });
 
     /** @scenario REFRESH keeps the tenant counter TTL aligned with activeKey */
-    it("REFRESH_LUA renews the tenant counter TTL in lockstep with activeKey", async () => {
+    it("REFRESH_LUA bumps the tenant slot's expiry score in lockstep with activeKey", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       const groupId = await stageOne({
         tenantId: "proj_acme",
@@ -2586,27 +2601,48 @@ describe("GroupStagingScripts", () => {
         activeTtlSec: 60,
       });
 
-      // Force the counter into a low-TTL state to prove EXPIRE renewal works
-      await redis.expire(tenantCounterKey("proj_acme"), 5);
-      const beforeRefresh = await redis.ttl(tenantCounterKey("proj_acme"));
-      expect(beforeRefresh).toBeLessThanOrEqual(5);
+      // Initial slot score = dispatch nowMs (2000) + 60000 = 62000.
+      expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBe("62000");
 
+      // refreshActiveKey uses Date.now() internally, so the bumped score is a
+      // real wall-clock expiry far past the initial 62000 placeholder.
       await scripts.refreshActiveKey({
         groupId,
         stagedJobId: dispatched!.stagedJobId,
         activeTtlSec: 60,
       });
 
-      const counterTtl = await redis.ttl(tenantCounterKey("proj_acme"));
-      const activeTtl = await redis.ttl(
-        `${keyPrefix()}group:${groupId}:active`,
-      );
-      expect(counterTtl).toBeGreaterThan(beforeRefresh);
-      expect(Math.abs(counterTtl - activeTtl)).toBeLessThanOrEqual(1);
+      const score = Number(await redis.zscore(tenantActiveZKey("proj_acme"), groupId));
+      const expectedExpiry = Date.now() + 60 * 1000;
+      expect(score).toBeGreaterThan(62000);
+      // Slot expiry tracks the activeKey heartbeat (Date.now() + ttl), within a
+      // generous skew for test execution time.
+      expect(Math.abs(score - expectedExpiry)).toBeLessThanOrEqual(2000);
+    });
+
+    it("REFRESH_LUA does not re-create a slot that was already freed (XX semantics)", async () => {
+      process.env[TENANT_CAP_ENV] = "10";
+      const groupId = await stageOne({
+        tenantId: "proj_acme",
+        groupSuffix: "g1",
+        stagedJobId: "j1",
+      });
+      const dispatched = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
+
+      // Free the slot out from under an in-flight heartbeat (as COMPLETE would).
+      await redis.zrem(tenantActiveZKey("proj_acme"), groupId);
+
+      // A racing refresh must NOT re-insert the freed slot (ZADD XX).
+      await scripts.refreshActiveKey({
+        groupId,
+        stagedJobId: dispatched!.stagedJobId,
+        activeTtlSec: 60,
+      });
+      expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBeNull();
     });
 
     /** @scenario RETRY_RESTAGE keeps the tenant counter TTL aligned through backoff */
-    it("RETRY_RESTAGE_LUA aligns the tenant counter TTL with the retry TTL", async () => {
+    it("RETRY_RESTAGE_LUA bumps the tenant slot's expiry score to the retry window", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       const groupId = await stageOne({
         tenantId: "proj_acme",
@@ -2627,13 +2663,12 @@ describe("GroupStagingScripts", () => {
         backoffMs: 30_000,
       });
 
-      const counterTtl = await redis.ttl(tenantCounterKey("proj_acme"));
-      const activeTtl = await redis.ttl(
-        `${keyPrefix()}group:${groupId}:active`,
-      );
-      // retryRestage sets activeKey TTL to ceil(backoffMs/1000)+2 = 32s
-      expect(counterTtl).toBeGreaterThan(0);
-      expect(Math.abs(counterTtl - activeTtl)).toBeLessThanOrEqual(2);
+      // retryRestage sets the slot expiry to Date.now() + retryTtlSec*1000,
+      // retryTtlSec = ceil(backoffMs/1000)+2 = 32s.
+      const score = Number(await redis.zscore(tenantActiveZKey("proj_acme"), groupId));
+      const expectedExpiry = Date.now() + 32 * 1000;
+      expect(score).toBeGreaterThan(0);
+      expect(Math.abs(score - expectedExpiry)).toBeLessThanOrEqual(2000);
     });
 
     /** @scenario DISPATCH_LUA refuses to dispatch when tenant is at cap */
@@ -2659,13 +2694,13 @@ describe("GroupStagingScripts", () => {
       // First two dispatches OK
       expect(await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 })).not.toBeNull();
       expect(await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 })).not.toBeNull();
-      expect(await redis.get(tenantCounterKey("proj_noisy"))).toBe("2");
+      expect(await redis.zcard(tenantActiveZKey("proj_noisy"))).toBe(2);
 
-      // Third dispatch must be refused — tenant is at cap=2
+      // Third dispatch must be refused: tenant is at cap=2
       const third = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
       expect(third).toBeNull();
-      // Counter unchanged — over-cap groups don't INCR
-      expect(await redis.get(tenantCounterKey("proj_noisy"))).toBe("2");
+      // Live count unchanged: over-cap groups don't add a slot
+      expect(await redis.zcard(tenantActiveZKey("proj_noisy"))).toBe(2);
       // g3 was parked OUT of the ready scan (not left at the head to be
       // re-walked on every poll) and registered for reconcile.
       const ready = await inspectReadySet();
@@ -2698,17 +2733,17 @@ describe("GroupStagingScripts", () => {
         dispatchAfterMs: 1001,
       });
 
-      // First dispatch: proj_noisy/g0 wins (counter goes 0→1)
+      // First dispatch: proj_noisy/g0 wins (live count goes 0->1)
       const first = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
       expect(first?.groupId).toMatch(/^proj_noisy\//);
-      expect(await redis.get(tenantCounterKey("proj_noisy"))).toBe("1");
+      expect(await redis.zcard(tenantActiveZKey("proj_noisy"))).toBe(1);
 
       // Second dispatch: proj_noisy is at cap, scheduler MUST walk past
       // its remaining 49 over-cap groups and find proj_quiet's one group.
       const second = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
       expect(second).not.toBeNull();
       expect(second!.groupId).toBe("proj_quiet/only");
-      expect(await redis.get(tenantCounterKey("proj_quiet"))).toBe("1");
+      expect(await redis.zcard(tenantActiveZKey("proj_quiet"))).toBe(1);
     });
 
     /** @scenario Over-cap groups are parked out of ready so they don't starve other tenants on repeated polls */
@@ -2796,7 +2831,7 @@ describe("GroupStagingScripts", () => {
     });
 
     /** @scenario cap=0 produces zero tenant counter keys (back-compat regression) */
-    it("when cap=0 (kill switch), no tenant_active:* keys are ever created", async () => {
+    it("when cap=0 (kill switch), no tenant_active_z:* keys are ever created", async () => {
       process.env[TENANT_CAP_ENV] = "0";
 
       const groupId = await stageOne({
@@ -2810,22 +2845,22 @@ describe("GroupStagingScripts", () => {
       });
       expect(dispatched).not.toBeNull();
 
-      // Scan for any tenant_active:* keys — must be none.
-      const keysAfterDispatch = await redis.keys(`${keyPrefix()}tenant_active:*`);
+      // Scan for any tenant_active_z:* keys: must be none.
+      const keysAfterDispatch = await redis.keys(`${keyPrefix()}tenant_active_z:*`);
       expect(keysAfterDispatch).toEqual([]);
 
       // Round-trip a full lifecycle to confirm no key is created at any
-      // step (COMPLETE attempts the DEL branch even with cap=0; that
+      // step (COMPLETE attempts the free branch even with cap=0; that
       // branch must not silently create keys).
       await scripts.complete({
         groupId,
         stagedJobId: dispatched!.stagedJobId,
       });
-      const keysAfterComplete = await redis.keys(`${keyPrefix()}tenant_active:*`);
+      const keysAfterComplete = await redis.keys(`${keyPrefix()}tenant_active_z:*`);
       expect(keysAfterComplete).toEqual([]);
 
-      // restageAndBlock path too — re-stage a fresh group and walk the
-      // failure path. Counter must still not appear.
+      // restageAndBlock path too: re-stage a fresh group and walk the
+      // failure path. No ZSET must appear.
       await stageOne({
         tenantId: "proj_acme",
         groupSuffix: "g2",
@@ -2840,7 +2875,7 @@ describe("GroupStagingScripts", () => {
         errorMessage: "boom",
       });
       const keysAfterRestage = await redis.keys(
-        `${keyPrefix()}tenant_active:*`,
+        `${keyPrefix()}tenant_active_z:*`,
       );
       expect(keysAfterRestage).toEqual([]);
 
@@ -2904,7 +2939,7 @@ describe("GroupStagingScripts", () => {
       });
 
       /** @scenario A crashed tenant's parked groups are restored once its in-flight count expires */
-      it("reconciles parked groups back to ready when the tenant counter expires (orphan recovery)", async () => {
+      it("reconciles parked groups back to ready when the tenant's in-flight slots lapse (orphan recovery)", async () => {
         process.env[TENANT_CAP_ENV] = "1";
         await stageOne({
           tenantId: "proj_crash",
@@ -2919,22 +2954,28 @@ describe("GroupStagingScripts", () => {
           dispatchAfterMs: 1001,
         });
 
-        const d1 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 });
-        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 60 }); // parks g2
+        // Dispatch g1 with a short active TTL so its in-flight slot lapses
+        // quickly; its slot score = 2000 + 5*1000 = 7000.
+        const d1 = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 5 });
+        await scripts.dispatch({ nowMs: 2000, activeTtlSec: 5 }); // parks g2
         expect(await redis.zcard(parkedKey("proj_crash"))).toBe(1);
+        expect(await redis.zscore(tenantActiveZKey("proj_crash"), d1!.groupId)).toBe("7000");
 
-        // Simulate the worker crashing: the active job never completes and both
-        // the active key and the tenant_active counter TTL-expire. No COMPLETE
-        // fires, so without the dispatch reconcile g2 would strand forever.
-        await redis.del(`${keyPrefix()}tenant_active:proj_crash`);
+        // Simulate the worker dying ungracefully: no COMPLETE, no heartbeat. The
+        // active key expires on its own; we drop it here to mirror that. The
+        // tenant's in-flight slot keeps its now-stale score (7000) because
+        // nothing refreshes it. No COMPLETE fires, so without self-healing g2
+        // would strand forever.
         await redis.del(`${keyPrefix()}group:${d1!.groupId}:active`);
 
-        // A later poll past the reconcile interval reads the missing counter as
-        // 0 (under cap) and restores g2 — even though dispatch was never idle in
-        // the way the return-nil path needs.
-        const recovered = await scripts.dispatch({ nowMs: 5000, activeTtlSec: 60 });
+        // A later poll whose nowMs (8000) is past the lapsed slot score (7000):
+        // tenantActiveCount GCs the stale member, reads 0 (under cap), and the
+        // reconcile restores g2 with NO manual counter reset.
+        const recovered = await scripts.dispatch({ nowMs: 8000, activeTtlSec: 5 });
         expect(recovered!.groupId).toBe("proj_crash/g2");
         expect(await redis.zcard(parkedKey("proj_crash"))).toBe(0);
+        // The lapsed slot was garbage-collected out of the ZSET.
+        expect(await redis.zscore(tenantActiveZKey("proj_crash"), d1!.groupId)).toBeNull();
       });
 
       /** @scenario Disabling the cap restores all parked groups */
@@ -3005,17 +3046,22 @@ describe("GroupStagingScripts", () => {
             dispatchAfterMs: 1000 + i,
           });
         }
-        const d1 = await scripts.dispatch({ nowMs: 3000, activeTtlSec: 60 });
-        await scripts.dispatch({ nowMs: 3000, activeTtlSec: 60 });
-        expect(await redis.get(tenantCounterKey("proj_acme"))).toBe("2");
+        // Real wall-clock nowMs so the active slots' expiry scores stay in the
+        // future when COMPLETE runs its lapsed-slot GC against Date.now();
+        // otherwise both slots would be GC'd and one completion would over-unpark.
+        const now = Date.now();
+        const d1 = await scripts.dispatch({ nowMs: now, activeTtlSec: 60 });
+        await scripts.dispatch({ nowMs: now, activeTtlSec: 60 });
+        expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(2);
         // Next poll parks the remaining 3 (tenant at cap=2).
-        expect(await scripts.dispatch({ nowMs: 3000, activeTtlSec: 60 })).toBeNull();
+        expect(await scripts.dispatch({ nowMs: now, activeTtlSec: 60 })).toBeNull();
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(3);
 
         // Completing ONE frees exactly one slot → exactly ONE group unparks.
         await scripts.complete({ groupId: d1!.groupId, stagedJobId: d1!.stagedJobId });
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(2);
-        // The single restored group is the only one due in ready.
+        // The single restored group is the only one due in ready (its preserved
+        // score is the small staged dispatchAfter, well under the active scores).
         expect(await redis.zcount(`${keyPrefix()}ready`, "-inf", "3000")).toBe(1);
       });
 
@@ -3108,6 +3154,61 @@ describe("GroupStagingScripts", () => {
 
         expect(await redis.zscore(`${keyPrefix()}ready`, "proj_acme/g2")).toBeNull();
         expect(await redis.zcard(parkedKey("proj_acme"))).toBe(1);
+      });
+
+      /** @scenario A tenant's in-flight slots self-heal after an ungraceful worker death */
+      it("self-heals the tenant cap after an ungraceful mass worker death without an operator reset", async () => {
+        process.env[TENANT_CAP_ENV] = "3";
+
+        // A tenant fills its cap with several in-flight groups, plus an extra
+        // group that will be parked over-cap.
+        for (let i = 1; i <= 4; i++) {
+          await stageOne({
+            tenantId: "proj_dead",
+            groupSuffix: `g${i}`,
+            stagedJobId: `j${i}`,
+            dispatchAfterMs: 1000 + i,
+          });
+        }
+
+        // Dispatch fills cap (3 slots) with a short active TTL; each slot's
+        // expiry score = 2000 + 5*1000 = 7000. The 4th group is parked.
+        const dispatched: DispatchResult[] = [];
+        for (let i = 0; i < 4; i++) {
+          const d = await scripts.dispatch({ nowMs: 2000, activeTtlSec: 5 });
+          if (d) dispatched.push(d);
+        }
+        expect(dispatched).toHaveLength(3);
+        expect(await tenantLiveCount("proj_dead", 2000)).toBe(3);
+        expect(await redis.zcard(parkedKey("proj_dead"))).toBe(1);
+        expect(
+          await redis.sismember(`${keyPrefix()}parked-tenants`, "proj_dead"),
+        ).toBe(1);
+
+        // Workers die ungracefully: no COMPLETE, no drain, no heartbeat. The
+        // active keys expire on their own; we delete them to mirror that. The
+        // in-flight slots keep their now-stale scores (7000) because nothing
+        // refreshes them. A scalar counter would stay pinned at 3 forever here.
+        for (const d of dispatched) {
+          await redis.del(`${keyPrefix()}group:${d.groupId}:active`);
+        }
+        // Slots are still physically present, just stale.
+        expect(await redis.zcard(tenantActiveZKey("proj_dead"))).toBe(3);
+
+        // Liveness lapses past the active TTL: at nowMs=8000 every slot score
+        // (7000) is in the past, so the live count is 0 with no operator action.
+        expect(await tenantLiveCount("proj_dead", 8000)).toBe(0);
+
+        // A poll past the lapsed scores GCs the dead slots, reads the tenant as
+        // under cap, and the reconcile restores the parked group: dispatch
+        // resumes for the live tenant with NO manual counter reset.
+        const recovered = await scripts.dispatch({ nowMs: 8000, activeTtlSec: 5 });
+        expect(recovered).not.toBeNull();
+        expect(recovered!.groupId).toBe("proj_dead/g4");
+        expect(await redis.zcard(parkedKey("proj_dead"))).toBe(0);
+        // The stale dead-worker slots were garbage-collected; only the freshly
+        // dispatched group counts now.
+        expect(await tenantLiveCount("proj_dead", 8000)).toBe(1);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -2479,12 +2479,12 @@ describe("GroupStagingScripts", () => {
     }
 
     // Live in-flight count for a tenant = ZSET members whose expiry score is
-    // still in the future relative to nowMs (lapsed members no longer count).
+    // strictly in the future (> nowMs); a slot at-or-past nowMs has lapsed.
     async function tenantLiveCount(tenantId: string, nowMs: number) {
-      // Inclusive lower bound to mirror the Lua live-count contract: the script
-      // GCs only scores STRICTLY below nowMs (ZREMRANGEBYSCORE "-inf" "(nowMs")
-      // then ZCARDs, so a slot scored exactly nowMs is still live.
-      return redis.zcount(tenantActiveZKey(tenantId), `${nowMs}`, "+inf");
+      // Exclusive lower bound mirrors the Lua live-count contract: the script
+      // GCs scores at-or-below nowMs (ZREMRANGEBYSCORE "-inf" nowMs) then ZCARDs,
+      // so a slot scored exactly nowMs has lapsed and is not counted.
+      return redis.zcount(tenantActiveZKey(tenantId), `(${nowMs}`, "+inf");
     }
 
     async function stageOne({
@@ -2505,7 +2505,7 @@ describe("GroupStagingScripts", () => {
       return groupId;
     }
 
-    /** @scenario Counter increments on dispatch, decrements on completion */
+    /** @scenario An in-flight slot is added on dispatch and removed on completion */
     it("adds the group to the tenant ZSET on dispatch and removes it on completion", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       const groupId = await stageOne({
@@ -2524,6 +2524,12 @@ describe("GroupStagingScripts", () => {
       // (nowMs + activeTtlSec*1000 = 2000 + 60000 = 62000).
       expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(1);
       expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBe("62000");
+
+      // Live-count boundary: a slot is live only while strictly in the future
+      // (score > nowMs). One ms before its 62000 expiry it counts; AT exactly
+      // 62000 it has lapsed and does not (mirrors the activeKey vanishing at TTL).
+      expect(await tenantLiveCount("proj_acme", 61999)).toBe(1);
+      expect(await tenantLiveCount("proj_acme", 62000)).toBe(0);
 
       // Completing the only in-flight group removes its slot, leaving the ZSET
       // empty (Redis drops a ZSET key once its last member is removed).
@@ -2570,7 +2576,7 @@ describe("GroupStagingScripts", () => {
       expect(await redis.zscore(tenantActiveZKey("proj_acme"), d1!.groupId)).toBeNull();
     });
 
-    /** @scenario RESTAGE_AND_BLOCK decrements the counter on exhausted retries */
+    /** @scenario RESTAGE_AND_BLOCK removes the in-flight slot on exhausted retries */
     it("RESTAGE_AND_BLOCK_LUA removes the tenant slot (preventing slot leak on terminal failures)", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       const groupId = await stageOne({
@@ -2591,7 +2597,7 @@ describe("GroupStagingScripts", () => {
       expect(await redis.zcard(tenantActiveZKey("proj_acme"))).toBe(0);
     });
 
-    /** @scenario REFRESH keeps the tenant counter TTL aligned with activeKey */
+    /** @scenario REFRESH bumps the in-flight slot expiry in lockstep with activeKey */
     it("REFRESH_LUA bumps the tenant slot's expiry score in lockstep with activeKey", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       const groupId = await stageOne({
@@ -2644,7 +2650,7 @@ describe("GroupStagingScripts", () => {
       expect(await redis.zscore(tenantActiveZKey("proj_acme"), groupId)).toBeNull();
     });
 
-    /** @scenario RETRY_RESTAGE keeps the tenant counter TTL aligned through backoff */
+    /** @scenario RETRY_RESTAGE bumps the in-flight slot expiry to the retry window */
     it("RETRY_RESTAGE_LUA bumps the tenant slot's expiry score to the retry window", async () => {
       process.env[TENANT_CAP_ENV] = "10";
       const groupId = await stageOne({
@@ -2833,7 +2839,7 @@ describe("GroupStagingScripts", () => {
       expect(await redis.zcount(`${keyPrefix()}ready`, "-inf", "2000")).toBe(0);
     });
 
-    /** @scenario cap=0 produces zero tenant counter keys (back-compat regression) */
+    /** @scenario cap=0 produces zero tenant in-flight slot keys (back-compat regression) */
     it("when cap=0 (kill switch), no tenant_active_z:* keys are ever created", async () => {
       process.env[TENANT_CAP_ENV] = "0";
 
@@ -2941,7 +2947,7 @@ describe("GroupStagingScripts", () => {
         expect(d2!.groupId).toBe("proj_acme/g2");
       });
 
-      /** @scenario A crashed tenant's parked groups are restored once its in-flight count expires */
+      /** @scenario A crashed tenant's parked groups are restored once its in-flight slots lapse */
       it("reconciles parked groups back to ready when the tenant's in-flight slots lapse (orphan recovery)", async () => {
         process.env[TENANT_CAP_ENV] = "1";
         await stageOne({

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -43,6 +43,39 @@ local function refreshGroupKeyTtl(jobsKey, dataKey, nowMs)
 end
 `;
 
+// Lua helper for the per-tenant in-flight count that backs the soft cap.
+//
+// Modeled as a ZSET per tenant (member = groupId, score = the slot's expiry in
+// ms) instead of a scalar INCR/DECR counter. A scalar counter leaks UP when a
+// worker dies UNGRACEFULLY (no COMPLETE to decrement) and never self-heals,
+// because dispatch keeps refreshing its TTL — the 2026-05-28 incident, where an
+// ElastiCache node replacement dropped every worker's Redis connection mid-job,
+// stranding a live tenant permanently at cap with thousands of groups parked.
+//
+// Each in-flight slot instead carries the SAME expiry as its activeKey heartbeat
+// (renewed by REFRESH while the worker lives). A slot whose heartbeat lapses has
+// a past score, so it stops counting against the cap once its expiry passes: an
+// ungraceful mass death self-heals within the active TTL with no operator reset.
+// The live count GCs lapsed members first so dead-worker entries can't grow the
+// ZSET unbounded. Keys share the keyPrefix hash tag so they stay in one slot.
+// See specs/event-sourcing/tenant-soft-cap.feature (self-heal scenario).
+const TENANT_ACTIVE_HELPER_LUA = `
+local function tenantActiveAdd(taPrefix, tenantId, groupId, expiryMs)
+  redis.call("ZADD", taPrefix .. tenantId, expiryMs, groupId)
+end
+local function tenantActiveRemove(taPrefix, tenantId, groupId)
+  redis.call("ZREM", taPrefix .. tenantId, groupId)
+end
+-- Live in-flight count = members whose expiry is still in the future. GC the
+-- lapsed members first (cheap: only removes already-expired entries) so a burst
+-- of dead-worker slots can't grow the ZSET without bound.
+local function tenantActiveCount(taPrefix, tenantId, nowMs)
+  local key = taPrefix .. tenantId
+  redis.call("ZREMRANGEBYSCORE", key, "-inf", "(" .. nowMs)
+  return redis.call("ZCARD", key)
+end
+`;
+
 // Lua helper for the tenant soft-cap "parking" model, prepended to every script
 // that writes the ready set. Over-cap groups are moved OUT of ready into a
 // per-tenant parked zset ONCE (not re-scored every poll), so the dispatch scan
@@ -55,7 +88,10 @@ end
 // (which is what re-creates the over-cap ZADD storm). The parked set and the
 // parked-tenants registry share the same hash tag as ready (keyPrefix carries
 // it), so all keys stay in one Redis Cluster slot.
-export const PARK_HELPER_LUA = `
+//
+// Prepends TENANT_ACTIVE_HELPER_LUA so reconcileParked can read the self-healing
+// in-flight count; every script that includes PARK_HELPER_LUA gets both.
+export const PARK_HELPER_LUA = TENANT_ACTIVE_HELPER_LUA + `
 -- Tenant segment of a groupId (everything before the first '/'), else the id.
 local function parkTenantOf(groupId)
   local slashPos = string.find(groupId, "/", 1, true)
@@ -131,21 +167,22 @@ local function unparkUpTo(readyKey, tenantId, slots)
   return moved
 end
 
--- Safety-net reconcile, run by DISPATCH on a cadence (not the normal path —
+-- Safety-net reconcile, run by DISPATCH on a cadence (not the normal path:
 -- COMPLETE-unpark frees slots as jobs finish). Restores parked groups whose
 -- tenant has dropped below cap, covering two cases COMPLETE cannot:
 --   * orphan recovery (TRAP 2): a crashed/timed-out tenant never fires COMPLETE,
---     so its tenant_active key TTL-expires; read missing as 0 = under cap = unpark,
---     else the parked groups strand forever (a new stranding mode).
+--     so its in-flight slots lapse out of tenantActiveCount once their expiry
+--     scores fall into the past; the live count drops below cap and the parked
+--     groups are restored, instead of stranding forever (a new stranding mode).
 --   * cap disabled: flipping LANGWATCH_DISPATCH_TENANT_CAP to 0 must not leave
 --     groups parked out of the dispatch scan, so drain the whole tenant.
 -- Self-limiting via unparkUpTo (bounded by cap - active), so it never over-unparks.
-local function reconcileParked(readyKey, keyPrefix, tenantCap)
+local function reconcileParked(readyKey, keyPrefix, tenantCap, nowMs)
   local tenants = redis.call("SMEMBERS", keyPrefix .. "parked-tenants")
   for _, tenantId in ipairs(tenants) do
     local slots
     if tenantCap > 0 then
-      local active = tonumber(redis.call("GET", keyPrefix .. "tenant_active:" .. tenantId)) or 0
+      local active = tenantActiveCount(keyPrefix .. "tenant_active_z:", tenantId, nowMs)
       slots = tenantCap - active
     else
       -- Cap disabled: drain the tenant, but in bounded chunks across reconciles
@@ -352,8 +389,9 @@ local activeUntil = nowMs + activeTtlSec * 1000
 -- Restore parked over-cap groups on a cadence (TRAP 2 orphan recovery + cap=0
 -- drain). COMPLETE-unpark handles the normal slot-freeing as jobs finish; this
 -- only backstops what it can't: a crashed/timed-out tenant that never fires
--- COMPLETE (its tenant_active TTL-expires to 0 = under cap = unpark), and
--- flipping the cap off (drain everything parked). Time-gated rather than
+-- COMPLETE (its in-flight slots lapse out of the live count as their expiry
+-- scores pass = back under cap = unpark), and flipping the cap off (drain
+-- everything parked). Time-gated rather than
 -- per-poll so under sustained load (dispatch rarely idle) orphan recovery is
 -- not starved, while the cap=0 steady state pays only a GET + an occasional
 -- empty SMEMBERS. SCARD-gated so it is a true no-op when nothing is parked.
@@ -362,7 +400,7 @@ local lastReconcile = tonumber(redis.call("GET", reconcileTsKey)) or 0
 if (nowMs - lastReconcile) >= 2000 then
   redis.call("SET", reconcileTsKey, nowMs)
   if redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
-    reconcileParked(readyKey, keyPrefix, tenantCap)
+    reconcileParked(readyKey, keyPrefix, tenantCap, nowMs)
   end
 end
 
@@ -392,17 +430,15 @@ while offset < scanBudget do
     if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
       -- Tenant soft-cap check (no-op when tenantCap == 0).
       local tenantOverCap = false
-      local tenantCountKey = nil
+      local capTenantId = nil
       if tenantCap > 0 then
         local slashPos = string.find(groupId, "/", 1, true)
         if slashPos and slashPos > 1 then
-          local tenantId = string.sub(groupId, 1, slashPos - 1)
-          tenantCountKey = keyPrefix .. "tenant_active:" .. tenantId
-          local cached = tenantCapCache[tenantId]
+          capTenantId = string.sub(groupId, 1, slashPos - 1)
+          local cached = tenantCapCache[capTenantId]
           if cached == nil then
-            local n = tonumber(redis.call("GET", tenantCountKey)) or 0
-            cached = n >= tenantCap
-            tenantCapCache[tenantId] = cached
+            cached = tenantActiveCount(keyPrefix .. "tenant_active_z:", capTenantId, nowMs) >= tenantCap
+            tenantCapCache[capTenantId] = cached
           end
           if cached then
             tenantOverCap = true
@@ -489,10 +525,11 @@ while offset < scanBudget do
             -- If process crashes, heartbeat stops, score becomes past, group becomes dispatchable again.
             redis.call("ZADD", readyKey, activeUntil, groupId)
 
-            -- Tenant in-flight counter (back-compat: only when cap is set).
-            if tenantCap > 0 and tenantCountKey then
-              redis.call("INCR", tenantCountKey)
-              redis.call("EXPIRE", tenantCountKey, activeTtlSec)
+            -- Tenant in-flight slot (self-healing ZSET; only when cap is set).
+            -- Score = activeUntil so a worker that dies without COMPLETE has its
+            -- slot lapse out of the live count instead of stranding the cap.
+            if tenantCap > 0 and capTenantId then
+              tenantActiveAdd(keyPrefix .. "tenant_active_z:", capTenantId, groupId, activeUntil)
             end
 
             local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
@@ -552,7 +589,7 @@ local lastReconcile = tonumber(redis.call("GET", reconcileTsKey)) or 0
 if (nowMs - lastReconcile) >= 2000 then
   redis.call("SET", reconcileTsKey, nowMs)
   if redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
-    reconcileParked(readyKey, keyPrefix, tenantCap)
+    reconcileParked(readyKey, keyPrefix, tenantCap, nowMs)
   end
 end
 
@@ -585,17 +622,15 @@ while offset < scanBudget and dispatched < maxJobs do
     -- Checked before SISMEMBER so over-cap groups skip with 0 Redis commands
     -- (the cap result is cached per-tenant in a Lua table).
     local tenantOverCap = false
-    local tenantCountKey = nil
+    local capTenantId = nil
     if tenantCap > 0 then
       local slashPos = string.find(groupId, "/", 1, true)
       if slashPos and slashPos > 1 then
-        local tenantId = string.sub(groupId, 1, slashPos - 1)
-        tenantCountKey = keyPrefix .. "tenant_active:" .. tenantId
-        local cached = tenantCapCache[tenantId]
+        capTenantId = string.sub(groupId, 1, slashPos - 1)
+        local cached = tenantCapCache[capTenantId]
         if cached == nil then
-          local n = tonumber(redis.call("GET", tenantCountKey)) or 0
-          cached = n >= tenantCap
-          tenantCapCache[tenantId] = cached
+          cached = tenantActiveCount(keyPrefix .. "tenant_active_z:", capTenantId, nowMs) >= tenantCap
+          tenantCapCache[capTenantId] = cached
         end
         if cached then
           tenantOverCap = true
@@ -676,15 +711,13 @@ while offset < scanBudget and dispatched < maxJobs do
             -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
             redis.call("ZADD", readyKey, activeUntil, groupId)
 
-            -- Tenant in-flight counter (back-compat: only when cap is set).
-            if tenantCap > 0 and tenantCountKey then
-              redis.call("INCR", tenantCountKey)
-              redis.call("EXPIRE", tenantCountKey, activeTtlSec)
+            -- Tenant in-flight slot (self-healing ZSET; only when cap is set).
+            -- Score = activeUntil so a worker that dies without COMPLETE has its
+            -- slot lapse out of the live count instead of stranding the cap.
+            if tenantCap > 0 and capTenantId then
+              tenantActiveAdd(keyPrefix .. "tenant_active_z:", capTenantId, groupId, activeUntil)
               -- Invalidate cache — count changed, may now be at cap
-              local slashPos2 = string.find(groupId, "/", 1, true)
-              if slashPos2 then
-                tenantCapCache[string.sub(groupId, 1, slashPos2 - 1)] = nil
-              end
+              tenantCapCache[capTenantId] = nil
             end
 
             local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
@@ -780,16 +813,17 @@ local errorKey        = KEYS[6]
 local groupId      = ARGV[1]
 local stagedJobId  = ARGV[2]
 local jobName      = ARGV[3]
--- Tenant in-flight key prefix (post-2026-05-11 follow-up). When the
--- soft-cap is enabled in DISPATCH_LUA, completing a job must DECR the
--- counter so freed slots are picked up by other tenants. Passing the
--- prefix in (not a derived tenantId) lets us keep the cap optional
--- without breaking back-compat with older call sites.
+-- Tenant in-flight ZSET key prefix. When the soft-cap is enabled in
+-- DISPATCH_LUA, completing a job must remove this group's slot from the
+-- per-tenant ZSET so freed slots are picked up by other tenants. Passing the
+-- prefix in (not a derived tenantId) lets us keep the cap optional without
+-- breaking back-compat with older call sites.
 local tenantCountKeyPrefix = ARGV[4]
 -- Tenant soft-cap (same value DISPATCH_LUA reads). When > 0, a completion
 -- frees a slot that may let one of the tenant's parked over-cap groups resume,
 -- so we unpark up to the freed headroom. 0 = cap disabled, no parking in play.
 local tenantCap = tonumber(ARGV[5]) or 0
+local nowMs = tonumber(ARGV[6])
 
 local currentActive = redis.call("GET", activeKey)
 if currentActive ~= stagedJobId then
@@ -798,18 +832,11 @@ end
 
 redis.call("DEL", activeKey)
 
--- Decrement tenant in-flight counter when the soft-cap is enabled.
+-- Free the tenant in-flight slot when the soft-cap is enabled.
 if tenantCountKeyPrefix and tenantCountKeyPrefix ~= "" then
   local slashPos = string.find(groupId, "/", 1, true)
   if slashPos and slashPos > 1 then
-    local tenantId = string.sub(groupId, 1, slashPos - 1)
-    local key = tenantCountKeyPrefix .. tenantId
-    local n = tonumber(redis.call("GET", key)) or 0
-    if n > 1 then
-      redis.call("DECR", key)
-    else
-      redis.call("DEL", key)
-    end
+    tenantActiveRemove(tenantCountKeyPrefix, string.sub(groupId, 1, slashPos - 1), groupId)
   end
 end
 
@@ -820,7 +847,7 @@ end
 -- reconcile can't over-unpark into re-park churn. The LPUSH below wakes a waiter.
 if tenantCap > 0 then
   local tenantId = parkTenantOf(groupId)
-  local active = tonumber(redis.call("GET", tenantCountKeyPrefix .. tenantId)) or 0
+  local active = tenantActiveCount(tenantCountKeyPrefix, tenantId, nowMs)
   unparkUpTo(readyKey, tenantId, tenantCap - active)
 end
 
@@ -864,10 +891,10 @@ local stagedJobId           = ARGV[1]
 local activeTtlSec          = tonumber(ARGV[2])
 local groupId               = ARGV[3]
 local nowMs                 = tonumber(ARGV[4])
--- Tenant counter prefix (post-2026-05-11 soft-cap). When provided, the
--- tenant_active counter's TTL is refreshed alongside the activeKey TTL
--- so long-running groups don't expire their tenant slot mid-execution
--- (which would let the same tenant grab another slot, drifting cap up).
+-- Tenant in-flight ZSET key prefix (soft-cap). When provided, this group's
+-- slot expiry score is bumped alongside the activeKey TTL so long-running
+-- groups keep counting against the cap mid-execution (a stale-scored slot
+-- would lapse out of the live count and let the same tenant grab another).
 local tenantCountKeyPrefix  = ARGV[5]
 
 local currentActive = redis.call("GET", activeKey)
@@ -889,11 +916,10 @@ if currentActive == stagedJobId then
   if tenantCountKeyPrefix and tenantCountKeyPrefix ~= "" then
     local slashPos = string.find(groupId, "/", 1, true)
     if slashPos and slashPos > 1 then
-      local tenantId = string.sub(groupId, 1, slashPos - 1)
-      local key = tenantCountKeyPrefix .. tenantId
-      if redis.call("EXISTS", key) == 1 then
-        redis.call("EXPIRE", key, activeTtlSec)
-      end
+      -- Bump this in-flight slot's expiry in lockstep with the activeKey
+      -- heartbeat. XX = only if the slot still exists, so we never re-create a
+      -- slot COMPLETE legitimately freed.
+      redis.call("ZADD", tenantCountKeyPrefix .. string.sub(groupId, 1, slashPos - 1), "XX", nowMs + activeTtlSec * 1000, groupId)
     end
   end
   return 1
@@ -914,10 +940,10 @@ local score                 = tonumber(ARGV[4])
 local jobDataJson           = ARGV[5]
 local errorMessage          = ARGV[6]
 local errorStack            = ARGV[7]
--- Same shape as COMPLETE_LUA's ARGV[4]: when non-empty, DECRs the
--- tenant_active counter so the soft cap doesn't leak slots when a
--- group exhausts retries. Without this, every exhausted-retry leaves
--- the counter +1 and the cap eventually starves the tenant.
+-- Same shape as COMPLETE_LUA's ARGV[4]: when non-empty, removes this
+-- group's slot from the per-tenant in-flight ZSET so the soft cap doesn't
+-- leak slots when a group exhausts retries. Without this the slot would
+-- count against the cap until its expiry score lapses on its own.
 local tenantCountKeyPrefix  = ARGV[8]
 
 local groupJobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
@@ -944,22 +970,15 @@ redis.call("PERSIST", groupDataKey)
 --    UNBLOCK_LUA re-adds the group when it is unblocked.
 redis.call("ZREM", readyKey, groupId)
 
--- 4. Free the in-flight slot. activeKey would expire on its own after
--- activeTtlSec, but the tenant_active counter wouldn't — Redis key
--- expiration has no callback. Mirror COMPLETE_LUA's free path.
+-- 4. Free the in-flight slot. The activeKey expires on its own after
+-- activeTtlSec; removing the ZSET slot here frees it immediately rather than
+-- waiting for its expiry score to lapse. Mirror COMPLETE_LUA's free path.
 redis.call("DEL", activeKey)
 
 if tenantCountKeyPrefix and tenantCountKeyPrefix ~= "" then
   local slashPos = string.find(groupId, "/", 1, true)
   if slashPos and slashPos > 1 then
-    local tenantId = string.sub(groupId, 1, slashPos - 1)
-    local key = tenantCountKeyPrefix .. tenantId
-    local n = tonumber(redis.call("GET", key)) or 0
-    if n > 1 then
-      redis.call("DECR", key)
-    else
-      redis.call("DEL", key)
-    end
+    redis.call("ZREM", tenantCountKeyPrefix .. string.sub(groupId, 1, slashPos - 1), groupId)
   end
 end
 
@@ -995,9 +1014,9 @@ local newStagedJobId        = ARGV[4]
 local dispatchAfterMs       = tonumber(ARGV[5])
 local jobDataJson           = ARGV[6]
 local retryTtlSec           = tonumber(ARGV[7])
--- Tenant counter prefix (post-2026-05-11 soft-cap). Keeps the tenant
--- counter TTL aligned with the activeKey TTL across backoff retries
--- so an in-flight retry doesn't expire its tenant slot.
+-- Tenant in-flight ZSET key prefix (soft-cap). Keeps this group's slot
+-- expiry score aligned with the activeKey TTL across backoff retries so an
+-- in-flight retry's slot doesn't lapse out of the live count.
 local tenantCountKeyPrefix  = ARGV[8]
 local nowMs                 = tonumber(ARGV[9])
 
@@ -1029,18 +1048,15 @@ addToReadyOrParked(readyKey, groupId, dispatchAfterMs, false)
 --    When it expires the dispatcher picks up the retry job on its next poll.
 redis.call("EXPIRE", activeKey, retryTtlSec)
 
--- 5. Mirror activeKey TTL onto tenant_active counter so the soft cap
--- stays accurate during backoff windows. Only set when the counter
--- exists to avoid silently re-creating a counter that COMPLETE_LUA
--- legitimately decremented to zero.
+-- 5. Bump this slot's expiry score in lockstep with the activeKey TTL so the
+-- soft cap stays accurate during backoff windows. XX (below) only updates an
+-- existing slot, so we never re-create a slot COMPLETE_LUA legitimately freed.
 if tenantCountKeyPrefix and tenantCountKeyPrefix ~= "" then
   local slashPos = string.find(groupId, "/", 1, true)
   if slashPos and slashPos > 1 then
-    local tenantId = string.sub(groupId, 1, slashPos - 1)
-    local key = tenantCountKeyPrefix .. tenantId
-    if redis.call("EXISTS", key) == 1 then
-      redis.call("EXPIRE", key, retryTtlSec)
-    end
+    -- Bump this slot's expiry to the backoff window so an in-flight retry keeps
+    -- its tenant slot. XX = only if still in-flight, never re-create a freed slot.
+    redis.call("ZADD", tenantCountKeyPrefix .. string.sub(groupId, 1, slashPos - 1), "XX", nowMs + retryTtlSec * 1000, groupId)
   end
 end
 
@@ -1389,8 +1405,9 @@ export class GroupStagingScripts {
       groupId,
       stagedJobId,
       jobName ?? "",
-      `${this.keyPrefix}tenant_active:`,
+      `${this.keyPrefix}tenant_active_z:`,
       String(readTenantCap()),
+      String(Date.now()),
     );
 
     return result === 1;
@@ -1468,7 +1485,7 @@ export class GroupStagingScripts {
       String(activeTtlSec),
       groupId,
       String(Date.now()),
-      `${this.keyPrefix}tenant_active:`,
+      `${this.keyPrefix}tenant_active_z:`,
     );
 
     return result === 1;
@@ -1512,7 +1529,7 @@ export class GroupStagingScripts {
       jobDataJson,
       errorMessage ?? "",
       errorStack ?? "",
-      `${this.keyPrefix}tenant_active:`,
+      `${this.keyPrefix}tenant_active_z:`,
     );
   }
 
@@ -1559,7 +1576,7 @@ export class GroupStagingScripts {
       String(dispatchAfterMs),
       jobDataJson,
       String(retryTtlSec),
-      `${this.keyPrefix}tenant_active:`,
+      `${this.keyPrefix}tenant_active_z:`,
       String(Date.now()),
     );
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -66,12 +66,15 @@ end
 local function tenantActiveRemove(taPrefix, tenantId, groupId)
   redis.call("ZREM", taPrefix .. tenantId, groupId)
 end
--- Live in-flight count = members whose expiry is still in the future. GC the
--- lapsed members first (cheap: only removes already-expired entries) so a burst
--- of dead-worker slots can't grow the ZSET without bound.
+-- Live in-flight count = members whose expiry score is strictly in the future
+-- (> nowMs). GC the lapsed members first (scores at-or-past nowMs: cheap, only
+-- removes already-expired entries) so a burst of dead-worker slots can't grow
+-- the ZSET without bound. A slot scored exactly nowMs has just reached its
+-- deadline = lapsed (mirrors the activeKey EX TTL, which vanishes at expiry),
+-- so it is removed and not counted.
 local function tenantActiveCount(taPrefix, tenantId, nowMs)
   local key = taPrefix .. tenantId
-  redis.call("ZREMRANGEBYSCORE", key, "-inf", "(" .. nowMs)
+  redis.call("ZREMRANGEBYSCORE", key, "-inf", nowMs)
   return redis.call("ZCARD", key)
 end
 `;

--- a/specs/event-sourcing/tenant-soft-cap.feature
+++ b/specs/event-sourcing/tenant-soft-cap.feature
@@ -174,3 +174,22 @@ Feature: Per-tenant soft cap on in-flight dispatch
     Given a tenant over cap with a parked group
     When a new job is staged for that parked group
     Then the group stays in the parked set and does not reappear in ready
+
+  # In-flight count must survive an UNGRACEFUL worker death — incident 2026-05-28
+  #
+  # An ElastiCache node replacement dropped every worker's Redis connection mid-job,
+  # bypassing the graceful drain that runs COMPLETE. The in-flight slots were never
+  # released, so the tenant read as permanently at-cap and every one of its groups
+  # was parked out of the dispatch scan: a live tenant stalled with thousands of
+  # groups stranded while the workers sat ~90% idle. A scalar counter cannot tell a
+  # live slot from one stranded by a dead worker. The in-flight slot is therefore
+  # tied to the same liveness as the activeKey heartbeat: a slot whose heartbeat
+  # lapsed stops counting against the cap, so an ungraceful mass death self-heals
+  # within the active TTL instead of stranding the tenant forever.
+  @integration @tenant-cap @self-heal
+  Scenario: A tenant's in-flight slots self-heal after an ungraceful worker death
+    Given a tenant at cap with several in-flight groups
+    And the workers holding those groups die without completing (no COMPLETE, no drain)
+    When the in-flight slots' liveness lapses past the active TTL
+    Then those slots stop counting against the tenant cap
+    And the tenant's parked groups are dispatched again without an operator reset

--- a/specs/event-sourcing/tenant-soft-cap.feature
+++ b/specs/event-sourcing/tenant-soft-cap.feature
@@ -36,30 +36,30 @@ Feature: Per-tenant soft cap on in-flight dispatch
     Then it returns 0 and DISPATCH_LUA skips all cap-related branches
 
   @integration @tenant-cap @lifecycle
-  Scenario: Counter increments on dispatch, decrements on completion
+  Scenario: An in-flight slot is added on dispatch and removed on completion
     Given a tenant "proj_acme" with no in-flight groups
     When DISPATCH_LUA dispatches one of its groups under cap=10
-    Then the tenant_active:proj_acme counter equals 1
+    Then "proj_acme" has 1 live in-flight slot
     When COMPLETE_LUA completes that group
-    Then the tenant_active:proj_acme counter is deleted
+    Then "proj_acme" has 0 live in-flight slots
 
   @integration @tenant-cap @lifecycle
-  Scenario: RESTAGE_AND_BLOCK decrements the counter on exhausted retries
+  Scenario: RESTAGE_AND_BLOCK removes the in-flight slot on exhausted retries
     Given a tenant "proj_acme" with one dispatched in-flight group
     When RESTAGE_AND_BLOCK_LUA fires (retries exhausted)
-    Then the tenant_active:proj_acme counter is decremented
+    Then "proj_acme"'s in-flight slot is removed
 
   @integration @tenant-cap @lifecycle
-  Scenario: REFRESH keeps the tenant counter TTL aligned with activeKey
-    Given a tenant "proj_acme" with one in-flight group nearing TTL expiry
+  Scenario: REFRESH bumps the in-flight slot expiry in lockstep with activeKey
+    Given a tenant "proj_acme" with one in-flight group nearing slot expiry
     When REFRESH_LUA renews the heartbeat
-    Then the tenant_active:proj_acme TTL is renewed in lockstep with activeKey
+    Then "proj_acme"'s in-flight slot expiry is bumped in lockstep with the activeKey heartbeat
 
   @integration @tenant-cap @lifecycle
-  Scenario: RETRY_RESTAGE keeps the tenant counter TTL aligned through backoff
+  Scenario: RETRY_RESTAGE bumps the in-flight slot expiry to the retry window
     Given a tenant "proj_acme" with one in-flight group entering retry backoff
     When RETRY_RESTAGE_LUA reschedules the job
-    Then the tenant_active:proj_acme TTL is set to the retry TTL
+    Then "proj_acme"'s in-flight slot expiry is set to the retry window
 
   @integration @tenant-cap @enforcement
   Scenario: DISPATCH_LUA refuses to dispatch when tenant is at cap
@@ -78,10 +78,10 @@ Feature: Per-tenant soft cap on in-flight dispatch
     And "proj_quiet"'s group is dispatched
 
   @integration @tenant-cap @kill-switch
-  Scenario: cap=0 produces zero tenant counter keys (back-compat regression)
+  Scenario: cap=0 produces zero tenant in-flight slot keys (back-compat regression)
     Given the env var "LANGWATCH_DISPATCH_TENANT_CAP" is set to "0"
     When a full dispatch then completion lifecycle runs for any tenant
-    Then no tenant counter keys are ever created in Redis
+    Then no tenant in-flight slot keys are ever created in Redis
 
   # DISPATCH_BATCH_LUA parity — the batch path shares the same cap logic
   # but iterates multiple groups per EVAL. These scenarios guard against
@@ -142,12 +142,13 @@ Feature: Per-tenant soft cap on in-flight dispatch
     And it keeps the score it had before being parked
 
   # COMPLETE covers the normal case; a crashed tenant never completes, so its
-  # in-flight counter TTL-expires. A later poll must read the missing counter as
-  # zero and restore the parked groups, or they strand out of the scan forever.
+  # in-flight slots lapse out of the live count as their expiry scores pass. A
+  # later poll reads the live count as zero and restores the parked groups,
+  # or they strand out of the scan forever.
   @integration @tenant-cap @parking
-  Scenario: A crashed tenant's parked groups are restored once its in-flight count expires
+  Scenario: A crashed tenant's parked groups are restored once its in-flight slots lapse
     Given a tenant over cap with a parked group
-    And the tenant's in-flight counter has expired without a completion
+    And the tenant's in-flight slots have lapsed without a completion
     When dispatch is next polled past the reconcile interval
     Then the parked group is restored to ready and dispatched
 

--- a/specs/event-sourcing/tenant-soft-cap.feature
+++ b/specs/event-sourcing/tenant-soft-cap.feature
@@ -189,7 +189,8 @@ Feature: Per-tenant soft cap on in-flight dispatch
   @integration @tenant-cap @self-heal
   Scenario: A tenant's in-flight slots self-heal after an ungraceful worker death
     Given a tenant at cap with several in-flight groups
-    And the workers holding those groups die without completing (no COMPLETE, no drain)
+    And the same tenant has additional groups parked over its cap
+    And the workers holding the in-flight groups die without completing (no COMPLETE, no drain)
     When the in-flight slots' liveness lapses past the active TTL
     Then those slots stop counting against the tenant cap
     And the tenant's parked groups are dispatched again without an operator reset


### PR DESCRIPTION
## Problem

The per-tenant dispatch soft cap counts a tenant's in-flight groups with a scalar Redis counter (`tenant_active:<tenant>`): INCR on dispatch, DECR on COMPLETE, TTL refreshed by the heartbeat.

When a worker dies **ungracefully** (Redis connection dropped mid-job, OOM, node replacement) it never runs COMPLETE, so the counter is never decremented. It does not self-heal either, because ongoing dispatch of the tenant's other groups keeps refreshing its TTL. The counter drifts up to the cap and pins there. From then on the tenant reads as permanently at cap, so every one of its groups is parked out of the dispatch scan: a live tenant stalls with thousands of groups stranded while the workers sit mostly idle.

This is not theoretical. It happened in prod when an ElastiCache node replacement dropped every worker's Redis connection mid-job, and again on each HPA scale-down that force-closed pods holding long-running eval jobs. The only mitigation was a manual counter reset, which had to be repeated every minute because the leak recurs under load.

## Fix

Replace the scalar counter with a per-tenant ZSET `tenant_active_z:<tenant>` where each member is a `groupId` and its score is the slot's expiry (`nowMs + activeTtlSec*1000`), the same liveness window as the group's `:active` heartbeat key.

The in-flight count is the number of members whose expiry is still in the future. A slot whose worker died keeps its now-past score and falls out of the count once its expiry passes, exactly like the `:active` key does. So an ungraceful death self-heals within the active TTL, with no operator reset and no separately-refreshed counter to perpetuate the leak.

- **cap check / unpark headroom**: count of non-expired members (lapsed members GC'd first so dead-worker entries cannot grow the set unbounded)
- **dispatch**: `ZADD` the slot at its expiry score
- **REFRESH / retry backoff**: `ZADD XX` score-bump (only an existing slot, never re-create a freed one)
- **COMPLETE / restage**: `ZREM` the slot
- **reconcile**: reads the same live count

Converted across all six scripts that touched the counter (DISPATCH, DISPATCH_BATCH, COMPLETE, REFRESH, RESTAGE_AND_BLOCK, RETRY_RESTAGE) plus the TS call sites. Deploy is a clean cutover: old scalar counters TTL out, the ZSETs build fresh, one benign warmup within the active TTL.

## Scope

This fixes the **trigger**. The amplifier that turned the stall into an out-of-memory event (heavy per-trace fold state piling on the blocked tenant) is the separate huge-trace fold-state issue and is a follow-up (bound per-trace fold size at ingestion).

## Tests

- New `@self-heal` BDD scenario in `specs/event-sourcing/tenant-soft-cap.feature`.
- Integration test that simulates an ungraceful mass death (active keys deleted, no COMPLETE, stale slot scores) and asserts the live count drops to 0 and the parked group dispatches again with no manual reset.
- Existing tenant-cap integration tests translated from scalar assertions to the ZSET model.
- 132/132 integration tests green against testcontainer Redis; typecheck clean.
