### PR TITLE
feat(observability): report handled client errors to PostHog via toaster

### DIFF
--- a/langwatch/specs/toaster-error-reporting.feature
+++ b/langwatch/specs/toaster-error-reporting.feature
@@ -1,0 +1,32 @@
+Feature: Handled client errors reach PostHog via the toaster
+  As an operator watching the client error-rate quality metric
+  I want handled failures that show an error toast to also report to PostHog
+  So that the metric reflects real user pain, not only uncaught crashes
+
+  Context: audit of the "the truth" dashboard found that ~150 client catch
+  blocks showed an error toast but never reported the error, so handled
+  failures (failed uploads, saves, billing actions) were invisible to the
+  $exception metric. The shared toaster now accepts an opt-in `error` field:
+  passing the caught error forwards it to PostHog as a $exception. Validation
+  toasts pass no error and stay silent — the presence of a real error is the
+  signal, so we never report plain "field required" messages.
+
+  @unit
+  Scenario: An error toast that carries a caught error reports to PostHog
+    Given a catch block calls toaster.create with type "error" and the caught error
+    When the toast is created
+    Then a "$exception" event is captured tagged source=toaster
+    And the toast still renders unchanged
+
+  @unit
+  Scenario: A validation toast without an error stays silent
+    Given a toaster.create call with type "error" and no error field
+    When the toast is created
+    Then no "$exception" event is captured
+    And the toast renders normally
+
+  @unit
+  Scenario: Non-error toasts never report
+    Given a toaster.create call with type "success", "info", or "loading"
+    When the toast is created
+    Then no "$exception" event is captured

--- a/langwatch/src/components/UpgradeModal.tsx
+++ b/langwatch/src/components/UpgradeModal.tsx
@@ -167,6 +167,7 @@ function SeatsContent({
           err instanceof Error ? err.message : "An unexpected error occurred",
         type: "error",
         meta: { closable: true },
+        error: err,
       });
     } finally {
       setIsConfirming(false);

--- a/langwatch/src/components/agents/WorkflowSelectorDrawer.tsx
+++ b/langwatch/src/components/agents/WorkflowSelectorDrawer.tsx
@@ -173,6 +173,7 @@ export function WorkflowSelectorDrawer(props: WorkflowSelectorDrawerProps) {
           title: "Error",
           description: "Failed to create workflow agent",
           type: "error",
+          error: error,
         });
       }
     },

--- a/langwatch/src/components/checks/TryItOut.tsx
+++ b/langwatch/src/components/checks/TryItOut.tsx
@@ -198,6 +198,7 @@ export function TryItOut({
           meta: {
             closable: true,
           },
+          error: e,
         });
         console.error(e);
         return;

--- a/langwatch/src/components/datasets/AddRowsFromCSVModal.tsx
+++ b/langwatch/src/components/datasets/AddRowsFromCSVModal.tsx
@@ -117,6 +117,7 @@ export function AddRowsFromCSVModal({
         meta: {
           closable: true,
         },
+        error: error,
       });
 
       return;

