### PR TITLE
fix(python-sdk): tolerate non-IANA HTTP status codes in generated REST client

### DIFF
--- a/python-sdk/Makefile
+++ b/python-sdk/Makefile
@@ -107,6 +107,7 @@ generate/api-client: ensure-openapi-python-client
 	uv run openapi-python-client generate \
 		--path ../langwatch/src/app/api/openapiLangWatch.json \
 		--output-path .tmp/api-client \
+		--custom-template-path openapi-templates \
 		--overwrite
 	@echo "Copying necessary files to SDK..."
 	@mkdir -p src/langwatch/generated/langwatch_rest_api_client

--- a/python-sdk/openapi-templates/endpoint_module.py.jinja
+++ b/python-sdk/openapi-templates/endpoint_module.py.jinja
@@ -1,0 +1,157 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET, safe_http_status
+from ... import errors
+
+{% for relative in endpoint.relative_imports | sort %}
+{{ relative }}
+{% endfor %}
+
+{% from "endpoint_macros.py.jinja" import header_params, cookie_params, query_params,
+    arguments, client, kwargs, parse_response, docstring, body_to_kwarg %}
+
+{% set return_string = endpoint.response_type() %}
+{% set parsed_responses = (endpoint.responses | length > 0) and return_string != "Any" %}
+
+def _get_kwargs(
+    {{ arguments(endpoint, include_client=False) | indent(4) }}
+) -> dict[str, Any]:
+    {{ header_params(endpoint) | indent(4) }}
+
+    {{ cookie_params(endpoint) | indent(4) }}
+
+    {{ query_params(endpoint) | indent(4) }}
+
+    _kwargs: dict[str, Any] = {
+        "method": "{{ endpoint.method }}",
+        {% if endpoint.path_parameters %}
+        "url": "{{ endpoint.path }}".format(
+        {%- for parameter in endpoint.path_parameters -%}
+        {{parameter.python_name}}=quote(str({{parameter.python_name}}), safe=""),
+        {%- endfor -%}
+        ),
+        {% else %}
+        "url": "{{ endpoint.path }}",
+        {% endif %}
+        {% if endpoint.query_parameters %}
+        "params": params,
+        {% endif %}
+        {% if endpoint.cookie_parameters %}
+        "cookies": cookies,
+        {% endif %}
+    }
+
+{% if endpoint.bodies | length > 1 %}
+{% for body in endpoint.bodies %}
+    if isinstance(body, {{body.prop.get_type_string(no_optional=True) }}):
+        {{ body_to_kwarg(body) | indent(8) }}
+        headers["Content-Type"] = "{{ body.content_type }}"
+{% endfor %}
+{% elif endpoint.bodies | length == 1 %}
+{% set body = endpoint.bodies[0] %}
+    {{ body_to_kwarg(body) | indent(4) }}
+    {% if body.content_type != "multipart/form-data" %}{# Need httpx to set the boundary automatically #}
+    headers["Content-Type"] = "{{ body.content_type }}"
+    {% endif %}
+{% endif %}
+
+{% if endpoint.header_parameters or endpoint.bodies | length > 0 %}
+    _kwargs["headers"] = headers
+{% endif %}
+    return _kwargs
+
+{% if endpoint.responses.default %}
+    {% set return_type = return_string %}
+{% else %}
+    {% set return_type = return_string + " | None" %}
+{% endif %}
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> {{return_type}}:
+    {% for response in endpoint.responses.patterns %}
+    {% set code_range = response.status_code.range %}
+    {% if code_range[0] == code_range[1] %}
+    if response.status_code == {{ code_range[0] }}:
+    {% else %}
+    if {{ code_range[0] }} <= response.status_code <= {{ code_range[1] }}:
+    {% endif %}
+        {{ parse_response(parsed_responses, response) | indent(8) }}
+    {% endfor %}
+    {% if endpoint.responses.default %}
+    {{ parse_response(parsed_responses, endpoint.responses.default) | indent(4) }}
+    {% else %}
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+    {% endif %}
+
+
+def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[{{ return_string }}]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
+    return Response(
+        status_code=safe_http_status(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint, include_client=False) }}
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+{% if parsed_responses %}
+def sync(
+    {{ arguments(endpoint) | indent(4) }}
+) -> {{ return_string }} | None:
+    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+
+    return sync_detailed(
+        {{ kwargs(endpoint) }}
+    ).parsed
+{% endif %}
+
+async def asyncio_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint, include_client=False) }}
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+{% if parsed_responses %}
+async def asyncio(
+    {{ arguments(endpoint) | indent(4) }}
+) -> {{ return_string }} | None:
+    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+
+    return (await asyncio_detailed(
+        {{ kwargs(endpoint) }}
+    )).parsed
+{% endif %}

--- a/python-sdk/openapi-templates/types.py.jinja
+++ b/python-sdk/openapi-templates/types.py.jinja
@@ -1,8 +1,8 @@
-"""Contains some shared types for properties"""
+""" Contains some shared types for properties """
 
 from collections.abc import Mapping, MutableMapping
 from http import HTTPStatus
-from typing import IO, BinaryIO, Generic, Literal, TypeVar
+from typing import BinaryIO, Generic, TypeVar, Literal, IO
 
 from attrs import define
 
@@ -24,17 +24,16 @@ FileTypes = (
 )
 RequestFiles = list[tuple[str, FileTypes]]
 
-
 @define
 class File:
-    """Contains information for file uploads"""
+    """ Contains information for file uploads """
 
     payload: BinaryIO
     file_name: str | None = None
     mime_type: str | None = None
 
     def to_tuple(self) -> FileTypes:
-        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        """ Return a tuple representation that httpx will accept for multipart/form-data """
         return self.file_name, self.payload, self.mime_type
 
 
@@ -56,7 +55,7 @@ def safe_http_status(status_code: int) -> HTTPStatus | int:
 
 @define
 class Response(Generic[T]):
