### PR TITLE
perf(clickhouse): optimize span attribute-keys facet discovery (stop OOM, -read bytes/p50)

### DIFF
--- a/langwatch/src/server/app-layer/traces/facets/__tests__/registry-invariants.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/facets/__tests__/registry-invariants.unit.test.ts
@@ -210,3 +210,28 @@ describe("each query-builder facet", () => {
     },
   );
 });
+
+describe("Map-keys discovery facets", () => {
+  // Facets that discover the distinct keys of a `Map` column by exploding its
+  // `.keys` subcolumn. Probing the empty-map short-circuit against the whole
+  // Map (`length(<Map>)`) instead of `<Map>.keys` forces ClickHouse to read
+  // the heavy values column and trips MEMORY_LIMIT_EXCEEDED on busy tenants.
+  const MAP_KEY_FACETS: Array<{ key: string; map: string }> = [
+    { key: "spanAttributeKeys", map: "SpanAttributes" },
+    { key: "metadataKeys", map: "Attributes" },
+  ];
+
+  it.each(MAP_KEY_FACETS.map((f) => [f.key, f.map]))(
+    "[%s] keeps the empty-map filter on the keys subcolumn",
+    (key, map) => {
+      const def = FACET_REGISTRY.find((d) => d.key === key);
+      if (!def || def.kind !== "dynamic_keys") {
+        throw new Error(`expected ${key} to be a dynamic_keys facet`);
+      }
+      const { sql } = def.queryBuilder(baseCtx);
+      expect(sql).toContain(`length(${map}.keys)`);
+      // Bare `length(<Map>)` would materialise the values column.
+      expect(sql).not.toMatch(new RegExp(`length\\(${map}\\)`));
+    },
+  );
+});

