### PR TITLE
fix(eval): cap oversized evaluator inputs before the clickhouse write

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -4,6 +4,7 @@ import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
 import { EVALUATION_PROJECTION_VERSIONS } from "~/server/event-sourcing/pipelines/evaluation-processing/schemas/constants";
 import { IdUtils } from "~/server/event-sourcing/pipelines/evaluation-processing/utils/id.utils";
 import { createLogger } from "~/utils/logger/server";
+import { capStoredJson } from "~/server/utils/capStoredPayload";
 import { validateBatchTenants } from "../../_shared/clickhouse-batch";
 import type { EvalSummary, EvaluationRunData } from "../types";
 import type { EvaluationRunRepository, GetByEvaluationIdParams } from "./evaluation-run.repository";
@@ -484,7 +485,7 @@ export class EvaluationRunClickHouseRepository
       Passed: data.passed === null ? null : data.passed ? 1 : 0,
       Label: data.label,
       Details: data.details,
-      Inputs: data.inputs ? JSON.stringify(data.inputs) : null,
+      Inputs: capStoredJson(data.inputs),
       Error: data.error,
       ErrorDetails: data.errorDetails,
       CreatedAt: new Date(data.createdAt),

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
@@ -1,4 +1,5 @@
 import { ATTR_KEYS } from "~/server/app-layer/traces/canonicalisation/extractors/_constants";