--- a/langwatch/src/components/datasets/CopyDatasetDialog.tsx
+++ b/langwatch/src/components/datasets/CopyDatasetDialog.tsx
@@ -99,6 +99,7 @@ export const CopyDatasetDialog = ({
         title: "Error replicating dataset",
         description: error instanceof Error ? error.message : "Unknown error",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/datasets/UploadCSVModal.tsx
+++ b/langwatch/src/components/datasets/UploadCSVModal.tsx
@@ -335,6 +335,7 @@ export function CSVReaderComponent({
               meta: {
                 closable: true,
               },
+              error: error,
             });
           }
         } else {

--- a/langwatch/src/components/evaluations/CopyEvaluationDialog.tsx
+++ b/langwatch/src/components/evaluations/CopyEvaluationDialog.tsx
@@ -116,6 +116,7 @@ export const CopyEvaluationDialog = ({
         title: "Error replicating evaluation",
         description: error instanceof Error ? error.message : "Unknown error",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/evaluations/wizard/hooks/useAutosaveWizard.tsx
+++ b/langwatch/src/components/evaluations/wizard/hooks/useAutosaveWizard.tsx
@@ -139,7 +139,6 @@ const useAutosaveWizard = () => {
             meta: {
               closable: true,
             },
-            error: error,
           });
           captureException(error, {
             extra: {

--- a/langwatch/src/components/evaluations/wizard/hooks/useAutosaveWizard.tsx
+++ b/langwatch/src/components/evaluations/wizard/hooks/useAutosaveWizard.tsx
@@ -139,6 +139,7 @@ const useAutosaveWizard = () => {
             meta: {
               closable: true,
             },
+            error: error,
           });
           captureException(error, {
             extra: {

--- a/langwatch/src/components/evaluations/wizard/steps/datasets/DatasetGeneration.tsx
+++ b/langwatch/src/components/evaluations/wizard/steps/datasets/DatasetGeneration.tsx
@@ -285,6 +285,7 @@ export function DatasetGeneration() {
           meta: {
             closable: true,
           },
+          error: error,
         });
       }
     },

--- a/langwatch/src/components/evaluators/WorkflowSelectorForEvaluatorDrawer.tsx
+++ b/langwatch/src/components/evaluators/WorkflowSelectorForEvaluatorDrawer.tsx
@@ -176,6 +176,7 @@ export function WorkflowSelectorForEvaluatorDrawer(
           title: "Error",
           description: "Failed to create workflow evaluator",
           type: "error",
+          error: error,
         });
       }
     },

--- a/langwatch/src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx
+++ b/langwatch/src/components/experiments/BatchEvaluationV2/BatchEvaluationV2EvaluationResults.tsx
@@ -197,6 +197,7 @@ export const useBatchEvaluationDownloadCSV = ({
         meta: {
           closable: true,
         },
+        error: error,
       });
       console.error(error);
     }

