### PR TITLE
fix(security): require an explicit scope to archive scenario runs

### DIFF
--- a/langwatch/src/app/api/openapiLangWatch.json
+++ b/langwatch/src/app/api/openapiLangWatch.json
@@ -19834,7 +19834,7 @@
       "delete": {
         "responses": {
           "200": {
-            "description": "Events deleted successfully",
+            "description": "Matching runs archived successfully",
             "content": {
               "application/json": {
                 "schema": {
@@ -19858,16 +19858,13 @@
             }
           },
           "400": {
-            "description": "Bad Request",
+            "description": "No scope provided — a batchRunId or scenarioSetId is required",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
                     "error": {
-                      "type": "string"
-                    },
-                    "message": {
                       "type": "string"
                     }
                   },
@@ -19943,8 +19940,25 @@
           }
         },
         "operationId": "deleteApiScenario-events",
-        "parameters": [],
-        "description": "Delete all events"
+        "parameters": [
+          {
+            "in": "query",
+            "name": "batchRunId",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "scenarioSetId",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "description": "Archive the simulation runs for a batch run and/or scenario set. Requires at least one of batchRunId or scenarioSetId — archiving every run in the project in one call is not supported."
       }
     },
     "/api/scenarios": {

--- a/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
+++ b/langwatch/src/app/api/scenario-events/[[...route]]/app.ts
@@ -1,12 +1,16 @@
 import { bodyLimit } from "hono/body-limit";
 import { describeRoute } from "hono-openapi";
 import { resolver, validator as zValidator } from "hono-openapi/zod";
+import { z } from "zod";
 import { createProjectApp, requires } from "~/server/api/security";
 import { getApp } from "~/server/app-layer/app";
+import { DEFAULT_SET_ID } from "~/server/scenarios/internal-set-id";
 import { ScenarioEventType } from "~/server/scenarios/scenario-event.enums";
 import type { ScenarioEvent } from "~/server/scenarios/scenario-event.types";
-import { DEFAULT_SET_ID } from "~/server/scenarios/internal-set-id";
-import { responseSchemas, scenarioEventSchema } from "~/server/scenarios/schemas";
+import {
+  responseSchemas,
+  scenarioEventSchema,
+} from "~/server/scenarios/schemas";
 import { extractInlineMediaFromEvent } from "~/server/stored-objects/content-extractor";
 import { createStoredObjectsService } from "~/server/stored-objects/stored-objects-factory";
 import { createLogger } from "~/utils/logger/server";
@@ -65,14 +69,15 @@ secured.access(requires("scenarios:manage")).post(
     // Extract inline media bytes, externalize to stored objects, and rewrite
     // the event payload to reference them by URL before dispatch.
     const service = createStoredObjectsService({ projectId: project.id });
-    const { rewrittenEvent: rawRewritten, refs } = await extractInlineMediaFromEvent({
-      event: validatedEvent,
-      projectId: project.id,
-      ownerKind: "scenario_run",
-      ownerId: validatedEvent.scenarioRunId,
-      purpose: "scenario_event",
-      service,
-    });
+    const { rewrittenEvent: rawRewritten, refs } =
+      await extractInlineMediaFromEvent({
+        event: validatedEvent,
+        projectId: project.id,
+        ownerKind: "scenario_run",
+        ownerId: validatedEvent.scenarioRunId,
+        purpose: "scenario_event",
+        service,
+      });
 
     // Cast back to the typed ScenarioEvent — the rewrite only touches content
     // arrays inside message objects; all discriminant fields are preserved.
@@ -132,26 +137,57 @@ secured.access(requires("scenarios:manage")).post(
   },
 );
 
-// DELETE /api/scenario-events - Delete all events for a project
+// DELETE /api/scenario-events - Archive the simulation runs for a specific
+// batch run and/or scenario set. A scope is MANDATORY: an unqualified request
+// is rejected so a single call can never archive every run in the project.
+const deleteScenarioEventsQuerySchema = z.object({
+  batchRunId: z.string().min(1).optional(),
+  scenarioSetId: z.string().min(1).optional(),
+});
+
 export const route = secured.access(requires("scenarios:manage")).delete(
   "/",
   blockTraceUsageExceededMiddleware,
   describeRoute({
-    description: "Delete all events",
+    description:
+      "Archive the simulation runs for a batch run and/or scenario set. Requires at least one of batchRunId or scenarioSetId — archiving every run in the project in one call is not supported.",
     responses: {
       ...baseResponses,
       200: {
-        description: "Events deleted successfully",
+        description: "Matching runs archived successfully",
         content: {
           "application/json": { schema: resolver(responseSchemas.success) },
         },
       },
+      400: {
+        description:
+          "No scope provided — a batchRunId or scenarioSetId is required",
+        content: {
+          "application/json": { schema: resolver(responseSchemas.error) },
+        },
+      },
     },
   }),
+  zValidator("query", deleteScenarioEventsQuerySchema),
   async (c) => {
     const { project } = c.var;
+    const { batchRunId, scenarioSetId } = c.req.valid("query");
 
-    await archiveAllSimulationRuns(project.id);
+    if (!batchRunId && !scenarioSetId) {
+      return c.json(
+        {
+          error:
+            "A batchRunId or scenarioSetId must be specified. Archiving every simulation run for the project in one request is not supported.",
+        },
+        400,
+      );
+    }
+
+    await archiveSimulationRunsForScope({
+      projectId: project.id,
+      batchRunId,
+      scenarioSetId,
+    });
 
     return c.json({ success: true }, 200);
   },
@@ -185,7 +221,10 @@ async function dispatchSimulationEvent(
     const messages = event.messages ?? [];
     await getApp().simulations.messageSnapshot({
       ...basePayload,
-      messages: messages as Array<{ trace_id?: string; [key: string]: unknown }>,
+      messages: messages as Array<{
+        trace_id?: string;
+        [key: string]: unknown;
+      }>,
       traceIds: messages
         .map((m: { trace_id?: string }) => m.trace_id)
         .filter((id): id is string => typeof id === "string"),
@@ -234,9 +273,21 @@ function isStreamingEvent(type: string): boolean {
   );
 }
 
-async function archiveAllSimulationRuns(projectId: string): Promise<void> {
+async function archiveSimulationRunsForScope({
+  projectId,
+  batchRunId,
+  scenarioSetId,
+}: {
+  projectId: string;
+  batchRunId?: string;
+  scenarioSetId?: string;
+}): Promise<void> {
   const app = getApp();
-  const runIds = await app.simulations.runs.getAllRunIdsForProject({ projectId });
+  const runIds = await app.simulations.runs.getRunIdsForScope({
+    projectId,
+    batchRunId,
+    scenarioSetId,
+  });
 
   const now = Date.now();
   await Promise.all(
@@ -249,7 +300,10 @@ async function archiveAllSimulationRuns(projectId: string): Promise<void> {
     ),
   );
 
-  logger.info({ projectId, count: runIds.length }, "Dispatched archive commands for all simulation runs");
+  logger.info(
+    { projectId, batchRunId, scenarioSetId, count: runIds.length },
+    "Dispatched archive commands for scoped simulation runs",
+  );
 }
 
 async function broadcastStreamingEvent(

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -941,14 +941,20 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     }
 
     const predicates = ["TenantId = {tenantId:String}", "ArchivedAt IS NULL"];
-    const query_params: Record<string, string> = { tenantId: projectId };
+    const query_params: Record<string, string | string[]> = {
+      tenantId: projectId,
+    };
     if (batchRunId) {
       predicates.push("BatchRunId = {batchRunId:String}");
       query_params.batchRunId = batchRunId;
     }
     if (scenarioSetId) {
-      predicates.push("ScenarioSetId = {scenarioSetId:String}");
-      query_params.scenarioSetId = scenarioSetId;
+      // The default set is stored as '' but addressed as 'default' (and
+      // vice-versa). Expand to both storage forms so archiving the default
+      // set matches its rows — the same normalization every other
+      // set-scoped query uses via expandSetIdFilter.
+      predicates.push("ScenarioSetId IN ({scenarioSetIds:Array(String)})");
+      query_params.scenarioSetIds = expandSetIdFilter(scenarioSetId);
     }
 
     const client = await this.getClient(projectId);

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -1,5 +1,10 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import {
+  DEFAULT_SET_ID,
+  expandSetIdFilter,
+  INTERNAL_SET_PREFIX,
+} from "~/server/scenarios/internal-set-id";
 import type {
   BatchHistoryItem,
   ExternalSetSummary,
@@ -8,11 +13,10 @@ import type {
 } from "~/server/scenarios/scenario-event.types";
 import { resolveRunStatus } from "~/server/scenarios/stall-detection";
 import {
+  type ClickHouseSimulationRunRow,
   mapClickHouseRowToScenarioRunData,
   mapStatus,
-  type ClickHouseSimulationRunRow,
 } from "~/server/simulations/simulation-run.mappers";
-import { DEFAULT_SET_ID, INTERNAL_SET_PREFIX, expandSetIdFilter } from "~/server/scenarios/internal-set-id";
 import type { SimulationRepository } from "./simulation.repository";
 
 const TABLE_NAME = "simulation_runs" as const;
@@ -59,7 +63,11 @@ function buildDateFilter({
 }: {
   startDate?: number;
   endDate?: number;
-}): { havingClause: string | null; whereClause: string; params: Record<string, string> } {
+}): {
+  havingClause: string | null;
+  whereClause: string;
+  params: Record<string, string>;
+} {
   const havingParts: string[] = [];
   const whereParts: string[] = [];
   const params: Record<string, string> = {};
@@ -331,19 +339,30 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       {
         tenantId: projectId,
         scenarioSetIds: expandSetIdFilter(scenarioSetId),
-        ...(decoded ? { cursorTs: decoded.ts, cursorBatchRunId: decoded.batchRunId } : {}),
+        ...(decoded
+          ? { cursorTs: decoded.ts, cursorBatchRunId: decoded.batchRunId }
+          : {}),
         fetchLimit: String(validatedLimit + 1),
       },
     );
 
-    const [totalCountRows, batchRows] = await Promise.all([totalCountPromise, batchRowsPromise]);
+    const [totalCountRows, batchRows] = await Promise.all([
+      totalCountPromise,
+      batchRowsPromise,
+    ]);
     const totalCount = parseInt(totalCountRows[0]?.TotalBatchCount ?? "0", 10);
 
     const hasMore = batchRows.length > validatedLimit;
     const pageRows = hasMore ? batchRows.slice(0, validatedLimit) : batchRows;
 
     if (pageRows.length === 0) {
-      return { batches: [], nextCursor: undefined, hasMore: false, lastUpdatedAt: 0, totalCount };
+      return {
+        batches: [],
+        nextCursor: undefined,
+        hasMore: false,
+        lastUpdatedAt: 0,
+        totalCount,
+      };
     }
 
     const lastRow = pageRows[pageRows.length - 1]!;
@@ -374,7 +393,11 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          AND ArchivedAt IS NULL
          ${simulationRunDedupPredicate("TenantId = {tenantId:String} AND ScenarioSetId IN ({scenarioSetIds:Array(String)}) AND BatchRunId IN ({batchRunIds:Array(String)})")}
        ORDER BY CreatedAt ASC`,
-      { tenantId: projectId, scenarioSetIds: expandSetIdFilter(scenarioSetId), batchRunIds },
+      {
+        tenantId: projectId,
+        scenarioSetIds: expandSetIdFilter(scenarioSetId),
+        batchRunIds,
+      },
     );
 
     // Group items by batchRunId
@@ -390,11 +413,13 @@ export class SimulationClickHouseRepository implements SimulationRepository {
 
     const batches: BatchHistoryItem[] = pageRows.map((b) => {
       const lastUpdatedAt = Number(b.LastUpdatedAt);
-      if (lastUpdatedAt > globalLastUpdatedAt) globalLastUpdatedAt = lastUpdatedAt;
+      if (lastUpdatedAt > globalLastUpdatedAt)
+        globalLastUpdatedAt = lastUpdatedAt;
 
       const items = (itemsByBatch.get(b.BatchRunId) ?? []).map((r) => {
         const baseStatus = mapStatus(r.Status);
-        const durationMs = r.DurationMs != null ? parseInt(r.DurationMs, 10) : 0;
+        const durationMs =
+          r.DurationMs != null ? parseInt(r.DurationMs, 10) : 0;
         const perRunUpdatedAt = Number(r.UpdatedAt);
         const hasFinished = r.FinishedAt != null && Number(r.FinishedAt) > 0;
         const resolvedStatus = resolveRunStatus({
@@ -436,7 +461,13 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       };
     });
 
-    return { batches, nextCursor, hasMore, lastUpdatedAt: globalLastUpdatedAt, totalCount };
+    return {
+      batches,
+      nextCursor,
+      hasMore,
+      lastUpdatedAt: globalLastUpdatedAt,
+      totalCount,
+    };
   }
 
   async getRunDataForBatchRun({
@@ -484,7 +515,11 @@ export class SimulationClickHouseRepository implements SimulationRepository {
            GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
          )
        ORDER BY CreatedAt ASC`,
-      { tenantId: projectId, scenarioSetIds: expandSetIdFilter(scenarioSetId), batchRunId },
+      {
+        tenantId: projectId,
+        scenarioSetIds: expandSetIdFilter(scenarioSetId),
+        batchRunId,
+      },
     );
 
     const now = Date.now();
@@ -589,7 +624,11 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     cursor?: string;
     startDate?: number;
     endDate?: number;
-  }): Promise<{ runs: ScenarioRunData[]; nextCursor?: string; hasMore: boolean }> {
+  }): Promise<{
+    runs: ScenarioRunData[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
     const validatedLimit = Math.min(Math.max(1, limit), 100);
     const decoded = cursor ? this.decodeCursor(cursor) : null;
 
@@ -601,7 +640,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       : "1 = 1";
 
     const dateFilter = buildDateFilter({ startDate, endDate });
-    
+
     const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.havingClause].filter(Boolean).join(" AND ")}`;
 
     const batchRows = await this.queryRows<{
@@ -624,7 +663,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       {
         tenantId: projectId,
         scenarioSetIds: expandSetIdFilter(scenarioSetId),
-        ...(decoded ? { cursorTs: decoded.ts, cursorBatchRunId: decoded.batchRunId } : {}),
+        ...(decoded
+          ? { cursorTs: decoded.ts, cursorBatchRunId: decoded.batchRunId }
+          : {}),
         ...dateFilter.params,
         fetchLimit: String(validatedLimit + 1),
       },
@@ -639,12 +680,17 @@ export class SimulationClickHouseRepository implements SimulationRepository {
 
     const lastRow = pageRows[pageRows.length - 1];
 
-    const nextCursor = lastRow && hasMore
-      ? this.encodeCursor(lastRow.MaxCreatedAt, lastRow.BatchRunId)
-      : undefined;
+    const nextCursor =
+      lastRow && hasMore
+        ? this.encodeCursor(lastRow.MaxCreatedAt, lastRow.BatchRunId)
+        : undefined;
 
     const batchRunIds = pageRows.map((r) => r.BatchRunId);
-    const runs = await this.getRunsForBatchIds({ projectId, batchRunIds, scenarioSetId });
+    const runs = await this.getRunsForBatchIds({
+      projectId,
+      batchRunIds,
+      scenarioSetId,
+    });
 
     return { runs, nextCursor, hasMore };
   }
@@ -700,7 +746,7 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       : "1 = 1";
 
     const dateFilter = buildDateFilter({ startDate, endDate });
-    
+
     const combinedHaving = `HAVING ${[cursorPredicate, dateFilter.havingClause].filter(Boolean).join(" AND ")}`;
 
     // NOTE: The aggregate is aliased as NormalizedSetId (not ScenarioSetId) on
@@ -727,7 +773,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
        LIMIT {fetchLimit:UInt32}`,
       {
         tenantId: projectId,
-        ...(decoded ? { cursorTs: decoded.ts, cursorBatchRunId: decoded.batchRunId } : {}),
+        ...(decoded
+          ? { cursorTs: decoded.ts, cursorBatchRunId: decoded.batchRunId }
+          : {}),
         ...dateFilter.params,
         fetchLimit: String(validatedLimit + 1),
       },
@@ -737,7 +785,14 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     const pageRows = hasMore ? batchRows.slice(0, validatedLimit) : batchRows;
 
     if (pageRows.length === 0) {
-      return { changed: true, lastUpdatedAt: 0, runs: [], scenarioSetIds: {}, nextCursor: undefined, hasMore: false };
+      return {
+        changed: true,
+        lastUpdatedAt: 0,
+        runs: [],
+        scenarioSetIds: {},
+        nextCursor: undefined,
+        hasMore: false,
+      };
     }
 
     const lastRow = pageRows[pageRows.length - 1]!;
@@ -757,7 +812,14 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       0,
     );
 
-    return { changed: true, lastUpdatedAt, runs, scenarioSetIds, nextCursor, hasMore };
+    return {
+      changed: true,
+      lastUpdatedAt,
+      runs,
+      scenarioSetIds,
+      nextCursor,
+      hasMore,
+    };
   }
 
   async getExternalSetSummaries(params: {
@@ -794,17 +856,21 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     filter: "external" | "internal-suites";
   }): Promise<ExternalSetSummary[]> {
     const dateFilter = buildDateFilter({ startDate, endDate });
-    
-    const havingClause = dateFilter.havingClause ? `HAVING ${dateFilter.havingClause}` : "";
 
-    const wherePredicate = filter === "external"
-      ? "AND NOT startsWith(ScenarioSetId, '__internal__')"
-      : "AND startsWith(ScenarioSetId, '__internal__') AND endsWith(ScenarioSetId, '__suite')";
+    const havingClause = dateFilter.havingClause
+      ? `HAVING ${dateFilter.havingClause}`
+      : "";
+
+    const wherePredicate =
+      filter === "external"
+        ? "AND NOT startsWith(ScenarioSetId, '__internal__')"
+        : "AND startsWith(ScenarioSetId, '__internal__') AND endsWith(ScenarioSetId, '__suite')";
 
     // External sets normalize empty ScenarioSetId to 'default'
-    const selectId = filter === "external"
-      ? "IF(ScenarioSetId = '', 'default', ScenarioSetId) AS NormalizedSetId"
-      : "ScenarioSetId AS NormalizedSetId";
+    const selectId =
+      filter === "external"
+        ? "IF(ScenarioSetId = '', 'default', ScenarioSetId) AS NormalizedSetId"
+        : "ScenarioSetId AS NormalizedSetId";
 
     const rows = await this.queryRows<{
       ScenarioSetId: string;
@@ -855,15 +921,42 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     }));
   }
 
