### PR TITLE
perf(clickhouse): cap single-trace span-read memory to contain OOM blast radius

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -3,12 +3,13 @@
  * `SpanStorageClickHouseRepository`, exercised against a real ClickHouse
  * testcontainer on the production `stored_spans` schema.
  *
- * Focus: `getSpansByTraceId` / `getNormalizedSpansByTraceId` must read the
- * heavy `SpanAttributes` payload for at most `limit` spans, not for every span
- * in the trace. A trace with far more spans than the read limit is the shape
- * that tips this path into MEMORY_LIMIT_EXCEEDED in prod, so the test seeds
- * such a trace and asserts both correctness and a real peak-memory reduction
- * versus the naive single-scan form.
+ * These readers carry an explicit `max_memory_usage` cap so a trace with very
+ * large per-span attribute values fails its own read instead of pressuring the
+ * whole server (see `SINGLE_TRACE_READ_MAX_MEMORY_BYTES`). The cap itself can't
+ * be asserted by tripping an OOM here — an errored ClickHouse response stream
+ * wedges the vitest worker — so the unit test asserts the setting is passed,
+ * and this suite confirms a normal trace read still returns correct results
+ * under the cap (ordering, latest-version dedup, full payload preserved).
  */
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -23,12 +24,10 @@ const tenantId = `test-span-fetch-${nanoid()}`;
 const traceId = `trace-${nanoid()}`;
 const base = Date.now() - 60 * 60 * 1000;
 
-// Wide enough that the trace holds many more spans than MAX_DERIVATION_SPANS
-// (512), so the naive form pays to read heavy columns for spans it then drops.
-const TOTAL_SPANS = 1000;
+const TOTAL_SPANS = 600;
 const READ_LIMIT = 512;
-const ATTR_KEYS = 30;
-const ATTR_VALUE = "v".repeat(2000); // ~60KB of SpanAttributes per span
+const ATTR_KEYS = 20;
+const ATTR_VALUE = "v".repeat(1000);
 
 let ch: ClickHouseClient;
 let repo: SpanStorageClickHouseRepository;
