### PR TITLE
fix(analytics): retry ClickHouse reads on transient overload

### DIFF
--- a/langwatch/src/features/traces-v2/hooks/__tests__/useTraceNewCount.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useTraceNewCount.unit.test.ts
@@ -77,8 +77,8 @@ describe("useTraceNewCount", () => {
     vi.clearAllMocks();
   });
 
-  /** @scenario Live polling eases off when ClickHouse is overloaded */
   describe("when a live poll fails because ClickHouse is overloaded", () => {
+    /** @scenario Live polling eases off when ClickHouse is overloaded */
     it("backs the poll cadence off to the slow interval", () => {
       renderHook(() => useTraceNewCount());
 

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useTraceNewCount.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useTraceNewCount.unit.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTraceNewCount } from "../useTraceNewCount";
+
+type QueryOptions = {
+  retry: number;
+  refetchInterval: number | false;
+  onSuccess: (data: { count: number }) => void;
+  onError: (error: Error) => void;
+};
+
+const capturedOptions: QueryOptions[] = [];
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    tracesV2: {
+      newCount: {
+        useQuery: (_input: unknown, options: QueryOptions) => {
+          capturedOptions.push(options);
+          return { data: { count: 0 }, isLoading: false };
+        },
+      },
+    },
+    useContext: () => ({
+      tracesV2: {
+        newCount: { invalidate: vi.fn() },
+      },
+    }),
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "p1" } }),
+}));
+
+vi.mock("~/hooks/usePageVisibility", () => ({
+  usePageVisibility: () => true,
+}));
+
+vi.mock("../stores/filterStore", () => ({
+  useFilterStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      debouncedTimeRange: { from: 1, to: 2, label: "Last 24h" },
+      debouncedQueryText: "evaluator:monitor_x",
+    }),
+}));
+
+vi.mock("../stores/sseStatusStore", () => ({
+  useSseStatusStore: Object.assign(
+    (selector: (s: unknown) => unknown) =>
+      selector({
+        sseConnectionState: "disconnected",
+        fastPollRequestedAt: 0,
+        liveUpdatesMode: "live",
+      }),
+    { getState: () => ({ liveUpdatesMode: "live" }) }
+  ),
+}));
+
+vi.mock("../useTraceListRefresh", () => ({
+  useTraceListRefresh: () => vi.fn(),
+}));
+
+const lastOptions = (): QueryOptions => {
+  const options = capturedOptions[capturedOptions.length - 1];
+  if (!options) {
+    throw new Error("no query options were captured");
+  }
+  return options;
+};
+
+describe("useTraceNewCount", () => {
+  beforeEach(() => {
+    capturedOptions.length = 0;
+    vi.clearAllMocks();
+  });
+
+  /** @scenario Live polling eases off when ClickHouse is overloaded */
+  describe("when a live poll fails because ClickHouse is overloaded", () => {
+    it("backs the poll cadence off to the slow interval", () => {
+      renderHook(() => useTraceNewCount());
+
+      const initialOptions = lastOptions();
+      expect(initialOptions.retry).toBe(1);
+      expect(initialOptions.refetchInterval).toBe(5000);
+
+      act(() => {
+        initialOptions.onError(
+          new Error("Too many simultaneous queries. Maximum: 100.")
+        );
+      });
+
+      expect(lastOptions().refetchInterval).toBe(30000);
+    });
+
+    it("returns to the fast cadence once a poll succeeds again", () => {
+      renderHook(() => useTraceNewCount());
+
+      act(() => {
+        lastOptions().onError(
+          new Error("Too many simultaneous queries. Maximum: 100.")
+        );
+      });
+      expect(lastOptions().refetchInterval).toBe(30000);
+
+      act(() => {
+        lastOptions().onSuccess({ count: 3 });
+      });
+
+      expect(lastOptions().refetchInterval).toBe(5000);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/hooks/useTraceNewCount.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceNewCount.ts
@@ -105,6 +105,10 @@ export function useTraceNewCount(): TraceNewCountResult {
       // pings they explicitly turned off.
       enabled: !!project?.id && liveUpdatesMode !== "paused",
       staleTime: 0,
+      // A failing poll is almost always ClickHouse easing us off under
+      // concurrent load. One client-side retry is enough; the refetch
+      // interval (backed off in onError) will try again shortly.
+      retry: 1,
       refetchInterval: isVisible && !sseConnected ? intervalMs : false,
       onSuccess: (data) => {
         if (data.count === 0) {
@@ -116,6 +120,13 @@ export function useTraceNewCount(): TraceNewCountResult {
           consecutiveZerosRef.current = 0;
           setIntervalMs(FAST_MS);
         }
+      },
+      onError: () => {
+        // Ease off when the count query fails (typically ClickHouse
+        // "Too many simultaneous queries" under load) so the client does
+        // not amplify the storm with fast polling. Recovers to the fast
+        // cadence on the next successful poll or SSE fast-poll signal.
+        setIntervalMs(SLOW_MS);
       },
     },
   );

--- a/langwatch/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/__tests__/clickhouse/resilient-client.unit.test.ts
@@ -185,10 +185,10 @@ describe("createResilientClickHouseClient()", () => {
     });
   });
 
-  describe("when query fails", () => {
-    /** @scenario Queries are not retried on failure */
-    it("throws without retrying", async () => {
-      const err = new Error("MEMORY_LIMIT_EXCEEDED");
+  describe("when query fails with a non-transient error", () => {
+    /** @scenario A read failing with a non-transient error fails fast */
+    it("throws immediately without retrying", async () => {
+      const err = new Error("Syntax error in query");
       const mock = makeMockClient({
         query: vi.fn().mockRejectedValue(err),
       });
@@ -199,13 +199,13 @@ describe("createResilientClickHouseClient()", () => {
 
       await expect(
         client.query({ query: "SELECT 1" })
-      ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+      ).rejects.toThrow("Syntax error in query");
       expect(mock.query).toHaveBeenCalledTimes(1);
     });
 
     /** @scenario Query failures are logged with structured metadata */
     it("logs structured error fields", async () => {
-      const err = new Error("MEMORY_LIMIT_EXCEEDED");
+      const err = new Error("Syntax error in query");
       const mock = makeMockClient({
         query: vi.fn().mockRejectedValue(err),
       });
@@ -216,7 +216,7 @@ describe("createResilientClickHouseClient()", () => {
 
       await expect(
         client.query({ query: "SELECT 1" })
-      ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+      ).rejects.toThrow("Syntax error in query");
 
       expect(mockQueryLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -228,7 +228,7 @@ describe("createResilientClickHouseClient()", () => {
     });
 
     it("passes the raw error object for Pino serializer", async () => {
-      const err = new Error("MEMORY_LIMIT_EXCEEDED");
+      const err = new Error("Syntax error in query");
       const mock = makeMockClient({
         query: vi.fn().mockRejectedValue(err),
       });
@@ -239,13 +239,58 @@ describe("createResilientClickHouseClient()", () => {
 
       await expect(
         client.query({ query: "SELECT 1" })
-      ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+      ).rejects.toThrow("Syntax error in query");
 
       const loggedObj = mockQueryLogger.error.mock.calls[0]![0] as Record<
         string,
         unknown
       >;
       expect(loggedObj.error).toBe(err);
+    });
+  });
+
+  describe("when query fails with a transient overload error", () => {
+    const fastRetryClient = (mock: ClickHouseClient) =>
+      createResilientClickHouseClient({
+        client: mock,
+        maxRetries: 2,
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+      });
+
+    /** @scenario A read rejected for transient overload is retried and succeeds */
+    it("retries and returns the result once a slot frees", async () => {
+      const overload = new Error(
+        "Code: 202. DB::Exception: Too many simultaneous queries. Maximum: 100. ",
+      );
+      const result = { data: [{ ok: 1 }] };
+      const mock = makeMockClient({
+        query: vi
+          .fn()
+          .mockRejectedValueOnce(overload)
+          .mockResolvedValueOnce(result),
+      });
+
+      const client = fastRetryClient(mock);
+      await expect(client.query({ query: "SELECT 1" })).resolves.toBe(result);
+      expect(mock.query).toHaveBeenCalledTimes(2);
+    });
+
+    /** @scenario A read that keeps failing transiently eventually surfaces the error */
+    it("surfaces the error only after retries are exhausted", async () => {
+      const overload = new Error(
+        "Too many simultaneous queries. Maximum: 100. ",
+      );
+      const mock = makeMockClient({
+        query: vi.fn().mockRejectedValue(overload),
+      });
+
+      const client = fastRetryClient(mock);
+      await expect(client.query({ query: "SELECT 1" })).rejects.toThrow(
+        "Too many simultaneous queries",
+      );
+      // maxRetries: 2 -> 1 initial attempt + 2 retries = 3 total
+      expect(mock.query).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -275,7 +320,7 @@ describe("createResilientClickHouseClient()", () => {
   describe("when logging throws during query failure", () => {
     /** @scenario Logging crashes do not affect query results */
     it("still propagates the original ClickHouse error", async () => {
-      const chError = new Error("MEMORY_LIMIT_EXCEEDED");
+      const chError = new Error("Syntax error in query");
       const mock = makeMockClient({
         query: vi.fn().mockRejectedValue(chError),
       });
@@ -290,7 +335,7 @@ describe("createResilientClickHouseClient()", () => {
 
       await expect(
         client.query({ query: "SELECT 1" })
-      ).rejects.toThrow("MEMORY_LIMIT_EXCEEDED");
+      ).rejects.toThrow("Syntax error in query");
     });
   });
 

--- a/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -59,6 +59,69 @@ function jitteredBackoff({
   return Math.min(exponential + jitter, maxDelayMs);
 }
 
+/**
+ * Runs an operation against ClickHouse, retrying transient failures with
+ * jittered backoff. Both reads and writes use this: a read rejected with
+ * "Too many simultaneous queries" (or any other transient overload /
+ * cluster-recovery condition) frees up within moments, and reads are
+ * idempotent, so retrying rides through the spike instead of surfacing a
+ * 500 to the user. Non-transient errors (e.g. a query syntax error) fail
+ * fast on the first attempt.
+ */
+async function withTransientRetry<T>(
+  fn: () => Promise<T>,
+  {
+    operation,
+    maxRetries,
+    baseDelayMs,
+    maxDelayMs,
+  }: {
+    operation: "query" | "insert";
+    maxRetries: number;
+    baseDelayMs: number;
+    maxDelayMs: number;
+  },
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (!isTransientError(error) || attempt === maxRetries) {
+        throw error;
+      }
+
+      const delay = jitteredBackoff({ attempt, baseDelayMs, maxDelayMs });
+
+      try {
+        logger.warn(
+          {
+            source: "clickhouse",
+            operation,
+            attempt: attempt + 1,
+            maxRetries,
+            delayMs: Math.round(delay),
+            error,
+          },
+          `Transient ClickHouse ${operation} error, retrying`,
+        );
+      } catch (loggingError) {
+        logger.error(
+          { loggingError },
+          `Failed to log transient ${operation} retry`,
+        );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
 function safeQueryMeta(params: unknown): {
   queryId?: string;
   format?: string;
@@ -306,7 +369,11 @@ export function createResilientClickHouseClient({
     const table = extractTableName(params);
     const start = performance.now();
     try {
-      const result = await client.query(cleanedParams as Parameters<typeof client.query>[0]);
+      const result = await withTransientRetry(
+        () =>
+          client.query(cleanedParams as Parameters<typeof client.query>[0]),
+        { operation: "query", maxRetries, baseDelayMs, maxDelayMs },
+      );
       const durationMs = performance.now() - start;
       const readBytes = extractReadBytes(result);
       // params (not cleanedParams) so extractExpectations can read langwatch_* keys
@@ -326,53 +393,25 @@ export function createResilientClickHouseClient({
   wrapper.insert = async (params) => {
     const insertTable = (params as unknown as Record<string, unknown>).table as string ?? "unknown";
     const start = performance.now();
-    let lastError: unknown;
-
-    for (let attempt = 0; attempt <= maxRetries; attempt++) {
-      try {
-        const result = await client.insert(params);
-        const durationMs = performance.now() - start;
-        logSuccess({ operation: "insert", durationMs, params });
-        observeClickHouseQueryDuration("INSERT", insertTable, durationMs / 1000);
-        incrementClickHouseQueryCount("INSERT", "success");
-        return result;
-      } catch (error) {
-        lastError = error;
-
-        if (!isTransientError(error) || attempt === maxRetries) {
-          const durationMs = performance.now() - start;
-          logFailure({ operation: "insert", error, durationMs, params });
-          observeClickHouseQueryDuration("INSERT", insertTable, durationMs / 1000);
-          incrementClickHouseQueryCount("INSERT", "error");
-          throw error;
-        }
-
-        const delay = jitteredBackoff({ attempt, baseDelayMs, maxDelayMs });
-
-        try {
-          logger.warn(
-            {
-              source: "clickhouse",
-              operation: "insert",
-              attempt: attempt + 1,
-              maxRetries,
-              delayMs: Math.round(delay),
-              error,
-            },
-            "Transient ClickHouse insert error, retrying"
-          );
-        } catch (loggingError) {
-          logger.error(
-            { loggingError },
-            "Failed to log transient insert retry"
-          );
-        }
-
-        await new Promise((resolve) => setTimeout(resolve, delay));
-      }
+    try {
+      const result = await withTransientRetry(() => client.insert(params), {
+        operation: "insert",
+        maxRetries,
+        baseDelayMs,
+        maxDelayMs,
+      });
+      const durationMs = performance.now() - start;
+      logSuccess({ operation: "insert", durationMs, params });
+      observeClickHouseQueryDuration("INSERT", insertTable, durationMs / 1000);
+      incrementClickHouseQueryCount("INSERT", "success");
+      return result;
+    } catch (error) {
+      const durationMs = performance.now() - start;
+      logFailure({ operation: "insert", error, durationMs, params });
+      observeClickHouseQueryDuration("INSERT", insertTable, durationMs / 1000);
+      incrementClickHouseQueryCount("INSERT", "error");
+      throw error;
     }
-
-    throw lastError;
   };
 
   return wrapper;

--- a/specs/analytics/clickhouse-concurrency-resilience.feature
+++ b/specs/analytics/clickhouse-concurrency-resilience.feature
@@ -1,0 +1,37 @@
+Feature: ClickHouse analytics stays available under concurrent query load
+  When many dashboards, monitor graphs, and live "new traces" pollers hit ClickHouse
+  at the same time, the server can briefly reject queries with
+  "Too many simultaneous queries. Maximum: 100." This is a transient overload
+  signal, not a failure of the request itself: a slot frees within moments.
+
+  Reads are idempotent, so the platform should ride through a transient overload
+  spike instead of surfacing it to the operator as a 500. Live pollers should ease
+  off when ClickHouse is overloaded so the client does not amplify the storm.
+
+  Background:
+    Given a user is viewing analytics backed by ClickHouse
+
+  Scenario: A read rejected for transient overload is retried and succeeds
+    Given ClickHouse rejects the first read with "Too many simultaneous queries"
+    And the next read would succeed once a query slot frees
+    When the analytics query runs
+    Then the read is retried after a short backoff
+    And the user receives the query result instead of an error
+
+  Scenario: A read that keeps failing transiently eventually surfaces the error
+    Given ClickHouse rejects every read with a transient overload error
+    When the analytics query runs
+    Then the read is retried a bounded number of times with backoff
+    And the error is surfaced only after retries are exhausted
+
+  Scenario: A read failing with a non-transient error fails fast
+    Given ClickHouse rejects a read with a query syntax error
+    When the analytics query runs
+    Then the read is not retried
+    And the error is surfaced immediately
+
+  Scenario: Live polling eases off when ClickHouse is overloaded
+    Given the traces view is polling for new traces every few seconds
+    When a poll fails because ClickHouse is overloaded
+    Then the next poll is scheduled after a longer interval
+    And polling returns to its fast cadence once a poll succeeds again

--- a/specs/analytics/clickhouse-concurrency-resilience.feature
+++ b/specs/analytics/clickhouse-concurrency-resilience.feature
@@ -11,6 +11,7 @@ Feature: ClickHouse analytics stays available under concurrent query load
   Background:
     Given a user is viewing analytics backed by ClickHouse
 
+  @unit @regression
   Scenario: A read rejected for transient overload is retried and succeeds
     Given ClickHouse rejects the first read with "Too many simultaneous queries"
     And the next read would succeed once a query slot frees
@@ -18,18 +19,21 @@ Feature: ClickHouse analytics stays available under concurrent query load
     Then the read is retried after a short backoff
     And the user receives the query result instead of an error
 
+  @unit @regression
   Scenario: A read that keeps failing transiently eventually surfaces the error
     Given ClickHouse rejects every read with a transient overload error
     When the analytics query runs
     Then the read is retried a bounded number of times with backoff
     And the error is surfaced only after retries are exhausted
 
+  @unit @regression
   Scenario: A read failing with a non-transient error fails fast
     Given ClickHouse rejects a read with a query syntax error
     When the analytics query runs
     Then the read is not retried
     And the error is surfaced immediately
 
+  @unit @regression
   Scenario: Live polling eases off when ClickHouse is overloaded
     Given the traces view is polling for new traces every few seconds
     When a poll fails because ClickHouse is overloaded

--- a/specs/analytics/clickhouse-structured-logging-alerting.feature
+++ b/specs/analytics/clickhouse-structured-logging-alerting.feature
@@ -34,7 +34,12 @@ Feature: Structured Logging for ClickHouse Queries
     And only safe metadata is logged: queryId, format, parameter key names, and table name
 
   # ---------------------------------------------------------------------------
-  # Retry behavior (insert only)
+  # Retry behavior
+  #
+  # Both reads and inserts retry transient ClickHouse failures (overload,
+  # connection, cluster-recovery). Read-side retry behavior lives in
+  # clickhouse-concurrency-resilience.feature; the insert scenarios stay here
+  # next to the logging they emit.
   # ---------------------------------------------------------------------------
 
   @unit @regression
@@ -47,12 +52,6 @@ Feature: Structured Logging for ClickHouse Queries
   Scenario: Non-transient insert errors fail immediately
     When an insert fails with a non-transient error (e.g. syntax)
     Then the insert is not retried
-    And a structured error log is emitted
-
-  @unit @regression
-  Scenario: Queries are not retried on failure
-    When a query fails with any error type
-    Then the query is not retried
     And a structured error log is emitted
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Production analytics endpoints (`analytics.getTimeseries`, `tracesV2.newCount`, `tracesV2.list`) returned 500s with `Too many simultaneous queries. Maximum: 100.` That is ClickHouse's server-global `max_concurrent_queries` limit being hit during bursts: many monitor graphs rendering at once, live trace polling, and several app pods sharing one cluster.

The resilient ClickHouse client already classified this error as transient and already retried it, but only for inserts. Reads went straight through with no retry, so a brief, self-clearing overload surfaced to the operator as a hard error.

## Changes

- Reads now retry on transient ClickHouse errors (overload, connection, cluster-recovery) with the same bounded jittered backoff already used for inserts. Reads are idempotent, so retrying rides through a concurrency spike instead of failing the request. Non-transient errors such as a query syntax error still fail fast on the first attempt. The retry loop is extracted into a shared helper so reads and writes stay in lock-step.
- Live "new traces" polling backs off to a slower cadence when a poll fails and caps client retries to one, so the browser does not amplify an overload by hammering every few seconds. It returns to the fast cadence on the next successful poll.

## Why this layer

Per-pod query concurrency is already bounded by the HTTP connection pool, so the 100 limit is an aggregate, multi-pod spike against the shared cluster. Bounded retry with backoff is the standard way to absorb a transient concurrency rejection without dropping a user request.

## Tests

- resilient-client unit tests: a read rejected for transient overload is retried and succeeds once a slot frees; the error is surfaced only after retries are exhausted; a non-transient read error fails fast with no retry.
- useTraceNewCount unit test: live polling eases off on error and recovers on success.
- `specs/analytics/clickhouse-concurrency-resilience.feature` added.

## Note on QA

The overload path (100+ concurrent cluster queries) is not reproducible locally, so the proof is the unit tests plus the existing real-ClickHouse integration test for the resilient wrapper. App deploy is release-gated, so production validation will be via the ClickHouse query metrics after the next release.
