### PR TITLE
perf(clickhouse): optimize topic-clustering trace fetch (stop OOM, -read bytes/p50)

### DIFF
--- a/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Integration coverage for the topic-clustering trace fetch against a real
+ * ClickHouse.
+ *
+ * The pre-fix query read `ComputedInput` (a potentially large payload) for
+ * the entire deduped 12-month trace set before `ORDER BY ... LIMIT 2000`
+ * trimmed it. On busy tenants that materialised gigabytes of payload and the
+ * query died with MEMORY_LIMIT_EXCEEDED (observed in prod).
+ *
+ * The fix pages the 2000 most-recent trace keys first (lightweight columns
+ * only) and reads `ComputedInput` for that bounded set alone.
+ *
+ * Two layers here:
+ *  - correctness: `fetchTracesFromClickHouse` returns the right latest-version
+ *    traces, newest first, respecting the search cursor.
+ *  - memory: the paged query's peak memory (read from `system.query_log`) is a
+ *    fraction of the pre-fix whole-set read on the same data. Both queries run
+ *    to completion and drain — we measure memory rather than tripping an OOM,
+ *    so the test can't leave a half-read socket wedging the worker.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { fetchTracesFromClickHouse } from "../topicClustering";
+
+const TENANT_ID = "topic-fetch-test";
+const N_TRACES = 20_000;
+const INPUT_BYTES = 4096; // heavy payload — the column we must not read in bulk
+const twelveMonthsAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+
+async function seedTraceSummaries(ch: ClickHouseClient) {
+  const now = Date.now();
+  const bigInput = JSON.stringify("x".repeat(INPUT_BYTES));
+  const BATCH = 2000;
+  let batch: Array<Record<string, unknown>> = [];
+  const flush = async () => {
+    if (!batch.length) return;
+    await ch.insert({
+      table: "trace_summaries",
+      values: batch,
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+    batch = [];
+  };
+  for (let i = 0; i < N_TRACES; i++) {
+    batch.push({
+      ProjectionId: `proj-${nanoid()}`,
+      TenantId: TENANT_ID,
+      TraceId: `${TENANT_ID}-trace-${String(i).padStart(6, "0")}`,
+      Version: "v1",
+      Attributes: {},
+      // Spread across the last ~weeks; newest = lowest index.
+      OccurredAt: new Date(now - i * 60_000),
+      CreatedAt: new Date(now),
+      UpdatedAt: new Date(now - i),
+      ComputedIOSchemaVersion: "",
+      ComputedInput: bigInput,
+      ComputedOutput: "out",
+      TimeToFirstTokenMs: 1,
+      TimeToLastTokenMs: 1,
+      TotalDurationMs: 1,
+      TokensPerSecond: 1,
+      SpanCount: 1,
+      ContainsErrorStatus: 0,
+      ContainsOKStatus: 1,
+      ErrorMessage: null,
+      Models: ["gpt-5-mini"],
+      TotalCost: 0.01,
+      TokensEstimated: false,
+      TotalPromptTokenCount: 1,
+      TotalCompletionTokenCount: 1,
+      OutputFromRootSpan: 0,
+      OutputSpanEndTimeMs: 0,
+      BlockedByGuardrail: 0,
+      TopicId: i % 3 === 0 ? `topic-${i % 5}` : null,
+      SubTopicId: null,
+      HasAnnotation: null,
+    });
+    if (batch.length >= BATCH) await flush();
+  }
+  await flush();
+}
+
+/** Run a query to completion under a stable query_id and return its peak memory. */
+async function peakMemoryBytes(
+  ch: ClickHouseClient,
+  sql: string,
+): Promise<number> {
+  const queryId = `mem-${nanoid()}`;
+  const r = await ch.query({
+    query: sql,
+    query_params: { tenantId: TENANT_ID, twelveMonthsAgo },
+    format: "JSONEachRow",
+    query_id: queryId,
+  });
+  await r.json(); // fully drain
+  await ch.command({ query: "SYSTEM FLUSH LOGS" });
+  const log = await ch.query({
+    query: `
+      SELECT max(memory_usage) AS mem
+      FROM system.query_log
+      WHERE query_id = {queryId:String} AND type = 'QueryFinish'`,
+    query_params: { queryId },
+    format: "JSONEachRow",
+  });
+  const rows = (await log.json()) as Array<{ mem: string }>;
+  return Number(rows[0]?.mem ?? 0);
+}
+
+const PAGED_SQL = `
+  WITH page AS (
+    SELECT TraceId FROM trace_summaries
+    WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
+    GROUP BY TenantId, TraceId
+    ORDER BY argMax(OccurredAt, UpdatedAt) DESC, TraceId ASC
+    LIMIT 2000)
+  SELECT t.TraceId, t.ComputedInput, t.TopicId, t.SubTopicId, toString(toUnixTimestamp64Milli(t.OccurredAt)) AS OccurredAtMs
+  FROM trace_summaries t
+  WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
+    AND ComputedInput IS NOT NULL AND ComputedInput != ''
+    AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
+      SELECT TenantId, TraceId, max(UpdatedAt) FROM trace_summaries
+      WHERE TenantId = {tenantId:String} AND TraceId IN (SELECT TraceId FROM page)
+      GROUP BY TenantId, TraceId)
+  ORDER BY t.OccurredAt DESC, t.TraceId ASC LIMIT 2000`;
+
+const PRE_FIX_SQL = `
+  SELECT t.TraceId, t.ComputedInput, t.TopicId, t.SubTopicId, toString(toUnixTimestamp64Milli(t.OccurredAt)) AS OccurredAtMs
+  FROM trace_summaries t
+  WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
+    AND ComputedInput IS NOT NULL AND ComputedInput != ''
+    AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
+      SELECT TenantId, TraceId, max(UpdatedAt) FROM trace_summaries
+      WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
+        AND ComputedInput IS NOT NULL AND ComputedInput != ''
+      GROUP BY TenantId, TraceId)
+  ORDER BY t.OccurredAt DESC, t.TraceId ASC LIMIT 2000`;
+
+describe("fetchTracesFromClickHouse integration", () => {
+  let ch: ClickHouseClient;
+
+  beforeAll(async () => {
+    const raw = getTestClickHouseClient();
+    if (!raw) throw new Error("ClickHouse client not available");
+    ch = wrapWithDefaultSettings(raw);
+    await seedTraceSummaries(ch);
+  }, 180_000);
+
+  afterAll(async () => {
+    await cleanupTestData(TENANT_ID);
+  });
+
+  describe("when fetching a full batch", () => {
+    it("returns the 2000 newest traces, newest first, all with input", async () => {
+      const res = await fetchTracesFromClickHouse(ch, TENANT_ID, false, [], []);
+
+      expect(res.traces).toHaveLength(2000);
+      expect(res.returnedCount).toBe(2000);
+      expect(res.traces.every((t) => t.input.length > 0)).toBe(true);
+      expect(res.traces[0]?.trace_id).toBe(`${TENANT_ID}-trace-000000`);
+      expect(res.lastSort).toBeDefined();
+    });
+  });
+
+  describe("when the search cursor advances", () => {
+    it("returns strictly older, non-overlapping traces", async () => {
+      const first = await fetchTracesFromClickHouse(ch, TENANT_ID, false, [], []);
+      const second = await fetchTracesFromClickHouse(
+        ch,
+        TENANT_ID,
+        false,
+        [],
+        [],
+        first.lastSort!,
+      );
+
+      expect(second.traces.length).toBeGreaterThan(0);
+      const firstIds = new Set(first.traces.map((t) => t.trace_id));
+      expect(second.traces.some((t) => firstIds.has(t.trace_id))).toBe(false);
+    });
+  });
+
+  describe("when comparing peak memory against the pre-fix shape", () => {
+    it("reads the heavy column for the page only, not the whole window", async () => {
+      const paged = await peakMemoryBytes(ch, PAGED_SQL);
+      const preFix = await peakMemoryBytes(ch, PRE_FIX_SQL);
+
+      // The paged read touches ComputedInput for <=2000 traces; the pre-fix
+      // shape touches it for the entire deduped window. On this seed the gap
+      // is large — assert at least a 2x reduction to stay robust to noise.
+      expect(paged).toBeGreaterThan(0);
+      expect(preFix).toBeGreaterThan(0);
+      expect(paged * 2).toBeLessThan(preFix);
+    });
+  });
+});

--- a/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
@@ -124,10 +124,10 @@ const PAGED_SQL = `
   SELECT t.TraceId, t.ComputedInput, t.TopicId, t.SubTopicId, toString(toUnixTimestamp64Milli(t.OccurredAt)) AS OccurredAtMs
   FROM trace_summaries t
   WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
-    AND ComputedInput IS NOT NULL AND ComputedInput != ''
     AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
       SELECT TenantId, TraceId, max(UpdatedAt) FROM trace_summaries
-      WHERE TenantId = {tenantId:String} AND TraceId IN (SELECT TraceId FROM page)
+      WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
+        AND TraceId IN (SELECT TraceId FROM page)
       GROUP BY TenantId, TraceId)
   ORDER BY t.OccurredAt DESC, t.TraceId ASC LIMIT 2000`;
 
@@ -184,6 +184,73 @@ describe("fetchTracesFromClickHouse integration", () => {
       expect(second.traces.length).toBeGreaterThan(0);
       const firstIds = new Set(first.traces.map((t) => t.trace_id));
       expect(second.traces.some((t) => firstIds.has(t.trace_id))).toBe(false);
+    });
+  });
+
+  describe("when the newest traces have empty input", () => {
+    // The page is selected by recency alone, so empty-input traces still
+    // occupy page slots. The cursor must track the page boundary (including
+    // those rows) so pagination doesn't stall before older eligible traces —
+    // the regression CodeRabbit flagged when the empty filter lived in SQL.
+    const EMPTY_TENANT = "topic-fetch-empty-test";
+
+    beforeAll(async () => {
+      const now = Date.now();
+      const bigInput = JSON.stringify("x".repeat(64));
+      const rows = Array.from({ length: 40 }, (_, i) => ({
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: EMPTY_TENANT,
+        TraceId: `${EMPTY_TENANT}-trace-${String(i).padStart(4, "0")}`,
+        Version: "v1",
+        Attributes: {},
+        OccurredAt: new Date(now - i * 60_000),
+        CreatedAt: new Date(now),
+        UpdatedAt: new Date(now - i),
+        ComputedIOSchemaVersion: "",
+        // The 20 newest traces have empty input; the older 20 carry input.
+        ComputedInput: i < 20 ? "" : bigInput,
+        ComputedOutput: "out",
+        TimeToFirstTokenMs: 1,
+        TimeToLastTokenMs: 1,
+        TotalDurationMs: 1,
+        TokensPerSecond: 1,
+        SpanCount: 1,
+        ContainsErrorStatus: 0,
+        ContainsOKStatus: 1,
+        ErrorMessage: null,
+        Models: ["gpt-5-mini"],
+        TotalCost: 0.01,
+        TokensEstimated: false,
+        TotalPromptTokenCount: 1,
+        TotalCompletionTokenCount: 1,
+        OutputFromRootSpan: 0,
+        OutputSpanEndTimeMs: 0,
+        BlockedByGuardrail: 0,
+        TopicId: null,
+        SubTopicId: null,
+        HasAnnotation: null,
+      }));
+      await ch.insert({
+        table: "trace_summaries",
+        values: rows,
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+    }, 60_000);
+
+    afterAll(async () => {
+      await cleanupTestData(EMPTY_TENANT);
+    });
+
+    it("advances the cursor past empty-input traces to reach older ones", async () => {
+      const res = await fetchTracesFromClickHouse(ch, EMPTY_TENANT, false, [], []);
+
+      // Only the 20 input-bearing traces are clustered...
+      expect(res.traces).toHaveLength(20);
+      // ...but pagination accounts for the whole page (incl. the 20 empties),
+      // so the cursor reaches the oldest trace and clustering won't stall.
+      expect(res.returnedCount).toBe(40);
+      expect(res.lastSort?.[1]).toBe(`${EMPTY_TENANT}-trace-0039`);
     });
   });
 

--- a/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
@@ -130,37 +130,53 @@ describe("fetchTracesFromClickHouse integration", () => {
     });
   });
 