@@ -83,7 +82,7 @@ function makeSpanRow(i: number, overrides: Record<string, unknown> = {}) {
 }
 
 async function insertRows(rows: ReturnType<typeof makeSpanRow>[]) {
-  const chunk = 250;
+  const chunk = 200;
   for (let i = 0; i < rows.length; i += chunk) {
     await ch.insert({
       table: "stored_spans",
@@ -124,7 +123,7 @@ afterAll(async () => {
 });
 
 describe("SpanStorageClickHouseRepository single-trace reads (integration)", () => {
-  describe("when a trace holds far more spans than the read limit", () => {
+  describe("when reading a trace under the per-query memory cap", () => {
     it("returns the earliest `limit` spans ordered by StartTime", async () => {
       const spans = await repo.getNormalizedSpansByTraceId({
         tenantId,
@@ -163,85 +162,6 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       const sample = spans[10]!;
       expect(Object.keys(sample.spanAttributes)).toContain("k0");
       expect(sample.spanAttributes.k0).toBe(ATTR_VALUE);
-    });
-
-    it("reads heavy columns for fewer spans than the naive single-scan form", async () => {
-      const dedup = `(TenantId, TraceId, SpanId, UpdatedAt) IN (
-        SELECT TenantId, TraceId, SpanId, max(UpdatedAt)
-        FROM stored_spans
-        WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
-        GROUP BY TenantId, TraceId, SpanId
-      )`;
-
-      const naiveId = `naive-${nanoid()}`;
-      const pagedId = `paged-${nanoid()}`;
-
-      // Naive: materialize SpanAttributes for every deduped span, then trim.
-      await ch
-        .query({
-          query: `
-            SELECT SpanId, SpanAttributes
-            FROM stored_spans
-            WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
-              AND ${dedup}
-            ORDER BY StartTime ASC
-            LIMIT {limit:UInt32}
-          `,
-          query_params: { tenantId, traceId, limit: READ_LIMIT },
-          query_id: naiveId,
-          format: "JSONEachRow",
-        })
-        .then((r) => r.json());
-
-      // Paged: pick the SpanId set first, read SpanAttributes for those only.
-      await ch
-        .query({
-          query: `
-            SELECT SpanId, SpanAttributes
-            FROM stored_spans
-            WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
-              AND SpanId IN (
-                SELECT SpanId
-                FROM stored_spans
-                WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
-                  AND ${dedup}
-                ORDER BY StartTime ASC
-                LIMIT {limit:UInt32}
-              )
-              AND ${dedup}
-            ORDER BY StartTime ASC
-            LIMIT {limit:UInt32}
-          `,
-          query_params: { tenantId, traceId, limit: READ_LIMIT },
-          query_id: pagedId,
-          format: "JSONEachRow",
-        })
-        .then((r) => r.json());
-
-      await ch.exec({ query: "SYSTEM FLUSH LOGS" });
-
-      const memRows = (await (
-        await ch.query({
-          query: `
-            SELECT query_id, max(memory_usage) AS mem
-            FROM system.query_log
-            WHERE query_id IN ({naiveId:String}, {pagedId:String})
-              AND type = 'QueryFinish'
-            GROUP BY query_id
-          `,
-          query_params: { naiveId, pagedId },
-          format: "JSONEachRow",
-        })
-      ).json()) as Array<{ query_id: string; mem: string }>;
-
-      const memOf = (id: string) =>
-        Number(memRows.find((r) => r.query_id === id)?.mem ?? 0);
-      const naiveMem = memOf(naiveId);
-      const pagedMem = memOf(pagedId);
-
-      expect(naiveMem).toBeGreaterThan(0);
-      expect(pagedMem).toBeGreaterThan(0);
-      expect(pagedMem).toBeLessThan(naiveMem);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Integration tests for the single-trace span readers on
+ * `SpanStorageClickHouseRepository`, exercised against a real ClickHouse
+ * testcontainer on the production `stored_spans` schema.
+ *
+ * Focus: `getSpansByTraceId` / `getNormalizedSpansByTraceId` must read the
+ * heavy `SpanAttributes` payload for at most `limit` spans, not for every span
+ * in the trace. A trace with far more spans than the read limit is the shape
+ * that tips this path into MEMORY_LIMIT_EXCEEDED in prod, so the test seeds
+ * such a trace and asserts both correctness and a real peak-memory reduction
+ * versus the naive single-scan form.
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { SpanStorageClickHouseRepository } from "../span-storage.clickhouse.repository";
+
+const tenantId = `test-span-fetch-${nanoid()}`;
+const traceId = `trace-${nanoid()}`;
+const base = Date.now() - 60 * 60 * 1000;
+
+// Wide enough that the trace holds many more spans than MAX_DERIVATION_SPANS
+// (512), so the naive form pays to read heavy columns for spans it then drops.
+const TOTAL_SPANS = 1000;
+const READ_LIMIT = 512;
+const ATTR_KEYS = 30;
+const ATTR_VALUE = "v".repeat(2000); // ~60KB of SpanAttributes per span
+
+let ch: ClickHouseClient;
+let repo: SpanStorageClickHouseRepository;
+
+function spanIdFor(i: number): string {
+  return `span-${String(i).padStart(4, "0")}`;
+}
+
+function heavyAttributes(i: number): Record<string, string> {
+  const attrs: Record<string, string> = { idx: String(i) };
+  for (let k = 0; k < ATTR_KEYS; k++) {
+    attrs[`k${k}`] = ATTR_VALUE;
+  }
+  return attrs;
+}
+
+function makeSpanRow(i: number, overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    SpanId: spanIdFor(i),
+    ParentSpanId: null,
+    ParentTraceId: null,
+    ParentIsRemote: null,
+    Sampled: 1,
+    StartTime: new Date(base + i),
+    EndTime: new Date(base + i + 50),
+    DurationMs: 50,
+    SpanName: "test-span",
+    SpanKind: 1,
+    ServiceName: "test-service",
+    ResourceAttributes: {},
+    SpanAttributes: heavyAttributes(i),
+    StatusCode: 1,
+    StatusMessage: null,
+    ScopeName: "test",
+    ScopeVersion: null,
+    "Events.Timestamp": [],
+    "Events.Name": [],
+    "Events.Attributes": [],
+    "Links.TraceId": [],
+    "Links.SpanId": [],
+    "Links.Attributes": [],
+    DroppedAttributesCount: 0,
+    DroppedEventsCount: 0,
+    DroppedLinksCount: 0,
+    CreatedAt: new Date(base + i),
+    UpdatedAt: new Date(base + i),
+    ...overrides,
+  };
+}
+
+async function insertRows(rows: ReturnType<typeof makeSpanRow>[]) {
+  const chunk = 250;
+  for (let i = 0; i < rows.length; i += chunk) {
+    await ch.insert({
+      table: "stored_spans",
+      values: rows.slice(i, i + chunk),
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+  }
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  repo = new SpanStorageClickHouseRepository(async () => ch);
+
+  const rows = Array.from({ length: TOTAL_SPANS }, (_, i) => makeSpanRow(i));
+  await insertRows(rows);
+
+  // A stale earlier version of the first span: the dedup must return the
+  // latest version (no `stale` marker), never this one.
+  await insertRows([
+    makeSpanRow(0, {
+      SpanAttributes: { idx: "0", stale: "yes" },
+      UpdatedAt: new Date(base - 10_000),
+      CreatedAt: new Date(base - 10_000),
+    }),
+  ]);
+}, 120_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: "ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}",
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("SpanStorageClickHouseRepository single-trace reads (integration)", () => {
+  describe("when a trace holds far more spans than the read limit", () => {
+    it("returns the earliest `limit` spans ordered by StartTime", async () => {
+      const spans = await repo.getNormalizedSpansByTraceId({
+        tenantId,
+        traceId,
+      });
+
+      expect(spans).toHaveLength(READ_LIMIT);
+      expect(spans.map((s) => s.spanId)).toEqual(
+        Array.from({ length: READ_LIMIT }, (_, i) => spanIdFor(i)),
+      );
+
+      const startTimes = spans.map((s) => s.startTimeUnixMs);
+      const sorted = [...startTimes].sort((a, b) => a - b);
+      expect(startTimes).toEqual(sorted);
+    });
+
+    it("returns the latest version of a duplicated span, not the stale one", async () => {
+      const spans = await repo.getNormalizedSpansByTraceId({
+        tenantId,
+        traceId,
+      });
+
+      const first = spans.find((s) => s.spanId === spanIdFor(0));
+      expect(first).toBeDefined();
+      // The stale version carried a `stale` marker; the latest one never did.
+      expect(first?.spanAttributes.stale).toBeUndefined();
+      expect(String(first?.spanAttributes.idx)).toBe("0");
+    });
+
+    it("preserves the full heavy SpanAttributes payload", async () => {
+      const spans = await repo.getNormalizedSpansByTraceId({
+        tenantId,
+        traceId,
+      });
+
+      const sample = spans[10]!;
+      expect(Object.keys(sample.spanAttributes)).toContain("k0");
+      expect(sample.spanAttributes.k0).toBe(ATTR_VALUE);
+    });
+
+    it("reads heavy columns for fewer spans than the naive single-scan form", async () => {
+      const dedup = `(TenantId, TraceId, SpanId, UpdatedAt) IN (
+        SELECT TenantId, TraceId, SpanId, max(UpdatedAt)
+        FROM stored_spans
+        WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
+        GROUP BY TenantId, TraceId, SpanId
+      )`;
+
+      const naiveId = `naive-${nanoid()}`;
+      const pagedId = `paged-${nanoid()}`;
+
+      // Naive: materialize SpanAttributes for every deduped span, then trim.
+      await ch
+        .query({
+          query: `
+            SELECT SpanId, SpanAttributes
+            FROM stored_spans
+            WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
+              AND ${dedup}
+            ORDER BY StartTime ASC
+            LIMIT {limit:UInt32}
+          `,
+          query_params: { tenantId, traceId, limit: READ_LIMIT },
+          query_id: naiveId,
+          format: "JSONEachRow",
+        })
+        .then((r) => r.json());
+
+      // Paged: pick the SpanId set first, read SpanAttributes for those only.
+      await ch
+        .query({
+          query: `
+            SELECT SpanId, SpanAttributes
+            FROM stored_spans
+            WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
+              AND SpanId IN (
+                SELECT SpanId
+                FROM stored_spans
+                WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
+                  AND ${dedup}
+                ORDER BY StartTime ASC
+                LIMIT {limit:UInt32}
+              )
+              AND ${dedup}
+            ORDER BY StartTime ASC
+            LIMIT {limit:UInt32}
+          `,
+          query_params: { tenantId, traceId, limit: READ_LIMIT },
+          query_id: pagedId,
+          format: "JSONEachRow",
+        })
+        .then((r) => r.json());
+
+      await ch.exec({ query: "SYSTEM FLUSH LOGS" });
+
+      const memRows = (await (
+        await ch.query({
+          query: `
+            SELECT query_id, max(memory_usage) AS mem
+            FROM system.query_log
+            WHERE query_id IN ({naiveId:String}, {pagedId:String})
+              AND type = 'QueryFinish'
+            GROUP BY query_id
+          `,
+          query_params: { naiveId, pagedId },
+          format: "JSONEachRow",
+        })
+      ).json()) as Array<{ query_id: string; mem: string }>;
+
+      const memOf = (id: string) =>
+        Number(memRows.find((r) => r.query_id === id)?.mem ?? 0);
+      const naiveMem = memOf(naiveId);
+      const pagedMem = memOf(pagedId);
+
+      expect(naiveMem).toBeGreaterThan(0);
+      expect(pagedMem).toBeGreaterThan(0);
+      expect(pagedMem).toBeLessThan(naiveMem);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.unit.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  SpanStorageClickHouseRepository,
   deserializeAttributes,
   serializeAttributes,
 } from "../span-storage.clickhouse.repository";
@@ -221,6 +222,44 @@ describe("given a requested span-read limit", () => {
     it("defaults to the ceiling instead of propagating NaN/Infinity", () => {
       expect(clampSpanReadLimit(NaN)).toBe(MAX_DERIVATION_SPANS);
       expect(clampSpanReadLimit(Infinity)).toBe(MAX_DERIVATION_SPANS);
+    });
+  });
+});
+
+describe("SpanStorageClickHouseRepository single-trace reads", () => {
+  function repoWithSpyClient() {
+    const query = vi.fn().mockResolvedValue({ json: async () => [] });
+    const repo = new SpanStorageClickHouseRepository(
+      (async () => ({ query })) as unknown as ConstructorParameters<
+        typeof SpanStorageClickHouseRepository
+      >[0],
+    );
+    return { repo, query };
+  }
+
+  describe("when reading a trace's full-attribute spans", () => {
+    it("caps query memory so one heavy trace cannot pressure the whole server", async () => {
+      const { repo, query } = repoWithSpyClient();
+      await repo.getSpansByTraceId({ tenantId: "p-1", traceId: "t-1" });
+
+      const settings = query.mock.calls[0]?.[0]?.clickhouse_settings;
+      expect(settings?.max_memory_usage).toBe(String(2 * 1024 * 1024 * 1024));
+    });
+
+    it("caps query memory on the normalized-spans read", async () => {
+      const { repo, query } = repoWithSpyClient();
+      await repo.getNormalizedSpansByTraceId({ tenantId: "p-1", traceId: "t-1" });
+
+      const settings = query.mock.calls[0]?.[0]?.clickhouse_settings;
+      expect(settings?.max_memory_usage).toBe(String(2 * 1024 * 1024 * 1024));
+    });
+
+    it("caps query memory on the single-span read", async () => {
+      const { repo, query } = repoWithSpyClient();
+      await repo.getSpanByIds({ tenantId: "p-1", traceId: "t-1", spanId: "s-1" });
+
+      const settings = query.mock.calls[0]?.[0]?.clickhouse_settings;
+      expect(settings?.max_memory_usage).toBe(String(2 * 1024 * 1024 * 1024));
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -190,47 +190,6 @@ function dedupInTuple(extraInnerWhere: string): string {
 }
 
 /**
- * Read the earliest `limit` spans of a trace (ordered by StartTime) while
- * touching the heavy `SpanAttributes`/`Events.*`/`Links.*` columns for those
- * `limit` spans only.
- *
- * The straight `SELECT FULL_SPAN_SELECT … ORDER BY StartTimeMs LIMIT n` makes
- * ClickHouse materialize every heavy column for every deduped span in the
- * trace before the ORDER BY trims it down to `n`. A trace with tens of
- * thousands of spans (a leaked or pathological trace_id — the exact case
- * `clampSpanReadLimit` guards the row count for) reads all of those payloads
- * into memory and tips this path into MEMORY_LIMIT_EXCEEDED.
- *
- * The inner page selects only the SpanId set we keep — key columns plus
- * StartTime for the sort, no payload — then the outer scan reads the heavy
- * columns for that bounded SpanId set. For traces at or under `limit` spans
- * the result is identical to the single-scan form; the win is entirely on the
- * long traces.
- */
-function fullSpansByTraceIdQuery(partition: PartitionFragment): string {
-  return `
-    SELECT ${FULL_SPAN_SELECT}
-    FROM ${TABLE_NAME}
-    WHERE TenantId = {tenantId:String}
-      AND TraceId = {traceId:String}
-      ${partition.sqlAnd}
-      AND SpanId IN (
-        SELECT SpanId
-        FROM ${TABLE_NAME}
-        WHERE TenantId = {tenantId:String}
-          AND TraceId = {traceId:String}
-          ${partition.sqlAnd}
-          AND ${dedupInTuple(partition.sqlAndInner)}
-        ORDER BY StartTime ASC
-        LIMIT {limit:UInt32}
-      )
-      AND ${dedupInTuple(partition.sqlAndInner)}
-    ORDER BY StartTimeMs ASC
-    LIMIT {limit:UInt32}
-  `;
-}
-
-/**
  * Per-bucket key matchers for the LangWatch signals projection. Each entry
  * compiles to one ClickHouse boolean expression over `mapKeys(SpanAttributes)`.
  * Order must match `LANGWATCH_SIGNAL_BUCKETS` in span-storage.repository.ts —
@@ -702,7 +661,16 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);
           const result = await client.query({
-            query: fullSpansByTraceIdQuery(partition),
+            query: `
+              SELECT ${FULL_SPAN_SELECT}
+              FROM ${TABLE_NAME}
+              WHERE TenantId = {tenantId:String}
+                AND TraceId = {traceId:String}
+                ${partition.sqlAnd}
+                AND ${dedupInTuple(partition.sqlAndInner)}
+              ORDER BY StartTimeMs ASC
+              LIMIT {limit:UInt32}
+            `,
             query_params: {
               tenantId,
               traceId,
@@ -759,7 +727,16 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);
           const result = await client.query({
-            query: fullSpansByTraceIdQuery(partition),
+            query: `
+              SELECT ${FULL_SPAN_SELECT}
+              FROM ${TABLE_NAME}
+              WHERE TenantId = {tenantId:String}
+                AND TraceId = {traceId:String}
+                ${partition.sqlAnd}
+                AND ${dedupInTuple(partition.sqlAndInner)}
+              ORDER BY StartTimeMs ASC
+              LIMIT {limit:UInt32}
+            `,
             query_params: {
               tenantId,
               traceId,

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -130,6 +130,29 @@ const FULL_SPAN_SELECT = `
 `;
 
 /**
+ * Per-query memory ceiling for the single-trace full-attribute reads below.
+ *
+ * The heavy column on these reads is the `SpanAttributes` Map: ClickHouse reads
+ * the whole values array to return any of it, so a trace with very large
+ * per-span attribute values (big prompts / responses / embeddings) can allocate
+ * gigabytes even at a low span count. Without a cap those allocations land
+ * against the server's *total* memory limit, where the OvercommitTracker
+ * resolves the pressure by killing whichever query is allocating — so one
+ * pathological trace can take down unrelated requests across the cluster.
+ *
+ * With an explicit `max_memory_usage` the offending read fails on its own
+ * (`MEMORY_LIMIT_EXCEEDED`) and surfaces as a drawer/query error, instead of
+ * degrading everyone. Set generously above any normal trace (p95 read is
+ * single-digit MB) and below the global per-query limit, so it only ever trips
+ * on the pathological tail. Tune here if legitimate large traces start failing.
+ */
+const SINGLE_TRACE_READ_MAX_MEMORY_BYTES = 2 * 1024 * 1024 * 1024; // 2 GiB
+const SINGLE_TRACE_READ_SETTINGS = {
+  // ClickHouse settings are string-typed over the wire.
+  max_memory_usage: String(SINGLE_TRACE_READ_MAX_MEMORY_BYTES),
+} as const;
+
+/**
  * Light projection used by readers that only need the span tree shape
  * (waterfall/flame, span list). Avoids reading heavy `SpanAttributes`,
  * `Events.*`, and `Links.*` columns. Map subscripts (`['key']`) read a
@@ -686,6 +709,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               limit: effectiveLimit,
               ...partition.params,
             },
+            clickhouse_settings: SINGLE_TRACE_READ_SETTINGS,
             format: "JSONEachRow",
           });
 
@@ -742,6 +766,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               limit: effectiveLimit,
               ...partition.params,
             },
+            clickhouse_settings: SINGLE_TRACE_READ_SETTINGS,
             format: "JSONEachRow",
           });
 
@@ -800,6 +825,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               LIMIT 1
             `,
             query_params: { tenantId, traceId, spanId, ...partition.params },
+            clickhouse_settings: SINGLE_TRACE_READ_SETTINGS,
             format: "JSONEachRow",
           });
 

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -167,6 +167,47 @@ function dedupInTuple(extraInnerWhere: string): string {
 }
 
 /**
+ * Read the earliest `limit` spans of a trace (ordered by StartTime) while
+ * touching the heavy `SpanAttributes`/`Events.*`/`Links.*` columns for those
+ * `limit` spans only.
+ *
+ * The straight `SELECT FULL_SPAN_SELECT … ORDER BY StartTimeMs LIMIT n` makes
+ * ClickHouse materialize every heavy column for every deduped span in the
+ * trace before the ORDER BY trims it down to `n`. A trace with tens of
+ * thousands of spans (a leaked or pathological trace_id — the exact case
+ * `clampSpanReadLimit` guards the row count for) reads all of those payloads
+ * into memory and tips this path into MEMORY_LIMIT_EXCEEDED.
+ *
+ * The inner page selects only the SpanId set we keep — key columns plus
+ * StartTime for the sort, no payload — then the outer scan reads the heavy
+ * columns for that bounded SpanId set. For traces at or under `limit` spans
+ * the result is identical to the single-scan form; the win is entirely on the
+ * long traces.
+ */
+function fullSpansByTraceIdQuery(partition: PartitionFragment): string {
+  return `
+    SELECT ${FULL_SPAN_SELECT}
+    FROM ${TABLE_NAME}
+    WHERE TenantId = {tenantId:String}
+      AND TraceId = {traceId:String}
+      ${partition.sqlAnd}
+      AND SpanId IN (
+        SELECT SpanId
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND TraceId = {traceId:String}
+          ${partition.sqlAnd}
+          AND ${dedupInTuple(partition.sqlAndInner)}
+        ORDER BY StartTime ASC
+        LIMIT {limit:UInt32}
+      )
+      AND ${dedupInTuple(partition.sqlAndInner)}
+    ORDER BY StartTimeMs ASC
+    LIMIT {limit:UInt32}
+  `;
+}
+
+/**
  * Per-bucket key matchers for the LangWatch signals projection. Each entry
  * compiles to one ClickHouse boolean expression over `mapKeys(SpanAttributes)`.
  * Order must match `LANGWATCH_SIGNAL_BUCKETS` in span-storage.repository.ts —
@@ -638,16 +679,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);
           const result = await client.query({
-            query: `
-              SELECT ${FULL_SPAN_SELECT}
-              FROM ${TABLE_NAME}
-              WHERE TenantId = {tenantId:String}
-                AND TraceId = {traceId:String}
-                ${partition.sqlAnd}
-                AND ${dedupInTuple(partition.sqlAndInner)}
-              ORDER BY StartTimeMs ASC
-              LIMIT {limit:UInt32}
-            `,
+            query: fullSpansByTraceIdQuery(partition),
             query_params: {
               tenantId,
               traceId,
@@ -703,16 +735,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);
           const result = await client.query({
-            query: `
-              SELECT ${FULL_SPAN_SELECT}
-              FROM ${TABLE_NAME}
-              WHERE TenantId = {tenantId:String}
-                AND TraceId = {traceId:String}
-                ${partition.sqlAnd}
-                AND ${dedupInTuple(partition.sqlAndInner)}
-              ORDER BY StartTimeMs ASC
-              LIMIT {limit:UInt32}
-            `,
+            query: fullSpansByTraceIdQuery(partition),
             query_params: {
               tenantId,
               traceId,

--- a/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
@@ -158,15 +158,23 @@ describe("trace dedup OOM safety", () => {
     const spanStorageSource = fs.readFileSync(spanStoragePath, "utf-8");
     const body = extractMethodBody(spanStorageSource, "getSpansByTraceId");
     const dedupHelper = extractFunctionBody(spanStorageSource, "dedupInTuple");
+    // getSpansByTraceId builds its SQL through this helper, which pages the
+    // SpanId set before reading heavy columns. The dedup lives in the helper.
+    const queryBuilder = extractFunctionBody(
+      spanStorageSource,
+      "fullSpansByTraceIdQuery",
+    );
 
     describe("when the stored_spans query SQL is inspected", () => {
       it("does not use LIMIT 1 BY for deduplication", () => {
         expect(body).not.toContain("LIMIT 1 BY");
+        expect(queryBuilder).not.toContain("LIMIT 1 BY");
         expect(dedupHelper).not.toContain("LIMIT 1 BY");
       });
 
       it("delegates dedup to the IN-tuple helper", () => {
-        expect(body).toContain("dedupInTuple");
+        expect(body).toContain("fullSpansByTraceIdQuery");
+        expect(queryBuilder).toContain("dedupInTuple");
       });
 
       it("uses max(UpdatedAt) GROUP BY for span dedup", () => {

--- a/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/trace-dedup-oom-safety.unit.test.ts
@@ -158,23 +158,15 @@ describe("trace dedup OOM safety", () => {
     const spanStorageSource = fs.readFileSync(spanStoragePath, "utf-8");
     const body = extractMethodBody(spanStorageSource, "getSpansByTraceId");
     const dedupHelper = extractFunctionBody(spanStorageSource, "dedupInTuple");
-    // getSpansByTraceId builds its SQL through this helper, which pages the
-    // SpanId set before reading heavy columns. The dedup lives in the helper.
-    const queryBuilder = extractFunctionBody(
-      spanStorageSource,
-      "fullSpansByTraceIdQuery",
-    );
 
     describe("when the stored_spans query SQL is inspected", () => {
       it("does not use LIMIT 1 BY for deduplication", () => {
         expect(body).not.toContain("LIMIT 1 BY");
-        expect(queryBuilder).not.toContain("LIMIT 1 BY");
         expect(dedupHelper).not.toContain("LIMIT 1 BY");
       });
 
       it("delegates dedup to the IN-tuple helper", () => {
-        expect(body).toContain("fullSpansByTraceIdQuery");
-        expect(queryBuilder).toContain("dedupInTuple");
+        expect(body).toContain("dedupInTuple");
       });
 
       it("uses max(UpdatedAt) GROUP BY for span dedup", () => {


### PR DESCRIPTION
## Evidence

Sourced from prod CloudWatch (read-only, last 24h). Redacted; no raw tenant values.

The single-trace span fetch (`SELECT <full span columns> FROM stored_spans WHERE TenantId = .. AND TraceId = ..`) is the highest-volume shape in the codebase slow-query warnings (~76% of a 5,000-row sample, p95 read ~15MB for one trace) and recurs as a `MEMORY_LIMIT_EXCEEDED` (Code 241) reading the `SpanAttributes` column. The exceptions are server-wide: `(total) memory limit exceeded ... maximum: 14.00 GiB ... while reading column SpanAttributes`, resolved by the OvercommitTracker killing an in-flight query.

## Root cause (validated against prod via the read-only EXPLAIN endpoint)

`INDEXES` on the exact trace the OOM log named shows it holds only ~15 spans (the dedup resolves to a ~15-element SpanId set) in a single granule. So the blow-up is **not** span count: it is **large per-span attribute values** (big prompts / responses / embeddings stored in `SpanAttributes`). ClickHouse reads the whole `SpanAttributes` Map values array to return any of it, so a few spans with multi-MB attributes allocate heavily, and under concurrency that pushes the server past its total memory limit, where the OvercommitTracker kills an arbitrary query — one pathological trace then degrades unrelated requests.

There is no cheap way to read a subset of a Map's values (`mapFilter` / `m['k']` both read the whole values array; only the `.keys` subcolumn is cheap), and there is no write-time cap on attribute value size. The callers that read full attributes are `getSpansByTraceId`, `getNormalizedSpansByTraceId`, and `getSpanByIds`.

## Fix

Set an explicit `max_memory_usage` (`SINGLE_TRACE_READ_MAX_MEMORY_BYTES`, 2 GiB) on those three full-attribute single-trace reads. A pathological trace now fails *its own* read with `MEMORY_LIMIT_EXCEEDED` (surfaced as a drawer/query error) instead of pressuring the whole 14 GiB cluster — containing the blast radius that caused the observed server-wide OOM. The resilient client forwards real `clickhouse_settings` (it strips only `langwatch_*` keys), so the cap reaches ClickHouse.

The ceiling sits far above any normal trace (p95 read ~15MB) and below the global per-query limit, so it only trips on the pathological tail. It is a single named constant — tune there if legitimate large traces start failing.

This PR intentionally does **not** change the query shape. An earlier revision paged the SpanId set before reading heavy columns, but real-tenant `INDEXES` showed that gives no reduction for actual traces (they fit in one granule — the win only existed for >8k-span traces, which are not the OOM cause), so it was dropped to keep the change to the one thing that addresses the observed symptom.

## Expected impact

- A single huge-attribute trace can no longer drive the cluster into a total-memory OOM that kills unrelated queries; it fails in isolation and the drawer shows an error.
- No change to results, ordering, dedup, or the query plan for normal traces.

## Test plan

`span-storage.clickhouse.repository.unit.test.ts`: asserts all three full-attribute reads pass `max_memory_usage` in `clickhouse_settings` (via a mock-client spy — the cap is asserted by inspection, not by tripping an intentional OOM, which would wedge the vitest worker).

`span-storage.clickhouse.repository.integration.test.ts` (real ClickHouse testcontainer): seeds a 600-span trace with a stale duplicate and confirms the readers still return correct results **under the 2 GiB cap** — earliest 512 ordered by `StartTime`, latest version (not the stale one), full payload preserved.

Local run: unit 60/60, integration 3/3 (stable across repeated runs), OOM-safety guard 24/24, typecheck clean.

## EXPLAIN check (self-validated via the read-only `/api/ops/clickhouse/explain` endpoint, real tenant)

`INDEXES` / `PLAN` against prod using the real tenant + the exact OOM trace (both redacted) confirmed the trace is ~15 spans / 1 part / 1 granule — i.e. the OOM is value size, not granule count, which is why this PR is a memory guardrail rather than a query rewrite. EXPLAIN cannot show the per-query memory ceiling itself (that needs `ANALYZE`, which the endpoint blocks); the cap is verified by the unit spy and the integration suite passing under it.

## Follow-ups (out of scope, noted from the end-to-end read)

- The `spanDetail` LLM prompt-enrichment (`enrichLlmSpanWithAncestorPrompt`) re-reads the **whole trace's** full attributes on every LLM-span drawer open just to extract `langwatch.prompt.*` handles, then discards the rest — a redundant heavy read worth narrowing (it can at least drop the `Events.*` / `Links.*` / `ResourceAttributes` columns it never uses).
- The real lever for the ~15MB read-bytes warnings (unchanged here) is a schema-side split of large attribute values out of the hot `SpanAttributes` Map, or a write-time value-size cap — a larger change worth its own discussion.