--- a/langwatch/src/server/app-layer/traces/facets/__tests__/span-attribute-keys.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/facets/__tests__/span-attribute-keys.integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Integration coverage for the span-attribute-keys discovery facet against a
+ * real ClickHouse.
+ *
+ * The facet explodes `arrayJoin(SpanAttributes.keys)` to discover every
+ * distinct attribute key. The trap is the empty-map short-circuit: probing
+ * `length(SpanAttributes)` makes ClickHouse materialise the whole Map (keys
+ * AND values) just to count entries, dragging the heavy values column into
+ * memory. On busy tenants that tips the query into MEMORY_LIMIT_EXCEEDED
+ * (observed 110x/24h in prod). Probing `length(SpanAttributes.keys)` instead
+ * keeps the whole query on the lightweight keys subcolumn.
+ *
+ * This test reproduces the failure shape on a small container: under a tight
+ * memory budget the keys-subcolumn query completes and returns the correct
+ * key list. The pre-fix `length(SpanAttributes)` variant is asserted to blow
+ * the same budget, so this is a real regression test, not a string check.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import { seedSpans } from "../../../../analytics/clickhouse/__tests__/test-utils/clickhouse-fixtures";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { buildSpanAttributeKeysFacetQuery } from "../span-attribute-keys";
+
+const TENANT_ID = "facet-span-attr-keys-test";
+const ATTRIBUTE_KEYS = 80;
+// seedSpans adds one extra synthetic key ("langwatch.span.type") on top of the
+// attr_key_0..N-1 it generates.
+const EXPECTED_DISTINCT_KEYS = ATTRIBUTE_KEYS + 1;
+
+// Tight enough that reading the values column OOMs, loose enough that the
+// keys-only read completes comfortably. Tuned against CH 25.10 on the seed below.
+const MEMORY_CAP = "95000000"; // 95 MB
+
+type FacetRow = { facet_value: string; cnt: string; total_distinct: string };
+
+describe("span-attribute-keys facet integration", () => {
+  let ch: ClickHouseClient;
+
+  beforeAll(async () => {
+    const rawClient = getTestClickHouseClient();
+    if (!rawClient) throw new Error("ClickHouse client not available");
+    ch = wrapWithDefaultSettings(rawClient);
+
+    await seedSpans(ch, {
+      tenantId: TENANT_ID,
+      count: 40_000,
+      attributeKeys: ATTRIBUTE_KEYS,
+      attributeValueSize: 512, // heavy values — the column we must NOT read
+      traceCount: 1000,
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    await cleanupTestData(TENANT_ID);
+  });
+
+  const ctx = {
+    tenantId: TENANT_ID,
+    // Wide window: seeded spans land within a few minutes of now.
+    timeRange: { from: Date.now() - 60 * 60 * 1000, to: Date.now() + 60_000 },
+    limit: 1000,
+    offset: 0,
+  };
+
+  describe("when discovering keys under a tight memory budget", () => {
+    it("completes and returns every distinct key exactly once", async () => {
+      const query = buildSpanAttributeKeysFacetQuery(ctx);
+      const result = await ch.query({
+        query: query.sql,
+        query_params: query.params,
+        format: "JSONEachRow",
+        clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+      });
+      const rows = await result.json<FacetRow>();
+
+      const keys = rows.map((r) => r.facet_value);
+      expect(new Set(keys).size).toBe(keys.length); // GROUP BY => no dupes
+      expect(keys).toContain("langwatch.span.type");
+      expect(keys).toContain("attr_key_0");
+      expect(keys).not.toContain(""); // empty keys filtered out
+      expect(rows).toHaveLength(EXPECTED_DISTINCT_KEYS);
+      expect(Number(rows[0]?.total_distinct)).toBe(EXPECTED_DISTINCT_KEYS);
+    });
+  });
+
+  describe("when probing the whole Map instead of the keys subcolumn", () => {
+    it("blows the same memory budget (the bug this fixes)", async () => {
+      // Identical query except the empty-map short-circuit reads the full
+      // Map. This is the pre-fix shape; it must exceed the budget that the
+      // keys-only query clears.
+      const query = buildSpanAttributeKeysFacetQuery(ctx);
+      const preFixSql = query.sql.replace(
+        "length(SpanAttributes.keys) > 0",
+        "length(SpanAttributes) > 0",
+      );
+      expect(preFixSql).not.toBe(query.sql); // guard: the replace actually hit
+
+      await expect(
+        ch
+          .query({
+            query: preFixSql,
+            query_params: query.params,
+            format: "JSONEachRow",
+            clickhouse_settings: { max_memory_usage: MEMORY_CAP },
+          })
+          .then((r) => r.json()),
+      ).rejects.toThrow(/memory limit exceeded/i);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/facets/__tests__/span-attribute-keys.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/facets/__tests__/span-attribute-keys.unit.test.ts
@@ -61,10 +61,15 @@ describe("buildSpanAttributeKeysFacetQuery", () => {
       expect(query.sql).not.toContain("SpanAttributes.values");
     });
 
-    it("short-circuits rows where SpanAttributes is empty", () => {
-      // length() check kicks in before the arrayJoin so empty-attr granules
-      // get pruned cleanly. Mirrors what `events.ts` does for Events.Name.
-      expect(query.sql).toMatch(/length\(SpanAttributes\)\s*>\s*0/);
+    it("short-circuits empty maps via the keys subcolumn, not the whole Map", () => {
+      // The empty-map check must probe `SpanAttributes.keys`, never
+      // `SpanAttributes`: `length(SpanAttributes)` makes ClickHouse
+      // materialise the entire Map (keys AND values) just to count entries,
+      // pulling the heavy values column into memory and tipping busy tenants
+      // into MEMORY_LIMIT_EXCEEDED. Reproduced against a real ClickHouse in
+      // span-attribute-keys.integration.test.ts.
+      expect(query.sql).toMatch(/length\(SpanAttributes\.keys\)\s*>\s*0/);
+      expect(query.sql).not.toMatch(/length\(SpanAttributes\)\s*>\s*0/);
     });
 
     it("groups by key and orders by frequency", () => {
@@ -117,6 +122,18 @@ describe("buildSpanAttributeKeysFacetQuery", () => {
     it("filters out '' rows in the outer WHERE", () => {
       const query = buildSpanAttributeKeysFacetQuery(baseCtx);
       expect(query.sql).toMatch(/WHERE key\s*!=\s*''/);
+    });
+  });
+
+  describe("memory safety", () => {
+    it("never reads the SpanAttributes values column", () => {
+      // Both the projection and the empty-map filter must stay on the keys
+      // subcolumn. Touching the full `SpanAttributes` Map anywhere pulls the
+      // heavy values column into memory — the cause of the prod OOM.
+      const query = buildSpanAttributeKeysFacetQuery(baseCtx);
+      expect(query.sql).not.toMatch(/length\(SpanAttributes\)/);
+      expect(query.sql).not.toContain("mapValues");
+      expect(query.sql).not.toContain("SpanAttributes.values");
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/facets/metadata-keys.ts
+++ b/langwatch/src/server/app-layer/traces/facets/metadata-keys.ts
@@ -23,9 +23,11 @@ export function buildMetadataKeysFacetQuery(
     ? "AND lower(key) ILIKE concat({prefix:String}, '%')"
     : "";
 
-  // Same I/O optimisation as `span-attribute-keys.ts`: read the keys
-  // subcolumn directly so the values side of the Map never gets loaded,
-  // and short-circuit empty maps before the arrayJoin fans out rows.
+  // Same I/O optimisation as `span-attribute-keys.ts`: stay entirely on the
+  // keys subcolumn so the values side of the Map never gets loaded. The
+  // empty-map short-circuit probes `Attributes.keys`, not `Attributes` —
+  // `length(Attributes)` would materialise the whole Map (keys and values)
+  // just to count entries, pulling the heavy values column into memory.
   return {
     sql: `
       SELECT
@@ -36,7 +38,7 @@ export function buildMetadataKeysFacetQuery(
         SELECT arrayJoin(Attributes.keys) AS key
         FROM trace_summaries
         WHERE ${where}
-          AND length(Attributes) > 0
+          AND length(Attributes.keys) > 0
       )
       WHERE key != ''
         ${prefixFilter}

--- a/langwatch/src/server/app-layer/traces/facets/span-attribute-keys.ts
+++ b/langwatch/src/server/app-layer/traces/facets/span-attribute-keys.ts
@@ -19,8 +19,12 @@ import { baseParams, buildTimeWhere } from "./helpers";
  *   - `SpanAttributes.keys` is the keys subcolumn of the Map. Reading it
  *     directly skips loading the values column entirely — meaningful at
  *     scale because span attribute values can be large strings.
- *   - `length(SpanAttributes) > 0` short-circuits granules where every
- *     span has empty attrs, mirroring the events facet's prefilter.
+ *   - The empty-map short-circuit also probes `SpanAttributes.keys`, never
+ *     `SpanAttributes` itself: `length(SpanAttributes) > 0` makes ClickHouse
+ *     materialise the whole Map (keys *and* values) just to count entries,
+ *     which pulls the heavy values column into memory and tips busy tenants
+ *     into MEMORY_LIMIT_EXCEEDED. `length(SpanAttributes.keys)` reads only
+ *     the keys subcolumn, keeping the whole query on the keys side of the Map.
  *
  * The actual filter side (`span.attribute.<k>:value`) is already wired
  * through `filter-to-clickhouse/ast.ts` — this facet only feeds the
@@ -44,7 +48,7 @@ export function buildSpanAttributeKeysFacetQuery(
         SELECT arrayJoin(SpanAttributes.keys) AS key
         FROM stored_spans
         WHERE ${where}
-          AND length(SpanAttributes) > 0
+          AND length(SpanAttributes.keys) > 0
       )
       WHERE key != ''
         ${prefixFilter}


### PR DESCRIPTION
## What

The span and metadata **attribute-key discovery facets** (the sidebar lists of "which attribute keys exist") explode `arrayJoin(<Map>.keys)` to enumerate distinct keys. Both short-circuit empty maps with `length(<Map>) > 0`. On a `Map` column, `length(<Map>)` makes ClickHouse materialise the **whole Map — keys *and* values** — just to count entries, which drags the heavy values column into memory even though the query only ever needs the keys subcolumn.

This swaps the predicate to `length(<Map>.keys) > 0`, keeping the entire query on the lightweight keys subcolumn.

- `span-attribute-keys.ts`: `length(SpanAttributes) > 0` → `length(SpanAttributes.keys) > 0`
- `metadata-keys.ts`: `length(Attributes) > 0` → `length(Attributes.keys) > 0`

## Evidence (prod, last 24h, redacted)

Sourced read-only from the ClickHouse server stdout exception stream via CloudWatch Logs Insights. The single most frequent failing query pattern:

- **~110 `MEMORY_LIMIT_EXCEEDED` (Code 241)** in 24h on this exact shape:
  ```
  SELECT key AS facet_value, count() AS cnt, count() OVER () AS total_distinct
  FROM (SELECT arrayJoin(SpanAttributes.keys) AS key FROM stored_spans
        WHERE TenantId = '<redacted>' AND StartTime BETWEEN <redacted> AND <redacted>
          AND length(SpanAttributes) > 0)
  WHERE key != '' GROUP BY key ORDER BY cnt DESC LIMIT 50
  ```
- The exceptions fail **while executing `ARRAY JOIN SpanAttributes.keys`**, attempting to allocate multi-GB chunks against the 3.5 GiB per-query limit. The allocation is a **column read**, not the aggregation — which is why memory-spill settings (`max_bytes_before_external_group_by`) do not help (verified, see below).

All tenant IDs / time literals redacted; no raw log content is reproduced here.

## Suspected cause

`length(SpanAttributes) > 0` references the full `Map` column, so ClickHouse reads both the keys and the (large) values subcolumns before the `arrayJoin` even runs. The values column is exactly what the facet's keys-only design was meant to avoid — the code comment already claimed it "skips loading the values column entirely", but the empty-map predicate quietly defeated that.

## Fix + why it works

`length(SpanAttributes.keys)` reads only the keys subcolumn (array offsets over `LowCardinality(String)`), so the values column is never touched. Result set is byte-for-byte identical — this only changes which subcolumn is read.

## Verification (real ClickHouse 25.10, same version as prod)

Added `span-attribute-keys.integration.test.ts` (testcontainers), seeding 40k spans × 80 attribute keys × 512-byte values across 1k traces, then running under a deliberately tight `max_memory_usage` (95 MB):

- keys-only query (the fix): **completes**, returns the correct distinct-key list.
- pre-fix `length(SpanAttributes)` shape: **exceeds the same budget** (the bug), asserted with `.rejects.toThrow(/memory limit exceeded/i)`.

I also empirically swept memory-spill / block-size / thread settings on the same container — **none** prevented the OOM, confirming the column read (not the aggregation) is the cause and that the predicate change is the actual fix.

`pnpm typecheck` clean; 134 facet unit tests pass; the 2 integration tests pass.

## Expected impact

The values column is large for tenants with verbose span attributes; not reading it removes the dominant memory and read-bytes cost of this query. Expected: the 110/24h `MEMORY_LIMIT_EXCEEDED` failures for this facet go to ~0, with a corresponding drop in p50 latency and read bytes for the attribute-key sidebar. No change to results.

## Please run before merging (I cannot — read-only prod access)

- `EXPLAIN PIPELINE` / `EXPLAIN actions=1` on the before/after query against prod ClickHouse to confirm the `ReadFromMergeTree` step no longer reads the `SpanAttributes` values column.
- Optionally compare `read_bytes` in `system.query_log` for the two shapes on a real tenant.

## Scope notes

- `event-attribute-keys.ts` is intentionally untouched: its filter is `length(Events.Attributes) > 0` where `Events.Attributes` is `Array(Map(...))`, so `length()` reads only the array offsets, not Map values.
- Advisory PR. Not merging/approving — a human should run EXPLAIN and decide.