-  async getAllRunIdsForProject({
+  async getRunIdsForScope({
     projectId,
+    batchRunId,
+    scenarioSetId,
   }: {
     projectId: string;
+    batchRunId?: string;
+    scenarioSetId?: string;
   }): Promise<string[]> {
+    // Guard: a scope is mandatory. Without a batch or set predicate this would
+    // select every run in the tenant — the bulk-archive footgun this method
+    // exists to prevent. The API layer rejects the request before reaching
+    // here; this is defence in depth at the data layer.
+    if (!batchRunId && !scenarioSetId) {
+      throw new Error(
+        "getRunIdsForScope requires a batchRunId or scenarioSetId; refusing to select all runs for the tenant",
+      );
+    }
+
+    const predicates = ["TenantId = {tenantId:String}", "ArchivedAt IS NULL"];
+    const query_params: Record<string, string> = { tenantId: projectId };
+    if (batchRunId) {
+      predicates.push("BatchRunId = {batchRunId:String}");
+      query_params.batchRunId = batchRunId;
+    }
+    if (scenarioSetId) {
+      predicates.push("ScenarioSetId = {scenarioSetId:String}");
+      query_params.scenarioSetId = scenarioSetId;
+    }
+
     const client = await this.getClient(projectId);
     const result = await client.query({
-      query: `SELECT DISTINCT ScenarioRunId FROM ${TABLE_NAME} WHERE TenantId = {tenantId:String} AND ArchivedAt IS NULL LIMIT 10000`,
-      query_params: { tenantId: projectId },
+      query: `SELECT DISTINCT ScenarioRunId FROM ${TABLE_NAME} WHERE ${predicates.join(
+        " AND ",
+      )} LIMIT 10000`,
+      query_params,
       format: "JSONEachRow",
     });
     const rows = await result.json<{ ScenarioRunId: string }>();
@@ -897,7 +990,9 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     );
 
     return new Set(
-      rows.map((r) => (r.ScenarioSetId === "" ? DEFAULT_SET_ID : r.ScenarioSetId)),
+      rows.map((r) =>
+        r.ScenarioSetId === "" ? DEFAULT_SET_ID : r.ScenarioSetId,
+      ),
     );
   }
 
@@ -912,7 +1007,10 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     try {
       const json = Buffer.from(cursor, "base64").toString("utf-8");
       const parsed = JSON.parse(json) as Record<string, unknown>;
-      if (typeof parsed.ts !== "string" || typeof parsed.batchRunId !== "string") {
+      if (
+        typeof parsed.ts !== "string" ||
+        typeof parsed.batchRunId !== "string"
+      ) {
         return null;
       }
       return { ts: parsed.ts, batchRunId: parsed.batchRunId };
@@ -958,7 +1056,13 @@ export class SimulationClickHouseRepository implements SimulationRepository {
          )
        ORDER BY CreatedAt ASC
        LIMIT 5000`,
-      { tenantId: projectId, batchRunIds, ...(scenarioSetId ? { scenarioSetIds: expandSetIdFilter(scenarioSetId) } : {}) },
+      {
+        tenantId: projectId,
+        batchRunIds,
+        ...(scenarioSetId
+          ? { scenarioSetIds: expandSetIdFilter(scenarioSetId) }
+          : {}),
+      },
       { expectedMaxDurationMs: 5000, expectedMaxReadBytes: 5_000_000 },
     );
 

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.repository.ts
@@ -48,7 +48,11 @@ export interface SimulationRepository {
     cursor?: string;
     startDate?: number;
     endDate?: number;
-  }): Promise<{ runs: ScenarioRunData[]; nextCursor?: string; hasMore: boolean }>;
+  }): Promise<{
+    runs: ScenarioRunData[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }>;
 
   getAllRunDataForScenarioSet(params: {
     projectId: string;
@@ -86,8 +90,16 @@ export interface SimulationRepository {
     sinceTimestamp?: number;
   }): Promise<AllSuitesRunDataResult>;
 
-  getAllRunIdsForProject(params: {
+  /**
+   * Returns the run ids for a SPECIFIC scope — a batch run and/or a scenario
+   * set — never the whole project. At least one of `batchRunId` /
+   * `scenarioSetId` must be provided; callers must not be able to address
+   * every run in a tenant with one unqualified request.
+   */
+  getRunIdsForScope(params: {
     projectId: string;
+    batchRunId?: string;
+    scenarioSetId?: string;
   }): Promise<string[]>;
 
   /**
@@ -116,7 +128,11 @@ export class NullSimulationRepository implements SimulationRepository {
     return { changed: true, lastUpdatedAt: 0, runs: [] };
   }
 
-  async getRunDataForScenarioSet(): Promise<{ runs: ScenarioRunData[]; nextCursor?: string; hasMore: boolean }> {
+  async getRunDataForScenarioSet(): Promise<{
+    runs: ScenarioRunData[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
     return { runs: [], hasMore: false };
   }
 
@@ -141,10 +157,16 @@ export class NullSimulationRepository implements SimulationRepository {
   }
 
   async getRunDataForAllSuites(): Promise<AllSuitesRunDataResult> {
-    return { changed: true, lastUpdatedAt: 0, runs: [], scenarioSetIds: {}, hasMore: false };
+    return {
+      changed: true,
+      lastUpdatedAt: 0,
+      runs: [],
+      scenarioSetIds: {},
+      hasMore: false,
+    };
   }
 
-  async getAllRunIdsForProject(): Promise<string[]> {
+  async getRunIdsForScope(): Promise<string[]> {
     return [];
   }
 

--- a/langwatch/src/server/app-layer/simulations/simulation-run.service.ts
+++ b/langwatch/src/server/app-layer/simulations/simulation-run.service.ts
@@ -16,18 +16,25 @@ import {
 export class SimulationRunService {
   constructor(readonly repository: SimulationRepository) {}
 
-  static create(resolveClient: ClickHouseClientResolver | null): SimulationRunService {
+  static create(
+    resolveClient: ClickHouseClientResolver | null,
+  ): SimulationRunService {
     const repo = resolveClient
       ? new SimulationClickHouseRepository(resolveClient)
       : new NullSimulationRepository();
     return traced(new SimulationRunService(repo), "SimulationRunService");
   }
 
-  async getScenarioSetsData(params: { projectId: string }): Promise<ScenarioSetData[]> {
+  async getScenarioSetsData(params: {
+    projectId: string;
+  }): Promise<ScenarioSetData[]> {
     return this.repository.getScenarioSetsData(params);
   }
 
-  async getScenarioRunData(params: { projectId: string; scenarioRunId: string }): Promise<ScenarioRunData | null> {
+  async getScenarioRunData(params: {
+    projectId: string;
+    scenarioRunId: string;
+  }): Promise<ScenarioRunData | null> {
     return this.repository.getScenarioRunData(params);
   }
 
@@ -56,7 +63,11 @@ export class SimulationRunService {
     cursor?: string;
     startDate?: number;
     endDate?: number;
-  }): Promise<{ runs: ScenarioRunData[]; nextCursor?: string; hasMore: boolean }> {
+  }): Promise<{
+    runs: ScenarioRunData[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
     return this.repository.getRunDataForScenarioSet(params);
   }
 
@@ -81,11 +92,19 @@ export class SimulationRunService {
     return this.repository.getBatchRunCountForScenarioSet(params);
   }
 
-  async getExternalSetSummaries(params: { projectId: string; startDate?: number; endDate?: number }): Promise<ExternalSetSummary[]> {
+  async getExternalSetSummaries(params: {
+    projectId: string;
+    startDate?: number;
+    endDate?: number;
+  }): Promise<ExternalSetSummary[]> {
     return this.repository.getExternalSetSummaries(params);
   }
 
-  async getInternalSuiteSummaries(params: { projectId: string; startDate?: number; endDate?: number }): Promise<ExternalSetSummary[]> {
+  async getInternalSuiteSummaries(params: {
+    projectId: string;
+    startDate?: number;
+    endDate?: number;
+  }): Promise<ExternalSetSummary[]> {
     return this.repository.getInternalSuiteSummaries(params);
   }
 
@@ -100,15 +119,21 @@ export class SimulationRunService {
     return this.repository.getRunDataForAllSuites(params);
   }
 
-  async getAllRunIdsForProject(params: { projectId: string }): Promise<string[]> {
-    return this.repository.getAllRunIdsForProject(params);
+  async getRunIdsForScope(params: {
+    projectId: string;
+    batchRunId?: string;
+    scenarioSetId?: string;
+  }): Promise<string[]> {
+    return this.repository.getRunIdsForScope(params);
   }
 
   /**
    * Returns distinct external (non-internal) scenario set IDs across the given projects.
    * Used by UsageService for cross-org scenario set limit enforcement.
    */
-  async getDistinctExternalSetIds(params: { projectIds: string[] }): Promise<Set<string>> {
+  async getDistinctExternalSetIds(params: {
+    projectIds: string[];
+  }): Promise<Set<string>> {
     return this.repository.getDistinctExternalSetIds(params);
   }
 }

--- a/langwatch/src/server/scenarios/scenario-event.repository.ts
+++ b/langwatch/src/server/scenarios/scenario-event.repository.ts
@@ -5,10 +5,8 @@ import { z } from "zod";
 import { esClient, SCENARIO_EVENTS_INDEX } from "~/server/elasticsearch";
 import { createLogger } from "~/utils/logger/server";
 import { captureException } from "~/utils/posthogErrorCapture";
-import { ScenarioEventType, Verdict } from "./scenario-event.enums";
-import { scenarioEventSchema } from "./schemas";
-import { batchRunIdSchema, scenarioRunIdSchema } from "./schemas/event-schemas";
 import { DEFAULT_SET_ID, expandSetIdFilter } from "./internal-set-id";
+import { ScenarioEventType, Verdict } from "./scenario-event.enums";
 import type {
   ScenarioEvent,
   ScenarioMessageSnapshotEvent,
@@ -16,6 +14,8 @@ import type {
   ScenarioRunStartedEvent,
   ScenarioSetData,
 } from "./scenario-event.types";
+import { scenarioEventSchema } from "./schemas";
+import { batchRunIdSchema, scenarioRunIdSchema } from "./schemas/event-schemas";
 import {
   ES_FIELDS,
   transformFromElasticsearch,
@@ -92,7 +92,12 @@ export class ScenarioEventRepository {
         const validatedEvent = scenarioEventSchema.parse(event);
 
         logger.debug(
-          { projectId, scenarioId: event.scenarioId, scenarioRunId: event.scenarioRunId, type: event.type },
+          {
+            projectId,
+            scenarioId: event.scenarioId,
+            scenarioRunId: event.scenarioRunId,
+            type: event.type,
+          },
           "Indexing scenario event",
         );
 
@@ -149,7 +154,10 @@ export class ScenarioEventRepository {
         const validatedProjectId = projectIdSchema.parse(projectId);
         const validatedScenarioRunId = scenarioRunIdSchema.parse(scenarioRunId);
 
-        logger.debug({ projectId, scenarioRunId }, "Querying latest message snapshot event");
+        logger.debug(
+          { projectId, scenarioRunId },
+          "Querying latest message snapshot event",
+        );
 
         const client = await this.getClient();
 
@@ -160,7 +168,9 @@ export class ScenarioEventRepository {
               bool: {
                 must: [
                   { term: { [ES_FIELDS.projectId]: validatedProjectId } },
-                  { term: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunId } },
+                  {
+                    term: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunId },
+                  },
                   { term: { type: ScenarioEventType.MESSAGE_SNAPSHOT } },
                 ],
               },
@@ -189,7 +199,9 @@ export class ScenarioEventRepository {
         span.setAttribute("result.found", rawResult !== undefined);
 
         return rawResult
-          ? (transformFromElasticsearch(rawResult) as ScenarioMessageSnapshotEvent)
+          ? (transformFromElasticsearch(
+              rawResult,
+            ) as ScenarioMessageSnapshotEvent)
           : undefined;
       },
     );
@@ -226,7 +238,10 @@ export class ScenarioEventRepository {
         const validatedProjectId = projectIdSchema.parse(projectId);
         const validatedScenarioRunId = scenarioRunIdSchema.parse(scenarioRunId);
 
-        logger.debug({ projectId, scenarioRunId }, "Querying latest run finished event");
+        logger.debug(
+          { projectId, scenarioRunId },
+          "Querying latest run finished event",
+        );
 
         const client = await this.getClient();
 
@@ -237,7 +252,9 @@ export class ScenarioEventRepository {
               bool: {
                 must: [
                   { term: { [ES_FIELDS.projectId]: validatedProjectId } },
-                  { term: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunId } },
+                  {
+                    term: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunId },
+                  },
                   { term: { type: ScenarioEventType.RUN_FINISHED } },
                 ],
               },
@@ -256,43 +273,6 @@ export class ScenarioEventRepository {
         return rawResult
           ? (transformFromElasticsearch(rawResult) as ScenarioRunFinishedEvent)
           : undefined;
-      },
-    );
-  }
-
-  /**
-   * Deletes all events associated with a project.
-   * This is a destructive operation that cannot be undone.
-   *
-   * @param projectId - The project identifier
-   * @throws {z.ZodError} If validation fails for projectId
-   */
-  async deleteAllEvents({ projectId }: { projectId: string }): Promise<void> {
-    return tracer.withActiveSpan(
-      "ScenarioEventRepository.deleteAllEvents",
-      {
-        kind: SpanKind.CLIENT,
-        attributes: {
-          "db.system": "elasticsearch",
-          "db.operation": "DELETE_BY_QUERY",
-          "tenant.id": projectId,
-        },
-      },
-      async () => {
-        const validatedProjectId = projectIdSchema.parse(projectId);
-
-        logger.debug({ projectId }, "Deleting all events for project");
-
-        const client = await this.getClient();
-
-        await client.deleteByQuery({
-          index: SCENARIO_EVENTS_INDEX.alias,
-          body: {
-            query: {
-              term: { [ES_FIELDS.projectId]: validatedProjectId },
-            },
-          },
-        });
       },
     );
   }
@@ -328,7 +308,10 @@ export class ScenarioEventRepository {
         const validatedProjectId = projectIdSchema.parse(projectId);
         const validatedScenarioId = scenarioIdSchema.parse(scenarioId);
 
-        logger.debug({ projectId, scenarioId }, "Querying scenario run ids for scenario");
+        logger.debug(
+          { projectId, scenarioId },
+          "Querying scenario run ids for scenario",
+        );
 
         const client = await this.getClient();
 
@@ -492,14 +475,21 @@ export class ScenarioEventRepository {
 
         // Normalize "" to "default" and merge counts for backwards-compatibility:
         // old rows may have scenarioSetId="" while new rows have "default".
-        const mergedMap = new Map<string, { scenarioCount: number; lastRunAt: number }>();
+        const mergedMap = new Map<
+          string,
+          { scenarioCount: number; lastRunAt: number }
+        >();
         for (const bucket of setBuckets) {
           const key = bucket.key === "" ? DEFAULT_SET_ID : bucket.key;
           const existing = mergedMap.get(key);
           if (existing) {
             mergedMap.set(key, {
-              scenarioCount: existing.scenarioCount + bucket.unique_scenario_count.value,
-              lastRunAt: Math.max(existing.lastRunAt, bucket.latest_run_timestamp.value),
+              scenarioCount:
+                existing.scenarioCount + bucket.unique_scenario_count.value,
+              lastRunAt: Math.max(
+                existing.lastRunAt,
+                bucket.latest_run_timestamp.value,
+              ),
             });
           } else {
             mergedMap.set(key, {
@@ -559,7 +549,13 @@ export class ScenarioEventRepository {
           projectId,
           limit,
           cursor,
-          setFilter: { terms: { [ES_FIELDS.scenarioSetId]: expandSetIdFilter(validatedScenarioSetId) } },
+          setFilter: {
+            terms: {
+              [ES_FIELDS.scenarioSetId]: expandSetIdFilter(
+                validatedScenarioSetId,
+              ),
+            },
+          },
           startDate,
           endDate,
         });
@@ -653,7 +649,10 @@ export class ScenarioEventRepository {
     const searchAfter = cursor ? this.decodeCursor(cursor) : undefined;
 
     // Request 5x the limit (min 1000) to account for deduplication
-    const requestSize = Math.max(actualLimit * DEDUP_OVERSAMPLE_FACTOR, DEDUP_MIN_REQUEST_SIZE);
+    const requestSize = Math.max(
+      actualLimit * DEDUP_OVERSAMPLE_FACTOR,
+      DEDUP_MIN_REQUEST_SIZE,
+    );
 
     // Build optional date range filter
     const dateRangeFilter = buildEsDateRangeFilter({ startDate, endDate });
@@ -809,7 +808,13 @@ export class ScenarioEventRepository {
               bool: {
                 filter: [
                   { term: { [ES_FIELDS.projectId]: validatedProjectId } },
-                  { terms: { [ES_FIELDS.scenarioSetId]: expandSetIdFilter(validatedScenarioSetId) } },
+                  {
+                    terms: {
+                      [ES_FIELDS.scenarioSetId]: expandSetIdFilter(
+                        validatedScenarioSetId,
+                      ),
+                    },
+                  },
                   { exists: { field: ES_FIELDS.batchRunId } },
                 ],
               },
@@ -877,7 +882,13 @@ export class ScenarioEventRepository {
               bool: {
                 filter: [
                   { term: { [ES_FIELDS.projectId]: validatedProjectId } },
-                  { terms: { [ES_FIELDS.scenarioSetId]: expandSetIdFilter(validatedScenarioSetId) } },
+                  {
+                    terms: {
+                      [ES_FIELDS.scenarioSetId]: expandSetIdFilter(
+                        validatedScenarioSetId,
+                      ),
+                    },
+                  },
                   { term: { [ES_FIELDS.batchRunId]: validatedBatchRunId } },
                 ],
               },
@@ -1022,7 +1033,10 @@ export class ScenarioEventRepository {
         const validatedProjectId = projectIdSchema.parse(projectId);
         const validatedScenarioRunId = scenarioRunIdSchema.parse(scenarioRunId);
 
-        logger.debug({ projectId, scenarioRunId }, "Querying run started event");
+        logger.debug(
+          { projectId, scenarioRunId },
+          "Querying run started event",
+        );
 
         const client = await this.getClient();
 
@@ -1033,7 +1047,9 @@ export class ScenarioEventRepository {
               bool: {
                 must: [
                   { term: { [ES_FIELDS.projectId]: validatedProjectId } },
-                  { term: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunId } },
+                  {
+                    term: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunId },
+                  },
                   { term: { type: ScenarioEventType.RUN_STARTED } },
                 ],
               },
@@ -1094,7 +1110,10 @@ export class ScenarioEventRepository {
           new Set(scenarioRunIds.map((id) => scenarioRunIdSchema.parse(id))),
         );
 
-        logger.debug({ projectId, scenarioRunIdsCount: validatedScenarioRunIds.length }, "Batch querying run started events");
+        logger.debug(
+          { projectId, scenarioRunIdsCount: validatedScenarioRunIds.length },
+          "Batch querying run started events",
+        );
 
         const client = await this.getClient();
 
@@ -1106,7 +1125,11 @@ export class ScenarioEventRepository {
               bool: {
                 filter: [
                   { term: { [ES_FIELDS.projectId]: validatedProjectId } },
-                  { terms: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunIds } },
+                  {
+                    terms: {
+                      [ES_FIELDS.scenarioRunId]: validatedScenarioRunIds,
+                    },
+                  },
                   { term: { type: ScenarioEventType.RUN_STARTED } },
                 ],
               },
@@ -1194,7 +1217,10 @@ export class ScenarioEventRepository {
           new Set(scenarioRunIds.map((id) => scenarioRunIdSchema.parse(id))),
         );
 
-        logger.debug({ projectId, scenarioRunIdsCount: validatedScenarioRunIds.length }, "Batch querying message snapshot events");
+        logger.debug(
+          { projectId, scenarioRunIdsCount: validatedScenarioRunIds.length },
+          "Batch querying message snapshot events",
+        );
 
         const client = await this.getClient();
 
@@ -1206,7 +1232,11 @@ export class ScenarioEventRepository {
               bool: {
                 filter: [
                   { term: { [ES_FIELDS.projectId]: validatedProjectId } },
-                  { terms: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunIds } },
+                  {
+                    terms: {
+                      [ES_FIELDS.scenarioRunId]: validatedScenarioRunIds,
+                    },
+                  },
                   { term: { type: ScenarioEventType.MESSAGE_SNAPSHOT } },
                 ],
               },
@@ -1306,7 +1336,10 @@ export class ScenarioEventRepository {
           new Set(scenarioRunIds.map((id) => scenarioRunIdSchema.parse(id))),
         );
 
-        logger.debug({ projectId, scenarioRunIdsCount: validatedScenarioRunIds.length }, "Batch querying run finished events");
+        logger.debug(
+          { projectId, scenarioRunIdsCount: validatedScenarioRunIds.length },
+          "Batch querying run finished events",
+        );
 
         const client = await this.getClient();
 
@@ -1318,7 +1351,11 @@ export class ScenarioEventRepository {
               bool: {
                 filter: [
                   { term: { [ES_FIELDS.projectId]: validatedProjectId } },
-                  { terms: { [ES_FIELDS.scenarioRunId]: validatedScenarioRunIds } },
+                  {
+                    terms: {
+                      [ES_FIELDS.scenarioRunId]: validatedScenarioRunIds,
+                    },
+                  },
                   { term: { type: ScenarioEventType.RUN_FINISHED } },
                 ],
               },
@@ -1419,7 +1456,8 @@ export class ScenarioEventRepository {
           },
         });
 
-        const timestamp = (response.aggregations as any)?.max_timestamp?.value ?? 0;
+        const timestamp =
+          (response.aggregations as any)?.max_timestamp?.value ?? 0;
         span.setAttribute("result.timestamp", timestamp);
         return timestamp;
       },

--- a/langwatch/src/server/scenarios/scenario-event.service.ts
+++ b/langwatch/src/server/scenarios/scenario-event.service.ts
@@ -1,6 +1,7 @@
 import { SpanKind } from "@opentelemetry/api";
 import { getLangWatchTracer } from "langwatch";
 import { createLogger } from "~/utils/logger/server";
+import { isInternalSetId } from "./internal-set-id";
 import { ScenarioEventRepository } from "./scenario-event.repository";
 import type {
   BatchHistoryResult,
@@ -9,9 +10,7 @@ import type {
   ScenarioEvent,
   ScenarioRunData,
 } from "./scenario-event.types";
-import { isInternalSetId } from "./internal-set-id";
 import { resolveRunStatus } from "./stall-detection";
-
 
 const tracer = getLangWatchTracer("langwatch.scenario-events.service");
 const logger = createLogger("langwatch:scenario-events:service");
@@ -72,7 +71,12 @@ export class ScenarioEventService {
       },
       async () => {
         logger.debug(
-          { projectId, scenarioId: event.scenarioId, scenarioRunId: event.scenarioRunId, type: event.type },
+          {
+            projectId,
+            scenarioId: event.scenarioId,
+            scenarioRunId: event.scenarioRunId,
+            type: event.type,
+          },
           "Saving scenario event",
         );
 
@@ -83,7 +87,6 @@ export class ScenarioEventService {
       },
     );
   }
-
 
   /**
    * Retrieves the complete run data for a specific scenario run.
@@ -109,7 +112,10 @@ export class ScenarioEventService {
         },
       },
       async (span) => {
-        logger.debug({ projectId, scenarioRunId }, "Fetching scenario run data");
+        logger.debug(
+          { projectId, scenarioRunId },
+          "Fetching scenario run data",
+        );
 
         // Get run started event using dedicated repository method
         const runStartedEvent =
@@ -125,10 +131,12 @@ export class ScenarioEventService {
 
         // Get latest message snapshot event using dedicated repository method (optional)
         const latestMessageEvent =
-          await this.eventRepository.getLatestMessageSnapshotEventByScenarioRunId({
-            projectId,
-            scenarioRunId,
-          });
+          await this.eventRepository.getLatestMessageSnapshotEventByScenarioRunId(
+            {
+              projectId,
+              scenarioRunId,
+            },
+          );
 
         // Get latest run finished event using dedicated repository method
         const latestRunFinishedEvent =
@@ -170,30 +178,6 @@ export class ScenarioEventService {
   }
 
   /**
-   * Deletes all events associated with a specific project.
-   * @param {Object} params - The parameters for deletion
-   * @param {string} params.projectId - The ID of the project
-   * @returns {Promise<void>}
-   */
-  async deleteAllEventsForProject({ projectId }: { projectId: string }) {
-    return tracer.withActiveSpan(
-      "ScenarioEventService.deleteAllEventsForProject",
-      {
-        kind: SpanKind.INTERNAL,
-        attributes: {
-          "tenant.id": projectId,
-        },
-      },
-      async () => {
-        logger.debug({ projectId }, "Deleting all events for project");
-        return await this.eventRepository.deleteAllEvents({
-          projectId,
-        });
-      },
-    );
-  }
-
-  /**
    * Retrieves run data for a specific scenario (by scenarioId).
    * Single Responsibility: fetch run data for one scenario without mixing set-level concerns.
    * Note: Temporary implementation; optimize batching later.
@@ -219,7 +203,10 @@ export class ScenarioEventService {
         },
       },
       async (span) => {
-        logger.debug({ projectId, scenarioId }, "Fetching scenario run data by scenario id");
+        logger.debug(
+          { projectId, scenarioId },
+          "Fetching scenario run data by scenario id",
+        );
 
         const scenarioRunIds =
           await this.eventRepository.getScenarioRunIdsForScenario({
@@ -261,9 +248,11 @@ export class ScenarioEventService {
       },
       async (span) => {
         logger.debug({ projectId }, "Fetching scenario sets data for project");
-        const result = await this.eventRepository.getScenarioSetsDataForProject({
-          projectId,
-        });
+        const result = await this.eventRepository.getScenarioSetsDataForProject(
+          {
+            projectId,
+          },
+        );
         span.setAttribute("result.count", result.length);
         return result;
       },
@@ -308,7 +297,10 @@ export class ScenarioEventService {
         },
       },
       async (span) => {
-        logger.debug({ projectId, scenarioSetId, limit, hasCursor: !!cursor }, "Fetching run data for scenario set");
+        logger.debug(
+          { projectId, scenarioSetId, limit, hasCursor: !!cursor },
+          "Fetching run data for scenario set",
+        );
 
         // Validate limit to prevent abuse
         const validatedLimit = Math.min(Math.max(1, limit), 100);
@@ -374,7 +366,10 @@ export class ScenarioEventService {
         },
       },
       async (span) => {
-        logger.debug({ projectId, scenarioSetId }, "Fetching all run data for scenario set");
+        logger.debug(
+          { projectId, scenarioSetId },
+          "Fetching all run data for scenario set",
+        );
 
         const batchRunIds = new Set<string>();
         let cursor: string | undefined = undefined;
@@ -459,13 +454,22 @@ export class ScenarioEventService {
           });
 
         if (batchRunIds.length === 0) {
-          return { batches: [], nextCursor: undefined, hasMore: false, lastUpdatedAt: 0, totalCount: 0 };
+          return {
+            batches: [],
+            nextCursor: undefined,
+            hasMore: false,
+            lastUpdatedAt: 0,
+            totalCount: 0,
+          };
         }
 
         // Fetch total count in parallel with run data
         const [runs, totalCount] = await Promise.all([
           this.getRunDataForBatchIds({ projectId, batchRunIds }),
-          this.eventRepository.getBatchRunCountForScenarioSet({ projectId, scenarioSetId }),
+          this.eventRepository.getBatchRunCountForScenarioSet({
+            projectId,
+            scenarioSetId,
+          }),
         ]);
 
         // Group by batchRunId and build BatchHistoryItem
@@ -478,25 +482,51 @@ export class ScenarioEventService {
 
         let globalLastUpdatedAt = 0;
 
-        const completedStatuses = new Set(["SUCCESS", "FAILED", "FAILURE", "ERROR", "CANCELLED"]);
+        const completedStatuses = new Set([
+          "SUCCESS",
+          "FAILED",
+          "FAILURE",
+          "ERROR",
+          "CANCELLED",
+        ]);
 
         const batches = batchRunIds.map((batchRunId) => {
           const items = batchMap.get(batchRunId) ?? [];
-          const lastUpdatedAt = items.reduce((max, r) => Math.max(max, r.updatedAt ?? r.timestamp), 0);
-          if (lastUpdatedAt > globalLastUpdatedAt) globalLastUpdatedAt = lastUpdatedAt;
+          const lastUpdatedAt = items.reduce(
+            (max, r) => Math.max(max, r.updatedAt ?? r.timestamp),
+            0,
+          );
+          if (lastUpdatedAt > globalLastUpdatedAt)
+            globalLastUpdatedAt = lastUpdatedAt;
 
-          const completedItems = items.filter((r) => completedStatuses.has(r.status));
-          const completedTimestamps = completedItems.map((r) => r.updatedAt ?? r.timestamp).filter((t) => t > 0);
-          const firstCompletedAt = completedTimestamps.length > 0 ? Math.min(...completedTimestamps) : null;
-          const nonPendingItems = items.filter((r) => !["STALLED", "IN_PROGRESS", "PENDING"].includes(r.status));
-          const nonPendingTimestamps = nonPendingItems.map((r) => r.updatedAt ?? r.timestamp).filter((t) => t > 0);
-          const allCompletedAt = nonPendingTimestamps.length > 0 ? Math.max(...nonPendingTimestamps) : null;
+          const completedItems = items.filter((r) =>
+            completedStatuses.has(r.status),
+          );
+          const completedTimestamps = completedItems
+            .map((r) => r.updatedAt ?? r.timestamp)
+            .filter((t) => t > 0);
+          const firstCompletedAt =
+            completedTimestamps.length > 0
+              ? Math.min(...completedTimestamps)
+              : null;
+          const nonPendingItems = items.filter(
+            (r) => !["STALLED", "IN_PROGRESS", "PENDING"].includes(r.status),
+          );
+          const nonPendingTimestamps = nonPendingItems
+            .map((r) => r.updatedAt ?? r.timestamp)
+            .filter((t) => t > 0);
+          const allCompletedAt =
+            nonPendingTimestamps.length > 0
+              ? Math.max(...nonPendingTimestamps)
+              : null;
 
           return {
             batchRunId,
             totalCount: items.length,
             passCount: items.filter((r) => r.status === "SUCCESS").length,
-            failCount: items.filter((r) => completedStatuses.has(r.status) && r.status !== "SUCCESS").length,
+            failCount: items.filter(
+              (r) => completedStatuses.has(r.status) && r.status !== "SUCCESS",
+            ).length,
             runningCount: items.filter((r) =>
               ["IN_PROGRESS", "PENDING"].includes(r.status),
             ).length,
@@ -512,15 +542,22 @@ export class ScenarioEventService {
               status: r.status,
               durationInMs: r.durationInMs,
               messagePreview: r.messages.slice(0, 4).map((m) => ({
-                role: (m as Record<string, unknown>).role as string ?? "",
-                content: (m as Record<string, unknown>).content as string ?? "",
+                role: ((m as Record<string, unknown>).role as string) ?? "",
+                content:
+                  ((m as Record<string, unknown>).content as string) ?? "",
               })),
             })),
           };
         });
 
         span.setAttribute("result.count", batches.length);
-        return { batches, nextCursor, hasMore, lastUpdatedAt: globalLastUpdatedAt, totalCount };
+        return {
+          batches,
+          nextCursor,
+          hasMore,
+          lastUpdatedAt: globalLastUpdatedAt,
+          totalCount,
+        };
       },
     );
   }
@@ -557,7 +594,10 @@ export class ScenarioEventService {
         },
       },
       async (span) => {
-        logger.debug({ projectId, scenarioSetId, batchRunId }, "Fetching run data for batch run");
+        logger.debug(
+          { projectId, scenarioSetId, batchRunId },
+          "Fetching run data for batch run",
+        );
 
         // Conditional check for ES: compute max event timestamp for this batch
         if (sinceTimestamp !== undefined) {
@@ -590,7 +630,10 @@ export class ScenarioEventService {
           scenarioRunIds,
         });
 
-        const lastUpdatedAt = runs.reduce((max, r) => Math.max(max, r.updatedAt ?? r.timestamp), 0);
+        const lastUpdatedAt = runs.reduce(
+          (max, r) => Math.max(max, r.updatedAt ?? r.timestamp),
+          0,
+        );
         span.setAttribute("result.count", runs.length);
         return { changed: true as const, lastUpdatedAt, runs };
       },
@@ -621,7 +664,10 @@ export class ScenarioEventService {
         },
       },
       async (span) => {
-        logger.debug({ projectId, batchRunIdsCount: batchRunIds.length }, "Fetching run data for batch ids");
+        logger.debug(
+          { projectId, batchRunIdsCount: batchRunIds.length },
+          "Fetching run data for batch ids",
+        );
 
         // 2. Get scenario run IDs
         const scenarioRunIds =
@@ -679,7 +725,10 @@ export class ScenarioEventService {
           return [];
         }
 
-        logger.debug({ projectId, scenarioRunIdsCount: scenarioRunIds.length }, "Batch fetching scenario run data");
+        logger.debug(
+          { projectId, scenarioRunIdsCount: scenarioRunIds.length },
+          "Batch fetching scenario run data",
+        );
 
         // Dedupe to reduce payload and ensure stable, unique iteration order
         const uniqueScenarioRunIds = Array.from(new Set(scenarioRunIds));
@@ -695,10 +744,12 @@ export class ScenarioEventService {
               projectId,
               scenarioRunIds: uniqueScenarioRunIds,
             }),
-            this.eventRepository.getLatestMessageSnapshotEventsByScenarioRunIds({
-              projectId,
-              scenarioRunIds: uniqueScenarioRunIds,
-            }),
+            this.eventRepository.getLatestMessageSnapshotEventsByScenarioRunIds(
+              {
+                projectId,
+                scenarioRunIds: uniqueScenarioRunIds,
+              },
+            ),
             this.eventRepository.getLatestRunFinishedEventsByScenarioRunIds({
               projectId,
               scenarioRunIds: uniqueScenarioRunIds,
@@ -741,7 +792,10 @@ export class ScenarioEventService {
             description: runStartedEvent?.metadata?.description ?? null,
             metadata: runStartedEvent?.metadata ?? null,
             durationInMs: runFinishedEvent
-              ? Math.max(0, runFinishedEvent.timestamp - runStartedEvent.timestamp)
+              ? Math.max(
+                  0,
+                  runFinishedEvent.timestamp - runStartedEvent.timestamp,
+                )
               : Math.max(0, lastEventTimestamp - runStartedEvent.timestamp),
           });
         }
@@ -778,11 +832,16 @@ export class ScenarioEventService {
         },
       },
       async (span) => {
-        logger.debug({ projectId, scenarioSetId }, "Getting batch run count for scenario set");
-        const count = await this.eventRepository.getBatchRunCountForScenarioSet({
-          projectId,
-          scenarioSetId,
-        });
+        logger.debug(
+          { projectId, scenarioSetId },
+          "Getting batch run count for scenario set",
+        );
+        const count = await this.eventRepository.getBatchRunCountForScenarioSet(
+          {
+            projectId,
+            scenarioSetId,
+          },
+        );
         span.setAttribute("result.count", count);
         return count;
       },
@@ -821,7 +880,10 @@ export class ScenarioEventService {
         },
       },
       async (span) => {
-        logger.debug({ projectId, limit, hasCursor: !!cursor }, "Fetching run data for all suites");
+        logger.debug(
+          { projectId, limit, hasCursor: !!cursor },
+          "Fetching run data for all suites",
+        );
 
         // Validate limit to prevent abuse
         const validatedLimit = Math.min(Math.max(1, limit), 100);
@@ -893,7 +955,10 @@ export class ScenarioEventService {
         attributes: { "tenant.id": projectId },
       },
       async (span) => {
-        const allSets = await this.eventRepository.getScenarioSetsDataForProject({ projectId });
+        const allSets =
+          await this.eventRepository.getScenarioSetsDataForProject({
+            projectId,
+          });
         const externalSets = allSets.filter(
           (s) => !isInternalSetId(s.scenarioSetId),
         );

--- a/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/scenario-events-ingest.integration.test.ts
@@ -16,9 +16,17 @@
  * mocked to keep these tests scoped to the storage path.
  */
 import { nanoid } from "nanoid";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { prisma } from "~/server/db";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { projectFactory } from "~/factories/project.factory";
+import { prisma } from "~/server/db";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — declared before any imports that might trigger module load
@@ -29,6 +37,13 @@ import { projectFactory } from "~/factories/project.factory";
 // the `/*` chain before the POST handler; without it the middleware throws
 // "Cannot read properties of undefined (reading 'checkLimit')" and the
 // onError handler turns that into a 500 — masking the route logic entirely.
+// Hoisted so the DELETE scope-guard tests can control the scoped run-id
+// lookup and assert which runs get archived (or that none do).
+const { mockGetRunIdsForScope, mockDeleteRun } = vi.hoisted(() => ({
+  mockGetRunIdsForScope: vi.fn().mockResolvedValue([] as string[]),
+  mockDeleteRun: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("~/server/app-layer/app", () => ({
   getApp: () => ({
     simulations: {
@@ -37,8 +52,8 @@ vi.mock("~/server/app-layer/app", () => ({
       textMessageStart: vi.fn().mockResolvedValue(undefined),
       textMessageEnd: vi.fn().mockResolvedValue(undefined),
       finishRun: vi.fn().mockResolvedValue(undefined),
-      deleteRun: vi.fn().mockResolvedValue(undefined),
-      runs: { getAllRunIdsForProject: vi.fn().mockResolvedValue([]) },
+      deleteRun: mockDeleteRun,
+      runs: { getRunIdsForScope: mockGetRunIdsForScope },
     },
     broadcast: {
       broadcastToTenantRateLimited: vi.fn().mockResolvedValue(undefined),
@@ -55,12 +70,9 @@ vi.mock("~/server/app-layer/app", () => ({
   }),
 }));
 
-vi.mock(
-  "~/app/api/scenario-events/[[...route]]/scenario-set-limit",
-  () => ({
-    checkScenarioSetLimitForRunStarted: vi.fn().mockResolvedValue(undefined),
-  }),
-);
+vi.mock("~/app/api/scenario-events/[[...route]]/scenario-set-limit", () => ({
+  checkScenarioSetLimitForRunStarted: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Mock the auth-middleware module to neutralize requirePermission's RBAC
 // check. The integration test's postgres schema doesn't grant the test
@@ -70,14 +82,14 @@ vi.mock(
 // the actual authMiddleware (project resolution from X-Auth-Token); only
 // the project-permission gate is replaced with a passthrough.
 vi.mock("~/app/api/middleware/auth", async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import("~/app/api/middleware/auth")
-  >();
+  const actual =
+    await importOriginal<typeof import("~/app/api/middleware/auth")>();
   return {
     ...actual,
-    requirePermission: () => async (_c: unknown, next: () => Promise<unknown>) => {
-      await next();
-    },
+    requirePermission:
+      () => async (_c: unknown, next: () => Promise<unknown>) => {
+        await next();
+      },
   };
 });
 
@@ -98,12 +110,14 @@ vi.mock("~/server/stored-objects/stored-objects-factory", () => ({
 // route emits (e.g. AC34: the ingest log line must list every stored_objects
 // id extracted for an event). Each createLogger() call returns the same
 // proxy backed by a single vi.fn() ledger keyed by level.
-const { mockLogInfo, mockLogWarn, mockLogError, mockLogDebug } = vi.hoisted(() => ({
-  mockLogInfo: vi.fn(),
-  mockLogWarn: vi.fn(),
-  mockLogError: vi.fn(),
-  mockLogDebug: vi.fn(),
-}));
+const { mockLogInfo, mockLogWarn, mockLogError, mockLogDebug } = vi.hoisted(
+  () => ({
+    mockLogInfo: vi.fn(),
+    mockLogWarn: vi.fn(),
+    mockLogError: vi.fn(),
+    mockLogDebug: vi.fn(),
+  }),
+);
 
 vi.mock("~/utils/logger/server", () => ({
   createLogger: () => ({
@@ -117,12 +131,11 @@ vi.mock("~/utils/logger/server", () => ({
 // Tracer pass-through
 vi.mock("langwatch", () => ({
   getLangWatchTracer: () => ({
-    withActiveSpan: (
-      _name: string,
-      ...args: unknown[]
-    ) => {
+    withActiveSpan: (_name: string, ...args: unknown[]) => {
       const fn = args.length === 1 ? args[0] : args[1];
-      const span: { setAttribute: ReturnType<typeof vi.fn> } = { setAttribute: vi.fn() };
+      const span: { setAttribute: ReturnType<typeof vi.fn> } = {
+        setAttribute: vi.fn(),
+      };
       return (fn as (s: typeof span) => Promise<unknown>)(span);
     },
   }),
@@ -235,7 +248,9 @@ beforeAll(async () => {
   });
   teamId = team.id;
 
-  const project = projectFactory.build({ slug: `--so-ingest-proj-${nanoid(6)}` });
+  const project = projectFactory.build({
+    slug: `--so-ingest-proj-${nanoid(6)}`,
+  });
   const created = await prisma.project.create({
     data: { ...project, teamId: team.id, personalFeatures: {} },
   });
@@ -271,7 +286,10 @@ afterAll(async () => {
       (error.code === "P2003" || error.code === "P2021");
     if (!knownMissingFixture) {
       // eslint-disable-next-line no-console
-      console.warn("Unexpected cleanup error in scenario-events-ingest integration suite:", error);
+      console.warn(
+        "Unexpected cleanup error in scenario-events-ingest integration suite:",
+        error,
+      );
     }
   }
   if (previousBaseHost === undefined) {
@@ -311,7 +329,9 @@ describe("POST /api/scenario-events (ingest)", () => {
     /** @scenario "Storage put failure aborts the entire event with a 5xx and no partial state" */
     it("returns a 5xx and does not partially persist any data", async () => {
       // Arrange: storage PUT will throw
-      mockStoreFromBytes.mockRejectedValueOnce(new Error("storage unavailable"));
+      mockStoreFromBytes.mockRejectedValueOnce(
+        new Error("storage unavailable"),
+      );
 
       const scenarioRunId = `run-${nanoid(6)}`;
       const body = makeEventWithInlineImage(scenarioRunId);
@@ -415,9 +435,61 @@ describe("POST /api/scenario-events (ingest)", () => {
         return Array.isArray(ctx?.stored_object_ids);
       });
 
-      expect(matchingCall, "expected an info-level log with stored_object_ids").toBeDefined();
+      expect(
+        matchingCall,
+        "expected an info-level log with stored_object_ids",
+      ).toBeDefined();
       const ctx = matchingCall![0] as { stored_object_ids: string[] };
       expect(ctx.stored_object_ids).toContain(id1);
+    });
+  });
+});
+
+describe("DELETE /api/scenario-events (scoped archive)", () => {
+  beforeEach(() => {
+    mockGetRunIdsForScope.mockClear();
+    mockDeleteRun.mockClear();
+    mockGetRunIdsForScope.mockResolvedValue([] as string[]);
+  });
+
+  describe("when no batchRunId or scenarioSetId is provided", () => {
+    /** @scenario "Archiving scenario runs without a scope is rejected" */
+    it("returns 400 and archives nothing — never wipes the whole project", async () => {
+      const res = await app.request("/api/scenario-events", {
+        method: "DELETE",
+        headers: { "X-Auth-Token": testApiKey },
+      });
+
+      expect(res.status).toBe(400);
+      // The footgun guard: neither the run lookup nor any archive ran.
+      expect(mockGetRunIdsForScope).not.toHaveBeenCalled();
+      expect(mockDeleteRun).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a batchRunId is provided", () => {
+    /** @scenario "Archiving scenario runs by batchRunId archives only that batch" */
+    it("archives only the runs the scoped lookup returns", async () => {
+      mockGetRunIdsForScope.mockResolvedValueOnce(["run-a", "run-b"]);
+
+      const res = await app.request(
+        "/api/scenario-events?batchRunId=batch-xyz",
+        { method: "DELETE", headers: { "X-Auth-Token": testApiKey } },
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockGetRunIdsForScope).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: testProjectId,
+          batchRunId: "batch-xyz",
+        }),
+      );
+      // Only the two runs the scoped lookup returned are archived.
+      expect(mockDeleteRun).toHaveBeenCalledTimes(2);
+      const archivedIds = mockDeleteRun.mock.calls.map(
+        (args) => (args[0] as { scenarioRunId: string }).scenarioRunId,
+      );
+      expect(archivedIds).toEqual(["run-a", "run-b"]);
     });
   });
 });

