### PR TITLE
fix(nlpgo): skip disconnected nodes + honor until_node_id in the planner

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -77,13 +77,7 @@ jobs:
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.4
-          # services/nlpgo intentionally NOT in lint args yet — it has
-          # ~140 pre-existing golangci-lint findings (testifylint,
-          # usestdlibvars, gofmt) accumulated while the package was
-          # outside CI coverage. Lint scope expansion is queued as a
-          # separate cleanup PR so this workflow stays green on the
-          # nlpgo unit/integration test additions.
-          args: ./services/aigateway/... ./pkg/... ./cmd/...
+          args: ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...
 
   vet:
     needs: changes

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -28,6 +28,7 @@ jobs:
           filters: |
             go:
               - 'services/aigateway/**'
+              - 'services/nlpgo/**'
               - 'pkg/**'
               - 'cmd/**'
               - 'go.mod'
@@ -60,7 +61,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go test -count=1 -race ./services/aigateway/... ./pkg/...
+      - run: go test -count=1 -race ./services/aigateway/... ./services/nlpgo/... ./pkg/...
 
   lint:
     needs: changes
@@ -76,7 +77,7 @@ jobs:
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.4
-          args: ./services/aigateway/... ./pkg/... ./cmd/...
+          args: ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...
 
   vet:
     needs: changes
@@ -89,4 +90,4 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go vet ./services/aigateway/... ./pkg/... ./cmd/...
+      - run: go vet ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -77,7 +77,13 @@ jobs:
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.4
-          args: ./services/aigateway/... ./services/nlpgo/... ./pkg/... ./cmd/...
+          # services/nlpgo intentionally NOT in lint args yet — it has
+          # ~140 pre-existing golangci-lint findings (testifylint,
+          # usestdlibvars, gofmt) accumulated while the package was
+          # outside CI coverage. Lint scope expansion is queued as a
+          # separate cleanup PR so this workflow stays green on the
+          # nlpgo unit/integration test additions.
+          args: ./services/aigateway/... ./pkg/... ./cmd/...
 
   vet:
     needs: changes

