### PR TITLE
feat(trace-processing): bound spans per trace at ingestion to protect shared redis

### DIFF
--- a/langwatch/src/server/app-layer/dependencies.ts
+++ b/langwatch/src/server/app-layer/dependencies.ts
@@ -18,6 +18,7 @@ import type { LogRequestCollectionService } from "./traces/log-request-collectio
 import type { MetricRequestCollectionService } from "./traces/metric-request-collection.service";
 import type { TraceListService } from "./traces/trace-list.service";
 import type { TraceRequestCollectionService } from "./traces/trace-request-collection.service";
+import type { TraceSpanBoundService } from "./traces/trace-span-bound.service";
 import type { TraceSummaryService } from "./traces/trace-summary.service";
 import type { PlanProvider } from "./subscription/plan-provider";
 import type { SubscriptionService } from "./subscription/subscription.service";
@@ -56,6 +57,7 @@ export interface AppDependencies {
     collection: TraceRequestCollectionService;
     logCollection: LogRequestCollectionService;
     metricCollection: MetricRequestCollectionService;
+    spanBound?: TraceSpanBoundService;
   };
   evaluations: {
     runs: EvaluationRunService;

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -58,6 +58,7 @@ import { TokenizerService } from "./traces/tokenizer.service";
 import { LogRequestCollectionService } from "./traces/log-request-collection.service";
 import { MetricRequestCollectionService } from "./traces/metric-request-collection.service";
 import { TraceRequestCollectionService } from "./traces/trace-request-collection.service";
+import { TraceSpanBoundService } from "./traces/trace-span-bound.service";
 import { TraceListService } from "./traces/trace-list.service";
 import { TraceListClickHouseRepository } from "./traces/repositories/trace-list.clickhouse.repository";
 import { NullTraceListRepository } from "./traces/repositories/trace-list.repository";
@@ -398,10 +399,15 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     queueSimulationRun: commands.simulations.queueRun,
   });
 
+  const traceSpanBound = redis
+    ? new TraceSpanBoundService({ redis })
+    : undefined;
+
   const traceCollection = traced(
     new TraceRequestCollectionService({
       dedup: spanDedup,
       recordSpan: commands.traces.recordSpan,
+      spanBound: traceSpanBound,
     }),
     "TraceRequestCollectionService",
   );
@@ -429,6 +435,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     collection: traceCollection,
     logCollection,
     metricCollection,
+    spanBound: traceSpanBound,
   };
 
   // Collect closeables for graceful shutdown