--- a/specs/scenarios/scenario-events-scoped-archive.feature
+++ b/specs/scenarios/scenario-events-scoped-archive.feature
@@ -1,0 +1,25 @@
+Feature: Archiving scenario runs always requires an explicit scope
+  As a platform owner
+  I do not want a single API call to be able to archive every simulation run
+  in a project
+  So that an accidental or misissued bulk request cannot wipe a tenant's
+  scenario history.
+
+  Background: A project-wide "delete all" footgun existed — DELETE
+  /api/scenario-events took no input and archived every simulation run for
+  the authenticated project. The endpoint now requires a batchRunId and/or
+  scenarioSetId; an unscoped request is refused.
+
+  @integration
+  Scenario: Archiving scenario runs without a scope is rejected
+    Given an authenticated request to DELETE /api/scenario-events
+    When the request carries neither a batchRunId nor a scenarioSetId
+    Then the response status is 400
+    And no simulation run is archived
+
+  @integration
+  Scenario: Archiving scenario runs by batchRunId archives only that batch
+    Given an authenticated request to DELETE /api/scenario-events with a batchRunId
+    When the request is handled
+    Then only the runs belonging to that batch are archived
+    And runs outside the batch are left untouched


### PR DESCRIPTION
## What

`DELETE /api/scenario-events` took **no input** and archived **every simulation run** for the authenticated project (`archiveAllSimulationRuns(project.id)` → `getAllRunIdsForProject` → `deleteRun` per id). A single unqualified request could wipe a tenant's entire scenario-run history. This is the "I accidentally archived ALL scenario runs at once" footgun.