--- a/services/nlpgo/adapters/gatewayproxy/headers.go
+++ b/services/nlpgo/adapters/gatewayproxy/headers.go
@@ -26,15 +26,15 @@ import (
 // Header names — case-insensitive on the wire (Go canonicalizes via
 // http.Header.Get / textproto.CanonicalMIMEHeaderKey).
 const (
-	headerPrefix          = "x-litellm-"
-	headerModel           = "x-litellm-model"
+	headerPrefix            = "x-litellm-"
+	headerModel             = "x-litellm-model"
 	headerCustomLLMProvider = "x-litellm-custom_llm_provider"
 
 	// Provider-specific
-	headerAPIKey          = "x-litellm-api_key"
-	headerAPIBase         = "x-litellm-api_base"
-	headerOrganization    = "x-litellm-organization"
-	headerAPIVersion      = "x-litellm-api_version"
+	headerAPIKey       = "x-litellm-api_key"
+	headerAPIBase      = "x-litellm-api_base"
+	headerOrganization = "x-litellm-organization"
+	headerAPIVersion   = "x-litellm-api_version"
 
 	headerAWSAccessKeyID     = "x-litellm-aws_access_key_id"
 	headerAWSSecretAccessKey = "x-litellm-aws_secret_access_key"
@@ -46,8 +46,8 @@ const (
 	headerVertexProject     = "x-litellm-vertex_project"
 	headerVertexLocation    = "x-litellm-vertex_location"
 
-	headerExtraHeaders   = "x-litellm-extra_headers"
-	headerUseAzureGW     = "x-litellm-use_azure_gateway"
+	headerExtraHeaders = "x-litellm-extra_headers"
+	headerUseAzureGW   = "x-litellm-use_azure_gateway"
 )
 
 // ParseCredentialFromHeaders builds a domain.Credential from the
@@ -72,6 +72,7 @@ func ParseCredentialFromHeaders(h http.Header) (domain.Credential, error) {
 		Extra:      make(map[string]string),
 	}
 
+	//nolint:exhaustive // playground credential header extraction only models the provider shapes that ship credentials inline today; unmapped providers (e.g. ProviderVoyage) fall through with empty Extra.
 	switch provider {
 	case domain.ProviderOpenAI, domain.ProviderAnthropic, domain.ProviderGemini:
 		cred.APIKey = h.Get(headerAPIKey)

--- a/services/nlpgo/adapters/gatewayproxy/headers_test.go
+++ b/services/nlpgo/adapters/gatewayproxy/headers_test.go
@@ -205,11 +205,11 @@ func TestParseCredentialFromHeaders_AzureAIAlias(t *testing.T) {
 
 func TestBareModel_StripsProviderPrefix(t *testing.T) {
 	cases := map[string]string{
-		"openai/gpt-5-mini":                       "gpt-5-mini",
-		"anthropic/claude-sonnet-4-20250514":      "claude-sonnet-4-20250514",
+		"openai/gpt-5-mini":                               "gpt-5-mini",
+		"anthropic/claude-sonnet-4-20250514":              "claude-sonnet-4-20250514",
 		"bedrock/anthropic.claude-3-sonnet-20240229-v1:0": "anthropic.claude-3-sonnet-20240229-v1:0",
-		"vertex_ai/gemini-2.0-flash":              "gemini-2.0-flash",
-		"no-prefix-here":                          "no-prefix-here",
+		"vertex_ai/gemini-2.0-flash":                      "gemini-2.0-flash",
+		"no-prefix-here":                                  "no-prefix-here",
 	}
 	for in, want := range cases {
 		if got := gatewayproxy.BareModel(in); got != want {

--- a/services/nlpgo/adapters/httpapi/causality_test.go
+++ b/services/nlpgo/adapters/httpapi/causality_test.go
@@ -27,7 +27,7 @@ func TestApplyInboundCausality_HeaderToBaggage_DepthPlusOne(t *testing.T) {
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
-	r := httptest.NewRequest("POST", "/", nil)
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
 	r.Header.Set(CausalityDepthHeader, "3")
 
 	ctx := applyInboundCausality(context.Background(), r)
@@ -47,7 +47,7 @@ func TestApplyInboundCausality_MissingHeader_NoStamp(t *testing.T) {
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
-	r := httptest.NewRequest("POST", "/", nil)
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
 
 	ctx := applyInboundCausality(context.Background(), r)
 
@@ -62,7 +62,7 @@ func TestApplyInboundCausality_NegativeHeader_TreatedAsZero(t *testing.T) {
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
-	r := httptest.NewRequest("POST", "/", nil)
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
 	r.Header.Set(CausalityDepthHeader, "-5")
 
 	ctx := applyInboundCausality(context.Background(), r)
@@ -81,7 +81,7 @@ func TestApplyInboundCausality_HeaderZero_StampsOne(t *testing.T) {
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
-	r := httptest.NewRequest("POST", "/", nil)
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
 	r.Header.Set(CausalityDepthHeader, "0")
 
 	ctx := applyInboundCausality(context.Background(), r)
@@ -97,7 +97,7 @@ func TestApplyInboundCausality_ExtractsTraceparent(t *testing.T) {
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	))
-	r := httptest.NewRequest("POST", "/", nil)
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
 	traceID := "0af7651916cd43dd8448eb211c80319c"
 	spanID := "b7ad6b7169203331"
 	r.Header.Set("traceparent", "00-"+traceID+"-"+spanID+"-01")

--- a/services/nlpgo/adapters/httpapi/handlers_do_not_trace_test.go
+++ b/services/nlpgo/adapters/httpapi/handlers_do_not_trace_test.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -21,7 +22,7 @@ func TestDecodeStudioClientEvent_DoNotTrace_FromEnvelope(t *testing.T) {
 			"do_not_trace": true
 		}
 	}`)
-	r := httptest.NewRequest("POST", "/", strings.NewReader(string(body)))
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
 	req, herrErr := decodeStudioClientEvent(r, body)
 	if herrErr != nil {
 		t.Fatalf("decode failed: %v", herrErr)
@@ -44,7 +45,7 @@ func TestDecodeStudioClientEvent_DoNotTrace_FromEnableTracingFalse(t *testing.T)
 			"workflow": {"workflow_id": "wf", "api_key": "k", "spec_version": "1.3", "enable_tracing": false}
 		}
 	}`)
-	r := httptest.NewRequest("POST", "/", strings.NewReader(string(body)))
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
 	req, herrErr := decodeStudioClientEvent(r, body)
 	if herrErr != nil {
 		t.Fatalf("decode failed: %v", herrErr)
@@ -67,7 +68,7 @@ func TestDecodeStudioClientEvent_DoNotTrace_DefaultsFalse(t *testing.T) {
 			"workflow": {"workflow_id": "wf", "api_key": "k", "spec_version": "1.3"}
 		}
 	}`)
-	r := httptest.NewRequest("POST", "/", strings.NewReader(string(body)))
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
 	req, herrErr := decodeStudioClientEvent(r, body)
 	if herrErr != nil {
 		t.Fatalf("decode failed: %v", herrErr)

--- a/services/nlpgo/adapters/httpapi/playground_proxy_test.go
+++ b/services/nlpgo/adapters/httpapi/playground_proxy_test.go
@@ -109,7 +109,7 @@ func TestPlaygroundProxy_NonStreamingChatCompletions_ForwardsBodyAndCredential(t
 		t.Fatalf("Do: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, body = %s", resp.StatusCode, respBody)
 	}
@@ -186,7 +186,7 @@ func TestPlaygroundProxy_NonReasoningModelBodyForwardedByteForByte(t *testing.T)
 		t.Fatalf("Do: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, body = %s", resp.StatusCode, respBody)
 	}
@@ -224,7 +224,7 @@ func TestPlaygroundProxy_ReasoningModelMigratesMaxTokensToCompletion(t *testing.
 		t.Fatalf("Do: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, body = %s", resp.StatusCode, respBody)
 	}
@@ -266,7 +266,7 @@ func TestPlaygroundProxy_StreamingDeltasFlushAsTheyArrive(t *testing.T) {
 		t.Fatalf("Do: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", resp.StatusCode)
 	}
 	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
@@ -317,7 +317,7 @@ func TestPlaygroundProxy_MissingProviderHeader_400(t *testing.T) {
 		t.Fatalf("Do: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 400 {
+	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
 	}
 	if fake.called != 0 {
@@ -387,8 +387,8 @@ func TestFilterPassthroughHeaders_StripsConnectionNominatedHeaders(t *testing.T)
 	in.Set("Connection", "X-Hop-By-Hop, Trailer-Test")
 	in.Set("X-Hop-By-Hop", "should-be-stripped")
 	in.Set("Trailer-Test", "should-be-stripped-too")
-	in.Set("Accept", "application/json") // canonical pass-through
-	in.Set("Authorization", "Bearer x")  // explicit deny
+	in.Set("Accept", "application/json")  // canonical pass-through
+	in.Set("Authorization", "Bearer x")   // explicit deny
 	in.Set("X-LangWatch-Trace-Id", "tid") // pass-through
 	in.Set("x-litellm-model", "leak")     // explicit deny
 
@@ -444,7 +444,7 @@ func TestPlaygroundProxy_PassthroughForwardsHTTPShapeToDispatcher(t *testing.T) 
 		t.Fatalf("Do: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, body = %s", resp.StatusCode, respBody)
 	}
@@ -493,12 +493,12 @@ func TestPlaygroundProxy_PassthroughForwardsHTTPShapeToDispatcher(t *testing.T) 
 
 func TestPlaygroundProxy_PathClassification(t *testing.T) {
 	cases := map[string]domain.RequestType{
-		"/go/proxy/v1/chat/completions":                 domain.RequestTypeChat,
-		"/go/proxy/v1/messages":                         domain.RequestTypeMessages,
-		"/go/proxy/v1/embeddings":                       domain.RequestTypeEmbeddings,
-		"/go/proxy/v1/responses":                        domain.RequestTypeResponses,
-		"/go/proxy/v1beta/models/gemini-2.0-flash:run":  domain.RequestTypePassthrough,
-		"/go/proxy/v1/some/unknown/path":                domain.RequestTypePassthrough,
+		"/go/proxy/v1/chat/completions":                domain.RequestTypeChat,
+		"/go/proxy/v1/messages":                        domain.RequestTypeMessages,
+		"/go/proxy/v1/embeddings":                      domain.RequestTypeEmbeddings,
+		"/go/proxy/v1/responses":                       domain.RequestTypeResponses,
+		"/go/proxy/v1beta/models/gemini-2.0-flash:run": domain.RequestTypePassthrough,
+		"/go/proxy/v1/some/unknown/path":               domain.RequestTypePassthrough,
 	}
 	for path, want := range cases {
 		got, _ := classifyPath(path)
@@ -530,7 +530,7 @@ func TestPlaygroundProxy_NilDispatcherFallsBackTo501(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != 500 {
+	if resp.StatusCode != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500 from the fall-back stub", resp.StatusCode)
 	}
 	var env map[string]any

--- a/services/nlpgo/adapters/httpapi/staged_payload.go
+++ b/services/nlpgo/adapters/httpapi/staged_payload.go
@@ -95,11 +95,11 @@ func fetchStagedPayload(ctx context.Context, client *http.Client, raw string, ma
 	if client == nil {
 		client = http.DefaultClient
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, raw, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, raw, nil) //nolint:gosec // url is validated by validateStagedPayloadURL above (https + AWS S3 host only)
 	if err != nil {
 		return nil, fmt.Errorf("build staged payload request: %w", err)
 	}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // url is validated by validateStagedPayloadURL above (https + AWS S3 host only)
 	if err != nil {
 		return nil, fmt.Errorf("fetch staged payload: %w", err)
 	}

--- a/services/nlpgo/adapters/httpapi/tracing.go
+++ b/services/nlpgo/adapters/httpapi/tracing.go
@@ -125,11 +125,12 @@ func startStudioSpan(ctx context.Context, req *app.WorkflowRequest, workflowAPIK
 	tracer := otelapi.Tracer(tracerName)
 	attrs := studioRequestAttrs(req)
 	attrs = append(attrs, attribute.String("langwatch.span.type", spanType))
+	//nolint:spancheck // caller (executeSyncHandler) defers span.End() on the returned span.
 	ctx, span := tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(attrs...),
 	)
-	return ctx, span
+	return ctx, span //nolint:spancheck // caller (executeSyncHandler) defers span.End() on the returned span.
 }
 
 func studioRequestAttrs(req *app.WorkflowRequest) []attribute.KeyValue {
@@ -172,4 +173,3 @@ func parseTraceID(s string) (trace.TraceID, bool) {
 	}
 	return tid, true
 }
-

--- a/services/nlpgo/adapters/litellm/translator.go
+++ b/services/nlpgo/adapters/litellm/translator.go
@@ -13,14 +13,14 @@ import (
 // shape — keep them in sync. Only the slot for the active provider should
 // be populated; the rest should be omitted.
 type InlineCredentials struct {
-	Provider  string                 `json:"provider"`
-	OpenAI    map[string]string      `json:"openai,omitempty"`
-	Anthropic map[string]string      `json:"anthropic,omitempty"`
-	Azure     map[string]any         `json:"azure,omitempty"`
-	Bedrock   map[string]string      `json:"bedrock,omitempty"`
-	VertexAI  map[string]string      `json:"vertex_ai,omitempty"`
-	Gemini    map[string]string      `json:"gemini,omitempty"`
-	Custom    map[string]string      `json:"custom,omitempty"`
+	Provider  string            `json:"provider"`
+	OpenAI    map[string]string `json:"openai,omitempty"`
+	Anthropic map[string]string `json:"anthropic,omitempty"`
+	Azure     map[string]any    `json:"azure,omitempty"`
+	Bedrock   map[string]string `json:"bedrock,omitempty"`
+	VertexAI  map[string]string `json:"vertex_ai,omitempty"`
+	Gemini    map[string]string `json:"gemini,omitempty"`
+	Custom    map[string]string `json:"custom,omitempty"`
 }
 
 // Encode returns the base64-JSON header value for the inline-credentials

--- a/services/nlpgo/adapters/llmexecutor/executor.go
+++ b/services/nlpgo/adapters/llmexecutor/executor.go
@@ -3,17 +3,17 @@
 // pluggable app.GatewayClient.
 //
 // The LLM block in Sarah's engine talks to this executor. The executor:
-//   1. parses provider+model from the LLMRequest
-//   2. applies model-id rewrites (anthropic dot→dash, alias expansion)
-//   3. builds the OpenAI-shape request body (messages, tools, params)
-//   4. applies reasoning-model overrides + anthropic temperature clamp
-//   5. normalizes reasoning_effort spelling
-//   6. encodes inline credentials from litellm_params into the
-//      X-LangWatch-Inline-Credentials header that the GatewayClient
-//      consumes
-//   7. invokes the GatewayClient (in-process dispatcher in production
-//      since the library pivot)
-//   8. parses the response back into app.LLMResponse
+//  1. parses provider+model from the LLMRequest
+//  2. applies model-id rewrites (anthropic dot→dash, alias expansion)
+//  3. builds the OpenAI-shape request body (messages, tools, params)
+//  4. applies reasoning-model overrides + anthropic temperature clamp
+//  5. normalizes reasoning_effort spelling
+//  6. encodes inline credentials from litellm_params into the
+//     X-LangWatch-Inline-Credentials header that the GatewayClient
+//     consumes
+//  7. invokes the GatewayClient (in-process dispatcher in production
+//     since the library pivot)
+//  8. parses the response back into app.LLMResponse
 //
 // All providers route through chat/completions — Bifrost's per-provider
 // adapter handles native-format translation downstream. This matches the
@@ -335,7 +335,7 @@ func parseChatCompletionResponse(body []byte, durationMS int64) (*app.LLMRespons
 	choice := raw.Choices[0]
 
 	out := &app.LLMResponse{
-		ToolCalls:  choice.Message.ToolCalls,
+		ToolCalls: choice.Message.ToolCalls,
 		Usage: app.Usage{
 			PromptTokens:     raw.Usage.PromptTokens,
 			CompletionTokens: raw.Usage.CompletionTokens,
@@ -414,9 +414,9 @@ func filterEmptyContentMessages(messages []app.ChatMessage) []app.ChatMessage {
 			if len(filtered) == 0 {
 				continue
 			}
-			copy := m
-			copy.Content = filtered
-			out = append(out, copy)
+			msgCopy := m
+			msgCopy.Content = filtered
+			out = append(out, msgCopy)
 		default:
 			// Other content shapes (e.g. typed message structs) flow
 			// through unchanged — only the explicit empty cases above

--- a/services/nlpgo/adapters/llmexecutor/executor_test.go
+++ b/services/nlpgo/adapters/llmexecutor/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -506,7 +507,7 @@ func TestExecute_GatewayNon2xxReturnsTypedError(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *GatewayHTTPError, got %T", err)
 	}
-	if herr.StatusCode != 401 {
+	if herr.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected 401, got %d", herr.StatusCode)
 	}
 	if !strings.Contains(string(herr.Body), "auth_failed") {

--- a/services/nlpgo/adapters/proxypass/proxy.go
+++ b/services/nlpgo/adapters/proxypass/proxy.go
@@ -137,7 +137,7 @@ func New(opts Options) (http.Handler, error) {
 // explicitly (http://example.com → "example.com", no ":80"), so dialing
 // it raw fails with "missing port in address" and our cold-start probe
 // silently returns 503 every time. Resolve the scheme default
-// (80 for http, 443 for https) before joining; an unrecognised scheme
+// (80 for http, 443 for https) before joining; an unrecognized scheme
 // without a port is a configuration error and surfaces from New().
 func probeAddress(u *url.URL) (string, error) {
 	host := u.Hostname()
@@ -179,7 +179,7 @@ func waitForUpstream(next http.Handler, host string, opts Options) http.Handler 
 		deadline := time.Now().Add(opts.ColdStartWait)
 		probeStart := time.Now()
 		for {
-			if conn, err := net.DialTimeout("tcp", host, opts.ColdStartProbeTimeout); err == nil {
+			if conn, err := (&net.Dialer{Timeout: opts.ColdStartProbeTimeout}).DialContext(r.Context(), "tcp", host); err == nil {
 				_ = conn.Close()
 				if waited := time.Since(probeStart); waited > opts.ColdStartProbeInterval {
 					// Only log when we actually waited — happy path stays quiet.

--- a/services/nlpgo/adapters/proxypass/proxy_internal_test.go
+++ b/services/nlpgo/adapters/proxypass/proxy_internal_test.go
@@ -47,7 +47,7 @@ func TestProbeAddress_ResolvesSchemeDefaultPort(t *testing.T) {
 
 // TestProbeAddress_RejectsUnknownSchemeWithoutPort pins the surfaced
 // startup error for misconfigured URLs. A bare hostname under an
-// unrecognised scheme has no obvious default port to fill in, so we
+// unrecognized scheme has no obvious default port to fill in, so we
 // fail loud at New() rather than silently failing every probe at
 // runtime — the latter mode is exactly what hid the bug CR flagged.
 func TestProbeAddress_RejectsUnknownSchemeWithoutPort(t *testing.T) {

--- a/services/nlpgo/adapters/proxypass/proxy_test.go
+++ b/services/nlpgo/adapters/proxypass/proxy_test.go
@@ -42,7 +42,7 @@ func TestReverseProxy_SSE_StreamsChunksUnbuffered(t *testing.T) {
 		w.Header().Set("Cache-Control", "no-cache")
 		w.WriteHeader(http.StatusOK)
 		flusher, ok := w.(http.Flusher)
-		require.True(t, ok, "test upstream must support flushing")
+		assert.True(t, ok, "test upstream must support flushing")
 		for _, c := range chunks {
 			_, _ = w.Write([]byte(c))
 			flusher.Flush()

--- a/services/nlpgo/adapters/uvicornchild/manager.go
+++ b/services/nlpgo/adapters/uvicornchild/manager.go
@@ -102,7 +102,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		m.mu.Unlock()
 		return errors.New("uvicornchild: already started")
 	}
-	cmd := exec.Command(m.opts.Command, m.opts.Args...) //nolint:gosec // command is operator-configured
+	cmd := exec.CommandContext(ctx, m.opts.Command, m.opts.Args...) //nolint:gosec // command is operator-configured
 	cmd.Env = append(cmd.Environ(), m.opts.Env...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Stdout = newLogWriter(m.opts.Logger, "uvicorn_stdout")

--- a/services/nlpgo/app/engine/blocks/agentblock/workflow_runner.go
+++ b/services/nlpgo/app/engine/blocks/agentblock/workflow_runner.go
@@ -6,8 +6,8 @@
 //   - `agent_type=http`     → delegates to the HTTP-block executor.
 //   - `agent_type=code`     → delegates to the code-block executor.
 //   - `agent_type=workflow` → POST {api_host}/api/workflows/{workflow_id}/run
-//                             (this file). Mirrors langwatch_nlp's
-//                             dspy/custom_node.py CustomNode.
+//     (this file). Mirrors langwatch_nlp's
+//     dspy/custom_node.py CustomNode.
 //
 // HTTP and code modes are thin re-uses of existing block executors and
 // will be wired by the engine's block dispatcher; this file owns only the
@@ -111,7 +111,9 @@ func (e *HTTPError) Error() string {
 
 // MissingResultError signals that the upstream returned 200 but the body
 // did not contain a `result` field. Mirrors CustomNode.forward's:
-//   if "result" not in result: raise Exception(json.dumps(result))
+//
+//	if "result" not in result: raise Exception(json.dumps(result))
+//
 // — preserving the Python behavior where any unexpected upstream shape
 // surfaces as an error rather than a silently-empty success.
 type MissingResultError struct {

--- a/services/nlpgo/app/engine/blocks/agentblock/workflow_runner_test.go
+++ b/services/nlpgo/app/engine/blocks/agentblock/workflow_runner_test.go
@@ -131,7 +131,7 @@ func TestWorkflowRunner_NonTwoXxReturnsHTTPError(t *testing.T) {
 	if !errors.As(err, &httpErr) {
 		t.Fatalf("Execute: error = %v, want *HTTPError", err)
 	}
-	if httpErr.StatusCode != 502 {
+	if httpErr.StatusCode != http.StatusBadGateway {
 		t.Errorf("StatusCode = %d, want 502", httpErr.StatusCode)
 	}
 	if !strings.Contains(httpErr.Body, "upstream gone") {

--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
@@ -39,7 +39,7 @@ func TestCodeBlock_HappyPath(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
-	assert.Equal(t, float64(5), res.Outputs["sum"])
+	assert.InDelta(t, 5.0, res.Outputs["sum"], 1e-9)
 }
 
 func TestCodeBlock_StdoutCaptured(t *testing.T) {
@@ -78,7 +78,7 @@ func TestCodeBlock_ExtraOutputKeysPreserved(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Nil(t, res.Error)
-	assert.Equal(t, float64(5), res.Outputs["sum"])
+	assert.InDelta(t, 5.0, res.Outputs["sum"], 1e-9)
 	scratch, hasScratch := res.Outputs["scratch"]
 	assert.True(t, hasScratch, "undeclared output keys must be preserved (legacy parity)")
 	assert.Equal(t, []any{float64(1), float64(2), float64(3)}, scratch)
@@ -155,7 +155,7 @@ class Code(dspy.Module):
 	})
 	require.NoError(t, err)
 	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
-	assert.Equal(t, float64(15), res.Outputs["sum"])
+	assert.InDelta(t, 15.0, res.Outputs["sum"], 1e-9)
 }
 
 // TestCodeBlock_PlainClassWithForward covers the new default template:
@@ -174,7 +174,7 @@ func TestCodeBlock_PlainClassWithForward(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
-	assert.Equal(t, float64(42), res.Outputs["doubled"])
+	assert.InDelta(t, 42.0, res.Outputs["doubled"], 1e-9)
 }
 
 // TestCodeBlock_PlainClassWithCallable pins the idiomatic-Python
@@ -202,7 +202,7 @@ func TestCodeBlock_PlainClassWithCallable(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
-	assert.Equal(t, float64(42), res.Outputs["doubled"])
+	assert.InDelta(t, 42.0, res.Outputs["doubled"], 1e-9)
 }
 
 // TestCodeBlock_CallableTakesPriorityOverForward pins the resolution
@@ -253,7 +253,7 @@ class Code(dspy.Module):
 	require.NoError(t, err)
 	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
 	assert.Equal(t, "42", res.Outputs["answer"])
-	assert.Equal(t, 0.9, res.Outputs["confidence"])
+	assert.InDelta(t, 0.9, res.Outputs["confidence"], 1e-9)
 }
 
 // TestCodeBlock_DspyMarkerImportsAreInert covers the marker-only
@@ -353,6 +353,6 @@ func TestCodeBlock_InvocationsAreIsolated(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Nil(t, res.Error, "iter %d", i)
-		assert.Equal(t, float64(1), res.Outputs["x"], "no global state leak between invocations")
+		assert.InDelta(t, 1.0, res.Outputs["x"], 1e-9, "no global state leak between invocations")
 	}
 }

--- a/services/nlpgo/app/engine/blocks/dataset/dataset.go
+++ b/services/nlpgo/app/engine/blocks/dataset/dataset.go
@@ -98,7 +98,7 @@ func SplitRecords(rows Records, trainSize, testSize float64, seed int64) (*Split
 	for i := range indices {
 		indices[i] = i
 	}
-	src := rand.New(rand.NewPCG(uint64(seed), uint64(seed)))
+	src := rand.New(rand.NewPCG(uint64(seed), uint64(seed))) //nolint:gosec // dataset sampling RNG is reproducibility-keyed, not security-sensitive
 	src.Shuffle(n, func(i, j int) {
 		indices[i], indices[j] = indices[j], indices[i]
 	})
@@ -159,7 +159,7 @@ func SelectByEntry(rows Records, sel *dsl.EntrySelection, byString func(rows Rec
 			if len(rows) == 0 {
 				return nil, &EntrySelectionInvalidError{Reason: "entry_selection_empty_dataset"}
 			}
-			return rows[rand.IntN(len(rows))], nil
+			return rows[rand.IntN(len(rows))], nil //nolint:gosec // dataset sampling RNG is reproducibility-keyed, not security-sensitive
 		}
 		if byString == nil {
 			return nil, &EntrySelectionInvalidError{Reason: "string_selection_lookup_not_provided"}

--- a/services/nlpgo/app/engine/blocks/dataset/dataset_test.go
+++ b/services/nlpgo/app/engine/blocks/dataset/dataset_test.go
@@ -1,7 +1,6 @@
 package dataset_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +40,7 @@ func TestMaterialize_RejectsColumnLengthMismatch(t *testing.T) {
 	_, err := dataset.Materialize(ds)
 	require.Error(t, err)
 	var mm *dataset.ColumnMismatchError
-	require.True(t, errors.As(err, &mm))
+	require.ErrorAs(t, err, &mm)
 }
 
 func TestMaterialize_EmptyDataset(t *testing.T) {
@@ -76,7 +75,7 @@ func TestSplitRecords_RejectsOversize(t *testing.T) {
 	_, err := dataset.SplitRecords(rows, 0.8, 0.5, 1)
 	require.Error(t, err)
 	var bad *dataset.SplitInvalidError
-	require.True(t, errors.As(err, &bad))
+	require.ErrorAs(t, err, &bad)
 }
 
 func TestSelectByEntry_Int(t *testing.T) {
@@ -93,7 +92,7 @@ func TestSelectByEntry_OutOfRange(t *testing.T) {
 	_, err := dataset.SelectByEntry(rows, sel, nil)
 	require.Error(t, err)
 	var bad *dataset.EntrySelectionInvalidError
-	require.True(t, errors.As(err, &bad))
+	require.ErrorAs(t, err, &bad)
 	assert.Equal(t, "entry_selection_out_of_range", bad.Reason)
 }
 
@@ -119,7 +118,7 @@ func TestSelectByEntry_StringWithoutLookup(t *testing.T) {
 	_, err := dataset.SelectByEntry(rows, sel, nil)
 	require.Error(t, err)
 	var bad *dataset.EntrySelectionInvalidError
-	require.True(t, errors.As(err, &bad))
+	require.ErrorAs(t, err, &bad)
 	assert.Equal(t, "string_selection_lookup_not_provided", bad.Reason)
 }
 
@@ -181,7 +180,7 @@ func TestSelectByEntry_ModeKeyword_EmptyDataset(t *testing.T) {
 			_, err := dataset.SelectByEntry(nil, sel, nil)
 			require.Error(t, err)
 			var bad *dataset.EntrySelectionInvalidError
-			require.True(t, errors.As(err, &bad))
+			require.ErrorAs(t, err, &bad)
 			assert.Equal(t, "entry_selection_empty_dataset", bad.Reason)
 		})
 	}

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/executor.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/executor.go
@@ -101,14 +101,14 @@ type Request struct {
 // Result is the executor's parsed output. Mirrors the Python
 // EvaluationResultWithMetadata shape so engine output is consumer-stable.
 type Result struct {
-	Status   string         // "processed" | "skipped" | "error"
-	Score    *float64       // nil when not produced
-	Passed   *bool          // nil when not produced
-	Details  string         // free-text explanation; non-empty on skipped/error
-	Label    string         // optional category label
-	Cost     *Money         // nil when not produced
-	Inputs   map[string]any // echo of Data, useful for trace surfacing
-	Duration time.Duration  // wall-clock; sender-side measurement
+	Status   string          // "processed" | "skipped" | "error"
+	Score    *float64        // nil when not produced
+	Passed   *bool           // nil when not produced
+	Details  string          // free-text explanation; non-empty on skipped/error
+	Label    string          // optional category label
+	Cost     *Money          // nil when not produced
+	Inputs   map[string]any  // echo of Data, useful for trace surfacing
+	Duration time.Duration   // wall-clock; sender-side measurement
 	Raw      json.RawMessage // full upstream body for diagnostics
 }
 

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/executor_test.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/executor_test.go
@@ -16,12 +16,12 @@ import (
 // captureCall is a one-shot httptest fixture that records the inbound
 // request and replies with whatever the test wants.
 type captureCall struct {
-	method        string
-	path          string
-	authToken     string
-	traceID       string
-	origin        string
-	requestBody   map[string]any
+	method      string
+	path        string
+	authToken   string
+	traceID     string
+	origin      string
+	requestBody map[string]any
 }
 
 func newServer(t *testing.T, status int, response any, capture *captureCall) *httptest.Server {
@@ -184,7 +184,7 @@ func TestExecute_ErrorResultStatusErrorAndDetails(t *testing.T) {
 
 func TestExecute_NonJSONErrorBodyPropagatesAsHTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("internal server error"))
 	}))
 	defer srv.Close()
@@ -203,7 +203,7 @@ func TestExecute_NonJSONErrorBodyPropagatesAsHTTPError(t *testing.T) {
 	if !errors.As(err, &httpErr) {
 		t.Fatalf("Execute: error = %v, want *HTTPError", err)
 	}
-	if httpErr.StatusCode != 500 {
+	if httpErr.StatusCode != http.StatusInternalServerError {
 		t.Errorf("StatusCode = %d, want 500", httpErr.StatusCode)
 	}
 	if !strings.Contains(httpErr.Body, "internal server error") {

--- a/services/nlpgo/app/engine/blocks/httpblock/executor.go
+++ b/services/nlpgo/app/engine/blocks/httpblock/executor.go
@@ -23,10 +23,10 @@ type Executor struct {
 
 // Options configures an Executor.
 type Options struct {
-	Client            *http.Client // nil → http.DefaultClient with our SSRF policy
-	SSRF              SSRFOptions
-	DefaultTimeout    time.Duration
-	MaxResponseBytes  int64 // 0 → 4 MiB
+	Client           *http.Client // nil → http.DefaultClient with our SSRF policy
+	SSRF             SSRFOptions
+	DefaultTimeout   time.Duration
+	MaxResponseBytes int64 // 0 → 4 MiB
 }
 
 // defaultMaxResponseBytes caps untrusted upstream payloads so a hostile
@@ -97,11 +97,11 @@ type Auth struct {
 
 // Result is the executor's output.
 type Result struct {
-	Output         any
-	StatusCode     int
-	UpstreamBody   []byte
-	RenderedBody   string
-	Warnings       []string
+	Output       any
+	StatusCode   int
+	UpstreamBody []byte
+	RenderedBody string
+	Warnings     []string
 }
 
 // Execute runs the request, performs SSRF check, sends, and extracts.

--- a/services/nlpgo/app/engine/blocks/httpblock/httpblock_test.go
+++ b/services/nlpgo/app/engine/blocks/httpblock/httpblock_test.go
@@ -3,7 +3,6 @@ package httpblock_test
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -23,14 +22,14 @@ func TestRenderTemplate_StringEscaping(t *testing.T) {
 	})
 	assert.Empty(t, warns)
 	// json.Marshal will escape both quotes and the newline.
-	assert.Equal(t, `{"x":"hello \"world\"\n"}`, out)
+	assert.JSONEq(t, `{"x":"hello \"world\"\n"}`, out)
 }
 
 func TestRenderTemplate_ArrayEmbedding(t *testing.T) {
 	out, _ := httpblock.RenderTemplate(`{"ids": {{ ids }}}`, map[string]any{
 		"ids": []any{float64(1), float64(2), float64(3)},
 	})
-	assert.Equal(t, `{"ids": [1,2,3]}`, out)
+	assert.JSONEq(t, `{"ids": [1,2,3]}`, out)
 }
 
 func TestRenderTemplate_NestedPath(t *testing.T) {
@@ -42,7 +41,7 @@ func TestRenderTemplate_NestedPath(t *testing.T) {
 
 func TestRenderTemplate_MissingVariableEmitsWarning(t *testing.T) {
 	out, warns := httpblock.RenderTemplate("{{ ghost }}", map[string]any{})
-	assert.Equal(t, "", out)
+	assert.Empty(t, out)
 	require.Len(t, warns, 1)
 	assert.Contains(t, warns[0], "ghost")
 }
@@ -82,7 +81,7 @@ func TestExtractJSONPath_NoMatch(t *testing.T) {
 	data := map[string]any{"present": "value"}
 	_, err := httpblock.ExtractJSONPath(data, "$.missing")
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, httpblock.ErrNoMatch))
+	assert.ErrorIs(t, err, httpblock.ErrNoMatch)
 }
 
 func TestExtractJSONPath_NumericIndex(t *testing.T) {
@@ -92,7 +91,7 @@ func TestExtractJSONPath_NumericIndex(t *testing.T) {
 	}
 	got, err := httpblock.ExtractJSONPath(data, "$[1].id")
 	require.NoError(t, err)
-	assert.Equal(t, float64(2), got)
+	assert.InDelta(t, 2.0, got, 1e-9)
 }
 
 func TestSSRF_BlocksLoopback(t *testing.T) {
@@ -139,11 +138,11 @@ func TestSSRF_DNSResolutionToPrivate(t *testing.T) {
 func TestExecute_HappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		require.Equal(t, "POST", r.Method)
-		require.Equal(t, "Bearer tok-abc", r.Header.Get("Authorization"))
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "Bearer tok-abc", r.Header.Get("Authorization"))
 		var got map[string]any
-		require.NoError(t, json.Unmarshal(body, &got))
-		require.Equal(t, "ping", got["q"])
+		assert.NoError(t, json.Unmarshal(body, &got))
+		assert.Equal(t, "ping", got["q"])
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"result":"pong"}`)
 	}))
@@ -169,7 +168,7 @@ func TestExecute_HappyPath(t *testing.T) {
 func TestExecute_TimeoutAbortsRequest(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(2 * time.Second)
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 	host, _, _ := net.SplitHostPort(srv.Listener.Addr().String())
@@ -190,7 +189,7 @@ func TestExecute_TimeoutAbortsRequest(t *testing.T) {
 
 func TestExecute_NonSuccessStatusReturnsUpstreamError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(503)
+		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = io.WriteString(w, `{"err":"boom"}`)
 	}))
 	defer srv.Close()
@@ -205,14 +204,14 @@ func TestExecute_NonSuccessStatusReturnsUpstreamError(t *testing.T) {
 	})
 	require.Error(t, err)
 	var ue *httpblock.UpstreamError
-	require.True(t, errors.As(err, &ue))
+	require.ErrorAs(t, err, &ue)
 	assert.Equal(t, 503, ue.Status)
 	assert.Contains(t, string(ue.Body), "boom")
 }
 
 func TestExecute_ApiKeyAuth(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "secret-123", r.Header.Get("X-API-Key"))
+		assert.Equal(t, "secret-123", r.Header.Get("X-API-Key"))
 		_, _ = io.WriteString(w, `{}`)
 	}))
 	defer srv.Close()
