### PR TITLE
fix(studio): generate trace ids natively + show full eval error on hover

### DIFF
--- a/langwatch/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/langwatch/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -30,7 +30,7 @@ import { useEffect, useMemo, useState } from "react";
 import { OttlEditor } from "@ee/governance/dashboard/components/OttlEditor";
 import { isOttlEnabledSourceType } from "@ee/governance/services/activity-monitor/ottlStarterTemplates";
 
-import { NON_ENTERPRISE_INGESTION_SOURCE_CAP } from "@ee/governance/services/activity-monitor/ingestionSource.service";
+import { NON_ENTERPRISE_INGESTION_SOURCE_CAP } from "@ee/governance/services/activity-monitor/ingestionSource.constants";
 import GovernanceLayout from "~/components/governance/GovernanceLayout";
 import { LoadingScreen } from "~/components/LoadingScreen";
 import { NotFoundScene } from "~/components/NotFoundScene";

--- a/langwatch/ee/governance/routers/__tests__/license-gate-governance.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/license-gate-governance.integration.test.ts
@@ -34,10 +34,8 @@ import { FREE_PLAN } from "@ee/licensing/constants";
 import type { PlanInfo } from "@ee/licensing/planInfo";
 
 import { prisma } from "~/server/db";
-import {
-  IngestionSourceService,
-  NON_ENTERPRISE_INGESTION_SOURCE_CAP,
-} from "@ee/governance/services/activity-monitor/ingestionSource.service";
+import { IngestionSourceService } from "@ee/governance/services/activity-monitor/ingestionSource.service";
+import { NON_ENTERPRISE_INGESTION_SOURCE_CAP } from "@ee/governance/services/activity-monitor/ingestionSource.constants";
 import { globalForApp, resetApp } from "~/server/app-layer/app";
 import { createTestApp } from "~/server/app-layer/presets";
 import { PlanProviderService } from "~/server/app-layer/subscription/plan-provider";

--- a/langwatch/ee/governance/services/activity-monitor/ingestionSource.constants.ts
+++ b/langwatch/ee/governance/services/activity-monitor/ingestionSource.constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Client-safe constants for ingestion sources.
+ *
+ * Kept separate from `ingestionSource.service.ts` so the dashboard page can
+ * import the cap without pulling the service's server-only dependencies
+ * (Prisma, app layer, `node:async_hooks` AsyncLocalStorage) into the client
+ * bundle — that leak crashes the page at load with "AsyncLocalStorage is not a
+ * constructor".
+ */
+
+/**
+ * Non-enterprise plans can create up to this many active IngestionSources
+ * per org. Composer separately restricts source TYPE to otel_generic, so
+ * a non-enterprise org gets 3 generic OTel sources to try the pillar
+ * before needing to upgrade. Spec: specs/ai-gateway/license-gate-governance.feature.
+ */
+export const NON_ENTERPRISE_INGESTION_SOURCE_CAP = 3;

--- a/langwatch/ee/governance/services/activity-monitor/ingestionSource.service.ts
+++ b/langwatch/ee/governance/services/activity-monitor/ingestionSource.service.ts
@@ -31,14 +31,7 @@ import { getApp } from "~/server/app-layer/app";
 import { isEnterpriseTier } from "~/server/api/enterprise";
 import { ensureHiddenGovernanceProject } from "@ee/governance/services/governanceProject.service";
 import { encryptParserConfigCredentials } from "./ingestionCredentials";
-
-/**
- * Non-enterprise plans can create up to this many active IngestionSources
- * per org. Composer separately restricts source TYPE to otel_generic, so
- * a non-enterprise org gets 3 generic OTel sources to try the pillar
- * before needing to upgrade. Spec: specs/ai-gateway/license-gate-governance.feature.
- */
-export const NON_ENTERPRISE_INGESTION_SOURCE_CAP = 3;
+import { NON_ENTERPRISE_INGESTION_SOURCE_CAP } from "./ingestionSource.constants";
 
 export type SourceType =
   | "otel_generic"

--- a/langwatch/scripts/smoke-boot.mjs
+++ b/langwatch/scripts/smoke-boot.mjs
@@ -73,7 +73,7 @@ try {
       try {
         await import(`/assets/${name}`);
       } catch (e) {
-        errs.push(`${name}: ${e?.message ?? String(e)}`);
+        errs.push(`${name}: ${e instanceof Error ? e.message : String(e)}`);
       }
     }
     return errs;

