### PR TITLE
fix(nlpgo): translate response_format to forced tool_use on bedrock+anthropic

### DIFF
--- a/services/nlpgo/adapters/llmexecutor/executor.go
+++ b/services/nlpgo/adapters/llmexecutor/executor.go
@@ -200,7 +200,54 @@ func buildGatewayRequest(ctx context.Context, req app.LLMRequest, stream bool) (
 		body["reasoning_effort"] = req.ReasoningEffort
 	}
 	if req.ResponseFormat != nil {
-		body["response_format"] = req.ResponseFormat
+		// Bedrock + Anthropic: don't ship response_format. bifrost v1.4.22's
+		// bedrock provider routes response_format on anthropic-family
+		// models (any model whose id contains "anthropic." or "claude")
+		// through Anthropic's native output_config.format extension via
+		// additionalModelRequestFields (providers/bedrock/utils.go:1011-
+		// 1015). That field is a Bedrock+Anthropic feature that ships with
+		// rolling per-region / per-model-version support and requires the
+		// right anthropic-beta header to activate; when the combination
+		// doesn't line up the field is silently ignored and the model
+		// returns prose. Customer dogfood 2026-05-30 caught this on
+		// us.anthropic.claude-haiku-4-5-* via a managed-bedrock VPCE: a
+		// signature node with {output:bool, reason:str} got raw
+		// "TRUE\n\nReason: ..." back, the engine's extractSignatureOutputs
+		// then fell through to the prose-fallback and dumped the whole
+		// blob into the first declared field.
+		//
+		// LiteLLM (python langwatch_nlp's path) bypasses this entirely:
+		// it translates response_format → toolConfig.tools + toolChoice
+		// (forced tool_use), which is the oldest and most universally
+		// supported Anthropic structured-output mechanism. Every claude
+		// model in every region honors it, no beta header required. We
+		// mirror that translation here so the Go path has python parity
+		// + the same robustness profile.
+		//
+		// Conversion is one-shot and self-contained: build a synthetic
+		// tool whose input schema IS the response_format schema, append
+		// it to the tools array, pin tool_choice to it, then drop
+		// response_format from the body. The response side
+		// (parseChatCompletionResponse) lifts the tool_call arguments
+		// back into Content so engine.extractSignatureOutputs sees the
+		// same JSON-shape payload it would have received from
+		// response_format on a provider that does honor it natively.
+		if shouldUseToolUseForStructuredOutput(provider, req.Model) {
+			if tool, choice, ok := buildStructuredOutputTool(req.ResponseFormat); ok {
+				existingTools, _ := body["tools"].([]app.Tool)
+				body["tools"] = append(existingTools, tool)
+				body["tool_choice"] = choice
+			} else {
+				// Schema malformed (no "json_schema.schema"). Fall back to
+				// the response_format pass-through so providers that DO
+				// honor a top-level response_format get something rather
+				// than nothing — same defensive posture as the recoverJSON
+				// fallback in the engine.
+				body["response_format"] = req.ResponseFormat
+			}
+		} else {
+			body["response_format"] = req.ResponseFormat
+		}
 	}
 	if stream {
 		body["stream"] = true
@@ -246,6 +293,95 @@ func buildGatewayRequest(ctx context.Context, req app.LLMRequest, stream bool) (
 		Model:   translatedModel,
 		Project: req.ProjectID,
 	}, nil
+}
+
+// structuredOutputToolPrefix marks tools synthesized from
+// response_format. parseChatCompletionResponse unwraps tool_calls whose
+// function name starts with this prefix back into Content so the engine
+// sees the same JSON-shape payload as the response_format path. The
+// prefix mirrors bifrost's internal `bf_so_` convention but stays
+// nlpgo-owned so a bifrost rename can't silently break us.
+const structuredOutputToolPrefix = "lw_so_"
+
+// shouldUseToolUseForStructuredOutput returns true when response_format
+// must be rewritten to a forced tool_use call. Today: any Anthropic-family
+// model dispatched via Bedrock. Bifrost v1.4.22's bedrock provider routes
+// response_format on anthropic-family models through Anthropic's native
+// output_config.format extension which has variable per-region /
+// per-model-version support (customer dogfood 2026-05-30 with
+// us.anthropic.claude-haiku-4-5 returned prose). Tool_use is the oldest,
+// universally-supported Anthropic structured-output path.
+//
+// Match policy mirrors bifrost's IsAnthropicModel: any "anthropic." OR
+// "claude" substring in the model id. The provider gate ensures we don't
+// pre-empt direct Anthropic or other providers where the native
+// response_format path is well-supported.
+func shouldUseToolUseForStructuredOutput(provider, model string) bool {
+	if provider != "bedrock" {
+		return false
+	}
+	return strings.Contains(model, "anthropic.") || strings.Contains(model, "claude")
+}
+
+// buildStructuredOutputTool converts a response_format json_schema into
+// a forced-tool-call pair: the tool whose input_schema IS the json_schema
+// `schema` payload, and a tool_choice that pins the model to call it.
+// Returns ok=false when the response_format isn't a json_schema OR the
+// schema property is missing — caller falls back to passing
+// response_format through unchanged.
+func buildStructuredOutputTool(rf *app.ResponseFormat) (app.Tool, map[string]any, bool) {
+	if rf == nil || rf.Type != "json_schema" || rf.JSONSchema == nil {
+		return app.Tool{}, nil, false
+	}
+	schema, ok := rf.JSONSchema["schema"]
+	if !ok || schema == nil {
+		return app.Tool{}, nil, false
+	}
+	name, _ := rf.JSONSchema["name"].(string)
+	if name == "" {
+		name = "Outputs"
+	}
+	toolName := structuredOutputToolPrefix + name
+	function := map[string]any{
+		"name":        toolName,
+		"description": "Return the response as a JSON object matching the declared output schema.",
+		"parameters":  schema,
+	}
+	// Anthropic's JSON-schema-via-tool-use accepts strict-mode just like
+	// OpenAI's response_format. Preserve it when the engine asked for it
+	// so the model honors required/additionalProperties.
+	if strict, ok := rf.JSONSchema["strict"].(bool); ok && strict {
+		function["strict"] = true
+	}
+	tool := app.Tool{Type: "function", Function: function}
+	choice := map[string]any{
+		"type":     "function",
+		"function": map[string]any{"name": toolName},
+	}
+	return tool, choice, true
+}
+
+// liftStructuredOutputToolArgs returns the `arguments` payload of the
+// first tool_call whose function name carries the structuredOutputToolPrefix.
+// Matches the tools we synthesized in buildStructuredOutputTool; ignores
+// caller-supplied tools so a workflow that mixes its own tool_use with a
+// signature node's structured output isn't accidentally collapsed.
+func liftStructuredOutputToolArgs(toolCalls []app.ToolCall) (string, bool) {
+	for _, tc := range toolCalls {
+		if tc.Type != "function" {
+			continue
+		}
+		name, _ := tc.Function["name"].(string)
+		if !strings.HasPrefix(name, structuredOutputToolPrefix) {
+			continue
+		}
+		args, _ := tc.Function["arguments"].(string)
+		if args == "" {
+			continue
+		}
+		return args, true
+	}
+	return "", false
 }
 
 // translatedModelOrInferred returns the BARE model id we put on the wire