The endpoint now **requires at least one of `batchRunId` / `scenarioSetId`** and rejects an unscoped request with `400`; only the matching runs are archived. The unbounded `getAllRunIdsForProject` repository method is replaced with `getRunIdsForScope`, which itself refuses to run without a batch/set predicate (defence in depth at the data layer).

Also removes two **dead, unreachable mass-delete methods** that were loaded guns:
- `ScenarioEventService.deleteAllEventsForProject` and its repository `deleteAllEvents` (an Elasticsearch `deleteByQuery` scoped only by `projectId`).

## Why a query/id is now mandatory

The principle: a bulk archive/delete must always name what it targets. A request scoped only by tenant (`projectId`) is treated as "everything", which should never be reachable in one call. Scoped batch archival (clear a batch run, clear a named set) is still supported because it is explicit and bounded.

## The sweep behind this

I audited every delete/archive entrypoint (Hono routes, tRPC, CLI, pages/api) and every data-layer mass mutation (Prisma `deleteMany`/`updateMany`, ClickHouse bulk deletes, event-sourcing archive dispatchers):

- **The one reachable footgun:** `DELETE /api/scenario-events` (fixed here).
- **Two dormant footguns** with no caller: `scenario-event` mass-delete (removed here) and `stored-objects.repository.deleteByProject` (an irreversible CH `ALTER TABLE ... DELETE WHERE project_id`). The latter is internal-only and already has guard tests asserting it is never called during archival, so it is left as a deliberate, unreachable primitive.
- **One deliberate, controlled batch:** `share.revokeAllTraceShares` (regenerable share-links only, permission-gated, the intended "disable trace sharing" toggle) — left as-is.
- Everything else requires a specific entity id or an explicit caller-constructed id list.

## Tests

- Integration regression test: unscoped `DELETE` → `400` with **nothing archived** (would fail on the old delete-all code); scoped `DELETE ?batchRunId=...` → only that batch's runs archived.
- Feature spec: `specs/scenarios/scenario-events-scoped-archive.feature`.
- `openapiLangWatch.json` regenerated to reflect the new contract.

Typecheck clean, tests green.