### PR TITLE
fix(ci): stop integration shard from single-forking under coverage

### DIFF
--- a/langwatch/vitest.integration.config.ts
+++ b/langwatch/vitest.integration.config.ts
@@ -32,8 +32,15 @@ export default defineConfig({
     hookTimeout: 60_000, // 60 seconds for beforeAll/afterAll hooks
     teardownTimeout: 30_000, // 30 seconds for cleanup
     // Run test files sequentially to avoid BullMQ/Redis resource contention
-    // when multiple pipelines are created and destroyed in parallel
-    fileParallelism: false,
+    // when multiple pipelines are created and destroyed in parallel. Use
+    // maxWorkers/minWorkers (NOT `fileParallelism: false`) because the
+    // coverage module reads `!fileParallelism` as "treat this run as
+    // singleFork" -- it then groups every file into one long-lived fork,
+    // which is what caused the integration shard to wedge post-test once
+    // v8 coverage data accumulated past the heap (see #4417). maxWorkers:1
+    // gives the same sequential guarantee with a fresh fork per file.
+    maxWorkers: 1,
+    minWorkers: 1,
     // Run integration files in forked child processes (vs the unit pool's
     // `vmThreads`) so each worker is force-killed on file exit. With vmThreads
     // a single un-`unref`'d timer or unclosed client in any file makes the


### PR DESCRIPTION
## Summary

The integration shard CI runs were wedging post-test in shard 4 (and shard 3 on `pnpm test:integration`), no `Test Files` summary printed, no next file attempted, until the GHA per-job timeout cancelled them. `#4417` worked around the symptom (6 shards + 25min cap); this fixes the cause.

vitest 4.x's coverage plugin contains this short-circuit:

```js
// node_modules/.../vitest/dist/chunks/coverage.DL5VHqXY.js:2628
if (poolOptions.singleFork || !vitest.config.fileParallelism) { ... }
```

`vitest.integration.config.ts` sets `fileParallelism: false` (for BullMQ/Redis contention reasons). Combined with `pool: "forks"` and `--coverage` in CI, the short-circuit treats the whole shard as one long-lived single fork. V8 coverage data accumulates inside that fork's heap; once the heaviest shard's coverage map gets large enough, the fork can no longer finalize cleanly and the run hangs. Adding shards reduces per-shard volume but the heaviest still trips the threshold.

Switch sequential execution from `fileParallelism: false` to `maxWorkers: 1` / `minWorkers: 1`. One file at a time, same BullMQ/Redis safety, but the coverage short-circuit is no longer triggered and `pool: "forks"` actually gets a fresh fork per file with coverage flushed to the main process per file instead of accumulating in a single worker for the life of the shard.

## Test plan

- [ ] `langwatch-app-ci` `test-integration` runs settle green on all 6 shards (especially shard 4) within the 25-min cap, with a `Test Files` summary printed
- [ ] No regression on shards 1, 2, 3, 5, 6
- [ ] Run log shows PIDs changing between files (= per-file forks active)

## Local verification

- 3-file slice (coverage on) → 10/10 pass + clean exit in 7.56s
- Full `--shard=4/6` (coverage on) → exits cleanly (RC=0), no hang; log shows worker PID change between files confirming per-file forks
- Pre-existing `Database test_langwatch does not exist` flakes on a stale local CH container are unrelated to this fix (same failures on baseline)