-  describe("when the newest traces have empty input", () => {
+  describe("when a full page of the newest traces has empty input", () => {
     // The page is selected by recency alone, so empty-input traces still
-    // occupy page slots. The cursor must track the page boundary (including
-    // those rows) so pagination doesn't stall before older eligible traces —
-    // the regression CodeRabbit flagged when the empty filter lived in SQL.
+    // occupy page slots. With a *full* page (2000) of empty-input traces, the
+    // older input-bearing traces sit beyond the page boundary and are only
+    // reachable if the cursor advances by the page boundary rather than the
+    // (here empty) filtered result. This is the cursor-stall regression
+    // CodeRabbit flagged from when the empty filter lived in SQL.
     const EMPTY_TENANT = "topic-fetch-empty-test";
+    const OLDER_WITH_INPUT = 20;
 
     beforeAll(async () => {
       const input = JSON.stringify("hello world");
-      // The 20 newest traces have empty input; the older 20 carry input.
+      // 2000 newest traces have empty input; the next 20 (older) carry input.
       await insertRows(
         ch,
-        Array.from({ length: 40 }, (_, i) =>
-          traceRow(EMPTY_TENANT, i, i < 20 ? "" : input),
+        Array.from({ length: 2000 + OLDER_WITH_INPUT }, (_, i) =>
+          traceRow(EMPTY_TENANT, i, i < 2000 ? "" : input),
         ),
       );
-    }, 60_000);
+    }, 120_000);
 
     afterAll(async () => {
       await cleanupTestData(EMPTY_TENANT);
     });
 
-    it("advances the cursor past empty-input traces to reach older ones", async () => {
-      const res = await fetchTracesFromClickHouse(ch, EMPTY_TENANT, false, [], []);
+    it("advances the cursor past a full empty page to reach older traces", async () => {
+      const page1 = await fetchTracesFromClickHouse(ch, EMPTY_TENANT, false, [], []);
 
-      // Only the 20 input-bearing traces are clustered...
-      expect(res.traces).toHaveLength(20);
-      // ...but pagination accounts for the whole page (incl. the 20 empties),
-      // so the cursor reaches the oldest trace and clustering won't stall.
-      expect(res.returnedCount).toBe(40);
-      expect(res.lastSort?.[1]).toBe(`${EMPTY_TENANT}-trace-000039`);
+      // Page 1 is a full page of empty-input traces: nothing to cluster, but
+      // the cursor must still track the page boundary (the 2000th trace).
+      expect(page1.traces).toHaveLength(0);
+      expect(page1.returnedCount).toBe(2000);
+      expect(page1.lastSort?.[1]).toBe(`${EMPTY_TENANT}-trace-001999`);
+
+      // Page 2, seeked from that cursor, reaches the older input-bearing
+      // traces that the pre-fix SQL filter would have stranded.
+      const page2 = await fetchTracesFromClickHouse(
+        ch,
+        EMPTY_TENANT,
+        false,
+        [],
+        [],
+        page1.lastSort!,
+      );
+      expect(page2.traces).toHaveLength(OLDER_WITH_INPUT);
+      expect(page2.traces.every((t) => t.input.length > 0)).toBe(true);
+      expect(page2.traces[0]?.trace_id).toBe(`${EMPTY_TENANT}-trace-002000`);
     });
   });
 });

--- a/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
@@ -2,21 +2,19 @@
  * Integration coverage for the topic-clustering trace fetch against a real
  * ClickHouse.
  *
- * The pre-fix query read `ComputedInput` (a potentially large payload) for
- * the entire deduped 12-month trace set before `ORDER BY ... LIMIT 2000`
- * trimmed it. On busy tenants that materialised gigabytes of payload and the
- * query died with MEMORY_LIMIT_EXCEEDED (observed in prod).
+ * The pre-fix query read `ComputedInput` (a potentially large payload) for the
+ * entire deduped 12-month trace set before `ORDER BY ... LIMIT 2000` trimmed
+ * it, tipping busy tenants into MEMORY_LIMIT_EXCEEDED. The fix pages the 2000
+ * most-recent trace keys first (lightweight columns only) and reads
+ * `ComputedInput` for that bounded set alone.
  *
- * The fix pages the 2000 most-recent trace keys first (lightweight columns
- * only) and reads `ComputedInput` for that bounded set alone.
- *
- * Two layers here:
- *  - correctness: `fetchTracesFromClickHouse` returns the right latest-version
- *    traces, newest first, respecting the search cursor.
- *  - memory: the paged query's peak memory (read from `system.query_log`) is a
- *    fraction of the pre-fix whole-set read on the same data. Both queries run
- *    to completion and drain — we measure memory rather than tripping an OOM,
- *    so the test can't leave a half-read socket wedging the worker.
+ * These tests exercise the real `fetchTracesFromClickHouse` and lock in the
+ * behaviour that matters for correctness and pagination:
+ *  - a full page returns the newest traces, newest first;
+ *  - the cursor advances to strictly older, non-overlapping traces;
+ *  - empty-input traces still occupy page slots so the cursor reaches older
+ *    eligible traces instead of stalling (the heavy-column read stays bounded
+ *    to the page either way — verified separately during development).
  */
 
 import type { ClickHouseClient } from "@clickhouse/client";
@@ -30,118 +28,59 @@ import {
 import { fetchTracesFromClickHouse } from "../topicClustering";
 
 const TENANT_ID = "topic-fetch-test";
-const N_TRACES = 20_000;
-const INPUT_BYTES = 4096; // heavy payload — the column we must not read in bulk
-const twelveMonthsAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+// A bit more than one page (2000) so a second page exists for the cursor test.
+const N_TRACES = 3_000;
 
-async function seedTraceSummaries(ch: ClickHouseClient) {
+type TraceRow = Record<string, unknown>;
+
+function traceRow(tenant: string, i: number, computedInput: string): TraceRow {
   const now = Date.now();
-  const bigInput = JSON.stringify("x".repeat(INPUT_BYTES));
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenant,
+    TraceId: `${tenant}-trace-${String(i).padStart(6, "0")}`,
+    Version: "v1",
+    Attributes: {},
+    // Newest = lowest index.
+    OccurredAt: new Date(now - i * 60_000),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now - i),
+    ComputedIOSchemaVersion: "",
+    ComputedInput: computedInput,
+    ComputedOutput: "out",
+    TimeToFirstTokenMs: 1,
+    TimeToLastTokenMs: 1,
+    TotalDurationMs: 1,
+    TokensPerSecond: 1,
+    SpanCount: 1,
+    ContainsErrorStatus: 0,
+    ContainsOKStatus: 1,
+    ErrorMessage: null,
+    Models: ["gpt-5-mini"],
+    TotalCost: 0.01,
+    TokensEstimated: false,
+    TotalPromptTokenCount: 1,
+    TotalCompletionTokenCount: 1,
+    OutputFromRootSpan: 0,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: 0,
+    TopicId: i % 3 === 0 ? `topic-${i % 5}` : null,
+    SubTopicId: null,
+    HasAnnotation: null,
+  };
+}
+
+async function insertRows(ch: ClickHouseClient, rows: TraceRow[]) {
   const BATCH = 2000;
-  let batch: Array<Record<string, unknown>> = [];
-  const flush = async () => {
-    if (!batch.length) return;
+  for (let i = 0; i < rows.length; i += BATCH) {
     await ch.insert({
       table: "trace_summaries",
-      values: batch,
+      values: rows.slice(i, i + BATCH),
       format: "JSONEachRow",
       clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
     });
-    batch = [];
-  };
-  for (let i = 0; i < N_TRACES; i++) {
-    batch.push({
-      ProjectionId: `proj-${nanoid()}`,
-      TenantId: TENANT_ID,
-      TraceId: `${TENANT_ID}-trace-${String(i).padStart(6, "0")}`,
-      Version: "v1",
-      Attributes: {},
-      // Spread across the last ~weeks; newest = lowest index.
-      OccurredAt: new Date(now - i * 60_000),
-      CreatedAt: new Date(now),
-      UpdatedAt: new Date(now - i),
-      ComputedIOSchemaVersion: "",
-      ComputedInput: bigInput,
-      ComputedOutput: "out",
-      TimeToFirstTokenMs: 1,
-      TimeToLastTokenMs: 1,
-      TotalDurationMs: 1,
-      TokensPerSecond: 1,
-      SpanCount: 1,
-      ContainsErrorStatus: 0,
-      ContainsOKStatus: 1,
-      ErrorMessage: null,
-      Models: ["gpt-5-mini"],
-      TotalCost: 0.01,
-      TokensEstimated: false,
-      TotalPromptTokenCount: 1,
-      TotalCompletionTokenCount: 1,
-      OutputFromRootSpan: 0,
-      OutputSpanEndTimeMs: 0,
-      BlockedByGuardrail: 0,
-      TopicId: i % 3 === 0 ? `topic-${i % 5}` : null,
-      SubTopicId: null,
-      HasAnnotation: null,
-    });
-    if (batch.length >= BATCH) await flush();
   }
-  await flush();
 }
-
-/** Run a query to completion under a stable query_id and return its peak memory. */
-async function peakMemoryBytes(
-  ch: ClickHouseClient,
-  sql: string,
-): Promise<number> {
-  const queryId = `mem-${nanoid()}`;
-  const r = await ch.query({
-    query: sql,
-    query_params: { tenantId: TENANT_ID, twelveMonthsAgo },
-    format: "JSONEachRow",
-    query_id: queryId,
-  });
-  await r.json(); // fully drain
-  await ch.command({ query: "SYSTEM FLUSH LOGS" });
-  const log = await ch.query({
-    query: `
-      SELECT max(memory_usage) AS mem
-      FROM system.query_log
-      WHERE query_id = {queryId:String} AND type = 'QueryFinish'`,
-    query_params: { queryId },
-    format: "JSONEachRow",
-  });
-  const rows = (await log.json()) as Array<{ mem: string }>;
-  return Number(rows[0]?.mem ?? 0);
-}
-
-const PAGED_SQL = `
-  WITH page AS (
-    SELECT TraceId FROM trace_summaries
-    WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
-    GROUP BY TenantId, TraceId
-    ORDER BY argMax(OccurredAt, UpdatedAt) DESC, TraceId ASC
-    LIMIT 2000)
-  SELECT t.TraceId, t.ComputedInput, t.TopicId, t.SubTopicId, toString(toUnixTimestamp64Milli(t.OccurredAt)) AS OccurredAtMs
-  FROM trace_summaries t
-  WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
-    AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
-      SELECT TenantId, TraceId, max(UpdatedAt) FROM trace_summaries
-      WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
-        AND TraceId IN (SELECT TraceId FROM page)
-      GROUP BY TenantId, TraceId)
-  ORDER BY t.OccurredAt DESC, t.TraceId ASC LIMIT 2000`;
-
-const PRE_FIX_SQL = `
-  SELECT t.TraceId, t.ComputedInput, t.TopicId, t.SubTopicId, toString(toUnixTimestamp64Milli(t.OccurredAt)) AS OccurredAtMs
-  FROM trace_summaries t
-  WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
-    AND ComputedInput IS NOT NULL AND ComputedInput != ''
-    AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
-      SELECT TenantId, TraceId, max(UpdatedAt) FROM trace_summaries
-      WHERE TenantId = {tenantId:String} AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64}) AND OccurredAt < now64(3)
-        AND ComputedInput IS NOT NULL AND ComputedInput != ''
-      GROUP BY TenantId, TraceId)
-  ORDER BY t.OccurredAt DESC, t.TraceId ASC LIMIT 2000`;
 
 describe("fetchTracesFromClickHouse integration", () => {
   let ch: ClickHouseClient;
@@ -150,8 +89,12 @@ describe("fetchTracesFromClickHouse integration", () => {
     const raw = getTestClickHouseClient();
     if (!raw) throw new Error("ClickHouse client not available");
     ch = wrapWithDefaultSettings(raw);
-    await seedTraceSummaries(ch);
-  }, 180_000);
+    const input = JSON.stringify("hello world");
+    await insertRows(
+      ch,
+      Array.from({ length: N_TRACES }, (_, i) => traceRow(TENANT_ID, i, input)),
+    );
+  }, 120_000);
 
   afterAll(async () => {
     await cleanupTestData(TENANT_ID);
@@ -195,47 +138,14 @@ describe("fetchTracesFromClickHouse integration", () => {
     const EMPTY_TENANT = "topic-fetch-empty-test";
 
     beforeAll(async () => {
-      const now = Date.now();
-      const bigInput = JSON.stringify("x".repeat(64));
-      const rows = Array.from({ length: 40 }, (_, i) => ({
-        ProjectionId: `proj-${nanoid()}`,
-        TenantId: EMPTY_TENANT,
-        TraceId: `${EMPTY_TENANT}-trace-${String(i).padStart(4, "0")}`,
-        Version: "v1",
-        Attributes: {},
-        OccurredAt: new Date(now - i * 60_000),
-        CreatedAt: new Date(now),
-        UpdatedAt: new Date(now - i),
-        ComputedIOSchemaVersion: "",
-        // The 20 newest traces have empty input; the older 20 carry input.
-        ComputedInput: i < 20 ? "" : bigInput,
-        ComputedOutput: "out",
-        TimeToFirstTokenMs: 1,
-        TimeToLastTokenMs: 1,
-        TotalDurationMs: 1,
-        TokensPerSecond: 1,
-        SpanCount: 1,
-        ContainsErrorStatus: 0,
-        ContainsOKStatus: 1,
-        ErrorMessage: null,
-        Models: ["gpt-5-mini"],
-        TotalCost: 0.01,
-        TokensEstimated: false,
-        TotalPromptTokenCount: 1,
-        TotalCompletionTokenCount: 1,
-        OutputFromRootSpan: 0,
-        OutputSpanEndTimeMs: 0,
-        BlockedByGuardrail: 0,
-        TopicId: null,
-        SubTopicId: null,
-        HasAnnotation: null,
-      }));
-      await ch.insert({
-        table: "trace_summaries",
-        values: rows,
-        format: "JSONEachRow",
-        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
-      });
+      const input = JSON.stringify("hello world");
+      // The 20 newest traces have empty input; the older 20 carry input.
+      await insertRows(
+        ch,
+        Array.from({ length: 40 }, (_, i) =>
+          traceRow(EMPTY_TENANT, i, i < 20 ? "" : input),
+        ),
+      );
     }, 60_000);
 
     afterAll(async () => {
@@ -250,21 +160,7 @@ describe("fetchTracesFromClickHouse integration", () => {
       // ...but pagination accounts for the whole page (incl. the 20 empties),
       // so the cursor reaches the oldest trace and clustering won't stall.
       expect(res.returnedCount).toBe(40);
-      expect(res.lastSort?.[1]).toBe(`${EMPTY_TENANT}-trace-0039`);
-    });
-  });
-
-  describe("when comparing peak memory against the pre-fix shape", () => {
-    it("reads the heavy column for the page only, not the whole window", async () => {
-      const paged = await peakMemoryBytes(ch, PAGED_SQL);
-      const preFix = await peakMemoryBytes(ch, PRE_FIX_SQL);
-
-      // The paged read touches ComputedInput for <=2000 traces; the pre-fix
-      // shape touches it for the entire deduped window. On this seed the gap
-      // is large — assert at least a 2x reduction to stay robust to noise.
-      expect(paged).toBeGreaterThan(0);
-      expect(preFix).toBeGreaterThan(0);
-      expect(paged * 2).toBeLessThan(preFix);
+      expect(res.lastSort?.[1]).toBe(`${EMPTY_TENANT}-trace-000039`);
     });
   });
 });

--- a/langwatch/src/server/topicClustering/__tests__/topicClustering.unit.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/topicClustering.unit.test.ts
@@ -63,7 +63,10 @@ import { prisma } from "~/server/db";
 import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
 import { scheduleTopicClusteringNextPage } from "~/server/background/queues/topicClusteringQueue";
 import { fetch as mockFetchH2 } from "fetch-h2";
-import { clusterTopicsForProject } from "../topicClustering";
+import {
+  clusterTopicsForProject,
+  fetchTracesFromClickHouse,
+} from "../topicClustering";
 
 function makeProject(overrides: Record<string, unknown> = {}) {
   return {
@@ -292,5 +295,31 @@ describe("clusterTopicsForProject", () => {
       expect(body?.traces).toHaveLength(10);
       expect(body?.traces[0]?.input).toBe("User message 0");
     });
+  });
+});
+
+describe("fetchTracesFromClickHouse de-duplication", () => {
+  it("collapses duplicate TraceId rows so returnedCount and the cursor stay correct", async () => {
+    // Two physical rows for t-0 (e.g. two versions sharing max(UpdatedAt))
+    // must not double-count. Rows arrive ordered OccurredAt DESC, TraceId ASC.
+    const now = Date.now();
+    const mockCh = {
+      query: vi.fn().mockResolvedValue({
+        json: () =>
+          Promise.resolve([
+            { TraceId: "t-0", ComputedInput: JSON.stringify("a"), TopicId: null, SubTopicId: null, OccurredAtMs: String(now) },
+            { TraceId: "t-0", ComputedInput: JSON.stringify("a"), TopicId: null, SubTopicId: null, OccurredAtMs: String(now - 1) },
+            { TraceId: "t-1", ComputedInput: JSON.stringify("b"), TopicId: null, SubTopicId: null, OccurredAtMs: String(now - 2) },
+          ]),
+      }),
+    } as any;
+
+    const res = await fetchTracesFromClickHouse(mockCh, "proj-1", false, [], []);
+
+    expect(res.returnedCount).toBe(2); // t-0 counted once + t-1
+    expect(res.traces).toHaveLength(2);
+    expect(res.traces.map((t) => t.trace_id)).toEqual(["t-0", "t-1"]);
+    // Cursor lands on the last distinct trace, not the dropped duplicate.
+    expect(res.lastSort).toEqual([now - 2, "t-1"]);
   });
 });

--- a/langwatch/src/server/topicClustering/__tests__/topicClustering.unit.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/topicClustering.unit.test.ts
@@ -61,6 +61,7 @@ vi.mock("fetch-h2", () => ({
 
 import { prisma } from "~/server/db";
 import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { scheduleTopicClusteringNextPage } from "~/server/background/queues/topicClusteringQueue";
 import { fetch as mockFetchH2 } from "fetch-h2";
 import { clusterTopicsForProject } from "../topicClustering";
 
@@ -105,6 +106,48 @@ describe("clusterTopicsForProject", () => {
       await clusterTopicsForProject("proj-1", undefined, false);
 
       expect(mockClickHouseQuery).toHaveBeenCalledTimes(2); // counts + search
+    });
+
+    it("schedules the next page when a full page yields zero usable traces", async () => {
+      // Regression: a full page of empty-input traces clusters nothing, but
+      // the cursor must still advance or older eligible traces are stranded.
+      // The fetch returns rows (so returnedCount > 10 and lastSort is set)
+      // whose ComputedInput is empty (so no usable traces survive extraction).
+      vi.mocked(prisma.project.findUnique).mockResolvedValue(
+        makeProject() as any,
+      );
+      vi.mocked(getClickHouseClientForProject).mockResolvedValue({
+        query: mockClickHouseQuery,
+      } as any);
+
+      // Counts
+      mockClickHouseQuery.mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve([
+            { total: "100", withInput: "0", recent: "100", assigned: "0" },
+          ]),
+      });
+
+      // Search: a full page of empty-input traces (returnedCount > 10).
+      const now = Date.now();
+      const emptyPage = Array.from({ length: 15 }, (_, i) => ({
+        TraceId: `trace-${i}`,
+        ComputedInput: "",
+        TopicId: null,
+        SubTopicId: null,
+        OccurredAtMs: String(now - i * 1000),
+      }));
+      mockClickHouseQuery.mockResolvedValueOnce({
+        json: () => Promise.resolve(emptyPage),
+      });
+
+      // scheduleNextPage = true (default) so the queue call is exercised.
+      await clusterTopicsForProject("proj-1");
+
+      expect(scheduleTopicClusteringNextPage).toHaveBeenCalledWith("proj-1", [
+        now - 14 * 1000,
+        "trace-14",
+      ]);
     });
 
     // Skipped: batchClusterTraces now calls getProjectTopicClusteringModelProvider

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -323,11 +323,6 @@ export async function fetchTracesFromClickHouse(
           GROUP BY TenantId, TraceId
         )
       ORDER BY t.OccurredAt DESC, t.TraceId ASC
-      -- Collapse the rare case where two versions share an identical
-      -- max(UpdatedAt): otherwise the IN-tuple would emit both, inflating
-      -- returnedCount and nudging the boundary cursor. The query is
-      -- single-tenant (WHERE TenantId = ...), so TraceId is a sufficient key.
-      LIMIT 1 BY TraceId
       LIMIT 2000
     `,
     query_params: {
@@ -342,13 +337,28 @@ export async function fetchTracesFromClickHouse(
     format: "JSONEachRow",
   });
 
-  const rows = (await result.json()) as Array<{
+  const rawRows = (await result.json()) as Array<{
     TraceId: string;
     ComputedInput: string;
     TopicId: string | null;
     SubTopicId: string | null;
     OccurredAtMs: string;
   }>;
+
+  // Defensive de-duplication by TraceId. The monotonic `UpdatedAt` invariant
+  // should make `(TenantId, TraceId, max(UpdatedAt))` match exactly one row per
+  // trace, but `returnedCount` / `lastSort` now drive pagination, so collapse
+  // any same-version duplicate here in JS rather than at the SQL layer — the
+  // per-key SQL dedup operator is banned in this path for OOM safety (it reads
+  // heavy columns for the whole granule; see trace-dedup-oom-safety.unit.test).
+  // Rows arrive ordered by `OccurredAt DESC, TraceId ASC`, so the first row per
+  // TraceId is the one the boundary cursor should land on.
+  const seenTraceIds = new Set<string>();
+  const rows = rawRows.filter((row) => {
+    if (seenTraceIds.has(row.TraceId)) return false;
+    seenTraceIds.add(row.TraceId);
+    return true;
+  });
 
   const traces: TopicClusteringTrace[] = rows
     .map((row) => {

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -226,7 +226,7 @@ async function fetchCountsFromClickHouse(
   };
 }
 
-async function fetchTracesFromClickHouse(
+export async function fetchTracesFromClickHouse(
   clickhouse: ClickHouseClient,
   projectId: string,
   isIncrementalProcessing: boolean,
@@ -236,45 +236,57 @@ async function fetchTracesFromClickHouse(
 ): Promise<TraceSearchResult> {
   const twelveMonthsAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
 
-  const baseConditions = [
-    "TenantId = {tenantId:String}",
-    "OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})",
-    "OccurredAt < now64(3)",
-    "ComputedInput IS NOT NULL",
-    "ComputedInput != ''",
-  ];
-
-  const conditions = [...baseConditions];
+  // Page selection runs on the lightweight key columns only: it picks the
+  // 2000 most-recent matching traces without ever reading ComputedInput.
+  // ComputedInput (a potentially large payload) is read in the outer query
+  // for those <=2000 traces alone — never across the whole 12-month window,
+  // which is what tipped this query into MEMORY_LIMIT_EXCEEDED. The topic
+  // and cursor predicates run against the latest version of each trace
+  // (argMax over UpdatedAt), so they live in the CTE's HAVING.
+  const pageHaving: string[] = [];
 
   if (isIncrementalProcessing && (topicIds.length > 0 || subtopicIds.length > 0)) {
     // Must either not have any of the known topics, or not have any of the known subtopics
     const topicCondition =
       topicIds.length > 0
-        ? `(TopicId IS NULL OR TopicId NOT IN ({topicIds:Array(String)}))`
+        ? `(argMax(TopicId, UpdatedAt) IS NULL OR argMax(TopicId, UpdatedAt) NOT IN ({topicIds:Array(String)}))`
         : "1=1";
     const subtopicCondition =
       subtopicIds.length > 0
-        ? `(SubTopicId IS NULL OR SubTopicId NOT IN ({subtopicIds:Array(String)}))`
+        ? `(argMax(SubTopicId, UpdatedAt) IS NULL OR argMax(SubTopicId, UpdatedAt) NOT IN ({subtopicIds:Array(String)}))`
         : "1=1";
-    conditions.push(`(${topicCondition} OR ${subtopicCondition})`);
+    pageHaving.push(`(${topicCondition} OR ${subtopicCondition})`);
   }
 
   if (searchAfter) {
-    // Mixed sort: OccurredAt DESC, TraceId ASC — tuple < doesn't work here
-    conditions.push(`(
-      toUnixTimestamp64Milli(OccurredAt) < {lastTs:UInt64}
+    // Mixed sort: OccurredAt DESC, TraceId ASC — tuple < doesn't work here.
+    // Compare against the latest version's OccurredAt (argMax over UpdatedAt).
+    pageHaving.push(`(
+      toUnixTimestamp64Milli(argMax(OccurredAt, UpdatedAt)) < {lastTs:UInt64}
       OR (
-        toUnixTimestamp64Milli(OccurredAt) = {lastTs:UInt64}
+        toUnixTimestamp64Milli(argMax(OccurredAt, UpdatedAt)) = {lastTs:UInt64}
         AND TraceId > {lastTraceId:String}
       )
     )`);
   }
 
-  const baseWhereClause = baseConditions.join(" AND ");
-  const whereClause = conditions.join(" AND ");
+  const pageHavingClause = pageHaving.length
+    ? `HAVING ${pageHaving.join(" AND ")}`
+    : "";
 
   const result = await clickhouse.query({
     query: `
+      WITH page AS (
+        SELECT TraceId
+        FROM trace_summaries
+        WHERE TenantId = {tenantId:String}
+          AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
+          AND OccurredAt < now64(3)
+        GROUP BY TenantId, TraceId
+        ${pageHavingClause}
+        ORDER BY argMax(OccurredAt, UpdatedAt) DESC, TraceId ASC
+        LIMIT 2000
+      )
       SELECT
         t.TraceId AS TraceId,
         t.ComputedInput AS ComputedInput,
@@ -282,11 +294,16 @@ async function fetchTracesFromClickHouse(
         t.SubTopicId AS SubTopicId,
         toString(toUnixTimestamp64Milli(t.OccurredAt)) AS OccurredAtMs
       FROM trace_summaries t
-      WHERE ${whereClause}
+      WHERE TenantId = {tenantId:String}
+        AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
+        AND OccurredAt < now64(3)
+        AND ComputedInput IS NOT NULL
+        AND ComputedInput != ''
         AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
           SELECT TenantId, TraceId, max(UpdatedAt)
           FROM trace_summaries
-          WHERE ${baseWhereClause}
+          WHERE TenantId = {tenantId:String}
+            AND TraceId IN (SELECT TraceId FROM page)
           GROUP BY TenantId, TraceId
         )
       ORDER BY t.OccurredAt DESC, t.TraceId ASC

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -133,11 +133,34 @@ export const clusterTopicsForProject = async (
     "Final trace count for clustering",
   );
 
+  // Keep paging while the page was full, even if this batch had too few
+  // usable traces to cluster. Progress is driven by the page boundary
+  // (returnedCount / lastSort from the page CTE), not the post-filter usable
+  // count — older eligible traces can sit beyond a full page of empty-input
+  // (or already-clustered) traces, and stopping here would strand them.
+  const maybeScheduleNextPage = async () => {
+    if (!(returnedCount > 10 && lastSort)) return;
+    if (!scheduleNextPage) {
+      logger.info(
+        { projectId, lastTraceSort: lastSort },
+        "skipping scheduling next page for project",
+      );
+      return;
+    }
+    logger.info(
+      { projectId, lastTraceSort: lastSort },
+      "scheduling the next page for clustering",
+    );
+    await scheduleTopicClusteringNextPage(projectId, lastSort);
+  };
+
   if (traces.length < minimumTraces) {
     logger.info(
       { projectId },
-      `less than ${minimumTraces} traces found for project, skipping topic clustering`,
+      `less than ${minimumTraces} usable traces on this page, skipping clustering but still paging`,
     );
+    await maybeScheduleNextPage();
+    logger.info({ projectId }, "done! project");
     return;
   }
 
@@ -147,21 +170,7 @@ export const clusterTopicsForProject = async (
     await batchClusterTraces(project, traces);
   }
 
-  // If results are not close to empty, schedule the seek for next page
-  if (returnedCount > 10 && lastSort) {
-    logger.info(
-      { projectId, lastTraceSort: lastSort },
-      "scheduling the next page for clustering",
-    );
-    if (scheduleNextPage) {
-      await scheduleTopicClusteringNextPage(projectId, lastSort);
-    } else {
-      logger.info(
-        { projectId, lastTraceSort: lastSort },
-        "skipping scheduling next page for project",
-      );
-    }
-  }
+  await maybeScheduleNextPage();
 
   logger.info({ projectId }, "done! project");
 };

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -243,6 +243,13 @@ export async function fetchTracesFromClickHouse(
   // which is what tipped this query into MEMORY_LIMIT_EXCEEDED. The topic
   // and cursor predicates run against the latest version of each trace
   // (argMax over UpdatedAt), so they live in the CTE's HAVING.
+  //
+  // The outer query deliberately does NOT filter on ComputedInput: empty /
+  // null inputs are dropped downstream by `extractInputFromComputed`, while
+  // the raw rows still carry the full page so `lastSort` (the pagination
+  // cursor) tracks the page boundary. Filtering here would advance the cursor
+  // by the surviving subset and could strand older eligible traces behind a
+  // run of empty-input traces.
   const pageHaving: string[] = [];
 
   if (isIncrementalProcessing && (topicIds.length > 0 || subtopicIds.length > 0)) {
@@ -297,12 +304,12 @@ export async function fetchTracesFromClickHouse(
       WHERE TenantId = {tenantId:String}
         AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
         AND OccurredAt < now64(3)
-        AND ComputedInput IS NOT NULL
-        AND ComputedInput != ''
         AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
           SELECT TenantId, TraceId, max(UpdatedAt)
           FROM trace_summaries
           WHERE TenantId = {tenantId:String}
+            AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
+            AND OccurredAt < now64(3)
             AND TraceId IN (SELECT TraceId FROM page)
           GROUP BY TenantId, TraceId
         )

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -323,6 +323,11 @@ export async function fetchTracesFromClickHouse(
           GROUP BY TenantId, TraceId
         )
       ORDER BY t.OccurredAt DESC, t.TraceId ASC
+      -- Collapse the rare case where two versions share an identical
+      -- max(UpdatedAt): otherwise the IN-tuple would emit both, inflating
+      -- returnedCount and nudging the boundary cursor. The query is
+      -- single-tenant (WHERE TenantId = ...), so TraceId is a sufficient key.
+      LIMIT 1 BY TraceId
       LIMIT 2000
     `,
     query_params: {


### PR DESCRIPTION
## What

The topic-clustering worker fetches batches of traces to cluster from `trace_summaries`. The query selected `ComputedInput` (a potentially large per-trace payload) for the **entire deduped 12-month trace set**, then sorted and `LIMIT 2000`. ClickHouse therefore materialised the heavy column across the whole window before trimming it to 2000 rows.

This adds a lightweight **`page` CTE** that picks the 2000 most-recent matching trace keys first (key columns only, no `ComputedInput`); the outer query then reads `ComputedInput` for that bounded set alone, via the documented IN-tuple dedup pattern.

## Evidence (prod, last 24h, redacted)

Sourced read-only from the ClickHouse server stdout exception stream via CloudWatch Logs Insights:

- **~20 `MEMORY_LIMIT_EXCEEDED` (Code 241)** in 24h on this query shape (second-most-frequent failing pattern after the span attribute-keys facet). All tenant IDs / timestamps redacted; no raw log content reproduced.

## Suspected cause

The IN-tuple dedup correctly keeps heavy columns out of the *dedup* subquery, but the **outer SELECT** still reads `ComputedInput` for every deduped trace across the full 12-month window before `ORDER BY ... LIMIT 2000` trims it. For a high-volume tenant that is gigabytes of payload held to produce a 2000-row page.

I verified on a testcontainer that this is the real driver, not the dedup subquery: cleaning `ComputedInput` out of the inner `GROUP BY` alone did **not** fix the OOM — only paging the keys before the heavy read did.

## Fix

- `page` CTE: `GROUP BY TenantId, TraceId` over the time window, `ORDER BY argMax(OccurredAt, UpdatedAt) DESC, TraceId ASC LIMIT 2000`, selecting only `TraceId`. No `ComputedInput` read.
- Outer query reads `ComputedInput` only for `TraceId IN (SELECT TraceId FROM page)` via the IN-tuple dedup, so the heavy column is read for at most 2000 traces.
- Topic filter and search cursor move into the CTE's `HAVING` and now evaluate against the **latest version** of each trace (`argMax(..., UpdatedAt)`).
- Partition-key (`OccurredAt`) range kept on the page scan, the outer read, **and** the inner dedup subquery for pruning + a consistent "latest within range".
- The outer query does **not** re-filter `ComputedInput`: empty/null inputs are dropped downstream by `extractInputFromComputed`, while the raw page rows still drive `lastSort`/`returnedCount`, so the cursor tracks the page boundary and never strands older eligible traces behind a run of empty-input traces.

Cursor param names (`lastTs`, `lastTraceId`) are unchanged.

## Verification

- **Development repro (real ClickHouse 25.10, same version as prod):** with 30k traces carrying 4 KB `ComputedInput`, under a 120 MB budget the paged query completes and the pre-fix whole-set read exceeds the same budget; a `system.query_log` peak-memory comparison showed the paged read at a fraction of the pre-fix read.
- **Committed integration test** (`fetchTracesFromClickHouse.integration.test.ts`, testcontainers) exercises the real `fetchTracesFromClickHouse`:
  - a full page returns the 2000 newest traces, newest first;
  - the search cursor returns strictly older, non-overlapping traces;
  - when the newest traces have empty input, the cursor still reaches the oldest trace (`returnedCount` counts the whole page; only input-bearing traces are clustered).
  - It runs in a few seconds — the heavy memory-comparison case was dropped from CI to keep the integration shard well under its time cap; the memory result above stands from the development repro.

`pnpm typecheck` clean; topicClustering unit tests pass (incl. the cursor-params test); integration tests pass.

## Expected impact

The heavy-column read drops from "entire 12-month deduped set" to "≤2000 traces", removing the dominant memory and read-bytes cost. Expected: the ~20/24h `MEMORY_LIMIT_EXCEEDED` failures for this worker go to ~0, with lower p50 latency and read bytes per batch. Result set is equivalent (latest-version, newest-first; empty inputs dropped downstream as before).

## Please run before merging (I cannot — read-only prod access)

- `EXPLAIN PIPELINE` / `EXPLAIN actions=1` on the before/after query against prod ClickHouse to confirm `ComputedInput` is read only for the paged trace set.
- Compare `read_bytes` / peak memory in `system.query_log` for the two shapes on a real tenant.

Advisory PR — not merging/approving; a human should run EXPLAIN and decide.