### PR TITLE
fix(nlpgo): strip markdown json fence before parsing signature outputs

### DIFF
--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -596,13 +596,20 @@ func jsonSchemaForField(f dsl.Field) map[string]any {
 // non-JSON fallback.
 func extractSignatureOutputs(content string, outputs []dsl.Field) (map[string]any, []string) {
 	out := make(map[string]any, len(outputs))
-	var parsed map[string]any
-	if err := jsonUnmarshalRaw([]byte(content), &parsed); err != nil {
+
+	parsed, ok := recoverJSONObject(content)
+	if !ok {
+		// The completion wasn't a JSON object even after stripping a
+		// markdown ```json fence and extracting the first balanced {...}.
+		// Preserve the raw text in the first declared field so the
+		// response isn't lost, and warn so operators see the malformed
+		// structured response.
 		if len(outputs) > 0 {
 			out[outputs[0].Identifier] = content
 		}
-		return out, []string{fmt.Sprintf("signature: structured response did not parse as JSON object: %v", err)}
+		return out, []string{"signature: structured response did not parse as a JSON object"}
 	}
+
 	var warnings []string
 	for _, f := range outputs {
 		if v, ok := parsed[f.Identifier]; ok {
@@ -612,6 +619,32 @@ func extractSignatureOutputs(content string, outputs []dsl.Field) (map[string]an
 		}
 	}
 	return out, warnings
+}
+
+// recoverJSONObject parses an LLM completion into a JSON object, tolerating
+// the markdown ```json fence and surrounding prose that models (notably
+// Anthropic/Claude) emit even when a JSON response_format is requested.
+// Mirrors DSPy's JSONAdapter.parse, which strips the fence and extracts the
+// first balanced object before parsing. Tries, in order: the raw content,
+// the fence-stripped content, then the first balanced {...} object. Without
+// this, a fenced ```json{...}``` completion fails to parse and the whole
+// blob is dumped into the first output field instead of being split across
+// the declared fields.
+func recoverJSONObject(content string) (map[string]any, bool) {
+	candidates := []string{content}
+	if stripped := stripJSONFence(content); stripped != content {
+		candidates = append(candidates, stripped)
+	}
+	if obj, ok := extractFirstJSONObject(content); ok {
+		candidates = append(candidates, obj)
+	}
+	for _, c := range candidates {
+		var parsed map[string]any
+		if err := jsonUnmarshalRaw([]byte(c), &parsed); err == nil && parsed != nil {
+			return parsed, true
+		}
+	}
+	return nil, false
 }
 
 // runEvaluator dispatches an evaluator node to the LangWatch evaluator

--- a/services/nlpgo/app/engine/json.go
+++ b/services/nlpgo/app/engine/json.go
@@ -1,10 +1,78 @@
 package engine
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // jsonUnmarshalCompat is a small wrapper that gives us a single point
 // to swap the JSON library if we ever switch to sonic for parity with
 // the gateway's hot path.
 func jsonUnmarshalCompat(b []byte, v any) error {
 	return json.Unmarshal(b, v)
+}
+
+// stripJSONFence removes a single surrounding markdown code fence from s,
+// e.g. "```json\n{...}\n```" -> "{...}". Models (notably Anthropic/Claude)
+// wrap a JSON response in a fence even when a JSON response_format is
+// requested, so the raw completion won't parse without this. Returns s
+// unchanged when there is no leading fence.
+func stripJSONFence(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if !strings.HasPrefix(trimmed, "```") {
+		return s
+	}
+	// Drop the opening fence line, including an optional language tag
+	// (```json / ```JSON / ```).
+	nl := strings.IndexByte(trimmed, '\n')
+	if nl == -1 {
+		return s
+	}
+	inner := trimmed[nl+1:]
+	// Drop the trailing closing fence if present.
+	if idx := strings.LastIndex(inner, "```"); idx != -1 {
+		inner = inner[:idx]
+	}
+	return strings.TrimSpace(inner)
+}
+
+// extractFirstJSONObject returns the first balanced top-level {...} object in
+// s, respecting string literals and escapes so braces inside strings don't
+// confuse the scan. Mirrors DSPy's JSONAdapter fallback for completions that
+// surround the JSON object with prose. Returns ("", false) when no balanced
+// object is found.
+func extractFirstJSONObject(s string) (string, bool) {
+	start := strings.IndexByte(s, '{')
+	if start == -1 {
+		return "", false
+	}
+	depth := 0
+	inStr := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1], true
+			}
+		}
+	}
+	return "", false
 }