+import { capStoredText } from "~/server/utils/capStoredPayload";
 import type { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import type { LogRecordReceivedEventData } from "../../schemas/events";
@@ -244,12 +245,15 @@ export class TraceIOAccumulationService {
  * via the fold projection, not directly.
  */
 function preferText(text: string | null | undefined, raw: unknown): string {
-  if (typeof text === "string" && text.length > 0) return text;
-  if (typeof raw === "string") return raw;
+  // Bound the persisted trace IO so a pathological agentic conversation can't
+  // grow the fold state / trace-summary column without limit. Defense-in-depth
+  // alongside the eval-input cap; normal IO is well under the threshold.
+  if (typeof text === "string" && text.length > 0) return capStoredText(text);
+  if (typeof raw === "string") return capStoredText(raw);
   // JSON.stringify(undefined) returns the literal value `undefined`,
   // not the string "undefined". Guard explicitly so a future caller
   // that hands us `undefined` doesn't silently corrupt the trace
   // summary with a non-string value cast to string.
   if (raw === undefined) return "";
-  return JSON.stringify(raw);
+  return capStoredText(JSON.stringify(raw));
 }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/trace-io-accumulation.service.ts
@@ -1,5 +1,4 @@
 import { ATTR_KEYS } from "~/server/app-layer/traces/canonicalisation/extractors/_constants";
-import { capStoredText } from "~/server/utils/capStoredPayload";
 import type { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import type { LogRecordReceivedEventData } from "../../schemas/events";
@@ -245,15 +244,12 @@ export class TraceIOAccumulationService {
  * via the fold projection, not directly.
  */
 function preferText(text: string | null | undefined, raw: unknown): string {
-  // Bound the persisted trace IO so a pathological agentic conversation can't
-  // grow the fold state / trace-summary column without limit. Defense-in-depth
-  // alongside the eval-input cap; normal IO is well under the threshold.
-  if (typeof text === "string" && text.length > 0) return capStoredText(text);
-  if (typeof raw === "string") return capStoredText(raw);
+  if (typeof text === "string" && text.length > 0) return text;
+  if (typeof raw === "string") return raw;
   // JSON.stringify(undefined) returns the literal value `undefined`,
   // not the string "undefined". Guard explicitly so a future caller
   // that hands us `undefined` doesn't silently corrupt the trace
   // summary with a non-string value cast to string.
   if (raw === undefined) return "";
-  return capStoredText(JSON.stringify(raw));
+  return JSON.stringify(raw);
 }

--- a/langwatch/src/server/utils/__tests__/capStoredPayload.unit.test.ts
+++ b/langwatch/src/server/utils/__tests__/capStoredPayload.unit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAX_STORED_PAYLOAD_BYTES,
+  capStoredJson,
+  capStoredText,
+  utf8ByteLength,
+} from "../capStoredPayload";
+
+describe("capStoredJson", () => {
+  describe("given a null or undefined value", () => {
+    it("returns null", () => {
+      expect(capStoredJson(null)).toBeNull();
+      expect(capStoredJson(undefined)).toBeNull();
+    });
+  });
+
+  describe("given a value within the cap", () => {
+    it("returns the value serialized byte-for-byte", () => {
+      const value = { question: "what is 2+2?", answer: "4" };
+      expect(capStoredJson(value)).toBe(JSON.stringify(value));
+    });
+
+    it("serializes an empty object unchanged", () => {
+      expect(capStoredJson({})).toBe("{}");
+    });
+  });
+
+  describe("given a value over the cap", () => {
+    const big = { conversation: "x".repeat(5 * 1024 * 1024) };
+    const capped = capStoredJson(big, 32 * 1024);
+
+    it("stays valid JSON that downstream JSON.parse can read", () => {
+      expect(() => JSON.parse(capped!)).not.toThrow();
+    });
+
+    it("marks the payload as truncated with the original size", () => {
+      const parsed = JSON.parse(capped!) as {
+        _truncated: boolean;
+        _originalBytes: number;
+        _maxBytes: number;
+      };
+      expect(parsed._truncated).toBe(true);
+      expect(parsed._originalBytes).toBe(utf8ByteLength(JSON.stringify(big)));
+      expect(parsed._maxBytes).toBe(32 * 1024);
+    });
+
+    it("collapses a multi-MB input to a small placeholder", () => {
+      expect(utf8ByteLength(capped!)).toBeLessThan(32 * 1024);
+    });
+
+    it("keeps a preview of the original payload for debugging", () => {
+      const parsed = JSON.parse(capped!) as { _preview: string };
+      expect(parsed._preview.length).toBeGreaterThan(0);
+      expect(parsed._preview.startsWith('{"conversation":"xxx')).toBe(true);
+    });
+  });
+
+  describe("given a value that JSON.stringify drops to undefined", () => {
+    it("returns null rather than the literal string undefined", () => {
+      expect(capStoredJson(() => 1)).toBeNull();
+    });
+  });
+});
+
+describe("capStoredText", () => {
+  describe("given a null or undefined value", () => {
+    it("returns it unchanged", () => {
+      expect(capStoredText(null)).toBeNull();
+      expect(capStoredText(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("given text within the cap", () => {
+    it("returns it unchanged", () => {
+      const text = "a normal short trace output";
+      expect(capStoredText(text)).toBe(text);
+    });
+  });
+
+  describe("given text over the cap", () => {
+    const text = "y".repeat(2 * 1024 * 1024);
+    const capped = capStoredText(text, 32 * 1024);
+
+    it("stays at or under the byte cap", () => {
+      expect(utf8ByteLength(capped)).toBeLessThanOrEqual(32 * 1024);
+    });
+
+    it("appends a marker naming the original size", () => {
+      expect(capped.endsWith(`bytes total]`)).toBe(true);
+      expect(capped).toContain(String(utf8ByteLength(text)));
+    });
+  });
+
+  describe("given multibyte text right at the boundary", () => {
+    it("never throws and stays within the cap", () => {
+      const emoji = "😀".repeat(20 * 1024); // 4 bytes each
+      const capped = capStoredText(emoji, 1024);
+      expect(utf8ByteLength(capped)).toBeLessThanOrEqual(1024);
+    });
+  });
+
+  describe("default cap", () => {
+    it("is 32KB", () => {
+      expect(DEFAULT_MAX_STORED_PAYLOAD_BYTES).toBe(32 * 1024);
+    });
+  });
+});

--- a/langwatch/src/server/utils/__tests__/capStoredPayload.unit.test.ts
+++ b/langwatch/src/server/utils/__tests__/capStoredPayload.unit.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_MAX_STORED_PAYLOAD_BYTES,
   capStoredJson,
-  capStoredText,
   utf8ByteLength,
 } from "../capStoredPayload";
 
@@ -80,46 +79,8 @@ describe("capStoredJson", () => {
   });
 });
 
-describe("capStoredText", () => {
-  describe("given a null or undefined value", () => {
-    it("returns it unchanged", () => {
-      expect(capStoredText(null)).toBeNull();
-      expect(capStoredText(undefined)).toBeUndefined();
-    });
-  });
-
-  describe("given text within the cap", () => {
-    it("returns it unchanged", () => {
-      const text = "a normal short trace output";
-      expect(capStoredText(text)).toBe(text);
-    });
-  });
-
-  describe("given text over the cap", () => {
-    const text = "y".repeat(2 * 1024 * 1024);
-    const capped = capStoredText(text, 32 * 1024);
-
-    it("stays at or under the byte cap", () => {
-      expect(utf8ByteLength(capped)).toBeLessThanOrEqual(32 * 1024);
-    });
-
-    it("appends a marker naming the original size", () => {
-      expect(capped.endsWith(`bytes total]`)).toBe(true);
-      expect(capped).toContain(String(utf8ByteLength(text)));
-    });
-  });
-
-  describe("given multibyte text right at the boundary", () => {
-    it("never throws and stays within the cap", () => {
-      const emoji = "😀".repeat(20 * 1024); // 4 bytes each
-      const capped = capStoredText(emoji, 1024);
-      expect(utf8ByteLength(capped)).toBeLessThanOrEqual(1024);
-    });
-  });
-
-  describe("default cap", () => {
-    it("is 32KB", () => {
-      expect(DEFAULT_MAX_STORED_PAYLOAD_BYTES).toBe(32 * 1024);
-    });
+describe("default cap", () => {
+  it("is 32KB", () => {
+    expect(DEFAULT_MAX_STORED_PAYLOAD_BYTES).toBe(32 * 1024);
   });
 });

--- a/langwatch/src/server/utils/__tests__/capStoredPayload.unit.test.ts
+++ b/langwatch/src/server/utils/__tests__/capStoredPayload.unit.test.ts
@@ -55,6 +55,24 @@ describe("capStoredJson", () => {
     });
   });
 
+  describe("given a cap tighter than the preview size", () => {
+    const big = { conversation: "x".repeat(1024 * 1024) };
+
+    it("keeps the placeholder within the tight cap", () => {
+      const capped = capStoredJson(big, 512);
+      expect(utf8ByteLength(capped!)).toBeLessThanOrEqual(512);
+      expect(() => JSON.parse(capped!)).not.toThrow();
+    });
+
+    it("still produces valid JSON when the cap leaves no room for a preview", () => {
+      const capped = capStoredJson(big, 64);
+      expect(() => JSON.parse(capped!)).not.toThrow();
+      const parsed = JSON.parse(capped!) as { _truncated: boolean; _preview: string };
+      expect(parsed._truncated).toBe(true);
+      expect(parsed._preview).toBe("");
+    });
+  });
+
   describe("given a value that JSON.stringify drops to undefined", () => {
     it("returns null rather than the literal string undefined", () => {
       expect(capStoredJson(() => 1)).toBeNull();

--- a/langwatch/src/server/utils/capStoredPayload.ts
+++ b/langwatch/src/server/utils/capStoredPayload.ts
@@ -1,7 +1,6 @@
 /**
- * capStoredPayload — bounds the byte-size of large text/JSON values before they
- * are written into the hot ClickHouse path (evaluation_runs.Inputs and the
- * trace-summary computedInput/Output).
+ * capStoredJson — bounds the byte-size of a large serialized-JSON value before
+ * it is written into the hot ClickHouse path (evaluation_runs.Inputs).
  *
  * Why this exists
  * ---------------
@@ -13,18 +12,11 @@
  * part-storm. Normal inputs are a couple KB; only the pathological tail is a
  * problem, so we cap by size at the write site.
  *
- * Two shapes, two helpers
- * -----------------------
- * - `capStoredJson` is for columns persisted as serialized JSON and JSON-parsed
- *   on read (evaluation_runs.Inputs). A mid-string truncation would break
- *   `JSON.parse`, so an oversized value is replaced with a small, still-valid
- *   JSON placeholder that carries the original size and a preview.
- * - `capStoredText` is for columns stored and rendered as free text
- *   (trace-summary computedInput/Output). An oversized value is truncated on a
- *   UTF-8 boundary with a human-readable marker appended.
- *
- * Both are allocation-light, never throw, and leave normal-sized values
- * byte-for-byte unchanged.
+ * The column is JSON-parsed on read, so a mid-string truncation would break
+ * `JSON.parse`. An oversized value is therefore replaced with a small,
+ * still-valid JSON placeholder that carries the original size and a preview.
+ * Allocation-light, never throws, leaves normal-sized values byte-for-byte
+ * unchanged.
  */
 
 const KB = 1024;
@@ -101,23 +93,4 @@ export function capStoredJson(
     _maxBytes: maxBytes,
     _preview: "",
   });
-}
-
-/**
- * Caps a free-text value to `maxBytes`. Returns the value unchanged when it is
- * null/undefined or within the cap; otherwise truncates on a UTF-8 boundary and
- * appends a marker naming the original size. The marker is included in the
- * budget so the result stays at or under `maxBytes`.
- */
-export function capStoredText<T extends string | null | undefined>(
-  value: T,
-  maxBytes: number = DEFAULT_MAX_STORED_PAYLOAD_BYTES,
-): T {
-  if (typeof value !== "string") return value;
-  const bytes = utf8ByteLength(value);
-  if (bytes <= maxBytes) return value;
-
-  const marker = `…[truncated: ${bytes} bytes total]`;
-  const room = Math.max(0, maxBytes - utf8ByteLength(marker));
-  return (truncateUtf8(value, room) + marker) as T;
 }

--- a/langwatch/src/server/utils/capStoredPayload.ts
+++ b/langwatch/src/server/utils/capStoredPayload.ts
@@ -1,0 +1,100 @@
+/**
+ * capStoredPayload — bounds the byte-size of large text/JSON values before they
+ * are written into the hot ClickHouse path (evaluation_runs.Inputs and the
+ * trace-summary computedInput/Output).
+ *
+ * Why this exists
+ * ---------------
+ * A few heavy-agentic tenants run evaluators over the entire growing
+ * conversation, so a single evaluator-input row can reach multiple megabytes.
+ * ClickHouse merges materialize whole granules, so one multi-MB row makes a
+ * granule larger than 2GB and a background merge can exceed the server memory
+ * cap, OOM, and stall merges cluster-wide — which is what tipped a production
+ * part-storm. Normal inputs are a couple KB; only the pathological tail is a
+ * problem, so we cap by size at the write site.
+ *
+ * Two shapes, two helpers
+ * -----------------------
+ * - `capStoredJson` is for columns persisted as serialized JSON and JSON-parsed
+ *   on read (evaluation_runs.Inputs). A mid-string truncation would break
+ *   `JSON.parse`, so an oversized value is replaced with a small, still-valid
+ *   JSON placeholder that carries the original size and a preview.
+ * - `capStoredText` is for columns stored and rendered as free text
+ *   (trace-summary computedInput/Output). An oversized value is truncated on a
+ *   UTF-8 boundary with a human-readable marker appended.
+ *
+ * Both are allocation-light, never throw, and leave normal-sized values
+ * byte-for-byte unchanged.
+ */
+
+const KB = 1024;
+
+/**
+ * Generous default cap (32KB). Normal evaluator inputs and trace IO are a few
+ * KB; this only trips on the multi-MB tail from agentic full-conversation
+ * payloads. Override per call site / via env if a tighter bound is needed.
+ */
+export const DEFAULT_MAX_STORED_PAYLOAD_BYTES = 32 * KB;
+
+/** Bytes of the original kept as a debugging preview inside a JSON placeholder. */
+const JSON_PREVIEW_BYTES = 2 * KB;
+
+/** UTF-8 byte length of a string, without allocating a Buffer copy. */
+export function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+/**
+ * Truncates a string to at most `maxBytes` UTF-8 bytes. A trailing multibyte
+ * sequence cut by the slice decodes to the replacement char, which is fine for
+ * a preview / display value.
+ */
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  if (utf8ByteLength(value) <= maxBytes) return value;
+  return Buffer.from(value, "utf8").subarray(0, maxBytes).toString("utf8");
+}
+
+/**
+ * Serializes `value` to JSON, capping the result to `maxBytes`. Returns null for
+ * null/undefined (matching the column's nullable contract). When the serialized
+ * value exceeds the cap, returns a small placeholder object (still valid JSON)
+ * describing what was cut, so downstream `JSON.parse` stays valid.
+ */
+export function capStoredJson(
+  value: unknown,
+  maxBytes: number = DEFAULT_MAX_STORED_PAYLOAD_BYTES,
+): string | null {
+  if (value == null) return null;
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) return null;
+
+  const bytes = utf8ByteLength(serialized);
+  if (bytes <= maxBytes) return serialized;
+
+  return JSON.stringify({
+    _truncated: true,
+    _originalBytes: bytes,
+    _maxBytes: maxBytes,
+    _preview: truncateUtf8(serialized, JSON_PREVIEW_BYTES),
+  });
+}
+
+/**
+ * Caps a free-text value to `maxBytes`. Returns the value unchanged when it is
+ * null/undefined or within the cap; otherwise truncates on a UTF-8 boundary and
+ * appends a marker naming the original size. The marker is included in the
+ * budget so the result stays at or under `maxBytes`.
+ */
+export function capStoredText<T extends string | null | undefined>(
+  value: T,
+  maxBytes: number = DEFAULT_MAX_STORED_PAYLOAD_BYTES,
+): T {
+  if (typeof value !== "string") return value;
+  const bytes = utf8ByteLength(value);
+  if (bytes <= maxBytes) return value;
+
+  const marker = `…[truncated: ${bytes} bytes total]`;
+  const room = Math.max(0, maxBytes - utf8ByteLength(marker));
+  return (truncateUtf8(value, room) + marker) as T;
+}

--- a/langwatch/src/server/utils/capStoredPayload.ts
+++ b/langwatch/src/server/utils/capStoredPayload.ts
@@ -36,8 +36,15 @@ const KB = 1024;
  */
 export const DEFAULT_MAX_STORED_PAYLOAD_BYTES = 32 * KB;
 
-/** Bytes of the original kept as a debugging preview inside a JSON placeholder. */
+/** Upper bound on the debugging preview kept inside a JSON placeholder. */
 const JSON_PREVIEW_BYTES = 2 * KB;
+
+/**
+ * Generous allowance for the placeholder's fixed parts (the metadata keys, the
+ * numeric values, and JSON punctuation) so the preview budget leaves room for
+ * them under a tight cap.
+ */
+const PLACEHOLDER_OVERHEAD_BYTES = 128;
 
 /** UTF-8 byte length of a string, without allocating a Buffer copy. */
 export function utf8ByteLength(value: string): number {
@@ -72,11 +79,27 @@ export function capStoredJson(
   const bytes = utf8ByteLength(serialized);
   if (bytes <= maxBytes) return serialized;
 
+  // Bound the preview by the cap, not just the fixed upper limit, so a caller
+  // passing a tighter maxBytes still gets a placeholder within the cap.
+  const previewBudget = Math.max(
+    0,
+    Math.min(JSON_PREVIEW_BYTES, maxBytes - PLACEHOLDER_OVERHEAD_BYTES),
+  );
+  const placeholder = JSON.stringify({
+    _truncated: true,
+    _originalBytes: bytes,
+    _maxBytes: maxBytes,
+    _preview: truncateUtf8(serialized, previewBudget),
+  });
+  // JSON-escaping the preview can expand it past the budget; if the placeholder
+  // still exceeds the cap, drop the preview so the result is guaranteed within
+  // maxBytes (the no-preview skeleton fits any realistic cap).
+  if (utf8ByteLength(placeholder) <= maxBytes) return placeholder;
   return JSON.stringify({
     _truncated: true,
     _originalBytes: bytes,
     _maxBytes: maxBytes,
-    _preview: truncateUtf8(serialized, JSON_PREVIEW_BYTES),
+    _preview: "",
   });
 }
 


### PR DESCRIPTION
## Summary

A production ClickHouse part-storm was caused by **fat payloads in the hot path**, not by event multiplication or a uniform code regression. A few heavy-agentic tenants run evaluators over the entire growing conversation, so a single `evaluation_runs.Inputs` row can reach multiple megabytes (one tenant averaged ~712 KiB per input, max ~5.14 MiB, and alone accounted for ~94% of the week's `Inputs` bytes while being only ~12% of rows). ClickHouse merges materialize whole granules, so one multi-MB row makes a granule larger than 2GB and a background merge can exceed the server memory cap, OOM, and stall merges cluster-wide. That stuck eval-inputs merge competing for the memory budget is what tipped the cluster into the insert cliff.

This PR closes the **new-row** side of that: it bounds the evaluator `Inputs` at the write site so a pathological input can never again produce a granule big enough to OOM a merge.

## What this changes

- New `capStoredJson` util (server-side, never throws, leaves normal-sized values byte-for-byte unchanged): for `evaluation_runs.Inputs`, which is JSON-parsed on read. An oversized value is replaced with a small **still-valid-JSON** placeholder carrying the original byte size and a 2KB preview, so downstream `JSON.parse` / `safeJsonParse` stay valid. The preview budget is bounded by the cap so the placeholder itself always fits within `maxBytes`.
- Wired `capStoredJson` into the eval-run ClickHouse repository write (the dominant ~94%-of-bytes lever).
- Generous **32KB** default cap. Normal evaluator inputs are a couple KB, so only the multi-MB tail is affected.

## Scope

Intentionally limited to `evaluation_runs.Inputs`. An earlier revision also capped the trace-summary `computedInput/Output`; that was dropped on request because that column is customer-visible trace observability and was not a merge driver (it measured flat ~4-7 KiB across the incident window). The acute fix is the eval-Inputs cap.

## Out of scope (companion ops work, tracked separately)

- The **existing** fat rows and the currently stuck OOM-retrying merge will not shrink on their own (TTL-to-cold does not reduce merge memory). Those need a one-time clear: temporarily lowering `max_bytes_to_merge_at_max_space_in_pool` so ClickHouse stops attempting the >7GB merge, then a targeted re-upsert of the fattest rows (ReplacingMergeTree collapse) once this cap is deployed. Reversible config, no memory increase.
- An **aggregate / per-trace span cap** for the `gen_ai.input.messages` pattern (the other large-merge source) is a separate product tradeoff (it truncates real conversation content shown in traces) and is not bundled here.

## Test plan

- [x] `capStoredJson` unit tests: null passthrough, within-cap byte-for-byte passthrough, over-cap placeholder stays valid JSON with original size + preview, multi-MB collapse stays under cap, tight-cap (<2KB) placeholder still within cap + empty-preview fallback.
- [x] Existing `trace-io-accumulation.service` unit tests still pass (that file is unchanged from main).