--- a/langwatch/src/components/gateway/BudgetCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/BudgetCreateDrawer.tsx
@@ -114,6 +114,7 @@ export function BudgetCreateDrawer({
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to create budget",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/gateway/BudgetEditDrawer.tsx
+++ b/langwatch/src/components/gateway/BudgetEditDrawer.tsx
@@ -96,6 +96,7 @@ export function BudgetEditDrawer({
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to update budget",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/gateway/CacheRuleCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/CacheRuleCreateDrawer.tsx
@@ -55,6 +55,7 @@ export function CacheRuleCreateDrawer({ open, onOpenChange, onCreated }: Props) 
       toaster.create({
         title: e instanceof Error ? e.message : "Failed to create cache rule",
         type: "error",
+        error: e,
       });
     }
   };

--- a/langwatch/src/components/gateway/CacheRuleEditDrawer.tsx
+++ b/langwatch/src/components/gateway/CacheRuleEditDrawer.tsx
@@ -86,6 +86,7 @@ export function CacheRuleEditDrawer({ rule, onOpenChange, onSaved }: Props) {
       toaster.create({
         title: e instanceof Error ? e.message : "Failed to save cache rule",
         type: "error",
+        error: e,
       });
     }
   };

--- a/langwatch/src/components/gateway/ProviderBindingCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/ProviderBindingCreateDrawer.tsx
@@ -110,6 +110,7 @@ export function ProviderBindingCreateDrawer({
         title:
           error instanceof Error ? error.message : "Failed to bind provider",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/gateway/ProviderBindingEditDrawer.tsx
+++ b/langwatch/src/components/gateway/ProviderBindingEditDrawer.tsx
@@ -90,6 +90,7 @@ export function ProviderBindingEditDrawer({
         title:
           error instanceof Error ? error.message : "Failed to update binding",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/gateway/VirtualKeyCreateDrawer.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyCreateDrawer.tsx
@@ -110,6 +110,7 @@ export function VirtualKeyCreateDrawer({
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to create virtual key",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/gateway/VirtualKeyEditDrawer.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyEditDrawer.tsx
@@ -376,6 +376,7 @@ export function VirtualKeyEditDrawer({
         title:
           error instanceof Error ? error.message : "Failed to update virtual key",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
+++ b/langwatch/src/components/scenarios/ScenarioAIGeneration.tsx
@@ -186,6 +186,7 @@ export function ScenarioAIGeneration({ form }: ScenarioAIGenerationProps) {
         type: "error",
         duration: TOAST_DURATION_MS,
         meta: { closable: true },
+        error: error,
       });
     }
   }, [

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -302,6 +302,7 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
             error instanceof Error ? error.message : "An error occurred",
           type: "error",
           meta: { closable: true },
+          error: error,
         });
       }
     },

--- a/langwatch/src/components/settings/ChangePasswordDialog.tsx
+++ b/langwatch/src/components/settings/ChangePasswordDialog.tsx
@@ -72,6 +72,7 @@ export function ChangePasswordDialog({
           error instanceof Error ? error.message : "Please try again",
         type: "error",
         meta: { closable: true },
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/settings/CreateGroupDialog.tsx
+++ b/langwatch/src/components/settings/CreateGroupDialog.tsx
@@ -73,7 +73,7 @@ export function CreateGroupDialog({
       reset();
       onClose();
     } catch (e: any) {
-      toaster.create({ title: e.message ?? "Failed to create group", type: "error" });
+      toaster.create({ title: e.message ?? "Failed to create group", type: "error", error: e });
     }
   }
 

--- a/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
+++ b/langwatch/src/components/settings/DefaultModelOverrideDrawer.tsx
@@ -320,6 +320,7 @@ export function DefaultModelOverrideDrawer({ editingId }: Props) {
         type: "error",
         duration: 6000,
         meta: { closable: true },
+        error: err,
       });
     } finally {
       setBusy(false);

--- a/langwatch/src/components/settings/DefaultModelsSection.tsx
+++ b/langwatch/src/components/settings/DefaultModelsSection.tsx
@@ -143,6 +143,7 @@ export function DefaultModelsSection({
         type: "error",
         duration: 6000,
         meta: { closable: true },
+        error: err,
       });
     }
   };

--- a/langwatch/src/components/settings/GroupDetailDialog.tsx
+++ b/langwatch/src/components/settings/GroupDetailDialog.tsx
@@ -133,7 +133,7 @@ export function GroupDetailDialog({
       onClose();
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to save";
-      toaster.create({ title: message, type: "error" });
+      toaster.create({ title: message, type: "error", error: e });
     } finally {
       setIsSaving(false);
     }

--- a/langwatch/src/components/settings/MemberDetailDialog.tsx
+++ b/langwatch/src/components/settings/MemberDetailDialog.tsx
@@ -133,7 +133,7 @@ export function MemberDetailDialog({
       onClose();
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to save";
-      toaster.create({ title: message, type: "error" });
+      toaster.create({ title: message, type: "error", error: e });
     } finally {
       setIsSaving(false);
     }

--- a/langwatch/src/components/subscription/useSubscriptionActions.ts
+++ b/langwatch/src/components/subscription/useSubscriptionActions.ts
@@ -94,6 +94,7 @@ export function useSubscriptionActions({
           err instanceof Error ? err.message : "An unexpected error occurred",
         type: "error",
         meta: { closable: true },
+        error: err,
       });
     }
   };
@@ -134,6 +135,7 @@ export function useSubscriptionActions({
               err instanceof Error ? err.message : "An unexpected error occurred",
             type: "error",
             meta: { closable: true },
+            error: err,
           });
         }
       },
@@ -159,6 +161,7 @@ export function useSubscriptionActions({
           err instanceof Error ? err.message : "An unexpected error occurred",
         type: "error",
         meta: { closable: true },
+        error: err,
       });
     }
   };

--- a/langwatch/src/components/ui/PushToCopiesDialog.tsx
+++ b/langwatch/src/components/ui/PushToCopiesDialog.tsx
@@ -75,6 +75,7 @@ export function PushToCopiesDialog({
             ? String((err as { message: unknown }).message)
             : "Unknown error",
         type: "error",
+        error: err,
       });
     }
   };