--- a/langwatch/scripts/smoke-boot.mjs
+++ b/langwatch/scripts/smoke-boot.mjs
@@ -1,15 +1,34 @@
 // Boot smoke test: loads the production bundle in a headless browser and
-// fails if the app does not mount or throws a fatal module-init error.
+// fails if the app does not mount, or if any emitted chunk throws a fatal
+// module-init error.
 //
 // This catches a class of bug that `vite build` succeeding cannot: a bundle
-// that compiles cleanly but white-screens at runtime (e.g. a cross-chunk
-// import cycle where a chunk calls a not-yet-initialized export at module
-// top level). No backend is required — React still mounts the shell / error
-// states when API calls fail, so an empty #root means the JS never booted.
+// that compiles cleanly but breaks at runtime because the bundler split a
+// cross-chunk export into a chunk that references a not-yet-initialized
+// binding. That shows up as a white screen at boot (the Shiki regression) or
+// as "X is not a constructor" the moment a lazy chunk's top-level code runs
+// (e.g. a server-only `new AsyncLocalStorage()` leaking into a client chunk).
+//
+// Two phases, no backend required:
+//   1. Boot — the app mounts (React renders the shell / error states even when
+//      API calls fail, so an empty #root means the JS never booted).
+//   2. Chunk scan — every emitted JS chunk is imported so its top-level code
+//      runs. Boot only exercises the entry + eagerly-loaded chunks; lazy route
+//      and feature chunks (where these regressions hide) only evaluate here.
+//
+// Note this is an init-time net: a bug that only throws when a function is
+// *called* (not at module load) still needs an interaction/e2e test.
 import { chromium } from "playwright";
+import { readdirSync } from "node:fs";
 
-const url = process.env.SMOKE_URL ?? "http://localhost:4173/";
-const FATAL = /is not a function|Cannot access .* before initialization|is not defined/;
+const baseUrl = process.env.SMOKE_URL ?? "http://localhost:4173/";
+// Where `vite build` writes the client chunks, relative to the cwd the script
+// runs from (langwatch/).
+const assetsDir = process.env.SMOKE_ASSETS_DIR ?? "dist/client/assets";
+// "is not a constructor" is the signature of a chunk resolving a cross-chunk
+// export to an uninitialized value and only failing when the value is `new`'d.
+const FATAL =
+  /is not a function|is not a constructor|Cannot access .* before initialization|is not defined/;
 
 // In CI we point at the runner's preinstalled Google Chrome
 // (SMOKE_BROWSER_CHANNEL=chrome) to skip the ~170 MB Chromium download.
@@ -23,9 +42,10 @@ page.on("pageerror", (e) => {
   if (FATAL.test(e.message)) fatal.push(e.message);
 });
 
