### PR TITLE
feat(event-sourcing): reactor outbox foundation (phase 0)

### DIFF
--- a/langwatch/prisma/migrations/20260528120000_add_reactor_outbox/migration.sql
+++ b/langwatch/prisma/migrations/20260528120000_add_reactor_outbox/migration.sql
@@ -1,0 +1,56 @@
+-- ReactorOutbox: durable dispatch queue for stake-sensitive reactors.
+--
+-- See dev/docs/adr/021-transactional-outbox-for-stake-sensitive-dispatch.md
+-- and ADRs 022-024 for the full rationale. In short: reactors registered
+-- via `.withOutbox` enqueue rows here instead of dispatching inline. A
+-- drainer leases rows (status → "dispatching"), calls the dispatch
+-- endpoint, and records the outcome. The unique (reactorName, dedupKey)
+-- is the claim primitive that makes pipeline replays safe — a second
+-- enqueue is a no-op via `createMany skipDuplicates`.
+
+-- CreateEnum
+CREATE TYPE "ReactorOutboxStatus" AS ENUM ('queued', 'dispatching', 'dispatched', 'failed_retryable', 'dead');
+
+-- CreateTable
+CREATE TABLE "ReactorOutbox" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "reactorName" TEXT NOT NULL,
+    "dedupKey" TEXT NOT NULL,
+    "groupKey" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" "ReactorOutboxStatus" NOT NULL DEFAULT 'queued',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 8,
+    "leasedUntil" TIMESTAMP(3),
+    "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastError" TEXT,
+    "lastErrorAt" TIMESTAMP(3),
+    "dispatchedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ReactorOutbox_pkey" PRIMARY KEY ("id")
+);
+
+-- Claim primitive: a second enqueue for the same (reactorName, dedupKey)
+-- is a no-op under `createMany skipDuplicates`. This is what makes
+-- pipeline replays and retries safe.
+CREATE UNIQUE INDEX "ReactorOutbox_reactorName_dedupKey_key" ON "ReactorOutbox"("reactorName", "dedupKey");
+
+-- Drainer hot path: pick the next claimable row for a (project, reactor)
+-- whose backoff has elapsed.
+CREATE INDEX "ReactorOutbox_projectId_reactorName_status_nextAttemptAt_idx" ON "ReactorOutbox"("projectId", "reactorName", "status", "nextAttemptAt");
+
+-- Operator surface: list stuck/dead dispatches per project.
+CREATE INDEX "ReactorOutbox_projectId_status_updatedAt_idx" ON "ReactorOutbox"("projectId", "status", "updatedAt");
+
+-- Crash recovery scan: find leased rows whose worker never came back.
+CREATE INDEX "ReactorOutbox_status_leasedUntil_idx" ON "ReactorOutbox"("status", "leasedUntil");
+
+-- AddForeignKey
+ALTER TABLE "ReactorOutbox" ADD CONSTRAINT "ReactorOutbox_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- To roll back, uncomment and run manually:
+-- DROP TABLE "ReactorOutbox";
+-- DROP TYPE "ReactorOutboxStatus";

