### PR TITLE
fix(traces): increase facet discover limit from 10 to 50

### DIFF
--- a/langwatch/src/server/app-layer/traces/trace-list.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-list.service.ts
@@ -474,7 +474,7 @@ export class TraceListService {
   private async computeDiscover(
     params: DiscoverParams,
   ): Promise<FacetDescriptor[]> {
-    const TOP_N = 10;
+    const TOP_N = 50;
 
     // Partition the registry: simple-expression facets per table go through
     // the batched ClickHouse path; arrayJoin/queryBuilder/dynamic_keys facets


### PR DESCRIPTION
## Summary

- Customer report: filter sidebar and search-bar value picker only show 10 labels, even when the project has many more
- Root cause: `TOP_N = 10` in `computeDiscover()` capped every facet to 10 values
- The sidebar supports 30 expanded values + search filtering, and the TokenValuePicker supports 60 per page — 10 was the bottleneck
- Increased to 50, which covers both UI surfaces without needing a separate lazy-load endpoint

## Test plan

- [ ] Open a project with >10 labels
- [ ] Verify the filter sidebar Label section shows more than 10 values
- [ ] Verify the search-bar `label:` autocomplete/picker shows more than 10 values
- [ ] Verify other facet sections (status, model, user) still load correctly
- [ ] Verify discover endpoint response time is not significantly impacted