+// Phase 1 — the app mounts.
 let mounted = false;
 try {
-  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
+  await page.goto(baseUrl, { waitUntil: "domcontentloaded", timeout: 60000 });
   await page.waitForFunction(
     () => (document.getElementById("root")?.innerHTML?.length ?? 0) > 100,
     { timeout: 30000 },
@@ -36,6 +56,41 @@ try {
   fatal.push(`app did not mount within timeout: ${message}`);
 }
 
+// Phase 2 — every emitted chunk evaluates without a module-init error.
+let scanned = 0;
+try {
+  const files = readdirSync(assetsDir).filter((f) => f.endsWith(".js"));
+  // Scan from a terminal public page (/auth/signin) so nothing redirects
+  // mid-scan and tears down the JS context we're importing into.
+  await page.goto(new URL("/auth/signin", baseUrl).toString(), {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
+  const chunkErrors = await page.evaluate(async (names) => {
+    const errs = [];
+    // Sequential so a chunk that navigates can't abort the whole batch.
+    for (const name of names) {
+      try {
+        await import(`/assets/${name}`);
+      } catch (e) {
+        errs.push(`${name}: ${e?.message ?? String(e)}`);
+      }
+    }
+    return errs;
+  }, files);
+  scanned = files.length;
+  // Only the chunk-init signatures we care about fail the build. Anything else
+  // a chunk might throw on import in a headless/no-backend context is surfaced
+  // as a warning so a benign quirk can't wedge CI.
+  for (const e of chunkErrors) {
+    if (FATAL.test(e)) fatal.push(`chunk failed to evaluate: ${e}`);
+    else console.warn(`WARN non-fatal chunk import error: ${e}`);
+  }
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  fatal.push(`chunk scan did not run: ${message}`);
+}
+
 await browser.close();
 
 if (fatal.length > 0) {
@@ -44,4 +99,6 @@ if (fatal.length > 0) {
   process.exit(1);
 }
 
-console.log(`BOOT SMOKE PASSED (#root mounted: ${mounted})`);
+console.log(
+  `BOOT SMOKE PASSED (#root mounted: ${mounted}, chunks scanned: ${scanned})`,
+);

--- a/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
@@ -117,7 +117,7 @@ export function BatchTargetCell({
   const renderOutput = (expanded: boolean) => {
     // Error state
     if (targetOutput.error) {
-      return (
+      const errorBox = (
         <HStack
           gap={2}
           p={2}
@@ -125,12 +125,42 @@ export function BatchTargetCell({
           borderRadius="md"
           color="red.fg"
           fontSize="13px"
+          cursor={expanded ? undefined : "pointer"}
+          onClick={expanded ? undefined : handleExpandOutput}
+          data-testid={`error-output-${targetOutput.targetId}`}
         >
           <Box flexShrink={0}>
             <LuCircleAlert size={16} />
           </Box>
           <Text lineClamp={expanded ? undefined : 2}>{targetOutput.error}</Text>
         </HStack>
+      );
+
+      // The cell clamps to two lines, so the full error is hidden. Surface it
+      // on hover (and on click via the expanded overlay above) instead of
+      // forcing the user to inspect the DOM.
+      if (expanded) {
+        return errorBox;
+      }
+
+      return (
+        <Tooltip
+          content={
+            <Text
+              fontSize="13px"
+              whiteSpace="pre-wrap"
+              wordBreak="break-word"
+              data-testid={`error-tooltip-${targetOutput.targetId}`}
+            >
+              {targetOutput.error}
+            </Text>
+          }
+          positioning={{ placement: "top" }}
+          openDelay={100}
+          contentProps={{ maxWidth: "480px" }}
+        >
+          {errorBox}
+        </Tooltip>
       );
     }
 

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchTargetCell.browser.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchTargetCell.browser.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Real-Chromium QA for the errored Output cell. jsdom can assert the tooltip
+ * node exists, but it cannot prove that a real pointer hover surfaces the full
+ * message above a two-line clamp. This drives an actual browser hover and
+ * captures a screenshot of the revealed tooltip for the PR.
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { page, userEvent } from "vitest/browser";
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ openDrawer: vi.fn() }),
+}));
+
+import { BatchTargetCell } from "../BatchTargetCell";
+import type { BatchTargetOutput } from "../types";
+
+const longError =
+  "gateway chat/completions: provider_error: the upstream model returned an " +
+  "error after exhausting all retries. Detail: rate limit exceeded for the " +
+  "organization on requests per minute. Please retry after the cooldown window.";
+
+const erroredOutput: BatchTargetOutput = {
+  targetId: "target-1",
+  output: null,
+  cost: null,
+  duration: null,
+  error: longError,
+  traceId: null,
+  evaluatorResults: [],
+};
+
+afterEach(() => cleanup());
+
+describe("errored Output cell in real Chromium", () => {
+  describe("when the user hovers the clamped error", () => {
+    it("reveals the full error message in a tooltip", async () => {
+      await page.viewport(640, 360);
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <div style={{ width: 320, padding: 24 }}>
+            <BatchTargetCell targetOutput={erroredOutput} />
+          </div>
+        </ChakraProvider>,
+      );
+
+      await userEvent.hover(screen.getByTestId("error-output-target-1"));
+
+      const tooltip = await screen.findByTestId("error-tooltip-target-1");
+      await waitFor(() => expect(tooltip).toBeVisible());
+      expect(tooltip).toHaveTextContent(longError);
+
+      await page.screenshot({ path: "/tmp/pr4289/eval-error-tooltip.png" });
+    });
+  });
+});

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchTargetCell.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchTargetCell.test.tsx
@@ -5,6 +5,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -95,6 +96,51 @@ describe("BatchTargetCell", () => {
       });
 
       expect(screen.getByText("Connection timeout")).toBeInTheDocument();
+    });
+
+    describe("when the error message is long and clamped", () => {
+      const longError =
+        "gateway chat/completions: provider_error: the upstream model " +
+        "returned an error after exhausting all retries. " +
+        "Detail: rate limit exceeded for organization on requests per minute.";
+
+      /** @scenario Reveal full error message on hover */
+      it("shows the full error in a tooltip on hover", async () => {
+        const user = userEvent.setup();
+        const targetOutput = createTargetOutput({
+          output: null,
+          error: longError,
+        });
+
+        render(<BatchTargetCell targetOutput={targetOutput} />, {
+          wrapper: Wrapper,
+        });
+
+        await user.hover(screen.getByTestId("error-output-target-1"));
+
+        expect(
+          await screen.findByTestId("error-tooltip-target-1"),
+        ).toHaveTextContent(longError);
+      });
+
+      /** @scenario Expand full error message on click */
+      it("expands the full error into the overlay on click", async () => {
+        const user = userEvent.setup();
+        const targetOutput = createTargetOutput({
+          output: null,
+          error: longError,
+        });
+
+        render(<BatchTargetCell targetOutput={targetOutput} />, {
+          wrapper: Wrapper,
+        });
+
+        await user.click(screen.getByTestId("error-output-target-1"));
+
+        expect(
+          screen.getByTestId("expanded-cell-backdrop"),
+        ).toBeInTheDocument();
+      });
     });
 
     /** @scenario Expand long target output */

--- a/langwatch/src/utils/trace.browser.test.ts
+++ b/langwatch/src/utils/trace.browser.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Real-Chromium check that trace/span id generation works in an actual
+ * browser. The production crash was a bundling failure, but this also proves
+ * the runtime path (global Web Crypto) is available client-side, not only in
+ * Node.
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateOtelSpanId, generateOtelTraceId } from "./trace";
+
+describe("trace id generation in real Chromium", () => {
+  it("generates a valid OTel trace id", () => {
+    expect(generateOtelTraceId()).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("generates a valid OTel span id", () => {
+    expect(generateOtelSpanId()).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("does not reuse ids across calls", () => {
+    expect(generateOtelTraceId()).not.toBe(generateOtelTraceId());
+  });
+});

--- a/langwatch/src/utils/trace.browser.test.ts
+++ b/langwatch/src/utils/trace.browser.test.ts
@@ -11,10 +11,12 @@ import { generateOtelSpanId, generateOtelTraceId } from "./trace";
 describe("trace id generation in real Chromium", () => {
   it("generates a valid OTel trace id", () => {
     expect(generateOtelTraceId()).toMatch(/^[0-9a-f]{32}$/);
+    expect(generateOtelTraceId()).not.toBe("0".repeat(32));
   });
 
   it("generates a valid OTel span id", () => {
     expect(generateOtelSpanId()).toMatch(/^[0-9a-f]{16}$/);
+    expect(generateOtelSpanId()).not.toBe("0".repeat(16));
   });
 
   it("does not reuse ids across calls", () => {

--- a/langwatch/src/utils/trace.test.ts
+++ b/langwatch/src/utils/trace.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { generateOtelSpanId, generateOtelTraceId } from "./trace";
+
+describe("generateOtelTraceId", () => {
+  /** @scenario Generated trace id has the OpenTelemetry format */
+  it("returns 32 lowercase hex characters that are not the all-zero id", () => {
+    const traceId = generateOtelTraceId();
+    expect(traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(traceId).not.toBe("0".repeat(32));
+  });
+
+  describe("when called repeatedly", () => {
+    /** @scenario Repeated generation yields unique trace ids */
+    it("produces unique ids", () => {
+      const ids = new Set(
+        Array.from({ length: 1000 }, () => generateOtelTraceId()),
+      );
+      expect(ids.size).toBe(1000);
+    });
+  });
+});
+
+describe("generateOtelSpanId", () => {
+  /** @scenario Generated span id has the OpenTelemetry format */
+  it("returns 16 lowercase hex characters that are not the all-zero id", () => {
+    const spanId = generateOtelSpanId();
+    expect(spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(spanId).not.toBe("0".repeat(16));
+  });
+
+  describe("when called repeatedly", () => {
+    it("produces unique ids", () => {
+      const ids = new Set(
+        Array.from({ length: 1000 }, () => generateOtelSpanId()),
+      );
+      expect(ids.size).toBe(1000);
+    });
+  });
+});

--- a/langwatch/src/utils/trace.ts
+++ b/langwatch/src/utils/trace.ts
@@ -1,4 +1,3 @@
-import { RandomIdGenerator } from "@opentelemetry/sdk-trace-web";
 import type { LLMSpan, Span } from "../server/tracer/types";
 
 export const getSpanNameOrModel = (span: Span) => {
@@ -7,10 +6,27 @@ export const getSpanNameOrModel = (span: Span) => {
   );
 };
 
-export const generateOtelTraceId = (): string => {
-  return new RandomIdGenerator().generateTraceId();
+const TRACE_ID_BYTES = 16;
+const SPAN_ID_BYTES = 8;
+
+/**
+ * Lowercase-hex random id matching the OpenTelemetry id format
+ * (32 hex chars for trace ids, 16 for span ids). Generated with the global
+ * Web Crypto API, which is available in both modern Node and the browser,
+ * so it works the same on the server and in the bundled client.
+ */
+const generateRandomHexId = (byteCount: number): string => {
+  const bytes = new Uint8Array(byteCount);
+  crypto.getRandomValues(bytes);
+  let hex = "";
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
 };
 
-export const generateOtelSpanId = (): string => {
-  return new RandomIdGenerator().generateSpanId();
-};
+export const generateOtelTraceId = (): string =>
+  generateRandomHexId(TRACE_ID_BYTES);
+
+export const generateOtelSpanId = (): string =>
+  generateRandomHexId(SPAN_ID_BYTES);

--- a/specs/batch-evaluation-results/batch-evaluation-results.feature
+++ b/specs/batch-evaluation-results/batch-evaluation-results.feature
@@ -81,6 +81,19 @@ Feature: Batch Evaluation Results Visualization
     Then the target cell shows an error indicator
     And the error message "Rate limit exceeded" is visible
 
+  Scenario: Reveal full error message on hover
+    Given a target execution failed with an error longer than two lines
+    When the results table renders
+    Then the error cell clamps the message to two lines
+    When I hover over the error cell
+    Then a tooltip shows the full error message
+
+  Scenario: Expand full error message on click
+    Given a target execution failed with an error longer than two lines
+    When I click on the error cell
+    Then the error expands into an overlay showing the full message
+    And I can dismiss the expanded view by clicking outside
+
   @unimplemented
   Scenario: Expand long target output
     Given a target output is longer than the cell max height (120px)

--- a/specs/ops/production-bundle-integrity.feature
+++ b/specs/ops/production-bundle-integrity.feature
@@ -1,0 +1,29 @@
+Feature: Production bundle integrity
+  As an engineer shipping the app
+  I want the production bundle verified before release
+  So that bundler chunk-splitting regressions fail CI instead of users
+
+  # A successful `vite build` only proves the bundle compiles. It does not catch
+  # a bundle that breaks at runtime because the bundler split a cross-chunk
+  # export into a chunk that references a not-yet-initialized binding — which
+  # white-screens at boot (the Shiki regression) or throws "X is not a
+  # constructor" when a lazy chunk's top-level code runs (server-only code such
+  # as `new AsyncLocalStorage()` leaking into a client chunk). The boot smoke
+  # test (scripts/smoke-boot.mjs) loads the built bundle in a headless browser
+  # to catch both.
+
+  Scenario: The built app mounts
+    Given the production bundle is built and served
+    When a headless browser loads the app
+    Then the app mounts instead of white-screening
+
+  Scenario: Every emitted chunk evaluates without a module-init error
+    Given the production bundle is built and served
+    When the smoke test imports each emitted chunk
+    Then no chunk throws while its top-level code runs
+    And a server-only construct leaking into a client chunk fails the smoke test
+
+  # Known gap: this is an initialization-time net. A bug that only throws when a
+  # function is called (not when its module loads) — like the trace id
+  # generator crash — is invisible here and is covered by interaction/e2e tests
+  # instead.

--- a/specs/optimization-studio/component-execution.feature
+++ b/specs/optimization-studio/component-execution.feature
@@ -1,0 +1,34 @@
+Feature: Optimization Studio component and workflow execution
+  As a user building a workflow in the Optimization Studio
+  I want to run a single component or the workflow up to a node
+  So that I can test my pipeline with manual inputs
+
+  # ---------------------------------------------------------------------------
+  # Trace id generation underpins every execution: each run mints a fresh OTel
+  # trace id before posting the execute event. It must work in the bundled
+  # client, not only in dev, so the "Run with manual inputs" and "Run workflow
+  # until here" actions never throw at click time.
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: Generated trace id has the OpenTelemetry format
+    When a workflow trace id is generated
+    Then it is 32 lowercase hexadecimal characters
+    And it is not the all-zero invalid id
+
+  @unit
+  Scenario: Generated span id has the OpenTelemetry format
+    When a workflow span id is generated
+    Then it is 16 lowercase hexadecimal characters
+    And it is not the all-zero invalid id
+
+  @unit
+  Scenario: Repeated generation yields unique trace ids
+    When many trace ids are generated in a row
+    Then each generated id is unique
+
+  Scenario: Running a component with manual inputs starts execution
+    Given a connected studio with a component that has its required inputs filled
+    When the user clicks "Run with manual inputs"
+    Then a fresh trace id is minted without error
+    And an execute_component event is posted for that node


### PR DESCRIPTION
## What

Three things, all stemming from the Optimization Studio bug report.

### 1. "Run with manual inputs" / "Run workflow until here" crashed in production

Clicking either Run action threw `TypeError: LJe is not a constructor` and did nothing. `generateOtelTraceId()` called `new RandomIdGenerator()` from `@opentelemetry/sdk-trace-web`; under the rolldown bundler that re-export gets split into a chunk that references a not-yet-initialized entry export, so the constructor was undefined at click time. Same chunk-init failure mode as the earlier Shiki boot fix, just triggered on interaction instead of boot, which is why a clean `vite build` and the boot smoke didn't catch it.

Generating an OTel id is just random bytes hex-encoded, so this drops the SDK dependency and uses the global Web Crypto API (32 hex chars for trace ids, 16 for span ids). It runs identically on the server and in the bundled client, so it cannot be broken by chunk splitting.

Reproduced the exact crash in a local production build before and after the fix to confirm.

### 2. Evaluation Output cell hid the full error message

In the batch evaluation results table, an errored Output cell clamped the message to two lines with no way to read the rest short of inspecting the DOM. The cell now shows the full message in a hover tooltip and expands into the existing overlay on click, matching how normal output cells already behave.

![eval error tooltip](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4289/eval-error-tooltip/tooltip-revealed.png)

### 3. A general guard for this whole class of bundler bug

A successful `vite build` only proves the bundle compiles, and the boot smoke only proved it mounts. Neither catches a chunk that resolves a cross-chunk export to a not-yet-initialized binding. The boot smoke now imports every emitted chunk so each chunk's top-level code runs, catching both the boot white-screen (Shiki) and "X is not a constructor" when a lazy chunk initializes. Failures are scoped to those signatures so a benign import quirk can't wedge CI.

This is an initialization-time net. A bug that only throws when a function is called (like the trace id crash above) stays invisible to it and needs interaction/e2e coverage, so the trace id fix is covered by unit + real-Chromium tests instead.

The scan immediately found a real latent bug: the ingestion-sources dashboard page imported a constant from the server-side service, dragging `node:async_hooks` `AsyncLocalStorage` into the client chunk, so that page crashed on load with "AsyncLocalStorage is not a constructor". Fixed by moving the constant to a client-safe module.

## Tests

- `trace.test.ts` / `trace.browser.test.ts`: trace/span ids match the OTel hex format, are not the all-zero id, and are unique. Browser variant runs in real Chromium.
- `BatchTargetCell.test.tsx` / `BatchTargetCell.browser.test.tsx`: hovering an errored cell reveals the full error in a tooltip; clicking expands it. Browser variant drives a real pointer hover and captured the screenshot above.
- `scripts/smoke-boot.mjs`: now scans every emitted chunk; runs in the existing CI boot-smoke step.
- Specs under `specs/optimization-studio/`, `specs/batch-evaluation-results/`, and `specs/ops/production-bundle-integrity.feature`.