### PR TITLE
fix(build): bundle Shiki into one chunk to stop boot-time white screen

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -162,8 +162,13 @@ jobs:
         working-directory: agentic-e2e-tests
         run: pnpm install --frozen-lockfile --ignore-workspace
 
-      # No Playwright browser download: the tests launch the runner's
+      # Skip the ~170 MB Chromium download: the tests launch the runner's
       # preinstalled Google Chrome via channel (see E2E_BROWSER_CHANNEL below).
+      # Still install ffmpeg (~few MB) since Playwright needs it to record the
+      # retain-on-failure video; without it browserContext.newPage throws.
+      - name: Install Playwright ffmpeg
+        working-directory: agentic-e2e-tests
+        run: pnpm exec playwright install ffmpeg
 
       - name: Prepare files
         working-directory: langwatch

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -52,6 +52,12 @@ jobs:
       NEXTAUTH_SECRET: "test-secret-for-e2e-testing"
       NEXTAUTH_URL: "http://localhost:5570"
       API_TOKEN_JWT_SECRET: "test-jwt-secret-for-e2e"
+      # AI Gateway data-plane secrets (shared by control plane + Go gateway).
+      # The gateway validates these as required; without them `make service
+      # svc=aigateway` crash-loops. Test-only values, 32+ chars.
+      LW_GATEWAY_INTERNAL_SECRET: "e2e-gateway-internal-secret-000000000000000000000000000000000000"
+      LW_GATEWAY_JWT_SECRET: "e2e-gateway-jwt-secret-00000000000000000000000000000000000000000"
+      LW_VIRTUAL_KEY_PEPPER: "e2e-virtual-key-pepper-00000000000000000000000000000000000000000"
       SKIP_ENV_VALIDATION: "true"
       DISABLE_PII_REDACTION: "true"
       NODE_ENV: "development"

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -162,9 +162,8 @@ jobs:
         working-directory: agentic-e2e-tests
         run: pnpm install --frozen-lockfile --ignore-workspace
 
-      - name: Install Playwright browsers
-        working-directory: agentic-e2e-tests
-        run: pnpm exec playwright install --with-deps chromium
+      # No Playwright browser download: the tests launch the runner's
+      # preinstalled Google Chrome via channel (see E2E_BROWSER_CHANNEL below).
 
       - name: Prepare files
         working-directory: langwatch
@@ -190,6 +189,8 @@ jobs:
           # Migrations already ran in earlier steps; skip them during pnpm start
           SKIP_PRISMA_MIGRATE: "true"
           SKIP_CLICKHOUSE_MIGRATE: "true"
+          # Launch the runner's preinstalled Google Chrome (no browser download)
+          E2E_BROWSER_CHANNEL: chrome
         run: |
           # Start the app in background
           cd langwatch && PORT=5570 pnpm start &

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -168,13 +168,9 @@ jobs:
         working-directory: agentic-e2e-tests
         run: pnpm install --frozen-lockfile --ignore-workspace
 
-      # Skip the ~170 MB Chromium download: the tests launch the runner's
-      # preinstalled Google Chrome via channel (see E2E_BROWSER_CHANNEL below).
-      # Still install ffmpeg (~few MB) since Playwright needs it to record the
-      # retain-on-failure video; without it browserContext.newPage throws.
-      - name: Install Playwright ffmpeg
-        working-directory: agentic-e2e-tests
-        run: pnpm exec playwright install ffmpeg
+      # No Playwright browser/ffmpeg download: the tests launch the runner's
+      # preinstalled Google Chrome via channel (E2E_BROWSER_CHANNEL below) and
+      # video recording is off in CI, so no ffmpeg binary is needed.
 
       - name: Prepare files
         working-directory: langwatch

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -383,6 +383,27 @@ jobs:
         working-directory: langwatch
         run: pnpm build
 
+      # A successful `vite build` only proves the bundle compiles, not that it
+      # boots. Serve the built output and load it in a headless browser to
+      # catch runtime boot failures (white screens from chunk-init errors).
+      - name: Install Playwright Chromium
+        working-directory: langwatch
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Boot smoke test
+        working-directory: langwatch
+        run: |
+          pnpm exec vite preview --port 4173 --outDir dist/client &
+          PREVIEW_PID=$!
+          for i in $(seq 1 30); do
+            curl -sf -o /dev/null http://localhost:4173/ && break
+            sleep 1
+          done
+          node scripts/smoke-boot.mjs
+          STATUS=$?
+          kill $PREVIEW_PID 2>/dev/null || true
+          exit $STATUS
+
       - name: Notify Slack on failure
         if: failure() && github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -394,14 +394,14 @@ jobs:
         run: |
           pnpm exec vite preview --port 4173 --outDir dist/client &
           PREVIEW_PID=$!
