### PR TITLE
test(e2e): fix specs broken by personal-portal removing the Home nav link

### DIFF
--- a/agentic-e2e-tests/tests/auth.setup.ts
+++ b/agentic-e2e-tests/tests/auth.setup.ts
@@ -128,12 +128,14 @@ setup("authenticate", async ({ page, request }) => {
     console.log("Org/project already exists, skipping setup.");
   }
 
-  // Step 4: Navigate to the app root and confirm the authenticated shell.
-  // The root redirects to the signed-in landing (personal portal), so we
-  // confirm we did not bounce back to /auth and that the sidebar rendered.
-  // (The old "Home" link no longer exists in the personal-portal sidebar.)
-  console.log("Navigating to app root to confirm setup...");
-  await page.goto("/");
+  // Step 4: Confirm the authenticated shell on a settings page. We use
+  // /settings rather than the app root because root redirects to the
+  // trace-backed personal landing, whose data fetch can disturb the layout;
+  // /settings renders the same sidebar from Postgres alone. We confirm we did
+  // not bounce back to /auth and that the sidebar rendered. (The old "Home"
+  // link no longer exists in the personal-portal sidebar.)
+  console.log("Navigating to settings to confirm setup...");
+  await page.goto("/settings");
 
   try {
     await page.waitForURL((url) => !url.pathname.startsWith("/auth/"), {

--- a/agentic-e2e-tests/tests/evaluations-v3/steps.ts
+++ b/agentic-e2e-tests/tests/evaluations-v3/steps.ts
@@ -9,6 +9,8 @@
  */
 import { Page, expect } from "@playwright/test";
 
+import { getProjectSlug } from "../helpers";
+
 // =============================================================================
 // Navigation Steps
 // =============================================================================
@@ -17,19 +19,7 @@ import { Page, expect } from "@playwright/test";
  * Given I am on the evaluations page
  */
 export async function givenIAmOnTheEvaluationsPage(page: Page) {
-  await page.goto("/");
-
-  // Wait for the sidebar Home link to appear (indicates app is loaded)
-  const homeLink = page.getByRole("link", { name: "Home", exact: true });
-  await expect(homeLink).toBeVisible({ timeout: 30000 });
-
-  const href = await homeLink.getAttribute("href");
-  const projectSlug = href?.replace(/^\//, "") || "";
-
-  if (!projectSlug) {
-    throw new Error("Could not extract project slug from Home link");
-  }
-
+  const projectSlug = await getProjectSlug(page);
   await page.goto(`/${projectSlug}/evaluations`);
   await expect(page).toHaveURL(/evaluations/);
 }

--- a/agentic-e2e-tests/tests/helpers.ts
+++ b/agentic-e2e-tests/tests/helpers.ts
@@ -1,0 +1,34 @@
+import { type Page } from "@playwright/test";
+
+const NON_PROJECT_SEGMENTS = new Set([
+  "me",
+  "auth",
+  "settings",
+  "onboarding",
+  "admin",
+]);
+
+/**
+ * Derives the active project slug from the authenticated landing URL.
+ *
+ * The app root redirects to the signed-in landing (the personal portal's
+ * project messages page), so the first path segment is the project slug. This
+ * replaces reading the old sidebar "Home" link, which the personal portal
+ * removed. Using the URL (set by the client router) rather than a sidebar link
+ * keeps this independent of the trace backend that the landing page queries.
+ */
+export async function getProjectSlug(page: Page): Promise<string> {
+  await page.goto("/");
+  await page.waitForURL(
+    (url) => {
+      const segment = url.pathname.split("/").filter(Boolean)[0];
+      return !!segment && !NON_PROJECT_SEGMENTS.has(segment);
+    },
+    { timeout: 30000 },
+  );
+  const slug = new URL(page.url()).pathname.split("/").filter(Boolean)[0] ?? "";
+  if (!slug) {
+    throw new Error(`Could not derive project slug from URL: ${page.url()}`);
+  }
+  return slug;
+}

--- a/agentic-e2e-tests/tests/helpers.ts
+++ b/agentic-e2e-tests/tests/helpers.ts
@@ -1,11 +1,20 @@
 import { type Page } from "@playwright/test";
 
+// Top-level route segments in langwatch/src/routes.tsx that are not a project
+// slug. Anything else as the first path segment is treated as the slug.
 const NON_PROJECT_SEGMENTS = new Set([
-  "me",
-  "auth",
-  "settings",
-  "onboarding",
   "admin",
+  "auth",
+  "authorize",
+  "cli",
+  "governance",
+  "invite",
+  "mcp",
+  "me",
+  "onboarding",
+  "ops",
+  "settings",
+  "share",
 ]);
 
 /**

--- a/agentic-e2e-tests/tests/members/steps.ts
+++ b/agentic-e2e-tests/tests/members/steps.ts
@@ -8,6 +8,8 @@
  */
 import { Page, expect } from "@playwright/test";
 
+import { getProjectSlug } from "../helpers";
+
 /**
  * Typed shape of a tRPC response from organization.getAll.
  * tRPC wraps results in a nested `result.data` structure,
@@ -38,18 +40,7 @@ interface TrpcOrganizationResponse {
  * Extracts the org slug from the Home link to build the URL.
  */
 export async function givenIAmOnTheMembersPage(page: Page) {
-  await page.goto("/");
-  await expect(page).not.toHaveURL(/\/auth\//);
-
-  // Extract org slug from the Home link
-  const homeLink = page.getByRole("link", { name: "Home", exact: true });
-  await expect(homeLink).toBeVisible({ timeout: 30000 });
-  const href = await homeLink.getAttribute("href");
-  const projectSlug = href?.replace(/^\//, "") || "";
-
-  if (!projectSlug) {
-    throw new Error("Could not extract project slug from Home link");
-  }
+  const projectSlug = await getProjectSlug(page);
 
   // Navigate to settings/members using the org context
   await page.goto(`/${projectSlug}/settings/members`);
@@ -222,10 +213,8 @@ export async function getOrgAndTeamIds(page: Page): Promise<{
   organizationId: string;
   teamId: string;
 }> {
-  // Navigate to the home page and extract org info from the URL/page state
-  await page.goto("/");
-  const homeLink = page.getByRole("link", { name: "Home", exact: true });
-  await expect(homeLink).toBeVisible({ timeout: 30000 });
+  // Confirm the authenticated app loaded before calling the org API.
+  await getProjectSlug(page);
 
   // Use the settings API to get org data
   const orgData = await page.evaluate(async () => {

--- a/agentic-e2e-tests/tests/scenarios/steps.ts
+++ b/agentic-e2e-tests/tests/scenarios/steps.ts
@@ -11,6 +11,8 @@
  */
 import { Page, expect } from "@playwright/test";
 
+import { getProjectSlug } from "../helpers";
+
 // =============================================================================
 // Background Steps
 // =============================================================================
@@ -32,19 +34,7 @@ export async function givenIAmLoggedIntoProject(page: Page) {
  * When I am on the scenarios list page
  */
 export async function givenIAmOnTheScenariosListPage(page: Page) {
-  await page.goto("/");
-
-  // Wait for the sidebar Home link to appear (indicates app is loaded)
-  const homeLink = page.getByRole("link", { name: "Home", exact: true });
-  await expect(homeLink).toBeVisible({ timeout: 30000 });
-
-  const href = await homeLink.getAttribute("href");
-  const projectSlug = href?.replace(/^\//, "") || "";
-
-  if (!projectSlug) {
-    throw new Error("Could not extract project slug from Home link");
-  }
-
+  const projectSlug = await getProjectSlug(page);
   await page.goto(`/${projectSlug}/simulations/scenarios`);
   await expect(page).toHaveURL(/simulations\/scenarios/);
 }
@@ -53,19 +43,7 @@ export async function givenIAmOnTheScenariosListPage(page: Page) {
  * Given I am on the simulations page (Runs)
  */
 export async function givenIAmOnTheSimulationsPage(page: Page) {
-  await page.goto("/");
-
-  // Wait for the sidebar Home link to appear (indicates app is loaded)
-  const homeLink = page.getByRole("link", { name: "Home", exact: true });
-  await expect(homeLink).toBeVisible({ timeout: 30000 });
-
-  const href = await homeLink.getAttribute("href");
-  const projectSlug = href?.replace(/^\//, "") || "";
-
-  if (!projectSlug) {
-    throw new Error("Could not extract project slug from Home link");
-  }
-
+  const projectSlug = await getProjectSlug(page);
   await page.goto(`/${projectSlug}/simulations`);
   await expect(page).toHaveURL(/simulations/, { timeout: 10000 });
 }

--- a/agentic-e2e-tests/tests/smoke.spec.ts
+++ b/agentic-e2e-tests/tests/smoke.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+import { getProjectSlug } from "./helpers";
+
 /**
  * Smoke Tests
  *
@@ -13,8 +15,8 @@ test("app loads after authentication", async ({ page }) => {
   // Verify we're not redirected to login
   await expect(page).not.toHaveURL(/\/auth\/signin/);
 
-  // Verify navigation is visible (indicates app is functional)
-  await expect(
-    page.getByRole("link", { name: "Home", exact: true })
-  ).toBeVisible({ timeout: 15000 });
+  // The app is functional if it redirects to a project route (the personal
+  // portal landing) rather than bouncing to login. getProjectSlug throws if
+  // it never reaches one.
+  await getProjectSlug(page);
 });


### PR DESCRIPTION
## What

The personal-portal UI removed the sidebar **Home** link. The e2e specs used it two ways: as an "app loaded" gate, and to read its `href` for the active project slug. Every spec that did this broke — `auth.setup`, `smoke`, and the `scenarios` / `evaluations-v3` / `members` step helpers all timed out waiting for a link that no longer renders.

## Fix

- `auth.setup`: confirm the authenticated shell on `/settings` (Postgres-backed) instead of the app root, which redirects to the trace-backed personal landing whose data fetch can disturb the layout.
- New shared `getProjectSlug(page)` helper: derives the project slug from the authenticated landing URL. The client router lands on `/<slug>/...` before the trace backend responds, so it works regardless of ClickHouse. Routed `smoke`, `scenarios/steps`, `evaluations-v3/steps`, and `members/steps` through it.

## Verification

Verified locally end-to-end (per the request to stop round-tripping through CI): ran the app against test Postgres + Redis (no opensearch, no ClickHouse) with the runner-style system Chrome (`E2E_BROWSER_CHANNEL=chrome`). `auth.setup` + `smoke` pass; all 11 spec files compile. The scenario/evaluation content assertions still need the search backend, which CI provides, but the navigation/slug derivation this PR changes is exercised by the passing smoke run.

Follows up #4278 (the rest of the e2e startup chain: system Chrome, no ffmpeg, gateway boot, API readiness gate).