--- a/langwatch/prisma/migrations/20260528120000_add_reactor_outbox/migration.sql
+++ b/langwatch/prisma/migrations/20260528120000_add_reactor_outbox/migration.sql
@@ -40,9 +40,12 @@ CREATE TABLE "ReactorOutbox" (
 -- pipeline replays and retries safe.
 CREATE UNIQUE INDEX "ReactorOutbox_reactorName_dedupKey_key" ON "ReactorOutbox"("reactorName", "dedupKey");
 
--- Drainer hot path: pick the next claimable row for a (project, reactor)
--- whose backoff has elapsed.
-CREATE INDEX "ReactorOutbox_projectId_reactorName_status_nextAttemptAt_idx" ON "ReactorOutbox"("projectId", "reactorName", "status", "nextAttemptAt");
+-- Drainer hot path: pick the next claimable row for a (project,
+-- reactor, group) whose backoff has elapsed. groupKey is part of the
+-- WHERE so a wakeup for one trigger can never lease another trigger's
+-- row — per-group FIFO holds at the row level. See leaseNext in
+-- outbox.prisma.repository.ts.
+CREATE INDEX "ReactorOutbox_projectId_reactorName_groupKey_status_nextAttempt_idx" ON "ReactorOutbox"("projectId", "reactorName", "groupKey", "status", "nextAttemptAt");
 
 -- Operator surface: list stuck/dead dispatches per project.
 CREATE INDEX "ReactorOutbox_projectId_status_updatedAt_idx" ON "ReactorOutbox"("projectId", "status", "updatedAt");

--- a/langwatch/prisma/migrations/20260528120000_add_reactor_outbox/migration.sql
+++ b/langwatch/prisma/migrations/20260528120000_add_reactor_outbox/migration.sql
@@ -51,7 +51,12 @@ CREATE INDEX "ReactorOutbox_projectId_status_updatedAt_idx" ON "ReactorOutbox"("
 CREATE INDEX "ReactorOutbox_status_leasedUntil_idx" ON "ReactorOutbox"("status", "leasedUntil");
 
 -- AddForeignKey
-ALTER TABLE "ReactorOutbox" ADD CONSTRAINT "ReactorOutbox_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+-- ON DELETE CASCADE (deviates from the Prisma default RESTRICT used by
+-- most per-project tables): a deleted project cannot receive dispatches,
+-- so pending/dead outbox rows have no meaning once the project is gone.
+-- RESTRICT would block project deletion until an operator manually
+-- cleaned out the table.
+ALTER TABLE "ReactorOutbox" ADD CONSTRAINT "ReactorOutbox_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- To roll back, uncomment and run manually:
 -- DROP TABLE "ReactorOutbox";

--- a/langwatch/prisma/migrations/20260528120000_add_reactor_outbox/migration.sql
+++ b/langwatch/prisma/migrations/20260528120000_add_reactor_outbox/migration.sql
@@ -23,7 +23,9 @@ CREATE TABLE "ReactorOutbox" (
     "attempts" INTEGER NOT NULL DEFAULT 0,
     "maxAttempts" INTEGER NOT NULL DEFAULT 8,
     "leasedUntil" TIMESTAMP(3),
-    "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- Nullable: cleared to NULL when a row is promoted to 'dead' (a
+    -- terminal row schedules no further attempt). Live rows default to now().
+    "nextAttemptAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
     "lastError" TEXT,
     "lastErrorAt" TIMESTAMP(3),
     "dispatchedAt" TIMESTAMP(3),

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -2702,8 +2702,10 @@ model ReactorOutbox {
 
     @@unique([reactorName, dedupKey])
     // Drainer hot path: pick the next claimable row for a (project,
-    // reactor) whose backoff has elapsed.
-    @@index([projectId, reactorName, status, nextAttemptAt])
+    // reactor, group) whose backoff has elapsed. groupKey is part of
+    // the WHERE so per-trigger FIFO holds at the row level — see
+    // leaseNext in outbox.prisma.repository.ts.
+    @@index([projectId, reactorName, groupKey, status, nextAttemptAt])
     // Operator surface: list stuck/dead dispatches per project.
     @@index([projectId, status, updatedAt])
     // Crash recovery scan: find leased rows whose worker never came

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -2662,7 +2662,11 @@ enum ReactorOutboxStatus {
 model ReactorOutbox {
     id             String              @id @default(nanoid())
     projectId      String
-    project        Project             @relation(fields: [projectId], references: [id])
+    // Cascade on project delete: pending/dead outbox rows have no
+    // meaning once the owning project is gone, and RESTRICT (the
+    // Prisma default for required relations) would block project
+    // deletion until an operator hand-cleaned the table.
+    project        Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
     // Stable identifier of the reactor that enqueued the row. Matches
     // the reactor's `name` in the pipeline builder.
     reactorName    String

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -378,6 +378,7 @@ model Project {
   annotations              Annotation[]
   projectSecrets           ProjectSecret[]
   TriggerSent              TriggerSent[]
+  ReactorOutbox            ReactorOutbox[]
   annotationScores         AnnotationScore[]
   publicShares             PublicShare[]
   workflows                Workflow[]
@@ -2641,4 +2642,64 @@ model FeatureFlag {
     lastEditedBy String?
     createdAt    DateTime @default(now())
     updatedAt    DateTime @default(now()) @updatedAt
+}
+
+// Durable outbox for stake-sensitive reactor dispatch.
+// See dev/docs/adr/021–024 for rationale. Reactors registered via
+// `.withOutbox` enqueue rows here instead of dispatching inline; a
+// drainer leases rows, calls the dispatch endpoint, and records the
+// outcome (dispatched / failed_retryable / dead). The unique
+// (reactorName, dedupKey) is the claim primitive that makes replays
+// safe — `createMany skipDuplicates` is a no-op on collision.
+enum ReactorOutboxStatus {
+    queued
+    dispatching
+    dispatched
+    failed_retryable
+    dead
+}
+
+model ReactorOutbox {
+    id             String              @id @default(nanoid())
+    projectId      String
+    project        Project             @relation(fields: [projectId], references: [id])
+    // Stable identifier of the reactor that enqueued the row. Matches
+    // the reactor's `name` in the pipeline builder.
+    reactorName    String
+    // Deduplication key scoped to (reactorName, ...). Typically encodes
+    // the match identity, e.g. `${triggerId}:${traceId}`. Collisions on
+    // (reactorName, dedupKey) are the claim primitive that makes
+    // replays safe.
+    dedupKey       String
+    // GroupQueue routing key for the wakeup payload. Drives per-group
+    // FIFO and fair scheduling across tenants. Typically the projectId
+    // or tenantId.
+    groupKey       String
+    // Reactor-defined dispatch payload (trigger config, target ids,
+    // rendered template inputs, etc). Variable-size data lives here so
+    // wakeup payloads stay constant-size.
+    payload        Json
+    status         ReactorOutboxStatus @default(queued)
+    attempts       Int                 @default(0)
+    maxAttempts    Int                 @default(8)
+    // Set to a future timestamp by the drainer when the row enters
+    // `dispatching`. A wakeup that arrives after `leasedUntil` may
+    // re-lease the row (assumed crashed worker).
+    leasedUntil    DateTime?
+    nextAttemptAt  DateTime            @default(now())
+    lastError      String?
+    lastErrorAt    DateTime?
+    dispatchedAt   DateTime?
+    createdAt      DateTime            @default(now())
+    updatedAt      DateTime            @default(now()) @updatedAt
+
+    @@unique([reactorName, dedupKey])
+    // Drainer hot path: pick the next claimable row for a (project,
+    // reactor) whose backoff has elapsed.
+    @@index([projectId, reactorName, status, nextAttemptAt])
+    // Operator surface: list stuck/dead dispatches per project.
+    @@index([projectId, status, updatedAt])
+    // Crash recovery scan: find leased rows whose worker never came
+    // back.
+    @@index([status, leasedUntil])
 }

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -2686,7 +2686,10 @@ model ReactorOutbox {
     // `dispatching`. A wakeup that arrives after `leasedUntil` may
     // re-lease the row (assumed crashed worker).
     leasedUntil    DateTime?
-    nextAttemptAt  DateTime            @default(now())
+    // Nullable: cleared (NULL) when a row is promoted to `dead`, since a
+    // terminal row no longer schedules a next attempt. Queued/retrying
+    // rows always carry a concrete timestamp (defaults to now()).
+    nextAttemptAt  DateTime?           @default(now())
     lastError      String?
     lastErrorAt    DateTime?
     dispatchedAt   DateTime?

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/backoff.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/backoff.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateBackoffMs,
+  DEFAULT_BACKOFF_CAP_MS,
+} from "../backoff";
+
+describe("calculateBackoffMs", () => {
+  describe("given an attempt count of 0", () => {
+    it("returns 0 (no backoff for an unattempted row)", () => {
+      expect(calculateBackoffMs({ attempts: 0, random: () => 1 })).toBe(0);
+    });
+  });
+
+  describe("given a deterministic random source", () => {
+    it("doubles the exponential ceiling on each attempt", () => {
+      const constantRandom = () => 1;
+      expect(
+        calculateBackoffMs({
+          attempts: 1,
+          baseMs: 1000,
+          random: constantRandom,
+        }),
+      ).toBe(1000);
+      expect(
+        calculateBackoffMs({
+          attempts: 2,
+          baseMs: 1000,
+          random: constantRandom,
+        }),
+      ).toBe(2000);
+      expect(
+        calculateBackoffMs({
+          attempts: 5,
+          baseMs: 1000,
+          random: constantRandom,
+        }),
+      ).toBe(16000);
+    });
+  });
+
+  describe("when the exponential exceeds the cap", () => {
+    it("clamps to the cap", () => {
+      const constantRandom = () => 1;
+      const ms = calculateBackoffMs({
+        attempts: 50,
+        baseMs: 1000,
+        random: constantRandom,
+        capMs: 30 * 60 * 1000,
+      });
+      expect(ms).toBe(30 * 60 * 1000);
+    });
+
+    it("clamps to the default 30-minute cap when no override is provided", () => {
+      const constantRandom = () => 1;
+      const ms = calculateBackoffMs({ attempts: 50, random: constantRandom });
+      expect(ms).toBe(DEFAULT_BACKOFF_CAP_MS);
+    });
+  });
+
+  describe("when full jitter is applied", () => {
+    it("returns a value between 0 and the exponential ceiling", () => {
+      const minResult = calculateBackoffMs({
+        attempts: 4,
+        baseMs: 1000,
+        random: () => 0,
+      });
+      const maxResult = calculateBackoffMs({
+        attempts: 4,
+        baseMs: 1000,
+        random: () => 0.9999,
+      });
+      expect(minResult).toBe(0);
+      expect(maxResult).toBeLessThanOrEqual(8000);
+      expect(maxResult).toBeGreaterThan(7000);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { DispatchError, isDispatchError } from "../dispatchError";
+
+describe("DispatchError", () => {
+  describe("when constructed", () => {
+    it("captures message, retryable flag, and cause", () => {
+      const cause = new Error("inner");
+      const err = new DispatchError({
+        message: "outer",
+        retryable: false,
+        cause,
+      });
+      expect(err.message).toBe("outer");
+      expect(err.retryable).toBe(false);
+      expect(err.cause).toBe(cause);
+      expect(err.name).toBe("DispatchError");
+    });
+
+    it("identifies as a real Error", () => {
+      const err = new DispatchError({ message: "x", retryable: true });
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(DispatchError);
+    });
+  });
+});
+
+describe("isDispatchError", () => {
+  describe("when given a DispatchError instance", () => {
+    it("returns true", () => {
+      expect(
+        isDispatchError(new DispatchError({ message: "x", retryable: true })),
+      ).toBe(true);
+    });
+  });
+
+  describe("when given anything else", () => {
+    it("returns false", () => {
+      expect(isDispatchError(new Error("plain"))).toBe(false);
+      expect(isDispatchError("string-error")).toBe(false);
+      expect(isDispatchError(null)).toBe(false);
+      expect(isDispatchError(undefined)).toBe(false);
+      expect(isDispatchError({ retryable: true })).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
@@ -24,15 +24,15 @@ class StubRepository implements OutboxRepository {
       async () => 0,
     );
   markDispatched =
-    vi.fn<(args: { rowId: string; now: Date }) => Promise<void>>(
-      async () => undefined,
-    );
+    vi.fn<
+      (args: { rowId: string; projectId: string; now: Date }) => Promise<void>
+    >(async () => undefined);
   markRetry = vi.fn<(update: OutboxRetryUpdate) => Promise<void>>(
     async () => undefined,
   );
-  findById = vi.fn<(rowId: string) => Promise<OutboxRow | null>>(
-    async (id: string) => this.rows.find((r) => r.id === id) ?? null,
-  );
+  findById = vi.fn<
+    (args: { rowId: string; projectId: string }) => Promise<OutboxRow | null>
+  >(async ({ rowId }) => this.rows.find((r) => r.id === rowId) ?? null);
   list = vi.fn<() => Promise<OutboxRow[]>>(async () => []);
 }
 
@@ -218,6 +218,30 @@ describe("OutboxDrainer.handleWakeup", () => {
       expect(dispatcher).toHaveBeenCalledTimes(3);
       expect(scheduleWakeup).toHaveBeenCalledTimes(1);
       expect(scheduleWakeup.mock.calls[0]![0].delayMs).toBeUndefined();
+    });
+  });
+
+  describe("when constructed with a non-positive maxRowsPerWakeup", () => {
+    it("throws so a wakeup-churn loop cannot be wired up", () => {
+      expect(
+        () =>
+          new OutboxDrainer(service, {
+            scheduleWakeup,
+            maxRowsPerWakeup: 0,
+          }),
+      ).toThrow(/maxRowsPerWakeup must be > 0/);
+    });
+  });
+
+  describe("when constructed with a non-positive leaseDurationMs", () => {
+    it("throws so already-expired leases cannot be handed out", () => {
+      expect(
+        () =>
+          new OutboxDrainer(service, {
+            scheduleWakeup,
+            leaseDurationMs: 0,
+          }),
+      ).toThrow(/leaseDurationMs must be > 0/);
     });
   });
 

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DispatchError } from "../dispatchError";
+import { OutboxDrainer } from "../drainer";
+import { OutboxService } from "../outbox.service";
+import type { OutboxRepository } from "../outbox.repository";
+import type { OutboxRow } from "../outbox.types";
+import type { OutboxWakeup } from "../wakeupQueue";
+
+class StubRepository implements OutboxRepository {
+  rows: OutboxRow[] = [];
+  insertIfAbsent = vi.fn(async () => true);
+  leaseNext = vi.fn(async () => null as OutboxRow | null);
+  recoverExpiredLeases = vi.fn(async () => 0);
+  markDispatched = vi.fn(async () => undefined);
+  markRetry = vi.fn(async () => undefined);
+  findById = vi.fn(async (id: string) =>
+    this.rows.find((r) => r.id === id) ?? null,
+  );
+  list = vi.fn(async () => [] as OutboxRow[]);
+}
+
+function makeRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
+  const now = new Date("2026-05-28T12:00:00Z");
+  return {
+    id: "row-1",
+    projectId: "proj1",
+    reactorName: "alertDispatch",
+    dedupKey: "k",
+    groupKey: "proj1",
+    payload: {},
+    status: "dispatching",
+    attempts: 1,
+    maxAttempts: 8,
+    leasedUntil: now,
+    nextAttemptAt: now,
+    lastError: null,
+    lastErrorAt: null,
+    dispatchedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+const baseWakeup: OutboxWakeup = {
+  reactorName: "alertDispatch",
+  groupKey: "proj1",
+  tenantId: "proj1",
+  scheduledAt: Date.now(),
+};
+
+describe("OutboxDrainer.handleWakeup", () => {
+  let repo: StubRepository;
+  let service: OutboxService;
+  let scheduleWakeup: ReturnType<typeof vi.fn>;
+  let drainer: OutboxDrainer;
+
+  beforeEach(() => {
+    repo = new StubRepository();
+    service = new OutboxService(repo);
+    scheduleWakeup = vi.fn(async () => undefined);
+    drainer = new OutboxDrainer(service, {
+      scheduleWakeup,
+      maxRowsPerWakeup: 3,
+    });
+  });
+
+  describe("when no dispatcher is registered for the wakeup", () => {
+    it("returns without leasing or calling scheduleWakeup", async () => {
+      await drainer.handleWakeup(baseWakeup);
+      expect(repo.leaseNext).not.toHaveBeenCalled();
+      expect(scheduleWakeup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the dispatcher succeeds for every leased row", () => {
+    it("marks each row dispatched and stops when the queue is empty", async () => {
+      const dispatcher = vi.fn(async () => undefined);
+      drainer.registerDispatcher("alertDispatch", dispatcher);
+      const rowA = makeRow({ id: "a" });
+      const rowB = makeRow({ id: "b" });
+      repo.rows = [rowA, rowB];
+      repo.leaseNext
+        .mockResolvedValueOnce(rowA)
+        .mockResolvedValueOnce(rowB)
+        .mockResolvedValueOnce(null);
+
+      await drainer.handleWakeup(baseWakeup);
+
+      expect(dispatcher).toHaveBeenCalledTimes(2);
+      expect(repo.markDispatched).toHaveBeenCalledTimes(2);
+      expect(repo.markDispatched).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ rowId: "a" }),
+      );
+      expect(scheduleWakeup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the dispatcher throws a retryable DispatchError", () => {
+    it("schedules a backoff retry and a delayed follow-up wakeup", async () => {
+      const dispatcher = vi.fn(async () => {
+        throw new DispatchError({
+          message: "503 from provider",
+          retryable: true,
+        });
+      });
+      drainer.registerDispatcher("alertDispatch", dispatcher);
+      const row = makeRow({ attempts: 1 });
+      repo.rows = [row];
+      repo.leaseNext
+        .mockResolvedValueOnce(row)
+        .mockResolvedValueOnce(null);
+
+      await drainer.handleWakeup(baseWakeup);
+
+      expect(repo.markRetry).toHaveBeenCalledTimes(1);
+      const update = repo.markRetry.mock.calls[0]![0];
+      expect(update.status).toBe("failed_retryable");
+      expect(update.lastError).toBe("503 from provider");
+      expect(scheduleWakeup).toHaveBeenCalledTimes(1);
+      expect(scheduleWakeup.mock.calls[0]![0].delayMs).toBeGreaterThanOrEqual(
+        0,
+      );
+    });
+  });
+
+  describe("when the dispatcher throws a non-retryable DispatchError", () => {
+    it("marks the row dead and does not schedule a follow-up", async () => {
+      const dispatcher = vi.fn(async () => {
+        throw new DispatchError({
+          message: "401 invalid Slack token",
+          retryable: false,
+        });
+      });
+      drainer.registerDispatcher("alertDispatch", dispatcher);
+      const row = makeRow();
+      repo.rows = [row];
+      repo.leaseNext
+        .mockResolvedValueOnce(row)
+        .mockResolvedValueOnce(null);
+
+      await drainer.handleWakeup(baseWakeup);
+
+      expect(repo.markRetry).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "dead" }),
+      );
+      expect(scheduleWakeup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the dispatcher throws an unclassified error", () => {
+    it("treats it as retryable", async () => {
+      const dispatcher = vi.fn(async () => {
+        throw new Error("ECONNRESET");
+      });
+      drainer.registerDispatcher("alertDispatch", dispatcher);
+      const row = makeRow({ attempts: 1 });
+      repo.rows = [row];
+      repo.leaseNext
+        .mockResolvedValueOnce(row)
+        .mockResolvedValueOnce(null);
+
+      await drainer.handleWakeup(baseWakeup);
+
+      expect(repo.markRetry).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "failed_retryable" }),
+      );
+    });
+  });
+
+  describe("when maxRowsPerWakeup is reached and rows remain", () => {
+    it("schedules an immediate follow-up wakeup to yield", async () => {
+      const dispatcher = vi.fn(async () => undefined);
+      drainer.registerDispatcher("alertDispatch", dispatcher);
+      repo.rows = [makeRow({ id: "a" }), makeRow({ id: "b" }), makeRow({ id: "c" })];
+      repo.leaseNext
+        .mockResolvedValueOnce(repo.rows[0]!)
+        .mockResolvedValueOnce(repo.rows[1]!)
+        .mockResolvedValueOnce(repo.rows[2]!);
+
+      await drainer.handleWakeup(baseWakeup);
+
+      expect(dispatcher).toHaveBeenCalledTimes(3);
+      expect(scheduleWakeup).toHaveBeenCalledTimes(1);
+      expect(scheduleWakeup.mock.calls[0]![0].delayMs).toBeUndefined();
+    });
+  });
+
+  describe("when a dispatcher is registered twice for the same name", () => {
+    it("throws", () => {
+      drainer.registerDispatcher("alertDispatch", async () => undefined);
+      expect(() =>
+        drainer.registerDispatcher("alertDispatch", async () => undefined),
+      ).toThrow(/already registered/);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
@@ -44,7 +44,7 @@ function makeRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
     id: "row-1",
     projectId: "proj1",
     reactorName: "alertDispatch",
-    dedupKey: "trigger1:trace:trace1",
+    dedupKey: "proj1/trigger1:trace:trace1",
     groupKey: "proj1/alertDispatch:trigger1",
     payload: {},
     status: "dispatching",

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
@@ -127,6 +127,15 @@ describe("OutboxDrainer.handleWakeup", () => {
         1,
         expect.objectContaining({ rowId: "a" }),
       );
+      // groupKey from the wakeup is forwarded to the lease query so a
+      // wakeup for trigger A can never lease trigger B's row.
+      expect(repo.leaseNext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          groupKey: baseWakeup.groupKey,
+        }),
+      );
       expect(scheduleWakeup).not.toHaveBeenCalled();
     });
   });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
@@ -25,8 +25,8 @@ function makeRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
     id: "row-1",
     projectId: "proj1",
     reactorName: "alertDispatch",
-    dedupKey: "k",
-    groupKey: "proj1",
+    dedupKey: "trigger1:trace:trace1",
+    groupKey: "proj1/alertDispatch:trigger1",
     payload: {},
     status: "dispatching",
     attempts: 1,
@@ -44,8 +44,7 @@ function makeRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
 
 const baseWakeup: OutboxWakeup = {
   reactorName: "alertDispatch",
-  groupKey: "proj1",
-  tenantId: "proj1",
+  groupKey: "proj1/alertDispatch:trigger1",
   scheduledAt: Date.now(),
 };
 
@@ -69,6 +68,22 @@ describe("OutboxDrainer.handleWakeup", () => {
     it("returns without leasing or calling scheduleWakeup", async () => {
       await drainer.handleWakeup(baseWakeup);
       expect(repo.leaseNext).not.toHaveBeenCalled();
+      expect(scheduleWakeup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the wakeup groupKey is missing the `${projectId}/` prefix", () => {
+    it("drops it without leasing (ADR-023 contract)", async () => {
+      const dispatcher = vi.fn(async () => undefined);
+      drainer.registerDispatcher("alertDispatch", dispatcher);
+
+      await drainer.handleWakeup({
+        ...baseWakeup,
+        groupKey: "alertDispatch:trigger1",
+      });
+
+      expect(repo.leaseNext).not.toHaveBeenCalled();
+      expect(dispatcher).not.toHaveBeenCalled();
       expect(scheduleWakeup).not.toHaveBeenCalled();
     });
   });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
@@ -1,23 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DispatchError } from "../dispatchError";
-import { OutboxDrainer } from "../drainer";
+import { OutboxDrainer, type OutboxDrainerOptions } from "../drainer";
 import { OutboxService } from "../outbox.service";
-import type { OutboxRepository } from "../outbox.repository";
+import type {
+  OutboxLeaseQuery,
+  OutboxRepository,
+  OutboxRetryUpdate,
+} from "../outbox.repository";
 import type { OutboxRow } from "../outbox.types";
 import type { OutboxWakeup } from "../wakeupQueue";
 
 class StubRepository implements OutboxRepository {
   rows: OutboxRow[] = [];
-  insertIfAbsent = vi.fn(async () => true);
-  leaseNext = vi.fn(async () => null as OutboxRow | null);
-  recoverExpiredLeases = vi.fn(async () => 0);
-  markDispatched = vi.fn(async () => undefined);
-  markRetry = vi.fn(async () => undefined);
-  findById = vi.fn(async (id: string) =>
-    this.rows.find((r) => r.id === id) ?? null,
+  insertIfAbsent =
+    vi.fn<(row: { reactorName: string; dedupKey: string }) => Promise<boolean>>(
+      async () => true,
+    );
+  leaseNext = vi.fn<(query: OutboxLeaseQuery) => Promise<OutboxRow | null>>(
+    async () => null,
   );
-  list = vi.fn(async () => [] as OutboxRow[]);
+  recoverExpiredLeases =
+    vi.fn<(args: { now: Date; limit: number }) => Promise<number>>(
+      async () => 0,
+    );
+  markDispatched =
+    vi.fn<(args: { rowId: string; now: Date }) => Promise<void>>(
+      async () => undefined,
+    );
+  markRetry = vi.fn<(update: OutboxRetryUpdate) => Promise<void>>(
+    async () => undefined,
+  );
+  findById = vi.fn<(rowId: string) => Promise<OutboxRow | null>>(
+    async (id: string) => this.rows.find((r) => r.id === id) ?? null,
+  );
+  list = vi.fn<() => Promise<OutboxRow[]>>(async () => []);
 }
+
+type ScheduleWakeup = OutboxDrainerOptions["scheduleWakeup"];
 
 function makeRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
   const now = new Date("2026-05-28T12:00:00Z");
@@ -51,13 +70,13 @@ const baseWakeup: OutboxWakeup = {
 describe("OutboxDrainer.handleWakeup", () => {
   let repo: StubRepository;
   let service: OutboxService;
-  let scheduleWakeup: ReturnType<typeof vi.fn>;
+  let scheduleWakeup: ReturnType<typeof vi.fn<ScheduleWakeup>>;
   let drainer: OutboxDrainer;
 
   beforeEach(() => {
     repo = new StubRepository();
     service = new OutboxService(repo);
-    scheduleWakeup = vi.fn(async () => undefined);
+    scheduleWakeup = vi.fn<ScheduleWakeup>(async () => undefined);
     drainer = new OutboxDrainer(service, {
       scheduleWakeup,
       maxRowsPerWakeup: 3,

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
@@ -17,44 +17,19 @@ import {
   it,
 } from "vitest";
 import { KSUID_RESOURCES } from "../../../../utils/constants";
+import { getTestProject } from "../../../../utils/testUtils";
 import { prisma } from "../../../db";
 import { PrismaOutboxRepository } from "../outbox.prisma.repository";
 
 const reactorName = `test-reactor-${generate(KSUID_RESOURCES.PROJECT)}`;
 
-async function ensureProject(): Promise<string> {
-  const projectId = `proj-${generate(KSUID_RESOURCES.PROJECT)}`;
-  // Minimal Project — relies on the test DB having Organization/Team
-  // fixtures available. We borrow whichever team already exists; if
-  // none, the test is skipped.
-  const team = await prisma.team.findFirst();
-  if (!team) {
-    throw new Error(
-      "ReactorOutbox integration tests need an existing Team fixture",
-    );
-  }
-  await prisma.project.create({
-    data: {
-      id: projectId,
-      name: "ReactorOutbox integration test",
-      slug: projectId,
-      apiKey: `key-${projectId}`,
-      teamId: team.id,
-      framework: "test",
-      language: "ts",
-    },
-  });
-  return projectId;
-}
-
 describe("PrismaOutboxRepository", () => {
   const repo = new PrismaOutboxRepository(prisma);
   let projectId: string;
-  const createdProjectIds: string[] = [];
 
   beforeAll(async () => {
-    projectId = await ensureProject();
-    createdProjectIds.push(projectId);
+    const project = await getTestProject("reactor-outbox");
+    projectId = project.id;
   });
 
   afterEach(async () => {
@@ -62,11 +37,8 @@ describe("PrismaOutboxRepository", () => {
   });
 
   afterAll(async () => {
-    if (createdProjectIds.length > 0) {
-      await prisma.project.deleteMany({
-        where: { id: { in: createdProjectIds } },
-      });
-    }
+    // Project / team / org are reused fixtures — don't delete them.
+    await prisma.reactorOutbox.deleteMany({ where: { reactorName } });
   });
 
   describe("insertIfAbsent", () => {

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
@@ -168,4 +168,109 @@ describe("PrismaOutboxRepository", () => {
       });
     });
   });
+
+  describe("markDispatched", () => {
+    describe("when the row is still leased to this worker", () => {
+      it("marks it dispatched (scoped by projectId)", async () => {
+        await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: "dispatch-me",
+          groupKey: `${projectId}/${reactorName}:trigger-A`,
+          payload: {},
+        });
+        const leased = await repo.leaseNext({
+          projectId,
+          reactorName,
+          leasedUntil: new Date(Date.now() + 60_000),
+          now: new Date(),
+        });
+        expect(leased).not.toBeNull();
+
+        await repo.markDispatched({
+          rowId: leased!.id,
+          projectId,
+          now: new Date(),
+        });
+
+        const row = await repo.findById({ rowId: leased!.id, projectId });
+        expect(row?.status).toBe("dispatched");
+        expect(row?.leasedUntil).toBeNull();
+        expect(row?.dispatchedAt).not.toBeNull();
+      });
+    });
+  });
+
+  describe("markRetry", () => {
+    describe("when the attempts count no longer matches the leased row", () => {
+      it("no-ops so a stale worker cannot clobber a re-leased row", async () => {
+        await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: "cas-guard",
+          groupKey: `${projectId}/${reactorName}:trigger-A`,
+          payload: {},
+        });
+        const leased = await repo.leaseNext({
+          projectId,
+          reactorName,
+          leasedUntil: new Date(Date.now() + 60_000),
+          now: new Date(),
+        });
+        // Simulate a concurrent recovery + re-lease bumping attempts.
+        await prisma.reactorOutbox.update({
+          where: { id: leased!.id },
+          data: { attempts: leased!.attempts + 1 },
+        });
+
+        await repo.markRetry({
+          rowId: leased!.id,
+          projectId,
+          attempts: leased!.attempts,
+          status: "failed_retryable",
+          nextAttemptAt: new Date(Date.now() + 1_000),
+          lastError: "stale",
+          lastErrorAt: new Date(),
+        });
+
+        const row = await repo.findById({ rowId: leased!.id, projectId });
+        // Untouched: still dispatching, lastError never written.
+        expect(row?.status).toBe("dispatching");
+        expect(row?.lastError).toBeNull();
+      });
+    });
+
+    describe("when promoting an exhausted row to dead", () => {
+      it("clears nextAttemptAt to null", async () => {
+        await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: "dead-row",
+          groupKey: `${projectId}/${reactorName}:trigger-A`,
+          payload: {},
+          maxAttempts: 1,
+        });
+        const leased = await repo.leaseNext({
+          projectId,
+          reactorName,
+          leasedUntil: new Date(Date.now() + 60_000),
+          now: new Date(),
+        });
+
+        await repo.markRetry({
+          rowId: leased!.id,
+          projectId,
+          attempts: leased!.attempts,
+          status: "dead",
+          nextAttemptAt: null,
+          lastError: "exhausted",
+          lastErrorAt: new Date(),
+        });
+
+        const row = await repo.findById({ rowId: leased!.id, projectId });
+        expect(row?.status).toBe("dead");
+        expect(row?.nextAttemptAt).toBeNull();
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
@@ -33,12 +33,12 @@ describe("PrismaOutboxRepository", () => {
   });
 
   afterEach(async () => {
-    await prisma.reactorOutbox.deleteMany({ where: { reactorName } });
+    await prisma.reactorOutbox.deleteMany({ where: { projectId, reactorName } });
   });
 
   afterAll(async () => {
     // Project / team / org are reused fixtures — don't delete them.
-    await prisma.reactorOutbox.deleteMany({ where: { reactorName } });
+    await prisma.reactorOutbox.deleteMany({ where: { projectId, reactorName } });
   });
 
   describe("insertIfAbsent", () => {
@@ -54,7 +54,7 @@ describe("PrismaOutboxRepository", () => {
         expect(inserted).toBe(true);
 
         const rows = await prisma.reactorOutbox.findMany({
-          where: { reactorName },
+          where: { projectId, reactorName },
         });
         expect(rows).toHaveLength(1);
         expect(rows[0]?.status).toBe("queued");
@@ -79,7 +79,7 @@ describe("PrismaOutboxRepository", () => {
         });
         expect(second).toBe(false);
         const rows = await prisma.reactorOutbox.findMany({
-          where: { reactorName },
+          where: { projectId, reactorName },
         });
         expect(rows).toHaveLength(1);
         expect((rows[0]?.payload as { v: number }).v).toBe(1);
@@ -161,7 +161,7 @@ describe("PrismaOutboxRepository", () => {
         expect(recovered).toBe(1);
 
         const row = await prisma.reactorOutbox.findFirst({
-          where: { reactorName },
+          where: { projectId, reactorName },
         });
         expect(row?.status).toBe("queued");
         expect(row?.leasedUntil).toBeNull();
@@ -218,8 +218,8 @@ describe("PrismaOutboxRepository", () => {
           now: new Date(),
         });
         // Simulate a concurrent recovery + re-lease bumping attempts.
-        await prisma.reactorOutbox.update({
-          where: { id: leased!.id },
+        await prisma.reactorOutbox.updateMany({
+          where: { id: leased!.id, projectId },
           data: { attempts: leased!.attempts + 1 },
         });
 

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for PrismaOutboxRepository — exercises the
+ * postgres-specific paths that an in-memory fake cannot model:
+ *   - createMany skipDuplicates as the atomic claim primitive
+ *   - FOR UPDATE SKIP LOCKED contention between concurrent leasers
+ *   - lease recovery after expiry
+ */
+import { generate } from "@langwatch/ksuid";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { KSUID_RESOURCES } from "../../../../utils/constants";
+import { prisma } from "../../../db";
+import { PrismaOutboxRepository } from "../outbox.prisma.repository";
+
+const reactorName = `test-reactor-${generate(KSUID_RESOURCES.PROJECT)}`;
+
+async function ensureProject(): Promise<string> {
+  const projectId = `proj-${generate(KSUID_RESOURCES.PROJECT)}`;
+  // Minimal Project — relies on the test DB having Organization/Team
+  // fixtures available. We borrow whichever team already exists; if
+  // none, the test is skipped.
+  const team = await prisma.team.findFirst();
+  if (!team) {
+    throw new Error(
+      "ReactorOutbox integration tests need an existing Team fixture",
+    );
+  }
+  await prisma.project.create({
+    data: {
+      id: projectId,
+      name: "ReactorOutbox integration test",
+      slug: projectId,
+      apiKey: `key-${projectId}`,
+      teamId: team.id,
+      framework: "test",
+      language: "ts",
+    },
+  });
+  return projectId;
+}
+
+describe("PrismaOutboxRepository", () => {
+  const repo = new PrismaOutboxRepository(prisma);
+  let projectId: string;
+  const createdProjectIds: string[] = [];
+
+  beforeAll(async () => {
+    projectId = await ensureProject();
+    createdProjectIds.push(projectId);
+  });
+
+  afterEach(async () => {
+    await prisma.reactorOutbox.deleteMany({ where: { reactorName } });
+  });
+
+  afterAll(async () => {
+    if (createdProjectIds.length > 0) {
+      await prisma.project.deleteMany({
+        where: { id: { in: createdProjectIds } },
+      });
+    }
+  });
+
+  describe("insertIfAbsent", () => {
+    describe("when no row exists for (reactorName, dedupKey)", () => {
+      it("inserts and returns true", async () => {
+        const inserted = await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: "trigger-A:trace-1",
+          groupKey: projectId,
+          payload: { triggerId: "trigger-A" },
+        });
+        expect(inserted).toBe(true);
+
+        const rows = await prisma.reactorOutbox.findMany({
+          where: { reactorName },
+        });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.status).toBe("queued");
+      });
+    });
+
+    describe("when a row exists for (reactorName, dedupKey)", () => {
+      it("returns false and leaves the existing row untouched", async () => {
+        await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: "trigger-A:trace-1",
+          groupKey: projectId,
+          payload: { v: 1 },
+        });
+        const second = await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: "trigger-A:trace-1",
+          groupKey: projectId,
+          payload: { v: 2 },
+        });
+        expect(second).toBe(false);
+        const rows = await prisma.reactorOutbox.findMany({
+          where: { reactorName },
+        });
+        expect(rows).toHaveLength(1);
+        expect((rows[0]?.payload as { v: number }).v).toBe(1);
+      });
+    });
+  });
+
+  describe("leaseNext", () => {
+    describe("when two concurrent leasers race on a single queued row", () => {
+      it("hands the row to exactly one of them", async () => {
+        await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: "only-one",
+          groupKey: projectId,
+          payload: {},
+        });
+
+        const now = new Date();
+        const leasedUntil = new Date(now.getTime() + 60_000);
+
+        const [a, b] = await Promise.all([
+          repo.leaseNext({ projectId, reactorName, leasedUntil, now }),
+          repo.leaseNext({ projectId, reactorName, leasedUntil, now }),
+        ]);
+
+        const winners = [a, b].filter((r) => r !== null);
+        expect(winners).toHaveLength(1);
+      });
+    });
+
+    describe("when a row's nextAttemptAt is in the future", () => {
+      it("does not lease it", async () => {
+        const future = new Date(Date.now() + 60_000);
+        await prisma.reactorOutbox.create({
+          data: {
+            projectId,
+            reactorName,
+            dedupKey: "backoff",
+            groupKey: projectId,
+            payload: {},
+            nextAttemptAt: future,
+            status: "failed_retryable",
+          },
+        });
+
+        const leased = await repo.leaseNext({
+          projectId,
+          reactorName,
+          leasedUntil: new Date(Date.now() + 30_000),
+          now: new Date(),
+        });
+        expect(leased).toBeNull();
+      });
+    });
+  });
+
+  describe("recoverExpiredLeases", () => {
+    describe("when a row's leasedUntil has passed", () => {
+      it("flips it back to queued", async () => {
+        const past = new Date(Date.now() - 60_000);
+        await prisma.reactorOutbox.create({
+          data: {
+            projectId,
+            reactorName,
+            dedupKey: "expired",
+            groupKey: projectId,
+            payload: {},
+            status: "dispatching",
+            leasedUntil: past,
+            attempts: 1,
+          },
+        });
+
+        const recovered = await repo.recoverExpiredLeases({
+          now: new Date(),
+          limit: 10,
+        });
+        expect(recovered).toBe(1);
+
+        const row = await prisma.reactorOutbox.findFirst({
+          where: { reactorName },
+        });
+        expect(row?.status).toBe("queued");
+        expect(row?.leasedUntil).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
@@ -76,7 +76,7 @@ describe("PrismaOutboxRepository", () => {
           projectId,
           reactorName,
           dedupKey: "trigger-A:trace-1",
-          groupKey: projectId,
+          groupKey: `${projectId}/${reactorName}:trigger-A`,
           payload: { triggerId: "trigger-A" },
         });
         expect(inserted).toBe(true);
@@ -95,14 +95,14 @@ describe("PrismaOutboxRepository", () => {
           projectId,
           reactorName,
           dedupKey: "trigger-A:trace-1",
-          groupKey: projectId,
+          groupKey: `${projectId}/${reactorName}:trigger-A`,
           payload: { v: 1 },
         });
         const second = await repo.insertIfAbsent({
           projectId,
           reactorName,
           dedupKey: "trigger-A:trace-1",
-          groupKey: projectId,
+          groupKey: `${projectId}/${reactorName}:trigger-A`,
           payload: { v: 2 },
         });
         expect(second).toBe(false);
@@ -122,7 +122,7 @@ describe("PrismaOutboxRepository", () => {
           projectId,
           reactorName,
           dedupKey: "only-one",
-          groupKey: projectId,
+          groupKey: `${projectId}/${reactorName}:trigger-A`,
           payload: {},
         });
 
@@ -147,7 +147,7 @@ describe("PrismaOutboxRepository", () => {
             projectId,
             reactorName,
             dedupKey: "backoff",
-            groupKey: projectId,
+            groupKey: `${projectId}/${reactorName}:trigger-A`,
             payload: {},
             nextAttemptAt: future,
             status: "failed_retryable",
@@ -174,7 +174,7 @@ describe("PrismaOutboxRepository", () => {
             projectId,
             reactorName,
             dedupKey: "expired",
-            groupKey: projectId,
+            groupKey: `${projectId}/${reactorName}:trigger-A`,
             payload: {},
             status: "dispatching",
             leasedUntil: past,

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
@@ -90,11 +90,12 @@ describe("PrismaOutboxRepository", () => {
   describe("leaseNext", () => {
     describe("when two concurrent leasers race on a single queued row", () => {
       it("hands the row to exactly one of them", async () => {
+        const groupKey = `${projectId}/${reactorName}:trigger-A`;
         await repo.insertIfAbsent({
           projectId,
           reactorName,
-          dedupKey: "only-one",
-          groupKey: `${projectId}/${reactorName}:trigger-A`,
+          dedupKey: `${projectId}/only-one`,
+          groupKey,
           payload: {},
         });
 
@@ -102,8 +103,8 @@ describe("PrismaOutboxRepository", () => {
         const leasedUntil = new Date(now.getTime() + 60_000);
 
         const [a, b] = await Promise.all([
-          repo.leaseNext({ projectId, reactorName, leasedUntil, now }),
-          repo.leaseNext({ projectId, reactorName, leasedUntil, now }),
+          repo.leaseNext({ projectId, reactorName, groupKey, leasedUntil, now }),
+          repo.leaseNext({ projectId, reactorName, groupKey, leasedUntil, now }),
         ]);
 
         const winners = [a, b].filter((r) => r !== null);
@@ -114,12 +115,13 @@ describe("PrismaOutboxRepository", () => {
     describe("when a row's nextAttemptAt is in the future", () => {
       it("does not lease it", async () => {
         const future = new Date(Date.now() + 60_000);
+        const groupKey = `${projectId}/${reactorName}:trigger-A`;
         await prisma.reactorOutbox.create({
           data: {
             projectId,
             reactorName,
-            dedupKey: "backoff",
-            groupKey: `${projectId}/${reactorName}:trigger-A`,
+            dedupKey: `${projectId}/backoff`,
+            groupKey,
             payload: {},
             nextAttemptAt: future,
             status: "failed_retryable",
@@ -129,9 +131,69 @@ describe("PrismaOutboxRepository", () => {
         const leased = await repo.leaseNext({
           projectId,
           reactorName,
+          groupKey,
           leasedUntil: new Date(Date.now() + 30_000),
           now: new Date(),
         });
+        expect(leased).toBeNull();
+      });
+    });
+
+    describe("when two groupKeys share the same (projectId, reactorName)", () => {
+      it("does not let a wakeup for trigger-A lease trigger-B's row", async () => {
+        const groupA = `${projectId}/${reactorName}:trigger-A`;
+        const groupB = `${projectId}/${reactorName}:trigger-B`;
+        // Trigger-B's row is enqueued first so its nextAttemptAt is
+        // strictly earlier — without groupKey scoping, the lease for
+        // trigger-A would steal it.
+        await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: `${projectId}/trigger-B:trace:1`,
+          groupKey: groupB,
+          payload: { trigger: "B" },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: `${projectId}/trigger-A:trace:1`,
+          groupKey: groupA,
+          payload: { trigger: "A" },
+        });
+
+        const leased = await repo.leaseNext({
+          projectId,
+          reactorName,
+          groupKey: groupA,
+          leasedUntil: new Date(Date.now() + 60_000),
+          now: new Date(),
+        });
+
+        expect(leased).not.toBeNull();
+        expect(leased?.groupKey).toBe(groupA);
+        expect((leased?.payload as { trigger: string }).trigger).toBe("A");
+      });
+
+      it("returns null when nothing claimable exists for the requested group", async () => {
+        const groupA = `${projectId}/${reactorName}:trigger-A`;
+        const groupB = `${projectId}/${reactorName}:trigger-B`;
+        await repo.insertIfAbsent({
+          projectId,
+          reactorName,
+          dedupKey: `${projectId}/only-b`,
+          groupKey: groupB,
+          payload: {},
+        });
+
+        const leased = await repo.leaseNext({
+          projectId,
+          reactorName,
+          groupKey: groupA,
+          leasedUntil: new Date(Date.now() + 60_000),
+          now: new Date(),
+        });
+
         expect(leased).toBeNull();
       });
     });
@@ -145,7 +207,7 @@ describe("PrismaOutboxRepository", () => {
           data: {
             projectId,
             reactorName,
-            dedupKey: "expired",
+            dedupKey: `${projectId}/expired`,
             groupKey: `${projectId}/${reactorName}:trigger-A`,
             payload: {},
             status: "dispatching",
@@ -172,16 +234,18 @@ describe("PrismaOutboxRepository", () => {
   describe("markDispatched", () => {
     describe("when the row is still leased to this worker", () => {
       it("marks it dispatched (scoped by projectId)", async () => {
+        const groupKey = `${projectId}/${reactorName}:trigger-A`;
         await repo.insertIfAbsent({
           projectId,
           reactorName,
-          dedupKey: "dispatch-me",
-          groupKey: `${projectId}/${reactorName}:trigger-A`,
+          dedupKey: `${projectId}/dispatch-me`,
+          groupKey,
           payload: {},
         });
         const leased = await repo.leaseNext({
           projectId,
           reactorName,
+          groupKey,
           leasedUntil: new Date(Date.now() + 60_000),
           now: new Date(),
         });
@@ -204,16 +268,18 @@ describe("PrismaOutboxRepository", () => {
   describe("markRetry", () => {
     describe("when the attempts count no longer matches the leased row", () => {
       it("no-ops so a stale worker cannot clobber a re-leased row", async () => {
+        const groupKey = `${projectId}/${reactorName}:trigger-A`;
         await repo.insertIfAbsent({
           projectId,
           reactorName,
-          dedupKey: "cas-guard",
-          groupKey: `${projectId}/${reactorName}:trigger-A`,
+          dedupKey: `${projectId}/cas-guard`,
+          groupKey,
           payload: {},
         });
         const leased = await repo.leaseNext({
           projectId,
           reactorName,
+          groupKey,
           leasedUntil: new Date(Date.now() + 60_000),
           now: new Date(),
         });
@@ -242,17 +308,19 @@ describe("PrismaOutboxRepository", () => {
 
     describe("when promoting an exhausted row to dead", () => {
       it("clears nextAttemptAt to null", async () => {
+        const groupKey = `${projectId}/${reactorName}:trigger-A`;
         await repo.insertIfAbsent({
           projectId,
           reactorName,
-          dedupKey: "dead-row",
-          groupKey: `${projectId}/${reactorName}:trigger-A`,
+          dedupKey: `${projectId}/dead-row`,
+          groupKey,
           payload: {},
           maxAttempts: 1,
         });
         const leased = await repo.leaseNext({
           projectId,
           reactorName,
+          groupKey,
           leasedUntil: new Date(Date.now() + 60_000),
           now: new Date(),
         });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts
@@ -47,7 +47,7 @@ describe("PrismaOutboxRepository", () => {
         const inserted = await repo.insertIfAbsent({
           projectId,
           reactorName,
-          dedupKey: "trigger-A:trace-1",
+          dedupKey: `${projectId}/trigger-A:trace:trace-1`,
           groupKey: `${projectId}/${reactorName}:trigger-A`,
           payload: { triggerId: "trigger-A" },
         });
@@ -66,14 +66,14 @@ describe("PrismaOutboxRepository", () => {
         await repo.insertIfAbsent({
           projectId,
           reactorName,
-          dedupKey: "trigger-A:trace-1",
+          dedupKey: `${projectId}/trigger-A:trace:trace-1`,
           groupKey: `${projectId}/${reactorName}:trigger-A`,
           payload: { v: 1 },
         });
         const second = await repo.insertIfAbsent({
           projectId,
           reactorName,
-          dedupKey: "trigger-A:trace-1",
+          dedupKey: `${projectId}/trigger-A:trace:trace-1`,
           groupKey: `${projectId}/${reactorName}:trigger-A`,
           payload: { v: 2 },
         });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "vitest";
+import { OutboxService } from "../outbox.service";
+import type {
+  OutboxInsertRow,
+  OutboxLeaseQuery,
+  OutboxListQuery,
+  OutboxRepository,
+  OutboxRetryUpdate,
+} from "../outbox.repository";
+import type { OutboxRow } from "../outbox.types";
+
+/**
+ * In-memory fake — exercises the service contract without touching
+ * PG. Lease selection is not concurrency-safe; the integration test
+ * covers the real `FOR UPDATE SKIP LOCKED` race.
+ */
+class InMemoryOutboxRepository implements OutboxRepository {
+  rows: OutboxRow[] = [];
+  private nextId = 1;
+
+  async insertIfAbsent(row: OutboxInsertRow): Promise<boolean> {
+    const existing = this.rows.find(
+      (r) => r.reactorName === row.reactorName && r.dedupKey === row.dedupKey,
+    );
+    if (existing) return false;
+    // Always-ready (`new Date(0)`) so the service's injected clock
+    // alone decides when a row becomes claimable. The real Prisma
+    // path uses CURRENT_TIMESTAMP, but that conflates the service
+    // clock with PG's clock and is what integration tests cover.
+    const alwaysReady = new Date(0);
+    this.rows.push({
+      id: `row-${this.nextId++}`,
+      projectId: row.projectId,
+      reactorName: row.reactorName,
+      dedupKey: row.dedupKey,
+      groupKey: row.groupKey,
+      payload: row.payload as object,
+      status: "queued",
+      attempts: 0,
+      maxAttempts: row.maxAttempts ?? 8,
+      leasedUntil: null,
+      nextAttemptAt: alwaysReady,
+      lastError: null,
+      lastErrorAt: null,
+      dispatchedAt: null,
+      createdAt: alwaysReady,
+      updatedAt: alwaysReady,
+    });
+    return true;
+  }
+
+  async leaseNext(query: OutboxLeaseQuery): Promise<OutboxRow | null> {
+    const candidate = this.rows.find(
+      (r) =>
+        r.projectId === query.projectId &&
+        r.reactorName === query.reactorName &&
+        (r.status === "queued" || r.status === "failed_retryable") &&
+        r.nextAttemptAt <= query.now,
+    );
+    if (!candidate) return null;
+    candidate.status = "dispatching";
+    candidate.leasedUntil = query.leasedUntil;
+    candidate.attempts += 1;
+    candidate.updatedAt = query.now;
+    return { ...candidate };
+  }
+
+  async recoverExpiredLeases({
+    now,
+    limit,
+  }: {
+    now: Date;
+    limit: number;
+  }): Promise<number> {
+    const expired = this.rows
+      .filter(
+        (r) =>
+          r.status === "dispatching" &&
+          r.leasedUntil !== null &&
+          r.leasedUntil < now,
+      )
+      .slice(0, limit);
+    for (const r of expired) {
+      r.status = "queued";
+      r.leasedUntil = null;
+      r.updatedAt = now;
+    }
+    return expired.length;
+  }
+
+  async markDispatched({
+    rowId,
+    now,
+  }: {
+    rowId: string;
+    now: Date;
+  }): Promise<void> {
+    const row = this.rows.find((r) => r.id === rowId);
+    if (!row) throw new Error(`row ${rowId} not found`);
+    row.status = "dispatched";
+    row.leasedUntil = null;
+    row.dispatchedAt = now;
+    row.updatedAt = now;
+  }
+
+  async markRetry(update: OutboxRetryUpdate): Promise<void> {
+    const row = this.rows.find((r) => r.id === update.rowId);
+    if (!row) throw new Error(`row ${update.rowId} not found`);
+    row.attempts = update.attempts;
+    row.status = update.status;
+    row.nextAttemptAt = update.nextAttemptAt ?? row.nextAttemptAt;
+    row.leasedUntil = null;
+    row.lastError = update.lastError;
+    row.lastErrorAt = update.lastErrorAt;
+    row.updatedAt = update.lastErrorAt;
+  }
+
+  async findById(rowId: string): Promise<OutboxRow | null> {
+    return this.rows.find((r) => r.id === rowId) ?? null;
+  }
+
+  async list(query: OutboxListQuery): Promise<OutboxRow[]> {
+    return this.rows
+      .filter(
+        (r) =>
+          r.projectId === query.projectId &&
+          (query.reactorName ? r.reactorName === query.reactorName : true) &&
+          (query.status ? r.status === query.status : true),
+      )
+      .slice(0, query.limit);
+  }
+}
+
+function buildService({
+  random = () => 1,
+  now,
+}: { random?: () => number; now?: () => Date } = {}) {
+  const repo = new InMemoryOutboxRepository();
+  const service = new OutboxService(repo, {
+    backoff: { baseMs: 1000, random },
+    now,
+  });
+  return { repo, service };
+}
+
+describe("OutboxService", () => {
+  describe("enqueue", () => {
+    describe("when no row exists for (reactorName, dedupKey)", () => {
+      it("inserts a queued row", async () => {
+        const { repo, service } = buildService();
+        const result = await service.enqueue({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          dedupKey: "trigger1:trace1",
+          groupKey: "proj1",
+          payload: { triggerId: "trigger1" },
+        });
+        expect(result.enqueued).toBe(true);
+        expect(repo.rows).toHaveLength(1);
+        expect(repo.rows[0]!.status).toBe("queued");
+      });
+    });
+
+    describe("when a row already exists for (reactorName, dedupKey)", () => {
+      it("returns enqueued: false without inserting", async () => {
+        const { repo, service } = buildService();
+        await service.enqueue({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          dedupKey: "trigger1:trace1",
+          groupKey: "proj1",
+          payload: {},
+        });
+        const second = await service.enqueue({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          dedupKey: "trigger1:trace1",
+          groupKey: "proj1",
+          payload: {},
+        });
+        expect(second.enqueued).toBe(false);
+        expect(repo.rows).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("leaseNext", () => {
+    describe("when a queued row is past its nextAttemptAt", () => {
+      it("flips it to dispatching with a leasedUntil in the future", async () => {
+        const fixedNow = new Date("2026-05-28T12:00:00Z");
+        const { service } = buildService({ now: () => fixedNow });
+        await service.enqueue({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          dedupKey: "k",
+          groupKey: "proj1",
+          payload: {},
+        });
+        const row = await service.leaseNext({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          leaseDurationMs: 30_000,
+        });
+        expect(row?.status).toBe("dispatching");
+        expect(row?.leasedUntil?.getTime()).toBe(
+          fixedNow.getTime() + 30_000,
+        );
+        expect(row?.attempts).toBe(1);
+      });
+    });
+
+    describe("when no claimable row exists", () => {
+      it("returns null", async () => {
+        const { service } = buildService();
+        const row = await service.leaseNext({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          leaseDurationMs: 30_000,
+        });
+        expect(row).toBeNull();
+      });
+    });
+  });
+
+  describe("markFailedRetryable", () => {
+    describe("when attempts remain", () => {
+      it("schedules a backoff retry and increments attempts", async () => {
+        const fixedNow = new Date("2026-05-28T12:00:00Z");
+        const { repo, service } = buildService({
+          now: () => fixedNow,
+          random: () => 1,
+        });
+        await service.enqueue({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          dedupKey: "k",
+          groupKey: "proj1",
+          payload: {},
+        });
+        const leased = await service.leaseNext({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          leaseDurationMs: 30_000,
+        });
+        const result = await service.markFailedRetryable({
+          rowId: leased!.id,
+          error: "transient",
+        });
+        expect(result.status).toBe("failed_retryable");
+        expect(result.nextAttemptAt?.getTime()).toBe(
+          fixedNow.getTime() + 1000,
+        );
+        const fresh = repo.rows[0]!;
+        expect(fresh.status).toBe("failed_retryable");
+        expect(fresh.attempts).toBe(1);
+        expect(fresh.lastError).toBe("transient");
+        expect(fresh.leasedUntil).toBeNull();
+      });
+    });
+
+    describe("when attempts have reached maxAttempts", () => {
+      it("promotes to dead instead of scheduling another retry", async () => {
+        const { repo, service } = buildService();
+        await service.enqueue({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          dedupKey: "k",
+          groupKey: "proj1",
+          payload: {},
+          maxAttempts: 1,
+        });
+        const leased = await service.leaseNext({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          leaseDurationMs: 30_000,
+        });
+        const result = await service.markFailedRetryable({
+          rowId: leased!.id,
+          error: "still broken",
+        });
+        expect(result.status).toBe("dead");
+        expect(result.nextAttemptAt).toBeNull();
+        expect(repo.rows[0]!.status).toBe("dead");
+      });
+    });
+  });
+
+  describe("markDead", () => {
+    describe("when called on an in-flight row", () => {
+      it("flips it to dead regardless of attempts", async () => {
+        const { repo, service } = buildService();
+        await service.enqueue({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          dedupKey: "k",
+          groupKey: "proj1",
+          payload: {},
+        });
+        const leased = await service.leaseNext({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          leaseDurationMs: 30_000,
+        });
+        await service.markDead({ rowId: leased!.id, error: "unrecoverable" });
+        expect(repo.rows[0]!.status).toBe("dead");
+        expect(repo.rows[0]!.lastError).toBe("unrecoverable");
+      });
+    });
+  });
+
+  describe("recoverStuckLeases", () => {
+    describe("when a leased row's leasedUntil has passed", () => {
+      it("resets it to queued", async () => {
+        const past = new Date("2026-05-28T11:00:00Z");
+        const future = new Date("2026-05-28T12:00:00Z");
+        let now = past;
+        const { repo, service } = buildService({ now: () => now });
+        await service.enqueue({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          dedupKey: "k",
+          groupKey: "proj1",
+          payload: {},
+        });
+        await service.leaseNext({
+          projectId: "proj1",
+          reactorName: "alertDispatch",
+          leaseDurationMs: 1_000,
+        });
+        now = future;
+        const recovered = await service.recoverStuckLeases({ limit: 10 });
+        expect(recovered).toBe(1);
+        expect(repo.rows[0]!.status).toBe("queued");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
@@ -55,6 +55,7 @@ class InMemoryOutboxRepository implements OutboxRepository {
         r.projectId === query.projectId &&
         r.reactorName === query.reactorName &&
         (r.status === "queued" || r.status === "failed_retryable") &&
+        r.nextAttemptAt !== null &&
         r.nextAttemptAt <= query.now,
     );
     if (!candidate) return null;
@@ -90,13 +91,22 @@ class InMemoryOutboxRepository implements OutboxRepository {
 
   async markDispatched({
     rowId,
+    projectId,
     now,
   }: {
     rowId: string;
+    projectId: string;
     now: Date;
   }): Promise<void> {
-    const row = this.rows.find((r) => r.id === rowId);
-    if (!row) throw new Error(`row ${rowId} not found`);
+    // Mirror the prisma CAS: only a still-`dispatching` row owned by
+    // the project transitions.
+    const row = this.rows.find(
+      (r) =>
+        r.id === rowId &&
+        r.projectId === projectId &&
+        r.status === "dispatching",
+    );
+    if (!row) return;
     row.status = "dispatched";
     row.leasedUntil = null;
     row.dispatchedAt = now;
@@ -104,19 +114,34 @@ class InMemoryOutboxRepository implements OutboxRepository {
   }
 
   async markRetry(update: OutboxRetryUpdate): Promise<void> {
-    const row = this.rows.find((r) => r.id === update.rowId);
-    if (!row) throw new Error(`row ${update.rowId} not found`);
-    row.attempts = update.attempts;
+    // Conditional CAS on (projectId, status `dispatching`, attempts) —
+    // a stale write no-ops instead of clobbering a re-leased row.
+    const row = this.rows.find(
+      (r) =>
+        r.id === update.rowId &&
+        r.projectId === update.projectId &&
+        r.status === "dispatching" &&
+        r.attempts === update.attempts,
+    );
+    if (!row) return;
     row.status = update.status;
-    row.nextAttemptAt = update.nextAttemptAt ?? row.nextAttemptAt;
+    row.nextAttemptAt = update.nextAttemptAt;
     row.leasedUntil = null;
     row.lastError = update.lastError;
     row.lastErrorAt = update.lastErrorAt;
     row.updatedAt = update.lastErrorAt;
   }
 
-  async findById(rowId: string): Promise<OutboxRow | null> {
-    return this.rows.find((r) => r.id === rowId) ?? null;
+  async findById({
+    rowId,
+    projectId,
+  }: {
+    rowId: string;
+    projectId: string;
+  }): Promise<OutboxRow | null> {
+    return (
+      this.rows.find((r) => r.id === rowId && r.projectId === projectId) ?? null
+    );
   }
 
   async list(query: OutboxListQuery): Promise<OutboxRow[]> {
@@ -271,7 +296,7 @@ describe("OutboxService", () => {
           leaseDurationMs: 30_000,
         });
         const result = await service.markFailedRetryable({
-          rowId: leased!.id,
+          row: leased!,
           error: "transient",
         });
         expect(result.status).toBe("failed_retryable");
@@ -303,7 +328,7 @@ describe("OutboxService", () => {
           leaseDurationMs: 30_000,
         });
         const result = await service.markFailedRetryable({
-          rowId: leased!.id,
+          row: leased!,
           error: "still broken",
         });
         expect(result.status).toBe("dead");
@@ -329,7 +354,7 @@ describe("OutboxService", () => {
           reactorName: "alertDispatch",
           leaseDurationMs: 30_000,
         });
-        await service.markDead({ rowId: leased!.id, error: "unrecoverable" });
+        await service.markDead({ row: leased!, error: "unrecoverable" });
         expect(repo.rows[0]!.status).toBe("dead");
         expect(repo.rows[0]!.lastError).toBe("unrecoverable");
       });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
@@ -152,7 +152,7 @@ describe("OutboxService", () => {
           projectId: "proj1",
           reactorName: "alertDispatch",
           dedupKey: "trigger1:trace1",
-          groupKey: "proj1",
+          groupKey: "proj1/alertDispatch:trigger1",
           payload: { triggerId: "trigger1" },
         });
         expect(result.enqueued).toBe(true);
@@ -168,18 +168,46 @@ describe("OutboxService", () => {
           projectId: "proj1",
           reactorName: "alertDispatch",
           dedupKey: "trigger1:trace1",
-          groupKey: "proj1",
+          groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         const second = await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
           dedupKey: "trigger1:trace1",
-          groupKey: "proj1",
+          groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         expect(second.enqueued).toBe(false);
         expect(repo.rows).toHaveLength(1);
+      });
+    });
+
+    describe("when groupKey does not start with `${projectId}/`", () => {
+      it("throws so the contract violation surfaces at enqueue (ADR-023)", async () => {
+        const { service } = buildService();
+        await expect(
+          service.enqueue({
+            projectId: "proj1",
+            reactorName: "alertDispatch",
+            dedupKey: "trigger1:trace1",
+            groupKey: "alertDispatch:trigger1",
+            payload: {},
+          }),
+        ).rejects.toThrow(/must start with "proj1\/"/);
+      });
+
+      it("also rejects a groupKey for a different project", async () => {
+        const { service } = buildService();
+        await expect(
+          service.enqueue({
+            projectId: "proj1",
+            reactorName: "alertDispatch",
+            dedupKey: "trigger1:trace1",
+            groupKey: "proj2/alertDispatch:trigger1",
+            payload: {},
+          }),
+        ).rejects.toThrow(/must start with "proj1\/"/);
       });
     });
   });
@@ -193,7 +221,7 @@ describe("OutboxService", () => {
           projectId: "proj1",
           reactorName: "alertDispatch",
           dedupKey: "k",
-          groupKey: "proj1",
+          groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         const row = await service.leaseNext({
@@ -234,7 +262,7 @@ describe("OutboxService", () => {
           projectId: "proj1",
           reactorName: "alertDispatch",
           dedupKey: "k",
-          groupKey: "proj1",
+          groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         const leased = await service.leaseNext({
@@ -265,7 +293,7 @@ describe("OutboxService", () => {
           projectId: "proj1",
           reactorName: "alertDispatch",
           dedupKey: "k",
-          groupKey: "proj1",
+          groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
           maxAttempts: 1,
         });
@@ -293,7 +321,7 @@ describe("OutboxService", () => {
           projectId: "proj1",
           reactorName: "alertDispatch",
           dedupKey: "k",
-          groupKey: "proj1",
+          groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         const leased = await service.leaseNext({
@@ -319,7 +347,7 @@ describe("OutboxService", () => {
           projectId: "proj1",
           reactorName: "alertDispatch",
           dedupKey: "k",
-          groupKey: "proj1",
+          groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         await service.leaseNext({

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
@@ -54,6 +54,7 @@ class InMemoryOutboxRepository implements OutboxRepository {
       (r) =>
         r.projectId === query.projectId &&
         r.reactorName === query.reactorName &&
+        r.groupKey === query.groupKey &&
         (r.status === "queued" || r.status === "failed_retryable") &&
         r.nextAttemptAt !== null &&
         r.nextAttemptAt <= query.now,
@@ -176,7 +177,7 @@ describe("OutboxService", () => {
         const result = await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
-          dedupKey: "trigger1:trace1",
+          dedupKey: "proj1/trigger1:trace1",
           groupKey: "proj1/alertDispatch:trigger1",
           payload: { triggerId: "trigger1" },
         });
@@ -192,14 +193,14 @@ describe("OutboxService", () => {
         await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
-          dedupKey: "trigger1:trace1",
+          dedupKey: "proj1/trigger1:trace1",
           groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         const second = await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
-          dedupKey: "trigger1:trace1",
+          dedupKey: "proj1/trigger1:trace1",
           groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
@@ -215,11 +216,11 @@ describe("OutboxService", () => {
           service.enqueue({
             projectId: "proj1",
             reactorName: "alertDispatch",
-            dedupKey: "trigger1:trace1",
+            dedupKey: "proj1/trigger1:trace1",
             groupKey: "alertDispatch:trigger1",
             payload: {},
           }),
-        ).rejects.toThrow(/must start with "proj1\/"/);
+        ).rejects.toThrow(/groupKey must start with "proj1\/"/);
       });
 
       it("also rejects a groupKey for a different project", async () => {
@@ -228,11 +229,40 @@ describe("OutboxService", () => {
           service.enqueue({
             projectId: "proj1",
             reactorName: "alertDispatch",
-            dedupKey: "trigger1:trace1",
+            dedupKey: "proj1/trigger1:trace1",
             groupKey: "proj2/alertDispatch:trigger1",
             payload: {},
           }),
-        ).rejects.toThrow(/must start with "proj1\/"/);
+        ).rejects.toThrow(/groupKey must start with "proj1\/"/);
+      });
+    });
+
+    describe("when dedupKey does not start with `${projectId}/`", () => {
+      it("throws before any row is written (ADR-022 — claim key is global on (reactorName, dedupKey))", async () => {
+        const { repo, service } = buildService();
+        await expect(
+          service.enqueue({
+            projectId: "proj1",
+            reactorName: "alertDispatch",
+            dedupKey: "trigger1:trace1",
+            groupKey: "proj1/alertDispatch:trigger1",
+            payload: {},
+          }),
+        ).rejects.toThrow(/dedupKey must start with "proj1\/"/);
+        expect(repo.rows).toHaveLength(0);
+      });
+
+      it("also rejects a dedupKey for a different project", async () => {
+        const { service } = buildService();
+        await expect(
+          service.enqueue({
+            projectId: "proj1",
+            reactorName: "alertDispatch",
+            dedupKey: "proj2/trigger1:trace1",
+            groupKey: "proj1/alertDispatch:trigger1",
+            payload: {},
+          }),
+        ).rejects.toThrow(/dedupKey must start with "proj1\/"/);
       });
     });
   });
@@ -245,13 +275,14 @@ describe("OutboxService", () => {
         await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
-          dedupKey: "k",
+          dedupKey: "proj1/k",
           groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         const row = await service.leaseNext({
           projectId: "proj1",
           reactorName: "alertDispatch",
+          groupKey: "proj1/alertDispatch:trigger1",
           leaseDurationMs: 30_000,
         });
         expect(row?.status).toBe("dispatching");
@@ -268,6 +299,7 @@ describe("OutboxService", () => {
         const row = await service.leaseNext({
           projectId: "proj1",
           reactorName: "alertDispatch",
+          groupKey: "proj1/alertDispatch:trigger1",
           leaseDurationMs: 30_000,
         });
         expect(row).toBeNull();
@@ -286,13 +318,14 @@ describe("OutboxService", () => {
         await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
-          dedupKey: "k",
+          dedupKey: "proj1/k",
           groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         const leased = await service.leaseNext({
           projectId: "proj1",
           reactorName: "alertDispatch",
+          groupKey: "proj1/alertDispatch:trigger1",
           leaseDurationMs: 30_000,
         });
         const result = await service.markFailedRetryable({
@@ -317,7 +350,7 @@ describe("OutboxService", () => {
         await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
-          dedupKey: "k",
+          dedupKey: "proj1/k",
           groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
           maxAttempts: 1,
@@ -325,6 +358,7 @@ describe("OutboxService", () => {
         const leased = await service.leaseNext({
           projectId: "proj1",
           reactorName: "alertDispatch",
+          groupKey: "proj1/alertDispatch:trigger1",
           leaseDurationMs: 30_000,
         });
         const result = await service.markFailedRetryable({
@@ -345,13 +379,14 @@ describe("OutboxService", () => {
         await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
-          dedupKey: "k",
+          dedupKey: "proj1/k",
           groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         const leased = await service.leaseNext({
           projectId: "proj1",
           reactorName: "alertDispatch",
+          groupKey: "proj1/alertDispatch:trigger1",
           leaseDurationMs: 30_000,
         });
         await service.markDead({ row: leased!, error: "unrecoverable" });
@@ -371,13 +406,14 @@ describe("OutboxService", () => {
         await service.enqueue({
           projectId: "proj1",
           reactorName: "alertDispatch",
-          dedupKey: "k",
+          dedupKey: "proj1/k",
           groupKey: "proj1/alertDispatch:trigger1",
           payload: {},
         });
         await service.leaseNext({
           projectId: "proj1",
           reactorName: "alertDispatch",
+          groupKey: "proj1/alertDispatch:trigger1",
           leaseDurationMs: 1_000,
         });
         now = future;

--- a/langwatch/src/server/event-sourcing/outbox/backoff.ts
+++ b/langwatch/src/server/event-sourcing/outbox/backoff.ts
@@ -4,9 +4,10 @@
  * Schedule (base 1s, factor 2, cap 30 min): 1s → 2s → 4s → 8s → 16s →
  * 32s → 1m4s → 2m8s → 4m16s → 8m32s → 17m4s → 30m (capped).
  *
- * Full jitter (random between [0, exponential]) spreads herds when many
- * rows fail simultaneously (e.g. provider outage recovers and 1000 rows
- * all want to retry at the same nextAttemptAt).
+ * Full jitter (random in [0, exponential), via `Math.floor(random() *
+ * exponential)`) spreads herds when many rows fail simultaneously
+ * (e.g. provider outage recovers and 1000 rows all want to retry at
+ * the same nextAttemptAt).
  */
 export const DEFAULT_BACKOFF_BASE_MS = 1_000;
 export const DEFAULT_BACKOFF_FACTOR = 2;

--- a/langwatch/src/server/event-sourcing/outbox/backoff.ts
+++ b/langwatch/src/server/event-sourcing/outbox/backoff.ts
@@ -1,0 +1,33 @@
+/**
+ * Exponential backoff with full jitter for outbox retries.
+ *
+ * Schedule (base 1s, factor 2, cap 30 min): 1s → 2s → 4s → 8s → 16s →
+ * 32s → 1m4s → 2m8s → 4m16s → 8m32s → 17m4s → 30m (capped).
+ *
+ * Full jitter (random between [0, exponential]) spreads herds when many
+ * rows fail simultaneously (e.g. provider outage recovers and 1000 rows
+ * all want to retry at the same nextAttemptAt).
+ */
+export const DEFAULT_BACKOFF_BASE_MS = 1_000;
+export const DEFAULT_BACKOFF_FACTOR = 2;
+export const DEFAULT_BACKOFF_CAP_MS = 30 * 60 * 1_000;
+
+export function calculateBackoffMs({
+  attempts,
+  baseMs = DEFAULT_BACKOFF_BASE_MS,
+  factor = DEFAULT_BACKOFF_FACTOR,
+  capMs = DEFAULT_BACKOFF_CAP_MS,
+  random = Math.random,
+}: {
+  /** Number of attempts already made (including the one that just failed). */
+  attempts: number;
+  baseMs?: number;
+  factor?: number;
+  capMs?: number;
+  /** Injectable for deterministic tests. */
+  random?: () => number;
+}): number {
+  if (attempts < 1) return 0;
+  const exponential = Math.min(baseMs * factor ** (attempts - 1), capMs);
+  return Math.floor(random() * exponential);
+}

--- a/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
@@ -1,0 +1,39 @@
+/**
+ * Typed error thrown by outbox dispatch endpoints to signal whether the
+ * failure is worth retrying.
+ *
+ * See dev/docs/adr/027-typed-dispatcherror-contract.md.
+ *
+ * Dispatch endpoints (alert dispatch, dataset append, etc.) should
+ * catch provider/transport errors and re-throw as DispatchError with
+ * an explicit `retryable` decision. The drainer interprets:
+ *   - retryable: true  → schedule backoff retry (`failed_retryable`)
+ *   - retryable: false → mark `dead`, surface to operator
+ *
+ * Any non-DispatchError thrown from a dispatch endpoint is treated as
+ * retryable by default — better to retry an unexpected crash than to
+ * silently dead-letter a row whose failure mode we did not classify.
+ */
+export class DispatchError extends Error {
+  readonly retryable: boolean;
+  readonly cause?: unknown;
+
+  constructor({
+    message,
+    retryable,
+    cause,
+  }: {
+    message: string;
+    retryable: boolean;
+    cause?: unknown;
+  }) {
+    super(message);
+    this.name = "DispatchError";
+    this.retryable = retryable;
+    this.cause = cause;
+  }
+}
+
+export function isDispatchError(error: unknown): error is DispatchError {
+  return error instanceof DispatchError;
+}

--- a/langwatch/src/server/event-sourcing/outbox/drainer.ts
+++ b/langwatch/src/server/event-sourcing/outbox/drainer.ts
@@ -1,0 +1,209 @@
+import type { EventSourcedQueueProcessor } from "../queues/queue.types";
+import { createLogger } from "../../../utils/logger/server";
+import { captureException } from "../../../utils/posthogErrorCapture";
+import { isDispatchError } from "./dispatchError";
+import type { OutboxService } from "./outbox.service";
+import type { OutboxRow } from "./outbox.types";
+import type { OutboxWakeup } from "./wakeupQueue";
+
+const logger = createLogger("langwatch:event-sourcing:outbox-drainer");
+
+/**
+ * Dispatcher registered for a specific reactorName. Called once per
+ * leased row; responsible for executing the actual side effect (HTTP
+ * call, mailer, dataset write). Must raise `DispatchError` to signal
+ * retryable / non-retryable failures — any other throw is treated as
+ * retryable, see ADR-027.
+ */
+export type OutboxDispatcher = (row: OutboxRow) => Promise<void>;
+
+export interface OutboxDrainerOptions {
+  /**
+   * How long the lease holds before another worker can re-claim. Set
+   * higher than the slowest dispatcher's p99 to avoid double-dispatch
+   * under healthy load.
+   */
+  leaseDurationMs?: number;
+  /**
+   * Soft cap on rows dispatched per wakeup. Prevents one busy group
+   * from monopolising the worker — when the cap is reached, the
+   * drainer schedules a follow-up wakeup and yields.
+   */
+  maxRowsPerWakeup?: number;
+  /**
+   * Called when a dispatched row needs a follow-up wakeup (drain cap
+   * hit, retryable failure scheduled, etc). Typically delegates to
+   * `wakeupQueue.send(...)`. Implementations should respect
+   * `delay` for backoff.
+   */
+  scheduleWakeup: (params: {
+    wakeup: OutboxWakeup;
+    delayMs?: number;
+  }) => Promise<void>;
+}
+
+const DEFAULT_LEASE_DURATION_MS = 60_000;
+const DEFAULT_MAX_ROWS_PER_WAKEUP = 50;
+
+/**
+ * Glues a registry of per-reactor dispatchers onto the OutboxService.
+ *
+ * Phase 0 ships the scaffolding without any registered dispatchers —
+ * Phase 1 attaches the alert-dispatch reactor and friends. Until then
+ * the drainer is a no-op for unknown reactor names; it logs at debug
+ * but does not error.
+ */
+export class OutboxDrainer {
+  private readonly dispatchers = new Map<string, OutboxDispatcher>();
+  private readonly leaseDurationMs: number;
+  private readonly maxRowsPerWakeup: number;
+  private readonly scheduleWakeup: OutboxDrainerOptions["scheduleWakeup"];
+
+  constructor(
+    private readonly outboxService: OutboxService,
+    options: OutboxDrainerOptions,
+  ) {
+    this.leaseDurationMs =
+      options.leaseDurationMs ?? DEFAULT_LEASE_DURATION_MS;
+    this.maxRowsPerWakeup =
+      options.maxRowsPerWakeup ?? DEFAULT_MAX_ROWS_PER_WAKEUP;
+    this.scheduleWakeup = options.scheduleWakeup;
+  }
+
+  registerDispatcher(reactorName: string, dispatcher: OutboxDispatcher): void {
+    if (this.dispatchers.has(reactorName)) {
+      throw new Error(
+        `OutboxDrainer: dispatcher for "${reactorName}" already registered`,
+      );
+    }
+    this.dispatchers.set(reactorName, dispatcher);
+  }
+
+  /**
+   * Handle a wakeup payload. Leases rows for (reactorName, groupKey)
+   * up to `maxRowsPerWakeup` and dispatches them through the
+   * registered dispatcher. Yields when the cap is hit by scheduling
+   * a follow-up wakeup.
+   */
+  async handleWakeup(wakeup: OutboxWakeup): Promise<void> {
+    const dispatcher = this.dispatchers.get(wakeup.reactorName);
+    if (!dispatcher) {
+      logger.debug(
+        { reactorName: wakeup.reactorName, groupKey: wakeup.groupKey },
+        "Wakeup for unregistered reactor — dropped",
+      );
+      return;
+    }
+
+    let dispatched = 0;
+    while (dispatched < this.maxRowsPerWakeup) {
+      const row = await this.outboxService.leaseNext({
+        projectId: wakeup.groupKey,
+        reactorName: wakeup.reactorName,
+        leaseDurationMs: this.leaseDurationMs,
+      });
+      if (!row) return;
+
+      await this.dispatchOne({ row, dispatcher });
+      dispatched += 1;
+    }
+
+    // Drain cap hit: yield with an immediate follow-up wakeup so
+    // other groups get a turn but this one keeps draining.
+    await this.scheduleWakeup({ wakeup });
+  }
+
+  private async dispatchOne({
+    row,
+    dispatcher,
+  }: {
+    row: OutboxRow;
+    dispatcher: OutboxDispatcher;
+  }): Promise<void> {
+    try {
+      await dispatcher(row);
+      await this.outboxService.markDispatched(row.id);
+      return;
+    } catch (error) {
+      const isRetryable = !isDispatchError(error) || error.retryable;
+      const message =
+        error instanceof Error ? error.message : String(error);
+
+      if (!isRetryable) {
+        await this.outboxService.markDead({ rowId: row.id, error: message });
+        logger.warn(
+          {
+            rowId: row.id,
+            reactorName: row.reactorName,
+            projectId: row.projectId,
+            error: message,
+          },
+          "Outbox dispatch failed permanently",
+        );
+        captureException(error, {
+          extra: {
+            outboxRowId: row.id,
+            reactorName: row.reactorName,
+            projectId: row.projectId,
+          },
+        });
+        return;
+      }
+
+      const result = await this.outboxService.markFailedRetryable({
+        rowId: row.id,
+        error: message,
+      });
+
+      if (result.status === "dead") {
+        logger.warn(
+          {
+            rowId: row.id,
+            reactorName: row.reactorName,
+            projectId: row.projectId,
+            attempts: row.attempts,
+            error: message,
+          },
+          "Outbox dispatch exhausted retries",
+        );
+        captureException(error, {
+          extra: {
+            outboxRowId: row.id,
+            reactorName: row.reactorName,
+            projectId: row.projectId,
+            attempts: row.attempts,
+          },
+        });
+        return;
+      }
+
+      if (result.nextAttemptAt) {
+        const delayMs = Math.max(
+          0,
+          result.nextAttemptAt.getTime() - Date.now(),
+        );
+        await this.scheduleWakeup({
+          wakeup: {
+            reactorName: row.reactorName,
+            groupKey: row.groupKey,
+            tenantId: row.projectId,
+            scheduledAt: result.nextAttemptAt.getTime(),
+          },
+          delayMs,
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Helper to build a `scheduleWakeup` callback backed by a GroupQueue
+ * processor. Used by `OutboxDrainer` constructor wiring at app boot.
+ */
+export function makeScheduleWakeupFromQueue(
+  queue: EventSourcedQueueProcessor<OutboxWakeup>,
+): OutboxDrainerOptions["scheduleWakeup"] {
+  return async ({ wakeup, delayMs }) => {
+    await queue.send(wakeup, delayMs ? { delay: delayMs } : undefined);
+  };
+}

--- a/langwatch/src/server/event-sourcing/outbox/drainer.ts
+++ b/langwatch/src/server/event-sourcing/outbox/drainer.ts
@@ -1,6 +1,7 @@
 import type { EventSourcedQueueProcessor } from "../queues/queue.types";
 import { createLogger } from "../../../utils/logger/server";
 import { captureException } from "../../../utils/posthogErrorCapture";
+import { tenantIdFromGroupId } from "../../observability/tenantRateTracker";
 import { isDispatchError } from "./dispatchError";
 import type { OutboxService } from "./outbox.service";
 import type { OutboxRow } from "./outbox.types";
@@ -80,10 +81,14 @@ export class OutboxDrainer {
   }
 
   /**
-   * Handle a wakeup payload. Leases rows for (reactorName, groupKey)
+   * Handle a wakeup payload. Leases rows for (projectId, reactorName)
    * up to `maxRowsPerWakeup` and dispatches them through the
    * registered dispatcher. Yields when the cap is hit by scheduling
    * a follow-up wakeup.
+   *
+   * `projectId` is derived from `wakeup.groupKey` via
+   * `tenantIdFromGroupId` — the producer is contracted to format
+   * groupKey as `${projectId}/...`. See ADR-023.
    */
   async handleWakeup(wakeup: OutboxWakeup): Promise<void> {
     const dispatcher = this.dispatchers.get(wakeup.reactorName);
@@ -95,10 +100,19 @@ export class OutboxDrainer {
       return;
     }
 
+    const projectId = tenantIdFromGroupId(wakeup.groupKey);
+    if (!projectId) {
+      logger.error(
+        { reactorName: wakeup.reactorName, groupKey: wakeup.groupKey },
+        "Wakeup groupKey missing `${projectId}/` prefix — dropping (see ADR-023)",
+      );
+      return;
+    }
+
     let dispatched = 0;
     while (dispatched < this.maxRowsPerWakeup) {
       const row = await this.outboxService.leaseNext({
-        projectId: wakeup.groupKey,
+        projectId,
         reactorName: wakeup.reactorName,
         leaseDurationMs: this.leaseDurationMs,
       });
@@ -186,7 +200,6 @@ export class OutboxDrainer {
           wakeup: {
             reactorName: row.reactorName,
             groupKey: row.groupKey,
-            tenantId: row.projectId,
             scheduledAt: result.nextAttemptAt.getTime(),
           },
           delayMs,

--- a/langwatch/src/server/event-sourcing/outbox/drainer.ts
+++ b/langwatch/src/server/event-sourcing/outbox/drainer.ts
@@ -69,6 +69,20 @@ export class OutboxDrainer {
     this.maxRowsPerWakeup =
       options.maxRowsPerWakeup ?? DEFAULT_MAX_ROWS_PER_WAKEUP;
     this.scheduleWakeup = options.scheduleWakeup;
+
+    // A non-positive cap would make handleWakeup's drain loop exit
+    // immediately and reschedule a follow-up wakeup every time —
+    // an infinite churn loop. A non-positive lease duration would
+    // hand out leases that are already expired. Fail loudly at wiring.
+    if (!Number.isFinite(this.leaseDurationMs) || this.leaseDurationMs <= 0) {
+      throw new Error("OutboxDrainer: leaseDurationMs must be > 0");
+    }
+    if (
+      !Number.isFinite(this.maxRowsPerWakeup) ||
+      this.maxRowsPerWakeup <= 0
+    ) {
+      throw new Error("OutboxDrainer: maxRowsPerWakeup must be > 0");
+    }
   }
 
   registerDispatcher(reactorName: string, dispatcher: OutboxDispatcher): void {
@@ -136,7 +150,10 @@ export class OutboxDrainer {
   }): Promise<void> {
     try {
       await dispatcher(row);
-      await this.outboxService.markDispatched(row.id);
+      await this.outboxService.markDispatched({
+        rowId: row.id,
+        projectId: row.projectId,
+      });
       return;
     } catch (error) {
       const isRetryable = !isDispatchError(error) || error.retryable;
@@ -144,7 +161,7 @@ export class OutboxDrainer {
         error instanceof Error ? error.message : String(error);
 
       if (!isRetryable) {
-        await this.outboxService.markDead({ rowId: row.id, error: message });
+        await this.outboxService.markDead({ row, error: message });
         logger.warn(
           {
             rowId: row.id,
@@ -165,7 +182,7 @@ export class OutboxDrainer {
       }
 
       const result = await this.outboxService.markFailedRetryable({
-        rowId: row.id,
+        row,
         error: message,
       });
 

--- a/langwatch/src/server/event-sourcing/outbox/drainer.ts
+++ b/langwatch/src/server/event-sourcing/outbox/drainer.ts
@@ -125,15 +125,16 @@ export class OutboxDrainer {
 
     let dispatched = 0;
     while (dispatched < this.maxRowsPerWakeup) {
-      // leaseNext filters by (projectId, reactorName) and orders by
-      // nextAttemptAt — so a wakeup for trigger A may dispatch rows
-      // belonging to trigger B if B's row is the earlier-claimable
-      // one. Per-trigger ordering holds only across wakeup boundaries
-      // (the GroupQueue serialises wakeups per groupKey), not within
-      // a single drain pass.
+      // leaseNext is scoped to this wakeup's groupKey: a wakeup for
+      // trigger A never leases trigger B's row, so per-trigger FIFO
+      // holds at the row level (not just at the wakeup boundary).
+      // Concurrent wakeups for different groups still drain in
+      // parallel — the GroupQueue serialises wakeups per groupKey but
+      // not across groupKeys.
       const row = await this.outboxService.leaseNext({
         projectId,
         reactorName: wakeup.reactorName,
+        groupKey: wakeup.groupKey,
         leaseDurationMs: this.leaseDurationMs,
       });
       if (!row) return;
@@ -143,11 +144,9 @@ export class OutboxDrainer {
     }
 
     // Drain cap hit: yield with an immediate follow-up wakeup so
-    // other groups get a turn. We re-post the original wakeup's
-    // groupKey, but the resumed drain still leases globally for
-    // (projectId, reactorName) — so "this one keeps draining" really
-    // means "the (project, reactor) backlog keeps draining," not
-    // "this trigger's rows keep draining."
+    // other groups get a turn. Re-posting the original groupKey keeps
+    // the resumed drain scoped to the same trigger — the (projectId,
+    // reactorName, groupKey) tuple matches the lease predicate above.
     await this.scheduleWakeup({ wakeup });
   }
 

--- a/langwatch/src/server/event-sourcing/outbox/drainer.ts
+++ b/langwatch/src/server/event-sourcing/outbox/drainer.ts
@@ -125,6 +125,12 @@ export class OutboxDrainer {
 
     let dispatched = 0;
     while (dispatched < this.maxRowsPerWakeup) {
+      // leaseNext filters by (projectId, reactorName) and orders by
+      // nextAttemptAt — so a wakeup for trigger A may dispatch rows
+      // belonging to trigger B if B's row is the earlier-claimable
+      // one. Per-trigger ordering holds only across wakeup boundaries
+      // (the GroupQueue serialises wakeups per groupKey), not within
+      // a single drain pass.
       const row = await this.outboxService.leaseNext({
         projectId,
         reactorName: wakeup.reactorName,
@@ -137,7 +143,11 @@ export class OutboxDrainer {
     }
 
     // Drain cap hit: yield with an immediate follow-up wakeup so
-    // other groups get a turn but this one keeps draining.
+    // other groups get a turn. We re-post the original wakeup's
+    // groupKey, but the resumed drain still leases globally for
+    // (projectId, reactorName) — so "this one keeps draining" really
+    // means "the (project, reactor) backlog keeps draining," not
+    // "this trigger's rows keep draining."
     await this.scheduleWakeup({ wakeup });
   }
 

--- a/langwatch/src/server/event-sourcing/outbox/outbox.prisma.repository.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.prisma.repository.ts
@@ -1,0 +1,154 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type {
+  OutboxInsertRow,
+  OutboxLeaseQuery,
+  OutboxListQuery,
+  OutboxRepository,
+  OutboxRetryUpdate,
+} from "./outbox.repository";
+import type { OutboxRow } from "./outbox.types";
+
+/**
+ * Prisma-backed ReactorOutbox repository.
+ *
+ * `leaseNext` and `recoverExpiredLeases` use raw SQL with
+ * `FOR UPDATE SKIP LOCKED` so concurrent drainers across processes
+ * race cleanly without dead-locking. See ADR-023 for the lease
+ * design and ADR-022 for the claim primitive.
+ */
+export class PrismaOutboxRepository implements OutboxRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async insertIfAbsent(row: OutboxInsertRow): Promise<boolean> {
+    const result = await this.prisma.reactorOutbox.createMany({
+      data: {
+        projectId: row.projectId,
+        reactorName: row.reactorName,
+        dedupKey: row.dedupKey,
+        groupKey: row.groupKey,
+        payload: row.payload as Prisma.InputJsonValue,
+        maxAttempts: row.maxAttempts,
+      },
+      skipDuplicates: true,
+    });
+    return result.count > 0;
+  }
+
+  async leaseNext({
+    projectId,
+    reactorName,
+    leasedUntil,
+    now,
+  }: OutboxLeaseQuery): Promise<OutboxRow | null> {
+    const rows = await this.prisma.$queryRaw<OutboxRow[]>`
+      UPDATE "ReactorOutbox"
+      SET
+        "status" = 'dispatching',
+        "leasedUntil" = ${leasedUntil},
+        "attempts" = "attempts" + 1,
+        "updatedAt" = ${now}
+      WHERE "id" = (
+        SELECT "id"
+        FROM "ReactorOutbox"
+        WHERE "projectId" = ${projectId}
+          AND "reactorName" = ${reactorName}
+          AND "status" IN ('queued', 'failed_retryable')
+          AND "nextAttemptAt" <= ${now}
+        ORDER BY "nextAttemptAt" ASC, "createdAt" ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING *
+    `;
+    return rows[0] ?? null;
+  }
+
+  async recoverExpiredLeases({
+    now,
+    limit,
+  }: {
+    now: Date;
+    limit: number;
+  }): Promise<number> {
+    const rows = await this.prisma.$queryRaw<{ id: string }[]>`
+      UPDATE "ReactorOutbox"
+      SET
+        "status" = 'queued',
+        "leasedUntil" = NULL,
+        "updatedAt" = ${now}
+      WHERE "id" IN (
+        SELECT "id"
+        FROM "ReactorOutbox"
+        WHERE "status" = 'dispatching'
+          AND "leasedUntil" IS NOT NULL
+          AND "leasedUntil" < ${now}
+        ORDER BY "leasedUntil" ASC
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING "id"
+    `;
+    return rows.length;
+  }
+
+  async markDispatched({
+    rowId,
+    now,
+  }: {
+    rowId: string;
+    now: Date;
+  }): Promise<void> {
+    await this.prisma.reactorOutbox.update({
+      where: { id: rowId },
+      data: {
+        status: "dispatched",
+        leasedUntil: null,
+        dispatchedAt: now,
+        updatedAt: now,
+      },
+    });
+  }
+
+  async markRetry({
+    rowId,
+    attempts,
+    status,
+    nextAttemptAt,
+    lastError,
+    lastErrorAt,
+  }: OutboxRetryUpdate): Promise<void> {
+    await this.prisma.reactorOutbox.update({
+      where: { id: rowId },
+      data: {
+        status,
+        attempts,
+        nextAttemptAt: nextAttemptAt ?? undefined,
+        leasedUntil: null,
+        lastError,
+        lastErrorAt,
+        updatedAt: lastErrorAt,
+      },
+    });
+  }
+
+  async findById(rowId: string): Promise<OutboxRow | null> {
+    return this.prisma.reactorOutbox.findUnique({ where: { id: rowId } });
+  }
+
+  async list({
+    projectId,
+    reactorName,
+    status,
+    limit,
+  }: OutboxListQuery): Promise<OutboxRow[]> {
+    return this.prisma.reactorOutbox.findMany({
+      where: {
+        projectId,
+        ...(reactorName ? { reactorName } : {}),
+        ...(status ? { status } : {}),
+      },
+      orderBy: { updatedAt: "desc" },
+      take: limit,
+    });
+  }
+}

--- a/langwatch/src/server/event-sourcing/outbox/outbox.prisma.repository.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.prisma.repository.ts
@@ -20,15 +20,20 @@ export class PrismaOutboxRepository implements OutboxRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
   async insertIfAbsent(row: OutboxInsertRow): Promise<boolean> {
+    // `data` is an array (not a bare object): the multitenancy guard's
+    // createMany branch maps over data to assert projectId on every row,
+    // so it requires the array form.
     const result = await this.prisma.reactorOutbox.createMany({
-      data: {
-        projectId: row.projectId,
-        reactorName: row.reactorName,
-        dedupKey: row.dedupKey,
-        groupKey: row.groupKey,
-        payload: row.payload,
-        maxAttempts: row.maxAttempts,
-      },
+      data: [
+        {
+          projectId: row.projectId,
+          reactorName: row.reactorName,
+          dedupKey: row.dedupKey,
+          groupKey: row.groupKey,
+          payload: row.payload,
+          maxAttempts: row.maxAttempts,
+        },
+      ],
       skipDuplicates: true,
     });
     return result.count > 0;

--- a/langwatch/src/server/event-sourcing/outbox/outbox.prisma.repository.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.prisma.repository.ts
@@ -1,4 +1,4 @@
-import type { Prisma, PrismaClient } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
 import type {
   OutboxInsertRow,
   OutboxLeaseQuery,
@@ -26,7 +26,7 @@ export class PrismaOutboxRepository implements OutboxRepository {
         reactorName: row.reactorName,
         dedupKey: row.dedupKey,
         groupKey: row.groupKey,
-        payload: row.payload as Prisma.InputJsonValue,
+        payload: row.payload,
         maxAttempts: row.maxAttempts,
       },
       skipDuplicates: true,
@@ -93,13 +93,18 @@ export class PrismaOutboxRepository implements OutboxRepository {
 
   async markDispatched({
     rowId,
+    projectId,
     now,
   }: {
     rowId: string;
+    projectId: string;
     now: Date;
   }): Promise<void> {
-    await this.prisma.reactorOutbox.update({
-      where: { id: rowId },
+    // CAS on `dispatching`: a row a recovery sweep already re-queued
+    // (and a second worker re-leased) must not be marked dispatched by
+    // this stale worker. projectId keeps the write tenant-scoped.
+    await this.prisma.reactorOutbox.updateMany({
+      where: { id: rowId, projectId, status: "dispatching" },
       data: {
         status: "dispatched",
         leasedUntil: null,
@@ -111,18 +116,23 @@ export class PrismaOutboxRepository implements OutboxRepository {
 
   async markRetry({
     rowId,
+    projectId,
     attempts,
     status,
     nextAttemptAt,
     lastError,
     lastErrorAt,
   }: OutboxRetryUpdate): Promise<void> {
-    await this.prisma.reactorOutbox.update({
-      where: { id: rowId },
+    // Conditional CAS: only transition while the row is still the one
+    // this worker leased (`dispatching` + the same attempt count). If a
+    // recovery sweep re-queued it and another worker re-leased
+    // (bumping attempts), this no-ops instead of clobbering live state.
+    // projectId scopes the write to the owning tenant.
+    await this.prisma.reactorOutbox.updateMany({
+      where: { id: rowId, projectId, status: "dispatching", attempts },
       data: {
         status,
-        attempts,
-        nextAttemptAt: nextAttemptAt ?? undefined,
+        nextAttemptAt,
         leasedUntil: null,
         lastError,
         lastErrorAt,
@@ -131,8 +141,16 @@ export class PrismaOutboxRepository implements OutboxRepository {
     });
   }
 
-  async findById(rowId: string): Promise<OutboxRow | null> {
-    return this.prisma.reactorOutbox.findUnique({ where: { id: rowId } });
+  async findById({
+    rowId,
+    projectId,
+  }: {
+    rowId: string;
+    projectId: string;
+  }): Promise<OutboxRow | null> {
+    return this.prisma.reactorOutbox.findFirst({
+      where: { id: rowId, projectId },
+    });
   }
 
   async list({

--- a/langwatch/src/server/event-sourcing/outbox/outbox.prisma.repository.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.prisma.repository.ts
@@ -42,9 +42,16 @@ export class PrismaOutboxRepository implements OutboxRepository {
   async leaseNext({
     projectId,
     reactorName,
+    groupKey,
     leasedUntil,
     now,
   }: OutboxLeaseQuery): Promise<OutboxRow | null> {
+    // Scope the claim by groupKey too: a wakeup for one trigger must
+    // never lease another trigger's row, otherwise per-group FIFO is
+    // lost and concurrent drainers across groups can interleave each
+    // other's dispatch order. The composite index
+    // (projectId, reactorName, groupKey, status, nextAttemptAt) on
+    // ReactorOutbox is shaped for this exact predicate.
     const rows = await this.prisma.$queryRaw<OutboxRow[]>`
       UPDATE "ReactorOutbox"
       SET
@@ -57,6 +64,7 @@ export class PrismaOutboxRepository implements OutboxRepository {
         FROM "ReactorOutbox"
         WHERE "projectId" = ${projectId}
           AND "reactorName" = ${reactorName}
+          AND "groupKey" = ${groupKey}
           AND "status" IN ('queued', 'failed_retryable')
           AND "nextAttemptAt" <= ${now}
         ORDER BY "nextAttemptAt" ASC, "createdAt" ASC

--- a/langwatch/src/server/event-sourcing/outbox/outbox.repository.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.repository.ts
@@ -1,0 +1,86 @@
+import type { OutboxRow, OutboxStatus } from "./outbox.types";
+
+export interface OutboxInsertRow {
+  projectId: string;
+  reactorName: string;
+  dedupKey: string;
+  groupKey: string;
+  payload: unknown;
+  maxAttempts?: number;
+}
+
+export interface OutboxLeaseQuery {
+  projectId: string;
+  reactorName: string;
+  leasedUntil: Date;
+  now: Date;
+}
+
+export interface OutboxRetryUpdate {
+  rowId: string;
+  attempts: number;
+  status: Extract<OutboxStatus, "failed_retryable" | "dead">;
+  nextAttemptAt: Date | null;
+  lastError: string;
+  lastErrorAt: Date;
+}
+
+export interface OutboxListQuery {
+  projectId: string;
+  reactorName?: string;
+  status?: OutboxStatus;
+  limit: number;
+}
+
+/**
+ * Data-only repository for ReactorOutbox.
+ *
+ * Stays free of business rules: backoff math, replay decisions,
+ * wakeup scheduling all live in `outbox.service.ts`. See
+ * dev/docs/adr/019-repository-service-layering.md for the convention.
+ */
+export interface OutboxRepository {
+  /**
+   * Insert a row if one does not already exist for (reactorName,
+   * dedupKey). Returns true when a row was inserted, false when a
+   * pre-existing row deduplicated the call. This is the claim
+   * primitive — see ADR-022.
+   */
+  insertIfAbsent(row: OutboxInsertRow): Promise<boolean>;
+
+  /**
+   * Atomically lease the next claimable row for (projectId,
+   * reactorName) whose nextAttemptAt has elapsed. Updates status to
+   * "dispatching", sets leasedUntil, increments attempts. Returns
+   * null when no row is claimable. See ADR-023 for why the lease
+   * lives in PG (not Redis).
+   */
+  leaseNext(query: OutboxLeaseQuery): Promise<OutboxRow | null>;
+
+  /**
+   * Recover rows whose lease expired without the worker reporting
+   * back — flip them from "dispatching" back to "queued" so the next
+   * drainer wake-up can re-lease.
+   */
+  recoverExpiredLeases({
+    now,
+    limit,
+  }: {
+    now: Date;
+    limit: number;
+  }): Promise<number>;
+
+  markDispatched({
+    rowId,
+    now,
+  }: {
+    rowId: string;
+    now: Date;
+  }): Promise<void>;
+
+  markRetry(update: OutboxRetryUpdate): Promise<void>;
+
+  findById(rowId: string): Promise<OutboxRow | null>;
+
+  list(query: OutboxListQuery): Promise<OutboxRow[]>;
+}

--- a/langwatch/src/server/event-sourcing/outbox/outbox.repository.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.repository.ts
@@ -12,6 +12,13 @@ export interface OutboxInsertRow {
 export interface OutboxLeaseQuery {
   projectId: string;
   reactorName: string;
+  /**
+   * GroupQueue routing key of the wakeup that triggered this lease.
+   * The lease SQL filters on it so a wakeup for trigger A can never
+   * drain a row belonging to trigger B — per-group FIFO holds at the
+   * row level, not just at the wakeup boundary. See ADR-023.
+   */
+  groupKey: string;
   leasedUntil: Date;
   now: Date;
 }
@@ -58,10 +65,11 @@ export interface OutboxRepository {
 
   /**
    * Atomically lease the next claimable row for (projectId,
-   * reactorName) whose nextAttemptAt has elapsed. Updates status to
-   * "dispatching", sets leasedUntil, increments attempts. Returns
-   * null when no row is claimable. See ADR-023 for why the lease
-   * lives in PG (not Redis).
+   * reactorName, groupKey) whose nextAttemptAt has elapsed. Updates
+   * status to "dispatching", sets leasedUntil, increments attempts.
+   * Returns null when no row is claimable. Scoping by `groupKey`
+   * preserves per-trigger FIFO at the row level (see ADR-023). See
+   * ADR-023 for why the lease lives in PG (not Redis).
    */
   leaseNext(query: OutboxLeaseQuery): Promise<OutboxRow | null>;
 

--- a/langwatch/src/server/event-sourcing/outbox/outbox.repository.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.repository.ts
@@ -1,11 +1,11 @@
-import type { OutboxRow, OutboxStatus } from "./outbox.types";
+import type { OutboxPayload, OutboxRow, OutboxStatus } from "./outbox.types";
 
 export interface OutboxInsertRow {
   projectId: string;
   reactorName: string;
   dedupKey: string;
   groupKey: string;
-  payload: unknown;
+  payload: OutboxPayload;
   maxAttempts?: number;
 }
 
@@ -18,6 +18,14 @@ export interface OutboxLeaseQuery {
 
 export interface OutboxRetryUpdate {
   rowId: string;
+  /** Tenancy guard — every write is scoped to the owning project. */
+  projectId: string;
+  /**
+   * Expected `attempts` of the leased row. The update is a conditional
+   * CAS — it only applies while the row is still `dispatching` with
+   * this exact attempt count, so a stale read cannot clobber a row a
+   * recovery sweep already re-queued and a second worker re-leased.
+   */
   attempts: number;
   status: Extract<OutboxStatus, "failed_retryable" | "dead">;
   nextAttemptAt: Date | null;
@@ -72,15 +80,23 @@ export interface OutboxRepository {
 
   markDispatched({
     rowId,
+    projectId,
     now,
   }: {
     rowId: string;
+    projectId: string;
     now: Date;
   }): Promise<void>;
 
   markRetry(update: OutboxRetryUpdate): Promise<void>;
 
-  findById(rowId: string): Promise<OutboxRow | null>;
+  findById({
+    rowId,
+    projectId,
+  }: {
+    rowId: string;
+    projectId: string;
+  }): Promise<OutboxRow | null>;
 
   list(query: OutboxListQuery): Promise<OutboxRow[]>;
 }

--- a/langwatch/src/server/event-sourcing/outbox/outbox.service.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.service.ts
@@ -70,6 +70,12 @@ export class OutboxService {
    * `enqueued: false`. The caller is responsible for posting a
    * wakeup to the GroupQueue afterwards.
    *
+   * Claim-once: when a row already exists, the second call's
+   * `payload` / `groupKey` / `maxAttempts` are DISCARDED — the
+   * original row is the source of truth (ADR-022 row-per-match). A
+   * caller that mutates the payload shape and replays will still
+   * dispatch the original payload, by design.
+   *
    * Validates that `groupKey` starts with `${projectId}/` so the
    * wakeup parses cleanly under `tenantIdFromGroupId` (ADR-023). A
    * misformatted key would silently land in the wrong tenant bucket
@@ -110,33 +116,42 @@ export class OutboxService {
     });
   }
 
-  async markDispatched(rowId: string): Promise<void> {
-    await this.repository.markDispatched({ rowId, now: this.now() });
+  async markDispatched({
+    rowId,
+    projectId,
+  }: {
+    rowId: string;
+    projectId: string;
+  }): Promise<void> {
+    await this.repository.markDispatched({
+      rowId,
+      projectId,
+      now: this.now(),
+    });
   }
 
   /**
-   * Record a retryable failure. Increments attempts, schedules the
-   * next attempt via exponential backoff, and promotes to `dead`
-   * when the row exceeds its `maxAttempts`.
+   * Record a retryable failure. Schedules the next attempt via
+   * exponential backoff, and promotes to `dead` when the row has
+   * exceeded its `maxAttempts`.
    *
-   * The repository has already incremented `attempts` on lease, so
-   * the row passed back here reflects the post-attempt count.
+   * Operates on the leased row passed in by the drainer — the
+   * repository already incremented `attempts` on lease, so
+   * `row.attempts` reflects the post-attempt count. No re-read: the
+   * underlying `markRetry` is a CAS on (status `dispatching`,
+   * `attempts`), so a concurrent recovery + re-lease cannot be
+   * clobbered by a stale write.
    */
   async markFailedRetryable(
     params: MarkFailedRetryableParams,
   ): Promise<MarkFailedRetryableResult> {
-    const row = await this.repository.findById(params.rowId);
-    if (!row) {
-      throw new Error(
-        `OutboxService.markFailedRetryable: row ${params.rowId} not found`,
-      );
-    }
-
+    const { row } = params;
     const now = this.now();
 
     if (row.attempts >= row.maxAttempts) {
       await this.repository.markRetry({
         rowId: row.id,
+        projectId: row.projectId,
         attempts: row.attempts,
         status: "dead",
         nextAttemptAt: null,
@@ -159,6 +174,7 @@ export class OutboxService {
 
     await this.repository.markRetry({
       rowId: row.id,
+      projectId: row.projectId,
       attempts: row.attempts,
       status: "failed_retryable",
       nextAttemptAt,
@@ -172,22 +188,20 @@ export class OutboxService {
   /**
    * Force a row to `dead` regardless of attempts — used when the
    * dispatcher reports a permanently fatal failure (e.g. 4xx from
-   * provider, malformed template).
+   * provider, malformed template). Operates on the leased row; the
+   * underlying CAS guards against clobbering a re-leased row.
    */
   async markDead({
-    rowId,
+    row,
     error,
   }: {
-    rowId: string;
+    row: OutboxRow;
     error: string;
   }): Promise<void> {
-    const row = await this.repository.findById(rowId);
-    if (!row) {
-      throw new Error(`OutboxService.markDead: row ${rowId} not found`);
-    }
     const now = this.now();
     await this.repository.markRetry({
       rowId: row.id,
+      projectId: row.projectId,
       attempts: row.attempts,
       status: "dead",
       nextAttemptAt: null,

--- a/langwatch/src/server/event-sourcing/outbox/outbox.service.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.service.ts
@@ -76,14 +76,30 @@ export class OutboxService {
    * caller that mutates the payload shape and replays will still
    * dispatch the original payload, by design.
    *
-   * Validates that `groupKey` starts with `${projectId}/` so the
-   * wakeup parses cleanly under `tenantIdFromGroupId` (ADR-023). A
-   * misformatted key would silently land in the wrong tenant bucket
-   * for fair-scheduling purposes — failing here at enqueue is much
-   * cheaper to debug than a starvation bug in production.
+   * Validates that BOTH `groupKey` and `dedupKey` start with
+   * `${projectId}/`:
+   *   - `groupKey` so the wakeup parses cleanly under
+   *     `tenantIdFromGroupId` (ADR-023). A misformatted key would
+   *     silently land in the wrong tenant bucket for fair-scheduling
+   *     purposes.
+   *   - `dedupKey` because the unique index is global
+   *     `(reactorName, dedupKey)` and the row carries `projectId` as
+   *     a column, not part of the claim key. Without the prefix, a
+   *     producer in project A could suppress an enqueue for the same
+   *     unprefixed key in project B under the same reactor. The
+   *     convention is documented on `EnqueueOutboxParams.dedupKey`.
+   *
+   * Failing here at enqueue is much cheaper to debug than either a
+   * starvation bug (wrong tenant bucket) or a cross-tenant dedup
+   * suppression in production.
    */
   async enqueue(params: EnqueueOutboxParams): Promise<EnqueueOutboxResult> {
     const required = `${params.projectId}/`;
+    if (!params.dedupKey.startsWith(required)) {
+      throw new Error(
+        `OutboxService.enqueue: dedupKey must start with "${required}" (got "${params.dedupKey}"). See ADR-022 / ADR-023.`,
+      );
+    }
     if (!params.groupKey.startsWith(required)) {
       throw new Error(
         `OutboxService.enqueue: groupKey must start with "${required}" (got "${params.groupKey}"). See ADR-023.`,
@@ -101,9 +117,10 @@ export class OutboxService {
   }
 
   /**
-   * Lease the next claimable row for (projectId, reactorName). Returns
-   * null when the queue for this group is empty or all rows are still
-   * backing off.
+   * Lease the next claimable row for (projectId, reactorName,
+   * groupKey). Returns null when this group's queue is empty or all
+   * its rows are still backing off. Scoping by groupKey keeps
+   * per-trigger FIFO at the row level — see ADR-023.
    */
   async leaseNext(params: LeaseOutboxParams): Promise<OutboxRow | null> {
     const now = this.now();
@@ -111,6 +128,7 @@ export class OutboxService {
     return this.repository.leaseNext({
       projectId: params.projectId,
       reactorName: params.reactorName,
+      groupKey: params.groupKey,
       leasedUntil,
       now,
     });

--- a/langwatch/src/server/event-sourcing/outbox/outbox.service.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.service.ts
@@ -1,0 +1,209 @@
+import {
+  calculateBackoffMs,
+  DEFAULT_BACKOFF_BASE_MS,
+  DEFAULT_BACKOFF_CAP_MS,
+  DEFAULT_BACKOFF_FACTOR,
+} from "./backoff";
+import type { OutboxRepository } from "./outbox.repository";
+import type {
+  EnqueueOutboxParams,
+  EnqueueOutboxResult,
+  LeaseOutboxParams,
+  ListOutboxParams,
+  MarkFailedRetryableParams,
+  MarkFailedRetryableResult,
+  OutboxRow,
+  RecoverStuckLeasesParams,
+} from "./outbox.types";
+
+export interface OutboxServiceOptions {
+  /**
+   * Cap on rows recovered per `recoverStuckLeases` sweep. Keeps the
+   * crash-recovery scan latency bounded under failure storms.
+   */
+  recoverLeasesBatchSize?: number;
+  backoff?: {
+    baseMs?: number;
+    factor?: number;
+    capMs?: number;
+    random?: () => number;
+  };
+  /** Injectable clock for deterministic tests. Defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+const DEFAULT_RECOVER_BATCH_SIZE = 500;
+
+/**
+ * Public surface for the reactor outbox. Wraps the repository with
+ * business rules: replay-safe enqueue, backoff math, retry promotion
+ * to `dead`. See dev/docs/adr/021-024 for the design.
+ *
+ * Consumers should not import the repository directly — go through
+ * this service so backoff/replay/dead promotion stay consistent
+ * across reactors.
+ */
+export class OutboxService {
+  private readonly recoverLeasesBatchSize: number;
+  private readonly baseMs: number;
+  private readonly factor: number;
+  private readonly capMs: number;
+  private readonly random: () => number;
+  private readonly now: () => Date;
+
+  constructor(
+    private readonly repository: OutboxRepository,
+    options: OutboxServiceOptions = {},
+  ) {
+    this.recoverLeasesBatchSize =
+      options.recoverLeasesBatchSize ?? DEFAULT_RECOVER_BATCH_SIZE;
+    this.baseMs = options.backoff?.baseMs ?? DEFAULT_BACKOFF_BASE_MS;
+    this.factor = options.backoff?.factor ?? DEFAULT_BACKOFF_FACTOR;
+    this.capMs = options.backoff?.capMs ?? DEFAULT_BACKOFF_CAP_MS;
+    this.random = options.backoff?.random ?? Math.random;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  /**
+   * Insert a row for a fresh match. Replay-safe: a second call with
+   * the same (reactorName, dedupKey) is a no-op and returns
+   * `enqueued: false`. The caller is responsible for posting a
+   * wakeup to the GroupQueue afterwards.
+   */
+  async enqueue(params: EnqueueOutboxParams): Promise<EnqueueOutboxResult> {
+    const enqueued = await this.repository.insertIfAbsent({
+      projectId: params.projectId,
+      reactorName: params.reactorName,
+      dedupKey: params.dedupKey,
+      groupKey: params.groupKey,
+      payload: params.payload,
+      maxAttempts: params.maxAttempts,
+    });
+    return { enqueued };
+  }
+
+  /**
+   * Lease the next claimable row for (projectId, reactorName). Returns
+   * null when the queue for this group is empty or all rows are still
+   * backing off.
+   */
+  async leaseNext(params: LeaseOutboxParams): Promise<OutboxRow | null> {
+    const now = this.now();
+    const leasedUntil = new Date(now.getTime() + params.leaseDurationMs);
+    return this.repository.leaseNext({
+      projectId: params.projectId,
+      reactorName: params.reactorName,
+      leasedUntil,
+      now,
+    });
+  }
+
+  async markDispatched(rowId: string): Promise<void> {
+    await this.repository.markDispatched({ rowId, now: this.now() });
+  }
+
+  /**
+   * Record a retryable failure. Increments attempts, schedules the
+   * next attempt via exponential backoff, and promotes to `dead`
+   * when the row exceeds its `maxAttempts`.
+   *
+   * The repository has already incremented `attempts` on lease, so
+   * the row passed back here reflects the post-attempt count.
+   */
+  async markFailedRetryable(
+    params: MarkFailedRetryableParams,
+  ): Promise<MarkFailedRetryableResult> {
+    const row = await this.repository.findById(params.rowId);
+    if (!row) {
+      throw new Error(
+        `OutboxService.markFailedRetryable: row ${params.rowId} not found`,
+      );
+    }
+
+    const now = this.now();
+
+    if (row.attempts >= row.maxAttempts) {
+      await this.repository.markRetry({
+        rowId: row.id,
+        attempts: row.attempts,
+        status: "dead",
+        nextAttemptAt: null,
+        lastError: params.error,
+        lastErrorAt: now,
+      });
+      return { status: "dead", nextAttemptAt: null };
+    }
+
+    const backoffMs =
+      params.backoffMs ??
+      calculateBackoffMs({
+        attempts: row.attempts,
+        baseMs: this.baseMs,
+        factor: this.factor,
+        capMs: this.capMs,
+        random: this.random,
+      });
+    const nextAttemptAt = new Date(now.getTime() + backoffMs);
+
+    await this.repository.markRetry({
+      rowId: row.id,
+      attempts: row.attempts,
+      status: "failed_retryable",
+      nextAttemptAt,
+      lastError: params.error,
+      lastErrorAt: now,
+    });
+
+    return { status: "failed_retryable", nextAttemptAt };
+  }
+
+  /**
+   * Force a row to `dead` regardless of attempts — used when the
+   * dispatcher reports a permanently fatal failure (e.g. 4xx from
+   * provider, malformed template).
+   */
+  async markDead({
+    rowId,
+    error,
+  }: {
+    rowId: string;
+    error: string;
+  }): Promise<void> {
+    const row = await this.repository.findById(rowId);
+    if (!row) {
+      throw new Error(`OutboxService.markDead: row ${rowId} not found`);
+    }
+    const now = this.now();
+    await this.repository.markRetry({
+      rowId: row.id,
+      attempts: row.attempts,
+      status: "dead",
+      nextAttemptAt: null,
+      lastError: error,
+      lastErrorAt: now,
+    });
+  }
+
+  /**
+   * Reset rows whose lease expired without the worker reporting back.
+   * Drainer worker should call this on a slow timer (every ~30s)
+   * since it is independent of any specific wakeup.
+   */
+  async recoverStuckLeases(
+    params: RecoverStuckLeasesParams = {},
+  ): Promise<number> {
+    return this.repository.recoverExpiredLeases({
+      now: this.now(),
+      limit: params.limit ?? this.recoverLeasesBatchSize,
+    });
+  }
+
+  async list(params: ListOutboxParams): Promise<OutboxRow[]> {
+    return this.repository.list({
+      projectId: params.projectId,
+      reactorName: params.reactorName,
+      status: params.status,
+      limit: params.limit ?? 100,
+    });
+  }
+}

--- a/langwatch/src/server/event-sourcing/outbox/outbox.service.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.service.ts
@@ -69,8 +69,20 @@ export class OutboxService {
    * the same (reactorName, dedupKey) is a no-op and returns
    * `enqueued: false`. The caller is responsible for posting a
    * wakeup to the GroupQueue afterwards.
+   *
+   * Validates that `groupKey` starts with `${projectId}/` so the
+   * wakeup parses cleanly under `tenantIdFromGroupId` (ADR-023). A
+   * misformatted key would silently land in the wrong tenant bucket
+   * for fair-scheduling purposes — failing here at enqueue is much
+   * cheaper to debug than a starvation bug in production.
    */
   async enqueue(params: EnqueueOutboxParams): Promise<EnqueueOutboxResult> {
+    const required = `${params.projectId}/`;
+    if (!params.groupKey.startsWith(required)) {
+      throw new Error(
+        `OutboxService.enqueue: groupKey must start with "${required}" (got "${params.groupKey}"). See ADR-023.`,
+      );
+    }
     const enqueued = await this.repository.insertIfAbsent({
       projectId: params.projectId,
       reactorName: params.reactorName,

--- a/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
@@ -19,10 +19,17 @@ export interface EnqueueOutboxParams {
    * are the claim primitive that makes pipeline replays safe — see
    * ADR-022.
    *
-   * Convention (subject-namespaced so a future trigger type cannot
-   * collide):
-   *   - Trace/evaluation triggers: `${triggerId}:trace:${traceId}`
-   *   - Custom-graph alerts:       `${triggerId}:graph:${customGraphId}`
+   * Convention (per-trigger subject scoping; the `${projectId}/` prefix
+   * mirrors the `groupKey` shape so every dedup/group identifier in the
+   * outbox layer is self-describing for an operator scanning rows; the
+   * `:trace:` / `:graph:` discriminator namespaces subject types):
+   *   - Trace/evaluation triggers: `${projectId}/${triggerId}:trace:${traceId}`
+   *   - Custom-graph alerts:       `${projectId}/${triggerId}:graph:${customGraphId}`
+   *
+   * Aggregate-driven triggers (window-bucketed, no per-occurrence
+   * subject row) are a separate future namespace —
+   * `${projectId}/${triggerId}:${groupByLabelsHash}:${windowBucket}` —
+   * not a per-subject key.
    */
   dedupKey: string;
   /**

--- a/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
@@ -1,0 +1,73 @@
+import type { Prisma, ReactorOutbox, ReactorOutboxStatus } from "@prisma/client";
+
+export type OutboxRow = ReactorOutbox;
+export type OutboxStatus = ReactorOutboxStatus;
+
+/**
+ * JSON payload stored on a ReactorOutbox row.
+ *
+ * Variable-size data goes here (trigger config, target ids, rendered
+ * template inputs) so wakeup payloads stay constant-size — see ADR-023.
+ */
+export type OutboxPayload = Prisma.InputJsonValue;
+
+export interface EnqueueOutboxParams {
+  projectId: string;
+  reactorName: string;
+  /**
+   * Stable identifier of the match. Collisions on (reactorName, dedupKey)
+   * are the claim primitive that makes pipeline replays safe — see
+   * ADR-022. Typical shape: `${entityId}:${targetId}`.
+   */
+  dedupKey: string;
+  /**
+   * GroupQueue routing key for the wakeup payload. Drives per-group
+   * FIFO and fair scheduling — typically the projectId or tenantId.
+   * See ADR-023.
+   */
+  groupKey: string;
+  payload: OutboxPayload;
+  /** Override the per-row max retry count (default 8). */
+  maxAttempts?: number;
+}
+
+export interface EnqueueOutboxResult {
+  /** False when a row already existed for (reactorName, dedupKey). */
+  enqueued: boolean;
+}
+
+export interface LeaseOutboxParams {
+  projectId: string;
+  reactorName: string;
+  /** How long the lease should hold before another worker can re-claim. */
+  leaseDurationMs: number;
+}
+
+export interface MarkFailedRetryableParams {
+  rowId: string;
+  error: string;
+  /**
+   * Optional explicit backoff override (ms). When omitted, the service
+   * derives the next attempt time from `attempts` via exponential
+   * backoff — see `backoff.ts`.
+   */
+  backoffMs?: number;
+}
+
+export interface MarkFailedRetryableResult {
+  /** "dead" when the failure pushed `attempts` past `maxAttempts`. */
+  status: Extract<OutboxStatus, "failed_retryable" | "dead">;
+  nextAttemptAt: Date | null;
+}
+
+export interface RecoverStuckLeasesParams {
+  /** Cap on rows touched per sweep to keep latency bounded. */
+  limit?: number;
+}
+
+export interface ListOutboxParams {
+  projectId: string;
+  reactorName?: string;
+  status?: OutboxStatus;
+  limit?: number;
+}

--- a/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
@@ -65,7 +65,12 @@ export interface LeaseOutboxParams {
 }
 
 export interface MarkFailedRetryableParams {
-  rowId: string;
+  /**
+   * The leased row being failed. Carries the post-lease `attempts`
+   * count and `projectId` so the service can decide dead-promotion and
+   * scope the write without a racy re-read.
+   */
+  row: OutboxRow;
   error: string;
   /**
    * Optional explicit backoff override (ms). When omitted, the service

--- a/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
@@ -17,13 +17,27 @@ export interface EnqueueOutboxParams {
   /**
    * Stable identifier of the match. Collisions on (reactorName, dedupKey)
    * are the claim primitive that makes pipeline replays safe — see
-   * ADR-022. Typical shape: `${entityId}:${targetId}`.
+   * ADR-022.
+   *
+   * Convention (subject-namespaced so a future trigger type cannot
+   * collide):
+   *   - Trace/evaluation triggers: `${triggerId}:trace:${traceId}`
+   *   - Custom-graph alerts:       `${triggerId}:graph:${customGraphId}`
    */
   dedupKey: string;
   /**
-   * GroupQueue routing key for the wakeup payload. Drives per-group
-   * FIFO and fair scheduling — typically the projectId or tenantId.
-   * See ADR-023.
+   * GroupQueue routing key for the wakeup payload — see ADR-023.
+   * MUST begin with `${projectId}/` so `tenantIdFromGroupId` can
+   * extract the tenant for per-tenant fairness via
+   * `TenantRateTracker`. The outbox queue is free-standing and
+   * bypasses `queueManager`'s automatic `${tenantId}/` wrapping, so
+   * the producer is responsible for the prefix.
+   *
+   * Convention for trigger reactors:
+   *   `${projectId}/${reactorName}:${triggerId}`
+   *
+   * Per-trigger FIFO falls out of this shape — every wakeup for the
+   * same trigger lands in the same group.
    */
   groupKey: string;
   payload: OutboxPayload;

--- a/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
@@ -43,8 +43,10 @@ export interface EnqueueOutboxParams {
    * Convention for trigger reactors:
    *   `${projectId}/${reactorName}:${triggerId}`
    *
-   * Per-trigger FIFO falls out of this shape — every wakeup for the
-   * same trigger lands in the same group.
+   * Wakeups for the same groupKey are serialised by the GroupQueue,
+   * so only one drainer at a time runs the dispatch loop for a given
+   * trigger. NOTE this is wakeup-level serialisation, not row-level
+   * ordering — see the longer note on `OutboxWakeup.groupKey`.
    */
   groupKey: string;
   payload: OutboxPayload;

--- a/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outbox.types.ts
@@ -19,6 +19,13 @@ export interface EnqueueOutboxParams {
    * are the claim primitive that makes pipeline replays safe — see
    * ADR-022.
    *
+   * MUST begin with `${projectId}/`. The unique index is global on
+   * `(reactorName, dedupKey)` and the row carries `projectId` as a
+   * column, not part of the claim key — without the prefix a producer
+   * in project A could suppress an enqueue for the same unprefixed key
+   * in project B under the same reactor. `OutboxService.enqueue`
+   * validates the prefix and throws before any row is written.
+   *
    * Convention (per-trigger subject scoping; the `${projectId}/` prefix
    * mirrors the `groupKey` shape so every dedup/group identifier in the
    * outbox layer is self-describing for an operator scanning rows; the
@@ -43,10 +50,10 @@ export interface EnqueueOutboxParams {
    * Convention for trigger reactors:
    *   `${projectId}/${reactorName}:${triggerId}`
    *
-   * Wakeups for the same groupKey are serialised by the GroupQueue,
-   * so only one drainer at a time runs the dispatch loop for a given
-   * trigger. NOTE this is wakeup-level serialisation, not row-level
-   * ordering — see the longer note on `OutboxWakeup.groupKey`.
+   * Per-trigger FIFO holds at both the wakeup boundary (the
+   * GroupQueue serialises wakeups per groupKey) and at the row
+   * level (the drainer's `leaseNext` scopes its claim by
+   * groupKey) — see the longer note on `OutboxWakeup.groupKey`.
    */
   groupKey: string;
   payload: OutboxPayload;
@@ -62,6 +69,13 @@ export interface EnqueueOutboxResult {
 export interface LeaseOutboxParams {
   projectId: string;
   reactorName: string;
+  /**
+   * GroupQueue routing key of the wakeup driving this lease. Scoping
+   * the claim by `groupKey` keeps per-trigger FIFO at the row level —
+   * a wakeup for trigger A can never drain trigger B's row, even when
+   * trigger B's `nextAttemptAt` is older. See ADR-023.
+   */
+  groupKey: string;
   /** How long the lease should hold before another worker can re-claim. */
   leaseDurationMs: number;
 }

--- a/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
@@ -1,0 +1,65 @@
+import type { Event } from "../domain/types";
+import type { ReactorContext, ReactorOptions } from "../reactors/reactor.types";
+
+/**
+ * A single dispatch decision returned by an outbox reactor. The
+ * reactor evaluates an event + fold state and returns zero or more
+ * requests; each maps 1:1 to a ReactorOutbox row (subject to
+ * dedupKey collision).
+ */
+export interface OutboxEnqueueRequest {
+  /**
+   * Stable identity of the match. (reactorName, dedupKey) is the
+   * claim primitive — collisions deduplicate. See ADR-022.
+   */
+  dedupKey: string;
+  /**
+   * GroupQueue routing key for the wakeup. Typically projectId or
+   * tenantId. See ADR-023.
+   */
+  groupKey: string;
+  /**
+   * Variable-size dispatch payload. Stays in PG; never carried in
+   * wakeup payloads.
+   */
+  payload: unknown;
+  /**
+   * Per-row override for the retry budget. Defaults to the
+   * outbox-wide setting (8 attempts).
+   */
+  maxAttempts?: number;
+}
+
+/**
+ * Definition of an outbox-backed reactor — a stake-sensitive
+ * side-effect handler whose dispatch is durable, retried, and
+ * operator-queryable.
+ *
+ * Use `.withOutbox(projection, name, definition)` instead of
+ * `.withReactor(...)` when the side effect MUST not be silently
+ * swallowed (customer emails, Slack messages, dataset writes). See
+ * ADR-024 for the criteria.
+ *
+ * Unlike a `ReactorDefinition`, an outbox reactor does not perform
+ * the side effect inline. It only decides — by returning enqueue
+ * requests — what to dispatch later. The actual dispatch logic
+ * lives in an `OutboxDispatcher` registered against the same
+ * `reactorName` on the OutboxDrainer.
+ */
+export interface OutboxReactorDefinition<
+  E extends Event = Event,
+  FoldState = unknown,
+> {
+  name: string;
+  /**
+   * Decide which (if any) outbox rows to enqueue for this event.
+   * Returns an empty array when nothing matches. Replay-safe — the
+   * outbox dedupes on (name, dedupKey) so callers do not need to
+   * track which matches they have already enqueued.
+   */
+  decide(
+    event: E,
+    context: ReactorContext<FoldState>,
+  ): Promise<OutboxEnqueueRequest[]>;
+  options?: ReactorOptions;
+}

--- a/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
@@ -12,10 +12,12 @@ export interface OutboxEnqueueRequest {
    * Stable identity of the match. (reactorName, dedupKey) is the
    * claim primitive — collisions deduplicate. See ADR-022.
    *
-   * Convention (subject-namespaced so a future trigger type cannot
-   * collide):
-   *   - Trace/evaluation triggers: `${triggerId}:trace:${traceId}`
-   *   - Custom-graph alerts:       `${triggerId}:graph:${customGraphId}`
+   * Convention (mirrors `groupKey` shape with a `${projectId}/`
+   * prefix so dedup/group identifiers stay self-describing for
+   * operator scans; `:trace:` / `:graph:` discriminator namespaces
+   * subject types):
+   *   - Trace/evaluation triggers: `${projectId}/${triggerId}:trace:${traceId}`
+   *   - Custom-graph alerts:       `${projectId}/${triggerId}:graph:${customGraphId}`
    */
   dedupKey: string;
   /**

--- a/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
@@ -31,7 +31,10 @@ export interface OutboxEnqueueRequest {
    * Convention for trigger reactors:
    *   `${projectId}/${reactorName}:${triggerId}`
    *
-   * Per-trigger FIFO falls out of this shape.
+   * Wakeups for the same groupKey are serialised by the GroupQueue,
+   * so only one drainer at a time runs the dispatch loop for a given
+   * trigger. NOTE this is wakeup-level serialisation, not row-level
+   * ordering — see the longer note on `OutboxWakeup.groupKey`.
    */
   groupKey: string;
   /**

--- a/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
@@ -31,10 +31,10 @@ export interface OutboxEnqueueRequest {
    * Convention for trigger reactors:
    *   `${projectId}/${reactorName}:${triggerId}`
    *
-   * Wakeups for the same groupKey are serialised by the GroupQueue,
-   * so only one drainer at a time runs the dispatch loop for a given
-   * trigger. NOTE this is wakeup-level serialisation, not row-level
-   * ordering — see the longer note on `OutboxWakeup.groupKey`.
+   * Per-trigger FIFO holds at both the wakeup boundary (the
+   * GroupQueue serialises wakeups per groupKey) and at the row
+   * level (the drainer's `leaseNext` scopes its claim by
+   * groupKey) — see the longer note on `OutboxWakeup.groupKey`.
    */
   groupKey: string;
   /**

--- a/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
+++ b/langwatch/src/server/event-sourcing/outbox/outboxReactor.types.ts
@@ -11,11 +11,25 @@ export interface OutboxEnqueueRequest {
   /**
    * Stable identity of the match. (reactorName, dedupKey) is the
    * claim primitive — collisions deduplicate. See ADR-022.
+   *
+   * Convention (subject-namespaced so a future trigger type cannot
+   * collide):
+   *   - Trace/evaluation triggers: `${triggerId}:trace:${traceId}`
+   *   - Custom-graph alerts:       `${triggerId}:graph:${customGraphId}`
    */
   dedupKey: string;
   /**
-   * GroupQueue routing key for the wakeup. Typically projectId or
-   * tenantId. See ADR-023.
+   * GroupQueue routing key for the wakeup — see ADR-023. MUST begin
+   * with `${projectId}/` because the outbox queue is free-standing
+   * and bypasses `queueManager`'s automatic `${tenantId}/` wrapping;
+   * the producer is responsible for the prefix so
+   * `tenantIdFromGroupId` can extract the tenant for per-tenant
+   * fairness via `TenantRateTracker`.
+   *
+   * Convention for trigger reactors:
+   *   `${projectId}/${reactorName}:${triggerId}`
+   *
+   * Per-trigger FIFO falls out of this shape.
    */
   groupKey: string;
   /**

--- a/langwatch/src/server/event-sourcing/outbox/wakeupQueue.ts
+++ b/langwatch/src/server/event-sourcing/outbox/wakeupQueue.ts
@@ -10,13 +10,21 @@ import type { EventSourcedQueueDefinition } from "../queues/queue.types";
  */
 export interface OutboxWakeup extends Record<string, unknown> {
   reactorName: string;
-  groupKey: string;
   /**
-   * Tenant for fair scheduling (`TenantRateTracker` reads this).
-   * Typically identical to `groupKey`, but kept explicit so callers
-   * can group by something other than tenant if needed.
+   * The wakeup's GroupQueue routing key. MUST start with `${projectId}/`
+   * because the outbox queue is free-standing — it bypasses
+   * `queueManager`'s automatic `${tenantId}/` wrapping, so the
+   * producer is responsible for the prefix so `tenantIdFromGroupId`
+   * (see `src/server/observability/tenantRateTracker.ts`) can extract
+   * the tenant for per-tenant fairness via `TenantRateTracker`.
+   *
+   * Convention for trigger reactors:
+   *   `${projectId}/${reactorName}:${triggerId}`
+   *
+   * Per-trigger FIFO falls out of this shape: every wakeup for the
+   * same trigger lands in the same group and is processed serially.
    */
-  tenantId: string;
+  groupKey: string;
   /**
    * Wall-clock score for global ordering — see ADR-023. Defaults to
    * the enqueue time but callers may override (e.g. retry scheduling
@@ -42,7 +50,11 @@ export function defineOutboxWakeupQueue({
   return {
     name,
     process,
-    groupKey: (payload) => `${payload.reactorName}:${payload.groupKey}`,
+    // groupKey IS already the full `${projectId}/${reactorName}:${triggerId}`
+    // form (or equivalent) — see the field comment on OutboxWakeup. The
+    // queue's per-group FIFO uses it as-is; `tenantIdFromGroupId` parses
+    // the projectId out for fair scheduling.
+    groupKey: (payload) => payload.groupKey,
     score: (payload) => payload.scheduledAt,
     options: {
       // Drainer workload is IO-bound (PG lease + HTTP dispatch). The

--- a/langwatch/src/server/event-sourcing/outbox/wakeupQueue.ts
+++ b/langwatch/src/server/event-sourcing/outbox/wakeupQueue.ts
@@ -21,14 +21,12 @@ export interface OutboxWakeup extends Record<string, unknown> {
    * Convention for trigger reactors:
    *   `${projectId}/${reactorName}:${triggerId}`
    *
-   * Wakeups for the same groupKey are serialised by the GroupQueue, so
-   * only one drainer at a time runs the dispatch loop for a given
-   * trigger. NOTE this is wakeup-level serialisation, not row-level
-   * ordering: the drainer's `leaseNext` filters by `(projectId,
-   * reactorName)` and orders by `nextAttemptAt`, so within a single
-   * wakeup it may dispatch rows from sibling triggers if theirs is
-   * the earlier nextAttemptAt. Per-trigger FIFO holds only at the
-   * wakeup boundary, not across an entire (project, reactor) backlog.
+   * Per-trigger FIFO holds at BOTH levels:
+   *   - The GroupQueue serialises wakeups per groupKey, so only one
+   *     drainer at a time runs the dispatch loop for a given trigger.
+   *   - The drainer's `leaseNext` scopes its claim by `groupKey` too,
+   *     so a wakeup for trigger A can never lease trigger B's row
+   *     even if B's `nextAttemptAt` is earlier.
    */
   groupKey: string;
   /**
@@ -58,15 +56,15 @@ export function defineOutboxWakeupQueue({
     process,
     // groupKey IS already the full `${projectId}/${reactorName}:${triggerId}`
     // form (or equivalent) — see the field comment on OutboxWakeup. The
-    // queue's per-group serialisation uses it as-is; `tenantIdFromGroupId`
-    // parses the projectId out for fair scheduling.
+    // queue's per-group FIFO uses it as-is; `tenantIdFromGroupId` parses
+    // the projectId out for fair scheduling.
     groupKey: (payload) => payload.groupKey,
     score: (payload) => payload.scheduledAt,
     options: {
       // Drainer workload is IO-bound (PG lease + HTTP dispatch). The
-      // per-group serialisation means an individual group never goes
-      // parallel — we just want enough parallelism across groups to
-      // cover dispatcher latency.
+      // per-group FIFO means an individual group never goes parallel —
+      // we just want enough parallelism across groups to cover
+      // dispatcher latency.
       concurrency: 10,
       globalConcurrency: 300,
     },

--- a/langwatch/src/server/event-sourcing/outbox/wakeupQueue.ts
+++ b/langwatch/src/server/event-sourcing/outbox/wakeupQueue.ts
@@ -21,8 +21,14 @@ export interface OutboxWakeup extends Record<string, unknown> {
    * Convention for trigger reactors:
    *   `${projectId}/${reactorName}:${triggerId}`
    *
-   * Per-trigger FIFO falls out of this shape: every wakeup for the
-   * same trigger lands in the same group and is processed serially.
+   * Wakeups for the same groupKey are serialised by the GroupQueue, so
+   * only one drainer at a time runs the dispatch loop for a given
+   * trigger. NOTE this is wakeup-level serialisation, not row-level
+   * ordering: the drainer's `leaseNext` filters by `(projectId,
+   * reactorName)` and orders by `nextAttemptAt`, so within a single
+   * wakeup it may dispatch rows from sibling triggers if theirs is
+   * the earlier nextAttemptAt. Per-trigger FIFO holds only at the
+   * wakeup boundary, not across an entire (project, reactor) backlog.
    */
   groupKey: string;
   /**
@@ -52,15 +58,15 @@ export function defineOutboxWakeupQueue({
     process,
     // groupKey IS already the full `${projectId}/${reactorName}:${triggerId}`
     // form (or equivalent) — see the field comment on OutboxWakeup. The
-    // queue's per-group FIFO uses it as-is; `tenantIdFromGroupId` parses
-    // the projectId out for fair scheduling.
+    // queue's per-group serialisation uses it as-is; `tenantIdFromGroupId`
+    // parses the projectId out for fair scheduling.
     groupKey: (payload) => payload.groupKey,
     score: (payload) => payload.scheduledAt,
     options: {
       // Drainer workload is IO-bound (PG lease + HTTP dispatch). The
-      // per-group FIFO means an individual group never goes parallel
-      // — we just want enough parallelism across groups to cover
-      // dispatcher latency.
+      // per-group serialisation means an individual group never goes
+      // parallel — we just want enough parallelism across groups to
+      // cover dispatcher latency.
       concurrency: 10,
       globalConcurrency: 300,
     },

--- a/langwatch/src/server/event-sourcing/outbox/wakeupQueue.ts
+++ b/langwatch/src/server/event-sourcing/outbox/wakeupQueue.ts
@@ -1,0 +1,56 @@
+import type { EventSourcedQueueDefinition } from "../queues/queue.types";
+
+/**
+ * Wakeup payload sent to the GroupQueue when a row is enqueued (or
+ * scheduled for retry). Carries only the routing keys — the variable-
+ * size dispatch payload stays in PG. See ADR-023.
+ *
+ * Constant size means the queue never bloats regardless of how many
+ * matches a single trigger produces.
+ */
+export interface OutboxWakeup extends Record<string, unknown> {
+  reactorName: string;
+  groupKey: string;
+  /**
+   * Tenant for fair scheduling (`TenantRateTracker` reads this).
+   * Typically identical to `groupKey`, but kept explicit so callers
+   * can group by something other than tenant if needed.
+   */
+  tenantId: string;
+  /**
+   * Wall-clock score for global ordering — see ADR-023. Defaults to
+   * the enqueue time but callers may override (e.g. retry scheduling
+   * sets it to the nextAttemptAt timestamp).
+   */
+  scheduledAt: number;
+}
+
+/**
+ * Process function for the wakeup queue. Receives a wakeup, then
+ * drains as many rows as it can for (reactorName, groupKey) by
+ * leasing from the outbox and calling the registered dispatcher.
+ */
+export type OutboxWakeupProcessor = (wakeup: OutboxWakeup) => Promise<void>;
+
+export function defineOutboxWakeupQueue({
+  name,
+  process,
+}: {
+  name: string;
+  process: OutboxWakeupProcessor;
+}): EventSourcedQueueDefinition<OutboxWakeup> {
+  return {
+    name,
+    process,
+    groupKey: (payload) => `${payload.reactorName}:${payload.groupKey}`,
+    score: (payload) => payload.scheduledAt,
+    options: {
+      // Drainer workload is IO-bound (PG lease + HTTP dispatch). The
+      // per-group FIFO means an individual group never goes parallel
+      // — we just want enough parallelism across groups to cover
+      // dispatcher latency.
+      concurrency: 10,
+      globalConcurrency: 300,
+    },
+  };
+}

--- a/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.test.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.test.ts
@@ -200,6 +200,24 @@ describe("StaticPipelineBuilder validations", () => {
     });
   });
 
+  describe("when the reactorName argument differs from definition.name", () => {
+    it("throws ConfigurationError so the identities cannot drift", () => {
+      const fold = createMockFoldProjectionDefinition<Event>("myFold");
+      const outboxReactor: OutboxReactorDefinition<Event> = {
+        name: "definitionName",
+        decide: vi.fn().mockResolvedValue([]),
+      };
+
+      expect(() =>
+        definePipeline<Event>()
+          .withName("test-pipeline")
+          .withAggregateType("trace")
+          .withFoldProjection("myFold", fold)
+          .withOutbox("myFold", "argName", outboxReactor),
+      ).toThrow(/name mismatch/);
+    });
+  });
+
   describe("when an outbox reactor reuses an existing reactor name", () => {
     it("throws ConfigurationError", () => {
       const fold = createMockFoldProjectionDefinition<Event>("myFold");

--- a/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.test.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.test.ts
@@ -5,6 +5,7 @@ import {
   createMockMapProjectionDefinition,
 } from "../../services/__tests__/testHelpers";
 import type { Event } from "../../domain/types";
+import type { OutboxReactorDefinition } from "../../outbox/outboxReactor.types";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
 
 describe("StaticPipelineBuilder validations", () => {
@@ -130,6 +131,117 @@ describe("StaticPipelineBuilder validations", () => {
           .withFoldProjection("myFold", fold)
           .withReactor("myFold", "sameName", reactor1)
           .withReactor("myFold", "sameName", reactor2),
+      ).toThrow(/already exists/);
+    });
+  });
+
+  describe("when outbox reactor is registered on a fold projection", () => {
+    it("stores it in foldOutboxReactors and leaves foldReactors empty", () => {
+      const fold = createMockFoldProjectionDefinition<Event>("myFold");
+      const outboxReactor: OutboxReactorDefinition<Event> = {
+        name: "alertDispatch",
+        decide: vi.fn().mockResolvedValue([]),
+      };
+
+      const pipeline = definePipeline<Event>()
+        .withName("test-pipeline")
+        .withAggregateType("trace")
+        .withFoldProjection("myFold", fold)
+        .withOutbox("myFold", "alertDispatch", outboxReactor)
+        .build();
+
+      expect(pipeline.foldOutboxReactors.size).toBe(1);
+      expect(pipeline.foldReactors.size).toBe(0);
+      expect(pipeline.mapOutboxReactors.size).toBe(0);
+      expect(
+        pipeline.foldOutboxReactors.get("alertDispatch")?.projectionName,
+      ).toBe("myFold");
+    });
+  });
+
+  describe("when outbox reactor is registered on a map projection", () => {
+    it("stores it in mapOutboxReactors", () => {
+      const mapProj = createMockMapProjectionDefinition<Event>("myMap");
+      const outboxReactor: OutboxReactorDefinition<Event> = {
+        name: "datasetWrite",
+        decide: vi.fn().mockResolvedValue([]),
+      };
+
+      const pipeline = definePipeline<Event>()
+        .withName("test-pipeline")
+        .withAggregateType("trace")
+        .withMapProjection("myMap", mapProj)
+        .withOutbox("myMap", "datasetWrite", outboxReactor)
+        .build();
+
+      expect(pipeline.mapOutboxReactors.size).toBe(1);
+      expect(pipeline.foldOutboxReactors.size).toBe(0);
+      expect(
+        pipeline.mapOutboxReactors.get("datasetWrite")?.projectionName,
+      ).toBe("myMap");
+    });
+  });
+
+  describe("when outbox reactor is registered on a non-existent projection", () => {
+    it("throws ConfigurationError", () => {
+      const fold = createMockFoldProjectionDefinition<Event>("myFold");
+      const outboxReactor: OutboxReactorDefinition<Event> = {
+        name: "alertDispatch",
+        decide: vi.fn().mockResolvedValue([]),
+      };
+
+      expect(() =>
+        definePipeline<Event>()
+          .withName("test-pipeline")
+          .withAggregateType("trace")
+          .withFoldProjection("myFold", fold)
+          .withOutbox("missing" as any, "alertDispatch", outboxReactor),
+      ).toThrow(/projection not found/);
+    });
+  });
+
+  describe("when an outbox reactor reuses an existing reactor name", () => {
+    it("throws ConfigurationError", () => {
+      const fold = createMockFoldProjectionDefinition<Event>("myFold");
+      const reactor: ReactorDefinition<Event> = {
+        name: "shared",
+        handle: vi.fn(),
+      };
+      const outboxReactor: OutboxReactorDefinition<Event> = {
+        name: "shared",
+        decide: vi.fn().mockResolvedValue([]),
+      };
+
+      expect(() =>
+        definePipeline<Event>()
+          .withName("test-pipeline")
+          .withAggregateType("trace")
+          .withFoldProjection("myFold", fold)
+          .withReactor("myFold", "shared", reactor)
+          .withOutbox("myFold", "shared", outboxReactor),
+      ).toThrow(/already exists/);
+    });
+  });
+
+  describe("when a regular reactor reuses an existing outbox-reactor name", () => {
+    it("throws ConfigurationError", () => {
+      const fold = createMockFoldProjectionDefinition<Event>("myFold");
+      const reactor: ReactorDefinition<Event> = {
+        name: "shared",
+        handle: vi.fn(),
+      };
+      const outboxReactor: OutboxReactorDefinition<Event> = {
+        name: "shared",
+        decide: vi.fn().mockResolvedValue([]),
+      };
+
+      expect(() =>
+        definePipeline<Event>()
+          .withName("test-pipeline")
+          .withAggregateType("trace")
+          .withFoldProjection("myFold", fold)
+          .withOutbox("myFold", "shared", outboxReactor)
+          .withReactor("myFold", "shared", reactor),
       ).toThrow(/already exists/);
     });
   });

--- a/langwatch/src/server/event-sourcing/pipeline/staticBuilder.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/staticBuilder.ts
@@ -12,6 +12,7 @@ import type {
 } from "../commands/commandHandlerClass";
 import type { AggregateType } from "../domain/aggregateType";
 import type { Event, Projection } from "../domain/types";
+import type { OutboxReactorDefinition } from "../outbox/outboxReactor.types";
 import type { FoldProjectionDefinition, FoldProjectionOptions } from "../projections/foldProjection.types";
 import type { MapProjectionDefinition, MapProjectionOptions } from "../projections/mapProjection.types";
 import type { ReactorDefinition } from "../reactors/reactor.types";
@@ -114,6 +115,18 @@ export class StaticPipelineBuilderWithNameAndType<
     string,
     { projectionName: string; definition: ReactorDefinition<EventType> }
   >();
+  // Outbox reactors are projection-attached like `foldReactors` /
+  // `mapReactors`, but their dispatch path runs through the
+  // ReactorOutbox + drainer rather than firing inline post-fold.
+  // See dev/docs/adr/024-withoutbox-pipeline-builder-primitive.md.
+  private foldOutboxReactors = new Map<
+    string,
+    { projectionName: string; definition: OutboxReactorDefinition<EventType> }
+  >();
+  private mapOutboxReactors = new Map<
+    string,
+    { projectionName: string; definition: OutboxReactorDefinition<EventType> }
+  >();
   private featureFlagService?: FeatureFlagServiceInterface;
 
   constructor(
@@ -214,7 +227,12 @@ export class StaticPipelineBuilderWithNameAndType<
     reactorName: string,
     definition: ReactorDefinition<EventType>,
   ): this {
-    if (this.foldReactors.has(reactorName) || this.mapReactors.has(reactorName)) {
+    const nameTaken =
+      this.foldReactors.has(reactorName) ||
+      this.mapReactors.has(reactorName) ||
+      this.foldOutboxReactors.has(reactorName) ||
+      this.mapOutboxReactors.has(reactorName);
+    if (nameTaken) {
       throw new ConfigurationError(
         "StaticPipelineBuilder",
         `Reactor with name "${reactorName}" already exists`,
@@ -230,6 +248,55 @@ export class StaticPipelineBuilderWithNameAndType<
       throw new ConfigurationError(
         "StaticPipelineBuilder",
         `Cannot register reactor "${reactorName}" on projection "${projectionName}" — projection not found`,
+        { projectionName, reactorName },
+      );
+    }
+
+    return this;
+  }
+
+  /**
+   * Register an outbox-backed reactor on a fold or map projection.
+   *
+   * Mirrors `.withReactor` but routes dispatch through the
+   * ReactorOutbox + drainer instead of firing inline post-fold. Use
+   * this for stake-sensitive side effects (customer email/Slack,
+   * dataset writes) that need durable retry and operator visibility
+   * — see dev/docs/adr/024-withoutbox-pipeline-builder-primitive.md.
+   *
+   * The definition's `decide(event, context)` returns the enqueue
+   * requests (zero or more); the runtime fans them into outbox rows
+   * and posts a single wakeup per request. The actual dispatch
+   * (HTTP call, mailer, dataset write) is performed by an
+   * `OutboxDispatcher` registered against the same `reactorName` on
+   * the OutboxDrainer.
+   */
+  withOutbox(
+    projectionName: FoldNames | MapNames,
+    reactorName: string,
+    definition: OutboxReactorDefinition<EventType>,
+  ): this {
+    const nameTaken =
+      this.foldReactors.has(reactorName) ||
+      this.mapReactors.has(reactorName) ||
+      this.foldOutboxReactors.has(reactorName) ||
+      this.mapOutboxReactors.has(reactorName);
+    if (nameTaken) {
+      throw new ConfigurationError(
+        "StaticPipelineBuilder",
+        `Reactor with name "${reactorName}" already exists`,
+        { reactorName },
+      );
+    }
+
+    if (this.foldProjections.has(projectionName)) {
+      this.foldOutboxReactors.set(reactorName, { projectionName, definition });
+    } else if (this.mapProjections.has(projectionName)) {
+      this.mapOutboxReactors.set(reactorName, { projectionName, definition });
+    } else {
+      throw new ConfigurationError(
+        "StaticPipelineBuilder",
+        `Cannot register outbox reactor "${reactorName}" on projection "${projectionName}" — projection not found`,
         { projectionName, reactorName },
       );
     }
@@ -375,6 +442,8 @@ export class StaticPipelineBuilderWithNameAndType<
       commands: this.commands,
       foldReactors: this.foldReactors,
       mapReactors: this.mapReactors,
+      foldOutboxReactors: this.foldOutboxReactors,
+      mapOutboxReactors: this.mapOutboxReactors,
       featureFlagService: this.featureFlagService,
 
       // Purely for typing: lets downstream code infer the command names + payloads

--- a/langwatch/src/server/event-sourcing/pipeline/staticBuilder.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/staticBuilder.ts
@@ -276,6 +276,14 @@ export class StaticPipelineBuilderWithNameAndType<
     reactorName: string,
     definition: OutboxReactorDefinition<EventType>,
   ): this {
+    if (definition.name !== reactorName) {
+      throw new ConfigurationError(
+        "StaticPipelineBuilder",
+        `Outbox reactor name mismatch: arg "${reactorName}" !== definition.name "${definition.name}"`,
+        { reactorName, definitionName: definition.name, projectionName },
+      );
+    }
+
     const nameTaken =
       this.foldReactors.has(reactorName) ||
       this.mapReactors.has(reactorName) ||

--- a/langwatch/src/server/event-sourcing/pipeline/staticBuilder.types.ts
+++ b/langwatch/src/server/event-sourcing/pipeline/staticBuilder.types.ts
@@ -2,6 +2,7 @@ import type { FeatureFlagKey } from "../../featureFlag/registry";
 import type { FeatureFlagServiceInterface } from "../../featureFlag/types";
 import type { CommandHandlerClass } from "../commands/commandHandlerClass";
 import type { Event, Projection } from "../domain/types";
+import type { OutboxReactorDefinition } from "../outbox/outboxReactor.types";
 import type { FoldProjectionDefinition, FoldProjectionOptions } from "../projections/foldProjection.types";
 import type { MapProjectionDefinition, MapProjectionOptions } from "../projections/mapProjection.types";
 import type { DeduplicationStrategy } from "../queues/queue.types";
@@ -113,6 +114,28 @@ export interface StaticPipelineDefinition<
   mapReactors: Map<
     string,
     { projectionName: string; definition: ReactorDefinition<EventType> }
+  >;
+
+  /**
+   * Outbox-backed reactors attached to fold projections. Dispatch
+   * runs through the ReactorOutbox + drainer rather than firing
+   * inline. See dev/docs/adr/024.
+   */
+  foldOutboxReactors: Map<
+    string,
+    {
+      projectionName: string;
+      definition: OutboxReactorDefinition<EventType>;
+    }
+  >;
+
+  /** Outbox-backed reactors attached to map projections. */
+  mapOutboxReactors: Map<
+    string,
+    {
+      projectionName: string;
+      definition: OutboxReactorDefinition<EventType>;
+    }
   >;
 
   /** Feature flag service for kill switches */

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -160,6 +160,7 @@ export class ProjectionRouter<
                 tenantId: payload.event.tenantId,
                 aggregateId: String(payload.event.aggregateId),
                 foldState: payload.foldState,
+                isReplay: false,
               });
             },
           },
@@ -189,6 +190,7 @@ export class ProjectionRouter<
                 tenantId: payload.event.tenantId,
                 aggregateId: String(payload.event.aggregateId),
                 foldState: payload.foldState,
+                isReplay: false,
               });
             },
           },
@@ -800,6 +802,7 @@ export class ProjectionRouter<
                 tenantId: event.tenantId,
                 aggregateId: String(event.aggregateId),
                 foldState,
+                isReplay: false,
               }),
               onComplete: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "completed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
               onFail: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "failed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
@@ -828,6 +831,7 @@ export class ProjectionRouter<
               tenantId: event.tenantId,
               aggregateId: String(event.aggregateId),
               foldState,
+              isReplay: false,
             }),
             onComplete: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "completed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
             onFail: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "failed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },

--- a/langwatch/src/server/event-sourcing/reactors/reactor.types.ts
+++ b/langwatch/src/server/event-sourcing/reactors/reactor.types.ts
@@ -20,6 +20,13 @@ export interface ReactorContext<FoldState = unknown> {
    * reactors can ignore it. Optional today so existing handlers and
    * test mocks don't need updating; framework call sites always pass
    * a defined value (live events get `false`).
+   *
+   * Phase 0 only: every call site in `ProjectionRouter` currently
+   * passes `false`. The replay-detection wiring (an `isReplay` flag
+   * on the event envelope or the projection runner) lands in Phase
+   * 1 alongside the `.withOutbox` reactor wrappers — see the
+   * "Replay short-circuits .withOutbox match after row retention has
+   * elapsed" scenario in specs/event-sourcing/reactor-outbox.feature.
    */
   isReplay?: boolean;
 }

--- a/langwatch/src/server/event-sourcing/reactors/reactor.types.ts
+++ b/langwatch/src/server/event-sourcing/reactors/reactor.types.ts
@@ -9,6 +9,19 @@ export interface ReactorContext<FoldState = unknown> {
   tenantId: string;
   aggregateId: string;
   foldState: FoldState;
+  /**
+   * True when the event was produced by a stream replay rather than
+   * live ingestion. The framework `.withOutbox` wrapper short-circuits
+   * `match` on replay to avoid re-firing customer-visible side effects
+   * after outbox rows have aged out of retention — see ADR-024.
+   *
+   * `.withReactor` handlers receive the same flag and may inspect it
+   * directly if they need replay-specific behavior; most best-effort
+   * reactors can ignore it. Optional today so existing handlers and
+   * test mocks don't need updating; framework call sites always pass
+   * a defined value (live events get `false`).
+   */
+  isReplay?: boolean;
 }
 
 /**

--- a/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -139,7 +139,6 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
     await prisma.modelProvider.create({
       data: {
         id: MP_ID,
-        organizationId: ORG_ID,
         name: "openai",
         provider: "openai",
         enabled: true,

--- a/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -250,11 +250,12 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
       where: { projectId: PROJECT_ID },
     });
     await prisma.monitor.deleteMany({
-      where: { id: { in: [MONITOR_ID, MONITOR_NOT_GUARDRAIL_ID] } },
+      where: { projectId: PROJECT_ID, id: { in: [MONITOR_ID, MONITOR_NOT_GUARDRAIL_ID] } },
     });
-    await prisma.routingPolicyScope.deleteMany({
-      where: { routingPolicyId: RP_ID },
-    });
+    // RoutingPolicyScope rows are removed by the onDelete: Cascade on the
+    // routingPolicy relation when the parent policy is deleted below — an
+    // explicit deleteMany here has no projectId column to satisfy the
+    // multitenancy guard and would throw.
     await prisma.routingPolicy.deleteMany({ where: { id: RP_ID } });
     await prisma.modelProviderScope.deleteMany({
       where: { modelProviderId: MP_ID },

--- a/langwatch/src/utils/dbMultiTenancyProtection.ts
+++ b/langwatch/src/utils/dbMultiTenancyProtection.ts
@@ -471,7 +471,13 @@ const SCOPED_MODELS: Record<string, ScopedModelConfig> = {
 };
 
 const _guardProjectId = ({ params }: { params: Prisma.MiddlewareParams }) => {
-  if (params.model && EXEMPT_MODELS.includes(params.model)) return;
+  // Raw queries ($queryRaw / $executeRaw) carry no model and no
+  // structured `where` clause for this guard to inspect — tenancy is
+  // the SQL author's responsibility (e.g. the outbox lease query filters
+  // by projectId in its SQL text). Mirrors guardOrganizationId, which
+  // also short-circuits when there is no model.
+  if (!params.model) return;
+  if (EXEMPT_MODELS.includes(params.model)) return;
 
   const action = params.action;
   const model = params.model;

--- a/langwatch/src/utils/dbMultiTenancyProtection.ts
+++ b/langwatch/src/utils/dbMultiTenancyProtection.ts
@@ -470,23 +470,35 @@ const SCOPED_MODELS: Record<string, ScopedModelConfig> = {
   },
 };
 
+// Prisma actions that carry no model and no structured `where` clause
+// for this guard to inspect — for these, tenancy is the SQL author's
+// responsibility (e.g. the outbox lease query filters by projectId in
+// its SQL text). We allow them through explicitly, instead of a blanket
+// `!params.model` early return, so that any *other* actionless call
+// (an unexpected shape from a future Prisma upgrade, a mis-typed
+// middleware param) still flows into the projectId checks below and
+// fails closed rather than silently bypassing tenancy.
+const RAW_QUERY_ACTIONS: ReadonlySet<string> = new Set([
+  "queryRaw",
+  "executeRaw",
+  "runCommandRaw",
+]);
+
 const _guardProjectId = ({ params }: { params: Prisma.MiddlewareParams }) => {
-  // Raw queries ($queryRaw / $executeRaw) carry no model and no
-  // structured `where` clause for this guard to inspect — tenancy is
-  // the SQL author's responsibility. The outbox lease query is the
-  // first in-tree use case (it filters by projectId in its SQL text),
-  // but the exemption applies to ALL raw queries: any future
-  // $queryRaw / $executeRaw call must include the tenancy predicate
-  // inline; this middleware will no longer catch a missing one.
-  //
-  // Mirrors `guardOrganizationId` (dbOrganizationIdProtection.ts),
-  // which also short-circuits when there is no model. The prior
-  // behaviour (fall through with `params.model === undefined`) was
-  // load-bearing only by accident — the create/findMany checks below
-  // throw on an undefined model, which would have surfaced as a
-  // confusing `The undefined action on the undefined model …` error
-  // rather than a real tenancy violation.
-  if (!params.model) return;
+  // Narrow, explicit allowlist for raw queries — see RAW_QUERY_ACTIONS
+  // comment above. Mirrors `guardOrganizationId`
+  // (dbOrganizationIdProtection.ts), which also short-circuits when
+  // there is no model, but tightened to known actions.
+  if (!params.model && RAW_QUERY_ACTIONS.has(params.action)) return;
+  if (!params.model) {
+    // Defence in depth: any non-raw actionless call is unexpected.
+    // Fail closed with a clear message rather than letting the
+    // create/findMany checks below throw a confusing "undefined
+    // action on undefined model" error.
+    throw new Error(
+      `_guardProjectId: refusing to run a tenancy-unscoped Prisma action "${params.action}" with no model — extend RAW_QUERY_ACTIONS if this is a legitimate raw query.`,
+    );
+  }
   if (EXEMPT_MODELS.includes(params.model)) return;
 
   const action = params.action;

--- a/langwatch/src/utils/dbMultiTenancyProtection.ts
+++ b/langwatch/src/utils/dbMultiTenancyProtection.ts
@@ -473,9 +473,19 @@ const SCOPED_MODELS: Record<string, ScopedModelConfig> = {
 const _guardProjectId = ({ params }: { params: Prisma.MiddlewareParams }) => {
   // Raw queries ($queryRaw / $executeRaw) carry no model and no
   // structured `where` clause for this guard to inspect — tenancy is
-  // the SQL author's responsibility (e.g. the outbox lease query filters
-  // by projectId in its SQL text). Mirrors guardOrganizationId, which
-  // also short-circuits when there is no model.
+  // the SQL author's responsibility. The outbox lease query is the
+  // first in-tree use case (it filters by projectId in its SQL text),
+  // but the exemption applies to ALL raw queries: any future
+  // $queryRaw / $executeRaw call must include the tenancy predicate
+  // inline; this middleware will no longer catch a missing one.
+  //
+  // Mirrors `guardOrganizationId` (dbOrganizationIdProtection.ts),
+  // which also short-circuits when there is no model. The prior
+  // behaviour (fall through with `params.model === undefined`) was
+  // load-bearing only by accident — the create/findMany checks below
+  // throw on an undefined model, which would have surfaced as a
+  // confusing `The undefined action on the undefined model …` error
+  // rather than a real tenancy violation.
   if (!params.model) return;
   if (EXEMPT_MODELS.includes(params.model)) return;
 

--- a/specs/event-sourcing/reactor-outbox.feature
+++ b/specs/event-sourcing/reactor-outbox.feature
@@ -78,6 +78,12 @@ Feature: Reactor Outbox for stake-sensitive dispatch
     When a new row is enqueued
     Then a wakeup payload {reactorName, groupKey} is sent to the GroupQueue
     And the wakeup payload does NOT carry the row's variable-size data
+    And the groupKey begins with "${projectId}/" so per-tenant fairness routing works
+
+  Scenario: A groupKey missing the project prefix is rejected at enqueue
+    When the producer calls enqueue with a groupKey that does NOT start with "${projectId}/"
+    Then enqueue throws before any row is written
+    And the contract violation is surfaced to the producer rather than landing in the wrong tenant bucket
 
   Scenario: Backoff retries schedule a delayed wakeup
     Given a row moved to "failed_retryable" with nextAttemptAt in the future

--- a/specs/event-sourcing/reactor-outbox.feature
+++ b/specs/event-sourcing/reactor-outbox.feature
@@ -1,0 +1,103 @@
+Feature: Reactor Outbox for stake-sensitive dispatch
+
+  Some reactors do work that cannot be silently swallowed: sending an
+  email, posting a Slack message, writing to a customer dataset. These
+  "stake-sensitive" reactors register through `.withOutbox` instead of
+  `.withReactor` so that every dispatch attempt is durable, retried with
+  backoff, and queryable for operator surfaces.
+
+  Best-effort reactors (UI websockets, fold projections, idempotent
+  syncs) keep using `.withReactor` — they do not pay the outbox cost.
+
+  Background:
+    Given a pipeline registers a reactor "alertDispatch" via .withOutbox
+    And the ReactorOutbox table is empty
+
+  # Enqueueing matches
+
+  Scenario: Reactor enqueues a row instead of dispatching inline
+    When the reactor's handler decides a match dispatches
+    Then a ReactorOutbox row is created with status "queued"
+    And the row carries reactorName, projectId, dedupKey, and payload
+    And no side effect (email, Slack, dataset write) has fired yet
+
+  Scenario: Duplicate matches are claimed once
+    Given a ReactorOutbox row exists for (reactorName, dedupKey)
+    When the same match is observed again (e.g. replay, retry, fan-in)
+    Then the second enqueue is a no-op
+    And only one row exists for (reactorName, dedupKey)
+
+  # Lease + dispatch
+
+  Scenario: Drainer claims the next queued row atomically
+    Given a queued ReactorOutbox row whose nextAttemptAt has elapsed
+    When the drainer wakes up for (reactorName, groupKey)
+    Then exactly one worker observes status "dispatching"
+    And the row carries a leasedUntil timestamp in the future
+    And competing drainers see no claimable row
+
+  Scenario: Successful dispatch marks the row "dispatched"
+    Given a leased ReactorOutbox row
+    When the dispatch endpoint returns success
+    Then the row moves to status "dispatched"
+    And leasedUntil is cleared
+    And the row is retained for operator inspection
+
+  # Retry semantics
+
+  Scenario: Retryable failure schedules a backoff retry
+    Given a leased ReactorOutbox row
+    When the dispatch endpoint raises a retryable DispatchError
+    Then the row moves to status "failed_retryable"
+    And attempts is incremented
+    And nextAttemptAt is set per exponential backoff
+    And lastError records the error message
+
+  Scenario: Non-retryable failure marks the row "dead"
+    Given a leased ReactorOutbox row
+    When the dispatch endpoint raises a non-retryable DispatchError
+    Then the row moves to status "dead"
+    And no further attempts are scheduled
+    And lastError records the error message
+
+  Scenario: Lease expires when a worker crashes mid-dispatch
+    Given a row leased to a worker that never completed
+    When the leasedUntil timestamp passes
+    Then a future drainer wake-up may re-lease the row
+    And attempts is incremented on the re-lease
+    And the row is not silently stuck in "dispatching"
+
+  Scenario: Attempts cap promotes a retryable failure to "dead"
+    Given a row that has reached the maximum retry count
+    When another retryable failure occurs
+    Then the row moves to status "dead" rather than "failed_retryable"
+
+  # Wakeup / scheduling
+
+  Scenario: Enqueue sends a wakeup with the row's group key
+    When a new row is enqueued
+    Then a wakeup payload {reactorName, groupKey} is sent to the GroupQueue
+    And the wakeup payload does NOT carry the row's variable-size data
+
+  Scenario: Backoff retries schedule a delayed wakeup
+    Given a row moved to "failed_retryable" with nextAttemptAt in the future
+    When the row is rescheduled
+    Then a delayed wakeup is enqueued matching nextAttemptAt
+    And the drainer pulls the row only after the delay elapses
+
+  # Replay safety
+
+  Scenario: Replaying past events does not re-dispatch
+    Given a pipeline replays historical events
+    And those events previously produced ReactorOutbox rows
+    When the reactor re-evaluates the same matches
+    Then no new rows are created (dedupKey collision)
+    And no additional side effects fire
+
+  # Operator surface
+
+  Scenario: Stuck dispatches are queryable per (project, reactor)
+    Given rows in statuses "queued", "failed_retryable", and "dead"
+    When an operator queries the outbox for a project
+    Then rows are filterable by reactorName and status
+    And each row exposes attempts, lastError, and timestamps

--- a/specs/event-sourcing/reactor-outbox.feature
+++ b/specs/event-sourcing/reactor-outbox.feature
@@ -19,6 +19,7 @@ Feature: Reactor Outbox for stake-sensitive dispatch
     When the reactor's handler decides a match dispatches
     Then a ReactorOutbox row is created with status "queued"
     And the row carries reactorName, projectId, dedupKey, and payload
+    And the dedupKey begins with "${projectId}/" so it is self-describing for operator scans
     And no side effect (email, Slack, dataset write) has fired yet
 
   Scenario: Duplicate matches are claimed once
@@ -99,6 +100,14 @@ Feature: Reactor Outbox for stake-sensitive dispatch
     When the reactor re-evaluates the same matches
     Then no new rows are created (dedupKey collision)
     And no additional side effects fire
+
+  Scenario: Replay short-circuits .withOutbox match after row retention has elapsed
+    Given an event is being replayed (ReactorContext.isReplay is true)
+    And the original ReactorOutbox row has aged out of retention
+    When the .withOutbox framework wrapper inspects the context
+    Then the reactor's match phase is skipped before any row is inserted
+    And no wakeup is scheduled
+    And no customer-visible side effect fires
 
   # Operator surface
 


### PR DESCRIPTION
## Summary

Phase 0 of the trigger dispatch refactor — durable outbox substrate for stake-sensitive reactors. Stacked on top of #4241 (ADRs 021-027).

**No reactor behavior changes ship yet.** Wire-up to actual reactors (alertTrigger / evaluationAlertTrigger) lands in Phase 1.

## What ships

- **`ReactorOutbox` model + migration** — claim primitive via unique `(reactorName, dedupKey)`; `status` / `attempts` / `leasedUntil` / `nextAttemptAt` for the drainer; per-project + per-status indexes for the operator surface.
- **`OutboxService`** — `enqueue` / `leaseNext` / `markDispatched` / `markFailedRetryable` / `markDead` / `recoverStuckLeases`. Full-jitter exponential backoff (1s → 30m cap). Promotes to `dead` when attempts exceed `maxAttempts`.
- **`PrismaOutboxRepository`** — raw-SQL `leaseNext` with `FOR UPDATE SKIP LOCKED` so concurrent drainers race cleanly.
- **`OutboxDrainer` + wakeup queue scaffold** — GroupQueue-based wakeup payloads (constant-size; variable data stays in PG), per-reactor dispatcher registry, soft drain cap with yield.
- **`DispatchError`** typed contract (`retryable: boolean`) — see ADR-027.
- **`.withOutbox` builder primitive** mirroring `.withReactor` — stored in `foldOutboxReactors` / `mapOutboxReactors` maps on the built definition; runtime wiring is Phase 1.

## Spec

`specs/event-sourcing/reactor-outbox.feature` — full BDD coverage of enqueue / lease / dispatch / retry / replay / operator-surface scenarios.

## Architecture refs

ADRs 021-024 + 027 (shipped in #4241, included in this stacked branch):
- 021 — Transactional outbox for stake-sensitive dispatch
- 022 — Two-tier dedup (`TriggerSent` for match-claim, `ReactorOutbox` for dispatch state)
- 023 — GroupQueue wakeup pattern
- 024 — `.withOutbox` as a pipeline-builder primitive
- 027 — Typed `DispatchError` contract

## Stack position

| Phase | PR | Status |
|---|---|---|
| ADRs | #4241 | open |
| **Phase 0: Foundation** | **this PR** | **open** |
| Phase 1: Dispatch refactor (notify/persistent split, alertTrigger / evaluationAlertTrigger refactor) | TBD | stacked on this |
| Phase 2: Templates (liquidjs, Slack Block Kit, email Markdown) | TBD | stacked on phase 1 |
| Phase 3: UI (template editor, previews, test-fire) | TBD | stacked on phase 2 |
| Phase 4: Cadence (5m / 15m / hourly digests) | TBD | stacked on phase 3 |

## Test plan

- [x] `pnpm test:unit src/server/event-sourcing/outbox/__tests__/` — 24 tests pass
- [x] `pnpm test:unit src/server/event-sourcing/pipeline/__tests__/staticBuilder.validations.test.ts` — 11 tests (6 existing + 5 new for `.withOutbox`) pass
- [ ] `pnpm test:integration src/server/event-sourcing/outbox/__tests__/outbox.prisma.repository.integration.test.ts` — verifies `createMany skipDuplicates` claim semantics + `FOR UPDATE SKIP LOCKED` race (runs in CI; needs PG container)
- [ ] Reviewer sanity: ADRs in this branch describe the design rationale — read `dev/docs/adr/021-027` if any decision feels surprising