### PR TITLE
feat(outbox): dispatch classification + DispatchError contract (Phase 1)

### DIFF
--- a/langwatch/ee/governance/reactors/__tests__/alertTrigger.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/alertTrigger.reactor.unit.test.ts
@@ -1,0 +1,221 @@
+import { TriggerAction } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import type { TriggerSummary } from "~/server/app-layer/triggers/repositories/trigger.repository";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import type { ReactorContext } from "~/server/event-sourcing/reactors/reactor.types";
+import type { TraceProcessingEvent } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
+import { sendTriggerEmail } from "~/server/mailer/triggerEmail";
+import { captureException } from "~/utils/posthogErrorCapture";
+import {
+  createAlertTriggerReactor,
+  type AlertTriggerReactorDeps,
+} from "../alertTrigger.reactor";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("~/utils/posthogErrorCapture", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("~/server/mailer/triggerEmail", () => ({
+  sendTriggerEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/server/triggers/sendSlackWebhook", () => ({
+  sendSlackWebhook: vi.fn().mockResolvedValue(undefined),
+}));
+
+function createFoldState(
+  overrides: Partial<TraceSummaryData> = {},
+): TraceSummaryData {
+  return {
+    traceId: "trace-1",
+    spanCount: 1,
+    totalDurationMs: 100,
+    computedIOSchemaVersion: "1",
+    computedInput: "hello",
+    computedOutput: "world",
+    timeToFirstTokenMs: null,
+    timeToLastTokenMs: null,
+    tokensPerSecond: null,
+    containsErrorStatus: false,
+    containsOKStatus: true,
+    errorMessage: null,
+    models: [],
+    totalCost: null,
+    tokensEstimated: false,
+    totalPromptTokenCount: null,
+    totalCompletionTokenCount: null,
+    outputFromRootSpan: false,
+    outputSpanEndTimeMs: 0,
+    blockedByGuardrail: false,
+    topicId: null,
+    subTopicId: null,
+    annotationIds: [],
+    occurredAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    LastEventOccurredAt: Date.now(),
+    attributes: { "langwatch.origin": "application" },
+    ...overrides,
+  } as TraceSummaryData;
+}
+
+function createEvent(
+  overrides: Record<string, unknown> = {},
+): TraceProcessingEvent {
+  return {
+    id: "event-1",
+    aggregateId: "trace-1",
+    aggregateType: "trace",
+    tenantId: "tenant-1",
+    createdAt: Date.now(),
+    occurredAt: Date.now(),
+    type: "lw.obs.trace.span_received",
+    version: 1,
+    data: {},
+    ...overrides,
+  } as unknown as TraceProcessingEvent;
+}
+
+function createContext(
+  foldState: TraceSummaryData,
+): ReactorContext<TraceSummaryData> {
+  return { tenantId: "tenant-1", aggregateId: "trace-1", foldState };
+}
+
+function createTrigger(overrides: Partial<TriggerSummary> = {}): TriggerSummary {
+  return {
+    id: "trigger-1",
+    projectId: "tenant-1",
+    name: "Latency Alert",
+    action: TriggerAction.SEND_EMAIL,
+    actionParams: { members: ["user@example.com"] },
+    filters: {},
+    alertType: "WARNING",
+    message: "",
+    customGraphId: null,
+    ...overrides,
+  };
+}
+
+function createDeps(
+  overrides: Partial<AlertTriggerReactorDeps> = {},
+): AlertTriggerReactorDeps {
+  return {
+    triggers: {
+      getActiveTraceTriggersForProject: vi.fn().mockResolvedValue([]),
+      claimSend: vi.fn().mockResolvedValue(true),
+      updateLastRunAt: vi.fn().mockResolvedValue(undefined),
+      invalidate: vi.fn(),
+    } as any,
+    projects: {
+      getById: vi.fn().mockResolvedValue({ id: "tenant-1", slug: "demo" }),
+    } as any,
+    traceById: vi.fn().mockResolvedValue(undefined),
+    addToAnnotationQueue: vi.fn().mockResolvedValue(undefined),
+    addToDataset: vi.fn().mockResolvedValue(undefined),
+    deriveEvents: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe("alertTrigger reactor", () => {
+  let deps: AlertTriggerReactorDeps;
+
+  beforeEach(() => {
+    deps = createDeps();
+    vi.clearAllMocks();
+  });
+
+  describe("when a trace-only trigger matches", () => {
+    it("claims the match, dispatches, and records the trigger as run", async () => {
+      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue([
+        createTrigger(),
+      ]);
+
+      const reactor = createAlertTriggerReactor(deps);
+      await reactor.handle(createEvent(), createContext(createFoldState()));
+
+      expect(deps.triggers.claimSend).toHaveBeenCalledWith({
+        triggerId: "trigger-1",
+        traceId: "trace-1",
+        projectId: "tenant-1",
+      });
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
+        "trigger-1",
+        "tenant-1",
+      );
+    });
+  });
+
+  describe("when the match was already claimed", () => {
+    it("does not dispatch or record the trigger as run", async () => {
+      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue([
+        createTrigger(),
+      ]);
+      (deps.triggers.claimSend as any).mockResolvedValue(false);
+
+      const reactor = createAlertTriggerReactor(deps);
+      await reactor.handle(createEvent(), createContext(createFoldState()));
+
+      expect(deps.triggers.claimSend).toHaveBeenCalled();
+      expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a trigger's dispatch fails", () => {
+    it("surfaces the failure with its retryable flag and does not record the trigger as run", async () => {
+      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue([
+        createTrigger(),
+      ]);
+      vi.mocked(sendTriggerEmail).mockRejectedValueOnce(
+        new DispatchError({ message: "provider 503", retryable: true }),
+      );
+
+      const reactor = createAlertTriggerReactor(deps);
+      await reactor.handle(createEvent(), createContext(createFoldState()));
+
+      expect(deps.triggers.claimSend).toHaveBeenCalled();
+      expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalledWith(
+        expect.any(DispatchError),
+        expect.objectContaining({
+          extra: expect.objectContaining({ retryable: true }),
+        }),
+      );
+    });
+  });
+
+  describe("when one of several matching triggers fails to dispatch", () => {
+    it("still dispatches the remaining triggers", async () => {
+      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue([
+        createTrigger({ id: "trigger-failing" }),
+        createTrigger({ id: "trigger-ok" }),
+      ]);
+      vi.mocked(sendTriggerEmail)
+        .mockRejectedValueOnce(
+          new DispatchError({ message: "revoked", retryable: false }),
+        )
+        .mockResolvedValueOnce(undefined);
+
+      const reactor = createAlertTriggerReactor(deps);
+      await reactor.handle(createEvent(), createContext(createFoldState()));
+
+      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(2);
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(1);
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
+        "trigger-ok",
+        "tenant-1",
+      );
+    });
+  });
+});

--- a/langwatch/ee/governance/reactors/__tests__/alertTrigger.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/alertTrigger.reactor.unit.test.ts
@@ -198,10 +198,12 @@ describe("alertTrigger reactor", () => {
   describe("when one of several matching triggers fails to dispatch", () => {
     it("still dispatches the remaining triggers", async () => {
       (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue([
+        createTrigger({ id: "trigger-before" }),
         createTrigger({ id: "trigger-failing" }),
-        createTrigger({ id: "trigger-ok" }),
+        createTrigger({ id: "trigger-after" }),
       ]);
       vi.mocked(sendTriggerEmail)
+        .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(
           new DispatchError({ message: "revoked", retryable: false }),
         )
@@ -210,10 +212,18 @@ describe("alertTrigger reactor", () => {
       const reactor = createAlertTriggerReactor(deps);
       await reactor.handle(createEvent(), createContext(createFoldState()));
 
-      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(2);
-      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(1);
+      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(3);
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(2);
       expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
-        "trigger-ok",
+        "trigger-before",
+        "tenant-1",
+      );
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
+        "trigger-after",
+        "tenant-1",
+      );
+      expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalledWith(
+        "trigger-failing",
         "tenant-1",
       );
     });

--- a/langwatch/ee/governance/reactors/alertTrigger.reactor.ts
+++ b/langwatch/ee/governance/reactors/alertTrigger.reactor.ts
@@ -11,6 +11,7 @@ import {
 import { createLogger } from "~/utils/logger/server";
 import { captureException } from "~/utils/posthogErrorCapture";
 import type { ReactorDefinition } from "~/server/event-sourcing/reactors/reactor.types";
+import { isDispatchError } from "~/server/event-sourcing/outbox/dispatchError";
 import {
   dispatchTriggerAction,
   type TriggerActionDispatchDeps,
@@ -114,11 +115,17 @@ export function createAlertTriggerReactor(
             foldState,
           });
         } catch (error) {
+          // A failed dispatch now throws (DispatchError) rather than being
+          // swallowed; surface its retryable classification for operators. The
+          // claim already landed, so the in-line path does not retry — the
+          // outbox migration is what adds durable retry.
+          const retryable = isDispatchError(error) ? error.retryable : undefined;
           logger.error(
             {
               tenantId,
               traceId,
               triggerId: trigger.id,
+              retryable,
               error: error instanceof Error ? error.message : String(error),
             },
             "Failed to evaluate trigger",
@@ -129,6 +136,7 @@ export function createAlertTriggerReactor(
               traceId,
               triggerId: trigger.id,
               triggerAction: trigger.action,
+              retryable,
             },
           });
         }

--- a/langwatch/src/pages/api/cron/triggers/__tests__/customGraphTrigger.test.ts
+++ b/langwatch/src/pages/api/cron/triggers/__tests__/customGraphTrigger.test.ts
@@ -49,7 +49,7 @@ import { prisma } from "~/server/db";
 import { captureException } from "~/utils/posthogErrorCapture";
 import { handleSendEmail } from "../actions/sendEmail";
 import { handleSendSlackMessage } from "../actions/sendSlackMessage";
-import { checkThreshold, updateAlert } from "../utils";
+import { addTriggersSent, checkThreshold, updateAlert } from "../utils";
 
 describe("processCustomGraphTrigger", () => {
   const mockProjects: Project[] = [
@@ -402,6 +402,52 @@ describe("processCustomGraphTrigger", () => {
       await processCustomGraphTrigger(trigger, mockProjects);
 
       expect(handleSendSlackMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the action wrapper throws", () => {
+    it("does not record the alert as sent and returns an error result", async () => {
+      const trigger = {
+        id: "trigger-1",
+        name: "Test Alert",
+        projectId: "project-1",
+        customGraphId: "graph-1",
+        action: TriggerAction.SEND_EMAIL,
+        actionParams: {
+          threshold: 10,
+          operator: "gt",
+          timePeriod: 60,
+          members: ["user@example.com"],
+          seriesName: "0/count/count",
+        },
+      } as unknown as Trigger;
+
+      vi.mocked(prisma.customGraph.findUnique).mockResolvedValue({
+        id: "graph-1",
+        name: "Test Graph",
+        graph: {
+          series: [{ name: "metric1", metric: "count", aggregation: "count" }],
+        },
+        filters: {},
+      } as any);
+
+      mockGetTimeseries.mockResolvedValue({
+        currentPeriod: [{ "0/count/count": 15 }],
+        previousPeriod: [],
+      } as any);
+      vi.mocked(checkThreshold).mockReturnValue(true);
+      vi.mocked(handleSendEmail).mockRejectedValueOnce(
+        new Error("Email dispatch failed"),
+      );
+
+      const result = await processCustomGraphTrigger(trigger, mockProjects);
+
+      expect(addTriggersSent).not.toHaveBeenCalled();
+      expect(updateAlert).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        triggerId: "trigger-1",
+        status: "error",
+      });
     });
   });
 

--- a/langwatch/src/pages/api/cron/triggers/actions/__tests__/sendEmail.test.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/__tests__/sendEmail.test.ts
@@ -83,7 +83,7 @@ describe("handleSendEmail", () => {
   });
 
   describe("when sendTriggerEmail throws an error", () => {
-    it("captures the exception with full context", async () => {
+    it("captures the exception with full context and rethrows", async () => {
       const error = new Error("Email send failed");
       vi.mocked(sendTriggerEmail).mockRejectedValue(error);
 
@@ -99,7 +99,7 @@ describe("handleSendEmail", () => {
         projectSlug: "test-project",
       };
 
-      await handleSendEmail(context);
+      await expect(handleSendEmail(context)).rejects.toBe(error);
 
       expect(captureException).toHaveBeenCalledWith(error, {
         extra: {

--- a/langwatch/src/pages/api/cron/triggers/actions/__tests__/sendSlackMessage.test.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/__tests__/sendSlackMessage.test.ts
@@ -85,7 +85,7 @@ describe("handleSendSlackMessage", () => {
   });
 
   describe("when sendSlackWebhook throws an error", () => {
-    it("captures the exception with full context", async () => {
+    it("captures the exception with full context and rethrows", async () => {
       const error = new Error("Slack webhook failed");
       vi.mocked(sendSlackWebhook).mockRejectedValue(error);
 
@@ -101,7 +101,7 @@ describe("handleSendSlackMessage", () => {
         projectSlug: "test-project",
       };
 
-      await handleSendSlackMessage(context);
+      await expect(handleSendSlackMessage(context)).rejects.toBe(error);
 
       expect(captureException).toHaveBeenCalledWith(error, {
         extra: {

--- a/langwatch/src/pages/api/cron/triggers/actions/sendEmail.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/sendEmail.ts
@@ -19,6 +19,10 @@ export const handleSendEmail = async (context: TriggerContext) => {
 
     await sendTriggerEmail(triggerInfo);
   } catch (error) {
+    // Capture with action-specific context, then rethrow so the caller skips
+    // recording the alert as sent. sendTriggerEmail now throws DispatchError
+    // (see dispatch-error-contract.feature) — swallowing here would undo the
+    // contract for the legacy customGraphTrigger path.
     captureException(error, {
       extra: {
         triggerId: trigger.id,
@@ -26,5 +30,6 @@ export const handleSendEmail = async (context: TriggerContext) => {
         action: TriggerAction.SEND_EMAIL,
       },
     });
+    throw error;
   }
 };

--- a/langwatch/src/pages/api/cron/triggers/actions/sendSlackMessage.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/sendSlackMessage.ts
@@ -19,6 +19,10 @@ export const handleSendSlackMessage = async (context: TriggerContext) => {
 
     await sendSlackWebhook(triggerInfo);
   } catch (error) {
+    // Capture with action-specific context, then rethrow so the caller skips
+    // recording the alert as sent. sendSlackWebhook now throws DispatchError
+    // (see dispatch-error-contract.feature) — swallowing here would undo the
+    // contract for the legacy customGraphTrigger path.
     captureException(error, {
       extra: {
         triggerId: trigger.id,
@@ -26,5 +30,6 @@ export const handleSendSlackMessage = async (context: TriggerContext) => {
         action: TriggerAction.SEND_SLACK_MESSAGE,
       },
     });
+    throw error;
   }
 };

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatchError.unit.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { DispatchError, isDispatchError } from "../dispatchError";
+import {
+  DispatchError,
+  extractHttpStatus,
+  isDispatchError,
+  isRetryableHttpStatus,
+  toDispatchError,
+} from "../dispatchError";
 
 describe("DispatchError", () => {
   describe("when constructed", () => {
@@ -40,6 +46,93 @@ describe("isDispatchError", () => {
       expect(isDispatchError(null)).toBe(false);
       expect(isDispatchError(undefined)).toBe(false);
       expect(isDispatchError({ retryable: true })).toBe(false);
+    });
+  });
+});
+
+describe("isRetryableHttpStatus", () => {
+  describe("when the status is a rate limit or server error", () => {
+    it("returns true for 429 and 5xx", () => {
+      expect(isRetryableHttpStatus(429)).toBe(true);
+      expect(isRetryableHttpStatus(500)).toBe(true);
+      expect(isRetryableHttpStatus(503)).toBe(true);
+    });
+  });
+
+  describe("when the status is a client error other than 429", () => {
+    it("returns false", () => {
+      expect(isRetryableHttpStatus(400)).toBe(false);
+      expect(isRetryableHttpStatus(404)).toBe(false);
+      expect(isRetryableHttpStatus(410)).toBe(false);
+    });
+  });
+});
+
+describe("extractHttpStatus", () => {
+  describe("when the error carries a status in a known shape", () => {
+    it("reads the AWS SDK v3 metadata status", () => {
+      expect(extractHttpStatus({ $metadata: { httpStatusCode: 500 } })).toBe(
+        500,
+      );
+    });
+
+    it("reads an axios/@slack/webhook nested response status", () => {
+      expect(extractHttpStatus({ original: { response: { status: 404 } } })).toBe(
+        404,
+      );
+    });
+
+    it("reads a numeric SendGrid code", () => {
+      expect(extractHttpStatus({ code: 429 })).toBe(429);
+    });
+  });
+
+  describe("when the error carries no recognizable status", () => {
+    it("ignores string transport codes and returns undefined", () => {
+      expect(extractHttpStatus({ code: "ECONNREFUSED" })).toBeUndefined();
+      expect(extractHttpStatus(new Error("boom"))).toBeUndefined();
+      expect(extractHttpStatus("nope")).toBeUndefined();
+      expect(extractHttpStatus(null)).toBeUndefined();
+    });
+  });
+});
+
+describe("toDispatchError", () => {
+  describe("when given an existing DispatchError", () => {
+    it("returns it unchanged", () => {
+      const original = new DispatchError({ message: "x", retryable: false });
+      expect(toDispatchError(original, { message: "wrapped" })).toBe(original);
+    });
+  });
+
+  describe("when the failure has a retryable status", () => {
+    it("produces a retryable DispatchError", () => {
+      const err = toDispatchError(
+        { $metadata: { httpStatusCode: 503 } },
+        { message: "send failed" },
+      );
+      expect(err).toBeInstanceOf(DispatchError);
+      expect(err.retryable).toBe(true);
+      expect(err.message).toBe("send failed");
+    });
+  });
+
+  describe("when the failure has a terminal status", () => {
+    it("produces a non-retryable DispatchError", () => {
+      const err = toDispatchError(
+        { response: { status: 404 } },
+        { message: "send failed" },
+      );
+      expect(err.retryable).toBe(false);
+    });
+  });
+
+  describe("when the failure has no recognizable status", () => {
+    it("defaults to retryable and preserves the cause", () => {
+      const cause = new Error("connection refused");
+      const err = toDispatchError(cause, { message: "send failed" });
+      expect(err.retryable).toBe(true);
+      expect(err.cause).toBe(cause);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatchError.ts
@@ -37,3 +37,59 @@ export class DispatchError extends Error {
 export function isDispatchError(error: unknown): error is DispatchError {
   return error instanceof DispatchError;
 }
+
+/**
+ * Whether an HTTP status warrants a retry, per ADR-027:
+ *   - 429 (rate limited) and 5xx (server error) → retry with backoff
+ *   - any other 4xx → terminal (revoked webhook, bad request, auth failure)
+ */
+export function isRetryableHttpStatus(status: number): boolean {
+  if (status === 429) return true;
+  return status >= 500 && status < 600;
+}
+
+/**
+ * Best-effort extraction of an HTTP status from the many error shapes the
+ * dispatch providers raise (AWS SDK v3, axios/@slack/webhook, SendGrid, fetch).
+ * Returns undefined for transport errors (ECONNREFUSED, ETIMEDOUT, …) that
+ * carry no HTTP status — those are treated as retryable by the caller.
+ *
+ * Note `code` is only read when numeric: SendGrid uses a numeric `code` for the
+ * status, whereas Node transport errors and @slack/webhook use a string `code`.
+ */
+export function extractHttpStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const e = error as Record<string, any>;
+  const candidates = [
+    e.$metadata?.httpStatusCode,
+    e.response?.status,
+    e.response?.statusCode,
+    e.statusCode,
+    e.status,
+    e.original?.response?.status,
+    e.original?.response?.statusCode,
+    typeof e.code === "number" ? e.code : undefined,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "number" && candidate >= 100 && candidate < 600) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Converts a raw dispatch failure into a DispatchError with a retryable
+ * decision derived from its HTTP status. An already-typed DispatchError is
+ * returned unchanged. Failures with no recognizable status default to
+ * retryable — see ADR-027 for why the unknown case is conservative.
+ */
+export function toDispatchError(
+  error: unknown,
+  { message }: { message: string },
+): DispatchError {
+  if (isDispatchError(error)) return error;
+  const status = extractHttpStatus(error);
+  const retryable = status === undefined ? true : isRetryableHttpStatus(status);
+  return new DispatchError({ message, retryable, cause: error });
+}

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/evaluationAlertTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/evaluationAlertTrigger.reactor.unit.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EvaluationRunData } from "~/server/app-layer/evaluations/types";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import type { TriggerSummary } from "~/server/app-layer/triggers/repositories/trigger.repository";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import { sendTriggerEmail } from "~/server/mailer/triggerEmail";
+import { captureException } from "~/utils/posthogErrorCapture";
 import type { ReactorContext } from "../../../../reactors/reactor.types";
 import type { EvaluationProcessingEvent } from "../../schemas/events";
 import {
@@ -492,6 +495,74 @@ describe("evaluationAlertTrigger reactor", () => {
 
       expect(deps.triggers.claimSend).toHaveBeenCalled();
       expect(deps.triggers.updateLastRunAt).toHaveBeenCalled();
+    });
+  });
+
+  describe("when a trigger's dispatch fails", () => {
+    it("surfaces the failure with its retryable flag and does not record the trigger as run", async () => {
+      const trigger = createTrigger();
+      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue([
+        trigger,
+      ]);
+      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
+        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
+      ]);
+      vi.mocked(sendTriggerEmail).mockRejectedValueOnce(
+        new DispatchError({ message: "provider 500", retryable: true }),
+      );
+
+      const reactor = createEvaluationAlertTriggerReactor(deps);
+      const context: ReactorContext<EvaluationRunData> = {
+        tenantId: "tenant-1",
+        aggregateId: "eval-1",
+        foldState: createEvalFoldState(),
+      };
+
+      await reactor.handle(createEvent(), context);
+
+      expect(deps.triggers.claimSend).toHaveBeenCalled();
+      expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalledWith(
+        expect.any(DispatchError),
+        expect.objectContaining({
+          extra: expect.objectContaining({ retryable: true }),
+        }),
+      );
+    });
+  });
+
+  describe("when one of several matching triggers fails to dispatch", () => {
+    it("still dispatches the remaining triggers", async () => {
+      const failing = createTrigger({ id: "trigger-failing" });
+      const succeeding = createTrigger({ id: "trigger-ok" });
+      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue([
+        failing,
+        succeeding,
+      ]);
+      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
+        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
+      ]);
+      vi.mocked(sendTriggerEmail)
+        .mockRejectedValueOnce(
+          new DispatchError({ message: "revoked", retryable: false }),
+        )
+        .mockResolvedValueOnce(undefined);
+
+      const reactor = createEvaluationAlertTriggerReactor(deps);
+      const context: ReactorContext<EvaluationRunData> = {
+        tenantId: "tenant-1",
+        aggregateId: "eval-1",
+        foldState: createEvalFoldState(),
+      };
+
+      await reactor.handle(createEvent(), context);
+
+      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(2);
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(1);
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
+        "trigger-ok",
+        "tenant-1",
+      );
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/evaluationAlertTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/evaluationAlertTrigger.reactor.unit.test.ts
@@ -533,16 +533,16 @@ describe("evaluationAlertTrigger reactor", () => {
 
   describe("when one of several matching triggers fails to dispatch", () => {
     it("still dispatches the remaining triggers", async () => {
-      const failing = createTrigger({ id: "trigger-failing" });
-      const succeeding = createTrigger({ id: "trigger-ok" });
       (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue([
-        failing,
-        succeeding,
+        createTrigger({ id: "trigger-before" }),
+        createTrigger({ id: "trigger-failing" }),
+        createTrigger({ id: "trigger-after" }),
       ]);
       (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
         createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
       ]);
       vi.mocked(sendTriggerEmail)
+        .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(
           new DispatchError({ message: "revoked", retryable: false }),
         )
@@ -557,10 +557,18 @@ describe("evaluationAlertTrigger reactor", () => {
 
       await reactor.handle(createEvent(), context);
 
-      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(2);
-      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(1);
+      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(3);
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(2);
       expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
-        "trigger-ok",
+        "trigger-before",
+        "tenant-1",
+      );
+      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
+        "trigger-after",
+        "tenant-1",
+      );
+      expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalledWith(
+        "trigger-failing",
         "tenant-1",
       );
     });

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTrigger.reactor.ts
@@ -11,6 +11,7 @@ import {
 } from "~/server/filters/triggerFilter.matcher";
 import { createLogger } from "~/utils/logger/server";
 import { captureException } from "~/utils/posthogErrorCapture";
+import { isDispatchError } from "../../../outbox/dispatchError";
 import type {
   ReactorContext,
   ReactorDefinition,
@@ -188,12 +189,18 @@ export function createEvaluationAlertTriggerReactor(
             foldState: traceSummary,
           });
         } catch (error) {
+          // A failed dispatch now throws (DispatchError) rather than being
+          // swallowed; surface its retryable classification for operators. The
+          // claim already landed, so the in-line path does not retry — the
+          // outbox migration is what adds durable retry.
+          const retryable = isDispatchError(error) ? error.retryable : undefined;
           logger.error(
             {
               tenantId,
               traceId,
               triggerId: trigger.id,
               evaluationId: evalRun.evaluationId,
+              retryable,
               error: error instanceof Error ? error.message : String(error),
             },
             "Failed to evaluate trigger on evaluation completion",
@@ -205,6 +212,7 @@ export function createEvaluationAlertTriggerReactor(
               triggerId: trigger.id,
               evaluationId: evalRun.evaluationId,
               triggerAction: trigger.action,
+              retryable,
             },
           });
         }

--- a/langwatch/src/server/event-sourcing/pipelines/shared/__tests__/triggerActionDispatch.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/__tests__/triggerActionDispatch.unit.test.ts
@@ -1,0 +1,109 @@
+import { TriggerAction } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import {
+  CADENCE_WINDOW_MS,
+  computeScheduledFor,
+  NOTIFICATION_CADENCES,
+  NOTIFY_TRIGGER_ACTIONS,
+  PERSIST_TRIGGER_ACTIONS,
+} from "../triggerActionDispatch";
+
+describe("trigger action classification", () => {
+  describe("when classifying notify actions", () => {
+    it("treats email and Slack as notify", () => {
+      expect(NOTIFY_TRIGGER_ACTIONS.has(TriggerAction.SEND_EMAIL)).toBe(true);
+      expect(
+        NOTIFY_TRIGGER_ACTIONS.has(TriggerAction.SEND_SLACK_MESSAGE),
+      ).toBe(true);
+    });
+  });
+
+  describe("when classifying persist actions", () => {
+    it("treats dataset and annotation-queue writes as persist", () => {
+      expect(PERSIST_TRIGGER_ACTIONS.has(TriggerAction.ADD_TO_DATASET)).toBe(
+        true,
+      );
+      expect(
+        PERSIST_TRIGGER_ACTIONS.has(TriggerAction.ADD_TO_ANNOTATION_QUEUE),
+      ).toBe(true);
+    });
+  });
+
+  describe("when combining the two classes", () => {
+    const allActions = Object.values(TriggerAction);
+
+    it("covers every trigger action exactly once", () => {
+      for (const action of allActions) {
+        const inNotify = NOTIFY_TRIGGER_ACTIONS.has(action);
+        const inPersist = PERSIST_TRIGGER_ACTIONS.has(action);
+        expect(
+          inNotify !== inPersist,
+          `${action} must be in exactly one class`,
+        ).toBe(true);
+      }
+    });
+
+    it("has no extra members beyond the enum", () => {
+      expect(
+        NOTIFY_TRIGGER_ACTIONS.size + PERSIST_TRIGGER_ACTIONS.size,
+      ).toBe(allActions.length);
+    });
+  });
+});
+
+describe("computeScheduledFor", () => {
+  const now = new Date("2026-05-29T12:00:00.000Z");
+
+  describe("when the action is a persist action", () => {
+    it("schedules immediately regardless of cadence", () => {
+      for (const cadence of NOTIFICATION_CADENCES) {
+        expect(
+          computeScheduledFor({
+            action: TriggerAction.ADD_TO_DATASET,
+            cadence,
+            now,
+          }),
+        ).toEqual(now);
+        expect(
+          computeScheduledFor({
+            action: TriggerAction.ADD_TO_ANNOTATION_QUEUE,
+            cadence,
+            now,
+          }),
+        ).toEqual(now);
+      }
+    });
+  });
+
+  describe("when the action is a notify action on the immediate cadence", () => {
+    it("schedules immediately", () => {
+      expect(
+        computeScheduledFor({
+          action: TriggerAction.SEND_SLACK_MESSAGE,
+          cadence: "immediate",
+          now,
+        }),
+      ).toEqual(now);
+    });
+  });
+
+  describe("when the action is a notify action on a digest cadence", () => {
+    it("schedules at the end of the digest window", () => {
+      expect(
+        computeScheduledFor({
+          action: TriggerAction.SEND_EMAIL,
+          cadence: "5min_digest",
+          now,
+        }),
+      ).toEqual(new Date(now.getTime() + CADENCE_WINDOW_MS["5min_digest"]));
+
+      expect(
+        computeScheduledFor({
+          action: TriggerAction.SEND_SLACK_MESSAGE,
+          cadence: "hourly_digest",
+          now,
+        }),
+      ).toEqual(new Date(now.getTime() + CADENCE_WINDOW_MS.hourly_digest));
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
@@ -16,6 +16,65 @@ import { createLogger } from "~/utils/logger/server";
 
 const logger = createLogger("langwatch:trigger-action-dispatch");
 
+/**
+ * Trigger actions split into two classes that dispatch on different schedules.
+ * See dev/docs/adr/025-notify-persistent-action-classification.md.
+ *
+ * - Notify actions land in front of a human; they may be batched into a digest
+ *   window to avoid notification storms.
+ * - Persist actions write durable data the customer asked for; batching them
+ *   would defeat the intent, so they always dispatch immediately.
+ *
+ * The two sets must together cover every TriggerAction value, with no overlap
+ * (enforced by the unit test). A new action type must be classified here at the
+ * point it is introduced.
+ */
+export const NOTIFY_TRIGGER_ACTIONS = new Set<TriggerAction>([
+  TriggerAction.SEND_EMAIL,
+  TriggerAction.SEND_SLACK_MESSAGE,
+]);
+
+export const PERSIST_TRIGGER_ACTIONS = new Set<TriggerAction>([
+  TriggerAction.ADD_TO_DATASET,
+  TriggerAction.ADD_TO_ANNOTATION_QUEUE,
+]);
+
+export const NOTIFICATION_CADENCES = [
+  "immediate",
+  "5min_digest",
+  "15min_digest",
+  "hourly_digest",
+] as const;
+
+export type NotificationCadence = (typeof NOTIFICATION_CADENCES)[number];
+
+export const CADENCE_WINDOW_MS: Record<NotificationCadence, number> = {
+  immediate: 0,
+  "5min_digest": 5 * 60 * 1000,
+  "15min_digest": 15 * 60 * 1000,
+  hourly_digest: 60 * 60 * 1000,
+};
+
+/**
+ * Resolves when a matched trigger should dispatch. This is the contract the
+ * outbox dispatch layer reads: persist actions and immediate-cadence notify
+ * actions fire now; digest-cadence notify actions open a window that closes
+ * `CADENCE_WINDOW_MS` later.
+ */
+export function computeScheduledFor({
+  action,
+  cadence,
+  now,
+}: {
+  action: TriggerAction;
+  cadence: NotificationCadence;
+  now: Date;
+}): Date {
+  if (PERSIST_TRIGGER_ACTIONS.has(action)) return now;
+  if (cadence === "immediate") return now;
+  return new Date(now.getTime() + CADENCE_WINDOW_MS[cadence]);
+}
+
 export interface TriggerActionDispatchDeps {
   triggers: TriggerService;
   projects: ProjectService;

--- a/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
@@ -25,19 +25,28 @@ const logger = createLogger("langwatch:trigger-action-dispatch");
  * - Persist actions write durable data the customer asked for; batching them
  *   would defeat the intent, so they always dispatch immediately.
  *
- * The two sets must together cover every TriggerAction value, with no overlap
- * (enforced by the unit test). A new action type must be classified here at the
- * point it is introduced.
+ * `satisfies Record<TriggerAction, …>` makes adding a TriggerAction without
+ * classifying it a build break — the runtime exhaustiveness test is defense
+ * in depth.
  */
-export const NOTIFY_TRIGGER_ACTIONS = new Set<TriggerAction>([
-  TriggerAction.SEND_EMAIL,
-  TriggerAction.SEND_SLACK_MESSAGE,
-]);
+export type TriggerActionClass = "notify" | "persist";
 
-export const PERSIST_TRIGGER_ACTIONS = new Set<TriggerAction>([
-  TriggerAction.ADD_TO_DATASET,
-  TriggerAction.ADD_TO_ANNOTATION_QUEUE,
-]);
+export const TRIGGER_ACTION_CLASS = {
+  [TriggerAction.SEND_EMAIL]: "notify",
+  [TriggerAction.SEND_SLACK_MESSAGE]: "notify",
+  [TriggerAction.ADD_TO_DATASET]: "persist",
+  [TriggerAction.ADD_TO_ANNOTATION_QUEUE]: "persist",
+} as const satisfies Record<TriggerAction, TriggerActionClass>;
+
+const actionsInClass = (cls: TriggerActionClass): ReadonlySet<TriggerAction> =>
+  new Set(
+    (Object.entries(TRIGGER_ACTION_CLASS) as [TriggerAction, TriggerActionClass][])
+      .filter(([, c]) => c === cls)
+      .map(([action]) => action),
+  );
+
+export const NOTIFY_TRIGGER_ACTIONS = actionsInClass("notify");
+export const PERSIST_TRIGGER_ACTIONS = actionsInClass("persist");
 
 export const NOTIFICATION_CADENCES = [
   "immediate",

--- a/langwatch/src/server/mailer/__tests__/triggerEmail.unit.test.tsx
+++ b/langwatch/src/server/mailer/__tests__/triggerEmail.unit.test.tsx
@@ -1,0 +1,63 @@
+import { AlertType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TriggerData } from "~/pages/api/cron/triggers/types";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import type { Trace } from "~/server/tracer/types";
+
+const { sendEmailMock } = vi.hoisted(() => ({ sendEmailMock: vi.fn() }));
+
+vi.mock("../emailSender", () => ({ sendEmail: sendEmailMock }));
+
+import { sendTriggerEmail } from "../triggerEmail";
+
+const triggerData: TriggerData[] = [
+  {
+    input: "in",
+    output: "out",
+    traceId: "trace-1",
+    projectId: "project-1",
+    fullTrace: { trace_id: "trace-1" } as unknown as Trace,
+  },
+];
+
+function callEmail() {
+  return sendTriggerEmail({
+    triggerEmails: ["user@example.com"],
+    triggerData,
+    triggerName: "Quality Alert",
+    projectSlug: "demo",
+    triggerType: AlertType.WARNING,
+    triggerMessage: "",
+  });
+}
+
+describe("sendTriggerEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when the provider accepts the send", () => {
+    it("returns without raising", async () => {
+      sendEmailMock.mockResolvedValue(undefined);
+      await expect(callEmail()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("when the provider throttles the send", () => {
+    it("raises a retryable DispatchError", async () => {
+      sendEmailMock.mockRejectedValue({ $metadata: { httpStatusCode: 500 } });
+      const err = await callEmail().catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(DispatchError);
+      expect((err as DispatchError).retryable).toBe(true);
+    });
+  });
+
+  describe("when the provider rejects the address", () => {
+    it("raises a non-retryable DispatchError", async () => {
+      sendEmailMock.mockRejectedValue({ $metadata: { httpStatusCode: 400 } });
+      const err = await callEmail().catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(DispatchError);
+      expect((err as DispatchError).retryable).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/mailer/__tests__/triggerEmail.unit.test.tsx
+++ b/langwatch/src/server/mailer/__tests__/triggerEmail.unit.test.tsx
@@ -45,7 +45,7 @@ describe("sendTriggerEmail", () => {
 
   describe("when the provider throttles the send", () => {
     it("raises a retryable DispatchError", async () => {
-      sendEmailMock.mockRejectedValue({ $metadata: { httpStatusCode: 500 } });
+      sendEmailMock.mockRejectedValue({ $metadata: { httpStatusCode: 429 } });
       const err = await callEmail().catch((e: unknown) => e);
       expect(err).toBeInstanceOf(DispatchError);
       expect((err as DispatchError).retryable).toBe(true);

--- a/langwatch/src/server/mailer/triggerEmail.tsx
+++ b/langwatch/src/server/mailer/triggerEmail.tsx
@@ -6,6 +6,7 @@ import { Html } from "@react-email/html";
 import { Img } from "@react-email/img";
 import { render } from "@react-email/render";
 import type { TriggerData } from "~/pages/api/cron/triggers/types";
+import { toDispatchError } from "~/server/event-sourcing/outbox/dispatchError";
 import { env } from "../../env.mjs";
 import { sendEmail } from "./emailSender";
 
@@ -53,13 +54,19 @@ export const sendTriggerEmail = async ({
     </Html>,
   );
 
-  await sendEmail({
-    to: triggerEmails,
-    subject: `${
-      triggerType ? `(${triggerType}) ` : ""
-    }Trigger - ${triggerName}`,
-    html: emailHtml,
-  });
+  try {
+    await sendEmail({
+      to: triggerEmails,
+      subject: `${
+        triggerType ? `(${triggerType}) ` : ""
+      }Trigger - ${triggerName}`,
+      html: emailHtml,
+    });
+  } catch (err) {
+    throw toDispatchError(err, {
+      message: `Trigger email dispatch failed for trigger "${triggerName}"`,
+    });
+  }
 };
 
 const TriggerTable = ({

--- a/langwatch/src/server/triggers/__tests__/sendSlackWebhook.unit.test.ts
+++ b/langwatch/src/server/triggers/__tests__/sendSlackWebhook.unit.test.ts
@@ -1,0 +1,76 @@
+import { AlertType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
+import type { Trace } from "~/server/tracer/types";
+
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+
+vi.mock("@slack/webhook", () => ({
+  IncomingWebhook: class {
+    send = sendMock;
+  },
+}));
+
+import { sendSlackWebhook } from "../sendSlackWebhook";
+
+function callSlack() {
+  return sendSlackWebhook({
+    triggerWebhook: "https://hooks.slack.com/services/T/B/X",
+    triggerData: [
+      {
+        traceId: "trace-1",
+        input: "in",
+        output: "out",
+        fullTrace: { trace_id: "trace-1", events: [] } as unknown as Trace,
+      },
+    ],
+    triggerName: "Quality Alert",
+    projectSlug: "demo",
+    triggerType: AlertType.WARNING,
+    triggerMessage: "",
+  });
+}
+
+describe("sendSlackWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when the webhook post succeeds", () => {
+    it("returns without raising", async () => {
+      sendMock.mockResolvedValue(undefined);
+      await expect(callSlack()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("when the webhook is rate limited", () => {
+    it("raises a retryable DispatchError", async () => {
+      sendMock.mockRejectedValue({
+        original: { response: { status: 429 } },
+      });
+      const err = await callSlack().catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(DispatchError);
+      expect((err as DispatchError).retryable).toBe(true);
+    });
+  });
+
+  describe("when the webhook was revoked", () => {
+    it("raises a non-retryable DispatchError", async () => {
+      sendMock.mockRejectedValue({
+        original: { response: { status: 404 } },
+      });
+      const err = await callSlack().catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(DispatchError);
+      expect((err as DispatchError).retryable).toBe(false);
+    });
+  });
+
+  describe("when the post fails with a transport error", () => {
+    it("raises a retryable DispatchError by default", async () => {
+      sendMock.mockRejectedValue({ code: "ECONNREFUSED" });
+      const err = await callSlack().catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(DispatchError);
+      expect((err as DispatchError).retryable).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/triggers/sendSlackWebhook.ts
+++ b/langwatch/src/server/triggers/sendSlackWebhook.ts
@@ -1,8 +1,8 @@
 import { type AlertType, AlertType as AlertTypeEnum } from "@prisma/client";
 import { IncomingWebhook } from "@slack/webhook";
 import type { Trace } from "~/server/tracer/types";
+import { toDispatchError } from "~/server/event-sourcing/outbox/dispatchError";
 import { env } from "../../env.mjs";
-import { captureException } from "../../utils/posthogErrorCapture";
 
 interface TriggerData {
   traceId?: string;
@@ -111,6 +111,8 @@ export const sendSlackWebhook = async ({
       icon_emoji: ":robot_face:",
     });
   } catch (err) {
-    captureException(err);
+    throw toDispatchError(err, {
+      message: `Slack webhook dispatch failed for trigger "${triggerName}"`,
+    });
   }
 };

--- a/specs/event-sourcing/alert-trigger-dispatch.feature
+++ b/specs/event-sourcing/alert-trigger-dispatch.feature
@@ -1,0 +1,52 @@
+Feature: Alert trigger dispatch
+
+  Two reactors evaluate user-defined alert triggers and dispatch their
+  configured action: the trace-pipeline reactor handles triggers whose
+  filters are trace-only, and the evaluation-pipeline reactor handles
+  triggers that also filter on evaluation results. Both can fire for the
+  same trigger and trace, so they share a match-claim that guarantees a
+  trigger dispatches at most once per trace.
+
+  This describes the in-line dispatch path. Now that dispatch endpoints
+  raise a DispatchError on failure (see dispatch-error-contract.feature),
+  a failed dispatch must surface rather than masquerade as success.
+
+  Scenario: A matching trace-only trigger is claimed then dispatched
+    Given an active trigger whose trace-only filters match an incoming trace
+    When the trace-pipeline reactor evaluates it
+    Then it claims the match for this trigger and trace
+    And it dispatches the trigger's action
+    And it records the trigger as having run
+
+  Scenario: A matching evaluation trigger fires on the evaluation pipeline
+    Given an active trigger with evaluation filters that match a completed evaluation
+    When the evaluation-pipeline reactor evaluates it
+    Then it claims the match for this trigger and trace
+    And it dispatches the trigger's action
+
+  Scenario: A trigger dispatches at most once across racing pipelines
+    Given the trace and evaluation pipelines both match the same trigger and trace
+    When both reactors attempt to claim the match
+    Then exactly one claim succeeds
+    And the trigger's action dispatches a single time
+
+  Scenario: A trigger already sent for this trace is skipped
+    Given a trigger whose match was already claimed for this trace
+    When a reactor evaluates it again
+    Then the claim fails
+    And no action is dispatched
+    And the trigger is not recorded as having run again
+
+  # Failure handling — the Phase 1 change
+
+  Scenario: A failed dispatch is surfaced, not swallowed
+    Given a matching trigger whose dispatch raises a DispatchError
+    When a reactor dispatches it
+    Then the failure is logged and captured for operators
+    And the failure's retryable classification is included
+    And the trigger is not recorded as having run
+
+  Scenario: One trigger's failure does not block the others
+    Given several matching triggers where one dispatch raises a DispatchError
+    When a reactor processes the batch
+    Then the remaining triggers are still evaluated and dispatched

--- a/specs/event-sourcing/dispatch-error-contract.feature
+++ b/specs/event-sourcing/dispatch-error-contract.feature
@@ -66,3 +66,12 @@ Feature: DispatchError contract for dispatch endpoints
     Given an email provider that accepts the send
     When the email dispatch endpoint runs
     Then it returns normally and raises nothing
+
+  # Callers must uphold the contract (legacy cron path)
+
+  Scenario: Dispatch wrappers in the cron path propagate failures
+    Given the legacy custom-graph cron path dispatches a trigger action
+    And the underlying dispatch endpoint raises a DispatchError
+    When the action wrapper handles the failure
+    Then it captures the exception with action-specific context
+    And it rethrows so the caller does not record the alert as sent

--- a/specs/event-sourcing/dispatch-error-contract.feature
+++ b/specs/event-sourcing/dispatch-error-contract.feature
@@ -1,0 +1,68 @@
+Feature: DispatchError contract for dispatch endpoints
+
+  Dispatch endpoints (Slack webhook, trigger email) perform stake-sensitive
+  side effects. When a side effect fails, the caller must learn two things:
+  that it failed at all, and whether retrying could succeed. Endpoints
+  communicate this by throwing a DispatchError carrying a `retryable` flag,
+  rather than logging and returning as if nothing went wrong.
+
+  The retryable flag is derived from the failure's HTTP semantics so the
+  outbox worker can choose between scheduling a backoff retry and surfacing
+  the row to an operator as dead.
+
+  See dev/docs/adr/027-typed-dispatcherror-contract.md.
+
+  # Classification policy (shared across all dispatch endpoints)
+
+  Scenario: Rate-limit and server errors are retryable
+    Given a dispatch fails with HTTP 429, a 5xx status, or a network timeout
+    When the failure is classified
+    Then a DispatchError is raised
+    And it is marked retryable
+
+  Scenario: Client errors are terminal
+    Given a dispatch fails with a 4xx status other than 429
+    When the failure is classified
+    Then a DispatchError is raised
+    And it is marked not retryable
+
+  Scenario: Unclassifiable failures default to retryable
+    Given a dispatch fails with an error that carries no recognizable status
+    When the failure is classified
+    Then a DispatchError is raised
+    And it is marked retryable
+
+  # Slack webhook endpoint
+
+  Scenario: A failing Slack webhook no longer swallows the error
+    Given a Slack webhook post that fails
+    When the Slack dispatch endpoint runs
+    Then it raises a DispatchError instead of logging and returning
+    And the retryable flag reflects the webhook's failure status
+
+  Scenario: A revoked Slack webhook is terminal
+    Given a Slack webhook that responds 404 because it was revoked
+    When the Slack dispatch endpoint runs
+    Then it raises a DispatchError that is not retryable
+
+  Scenario: A successful Slack post returns without raising
+    Given a Slack webhook post that succeeds
+    When the Slack dispatch endpoint runs
+    Then it returns normally and raises nothing
+
+  # Trigger email endpoint
+
+  Scenario: A throttled email send is retryable
+    Given an email provider that rejects the send with a throttling/5xx response
+    When the email dispatch endpoint runs
+    Then it raises a retryable DispatchError
+
+  Scenario: A rejected email address is terminal
+    Given an email provider that rejects the send with a 4xx response
+    When the email dispatch endpoint runs
+    Then it raises a DispatchError that is not retryable
+
+  Scenario: A successful email send returns without raising
+    Given an email provider that accepts the send
+    When the email dispatch endpoint runs
+    Then it returns normally and raises nothing

--- a/specs/event-sourcing/trigger-action-classification.feature
+++ b/specs/event-sourcing/trigger-action-classification.feature
@@ -1,0 +1,55 @@
+Feature: Trigger action classification — notify vs persist
+
+  A trigger's action falls into one of two classes, and the class decides
+  when dispatch happens:
+
+    - Notify actions land in front of a human (email, Slack). Many
+      invocations in a short window is a notification storm, so notify
+      actions may be batched into a digest window.
+    - Persist actions write durable data the customer asked for (dataset
+      rows, annotation-queue items). Many invocations is the intent, so
+      persist actions always dispatch immediately.
+
+  This classification is the contract the outbox dispatch layer reads to
+  decide when a matched trigger fires.
+
+  See dev/docs/adr/025-notify-persistent-action-classification.md.
+
+  Scenario: Email and Slack are notify actions
+    Given a trigger whose action sends an email or a Slack message
+    Then the action is classified as a notify action
+
+  Scenario: Dataset and annotation-queue writes are persist actions
+    Given a trigger whose action writes to a dataset or an annotation queue
+    Then the action is classified as a persist action
+
+  Scenario: Every trigger action belongs to exactly one class
+    When the notify and persist classes are combined
+    Then together they cover every trigger action
+    And no action appears in both classes
+
+  # Cadence only changes when notify actions fire; persist is always now.
+
+  Scenario: Persist actions dispatch immediately regardless of cadence
+    Given a trigger with a persist action
+    And the trigger is configured with any notification cadence
+    When the dispatch time is computed
+    Then dispatch is scheduled immediately
+
+  Scenario: Notify actions on the immediate cadence dispatch immediately
+    Given a trigger with a notify action
+    And the trigger is configured for immediate notification
+    When the dispatch time is computed
+    Then dispatch is scheduled immediately
+
+  Scenario: Notify actions on a digest cadence wait for the window to close
+    Given a trigger with a notify action
+    And the trigger is configured for a digest cadence
+    When the dispatch time is computed
+    Then dispatch is scheduled at the end of the digest window
+    And the window length matches the configured cadence
+
+  Scenario: Cadence is a per-trigger setting
+    Given two destinations that need different notification cadences
+    Then each destination is configured as its own trigger
+    And one trigger carries exactly one cadence


### PR DESCRIPTION
## Summary

Phase 1 of the trigger-dispatch refactor (stacked on #4242 / `feat/outbox-foundation`). Hardens the in-line dispatch path so stake-sensitive reactors can migrate to the outbox in a later phase. No `.withOutbox` wiring yet — this is the contract layer.

- **Notify/persist classification** (ADR-025): `NOTIFY_TRIGGER_ACTIONS` (email, Slack) vs `PERSIST_TRIGGER_ACTIONS` (dataset, annotation queue), plus `computeScheduledFor()` — persist and immediate-cadence notify fire now; digest-cadence notify waits for the window. A unit test enforces the two sets cover every `TriggerAction` with no overlap. This is the contract the outbox dispatch layer will read.
- **`DispatchError` contract** (ADR-027): `sendSlackWebhook` and `sendTriggerEmail` now throw a typed `DispatchError` with an HTTP-status-derived `retryable` flag (429/5xx/timeout → retryable, other 4xx → terminal, unknown → retryable) instead of swallowing. Adds `toDispatchError` / `extractHttpStatus` / `isRetryableHttpStatus` helpers. **Slack failures are no longer silently dropped.**
- **Reactor refactor**: `alertTrigger` (ee) + `evaluationAlertTrigger` surface the `retryable` classification on failure (log + captureException) and no longer mark a trigger as run when its dispatch fails. At-most-once via `claimSend` is unchanged.

## Scoping notes

- Deferred the ADR-025 `notificationCadence` Prisma column + UI to the phase that wires digest scheduling — nothing reads cadence yet, so a column now would be read-by-nobody. `computeScheduledFor` takes cadence as a parameter and is fully tested.
- Reactors stay on `.withReactor`; the `.withOutbox` migration is a later phase.

## Test plan

- [x] `pnpm typecheck` clean
- [x] Unit tests (48): classification + exhaustiveness, `DispatchError` HTTP helpers, both dispatch endpoints (retryable vs terminal), both reactors incl. a new test for the trace-side `alertTrigger`
- [ ] Merge after base #4242 lands

## Specs

`specs/event-sourcing/`: `trigger-action-classification.feature`, `dispatch-error-contract.feature`, `alert-trigger-dispatch.feature`