### PR TITLE
feat(event-sourcing): work-conserving max-min fair dispatch

### DIFF
--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -150,6 +150,13 @@ export function createEnvConfig() {
       // to retune (e.g. raise for a legitimate heavy single-tenant
       // workload).
       LANGWATCH_DISPATCH_TENANT_CAP: z.string().optional(),
+      // Post-2026-05-29 dynamic water-level cap (option C). Global in-flight
+      // budget = the fleet ceiling (pods x GLOBAL_QUEUE_CONCURRENCY) that the
+      // water-fill divides across competing tenants, so a lone tenant bursts to
+      // the full fleet and N contenders converge to a max-min fair share. Unset
+      // or "0" (default) keeps the fixed LANGWATCH_DISPATCH_TENANT_CAP behaviour
+      // — the feature ships inert and is enabled per-environment.
+      LANGWATCH_DISPATCH_GLOBAL_BUDGET: z.string().optional(),
       USE_S3_STORAGE: z.boolean().optional(),
       S3_ENDPOINT: z.string().optional(),
       S3_ACCESS_KEY_ID: z.string().optional(),
@@ -314,6 +321,8 @@ export function createEnvConfig() {
       LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD:
         process.env.LANGWATCH_DISABLE_CAUSALITY_LOOP_GUARD,
       LANGWATCH_DISPATCH_TENANT_CAP: process.env.LANGWATCH_DISPATCH_TENANT_CAP,
+      LANGWATCH_DISPATCH_GLOBAL_BUDGET:
+        process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET,
       USE_S3_STORAGE:
         process.env.USE_S3_STORAGE === "1" ||
         process.env.USE_S3_STORAGE?.toLowerCase() === "true",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
@@ -5,7 +5,7 @@ import {
   stopTestContainers,
   getTestRedisConnection,
 } from "../../../__tests__/integration/testContainers";
-import { GroupStagingScripts } from "../scripts";
+import { GroupStagingScripts, CLAIMANT_WINDOW_MS } from "../scripts";
 
 // Behavioral suite for specs/event-sourcing/work-conserving-fair-dispatch.feature.
 //
@@ -335,6 +335,47 @@ describe("work-conserving fair dispatch", () => {
 
         expect(first?.groupId).toBe(gid("solo", "early"));
         expect(second?.groupId).toBe(gid("solo", "late"));
+      });
+    });
+  });
+
+  // Regression for the dynamic-cap recompute (ebbd3eeea): a tenant that stops
+  // enqueuing for longer than the claimant window but still holds in-flight or
+  // parked work must stay a measured claimant - it must NOT be evicted from the
+  // water-fill by recency alone, or W inflates and a fresh co-tenant expands past
+  // its fair share, starving the quiet-but-working tenant.
+  describe("Rule: a still-working tenant is not evicted by going quiet", () => {
+    describe("when a tenant holds work but stops enqueuing past the claimant window", () => {
+      it("keeps its fair share while a fresh co-tenant does not take the whole fleet", async () => {
+        // quiet bursts and, alone, fills the fleet (W=G) with active + parked work
+        await stageForTenant("quiet", 50);
+        await fillToFleet(FLEET);
+        expect((await inFlightByTenant()).quiet).toBe(FLEET);
+
+        // age quiet's demand recency past the claimant window WITHOUT a new
+        // enqueue (it is still holding all that active + parked work)
+        await redis.zadd(
+          `${keyPrefix()}demanding-tenants`,
+          Date.now() - CLAIMANT_WINDOW_MS - 1000,
+          "quiet",
+        );
+
+        // a fresh co-tenant arrives and competes
+        await stageForTenant("fresh", 50);
+        // wait past the reconcile gate so the next dispatch recomputes W with both
+        await sleep(RECONCILE_GATE_MS);
+
+        for (let round = 0; round < 8; round++) {
+          await completeSome(5);
+          await fillToFleet(FLEET);
+        }
+
+        const inFlight = await inFlightByTenant();
+        // quiet was kept in the fill (its parked work still competes); it is not
+        // starved, and fresh is held to its fair share rather than the whole fleet
+        expect(inFlight.quiet ?? 0).toBeGreaterThanOrEqual(8);
+        expect(inFlight.fresh ?? 0).toBeLessThanOrEqual(12);
+        expect((inFlight.quiet ?? 0) + (inFlight.fresh ?? 0)).toBe(FLEET);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
@@ -107,18 +107,38 @@ beforeAll(async () => {
 
 const FLEET = 20;
 
+// Captured so afterEach restores the prior value instead of blindly deleting it,
+// in case the process started with a real budget set.
+let prevBudgetEnv: string | undefined;
+
+// Delete only this suite's namespaced keys rather than flushall(), so we never
+// wipe other integration suites sharing the test Redis container.
+async function flushSuiteKeys() {
+  let cursor = "0";
+  do {
+    const [next, keys] = await redis.scan(cursor, "MATCH", `${QUEUE_NAME}*`, "COUNT", 500);
+    cursor = next;
+    if (keys.length > 0) await redis.del(...keys);
+  } while (cursor !== "0");
+}
+
 beforeEach(async () => {
-  await redis.flushall();
+  await flushSuiteKeys();
   scripts = new GroupStagingScripts(redis, QUEUE_NAME);
   inflight = [];
   // Enable the dynamic water-level cap with the global budget = fleet size, so a
   // lone tenant gets W=G=20 and two contenders converge to G/2=10. readGlobalBudget
   // reads process.env per dispatch, so setting it here takes effect immediately.
+  prevBudgetEnv = process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET;
   process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET = String(FLEET);
 });
 
 afterEach(() => {
-  delete process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET;
+  if (prevBudgetEnv === undefined) {
+    delete process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET;
+  } else {
+    process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET = prevBudgetEnv;
+  }
 });
 
 afterAll(async () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
@@ -1,0 +1,276 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Redis } from "ioredis";
+import {
+  startTestContainers,
+  stopTestContainers,
+  getTestRedisConnection,
+} from "../../../__tests__/integration/testContainers";
+import { GroupStagingScripts } from "../scripts";
+
+// Behavioral suite for specs/event-sourcing/work-conserving-fair-dispatch.feature.
+//
+// These tests drive the STABLE public API (stage -> dispatch loop -> complete)
+// and assert on OUTCOMES: the per-tenant in-flight distribution read from the
+// authoritative tenant_active_z truth. They are deliberately mechanism-agnostic
+// so they hold under the chosen dispatch model (option C: the existing
+// scan-and-gate dispatch path with a dynamic water-level cap replacing the
+// static one). Fairness is produced INSIDE dispatch(); the signature does not
+// change, so these tests need no edit when the dynamic cap lands.
+//
+// The contention scenarios are it.skip until the dynamic water-level cap is
+// implemented: against today's static per-tenant cap they fail deterministically
+// (equal scores tie-break by member lex, so the lexically-smaller tenant prefix
+// monopolises the fleet). Un-skip each as the EVALSHA makes it pass - that is
+// the red-to-green contract. The work-conserving and priority guards below pass
+// today and protect against regressions.
+
+let redis: Redis;
+let scripts: GroupStagingScripts;
+const QUEUE_NAME = "{test/fair-dispatch}";
+const ACTIVE_TTL_SEC = 300;
+
+function keyPrefix() {
+  return `${QUEUE_NAME}:gq:`;
+}
+
+// groupId convention: "<tenantId>/<suffix>". The dispatch Lua derives the tenant
+// as the substring before the first slash (mirrors prod, e.g.
+// "project_FzsKx-.../fold/traceSummary/trace:...").
+function gid(tenantId: string, suffix: string) {
+  return `${tenantId}/${suffix}`;
+}
+
+function tenantOf(groupId: string) {
+  return groupId.slice(0, groupId.indexOf("/"));
+}
+
+async function stageForTenant(
+  tenantId: string,
+  count: number,
+  opts: { dispatchAfterMs?: number } = {},
+) {
+  for (let i = 0; i < count; i++) {
+    const uniq = crypto.randomUUID().slice(0, 8);
+    await scripts.stage({
+      stagedJobId: `${tenantId}-job-${i}-${uniq}`,
+      groupId: gid(tenantId, `g${i}-${uniq}`),
+      dispatchAfterMs: opts.dispatchAfterMs ?? 0,
+      dedupId: "",
+      dedupTtlMs: 0,
+      jobDataJson: JSON.stringify({ tenant: tenantId, i }),
+      shouldExtend: true,
+      shouldReplace: true,
+    });
+  }
+}
+
+// A fixed worker fleet is modelled by a tracked in-flight set: fillToFleet keeps
+// dispatching until the fleet is full or ready is empty; completeSome frees
+// slots (optionally for one tenant) so they can be refilled.
+type Slot = { groupId: string; stagedJobId: string };
+let inflight: Slot[] = [];
+
+async function fillToFleet(size: number) {
+  while (inflight.length < size) {
+    const r = await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: ACTIVE_TTL_SEC });
+    if (!r) break;
+    inflight.push({ groupId: r.groupId, stagedJobId: r.stagedJobId });
+  }
+}
+
+async function completeSome(n: number, tenant?: string) {
+  const victims = inflight
+    .filter((s) => !tenant || tenantOf(s.groupId) === tenant)
+    .slice(0, n);
+  for (const v of victims) {
+    await scripts.complete({ groupId: v.groupId, stagedJobId: v.stagedJobId });
+    inflight = inflight.filter((s) => s !== v);
+  }
+}
+
+// In-flight count per tenant, read the same way the dispatcher reads truth:
+// GC lapsed slots by score, then ZCARD.
+async function inFlightByTenant(): Promise<Record<string, number>> {
+  const prefix = `${keyPrefix()}tenant_active_z:`;
+  const keys = await redis.keys(`${prefix}*`);
+  const out: Record<string, number> = {};
+  for (const k of keys) {
+    await redis.zremrangebyscore(k, "-inf", Date.now());
+    const n = await redis.zcard(k);
+    if (n > 0) out[k.slice(prefix.length)] = n;
+  }
+  return out;
+}
+
+beforeAll(async () => {
+  await startTestContainers();
+  redis = getTestRedisConnection()!;
+});
+
+beforeEach(async () => {
+  await redis.flushall();
+  scripts = new GroupStagingScripts(redis, QUEUE_NAME);
+  inflight = [];
+});
+
+afterAll(async () => {
+  await stopTestContainers();
+});
+
+describe("work-conserving fair dispatch", () => {
+  describe("Rule: idle capacity is always used (work-conserving)", () => {
+    describe("when only one tenant has work and slots are free", () => {
+      it("dispatches that tenant into every idle slot", async () => {
+        await stageForTenant("tenantA", 50);
+
+        await fillToFleet(20);
+
+        expect(await inFlightByTenant()).toEqual({ tenantA: 20 });
+      });
+    });
+
+    describe("when one tenant under-demands and another wants more (max-min)", () => {
+      it.skip("gives the small tenant all its demand and the rest to the big one", async () => {
+        await stageForTenant("small", 3);
+        await stageForTenant("big", 50);
+
+        await fillToFleet(20);
+
+        const inFlight = await inFlightByTenant();
+        expect(inFlight.small).toBe(3);
+        expect(inFlight.big).toBe(17);
+      });
+    });
+  });
+
+  describe("Rule: fairness engages only under contention", () => {
+    describe("when two equally-demanding tenants saturate the fleet", () => {
+      it.skip("splits the slots about evenly", async () => {
+        await stageForTenant("tenantA", 50);
+        await stageForTenant("tenantB", 50);
+
+        await fillToFleet(20);
+
+        const inFlight = await inFlightByTenant();
+        expect(inFlight.tenantA).toBeGreaterThanOrEqual(8);
+        expect(inFlight.tenantA).toBeLessThanOrEqual(12);
+        expect(inFlight.tenantB).toBeGreaterThanOrEqual(8);
+        expect(inFlight.tenantB).toBeLessThanOrEqual(12);
+      });
+    });
+
+    describe("when a runaway tenant and a small tenant compete", () => {
+      it.skip("serves the small tenant promptly and holds the runaway to its fair share", async () => {
+        await stageForTenant("runaway", 100);
+        await stageForTenant("small", 2);
+
+        await fillToFleet(20);
+
+        const inFlight = await inFlightByTenant();
+        // small gets served promptly, not starved behind the runaway backlog
+        expect(inFlight.small).toBe(2);
+        // runaway is held to its fair share, not the whole fleet
+        expect(inFlight.runaway).toBe(18);
+      });
+    });
+  });
+
+  describe("Rule: a newcomer is served as capacity frees, without holding slots idle", () => {
+    describe("when a newcomer arrives after an incumbent has saturated the fleet", () => {
+      it.skip("serves the newcomer up to its fair share over sustained operation, having held no slot in reserve", async () => {
+        // Work-conserving when alone: the lone incumbent uses every slot. No
+        // capacity was held empty in reserve for a tenant that had not arrived.
+        await stageForTenant("incumbent", 100);
+        await fillToFleet(20);
+        expect((await inFlightByTenant()).incumbent).toBe(20);
+
+        // Newcomer arrives into a saturated fleet.
+        await stageForTenant("newcomer", 100);
+
+        // Sustained operation: slots free by natural drain and are refilled,
+        // round after round. The model-agnostic guarantee is that the newcomer
+        // climbs to its fair share and the incumbent yields - whether that
+        // happens per-slot or after the cap reflects the new tenant count. We do
+        // NOT assert which slot goes where on any single round.
+        for (let round = 0; round < 8; round++) {
+          await completeSome(5);
+          await fillToFleet(20);
+        }
+
+        const inFlight = await inFlightByTenant();
+        // newcomer reached its fair share; incumbent was held back to make room
+        expect(inFlight.newcomer ?? 0).toBeGreaterThanOrEqual(8);
+        expect(inFlight.incumbent).toBeLessThanOrEqual(12);
+        // and the fleet stayed full throughout - nothing left idle
+        expect((inFlight.newcomer ?? 0) + inFlight.incumbent).toBe(20);
+      });
+    });
+  });
+
+  describe("Rule: throttling is released the moment contention ends", () => {
+    describe("when the competing tenant runs out of work", () => {
+      it("lets the remaining tenant expand into all freed capacity", async () => {
+        await stageForTenant("steady", 50);
+        await stageForTenant("burst", 8);
+        await fillToFleet(20);
+
+        // burst's work is fully drained
+        await completeSome(8, "burst");
+
+        // refill: with no contention, steady reclaims the freed slots
+        await fillToFleet(20);
+
+        const inFlight = await inFlightByTenant();
+        expect(inFlight.burst ?? 0).toBe(0);
+        expect(inFlight.steady).toBe(20);
+      });
+    });
+  });
+
+  describe("Rule: a tenant's own work keeps its priority order", () => {
+    describe("when one tenant has groups queued at different priorities", () => {
+      it("dispatches that tenant's groups in priority order", async () => {
+        // lower dispatchAfterMs == higher priority (earlier due)
+        await scripts.stage({
+          stagedJobId: "p-late",
+          groupId: gid("solo", "late"),
+          dispatchAfterMs: 2000,
+          dedupId: "",
+          dedupTtlMs: 0,
+          jobDataJson: JSON.stringify({ p: "late" }),
+          shouldExtend: true,
+          shouldReplace: true,
+        });
+        await scripts.stage({
+          stagedJobId: "p-early",
+          groupId: gid("solo", "early"),
+          dispatchAfterMs: 1000,
+          dedupId: "",
+          dedupTtlMs: 0,
+          jobDataJson: JSON.stringify({ p: "early" }),
+          shouldExtend: true,
+          shouldReplace: true,
+        });
+
+        const first = await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: ACTIVE_TTL_SEC });
+        const second = await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: ACTIVE_TTL_SEC });
+
+        expect(first?.groupId).toBe(gid("solo", "early"));
+        expect(second?.groupId).toBe(gid("solo", "late"));
+      });
+    });
+  });
+
+  // Off by default; fails to the protective (low) side when clamp state is gone.
+  describe("Rule: an operator can still hard-clamp a pathological tenant", () => {
+    it.todo("holds a tenant to an explicit ceiling regardless of free capacity");
+    it.todo("leaves other tenants unaffected by one tenant's ceiling");
+  });
+
+  // Mixed-fleet rollout: old pods write legacy single-ready while new pods read
+  // the dynamic cap. Exercise once both code paths are co-resident.
+  describe("Rule: upgrading the dispatch path loses no in-flight work", () => {
+    it.todo("dispatches every group queued before the upgrade");
+    it.todo("keeps draining legacy-ready continuously-until-empty during the rollout");
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
@@ -263,7 +263,7 @@ describe("work-conserving fair dispatch", () => {
         expect(inFlight.newcomer ?? 0).toBeGreaterThanOrEqual(8);
         expect(inFlight.incumbent).toBeLessThanOrEqual(12);
         // and the fleet stayed full throughout - nothing left idle
-        expect((inFlight.newcomer ?? 0) + inFlight.incumbent).toBe(20);
+        expect((inFlight.newcomer ?? 0) + (inFlight.incumbent ?? 0)).toBe(20);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Redis } from "ioredis";
 import {
   startTestContainers,
@@ -107,15 +107,32 @@ beforeAll(async () => {
   redis = getTestRedisConnection()!;
 });
 
+const FLEET = 20;
+
 beforeEach(async () => {
   await redis.flushall();
   scripts = new GroupStagingScripts(redis, QUEUE_NAME);
   inflight = [];
+  // Enable the dynamic water-level cap with the global budget = fleet size, so a
+  // lone tenant gets W=G=20 and two contenders converge to G/2=10. readGlobalBudget
+  // reads process.env per dispatch, so setting it here takes effect immediately.
+  process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET = String(FLEET);
+});
+
+afterEach(() => {
+  delete process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET;
 });
 
 afterAll(async () => {
   await stopTestContainers();
 });
+
+// The water level is recomputed on the 2s-gated reconcile pass; the first
+// dispatch always recomputes (last-reconcile = 0). When a second tenant arrives
+// mid-test we must wait past that gate so the next dispatch recomputes W with
+// both tenants present. One real clock throughout (stage/complete use Date.now()).
+const RECONCILE_GATE_MS = 2100;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe("work-conserving fair dispatch", () => {
   describe("Rule: idle capacity is always used (work-conserving)", () => {
@@ -130,7 +147,7 @@ describe("work-conserving fair dispatch", () => {
     });
 
     describe("when one tenant under-demands and another wants more (max-min)", () => {
-      it.skip("gives the small tenant all its demand and the rest to the big one", async () => {
+      it("gives the small tenant all its demand and the rest to the big one", async () => {
         await stageForTenant("small", 3);
         await stageForTenant("big", 50);
 
@@ -158,7 +175,7 @@ describe("work-conserving fair dispatch", () => {
       // is still inside claimantWindow. Wire the exact clock advance
       // (recomputeInterval < delta < claimantWindow, via the dispatch nowMs)
       // once those constants are fixed in the EVALSHA.
-      it.skip("does not let the idle tenant's stale claim cap the busy one", async () => {
+      it("does not let the idle tenant's stale claim cap the busy one", async () => {
         // burster bursts and fully drains: no active, no parked, but still fresh
         await stageForTenant("burster", 10);
         await fillToFleet(10);
@@ -167,6 +184,10 @@ describe("work-conserving fair dispatch", () => {
 
         // busy is now the only tenant with real ready work
         await stageForTenant("busy", 50);
+        // wait past the reconcile gate so the next dispatch recomputes W with
+        // both tenants present while burster is still inside the claimant window
+        // - this is when the phantom claim would bite if the override were missing
+        await sleep(RECONCILE_GATE_MS);
         for (let round = 0; round < 6; round++) {
           await completeSome(5, "busy");
           await fillToFleet(20);
@@ -182,7 +203,7 @@ describe("work-conserving fair dispatch", () => {
 
   describe("Rule: fairness engages only under contention", () => {
     describe("when two equally-demanding tenants saturate the fleet", () => {
-      it.skip("splits the slots about evenly", async () => {
+      it("splits the slots about evenly", async () => {
         await stageForTenant("tenantA", 50);
         await stageForTenant("tenantB", 50);
 
@@ -197,7 +218,7 @@ describe("work-conserving fair dispatch", () => {
     });
 
     describe("when a runaway tenant and a small tenant compete", () => {
-      it.skip("serves the small tenant promptly and holds the runaway to its fair share", async () => {
+      it("serves the small tenant promptly and holds the runaway to its fair share", async () => {
         await stageForTenant("runaway", 100);
         await stageForTenant("small", 2);
 
@@ -214,7 +235,7 @@ describe("work-conserving fair dispatch", () => {
 
   describe("Rule: a newcomer is served as capacity frees, without holding slots idle", () => {
     describe("when a newcomer arrives after an incumbent has saturated the fleet", () => {
-      it.skip("serves the newcomer up to its fair share over sustained operation, having held no slot in reserve", async () => {
+      it("serves the newcomer up to its fair share over sustained operation, having held no slot in reserve", async () => {
         // Work-conserving when alone: the lone incumbent uses every slot. No
         // capacity was held empty in reserve for a tenant that had not arrived.
         await stageForTenant("incumbent", 100);
@@ -223,6 +244,9 @@ describe("work-conserving fair dispatch", () => {
 
         // Newcomer arrives into a saturated fleet.
         await stageForTenant("newcomer", 100);
+        // wait past the reconcile gate so W recomputes with the newcomer present
+        // (and still fresh) before the refill rounds
+        await sleep(RECONCILE_GATE_MS);
 
         // Sustained operation: slots free by natural drain and are refilled,
         // round after round. The model-agnostic guarantee is that the newcomer
@@ -304,10 +328,52 @@ describe("work-conserving fair dispatch", () => {
     it.todo("leaves other tenants unaffected by one tenant's ceiling");
   });
 
-  // Mixed-fleet rollout: old pods write legacy single-ready while new pods read
-  // the dynamic cap. Exercise once both code paths are co-resident.
+  // Mixed-fleet rollout: an old pod (feature off, static-cap path) and a new pod
+  // (feature on, dynamic-cap path) co-exist on the SAME ready zset - there is no
+  // separate structure to migrate. Modelled by toggling the budget env between
+  // the enqueue (old pod) and the dispatch (new pod).
   describe("Rule: upgrading the dispatch path loses no in-flight work", () => {
-    it.todo("dispatches every group queued before the upgrade");
-    it.todo("keeps draining legacy-ready continuously-until-empty during the rollout");
+    it("dispatches every group queued before the upgrade", async () => {
+      // old pod, feature off: groups land on the shared ready zset (and are NOT
+      // added to demanding-tenants)
+      delete process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET;
+      await stageForTenant("pre", 12);
+
+      // upgrade: feature on. The pre-upgrade groups are dispatched by the new
+      // path with nothing stranded (an empty demanding-tenants water-fills to
+      // W=G, so they are not starved by a zero-demand reading).
+      process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET = String(FLEET);
+      await fillToFleet(FLEET);
+
+      expect((await inFlightByTenant()).pre).toBe(12);
+    });
+
+    it("keeps draining legacy-ready continuously-until-empty during the rollout", async () => {
+      let staged = 0;
+      let dispatched = 0;
+      for (let wave = 0; wave < 3; wave++) {
+        // old pod keeps adding to legacy-ready mid-rollout
+        delete process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET;
+        await stageForTenant("rollout", 5);
+        staged += 5;
+        // new pod drains a few each pass
+        process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET = String(FLEET);
+        for (let i = 0; i < 3; i++) {
+          const r = await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: ACTIVE_TTL_SEC });
+          if (!r) break;
+          dispatched++;
+          await scripts.complete({ groupId: r.groupId, stagedJobId: r.stagedJobId });
+        }
+      }
+      // new dispatcher keeps draining until legacy-ready is empty
+      for (;;) {
+        const r = await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: ACTIVE_TTL_SEC });
+        if (!r) break;
+        dispatched++;
+        await scripts.complete({ groupId: r.groupId, stagedJobId: r.stagedJobId });
+      }
+      // every group an old pod added mid-rollout was dispatched - none stranded
+      expect(dispatched).toBe(staged);
+    });
   });
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
@@ -141,6 +141,43 @@ describe("work-conserving fair dispatch", () => {
         expect(inFlight.big).toBe(17);
       });
     });
+
+    describe("when a tenant bursts then goes idle while another stays busy", () => {
+      // Pins the work-conserving override against the "phantom claimant" hazard
+      // of the recency-based demand signal: a tenant that bursts then drains is
+      // still "fresh" in the demand window with active+parked=0, so it reads as
+      // a presence-claimant and pulls a fair share even though it has no real
+      // ready work. If the dynamic cap honoured that stale claim it would cap
+      // the genuinely-busy tenant and idle the freed slots - reintroducing the
+      // idle-behind-cap waste this whole feature removes. The contract: the cap
+      // binds only under real contention; a slot that would otherwise idle is
+      // filled past the fair cap rather than left empty.
+      //
+      // it.skip until the dynamic cap lands: this is timing-coupled - it only
+      // exercises the phantom if a water-level recompute fires while the burster
+      // is still inside claimantWindow. Wire the exact clock advance
+      // (recomputeInterval < delta < claimantWindow, via the dispatch nowMs)
+      // once those constants are fixed in the EVALSHA.
+      it.skip("does not let the idle tenant's stale claim cap the busy one", async () => {
+        // burster bursts and fully drains: no active, no parked, but still fresh
+        await stageForTenant("burster", 10);
+        await fillToFleet(10);
+        await completeSome(10, "burster");
+        expect((await inFlightByTenant()).burster ?? 0).toBe(0);
+
+        // busy is now the only tenant with real ready work
+        await stageForTenant("busy", 50);
+        for (let round = 0; round < 6; round++) {
+          await completeSome(5, "busy");
+          await fillToFleet(20);
+        }
+
+        const inFlight = await inFlightByTenant();
+        // busy uses the whole fleet; the burster's stale claim reserves nothing
+        expect(inFlight.busy).toBe(20);
+        expect(inFlight.burster ?? 0).toBe(0);
+      });
+    });
   });
 
   describe("Rule: fairness engages only under contention", () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
@@ -325,6 +325,14 @@ describe("work-conserving fair dispatch", () => {
     it.todo("leaves other tenants unaffected by one tenant's ceiling");
   });
 
+  // Fail-protective: when the dynamic-cap value lapses (stalled recompute), the
+  // gate falls back to the static operator cap until the next reconcile rebuilds
+  // the water level from in-flight + parked truth.
+  describe("Rule: a stale dynamic cap fails safe and is rebuilt from truth", () => {
+    it.todo("falls back to the static operator cap when the dynamic-cap value has lapsed");
+    it.todo("rebuilds the water level from authoritative counts on the next reconcile");
+  });
+
   // Mixed-fleet rollout: an old pod (feature off, static-cap path) and a new pod
   // (feature on, dynamic-cap path) co-exist on the SAME ready zset - there is no
   // separate structure to migrate. Modelled by toggling the budget env between

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/fairDispatch.integration.test.ts
@@ -17,12 +17,10 @@ import { GroupStagingScripts } from "../scripts";
 // static one). Fairness is produced INSIDE dispatch(); the signature does not
 // change, so these tests need no edit when the dynamic cap lands.
 //
-// The contention scenarios are it.skip until the dynamic water-level cap is
-// implemented: against today's static per-tenant cap they fail deterministically
-// (equal scores tie-break by member lex, so the lexically-smaller tenant prefix
-// monopolises the fleet). Un-skip each as the EVALSHA makes it pass - that is
-// the red-to-green contract. The work-conserving and priority guards below pass
-// today and protect against regressions.
+// The contention scenarios are enabled via LANGWATCH_DISPATCH_GLOBAL_BUDGET (set
+// in beforeEach) and assert the max-min fair outcome against the dynamic
+// water-level cap. The work-conserving and intra-tenant-priority guards hold
+// regardless of the cap and protect against regressions.
 
 let redis: Redis;
 let scripts: GroupStagingScripts;
@@ -170,11 +168,10 @@ describe("work-conserving fair dispatch", () => {
       // binds only under real contention; a slot that would otherwise idle is
       // filled past the fair cap rather than left empty.
       //
-      // it.skip until the dynamic cap lands: this is timing-coupled - it only
-      // exercises the phantom if a water-level recompute fires while the burster
-      // is still inside claimantWindow. Wire the exact clock advance
-      // (recomputeInterval < delta < claimantWindow, via the dispatch nowMs)
-      // once those constants are fixed in the EVALSHA.
+      // Timing-coupled: it only exercises the phantom if a water-level recompute
+      // fires while the burster is still inside the claimant window, so the test
+      // waits past the reconcile gate (RECONCILE_GATE_MS) after the busy tenant
+      // arrives, with the burster still fresh.
       it("does not let the idle tenant's stale claim cap the busy one", async () => {
         // burster bursts and fully drains: no active, no parked, but still fresh
         await stageForTenant("burster", 10);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -27,14 +27,35 @@ export const GROUP_KEY_TTL_MS = 6 * 60 * 60 * 1000;
 export const PARK_RECONCILE_MAX_DRAIN = 1000;
 
 /**
- * TTL (ms) on the dynamic water-level cap key. The recompute runs on the same
- * 2s-gated, single-pod reconcile pass and refreshes this key; the TTL is several
+ * Cadence (ms) of the dispatch-tail reconcile pass (parked-group restore + the
+ * dynamic-cap recompute), gated single-pod via the reconcile-ts marker. The
+ * dynamic-cap TTL and the claimant window are both defined as multiples of this,
+ * so it is a named const rather than a bare literal in the dispatch scripts —
+ * retuning it keeps those relationships intact. Interpolated into the Lua.
+ */
+export const RECONCILE_INTERVAL_MS = 2000;
+
+/**
+ * TTL (ms) on the dynamic water-level cap key (= 5x RECONCILE_INTERVAL_MS). The
+ * recompute refreshes this key on every reconcile pass; the TTL spans several
  * intervals so a brief miss does not drop the cap. If the recompute stalls
  * entirely (every pod dead or wedged) the key lapses and dispatch falls back to
  * the static operator cap — fail PROTECTIVE (the low side), never permissive.
  * Interpolated into the Lua so there is a single source of truth.
  */
-export const DYNAMIC_CAP_TTL_MS = 10000;
+export const DYNAMIC_CAP_TTL_MS = 5 * RECONCILE_INTERVAL_MS;
+
+/**
+ * Hard bound on how many tenants the dynamic-cap recompute processes in one
+ * pass. The recompute does O(1) Redis calls per tenant (active ZCARD + parked
+ * ZCARD) inside a single eval on the single-threaded Redis; bounding it to the
+ * most-recently-active N keeps the worst case at ~3N calls every
+ * RECONCILE_INTERVAL_MS (sub-millisecond at N=1000) even if a pathological
+ * fan-out leaves thousands of tenants in the demand registry. The N most-recent
+ * claimants are the current contention set; older ones have aged out of the
+ * window and their in-flight is still enforced directly via tenant_active_z.
+ */
+export const MAX_DEMANDING_TENANTS = 1000;
 
 // Lua helper, prepended to every script that writes group keys. Refreshes the
 // safety-net TTL on a group's jobs/data keys, deriving expiry from the LATEST
@@ -288,21 +309,31 @@ end
 -- needs to stop a newcomer reading 0 demand and pinning W at the full budget.
 local function recomputeDynamicCap(keyPrefix, budget, nowMs)
   local registryKey = keyPrefix .. "demanding-tenants"
-  local members = redis.call("ZRANGE", registryKey, 0, -1, "WITHSCORES")
+  -- Drop every tenant that has not enqueued within the claimant window in one
+  -- O(log N + M) trim. Enqueue-only freshness IS the demand signal, so an aged
+  -- member is no longer a claimant; this both bounds the ZSET and replaces the
+  -- per-member stale GC. A tenant still draining old in-flight work ages out of
+  -- the fairness fill here, but its slots stay enforced directly via
+  -- tenant_active_z, so it is never under-counted as a HARD cap, only as a
+  -- (work-conserving) fairness claim.
+  redis.call("ZREMRANGEBYSCORE", registryKey, "-inf", nowMs - ${CLAIMANT_WINDOW_MS})
+  -- Process at most MAX_DEMANDING_TENANTS most-recent claimants so a pathological
+  -- fan-out (thousands of distinct tenants active within the window) can never
+  -- block the single-threaded Redis on this 2s pass. The most-recent N are the
+  -- live contention set; the fill over them is the fair-share signal.
+  local members = redis.call("ZREVRANGE", registryKey, 0, ${MAX_DEMANDING_TENANTS} - 1)
   local measured = {}
   local presenceCount = 0
-  for i = 1, #members, 2 do
-    local tenantId = members[i]
-    local lastActive = tonumber(members[i + 1]) or 0
-    local fresh = (nowMs - lastActive) <= ${CLAIMANT_WINDOW_MS}
+  for _, tenantId in ipairs(members) do
+    -- Fresh by construction (aged members were trimmed above). demand_i =
+    -- in-flight (GC-d) + parked; a fresh tenant with zero of both is a brand-new
+    -- claimant whose burst is still entirely in ready = presence claimant.
     local d = tenantActiveCount(keyPrefix .. "tenant_active_z:", tenantId, nowMs)
             + redis.call("ZCARD", keyPrefix .. "parked:" .. tenantId)
     if d > 0 then
       measured[#measured + 1] = d
-    elseif fresh then
-      presenceCount = presenceCount + 1
     else
-      redis.call("ZREM", registryKey, tenantId)
+      presenceCount = presenceCount + 1
     end
   end
   local w = waterLevel(measured, presenceCount, budget)
@@ -549,7 +580,7 @@ local activeUntil = nowMs + activeTtlSec * 1000
 -- water-fill rides the same proven cadence at near-zero marginal cost.
 local reconcileTsKey = keyPrefix .. "reconcile-ts"
 local lastReconcile = tonumber(redis.call("GET", reconcileTsKey)) or 0
-if (nowMs - lastReconcile) >= 2000 then
+if (nowMs - lastReconcile) >= ${RECONCILE_INTERVAL_MS} then
   redis.call("SET", reconcileTsKey, nowMs)
   -- Recompute W before reconciling so unpark uses the fresh cap. Only when the
   -- cap is on (staticCap=0 is the kill switch) and a budget is configured.
@@ -766,7 +797,7 @@ local results = {}
 -- the same single-pod reconcile-ts cadence at near-zero marginal cost.
 local reconcileTsKey = keyPrefix .. "reconcile-ts"
 local lastReconcile = tonumber(redis.call("GET", reconcileTsKey)) or 0
-if (nowMs - lastReconcile) >= 2000 then
+if (nowMs - lastReconcile) >= ${RECONCILE_INTERVAL_MS} then
   redis.call("SET", reconcileTsKey, nowMs)
   if staticCap > 0 and globalBudget > 0 then
     recomputeDynamicCap(keyPrefix, globalBudget, nowMs)

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -26,6 +26,16 @@ export const GROUP_KEY_TTL_MS = 6 * 60 * 60 * 1000;
  */
 export const PARK_RECONCILE_MAX_DRAIN = 1000;
 
+/**
+ * TTL (ms) on the dynamic water-level cap key. The recompute runs on the same
+ * 2s-gated, single-pod reconcile pass and refreshes this key; the TTL is several
+ * intervals so a brief miss does not drop the cap. If the recompute stalls
+ * entirely (every pod dead or wedged) the key lapses and dispatch falls back to
+ * the static operator cap — fail PROTECTIVE (the low side), never permissive.
+ * Interpolated into the Lua so there is a single source of truth.
+ */
+export const DYNAMIC_CAP_TTL_MS = 10000;
+
 // Lua helper, prepended to every script that writes group keys. Refreshes the
 // safety-net TTL on a group's jobs/data keys, deriving expiry from the LATEST
 // pending dispatch score so a job legitimately delayed past the window (e.g. a
@@ -199,6 +209,128 @@ local function reconcileParked(readyKey, keyPrefix, tenantCap, nowMs)
 end
 `;
 
+/**
+ * How long (ms) a tenant stays a "claimant" after its last enqueue/dispatch.
+ * A brand-new tenant whose burst is still entirely in ready (no in-flight, none
+ * parked) is invisible to a count-only demand measure, so the water-level would
+ * keep W at the full budget and the newcomer would never be admitted (a stable
+ * starvation behind a higher-priority incumbent, not a one-tick lag). We instead
+ * treat any freshly-active tenant as a claimant that pulls a full fair share.
+ * The window is several recompute intervals so a tenant that briefly goes quiet
+ * is not dropped mid-burst; once it stops enqueueing AND drains, it ages out and
+ * its reserved share is released. Interpolated into the Lua for one source.
+ */
+export const CLAIMANT_WINDOW_MS = 15000;
+
+// Lua helper for the DYNAMIC per-tenant cap (option C, 2026-05-29 follow-up to
+// the fixed soft cap). The hot path is unchanged — it still parks a group when
+// its tenant's in-flight count reaches the cap — but the cap is now a water-level
+// W recomputed off the existing 2s reconcile pass instead of a fixed constant.
+// W water-fills a global in-flight budget G across the tenants with demand: a
+// lone tenant gets W=G (bursts to full), N contenders converge to a max-min fair
+// share, all emergent with no per-tenant allocation and no new dispatch path.
+// Requires tenantActiveCount (from TENANT_ACTIVE_HELPER_LUA via PARK_HELPER_LUA),
+// so it is always concatenated after PARK_HELPER_LUA.
+const WATER_LEVEL_HELPER_LUA = `
+-- Effective per-tenant cap = the dynamic water-level W when present, else the
+-- static operator cap. A lapsed/never-written dynamic-cap key (recompute stalled
+-- on every pod, or the feature is off) falls back to the static cap = fail
+-- PROTECTIVE (the low side), never permissive.
+local function effectiveCap(keyPrefix, staticCap)
+  local w = redis.call("GET", keyPrefix .. "dynamic-cap")
+  if w then
+    local n = tonumber(w)
+    if n and n >= 1 then return n end
+  end
+  return staticCap
+end
+
+-- Water-fill the global budget across claimants: returns the uniform level W
+-- with sum(min(demand_i, W)) = budget. measured = realised demands (in-flight +
+-- parked) of tenants that are dispatching. presenceCount = brand-new claimants
+-- whose work is still all in ready (measured 0 but freshly enqueued); we treat
+-- them as constrained (each pulls a full share W) so a newcomer is not invisible
+-- to the fill. A measured tenant below the running share is satisfied and its
+-- slack redistributes UP to the constrained ones (max-min, emergent). No
+-- contention (everything fits, no presence) -> W = budget (burst to full).
+local function waterLevel(measured, presenceCount, budget)
+  table.sort(measured)
+  local nLeft = #measured + presenceCount
+  if nLeft == 0 then return budget end
+  local remaining = budget
+  for i = 1, #measured do
+    local share = remaining / nLeft
+    if measured[i] <= share then
+      remaining = remaining - measured[i]
+      nLeft = nLeft - 1
+    else
+      local w = math.floor(remaining / nLeft)
+      if w < 1 then w = 1 end
+      return w
+    end
+  end
+  -- All measured tenants satisfied; the remainder is split among presence
+  -- claimants. None left -> nothing is constrained -> W = the whole budget.
+  if nLeft <= 0 then return budget end
+  local w = math.floor(remaining / nLeft)
+  if w < 1 then w = 1 end
+  return w
+end
+
+-- Recompute W from the tenants with demand and store it under dynamic-cap with a
+-- TTL (a stalled recompute lapses to the static cap = fail-protective). Reads the
+-- demanding-tenants RECENCY ZSET (member=tenant, score=last enqueue/dispatch ms),
+-- avoiding the keyspace SCAN that once pegged Redis. Per tenant: measured =
+-- in-flight (tenant_active_z, GC-d) + parked; fresh = active within the claimant
+-- window. fresh & measured 0 = presence claimant (newcomer still in ready);
+-- stale & measured 0 = drained, GC. Deliberately omits the exact ready COUNT (no
+-- per-tenant ready index); ready PRESENCE via fresh membership is all the fill
+-- needs to stop a newcomer reading 0 demand and pinning W at the full budget.
+local function recomputeDynamicCap(keyPrefix, budget, nowMs)
+  local registryKey = keyPrefix .. "demanding-tenants"
+  local members = redis.call("ZRANGE", registryKey, 0, -1, "WITHSCORES")
+  local measured = {}
+  local presenceCount = 0
+  for i = 1, #members, 2 do
+    local tenantId = members[i]
+    local lastActive = tonumber(members[i + 1]) or 0
+    local fresh = (nowMs - lastActive) <= ${CLAIMANT_WINDOW_MS}
+    local d = tenantActiveCount(keyPrefix .. "tenant_active_z:", tenantId, nowMs)
+            + redis.call("ZCARD", keyPrefix .. "parked:" .. tenantId)
+    if d > 0 then
+      measured[#measured + 1] = d
+    elseif fresh then
+      presenceCount = presenceCount + 1
+    else
+      redis.call("ZREM", registryKey, tenantId)
+    end
+  end
+  local w = waterLevel(measured, presenceCount, budget)
+  redis.call("SET", keyPrefix .. "dynamic-cap", w, "PX", ${DYNAMIC_CAP_TTL_MS})
+end
+
+-- Unpark up to "slots" groups from the least-served (fewest in-flight) over-cap
+-- tenant that is not paused, so the work-conserving override can fill otherwise-
+-- idle slots from the most-starved over-cap tenant. Candidate set is the parked
+-- tenants ONLY, so a work-less phantom claimant (no parked groups) is never
+-- chosen and a free slot is never wasted on a tenant with nothing to run.
+local function unparkLeastServedParked(readyKey, keyPrefix, pausedJobKey, nowMs, slots)
+  local tenants = redis.call("SMEMBERS", keyPrefix .. "parked-tenants")
+  local best = nil
+  local bestCount = nil
+  for _, t in ipairs(tenants) do
+    if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. t) == 0 then
+      local c = tenantActiveCount(keyPrefix .. "tenant_active_z:", t, nowMs)
+      if bestCount == nil or c < bestCount then
+        best = t
+        bestCount = c
+      end
+    end
+  end
+  if best then unparkUpTo(readyKey, best, slots) end
+end
+`;
+
 const STAGE_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
 local groupJobsKey    = KEYS[1]
 local readyKey        = KEYS[2]
@@ -218,6 +350,16 @@ local jobDataJson    = ARGV[6]
 local shouldExtend   = tonumber(ARGV[7])
 local shouldReplace  = tonumber(ARGV[8])
 local nowMs          = tonumber(ARGV[9])
+-- Global in-flight budget; when set (>0), record this tenant as a live claimant
+-- in the demanding-tenants recency ZSET so the water-level recompute counts its
+-- demand even while its first burst is still entirely in ready (not yet
+-- dispatched). Enqueue-only freshness is the true "actively submitting" signal:
+-- a tenant that stops enqueuing ages out of the window even while it drains, so
+-- a bursted-then-idle tenant cannot linger as a phantom claimant.
+local globalBudget   = tonumber(ARGV[10]) or 0
+if globalBudget > 0 then
+  redis.call("ZADD", parkKeyPrefixOf(readyKey) .. "demanding-tenants", nowMs, parkTenantOf(groupId))
+end
 
 -- Skip ready-score updates while the group is processing (active key set) or
 -- blocked. In those states the ready score is owned by REFRESH_LUA / COMPLETE_LUA
@@ -285,8 +427,12 @@ local totalPendingKey = KEYS[3]
 
 local keyPrefix = ARGV[1]
 local count     = tonumber(ARGV[2])
--- nowMs is appended after all per-job args, so it is always the last element.
-local nowMs     = tonumber(ARGV[#ARGV])
+-- nowMs and globalBudget are appended after all per-job args: globalBudget is
+-- always last, nowMs just before it. globalBudget>0 enables the dynamic cap, in
+-- which case each enqueued group's tenant is recorded as a live claimant in the
+-- demanding-tenants recency ZSET (see STAGE_LUA for the enqueue-only rationale).
+local globalBudget = tonumber(ARGV[#ARGV]) or 0
+local nowMs        = tonumber(ARGV[#ARGV - 1])
 
 local newStagedCount = 0
 local affectedGroups = {}
@@ -348,6 +494,9 @@ end
 
 local blockedKey = keyPrefix .. "blocked"
 for groupId, minScore in pairs(affectedGroups) do
+  if globalBudget > 0 then
+    redis.call("ZADD", keyPrefix .. "demanding-tenants", nowMs, parkTenantOf(groupId))
+  end
   -- Score = earliest pending dispatchAfter (LT keeps the smallest).
   -- Skip when the group is processing or blocked — the active heartbeat /
   -- completion / unblock paths own the score in those states. Lowering it
@@ -369,7 +518,7 @@ end
 return newStagedCount
 `;
 
-const DISPATCH_LUA = PARK_HELPER_LUA + `
+const DISPATCH_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + `
 local readyKey         = KEYS[1]
 local blockedKey       = KEYS[2]
 local pausedJobKey     = KEYS[3]
@@ -378,194 +527,220 @@ local totalPendingKey  = KEYS[4]
 local keyPrefix    = ARGV[1]
 local nowMs        = tonumber(ARGV[2])
 local activeTtlSec = tonumber(ARGV[3])
--- Tenant soft-cap (post-2026-05-11 incident follow-up). When > 0, the
--- scheduler refuses to dispatch a group whose tenant already has >=
--- tenantCap groups in flight. Defaults to 50 in TS (see
--- DEFAULT_TENANT_CAP); operators can set LANGWATCH_DISPATCH_TENANT_CAP=0
--- as an explicit kill switch, or to a higher integer to retune.
--- The tenantId is derived from groupId prefix (segment before first '/').
-local tenantCap    = tonumber(ARGV[4]) or 0
+-- Static operator soft-cap (post-2026-05-11 incident follow-up). 0 = explicit
+-- kill switch (LANGWATCH_DISPATCH_TENANT_CAP=0): no cap, no parking. > 0 is the
+-- per-tenant in-flight ceiling AND the fail-protective fallback for the dynamic
+-- cap below. The tenantId is the groupId prefix (segment before first '/').
+local staticCap    = tonumber(ARGV[4]) or 0
+-- Global in-flight budget for the DYNAMIC water-level cap (option C). It is the
+-- hard ceiling = pods x concurrency; the water-fill divides the WHOLE capacity.
+-- 0 = dynamic disabled, dispatch uses the static cap unchanged (back-compat).
+local globalBudget = tonumber(ARGV[5]) or 0
 
 local hasPauses = redis.call("SCARD", pausedJobKey) > 0
 local activeUntil = nowMs + activeTtlSec * 1000
 
--- Restore parked over-cap groups on a cadence (TRAP 2 orphan recovery + cap=0
--- drain). COMPLETE-unpark handles the normal slot-freeing as jobs finish; this
--- only backstops what it can't: a crashed/timed-out tenant that never fires
--- COMPLETE (its in-flight slots lapse out of the live count as their expiry
--- scores pass = back under cap = unpark), and flipping the cap off (drain
--- everything parked). Time-gated rather than
--- per-poll so under sustained load (dispatch rarely idle) orphan recovery is
--- not starved, while the cap=0 steady state pays only a GET + an occasional
--- empty SMEMBERS. SCARD-gated so it is a true no-op when nothing is parked.
+-- Restore parked over-cap groups + recompute the water-level on a cadence (TRAP 2
+-- orphan recovery + cap=0 drain). COMPLETE-unpark handles the normal slot-freeing
+-- as jobs finish; this only backstops what it can't: a crashed/timed-out tenant
+-- that never fires COMPLETE (its in-flight slots lapse out of the live count as
+-- their expiry scores pass = back under cap = unpark), and flipping the cap off
+-- (drain everything parked). Time-gated and single-pod via reconcile-ts, so the
+-- water-fill rides the same proven cadence at near-zero marginal cost.
 local reconcileTsKey = keyPrefix .. "reconcile-ts"
 local lastReconcile = tonumber(redis.call("GET", reconcileTsKey)) or 0
 if (nowMs - lastReconcile) >= 2000 then
   redis.call("SET", reconcileTsKey, nowMs)
+  -- Recompute W before reconciling so unpark uses the fresh cap. Only when the
+  -- cap is on (staticCap=0 is the kill switch) and a budget is configured.
+  if staticCap > 0 and globalBudget > 0 then
+    recomputeDynamicCap(keyPrefix, globalBudget, nowMs)
+  end
   if redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
-    reconcileParked(readyKey, keyPrefix, tenantCap, nowMs)
+    local reconcileCap = staticCap
+    if staticCap > 0 and globalBudget > 0 then
+      reconcileCap = effectiveCap(keyPrefix, staticCap)
+    end
+    reconcileParked(readyKey, keyPrefix, reconcileCap, nowMs)
   end
 end
 
--- Pull only groups whose earliest job is due now (legacy entries with score=1 also pass).
--- Active groups carry future scores (nowMs + activeTtlSec*1000) and are excluded.
+-- Effective per-tenant cap for this dispatch: the dynamic water-level when a
+-- budget is configured, else the static cap. staticCap=0 (kill switch) always
+-- wins and disables parking entirely.
+local tenantCap = staticCap
+if staticCap > 0 and globalBudget > 0 then
+  tenantCap = effectiveCap(keyPrefix, staticCap)
+end
+
+-- Scan ready in priority order and dispatch ONE due job. effCap gates the
+-- per-tenant in-flight cap (0 = cap off). bypassPark skips the over-cap PARKING
+-- decision (used by the work-conserving override) while STILL recording the
+-- in-flight slot, so an override dispatch is counted against its tenant.
 -- Page through the ready zset so a head full of paused / blocked / legacy-drift
--- entries does not cause dispatch to return nil while eligible work exists later.
-local pageSize = 200
--- Default scan budget bounds the worst-case cost of a single dispatch
--- call. When the tenant soft-cap is enabled we widen it so a head full
--- of one tenant's over-cap groups (which we correctly skip but still
--- count against the budget) cannot starve other tenants deeper in the
--- zset. This is the explicit cost of the cap: more work per poll, in
--- exchange for cross-tenant fairness.
-local scanBudget = 1000
-if tenantCap > 0 then scanBudget = 10000 end
-local offset = 0
+-- entries does not return nil while eligible work exists later.
+local function scanAndDispatch(effCap, bypassPark)
+  local pageSize = 200
+  -- Widen the scan budget when the cap is on so a head full of one tenant's
+  -- over-cap groups (correctly skipped but still counted) cannot starve tenants
+  -- deeper in the zset. The explicit cost of the cap: more work per poll.
+  local scanBudget = 1000
+  if effCap > 0 then scanBudget = 10000 end
+  local offset = 0
+  -- Cache tenant cap lookups within this scan to avoid redundant GETs.
+  local tenantCapCache = {}
 
--- Cache tenant cap lookups within this EVAL to avoid redundant GETs.
-local tenantCapCache = {}
+  while offset < scanBudget do
+    local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", offset, pageSize)
+    if #groups == 0 then return nil end
 
-while offset < scanBudget do
-  local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", offset, pageSize)
-  if #groups == 0 then return nil end
-
-  for _, groupId in ipairs(groups) do
-    if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
-      -- Tenant soft-cap check (no-op when tenantCap == 0).
-      local tenantOverCap = false
-      local capTenantId = nil
-      if tenantCap > 0 then
-        local slashPos = string.find(groupId, "/", 1, true)
-        if slashPos and slashPos > 1 then
-          capTenantId = string.sub(groupId, 1, slashPos - 1)
-          local cached = tenantCapCache[capTenantId]
-          if cached == nil then
-            cached = tenantActiveCount(keyPrefix .. "tenant_active_z:", capTenantId, nowMs) >= tenantCap
-            tenantCapCache[capTenantId] = cached
+    for _, groupId in ipairs(groups) do
+      if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
+        -- Tenant cap check (no-op when effCap == 0). capTenantId is resolved
+        -- regardless of bypassPark so the in-flight slot is still recorded; only
+        -- the PARK decision is skipped under bypassPark.
+        local tenantOverCap = false
+        local capTenantId = nil
+        if effCap > 0 then
+          local slashPos = string.find(groupId, "/", 1, true)
+          if slashPos and slashPos > 1 then
+            capTenantId = string.sub(groupId, 1, slashPos - 1)
+            if not bypassPark then
+              local cached = tenantCapCache[capTenantId]
+              if cached == nil then
+                cached = tenantActiveCount(keyPrefix .. "tenant_active_z:", capTenantId, nowMs) >= effCap
+                tenantCapCache[capTenantId] = cached
+              end
+              if cached then
+                tenantOverCap = true
+                -- Park the over-cap group OUT of ready (once) so subsequent polls
+                -- reach other tenants without re-scanning it. Restored when the
+                -- tenant's in-flight count drops below cap (COMPLETE / reconcile).
+                parkGroup(readyKey, groupId)
+              end
+            end
           end
-          if cached then
-            tenantOverCap = true
-            -- Park the over-cap group OUT of ready (once) so subsequent polls
-            -- reach other tenants without re-scanning it. Restored when the
-            -- tenant's in-flight count drops below cap (COMPLETE / reconcile).
-            -- Replaces the per-poll ZADD defer that scaled writes with backlog.
+        end
+
+        -- Tenant-level pause: park the group OUT of ready (like over-cap) rather
+        -- than skip it in place. A paused tenant can hold a huge due-now backlog;
+        -- left in ready it sits at the front and the bounded scan burns its whole
+        -- budget skipping it, starving every other tenant (the 2026-05-27 stall).
+        local tenantPaused = false
+        if hasPauses then
+          if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. parkTenantOf(groupId)) == 1 then
+            tenantPaused = true
             parkGroup(readyKey, groupId)
           end
         end
-      end
 
-      -- Tenant-level pause: park the group OUT of ready (like over-cap) rather than
-      -- skip it in place. A paused tenant can hold a huge due-now backlog; left in
-      -- ready it sits at the front and the bounded scan burns its whole budget
-      -- skipping it, starving every other tenant (the 2026-05-27 head-of-line stall).
-      -- Parking moves it out so the scan reaches other tenants; the reconcile restores
-      -- it on unpause (unparkUpTo refuses to restore while still paused). Pipeline-level
-      -- pauses below stay skip-in-place (rarer, and need the job data to classify).
-      local tenantPaused = false
-      if hasPauses then
-        -- parkTenantOf handles both "tenant/..." and single-segment ids, so a
-        -- paused single-segment tenant is parked too, not left to skip-in-place.
-        if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. parkTenantOf(groupId)) == 1 then
-          tenantPaused = true
-          parkGroup(readyKey, groupId)
-        end
-      end
+        local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+        -- Defensive activeKey check — covers legacy state during migration
+        -- and the small race between ZADD ready and ZADD active.
+        local activeJob = redis.call("GET", activeKey)
+        if (not activeJob) and (not tenantOverCap) and (not tenantPaused) then
+          local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
+          local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
-      local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-      -- Defensive activeKey check — covers legacy state during migration
-      -- and the small race between ZADD ready and ZADD active.
-      local activeJob = redis.call("GET", activeKey)
-      if (not activeJob) and (not tenantOverCap) and (not tenantPaused) then
-        local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
-        local results = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
+          if #results >= 2 then
+            local stagedJobId = results[1]
+            local originalScore = results[2]
 
-        if #results >= 2 then
-          local stagedJobId = results[1]
-          local originalScore = results[2]
+            -- Check pause status before dequeuing
+            local paused = false
+            if hasPauses then
+              local slashIdx = string.find(groupId, "/", 1, true)
+              local tenantId = slashIdx and string.sub(groupId, 1, slashIdx - 1) or groupId
+              if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. tenantId) == 1 then
+                paused = true
+              end
 
-          -- Check pause status before dequeuing
-          local paused = false
-          if hasPauses then
-            -- Tenant-level pause: derived from groupId prefix (everything
-            -- before the first "/"). Added post-2026-05-11 incident so an
-            -- operator can halt ALL processing for a runaway tenant without
-            -- touching pipeline names. Pause key format: "tenant:<tenantId>".
-            local slashIdx = string.find(groupId, "/", 1, true)
-            local tenantId = slashIdx and string.sub(groupId, 1, slashIdx - 1) or groupId
-            if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. tenantId) == 1 then
-              paused = true
-            end
-
-            if not paused then
-              local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-              local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-              if jobDataJson then
-                local ok, data = pcall(cjson.decode, jobDataJson)
-                if ok and type(data) == "table" then
-                  local p = data["__pipelineName"]
-                  local t = data["__jobType"]
-                  local n = data["__jobName"]
-                  local pIsStr = type(p) == "string"
-                  local tIsStr = type(t) == "string"
-                  local nIsStr = type(n) == "string"
-                  if pIsStr then
-                    if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
-                    elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
-                    elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
+              if not paused then
+                local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+                local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+                if jobDataJson then
+                  local ok, data = pcall(cjson.decode, jobDataJson)
+                  if ok and type(data) == "table" then
+                    local p = data["__pipelineName"]
+                    local t = data["__jobType"]
+                    local n = data["__jobName"]
+                    local pIsStr = type(p) == "string"
+                    local tIsStr = type(t) == "string"
+                    local nIsStr = type(n) == "string"
+                    if pIsStr then
+                      if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
+                      elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
+                      elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
+                      end
                     end
                   end
                 end
               end
             end
-          end
 
-          if not paused then
-            redis.call("ZREM", jobsKey, stagedJobId)
-            redis.call("DECR", totalPendingKey)
-            redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
+            if not paused then
+              redis.call("ZREM", jobsKey, stagedJobId)
+              redis.call("DECR", totalPendingKey)
+              redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
 
-            -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
-            -- If process crashes, heartbeat stops, score becomes past, group becomes dispatchable again.
-            redis.call("ZADD", readyKey, activeUntil, groupId)
+              -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
+              redis.call("ZADD", readyKey, activeUntil, groupId)
 
-            -- Tenant in-flight slot (self-healing ZSET; only when cap is set).
-            -- Score = activeUntil so a worker that dies without COMPLETE has its
-            -- slot lapse out of the live count instead of stranding the cap.
-            if tenantCap > 0 and capTenantId then
-              tenantActiveAdd(keyPrefix .. "tenant_active_z:", capTenantId, groupId, activeUntil)
+              -- Tenant in-flight slot (self-healing ZSET; only when cap is set).
+              -- Recorded even under bypassPark so override dispatches are counted.
+              if effCap > 0 and capTenantId then
+                tenantActiveAdd(keyPrefix .. "tenant_active_z:", capTenantId, groupId, activeUntil)
+              end
+
+              local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+              local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+              redis.call("HDEL", dataKey, stagedJobId)
+
+              return {stagedJobId, groupId, jobDataJson or "", originalScore}
             end
-
-            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-            redis.call("HDEL", dataKey, stagedJobId)
-
-            return {stagedJobId, groupId, jobDataJson or "", originalScore}
-          end
-        else
-          -- Group is in ready but has no due jobs — drift cleanup.
-          local pendingCount = redis.call("ZCARD", jobsKey)
-          if pendingCount == 0 then
-            redis.call("ZREM", readyKey, groupId)
           else
-            -- All jobs are future-scheduled; re-score ready with earliest job's score
-            local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
-            if #nextScore >= 2 then
-              redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
+            -- Group is in ready but has no due jobs — drift cleanup.
+            local pendingCount = redis.call("ZCARD", jobsKey)
+            if pendingCount == 0 then
+              redis.call("ZREM", readyKey, groupId)
+            else
+              -- All jobs are future-scheduled; re-score ready with earliest job's score
+              local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
+              if #nextScore >= 2 then
+                redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
+              end
             end
           end
         end
       end
     end
+
+    if #groups < pageSize then return nil end
+    offset = offset + pageSize
   end
 
-  if #groups < pageSize then return nil end
-  offset = offset + pageSize
+  return nil
+end
+
+local r = scanAndDispatch(tenantCap, false)
+if r then return r end
+
+-- Work-conserving override: nothing was admittable under the cap, but over-cap
+-- work is parked while this slot would otherwise idle. Fairness binds ONLY under
+-- contention; a slot free here means no contention, so exceed the per-tenant cap
+-- W (never the global ceiling G — that is bounded by this pod's free slots)
+-- rather than idle, which is the static-cap idle-behind-cap waste this feature
+-- removes. Unpark the least-served over-cap tenant and dispatch it, parking
+-- bypassed for the pass. Only when the cap is active (tenantCap>0).
+if globalBudget > 0 and tenantCap > 0 and redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
+  unparkLeastServedParked(readyKey, keyPrefix, pausedJobKey, nowMs, 1)
+  return scanAndDispatch(tenantCap, true)
 end
 
 return nil
 `;
 
-const DISPATCH_BATCH_LUA = PARK_HELPER_LUA + `
+const DISPATCH_BATCH_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + `
 local readyKey         = KEYS[1]
 local blockedKey       = KEYS[2]
 local pausedJobKey     = KEYS[3]
@@ -575,184 +750,208 @@ local keyPrefix      = ARGV[1]
 local nowMs          = tonumber(ARGV[2])
 local activeTtlSec   = tonumber(ARGV[3])
 local maxJobs        = tonumber(ARGV[4])
--- Tenant soft-cap (post-2026-05-11 follow-up). See DISPATCH_LUA comment.
-local tenantCap      = tonumber(ARGV[5]) or 0
+-- Static operator soft-cap (0 = kill switch). See DISPATCH_LUA comment.
+local staticCap      = tonumber(ARGV[5]) or 0
+-- Global in-flight budget = hard ceiling for the dynamic water-level cap.
+-- 0 = dynamic disabled, static cap unchanged (back-compat). See DISPATCH_LUA.
+local globalBudget   = tonumber(ARGV[6]) or 0
 
 local hasPauses = redis.call("SCARD", pausedJobKey) > 0
 local activeUntil = nowMs + activeTtlSec * 1000
 local results = {}
-local dispatched = 0
 
--- Restore parked over-cap groups on a cadence (TRAP 2 orphan recovery + cap=0
--- drain) — see DISPATCH_LUA for the rationale. COMPLETE-unpark handles the
--- normal slot-freeing; this backstops crashed tenants and cap-disable. Time-
--- and SCARD-gated so it is a no-op at the cap=0 steady state.
+-- Restore parked over-cap groups + recompute the water-level on a cadence (TRAP 2
+-- orphan recovery + cap=0 drain) — see DISPATCH_LUA for the rationale. Time- and
+-- SCARD-gated so it is a no-op at the cap=0 steady state; the water-fill rides
+-- the same single-pod reconcile-ts cadence at near-zero marginal cost.
 local reconcileTsKey = keyPrefix .. "reconcile-ts"
 local lastReconcile = tonumber(redis.call("GET", reconcileTsKey)) or 0
 if (nowMs - lastReconcile) >= 2000 then
   redis.call("SET", reconcileTsKey, nowMs)
+  if staticCap > 0 and globalBudget > 0 then
+    recomputeDynamicCap(keyPrefix, globalBudget, nowMs)
+  end
   if redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
-    reconcileParked(readyKey, keyPrefix, tenantCap, nowMs)
+    local reconcileCap = staticCap
+    if staticCap > 0 and globalBudget > 0 then
+      reconcileCap = effectiveCap(keyPrefix, staticCap)
+    end
+    reconcileParked(readyKey, keyPrefix, reconcileCap, nowMs)
   end
 end
 
--- Pull only groups whose earliest job is due now. Active groups carry future
--- scores so they are naturally excluded. Over-fetch by 3x (min 30) per page to
--- leave headroom for blocked/paused/legacy-drift groups, then page through up
--- to scanBudget total entries so a head full of paused/blocked groups does
--- not starve runnable groups deeper in the zset.
-local pageSize = maxJobs * 3
-if pageSize < 30 then pageSize = 30 end
-local scanBudget = pageSize * 5
--- See DISPATCH_LUA: widen scan budget when the tenant cap is on so a
--- head full of one over-cap tenant cannot starve other tenants.
-if tenantCap > 0 then scanBudget = pageSize * 50 end
-local offset = 0
+-- Effective per-tenant cap: dynamic water-level when a budget is configured,
+-- else the static cap. staticCap=0 (kill switch) wins and disables parking.
+local tenantCap = staticCap
+if staticCap > 0 and globalBudget > 0 then
+  tenantCap = effectiveCap(keyPrefix, staticCap)
+end
 
--- Cache tenant cap lookups within this EVAL to avoid redundant GETs.
--- When 1,800 groups belong to one over-cap tenant, this turns 1,800
--- GET calls into 1 GET + 1,799 table lookups.
-local tenantCapCache = {}
+-- Scan ready in priority order and dispatch up to maxJobs, appending to results.
+-- effCap gates the per-tenant cap (0 = off). bypassPark skips the over-cap PARK
+-- decision (work-conserving override) while still recording the in-flight slot.
+-- Returns the new dispatched total.
+local function scanBatch(effCap, bypassPark, dispatched)
+  -- Over-fetch 3x (min 30) per page for blocked/paused/legacy-drift headroom,
+  -- then page through up to scanBudget so a head full of paused/blocked groups
+  -- does not starve runnable groups deeper in the zset. Widen the budget when
+  -- the cap is on so a head full of one over-cap tenant cannot starve others.
+  local pageSize = maxJobs * 3
+  if pageSize < 30 then pageSize = 30 end
+  local scanBudget = pageSize * 5
+  if effCap > 0 then scanBudget = pageSize * 50 end
+  local offset = 0
+  local tenantCapCache = {}
 
-while offset < scanBudget and dispatched < maxJobs do
-  local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", offset, pageSize)
-  if #groups == 0 then break end
+  while offset < scanBudget and dispatched < maxJobs do
+    local groups = redis.call("ZRANGEBYSCORE", readyKey, "-inf", nowMs, "LIMIT", offset, pageSize)
+    if #groups == 0 then break end
 
-  for _, groupId in ipairs(groups) do
-    if dispatched >= maxJobs then break end
+    for _, groupId in ipairs(groups) do
+      if dispatched >= maxJobs then break end
 
-    -- Tenant soft-cap check (no-op when tenantCap == 0).
-    -- Checked before SISMEMBER so over-cap groups skip with 0 Redis commands
-    -- (the cap result is cached per-tenant in a Lua table).
-    local tenantOverCap = false
-    local capTenantId = nil
-    if tenantCap > 0 then
-      local slashPos = string.find(groupId, "/", 1, true)
-      if slashPos and slashPos > 1 then
-        capTenantId = string.sub(groupId, 1, slashPos - 1)
-        local cached = tenantCapCache[capTenantId]
-        if cached == nil then
-          cached = tenantActiveCount(keyPrefix .. "tenant_active_z:", capTenantId, nowMs) >= tenantCap
-          tenantCapCache[capTenantId] = cached
+      -- Tenant cap check (no-op when effCap == 0). capTenantId resolved
+      -- regardless of bypassPark so the slot is still recorded; only the PARK
+      -- decision is skipped under bypassPark.
+      local tenantOverCap = false
+      local capTenantId = nil
+      if effCap > 0 then
+        local slashPos = string.find(groupId, "/", 1, true)
+        if slashPos and slashPos > 1 then
+          capTenantId = string.sub(groupId, 1, slashPos - 1)
+          if not bypassPark then
+            local cached = tenantCapCache[capTenantId]
+            if cached == nil then
+              cached = tenantActiveCount(keyPrefix .. "tenant_active_z:", capTenantId, nowMs) >= effCap
+              tenantCapCache[capTenantId] = cached
+            end
+            if cached then
+              tenantOverCap = true
+              parkGroup(readyKey, groupId)
+            end
+          end
         end
-        if cached then
-          tenantOverCap = true
+      end
+
+      -- Tenant-level pause: park OUT of ready instead of skip-in-place so a large
+      -- paused backlog cannot plug the bounded scan and starve others.
+      local tenantPaused = false
+      if hasPauses then
+        if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. parkTenantOf(groupId)) == 1 then
+          tenantPaused = true
           parkGroup(readyKey, groupId)
         end
       end
-    end
 
-    -- Tenant-level pause: park OUT of ready instead of skip-in-place, so a large
-    -- paused backlog cannot plug the bounded scan and starve other tenants
-    -- (head-of-line). See DISPATCH_LUA for the full rationale; unparkUpTo refuses
-    -- to restore a still-paused tenant, the reconcile restores it on unpause.
-    local tenantPaused = false
-    if hasPauses then
-      -- parkTenantOf handles single-segment ids too (see DISPATCH_LUA).
-      if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. parkTenantOf(groupId)) == 1 then
-        tenantPaused = true
-        parkGroup(readyKey, groupId)
-      end
-    end
+      if not tenantOverCap and not tenantPaused then
+        if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
+          local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
+          -- Defensive activeKey check — covers legacy state during migration
+          -- and the small race between ZADD ready and ZADD active.
+          local activeJob = redis.call("GET", activeKey)
 
-    if not tenantOverCap and not tenantPaused then
-      if redis.call("SISMEMBER", blockedKey, groupId) == 0 then
-        local activeKey = keyPrefix .. "group:" .. groupId .. ":active"
-        -- Defensive activeKey check — covers legacy state during migration
-        -- and the small race between ZADD ready and ZADD active.
-        local activeJob = redis.call("GET", activeKey)
+          if not activeJob then
+          local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
+          local jobResults = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
 
-        if not activeJob then
-        local jobsKey = keyPrefix .. "group:" .. groupId .. ":jobs"
-        local jobResults = redis.call("ZRANGEBYSCORE", jobsKey, "-inf", nowMs, "WITHSCORES", "LIMIT", 0, 1)
+          if #jobResults >= 2 then
+            local stagedJobId = jobResults[1]
+            local originalScore = jobResults[2]
 
-        if #jobResults >= 2 then
-          local stagedJobId = jobResults[1]
-          local originalScore = jobResults[2]
+            -- Check pause status before dequeuing
+            local paused = false
+            if hasPauses then
+              local slashIdx = string.find(groupId, "/", 1, true)
+              local tenantId = slashIdx and string.sub(groupId, 1, slashIdx - 1) or groupId
+              if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. tenantId) == 1 then
+                paused = true
+              end
 
-          -- Check pause status before dequeuing
-          local paused = false
-          if hasPauses then
-            -- Tenant-level pause: derived from groupId prefix (everything
-            -- before the first "/"). Added post-2026-05-11 incident so an
-            -- operator can halt ALL processing for a runaway tenant without
-            -- touching pipeline names. Pause key format: "tenant:<tenantId>".
-            local slashIdx = string.find(groupId, "/", 1, true)
-            local tenantId = slashIdx and string.sub(groupId, 1, slashIdx - 1) or groupId
-            if redis.call("SISMEMBER", pausedJobKey, "tenant:" .. tenantId) == 1 then
-              paused = true
-            end
-
-            if not paused then
-              local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-              local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-              if jobDataJson then
-                local ok, data = pcall(cjson.decode, jobDataJson)
-                if ok and type(data) == "table" then
-                  local p = data["__pipelineName"]
-                  local t = data["__jobType"]
-                  local n = data["__jobName"]
-                  local pIsStr = type(p) == "string"
-                  local tIsStr = type(t) == "string"
-                  local nIsStr = type(n) == "string"
-                  if pIsStr then
-                    if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
-                    elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
-                    elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
+              if not paused then
+                local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+                local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+                if jobDataJson then
+                  local ok, data = pcall(cjson.decode, jobDataJson)
+                  if ok and type(data) == "table" then
+                    local p = data["__pipelineName"]
+                    local t = data["__jobType"]
+                    local n = data["__jobName"]
+                    local pIsStr = type(p) == "string"
+                    local tIsStr = type(t) == "string"
+                    local nIsStr = type(n) == "string"
+                    if pIsStr then
+                      if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
+                      elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
+                      elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
+                      end
                     end
                   end
                 end
               end
             end
-          end
 
-          if not paused then
-            redis.call("ZREM", jobsKey, stagedJobId)
-            redis.call("DECR", totalPendingKey)
-            redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
+            if not paused then
+              redis.call("ZREM", jobsKey, stagedJobId)
+              redis.call("DECR", totalPendingKey)
+              redis.call("SET", activeKey, stagedJobId, "EX", activeTtlSec)
 
-            -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
-            redis.call("ZADD", readyKey, activeUntil, groupId)
+              -- Mark group as actively-processing in ready zset (future score suppresses redispatch).
+              redis.call("ZADD", readyKey, activeUntil, groupId)
 
-            -- Tenant in-flight slot (self-healing ZSET; only when cap is set).
-            -- Score = activeUntil so a worker that dies without COMPLETE has its
-            -- slot lapse out of the live count instead of stranding the cap.
-            if tenantCap > 0 and capTenantId then
-              tenantActiveAdd(keyPrefix .. "tenant_active_z:", capTenantId, groupId, activeUntil)
-              -- Invalidate cache — count changed, may now be at cap
-              tenantCapCache[capTenantId] = nil
+              -- Tenant in-flight slot (self-healing ZSET; only when cap is set).
+              -- Recorded even under bypassPark so override dispatches are counted.
+              if effCap > 0 and capTenantId then
+                tenantActiveAdd(keyPrefix .. "tenant_active_z:", capTenantId, groupId, activeUntil)
+                -- Invalidate cache — count changed, may now be at cap
+                tenantCapCache[capTenantId] = nil
+              end
+
+              local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
+              local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
+              redis.call("HDEL", dataKey, stagedJobId)
+
+              results[#results + 1] = stagedJobId
+              results[#results + 1] = groupId
+              results[#results + 1] = jobDataJson or ""
+              results[#results + 1] = tostring(originalScore)
+              dispatched = dispatched + 1
             end
-
-            local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
-            local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
-            redis.call("HDEL", dataKey, stagedJobId)
-
-            results[#results + 1] = stagedJobId
-            results[#results + 1] = groupId
-            results[#results + 1] = jobDataJson or ""
-            results[#results + 1] = tostring(originalScore)
-            dispatched = dispatched + 1
-          end
-        else
-          -- Group is in ready but has no due jobs — drift cleanup.
-          local pendingCount = redis.call("ZCARD", jobsKey)
-          if pendingCount == 0 then
-            redis.call("ZREM", readyKey, groupId)
           else
-            -- All jobs are future-scheduled; re-score ready with earliest job's score
-            local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
-            if #nextScore >= 2 then
-              redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
+            -- Group is in ready but has no due jobs — drift cleanup.
+            local pendingCount = redis.call("ZCARD", jobsKey)
+            if pendingCount == 0 then
+              redis.call("ZREM", readyKey, groupId)
+            else
+              -- All jobs are future-scheduled; re-score ready with earliest job's score
+              local nextScore = redis.call("ZRANGE", jobsKey, 0, 0, "WITHSCORES")
+              if #nextScore >= 2 then
+                redis.call("ZADD", readyKey, tonumber(nextScore[2]), groupId)
+              end
             end
           end
         end
       end
+      end
     end
-    end
+
+    if #groups < pageSize then break end
+    offset = offset + pageSize
   end
 
-  if #groups < pageSize then break end
-  offset = offset + pageSize
+  return dispatched
+end
+
+local dispatched = scanBatch(tenantCap, false, 0)
+
+-- Work-conserving override: spare local slots remain (dispatched < maxJobs) but
+-- nothing more was admittable under the cap, while over-cap work sits parked.
+-- Fairness binds only under contention; spare capacity = no contention, so fill
+-- the idle slots from the least-served over-cap tenant rather than return short
+-- and idle the fleet (the static-cap idle-behind-cap sin). Bounded to the
+-- remaining slots; this pod's free-slot budget keeps the fleet total at G.
+if globalBudget > 0 and tenantCap > 0 and dispatched < maxJobs and redis.call("SCARD", keyPrefix .. "parked-tenants") > 0 then
+  unparkLeastServedParked(readyKey, keyPrefix, pausedJobKey, nowMs, maxJobs - dispatched)
+  dispatched = scanBatch(tenantCap, true, dispatched)
 end
 
 return results
@@ -805,7 +1004,7 @@ end
 return results
 `;
 
-const COMPLETE_LUA = PARK_HELPER_LUA + `
+const COMPLETE_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + `
 local activeKey       = KEYS[1]
 local jobsKey         = KEYS[2]
 local readyKey        = KEYS[3]
@@ -822,10 +1021,10 @@ local jobName      = ARGV[3]
 -- prefix in (not a derived tenantId) lets us keep the cap optional without
 -- breaking back-compat with older call sites.
 local tenantCountKeyPrefix = ARGV[4]
--- Tenant soft-cap (same value DISPATCH_LUA reads). When > 0, a completion
--- frees a slot that may let one of the tenant's parked over-cap groups resume,
--- so we unpark up to the freed headroom. 0 = cap disabled, no parking in play.
-local tenantCap = tonumber(ARGV[5]) or 0
+-- Static operator soft-cap (same value DISPATCH_LUA reads). When > 0, a
+-- completion frees a slot that may let one of the tenant's parked over-cap
+-- groups resume, so we unpark up to the freed headroom. 0 = cap disabled.
+local staticCap = tonumber(ARGV[5]) or 0
 local nowMs = tonumber(ARGV[6])
 
 local currentActive = redis.call("GET", activeKey)
@@ -848,7 +1047,12 @@ end
 -- is the normal-case unpark; the dispatch reconcile only backstops orphans.
 -- Self-limiting (TRAP 3): bounded to current headroom so COMPLETE-unpark and the
 -- reconcile can't over-unpark into re-park churn. The LPUSH below wakes a waiter.
-if tenantCap > 0 then
+if staticCap > 0 then
+  -- Use the dynamic water-level for the unpark headroom when it is set (DISPATCH
+  -- is the source of W; COMPLETE only reads it), so a completion frees as many
+  -- parked groups as the live cap allows. Falls back to the static cap when W is
+  -- absent = fail-protective.
+  local tenantCap = effectiveCap(parkKeyPrefixOf(readyKey), staticCap)
   local tenantId = parkTenantOf(groupId)
   local active = tenantActiveCount(tenantCountKeyPrefix, tenantId, nowMs)
   unparkUpTo(readyKey, tenantId, tenantCap - active)
@@ -1132,6 +1336,29 @@ export function readTenantCap(): number {
 }
 
 /**
+ * Global in-flight budget for the dynamic water-level cap (option C, 2026-05-29).
+ * 0 (the default) disables the dynamic cap: dispatch falls back to the fixed
+ * per-tenant `readTenantCap()` and behaves exactly as before — the feature ships
+ * inert and is enabled per-environment by setting this to the fleet's true
+ * ceiling (pods x GLOBAL_QUEUE_CONCURRENCY). The water-fill then divides that
+ * whole capacity across competing tenants, so a lone tenant gets the full budget
+ * (bursts to fleet) while N contenders converge to a max-min fair share.
+ *
+ * Semantics:
+ *   - env unset / empty / non-numeric / negative -> DEFAULT_GLOBAL_BUDGET (0, off)
+ *   - env = positive integer -> that integer (enabled)
+ */
+export const DEFAULT_GLOBAL_BUDGET = 0;
+
+export function readGlobalBudget(): number {
+  const raw = process.env.LANGWATCH_DISPATCH_GLOBAL_BUDGET;
+  if (raw === undefined || raw === "") return DEFAULT_GLOBAL_BUDGET;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_GLOBAL_BUDGET;
+  return n;
+}
+
+/**
  * Set holding every active group-queue name (e.g. "{event-sourcing/jobs}").
  * Producers register themselves here on construction so the ops dashboard can
  * enumerate queues with an O(1) SMEMBERS instead of an O(keyspace)
@@ -1229,6 +1456,7 @@ export class GroupStagingScripts {
       String(shouldExtend ? 1 : 0),
       String(shouldReplace ? 1 : 0),
       String(Date.now()),
+      String(readGlobalBudget()),
     );
 
     return result === 1;
@@ -1270,8 +1498,11 @@ export class GroupStagingScripts {
         String((job.shouldReplace ?? true) ? 1 : 0),
       );
     }
-    // Appended last so the Lua reads it as ARGV[#ARGV] regardless of job count.
+    // Appended after all per-job args: nowMs then globalBudget last, so the Lua
+    // reads globalBudget as ARGV[#ARGV] and nowMs as ARGV[#ARGV-1] regardless of
+    // job count.
     args.push(String(Date.now()));
+    args.push(String(readGlobalBudget()));
 
     const result = await this.redis.eval(STAGE_BATCH_LUA, 3, readyKey, signalKey, totalPendingKey, ...args);
 
@@ -1310,6 +1541,7 @@ export class GroupStagingScripts {
       String(nowMs),
       String(activeTtlSec),
       String(tenantCap),
+      String(readGlobalBudget()),
     );
 
     if (!result || !Array.isArray(result) || result.length < 4) {
@@ -1356,6 +1588,7 @@ export class GroupStagingScripts {
       String(activeTtlSec),
       String(maxJobs),
       String(tenantCap),
+      String(readGlobalBudget()),
     );
 
     if (!result || !Array.isArray(result) || result.length < 4) {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -309,31 +309,38 @@ end
 -- needs to stop a newcomer reading 0 demand and pinning W at the full budget.
 local function recomputeDynamicCap(keyPrefix, budget, nowMs)
   local registryKey = keyPrefix .. "demanding-tenants"
-  -- Drop every tenant that has not enqueued within the claimant window in one
-  -- O(log N + M) trim. Enqueue-only freshness IS the demand signal, so an aged
-  -- member is no longer a claimant; this both bounds the ZSET and replaces the
-  -- per-member stale GC. A tenant still draining old in-flight work ages out of
-  -- the fairness fill here, but its slots stay enforced directly via
-  -- tenant_active_z, so it is never under-counted as a HARD cap, only as a
-  -- (work-conserving) fairness claim.
-  redis.call("ZREMRANGEBYSCORE", registryKey, "-inf", nowMs - ${CLAIMANT_WINDOW_MS})
-  -- Process at most MAX_DEMANDING_TENANTS most-recent claimants so a pathological
-  -- fan-out (thousands of distinct tenants active within the window) can never
-  -- block the single-threaded Redis on this 2s pass. The most-recent N are the
-  -- live contention set; the fill over them is the fair-share signal.
-  local members = redis.call("ZREVRANGE", registryKey, 0, ${MAX_DEMANDING_TENANTS} - 1)
+  -- Bound the registry SIZE by RANK (not by recency) so a churn of distinct
+  -- tenants cannot grow it unbounded, WITHOUT time-evicting a tenant that is
+  -- quiet-but-still-working: keep the most-recent 2*MAX by enqueue recency. This
+  -- is a no-op under normal load; only the least-recently-active tail is dropped
+  -- under extreme fan-out (and that tail is the least likely to still contend).
+  local size = redis.call("ZCARD", registryKey)
+  if size > 2 * ${MAX_DEMANDING_TENANTS} then
+    redis.call("ZREMRANGEBYRANK", registryKey, 0, size - 2 * ${MAX_DEMANDING_TENANTS} - 1)
+  end
+  -- Water-fill over at most MAX_DEMANDING_TENANTS most-recent claimants, bounding
+  -- the pass to ~3N Redis calls. Classify each by LIVE demand, consulting
+  -- tenant_active_z + parked BEFORE any recency eviction: a tenant with
+  -- active+parked>0 stays counted (measured) EVEN IF it stopped enqueuing more
+  -- than a window ago — dropping a still-draining tenant from the fill would
+  -- inflate W and let the others expand past their fair share under sustained
+  -- contention. Only a stale AND fully-idle member (no in-flight, none parked = a
+  -- drained phantom) is GC'd; a fresh idle member is a brand-new claimant whose
+  -- burst is still entirely in ready (presence).
+  local members = redis.call("ZREVRANGE", registryKey, 0, ${MAX_DEMANDING_TENANTS} - 1, "WITHSCORES")
   local measured = {}
   local presenceCount = 0
-  for _, tenantId in ipairs(members) do
-    -- Fresh by construction (aged members were trimmed above). demand_i =
-    -- in-flight (GC-d) + parked; a fresh tenant with zero of both is a brand-new
-    -- claimant whose burst is still entirely in ready = presence claimant.
+  for i = 1, #members, 2 do
+    local tenantId = members[i]
+    local lastActive = tonumber(members[i + 1]) or 0
     local d = tenantActiveCount(keyPrefix .. "tenant_active_z:", tenantId, nowMs)
             + redis.call("ZCARD", keyPrefix .. "parked:" .. tenantId)
     if d > 0 then
       measured[#measured + 1] = d
-    else
+    elseif (nowMs - lastActive) <= ${CLAIMANT_WINDOW_MS} then
       presenceCount = presenceCount + 1
+    else
+      redis.call("ZREM", registryKey, tenantId)
     end
   end
   local w = waterLevel(measured, presenceCount, budget)

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -237,11 +237,12 @@ end
  * keep W at the full budget and the newcomer would never be admitted (a stable
  * starvation behind a higher-priority incumbent, not a one-tick lag). We instead
  * treat any freshly-active tenant as a claimant that pulls a full fair share.
- * The window is several recompute intervals so a tenant that briefly goes quiet
- * is not dropped mid-burst; once it stops enqueueing AND drains, it ages out and
- * its reserved share is released. Interpolated into the Lua for one source.
+ * The window is several recompute intervals (= 8x RECONCILE_INTERVAL_MS, longer
+ * than the dynamic-cap TTL) so a tenant that briefly goes quiet is not dropped
+ * mid-burst; once it stops enqueueing AND drains, it ages out and its reserved
+ * share is released. Interpolated into the Lua for one source.
  */
-export const CLAIMANT_WINDOW_MS = 15000;
+export const CLAIMANT_WINDOW_MS = 8 * RECONCILE_INTERVAL_MS;
 
 // Lua helper for the DYNAMIC per-tenant cap (option C, 2026-05-29 follow-up to
 // the fixed soft cap). The hot path is unchanged — it still parks a group when

--- a/specs/event-sourcing/work-conserving-fair-dispatch.feature
+++ b/specs/event-sourcing/work-conserving-fair-dispatch.feature
@@ -28,57 +28,43 @@ Feature: Work-conserving max-min fair dispatch
   # starvation-triggered, which is strictly stronger than a blanket cap because
   # it never penalises a tenant that is not starving anyone.
   #
-  # How fairness is produced (no allocation is ever computed):
-  #   When a slot frees, the waiting tenant with the FEWEST in-flight groups
-  #   wins it. Repeating that greedy choice converges to max-min fair share by
-  #   construction. One tenant alone is always the least-loaded, so it takes
-  #   every idle slot (a burst is processed in full). Two tenants both wanting
-  #   more than half ping-pong and converge to half each. A small tenant gets
-  #   its full (small) demand and the big tenants split the rest. The split is
-  #   emergent, not configured: there is no 80/20, no per-tenant cap number.
+  # How fairness is produced (a single scalar cap, recomputed off the hot path):
+  #   A water-level W is recomputed on the existing 2s reconcile pass and stored
+  #   as one scalar. The unchanged scan-and-park dispatch gate admits a tenant
+  #   until its in-flight count reaches W, then parks its excess. W water-fills a
+  #   global budget G (the fleet ceiling = pods x concurrency) across the tenants
+  #   that currently have demand: a lone tenant gets W=G and bursts to the whole
+  #   fleet; two equal tenants converge to G/2 each; a small tenant takes its
+  #   full demand and the big tenants split the rest. The split is emergent from
+  #   the fill, not a configured 80/20 and not a per-tenant allocation.
   #
   # Implementation invariants (learned from the 2026-05-27/28 incidents):
-  #   - Selection reads a SOFT per-tenant load summary (member = tenantId,
-  #     score = in-flight count) for a cheap O(log n) argmin over waiting
-  #     tenants. The summary is ADVISORY: it orders selection only. It is
-  #     reconciled from the authoritative tenant_active_z ZSET
-  #     (ZREMRANGEBYSCORE -inf now to GC lapsed slots, then ZCARD) on the
-  #     periodic GC pass. Drift in the summary mis-orders one selection window
-  #     and self-heals on the next reconcile; it can NEVER stall dispatch or
-  #     over-admit, because the free-slot check, the operator clamp, and the
-  #     reconcile all read tenant_active_z truth, never the hint. (Contrast the
-  #     2026-05 soft-cap leak: there a derived counter was a HARD GATE, so drift
-  #     meant park-storm and stall. A counter that is lethal as a gate is
-  #     harmless as an ordering hint.)
-  #   - The reconcile runs on ONE pod per interval via a staleness marker (a pod
-  #     reconciles only if the last-reconcile marker is older than the
-  #     interval), not on all M pods every pass: ~1x not Mx work on the
-  #     single-thread Redis, no leader election, and any pod takes over the
-  #     instant the marker goes stale.
-  #   - Selecting the winning tenant and dispatching its next group is ONE
-  #     server-side script round-trip (GC candidates, pick least-in-flight, pop
-  #     that tenant's ready group, record the slot), never an N+1 of per-tenant
-  #     reads.
-  #   - Mapping a chosen tenant to its next ready group is one of two
-  #     behaviourally-equivalent implementations, chosen by measured skip-depth
-  #     and group-hold-time, NOT fixed by this contract: (A) an additive
-  #     per-tenant ready index (O(log n) pop of the tenant's head group) or
-  #     (B) scan-and-skip on the single ready zset (pop the global head, admit
-  #     if its tenant is the fair winner else skip). Either way the legacy
-  #     single-ready keeps being drained continuously-until-empty during the
-  #     mixed-fleet rollout (see the upgrade rule), so no group an old pod
-  #     enqueues is stranded.
-  #   - The reserve is TEMPORAL, not SPATIAL. No slots are ever held empty for a
-  #     tenant that has not arrived. A newcomer has zero in-flight, so it is
-  #     instantly the least-loaded and wins the next freed slots. Newcomer
-  #     latency therefore equals one group-hold-time (slots free only by natural
-  #     drain, since dispatch gates rather than preempts). A bounded reserved
-  #     floor is added ONLY for the long-hold (evaluation) class, and ONLY if
-  #     measured p95 hold-time shows temporal reserve alone starves newcomers.
-  #   - Fail PROTECTIVE: any safety fallback (operator clamp default, summary
-  #     unavailable) resolves to the low/protective side, never the permissive
-  #     side. Stale-permissive would reopen the monopoly we are deleting;
-  #     stale-protective is merely slower but stays safe and fair.
+  #   - No new dispatch structure: reuses the existing scan-and-park gate
+  #     (DISPATCH_LUA / DISPATCH_BATCH_LUA), so there is NO mixed-fleet ready
+  #     migration. Only the scalar cap changes from a constant to W. Old pods on
+  #     the static cap and new pods on W co-exist on the same ready zset.
+  #   - W is recomputed on the 2s-gated, single-pod reconcile pass (the
+  #     reconcile-ts marker), never per-dispatch. It reads demand_i = in-flight
+  #     (tenant_active_z, GC-d) + parked for each tenant in a demand-recency ZSET
+  #     (demanding-tenants), avoiding any keyspace SCAN. There is NO per-tenant
+  #     load summary and NO argmin — the gate admits in priority order, it does
+  #     not select a tenant.
+  #   - demanding-tenants is ENQUEUE-populated (recency score = last enqueue), so
+  #     a newcomer whose burst is still entirely in ready is counted as a
+  #     presence claimant pulling a full share W; without that it would read zero
+  #     demand, pin W at the budget, and starve behind a higher-priority
+  #     incumbent. Enqueue-only freshness ages a bursted-then-idle tenant out of
+  #     the claimant window so it cannot linger as a phantom claim.
+  #   - The reserve is TEMPORAL, not SPATIAL: no slot is held empty for a tenant
+  #     that has not arrived (W=G when alone). A work-conserving override fills an
+  #     otherwise-idle slot from the LEAST-SERVED parked tenant, exceeding W (never
+  #     G — bounded by the pod's free slots) so fairness binds only under real
+  #     contention. The override's candidate set is the parked tenants only, so a
+  #     work-less phantom claim never wins a slot.
+  #   - Fail PROTECTIVE: the dynamic-cap key carries a TTL; a stalled recompute
+  #     lapses back to the static operator cap (the low side), never permissive.
+  #     The whole feature is gated behind LANGWATCH_DISPATCH_GLOBAL_BUDGET (0 =
+  #     off, the default), so it ships inert and back-compatible.
   #   - Total queue depth = sum of per-tenant pending (ready + parked +
   #     in-flight), exposed as one shared helper: the dispatcher reads it for
   #     fairness, the queue-depth autoscaler (ADR-021) reads the same primitive

--- a/specs/event-sourcing/work-conserving-fair-dispatch.feature
+++ b/specs/event-sourcing/work-conserving-fair-dispatch.feature
@@ -1,0 +1,206 @@
+Feature: Work-conserving max-min fair dispatch
+  As an operator running multi-tenant event-sourcing on a shared worker fleet
+  I want a tenant to use as much capacity as is free, and to be throttled only
+  when it is actually starving another tenant
+  So that spare capacity is never left idle behind a fixed cap, and fairness
+  kicks in exactly when, and only when, tenants are competing for scarce slots.
+
+  # Why this supersedes the fixed per-tenant cap (event-sourcing/tenant-soft-cap.feature)
+  #
+  # The fixed soft cap (a flat N concurrent groups per tenant) is not
+  # work-conserving: on 2026-05-28 the worker fleet sat ~66% utilized (hundreds
+  # of idle slots) while a bursty tenant had groups parked behind its cap. Idle
+  # capacity behind a throttle is pure waste. Raising the fixed number does not
+  # fix it: a high cap just lets a big tenant starve small ones instead. Equal
+  # sharing (capacity / N) does not fix it either: under asymmetric demand (one
+  # big bursty tenant plus many tiny ones, which is our normal shape) an equal
+  # share strands the big tenant below capacity while the small tenants leave
+  # their slices unused. That recreates the exact "throttled while there is
+  # clearly room" complaint, just moved onto the big tenant.
+  #
+  # The principle: a tenant may consume whatever capacity is otherwise idle.
+  # Throttling engages only when the fleet is SATURATED and another tenant has
+  # work waiting that would be starved. Under contention the entitlement is a
+  # max-min fair share: capacity divided across the tenants that currently have
+  # waiting work, with any share a tenant does not need redistributed to those
+  # that do. There is no fixed ceiling and no computed allocation; the
+  # anti-runaway protection (the 2026-05-11 500K-group incident) becomes
+  # starvation-triggered, which is strictly stronger than a blanket cap because
+  # it never penalises a tenant that is not starving anyone.
+  #
+  # How fairness is produced (no allocation is ever computed):
+  #   When a slot frees, the waiting tenant with the FEWEST in-flight groups
+  #   wins it. Repeating that greedy choice converges to max-min fair share by
+  #   construction. One tenant alone is always the least-loaded, so it takes
+  #   every idle slot (a burst is processed in full). Two tenants both wanting
+  #   more than half ping-pong and converge to half each. A small tenant gets
+  #   its full (small) demand and the big tenants split the rest. The split is
+  #   emergent, not configured: there is no 80/20, no per-tenant cap number.
+  #
+  # Implementation invariants (learned from the 2026-05-27/28 incidents):
+  #   - Selection reads a SOFT per-tenant load summary (member = tenantId,
+  #     score = in-flight count) for a cheap O(log n) argmin over waiting
+  #     tenants. The summary is ADVISORY: it orders selection only. It is
+  #     reconciled from the authoritative tenant_active_z ZSET
+  #     (ZREMRANGEBYSCORE -inf now to GC lapsed slots, then ZCARD) on the
+  #     periodic GC pass. Drift in the summary mis-orders one selection window
+  #     and self-heals on the next reconcile; it can NEVER stall dispatch or
+  #     over-admit, because the free-slot check, the operator clamp, and the
+  #     reconcile all read tenant_active_z truth, never the hint. (Contrast the
+  #     2026-05 soft-cap leak: there a derived counter was a HARD GATE, so drift
+  #     meant park-storm and stall. A counter that is lethal as a gate is
+  #     harmless as an ordering hint.)
+  #   - The reconcile runs on ONE pod per interval via a staleness marker (a pod
+  #     reconciles only if the last-reconcile marker is older than the
+  #     interval), not on all M pods every pass: ~1x not Mx work on the
+  #     single-thread Redis, no leader election, and any pod takes over the
+  #     instant the marker goes stale.
+  #   - Selecting the winning tenant and dispatching its next group is ONE
+  #     server-side script round-trip (GC candidates, pick least-in-flight, pop
+  #     that tenant's ready group, record the slot), never an N+1 of per-tenant
+  #     reads.
+  #   - Mapping a chosen tenant to its next ready group is one of two
+  #     behaviourally-equivalent implementations, chosen by measured skip-depth
+  #     and group-hold-time, NOT fixed by this contract: (A) an additive
+  #     per-tenant ready index (O(log n) pop of the tenant's head group) or
+  #     (B) scan-and-skip on the single ready zset (pop the global head, admit
+  #     if its tenant is the fair winner else skip). Either way the legacy
+  #     single-ready keeps being drained continuously-until-empty during the
+  #     mixed-fleet rollout (see the upgrade rule), so no group an old pod
+  #     enqueues is stranded.
+  #   - The reserve is TEMPORAL, not SPATIAL. No slots are ever held empty for a
+  #     tenant that has not arrived. A newcomer has zero in-flight, so it is
+  #     instantly the least-loaded and wins the next freed slots. Newcomer
+  #     latency therefore equals one group-hold-time (slots free only by natural
+  #     drain, since dispatch gates rather than preempts). A bounded reserved
+  #     floor is added ONLY for the long-hold (evaluation) class, and ONLY if
+  #     measured p95 hold-time shows temporal reserve alone starves newcomers.
+  #   - Fail PROTECTIVE: any safety fallback (operator clamp default, summary
+  #     unavailable) resolves to the low/protective side, never the permissive
+  #     side. Stale-permissive would reopen the monopoly we are deleting;
+  #     stale-protective is merely slower but stays safe and fair.
+  #   - Total queue depth = sum of per-tenant pending (ready + parked +
+  #     in-flight), exposed as one shared helper: the dispatcher reads it for
+  #     fairness, the queue-depth autoscaler (ADR-021) reads the same primitive
+  #     for capacity.
+
+  Background:
+    Given the GroupQueue is dispatching across a shared worker fleet
+
+  Rule: Idle capacity is always used (work-conserving)
+
+    Scenario: A single bursty tenant uses all the spare capacity
+      Given only one tenant has groups waiting
+      And the worker fleet has idle slots
+      When dispatch runs
+      Then that tenant is dispatched into every idle slot
+      And no group of that tenant is parked while a slot sits idle
+
+    Scenario: A tenant past any fair share still dispatches while slots are free
+      Given a tenant already holds more in-flight groups than an equal share
+      And the fleet still has idle slots
+      And no other tenant has work waiting
+      When dispatch runs
+      Then that tenant keeps being dispatched into the idle slots
+
+    Scenario: A small tenant's unused share is given to a bigger one (max-min)
+      Given the fleet is saturated
+      And two tenants are competing
+      And one tenant has fewer waiting groups than an equal half
+      When dispatch runs over time
+      Then the smaller tenant gets all of its demand
+      And the bigger tenant expands into the half the smaller one does not use
+      And no slot is left idle while either has work waiting
+
+  Rule: Fairness engages only under contention (saturation and competing tenants)
+
+    Scenario: Two equally-demanding tenants split a saturated fleet evenly
+      Given the fleet is saturated
+      And two tenants each have more waiting groups than half the capacity
+      When dispatch runs over time
+      Then each tenant converges to about half the in-flight slots
+
+    Scenario: A runaway tenant is clamped only to protect a co-waiting tenant
+      Given the fleet is saturated
+      And one tenant has a very large backlog at the head of the queue
+      And a second tenant has a small amount of work waiting
+      When dispatch runs
+      Then the second tenant is served its fair share promptly
+      And the runaway tenant is held to its fair share, not the whole fleet
+
+  Rule: Throttling is released the moment contention ends
+
+    Scenario: A clamped tenant reclaims full capacity when others go idle
+      Given a tenant was being held to a fair share under contention
+      When the other tenants run out of waiting work
+      Then the previously-clamped tenant expands to use all the freed capacity
+      And it is never left with idle slots it could fill
+
+  Rule: A newcomer is served as capacity frees, without holding slots idle
+
+    Scenario: A newcomer is served on the next freed slots, not made to wait for a full drain
+      Given the fleet is saturated by one incumbent tenant
+      When a new tenant arrives with waiting work
+      Then the newcomer wins the slots freed by natural drain ahead of the incumbent
+      And no slot was held empty in reserve before the newcomer arrived
+
+    Scenario: The long-hold class keeps a bounded floor only when measurement requires it
+      Given the reserved floor for the long-hold class is disabled by default
+      When measured p95 group-hold-time shows newcomers starve under temporal reserve alone
+      And an operator enables the bounded floor
+      Then a newcomer is guaranteed the floor of slots within a bounded time
+      And the floor is never larger than the measured need
+
+  Rule: A tenant's own work keeps its priority order
+
+    Scenario: Within one tenant, higher-priority groups dispatch first
+      Given a tenant has several groups queued at different priorities
+      When that tenant is dispatched
+      Then its groups are taken in priority order
+      And fairness only reorders dispatch across tenants, never within one
+
+  Rule: A tenant leaves and rejoins the rotation cleanly
+
+    Scenario: A tenant drops out of dispatch the moment its work is exhausted
+      Given two tenants competing under saturation
+      When one tenant's waiting work is fully dispatched
+      Then it no longer takes a turn in the rotation
+      And the remaining tenant receives the freed capacity
+      And a tenant whose work is abandoned by a crash is swept from the rotation
+
+    Scenario: A drifted load summary self-heals and never stalls dispatch
+      Given the soft load summary disagrees with the authoritative in-flight truth
+      When the periodic reconcile runs
+      Then the summary is corrected from the authoritative counts
+      And dispatch never stalled or over-admitted while the summary was wrong
+
+  # Escape hatch only. The fair model should never need a hard ceiling, but ops
+  # keeps a manual clamp for a pathological tenant. Off by default, and when the
+  # clamp state is unavailable it fails to the protective (low) side.
+  Rule: An operator can still hard-clamp a pathological tenant
+
+    Scenario: An explicit per-tenant ceiling caps a tenant when set
+      Given the emergency hard ceiling is disabled by default
+      When an operator sets an explicit ceiling for one tenant
+      Then that tenant is held to the ceiling regardless of free capacity
+      And no other tenant is affected
+
+  # The change to fair selection touches the hot dispatch path on a live fleet.
+  # During the rolling deploy, old pods keep writing groups to the legacy
+  # single-ready while new pods select fairly (the same mixed-fleet window the
+  # 2026-05 cutover hit), so the carry-over must be continuous-until-drained,
+  # not a one-shot backfill.
+  Rule: Upgrading the dispatch path loses no in-flight work
+
+    Scenario: Work queued before the upgrade still dispatches after it
+      Given groups were queued under the pre-upgrade structure
+      When the new dispatcher runs
+      Then every previously-queued group is still dispatched
+      And none is stranded outside fair selection
+
+    Scenario: Work added to legacy-ready during the rollout is still picked up
+      Given the new dispatcher is selecting tenants fairly
+      And an old pod is still writing groups to the legacy single-ready
+      When the new dispatcher runs repeatedly
+      Then it keeps draining the legacy-ready on every pass until empty
+      And no group an old pod adds mid-rollout is left stranded

--- a/specs/event-sourcing/work-conserving-fair-dispatch.feature
+++ b/specs/event-sourcing/work-conserving-fair-dispatch.feature
@@ -132,12 +132,12 @@ Feature: Work-conserving max-min fair dispatch
       Then the newcomer wins the slots freed by natural drain ahead of the incumbent
       And no slot was held empty in reserve before the newcomer arrived
 
-    Scenario: The long-hold class keeps a bounded floor only when measurement requires it
-      Given the reserved floor for the long-hold class is disabled by default
-      When measured p95 group-hold-time shows newcomers starve under temporal reserve alone
-      And an operator enables the bounded floor
-      Then a newcomer is guaranteed the floor of slots within a bounded time
-      And the floor is never larger than the measured need
+    Scenario: An operator can guarantee newcomers a minimum capacity when long jobs starve them
+      Given the newcomer minimum-capacity guarantee is disabled by default
+      When monitoring shows newcomers are starved because long-running jobs hold their slots
+      And an operator enables the guarantee
+      Then a newcomer receives its minimum capacity within a bounded time
+      And the guarantee reserves no more capacity than the observed need
 
   Rule: A tenant's own work keeps its priority order
 
@@ -154,7 +154,12 @@ Feature: Work-conserving max-min fair dispatch
       When one tenant's waiting work is fully dispatched
       Then it ages out of the demand set and stops pulling a fair share
       And the remaining tenant expands into the freed capacity
-      And a tenant whose in-flight work is abandoned by a crash lapses out of the in-flight truth
+
+    Scenario: A tenant whose work is abandoned by a crash is swept from contention
+      Given a tenant holds in-flight work while competing for capacity
+      When its worker crashes without completing that work
+      Then the abandoned slots lapse out of the in-flight truth
+      And that tenant no longer pulls a fair share
 
     Scenario: A stale dynamic cap fails safe and is rebuilt from truth
       Given the dynamic-cap value has lapsed after a stalled recompute

--- a/specs/event-sourcing/work-conserving-fair-dispatch.feature
+++ b/specs/event-sourcing/work-conserving-fair-dispatch.feature
@@ -47,7 +47,7 @@ Feature: Work-conserving max-min fair dispatch
   #     reconcile-ts marker), never per-dispatch. It reads demand_i = in-flight
   #     (tenant_active_z, GC-d) + parked for each tenant in a demand-recency ZSET
   #     (demanding-tenants), avoiding any keyspace SCAN. There is NO per-tenant
-  #     load summary and NO argmin — the gate admits in priority order, it does
+  #     load summary and NO argmin: the gate admits in priority order, it does
   #     not select a tenant.
   #   - demanding-tenants is ENQUEUE-populated (recency score = last enqueue), so
   #     a newcomer whose burst is still entirely in ready is counted as a
@@ -58,17 +58,19 @@ Feature: Work-conserving max-min fair dispatch
   #   - The reserve is TEMPORAL, not SPATIAL: no slot is held empty for a tenant
   #     that has not arrived (W=G when alone). A work-conserving override fills an
   #     otherwise-idle slot from the LEAST-SERVED parked tenant, exceeding W (never
-  #     G — bounded by the pod's free slots) so fairness binds only under real
+  #     G, bounded by the pod's free slots) so fairness binds only under real
   #     contention. The override's candidate set is the parked tenants only, so a
   #     work-less phantom claim never wins a slot.
   #   - Fail PROTECTIVE: the dynamic-cap key carries a TTL; a stalled recompute
   #     lapses back to the static operator cap (the low side), never permissive.
   #     The whole feature is gated behind LANGWATCH_DISPATCH_GLOBAL_BUDGET (0 =
   #     off, the default), so it ships inert and back-compatible.
-  #   - Total queue depth = sum of per-tenant pending (ready + parked +
-  #     in-flight), exposed as one shared helper: the dispatcher reads it for
-  #     fairness, the queue-depth autoscaler (ADR-021) reads the same primitive
-  #     for capacity.
+  #   - Two distinct reads, do not conflate them: the dispatcher's fairness
+  #     demand_i is in-flight + parked per tenant (from tenant_active_z and the
+  #     parked set); a ready-only newcomer enters the fill via fresh presence in
+  #     demanding-tenants, never via a ready count, so the gate never reads ready
+  #     for fairness. The queue-depth autoscaler (ADR-021) reads a separate
+  #     primitive: the full pending depth ready + parked + in-flight.
 
   Background:
     Given the GroupQueue is dispatching across a shared worker fleet
@@ -145,20 +147,20 @@ Feature: Work-conserving max-min fair dispatch
       Then its groups are taken in priority order
       And fairness only reorders dispatch across tenants, never within one
 
-  Rule: A tenant leaves and rejoins the rotation cleanly
+  Rule: A tenant leaves and rejoins contention cleanly
 
-    Scenario: A tenant drops out of dispatch the moment its work is exhausted
+    Scenario: A tenant stops competing the moment its work is exhausted
       Given two tenants competing under saturation
       When one tenant's waiting work is fully dispatched
-      Then it no longer takes a turn in the rotation
-      And the remaining tenant receives the freed capacity
-      And a tenant whose work is abandoned by a crash is swept from the rotation
+      Then it ages out of the demand set and stops pulling a fair share
+      And the remaining tenant expands into the freed capacity
+      And a tenant whose in-flight work is abandoned by a crash lapses out of the in-flight truth
 
-    Scenario: A drifted load summary self-heals and never stalls dispatch
-      Given the soft load summary disagrees with the authoritative in-flight truth
-      When the periodic reconcile runs
-      Then the summary is corrected from the authoritative counts
-      And dispatch never stalled or over-admitted while the summary was wrong
+    Scenario: A stale dynamic cap fails safe and is rebuilt from truth
+      Given the dynamic-cap value has lapsed after a stalled recompute
+      When dispatch runs before the next reconcile
+      Then it falls back to the static operator cap, never a permissive value
+      And the next reconcile rebuilds the water level from the authoritative in-flight and parked counts
 
   # Escape hatch only. The fair model should never need a hard ceiling, but ops
   # keeps a manual clamp for a pathological tenant. Off by default, and when the


### PR DESCRIPTION
## Summary

Replaces the static per-tenant concurrency cap with a dynamic, work-conserving max-min fair share. A tenant may use as much capacity as is free, and is throttled only when it is actually starving another tenant. There is no hardcoded percentage; the split emerges.

Design (settled in #ACME-demo, option C): reuse the existing incident-hardened scan-and-gate dispatch path (parkGroup / reconcileParked / orphan-recovery from #4228) and make the cap dynamic, a water-level `W` computed lazy-inline on the existing staleness-gated reconcile pass. No new dispatch structure, no mixed-fleet migration, and the soft selection summary we debated evaporates entirely (a structure that never exists cannot drift or leak).

- Idle: one tenant alone takes every slot (`W = G`), so a burst is processed in full.
- Contention: `W` is the max-min water level. Small tenants get their full demand, big tenants split the rest. 40/40/20-style allocations emerge, never hardcoded.
- Newcomer service is temporal (a newcomer has 0 in-flight, competes immediately as slots free), not spatial. No slots are ever held empty in reserve.
- Fail-protective: a missing or stale `W` falls back to the low static cap, never a permissive high value.

## What's in this PR

- `scripts.ts`: the dynamic water-level cap. `waterLevel` water-fill, `recomputeDynamicCap` on the 2s-gated single-pod reconcile pass, the enqueue-populated `demanding-tenants` recency ZSET, and the work-conserving override (`unparkLeastServedParked`). Gated behind `LANGWATCH_DISPATCH_GLOBAL_BUDGET` (0 = off, the default), so it ships inert and back-compatible.
- `specs/event-sourcing/work-conserving-fair-dispatch.feature`: the behavioral contract.
- `fairDispatch.integration.test.ts`: mechanism-agnostic testcontainer harness driving the stable `stage`/`dispatch`/`complete` API and asserting the per-tenant in-flight distribution from real `tenant_active_z` truth.

## Test plan

All tests run against real Redis on testcontainers (no mocks, actual Lua `EVAL`); the dispatch/cap logic is pure Redis. 10 passed / 2 todo.

- [x] Work-conserving: a lone tenant uses every slot (`W = G`)
- [x] Max-min: a small tenant gets its full demand, the big tenant absorbs the rest
- [x] Contention: two equal tenants converge to `G/2` each
- [x] Runaway clamped to its fair share; small co-tenant served promptly (via the override)
- [x] Phantom claimant: a bursted-then-idle tenant never caps a busy one (the override picks only parked tenants)
- [x] Newcomer ramps to its fair share over sustained operation, no slot held in reserve
- [x] Throttling released the moment contention ends
- [x] Intra-tenant priority order preserved
- [x] Mixed-fleet rollout: pre-upgrade work and mid-rollout enqueues all dispatch, nothing stranded (old static-cap pod and new dynamic pod on the same ready zset)
- [ ] Operator hard-clamp (explicit per-tenant ceiling): `it.todo`, intentionally not built. It is the off-by-default escape hatch the spec frames as a safety valve the fair model should never need; a follow-up if ops ever wants it.

Note: the optional long-eval reserve floor stays off by default pending a prod hold-time (p50/p95/p99) measurement (currently blocked on EKS access); it does not gate this PR.