+          trap 'kill $PREVIEW_PID 2>/dev/null || true' EXIT
           for i in $(seq 1 30); do
             curl -sf -o /dev/null http://localhost:4173/ && break
             sleep 1
           done
+          # Under the runner's `bash -e`, a non-zero exit here fails the step
+          # (the gate we want); the EXIT trap still stops the preview server.
           node scripts/smoke-boot.mjs
-          STATUS=$?
-          kill $PREVIEW_PID 2>/dev/null || true
-          exit $STATUS
 
       - name: Notify Slack on failure
         if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -386,12 +386,11 @@ jobs:
       # A successful `vite build` only proves the bundle compiles, not that it
       # boots. Serve the built output and load it in a headless browser to
       # catch runtime boot failures (white screens from chunk-init errors).
-      - name: Install Playwright Chromium
-        working-directory: langwatch
-        run: pnpm exec playwright install --with-deps chromium
-
+      # Uses the runner's preinstalled Google Chrome (no browser download).
       - name: Boot smoke test
         working-directory: langwatch
+        env:
+          SMOKE_BROWSER_CHANNEL: chrome
         run: |
           pnpm exec vite preview --port 4173 --outDir dist/client &
           PREVIEW_PID=$!

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,10 @@ setup-hooks:
 DEV_ENV_FILE ?= langwatch/.env
 service:
 	@test -n "$(svc)" || (echo "usage: make service svc=<name>" && exit 1)
-	@test -f $(DEV_ENV_FILE) || (echo "$(DEV_ENV_FILE) not found — seed langwatch/.env first" && exit 1)
 	@_snap=$$(export -p) && \
-		set -a && . $(DEV_ENV_FILE) && set +a && \
+		{ test -f $(DEV_ENV_FILE) \
+			&& set -a && . $(DEV_ENV_FILE) && set +a \
+			|| echo "$(DEV_ENV_FILE) not found — using process environment"; } && \
 		eval "$$_snap" && \
 		export LOG_FORMAT=pretty && \
 		exec go run ./cmd/service $(svc)