--- a/langwatch/src/components/ui/ReplicateToProjectDialog.tsx
+++ b/langwatch/src/components/ui/ReplicateToProjectDialog.tsx
@@ -91,6 +91,7 @@ export function ReplicateToProjectDialog({
         title: `Error replicating ${entityLabel.toLowerCase()}`,
         description: error instanceof Error ? error.message : "Unknown error",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/components/ui/toaster.tsx
+++ b/langwatch/src/components/ui/toaster.tsx
@@ -9,6 +9,7 @@ import {
   Toast,
 } from "@chakra-ui/react";
 import { Info } from "react-feather";
+import { captureException } from "~/utils/posthogErrorCapture";
 
 const toaster_ = createToaster({
   placement: "top-end",
@@ -18,12 +19,23 @@ const toaster_ = createToaster({
 // Workaround for https://github.com/chakra-ui/chakra-ui/issues/9490#issuecomment-2601014577
 export const toaster = {
   ...toaster_,
-  create: (args: Parameters<typeof toaster_.create>[0]) => {
+  // Opt-in error reporting: pass the caught `error` and it's forwarded to
+  // PostHog as a $exception, so handled failures (not just uncaught crashes)
+  // reach the error/quality metrics. Validation toasts pass no `error` and
+  // stay silent — the presence of a real error is the signal, so we never
+  // report plain "field required" messages.
+  create: (
+    args: Parameters<typeof toaster_.create>[0] & { error?: unknown },
+  ) => {
+    const { error, ...toastArgs } = args;
+    if (error !== undefined) {
+      captureException(error, { tags: { source: "toaster" } });
+    }
     return toaster_.create({
       duration: 5000,
-      ...args,
+      ...toastArgs,
       meta: {
-        ...args.meta,
+        ...toastArgs.meta,
         placement: "top-end",
       },
     });

--- a/langwatch/src/experiments-v3/hooks/useAutosaveEvaluationsV3.ts
+++ b/langwatch/src/experiments-v3/hooks/useAutosaveEvaluationsV3.ts
@@ -261,7 +261,6 @@ export const useAutosaveEvaluationsV3 = () => {
             meta: {
               closable: true,
             },
-            error: error,
           });
           captureException(error, {
             extra: {

--- a/langwatch/src/experiments-v3/hooks/useAutosaveEvaluationsV3.ts
+++ b/langwatch/src/experiments-v3/hooks/useAutosaveEvaluationsV3.ts
@@ -261,6 +261,7 @@ export const useAutosaveEvaluationsV3 = () => {
             meta: {
               closable: true,
             },
+            error: error,
           });
           captureException(error, {
             extra: {

--- a/langwatch/src/experiments-v3/hooks/useExecuteEvaluation.ts
+++ b/langwatch/src/experiments-v3/hooks/useExecuteEvaluation.ts
@@ -696,6 +696,7 @@ export const useExecuteEvaluation = (): UseExecuteEvaluationReturn => {
         title: "Abort Failed",
         description: message,
         type: "error",
+        error: err,
       });
     }
     // Note: No finally block - isAborting stays true until `stopped` event

--- a/langwatch/src/hooks/useInviteActions.ts
+++ b/langwatch/src/hooks/useInviteActions.ts
@@ -251,6 +251,7 @@ export function useInviteActions({
               type: "error",
               duration: 5000,
               meta: { closable: true },
+              error: err,
             });
           }
         },

--- a/langwatch/src/hooks/useProviderFormSubmit.ts
+++ b/langwatch/src/hooks/useProviderFormSubmit.ts
@@ -107,6 +107,7 @@ export function useProviderFormSubmit({
           type: "error",
           duration: 4000,
           meta: { closable: true },
+          error: err,
         });
       }
     },
@@ -391,6 +392,7 @@ export function useProviderFormSubmit({
         type: "error",
         duration: 4000,
         meta: { closable: true },
+        error: err,
       });
     } finally {
       setIsSaving(false);

--- a/langwatch/src/hooks/useRunScenario.tsx
+++ b/langwatch/src/hooks/useRunScenario.tsx
@@ -121,6 +121,7 @@ export function useRunScenario({
           description: message,
           type: "error",
           meta: { closable: true },
+          error: error,
         });
       } finally {
         setIsPolling(false);

--- a/langwatch/src/optimization_studio/components/Evaluate.tsx
+++ b/langwatch/src/optimization_studio/components/Evaluate.tsx
@@ -287,6 +287,7 @@ export function EvaluateModalContent({
               type: "error",
               duration: 5000,
               meta: { closable: true },
+              error: error,
             });
             throw error;
           }

--- a/langwatch/src/optimization_studio/components/Optimize.tsx
+++ b/langwatch/src/optimization_studio/components/Optimize.tsx
@@ -284,6 +284,7 @@ export function OptimizeModalContent({
             title: "Error",
             description: "Failed to save version",
             type: "error",
+            error: error,
           });
           throw error;
         }

--- a/langwatch/src/optimization_studio/components/Publish.tsx
+++ b/langwatch/src/optimization_studio/components/Publish.tsx
@@ -512,6 +512,7 @@ function PublishModalContent({
             meta: {
               closable: true,
             },
+            error: error,
           });
           throw error;
         }

--- a/langwatch/src/optimization_studio/components/properties/llm-configs/signature-properties-panel/hooks/useResetFormWithLatestDatabaseVersion.ts
+++ b/langwatch/src/optimization_studio/components/properties/llm-configs/signature-properties-panel/hooks/useResetFormWithLatestDatabaseVersion.ts
@@ -56,6 +56,7 @@ export function useResetFormWithLatestDatabaseVersion(params: {
         title: "Failed to load latest version",
         description: "Please try again",
         type: "error",
+        error: error,
       });
     }
   }, [getPromptById, formProps, configId]);

--- a/langwatch/src/optimization_studio/components/workflow/NewWorkflowModal.tsx
+++ b/langwatch/src/optimization_studio/components/workflow/NewWorkflowModal.tsx
@@ -120,6 +120,7 @@ export const NewWorkflowModal = ({
               error instanceof Error ? error.message : "Unknown error occurred",
             type: "error",
             meta: { closable: true },
+            error: error,
           });
         }
       };