-    """A response from an endpoint"""
+    """ A response from an endpoint """
 
     status_code: HTTPStatus | int
     content: bytes

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_agents_by_id.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -31,8 +31,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_annotations_id.py
@@ -8,7 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_api_annotations_id_response_200 import DeleteApiAnnotationsIdResponse200
 from ...models.error import Error
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -47,8 +47,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[DeleteApiAnnotationsIdResponse200 | Error]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dashboards_by_id.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -31,8 +31,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -31,8 +31,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id_records.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_api_dataset_by_slug_or_id_records_body import DeleteApiDatasetBySlugOrIdRecordsBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -41,8 +41,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_evaluators_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_evaluators_by_id.py
@@ -12,7 +12,7 @@ from ...models.delete_api_evaluators_by_id_response_401 import DeleteApiEvaluato
 from ...models.delete_api_evaluators_by_id_response_404 import DeleteApiEvaluatorsByIdResponse404
 from ...models.delete_api_evaluators_by_id_response_422 import DeleteApiEvaluatorsByIdResponse422
 from ...models.delete_api_evaluators_by_id_response_500 import DeleteApiEvaluatorsByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | DeleteApiEvaluatorsByIdResponse422
     | DeleteApiEvaluatorsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_graphs_by_id.py
@@ -12,7 +12,7 @@ from ...models.delete_api_graphs_by_id_response_401 import DeleteApiGraphsByIdRe
 from ...models.delete_api_graphs_by_id_response_404 import DeleteApiGraphsByIdResponse404
 from ...models.delete_api_graphs_by_id_response_422 import DeleteApiGraphsByIdResponse422
 from ...models.delete_api_graphs_by_id_response_500 import DeleteApiGraphsByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | DeleteApiGraphsByIdResponse422
     | DeleteApiGraphsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_by_id.py
@@ -12,7 +12,7 @@ from ...models.delete_api_prompts_by_id_response_401 import DeleteApiPromptsById
 from ...models.delete_api_prompts_by_id_response_404 import DeleteApiPromptsByIdResponse404
 from ...models.delete_api_prompts_by_id_response_422 import DeleteApiPromptsByIdResponse422
 from ...models.delete_api_prompts_by_id_response_500 import DeleteApiPromptsByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | DeleteApiPromptsByIdResponse422
     | DeleteApiPromptsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_tags_by_tag.py
@@ -10,7 +10,7 @@ from ...models.delete_api_prompts_tags_by_tag_response_400 import DeleteApiPromp
 from ...models.delete_api_prompts_tags_by_tag_response_401 import DeleteApiPromptsTagsByTagResponse401
 from ...models.delete_api_prompts_tags_by_tag_response_422 import DeleteApiPromptsTagsByTagResponse422
 from ...models.delete_api_prompts_tags_by_tag_response_500 import DeleteApiPromptsTagsByTagResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -76,8 +76,11 @@ def _build_response(
     | DeleteApiPromptsTagsByTagResponse422
     | DeleteApiPromptsTagsByTagResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenario_events.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenario_events.py
@@ -10,7 +10,7 @@ from ...models.delete_api_scenario_events_response_400 import DeleteApiScenarioE
 from ...models.delete_api_scenario_events_response_401 import DeleteApiScenarioEventsResponse401
 from ...models.delete_api_scenario_events_response_422 import DeleteApiScenarioEventsResponse422
 from ...models.delete_api_scenario_events_response_500 import DeleteApiScenarioEventsResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -73,8 +73,11 @@ def _build_response(
     | DeleteApiScenarioEventsResponse422
     | DeleteApiScenarioEventsResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenarios_by_id.py
@@ -12,7 +12,7 @@ from ...models.delete_api_scenarios_by_id_response_401 import DeleteApiScenarios
 from ...models.delete_api_scenarios_by_id_response_404 import DeleteApiScenariosByIdResponse404
 from ...models.delete_api_scenarios_by_id_response_422 import DeleteApiScenariosByIdResponse422
 from ...models.delete_api_scenarios_by_id_response_500 import DeleteApiScenariosByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | DeleteApiScenariosByIdResponse422
     | DeleteApiScenariosByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_suites_by_id.py
@@ -12,7 +12,7 @@ from ...models.delete_api_suites_by_id_response_401 import DeleteApiSuitesByIdRe
 from ...models.delete_api_suites_by_id_response_404 import DeleteApiSuitesByIdResponse404
 from ...models.delete_api_suites_by_id_response_422 import DeleteApiSuitesByIdResponse422
 from ...models.delete_api_suites_by_id_response_500 import DeleteApiSuitesByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | DeleteApiSuitesByIdResponse422
     | DeleteApiSuitesByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_triggers_by_id.py
@@ -12,7 +12,7 @@ from ...models.delete_api_triggers_by_id_response_401 import DeleteApiTriggersBy
 from ...models.delete_api_triggers_by_id_response_404 import DeleteApiTriggersByIdResponse404
 from ...models.delete_api_triggers_by_id_response_422 import DeleteApiTriggersByIdResponse422
 from ...models.delete_api_triggers_by_id_response_500 import DeleteApiTriggersByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | DeleteApiTriggersByIdResponse422
     | DeleteApiTriggersByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_workflows_by_id.py
@@ -12,7 +12,7 @@ from ...models.delete_api_workflows_by_id_response_401 import DeleteApiWorkflows
 from ...models.delete_api_workflows_by_id_response_404 import DeleteApiWorkflowsByIdResponse404
 from ...models.delete_api_workflows_by_id_response_422 import DeleteApiWorkflowsByIdResponse422
 from ...models.delete_api_workflows_by_id_response_500 import DeleteApiWorkflowsByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | DeleteApiWorkflowsByIdResponse422
     | DeleteApiWorkflowsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -39,8 +39,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents_by_id.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -31,8 +31,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations.py
@@ -7,7 +7,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.annotation import Annotation
 from ...models.error import Error
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -47,8 +47,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | list[Annotation]]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_id.py
@@ -8,7 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.annotation import Annotation
 from ...models.error import Error
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -43,8 +43,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Annotation | Error]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_trace_id.py
@@ -8,7 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.annotation import Annotation
 from ...models.error import Error
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -52,8 +52,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | list[Annotation]]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -26,8 +26,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards_by_id.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -31,8 +31,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -39,8 +39,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id.py
@@ -12,7 +12,7 @@ from ...models.get_api_dataset_by_slug_or_id_response_401 import GetApiDatasetBy
 from ...models.get_api_dataset_by_slug_or_id_response_404 import GetApiDatasetBySlugOrIdResponse404
 from ...models.get_api_dataset_by_slug_or_id_response_422 import GetApiDatasetBySlugOrIdResponse422
 from ...models.get_api_dataset_by_slug_or_id_response_500 import GetApiDatasetBySlugOrIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | GetApiDatasetBySlugOrIdResponse422
     | GetApiDatasetBySlugOrIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id_records.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -43,8 +43,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators.py