--- a/agentic-e2e-tests/playwright.config.ts
+++ b/agentic-e2e-tests/playwright.config.ts
@@ -55,7 +55,12 @@ export default defineConfig({
     /* Collect trace on failure for debugging */
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    /* Video needs Playwright's own pinned ffmpeg binary, which the bundled
+     * Chromium download would normally supply. We skip that download in CI
+     * (system Chrome via channel), so video is opt-in via E2E_RECORD_VIDEO to
+     * avoid a separate ffmpeg install. Trace already captures DOM, network,
+     * and console for debugging. */
+    video: process.env.E2E_RECORD_VIDEO ? "retain-on-failure" : "off",
 
     /* Reasonable timeouts */
     actionTimeout: 15000,

--- a/agentic-e2e-tests/playwright.config.ts
+++ b/agentic-e2e-tests/playwright.config.ts
@@ -44,6 +44,14 @@ export default defineConfig({
   use: {
     baseURL: BASE_URL,
 
+    /* In CI, use the runner's preinstalled Google Chrome
+     * (E2E_BROWSER_CHANNEL=chrome) to skip the ~170 MB Chromium download.
+     * Locally it falls back to Playwright's bundled Chromium. Applies to all
+     * projects (setup + specs) since none override channel. */
+    ...(process.env.E2E_BROWSER_CHANNEL
+      ? { channel: process.env.E2E_BROWSER_CHANNEL }
+      : {}),
+
     /* Collect trace on failure for debugging */
     trace: "retain-on-failure",
     screenshot: "only-on-failure",

--- a/agentic-e2e-tests/tests/auth.setup.ts
+++ b/agentic-e2e-tests/tests/auth.setup.ts
@@ -128,16 +128,24 @@ setup("authenticate", async ({ page, request }) => {
     console.log("Org/project already exists, skipping setup.");
   }
 
-  // Step 4: Navigate to the app root and wait for main navigation.
-  // This confirms the session + org/project are wired up before saving state.
+  // Step 4: Navigate to the app root and confirm the authenticated shell.
+  // The root redirects to the signed-in landing (personal portal), so we
+  // confirm we did not bounce back to /auth and that the sidebar rendered.
+  // (The old "Home" link no longer exists in the personal-portal sidebar.)
   console.log("Navigating to app root to confirm setup...");
   await page.goto("/");
 
-  const homeLink = page.getByRole("link", { name: "Home", exact: true });
   try {
-    await homeLink.waitFor({ state: "visible", timeout: 30000 });
+    await page.waitForURL((url) => !url.pathname.startsWith("/auth/"), {
+      timeout: 30000,
+    });
+    // href is stable regardless of sidebar expand state (collapsed links
+    // drop their text label), so match the Settings nav link by href.
+    await expect(
+      page.locator('a[href="/settings"]').first(),
+    ).toBeVisible({ timeout: 30000 });
   } catch (err) {
-    console.log("Home link not visible. URL:", page.url());
+    console.log("Authenticated shell not confirmed. URL:", page.url());
     await page.screenshot({
       path: path.join(__dirname, "..", "debug-post-setup.png"),
     });

--- a/agentic-e2e-tests/tests/global-setup.ts
+++ b/agentic-e2e-tests/tests/global-setup.ts
@@ -49,6 +49,45 @@ async function waitForApp(): Promise<void> {
   );
 }
 
+// A 200 from vite's `/` only proves the dev server's shell is up; the API
+// (proxied, on-demand compiled in dev) can still be cold. The signin page
+// renders blank until the public `publicEnv` tRPC query resolves, so tests
+// race a not-yet-ready backend. Wait for that exact endpoint to serve 200.
+async function waitForApi(): Promise<void> {
+  const url =
+    `${BASE_URL}/api/trpc/publicEnv?batch=1` +
+    `&input=${encodeURIComponent('{"0":{"json":{}}}')}`;
+  console.log(`\n🔍 Checking API readiness at ${url}...`);
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        signal: AbortSignal.timeout(10000),
+      });
+      if (response.ok) {
+        console.log(`✅ API is ready (status: ${response.status})`);
+        return;
+      }
+      console.log(
+        `⏳ Attempt ${attempt}/${MAX_RETRIES}: API status ${response.status}, retrying...`
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(`⏳ Attempt ${attempt}/${MAX_RETRIES}: ${message}, retrying...`);
+    }
+
+    if (attempt < MAX_RETRIES) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+  }
+
+  throw new Error(
+    `\n❌ API not ready at ${url} after ${MAX_RETRIES} attempts.\n` +
+      `The app shell loaded but the backend never served publicEnv.\n`
+  );
+}
+
 function validateEnvironment(): void {
   console.log("\n🔍 Validating environment configuration...");
 
@@ -100,6 +139,7 @@ export default async function globalSetup(): Promise<void> {
 
   validateEnvironment();
   await waitForApp();
+  await waitForApi();
 
   console.log("\n" + "=".repeat(60));
   console.log("Global setup complete, starting tests...");

--- a/langwatch/scripts/smoke-boot.mjs
+++ b/langwatch/scripts/smoke-boot.mjs
@@ -28,7 +28,8 @@ try {
   );
   mounted = true;
 } catch (err) {
-  fatal.push(`app did not mount within timeout: ${err.message}`);
+  const message = err instanceof Error ? err.message : String(err);
+  fatal.push(`app did not mount within timeout: ${message}`);
 }
 
 await browser.close();

--- a/langwatch/scripts/smoke-boot.mjs
+++ b/langwatch/scripts/smoke-boot.mjs
@@ -11,7 +11,11 @@ import { chromium } from "playwright";
 const url = process.env.SMOKE_URL ?? "http://localhost:4173/";
 const FATAL = /is not a function|Cannot access .* before initialization|is not defined/;
 
-const browser = await chromium.launch();
+// In CI we point at the runner's preinstalled Google Chrome
+// (SMOKE_BROWSER_CHANNEL=chrome) to skip the ~170 MB Chromium download.
+// Locally it falls back to Playwright's bundled Chromium.
+const channel = process.env.SMOKE_BROWSER_CHANNEL || undefined;
+const browser = await chromium.launch(channel ? { channel } : {});
 const page = await (await browser.newContext()).newPage();
 
 const fatal = [];

--- a/langwatch/scripts/smoke-boot.mjs
+++ b/langwatch/scripts/smoke-boot.mjs
@@ -1,0 +1,42 @@
+// Boot smoke test: loads the production bundle in a headless browser and
+// fails if the app does not mount or throws a fatal module-init error.
+//
+// This catches a class of bug that `vite build` succeeding cannot: a bundle
+// that compiles cleanly but white-screens at runtime (e.g. a cross-chunk
+// import cycle where a chunk calls a not-yet-initialized export at module
+// top level). No backend is required — React still mounts the shell / error
+// states when API calls fail, so an empty #root means the JS never booted.
+import { chromium } from "playwright";
+
+const url = process.env.SMOKE_URL ?? "http://localhost:4173/";
+const FATAL = /is not a function|Cannot access .* before initialization|is not defined/;
+
+const browser = await chromium.launch();
+const page = await (await browser.newContext()).newPage();
+
+const fatal = [];
+page.on("pageerror", (e) => {
+  if (FATAL.test(e.message)) fatal.push(e.message);
+});
+
+let mounted = false;
+try {
+  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
+  await page.waitForFunction(
+    () => (document.getElementById("root")?.innerHTML?.length ?? 0) > 100,
+    { timeout: 30000 },
+  );
+  mounted = true;
+} catch (err) {
+  fatal.push(`app did not mount within timeout: ${err.message}`);
+}
+
+await browser.close();
+
+if (fatal.length > 0) {
+  console.error("BOOT SMOKE FAILED:");
+  for (const f of fatal) console.error("  - " + f);
+  process.exit(1);
+}
+
+console.log(`BOOT SMOKE PASSED (#root mounted: ${mounted})`);

--- a/langwatch/vite.config.ts
+++ b/langwatch/vite.config.ts
@@ -152,6 +152,27 @@ export default defineConfig({
   build: {
     outDir: "dist/client",
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id: string) {
+          // Keep the whole Shiki ecosystem in one self-contained chunk.
+          // Under the rolldown bundler the default split hoists Shiki's
+          // singleton factory into the entry chunk and leaves the Shiki
+          // chunk calling back into it at module top level. Because the
+          // entry eagerly loads Shiki, that call runs before the entry has
+          // initialized the export, throwing "undefined is not a function"
+          // at boot and white-screening the app. One chunk removes the
+          // cross-chunk cycle.
+          if (
+            /[\\/]node_modules[\\/](\.pnpm[\\/])?(@shikijs[\\/+]|shiki[\\/@]|oniguruma-to-es|oniguruma-parser|hast-util-to-html)/.test(
+              id,
+            )
+          ) {
+            return "shiki";
+          }
+        },
+      },
+    },
   },
   server: {
     watch: {


### PR DESCRIPTION
## What

Production app boot was white-screening with `Uncaught TypeError: undefined is not a function` (`n is not a function` in Chrome) thrown from the Shiki vendor chunk at module init.

## Root cause

The app moved to vite 8, which builds with the rolldown bundler. Rolldown's default chunking split Shiki such that the Shiki chunk imported a binding from the entry chunk and called it at module top level:

```js
import { vb as n } from "./index-<hash>.js";
// ...
n(); // n is undefined here
```

The entry chunk eagerly loads Shiki (the markdown/code views are reachable from the boot graph), so the Shiki chunk's top-level call ran while the entry chunk was still initializing, before that export existed. The result was a hard throw during boot that took down the whole app.

This only surfaced in a production build (the broken cross-chunk cycle does not exist in the dev server), so it passed CI and dev testing and only broke once a release built on vite 8 reached production.

## Fix

Force the whole Shiki ecosystem (`@shikijs/*`, `shiki`, `oniguruma-to-es`, `oniguruma-parser`, `hast-util-to-html`) into a single self-contained chunk via `build.rollupOptions.output.manualChunks`. With Shiki in one chunk there is no cross-chunk reference back into the entry, so the top-level call resolves against a binding defined in the same chunk.

## Verification

Reproduced and verified with a real production build loaded headlessly:

- Before: `#root` empty, pageerror `n is not a function`.
- After: `#root` mounts (5186 chars of content), zero fatal boot errors. The Shiki chunk now imports only the rolldown runtime, not the entry.

## Prevention

Added a boot smoke test to the (required) `build` job: after `vite build`, serve the output and load `/` in headless Chromium, failing if the app does not mount or throws a fatal module-init error (`scripts/smoke-boot.mjs`). A green `vite build` only proves the bundle compiles; this proves it boots. This same check, run on this PR, validates the fix.