--- a/langwatch/src/optimization_studio/hooks/useRunEvalution.ts
+++ b/langwatch/src/optimization_studio/hooks/useRunEvalution.ts
@@ -155,6 +155,7 @@ export const useRunEvalution = () => {
               type: "error",
               duration: 5000,
               meta: { closable: true },
+              error: err,
             });
           }
         }
@@ -185,6 +186,7 @@ export const useRunEvalution = () => {
             type: "error",
             duration: 5000,
             meta: { closable: true },
+            error: err,
           });
           return;
         }

--- a/langwatch/src/pages/[project]/gateway/budgets.tsx
+++ b/langwatch/src/pages/[project]/gateway/budgets.tsx
@@ -86,6 +86,7 @@ function BudgetsPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to archive",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/pages/[project]/gateway/budgets/[id].tsx
+++ b/langwatch/src/pages/[project]/gateway/budgets/[id].tsx
@@ -75,6 +75,7 @@ function BudgetDetailPage() {
       toaster.create({
         title: err instanceof Error ? err.message : "Failed to archive",
         type: "error",
+        error: err,
       });
     }
   };

--- a/langwatch/src/pages/[project]/gateway/cache-rules.tsx
+++ b/langwatch/src/pages/[project]/gateway/cache-rules.tsx
@@ -97,6 +97,7 @@ function CacheRulesPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to archive",
         type: "error",
+        error: error,
       });
     }
   };
@@ -113,6 +114,7 @@ function CacheRulesPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to toggle rule",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/pages/[project]/gateway/providers.tsx
+++ b/langwatch/src/pages/[project]/gateway/providers.tsx
@@ -72,6 +72,7 @@ function ProvidersPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to disable",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/pages/[project]/gateway/virtual-keys.tsx
+++ b/langwatch/src/pages/[project]/gateway/virtual-keys.tsx
@@ -89,6 +89,7 @@ function VirtualKeysPage() {
       toaster.create({
         title: err instanceof Error ? err.message : "Failed to rotate key",
         type: "error",
+        error: err,
       });
     }
   };
@@ -105,6 +106,7 @@ function VirtualKeysPage() {
       toaster.create({
         title: err instanceof Error ? err.message : "Failed to revoke key",
         type: "error",
+        error: err,
       });
     }
   };

--- a/langwatch/src/pages/[project]/gateway/virtual-keys/[id].tsx
+++ b/langwatch/src/pages/[project]/gateway/virtual-keys/[id].tsx
@@ -100,6 +100,7 @@ function VirtualKeyDetailPage() {
       toaster.create({
         title: err instanceof Error ? err.message : "Failed to rotate key",
         type: "error",
+        error: err,
       });
     }
   };