@@ -10,7 +10,7 @@ from ...models.get_api_evaluators_response_400 import GetApiEvaluatorsResponse40
 from ...models.get_api_evaluators_response_401 import GetApiEvaluatorsResponse401
 from ...models.get_api_evaluators_response_422 import GetApiEvaluatorsResponse422
 from ...models.get_api_evaluators_response_500 import GetApiEvaluatorsResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -78,8 +78,11 @@ def _build_response(
     | GetApiEvaluatorsResponse500
     | list[GetApiEvaluatorsResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators_by_id_or_slug.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators_by_id_or_slug.py
@@ -12,7 +12,7 @@ from ...models.get_api_evaluators_by_id_or_slug_response_401 import GetApiEvalua
 from ...models.get_api_evaluators_by_id_or_slug_response_404 import GetApiEvaluatorsByIdOrSlugResponse404
 from ...models.get_api_evaluators_by_id_or_slug_response_422 import GetApiEvaluatorsByIdOrSlugResponse422
 from ...models.get_api_evaluators_by_id_or_slug_response_500 import GetApiEvaluatorsByIdOrSlugResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | GetApiEvaluatorsByIdOrSlugResponse422
     | GetApiEvaluatorsByIdOrSlugResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs.py
@@ -10,7 +10,7 @@ from ...models.get_api_graphs_response_400 import GetApiGraphsResponse400
 from ...models.get_api_graphs_response_401 import GetApiGraphsResponse401
 from ...models.get_api_graphs_response_422 import GetApiGraphsResponse422
 from ...models.get_api_graphs_response_500 import GetApiGraphsResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -88,8 +88,11 @@ def _build_response(
     | GetApiGraphsResponse500
     | list[GetApiGraphsResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs_by_id.py
@@ -12,7 +12,7 @@ from ...models.get_api_graphs_by_id_response_401 import GetApiGraphsByIdResponse
 from ...models.get_api_graphs_by_id_response_404 import GetApiGraphsByIdResponse404
 from ...models.get_api_graphs_by_id_response_422 import GetApiGraphsByIdResponse422
 from ...models.get_api_graphs_by_id_response_500 import GetApiGraphsByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | GetApiGraphsByIdResponse422
     | GetApiGraphsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_model_providers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_model_providers.py
@@ -10,7 +10,7 @@ from ...models.get_api_model_providers_response_400 import GetApiModelProvidersR
 from ...models.get_api_model_providers_response_401 import GetApiModelProvidersResponse401
 from ...models.get_api_model_providers_response_422 import GetApiModelProvidersResponse422
 from ...models.get_api_model_providers_response_500 import GetApiModelProvidersResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -73,8 +73,11 @@ def _build_response(
     | GetApiModelProvidersResponse422
     | GetApiModelProvidersResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts.py
@@ -10,7 +10,7 @@ from ...models.get_api_prompts_response_400 import GetApiPromptsResponse400
 from ...models.get_api_prompts_response_401 import GetApiPromptsResponse401
 from ...models.get_api_prompts_response_422 import GetApiPromptsResponse422
 from ...models.get_api_prompts_response_500 import GetApiPromptsResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -78,8 +78,11 @@ def _build_response(
     | GetApiPromptsResponse500
     | list[GetApiPromptsResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id.py
@@ -12,7 +12,7 @@ from ...models.get_api_prompts_by_id_response_401 import GetApiPromptsByIdRespon
 from ...models.get_api_prompts_by_id_response_404 import GetApiPromptsByIdResponse404
 from ...models.get_api_prompts_by_id_response_422 import GetApiPromptsByIdResponse422
 from ...models.get_api_prompts_by_id_response_500 import GetApiPromptsByIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -98,8 +98,11 @@ def _build_response(
     | GetApiPromptsByIdResponse422
     | GetApiPromptsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id_versions.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id_versions.py
@@ -12,7 +12,7 @@ from ...models.get_api_prompts_by_id_versions_response_401 import GetApiPromptsB
 from ...models.get_api_prompts_by_id_versions_response_404 import GetApiPromptsByIdVersionsResponse404
 from ...models.get_api_prompts_by_id_versions_response_422 import GetApiPromptsByIdVersionsResponse422
 from ...models.get_api_prompts_by_id_versions_response_500 import GetApiPromptsByIdVersionsResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -91,8 +91,11 @@ def _build_response(
     | GetApiPromptsByIdVersionsResponse500
     | list[GetApiPromptsByIdVersionsResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_tags.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_tags.py
@@ -10,7 +10,7 @@ from ...models.get_api_prompts_tags_response_400 import GetApiPromptsTagsRespons
 from ...models.get_api_prompts_tags_response_401 import GetApiPromptsTagsResponse401
 from ...models.get_api_prompts_tags_response_422 import GetApiPromptsTagsResponse422
 from ...models.get_api_prompts_tags_response_500 import GetApiPromptsTagsResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -78,8 +78,11 @@ def _build_response(
     | GetApiPromptsTagsResponse500
     | list[GetApiPromptsTagsResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios.py
@@ -10,7 +10,7 @@ from ...models.get_api_scenarios_response_400 import GetApiScenariosResponse400
 from ...models.get_api_scenarios_response_401 import GetApiScenariosResponse401
 from ...models.get_api_scenarios_response_422 import GetApiScenariosResponse422
 from ...models.get_api_scenarios_response_500 import GetApiScenariosResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -78,8 +78,11 @@ def _build_response(
     | GetApiScenariosResponse500
     | list[GetApiScenariosResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios_by_id.py
@@ -12,7 +12,7 @@ from ...models.get_api_scenarios_by_id_response_401 import GetApiScenariosByIdRe
 from ...models.get_api_scenarios_by_id_response_404 import GetApiScenariosByIdResponse404
 from ...models.get_api_scenarios_by_id_response_422 import GetApiScenariosByIdResponse422
 from ...models.get_api_scenarios_by_id_response_500 import GetApiScenariosByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | GetApiScenariosByIdResponse422
     | GetApiScenariosByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs.py
@@ -10,7 +10,7 @@ from ...models.get_api_simulation_runs_response_400 import GetApiSimulationRunsR
 from ...models.get_api_simulation_runs_response_401 import GetApiSimulationRunsResponse401
 from ...models.get_api_simulation_runs_response_422 import GetApiSimulationRunsResponse422
 from ...models.get_api_simulation_runs_response_500 import GetApiSimulationRunsResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -92,8 +92,11 @@ def _build_response(
     | GetApiSimulationRunsResponse422
     | GetApiSimulationRunsResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_batches_list.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_batches_list.py
@@ -10,7 +10,7 @@ from ...models.get_api_simulation_runs_batches_list_response_400 import GetApiSi
 from ...models.get_api_simulation_runs_batches_list_response_401 import GetApiSimulationRunsBatchesListResponse401
 from ...models.get_api_simulation_runs_batches_list_response_422 import GetApiSimulationRunsBatchesListResponse422
 from ...models.get_api_simulation_runs_batches_list_response_500 import GetApiSimulationRunsBatchesListResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -89,8 +89,11 @@ def _build_response(
     | GetApiSimulationRunsBatchesListResponse422
     | GetApiSimulationRunsBatchesListResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_by_scenario_run_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_by_scenario_run_id.py
@@ -24,7 +24,7 @@ from ...models.get_api_simulation_runs_by_scenario_run_id_response_422 import (
 from ...models.get_api_simulation_runs_by_scenario_run_id_response_500 import (
     GetApiSimulationRunsByScenarioRunIdResponse500,
 )
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -98,8 +98,11 @@ def _build_response(
     | GetApiSimulationRunsByScenarioRunIdResponse422
     | GetApiSimulationRunsByScenarioRunIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites.py
@@ -10,7 +10,7 @@ from ...models.get_api_suites_response_400 import GetApiSuitesResponse400
 from ...models.get_api_suites_response_401 import GetApiSuitesResponse401
 from ...models.get_api_suites_response_422 import GetApiSuitesResponse422
 from ...models.get_api_suites_response_500 import GetApiSuitesResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -78,8 +78,11 @@ def _build_response(
     | GetApiSuitesResponse500
     | list[GetApiSuitesResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites_by_id.py
@@ -12,7 +12,7 @@ from ...models.get_api_suites_by_id_response_401 import GetApiSuitesByIdResponse
 from ...models.get_api_suites_by_id_response_404 import GetApiSuitesByIdResponse404
 from ...models.get_api_suites_by_id_response_422 import GetApiSuitesByIdResponse422
 from ...models.get_api_suites_by_id_response_500 import GetApiSuitesByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | GetApiSuitesByIdResponse422
     | GetApiSuitesByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_trace_id.py
@@ -8,7 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.get_api_trace_id_response_200 import GetApiTraceIdResponse200
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -47,8 +47,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | GetApiTraceIdResponse200]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_traces_by_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_traces_by_trace_id.py
@@ -14,7 +14,7 @@ from ...models.get_api_traces_by_trace_id_response_401 import GetApiTracesByTrac
 from ...models.get_api_traces_by_trace_id_response_404 import GetApiTracesByTraceIdResponse404
 from ...models.get_api_traces_by_trace_id_response_422 import GetApiTracesByTraceIdResponse422
 from ...models.get_api_traces_by_trace_id_response_500 import GetApiTracesByTraceIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -108,8 +108,11 @@ def _build_response(
     | GetApiTracesByTraceIdResponse422
     | GetApiTracesByTraceIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers.py
@@ -10,7 +10,7 @@ from ...models.get_api_triggers_response_400 import GetApiTriggersResponse400
 from ...models.get_api_triggers_response_401 import GetApiTriggersResponse401
 from ...models.get_api_triggers_response_422 import GetApiTriggersResponse422
 from ...models.get_api_triggers_response_500 import GetApiTriggersResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -78,8 +78,11 @@ def _build_response(
     | GetApiTriggersResponse500
     | list[GetApiTriggersResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers_by_id.py
@@ -12,7 +12,7 @@ from ...models.get_api_triggers_by_id_response_401 import GetApiTriggersByIdResp
 from ...models.get_api_triggers_by_id_response_404 import GetApiTriggersByIdResponse404
 from ...models.get_api_triggers_by_id_response_422 import GetApiTriggersByIdResponse422
 from ...models.get_api_triggers_by_id_response_500 import GetApiTriggersByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | GetApiTriggersByIdResponse422
     | GetApiTriggersByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows.py
@@ -10,7 +10,7 @@ from ...models.get_api_workflows_response_400 import GetApiWorkflowsResponse400
 from ...models.get_api_workflows_response_401 import GetApiWorkflowsResponse401
 from ...models.get_api_workflows_response_422 import GetApiWorkflowsResponse422
 from ...models.get_api_workflows_response_500 import GetApiWorkflowsResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -78,8 +78,11 @@ def _build_response(
     | GetApiWorkflowsResponse500
     | list[GetApiWorkflowsResponse200Item]
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows_by_id.py
@@ -12,7 +12,7 @@ from ...models.get_api_workflows_by_id_response_401 import GetApiWorkflowsByIdRe
 from ...models.get_api_workflows_by_id_response_404 import GetApiWorkflowsByIdResponse404
 from ...models.get_api_workflows_by_id_response_422 import GetApiWorkflowsByIdResponse422
 from ...models.get_api_workflows_by_id_response_500 import GetApiWorkflowsByIdResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | GetApiWorkflowsByIdResponse422
     | GetApiWorkflowsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_index.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_index.py
@@ -9,7 +9,7 @@ from ...models.get_index_response_200_item import GetIndexResponse200Item
 from ...models.get_index_response_400 import GetIndexResponse400
 from ...models.get_index_response_401 import GetIndexResponse401
 from ...models.get_index_response_500 import GetIndexResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -59,8 +59,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[GetIndexResponse400 | GetIndexResponse401 | GetIndexResponse500 | list[GetIndexResponse200Item]]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_agents_by_id.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.patch_api_agents_by_id_body import PatchApiAgentsByIdBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -41,8 +41,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_annotations_id.py
@@ -9,7 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.patch_api_annotations_id_body import PatchApiAnnotationsIdBody
 from ...models.patch_api_annotations_id_response_200 import PatchApiAnnotationsIdResponse200
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -56,8 +56,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | PatchApiAnnotationsIdResponse200]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dashboards_by_id.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.patch_api_dashboards_by_id_body import PatchApiDashboardsByIdBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -41,8 +41,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.patch_api_dataset_by_slug_or_id_body import PatchApiDatasetBySlugOrIdBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -41,8 +41,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id_records_by_record_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id_records_by_record_id.py
@@ -9,7 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.patch_api_dataset_by_slug_or_id_records_by_record_id_body import (
     PatchApiDatasetBySlugOrIdRecordsByRecordIdBody,
 )
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -45,8 +45,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_graphs_by_id.py
@@ -13,7 +13,7 @@ from ...models.patch_api_graphs_by_id_response_401 import PatchApiGraphsByIdResp
 from ...models.patch_api_graphs_by_id_response_404 import PatchApiGraphsByIdResponse404
 from ...models.patch_api_graphs_by_id_response_422 import PatchApiGraphsByIdResponse422
 from ...models.patch_api_graphs_by_id_response_500 import PatchApiGraphsByIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -96,8 +96,11 @@ def _build_response(
     | PatchApiGraphsByIdResponse422
     | PatchApiGraphsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_suites_by_id.py
@@ -13,7 +13,7 @@ from ...models.patch_api_suites_by_id_response_401 import PatchApiSuitesByIdResp
 from ...models.patch_api_suites_by_id_response_404 import PatchApiSuitesByIdResponse404
 from ...models.patch_api_suites_by_id_response_422 import PatchApiSuitesByIdResponse422
 from ...models.patch_api_suites_by_id_response_500 import PatchApiSuitesByIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -96,8 +96,11 @@ def _build_response(
     | PatchApiSuitesByIdResponse422
     | PatchApiSuitesByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_triggers_by_id.py
@@ -13,7 +13,7 @@ from ...models.patch_api_triggers_by_id_response_401 import PatchApiTriggersById
 from ...models.patch_api_triggers_by_id_response_404 import PatchApiTriggersByIdResponse404
 from ...models.patch_api_triggers_by_id_response_422 import PatchApiTriggersByIdResponse422
 from ...models.patch_api_triggers_by_id_response_500 import PatchApiTriggersByIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -96,8 +96,11 @@ def _build_response(
     | PatchApiTriggersByIdResponse422
     | PatchApiTriggersByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_workflows_by_id.py
@@ -13,7 +13,7 @@ from ...models.patch_api_workflows_by_id_response_401 import PatchApiWorkflowsBy
 from ...models.patch_api_workflows_by_id_response_404 import PatchApiWorkflowsByIdResponse404
 from ...models.patch_api_workflows_by_id_response_422 import PatchApiWorkflowsByIdResponse422
 from ...models.patch_api_workflows_by_id_response_500 import PatchApiWorkflowsByIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -96,8 +96,11 @@ def _build_response(
     | PatchApiWorkflowsByIdResponse422
     | PatchApiWorkflowsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_agents.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_agents.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.post_api_agents_body import PostApiAgentsBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -37,8 +37,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_analytics_timeseries.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_analytics_timeseries.py
@@ -11,7 +11,7 @@ from ...models.post_api_analytics_timeseries_response_400 import PostApiAnalytic
 from ...models.post_api_analytics_timeseries_response_401 import PostApiAnalyticsTimeseriesResponse401
 from ...models.post_api_analytics_timeseries_response_422 import PostApiAnalyticsTimeseriesResponse422
 from ...models.post_api_analytics_timeseries_response_500 import PostApiAnalyticsTimeseriesResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -84,8 +84,11 @@ def _build_response(
     | PostApiAnalyticsTimeseriesResponse422
     | PostApiAnalyticsTimeseriesResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_annotations_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_annotations_trace_id.py
@@ -9,7 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.annotation import Annotation
 from ...models.error import Error
 from ...models.post_api_annotations_trace_id_body import PostApiAnnotationsTraceIdBody
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -52,8 +52,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Annotation | Error]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dashboards.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dashboards.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.post_api_dashboards_body import PostApiDashboardsBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -37,8 +37,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.post_api_dataset_body import PostApiDatasetBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -37,8 +37,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_entries.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_entries.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.dataset_post_entries import DatasetPostEntries
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -41,8 +41,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_records.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.post_api_dataset_by_slug_or_id_records_body import PostApiDatasetBySlugOrIdRecordsBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -41,8 +41,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_upload.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_upload.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -31,8 +31,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_upload.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_upload.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -26,8 +26,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_evaluators.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_evaluators.py
@@ -11,7 +11,7 @@ from ...models.post_api_evaluators_response_400 import PostApiEvaluatorsResponse
 from ...models.post_api_evaluators_response_401 import PostApiEvaluatorsResponse401
 from ...models.post_api_evaluators_response_422 import PostApiEvaluatorsResponse422
 from ...models.post_api_evaluators_response_500 import PostApiEvaluatorsResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -84,8 +84,11 @@ def _build_response(
     | PostApiEvaluatorsResponse422
     | PostApiEvaluatorsResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_graphs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_graphs.py
@@ -11,7 +11,7 @@ from ...models.post_api_graphs_response_400 import PostApiGraphsResponse400
 from ...models.post_api_graphs_response_401 import PostApiGraphsResponse401
 from ...models.post_api_graphs_response_422 import PostApiGraphsResponse422
 from ...models.post_api_graphs_response_500 import PostApiGraphsResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -84,8 +84,11 @@ def _build_response(
     | PostApiGraphsResponse422
     | PostApiGraphsResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts.py
@@ -12,7 +12,7 @@ from ...models.post_api_prompts_response_401 import PostApiPromptsResponse401
 from ...models.post_api_prompts_response_409 import PostApiPromptsResponse409
 from ...models.post_api_prompts_response_422 import PostApiPromptsResponse422
 from ...models.post_api_prompts_response_500 import PostApiPromptsResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -92,8 +92,11 @@ def _build_response(
     | PostApiPromptsResponse422
     | PostApiPromptsResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_by_id_sync.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_by_id_sync.py
@@ -12,7 +12,7 @@ from ...models.post_api_prompts_by_id_sync_response_400 import PostApiPromptsByI
 from ...models.post_api_prompts_by_id_sync_response_401 import PostApiPromptsByIdSyncResponse401
 from ...models.post_api_prompts_by_id_sync_response_422 import PostApiPromptsByIdSyncResponse422
 from ...models.post_api_prompts_by_id_sync_response_500 import PostApiPromptsByIdSyncResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -88,8 +88,11 @@ def _build_response(
     | PostApiPromptsByIdSyncResponse422
     | PostApiPromptsByIdSyncResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_tags.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_tags.py
@@ -11,7 +11,7 @@ from ...models.post_api_prompts_tags_response_400 import PostApiPromptsTagsRespo
 from ...models.post_api_prompts_tags_response_401 import PostApiPromptsTagsResponse401
 from ...models.post_api_prompts_tags_response_422 import PostApiPromptsTagsResponse422
 from ...models.post_api_prompts_tags_response_500 import PostApiPromptsTagsResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -84,8 +84,11 @@ def _build_response(
     | PostApiPromptsTagsResponse422
     | PostApiPromptsTagsResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenario_events.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenario_events.py
@@ -19,7 +19,7 @@ from ...models.post_api_scenario_events_response_400 import PostApiScenarioEvent
 from ...models.post_api_scenario_events_response_401 import PostApiScenarioEventsResponse401
 from ...models.post_api_scenario_events_response_422 import PostApiScenarioEventsResponse422
 from ...models.post_api_scenario_events_response_500 import PostApiScenarioEventsResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -117,8 +117,11 @@ def _build_response(
     | PostApiScenarioEventsResponse422
     | PostApiScenarioEventsResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenarios.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenarios.py
@@ -11,7 +11,7 @@ from ...models.post_api_scenarios_response_400 import PostApiScenariosResponse40
 from ...models.post_api_scenarios_response_401 import PostApiScenariosResponse401
 from ...models.post_api_scenarios_response_422 import PostApiScenariosResponse422
 from ...models.post_api_scenarios_response_500 import PostApiScenariosResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -84,8 +84,11 @@ def _build_response(
     | PostApiScenariosResponse422
     | PostApiScenariosResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites.py
@@ -11,7 +11,7 @@ from ...models.post_api_suites_response_400 import PostApiSuitesResponse400
 from ...models.post_api_suites_response_401 import PostApiSuitesResponse401
 from ...models.post_api_suites_response_422 import PostApiSuitesResponse422
 from ...models.post_api_suites_response_500 import PostApiSuitesResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -84,8 +84,11 @@ def _build_response(
     | PostApiSuitesResponse422
     | PostApiSuitesResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_duplicate.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_duplicate.py
@@ -12,7 +12,7 @@ from ...models.post_api_suites_by_id_duplicate_response_401 import PostApiSuites
 from ...models.post_api_suites_by_id_duplicate_response_404 import PostApiSuitesByIdDuplicateResponse404
 from ...models.post_api_suites_by_id_duplicate_response_422 import PostApiSuitesByIdDuplicateResponse422
 from ...models.post_api_suites_by_id_duplicate_response_500 import PostApiSuitesByIdDuplicateResponse500
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -86,8 +86,11 @@ def _build_response(
     | PostApiSuitesByIdDuplicateResponse422
     | PostApiSuitesByIdDuplicateResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_run.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_run.py
@@ -13,7 +13,7 @@ from ...models.post_api_suites_by_id_run_response_401 import PostApiSuitesByIdRu
 from ...models.post_api_suites_by_id_run_response_404 import PostApiSuitesByIdRunResponse404
 from ...models.post_api_suites_by_id_run_response_422 import PostApiSuitesByIdRunResponse422
 from ...models.post_api_suites_by_id_run_response_500 import PostApiSuitesByIdRunResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -96,8 +96,11 @@ def _build_response(
     | PostApiSuitesByIdRunResponse422
     | PostApiSuitesByIdRunResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_share.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_share.py
@@ -8,7 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.post_api_trace_id_share_response_200 import PostApiTraceIdShareResponse200
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -47,8 +47,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | PostApiTraceIdShareResponse200]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_unshare.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_unshare.py
@@ -8,7 +8,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error import Error
 from ...models.post_api_trace_id_unshare_response_200 import PostApiTraceIdUnshareResponse200
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -47,8 +47,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[Error | PostApiTraceIdUnshareResponse200]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_traces_search.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_traces_search.py
@@ -11,7 +11,7 @@ from ...models.post_api_traces_search_response_400 import PostApiTracesSearchRes
 from ...models.post_api_traces_search_response_401 import PostApiTracesSearchResponse401
 from ...models.post_api_traces_search_response_422 import PostApiTracesSearchResponse422
 from ...models.post_api_traces_search_response_500 import PostApiTracesSearchResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -84,8 +84,11 @@ def _build_response(
     | PostApiTracesSearchResponse422
     | PostApiTracesSearchResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_triggers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_triggers.py
@@ -11,7 +11,7 @@ from ...models.post_api_triggers_response_400 import PostApiTriggersResponse400
 from ...models.post_api_triggers_response_401 import PostApiTriggersResponse401
 from ...models.post_api_triggers_response_422 import PostApiTriggersResponse422
 from ...models.post_api_triggers_response_500 import PostApiTriggersResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -84,8 +84,11 @@ def _build_response(
     | PostApiTriggersResponse422
     | PostApiTriggersResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_index.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_index.py
@@ -10,7 +10,7 @@ from ...models.post_index_response_200 import PostIndexResponse200
 from ...models.post_index_response_400 import PostIndexResponse400
 from ...models.post_index_response_401 import PostIndexResponse401
 from ...models.post_index_response_500 import PostIndexResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -65,8 +65,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[PostIndexResponse200 | PostIndexResponse400 | PostIndexResponse401 | PostIndexResponse500]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_dashboards_reorder.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_dashboards_reorder.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.put_api_dashboards_reorder_body import PutApiDashboardsReorderBody
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -37,8 +37,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[Any]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_evaluators_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_evaluators_by_id.py
@@ -13,7 +13,7 @@ from ...models.put_api_evaluators_by_id_response_401 import PutApiEvaluatorsById
 from ...models.put_api_evaluators_by_id_response_404 import PutApiEvaluatorsByIdResponse404
 from ...models.put_api_evaluators_by_id_response_422 import PutApiEvaluatorsByIdResponse422
 from ...models.put_api_evaluators_by_id_response_500 import PutApiEvaluatorsByIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -96,8 +96,11 @@ def _build_response(
     | PutApiEvaluatorsByIdResponse422
     | PutApiEvaluatorsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_model_providers_by_provider.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_model_providers_by_provider.py
@@ -12,7 +12,7 @@ from ...models.put_api_model_providers_by_provider_response_400 import PutApiMod
 from ...models.put_api_model_providers_by_provider_response_401 import PutApiModelProvidersByProviderResponse401
 from ...models.put_api_model_providers_by_provider_response_422 import PutApiModelProvidersByProviderResponse422
 from ...models.put_api_model_providers_by_provider_response_500 import PutApiModelProvidersByProviderResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -88,8 +88,11 @@ def _build_response(
     | PutApiModelProvidersByProviderResponse422
     | PutApiModelProvidersByProviderResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id.py
@@ -14,7 +14,7 @@ from ...models.put_api_prompts_by_id_response_404 import PutApiPromptsByIdRespon
 from ...models.put_api_prompts_by_id_response_409 import PutApiPromptsByIdResponse409
 from ...models.put_api_prompts_by_id_response_422 import PutApiPromptsByIdResponse422
 from ...models.put_api_prompts_by_id_response_500 import PutApiPromptsByIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -104,8 +104,11 @@ def _build_response(
     | PutApiPromptsByIdResponse422
     | PutApiPromptsByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id_tags_by_tag.py
@@ -13,7 +13,7 @@ from ...models.put_api_prompts_by_id_tags_by_tag_response_401 import PutApiPromp
 from ...models.put_api_prompts_by_id_tags_by_tag_response_404 import PutApiPromptsByIdTagsByTagResponse404
 from ...models.put_api_prompts_by_id_tags_by_tag_response_422 import PutApiPromptsByIdTagsByTagResponse422
 from ...models.put_api_prompts_by_id_tags_by_tag_response_500 import PutApiPromptsByIdTagsByTagResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -98,8 +98,11 @@ def _build_response(
     | PutApiPromptsByIdTagsByTagResponse422
     | PutApiPromptsByIdTagsByTagResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_tags_by_tag.py
@@ -12,7 +12,7 @@ from ...models.put_api_prompts_tags_by_tag_response_400 import PutApiPromptsTags
 from ...models.put_api_prompts_tags_by_tag_response_401 import PutApiPromptsTagsByTagResponse401
 from ...models.put_api_prompts_tags_by_tag_response_422 import PutApiPromptsTagsByTagResponse422
 from ...models.put_api_prompts_tags_by_tag_response_500 import PutApiPromptsTagsByTagResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -88,8 +88,11 @@ def _build_response(
     | PutApiPromptsTagsByTagResponse422
     | PutApiPromptsTagsByTagResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_scenarios_by_id.py
@@ -13,7 +13,7 @@ from ...models.put_api_scenarios_by_id_response_401 import PutApiScenariosByIdRe
 from ...models.put_api_scenarios_by_id_response_404 import PutApiScenariosByIdResponse404
 from ...models.put_api_scenarios_by_id_response_422 import PutApiScenariosByIdResponse422
 from ...models.put_api_scenarios_by_id_response_500 import PutApiScenariosByIdResponse500
-from ...types import UNSET, Response, Unset
+from ...types import UNSET, Response, Unset, safe_http_status
 
 
 def _get_kwargs(
@@ -96,8 +96,11 @@ def _build_response(
     | PutApiScenariosByIdResponse422
     | PutApiScenariosByIdResponse500
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/get_evaluations_v3_run_status.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/get_evaluations_v3_run_status.py
@@ -9,7 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.get_evaluations_v3_run_status_response_200 import GetEvaluationsV3RunStatusResponse200
 from ...models.get_evaluations_v3_run_status_response_401 import GetEvaluationsV3RunStatusResponse401
 from ...models.get_evaluations_v3_run_status_response_404 import GetEvaluationsV3RunStatusResponse404
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -60,8 +60,11 @@ def _build_response(
 ) -> Response[
     GetEvaluationsV3RunStatusResponse200 | GetEvaluationsV3RunStatusResponse401 | GetEvaluationsV3RunStatusResponse404
 ]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/post_evaluations_v3_run.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/post_evaluations_v3_run.py
@@ -9,7 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.post_evaluations_v3_run_response_200 import PostEvaluationsV3RunResponse200
 from ...models.post_evaluations_v3_run_response_401 import PostEvaluationsV3RunResponse401
 from ...models.post_evaluations_v3_run_response_404 import PostEvaluationsV3RunResponse404
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -53,8 +53,11 @@ def _parse_response(
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
 ) -> Response[PostEvaluationsV3RunResponse200 | PostEvaluationsV3RunResponse401 | PostEvaluationsV3RunResponse404]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/traces/post_api_trace_search.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/traces/post_api_trace_search.py
@@ -7,7 +7,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.search_request import SearchRequest
 from ...models.search_response import SearchResponse
-from ...types import Response
+from ...types import Response, safe_http_status
 
 
 def _get_kwargs(
@@ -42,8 +42,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 
 def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> Response[SearchResponse]:
+    # LangWatch override: use safe_http_status to tolerate non-IANA status codes
+    # (Cloudflare 520-527, AWS WAF 561, etc). Upstream still crashes here.
+    # Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
     return Response(
-        status_code=HTTPStatus(response.status_code),
+        status_code=safe_http_status(response.status_code),
         content=response.content,
         headers=response.headers,
         parsed=_parse_response(client=client, response=response),

--- a/python-sdk/tests/test_generated_client_status_codes.py
+++ b/python-sdk/tests/test_generated_client_status_codes.py
@@ -1,0 +1,68 @@
+"""
+Regression tests for non-IANA HTTP status codes in the generated REST client.
+
+Cloudflare (520-527), AWS WAF (561), and other proxies return status codes that
+are not in Python's http.HTTPStatus enum. Upstream openapi-python-client blindly
+calls HTTPStatus(code) in _build_response, which raises ValueError on those codes.
+
+Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pull/1407
+"""
+
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from langwatch.generated.langwatch_rest_api_client.api.default import (
+    get_api_prompts_by_id,
+)
+from langwatch.generated.langwatch_rest_api_client.client import Client
+from langwatch.generated.langwatch_rest_api_client.types import safe_http_status
+
+pytestmark = pytest.mark.unit
+
+
+class TestSafeHttpStatus:
+    def test_returns_httpstatus_for_iana_codes(self) -> None:
+        assert safe_http_status(200) is HTTPStatus.OK
+        assert safe_http_status(404) is HTTPStatus.NOT_FOUND
+        assert safe_http_status(500) is HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def test_returns_raw_int_for_cloudflare_codes(self) -> None:
+        for code in (520, 521, 522, 523, 524, 525, 526, 527):
+            assert safe_http_status(code) == code
+            assert not isinstance(safe_http_status(code), HTTPStatus)
+
+    def test_returns_raw_int_for_other_non_iana_codes(self) -> None:
+        assert safe_http_status(561) == 561  # AWS WAF
+        assert safe_http_status(499) == 499  # nginx client closed request
+
+
+class TestBuildResponseWithNonStandardStatus:
+    def _make_httpx_response(self, status_code: int) -> httpx.Response:
+        return httpx.Response(
+            status_code=status_code,
+            content=b"<html>upstream broken</html>",
+            headers={"content-type": "text/html"},
+        )
+
+    def test_does_not_crash_on_cloudflare_520(self) -> None:
+        """Customer-reported scenario: Cloudflare returns 520 when origin is unreachable."""
+        client = Client(base_url="https://example.com", raise_on_unexpected_status=False)
+        response = self._make_httpx_response(520)
+
+        built = get_api_prompts_by_id._build_response(client=client, response=response)
+
+        assert built.status_code == 520
+        assert built.parsed is None  # no matching response handler for 520
+
+    def test_preserves_httpstatus_for_iana_codes_without_handler(self) -> None:
+        """418 is IANA-registered but has no _parse_response handler for this endpoint."""
+        client = Client(base_url="https://example.com", raise_on_unexpected_status=False)
+        response = self._make_httpx_response(418)
+
+        built = get_api_prompts_by_id._build_response(client=client, response=response)
+
+        assert built.status_code is HTTPStatus.IM_A_TEAPOT
+        assert built.parsed is None

--- a/python-sdk/tests/test_generated_client_status_codes.py
+++ b/python-sdk/tests/test_generated_client_status_codes.py
@@ -9,7 +9,6 @@ Tracked upstream: https://github.com/openapi-generators/openapi-python-client/pu
 """
 
 from http import HTTPStatus
-from unittest.mock import MagicMock
 
 import httpx
 import pytest


### PR DESCRIPTION
Closes #4405

## Summary

- Python SDK crashed on Cloudflare 520 (and any other non-IANA status code) with `ValueError: 520 is not a valid HTTPStatus`. Reported via a customer trace.
- Root cause is in the upstream `openapi-python-client` template — `_build_response` blindly calls `HTTPStatus(response.status_code)`. Upstream fix ([PR #1407](https://github.com/openapi-generators/openapi-python-client/pull/1407)) is open since Feb, unmerged, and would make the safer behavior opt-in.
- Fix: add `safe_http_status()` helper, widen `Response.status_code` to `HTTPStatus | int`, ship custom Jinja overrides so future regenerations preserve the fix, and apply the patch to all 90 currently-generated endpoint files in place.

## What changed

- `python-sdk/openapi-templates/endpoint_module.py.jinja` and `types.py.jinja` — forked from upstream v0.28.4 with the override (each carries a comment pointing at PR #1407).
- `python-sdk/Makefile` — `generate/api-client` now passes `--custom-template-path openapi-templates`, so regenerations apply the override automatically.
- `python-sdk/src/langwatch/generated/langwatch_rest_api_client/types.py` — adds the helper, widens the type, exports `safe_http_status`.
- 90 endpoint files under `api/` — `HTTPStatus(response.status_code)` → `safe_http_status(response.status_code)` + import + PR-ref comment.
- `python-sdk/tests/test_generated_client_status_codes.py` — regression tests for 520 (customer scenario), other non-IANA codes (561, 499, 521–527), and IANA codes (200, 404, 418).

## Blast radius

Bug is contained to the Python SDK generated client. Verified no equivalent crash path in `langwatch_nlp`, `langwatch_server`, `langwatch` (Next.js), `typescript-sdk`, or `services/aigateway` — they all treat status as raw int.

## Test plan

- [x] `make test-unit` — 347 passed, 0 failed
- [x] New regression suite (`tests/test_generated_client_status_codes.py`) — 5 passed
- [ ] CI green

## Upstream

- Issue filed: https://github.com/openapi-generators/openapi-python-client/issues/1442
- Existing PR: https://github.com/openapi-generators/openapi-python-client/pull/1407