### PR TITLE
feat(governance): restore switcher add-project, gate the personal entry

### DIFF
--- a/langwatch/ee/admin/backoffice/__tests__/UsersView.integration.test.tsx
+++ b/langwatch/ee/admin/backoffice/__tests__/UsersView.integration.test.tsx
@@ -66,6 +66,18 @@ describe("Feature: Backoffice User Impersonation Reason", () => {
       expect(reason.tagName).toBe("INPUT");
     });
 
+    /** @scenario Impersonation dialog focuses the reason field on open */
+    it("focuses the reason field as soon as the dialog opens", async () => {
+      render(<ImpersonateDialog user={user} onClose={vi.fn()} />, {
+        wrapper: Wrapper,
+      });
+
+      const reason = screen.getByLabelText("Reason");
+      await waitFor(() => {
+        expect(document.activeElement).toBe(reason);
+      });
+    });
+
     /** @scenario Enter submits a completed impersonation reason */
     it("submits the reason when Enter is pressed", async () => {
       const testingUser = userEvent.setup();

--- a/langwatch/ee/admin/backoffice/resources/UsersView.tsx
+++ b/langwatch/ee/admin/backoffice/resources/UsersView.tsx
@@ -13,7 +13,7 @@ import {
   Wrap,
 } from "@chakra-ui/react";
 import { MoreVertical, Pencil, UserCheck } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useDebounce } from "use-debounce";
 import { Dialog } from "~/components/ui/dialog";
 import { Drawer } from "~/components/ui/drawer";
@@ -224,6 +224,7 @@ export function ImpersonateDialog({
 }) {
   const [reason, setReason] = useState("");
   const [loading, setLoading] = useState(false);
+  const reasonRef = useRef<HTMLInputElement>(null);
 
   // Re-seed the reason on every new target user — prevents leaking one
   // reason across multiple impersonation attempts.
@@ -266,6 +267,7 @@ export function ImpersonateDialog({
   return (
     <Dialog.Root
       open={!!user}
+      initialFocusEl={() => reasonRef.current}
       onOpenChange={({ open }) => {
         if (!open && !loading) onClose();
       }}
@@ -287,6 +289,7 @@ export function ImpersonateDialog({
             <Field.Root required>
               <Field.Label>Reason</Field.Label>
               <Input
+                ref={reasonRef}
                 value={reason}
                 onChange={(e) => setReason(e.target.value)}
                 onKeyDown={(e) => {

--- a/langwatch/ee/governance/routers/governance.ts
+++ b/langwatch/ee/governance/routers/governance.ts
@@ -23,6 +23,7 @@ import {
   type PersonaResolution,
 } from "@ee/governance/services/personaResolver.service";
 import { UsageStatsService } from "~/server/license-enforcement/usage-stats.service";
+import { featureFlagService } from "~/server/featureFlag";
 import { GovernanceOcsfExportService } from "@ee/governance/services/governanceOcsfExport.service";
 import {
   QUARANTINE_DEFAULT_THRESHOLD,
@@ -89,35 +90,51 @@ export const governanceRouter = createTRPCRouter({
       const setupService = GovernanceSetupStateService.create(ctx.prisma);
       const usageService = UsageStatsService.create(ctx.prisma);
 
-      const [setupState, firstProject, isEnterprise, hasManage, userPin] =
-        await Promise.all([
-          // hasApplicationTraces is part of setupState as of 9d2688c84.
-          setupService.resolve(input.organizationId),
-          ctx.prisma.project.findFirst({
-            where: {
-              team: {
-                organizationId: input.organizationId,
-                members: { some: { userId } },
-              },
-              archivedAt: null,
+      const [
+        setupState,
+        firstProject,
+        isEnterprise,
+        hasManage,
+        userPin,
+        hasGovernanceUi,
+      ] = await Promise.all([
+        // hasApplicationTraces is part of setupState as of 9d2688c84.
+        setupService.resolve(input.organizationId),
+        ctx.prisma.project.findFirst({
+          where: {
+            team: {
+              organizationId: input.organizationId,
+              members: { some: { userId } },
             },
-            orderBy: { createdAt: "asc" },
-            select: { slug: true },
-          }),
-          usageService
-            .getUsageStats(input.organizationId, ctx.session.user)
-            .then((u) => u?.activePlan?.type === "ENTERPRISE")
-            .catch(() => false),
-          hasOrganizationPermission(
-            ctx,
-            input.organizationId,
-            "organization:manage",
-          ),
-          ctx.prisma.user.findUnique({
-            where: { id: userId },
-            select: { lastHomePath: true },
-          }),
-        ]);
+            archivedAt: null,
+          },
+          orderBy: { createdAt: "asc" },
+          select: { slug: true },
+        }),
+        usageService
+          .getUsageStats(input.organizationId, ctx.session.user)
+          .then((u) => u?.activePlan?.type === "ENTERPRISE")
+          .catch(() => false),
+        hasOrganizationPermission(
+          ctx,
+          input.organizationId,
+          "organization:manage",
+        ),
+        ctx.prisma.user.findUnique({
+          where: { id: userId },
+          select: { lastHomePath: true },
+        }),
+        // `/me` and `/governance` are gated behind this flag; without it both
+        // 404. Gate the auto-detected destination on it so a non-governance
+        // org (e.g. a customer being impersonated) never lands on /me.
+        featureFlagService
+          .isEnabled("release_ui_ai_governance_enabled", {
+            distinctId: userId,
+            defaultValue: false,
+            organizationId: input.organizationId,
+          })
+          .catch(() => false),
+      ]);
 
       return resolvePersonaHomeSafe({
         userLastHomePath: userPin?.lastHomePath ?? null,
@@ -129,6 +146,7 @@ export const governanceRouter = createTRPCRouter({
         hasApplicationTraces: setupState.hasApplicationTraces,
         hasOrganizationManagePermission: hasManage,
         isEnterprise,
+        hasGovernanceUi,
         firstProjectSlug: firstProject?.slug ?? null,
       });
     }),

--- a/langwatch/ee/governance/services/__tests__/personaResolver.service.unit.test.ts
+++ b/langwatch/ee/governance/services/__tests__/personaResolver.service.unit.test.ts
@@ -177,6 +177,18 @@ describe("resolvePersonaHome", () => {
       expect(result.destination).not.toBe("/governance");
     });
 
+    it("routes a member with no projects to onboarding, not the gated /me", () => {
+      const result = resolvePersonaHome({
+        ...baseInput,
+        hasGovernanceUi: false,
+        firstProjectSlug: null,
+      });
+      // /me is flag-gated and 404s here, so there is no usable personal home;
+      // send the user to the recoverable onboarding bootstrap instead.
+      expect(result.destination).toBe("/onboarding/welcome");
+      expect(result.destination).not.toBe("/me");
+    });
+
     it("still honors an explicit user pin even when the flag is off", () => {
       const result = resolvePersonaHome({
         ...baseInput,
@@ -212,11 +224,21 @@ describe("resolvePersonaHomeSafe", () => {
     expect(result.destination).toBe("/team-prod/messages");
   });
 
-  it("falls back to /me when given partial input + no project slug", () => {
+  it("falls back to onboarding when partial input has no project slug and no governance UI", () => {
     const result = resolvePersonaHomeSafe({
       firstProjectSlug: null,
     });
+    // hasGovernanceUi defaults to false, so /me would 404 — route to the
+    // recoverable onboarding bootstrap instead.
     expect(result.persona).toBe("project_only");
+    expect(result.destination).toBe("/onboarding/welcome");
+  });
+
+  it("falls back to /me when no project slug but the governance UI is enabled", () => {
+    const result = resolvePersonaHomeSafe({
+      firstProjectSlug: null,
+      hasGovernanceUi: true,
+    });
     expect(result.destination).toBe("/me");
   });
 

--- a/langwatch/ee/governance/services/__tests__/personaResolver.service.unit.test.ts
+++ b/langwatch/ee/governance/services/__tests__/personaResolver.service.unit.test.ts
@@ -26,6 +26,10 @@ const baseInput: PersonaResolverInput = {
   hasApplicationTraces: false,
   hasOrganizationManagePermission: false,
   isEnterprise: false,
+  // The persona 1/2/4 destinations (/me, /governance) only exist for orgs
+  // with the governance UI flag; default the fixture to enabled so those
+  // matrices read cleanly. The gate is exercised explicitly below.
+  hasGovernanceUi: true,
   firstProjectSlug: null,
 };
 
@@ -141,6 +145,49 @@ describe("resolvePersonaHome", () => {
       expect(result.isOverride).toBe(true);
       // Persona is still detected even when overridden
       expect(result.persona).toBe("mixed");
+    });
+  });
+
+  describe("when the org does not have the governance UI flag", () => {
+    it("routes a personal-VK customer to the project home instead of /me", () => {
+      const result = resolvePersonaHome({
+        ...baseInput,
+        hasGovernanceUi: false,
+        setupState: { ...baseInput.setupState, hasPersonalVKs: true },
+        firstProjectSlug: "team-prod",
+      });
+      // Persona is still detected (mixed: personal VK + project), but /me is
+      // flag-gated and 404s, so the destination falls back to the project
+      // home — this is the impersonated-customer case.
+      expect(result.persona).toBe("mixed");
+      expect(result.destination).toBe("/team-prod/messages");
+      expect(result.governanceUiEnabled).toBe(false);
+    });
+
+    it("does NOT route a would-be governance admin to /governance", () => {
+      const result = resolvePersonaHome({
+        ...baseInput,
+        hasGovernanceUi: false,
+        hasOrganizationManagePermission: true,
+        isEnterprise: true,
+        setupState: { ...baseInput.setupState, hasIngestionSources: true },
+        firstProjectSlug: "team-prod",
+      });
+      expect(result.destination).toBe("/team-prod/messages");
+      expect(result.destination).not.toBe("/governance");
+    });
+
+    it("still honors an explicit user pin even when the flag is off", () => {
+      const result = resolvePersonaHome({
+        ...baseInput,
+        hasGovernanceUi: false,
+        userLastHomePath: "/me",
+        setupState: { ...baseInput.setupState, hasPersonalVKs: true },
+        firstProjectSlug: "team-prod",
+      });
+      // A pin can only have been set while the surface was reachable; keep it.
+      expect(result.destination).toBe("/me");
+      expect(result.isOverride).toBe(true);
     });
   });
 

--- a/langwatch/ee/governance/services/personaResolver.service.ts
+++ b/langwatch/ee/governance/services/personaResolver.service.ts
@@ -62,6 +62,16 @@ export interface PersonaResolverInput {
   isEnterprise: boolean;
 
   /**
+   * True when `release_ui_ai_governance_enabled` is on for this org. The
+   * `/me` and `/governance` surfaces are gated behind this flag and 404
+   * when it is off, so the resolver must never auto-route there for an org
+   * without it — it falls back to the project home (the pre-governance
+   * LLMOps experience). A user-pinned `lastHomePath` still wins, since a
+   * pin can only have been set while the surface was reachable.
+   */
+  hasGovernanceUi: boolean;
+
+  /**
    * The user's first project slug, or null if the user has no project
    * memberships. Drives the project_only destination + the personal_only
    * vs mixed fork.
@@ -74,6 +84,12 @@ export interface PersonaResolution {
   destination: string;
   /** True when User.lastHomePath was set and used. */
   isOverride: boolean;
+  /**
+   * Mirrors the input `hasGovernanceUi`. Lets the `/` redirect client gate
+   * its own `lastVisitedHomeKind === "personal"` fallback so it never
+   * overrides to `/me` when that surface is flag-gated off for the org.
+   */
+  governanceUiEnabled: boolean;
 }
 
 export function resolvePersonaHome(
@@ -86,6 +102,7 @@ export function resolvePersonaHome(
       persona,
       destination: input.userLastHomePath,
       isOverride: true,
+      governanceUiEnabled: input.hasGovernanceUi,
     };
   }
 
@@ -93,6 +110,7 @@ export function resolvePersonaHome(
     persona,
     destination: mapPersonaToDestination(persona, input),
     isOverride: false,
+    governanceUiEnabled: input.hasGovernanceUi,
   };
 }
 
@@ -116,6 +134,7 @@ export function resolvePersonaHomeSafe(
       hasOrganizationManagePermission:
         input.hasOrganizationManagePermission ?? false,
       isEnterprise: input.isEnterprise ?? false,
+      hasGovernanceUi: input.hasGovernanceUi ?? false,
       firstProjectSlug: input.firstProjectSlug,
     };
     return resolvePersonaHome(full);
@@ -126,6 +145,7 @@ export function resolvePersonaHomeSafe(
         ? `/${input.firstProjectSlug}/messages`
         : "/me",
       isOverride: false,
+      governanceUiEnabled: input.hasGovernanceUi ?? false,
     };
   }
 }
@@ -155,6 +175,19 @@ function mapPersonaToDestination(
   persona: Persona,
   input: PersonaResolverInput,
 ): string {
+  const projectHome = input.firstProjectSlug
+    ? `/${input.firstProjectSlug}/messages`
+    : "/me";
+
+  // `/me` and `/governance` are gated behind release_ui_ai_governance_enabled
+  // and 404 when it is off. An org without the governance UI gets the
+  // pre-governance project home, no matter the detected persona — this is
+  // what keeps an impersonated (or freshly signed-in) non-governance
+  // customer off the dead-end /me page.
+  if (!input.hasGovernanceUi) {
+    return projectHome;
+  }
+
   switch (persona) {
     case "governance_admin":
       return "/governance";
@@ -162,8 +195,6 @@ function mapPersonaToDestination(
     case "mixed":
       return "/me";
     case "project_only":
-      return input.firstProjectSlug
-        ? `/${input.firstProjectSlug}/messages`
-        : "/me";
+      return projectHome;
   }
 }

--- a/langwatch/ee/governance/services/personaResolver.service.ts
+++ b/langwatch/ee/governance/services/personaResolver.service.ts
@@ -177,7 +177,7 @@ function mapPersonaToDestination(
 ): string {
   const projectHome = input.firstProjectSlug
     ? `/${input.firstProjectSlug}/messages`
-    : "/me";
+    : noProjectFallback(input.hasGovernanceUi);
 
   // `/me` and `/governance` are gated behind release_ui_ai_governance_enabled
   // and 404 when it is off. An org without the governance UI gets the
@@ -197,4 +197,15 @@ function mapPersonaToDestination(
     case "project_only":
       return projectHome;
   }
+}
+
+/**
+ * Where to send a user with no project membership. `/me` is the natural
+ * personal home, but it is flag-gated and 404s without the governance UI, so
+ * a non-governance org with no project falls back to the recoverable
+ * onboarding bootstrap instead (mirrors the org-less branch in
+ * pages/index.tsx) rather than the dead-end /me.
+ */
+function noProjectFallback(hasGovernanceUi: boolean): string {
+  return hasGovernanceUi ? "/me" : "/onboarding/welcome";
 }

--- a/langwatch/src/components/WorkspaceSwitcher.tsx
+++ b/langwatch/src/components/WorkspaceSwitcher.tsx
@@ -2,16 +2,18 @@ import {
   Box,
   Button,
   HStack,
+  IconButton,
   Portal,
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { Check, ChevronDown, Folder, User, Users } from "lucide-react";
+import { Check, ChevronDown, Folder, Plus, User, Users } from "lucide-react";
 import React, { useState } from "react";
 import { useRouter } from "~/utils/compat/next-router";
 
 import { Menu } from "./ui/menu";
 import { Link } from "./ui/link";
+import { Tooltip } from "./ui/tooltip";
 import { ProjectAvatar } from "./ProjectAvatar";
 
 import { useWorkspaceCurrent } from "./useWorkspaceCurrent";
@@ -31,6 +33,12 @@ export type WorkspaceSwitcherEntry =
       href: string;
       label: string;
       subtitle?: string;
+      /**
+       * Whether the current user may create a project in this team (org or
+       * team admin). Drives the per-team "+ New project" affordance — viewers
+       * never see it. Defaults to false when omitted.
+       */
+      canCreateProject?: boolean;
     }
   | {
       kind: "project";
@@ -58,7 +66,12 @@ export type WorkspaceSwitcherCurrent =
   | { kind: "unknown" };
 
 export type WorkspaceSwitcherProps = {
-  personal: Extract<WorkspaceSwitcherEntry, { kind: "personal" }>;
+  /**
+   * The "My Workspace" personal entry. Omitted when the personal portal is
+   * not available to the user (no organization has the governance flag), so
+   * the switcher hides the entry rather than linking to a page that 404s.
+   */
+  personal?: Extract<WorkspaceSwitcherEntry, { kind: "personal" }>;
   teams: Array<Extract<WorkspaceSwitcherEntry, { kind: "team" }>>;
   projects: Array<Extract<WorkspaceSwitcherEntry, { kind: "project" }>>;
   /**
@@ -68,6 +81,13 @@ export type WorkspaceSwitcherProps = {
    * URL-driven selection (e.g. tests, programmatic preview cards).
    */
   current?: WorkspaceSwitcherCurrent;
+  /**
+   * Invoked when the user clicks a team row's "+ New project" button. The
+   * consumer opens the create-project drawer scoped to that team. The button
+   * only renders for teams whose `canCreateProject` is true and only when
+   * this callback is provided.
+   */
+  onCreateProjectForTeam?: (args: { teamId: string; orgId: string }) => void;
 };
 
 const ICON_BY_KIND = {
@@ -96,7 +116,7 @@ function currentLabel(
   projects: WorkspaceSwitcherProps["projects"],
 ): { label: string; kind: keyof typeof ICON_BY_KIND } {
   if (current.kind === "personal") {
-    return { label: personal.label, kind: "personal" };
+    return { label: personal?.label ?? "My Workspace", kind: "personal" };
   }
   if (current.kind === "team") {
     const t = teams.find((t) => t.teamId === current.teamId);
@@ -132,6 +152,7 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
   teams,
   projects,
   current: currentProp,
+  onCreateProjectForTeam,
 }: WorkspaceSwitcherProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -250,16 +271,18 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
         <Box zIndex="popover" padding={0}>
           {open && (
             <Menu.Content minWidth="280px" maxHeight="70vh" overflowY="auto">
-              <Group title="My Workspace">
-                <SwitcherItem
-                  entry={personal}
-                  active={entryIsCurrent(personal, current)}
-                  onSelect={() => {
-                    setOpen(false);
-                    void router.push(personal.href);
-                  }}
-                />
-              </Group>
+              {personal && (
+                <Group title="My Workspace">
+                  <SwitcherItem
+                    entry={personal}
+                    active={entryIsCurrent(personal, current)}
+                    onSelect={() => {
+                      setOpen(false);
+                      void router.push(personal.href);
+                    }}
+                  />
+                </Group>
+              )}
 
               {orgs.map((org) => (
                 <Group
@@ -270,14 +293,40 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
                     const teamProjects = projectsByTeam.get(team.teamId) ?? [];
                     return (
                       <Box key={team.teamId}>
-                        <SwitcherItem
-                          entry={team}
-                          active={entryIsCurrent(team, current)}
-                          onSelect={() => {
-                            setOpen(false);
-                            void router.push(team.href);
-                          }}
-                        />
+                        <Box position="relative">
+                          <SwitcherItem
+                            entry={team}
+                            active={entryIsCurrent(team, current)}
+                            onSelect={() => {
+                              setOpen(false);
+                              void router.push(team.href);
+                            }}
+                          />
+                          {team.canCreateProject && onCreateProjectForTeam && (
+                            <Tooltip content="New project in this team">
+                              <IconButton
+                                aria-label={`New project in ${team.label}`}
+                                size="xs"
+                                variant="ghost"
+                                position="absolute"
+                                right={2}
+                                top="50%"
+                                transform="translateY(-50%)"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  e.preventDefault();
+                                  setOpen(false);
+                                  onCreateProjectForTeam({
+                                    teamId: team.teamId,
+                                    orgId: team.orgId,
+                                  });
+                                }}
+                              >
+                                <Plus size={14} />
+                              </IconButton>
+                            </Tooltip>
+                          )}
+                        </Box>
                         {teamProjects.length > 0 && (
                           <VStack gap={0} align="stretch" paddingLeft={5}>
                             {teamProjects.map((project) => (

--- a/langwatch/src/components/WorkspaceSwitcher.tsx
+++ b/langwatch/src/components/WorkspaceSwitcher.tsx
@@ -35,7 +35,7 @@ export type WorkspaceSwitcherEntry =
       subtitle?: string;
       /**
        * Whether the current user may create a project in this team (org or
-       * team admin). Drives the per-team "+ New project" affordance — viewers
+       * team admin). Drives the per-team "Create project" affordance — viewers
        * never see it. Defaults to false when omitted.
        */
       canCreateProject?: boolean;
@@ -82,7 +82,7 @@ export type WorkspaceSwitcherProps = {
    */
   current?: WorkspaceSwitcherCurrent;
   /**
-   * Invoked when the user clicks a team row's "+ New project" button. The
+   * Invoked when the user clicks a team row's "Create project" button. The
    * consumer opens the create-project drawer scoped to that team. The button
    * only renders for teams whose `canCreateProject` is true and only when
    * this callback is provided.
@@ -303,9 +303,9 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
                             }}
                           />
                           {team.canCreateProject && onCreateProjectForTeam && (
-                            <Tooltip content="New project in this team">
+                            <Tooltip content="Create project">
                               <IconButton
-                                aria-label={`New project in ${team.label}`}
+                                aria-label={`Create project in ${team.label}`}
                                 size="xs"
                                 variant="ghost"
                                 position="absolute"

--- a/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
@@ -148,7 +148,7 @@ describe("WorkspaceSwitcher", () => {
   });
 
   describe("given a team the user can create projects in", () => {
-    /** @scenario The dropdown shows a per-team "+ New project" button (admin-only) */
+    /** @scenario The dropdown shows a per-team "Create project" button (admin-only) */
     it("renders a + button that opens the create-project drawer scoped to that team", async () => {
       const user = userEvent.setup();
       const onCreateProjectForTeam = vi.fn();
@@ -164,7 +164,7 @@ describe("WorkspaceSwitcher", () => {
         screen.getByRole("button", { name: /switch workspace/i }),
       );
       const addButton = await screen.findByRole("button", {
-        name: /new project in acme engineering/i,
+        name: /create project in acme engineering/i,
       });
       await user.click(addButton);
 
@@ -174,7 +174,7 @@ describe("WorkspaceSwitcher", () => {
       });
     });
 
-    /** @scenario The "+ New project" button is suppressed for non-admin members */
+    /** @scenario The "Create project" button is suppressed for non-admin members */
     it("hides the + button when the user cannot create projects in the team", async () => {
       const user = userEvent.setup();
       renderSwitcher({
@@ -190,7 +190,7 @@ describe("WorkspaceSwitcher", () => {
       );
       expect(await screen.findByText("Acme Engineering")).toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: /new project in/i }),
+        screen.queryByRole("button", { name: /create project in/i }),
       ).not.toBeInTheDocument();
     });
   });

--- a/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
@@ -147,6 +147,92 @@ describe("WorkspaceSwitcher", () => {
     });
   });
 
+  describe("given a team the user can create projects in", () => {
+    /** @scenario The dropdown shows a per-team "+ New project" button (admin-only) */
+    it("renders a + button that opens the create-project drawer scoped to that team", async () => {
+      const user = userEvent.setup();
+      const onCreateProjectForTeam = vi.fn();
+      renderSwitcher({
+        personal,
+        teams: [{ ...teamA, canCreateProject: true }],
+        projects: [projectFoo],
+        current: { kind: "personal" },
+        onCreateProjectForTeam,
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      const addButton = await screen.findByRole("button", {
+        name: /new project in acme engineering/i,
+      });
+      await user.click(addButton);
+
+      expect(onCreateProjectForTeam).toHaveBeenCalledWith({
+        teamId: "team_a",
+        orgId: "org_acme",
+      });
+    });
+
+    /** @scenario The "+ New project" button is suppressed for non-admin members */
+    it("hides the + button when the user cannot create projects in the team", async () => {
+      const user = userEvent.setup();
+      renderSwitcher({
+        personal,
+        teams: [{ ...teamA, canCreateProject: false }],
+        projects: [projectFoo],
+        current: { kind: "personal" },
+        onCreateProjectForTeam: vi.fn(),
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      expect(await screen.findByText("Acme Engineering")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /new project in/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("personal entry governance gate", () => {
+    /** @scenario The personal entry is hidden when no organization enables governance */
+    it("does not render the My Workspace entry when personal is omitted", async () => {
+      const user = userEvent.setup();
+      renderSwitcher({
+        teams: [teamA],
+        projects: [projectFoo],
+        current: { kind: "team", teamId: "team_a" },
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      // "Foo Project" is unique to the open dropdown (the trigger shows the
+      // current team), so finding it confirms the menu opened.
+      expect(await screen.findByText("Foo Project")).toBeInTheDocument();
+      expect(screen.queryByText("My Workspace")).not.toBeInTheDocument();
+    });
+
+    /** @scenario The personal entry shows when any organization enables governance */
+    it("renders the My Workspace entry when personal is provided", async () => {
+      const user = userEvent.setup();
+      renderSwitcher({
+        personal,
+        teams: [teamA],
+        projects: [projectFoo],
+        current: { kind: "team", teamId: "team_a" },
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      expect(
+        (await screen.findAllByText("My Workspace")).length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
   describe("given an unknown current context", () => {
     it("falls back to a 'choose workspace' label", () => {
       renderSwitcher({

--- a/langwatch/src/components/settings/CostCenterPicker.tsx
+++ b/langwatch/src/components/settings/CostCenterPicker.tsx
@@ -67,7 +67,7 @@ export function CostCenterPicker({
   };
 
   return (
-    <NativeSelect.Root size="sm" maxW="200px" disabled={isPending}>
+    <NativeSelect.Root size="sm" minW="160px" maxW="220px" disabled={isPending}>
       <NativeSelect.Field
         value={value ?? ""}
         onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>

--- a/langwatch/src/components/settings/CostCenterPicker.tsx
+++ b/langwatch/src/components/settings/CostCenterPicker.tsx
@@ -19,6 +19,7 @@ export function CostCenterPicker({
   value,
   costCenters,
   onAssigned,
+  width,
 }: {
   organizationId: string;
   kind: "user" | "team" | "project";
@@ -26,6 +27,12 @@ export function CostCenterPicker({
   value: string | null;
   costCenters: CostCenterOption[];
   onAssigned: () => Promise<unknown> | void;
+  /**
+   * Fixed width override. Members-table usage leaves this unset and relies on
+   * the min/max range; the compact labeled variant on the teams page passes a
+   * smaller fixed width.
+   */
+  width?: string;
 }) {
   const assignUser = api.costCenters.assignUser.useMutation();
   const assignTeam = api.costCenters.assignTeam.useMutation();
@@ -67,7 +74,11 @@ export function CostCenterPicker({
   };
 
   return (
-    <NativeSelect.Root size="sm" minW="160px" maxW="220px" disabled={isPending}>
+    <NativeSelect.Root
+      size="sm"
+      {...(width ? { width } : { minW: "160px", maxW: "220px" })}
+      disabled={isPending}
+    >
       <NativeSelect.Field
         value={value ?? ""}
         onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>

--- a/langwatch/src/components/settings/__tests__/costCenterAssignment.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/costCenterAssignment.integration.test.tsx
@@ -140,8 +140,13 @@ describe("cost-center assignment UI", () => {
       expect(
         screen.getByRole("link", { name: /People/i }).getAttribute("href"),
       ).toBe("/settings/members");
+      // Anchored to the link title: the Projects link now also mentions the
+      // "teams page" in its description and points to /settings/teams too.
       expect(
-        screen.getByRole("link", { name: /Teams/i }).getAttribute("href"),
+        screen.getByRole("link", { name: /^Teams/i }).getAttribute("href"),
+      ).toBe("/settings/teams");
+      expect(
+        screen.getByRole("link", { name: /^Projects/i }).getAttribute("href"),
       ).toBe("/settings/teams");
       // The per-person assignment list is gone: no <select> on the page.
       expect(document.querySelector("select")).toBeNull();

--- a/langwatch/src/components/useWorkspaceData.ts
+++ b/langwatch/src/components/useWorkspaceData.ts
@@ -1,6 +1,11 @@
-import { useMemo } from "react";
+import { OrganizationUserRole, TeamUserRole } from "@prisma/client";
+import { useCallback, useMemo } from "react";
 
+import { useDrawer } from "~/hooks/useDrawer";
+import { CLIENT_FLAG_STALE_TIME_MS } from "~/hooks/useFeatureFlag";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { useRequiredSession } from "~/hooks/useRequiredSession";
+import { api } from "~/utils/api";
 
 import type { WorkspaceSwitcherProps } from "./WorkspaceSwitcher";
 
@@ -20,25 +25,63 @@ import type { WorkspaceSwitcherProps } from "./WorkspaceSwitcher";
  * entry above (rchaves caught this in dogfood). Same filter cascades to
  * projects since they iterate via the filtered team list.
  *
+ * The personal "My Workspace" entry is gated on the AI governance flag: it
+ * only renders when at least one of the user's organizations has
+ * `release_ui_ai_governance_enabled`, since /me 404s otherwise. Org-less
+ * users (no organizations at all) still see it — it is their only context.
+ *
+ * Each team carries `canCreateProject` (org or team admin) which drives the
+ * per-team "+ New project" affordance, wired here to the create-project
+ * drawer.
+ *
  * Spec: specs/ai-gateway/governance/workspace-switcher.feature
  */
 export function useWorkspaceData(): Pick<
   WorkspaceSwitcherProps,
-  "personal" | "teams" | "projects"
+  "personal" | "teams" | "projects" | "onCreateProjectForTeam"
 > {
   const { organizations } = useOrganizationTeamProject({
     redirectToOnboarding: false,
     redirectToProjectOnboarding: false,
   });
+  const { data: session } = useRequiredSession();
+  const userId = session?.user?.id;
+  const { openDrawer } = useDrawer();
 
-  return useMemo(() => {
-    const personal = {
-      kind: "personal" as const,
-      href: "/me",
-      label: "My Workspace",
-      subtitle: "Personal usage, personal budget",
-    };
+  const organizationIds = useMemo(
+    () => (organizations ?? []).map((org) => org.id),
+    [organizations],
+  );
 
+  const governanceQuery =
+    api.featureFlag.isEnabledForAnyOrganization.useQuery(
+      {
+        flag: "release_ui_ai_governance_enabled",
+        organizationIds,
+      },
+      {
+        enabled: organizationIds.length > 0,
+        staleTime: CLIENT_FLAG_STALE_TIME_MS,
+      },
+    );
+
+  // Hide the personal entry only when the user has organizations and none of
+  // them enable governance. Org-less users keep it — it is their only context.
+  const showPersonal =
+    organizationIds.length === 0 || (governanceQuery.data?.enabled ?? false);
+
+  const onCreateProjectForTeam = useCallback(
+    ({ teamId, orgId }: { teamId: string; orgId: string }) => {
+      openDrawer("createProject", {
+        navigateOnCreate: true,
+        defaultTeamId: teamId,
+        organizationId: orgId,
+      });
+    },
+    [openDrawer],
+  );
+
+  const { teams, projects } = useMemo(() => {
     // Personal teams never render in the team list — the top-level
     // "My Workspace" entry already covers the caller's own one, and
     // every other user's belongs only to them. Cascades to projects
@@ -46,18 +89,27 @@ export function useWorkspaceData(): Pick<
     const isVisibleTeam = (team: { isPersonal?: boolean }) => !team.isPersonal;
 
     const teams = (organizations ?? [])
-      .flatMap((org) =>
-        (org.teams ?? []).filter(isVisibleTeam).map((team) => ({
-          kind: "team" as const,
-          teamId: team.id,
-          teamSlug: team.slug,
-          orgId: org.id,
-          orgName: org.name,
-          orgSlug: org.slug,
-          href: `/settings/teams/${team.slug}`,
-          label: team.name,
-        })),
-      )
+      .flatMap((org) => {
+        const isOrgAdmin =
+          org.members?.find((m) => m.userId === userId)?.role ===
+          OrganizationUserRole.ADMIN;
+        return (org.teams ?? []).filter(isVisibleTeam).map((team) => {
+          const isTeamAdmin =
+            team.members?.find((m) => m.userId === userId)?.role ===
+            TeamUserRole.ADMIN;
+          return {
+            kind: "team" as const,
+            teamId: team.id,
+            teamSlug: team.slug,
+            orgId: org.id,
+            orgName: org.name,
+            orgSlug: org.slug,
+            href: `/settings/teams/${team.slug}`,
+            label: team.name,
+            canCreateProject: isOrgAdmin || isTeamAdmin,
+          };
+        });
+      })
       .sort((a, b) => a.label.localeCompare(b.label));
 
     const projects = (organizations ?? [])
@@ -78,6 +130,17 @@ export function useWorkspaceData(): Pick<
       )
       .sort((a, b) => a.label.localeCompare(b.label));
 
-    return { personal, teams, projects };
-  }, [organizations]);
+    return { teams, projects };
+  }, [organizations, userId]);
+
+  const personal = showPersonal
+    ? {
+        kind: "personal" as const,
+        href: "/me",
+        label: "My Workspace",
+        subtitle: "Personal usage, personal budget",
+      }
+    : undefined;
+
+  return { personal, teams, projects, onCreateProjectForTeam };
 }

--- a/langwatch/src/pages/index.tsx
+++ b/langwatch/src/pages/index.tsx
@@ -41,7 +41,12 @@ export default function Index() {
     if (resolved.data?.destination) {
       // Explicit picker pin always wins. Only override the auto-detected
       // destination when the user has no pin AND their last visit was /me.
+      // Gate on governanceUiEnabled: /me is flag-gated and 404s for orgs
+      // without it, so never fall back there for a non-governance org (this
+      // is the admin's own localStorage leaking into an impersonated
+      // session — the impersonated customer must not be sent to /me).
       const detectedFallback =
+        resolved.data.governanceUiEnabled &&
         !resolved.data.isOverride &&
         lastVisitedHomeKind === "personal" &&
         resolved.data.destination !== "/me";

--- a/langwatch/src/pages/settings/governance/cost-centers.tsx
+++ b/langwatch/src/pages/settings/governance/cost-centers.tsx
@@ -170,9 +170,9 @@ function AssignmentGuide() {
         description="A team cost center is the default its members and projects inherit when they have none of their own. Assign each team from the teams page."
       />
       <AssignmentLink
-        href="/settings"
+        href="/settings/teams"
         title="Projects"
-        description="A project is where an autonomous agent runs. Agent spend with no human principal rolls up to the project's cost center. Assign a project from its settings."
+        description="A project is where an autonomous agent runs. Agent spend with no human principal rolls up to the project's cost center. Assign each project from the teams page, next to its team."
       />
     </VStack>
   );

--- a/langwatch/src/pages/settings/teams.tsx
+++ b/langwatch/src/pages/settings/teams.tsx
@@ -454,16 +454,14 @@ function ProjectSection({
             {access.length} with access
           </Text>
           {costCenter.show && canManage && (
-            <Box onClick={(e) => e.stopPropagation()}>
-              <LabeledCostCenter
-                organizationId={organizationId}
-                kind="project"
-                entityId={project.id}
-                value={costCenter.byProject.get(project.id) ?? null}
-                costCenters={costCenter.costCenters}
-                onAssigned={costCenter.refetch}
-              />
-            </Box>
+            <InlineCostCenter
+              organizationId={organizationId}
+              kind="project"
+              entityId={project.id}
+              value={costCenter.byProject.get(project.id) ?? null}
+              costCenters={costCenter.costCenters}
+              onAssigned={costCenter.refetch}
+            />
           )}
         </HStack>
 
@@ -624,10 +622,10 @@ function ProjectSection({
 
 // ── Team card ─────────────────────────────────────────────────────────────────
 
-// Compact labeled cost-center picker for the teams page. A bare select gives
-// no hint of what it controls, so team and project rows pair a small "Cost
-// center" caption with a narrower select.
-function LabeledCostCenter({
+// Inline cost-center picker for team and project rows. Reads as one more meta
+// item next to "N projects · M members": a leading dot, a normal-case "Cost
+// center" caption, then a compact select.
+function InlineCostCenter({
   organizationId,
   kind,
   entityId,
@@ -643,17 +641,15 @@ function LabeledCostCenter({
   onAssigned: () => Promise<unknown> | void;
 }) {
   return (
-    <VStack align="start" gap={0.5}>
-      <Text
-        fontSize="2xs"
-        fontWeight="semibold"
-        color="fg.muted"
-        textTransform="uppercase"
-        letterSpacing="wide"
-        lineHeight="1"
-      >
-        Cost center
-      </Text>
+    <HStack
+      gap={2}
+      pl={2}
+      color="gray.500"
+      fontSize="sm"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Text>·</Text>
+      <Text>Cost center</Text>
       <CostCenterPicker
         organizationId={organizationId}
         kind={kind}
@@ -661,9 +657,9 @@ function LabeledCostCenter({
         value={value}
         costCenters={costCenters}
         onAssigned={onAssigned}
-        width="150px"
+        width="130px"
       />
-    </VStack>
+    </HStack>
   );
 }
 
@@ -727,16 +723,14 @@ function TeamCard({
               ` · ${team.projectOnlyAccess.length} via projects`}
           </Text>
           {costCenter.show && canManage && (
-            <Box onClick={(e) => e.stopPropagation()}>
-              <LabeledCostCenter
-                organizationId={organizationId}
-                kind="team"
-                entityId={team.id}
-                value={costCenter.byTeam.get(team.id) ?? null}
-                costCenters={costCenter.costCenters}
-                onAssigned={costCenter.refetch}
-              />
-            </Box>
+            <InlineCostCenter
+              organizationId={organizationId}
+              kind="team"
+              entityId={team.id}
+              value={costCenter.byTeam.get(team.id) ?? null}
+              costCenters={costCenter.costCenters}
+              onAssigned={costCenter.refetch}
+            />
           )}
           {canManage && (
             <Link

--- a/langwatch/src/pages/settings/teams.tsx
+++ b/langwatch/src/pages/settings/teams.tsx
@@ -21,7 +21,10 @@ import { PageLayout } from "~/components/ui/layouts/PageLayout";
 import { Link } from "~/components/ui/link";
 import { toaster } from "~/components/ui/toaster";
 import { CostCenterPicker } from "../../components/settings/CostCenterPicker";
-import { useCostCenterColumn } from "../../components/settings/useCostCenterColumn";
+import {
+  useCostCenterColumn,
+  type CostCenterOption,
+} from "../../components/settings/useCostCenterColumn";
 import SettingsLayout from "../../components/SettingsLayout";
 import { withPermissionGuard } from "../../components/WithPermissionGuard";
 import { useDrawer } from "../../hooks/useDrawer";
@@ -395,11 +398,13 @@ function ProjectSection({
   access,
   organizationId,
   canManage,
+  costCenter,
 }: {
   project: { id: string; name: string };
   access: ProjectAccessEntry[];
   organizationId: string;
   canManage: boolean;
+  costCenter: ReturnType<typeof useCostCenterColumn>;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [addingPerson, setAddingPerson] = useState(false);
@@ -448,6 +453,18 @@ function ProjectSection({
           <Text fontSize="xs" color="gray.500">
             {access.length} with access
           </Text>
+          {costCenter.show && canManage && (
+            <Box onClick={(e) => e.stopPropagation()}>
+              <LabeledCostCenter
+                organizationId={organizationId}
+                kind="project"
+                entityId={project.id}
+                value={costCenter.byProject.get(project.id) ?? null}
+                costCenters={costCenter.costCenters}
+                onAssigned={costCenter.refetch}
+              />
+            </Box>
+          )}
         </HStack>
 
         {expanded && (
@@ -607,6 +624,49 @@ function ProjectSection({
 
 // ── Team card ─────────────────────────────────────────────────────────────────
 
+// Compact labeled cost-center picker for the teams page. A bare select gives
+// no hint of what it controls, so team and project rows pair a small "Cost
+// center" caption with a narrower select.
+function LabeledCostCenter({
+  organizationId,
+  kind,
+  entityId,
+  value,
+  costCenters,
+  onAssigned,
+}: {
+  organizationId: string;
+  kind: "team" | "project";
+  entityId: string;
+  value: string | null;
+  costCenters: CostCenterOption[];
+  onAssigned: () => Promise<unknown> | void;
+}) {
+  return (
+    <VStack align="start" gap={0.5}>
+      <Text
+        fontSize="2xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        textTransform="uppercase"
+        letterSpacing="wide"
+        lineHeight="1"
+      >
+        Cost center
+      </Text>
+      <CostCenterPicker
+        organizationId={organizationId}
+        kind={kind}
+        entityId={entityId}
+        value={value}
+        costCenters={costCenters}
+        onAssigned={onAssigned}
+        width="150px"
+      />
+    </VStack>
+  );
+}
+
 function TeamCard({
   team,
   organizationId,
@@ -668,7 +728,7 @@ function TeamCard({
           </Text>
           {costCenter.show && canManage && (
             <Box onClick={(e) => e.stopPropagation()}>
-              <CostCenterPicker
+              <LabeledCostCenter
                 organizationId={organizationId}
                 kind="team"
                 entityId={team.id}
@@ -885,6 +945,7 @@ function TeamCard({
                     access={team.projectAccess[proj.id] ?? []}
                     organizationId={organizationId}
                     canManage={canManage}
+                    costCenter={costCenter}
                   />
                 ))
               )}

--- a/langwatch/src/server/api/routers/featureFlag.ts
+++ b/langwatch/src/server/api/routers/featureFlag.ts
@@ -80,4 +80,46 @@ export const featureFlagRouter = createTRPCRouter({
 
       return { enabled };
     }),
+
+  /**
+   * Check if a feature flag is enabled for ANY of the given organizations.
+   *
+   * Org-targeted flags can only be evaluated one organization at a time, but
+   * some UI (the workspace switcher's personal entry) gates on whether the
+   * user has the flag in any organization they belong to. Returns true as
+   * soon as one organization has it enabled.
+   *
+   * @param flag - The feature flag key (must be in FRONTEND_FEATURE_FLAGS)
+   * @param organizationIds - Organizations to evaluate the flag against
+   * @returns { enabled: boolean }
+   */
+  isEnabledForAnyOrganization: protectedProcedure
+    .input(
+      z.object({
+        flag: frontendFeatureFlagSchema,
+        organizationIds: z.array(z.string()),
+      }),
+    )
+    // organizationIds is a plural targeting param, not one of the sensitive
+    // singular keys (organizationId/teamId/projectId), so no allow-list needed.
+    .use(skipPermissionCheck())
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      if (input.organizationIds.length === 0) {
+        return { enabled: false };
+      }
+
+      const results = await Promise.all(
+        input.organizationIds.map((organizationId) =>
+          featureFlagService.isEnabled(input.flag as FeatureFlagKey, {
+            distinctId: userId,
+            defaultValue: false,
+            organizationId,
+          }),
+        ),
+      );
+
+      return { enabled: results.some(Boolean) };
+    }),
 });

--- a/langwatch/src/server/posthog.ts
+++ b/langwatch/src/server/posthog.ts
@@ -92,6 +92,12 @@ export function trackServerEvent({
 export async function shutdownPostHog(): Promise<void> {
   if (_posthogInstance) {
     logger.info("Shutting down PostHog client");
-    await _posthogInstance.shutdown();
+    const instance = _posthogInstance;
+    // Reset before awaiting so the next getPostHogInstance() rebuilds a fresh
+    // client rather than handing back the shut-down one. Harmless in prod
+    // (called once at exit) and load-bearing in tests, where one worker runs
+    // many files and a later file may evaluate a flag after this teardown.
+    _posthogInstance = undefined;
+    await instance.shutdown();
   }
 }

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -1,8 +1,20 @@
 import "@testing-library/jest-dom/vitest";
 import dotenv from "dotenv";
-import { vi } from "vitest";
+import { afterAll, vi } from "vitest";
 import { TEST_PUBLIC_KEY } from "./ee/licensing/__tests__/fixtures/testKeys";
+import { shutdownPostHog } from "./src/server/posthog";
 dotenv.config({ path: ".env" });
+
+// Any test that evaluates a PostHog-backed PRODUCT flag (e.g. resolveHome ->
+// featureFlagService.isEnabled) constructs the posthog-node client, whose
+// local-evaluation poller is a setInterval that posthog-node does not unref.
+// That timer keeps the worker's event loop alive, so under --coverage (where
+// vitest awaits a graceful worker exit instead of force-killing the pool) the
+// shard hangs after every test has already passed. Shutting the client down
+// per file clears the interval; it no-ops when nothing constructed a client.
+afterAll(async () => {
+  await shutdownPostHog();
+});
 
 // Mock recharts to avoid ESM/CJS compatibility issues with @reduxjs/toolkit in vmThreads pool.
 // Tests don't need actual chart rendering - we're testing our logic, not recharts itself.

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -17,9 +17,20 @@ dotenv.config({ path: ".env" });
 // file's graph at setup time, before that file's own `vi.mock("posthog-node")`
 // hoist applies, breaking posthog.unit.test.ts. Loading it after the tests run
 // keeps each file's mocks intact.
+//
+// The flush is wrapped because posthog-node's shutdown clears the local-eval
+// poller (the hang fix) FIRST, then does a final network flush that builds a
+// `new URL(...)`. In a jsdom suite this hook runs as the env globals are being
+// torn down, so `URL` may already be gone and the flush throws — by which
+// point the interval is already cleared, so the error is safe to ignore.
 afterAll(async () => {
-  const { shutdownPostHog } = await import("./src/server/posthog");
-  await shutdownPostHog();
+  try {
+    const { shutdownPostHog } = await import("./src/server/posthog");
+    await shutdownPostHog();
+  } catch {
+    // Teardown-phase flush can throw once test env globals (URL/fetch) are
+    // gone; the poller is already cleared by then, so swallow it.
+  }
 });
 
 // Mock recharts to avoid ESM/CJS compatibility issues with @reduxjs/toolkit in vmThreads pool.

--- a/langwatch/test-setup.ts
+++ b/langwatch/test-setup.ts
@@ -2,7 +2,6 @@ import "@testing-library/jest-dom/vitest";
 import dotenv from "dotenv";
 import { afterAll, vi } from "vitest";
 import { TEST_PUBLIC_KEY } from "./ee/licensing/__tests__/fixtures/testKeys";
-import { shutdownPostHog } from "./src/server/posthog";
 dotenv.config({ path: ".env" });
 
 // Any test that evaluates a PostHog-backed PRODUCT flag (e.g. resolveHome ->
@@ -12,7 +11,14 @@ dotenv.config({ path: ".env" });
 // vitest awaits a graceful worker exit instead of force-killing the pool) the
 // shard hangs after every test has already passed. Shutting the client down
 // per file clears the interval; it no-ops when nothing constructed a client.
+//
+// The module is loaded lazily inside the hook, NOT via a top-level import: a
+// static import here would pull the real posthog module into every test
+// file's graph at setup time, before that file's own `vi.mock("posthog-node")`
+// hoist applies, breaking posthog.unit.test.ts. Loading it after the tests run
+// keeps each file's mocks intact.
 afterAll(async () => {
+  const { shutdownPostHog } = await import("./src/server/posthog");
   await shutdownPostHog();
 });
 

--- a/langwatch/vitest.integration.config.ts
+++ b/langwatch/vitest.integration.config.ts
@@ -34,6 +34,14 @@ export default defineConfig({
     // Run test files sequentially to avoid BullMQ/Redis resource contention
     // when multiple pipelines are created and destroyed in parallel
     fileParallelism: false,
+    // Run integration files in forked child processes (vs the unit pool's
+    // `vmThreads`) so each worker is force-killed on file exit. With vmThreads
+    // a single un-`unref`'d timer or unclosed client in any file makes the
+    // whole shard wait forever under --coverage (which awaits a graceful
+    // worker exit instead of force-killing the pool); forks side-step that
+    // class of hang entirely. The startup cost is a few hundred ms per file,
+    // which is dwarfed by integration tests' actual work.
+    pool: "forks",
     // NOTE: BUILD_TIME is NOT set for integration tests because we need real Redis/ClickHouse connections.
     // The setup.ts file handles setting the correct URLs from globalSetup.
   },

--- a/specs/ai-gateway/governance/persona-home-resolver.feature
+++ b/specs/ai-gateway/governance/persona-home-resolver.feature
@@ -115,6 +115,14 @@ Feature: Persona-aware home resolver
     Then the resolver returns "/<projectSlug>/messages"
     And NOT "/governance"
 
+  Scenario: Non-governance org member with no projects → onboarding, not the gated /me
+    Given user "dave@acme.com" belongs to no projects (no ProjectMember rows)
+    But the org does not have the governance UI enabled
+    When the resolver runs for the user
+    Then the resolver returns "/onboarding/welcome"
+    And NOT "/me"
+    And the user lands on a recoverable bootstrap page rather than a 404
+
   # ---------------------------------------------------------------------------
   # User override
   # ---------------------------------------------------------------------------

--- a/specs/ai-gateway/governance/persona-home-resolver.feature
+++ b/specs/ai-gateway/governance/persona-home-resolver.feature
@@ -88,6 +88,34 @@ Feature: Persona-aware home resolver
     And the destination matches Persona 4 (super-admin governance)
 
   # ---------------------------------------------------------------------------
+  # Governance-UI gate — /me and /governance are flag-gated and 404 without it
+  # ---------------------------------------------------------------------------
+  # The /me and /governance surfaces are gated behind
+  # release_ui_ai_governance_enabled. A user whose org does not have the flag
+  # (for example a customer an admin is impersonating, or anyone signing in to
+  # a non-governance org) must never be auto-routed there — they land on the
+  # project home, the pre-governance LLMOps experience. An explicit user pin is
+  # the exception: it could only have been set while the surface was reachable.
+
+  Scenario: Personal-VK user in a non-governance org → project home, not /me
+    Given user "jane@acme.com" has a personal VirtualKey
+    And the user is a member of project "jane-team-prod"
+    But the org does not have the governance UI enabled
+    When the resolver runs for the user
+    Then the resolver returns "/<projectSlug>/messages"
+    And NOT "/me"
+
+  Scenario: Would-be governance admin in a non-governance org → project home, not /governance
+    Given user "carol@acme.com" has the "organization:manage" permission
+    And the user is on the Enterprise plan
+    And the org has governance ingest
+    But the org does not have the governance UI enabled
+    And the user is a member of project "carol-team-prod"
+    When the resolver runs for the user
+    Then the resolver returns "/<projectSlug>/messages"
+    And NOT "/governance"
+
+  # ---------------------------------------------------------------------------
   # User override
   # ---------------------------------------------------------------------------
 

--- a/specs/ai-gateway/governance/workspace-switcher.feature
+++ b/specs/ai-gateway/governance/workspace-switcher.feature
@@ -104,9 +104,32 @@ Feature: AI Gateway Governance — Workspace Switcher (top-left context dropdown
   @bdd @ui @workspace-switcher @empty
   Scenario: A user in no teams sees only the "My Workspace" entry plus a hint
     Given user "newhire@acme.com" is in zero teams and zero projects
+    And newhire's organization enables the AI governance feature
     When she opens the switcher
     Then she sees only the "My Workspace" entry
     And below it a hint reads "Ask your admin to add you to a team to see more contexts here."
+
+  # ---------------------------------------------------------------------------
+  # Personal entry governance gate
+  # ---------------------------------------------------------------------------
+  #
+  # "My Workspace" links to /me, which is gated behind the AI governance flag
+  # and 404s when the flag is off. So the personal entry only renders when at
+  # least one of the user's organizations enables governance. Org-less users
+  # keep it — it is their only context.
+
+  @bdd @ui @workspace-switcher @personal-gate @integration
+  Scenario: The personal entry is hidden when no organization enables governance
+    Given the user belongs to organizations, none of which enable AI governance
+    When the user opens the workspace switcher
+    Then the "My Workspace" personal entry is not shown
+    And only the team and project contexts are listed
+
+  @bdd @ui @workspace-switcher @personal-gate @integration
+  Scenario: The personal entry shows when any organization enables governance
+    Given at least one of the user's organizations enables AI governance
+    When the user opens the workspace switcher
+    Then the "My Workspace" personal entry is shown
 
   @bdd @ui @workspace-switcher @single-team
   Scenario: A solo user (no teams/projects) — switcher remains visible but does not auto-collapse
@@ -238,7 +261,7 @@ Feature: AI Gateway Governance — Workspace Switcher (top-left context dropdown
         loading (preserves intent without breaking the project's
         own redirect logic)
 
-  @bdd @ui @workspace-switcher @add-project @stage-2c
+  @bdd @ui @workspace-switcher @add-project @stage-2c @integration
   Scenario: The dropdown shows a per-team "+ New project" button (admin-only)
     Given the user is an organization admin OR a team admin on team T
     When the user opens the switcher
@@ -248,7 +271,7 @@ Feature: AI Gateway Governance — Workspace Switcher (top-left context dropdown
     And the user's org-membership / team-membership filters apply (a
         viewer-only member on team T sees no "+ New project" entry there)
 
-  @bdd @ui @workspace-switcher @add-project @stage-2c
+  @bdd @ui @workspace-switcher @add-project @stage-2c @integration
   Scenario: The "+ New project" button is suppressed for non-admin members
     Given the user is a regular member (not admin) on team T
     When the user opens the switcher

--- a/specs/ai-gateway/governance/workspace-switcher.feature
+++ b/specs/ai-gateway/governance/workspace-switcher.feature
@@ -262,20 +262,20 @@ Feature: AI Gateway Governance — Workspace Switcher (top-left context dropdown
         own redirect logic)
 
   @bdd @ui @workspace-switcher @add-project @stage-2c @integration
-  Scenario: The dropdown shows a per-team "+ New project" button (admin-only)
+  Scenario: The dropdown shows a per-team "Create project" button (admin-only)
     Given the user is an organization admin OR a team admin on team T
     When the user opens the switcher
-    Then within team T's "Projects" group there is a "+ New project" entry
+    Then within team T's "Projects" group there is a "Create project" entry
     And clicking it opens the existing CreateProject drawer
         (`useDrawer().openDrawer("createProject", ...)`)
     And the user's org-membership / team-membership filters apply (a
-        viewer-only member on team T sees no "+ New project" entry there)
+        viewer-only member on team T sees no "Create project" entry there)
 
   @bdd @ui @workspace-switcher @add-project @stage-2c @integration
-  Scenario: The "+ New project" button is suppressed for non-admin members
+  Scenario: The "Create project" button is suppressed for non-admin members
     Given the user is a regular member (not admin) on team T
     When the user opens the switcher
-    Then no "+ New project" entry is rendered in team T's group
+    Then no "Create project" entry is rendered in team T's group
         (non-admins cannot create projects from this UI)
 
   @bdd @ui @workspace-switcher @persistence @stage-2c

--- a/specs/features/backoffice-user-impersonation-reason.feature
+++ b/specs/features/backoffice-user-impersonation-reason.feature
@@ -15,6 +15,12 @@ Feature: Backoffice User Impersonation Reason
     And the reason field accepts a single line of text
 
   @integration
+  Scenario: Impersonation dialog focuses the reason field on open
+    When the ops admin chooses to impersonate "Yoel Ernst"
+    Then the reason field is focused immediately
+    And the ops admin can type the reason without clicking into the field first
+
+  @integration
   Scenario: Enter submits a completed impersonation reason
     Given the ops admin has opened the impersonation dialog for "Yoel Ernst"
     And the reason field contains "support"


### PR DESCRIPTION
## Summary

Follow-ups to the workspace switcher and cost-center pickers after the AI Governance work merged.

### Per-team "Create project" in the switcher

The unified project selector dropped the legacy project selector's ability to create a project. Each team row in the switcher now has a right-aligned "+" button (tooltip and label "Create project") that opens the existing create-project drawer scoped to that team. It is admin-only: it renders only for teams where the user is an organization or team admin, matching the spec. The two add-project scenarios in the feature file are now enforced (`@integration`) and bound to tests, so this affordance cannot silently regress again.

Note: the switcher already hides teams with zero projects, so the "+" appears on teams that have at least one project. The drawer's own team picker still covers creating a project in an empty team.

### Gate the personal "My Workspace" entry on governance

"My Workspace" links to /me, which is gated behind the AI governance flag and 404s when the flag is off. The personal entry now renders only when at least one of the user's organizations enables governance. Org-less users keep it, since it is their only context. A new `featureFlag.isEnabledForAnyOrganization` query does the cross-org evaluation.

### Wider cost-center picker

The cost-center select on the members, teams, and project settings pages had no minimum width and collapsed in tight table columns, truncating names like "Engineering". It now has a minimum width so the name and chevron always fit.

### Stop routing non-governance users to the flag-gated /me

`/me` and `/governance` are gated behind the AI governance flag and 404 when it is off. The persona home resolver was sending any user with a personal virtual key to `/me`, and any governance admin to `/governance`, regardless of whether the org had the flag. The visible symptom: impersonating a customer (or that customer simply signing in) dead-ended on a 404 `/me`.

The resolver now takes a `hasGovernanceUi` signal and falls back to the project home when the org lacks the flag, so a non-governance org gets the pre-governance LLMOps experience. An explicit user pin still wins, since a pin could only have been set while the surface was reachable. The `/` redirect also gated its "last visited was personal" localStorage fallback on the same signal: that fallback was a second way into `/me`, and during impersonation it was the admin's own preference leaking into the impersonated session. Audit result: the resolver and that localStorage fallback were the only two auto-routes to `/me`; sign-in and sign-up both flow through `/`, so they are covered by the same gate.

### Autofocus the impersonation reason field

The Backoffice impersonation dialog now focuses the reason input as soon as it opens, so an admin can type the reason without first clicking into the field.

## Test plan

- [ ] Switcher shows a "+" on team rows for admins, opens the create-project drawer scoped to that team, and creates the project there
- [ ] No "+" appears for viewer-only members
- [ ] "My Workspace" is hidden when no organization enables governance, shown when at least one does, and still present for org-less users
- [ ] Cost-center picker shows full names on members, teams, and project settings
- [ ] Impersonating a customer whose org lacks the governance flag lands on their first project, not a 404 `/me`
- [ ] Signing in to a non-governance org never routes to `/me`
- [ ] Opening the impersonation dialog focuses the reason field immediately

## Screenshots

_Added during browser verification (committed to the pr-screenshots repo, not this branch)._

### Cost-center assignment on the Teams & Projects page

Each project row on the Teams & Projects page now has its own cost-center picker, so projects are assigned next to their team instead of only on project settings. The cost-centers page Projects link points here. Both the team and project pickers read inline as part of the row metadata: a "· Cost center" label beside a compact select, matching the "N projects · M members" line next to it.

![Teams & Projects cost-center pickers](https://raw.githubusercontent.com/langwatch/pr-screenshots/7054f43fe15af15d307bb6857a626a01998ff679/pr-4407/teams-cost-center-inline-restyle.png)

### Add a project from the workspace switcher

Each team row in the switcher has a right-aligned "+" that opens the create-project drawer scoped to that team (here: Dogfooding Team preselected). "My Workspace" is hidden because no organization in this account enables governance; it reappears once any org does (cross-org gate).

![Switcher: + per team row, personal entry hidden](https://raw.githubusercontent.com/langwatch/pr-screenshots/b3049d2b8a58dbbb2829f70889692eb783e17c15/pr-4407/switcher-plus-icons-personal-hidden.png)

![Create-project drawer scoped to the team](https://raw.githubusercontent.com/langwatch/pr-screenshots/b3049d2b8a58dbbb2829f70889692eb783e17c15/pr-4407/create-project-drawer-from-switcher.png)

### Cost-center picker width on Members

Full cost-center names are visible (no longer truncated to "Engin").

![Members cost-center picker, full width](https://raw.githubusercontent.com/langwatch/pr-screenshots/b3049d2b8a58dbbb2829f70889692eb783e17c15/pr-4407/members-cost-center-width-fixed.png)

### "Create project" buttons on each team row

The per-team "+" now reads "Create project" in its tooltip and label.

![Switcher: Create project buttons per team row](https://raw.githubusercontent.com/langwatch/pr-screenshots/3098b7d/pr-4407/switcher-create-project-buttons.png)

### Impersonation dialog autofocus

The reason field is focused the moment the dialog opens.

![Impersonation dialog with the reason field focused](https://raw.githubusercontent.com/langwatch/pr-screenshots/3098b7d/pr-4407/impersonate-dialog-autofocus.png)

