### PR TITLE
fix(python-sdk): tidy non-IANA status fix follow-ups from review

### DIFF
--- a/python-sdk/Makefile
+++ b/python-sdk/Makefile
@@ -92,10 +92,13 @@ test-notebooks:
 batch-evaluation-example:
 	uv run python $(filter-out $@,$(MAKECMDGOALS))
 
+# Pinned to the upstream version that openapi-templates/ was forked from.
+# When bumping, re-diff openapi-templates/*.jinja against the new upstream
+# and drop the override if upstream PR #1407 has landed.
+OPENAPI_PYTHON_CLIENT_VERSION := 0.28.4
+
 ensure-openapi-python-client:
-	@if ! command -v openapi-python-client &> /dev/null; then \
-		uv pip install openapi-python-client; \
-	fi
+	@uv pip install --quiet "openapi-python-client==$(OPENAPI_PYTHON_CLIENT_VERSION)"
 
 generate/api-client: ensure-openapi-python-client
 	@echo "Generating OpenAPI spec..."

--- a/python-sdk/openapi-templates/endpoint_module.py.jinja
+++ b/python-sdk/openapi-templates/endpoint_module.py.jinja
@@ -1,8 +1,13 @@
 {# LangWatch fork of openapi-python-client v0.28.4 endpoint_module.py.jinja.
    The only change vs upstream is the safe_http_status wrapper used in
-   _build_response (see below). Drop this override when upstream merges
-   https://github.com/openapi-generators/openapi-python-client/pull/1407
-   (tracked at https://github.com/openapi-generators/openapi-python-client/issues/1442). #}
+   _build_response (see below).
+
+   Revisit this override when bumping openapi-python-client (pinned in
+   Makefile). Upstream tracking:
+     https://github.com/openapi-generators/openapi-python-client/issues/1442
+     https://github.com/openapi-generators/openapi-python-client/pull/1407
+   If a non-crashing path lands (opt-in flag or new default), switch to
+   it and drop this template. #}
 from typing import Any, cast
 from urllib.parse import quote
 

--- a/python-sdk/openapi-templates/endpoint_module.py.jinja
+++ b/python-sdk/openapi-templates/endpoint_module.py.jinja
@@ -1,4 +1,8 @@
-from http import HTTPStatus
+{# LangWatch fork of openapi-python-client v0.28.4 endpoint_module.py.jinja.
+   The only change vs upstream is the safe_http_status wrapper used in
+   _build_response (see below). Drop this override when upstream merges
+   https://github.com/openapi-generators/openapi-python-client/pull/1407
+   (tracked at https://github.com/openapi-generators/openapi-python-client/issues/1442). #}
 from typing import Any, cast
 from urllib.parse import quote
 

--- a/python-sdk/openapi-templates/types.py.jinja
+++ b/python-sdk/openapi-templates/types.py.jinja
@@ -1,8 +1,13 @@
 {# LangWatch fork of openapi-python-client v0.28.4 types.py.jinja.
    Changes vs upstream: adds safe_http_status() helper and widens
-   Response.status_code to HTTPStatus | int. Drop this override when
-   upstream merges https://github.com/openapi-generators/openapi-python-client/pull/1407
-   (tracked at https://github.com/openapi-generators/openapi-python-client/issues/1442). #}
+   Response.status_code to HTTPStatus | int.
+
+   Revisit this override when bumping openapi-python-client (pinned in
+   Makefile). Upstream tracking:
+     https://github.com/openapi-generators/openapi-python-client/issues/1442
+     https://github.com/openapi-generators/openapi-python-client/pull/1407
+   If a non-crashing path lands (opt-in flag or new default), switch to
+   it and drop this template. #}
 """ Contains some shared types for properties """
 
 from collections.abc import Mapping, MutableMapping

--- a/python-sdk/openapi-templates/types.py.jinja
+++ b/python-sdk/openapi-templates/types.py.jinja
@@ -1,3 +1,8 @@
+{# LangWatch fork of openapi-python-client v0.28.4 types.py.jinja.
+   Changes vs upstream: adds safe_http_status() helper and widens
+   Response.status_code to HTTPStatus | int. Drop this override when
+   upstream merges https://github.com/openapi-generators/openapi-python-client/pull/1407
+   (tracked at https://github.com/openapi-generators/openapi-python-client/issues/1442). #}
 """ Contains some shared types for properties """
 
 from collections.abc import Mapping, MutableMapping

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_agents_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_annotations_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dashboards_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_dataset_by_slug_or_id_records.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_evaluators_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_evaluators_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_graphs_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_prompts_tags_by_tag.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any, cast
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenario_events.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenario_events.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_scenarios_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_suites_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_triggers_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/delete_api_workflows_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_agents_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_annotations_trace_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dashboards_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_dataset_by_slug_or_id_records.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators_by_id_or_slug.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_evaluators_by_id_or_slug.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_graphs_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_model_providers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_model_providers.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id_versions.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_by_id_versions.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_tags.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_prompts_tags.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_scenarios_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_batches_list.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_batches_list.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_by_scenario_run_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_simulation_runs_by_scenario_run_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_suites_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_trace_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_traces_by_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_traces_by_trace_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_triggers_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_api_workflows_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_index.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/get_index.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_agents_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_agents_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_annotations_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_annotations_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dashboards_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dashboards_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id_records_by_record_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_dataset_by_slug_or_id_records_by_record_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_graphs_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_graphs_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_suites_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_suites_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_triggers_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_triggers_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_workflows_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/patch_api_workflows_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_agents.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_agents.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_analytics_timeseries.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_analytics_timeseries.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_annotations_trace_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_annotations_trace_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dashboards.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dashboards.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_entries.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_entries.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_records.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_records.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_upload.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_by_slug_or_id_upload.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_upload.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_dataset_upload.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_evaluators.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_evaluators.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_graphs.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_graphs.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_by_id_sync.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_by_id_sync.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_tags.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_prompts_tags.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenario_events.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenario_events.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenarios.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_scenarios.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_duplicate.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_duplicate.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_run.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_suites_by_id_run.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_share.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_share.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_unshare.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_trace_id_unshare.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_traces_search.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_traces_search.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_triggers.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_api_triggers.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_index.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/post_index.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_dashboards_reorder.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_dashboards_reorder.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_evaluators_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_evaluators_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_model_providers_by_provider.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_model_providers_by_provider.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_by_id_tags_by_tag.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_tags_by_tag.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_prompts_tags_by_tag.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_scenarios_by_id.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/default/put_api_scenarios_by_id.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/get_evaluations_v3_run_status.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/get_evaluations_v3_run_status.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/post_evaluations_v3_run.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/evaluations_v3/post_evaluations_v3_run.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 

--- a/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/traces/post_api_trace_search.py
+++ b/python-sdk/src/langwatch/generated/langwatch_rest_api_client/api/traces/post_api_trace_search.py
@@ -1,4 +1,3 @@
-from http import HTTPStatus
 from typing import Any
 
 import httpx

--- a/python-sdk/tests/prompts/test_prompt_tags.py
+++ b/python-sdk/tests/prompts/test_prompt_tags.py
@@ -60,11 +60,10 @@ def _make_api_response_200(
 
 def _mock_sync_detailed_response(parsed, status_code=200):
     """Create a mock Response object wrapping a parsed model."""
-    from http import HTTPStatus
-    from langwatch.generated.langwatch_rest_api_client.types import Response
+    from langwatch.generated.langwatch_rest_api_client.types import Response, safe_http_status
 
     return Response(
-        status_code=HTTPStatus(status_code),
+        status_code=safe_http_status(status_code),
         content=json.dumps({}).encode() if parsed else b"",
         headers={},
         parsed=parsed,

--- a/python-sdk/tests/test_generated_client_status_codes.py
+++ b/python-sdk/tests/test_generated_client_status_codes.py
@@ -13,6 +13,7 @@ from http import HTTPStatus
 import httpx
 import pytest
 
+from langwatch.generated.langwatch_rest_api_client import errors
 from langwatch.generated.langwatch_rest_api_client.api.default import (
     get_api_prompts_by_id,
 )
@@ -65,3 +66,13 @@ class TestBuildResponseWithNonStandardStatus:
 
         assert built.status_code is HTTPStatus.IM_A_TEAPOT
         assert built.parsed is None
+
+    def test_raises_unexpected_status_on_520_when_enabled(self) -> None:
+        """raise_on_unexpected_status=True must surface UnexpectedStatus(520), not ValueError."""
+        client = Client(base_url="https://example.com", raise_on_unexpected_status=True)
+        response = self._make_httpx_response(520)
+
+        with pytest.raises(errors.UnexpectedStatus) as exc_info:
+            get_api_prompts_by_id._build_response(client=client, response=response)
+
+        assert exc_info.value.status_code == 520


### PR DESCRIPTION
Follow-up to #4403 (merged). Addresses review items + a codebase sweep for the same anti-pattern.

## Changes

- **Remove dead `from http import HTTPStatus` import** from `openapi-templates/endpoint_module.py.jinja` and the 90 already-generated endpoint files. After the previous PR, `HTTPStatus` is only used inside `types.py` (for the `safe_http_status` helper and the `HTTPStatus | int` type alias); endpoint files don't reference it.
- **Document the template fork.** Both Jinja overrides get a header comment recording upstream source version (`openapi-python-client v0.28.4`) plus the tracking issue, so the override is removable when upstream lands [PR #1407](https://github.com/openapi-generators/openapi-python-client/pull/1407).
- **Pin `openapi-python-client==0.28.4`** in the Makefile's `ensure-openapi-python-client` target so regenerations are reproducible and the fork has a single source of truth.
- **New regression test** — `test_raises_unexpected_status_on_520_when_enabled` asserts that with `raise_on_unexpected_status=True` and a Cloudflare 520, the client surfaces `errors.UnexpectedStatus(520)` rather than `ValueError`. Locks the second half of the contract.
- **Test helper consistency** — `_mock_sync_detailed_response` in `tests/prompts/test_prompt_tags.py` wrapped its `status_code` in `HTTPStatus(...)` directly, i.e. the exact anti-pattern the SDK now guards against — it would itself raise `ValueError` if a test ever passed a non-IANA code. Swapped to `safe_http_status`. (IANA-only call sites elsewhere in the file are unaffected.)

## Blast-radius sweep

Swept the whole monorepo for the bug class (constructing a strict enum from an external status int). The fix is needed in exactly one place — the `openapi-python-client`-generated REST client — and it's fully covered (90/90 `_build_response` files use `safe_http_status`, verified zero gaps; a fresh regen from the committed spec emits the override at all 144 endpoint sites, 0 crash paths). Everything else is structurally immune:

- **typescript-sdk** — `openapi-typescript` (types only) + `openapi-fetch` runtime → raw `response.status` number, no enum coercion.
- **langwatch (Next.js)** — status handled via `>=` comparisons (`getLogLevelFromStatusCode`) and a null-returning validator (`validateStatusCode`).
- **langwatch_nlp / langwatch_server / langevals / mcp-server** — zero `HTTPStatus(...)` call sites; status read as raw int.
- **Go (aigateway, sdk-go, cmd, pkg)** — `http.StatusText(code)` returns `""` for unknown codes; never panics by design.

## Test plan

- [x] `make test-unit` — 348 passed, 0 failed
- [x] `tests/prompts/test_prompt_tags.py` — 45 passed after the helper swap
- [x] End-to-end repro: customer's exact crash path (`PromptApiService.get → sync_detailed → _build_response`) against a live mocked Cloudflare 520 now surfaces a clean `RuntimeError`, not `ValueError`
- [x] Reproducibility: fresh regen from committed spec + pinned generator emits `safe_http_status` everywhere, 0 bare `HTTPStatus(` crash paths

## Upstream

- Tracking issue: https://github.com/openapi-generators/openapi-python-client/issues/1442
- Upstream PR: https://github.com/openapi-generators/openapi-python-client/pull/1407