@@ -256,7 +255,7 @@ func TestExecute_BlocksSSRF(t *testing.T) {
 		Method: "GET",
 	})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, httpblock.ErrSSRFBlocked))
+	assert.ErrorIs(t, err, httpblock.ErrSSRFBlocked)
 }
 
 // TestSafeDialer_BlocksPrivateIPAtDialTime simulates the DNS-rebinding
@@ -271,7 +270,7 @@ func TestSafeDialer_BlocksPrivateIPAtDialTime(t *testing.T) {
 	})
 	_, err := dial(context.Background(), "tcp", "rebound.example:80")
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, httpblock.ErrSSRFBlocked),
+	assert.ErrorIs(t, err, httpblock.ErrSSRFBlocked,
 		"expected ErrSSRFBlocked, got %v", err)
 }
 
@@ -283,7 +282,7 @@ func TestSafeDialer_BlocksMetadataIPAtDialTime(t *testing.T) {
 	})
 	_, err := dial(context.Background(), "tcp", "imds-bait.example:80")
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, httpblock.ErrSSRFBlocked))
+	assert.ErrorIs(t, err, httpblock.ErrSSRFBlocked)
 }
 
 // TestSafeDialer_BlocksLiteralPrivateIP catches direct dials by IP.
@@ -291,7 +290,7 @@ func TestSafeDialer_BlocksLiteralPrivateIP(t *testing.T) {
 	dial := httpblock.SafeDialer(httpblock.SSRFOptions{})
 	_, err := dial(context.Background(), "tcp", "10.0.0.1:80")
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, httpblock.ErrSSRFBlocked))
+	assert.ErrorIs(t, err, httpblock.ErrSSRFBlocked)
 }
 
 // TestExecute_TruncatedBodySurfacesError proves a partial-read on a
@@ -322,7 +321,7 @@ func TestExecute_TruncatedBodySurfacesError(t *testing.T) {
 }
 
 // TestExecute_TruncatesResponseAtMaxBytes proves the configured cap
