### PR TITLE
feat(scopes): adr-021 follow-ups (NOT NULL anchors, custom-role scope gate, model-cost scope selector)

### DIFF
--- a/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
@@ -701,6 +701,7 @@ describe("aiToolsRouter integration", () => {
           name: `org-anthropic-${ns}`,
           provider: "anthropic",
           enabled: true,
+          organizationId,
           scopes: {
             create: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
           },
@@ -711,6 +712,7 @@ describe("aiToolsRouter integration", () => {
           name: `pf-openai-${ns}`,
           provider: "openai",
           enabled: true,
+          organizationId,
           scopes: {
             create: [{ scopeType: "TEAM", scopeId: teamPlatformId }],
           },
@@ -721,6 +723,7 @@ describe("aiToolsRouter integration", () => {
           name: `ds-azure-${ns}`,
           provider: "azure",
           enabled: true,
+          organizationId,
           scopes: {
             create: [{ scopeType: "TEAM", scopeId: teamDataScienceId }],
           },

--- a/langwatch/ee/governance/services/__tests__/personalVirtualKey.service.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/personalVirtualKey.service.integration.test.ts
@@ -99,6 +99,7 @@ describe("PersonalVirtualKeyService (real DB)", () => {
         name: `pvk-mp-${suffix}`,
         provider: "openai",
         enabled: true,
+        organizationId: ORG_ID,
         scopes: {
           create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],
         },

--- a/langwatch/prisma/migrations/20260530120000_model_provider_default_config_org_not_null/migration.sql
+++ b/langwatch/prisma/migrations/20260530120000_model_provider_default_config_org_not_null/migration.sql
@@ -1,0 +1,19 @@
+-- Tighten the ModelProvider + ModelDefaultConfig organization anchor to NOT
+-- NULL (ADR-021 follow-up to 20260529130000_model_provider_default_config_org_anchor).
+--
+-- The anchor was added nullable so the backfill could resolve each row's org
+-- from its scope rows. Any row still NULL after that backfill had only
+-- orphaned scopes (pointing at a deleted team/project) or no scopes at all, so
+-- it is unreachable through the scope-based access path and safe to remove.
+-- Delete those dead rows, then enforce the anchor.
+
+DELETE FROM "ModelProvider" WHERE "organizationId" IS NULL;
+DELETE FROM "ModelDefaultConfig" WHERE "organizationId" IS NULL;
+
+ALTER TABLE "ModelProvider" ALTER COLUMN "organizationId" SET NOT NULL;
+ALTER TABLE "ModelDefaultConfig" ALTER COLUMN "organizationId" SET NOT NULL;
+
+-- To roll back, uncomment and run manually (the deleted dead rows are not
+-- recoverable, but the constraint relaxation is):
+-- ALTER TABLE "ModelDefaultConfig" ALTER COLUMN "organizationId" DROP NOT NULL;
+-- ALTER TABLE "ModelProvider" ALTER COLUMN "organizationId" DROP NOT NULL;

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -843,9 +843,7 @@ model ModelProvider {
 
   // Single-organization tenancy anchor (ADR-021). Every scope of a given
   // provider resolves to the same organization, so this column is that org.
-  // Nullable for one release while the production backfill is verified; set
-  // NOT NULL in a follow-up migration.
-  organizationId         String?
+  organizationId         String
 
   @@index([healthStatus])
   @@index([fallbackPriorityGlobal])
@@ -923,9 +921,8 @@ model ModelDefaultConfig {
     scopes    ModelDefaultConfigScope[]
 
     // Single-organization tenancy anchor (ADR-021). Every scope a config
-    // attaches to resolves to the same organization. Nullable for one release
-    // while the production backfill is verified; set NOT NULL in a follow-up.
-    organizationId String?
+    // attaches to resolves to the same organization.
+    organizationId String
 
     @@index([organizationId])
 }

--- a/langwatch/prisma/seed.ts
+++ b/langwatch/prisma/seed.ts
@@ -64,6 +64,7 @@ async function main() {
   const defaultConfig = await prisma.modelDefaultConfig.create({
     data: {
       id: nanoid(),
+      organizationId: organization.id,
       config: {
         DEFAULT: "openai/gpt-5-mini",
         FAST: "openai/gpt-5-mini",

--- a/langwatch/scripts/dogfood/governance/seed-personas.ts
+++ b/langwatch/scripts/dogfood/governance/seed-personas.ts
@@ -194,6 +194,7 @@ export async function runSeedPersonas(
           name: "OpenAI",
           provider: "openai",
           enabled: true,
+          organizationId: org.id,
           // customKeys is an AES-GCM encrypted JSON blob, not a plain
           // object. config.materialiser decrypts and pick()s
           // OPENAI_API_KEY before handing it to the gateway. Empty {}

--- a/langwatch/scripts/dogfood/governance/setup-test-provider.ts
+++ b/langwatch/scripts/dogfood/governance/setup-test-provider.ts
@@ -36,7 +36,7 @@ async function main(): Promise<void> {
   } else {
     const created = await prisma.modelProvider.create({
       data: {
-        projectId: project.id,
+        organizationId: org.id,
         name: "OpenAI",
         provider: "openai",
         enabled: true,

--- a/langwatch/scripts/seed-governance-refactor-dogfood.ts
+++ b/langwatch/scripts/seed-governance-refactor-dogfood.ts
@@ -313,6 +313,7 @@ async function upsertModelProviderByName(input: {
       name: input.name,
       provider: input.provider,
       enabled: true,
+      organizationId: input.organizationId,
       customKeys: input.customKeys
         ? (input.customKeys as Prisma.InputJsonValue)
         : Prisma.DbNull,

--- a/langwatch/src/app/api/model-providers/__tests__/model-providers-api.integration.test.ts
+++ b/langwatch/src/app/api/model-providers/__tests__/model-providers-api.integration.test.ts
@@ -115,6 +115,7 @@ describe("Model Providers API", () => {
             name: "OpenAI",
             provider: "openai",
             enabled: true,
+            organizationId: testOrganization.id,
             customKeys: { OPENAI_API_KEY: "sk-real-key-12345" },
             scopes: {
               create: [{ scopeType: "PROJECT", scopeId: testProjectId }],
@@ -185,6 +186,7 @@ describe("Model Providers API", () => {
             name: "OpenAI",
             provider: "openai",
             enabled: true,
+            organizationId: testOrganization.id,
             customKeys: { OPENAI_API_KEY: "sk-original-key" },
             scopes: {
               create: [{ scopeType: "PROJECT", scopeId: testProjectId }],

--- a/langwatch/src/app/api/prompts/__tests__/prompts-api.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/prompts-api.integration.test.ts
@@ -103,6 +103,7 @@ describe("Prompts API", () => {
     const seededDefault = await prisma.modelDefaultConfig.create({
       data: {
         config: { DEFAULT: "openai/gpt-4o-mini" },
+        organizationId: testOrganization.id,
         scopes: {
           create: [{ scopeType: "PROJECT", scopeId: testProjectId }],
         },

--- a/langwatch/src/app/api/prompts/__tests__/shorthand-prompt-syntax.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/shorthand-prompt-syntax.integration.test.ts
@@ -70,6 +70,7 @@ describe("Feature: Shorthand prompt tag syntax (REST API)", () => {
     const seededDefault = await prisma.modelDefaultConfig.create({
       data: {
         config: { DEFAULT: "openai/gpt-4o-mini" },
+        organizationId: testOrganization.id,
         scopes: {
           create: [
             { scopeType: "ORGANIZATION", scopeId: testOrganization.id },

--- a/langwatch/src/components/settings/LLMModelCostDrawer.tsx
+++ b/langwatch/src/components/settings/LLMModelCostDrawer.tsx
@@ -1,4 +1,5 @@
 import { Button, Field, Heading, HStack, Input, Text } from "@chakra-ui/react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useDrawer } from "~/hooks/useDrawer";
 import { Drawer } from "../../components/ui/drawer";
@@ -10,6 +11,10 @@ import { api } from "../../utils/api";
 import { isSafeRegex } from "../../utils/safeRegex";
 import { isHandledByGlobalHandler } from "../../utils/trpcError";
 import { HorizontalFormControl } from "../HorizontalFormControl";
+import {
+  ScopeChipPicker,
+  type ScopeChipPickerEntry,
+} from "./ScopeChipPicker";
 
 export function LLMModelCostDrawer({
   id,
@@ -61,7 +66,7 @@ function LLMModelCostForm({
   cloneModel?: string;
   llmModelCosts: MaybeStoredLLMModelCost[];
 }) {
-  const { project } = useOrganizationTeamProject();
+  const { organization, team, project } = useOrganizationTeamProject();
 
   const { closeDrawer } = useDrawer();
   const createOrUpdate = api.llmModelCost.createOrUpdate.useMutation();
@@ -89,6 +94,24 @@ function LLMModelCostForm({
     regex: string;
   };
 
+  // Single-organization scope this cost applies to (ADR-021). Editing keeps
+  // the row's scope; new/cloned rows default to the current project. The
+  // org/team rows let an admin push one cost policy down the cascade
+  // (PROJECT -> TEAM -> ORGANIZATION) instead of every project re-entering it.
+  const [scope, setScope] = useState<ScopeChipPickerEntry[]>(() => {
+    if (currentLLMModelCost?.scopeType && currentLLMModelCost?.scopeId) {
+      return [
+        {
+          scopeType: currentLLMModelCost.scopeType,
+          scopeId: currentLLMModelCost.scopeId,
+        },
+      ];
+    }
+    return project?.id
+      ? [{ scopeType: "PROJECT", scopeId: project.id }]
+      : [];
+  });
+
   const {
     register,
     handleSubmit,
@@ -110,6 +133,8 @@ function LLMModelCostForm({
     const optionalRate = (value: number | undefined) =>
       value == null || isNaN(value) ? undefined : value;
 
+    const selectedScope = scope[0];
+
     createOrUpdate.mutate(
       {
         id,
@@ -120,6 +145,8 @@ function LLMModelCostForm({
         cacheReadCostPerToken: optionalRate(data.cacheReadCostPerToken),
         cacheCreationCostPerToken: optionalRate(data.cacheCreationCostPerToken),
         projectId: project.id,
+        scopeType: selectedScope?.scopeType,
+        scopeId: selectedScope?.scopeId,
       },
       {
         onSuccess: () => {
@@ -157,6 +184,26 @@ function LLMModelCostForm({
     <>
       {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
       <form onSubmit={handleSubmit(onSubmit)}>
+        <HorizontalFormControl
+          label="Applies to"
+          helper="Pick the scope this cost rule applies to. Project-level rules override team-level, which override organization-level."
+        >
+          <ScopeChipPicker
+            label=""
+            singleSelect
+            value={scope}
+            onChange={setScope}
+            organizationId={organization?.id}
+            organizationName={organization?.name}
+            teamId={team?.id}
+            teamName={team?.name}
+            projectId={project?.id}
+            projectName={project?.name}
+            currentOrganizationId={organization?.id}
+            currentTeamId={team?.id}
+            currentProjectId={project?.id}
+          />
+        </HorizontalFormControl>
         <HorizontalFormControl
           label="Model Name"
           helper="Identifier for your LLM model cost rule"

--- a/langwatch/src/components/settings/ScopeChipPicker.tsx
+++ b/langwatch/src/components/settings/ScopeChipPicker.tsx
@@ -185,6 +185,7 @@ export function ScopeChipPicker({
   label = "Scope",
   showSummary = true,
   showQuickPicks = false,
+  singleSelect = false,
   currentOrganizationId,
   currentTeamId,
   currentProjectId,
@@ -205,6 +206,12 @@ export function ScopeChipPicker({
   label?: string;
   /** When false, hides the helper "Shared across …" line below the field. */
   showSummary?: boolean;
+  /** Single-scope mode: a row may live at exactly one scope (inline
+   *  (scopeType, scopeId) resources like model costs / budgets). Renders the
+   *  org/team/project quick-pick chips as a single-select, drops the
+   *  "Multiple" chip and the multi-select dropdown entirely. `value` is still
+   *  an array but holds at most one entry. */
+  singleSelect?: boolean;
   /** When true, render the Organization/Team/Project quick-pick chip
    *  row above the field and collapse the multi-select dropdown by
    *  default. Clicking the 4th "Multiple" chip (CheckCheck icon)
@@ -342,12 +349,12 @@ export function ScopeChipPicker({
     if (derivedMultiple) setMultipleMode(true);
   }, [derivedMultiple]);
 
-  const dropdownVisible = !showQuickPicks || multipleMode;
+  const dropdownVisible = singleSelect ? false : !showQuickPicks || multipleMode;
 
   return (
     <VStack align="start" width="full" gap={1.5}>
       {label && <SmallLabel>{label}</SmallLabel>}
-      {showQuickPicks && quickPicks.length > 0 && (
+      {(showQuickPicks || singleSelect) && quickPicks.length > 0 && (
         <Wrap gap={2} role="group" aria-label="Quick scope">
           {quickPicks.map((pick) => {
             const active = matchingQuickPick?.key === pick.key && !multipleMode;
@@ -375,20 +382,23 @@ export function ScopeChipPicker({
               one-scope case but exposes the multi-select dropdown for
               the long tail (one policy attached to N projects /
               cross-team rules). Active whenever the current selection
-              doesn't reduce to a single quick-pick scope. */}
-          <Button
-            type="button"
-            size="xs"
-            variant={multipleMode ? "solid" : "outline"}
-            aria-pressed={multipleMode}
-            onClick={() => setMultipleMode(true)}
-            data-testid="quick-scope-multiple"
-          >
-            <HStack gap={1}>
-              <CheckCheck size={14} aria-hidden />
-              <Text>Multiple</Text>
-            </HStack>
-          </Button>
+              doesn't reduce to a single quick-pick scope. Hidden in
+              single-scope mode, where multi-scope is not representable. */}
+          {!singleSelect && (
+            <Button
+              type="button"
+              size="xs"
+              variant={multipleMode ? "solid" : "outline"}
+              aria-pressed={multipleMode}
+              onClick={() => setMultipleMode(true)}
+              data-testid="quick-scope-multiple"
+            >
+              <HStack gap={1}>
+                <CheckCheck size={14} aria-hidden />
+                <Text>Multiple</Text>
+              </HStack>
+            </Button>
+          )}
         </Wrap>
       )}
       {dropdownVisible && (

--- a/langwatch/src/components/settings/ScopeChipPicker.tsx
+++ b/langwatch/src/components/settings/ScopeChipPicker.tsx
@@ -210,7 +210,9 @@ export function ScopeChipPicker({
    *  (scopeType, scopeId) resources like model costs / budgets). Renders the
    *  org/team/project quick-pick chips as a single-select, drops the
    *  "Multiple" chip and the multi-select dropdown entirely. `value` is still
-   *  an array but holds at most one entry. */
+   *  an array; the component collapses it to its first entry and never emits
+   *  more than one, so the single-scope contract holds even if a caller passes
+   *  a longer array. */
   singleSelect?: boolean;
   /** When true, render the Organization/Team/Project quick-pick chip
    *  row above the field and collapse the multi-select dropdown by
@@ -282,9 +284,14 @@ export function ScopeChipPicker({
     [options],
   );
 
+  // In single-scope mode the picker represents exactly one scope, so the
+  // value it operates on is collapsed to the first entry. In multi-scope mode
+  // this is identical to `value`, so nothing downstream changes.
+  const scopes = singleSelect ? value.slice(0, 1) : value;
+
   const selectedValues = useMemo(
-    () => value.map((s) => `${s.scopeType}:${s.scopeId}`),
-    [value],
+    () => scopes.map((s) => `${s.scopeType}:${s.scopeId}`),
+    [scopes],
   );
 
   // Quick-pick row + collapsible-multi mode. See `showQuickPicks` prop.
@@ -323,15 +330,15 @@ export function ScopeChipPicker({
   }, [currentOrganizationId, currentTeamId, currentProjectId]);
 
   const matchingQuickPick = useMemo(() => {
-    if (value.length !== 1) return null;
-    const s = value[0]!;
+    if (scopes.length !== 1) return null;
+    const s = scopes[0]!;
     return (
       quickPicks.find(
         (qp) =>
           qp.scope.scopeType === s.scopeType && qp.scope.scopeId === s.scopeId,
       ) ?? null
     );
-  }, [value, quickPicks]);
+  }, [scopes, quickPicks]);
 
   // `multipleMode` is local UI state: when true the dropdown is
   // visible and the "Multiple" chip is highlighted. Derived from the
@@ -412,7 +419,7 @@ export function ScopeChipPicker({
             .filter((o) => picked.has(o.value))
             .map((o) => ({ scopeType: o.scopeType, scopeId: o.scopeId }));
           onChange(
-            collapseRedundantScopes(next, value, {
+            collapseRedundantScopes(next, scopes, {
               organizationId,
               availableProjects:
                 availableProjects && availableProjects.length > 0
@@ -427,14 +434,14 @@ export function ScopeChipPicker({
         <Select.Trigger>
           <Select.ValueText placeholder="Pick one or more scopes">
             {() => {
-              if (value.length === 0) return "Pick one or more scopes";
+              if (scopes.length === 0) return "Pick one or more scopes";
               // Hydrate the chips with names looked up from the picker's
               // `options` so each chip reads "LangWatch" / "Acme Team" /
               // "web-app" instead of bare "Organization" / "Team" /
               // "Project". Without this, multiple teams render as
               // identical "Team", "Team" pills — the bug rchaves caught
               // in the model-provider drawer screenshot.
-              const named = value.map((v) => {
+              const named = scopes.map((v) => {
                 const match = options.find(
                   (o) =>
                     o.scopeType === v.scopeType && o.scopeId === v.scopeId,
@@ -498,7 +505,7 @@ export function ScopeChipPicker({
       {showSummary && (
         <Box>
           <Text fontSize="xs" color="gray.600">
-            {summariseSelection(value)}
+            {summariseSelection(scopes)}
           </Text>
         </Box>
       )}

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -108,6 +108,51 @@ export type Resource = (typeof Resources)[keyof typeof Resources];
  */
 export type Permission = `${Resource}:${Action}`;
 
+/**
+ * Resources that only exist at the organization tier — there is no team- or
+ * project-scoped meaning for them (the AI Governance family plus the
+ * organization resource itself). Org-tier authority comes only from an
+ * ORGANIZATION-scoped RoleBinding; a TEAM- or PROJECT-scoped binding must
+ * never grant a permission on one of these, even via a custom role that lists
+ * it. This is the defense the scope-chain resolvers apply so a custom role
+ * misconfigured below the org tier can't escalate to organization:manage,
+ * governance:manage, anomalyRules:manage, and so on (ADR-021).
+ *
+ * Gateway + core resources (virtualKeys, gatewayBudgets, datasets, workflows,
+ * …) are deliberately NOT here: they are legitimately accessible at team and
+ * project scope, so team/project bindings may grant them.
+ */
+const ORG_EXCLUSIVE_RESOURCES: ReadonlySet<Resource> = new Set<Resource>([
+  Resources.ORGANIZATION,
+  Resources.GOVERNANCE,
+  Resources.INGESTION_SOURCES,
+  Resources.ANOMALY_RULES,
+  Resources.COMPLIANCE_EXPORT,
+  Resources.ACTIVITY_MONITOR,
+  Resources.AI_TOOLS,
+]);
+
+/** True when the permission targets an organization-tier-only resource. */
+export function isOrgExclusivePermission(permission: Permission): boolean {
+  const resource = permission.split(":")[0] as Resource;
+  return ORG_EXCLUSIVE_RESOURCES.has(resource);
+}
+
+/**
+ * Whether a binding at `scopeType` may grant `permission`. Org-exclusive
+ * permissions require an ORGANIZATION-scoped binding; everything else is
+ * grantable at any scope. Both the tRPC resolver (`checkPermissionFromBindings`)
+ * and the gateway resolver (`checkRoleBindingPermission`) gate on this so the
+ * rule holds no matter which path evaluates the binding.
+ */
+export function bindingScopeCanGrant(
+  scopeType: RoleBindingScopeType,
+  permission: Permission,
+): boolean {
+  if (scopeType === RoleBindingScopeType.ORGANIZATION) return true;
+  return !isOrgExclusivePermission(permission);
+}
+
 // ============================================================================
 // ROLE DEFINITIONS
 // ============================================================================
@@ -711,6 +756,11 @@ async function checkPermissionFromBindings({
     });
 
     if (!teamUser) return false;
+    // Legacy team membership is a TEAM-scoped grant, so it can't confer an
+    // org-exclusive permission even through a custom role (ADR-021).
+    if (!bindingScopeCanGrant(RoleBindingScopeType.TEAM, permission)) {
+      return false;
+    }
     return resolveBindingPermission(
       { role: teamUser.role, customRoleId: teamUser.assignedRoleId ?? null },
       organizationRole,
@@ -721,6 +771,10 @@ async function checkPermissionFromBindings({
 
   // Union permissions across ALL matching bindings — permitted if any grants it
   for (const binding of bindings) {
+    // A team/project binding can never grant an org-exclusive permission,
+    // even via a custom role that lists it (ADR-021).
+    if (!bindingScopeCanGrant(binding.scopeType, permission)) continue;
+
     // Org-scoped bindings: ADMIN grants everything; MEMBER grants org-level permissions only.
     // ORG-scoped MEMBER bindings do NOT imply any team- or project-level access — team/project
     // access requires a TEAM- or PROJECT-scoped binding. Only org:* permissions are checked here.
@@ -991,6 +1045,13 @@ export async function hasOrganizationPermission(
   // personal workspace. A personal team's legitimate ADMIN power is
   // team-scoped and flows through its TEAM-scoped RoleBinding, never this
   // org-wide union.
+  // The team-membership union below is a TEAM-scoped grant applied to an
+  // org-level check; org-exclusive permissions (organization:* / governance
+  // family) are never conferred through it — only an ORGANIZATION-scoped
+  // binding can (ADR-021). Gateway/audit resources stay grantable here.
+  if (!bindingScopeCanGrant(RoleBindingScopeType.TEAM, permission)) {
+    return false;
+  }
   const teamMemberships = await ctx.prisma.teamUser.findMany({
     where: { userId, team: { organizationId, isPersonal: false } },
     select: { role: true, assignedRoleId: true },
@@ -1110,6 +1171,9 @@ export async function batchScopePermissions(
     customRoleId: string | null;
     scopeType: RoleBindingScopeType;
   }): boolean => {
+    // A team/project binding can never grant an org-exclusive permission,
+    // even via a custom role that lists it (ADR-021).
+    if (!bindingScopeCanGrant(binding.scopeType, args.permission)) return false;
     if (binding.customRoleId) {
       const custom = customRoleById.get(binding.customRoleId);
       if (custom) {

--- a/langwatch/src/server/api/routers/__tests__/personalVirtualKeys.scopeRbac.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/personalVirtualKeys.scopeRbac.integration.test.ts
@@ -153,6 +153,7 @@ describe("personalVirtualKeys — scope-aware RBAC", () => {
         name: MODEL_PROVIDER_ID,
         provider: "openai",
         enabled: true,
+        organizationId: ORG_ID,
         scopes: { create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }] },
       },
     });

--- a/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
+++ b/langwatch/src/server/gateway/__tests__/config.materialiser.integration.test.ts
@@ -142,6 +142,7 @@ describe("GatewayConfigMaterialiser — real PG end-to-end", () => {
         name: "openai",
         provider: "openai",
         enabled: true,
+        organizationId: ORG_ID,
         customKeys: {},
         scopes: {
           create: [{ scopeType: "ORGANIZATION", scopeId: ORG_ID }],

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.integration.test.ts
@@ -5,14 +5,15 @@
  * Tests real database operations with real AES-256-GCM encryption.
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getTestUser } from "../../../utils/testUtils";
+import { getTestProject, getTestUser } from "../../../utils/testUtils";
 import { prisma } from "../../db";
 import { ModelProviderRepository } from "../modelProvider.repository";
 import { generate } from "@langwatch/ksuid";
 import { KSUID_RESOURCES } from "../../../utils/constants";
 import main from "../../../tasks/migrateModelProviderKeys";
 
-const projectId = "test-project-id";
+let projectId: string;
+let organizationId: string;
 
 describe("ModelProviderRepository Integration", () => {
   const repository = new ModelProviderRepository(prisma);
@@ -20,6 +21,16 @@ describe("ModelProviderRepository Integration", () => {
 
   beforeAll(async () => {
     await getTestUser();
+
+    // Seed a real org/team/project so repository.create can resolve the
+    // mandatory organizationId anchor from the project (ADR-021).
+    const project = await getTestProject("modelprovider-repo");
+    projectId = project.id;
+    const team = await prisma.team.findUnique({
+      where: { id: project.teamId },
+      select: { organizationId: true },
+    });
+    organizationId = team!.organizationId;
 
     // Ensure CREDENTIALS_SECRET is set for encryption
     if (!process.env.CREDENTIALS_SECRET) {
@@ -86,6 +97,7 @@ describe("ModelProviderRepository Integration", () => {
             name: "Azure OpenAI",
             provider: "azure",
             enabled: true,
+            organizationId,
             customKeys: { OPENAI_API_KEY: "sk-legacy-key" },
             scopes: {
               create: [{ scopeType: "PROJECT", scopeId: projectId }],
@@ -143,6 +155,7 @@ describe("ModelProviderRepository Integration", () => {
             name: "Cohere",
             provider: "cohere",
             enabled: true,
+            organizationId,
             customKeys: { COHERE_API_KEY: "sk-plain" },
             scopes: {
               create: [{ scopeType: "PROJECT", scopeId: projectId }],
@@ -161,6 +174,7 @@ describe("ModelProviderRepository Integration", () => {
             name: "Mistral",
             provider: "mistral",
             enabled: true,
+            organizationId,
             customKeys: undefined,
             scopes: {
               create: [{ scopeType: "PROJECT", scopeId: projectId }],

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
@@ -97,7 +97,7 @@ function createModelProvider(
     disabledAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
-    organizationId: null,
+    organizationId: "org_test",
     scopes: scopes ?? [createScope("PROJECT", seedProjectId, id)],
     ...rest,
   };
@@ -479,6 +479,14 @@ describe("ModelProviderRepository", () => {
   });
 
   describe("create()", () => {
+    beforeEach(() => {
+      // create() resolves the org anchor from the project (ADR-021), so the
+      // project must resolve to an organization.
+      (prisma.project.findUnique as any).mockResolvedValue({
+        team: { organizationId: "org_test" },
+      });
+    });
+
     describe("when customKeys are provided", () => {
       it("encrypts customKeys before storing", async () => {
         const keys = { OPENAI_API_KEY: "sk-secret" };

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
@@ -530,6 +530,40 @@ describe("ModelProviderRepository", () => {
         expect(createCall.data.customKeys).toBeUndefined();
       });
     });
+
+    describe("when scopes resolve to different organizations", () => {
+      it("rejects the create instead of persisting cross-org scope rows", async () => {
+        await expect(
+          repository.create({
+            projectId: "proj_test",
+            name: "OpenAI",
+            provider: "openai",
+            enabled: true,
+            scopes: [
+              { scopeType: "ORGANIZATION", scopeId: "org_a" },
+              { scopeType: "ORGANIZATION", scopeId: "org_b" },
+            ],
+          }),
+        ).rejects.toThrow(/same organization/);
+        expect(prisma.modelProvider.create as any).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a scope does not resolve to an organization", () => {
+      it("rejects the create", async () => {
+        (prisma.project.findUnique as any).mockResolvedValue(null);
+
+        await expect(
+          repository.create({
+            projectId: "proj_orphan",
+            name: "OpenAI",
+            provider: "openai",
+            enabled: true,
+          }),
+        ).rejects.toThrow(/organization/);
+        expect(prisma.modelProvider.create as any).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("update()", () => {

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.repository.unit.test.ts
@@ -21,6 +21,7 @@ function createMockPrisma() {
   return {
     modelProvider: {
       findFirst: vi.fn(),
+      findUnique: vi.fn(),
       findMany: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
@@ -598,6 +599,40 @@ describe("ModelProviderRepository", () => {
 
         const updateCall = (prisma.modelProvider.update as any).mock.calls[0][0];
         expect(updateCall.data.customKeys).toBeUndefined();
+      });
+    });
+
+    describe("when replacing scopes with a different organization", () => {
+      it("rejects the update so a credential can't be rebound across tenants", async () => {
+        (prisma.modelProvider.findUnique as any).mockResolvedValue({
+          organizationId: "org_existing",
+        });
+
+        await expect(
+          repository.update("mp_test123", "proj_test", {
+            scopes: [{ scopeType: "ORGANIZATION", scopeId: "org_other" }],
+          }),
+        ).rejects.toThrow(/organization/);
+        expect(prisma.modelProviderScope.deleteMany as any).not.toHaveBeenCalled();
+        expect(prisma.modelProviderScope.createMany as any).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when replacing scopes within the same organization", () => {
+      it("deletes and recreates the scope rows", async () => {
+        (prisma.modelProvider.findUnique as any).mockResolvedValue({
+          organizationId: "org_existing",
+        });
+        (prisma.modelProvider.update as any).mockResolvedValue(
+          createModelProvider(),
+        );
+
+        await repository.update("mp_test123", "proj_test", {
+          scopes: [{ scopeType: "ORGANIZATION", scopeId: "org_existing" }],
+        });
+
+        expect(prisma.modelProviderScope.deleteMany as any).toHaveBeenCalledTimes(1);
+        expect(prisma.modelProviderScope.createMany as any).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/langwatch/src/server/modelProviders/modelDefaults.repository.ts
+++ b/langwatch/src/server/modelProviders/modelDefaults.repository.ts
@@ -135,6 +135,26 @@ export class ModelDefaultsRepository {
       );
     }
     const prisma = this.prisma as PrismaClient;
+    // Single-organization invariant (ADR-021): newly attached scopes must
+    // resolve to the same org the config is already anchored to. Otherwise this
+    // path could attach cross-org or orphaned scopes while organizationId stays
+    // pinned to the old tenant — the inconsistency create() now prevents.
+    if (params.toAdd.length > 0) {
+      const organizationId = await resolveSingleOrganizationForScopes(
+        prisma,
+        params.toAdd,
+        "model default config",
+      );
+      const existing = await prisma.modelDefaultConfig.findUnique({
+        where: { id: params.id },
+        select: { organizationId: true },
+      });
+      if (existing && existing.organizationId !== organizationId) {
+        throw new Error(
+          "Cannot update model default config: scopes must stay within the config's organization",
+        );
+      }
+    }
     await prisma.$transaction([
       prisma.modelDefaultConfig.update({
         where: { id: params.id },

--- a/langwatch/src/server/modelProviders/modelDefaults.repository.ts
+++ b/langwatch/src/server/modelProviders/modelDefaults.repository.ts
@@ -78,16 +78,23 @@ export class ModelDefaultsRepository {
   }): Promise<{ id: string }> {
     const id = this.newConfigId();
     // Single-organization anchor (ADR-021): every scope a config attaches to
-    // resolves to the same org, so the first scope is authoritative.
-    const organizationId = params.scopes[0]
-      ? await resolveOrganizationForScope(this.prisma, params.scopes[0])
+    // resolves to the same org, so the first scope is authoritative. The
+    // column is NOT NULL, so an unresolvable scope is a hard error.
+    const firstScope = params.scopes[0];
+    const organizationId = firstScope
+      ? await resolveOrganizationForScope(this.prisma, firstScope)
       : null;
+    if (!organizationId) {
+      throw new Error(
+        "Cannot create model default config: scope does not resolve to an organization",
+      );
+    }
     await this.prisma.modelDefaultConfig.create({
       data: {
         id,
         config: params.config,
         authorId: params.authorId,
-        organizationId: organizationId ?? undefined,
+        organizationId,
         scopes: {
           create: params.scopes.map((s) => ({
             id: this.newScopeId(),

--- a/langwatch/src/server/modelProviders/modelDefaults.repository.ts
+++ b/langwatch/src/server/modelProviders/modelDefaults.repository.ts
@@ -7,7 +7,7 @@ import type {
 } from "@prisma/client";
 import { generate } from "@langwatch/ksuid";
 import { KSUID_RESOURCES } from "../../utils/constants";
-import { resolveOrganizationForScope } from "../scopes/resolveOrganizationForScope";
+import { resolveSingleOrganizationForScopes } from "../scopes/resolveOrganizationForScope";
 
 export type ModelDefaultsPrisma =
   | PrismaClient
@@ -78,17 +78,15 @@ export class ModelDefaultsRepository {
   }): Promise<{ id: string }> {
     const id = this.newConfigId();
     // Single-organization anchor (ADR-021): every scope a config attaches to
-    // resolves to the same org, so the first scope is authoritative. The
-    // column is NOT NULL, so an unresolvable scope is a hard error.
-    const firstScope = params.scopes[0];
-    const organizationId = firstScope
-      ? await resolveOrganizationForScope(this.prisma, firstScope)
-      : null;
-    if (!organizationId) {
-      throw new Error(
-        "Cannot create model default config: scope does not resolve to an organization",
-      );
-    }
+    // must resolve to the same org. Resolve all of them up front and reject a
+    // mixed or unresolvable set, so we never persist scope rows that disagree
+    // with the anchor. The column is NOT NULL, so an unresolvable scope is a
+    // hard error.
+    const organizationId = await resolveSingleOrganizationForScopes(
+      this.prisma,
+      params.scopes,
+      "model default config",
+    );
     await this.prisma.modelDefaultConfig.create({
       data: {
         id,

--- a/langwatch/src/server/modelProviders/modelProvider.repository.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.repository.ts
@@ -247,6 +247,25 @@ export class ModelProviderRepository {
 
     const runUpdate = async (workingTx: Prisma.TransactionClient) => {
       if (scopes) {
+        // Single-organization invariant (ADR-021): the replacement scope set
+        // must resolve to the same org the provider is already anchored to.
+        // Without this, swapping scopes could silently rebind the credential to
+        // another tenant while organizationId stays put — a multitenancy break,
+        // since provider visibility is driven from the scope table.
+        const organizationId = await resolveSingleOrganizationForScopes(
+          workingTx,
+          scopes,
+          "model provider",
+        );
+        const existing = await workingTx.modelProvider.findUnique({
+          where: { id },
+          select: { organizationId: true },
+        });
+        if (existing && existing.organizationId !== organizationId) {
+          throw new Error(
+            "Cannot update model provider: scopes must stay within the provider's organization",
+          );
+        }
         await workingTx.modelProviderScope.deleteMany({
           where: { modelProviderId: id },
         });

--- a/langwatch/src/server/modelProviders/modelProvider.repository.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.repository.ts
@@ -2,7 +2,7 @@ import type { ModelProvider, ModelProviderScope, Prisma, PrismaClient } from "@p
 import { generate } from "@langwatch/ksuid";
 import { KSUID_RESOURCES } from "../../utils/constants";
 import { encrypt, decrypt } from "../../utils/encryption";
-import { resolveOrganizationForScope } from "../scopes/resolveOrganizationForScope";
+import { resolveSingleOrganizationForScopes } from "../scopes/resolveOrganizationForScope";
 import { resolveScopeChain } from "../scopes/resolveScopeChain";
 import type { CustomModelsInput } from "./customModel.schema";
 
@@ -187,18 +187,16 @@ export class ModelProviderRepository {
         ? data.scopes
         : [{ scopeType: "PROJECT" as const, scopeId: data.projectId }];
 
-    // Single-organization anchor (ADR-021): every scope resolves to the same
-    // org, so the page-context project's org is authoritative. The column is
-    // NOT NULL, so a project that can't resolve an org is a hard error.
-    const organizationId = await resolveOrganizationForScope(client, {
-      scopeType: "PROJECT",
-      scopeId: data.projectId,
-    });
-    if (!organizationId) {
-      throw new Error(
-        `Cannot create model provider: project ${data.projectId} does not resolve to an organization`,
-      );
-    }
+    // Single-organization anchor (ADR-021): every scope this provider attaches
+    // to must resolve to the same org. Resolve them all and reject a mixed or
+    // unresolvable set, so a caller can't slip in scopes from another org under
+    // one anchor. The column is NOT NULL, so an unresolvable scope is a hard
+    // error.
+    const organizationId = await resolveSingleOrganizationForScopes(
+      client,
+      scopes,
+      "model provider",
+    );
 
     return client.modelProvider.create({
       data: {

--- a/langwatch/src/server/modelProviders/modelProvider.repository.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.repository.ts
@@ -188,11 +188,17 @@ export class ModelProviderRepository {
         : [{ scopeType: "PROJECT" as const, scopeId: data.projectId }];
 
     // Single-organization anchor (ADR-021): every scope resolves to the same
-    // org, so the page-context project's org is authoritative.
+    // org, so the page-context project's org is authoritative. The column is
+    // NOT NULL, so a project that can't resolve an org is a hard error.
     const organizationId = await resolveOrganizationForScope(client, {
       scopeType: "PROJECT",
       scopeId: data.projectId,
     });
+    if (!organizationId) {
+      throw new Error(
+        `Cannot create model provider: project ${data.projectId} does not resolve to an organization`,
+      );
+    }
 
     return client.modelProvider.create({
       data: {
@@ -200,7 +206,7 @@ export class ModelProviderRepository {
         name: data.name,
         provider: data.provider,
         enabled: data.enabled,
-        organizationId: organizationId ?? undefined,
+        organizationId,
         customKeys: encryptedKeys as Prisma.InputJsonValue | undefined,
         customModels: data.customModels as Prisma.InputJsonValue | undefined,
         customEmbeddingsModels: data.customEmbeddingsModels as

--- a/langwatch/src/server/modelProviders/seedOnboardingDefaults.ts
+++ b/langwatch/src/server/modelProviders/seedOnboardingDefaults.ts
@@ -1,7 +1,7 @@
 import type { ModelDefaultScopeType, PrismaClient } from "@prisma/client";
 
-import { resolveOrganizationForScope } from "../scopes/resolveOrganizationForScope";
 import { llmModels } from "./loadModelCatalog";
+import { ModelDefaultsRepository } from "./modelDefaults.repository";
 
 interface RegistryEntry {
   id: string;
@@ -132,27 +132,13 @@ export async function seedOnboardingDefaultsForProvider(params: {
   });
   if (existing) return;
 
-  // Single-organization anchor (ADR-021): resolve the org the seeded scope
-  // belongs to so the row is tenancy-anchored from creation. The column is
-  // NOT NULL, so an unresolvable scope is a hard error.
-  const organizationId = await resolveOrganizationForScope(prisma, {
-    scopeType,
-    scopeId,
-  });
-  if (!organizationId) {
-    throw new Error(
-      `Cannot seed onboarding defaults: scope ${scopeType}:${scopeId} does not resolve to an organization`,
-    );
-  }
-
-  await prisma.modelDefaultConfig.create({
-    data: {
-      config,
-      authorId: authorId ?? null,
-      organizationId,
-      scopes: {
-        create: [{ scopeType, scopeId }],
-      },
-    },
+  // Persist through the repository so the org anchor resolution + single-org
+  // invariant (ADR-021) live in one place. It mints the KSUIDs, resolves the
+  // org for the seeded scope, and hard-fails an unresolvable scope (the column
+  // is NOT NULL).
+  await new ModelDefaultsRepository(prisma).create({
+    config,
+    authorId: authorId ?? null,
+    scopes: [{ scopeType, scopeId }],
   });
 }

--- a/langwatch/src/server/modelProviders/seedOnboardingDefaults.ts
+++ b/langwatch/src/server/modelProviders/seedOnboardingDefaults.ts
@@ -133,17 +133,23 @@ export async function seedOnboardingDefaultsForProvider(params: {
   if (existing) return;
 
   // Single-organization anchor (ADR-021): resolve the org the seeded scope
-  // belongs to so the row is tenancy-anchored from creation.
+  // belongs to so the row is tenancy-anchored from creation. The column is
+  // NOT NULL, so an unresolvable scope is a hard error.
   const organizationId = await resolveOrganizationForScope(prisma, {
     scopeType,
     scopeId,
   });
+  if (!organizationId) {
+    throw new Error(
+      `Cannot seed onboarding defaults: scope ${scopeType}:${scopeId} does not resolve to an organization`,
+    );
+  }
 
   await prisma.modelDefaultConfig.create({
     data: {
       config,
       authorId: authorId ?? null,
-      organizationId: organizationId ?? undefined,
+      organizationId,
       scopes: {
         create: [{ scopeType, scopeId }],
       },

--- a/langwatch/src/server/onboarding-checks/__tests__/onboarding-checks.integration.test.ts
+++ b/langwatch/src/server/onboarding-checks/__tests__/onboarding-checks.integration.test.ts
@@ -31,7 +31,15 @@ describe("OnboardingChecksService Integration", () => {
       where: { id: projectId },
       include: { team: true },
     });
-    organizationId = project?.team.organizationId ?? "";
+    // The model-provider inserts below anchor on organizationId (NOT NULL), so
+    // fail fast here if the fixture didn't resolve an org rather than surfacing
+    // a confusing Prisma create error mid-test.
+    if (!project?.team.organizationId) {
+      throw new Error(
+        `Test setup failed: project ${projectId} did not resolve to an organization`,
+      );
+    }
+    organizationId = project.team.organizationId;
 
     service = new OnboardingChecksService();
   });

--- a/langwatch/src/server/onboarding-checks/__tests__/onboarding-checks.integration.test.ts
+++ b/langwatch/src/server/onboarding-checks/__tests__/onboarding-checks.integration.test.ts
@@ -78,6 +78,7 @@ describe("OnboardingChecksService Integration", () => {
           name: "OpenAI",
           provider: "openai",
           enabled: true,
+          organizationId,
           scopes: {
             create: [{ scopeType: "PROJECT", scopeId: projectId }],
           },
@@ -99,6 +100,7 @@ describe("OnboardingChecksService Integration", () => {
           name: "Anthropic",
           provider: "anthropic",
           enabled: false,
+          organizationId,
           scopes: {
             create: [{ scopeType: "PROJECT", scopeId: projectId }],
           },

--- a/langwatch/src/server/prompt-config/__tests__/prompt-tags.integration.test.ts
+++ b/langwatch/src/server/prompt-config/__tests__/prompt-tags.integration.test.ts
@@ -53,6 +53,7 @@ describe("Feature: Prompt version tags", () => {
     const seededDefault = await prisma.modelDefaultConfig.create({
       data: {
         config: { DEFAULT: "openai/gpt-4o-mini" },
+        organizationId: testOrganization.id,
         scopes: {
           create: [
             { scopeType: "ORGANIZATION", scopeId: testOrganization.id },

--- a/langwatch/src/server/rbac/__tests__/role-binding-resolver.unit.test.ts
+++ b/langwatch/src/server/rbac/__tests__/role-binding-resolver.unit.test.ts
@@ -395,4 +395,102 @@ describe("checkRoleBindingPermission()", () => {
       expect(result).toBe(false);
     });
   });
+
+  describe("when a custom role below the org tier lists an org-exclusive permission", () => {
+    it("does NOT grant governance:manage from a TEAM-scoped custom role", async () => {
+      const prisma = makePrisma({
+        directBindings: [
+          {
+            role: TeamUserRole.CUSTOM,
+            customRoleId: "cr1",
+            scopeType: RoleBindingScopeType.TEAM,
+            scopeId: TEAM_ID,
+          },
+        ],
+        customRolePermissions: ["governance:manage", "datasets:manage"],
+      });
+
+      const result = await checkRoleBindingPermission({
+        prisma,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        scope: teamScope,
+        permission: "governance:manage",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("does NOT grant organization:manage from a PROJECT-scoped custom role", async () => {
+      const prisma = makePrisma({
+        directBindings: [
+          {
+            role: TeamUserRole.CUSTOM,
+            customRoleId: "cr1",
+            scopeType: RoleBindingScopeType.PROJECT,
+            scopeId: PROJECT_ID,
+          },
+        ],
+        customRolePermissions: ["organization:manage"],
+      });
+
+      const result = await checkRoleBindingPermission({
+        prisma,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        scope: projectScope,
+        permission: "organization:manage",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("still grants a team-tier permission from the same TEAM-scoped custom role", async () => {
+      const prisma = makePrisma({
+        directBindings: [
+          {
+            role: TeamUserRole.CUSTOM,
+            customRoleId: "cr1",
+            scopeType: RoleBindingScopeType.TEAM,
+            scopeId: TEAM_ID,
+          },
+        ],
+        customRolePermissions: ["governance:manage", "datasets:manage"],
+      });
+
+      const result = await checkRoleBindingPermission({
+        prisma,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        scope: teamScope,
+        permission: "datasets:manage",
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("grants governance:manage when the custom role is ORGANIZATION-scoped", async () => {
+      const prisma = makePrisma({
+        directBindings: [
+          {
+            role: TeamUserRole.CUSTOM,
+            customRoleId: "cr1",
+            scopeType: RoleBindingScopeType.ORGANIZATION,
+            scopeId: ORG_ID,
+          },
+        ],
+        customRolePermissions: ["governance:manage"],
+      });
+
+      const result = await checkRoleBindingPermission({
+        prisma,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        scope: { type: "org", id: ORG_ID },
+        permission: "governance:manage",
+      });
+
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/langwatch/src/server/rbac/role-binding-resolver.ts
+++ b/langwatch/src/server/rbac/role-binding-resolver.ts
@@ -5,6 +5,7 @@ import {
   type PrismaClient,
 } from "@prisma/client";
 import {
+  bindingScopeCanGrant,
   hasPermissionWithHierarchy,
   organizationRoleHasPermission,
   teamRoleHasPermission,
@@ -196,6 +197,11 @@ export async function checkRoleBindingPermission({
   const bindings = await collectBindingsForScope({ prisma, principal: resolvedPrincipal, organizationId, scope });
 
   for (const binding of bindings) {
+    // A team/project binding can never grant an org-exclusive permission,
+    // even via a custom role that lists it (ADR-021). Stays in sync with
+    // checkPermissionFromBindings() in rbac.ts.
+    if (!bindingScopeCanGrant(binding.scopeType, permission)) continue;
+
     // Custom role — look up its permissions
     if (binding.role === TeamUserRole.CUSTOM && binding.customRoleId) {
       const customRole = await prisma.customRole.findUnique({

--- a/langwatch/src/server/scopes/resolveOrganizationForScope.ts
+++ b/langwatch/src/server/scopes/resolveOrganizationForScope.ts
@@ -34,3 +34,33 @@ export async function resolveOrganizationForScope(
   });
   return project?.team.organizationId ?? null;
 }
+
+/**
+ * Resolve the single organization a set of scope targets all belong to, for
+ * resources anchored to one org (ADR-021). Every scope must resolve, and they
+ * must all resolve to the same organization; otherwise we'd persist scope rows
+ * that disagree with the row's organizationId anchor. Throws on an empty,
+ * unresolvable, or cross-organization set. `resourceLabel` is woven into the
+ * error message (e.g. "model provider").
+ */
+export async function resolveSingleOrganizationForScopes(
+  client: Client,
+  scopes: { scopeType: string; scopeId: string }[],
+  resourceLabel: string,
+): Promise<string> {
+  if (scopes.length === 0) {
+    throw new Error(
+      `Cannot create ${resourceLabel}: at least one scope is required to resolve an organization`,
+    );
+  }
+  const resolved = await Promise.all(
+    scopes.map((scope) => resolveOrganizationForScope(client, scope)),
+  );
+  const organizationId = resolved[0];
+  if (!organizationId || resolved.some((orgId) => orgId !== organizationId)) {
+    throw new Error(
+      `Cannot create ${resourceLabel}: all scopes must resolve to the same organization`,
+    );
+  }
+  return organizationId;
+}

--- a/langwatch/src/server/scopes/resolveOrganizationForScope.ts
+++ b/langwatch/src/server/scopes/resolveOrganizationForScope.ts
@@ -1,6 +1,10 @@
 import type { Prisma, PrismaClient } from "@prisma/client";
 
+import type { ScopeTier } from "./scope.types";
+
 type Client = PrismaClient | Prisma.TransactionClient;
+
+type ScopeTarget = { scopeType: ScopeTier; scopeId: string };
 
 /**
  * Resolve the single organization a (scopeType, scopeId) target belongs to.
@@ -16,23 +20,34 @@ type Client = PrismaClient | Prisma.TransactionClient;
  */
 export async function resolveOrganizationForScope(
   client: Client,
-  scope: { scopeType: string; scopeId: string },
+  scope: ScopeTarget,
 ): Promise<string | null> {
-  if (scope.scopeType === "ORGANIZATION") {
-    return scope.scopeId;
+  switch (scope.scopeType) {
+    case "ORGANIZATION":
+      return scope.scopeId;
+    case "TEAM": {
+      const team = await client.team.findUnique({
+        where: { id: scope.scopeId },
+        select: { organizationId: true },
+      });
+      return team?.organizationId ?? null;
+    }
+    case "PROJECT": {
+      const project = await client.project.findUnique({
+        where: { id: scope.scopeId },
+        select: { team: { select: { organizationId: true } } },
+      });
+      return project?.team.organizationId ?? null;
+    }
+    default:
+      // Guard against type-unsafe / widened callers: an unknown scope type
+      // must fail fast rather than silently resolving against the project table.
+      throw new Error(
+        `resolveOrganizationForScope: unsupported scope type ${String(
+          (scope as { scopeType: unknown }).scopeType,
+        )}`,
+      );
   }
-  if (scope.scopeType === "TEAM") {
-    const team = await client.team.findUnique({
-      where: { id: scope.scopeId },
-      select: { organizationId: true },
-    });
-    return team?.organizationId ?? null;
-  }
-  const project = await client.project.findUnique({
-    where: { id: scope.scopeId },
-    select: { team: { select: { organizationId: true } } },
-  });
-  return project?.team.organizationId ?? null;
 }
 
 /**
@@ -45,7 +60,7 @@ export async function resolveOrganizationForScope(
  */
 export async function resolveSingleOrganizationForScopes(
   client: Client,
-  scopes: { scopeType: string; scopeId: string }[],
+  scopes: ScopeTarget[],
   resourceLabel: string,
 ): Promise<string> {
   if (scopes.length === 0) {


### PR DESCRIPTION
Follow-ups to #4281 (ADR-021 multi-scope targeting and single-organization tenancy), now that the foundation, model-costs backend, org-id guard, ModelProvider/ModelDefaultConfig anchors, and GatewayBudget collapse have merged.

## What this does

**1. NOT NULL on the ModelProvider + ModelDefaultConfig anchors.** The org anchor was added nullable so the backfill could resolve each row's org from its scopes. This tightens it to NOT NULL. The migration first deletes any row still NULL after the backfill (these had only orphaned scopes pointing at deleted teams or projects, so they are unreachable through the scope-based access path), then sets the constraint. The create paths now hard-fail if a scope cannot resolve to an organization instead of silently writing NULL, and every direct create call site (tests, scripts, prisma seed) seeds the resolved organizationId.

**2. Custom roles below the org tier can no longer grant org-level permissions.** A CUSTOM role bound at TEAM or PROJECT scope could grant an organization-tier permission it happened to list (governance:manage, organization:manage, and so on), because the scope-chain resolvers matched the permission against the custom role's set without checking the binding's scope. This adds an ORG_EXCLUSIVE_RESOURCES set (the AI Governance family plus organization) and a scope-tier gate applied at every binding-evaluation path, so the rule holds no matter which resolver runs. Gateway and core resources stay grantable at team and project scope. Read-side only by design: a custom role may legitimately mix tiers and be bound at team scope for its team-tier permissions, so the org-tier ones are ignored at resolution rather than rejected at write time.

**3 and 4. Model-costs scope selector, on the shared picker.** Model-cost rules are single-scope-per-row, so the shared ScopeChipPicker gains a single-select mode (org/team/project quick-pick chips, no multi-select dropdown). The cost drawer uses it as its first field: editing keeps the row's scope, new rows default to the current project, and an admin can push one cost policy up to the team or organization tier. The backend already accepted the scope and resolves the project to team to organization cascade. Multi-scope consumers are unaffected.

## Verification

- Migration applies clean on a throwaway Postgres with all three anchors NOT NULL, validated with seeded data across all three scope tiers.
- Full typecheck clean.
- 98 RBAC unit tests (including 4 new scope-gate cases), 24 model-provider repo unit tests, and the cost-drawer render test pass.
- Integration suites pass against a local migrated Postgres: model providers, default config, prompts, ai-tools, RBAC resolver, member-leak coverage, and spend-spike anomaly evaluator.

## Notes

The org-tier tRPC path was already solid before this PR (checkOrganizationPermission does a real membership-derived RoleBinding check; the apiKey router authorizes at the service layer). The custom-role scope gate above is the one genuine gap that remained. The legacy TeamUser org-admin fallback removal stays gated on the RoleBinding backfill and is not touched here.