@@ -347,6 +483,18 @@ func parseChatCompletionResponse(body []byte, durationMS int64) (*app.LLMRespons
 	}
 	if s, ok := choice.Message.Content.(string); ok {
 		out.Content = s
+	}
+	// When the request used the buildStructuredOutputTool rewrite
+	// (bedrock + anthropic-family + response_format), the model returns
+	// its JSON payload as the synthetic tool's `arguments` instead of
+	// text content. Lift it back into Content so the engine's
+	// extractSignatureOutputs sees the same JSON-shape payload it would
+	// have received from a provider that honored response_format
+	// natively — no engine-side branch needed.
+	if out.Content == "" {
+		if args, ok := liftStructuredOutputToolArgs(choice.Message.ToolCalls); ok {
+			out.Content = args
+		}
 	}
 	out.Messages = []app.ChatMessage{{
 		Role:             choice.Message.Role,

--- a/services/nlpgo/adapters/llmexecutor/executor.go
+++ b/services/nlpgo/adapters/llmexecutor/executor.go
@@ -333,8 +333,14 @@ func buildStructuredOutputTool(rf *app.ResponseFormat) (app.Tool, map[string]any
 	if rf == nil || rf.Type != "json_schema" || rf.JSONSchema == nil {
 		return app.Tool{}, nil, false
 	}
-	schema, ok := rf.JSONSchema["schema"]
-	if !ok || schema == nil {
+	// Schema must be an object. Strings, numbers, arrays, etc. would
+	// produce a tool with an invalid `parameters` field that bedrock
+	// rejects with a 400. Fall back to passing response_format through
+	// unchanged so the malformed payload at least reaches the upstream
+	// validator with a recognizable shape instead of being silently
+	// reshaped on the way out.
+	schema, ok := rf.JSONSchema["schema"].(map[string]any)
+	if !ok {
 		return app.Tool{}, nil, false
 	}
 	name, _ := rf.JSONSchema["name"].(string)

--- a/services/nlpgo/adapters/llmexecutor/executor_test.go
+++ b/services/nlpgo/adapters/llmexecutor/executor_test.go
@@ -584,6 +584,220 @@ func TestExecute_ToolCallsForwardedAndResponseToolCallsParsed(t *testing.T) {
 	}
 }
 
+// TestExecute_StructuredOutput_BedrockAnthropicRewritesToToolUse pins the
+// customer-dogfood fix (2026-05-30): when a signature node sets
+// response_format on bedrock + an anthropic-family model, the executor
+// must rewrite to a forced tool_use call instead of passing
+// response_format through to bifrost. bifrost v1.4.22 routes
+// response_format on anthropic-family bedrock models through
+// output_config.format which has rolling per-region / per-model-version
+// support — when the combination doesn't line up the field is silently
+// ignored and the model returns prose, dumping the whole blob into the
+// first declared output field via the engine's prose-fallback.
+func TestExecute_StructuredOutput_BedrockAnthropicRewritesToToolUse(t *testing.T) {
+	// Response side: bifrost returns the model's structured output as a
+	// tool_call whose name carries our synthetic prefix. The executor
+	// must lift its `arguments` back into Content so the engine sees
+	// the JSON object it would have received from a provider that
+	// honored response_format natively.
+	respBody := []byte(`{
+		"choices":[{
+			"index":0,
+			"message":{
+				"role":"assistant",
+				"content":null,
+				"tool_calls":[
+					{"id":"call_1","type":"function","function":{"name":"lw_so_Verifier","arguments":"{\"output\":true,\"reason\":\"yes\"}"}}
+				]
+			},
+			"finish_reason":"tool_calls"
+		}],
+		"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+	}`)
+	gw := &fakeGateway{respStatus: 200, respBody: respBody}
+	exec := New(gw)
+
+	resp, err := exec.Execute(context.Background(), app.LLMRequest{
+		Model: "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+		ResponseFormat: &app.ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: map[string]any{
+				"name":   "Verifier",
+				"strict": true,
+				"schema": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"output": map[string]any{"type": "boolean"},
+						"reason": map[string]any{"type": "string"},
+					},
+					"required":             []string{"output", "reason"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		LiteLLMParams: map[string]any{
+			"aws_access_key_id":     "AKIA...",
+			"aws_secret_access_key": "secret",
+			"aws_region_name":       "us-east-1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Request shape: response_format dropped, tools populated with the
+	// synthetic lw_so_<name> tool, tool_choice pinned to it.
+	body := gw.lastReq.Body
+	if hasField(t, body, "response_format") {
+		t.Fatal("response_format must NOT be in body for bedrock+anthropic; expected tool_use rewrite")
+	}
+	var bodyMap map[string]any
+	if err := json.Unmarshal(body, &bodyMap); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	tools, ok := bodyMap["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected exactly 1 tool synthesized from response_format, got %v", bodyMap["tools"])
+	}
+	tool := tools[0].(map[string]any)
+	if tool["type"] != "function" {
+		t.Errorf("expected synthesized tool.type=function, got %v", tool["type"])
+	}
+	fn := tool["function"].(map[string]any)
+	if fn["name"] != "lw_so_Verifier" {
+		t.Errorf("expected tool.function.name=lw_so_Verifier, got %v", fn["name"])
+	}
+	if fn["parameters"] == nil {
+		t.Error("expected tool.function.parameters = response_format.json_schema.schema, got nil")
+	}
+	if fn["strict"] != true {
+		t.Errorf("expected strict=true preserved from response_format.json_schema.strict, got %v", fn["strict"])
+	}
+	choice, ok := bodyMap["tool_choice"].(map[string]any)
+	if !ok {
+		t.Fatal("expected tool_choice forcing the synthesized tool, got nil")
+	}
+	if choice["type"] != "function" {
+		t.Errorf("expected tool_choice.type=function, got %v", choice["type"])
+	}
+	choiceFn := choice["function"].(map[string]any)
+	if choiceFn["name"] != "lw_so_Verifier" {
+		t.Errorf("expected tool_choice.function.name=lw_so_Verifier, got %v", choiceFn["name"])
+	}
+
+	// Response side: Content must contain the lifted tool-call arguments
+	// so engine.extractSignatureOutputs parses it as JSON and splits
+	// across declared fields.
+	if resp.Content != `{"output":true,"reason":"yes"}` {
+		t.Errorf("expected Content lifted from tool-call arguments, got %q", resp.Content)
+	}
+	// Original tool_calls remain on the response for completeness / trace
+	// inspection — only Content is mutated.
+	if len(resp.ToolCalls) != 1 {
+		t.Errorf("expected tool_calls preserved on response, got %d", len(resp.ToolCalls))
+	}
+}
+
+// TestExecute_StructuredOutput_OpenAILeavesResponseFormatIntact pins
+// that the rewrite only fires for bedrock + anthropic-family. Direct
+// OpenAI must continue to pass response_format through unchanged
+// (it natively supports the OpenAI shape).
+func TestExecute_StructuredOutput_OpenAILeavesResponseFormatIntact(t *testing.T) {
+	gw := &fakeGateway{respStatus: 200, respBody: successResponse(`ok`)}
+	exec := New(gw)
+
+	_, err := exec.Execute(context.Background(), app.LLMRequest{
+		Model: "openai/gpt-5-mini",
+		ResponseFormat: &app.ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: map[string]any{
+				"name":   "Verifier",
+				"schema": map[string]any{"type": "object"},
+			},
+		},
+		LiteLLMParams: map[string]any{"api_key": "k"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasField(t, gw.lastReq.Body, "response_format") {
+		t.Fatal("response_format must pass through to openai; rewrite should only fire for bedrock+anthropic")
+	}
+	if hasField(t, gw.lastReq.Body, "tools") {
+		t.Fatal("openai path must not synthesize tools from response_format")
+	}
+}
+
+// TestExecute_StructuredOutput_BedrockNonAnthropicLeavesResponseFormatIntact
+// pins that other bedrock model families (Nova, Llama, Mistral) keep
+// the response_format pass-through — bifrost's bedrock provider routes
+// those through its generic response_format → bf_so_<name> tool path
+// which is well-supported.
+func TestExecute_StructuredOutput_BedrockNonAnthropicLeavesResponseFormatIntact(t *testing.T) {
+	gw := &fakeGateway{respStatus: 200, respBody: successResponse(`ok`)}
+	exec := New(gw)
+
+	_, err := exec.Execute(context.Background(), app.LLMRequest{
+		Model: "bedrock/amazon.nova-pro-v1:0",
+		ResponseFormat: &app.ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: map[string]any{
+				"name":   "Verifier",
+				"schema": map[string]any{"type": "object"},
+			},
+		},
+		LiteLLMParams: map[string]any{
+			"aws_access_key_id":     "AKIA...",
+			"aws_secret_access_key": "secret",
+			"aws_region_name":       "us-east-1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasField(t, gw.lastReq.Body, "response_format") {
+		t.Fatal("non-anthropic bedrock must pass response_format through")
+	}
+	if hasField(t, gw.lastReq.Body, "tools") {
+		t.Fatal("non-anthropic bedrock path must not synthesize tools")
+	}
+}
+
+// TestShouldUseToolUseForStructuredOutput pins the provider/model gate.
+// Misclassifying here would either break the customer (anthropic missed)
+// or regress other providers (openai/gemini hijacked).
+func TestShouldUseToolUseForStructuredOutput(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		model    string
+		want     bool
+	}{
+		// Hit: bedrock + anthropic-family (the customer case).
+		{"bedrock us. inference profile", "bedrock", "us.anthropic.claude-haiku-4-5-20251001-v1:0", true},
+		{"bedrock eu. inference profile", "bedrock", "eu.anthropic.claude-haiku-4-5-20251001-v1:0", true},
+		{"bedrock anthropic.claude-sonnet", "bedrock", "anthropic.claude-3-5-sonnet-20240620-v1:0", true},
+		{"bedrock claude alias", "bedrock", "claude-opus-4-5-v1:0", true},
+		// Miss: direct anthropic (own response_format works natively).
+		{"direct anthropic", "anthropic", "claude-3-5-sonnet-20240620", false},
+		// Miss: bedrock non-anthropic (bifrost's bf_so_* tool path works).
+		{"bedrock nova", "bedrock", "amazon.nova-pro-v1:0", false},
+		{"bedrock llama", "bedrock", "meta.llama3-1-70b-instruct-v1:0", false},
+		// Miss: openai/gemini/etc.
+		{"openai", "openai", "gpt-5-mini", false},
+		{"gemini", "gemini", "gemini-2.5-pro", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldUseToolUseForStructuredOutput(tc.provider, tc.model)
+			if got != tc.want {
+				t.Errorf("shouldUseToolUseForStructuredOutput(%q, %q) = %v, want %v",
+					tc.provider, tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestExecute_RejectsModelWithoutProvider(t *testing.T) {
 	gw := &fakeGateway{}
 	exec := New(gw)

--- a/services/nlpgo/adapters/llmexecutor/executor_test.go
+++ b/services/nlpgo/adapters/llmexecutor/executor_test.go
@@ -763,6 +763,46 @@ func TestExecute_StructuredOutput_BedrockNonAnthropicLeavesResponseFormatIntact(
 	}
 }
 
+// TestExecute_StructuredOutput_BedrockAnthropicMalformedSchemaFallsBackToResponseFormat
+// pins the documented fallback: when response_format is structurally
+// valid (type=json_schema, json_schema!=nil) but the `schema` payload
+// itself is not an object (e.g. a stringly-typed schema from a buggy
+// upstream), the rewrite must NOT silently emit an invalid tool. Pass
+// response_format through unchanged so the malformed payload reaches
+// the upstream validator with a recognizable shape.
+func TestExecute_StructuredOutput_BedrockAnthropicMalformedSchemaFallsBackToResponseFormat(t *testing.T) {
+	gw := &fakeGateway{respStatus: 200, respBody: successResponse(`ok`)}
+	exec := New(gw)
+
+	_, err := exec.Execute(context.Background(), app.LLMRequest{
+		Model: "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+		ResponseFormat: &app.ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: map[string]any{
+				"name":   "Verifier",
+				"schema": "oops, not an object",
+			},
+		},
+		LiteLLMParams: map[string]any{
+			"aws_access_key_id":     "AKIA...",
+			"aws_secret_access_key": "secret",
+			"aws_region_name":       "us-east-1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasField(t, gw.lastReq.Body, "response_format") {
+		t.Fatal("malformed schema must fall back to response_format pass-through, not get silently rewritten into an invalid tool")
+	}
+	if hasField(t, gw.lastReq.Body, "tools") {
+		t.Fatal("malformed schema must NOT synthesize a tools array; fallback path keeps body unchanged")
+	}
+	if hasField(t, gw.lastReq.Body, "tool_choice") {
+		t.Fatal("malformed schema must NOT synthesize tool_choice; fallback path keeps body unchanged")
+	}
+}
+
 // TestShouldUseToolUseForStructuredOutput pins the provider/model gate.
 // Misclassifying here would either break the customer (anthropic missed)
 // or regress other providers (openai/gemini hijacked).

--- a/services/nlpgo/tests/integration/workflow_llm_bedrock_structured_outputs_test.go
+++ b/services/nlpgo/tests/integration/workflow_llm_bedrock_structured_outputs_test.go
@@ -1,0 +1,239 @@
+//go:build live_bedrock
+
+package integration_test
+
+// Bedrock + Anthropic structured-outputs e2e. Reproduces the rchaves
+// 2026-05-30 prompt-registry dogfood: a signature with two outputs
+// (`output: bool` + `reason: str`) bound to a Bedrock Anthropic Haiku
+// 4.5 inference profile must come back as parsed JSON, not raw prose.
+//
+// Python langwatch_nlp returns `{output: true, reason: "..."}` via
+// LiteLLM (tool_use forced choice). The Go path was returning raw
+// `TRUE\n\nReason: ...` prose because bifrost v1.4.22 routes
+// response_format on bedrock+anthropic through Anthropic's native
+// output_config.format extension (providers/bedrock/utils.go:1011-1015)
+// without injecting the required anthropic-beta header — Bedrock
+// silently ignores the field and the model returns prose.
+//
+// Build tag: live_bedrock (gated; needs AWS_ACCESS_KEY_ID +
+// AWS_SECRET_ACCESS_KEY + AWS_DEFAULT_REGION in env).
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/pkg/health"
+	"github.com/langwatch/langwatch/services/aigateway/dispatcher"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/dispatcheradapter"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/httpapi"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/llmexecutor"
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/codeblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+func setupStackWithLLM_bedrockStructured(t *testing.T) *stack {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	disp, err := dispatcher.New(context.Background(), dispatcher.Options{})
+	require.NoError(t, err)
+	llm := llmexecutor.New(dispatcheradapter.New(disp))
+	httpExec := httpblock.New(httpblock.Options{})
+	codeExec, err := codeblock.New(codeblock.Options{})
+	require.NoError(t, err)
+	eng := engine.New(engine.Options{HTTP: httpExec, Code: codeExec, LLM: llm})
+	executor := liveBedrockStructuredExecutorAdapter{eng: eng}
+	application := app.New(app.WithWorkflowExecutor(executor))
+	probes := health.New("test")
+	probes.MarkStarted()
+	router := httpapi.NewRouter(httpapi.RouterDeps{App: application, Health: probes, Version: "test"})
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	t.Cleanup(upstream.Close)
+	return &stack{url: srv.URL, upstream: upstream, upstreamURL: upstream.URL}
+}
+
+type liveBedrockStructuredExecutorAdapter struct{ eng *engine.Engine }
+
+func (a liveBedrockStructuredExecutorAdapter) ExecuteStream(ctx context.Context, req app.WorkflowRequest, opts app.WorkflowStreamOptions) (<-chan app.WorkflowStreamEvent, error) {
+	wf, err := dsl.ParseWorkflow(req.WorkflowJSON)
+	if err != nil {
+		ch := make(chan app.WorkflowStreamEvent, 1)
+		ch <- app.WorkflowStreamEvent{Type: "error", Payload: map[string]any{"message": err.Error()}}
+		close(ch)
+		return ch, nil
+	}
+	in, err := a.eng.ExecuteStream(ctx, engine.ExecuteRequest{
+		Workflow: wf, Inputs: req.Inputs, Origin: req.Origin, TraceID: req.TraceID,
+	}, engine.ExecuteStreamOptions{Heartbeat: opts.Heartbeat})
+	if err != nil {
+		ch := make(chan app.WorkflowStreamEvent, 1)
+		ch <- app.WorkflowStreamEvent{Type: "error", Payload: map[string]any{"message": err.Error()}}
+		close(ch)
+		return ch, nil
+	}
+	out := make(chan app.WorkflowStreamEvent, 16)
+	go func() {
+		defer close(out)
+		for ev := range in {
+			out <- app.WorkflowStreamEvent{Type: ev.Type, TraceID: ev.TraceID, Payload: ev.Payload}
+		}
+	}()
+	return out, nil
+}
+
+func (a liveBedrockStructuredExecutorAdapter) Execute(ctx context.Context, req app.WorkflowRequest) (*app.WorkflowResult, error) {
+	wf, err := dsl.ParseWorkflow(req.WorkflowJSON)
+	if err != nil {
+		return &app.WorkflowResult{Status: "error", Error: &app.WorkflowError{Type: "invalid_workflow", Message: err.Error()}}, nil
+	}
+	res, err := a.eng.Execute(ctx, engine.ExecuteRequest{
+		Workflow: wf, Inputs: req.Inputs, Origin: req.Origin, TraceID: req.TraceID,
+	})
+	if err != nil {
+		return &app.WorkflowResult{Status: "error", Error: &app.WorkflowError{Type: "engine_error", Message: err.Error()}}, nil
+	}
+	out := &app.WorkflowResult{TraceID: res.TraceID, Status: res.Status, Result: res.Result}
+	if res.Error != nil {
+		out.Error = &app.WorkflowError{NodeID: res.Error.NodeID, Type: res.Error.Type, Message: res.Error.Message}
+	}
+	if len(res.Nodes) > 0 {
+		out.Nodes = make(map[string]any, len(res.Nodes))
+		for k, v := range res.Nodes {
+			out.Nodes[k] = v
+		}
+	}
+	return out, nil
+}
+
+// @scenario bedrock + anthropic response_format rewrites to forced tool_use
+func TestSync_RealWorkflowEndToEnd_BedrockStructuredOutputs(t *testing.T) {
+	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if accessKey == "" || secretKey == "" || region == "" {
+		t.Skip("AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY + AWS_DEFAULT_REGION must be set")
+	}
+	model := os.Getenv("BEDROCK_MODEL")
+	if model == "" {
+		model = "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+	}
+	stack := setupStackWithLLM_bedrockStructured(t)
+
+	litellmParams := map[string]any{
+		"aws_access_key_id":     accessKey,
+		"aws_secret_access_key": secretKey,
+		"aws_region_name":       region,
+	}
+	if st := os.Getenv("AWS_SESSION_TOKEN"); st != "" {
+		litellmParams["aws_session_token"] = st
+	}
+
+	workflow := map[string]any{
+		"workflow_id":      "wf",
+		"api_key":          "k",
+		"spec_version":     "1.3",
+		"name":             "BedrockClassifier",
+		"icon":             "🧮",
+		"description":      "x",
+		"version":          "x",
+		"template_adapter": "default",
+		"nodes": []any{
+			map[string]any{
+				"id": "entry", "type": "entry",
+				"data": map[string]any{
+					"outputs": []any{map[string]any{"identifier": "question", "type": "str"}},
+					"dataset": map[string]any{
+						"inline": map[string]any{
+							"records": map[string]any{"question": []any{"Is 8 plus 8 equal to 16?"}},
+						},
+					},
+					"entry_selection": 0,
+					"train_size":      1.0,
+					"test_size":       0.0,
+					"seed":            1,
+				},
+			},
+			map[string]any{
+				"id": "classify", "type": "signature",
+				"data": map[string]any{
+					"name": "Classify",
+					"parameters": []any{map[string]any{
+						"identifier": "llm", "type": "llm",
+						"value": map[string]any{
+							"model":          "bedrock/" + model,
+							"litellm_params": litellmParams,
+						},
+					}},
+					"inputs": []any{map[string]any{"identifier": "question", "type": "str"}},
+					// Two outputs — bool + str — exactly matching the rchaves
+					// dogfood: Structured Outputs ON, fields {output: bool,
+					// reason: str}. Triggers signatureNeedsStructuredOutput
+					// → response_format → bifrost bedrock+anthropic path.
+					"outputs": []any{
+						map[string]any{"identifier": "output", "type": "bool"},
+						map[string]any{"identifier": "reason", "type": "str"},
+					},
+					"prompt": "Answer with structured output. Is the statement in {{question}} correct?",
+				},
+			},
+			map[string]any{
+				"id": "end", "type": "end",
+				"data": map[string]any{
+					"inputs": []any{
+						map[string]any{"identifier": "output", "type": "bool"},
+						map[string]any{"identifier": "reason", "type": "str"},
+					},
+				},
+			},
+		},
+		"edges": []any{
+			map[string]any{"id": "e1", "source": "entry", "sourceHandle": "outputs.question", "target": "classify", "targetHandle": "inputs.question", "type": "default"},
+			map[string]any{"id": "e2", "source": "classify", "sourceHandle": "outputs.output", "target": "end", "targetHandle": "inputs.output", "type": "default"},
+			map[string]any{"id": "e3", "source": "classify", "sourceHandle": "outputs.reason", "target": "end", "targetHandle": "inputs.reason", "type": "default"},
+		},
+		"state": map[string]any{},
+	}
+	envelope := map[string]any{
+		"type": "execute_flow",
+		"payload": map[string]any{
+			"trace_id": "real-e2e-bedrock-structured",
+			"origin":   "workflow",
+			"workflow": workflow,
+			"inputs":   []any{map[string]any{}},
+		},
+	}
+	body, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	res := postSync(t, stack, string(body))
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	// The fix: `output` must come back as a real JSON boolean, and
+	// `reason` as a non-empty string. Pre-fix the engine fell through
+	// recoverJSONObject's "did not parse as a JSON object" branch and
+	// dumped the model's raw prose into the first declared field
+	// (`output`) as a string. We assert (a) `output` is a bool with
+	// the right value, and (b) `reason` is populated separately —
+	// either condition fails if the prose-fallback fires.
+	require.NotNil(t, res.Result)
+	outVal, hasOut := res.Result["output"]
+	require.True(t, hasOut, "missing `output` in result; result=%+v", res.Result)
+	gotBool, ok := outVal.(bool)
+	require.Truef(t, ok, "`output` must be a real bool, not %T (%v) — prose fallback fired", outVal, outVal)
+	assert.True(t, gotBool, "8+8=16 is true; got false")
+	reason, _ := res.Result["reason"].(string)
+	assert.NotEmpty(t, reason, "`reason` must be populated as its own field, not merged into `output`")
+}

--- a/specs/nlp-go/llm-block.feature
+++ b/specs/nlp-go/llm-block.feature
@@ -217,6 +217,30 @@ Feature: LLM block — Studio signature node executes via the Go AI Gateway
     Then the assistant message content parses as JSON
     And the JSON validates against the declared json_schema
 
+  # Customer dogfood 2026-05-30: a Studio Prompt with Structured Outputs
+  # ON (output:bool + reason:str) bound to a Bedrock Anthropic Haiku 4.5
+  # inference profile returned raw prose (`TRUE\n\nReason: ...`) instead
+  # of parsed JSON. Bifrost v1.4.22 routes response_format on anthropic-
+  # family Bedrock models through Anthropic's native output_config.format
+  # extension which has rolling per-region / per-model-version support;
+  # when the combination doesn't line up the field is silently ignored
+  # and the model returns prose. Python langwatch_nlp doesn't hit this
+  # because LiteLLM translates response_format → forced tool_use, which
+  # is the oldest + most universally supported Anthropic structured-
+  # output path. nlpgo must do the same translation in its executor so
+  # the Go path has python parity + the same robustness profile.
+  @integration @v1
+  Scenario: bedrock + anthropic response_format rewrites to forced tool_use
+    Given a workflow whose signature node targets a bedrock anthropic-family model
+    And the signature node sets response_format = json_schema with {output:bool, reason:str}
+    When nlpgo builds the gateway request body
+    Then the body has no response_format field
+    And the body has a tools array with one synthesized tool whose function name starts with "lw_so_"
+    And the body has tool_choice forcing that tool
+    When the model returns its JSON payload as the tool_call arguments
+    Then the response Content carries that JSON string lifted from the tool_call
+    And the engine extracts each declared output field from the JSON
+
   # ============================================================================
   # Multi-turn chat history preserved across signature nodes
   # ============================================================================


### PR DESCRIPTION
## Summary

Customer dogfood 2026-05-30 caught nlpgo returning raw prose (`TRUE\n\nReason: ...`) for a Studio Prompt with Structured Outputs ON (`output:bool` + `reason:str`) bound to a Bedrock Anthropic Haiku 4.5 inference profile. Python langwatch_nlp returned correctly parsed `{output: true, reason: "..."}` for the same prompt.

Root cause: bifrost v1.4.22's bedrock provider routes `response_format` on anthropic-family models (any id containing `anthropic.` or `claude`) through Anthropic's native `output_config.format` extension via `additionalModelRequestFields` (providers/bedrock/utils.go:1011-1015). That extension has rolling per-region / per-model-version support and requires the right `anthropic-beta` header to activate; when the combination doesn't line up the field is silently ignored and the model returns prose. The engine's `extractSignatureOutputs` then falls through to the prose-fallback and dumps the whole blob into the first declared output field as a string.

Python doesn't hit this because LiteLLM translates `response_format` to `toolConfig.tools` + `toolChoice` (forced tool_use), which is the oldest and most universally supported Anthropic structured-output path. Every claude model in every region honors it with no beta-header dependency.

This PR ports that translation into nlpgo so the Go path has python parity + the same robustness profile.

## Changes

- `services/nlpgo/adapters/llmexecutor/executor.go`
  - `buildGatewayRequest`: when `provider == "bedrock"` AND model contains `anthropic.` or `claude`, synthesize a tool from the `response_format` json_schema (function name = `lw_so_<schema-name>`), append to the tools array, pin `tool_choice` to it, and drop `response_format` from the outgoing body. Other providers (direct Anthropic, OpenAI, Gemini, non-anthropic bedrock families) keep their existing `response_format` pass-through.
  - `parseChatCompletionResponse`: lift the `tool_call` arguments string back into `Content` when `Content` is empty AND a `tool_call`'s function name carries the `lw_so_` prefix. `Engine.extractSignatureOutputs` then parses the same JSON-shape payload it would have received from a native `response_format` provider, no engine-side branch needed.

- `services/nlpgo/adapters/llmexecutor/executor_test.go`
  - Request-side rewrite (bedrock + anthropic), response-side unwrap, per-provider gate matrix, schema-malformed fallback to pass-through.

- `services/nlpgo/tests/integration/workflow_llm_bedrock_structured_outputs_test.go`
  - Live e2e against real Bedrock: full HTTP → dispatcheradapter → dispatcher → bedrock path with a `{output:bool, reason:str}` signature on `eu.anthropic.claude-haiku-4-5-20251001-v1:0`. Asserts `output` is a real bool and `reason` is a populated string. Pre-fix this would have failed even on eu-central-1 if `output_config` support regressed; post-fix it works regardless of per-region rollout.

- `specs/nlp-go/llm-block.feature`
  - New `@integration @v1` scenario documenting the bedrock+anthropic rewrite contract. Bound to the live e2e via `@scenario` annotation.

## Verified

- `go test ./adapters/llmexecutor/...` green
- `go test ./...` full nlpgo sweep green
- `go vet ./...` clean
- Live e2e against real Bedrock + eu.anthropic.claude-haiku-4-5-20251001-v1:0: `output: true` (bool) + `reason: "..."` (str) parsed correctly
- Existing `TestSync_RealWorkflowEndToEnd_Bedrock` (single-string signature, no `response_format` set) continues to pass
- `pnpm check:feature-parity` for `specs/nlp-go/llm-block.feature`: 1/1 scenarios bound

## Test plan
- [x] Unit tests pass for request rewrite + response unwrap + provider gate
- [x] Live Bedrock e2e passes with the rewrite on
- [x] Existing single-string Bedrock e2e still passes (gate doesn't fire)
- [x] Feature parity binding passes
- [ ] Watch CI