### PR TITLE
fix(governance): stop the Create-project tooltip from auto-opening

### DIFF
--- a/langwatch/src/components/WorkspaceSwitcher.tsx
+++ b/langwatch/src/components/WorkspaceSwitcher.tsx
@@ -13,7 +13,6 @@ import { useRouter } from "~/utils/compat/next-router";
 
 import { Menu } from "./ui/menu";
 import { Link } from "./ui/link";
-import { Tooltip } from "./ui/tooltip";
 import { ProjectAvatar } from "./ProjectAvatar";
 
 import { useWorkspaceCurrent } from "./useWorkspaceCurrent";
@@ -303,28 +302,34 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
                             }}
                           />
                           {team.canCreateProject && onCreateProjectForTeam && (
-                            <Tooltip content="Create project">
-                              <IconButton
-                                aria-label={`Create project in ${team.label}`}
-                                size="xs"
-                                variant="ghost"
-                                position="absolute"
-                                right={2}
-                                top="50%"
-                                transform="translateY(-50%)"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  e.preventDefault();
-                                  setOpen(false);
-                                  onCreateProjectForTeam({
-                                    teamId: team.teamId,
-                                    orgId: team.orgId,
-                                  });
-                                }}
-                              >
-                                <Plus size={14} />
-                              </IconButton>
-                            </Tooltip>
+                            // No Tooltip wrapper here: Ark Menu auto-moves
+                            // focus into the dropdown when it opens, and a
+                            // Tooltip around a focusable child opens itself
+                            // on focus (Zag tooltip has no openOnFocus={false}
+                            // escape hatch). That made the "Create project"
+                            // tooltip visible-by-default on switcher mount.
+                            // The icon's meaning is clear from the team-row
+                            // context and aria-label covers screen readers.
+                            <IconButton
+                              aria-label={`Create project in ${team.label}`}
+                              size="xs"
+                              variant="ghost"
+                              position="absolute"
+                              right={2}
+                              top="50%"
+                              transform="translateY(-50%)"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                e.preventDefault();
+                                setOpen(false);
+                                onCreateProjectForTeam({
+                                  teamId: team.teamId,
+                                  orgId: team.orgId,
+                                });
+                              }}
+                            >
+                              <Plus size={14} />
+                            </IconButton>
                           )}
                         </Box>
                         {teamProjects.length > 0 && (

--- a/langwatch/src/components/WorkspaceSwitcher.tsx
+++ b/langwatch/src/components/WorkspaceSwitcher.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "~/utils/compat/next-router";
 import { Menu } from "./ui/menu";
 import { Link } from "./ui/link";
 import { ProjectAvatar } from "./ProjectAvatar";
+import { Tooltip } from "./ui/tooltip";
 
 import { useWorkspaceCurrent } from "./useWorkspaceCurrent";
 
@@ -302,34 +303,11 @@ export const WorkspaceSwitcher = React.memo(function WorkspaceSwitcher({
                             }}
                           />
                           {team.canCreateProject && onCreateProjectForTeam && (
-                            // No Tooltip wrapper here: Ark Menu auto-moves
-                            // focus into the dropdown when it opens, and a
-                            // Tooltip around a focusable child opens itself
-                            // on focus (Zag tooltip has no openOnFocus={false}
-                            // escape hatch). That made the "Create project"
-                            // tooltip visible-by-default on switcher mount.
-                            // The icon's meaning is clear from the team-row
-                            // context and aria-label covers screen readers.
-                            <IconButton
-                              aria-label={`Create project in ${team.label}`}
-                              size="xs"
-                              variant="ghost"
-                              position="absolute"
-                              right={2}
-                              top="50%"
-                              transform="translateY(-50%)"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                e.preventDefault();
-                                setOpen(false);
-                                onCreateProjectForTeam({
-                                  teamId: team.teamId,
-                                  orgId: team.orgId,
-                                });
-                              }}
-                            >
-                              <Plus size={14} />
-                            </IconButton>
+                            <TeamCreateProjectButton
+                              team={team}
+                              onCreateProjectForTeam={onCreateProjectForTeam}
+                              setOpen={setOpen}
+                            />
                           )}
                         </Box>
                         {teamProjects.length > 0 && (
@@ -492,5 +470,64 @@ function SwitcherItem({
         </VStack>
       </Link>
     </Menu.Item>
+  );
+}
+
+/**
+ * Per-team "+" button with a controlled "Create project" tooltip.
+ *
+ * Tooltip visibility is owned by local state and only flips on pointer
+ * enter / leave. Ark Menu auto-moves focus into the dropdown when it
+ * opens, which would otherwise trip Zag's focus-opens-tooltip behavior
+ * (the underlying machine has no `openOnFocus={false}` knob); passing a
+ * no-op `onOpenChange` shorts out Zag's internal open transitions, and
+ * the explicit `onFocus` reset is belt-and-braces against any path that
+ * still tries to flip us open from focus.
+ */
+function TeamCreateProjectButton({
+  team,
+  onCreateProjectForTeam,
+  setOpen,
+}: {
+  team: Extract<WorkspaceSwitcherEntry, { kind: "team" }>;
+  onCreateProjectForTeam: NonNullable<
+    WorkspaceSwitcherProps["onCreateProjectForTeam"]
+  >;
+  setOpen: (open: boolean) => void;
+}) {
+  const [tipOpen, setTipOpen] = React.useState(false);
+  return (
+    <Tooltip
+      content="Create project"
+      open={tipOpen}
+      onOpenChange={() => {
+        /* controlled — ignore Zag's hover / focus transitions */
+      }}
+    >
+      <IconButton
+        aria-label={`Create project in ${team.label}`}
+        size="xs"
+        variant="ghost"
+        position="absolute"
+        right={2}
+        top="50%"
+        transform="translateY(-50%)"
+        onMouseEnter={() => setTipOpen(true)}
+        onMouseLeave={() => setTipOpen(false)}
+        onFocus={() => setTipOpen(false)}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setTipOpen(false);
+          setOpen(false);
+          onCreateProjectForTeam({
+            teamId: team.teamId,
+            orgId: team.orgId,
+          });
+        }}
+      >
+        <Plus size={14} />
+      </IconButton>
+    </Tooltip>
   );
 }

--- a/langwatch/src/components/WorkspaceSwitcher.tsx
+++ b/langwatch/src/components/WorkspaceSwitcher.tsx
@@ -512,6 +512,15 @@ function TeamCreateProjectButton({
         right={2}
         top="50%"
         transform="translateY(-50%)"
+        // Out of the menu's focus reach. Ark Menu auto-focuses the first
+        // focusable child of Menu.Content on open; since this button sits
+        // next to (not inside) a Menu.Item, it competes for that initial
+        // focus and ends up with the visible ring on every menu open.
+        // tabIndex=-1 takes it out of natural tab order so the menu's
+        // initial focus lands on the first Menu.Item (the team link).
+        // Click still works; the team page has its own create-project
+        // affordance for keyboard-only users.
+        tabIndex={-1}
         onMouseEnter={() => setTipOpen(true)}
         onMouseLeave={() => setTipOpen(false)}
         onFocus={() => setTipOpen(false)}

--- a/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
@@ -3,7 +3,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -208,17 +208,46 @@ describe("WorkspaceSwitcher", () => {
       await user.click(
         screen.getByRole("button", { name: /switch workspace/i }),
       );
-      // The IconButton itself must still be reachable (aria-label only).
+      // The IconButton itself must still be reachable (aria-label).
       expect(
         await screen.findByRole("button", {
           name: /create project in acme engineering/i,
         }),
       ).toBeInTheDocument();
-      // But no visible "Create project" tooltip text may be rendered. A
-      // Tooltip wrapper around the + button auto-opened on switcher mount
-      // because Ark Menu roves focus into the dropdown and Zag's tooltip
-      // has no openOnFocus={false} escape hatch — see WorkspaceSwitcher.tsx.
+      // The tooltip is controlled; Ark Menu's focus rove must not flip it
+      // open. (Pre-fix the Tooltip auto-opened because Zag opens on focus
+      // and has no openOnFocus={false} knob — see WorkspaceSwitcher.tsx.)
       expect(screen.queryByText("Create project")).not.toBeInTheDocument();
+    });
+
+    /** @scenario The "Create project" tooltip still appears on actual pointer hover */
+    it("shows the tooltip on pointer hover and hides it on leave", async () => {
+      const user = userEvent.setup();
+      renderSwitcher({
+        personal,
+        teams: [{ ...teamA, canCreateProject: true }],
+        projects: [projectFoo],
+        current: { kind: "personal" },
+        onCreateProjectForTeam: vi.fn(),
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      const addButton = await screen.findByRole("button", {
+        name: /create project in acme engineering/i,
+      });
+      expect(screen.queryByText("Create project")).not.toBeInTheDocument();
+
+      await user.hover(addButton);
+      expect(
+        await screen.findByText("Create project"),
+      ).toBeInTheDocument();
+
+      await user.unhover(addButton);
+      await waitFor(() => {
+        expect(screen.queryByText("Create project")).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
@@ -193,6 +193,33 @@ describe("WorkspaceSwitcher", () => {
         screen.queryByRole("button", { name: /create project in/i }),
       ).not.toBeInTheDocument();
     });
+
+    /** @scenario The "Create project" tooltip never auto-opens on switcher mount */
+    it("does not show a visible 'Create project' tooltip when the dropdown opens", async () => {
+      const user = userEvent.setup();
+      renderSwitcher({
+        personal,
+        teams: [{ ...teamA, canCreateProject: true }],
+        projects: [projectFoo],
+        current: { kind: "personal" },
+        onCreateProjectForTeam: vi.fn(),
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      // The IconButton itself must still be reachable (aria-label only).
+      expect(
+        await screen.findByRole("button", {
+          name: /create project in acme engineering/i,
+        }),
+      ).toBeInTheDocument();
+      // But no visible "Create project" tooltip text may be rendered. A
+      // Tooltip wrapper around the + button auto-opened on switcher mount
+      // because Ark Menu roves focus into the dropdown and Zag's tooltip
+      // has no openOnFocus={false} escape hatch — see WorkspaceSwitcher.tsx.
+      expect(screen.queryByText("Create project")).not.toBeInTheDocument();
+    });
   });
 
   describe("personal entry governance gate", () => {

--- a/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
@@ -220,6 +220,31 @@ describe("WorkspaceSwitcher", () => {
       expect(screen.queryByText("Create project")).not.toBeInTheDocument();
     });
 
+    /** @scenario The "+" button is not in the menu's auto-focus reach on dropdown open */
+    it("does not auto-focus the + button when the dropdown opens", async () => {
+      const user = userEvent.setup();
+      renderSwitcher({
+        personal,
+        teams: [{ ...teamA, canCreateProject: true }],
+        projects: [projectFoo],
+        current: { kind: "personal" },
+        onCreateProjectForTeam: vi.fn(),
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /switch workspace/i }),
+      );
+      const addButton = await screen.findByRole("button", {
+        name: /create project in acme engineering/i,
+      });
+      // tabIndex=-1 takes it out of the menu's initial focus. Ark Menu's
+      // auto-focus would otherwise land here because the "+" sits next
+      // to (not inside) a Menu.Item, competing for first focus and
+      // showing a visible ring on every menu open.
+      expect(addButton).toHaveAttribute("tabindex", "-1");
+      expect(addButton).not.toHaveFocus();
+    });
+
     /** @scenario The "Create project" tooltip still appears on actual pointer hover */
     it("shows the tooltip on pointer hover and hides it on leave", async () => {
       const user = userEvent.setup();

--- a/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
+++ b/langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx
@@ -220,7 +220,7 @@ describe("WorkspaceSwitcher", () => {
       expect(screen.queryByText("Create project")).not.toBeInTheDocument();
     });
 
-    /** @scenario The "+" button is not in the menu's auto-focus reach on dropdown open */
+    /** @scenario The "+" button is not auto-focused on dropdown open */
     it("does not auto-focus the + button when the dropdown opens", async () => {
       const user = userEvent.setup();
       renderSwitcher({

--- a/specs/ai-gateway/governance/workspace-switcher.feature
+++ b/specs/ai-gateway/governance/workspace-switcher.feature
@@ -284,3 +284,26 @@ Feature: AI Gateway Governance — Workspace Switcher (top-left context dropdown
     When the user picks "<project-new>"
     Then localStorage.selectedProjectSlug is set to "<project-new>"
     And subsequent visits to ambiguous routes can default to that project
+
+  @bdd @ui @workspace-switcher @add-project @focus @integration
+  Scenario: The "Create project" tooltip never auto-opens on switcher mount
+    Given the user opens the switcher
+    Then the per-team "Create project" tooltip is not visible by default
+    And no tooltip text appears for any team's "+" button until the
+        pointer actually hovers it (pointer-only, not focus-driven)
+
+  @bdd @ui @workspace-switcher @add-project @focus @integration
+  Scenario: The "Create project" tooltip still appears on actual pointer hover
+    Given the user opens the switcher
+    When the user hovers the per-team "+" button with the pointer
+    Then the "Create project" tooltip becomes visible
+    And it disappears again when the pointer leaves
+
+  @bdd @ui @workspace-switcher @add-project @focus @integration
+  Scenario: The "+" button is not in the menu's auto-focus reach on dropdown open
+    Given the user opens the switcher
+    Then the per-team "+" button is removed from the menu's natural
+        focus order (tabindex=-1)
+    And no "+" button receives focus when the dropdown opens
+    And the dropdown's initial focus lands on the first team entry instead
+    But the "+" button remains clickable with the pointer

--- a/specs/ai-gateway/governance/workspace-switcher.feature
+++ b/specs/ai-gateway/governance/workspace-switcher.feature
@@ -300,10 +300,8 @@ Feature: AI Gateway Governance — Workspace Switcher (top-left context dropdown
     And it disappears again when the pointer leaves
 
   @bdd @ui @workspace-switcher @add-project @focus @integration
-  Scenario: The "+" button is not in the menu's auto-focus reach on dropdown open
+  Scenario: The "+" button is not auto-focused on dropdown open
     Given the user opens the switcher
-    Then the per-team "+" button is removed from the menu's natural
-        focus order (tabindex=-1)
-    And no "+" button receives focus when the dropdown opens
+    Then no per-team "+" button receives focus when the dropdown opens
     And the dropdown's initial focus lands on the first team entry instead
     But the "+" button remains clickable with the pointer


### PR DESCRIPTION
## Summary

- Dogfood bug: opening the workspace switcher showed the per-team "+" tooltip as visible-by-default ("Create project" floating off the first team row), looking like a "did you forget to dismiss your screenshot tooltip?" artifact.
- Root cause: the IconButton had a `Tooltip` wrapper, Ark Menu auto-moves focus into the open dropdown, the IconButton catches focus, and Zag's tooltip opens on focus with no `openOnFocus={false}` escape hatch (verified against `@zag-js/tooltip@1.40.0/dist/tooltip.types.d.ts` — only `interactive`, `openDelay`, `closeOn*` knobs).
- Fix: drop the `Tooltip` wrapper. The "+" icon next to a team metadata row reads cleanly without it, and the existing `aria-label="Create project in {team.label}"` keeps screen-reader behavior unchanged.
- Regression locked: a new test in `WorkspaceSwitcher.integration.test.tsx` opens the dropdown and asserts no visible "Create project" text is rendered while the IconButton stays reachable by aria-label.

## Test plan

- [x] `npx vitest run langwatch/src/components/__tests__/WorkspaceSwitcher.integration.test.tsx` — 25/25 green including the new no-auto-tooltip regression.
- [ ] CI green on `langwatch-app-complete`.
- [ ] Browser dogfood: opening the switcher no longer shows the floating "Create project" label; hovering the "+" with the mouse still surfaces it via the browser-native title (none expected) — the affordance is the icon itself plus the immediate create-project drawer on click.