### PR TITLE
fix(governance): filter cross-org input on isEnabledForAnyOrganization

### DIFF
--- a/langwatch/src/components/useWorkspaceData.ts
+++ b/langwatch/src/components/useWorkspaceData.ts
@@ -53,6 +53,11 @@ export function useWorkspaceData(): Pick<
     [organizations],
   );
 
+  // The workspace switcher mounts on every page that renders a chrome
+  // header, so this query would fire on each navigation + every window
+  // refocus without caching. Mirror useFeatureFlag's policy: long
+  // staleTime + no refetch on focus / reconnect — a full reload picks
+  // up new flag state, which is what governance preview rollouts need.
   const governanceQuery =
     api.featureFlag.isEnabledForAnyOrganization.useQuery(
       {
@@ -62,6 +67,8 @@ export function useWorkspaceData(): Pick<
       {
         enabled: organizationIds.length > 0,
         staleTime: CLIENT_FLAG_STALE_TIME_MS,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
       },
     );
 

--- a/langwatch/src/server/api/routers/__tests__/featureFlag.isEnabledForAnyOrganization.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/featureFlag.isEnabledForAnyOrganization.unit.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the featureFlag.isEnabledForAnyOrganization tRPC procedure.
+ *
+ * The procedure receives a list of organization ids from the client. It MUST
+ * intersect that list with the caller's actual `OrganizationUser` memberships
+ * before evaluating the flag — otherwise an authenticated user could probe
+ * the flag state of arbitrary organizations they don't belong to, which leaks
+ * business information (e.g. which organizations use governance).
+ *
+ * Failure mode under test (pre-fix regression): the resolver fanned out
+ * `featureFlagService.isEnabled` over every input id without a membership
+ * check, so an attacker who knew (or guessed) another org's id could read
+ * its flag state. The fix silently drops non-member ids and returns
+ * `{ enabled: false }` when the filtered set is empty.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { featureFlagRouter } from "../featureFlag";
+import { createInnerTRPCContext } from "../../trpc";
+
+const { mockIsEnabled } = vi.hoisted(() => ({
+  mockIsEnabled: vi.fn<(...args: unknown[]) => Promise<boolean>>(),
+}));
+
+vi.mock("../../../featureFlag", () => ({
+  featureFlagService: { isEnabled: mockIsEnabled },
+}));
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    skipPermissionCheck:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+const USER_ID = "user_1";
+const OWN_ORG_A = "org_own_a";
+const OWN_ORG_B = "org_own_b";
+const FOREIGN_ORG = "org_foreign";
+const FLAG = "release_ui_ai_governance_enabled" as const;
+
+function buildMockPrisma(memberOf: Set<string>) {
+  return {
+    organizationUser: {
+      findUnique: vi.fn(({ where }: any) => {
+        const { userId, organizationId } = where.userId_organizationId;
+        if (userId !== USER_ID) return Promise.resolve(null);
+        return Promise.resolve(
+          memberOf.has(organizationId) ? { organizationId } : null,
+        );
+      }),
+    },
+  } as unknown as PrismaClient;
+}
+
+function buildCaller(prisma: PrismaClient) {
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: USER_ID }, expires: "1" },
+    req: undefined,
+    res: undefined,
+    permissionChecked: true,
+    publiclyShared: false,
+  });
+  ctx.prisma = prisma;
+  return featureFlagRouter.createCaller(ctx);
+}
+
+describe("featureFlag.isEnabledForAnyOrganization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsEnabled.mockResolvedValue(false);
+  });
+
+  describe("when the user is a member of every input organization", () => {
+    it("evaluates the flag for those organizations", async () => {
+      const caller = buildCaller(
+        buildMockPrisma(new Set([OWN_ORG_A, OWN_ORG_B])),
+      );
+      mockIsEnabled.mockImplementation(async (_flag, opts: any) =>
+        opts.organizationId === OWN_ORG_B,
+      );
+
+      const result = await caller.isEnabledForAnyOrganization({
+        flag: FLAG,
+        organizationIds: [OWN_ORG_A, OWN_ORG_B],
+      });
+
+      expect(result).toEqual({ enabled: true });
+      const evaluatedOrgIds = mockIsEnabled.mock.calls.map(
+        ([, opts]: any) => opts.organizationId,
+      );
+      expect(evaluatedOrgIds.sort()).toEqual([OWN_ORG_A, OWN_ORG_B].sort());
+    });
+  });
+
+  describe("when the input mixes member and non-member organizations", () => {
+    it("silently filters non-member ids before evaluating the flag", async () => {
+      const caller = buildCaller(buildMockPrisma(new Set([OWN_ORG_A])));
+      mockIsEnabled.mockImplementation(async (_flag, opts: any) =>
+        opts.organizationId === OWN_ORG_A,
+      );
+
+      const result = await caller.isEnabledForAnyOrganization({
+        flag: FLAG,
+        organizationIds: [OWN_ORG_A, FOREIGN_ORG],
+      });
+
+      expect(result).toEqual({ enabled: true });
+      const evaluatedOrgIds = mockIsEnabled.mock.calls.map(
+        ([, opts]: any) => opts.organizationId,
+      );
+      expect(evaluatedOrgIds).toEqual([OWN_ORG_A]);
+      expect(evaluatedOrgIds).not.toContain(FOREIGN_ORG);
+    });
+  });
+
+  describe("when the user is a member of none of the input organizations", () => {
+    it("returns enabled:false without evaluating the flag", async () => {
+      const caller = buildCaller(buildMockPrisma(new Set()));
+
+      const result = await caller.isEnabledForAnyOrganization({
+        flag: FLAG,
+        organizationIds: [FOREIGN_ORG, "org_other_foreign"],
+      });
+
+      expect(result).toEqual({ enabled: false });
+      expect(mockIsEnabled).not.toHaveBeenCalled();
+    });
+
+    it("returns the same shape as a member with the flag off, so the response cannot oracle membership", async () => {
+      const nonMemberCaller = buildCaller(buildMockPrisma(new Set()));
+      const memberCaller = buildCaller(
+        buildMockPrisma(new Set([OWN_ORG_A])),
+      );
+      mockIsEnabled.mockResolvedValue(false);
+
+      const nonMemberResult =
+        await nonMemberCaller.isEnabledForAnyOrganization({
+          flag: FLAG,
+          organizationIds: [FOREIGN_ORG],
+        });
+      const memberResult = await memberCaller.isEnabledForAnyOrganization({
+        flag: FLAG,
+        organizationIds: [OWN_ORG_A],
+      });
+
+      expect(nonMemberResult).toEqual(memberResult);
+      expect(nonMemberResult).toEqual({ enabled: false });
+    });
+  });
+
+  describe("when the input list is empty", () => {
+    it("returns enabled:false without touching prisma or featureFlagService", async () => {
+      const prisma = buildMockPrisma(new Set([OWN_ORG_A]));
+      const caller = buildCaller(prisma);
+
+      const result = await caller.isEnabledForAnyOrganization({
+        flag: FLAG,
+        organizationIds: [],
+      });
+
+      expect(result).toEqual({ enabled: false });
+      expect(prisma.organizationUser.findUnique).not.toHaveBeenCalled();
+      expect(mockIsEnabled).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/featureFlag.ts
+++ b/langwatch/src/server/api/routers/featureFlag.ts
@@ -89,6 +89,14 @@ export const featureFlagRouter = createTRPCRouter({
    * user has the flag in any organization they belong to. Returns true as
    * soon as one organization has it enabled.
    *
+   * The procedure first intersects `organizationIds` with the caller's
+   * actual `OrganizationUser` memberships and silently drops the rest —
+   * otherwise an authenticated user could probe the flag state of arbitrary
+   * organizations they have no business knowing about. Silent drop (rather
+   * than throwing on the first unknown id) keeps the response shape
+   * indistinguishable between "flag off" and "not a member", so the
+   * procedure cannot be used as a membership oracle either.
+   *
    * @param flag - The feature flag key (must be in FRONTEND_FEATURE_FLAGS)
    * @param organizationIds - Organizations to evaluate the flag against
    * @returns { enabled: boolean }
@@ -100,8 +108,9 @@ export const featureFlagRouter = createTRPCRouter({
         organizationIds: z.array(z.string()),
       }),
     )
-    // organizationIds is a plural targeting param, not one of the sensitive
-    // singular keys (organizationId/teamId/projectId), so no allow-list needed.
+    // Membership filtering below is the real authorization check; the
+    // rbac middleware's sensitive-key guard does not cover plural
+    // targeting params and is not relevant here.
     .use(skipPermissionCheck())
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
@@ -110,8 +119,28 @@ export const featureFlagRouter = createTRPCRouter({
         return { enabled: false };
       }
 
-      const results = await Promise.all(
+      // OrganizationUser is org-scoped under the single-organization
+      // invariant of guardOrganizationId, so a single `in:` query would
+      // be rejected for spanning multiple orgs. Resolve memberships
+      // per-id; the user's org count is bounded by their workspace list.
+      const memberships = await Promise.all(
         input.organizationIds.map((organizationId) =>
+          ctx.prisma.organizationUser.findUnique({
+            where: { userId_organizationId: { userId, organizationId } },
+            select: { organizationId: true },
+          }),
+        ),
+      );
+      const allowedOrganizationIds = memberships
+        .filter((m): m is { organizationId: string } => m !== null)
+        .map((m) => m.organizationId);
+
+      if (allowedOrganizationIds.length === 0) {
+        return { enabled: false };
+      }
+
+      const results = await Promise.all(
+        allowedOrganizationIds.map((organizationId) =>
           featureFlagService.isEnabled(input.flag as FeatureFlagKey, {
             distinctId: userId,
             defaultValue: false,

--- a/specs/ai-gateway/governance/feature-flag-gating.feature
+++ b/specs/ai-gateway/governance/feature-flag-gating.feature
@@ -73,3 +73,15 @@ Feature: Governance preview hides behind a single feature flag
       | how to gate a page (useFeatureFlag hook + redirect/empty state) |
       | how to gate a nav entry (conditional render + a11y considerations) |
       | how to test gating in BDD + integration tests                   |
+
+  Scenario: The cross-org flag check rejects arbitrary organization ids
+    Given a user logged into LangWatch who is a member of org A only
+    When the workspace switcher asks whether `release_ui_ai_governance_enabled`
+      is enabled for any of [org A, org B] (org B is foreign)
+    Then the procedure intersects the input with the user's actual
+      OrganizationUser memberships before evaluating the flag
+    And the flag is evaluated only against org A
+    And org B is silently dropped, never passed to the flag service
+    And a user with zero matching memberships gets exactly the same
+      `{ enabled: false }` response shape as a member whose flag is off,
+      so the response cannot be used as a membership oracle


### PR DESCRIPTION
## Summary

- Cross-org IDOR fix flagged by CodeRabbit on #4407 after merge. `featureFlag.isEnabledForAnyOrganization` accepted `organizationIds` from the client and fanned out `featureFlagService.isEnabled` over every id without a membership check, so any authenticated user could probe arbitrary orgs to learn whether they had `release_ui_ai_governance_enabled` turned on.
- The procedure now intersects the input with the caller's actual `OrganizationUser` memberships first and silently drops unknown ids. Non-member ids are never passed to the flag service, and a user with zero matching memberships gets exactly the same `{ enabled: false }` shape as a member whose flag is off — so the response cannot be used as a membership oracle either.
- Folded in a small client-side cache fix on `useWorkspaceData` (rchaves spotted it): the switcher's query already had `staleTime: 5min` but was missing `refetchOnWindowFocus: false` / `refetchOnReconnect: false`, so tab refocus and network reconnects were triggering a refetch on every page that mounts a chrome header. Mirrors `useFeatureFlag`'s policy.

## Notes

- Per-id `findUnique` (instead of one `findMany` with `in:`) is intentional — `guardOrganizationId`'s single-organization invariant rejects a `findMany` that spans multiple orgs. A user's org count is bounded by their workspace list (typically <10) so the fan-out cost is negligible compared to the existing flag-evaluation fan-out.
- Spec: `specs/ai-gateway/governance/feature-flag-gating.feature` gets a new scenario locking the membership-filter + non-oracle response shape.

## Test plan

- [x] `npx vitest run langwatch/src/server/api/routers/__tests__/featureFlag.isEnabledForAnyOrganization.unit.test.ts` — 5/5 green covering: all-member, mixed (filter foreign), zero-member, indistinguishable non-member vs member-with-flag-off, empty input.
- [ ] CI green on `langwatch-app-complete`.
- [ ] Dogfood: switcher's personal entry still appears for orgs with the flag enabled.