-// is honoured (Options.MaxResponseBytes was previously documented but
+// is honored (Options.MaxResponseBytes was previously documented but
 // not wired — every response was capped at the hard-coded 4 MiB).
 func TestExecute_TruncatesResponseAtMaxBytes(t *testing.T) {
 	payload := make([]byte, 1024)
@@ -347,7 +346,7 @@ func TestExecute_TruncatesResponseAtMaxBytes(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	// Response is non-JSON so executor falls back to string output.
-	assert.Equal(t, 64, len(res.UpstreamBody),
+	assert.Len(t, res.UpstreamBody, 64,
 		"expected MaxResponseBytes to truncate at 64, got %d", len(res.UpstreamBody))
 }
 

--- a/services/nlpgo/app/engine/blocks/httpblock/jsonpath.go
+++ b/services/nlpgo/app/engine/blocks/httpblock/jsonpath.go
@@ -14,12 +14,13 @@ import (
 //
 // Supported syntax (a subset of JSONPath, sized for the workflows we
 // observe in the Python tests):
-//   $                     — root
-//   $.foo                 — child key
-//   $.foo.bar.baz         — nested keys
-//   $.items[0]            — numeric index
-//   $.items[*]            — every element
-//   $.items[*].id         — every element's "id" key
+//
+//	$                     — root
+//	$.foo                 — child key
+//	$.foo.bar.baz         — nested keys
+//	$.items[0]            — numeric index
+//	$.items[*]            — every element
+//	$.items[*].id         — every element's "id" key
 //
 // Anything outside this subset returns an error.
 func ExtractJSONPath(data any, path string) (any, error) {

--- a/services/nlpgo/app/engine/blocks/httpblock/ssrf.go
+++ b/services/nlpgo/app/engine/blocks/httpblock/ssrf.go
@@ -71,7 +71,7 @@ func CheckURL(raw string, opts SSRFOptions) error {
 		// DNS failed — let the actual request fail with a network
 		// error so the customer sees a real upstream message instead
 		// of a misleading SSRF reject.
-		return nil
+		return nil //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 	}
 	for _, ip := range ips {
 		if ipBlocked(ip) {
@@ -160,7 +160,7 @@ func ipBlocked(ip net.IP) bool { return isPrivate(ip) || metadataIP(ip) }
 func resolveHost(host string, opts SSRFOptions) ([]net.IP, error) {
 	r := opts.Resolver
 	if r == nil {
-		r = func(h string) ([]net.IP, error) { return net.LookupIP(h) }
+		r = net.LookupIP
 	}
 	return r(host)
 }

--- a/services/nlpgo/app/engine/build_messages_test.go
+++ b/services/nlpgo/app/engine/build_messages_test.go
@@ -103,7 +103,7 @@ func TestBuildMessages_DropsUnfilledPlaceholderTurn(t *testing.T) {
 	assert.Equal(t, "test6", msgs[0].Content)
 	for _, m := range msgs {
 		assert.NotEqual(t, "{{input}}", m.Content, "no literal placeholder turn may survive")
-		assert.NotEqual(t, "", strings.TrimSpace(m.Content.(string)), "no empty turn may survive")
+		assert.NotEmpty(t, strings.TrimSpace(m.Content.(string)), "no empty turn may survive")
 	}
 }
 
@@ -299,7 +299,7 @@ func TestBuildMessages_PreservesToolCallsThroughJSON(t *testing.T) {
 	assert.Equal(t, "call_abc", tc.ID)
 	assert.Equal(t, "function", tc.Type)
 	assert.Equal(t, "lookup", tc.Function["name"])
-	assert.Equal(t, `{"q":"weather"}`, tc.Function["arguments"])
+	assert.JSONEq(t, `{"q":"weather"}`, tc.Function["arguments"].(string))
 
 	// Tool turn keeps its linkage to the assistant call.
 	assert.Equal(t, "tool", msgs[1].Role)

--- a/services/nlpgo/app/engine/dsl/types.go
+++ b/services/nlpgo/app/engine/dsl/types.go
@@ -35,14 +35,14 @@ const (
 
 // Field is a parameter / input / output declaration on a component.
 type Field struct {
-	Identifier string         `json:"identifier"`
-	Type       FieldType      `json:"type"`
-	Optional   *bool          `json:"optional,omitempty"`
+	Identifier string          `json:"identifier"`
+	Type       FieldType       `json:"type"`
+	Optional   *bool           `json:"optional,omitempty"`
 	Value      json.RawMessage `json:"value,omitempty"`
-	Desc       *string        `json:"desc,omitempty"`
-	Prefix     *string        `json:"prefix,omitempty"`
-	Hidden     *bool          `json:"hidden,omitempty"`
-	JSONSchema map[string]any `json:"json_schema,omitempty"`
+	Desc       *string         `json:"desc,omitempty"`
+	Prefix     *string         `json:"prefix,omitempty"`
+	Hidden     *bool           `json:"hidden,omitempty"`
+	JSONSchema map[string]any  `json:"json_schema,omitempty"`
 }
 
 // ExecutionStatus mirrors the Python ExecutionStatus enum.
@@ -137,6 +137,8 @@ type NodeDataset struct {
 // EntrySelection is `Optional[str] | int` on the Python side. We carry
 // the raw value and expose typed accessors so callers don't have to
 // switch on `any`.
+//
+//nolint:recvcheck // UnmarshalJSON requires pointer receiver; read-only helpers (MarshalJSON, AsInt, AsString, IsSet) stay value-receiver so callers can use the type by value.
 type EntrySelection struct {
 	raw json.RawMessage
 }
@@ -266,10 +268,10 @@ type Component struct {
 	// version (user edited inline without persisting); base configId / handle /
 	// versionMetadata stay populated so the trace-UI can still surface
 	// "Open in Prompts" with "(unsaved edits)" appended.
-	PromptConfigID  *string                 `json:"configId,omitempty"`
-	PromptHandle    *string                 `json:"handle,omitempty"`
-	VersionMetadata *PromptVersionMetadata  `json:"versionMetadata,omitempty"`
-	PromptDraft     *bool                   `json:"promptDraft,omitempty"`
+	PromptConfigID  *string                `json:"configId,omitempty"`
+	PromptHandle    *string                `json:"handle,omitempty"`
+	VersionMetadata *PromptVersionMetadata `json:"versionMetadata,omitempty"`
+	PromptDraft     *bool                  `json:"promptDraft,omitempty"`
 }
 
 // PromptVersionMetadata mirrors signatureComponentSchema.versionMetadata
@@ -340,22 +342,22 @@ type WorkflowState struct {
 // schema 1:1 so JSON produced by the Python service deserializes here
 // without any massaging.
 type Workflow struct {
-	APIKey          string         `json:"api_key"`
-	WorkflowID      string         `json:"workflow_id"`
-	ProjectID       *string        `json:"project_id,omitempty"`
-	ExperimentID    *string        `json:"experiment_id,omitempty"`
-	SpecVersion     string         `json:"spec_version"`
-	Name            string         `json:"name"`
-	Icon            string         `json:"icon"`
-	Description     string         `json:"description"`
-	Version         string         `json:"version"`
-	DefaultLLM      *LLMConfig     `json:"default_llm,omitempty"`
-	Nodes           []Node         `json:"nodes"`
-	Edges           []Edge         `json:"edges"`
-	State           WorkflowState  `json:"state"`
-	TemplateAdapter string         `json:"template_adapter"`
-	EnableTracing   *bool          `json:"enable_tracing,omitempty"`
-	WorkflowType    *string        `json:"workflow_type,omitempty"`
+	APIKey          string            `json:"api_key"`
+	WorkflowID      string            `json:"workflow_id"`
+	ProjectID       *string           `json:"project_id,omitempty"`
+	ExperimentID    *string           `json:"experiment_id,omitempty"`
+	SpecVersion     string            `json:"spec_version"`
+	Name            string            `json:"name"`
+	Icon            string            `json:"icon"`
+	Description     string            `json:"description"`
+	Version         string            `json:"version"`
+	DefaultLLM      *LLMConfig        `json:"default_llm,omitempty"`
+	Nodes           []Node            `json:"nodes"`
+	Edges           []Edge            `json:"edges"`
+	State           WorkflowState     `json:"state"`
+	TemplateAdapter string            `json:"template_adapter"`
+	EnableTracing   *bool             `json:"enable_tracing,omitempty"`
+	WorkflowType    *string           `json:"workflow_type,omitempty"`
 	Secrets         map[string]string `json:"secrets,omitempty"`
 }
 

--- a/services/nlpgo/app/engine/dsl/types_test.go
+++ b/services/nlpgo/app/engine/dsl/types_test.go
@@ -215,7 +215,7 @@ func TestRoundTripFullWorkflow(t *testing.T) {
 	original, err := dsl.ParseWorkflow([]byte(fullWorkflowJSON))
 	require.NoError(t, err)
 
-	encoded, err := json.Marshal(original)
+	encoded, err := json.Marshal(original) //nolint:gosec // test fixture; "k" placeholder api_key, not a real secret
 	require.NoError(t, err)
 
 	roundTripped, err := dsl.ParseWorkflow(encoded)
@@ -223,9 +223,9 @@ func TestRoundTripFullWorkflow(t *testing.T) {
 
 	// Marshaling both and comparing the bytes catches any field
 	// ordering or nullability drift.
-	originalBytes, err := json.Marshal(original)
+	originalBytes, err := json.Marshal(original) //nolint:gosec // test fixture; "k" placeholder api_key, not a real secret
 	require.NoError(t, err)
-	rtBytes, err := json.Marshal(roundTripped)
+	rtBytes, err := json.Marshal(roundTripped) //nolint:gosec // test fixture; "k" placeholder api_key, not a real secret
 	require.NoError(t, err)
 	assert.JSONEq(t, string(originalBytes), string(rtBytes))
 }

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -705,8 +705,8 @@ func (e *Engine) runEvaluator(ctx context.Context, req ExecuteRequest, node *dsl
 	// final result panel. The Studio expects the same field names the
 	// Python EvaluationResultWithMetadata produces.
 	out := map[string]any{
-		"status":   res.Status,
-		"details":  res.Details,
+		"status":  res.Status,
+		"details": res.Details,
 	}
 	if res.Score != nil {
 		out["score"] = *res.Score
@@ -747,7 +747,7 @@ func (e *Engine) runEvaluator(ctx context.Context, req ExecuteRequest, node *dsl
 //   - http     → reuse the HTTP-block executor with the agent's URL/method/etc.
 //   - code     → reuse the code-block executor with the agent's `code`.
 //   - workflow → call the LangWatch app's /api/workflows/<id>[/<version>]/run
-//                via the agentblock.WorkflowRunner.
+//     via the agentblock.WorkflowRunner.
 func (e *Engine) runAgent(ctx context.Context, req ExecuteRequest, node *dsl.Node, inputs map[string]any, ns *NodeState) (map[string]any, *NodeError) {
 	agentType := paramString(node.Data.Parameters, "agent_type")
 	switch agentType {
@@ -928,13 +928,13 @@ func applyManualInputs(state *runState, req ExecuteRequest) {
 // runState aggregates per-node outputs and tracks the first error
 // observed. It is the engine's equivalent of WorkflowState.execution.
 type runState struct {
-	mu          sync.Mutex
-	nodes       map[string]*dsl.Node
-	outputs     map[string]map[string]any
-	states      map[string]*NodeState
-	firstError  *NodeError
-	endNodeID   string
-	totalCost   float64
+	mu         sync.Mutex
+	nodes      map[string]*dsl.Node
+	outputs    map[string]map[string]any
+	states     map[string]*NodeState
+	firstError *NodeError
+	endNodeID  string
+	totalCost  float64
 	// edgesByTarget indexes Edge entries by their target node id so
 	// resolveInputs can rename outputs.<source_name> → inputs.<target_name>
 	// per Studio's wire convention.
@@ -1071,7 +1071,7 @@ func finalize(state *runState, traceID string, started time.Time, ctxErr error) 
 	}
 	if ctxErr != nil {
 		res.Status = "error"
-		res.Error = &NodeError{Type: "context_cancelled", Message: ctxErr.Error()}
+		res.Error = &NodeError{Type: "context_canceled", Message: ctxErr.Error()}
 		return res
 	}
 	if state.firstError != nil {

--- a/services/nlpgo/app/engine/evaluation.go
+++ b/services/nlpgo/app/engine/evaluation.go
@@ -20,7 +20,7 @@ import (
 // random_state behavior — we don't need cryptographic randomness here
 // since the goal is "same seed → same shuffle for re-runnable evals".
 func newDeterministicRand(seed int64) *mathrand.Rand {
-	return mathrand.New(mathrand.NewSource(seed))
+	return mathrand.New(mathrand.NewSource(seed)) //nolint:gosec // evaluation row shuffle RNG is reproducibility-keyed, not security-sensitive
 }
 
 // evalLogResultsClient posts an evaluation batch to the LangWatch

--- a/services/nlpgo/app/engine/evaluation_test.go
+++ b/services/nlpgo/app/engine/evaluation_test.go
@@ -183,8 +183,8 @@ func TestSelectEvaluationEntries_TestSizeRespected(t *testing.T) {
 	wf := &dsl.Workflow{
 		Nodes: []dsl.Node{
 			{ID: "entry", Type: dsl.ComponentEntry, Data: dsl.Component{
-				TrainSize: ptrFloat(0.5),  // 5 rows
-				TestSize:  ptrFloat(0.2),  // 2 rows (not 5)
+				TrainSize: ptrFloat(0.5), // 5 rows
+				TestSize:  ptrFloat(0.2), // 2 rows (not 5)
 				Dataset: &dsl.NodeDataset{Inline: &dsl.DatasetInline{
 					Records: map[string][]any{"q": {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}},
 				}},

--- a/services/nlpgo/app/engine/manual_inputs_test.go
+++ b/services/nlpgo/app/engine/manual_inputs_test.go
@@ -18,7 +18,9 @@ import (
 // req.Inputs was treated as Entry-node outputs. A fresh-dragged Code
 // node with no Entry→Code wiring received an empty input map → the
 // Python runner raised
-//   `Code.__call__() missing 1 required positional argument: 'input'`
+//
+//	`Code.__call__() missing 1 required positional argument: 'input'`
+//
 // and the Studio input field appeared to be silently dropped on
 // Execute click.
 //

--- a/services/nlpgo/app/engine/planner/planner.go
+++ b/services/nlpgo/app/engine/planner/planner.go
@@ -159,7 +159,8 @@ func New(w *dsl.Workflow, opts ...Option) (*Plan, error) {
 
 	// 1. Duplicate ids.
 	nodeIDs := make(map[string]dsl.ComponentType, len(w.Nodes))
-	for _, n := range w.Nodes {
+	for i := range w.Nodes {
+		n := &w.Nodes[i]
 		if _, exists := nodeIDs[n.ID]; exists {
 			return nil, &DuplicateNodeError{NodeID: n.ID}
 		}
@@ -169,7 +170,8 @@ func New(w *dsl.Workflow, opts ...Option) (*Plan, error) {
 	// 2. Retired + unsupported kinds. Retired comes first so a workflow
 	// that has both a retired node and an unsupported one gets the more
 	// actionable error.
-	for _, n := range w.Nodes {
+	for i := range w.Nodes {
+		n := &w.Nodes[i]
 		if msg, retired := retiredKinds[n.Type]; retired {
 			return nil, &RetiredNodeKindError{NodeID: n.ID, Kind: n.Type, Message: msg}
 		}
@@ -283,7 +285,8 @@ func findCycle(nodes []dsl.Node, children map[string][]string) []string {
 		color[id] = black
 		return nil
 	}
-	for _, n := range nodes {
+	for i := range nodes {
+		n := &nodes[i]
 		if color[n.ID] == white {
 			if cycle := dfs(n.ID); cycle != nil {
 				return cycle
@@ -302,7 +305,8 @@ func findCycle(nodes []dsl.Node, children map[string][]string) []string {
 func layerize(nodes []dsl.Node, children, parents map[string][]string, allowed map[string]bool) [][]string {
 	indegree := make(map[string]int, len(nodes))
 	remaining := 0
-	for _, n := range nodes {
+	for i := range nodes {
+		n := &nodes[i]
 		if allowed != nil && !allowed[n.ID] {
 			continue
 		}
@@ -324,7 +328,8 @@ func layerize(nodes []dsl.Node, children, parents map[string][]string, allowed m
 		// Collect zero-indegree nodes preserving the input order so the
 		// emitted plan is deterministic regardless of map iteration.
 		var layer []string
-		for _, n := range nodes {
+		for i := range nodes {
+			n := &nodes[i]
 			if _, exists := indegree[n.ID]; !exists {
 				continue
 			}
@@ -364,9 +369,9 @@ func layerize(nodes []dsl.Node, children, parents map[string][]string, allowed m
 // Mirrors langwatch_nlp/studio/parser.py:605 `find_reachable_nodes`.
 func reachableFromEntry(nodes []dsl.Node, children map[string][]string) map[string]bool {
 	entryID := ""
-	for _, n := range nodes {
-		if n.Type == dsl.ComponentEntry {
-			entryID = n.ID
+	for i := range nodes {
+		if nodes[i].Type == dsl.ComponentEntry {
+			entryID = nodes[i].ID
 			break
 		}
 	}

--- a/services/nlpgo/app/engine/planner/planner_test.go
+++ b/services/nlpgo/app/engine/planner/planner_test.go
@@ -284,6 +284,7 @@ func disconnectedWorkflow() *dsl.Workflow {
 	}
 }
 
+// @scenario "a Signature node disconnected from Entry is not planned"
 func TestPlan_ExcludesOrphanNodeOnFullRun(t *testing.T) {
 	p, err := planner.New(disconnectedWorkflow())
 	require.NoError(t, err)
@@ -294,6 +295,7 @@ func TestPlan_ExcludesOrphanNodeOnFullRun(t *testing.T) {
 	assert.False(t, ids["orphan"], "orphan signature with no incoming edges must not be planned (Python find_reachable_nodes parity)")
 }
 
+// @scenario "a disconnected sub-chain whose root is not reachable from Entry is skipped"
 func TestPlan_ExcludesDisconnectedSubChain(t *testing.T) {
 	// Two parallel chains, only one of which roots at Entry. The whole
 	// floating chain (floatA -> floatB) must be skipped — neither node
@@ -320,6 +322,7 @@ func TestPlan_ExcludesDisconnectedSubChain(t *testing.T) {
 	assert.False(t, ids["floatB"], "floatB (child of disconnected root) must be skipped")
 }
 
+// @scenario "\"Run until here\" trims downstream nodes and disconnected siblings"
 func TestPlan_WithUntilNode_TrimsDownstreamAndOrphans(t *testing.T) {
 	// Entry -> A -> B -> C -> End, plus an orphan Signature. "Run until
 	// B" must plan {entry, A, B} only: C and End are downstream of the
@@ -350,6 +353,7 @@ func TestPlan_WithUntilNode_TrimsDownstreamAndOrphans(t *testing.T) {
 	assert.False(t, ids["orphan"], "orphan stays excluded under until-here")
 }
 
+// @scenario "\"Run until here\" with an unknown target returns an UnknownNodeError"
 func TestPlan_WithUntilNode_UnknownTargetErrors(t *testing.T) {
 	_, err := planner.New(disconnectedWorkflow(), planner.WithUntilNode("does-not-exist"))
 	require.Error(t, err)
@@ -358,6 +362,7 @@ func TestPlan_WithUntilNode_UnknownTargetErrors(t *testing.T) {
 	assert.Equal(t, "does-not-exist", une.NodeID)
 }
 
+// @scenario "\"Run until here\" pointed at Entry plans just Entry"
 func TestPlan_WithUntilNode_EntryItself(t *testing.T) {
 	// Until = Entry should plan just Entry: nothing else is upstream.
 	p, err := planner.New(linearWorkflow(), planner.WithUntilNode("A"))

--- a/services/nlpgo/app/engine/planner/planner_test.go
+++ b/services/nlpgo/app/engine/planner/planner_test.go
@@ -322,7 +322,7 @@ func TestPlan_ExcludesDisconnectedSubChain(t *testing.T) {
 	assert.False(t, ids["floatB"], "floatB (child of disconnected root) must be skipped")
 }
 
-// @scenario "\"Run until here\" trims downstream nodes and disconnected siblings"
+// @scenario '"Run until here" trims downstream nodes and disconnected siblings'
 func TestPlan_WithUntilNode_TrimsDownstreamAndOrphans(t *testing.T) {
 	// Entry -> A -> B -> C -> End, plus an orphan Signature. "Run until
 	// B" must plan {entry, A, B} only: C and End are downstream of the
@@ -353,7 +353,7 @@ func TestPlan_WithUntilNode_TrimsDownstreamAndOrphans(t *testing.T) {
 	assert.False(t, ids["orphan"], "orphan stays excluded under until-here")
 }
 
-// @scenario "\"Run until here\" with an unknown target returns an UnknownNodeError"
+// @scenario '"Run until here" with an unknown target returns an UnknownNodeError'
 func TestPlan_WithUntilNode_UnknownTargetErrors(t *testing.T) {
 	_, err := planner.New(disconnectedWorkflow(), planner.WithUntilNode("does-not-exist"))
 	require.Error(t, err)
@@ -362,7 +362,7 @@ func TestPlan_WithUntilNode_UnknownTargetErrors(t *testing.T) {
 	assert.Equal(t, "does-not-exist", une.NodeID)
 }
 
-// @scenario "\"Run until here\" pointed at Entry plans just Entry"
+// @scenario '"Run until here" pointed at Entry plans just Entry'
 func TestPlan_WithUntilNode_EntryItself(t *testing.T) {
 	// Until = Entry should plan just Entry: nothing else is upstream.
 	p, err := planner.New(linearWorkflow(), planner.WithUntilNode("A"))

--- a/services/nlpgo/app/engine/planner/planner_test.go
+++ b/services/nlpgo/app/engine/planner/planner_test.go
@@ -1,7 +1,6 @@
 package planner_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,7 +79,7 @@ func TestPlan_DetectsCycle(t *testing.T) {
 	_, err := planner.New(w)
 	require.Error(t, err)
 	var cyc *planner.CycleError
-	require.True(t, errors.As(err, &cyc))
+	require.ErrorAs(t, err, &cyc)
 	// Cycle includes all three nodes, with the entry node repeated at the end.
 	assert.Contains(t, cyc.Cycle, "A")
 	assert.Contains(t, cyc.Cycle, "B")
@@ -95,7 +94,7 @@ func TestPlan_DetectsSelfLoop(t *testing.T) {
 	_, err := planner.New(w)
 	require.Error(t, err)
 	var cyc *planner.CycleError
-	require.True(t, errors.As(err, &cyc))
+	require.ErrorAs(t, err, &cyc)
 	assert.Equal(t, []string{"A", "A"}, cyc.Cycle)
 }
 
@@ -107,7 +106,7 @@ func TestPlan_RejectsUnknownEdgeEndpoint(t *testing.T) {
 	_, err := planner.New(w)
 	require.Error(t, err)
 	var unk *planner.UnknownNodeError
-	require.True(t, errors.As(err, &unk))
+	require.ErrorAs(t, err, &unk)
 	assert.Equal(t, "ghost", unk.NodeID)
 	assert.Equal(t, "e1", unk.Edge)
 }
@@ -122,7 +121,7 @@ func TestPlan_RejectsDuplicateNodeID(t *testing.T) {
 	_, err := planner.New(w)
 	require.Error(t, err)
 	var dup *planner.DuplicateNodeError
-	require.True(t, errors.As(err, &dup))
+	require.ErrorAs(t, err, &dup)
 	assert.Equal(t, "A", dup.NodeID)
 }
 
@@ -142,7 +141,7 @@ func TestPlan_RejectsUnsupportedNodeKind(t *testing.T) {
 	_, err := planner.New(w)
 	require.Error(t, err)
 	var unsup *planner.UnsupportedNodeKindError
-	require.True(t, errors.As(err, &unsup))
+	require.ErrorAs(t, err, &unsup)
 	assert.Equal(t, "Future", unsup.NodeID)
 	assert.Equal(t, futureKind, unsup.Kind)
 }
@@ -158,7 +157,7 @@ func TestPlan_RejectsRetiredKindRetriever(t *testing.T) {
 	_, err := planner.New(w)
 	require.Error(t, err)
 	var ret *planner.RetiredNodeKindError
-	require.True(t, errors.As(err, &ret), "want RetiredNodeKindError, got %T: %v", err, err)
+	require.ErrorAs(t, err, &ret, "want RetiredNodeKindError, got %T: %v", err, err)
 	assert.Equal(t, "Retriever", ret.NodeID)
 	assert.Equal(t, dsl.ComponentRetriever, ret.Kind)
 	assert.Contains(t, ret.Message, "retired")
@@ -232,7 +231,7 @@ func TestPlan_RetiredTakesPriorityOverUnsupported(t *testing.T) {
 	_, err := planner.New(w)
 	require.Error(t, err)
 	var ret *planner.RetiredNodeKindError
-	assert.True(t, errors.As(err, &ret), "expected retired error to win, got %T: %v", err, err)
+	assert.ErrorAs(t, err, &ret, "expected retired error to win, got %T: %v", err, err)
 }
 
 func TestPlan_StableLayerOrdering(t *testing.T) {
@@ -358,7 +357,7 @@ func TestPlan_WithUntilNode_UnknownTargetErrors(t *testing.T) {
 	_, err := planner.New(disconnectedWorkflow(), planner.WithUntilNode("does-not-exist"))
 	require.Error(t, err)
 	var une *planner.UnknownNodeError
-	require.True(t, errors.As(err, &une), "expected UnknownNodeError, got %T", err)
+	require.ErrorAs(t, err, &une, "expected UnknownNodeError, got %T", err)
 	assert.Equal(t, "does-not-exist", une.NodeID)
 }
 

--- a/services/nlpgo/app/engine/prompt_spans_emit_test.go
+++ b/services/nlpgo/app/engine/prompt_spans_emit_test.go
@@ -25,11 +25,11 @@ import (
 )
 
 const (
-	testPromptConfigID    = "prompt_4RXLJtB9Cj-OA1BaLpxWc"
-	testPromptHandle      = "pizza-prompt"
-	testPromptVersionID   = "prompt_version_I21kDsHKtr5wQm9k1Dap2"
-	testPromptVersionNum  = 6
-	testPromptCreatedAt   = "2026-05-01T12:00:00Z"
+	testPromptConfigID   = "prompt_4RXLJtB9Cj-OA1BaLpxWc"
+	testPromptHandle     = "pizza-prompt"
+	testPromptVersionID  = "prompt_version_I21kDsHKtr5wQm9k1Dap2"
+	testPromptVersionNum = 6
+	testPromptCreatedAt  = "2026-05-01T12:00:00Z"
 )
 
 func signatureNodeWithPromptConfig(setup func(*dsl.Component)) *dsl.Node {
@@ -67,9 +67,9 @@ func TestEmitPromptSpans_SavedVersionEmitsBothSpansWithFullIdentity(t *testing.T
 	// PromptApiService.get: combined id + variables envelope.
 	getAttrs := attrMap(got.Attributes())
 	assert.Equal(t, "pizza-prompt:6", getAttrs["langwatch.prompt.id"])
-	assert.Equal(t,
+	assert.JSONEq(t,
 		`{"type":"json","value":{"prompt_id":"prompt_4RXLJtB9Cj-OA1BaLpxWc"}}`,
-		getAttrs["langwatch.prompt.variables"],
+		getAttrs["langwatch.prompt.variables"].(string),
 	)
 
 	// Prompt.compile: full 4-attr identity + variables + NO draft (saved).
@@ -78,9 +78,9 @@ func TestEmitPromptSpans_SavedVersionEmitsBothSpansWithFullIdentity(t *testing.T
 	assert.Equal(t, testPromptHandle, compileAttrs["langwatch.prompt.handle"])
 	assert.Equal(t, testPromptVersionID, compileAttrs["langwatch.prompt.version.id"])
 	assert.Equal(t, int64(6), compileAttrs["langwatch.prompt.version.number"])
-	assert.Equal(t,
+	assert.JSONEq(t,
 		`{"type":"json","value":{"input":"I want a refund"}}`,
-		compileAttrs["langwatch.prompt.variables"],
+		compileAttrs["langwatch.prompt.variables"].(string),
 	)
 	assert.NotContains(t, compileAttrs, "langwatch.prompt.draft",
 		"saved-version execution must OMIT langwatch.prompt.draft (not set to false) per python-sdk's _set_attribute_if_not_none convention")
@@ -134,9 +134,9 @@ func TestEmitPromptSpans_PartialIdentityOmitsCombinedId(t *testing.T) {
 	assert.NotContains(t, getAttrs, "langwatch.prompt.id",
 		"combined id must be omitted when version is unresolved")
 	// Variables envelope still emits with prompt_id input.
-	assert.Equal(t,
+	assert.JSONEq(t,
 		`{"type":"json","value":{"prompt_id":"prompt_4RXLJtB9Cj-OA1BaLpxWc"}}`,
-		getAttrs["langwatch.prompt.variables"],
+		getAttrs["langwatch.prompt.variables"].(string),
 	)
 
 	// Compile span: id + handle present, version.* absent.
@@ -160,7 +160,7 @@ func TestEmitPromptSpans_EmptyInputsRecordsEmptyVariablesMap(t *testing.T) {
 	require.Len(t, ended, 2)
 
 	compileAttrs := attrMap(ended[1].Attributes())
-	assert.Equal(t, `{"type":"json","value":{}}`, compileAttrs["langwatch.prompt.variables"])
+	assert.JSONEq(t, `{"type":"json","value":{}}`, compileAttrs["langwatch.prompt.variables"].(string))
 }
 
 // Regression for the 2026-05-17 prod report (#4094 post-merge dogfood):
@@ -190,9 +190,9 @@ func TestEmitPromptSpans_FiltersDispatchEnvelopeKeysFromCompileVariables(t *test
 	require.Len(t, ended, 2)
 
 	compileAttrs := attrMap(ended[1].Attributes())
-	assert.Equal(t,
+	assert.JSONEq(t,
 		`{"type":"json","value":{"example":"foobar","input":"how big is mars?"}}`,
-		compileAttrs["langwatch.prompt.variables"],
+		compileAttrs["langwatch.prompt.variables"].(string),
 		"messages + chat_messages are dispatch envelope and must be stripped from langwatch.prompt.variables; user vars (input, example) must survive",
 	)
 }

--- a/services/nlpgo/app/engine/stream_test.go
+++ b/services/nlpgo/app/engine/stream_test.go
@@ -34,7 +34,7 @@ func TestExecuteStream_HeartbeatExitDoesNotRaceWithClose(t *testing.T) {
 	}
 
 	// Tight loop: many iterations × 1ms heartbeat × very-fast workflow
-	// completion maximises the chance of an emit() landing in the
+	// completion maximizes the chance of an emit() landing in the
 	// closed-channel window. 200 iterations is enough that a real race
 	// shows up in CI under -race even at low scheduler pressure.
 	const iterations = 200

--- a/services/nlpgo/app/engine/template/template_test.go
+++ b/services/nlpgo/app/engine/template/template_test.go
@@ -63,7 +63,7 @@ func TestRender_PreservesNonASCIIUnicodeVerbatim(t *testing.T) {
 		out, _ := Render("Echo: {{ x }}", map[string]any{"x": value})
 		assert.Equal(t, "Echo: "+value, out, "case %q should round-trip verbatim", name)
 		// And no escape leakage.
-		assert.False(t, strings.Contains(out, `\u`),
+		assert.NotContains(t, out, `\u`,
 			"case %q produced escape sequences in %q", name, out)
 	}
 }

--- a/services/nlpgo/app/engine/tracing.go
+++ b/services/nlpgo/app/engine/tracing.go
@@ -6,13 +6,13 @@
 //
 // Span shape matches the Python langwatch_nlp engine:
 //   - name:                node.Data.Name (or node.ID fallback) — e.g.
-//                          "v1" for an LLM Call named v1. Mirrors Python's
-//                          DSPy autotracking which names spans by the
-//                          generated wrapper-module class name. Earlier
-//                          revisions used the literal "execute_component"
-//                          for every node, which surfaced 3 identical
-//                          spans in the Studio drawer for a 3-node
-//                          workflow (rchaves dogfood 2026-05-14).
+//     "v1" for an LLM Call named v1. Mirrors Python's
+//     DSPy autotracking which names spans by the
+//     generated wrapper-module class name. Earlier
+//     revisions used the literal "execute_component"
+//     for every node, which surfaced 3 identical
+//     spans in the Studio drawer for a 3-node
+//     workflow (rchaves dogfood 2026-05-14).
 //   - langwatch.span.type: "component"                (== Python's optional_langwatch_trace type)
 //   - langwatch.input:     JSON-encoded inputs map    (reserved attr; flips Studio output_source from inferred → explicit)
 //   - langwatch.output:    JSON-encoded outputs map   (reserved attr; same as above)
@@ -65,6 +65,7 @@ const (
 // — LLM call, code execution, HTTP request, evaluator dispatch,
 // sub-workflow run.
 func nodeEmitsSpan(kind dsl.ComponentType) bool {
+	//nolint:exhaustive // intentional default-to-true: only no-op pass-through kinds suppress the span.
 	switch kind {
 	case dsl.ComponentEntry, dsl.ComponentEnd, dsl.ComponentPromptingTechnique:
 		return false
@@ -107,6 +108,7 @@ func startNodeSpan(ctx context.Context, node *dsl.Node, req ExecuteRequest) (con
 	if req.Origin != "" {
 		attrs = append(attrs, attribute.String("langwatch.origin", req.Origin))
 	}
+	//nolint:spancheck // caller (engine.runLayer) owns the span lifecycle and ends it via endNodeSpan.
 	return tracer.Start(ctx, nodeSpanName(node),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(attrs...),
@@ -192,6 +194,7 @@ func startLLMSpan(ctx context.Context, model, provider string, messages []app.Ch
 	if v, ok := encodeJSONAttr(messages); ok {
 		attrs = append(attrs, attribute.String("langwatch.input", v))
 	}
+	//nolint:spancheck // caller owns the span lifecycle and ends it via endLLMSpan.
 	return tracer.Start(ctx, displayModel,
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(attrs...),

--- a/services/nlpgo/app/engine/tracing_e2e_test.go
+++ b/services/nlpgo/app/engine/tracing_e2e_test.go
@@ -43,7 +43,7 @@ func TestEngineExecute_SuppressesEntryAndEndSpans(t *testing.T) {
 	require.Equal(t, "success", res.Status)
 
 	spans := rec.Ended()
-	require.Len(t, spans, 0,
+	require.Empty(t, spans,
 		"Entry + End are pass-throughs and must NOT emit per-node spans (Python parity)")
 }
 

--- a/services/nlpgo/app/engine/tracing_test.go
+++ b/services/nlpgo/app/engine/tracing_test.go
@@ -72,7 +72,7 @@ func TestStartNodeSpan_NameIsUserSetNodeName(t *testing.T) {
 	assert.Equal(t, "thread_qq", attrs["langwatch.thread_id"])
 	assert.Equal(t, "workflow", attrs["langwatch.origin"])
 	assert.Equal(t, int64(42), attrs["langwatch.duration_ms"])
-	assert.Equal(t, 0.001, attrs["langwatch.cost"])
+	assert.InDelta(t, 0.001, attrs["langwatch.cost"], 1e-9)
 	assert.Equal(t, codes.Ok, got.Status().Code)
 }
 

--- a/services/nlpgo/cmd/engine_adapter.go
+++ b/services/nlpgo/cmd/engine_adapter.go
@@ -41,7 +41,7 @@ func (a engineAdapter) ExecuteStream(ctx context.Context, req app.WorkflowReques
 			"message": "invalid_workflow: " + err.Error(),
 		}}
 		close(ch)
-		return ch, nil
+		return ch, nil //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 	}
 	ctx = withWorkflowAPIKey(ctx, wf)
 	in, err := a.eng.ExecuteStream(ctx, engine.ExecuteRequest{
@@ -63,7 +63,7 @@ func (a engineAdapter) ExecuteStream(ctx context.Context, req app.WorkflowReques
 		ch := make(chan app.WorkflowStreamEvent, 1)
 		ch <- app.WorkflowStreamEvent{Type: "error", Payload: map[string]any{"message": err.Error()}}
 		close(ch)
-		return ch, nil
+		return ch, nil //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 	}
 	out := make(chan app.WorkflowStreamEvent, 16)
 	go func() {
@@ -83,7 +83,7 @@ func (a engineAdapter) ExecuteStream(ctx context.Context, req app.WorkflowReques
 func (a engineAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (*app.WorkflowResult, error) {
 	wf, err := dsl.ParseWorkflow(req.WorkflowJSON)
 	if err != nil {
-		return &app.WorkflowResult{
+		return &app.WorkflowResult{ //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 			Status: "error",
 			Error: &app.WorkflowError{
 				Type:    "invalid_workflow",
@@ -108,7 +108,7 @@ func (a engineAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (*a
 		DatasetEntry:      req.DatasetEntry,
 	})
 	if err != nil {
-		return &app.WorkflowResult{
+		return &app.WorkflowResult{ //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 			Status: "error",
 			Error: &app.WorkflowError{
 				Type:    "engine_error",

--- a/services/nlpgo/cmd/root.go
+++ b/services/nlpgo/cmd/root.go
@@ -24,7 +24,6 @@ import (
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
 )
 
-
 // Root is the service entrypoint called by cmd/service.
 func Root(ctx context.Context, _ []string) error {
 	cfg, err := nlpgo.LoadConfig(ctx)

--- a/services/nlpgo/serve_test.go
+++ b/services/nlpgo/serve_test.go
@@ -84,7 +84,7 @@ func TestBuildServices_UvicornChildWorkerDoesNotBlockStart(t *testing.T) {
 		t.Fatalf("uvicorn-child worker not registered; got names %v", names(services))
 	}
 
-	// Run Start with a context that will never be cancelled until we
+	// Run Start with a context that will never be canceled until we
 	// say so. If startFn synchronously blocks (the regression we want
 	// to catch), Start won't return and the deadline below fires.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -216,4 +216,3 @@ func names(services []lifecycle.Service) []string {
 	}
 	return out
 }
-

--- a/services/nlpgo/tests/integration/causality_propagation_test.go
+++ b/services/nlpgo/tests/integration/causality_propagation_test.go
@@ -117,11 +117,11 @@ func installProductionTracerStack(t *testing.T) *tracetest.SpanRecorder {
 // We snapshot exactly what we'll assert against — header values and the
 // body — so the test stays decoupled from the http.Request lifecycle.
 type capturedRequest struct {
-	path                string
-	traceparent         string
-	baggage             string
-	depthHeader         string
-	xLangwatchTraceID   string
+	path              string
+	traceparent       string
+	baggage           string
+	depthHeader       string
+	xLangwatchTraceID string
 }
 
 func setupCausalityStack(t *testing.T) (url string, captured *[]capturedRequest) {

--- a/services/nlpgo/tests/integration/code_block_realistic_test.go
+++ b/services/nlpgo/tests/integration/code_block_realistic_test.go
@@ -69,11 +69,11 @@ func TestSync_CodeBlock_StdlibHeavyComputation(t *testing.T) {
 	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
 	got, _ := res.Result["result"].(string)
 	// Sanity-check each stdlib feature reached the customer code.
-	assert.Contains(t, got, `"len": 18`)               // len("customer-data-2026")
-	assert.Contains(t, got, `"year": 2026`)            // datetime
+	assert.Contains(t, got, `"len": 18`)    // length of the 18-char input
+	assert.Contains(t, got, `"year": 2026`) // datetime imported
 	assert.Contains(t, got, `"raw": "customer-data-2026"`)
-	assert.Contains(t, got, `"sha256":`)               // hashlib produced something
-	// base64.b64encode("customer-data-2026") = "Y3VzdG9tZXItZGF0YS0yMDI2"
+	assert.Contains(t, got, `"sha256":`) // hashlib produced something
+	// "customer-data-2026" base64-encoded.
 	assert.Contains(t, got, `Y3VzdG9tZXItZGF0YS0yMDI2`)
 }
 

--- a/services/nlpgo/tests/integration/dsl_patterns_test.go
+++ b/services/nlpgo/tests/integration/dsl_patterns_test.go
@@ -40,7 +40,7 @@
 //      "evaluator with langevals/llm_judge slug + structured-output
 //      signature upstream + liquid-templated system prompt".
 //   2. Build the smallest fixture that exercises that exact shape. Use
-//      generic concept names (math, weather, dialogue, fiction).
+//      generic concept names (math, weather, dialog, fiction).
 //   3. Run it through the existing setupEvaluatorStack harness so the
 //      LangWatch endpoint is faked end-to-end, no real network calls.
 //   4. Assert on the *engine outputs* (workflow result, node states,
@@ -189,16 +189,16 @@ func setupPatternStack(t *testing.T, llm *fakeLLMClient, langwatch http.HandlerF
 // What this proves end-to-end through the engine (not through unit
 // tests of any single component):
 //
-//   1. The signature node's `instructions` parameter is liquid-rendered
-//      against upstream inputs before reaching the LLM (verified by
-//      inspecting what the fake LLM was actually called with — not just
-//      what buildMessages produced in isolation).
-//   2. The signature node's output flows down the edge into the
-//      evaluator node's `data` payload to the LangWatch evaluator API.
-//   3. The evaluator's score/passed/details propagate to the end node
-//      and surface in the workflow result.
-//   4. Per-node state for all four nodes is "success" and present in
-//      result.nodes.
+//  1. The signature node's `instructions` parameter is liquid-rendered
+//     against upstream inputs before reaching the LLM (verified by
+//     inspecting what the fake LLM was actually called with — not just
+//     what buildMessages produced in isolation).
+//  2. The signature node's output flows down the edge into the
+//     evaluator node's `data` payload to the LangWatch evaluator API.
+//  3. The evaluator's score/passed/details propagate to the end node
+//     and surface in the workflow result.
+//  4. Per-node state for all four nodes is "success" and present in
+//     result.nodes.
 //
 // Concept is intentionally generic (math Q&A judge); zero customer
 // domain or copy.
@@ -333,15 +333,15 @@ func TestPattern001_LinearChain_SignatureWithTemplateThenEvaluator(t *testing.T)
 //
 // What this proves:
 //
-//   1. The planner places the two signatures in the SAME layer (they
-//      share inputs, no dependency on each other) — verified by the
-//      fact that both LLM calls are observed and both end-node fields
-//      populate.
-//   2. The engine's per-layer concurrency (one goroutine per node)
-//      does not corrupt the per-node Inputs/Outputs maps when two
-//      signature nodes run side-by-side. Each fake LLM call sees the
-//      shared input and produces an independent output.
-//   3. End node merges both signature outputs into result.
+//  1. The planner places the two signatures in the SAME layer (they
+//     share inputs, no dependency on each other) — verified by the
+//     fact that both LLM calls are observed and both end-node fields
+//     populate.
+//  2. The engine's per-layer concurrency (one goroutine per node)
+//     does not corrupt the per-node Inputs/Outputs maps when two
+//     signature nodes run side-by-side. Each fake LLM call sees the
+//     shared input and produces an independent output.
+//  3. End node merges both signature outputs into result.
 func TestPattern002_BranchingParallelSignatures(t *testing.T) {
 	llm := &fakeLLMClient{
 		respond: func(req app.LLMRequest) (*app.LLMResponse, error) {
@@ -526,14 +526,14 @@ func TestPattern003_HeavyLiquidTemplating(t *testing.T) {
 //
 // What this proves:
 //
-//   1. The planner orders the two signatures in distinct layers
-//      (refine depends on draft); both LLM calls happen and the second
-//      sees the first's output as input.
-//   2. The signature output → next signature input edge resolves
-//      correctly (no DSL parser regression on chained signature-only
-//      paths).
-//   3. The evaluator at the tail reads the final refined answer and
-//      grades it.
+//  1. The planner orders the two signatures in distinct layers
+//     (refine depends on draft); both LLM calls happen and the second
+//     sees the first's output as input.
+//  2. The signature output → next signature input edge resolves
+//     correctly (no DSL parser regression on chained signature-only
+//     paths).
+//  3. The evaluator at the tail reads the final refined answer and
+//     grades it.
 func TestPattern004_SignatureChainThenEvaluator(t *testing.T) {
 	llm := &fakeLLMClient{
 		respond: func(req app.LLMRequest) (*app.LLMResponse, error) {
@@ -666,15 +666,15 @@ func TestPattern004_SignatureChainThenEvaluator(t *testing.T) {
 //
 // What this proves:
 //
-//   1. The signature node detects 2+ outputs and wires
-//      response_format = json_schema in the LLMRequest. Verified by
-//      inspecting the captured request at the LLM boundary.
-//   2. The composed JSON Schema lists both outputs as required and
-//      maps each to its appropriate JSON Schema type.
-//   3. The engine parses the LLM's JSON response and splits the
-//      properties into the corresponding outputs (label → str,
-//      confidence → number) — no longer assigning the same Content
-//      to every declared output.
+//  1. The signature node detects 2+ outputs and wires
+//     response_format = json_schema in the LLMRequest. Verified by
+//     inspecting the captured request at the LLM boundary.
+//  2. The composed JSON Schema lists both outputs as required and
+//     maps each to its appropriate JSON Schema type.
+//  3. The engine parses the LLM's JSON response and splits the
+//     properties into the corresponding outputs (label → str,
+//     confidence → number) — no longer assigning the same Content
+//     to every declared output.
 func TestPattern007_MultiOutputSignatureParseAndSplit(t *testing.T) {
 	llm := &fakeLLMClient{
 		respond: func(req app.LLMRequest) (*app.LLMResponse, error) {
@@ -942,14 +942,14 @@ func setupPatternStackWithUpstream(t *testing.T, llm *fakeLLMClient, langwatch h
 //
 // What this proves:
 //
-//   1. The http block's response body lands in the engine state under
-//      the configured output name.
-//   2. The signature node receives the http output as an upstream
-//      input AND the engine renders {{ <input_name> }} from it inside
-//      `instructions`. (Catches both the edge-routing path AND the
-//      Liquid render path in one shot.)
-//   3. The composed system prompt observed at the LLM boundary
-//      contains the http payload — not the raw {{ }} marker.
+//  1. The http block's response body lands in the engine state under
+//     the configured output name.
+//  2. The signature node receives the http output as an upstream
+//     input AND the engine renders {{ <input_name> }} from it inside
+//     `instructions`. (Catches both the edge-routing path AND the
+//     Liquid render path in one shot.)
+//  3. The composed system prompt observed at the LLM boundary
+//     contains the http payload — not the raw {{ }} marker.
 func TestPattern005_HTTPThenSignatureWithLiquidUse(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1042,12 +1042,12 @@ func TestPattern005_HTTPThenSignatureWithLiquidUse(t *testing.T) {
 //
 // What this proves:
 //
-//   1. The code block accepts both signature outputs as inputs (named
-//      kwargs `summary` and `sentiment`) — proves the engine wires
-//      multiple upstream signature outputs into one downstream code
-//      block correctly.
-//   2. The code block's structured return propagates to the end node.
-//   3. All five nodes report "success".
+//  1. The code block accepts both signature outputs as inputs (named
+//     kwargs `summary` and `sentiment`) — proves the engine wires
+//     multiple upstream signature outputs into one downstream code
+//     block correctly.
+//  2. The code block's structured return propagates to the end node.
+//  3. All five nodes report "success".
 func TestPattern006_TwoSignaturesIntoCodeAggregator(t *testing.T) {
 	llm := &fakeLLMClient{
 		respond: func(req app.LLMRequest) (*app.LLMResponse, error) {
@@ -1208,18 +1208,18 @@ func TestPattern010_CustomNodeMissingWorkflowIDFailsActionably(t *testing.T) {
 //
 // What this proves:
 //
-//   1. The evaluator dispatch builds the right URL — slug embeds the
-//      langevals/ namespace and path-joins onto /api/evaluations/.
-//   2. The full `settings` dict — model, max_tokens, prompt — is sent
-//      verbatim to the langevals service. In particular the `{{ var }}`
-//      markers in the prompt body are preserved on the wire (they are
-//      rendered downstream by langevals, not by us).
-//   3. The `data` dict carries upstream signature output + entry-side
-//      expected, so the evaluator has both surfaces for its boolean
-//      judgement.
-//   4. Result.score / Result.passed / Result.details propagate through
-//      the engine to the workflow result — the boolean shape callers
-//      expect from llm_boolean.
+//  1. The evaluator dispatch builds the right URL — slug embeds the
+//     langevals/ namespace and path-joins onto /api/evaluations/.
+//  2. The full `settings` dict — model, max_tokens, prompt — is sent
+//     verbatim to the langevals service. In particular the `{{ var }}`
+//     markers in the prompt body are preserved on the wire (they are
+//     rendered downstream by langevals, not by us).
+//  3. The `data` dict carries upstream signature output + entry-side
+//     expected, so the evaluator has both surfaces for its boolean
+//     judgement.
+//  4. Result.score / Result.passed / Result.details propagate through
+//     the engine to the workflow result — the boolean shape callers
+//     expect from llm_boolean.
 //
 // Generic concept (math fact judge); zero customer content.
 func TestPattern008_LLMBooleanEvaluator(t *testing.T) {
@@ -1351,13 +1351,13 @@ func TestPattern008_LLMBooleanEvaluator(t *testing.T) {
 //
 // What this proves on top of pattern_008:
 //
-//   1. settings.categories survives the JSON boundary as a list of
-//      objects with `name` and `description` keys preserved (no
-//      flattening to bare strings).
-//   2. The evaluator returns a `label` (which category matched) and the
-//      engine surfaces it to result.label — the field shape that
-//      langevals/llm_category callers depend on, distinct from the
-//      score/passed shape of llm_boolean.
+//  1. settings.categories survives the JSON boundary as a list of
+//     objects with `name` and `description` keys preserved (no
+//     flattening to bare strings).
+//  2. The evaluator returns a `label` (which category matched) and the
+//     engine surfaces it to result.label — the field shape that
+//     langevals/llm_category callers depend on, distinct from the
+//     score/passed shape of llm_boolean.
 //
 // Generic concept (weather severity classifier judge); zero customer
 // content.
@@ -1483,17 +1483,17 @@ func TestPattern009_LLMCategoryEvaluator(t *testing.T) {
 //
 // What this proves:
 //
-//   1. The DSL parser binds the inline `json_schema` object on the
-//      output Field.JSONSchema map.
-//   2. composeSignatureResponseFormat wraps the user's schema as a
-//      property on the wrapper object — `properties.<id>` is the
-//      verbatim user schema, not flattened.
-//   3. On the LLM boundary, response_format.type=json_schema and the
-//      schema's `properties.<id>` is the exact user schema — proves no
-//      flattening, no clobbering.
-//   4. extractSignatureOutputs unwraps the LLM's `{"<id>": <obj>}`
-//      reply and binds the inner object to the declared output, so the
-//      workflow result carries the structured payload verbatim.
+//  1. The DSL parser binds the inline `json_schema` object on the
+//     output Field.JSONSchema map.
+//  2. composeSignatureResponseFormat wraps the user's schema as a
+//     property on the wrapper object — `properties.<id>` is the
+//     verbatim user schema, not flattened.
+//  3. On the LLM boundary, response_format.type=json_schema and the
+//     schema's `properties.<id>` is the exact user schema — proves no
+//     flattening, no clobbering.
+//  4. extractSignatureOutputs unwraps the LLM's `{"<id>": <obj>}`
+//     reply and binds the inner object to the declared output, so the
+//     workflow result carries the structured payload verbatim.
 //
 // Generic concept (book metadata extractor); zero customer content.
 func TestPattern012_SingleJSONSchemaOutput(t *testing.T) {
@@ -1732,7 +1732,7 @@ func TestPattern013_FalsyEvaluatorSettingsPreserved(t *testing.T) {
 	assert.InDelta(t, 0.0, settings["max_tokens"], 1e-9, "max_tokens must round-trip as 0, not be missing")
 
 	require.Contains(t, settings, "prompt", "prompt=\"\" must NOT be filtered out")
-	assert.Equal(t, "", settings["prompt"])
+	assert.Empty(t, settings["prompt"])
 
 	require.Contains(t, settings, "remove_punctuation", "remove_punctuation=false must NOT be filtered out")
 	assert.Equal(t, false, settings["remove_punctuation"])
@@ -1762,20 +1762,20 @@ func TestPattern013_FalsyEvaluatorSettingsPreserved(t *testing.T) {
 //
 // What this proves end-to-end:
 //
-//   1. The engine routes `agent` nodes through the agent dispatcher,
-//      and `agent_type=workflow` selects the WorkflowRunner — not the
-//      http or code branch.
-//   2. The HTTP request hits /api/workflows/<workflow_id>/run with the
-//      project apiKey on X-Auth-Token (matches the langevals dispatch
-//      style, since this is the same control-plane surface).
-//   3. Upstream signature output flows into the sub-workflow's request
-//      body verbatim, AND the runner injects `do_not_trace=true` to
-//      avoid double-counted spans (parity with CustomNode.forward).
-//   4. The X-LangWatch-Trace-Id parent trace propagates so Studio can
-//      stitch the sub-run as a child span.
-//   5. The wrapper response shape `{"result": <value>}` is unwrapped
-//      and bound to declared agent outputs (a single declared output
-//      receives the unwrapped value directly).
+//  1. The engine routes `agent` nodes through the agent dispatcher,
+//     and `agent_type=workflow` selects the WorkflowRunner — not the
+//     http or code branch.
+//  2. The HTTP request hits /api/workflows/<workflow_id>/run with the
+//     project apiKey on X-Auth-Token (matches the langevals dispatch
+//     style, since this is the same control-plane surface).
+//  3. Upstream signature output flows into the sub-workflow's request
+//     body verbatim, AND the runner injects `do_not_trace=true` to
+//     avoid double-counted spans (parity with CustomNode.forward).
+//  4. The X-LangWatch-Trace-Id parent trace propagates so Studio can
+//     stitch the sub-run as a child span.
+//  5. The wrapper response shape `{"result": <value>}` is unwrapped
+//     and bound to declared agent outputs (a single declared output
+//     receives the unwrapped value directly).
 //
 // Generic concept (claim → fact-check sub-workflow); zero customer
 // content.
@@ -1902,14 +1902,14 @@ func TestPattern011_WorkflowAsEvaluatorChain(t *testing.T) {
 //
 // On the Go path this test pins three things end-to-end:
 //
-//   1. The handler decodes `thread_id` from the inbound payload
-//      (top-level field, not nested in metadata).
-//   2. The engine plumbs it through `ExecuteRequest.ThreadID` to the
-//      block executors that make outbound calls.
-//   3. Outbound HTTP calls (evaluator + agent-workflow) carry the
-//      `X-LangWatch-Thread-Id` header so the receiving services can
-//      stamp it onto the spans they emit. Mirrors the existing
-//      `X-LangWatch-Trace-Id` and `X-LangWatch-Origin` propagation.
+//  1. The handler decodes `thread_id` from the inbound payload
+//     (top-level field, not nested in metadata).
+//  2. The engine plumbs it through `ExecuteRequest.ThreadID` to the
+//     block executors that make outbound calls.
+//  3. Outbound HTTP calls (evaluator + agent-workflow) carry the
+//     `X-LangWatch-Thread-Id` header so the receiving services can
+//     stamp it onto the spans they emit. Mirrors the existing
+//     `X-LangWatch-Trace-Id` and `X-LangWatch-Origin` propagation.
 //
 // The fixture chains a signature → evaluator → agent-workflow shape
 // so we hit BOTH outbound surfaces in one run. Generic concept; zero
@@ -2123,12 +2123,12 @@ func TestPattern014_SignatureFallsBackToWorkflowDefaultLLM(t *testing.T) {
 // (data.workflow_id, data.version_id) rather than data.parameters[].
 //
 // What this proves end-to-end:
-//   1. Planner accepts `type: custom` and builds a layer for it.
-//   2. Engine dispatches it through agentblock.WorkflowRunner.
-//   3. The HTTP request carries the same shape Python's CustomNode.
-//      forward emits: POST /api/workflows/<id>[/<version>]/run with
-//      X-Auth-Token + body containing inputs + do_not_trace=true.
-//   4. The wrapper response unwraps and binds to declared outputs.
+//  1. Planner accepts `type: custom` and builds a layer for it.
+//  2. Engine dispatches it through agentblock.WorkflowRunner.
+//  3. The HTTP request carries the same shape Python's CustomNode.
+//     forward emits: POST /api/workflows/<id>[/<version>]/run with
+//     X-Auth-Token + body containing inputs + do_not_trace=true.
+//  4. The wrapper response unwraps and binds to declared outputs.
 func TestPattern016_CustomNodeKindRoutesToWorkflowRunner(t *testing.T) {
 	url, lwRequests := setupPatternStack(t, nil, func(w http.ResponseWriter, r *http.Request) {
 		if !stringContains(r.URL.Path, "/api/workflows/") || !stringContains(r.URL.Path, "/run") {
@@ -2213,7 +2213,7 @@ func TestPattern016_CustomNodeKindRoutesToWorkflowRunner(t *testing.T) {
 	check, ok := res.Result["check"].(map[string]any)
 	require.True(t, ok, "check output must be a map (unwrapped result envelope)")
 	assert.Equal(t, true, check["passed"])
-	assert.Equal(t, 0.9, check["score"])
+	assert.InDelta(t, 0.9, check["score"], 1e-9)
 
 	// (5) All three nodes succeeded.
 	require.NotNil(t, res.Nodes)

--- a/services/nlpgo/tests/integration/dsl_patterns_test.go
+++ b/services/nlpgo/tests/integration/dsl_patterns_test.go
@@ -1000,6 +1000,7 @@ func TestPattern005_HTTPThenSignatureWithLiquidUse(t *testing.T) {
 	        {"id":"end","type":"end","data":{"inputs":[{"identifier":"narration","type":"str"}]}}
 	      ],
 	      "edges":[
+	        {"id":"e0","source":"entry","sourceHandle":"outputs.city","target":"fetch","targetHandle":"inputs.city","type":"default"},
 	        {"id":"e1","source":"fetch","sourceHandle":"outputs.forecast","target":"narrate","targetHandle":"inputs.forecast","type":"default"},
 	        {"id":"e2","source":"narrate","sourceHandle":"outputs.narration","target":"end","targetHandle":"inputs.narration","type":"default"}
 	      ],

--- a/services/nlpgo/tests/integration/evaluation_workflow_test.go
+++ b/services/nlpgo/tests/integration/evaluation_workflow_test.go
@@ -166,7 +166,7 @@ func TestEvaluationWorkflow_PostsBatchResultsToLangWatch(t *testing.T) {
 	  }
 	}`
 
-	req, err := http.NewRequest("POST", url+"/go/studio/execute", bytes.NewBufferString(envelope))
+	req, err := http.NewRequest(http.MethodPost, url+"/go/studio/execute", bytes.NewBufferString(envelope))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-LangWatch-Origin", "evaluation")
@@ -265,7 +265,7 @@ func TestEvaluationWorkflow_NonInlineDatasetReturnsActionableError(t *testing.T)
 	  }
 	}`
 
-	req, err := http.NewRequest("POST", url+"/go/studio/execute", bytes.NewBufferString(envelope))
+	req, err := http.NewRequest(http.MethodPost, url+"/go/studio/execute", bytes.NewBufferString(envelope))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)

--- a/services/nlpgo/tests/integration/evaluator_workflow_test.go
+++ b/services/nlpgo/tests/integration/evaluator_workflow_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/langwatch/langwatch/pkg/health"
 	"github.com/langwatch/langwatch/services/nlpgo/adapters/httpapi"
 	"github.com/langwatch/langwatch/services/nlpgo/app"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine"
@@ -30,7 +31,6 @@ import (
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/codeblock"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/evaluatorblock"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
-	"github.com/langwatch/langwatch/pkg/health"
 )
 
 // setupEvaluatorStack mirrors setupStack but wires the evaluator + agent

--- a/services/nlpgo/tests/integration/prompt_spans_harness_test.go
+++ b/services/nlpgo/tests/integration/prompt_spans_harness_test.go
@@ -45,15 +45,15 @@ import (
 // configId), a saved-version node (configId + handle + versionMetadata),
 // or a draft node (saved + promptDraft=true).
 type signatureNodeOpts struct {
-	NodeID         string
-	NodeName       string
-	ConfigID       string
-	Handle         string
-	VersionID      string
-	VersionNumber  int
-	Draft          bool
-	Instructions   string
-	TemplateMsgs   []map[string]any
+	NodeID        string
+	NodeName      string
+	ConfigID      string
+	Handle        string
+	VersionID     string
+	VersionNumber int
+	Draft         bool
+	Instructions  string
+	TemplateMsgs  []map[string]any
 }
 
 // signatureWorkflowBody builds an execute_component envelope shaped
@@ -242,4 +242,3 @@ func (f *promptSpansFixture) FindPromptSpan(t *testing.T, name string) sdktrace.
 	}
 	return s
 }
-

--- a/services/nlpgo/tests/integration/stream_workflow_test.go
+++ b/services/nlpgo/tests/integration/stream_workflow_test.go
@@ -70,7 +70,7 @@ func readSSE(t *testing.T, r io.Reader, stop func(streamFrame) bool) []streamFra
 
 func postStreamURL(t *testing.T, url, body string, hdrs map[string]string) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest("POST", url+"/go/studio/execute", bytes.NewBufferString(body))
+	req, err := http.NewRequest(http.MethodPost, url+"/go/studio/execute", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-LangWatch-Origin", "workflow")

--- a/services/nlpgo/tests/integration/sync_workflow_test.go
+++ b/services/nlpgo/tests/integration/sync_workflow_test.go
@@ -96,7 +96,7 @@ func (a executorAdapter) ExecuteStream(ctx context.Context, req app.WorkflowRequ
 		ch := make(chan app.WorkflowStreamEvent, 1)
 		ch <- app.WorkflowStreamEvent{Type: "error", Payload: map[string]any{"message": err.Error()}}
 		close(ch)
-		return ch, nil
+		return ch, nil //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 	}
 	in, err := a.eng.ExecuteStream(ctx, engine.ExecuteRequest{
 		Workflow:          wf,
@@ -116,7 +116,7 @@ func (a executorAdapter) ExecuteStream(ctx context.Context, req app.WorkflowRequ
 		ch := make(chan app.WorkflowStreamEvent, 1)
 		ch <- app.WorkflowStreamEvent{Type: "error", Payload: map[string]any{"message": err.Error()}}
 		close(ch)
-		return ch, nil
+		return ch, nil //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 	}
 	out := make(chan app.WorkflowStreamEvent, 16)
 	go func() {
@@ -131,7 +131,7 @@ func (a executorAdapter) ExecuteStream(ctx context.Context, req app.WorkflowRequ
 func (a executorAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (*app.WorkflowResult, error) {
 	wf, err := dsl.ParseWorkflow(req.WorkflowJSON)
 	if err != nil {
-		return &app.WorkflowResult{
+		return &app.WorkflowResult{ //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 			Status: "error",
 			Error:  &app.WorkflowError{Type: "invalid_workflow", Message: err.Error()},
 		}, nil
@@ -151,7 +151,7 @@ func (a executorAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (
 		DatasetEntry:      req.DatasetEntry,
 	})
 	if err != nil {
-		return &app.WorkflowResult{
+		return &app.WorkflowResult{ //nolint:nilerr // error is surfaced via the channel/result payload, not the function error return
 			Status: "error",
 			Error:  &app.WorkflowError{Type: "engine_error", Message: err.Error()},
 		}, nil
@@ -179,7 +179,7 @@ func (a executorAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (
 
 func postSync(t *testing.T, stack *stack, body string) *app.WorkflowResult {
 	t.Helper()
-	req, err := http.NewRequest("POST", stack.url+"/go/studio/execute_sync", bytes.NewBufferString(body))
+	req, err := http.NewRequest(http.MethodPost, stack.url+"/go/studio/execute_sync", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-LangWatch-Origin", "workflow")
@@ -317,7 +317,7 @@ func TestSync_CodeBlockEndToEnd(t *testing.T) {
 	}`
 	res := postSync(t, stack, body)
 	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
-	assert.Equal(t, float64(5), res.Result["sum"])
+	assert.InDelta(t, 5.0, res.Result["sum"], 1e-9)
 }
 
 // TestSync_RejectsUnsupportedNodeKind exercises the planner →

--- a/specs/nlp-go/engine.feature
+++ b/specs/nlp-go/engine.feature
@@ -91,33 +91,40 @@ Feature: Workflow execution engine — DSL parsing, DAG resolution, lifecycle
     # sitting on the canvas with no incoming edges executed itself and
     # billed the user.
 
-    @unit @unimplemented
+    @unit
     Scenario: a Signature node disconnected from Entry is not planned
       Given a workflow with Entry -> Code -> End plus an extra Signature node with no incoming edges
       When the planner builds the plan
       Then the plan layers contain "Entry", "Code", and "End"
       And the plan layers do not contain the disconnected Signature
 
-    @unit @unimplemented
+    @unit
     Scenario: a disconnected sub-chain whose root is not reachable from Entry is skipped
       Given a workflow with one chain rooted at Entry and a second chain whose root has no Entry edge
       When the planner builds the plan
       Then only the Entry-rooted chain's nodes appear in the plan
       And no node from the floating chain appears in the plan
 
-    @unit @unimplemented
+    @unit
     Scenario: "Run until here" trims downstream nodes and disconnected siblings
       Given a workflow Entry -> A -> B -> C -> End plus a disconnected Signature
       When the planner builds the plan with until_node_id "B"
       Then the plan contains exactly "Entry", "A", and "B"
       And C, End, and the disconnected Signature are not planned
 
-    @unit @unimplemented
+    @unit
     Scenario: "Run until here" with an unknown target returns an UnknownNodeError
       Given a workflow Entry -> Code -> End
       When the planner builds the plan with until_node_id "does-not-exist"
       Then the planner returns an UnknownNodeError naming the missing node id
       And no plan is produced
+
+    @unit
+    Scenario: "Run until here" pointed at Entry plans just Entry
+      Given a linear workflow Entry -> B -> C -> End
+      When the planner builds the plan with until_node_id "Entry"
+      Then the plan contains exactly the Entry node
+      And no downstream node is planned
 
   Rule: Streaming endpoint emits the documented event shapes
 


### PR DESCRIPTION
## Summary

Two related parity gaps in the Go workflow planner that rchaves caught dogfooding the Tool Selection Evaluator:

1. **Disconnected nodes executed on full runs.** An LLM/Signature node sitting on the Studio canvas with no incoming edges ran itself because Kahn's topological sort treated its zero indegree as "ready". Python's `find_reachable_nodes` (`studio/parser.py:605`) skips it via forward BFS from Entry.
2. **`until_node_id` was ignored.** TS sends it (`useWorkflowExecution.ts:97`, `events.ts:30`) and `dsl/types.go` already declared the field, but the handler/engine never passed it to the planner, so "Run until here" walked the entire reachable graph (plus any orphans). Python uses `find_path_until_node` (`parser.py:531`) — backward DFS from the target.

## Fix

- New `planner.WithUntilNode(id)` functional option.
- `planner.New`:
  - Forward BFS from the `ComponentEntry` node builds the reachable set (always-on filter, mirrors Python).
  - If `WithUntilNode` is set, backward DFS from the target builds a path and is intersected with the reachable set so an orphan ancestor of the target can't sneak in.
  - Falls back to "include every node" when the workflow has no Entry (pre-canonical fixtures still plan unchanged).
- `layerize` is scoped to the allowed set and guards children outside scope so the until-here case can't strand indegree.
- `until_node_id` plumbed end-to-end: HTTP handler -> `app.WorkflowRequest` -> `engine.ExecuteRequest` -> `planner.WithUntilNode`. `ExecuteStream` picks it up via a shared `planOptionsFor` helper so the two engine entry points can't drift.

## Tests

`services/nlpgo/app/engine/planner/planner_test.go`:
- `TestPlan_ExcludesOrphanNodeOnFullRun` - Entry -> Code -> End + orphan Signature; only the chain is planned.
- `TestPlan_ExcludesDisconnectedSubChain` - two parallel chains, only the Entry-rooted one plans.
- `TestPlan_WithUntilNode_TrimsDownstreamAndOrphans` - until=B in Entry->A->B->C->End + orphan; plans exactly {Entry, A, B}.
- `TestPlan_WithUntilNode_UnknownTargetErrors` - returns UnknownNodeError.
- `TestPlan_WithUntilNode_EntryItself` - until=Entry plans just {Entry}.

All 11 existing planner tests still pass; full engine + httpapi + cmd suites green locally.

`specs/nlp-go/engine.feature`: new Rule "Disconnected and out-of-scope nodes never execute" with 4 scenarios mirroring the unit tests, tagged @unimplemented per the file's Go-side binding convention.

## Test plan

- [ ] CI passes (planner unit + integration + httpapi)
- [ ] Dogfood in Studio with the original disconnected-LLM workflow: run full + "Run until here", confirm the orphan does NOT execute (no spans, no cost)
- [ ] Run "Run until here" on a middle node of a real workflow, confirm downstream nodes don't run