### PR TITLE
fix(ci): raise heap for integration shard to stop coverage-OOM

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -226,6 +226,18 @@ jobs:
       - name: Run integration tests with coverage (shard ${{ matrix.shard }}/4)
         id: integration-tests
         working-directory: langwatch
+        # Integration files run sequentially in a single long-lived fork
+        # worker (fileParallelism:false, for Redis/BullMQ contention). Under
+        # --coverage the v8 coverage data accumulates in that worker across
+        # every file in the shard until it crosses Node's ~4GB default heap,
+        # then GC-thrashes for hours and OOMs ("FATAL: JS heap out of memory",
+        # surfacing as a forks-worker termination timeout on whichever file
+        # happened to be running). NODE_OPTIONS is inherited by the fork
+        # worker (execArgv is not), so it raises the heap where it's needed.
+        # Stopgap; the durable fix is recycling the worker / shrinking
+        # per-file coverage retention.
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: |
           pnpm test:integration --shard=${{ matrix.shard }}/4 \
             --coverage --coverage.reporter=lcov --coverage.reporter=text \

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -227,7 +227,7 @@ jobs:
         id: integration-tests
         working-directory: langwatch
         # Integration files run sequentially in a single long-lived fork
-        # worker (fileParallelism:false, for Redis/BullMQ contention). Under
+        # worker (fileParallelism:false, for Redis contention). Under
         # --coverage the v8 coverage data accumulates in that worker across
         # every file in the shard until it crosses Node's ~4GB default heap,
         # then GC-thrashes for hours and OOMs ("FATAL: JS heap out of memory",


### PR DESCRIPTION
## Summary

The `test-integration` shards (notably shard 3) have been hanging for hours and then failing CI with `FATAL: JS heap out of memory`, blocking app PRs. Root cause is **cumulative coverage memory**, not any single test:

- Integration files run **sequentially in one long-lived fork worker** (`fileParallelism: false`, to avoid Redis/BullMQ contention).
- Under `--coverage`, the v8 coverage data accumulates in that worker across every file in the shard until it crosses Node's ~4 GB default old-space limit (`Mark-Compact ... 3934MB ... allocation failure`).
- The worker then GC-thrashes for hours and OOMs. Vitest reports it as a forks-worker termination timeout on whichever file happened to be running when the heap filled — recently `api-keys-scope-filter.integration.test.tsx`, which is the **victim, not the cause** (a recently-added file that pushed the cumulative total over the edge).
- The same shard completes in ~90s **without** `--coverage`, which isolates the trigger to coverage retention.

## What changed

Raise the worker heap on the integration step via `NODE_OPTIONS=--max-old-space-size=8192`. `NODE_OPTIONS` is inherited by vitest's fork worker (execArgv is not), so it applies where the OOM actually happens. The public-repo `ubuntu-latest` runner has 16 GB, so 8 GB heap leaves ample room for the testcontainers (ClickHouse/Redis/Postgres) and OS.

This is a **stopgap** to unblock CI now. The durable fix is to stop the accumulation (recycle the fork worker periodically or shrink per-file coverage retention) and is worth a follow-up owned by CI.

## Test plan

- [x] YAML validates
- [ ] CI: the `test-integration` shards complete without the heap OOM (verified by this PR's own run)