--- a/langwatch/src/server/app-layer/traces/__tests__/integration/trace-span-bound.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/integration/trace-span-bound.integration.test.ts
@@ -1,0 +1,144 @@
+import type { Redis } from "ioredis";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { TraceSpanBoundService } from "../../trace-span-bound.service";
+
+let redis: Redis;
+
+beforeAll(async () => {
+  ({ redisConnection: redis } = await startTestContainers());
+});
+
+afterAll(async () => {
+  await stopTestContainers();
+});
+
+beforeEach(async () => {
+  await redis.flushall();
+});
+
+const TENANT = "proj_acme";
+const TRACE = "0af7651916cd43dd8448eb211c80319c";
+
+function makeService(overrides?: {
+  maxSpansPerTrace?: number;
+  ttlSeconds?: number;
+  logger?: { warn: ReturnType<typeof vi.fn> };
+}) {
+  return new TraceSpanBoundService({
+    redis,
+    maxSpansPerTrace: overrides?.maxSpansPerTrace ?? 3,
+    ttlSeconds: overrides?.ttlSeconds,
+    // Minimal logger surface; only warn is exercised by the bound.
+    logger: (overrides?.logger ?? { warn: vi.fn() }) as never,
+  });
+}
+
+describe("TraceSpanBoundService", () => {
+  describe("given a trace under its span ingestion bound", () => {
+    /** @scenario Spans within the bound are ingested normally */
+    it("admits spans while the trace is under the ceiling", async () => {
+      const service = makeService({ maxSpansPerTrace: 3 });
+
+      expect(await service.admit(TENANT, TRACE)).toBe(true);
+      expect(await service.admit(TENANT, TRACE)).toBe(true);
+      expect(await service.admit(TENANT, TRACE)).toBe(true);
+    });
+  });
+
+  describe("given a trace that has reached its span ingestion bound", () => {
+    /** @scenario Spans past the bound are dropped at ingestion */
+    it("drops every span once the trace passes the ceiling", async () => {
+      const service = makeService({ maxSpansPerTrace: 3 });
+
+      await service.admit(TENANT, TRACE); // 1
+      await service.admit(TENANT, TRACE); // 2
+      await service.admit(TENANT, TRACE); // 3 (at ceiling)
+
+      expect(await service.admit(TENANT, TRACE)).toBe(false); // 4
+      expect(await service.admit(TENANT, TRACE)).toBe(false); // 5
+    });
+
+    /** @scenario Spans past the bound are dropped at ingestion */
+    it("keeps counting past the ceiling so true magnitude stays visible", async () => {
+      const service = makeService({ maxSpansPerTrace: 2 });
+
+      for (let i = 0; i < 5; i++) await service.admit(TENANT, TRACE);
+
+      const counter = Number(await redis.get(`trace_spans:${TENANT}:${TRACE}`));
+      expect(counter).toBe(5);
+    });
+  });
+
+  describe("given one trace over its bound and another under it", () => {
+    /** @scenario Dropping one trace's overflow does not affect other traces */
+    it("drops only the over-bound trace's spans", async () => {
+      const service = makeService({ maxSpansPerTrace: 2 });
+      const otherTrace = "11111111111111111111111111111111";
+
+      await service.admit(TENANT, TRACE); // 1
+      await service.admit(TENANT, TRACE); // 2 (at ceiling)
+      expect(await service.admit(TENANT, TRACE)).toBe(false); // over
+
+      expect(await service.admit(TENANT, otherTrace)).toBe(true);
+      expect(await service.admit(TENANT, otherTrace)).toBe(true);
+    });
+  });
+
+  describe("given a trace that crosses its bound", () => {
+    /** @scenario Crossing the bound is logged once, not per dropped span */
+    it("logs the breach once on first crossing, not per dropped span", async () => {
+      const warn = vi.fn();
+      const service = makeService({ maxSpansPerTrace: 2, logger: { warn } });
+
+      await service.admit(TENANT, TRACE); // 1
+      await service.admit(TENANT, TRACE); // 2 (at ceiling, not over)
+      await service.admit(TENANT, TRACE); // 3 (first over -> log)
+      await service.admit(TENANT, TRACE); // 4 (over -> no log)
+      await service.admit(TENANT, TRACE); // 5 (over -> no log)
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given a trace that keeps accruing spans", () => {
+    it("slides the counter TTL forward on each span so an active trace stays bounded", async () => {
+      const service = makeService({ maxSpansPerTrace: 100, ttlSeconds: 50 });
+      const key = `trace_spans:${TENANT}:${TRACE}`;
+
+      await service.admit(TENANT, TRACE);
+      const firstTtl = await redis.ttl(key);
+      expect(firstTtl).toBeGreaterThan(0);
+      expect(firstTtl).toBeLessThanOrEqual(50);
+
+      await service.admit(TENANT, TRACE);
+      const secondTtl = await redis.ttl(key);
+      // Refreshed back near the full window rather than decaying.
+      expect(secondTtl).toBeGreaterThan(45);
+    });
+  });
+
+  describe("given the bound is disabled (kill switch)", () => {
+    it("admits every span and creates no counter key when the ceiling is 0", async () => {
+      const service = makeService({ maxSpansPerTrace: 0 });
+
+      for (let i = 0; i < 10; i++) {
+        expect(await service.admit(TENANT, TRACE)).toBe(true);
+      }
+      expect(await redis.get(`trace_spans:${TENANT}:${TRACE}`)).toBeNull();
+    });
+  });
+
+  describe("given an operator configures a custom ceiling", () => {
+    /** @scenario An operator can retune the bound */
+    it("enforces the configured ceiling", async () => {
+      const service = makeService({ maxSpansPerTrace: 1 });
+
+      expect(await service.admit(TENANT, TRACE)).toBe(true);
+      expect(await service.admit(TENANT, TRACE)).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/__tests__/trace-span-bound.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-span-bound.unit.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAX_SPANS_PER_TRACE,
+  readMaxSpansPerTrace,
+} from "../trace-span-bound.service";
+
+const ENV = "LANGWATCH_MAX_SPANS_PER_TRACE";
+
+describe("readMaxSpansPerTrace", () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[ENV];
+    delete process.env[ENV];
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV];
+    else process.env[ENV] = original;
+  });
+
+  describe("given the bound is not configured", () => {
+    /** @scenario The bound defaults ON when unconfigured */
+    it("returns the built-in default ceiling", () => {
+      expect(readMaxSpansPerTrace()).toBe(DEFAULT_MAX_SPANS_PER_TRACE);
+    });
+
+    it("falls back to the default for an empty value", () => {
+      process.env[ENV] = "";
+      expect(readMaxSpansPerTrace()).toBe(DEFAULT_MAX_SPANS_PER_TRACE);
+    });
+
+    it("falls back to the default for a non-numeric value", () => {
+      process.env[ENV] = "lots";
+      expect(readMaxSpansPerTrace()).toBe(DEFAULT_MAX_SPANS_PER_TRACE);
+    });
+
+    it("falls back to the default for a negative value", () => {
+      process.env[ENV] = "-5";
+      expect(readMaxSpansPerTrace()).toBe(DEFAULT_MAX_SPANS_PER_TRACE);
+    });
+  });
+
+  describe("given an operator configures the bound", () => {
+    /** @scenario An operator can retune the bound */
+    it("returns the configured ceiling", () => {
+      process.env[ENV] = "500";
+      expect(readMaxSpansPerTrace()).toBe(500);
+    });
+
+    it("returns 0 as the explicit kill switch", () => {
+      process.env[ENV] = "0";
+      expect(readMaxSpansPerTrace()).toBe(0);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/trace-request-collection.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-request-collection.service.ts
@@ -13,6 +13,7 @@ import {
   spanSchema,
 } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 import { TraceRequestUtils } from "../../event-sourcing/pipelines/trace-processing/utils/traceRequest.utils";
+import type { TraceSpanBoundService } from "./trace-span-bound.service";
 import type { SpanDedupService } from "./span-dedupe.service";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
@@ -50,6 +51,7 @@ export interface TraceRequestCollectionResult {
 export interface TraceRequestCollectionDeps {
   dedup: SpanDedupService;
   recordSpan: (data: RecordSpanCommandData) => Promise<void>;
+  spanBound?: TraceSpanBoundService;
 }
 
 /**
@@ -223,6 +225,25 @@ export class TraceRequestCollectionService {
         return { status: "deduped" };
       }
       lockAcquired = lockResult === true;
+
+      // Front-drop spans for a trace that has hit its ingestion ceiling, before
+      // staging recordSpan (which is what triggers storage + fold). Checked
+      // after dedup so retries don't inflate the count. Confirm the span as
+      // processed so retries are deduped away instead of re-hitting the bound.
+      if (
+        this.deps.spanBound &&
+        !(await this.deps.spanBound.admit(tenantId, normalizedSpan.traceId))
+      ) {
+        await this.deps.dedup.tryConfirmProcessed(
+          tenantId,
+          normalizedSpan.traceId,
+          normalizedSpan.spanId,
+        );
+        return {
+          status: "dropped",
+          error: "trace span ingestion bound exceeded",
+        };
+      }
 
       await this.deps.recordSpan({
         tenantId,

--- a/langwatch/src/server/app-layer/traces/trace-span-bound.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-span-bound.service.ts
@@ -1,0 +1,109 @@
+import type IORedis from "ioredis";
+import type { Cluster } from "ioredis";
+
+import { createLogger } from "~/utils/logger/server";
+import { STALE_TRACE_THRESHOLD_MS } from "../../event-sourcing/pipelines/trace-processing/schemas/constants";
+
+/**
+ * Hard ceiling on how many spans a single trace_id may accrue. Sized far above
+ * any legitimate trace (real traces run a handful of spans; the 2026-05-28
+ * incident trace reached ~26k) so only pathological reuse / instrumentation
+ * loops hit it. See specs/trace-processing/spans-per-trace-bound.feature.
+ */
+export const DEFAULT_MAX_SPANS_PER_TRACE = 10_000;
+
+/**
+ * Reads the per-trace span ingestion ceiling. Mirrors readTenantCap: an unset,
+ * empty, or invalid value falls back to the default; 0 disables the bound
+ * entirely (operator kill switch).
+ */
+export function readMaxSpansPerTrace(): number {
+  const raw = process.env.LANGWATCH_MAX_SPANS_PER_TRACE;
+  if (raw === undefined || raw === "") return DEFAULT_MAX_SPANS_PER_TRACE;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_MAX_SPANS_PER_TRACE;
+  return n;
+}
+
+// Atomic INCR + sliding EXPIRE in one round-trip. Sliding means a trace that
+// keeps accruing spans keeps its counter alive (so it stays bounded across days
+// of slow reuse), while a trace idle past the TTL lets its counter expire and
+// resets — the TTL is anchored to the pipeline's own trace-liveness window
+// (STALE_TRACE_THRESHOLD_MS). Doing both in one script closes the INCR-without-
+// TTL window that would otherwise strand a key with no expiry.
+const INCR_SLIDING_LUA = `
+local count = redis.call("INCR", KEYS[1])
+redis.call("EXPIRE", KEYS[1], ARGV[1])
+return count
+`;
+
+export interface TraceSpanBoundOptions {
+  redis: IORedis | Cluster;
+  maxSpansPerTrace?: number;
+  ttlSeconds?: number;
+  keyPrefix?: string;
+  logger?: ReturnType<typeof createLogger>;
+}
+
+/**
+ * Enforces the per-trace span ceiling at the ingestion boundary. A synchronous
+ * Redis counter is the authoritative signal: the fold's spanCount lags under the
+ * exact burst this defends against, so gating on it would let the burst through.
+ */
+export class TraceSpanBoundService {
+  private readonly redis: IORedis | Cluster;
+  private readonly maxSpansPerTrace: number;
+  private readonly ttlSeconds: number;
+  private readonly keyPrefix: string;
+  private readonly logger: ReturnType<typeof createLogger>;
+
+  constructor(options: TraceSpanBoundOptions) {
+    this.redis = options.redis;
+    this.maxSpansPerTrace =
+      options.maxSpansPerTrace ?? readMaxSpansPerTrace();
+    this.ttlSeconds =
+      options.ttlSeconds ?? Math.ceil(STALE_TRACE_THRESHOLD_MS / 1000);
+    this.keyPrefix = options.keyPrefix ?? "trace_spans:";
+    this.logger =
+      options.logger ?? createLogger("langwatch:trace-processing:span-bound");
+  }
+
+  private key(tenantId: string, traceId: string): string {
+    return `${this.keyPrefix}${tenantId}:${traceId}`;
+  }
+
+  /**
+   * Admit one span against its trace's ingestion ceiling. Returns true when the
+   * span is within the bound, false when the trace has reached the ceiling and
+   * the span must be dropped — a front-drop, so the caller skips staging the
+   * recordSpan command entirely (bounding all downstream storage + fold cost).
+   *
+   * Counts delivery attempts, so call this AFTER dedup where dedup exists (the
+   * OTLP path) to keep retries from inflating the count. On the collector path
+   * (no pre-dispatch dedup) a retry can over-count slightly, which only trips
+   * the ceiling marginally earlier — acceptable for an infra-protection bound.
+   */
+  async admit(tenantId: string, traceId: string): Promise<boolean> {
+    if (this.maxSpansPerTrace <= 0) return true; // disabled (kill switch)
+
+    const count = (await this.redis.eval(
+      INCR_SLIDING_LUA,
+      1,
+      this.key(tenantId, traceId),
+      String(this.ttlSeconds),
+    )) as number;
+
+    if (count > this.maxSpansPerTrace) {
+      // Log only when first crossing the bound, not once per dropped span.
+      if (count === this.maxSpansPerTrace + 1) {
+        this.logger.warn(
+          { tenantId, traceId, maxSpansPerTrace: this.maxSpansPerTrace },
+          "Trace reached span ingestion bound; dropping further spans for this trace",
+        );
+      }
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/langwatch/src/server/routes/collector.ts
+++ b/langwatch/src/server/routes/collector.ts
@@ -27,6 +27,7 @@ import {
   spanValidatorSchema,
 } from "../tracer/types.generated";
 import { CollectorSpanUtils } from "../traces/collectorSpan.utils";
+import { TraceRequestUtils } from "../event-sourcing/pipelines/trace-processing/utils/traceRequest.utils";
 import { createLogger } from "../../utils/logger/server";
 import { TokenResolver } from "../api-key/token-resolver";
 import {
@@ -554,25 +555,51 @@ app.post(
       });
 
       const results = await Promise.allSettled(
-        spans.map((span) =>
-          getApp().traces.recordSpan({
+        spans.map(async (span) => {
+          const otlpSpan = CollectorSpanUtils.convertSpanToOtlp(span);
+
+          // Front-drop spans for a trace over its ingestion ceiling, before
+          // dispatching recordSpan (which triggers storage + fold). Keyed on the
+          // same normalized trace id the command uses so both paths agree.
+          const spanBound = getApp().traces.spanBound;
+          if (spanBound) {
+            const { traceId: normalizedTraceId } =
+              TraceRequestUtils.normalizeOtlpSpanIds(otlpSpan);
+            if (!(await spanBound.admit(project.id, normalizedTraceId))) {
+              return { dropped: true as const };
+            }
+          }
+
+          await getApp().traces.recordSpan({
             tenantId: project.id,
-            span: CollectorSpanUtils.convertSpanToOtlp(span),
+            span: otlpSpan,
             resource,
             instrumentationScope: { name: "langwatch.rest.collector" },
             piiRedactionLevel: project.piiRedactionLevel,
             occurredAt: Date.now(),
-          }),
-        ),
+          });
+          return { dropped: false as const };
+        }),
       );
 
       const failures = results.filter(
         (r): r is PromiseRejectedResult => r.status === "rejected",
       );
-      rejectedSpans = failures.length;
+      const boundDrops = results.filter(
+        (r) => r.status === "fulfilled" && r.value.dropped,
+      ).length;
+      // Bound-drops are accept-but-drop: reported as rejectedSpans (the OTLP
+      // partial-success signal is non-retryable) so the drop is visible and the
+      // SDK does not retry-storm re-sending spans we will only drop again.
+      rejectedSpans = failures.length + boundDrops;
       rejectionErrors = failures.map((f) =>
         f.reason instanceof Error ? f.reason.message : String(f.reason),
       );
+      if (boundDrops > 0) {
+        rejectionErrors.push(
+          `${boundDrops} span(s) dropped: trace span ingestion bound exceeded`,
+        );
+      }
       if (failures.length > 0) {
         logger.error(
           {

--- a/specs/trace-processing/spans-per-trace-bound.feature
+++ b/specs/trace-processing/spans-per-trace-bound.feature
@@ -1,0 +1,73 @@
+Feature: Per-trace span bound on ingestion
+  As an operator running multi-tenant trace ingestion on shared infrastructure
+  I want a hard ceiling on how many spans a single trace_id can accumulate
+  So that one runaway trace (a reused trace_id, an instrumentation loop,
+  an accidental fan-out) cannot balloon the fold backlog, span storage, and
+  Redis memory and degrade ingestion for every other tenant.
+
+  # Why this exists — incident 2026-05-28
+  #
+  # A trace_id reused across days accumulated tens of thousands of spans. Every
+  # span became a queued fold job, so that one trace's fold backlog grew to
+  # hundreds of KB (heavy tail past 2 MB) of Redis state that re-piled on each
+  # ingest. Under a concurrent dispatch stall it could not drain, the shared
+  # single-threaded Redis filled toward its no-eviction ceiling, and span
+  # ingestion was rejected at the door for everyone. The per-tenant soft cap
+  # (see event-sourcing/tenant-soft-cap.feature) bounds how many groups a tenant
+  # holds in flight; it does not bound how large a single trace can get. This is
+  # the missing second ceiling.
+  #
+  # Two tiers, distinct jobs:
+  #   - The processing cap (512) stops DERIVING a trace summary past 512 spans:
+  #     the fold keeps counting so true magnitude stays visible, but it no longer
+  #     pays normalization cost. It does NOT bound storage or the queue.
+  #   - The ingestion bound (this feature) is the hard ceiling: past it, further
+  #     spans for the trace are dropped at ingestion — never queued, never stored,
+  #     never folded — so a single trace cannot grow shared infra without limit.
+  #
+  # The bound ships ON by default, sized far above any legitimate trace so only
+  # pathological reuse/loops hit it. Operators can retune it; a single trace
+  # hitting the bound never affects other traces or tenants.
+
+  Background:
+    Given the trace-processing ingestion pipeline is running
+
+  Rule: A trace stops accepting spans once it reaches the ingestion bound
+
+    Scenario: Spans within the bound are ingested normally
+      Given a trace under its span ingestion bound
+      When a new span arrives for that trace
+      Then the span is ingested, stored, and folded into the trace summary
+
+    Scenario: Spans past the bound are dropped at ingestion
+      Given a trace that has reached its span ingestion bound
+      When a further span arrives for that trace
+      Then the span is not stored, not queued, and not folded
+      And the drop is recorded so the trace's true magnitude stays visible
+
+    Scenario: Dropping one trace's overflow does not affect other traces
+      Given one trace that has reached its span ingestion bound
+      And a second trace from the same tenant well under the bound
+      When spans arrive for both traces
+      Then the second trace's span is ingested normally
+      And only the over-bound trace's span is dropped
+
+  Rule: The bound is observable, not silent
+
+    Scenario: Crossing the bound is logged once, not per dropped span
+      Given a trace that has just reached its span ingestion bound
+      When many further spans arrive for that trace
+      Then the bound breach is logged when first crossed
+      And the per-span drops do not each emit their own log line
+
+  Rule: The bound is configurable with a safe default
+
+    Scenario: The bound defaults ON when unconfigured
+      Given the span ingestion bound is not explicitly configured
+      When the pipeline reads the bound
+      Then it returns the built-in default ceiling
+
+    Scenario: An operator can retune the bound
+      Given the span ingestion bound is configured to a custom ceiling
+      When the pipeline reads the bound
+      Then it returns the configured ceiling


### PR DESCRIPTION
## What

Adds a hard per-trace span ceiling enforced at ingestion, so a single trace_id cannot balloon the shared event-sourcing infrastructure.

## Why

In the 2026-05-28 incident a trace_id reused across days accumulated around 26k spans. Every span became a queued fold job, so that one trace's Redis fold backlog grew into hundreds of KB (heavy tail past 2 MB) that re-piled on each ingest. Under a concurrent dispatch stall it could not drain, the shared single-threaded Redis filled toward its no-eviction ceiling, and span ingestion was rejected at the door for every tenant.

The per-tenant soft cap (#4214, #4220) bounds how many groups a tenant holds in flight. It does not bound how large one trace can get. This is the missing second ceiling.

## How

A per-trace counter in Redis, incremented synchronously at the recordSpan entrance (both the REST collector and the OTLP path converge there). Past the ceiling the span is front-dropped before staging, so it is never queued, stored, or folded, and the drop bounds all downstream cost.

Design decisions:

- Gates on the synchronous counter, not the fold spanCount. The fold count lags under exactly the burst this defends against, so gating on it would let the burst through.
- Sliding EXPIRE anchored to the existing `STALE_TRACE_THRESHOLD_MS` (1h), the pipeline's own trace-liveness window. A trace touched within the window keeps one bounded counter across days of slow reuse; a trace idle past it lets the counter expire. INCR and EXPIRE run in one Lua eval so there is no window where the key is left without a TTL.
- Dropped spans are surfaced as `partialSuccess.rejectedSpans`, the non-retryable OTLP signal, so the drop is visible and the SDK does not retry-storm re-sending spans that will only be dropped again.
- Counts attempts, so the check sits after dedup on the OTLP path; on the collector path a retry can over-count slightly, which only trips the ceiling marginally earlier (errs toward protection).

This complements the existing 512 fold derivation cap, which bounds fold compute but keeps counting and still stores and queues every span.

## Config

Default ceiling 10000 (far above legitimate traces, which run a handful of spans; well below the incident's 26k). `LANGWATCH_MAX_SPANS_PER_TRACE` retunes it; 0 disables the bound, mirroring `LANGWATCH_DISPATCH_TENANT_CAP`.

## Tests

- `specs/trace-processing/spans-per-trace-bound.feature` describes the behavior.
- Integration test against real Redis: admit within bound, drop past bound, keep counting for true magnitude, per-trace independence, log-once on first crossing, sliding TTL refresh, kill switch, custom ceiling.
- Unit test for the config reader (default, custom, kill switch, invalid).
