### PR TITLE
feat(trace-processing): skip evaluations on oversized traces, never drop spans

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/evaluationTrigger.reactor.unit.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../evaluationTrigger.reactor";
 import { DEFERRED_CHECK_DELAY_MS } from "../originGate.reactor";
 import { TRACK_EVENT_SPAN_NAME } from "~/server/tracer/constants";
+import { MAX_PROCESSED_SPANS } from "../../projections/traceSummary.foldProjection";
 
 function createFoldState(
   overrides: Partial<TraceSummaryData> = {},
@@ -258,6 +259,39 @@ describe("evaluationTrigger reactor", () => {
       await reactor.handle(createSpanEvent(), createContext(state));
 
       expect(deps.evaluation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the trace exceeds the processing cap", () => {
+    /** @scenario Evaluations run for a trace under the processing cap */
+    it("dispatches evaluations for a trace just under the cap", async () => {
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+        spanCount: MAX_PROCESSED_SPANS - 1,
+        occurredAt: Date.now(),
+      });
+
+      await reactor.handle(createSpanEvent(), createContext(state));
+
+      expect(deps.evaluation).toHaveBeenCalledTimes(1);
+    });
+
+    /** @scenario Evaluations are skipped for a trace over the processing cap */
+    it("skips evaluation dispatch once the trace passes the cap (span still stored elsewhere)", async () => {
+      const deps = createDeps();
+      const reactor = createEvaluationTriggerReactor(deps);
+      const state = createFoldState({
+        attributes: { "langwatch.origin": "application" },
+        spanCount: MAX_PROCESSED_SPANS,
+        occurredAt: Date.now(),
+      });
+
+      await reactor.handle(createSpanEvent(), createContext(state));
+
+      expect(deps.monitors.getEnabledOnMessageMonitors).not.toHaveBeenCalled();
+      expect(deps.evaluation).not.toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -56,13 +56,13 @@ export function createEvaluationTriggerReactor(
       // Oversized-trace guard (2026-05-28 incident follow-up). Past the same
       // processing cap the fold uses to stop deriving the summary
       // (MAX_PROCESSED_SPANS), a trace is a runaway / reused trace_id and is too
-      // large to keep evaluating — re-running every ON_MESSAGE monitor per span
+      // large to keep evaluating: re-running every ON_MESSAGE monitor per span
       // on a 26k-span trace is pure amplification for no added signal. Skip the
       // eval dispatch (lighter processing). The span itself is still stored and
       // the trace stays fully queryable: we drop the WORK, never the DATA.
       if (foldState.spanCount >= MAX_PROCESSED_SPANS) {
         // Log once, on the first crossing only. This is a per-span hot path: a
-        // runaway trace would otherwise emit thousands of identical warns — the
+        // runaway trace would otherwise emit thousands of identical warns, the
         // very per-span amplification we are skipping the eval to avoid.
         if (foldState.spanCount === MAX_PROCESSED_SPANS) {
           logger.warn(
@@ -72,7 +72,7 @@ export function createEvaluationTriggerReactor(
               spanCount: foldState.spanCount,
               cap: MAX_PROCESSED_SPANS,
             },
-            "Skipping evaluation dispatch — trace reached the processing cap (spans still stored)",
+            "Skipping evaluation dispatch: trace reached the processing cap (spans still stored)",
           );
         }
         return;

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -61,15 +61,20 @@ export function createEvaluationTriggerReactor(
       // eval dispatch (lighter processing). The span itself is still stored and
       // the trace stays fully queryable: we drop the WORK, never the DATA.
       if (foldState.spanCount >= MAX_PROCESSED_SPANS) {
-        logger.warn(
-          {
-            tenantId,
-            observedTraceId: traceId,
-            spanCount: foldState.spanCount,
-            cap: MAX_PROCESSED_SPANS,
-          },
-          "Skipping evaluation dispatch — trace exceeds the processing cap (span still stored)",
-        );
+        // Log once, on the first crossing only. This is a per-span hot path: a
+        // runaway trace would otherwise emit thousands of identical warns — the
+        // very per-span amplification we are skipping the eval to avoid.
+        if (foldState.spanCount === MAX_PROCESSED_SPANS) {
+          logger.warn(
+            {
+              tenantId,
+              observedTraceId: traceId,
+              spanCount: foldState.spanCount,
+              cap: MAX_PROCESSED_SPANS,
+            },
+            "Skipping evaluation dispatch — trace reached the processing cap (spans still stored)",
+          );
+        }
         return;
       }
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/evaluationTrigger.reactor.ts
@@ -7,7 +7,10 @@ import type { ExecuteEvaluationCommandData } from "../../evaluation-processing/s
 import { KSUID_RESOURCES } from "../../../../../utils/constants";
 import { createLogger } from "../../../../../utils/logger/server";
 import type { ReactorDefinition } from "../../../reactors/reactor.types";
-import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
+import {
+  MAX_PROCESSED_SPANS,
+  type TraceSummaryData,
+} from "../projections/traceSummary.foldProjection";
 import { isSpanReceivedEvent, type TraceProcessingEvent } from "../schemas/events";
 import { defineOriginGuardedTraceReactor } from "./_originGuardedReactor";
 import { SYNTHETIC_SPAN_NAMES } from "~/server/tracer/constants";
@@ -49,6 +52,26 @@ export function createEvaluationTriggerReactor(
         return;
       }
       const { tenantId, aggregateId: traceId, foldState } = context;
+
+      // Oversized-trace guard (2026-05-28 incident follow-up). Past the same
+      // processing cap the fold uses to stop deriving the summary
+      // (MAX_PROCESSED_SPANS), a trace is a runaway / reused trace_id and is too
+      // large to keep evaluating — re-running every ON_MESSAGE monitor per span
+      // on a 26k-span trace is pure amplification for no added signal. Skip the
+      // eval dispatch (lighter processing). The span itself is still stored and
+      // the trace stays fully queryable: we drop the WORK, never the DATA.
+      if (foldState.spanCount >= MAX_PROCESSED_SPANS) {
+        logger.warn(
+          {
+            tenantId,
+            observedTraceId: traceId,
+            spanCount: foldState.spanCount,
+            cap: MAX_PROCESSED_SPANS,
+          },
+          "Skipping evaluation dispatch — trace exceeds the processing cap (span still stored)",
+        );
+        return;
+      }
 
       // Infinite-loop prevention (post-2026-05-11 incident). See
       // specs/monitors/online-evaluator-loop-prevention.feature.

--- a/specs/trace-processing/oversized-trace-lighter-processing.feature
+++ b/specs/trace-processing/oversized-trace-lighter-processing.feature
@@ -1,0 +1,46 @@
+Feature: Oversized traces are processed lighter, never dropped
+  As an operator running multi-tenant trace ingestion on shared infrastructure
+  I want a runaway trace (a reused trace_id, an instrumentation loop) to stop
+  paying expensive per-span processing once it is clearly pathological
+  So that one trace cannot amplify shared work without bound, while every span
+  is still stored and the trace stays fully queryable.
+
+  # Why this exists — 2026-05-28 incident follow-up
+  #
+  # A reused trace_id accumulated tens of thousands of spans. The danger was
+  # never the storage (ClickHouse handles volume) — it was the per-span
+  # amplifying WORK: re-deriving the trace summary and re-firing every
+  # ON_MESSAGE evaluator for each of 26k spans. The fix is to refuse the WORK,
+  # never the DATA: past a processing cap a trace is handled lighter, but no
+  # span is ever dropped.
+  #
+  # One shared threshold (MAX_PROCESSED_SPANS) governs both halves, so "this
+  # trace is too big to keep processing" is decided in exactly one place:
+  #   - the trace-summary fold already stops DERIVING past the cap (it keeps
+  #     counting so true magnitude stays visible, but pays no derivation cost)
+  #   - the evaluation trigger stops DISPATCHING evaluations past the same cap
+  # Storage is untouched in both cases: every span is persisted regardless.
+  #
+  # This is NOT a dropping mechanism. Customers can send arbitrarily large
+  # traces; we simply stop re-evaluating a runaway one. Lossless memory relief
+  # for genuinely-large traces is handled separately (large-payload offload).
+
+  # Storage is a separate projection from evaluation, so skipping evaluation can
+  # never skip storage: every span is persisted regardless of trace size. That
+  # is the no-drop guarantee — asserted by construction, not gated anywhere.
+
+  Background:
+    Given the trace-processing pipeline is running
+
+  Rule: Evaluations stop firing once a trace passes the processing cap
+
+    Scenario: Evaluations run for a trace under the processing cap
+      Given a trace under the processing cap with enabled monitors
+      When a new span arrives for that trace
+      Then its enabled evaluations are dispatched
+
+    Scenario: Evaluations are skipped for a trace over the processing cap
+      Given a trace that has passed the processing cap with enabled monitors
+      When a new span arrives for that trace
+      Then no evaluation is dispatched for that span
+      And the skip is recorded so the oversized trace stays visible


### PR DESCRIPTION
## What

Past the existing `MAX_PROCESSED_SPANS` (512) threshold, the `evaluationTrigger` reactor stops dispatching evaluations for a trace. Every span is still stored; only the expensive per-span work is skipped.

## Why

In the 2026-05-28 incident a reused trace_id accumulated tens of thousands of spans. The danger was never storage (ClickHouse handles the volume) but the per-span amplifying work: re-firing every enabled ON_MESSAGE evaluator for each of ~26k spans. Re-evaluating a runaway trace 26k times adds no signal and amplifies shared queue/eval load without bound.

The fix is to refuse the WORK, never the DATA. This replaces the earlier (closed) #4232 approach, which dropped spans at ingestion. Dropping customer data is the wrong lever: LangWatch should handle arbitrarily large traces.

## How

One shared threshold decides "this trace is too big to keep processing" in a single place:

- the trace-summary fold already stops deriving the summary past `MAX_PROCESSED_SPANS` (keeps counting so true magnitude stays visible)
- the evaluation trigger now stops dispatching evaluations past the same threshold

Storage is a separate projection from evaluation, so skipping evaluation cannot skip storage. Every span is persisted and the trace stays fully queryable. No span is ever dropped.

Lossless memory relief for genuinely-large traces is handled separately (large-payload offload, #4216). Cross-tenant fairness so a large/bursty trace cannot starve others is the upcoming work-conserving dispatch.

## Tests

- `specs/trace-processing/oversized-trace-lighter-processing.feature` describes the behavior.
- Unit tests: evaluations dispatch for a trace just under the cap; evaluations are skipped (and monitors not even read) once the trace passes the cap.