@@ -113,6 +114,7 @@ function VirtualKeyDetailPage() {
       toaster.create({
         title: err instanceof Error ? err.message : "Failed to revoke key",
         type: "error",
+        error: err,
       });
     }
   };

--- a/langwatch/src/pages/settings/authentication.tsx
+++ b/langwatch/src/pages/settings/authentication.tsx
@@ -120,6 +120,7 @@ export default function AuthenticationSettings() {
         meta: {
           closable: true,
         },
+        error: error,
       });
     }
   };

--- a/langwatch/src/pages/settings/secrets.tsx
+++ b/langwatch/src/pages/settings/secrets.tsx
@@ -70,6 +70,7 @@ export default function SecretsPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to create secret",
         type: "error",
+        error: error,
       });
     }
   };
@@ -87,6 +88,7 @@ export default function SecretsPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to delete secret",
         type: "error",
+        error: error,
       });
     }
   };
@@ -106,6 +108,7 @@ export default function SecretsPage() {
       toaster.create({
         title: error instanceof Error ? error.message : "Failed to update secret",
         type: "error",
+        error: error,
       });
     }
   };

--- a/langwatch/src/prompts/PromptsList.tsx
+++ b/langwatch/src/prompts/PromptsList.tsx
@@ -117,6 +117,7 @@ export function PromptsList({
           meta: {
             closable: true,
           },
+          error: error,
         });
       }
     },

--- a/langwatch/src/prompts/prompt-playground/components/sidebar/PublishedPromptActions.tsx
+++ b/langwatch/src/prompts/prompt-playground/components/sidebar/PublishedPromptActions.tsx
@@ -87,6 +87,7 @@ export function PublishedPromptActions({
         meta: {
           closable: true,
         },
+        error: error,
       });
     }
   }, [syncFromSource, project, utils, promptId, promptHandle]);
@@ -123,6 +124,7 @@ export function PublishedPromptActions({
         description:
           error instanceof Error ? error.message : "An unknown error occurred",
         type: "error",
+        error: error,
       });
     } finally {
       setIsDeleteDialogOpen(false);


### PR DESCRIPTION
## Summary

Widens client-side error capture so the **"the truth"** dashboard error tile reflects real user pain, not just uncaught crashes.

- Adds an **opt-in `error` field** to the shared `toaster` (`src/components/ui/toaster.tsx`). When a caught error is passed, it's forwarded to PostHog as a `$exception` (tagged `source=toaster`). The toast renders identically — `error` is stripped before reaching Chakra.
- Converts **61 catch-block error toasts across 51 files** to pass their caught error.

## Why

Audit of dashboard `651303` (insight `fNE339yg`) found the client error metric only saw uncaught crashes + React render errors. Of ~150 client catch blocks, only ~10 reported to PostHog — the other ~140 showed an error toast and **swallowed** the error. So real, user-visible failures (failed CSV upload, failed save, failed billing action) were invisible to the metric.

```
BEFORE: capture surface           AFTER: capture surface
uncaught crashes      ###         uncaught crashes        ###
render errors         ##          render errors           ##
handled failures      (none)      handled failures        ########  <- NEW
```

## Design: opt-in, not automatic

The presence of a **real `Error` object** is the signal. Validation toasts (`"Name is required"`) pass no `error` and stay silent, so we never re-pollute the metric with expected-input noise. Coverage grows as catch sites adopt `error`; noise stays at zero.

```ts
// before
catch (error) { toaster.create({ type: "error", title: "Upload failed" }) }
// after
catch (error) { toaster.create({ type: "error", title: "Upload failed", error }) }
```

## Scope / safety

- Conversions done via a TypeScript AST transformer (nearest-enclosing-catch scope analysis, shadowing-aware), not regex. Catch variable names used verbatim (`error: error` / `error: err` / `error: e`).
- Skipped: error toasts **not** inside a catch (validation), and optional catch bindings (`catch {` with no variable) — listed for follow-up.
- `pnpm typecheck` passes. No visual/behavioral change to toasts.
- Adds `specs/toaster-error-reporting.feature`.

## Follow-ups
- Optional lint rule: new `type:"error"` toasts inside a catch must pass `error` (prevents the gap re-growing).
- A handful of optional-catch-binding sites could adopt `catch (e)` + `error: e` if those failures are worth tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)