--- a/services/nlpgo/app/engine/json.go
+++ b/services/nlpgo/app/engine/json.go
@@ -28,11 +28,12 @@ func stripJSONFence(s string) string {
 	if nl == -1 {
 		return s
 	}
-	inner := trimmed[nl+1:]
-	// Drop the trailing closing fence if present.
-	if idx := strings.LastIndex(inner, "```"); idx != -1 {
-		inner = inner[:idx]
-	}
+	// Only strip a real closing fence at the very end (TrimSuffix), never
+	// an interior ``` that legitimately appears inside a JSON string value
+	// (e.g. a fenced code snippet). Any prose after the closing fence is
+	// handled by the balanced-object recovery, so we don't need LastIndex.
+	inner := strings.TrimSpace(trimmed[nl+1:])
+	inner = strings.TrimSuffix(inner, "```")
 	return strings.TrimSpace(inner)
 }
 

--- a/services/nlpgo/app/engine/signature_outputs_test.go
+++ b/services/nlpgo/app/engine/signature_outputs_test.go
@@ -162,6 +162,100 @@ func TestExtractSignatureOutputs_MissingFieldWarns(t *testing.T) {
 	assert.Contains(t, warnings[0], `"b"`)
 }
 
+// TestExtractSignatureOutputs_StripsMarkdownFence is the regression for the
+// nlpgo structured-output bug (Skai "Tool Selection Evaluator", rchaves
+// dogfood 2026-05-29): Anthropic/Claude wraps the JSON object in a ```json
+// markdown fence even when a response_format is requested, so a bare
+// json.Unmarshal choked and the engine dumped the WHOLE fenced blob into the
+// first declared field — leaving passed/details unset. Downstream nodes bound
+// to a specific field then received the raw blob. This executes the actual
+// extract path and asserts the fields split correctly.
+func TestExtractSignatureOutputs_StripsMarkdownFence(t *testing.T) {
+	outputs := []dsl.Field{
+		{Identifier: "passed", Type: dsl.FieldTypeBool},
+		{Identifier: "details", Type: dsl.FieldTypeStr},
+		{Identifier: "reasoning", Type: dsl.FieldTypeStr},
+	}
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			"```json fence",
+			"```json\n{\"passed\": true, \"details\": \"CHECK 1: PASS\", \"reasoning\": \"no tools needed\"}\n```",
+		},
+		{
+			"bare ``` fence",
+			"```\n{\"passed\": true, \"details\": \"CHECK 1: PASS\", \"reasoning\": \"no tools needed\"}\n```",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warnings := extractSignatureOutputs(tc.content, outputs)
+			assert.Empty(t, warnings, "fenced JSON must parse cleanly across declared fields")
+			assert.Equal(t, true, got["passed"], "bool field must split out as a real bool, not be lost in a raw blob")
+			assert.Equal(t, "CHECK 1: PASS", got["details"])
+			assert.Equal(t, "no tools needed", got["reasoning"],
+				"the field a downstream node binds to must hold its own value, not the whole blob")
+		})
+	}
+}
+
+// TestExtractSignatureOutputs_RecoversProseWrappedJSON covers a model that
+// surrounds the object with prose (no fence) — the balanced-object fallback
+// recovers the first {...} so the fields still split.
+func TestExtractSignatureOutputs_RecoversProseWrappedJSON(t *testing.T) {
+	outputs := []dsl.Field{{Identifier: "label", Type: dsl.FieldTypeStr}}
+	got, warnings := extractSignatureOutputs(`Sure! Here is the result: {"label":"weather"} — hope that helps.`, outputs)
+	assert.Empty(t, warnings)
+	assert.Equal(t, "weather", got["label"])
+}
+
+func TestStripJSONFence(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no fence passthrough", `{"a":1}`, `{"a":1}`},
+		{"json tag", "```json\n{\"a\":1}\n```", `{"a":1}`},
+		{"uppercase tag", "```JSON\n{\"a\":1}\n```", `{"a":1}`},
+		{"bare fence", "```\n{\"a\":1}\n```", `{"a":1}`},
+		{"leading whitespace", "  ```json\n{\"a\":1}\n```  ", `{"a":1}`},
+		{"no closing fence", "```json\n{\"a\":1}", `{"a":1}`},
+		{"plain text untouched", "just text", "just text"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripJSONFence(tc.in))
+		})
+	}
+}
+
+func TestExtractFirstJSONObject(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"plain object", `{"a":1}`, `{"a":1}`, true},
+		{"object with prose around", `prefix {"a":1} suffix`, `{"a":1}`, true},
+		{"brace inside string ignored", `{"a":"}"}`, `{"a":"}"}`, true},
+		{"escaped quote inside string", `{"a":"x\"}y"}`, `{"a":"x\"}y"}`, true},
+		{"nested object", `{"a":{"b":2}}`, `{"a":{"b":2}}`, true},
+		{"no object", `just text, no braces`, "", false},
+		{"unbalanced", `{"a":1`, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := extractFirstJSONObject(tc.in)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestJSONSchemaForField_ScalarMappings(t *testing.T) {
 	cases := []struct {
 		ft   dsl.FieldType

--- a/services/nlpgo/app/engine/signature_outputs_test.go
+++ b/services/nlpgo/app/engine/signature_outputs_test.go
@@ -223,6 +223,10 @@ func TestStripJSONFence(t *testing.T) {
 		{"bare fence", "```\n{\"a\":1}\n```", `{"a":1}`},
 		{"leading whitespace", "  ```json\n{\"a\":1}\n```  ", `{"a":1}`},
 		{"no closing fence", "```json\n{\"a\":1}", `{"a":1}`},
+		// An interior ``` inside a string value (no real closing fence)
+		// must NOT be treated as the closing fence — only a genuine
+		// trailing fence is stripped.
+		{"interior fence not stripped", "```json\n{\"code\":\"a```b\"}", `{"code":"a` + "```" + `b"}`},
 		{"plain text untouched", "just text", "just text"},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

When a Studio LLM/Signature node runs through nlpgo (the Go engine), its output came back as the raw LLM completion including a ```json markdown fence (unparsed), instead of the declared typed fields. A downstream node bound to a specific field (e.g. `.reasoning`) then received the whole blob instead of that field's value. The python/DSPy path returns properly parsed fields, so this was a migration parity gap.

Root cause: `extractSignatureOutputs` called bare `json.Unmarshal`. Anthropic/Claude wraps the JSON object in a ```json fence even when a `response_format` is requested, so the unmarshal failed on the leading backtick and hit the fallback that dumps the entire blob into the first declared field, leaving the rest unset. The downstream "got the full content" symptom is purely a consequence: with no real per-field values, the key-addressed wiring had nothing to resolve.

## What changed

- `extractSignatureOutputs` now recovers the JSON object the way DSPy's `JSONAdapter.parse` does: tries the raw content, then the fence-stripped content, then the first balanced `{...}` object (for prose-wrapped completions). The declared fields then split correctly and the existing downstream wiring resolves the right value automatically, so no separate fix was needed for the "downstream gets the blob" symptom.
- New `stripJSONFence` and `extractFirstJSONObject` helpers in `app/engine/json.go` (colocated with the json handling). The balanced-object scan respects string literals and escapes so braces inside strings don't confuse it.
- The single-`str` text-only fast path is left untouched (DSPy returns a lone string output verbatim with no parse), preserving parity.

## Test plan

- [x] `go build ./app/engine/...` and `go vet ./app/engine/` clean
- [x] New regression test runs the actual extract path on a fenced `{passed, details, reasoning}` completion and asserts the fields split (bool stays a bool, the downstream-bound field holds its own value)
- [x] Added unit tests for `stripJSONFence` and `extractFirstJSONObject` (incl. brace-inside-string, escaped quotes, prose-wrapped, no-fence passthrough)
- [x] Full `go test ./app/engine/` package green, no regressions