### PR TITLE
perf(clickhouse): optimize trace-list query (-read bytes)

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Integration tests for `TraceListClickHouseRepository.findAll`, exercised
+ * against a real ClickHouse testcontainer on the production `trace_summaries`
+ * schema.
+ *
+ * Focus: the trace list must read the heavy `ComputedInput`/`ComputedOutput`
+ * payload for at most one page of traces, not for every deduped trace in the
+ * window. The window scan over those payloads (plus the `count() OVER ()`
+ * buffer) is the dominant read-bytes cost on this list in prod, so the test
+ * seeds far more traces than one page and asserts both correctness and a real
+ * peak-memory reduction versus the naive single-scan form.
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { TraceListClickHouseRepository } from "../trace-list.clickhouse.repository";
+import type { TraceListQuery } from "../trace-list.repository";
+
+const tenantId = `test-trace-list-${nanoid()}`;
+const base = Date.now() - 60 * 60 * 1000;
+
+const TOTAL_TRACES = 800;
+const PAGE_LIMIT = 200;
+const HEAVY_INPUT = "i".repeat(2000);
+const HEAVY_OUTPUT = "o".repeat(2000); // ~80KB of payload per trace
+
+let ch: ClickHouseClient;
+let repo: TraceListClickHouseRepository;
+
+function traceIdFor(i: number): string {
+  return `tr-${String(i).padStart(4, "0")}`;
+}
+
+function makeTraceSummaryRow(i: number, overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceIdFor(i),
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(base + i),
+    CreatedAt: new Date(base + i),
+    UpdatedAt: new Date(base + i),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: `input-${i}-${HEAVY_INPUT}`,
+    ComputedOutput: `output-${i}-${HEAVY_OUTPUT}`,
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: null,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    TopicId: null,
+    SubTopicId: null,
+    ...overrides,
+  };
+}
+
+async function insertRows(rows: ReturnType<typeof makeTraceSummaryRow>[]) {
+  const chunk = 200;
+  for (let i = 0; i < rows.length; i += chunk) {
+    await ch.insert({
+      table: "trace_summaries",
+      values: rows.slice(i, i + chunk),
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+  }
+}
+
+function baseQuery(): TraceListQuery {
+  return {
+    tenantId,
+    timeRange: { from: base - 60_000, to: base + TOTAL_TRACES + 60_000 },
+    sort: { column: "OccurredAt", direction: "desc" },
+    limit: PAGE_LIMIT,
+    offset: 0,
+  };
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  repo = new TraceListClickHouseRepository(async () => ch);
+
+  const rows = Array.from({ length: TOTAL_TRACES }, (_, i) =>
+    makeTraceSummaryRow(i),
+  );
+  await insertRows(rows);
+
+  // A stale earlier version of the newest trace (same OccurredAt, older
+  // UpdatedAt): dedup must return the latest payload, and the count must not
+  // double-count it.
+  await insertRows([
+    makeTraceSummaryRow(TOTAL_TRACES - 1, {
+      ComputedInput: "stale-input",
+      ComputedOutput: "stale-output",
+      UpdatedAt: new Date(base - 10_000),
+      CreatedAt: new Date(base - 10_000),
+    }),
+  ]);
+}, 120_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query:
+        "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("TraceListClickHouseRepository.findAll (integration)", () => {
+  describe("when the window holds far more traces than one page", () => {
+    it("returns one page ordered by the sort column", async () => {
+      const page = await repo.findAll(baseQuery());
+
+      expect(page.rows).toHaveLength(PAGE_LIMIT);
+      // OccurredAt DESC → the newest PAGE_LIMIT traces, newest first.
+      const expected = Array.from({ length: PAGE_LIMIT }, (_, i) =>
+        traceIdFor(TOTAL_TRACES - 1 - i),
+      );
+      expect(page.rows.map((r) => r.traceId)).toEqual(expected);
+    });
+
+    it("reports the full deduped total, not just the page size", async () => {
+      const page = await repo.findAll(baseQuery());
+      expect(page.totalHits).toBe(TOTAL_TRACES);
+    });
+
+    it("returns the latest version of a duplicated trace, not the stale one", async () => {
+      const page = await repo.findAll(baseQuery());
+      const newest = page.rows.find(
+        (r) => r.traceId === traceIdFor(TOTAL_TRACES - 1),
+      );
+      expect(newest).toBeDefined();
+      expect(newest?.computedInput).toContain(`input-${TOTAL_TRACES - 1}-`);
+      expect(newest?.computedInput).not.toContain("stale");
+    });
+
+    it("honours offset paging without overlap", async () => {
+      const page2 = await repo.findAll({ ...baseQuery(), offset: PAGE_LIMIT });
+      const expected = Array.from({ length: PAGE_LIMIT }, (_, i) =>
+        traceIdFor(TOTAL_TRACES - 1 - PAGE_LIMIT - i),
+      );
+      expect(page2.rows.map((r) => r.traceId)).toEqual(expected);
+    });
+
+    it("reads heavy columns for fewer traces than the naive single-scan form", async () => {
+      const dedup = `(TenantId, TraceId, UpdatedAt) IN (
+        SELECT TenantId, TraceId, max(UpdatedAt)
+        FROM trace_summaries
+        WHERE TenantId = {tenantId:String}
+          AND OccurredAt >= fromUnixTimestamp64Milli({from:Int64})
+        GROUP BY TenantId, TraceId
+      )`;
+      const where = `TenantId = {tenantId:String}
+        AND OccurredAt >= fromUnixTimestamp64Milli({from:Int64})`;
+      const params = { tenantId, from: base - 60_000, limit: PAGE_LIMIT };
+
+      const naiveId = `naive-${nanoid()}`;
+      const pagedId = `paged-${nanoid()}`;
+
+      // Naive: heavy payload for every deduped trace + count() OVER () buffer.
+      await ch
+        .query({
+          query: `
+            SELECT TraceId, ComputedInput, ComputedOutput,
+              count() OVER () AS TotalCount
+            FROM trace_summaries
+            WHERE ${where} AND ${dedup}
+            ORDER BY OccurredAt DESC
+            LIMIT {limit:UInt32}
+          `,
+          query_params: params,
+          query_id: naiveId,
+          format: "JSONEachRow",
+        })
+        .then((r) => r.json());
+
+      // Paged: pick the TraceId page first, read heavy payload for those only.
+      await ch
+        .query({
+          query: `
+            SELECT TraceId, ComputedInput, ComputedOutput
+            FROM trace_summaries
+            WHERE ${where}
+              AND TraceId IN (
+                SELECT TraceId
+                FROM trace_summaries
+                WHERE ${where} AND ${dedup}
+                ORDER BY OccurredAt DESC
+                LIMIT {limit:UInt32}
+              )
+              AND ${dedup}
+            ORDER BY OccurredAt DESC
+            LIMIT {limit:UInt32}
+          `,
+          query_params: params,
+          query_id: pagedId,
+          format: "JSONEachRow",
+        })
+        .then((r) => r.json());
+
+      await ch.exec({ query: "SYSTEM FLUSH LOGS" });
+
+      const memRows = (await (
+        await ch.query({
+          query: `
+            SELECT query_id, max(memory_usage) AS mem
+            FROM system.query_log
+            WHERE query_id IN ({naiveId:String}, {pagedId:String})
+              AND type = 'QueryFinish'
+            GROUP BY query_id
+          `,
+          query_params: { naiveId, pagedId },
+          format: "JSONEachRow",
+        })
+      ).json()) as Array<{ query_id: string; mem: string }>;
+
+      const memOf = (id: string) =>
+        Number(memRows.find((r) => r.query_id === id)?.mem ?? 0);
+      const naiveMem = memOf(naiveId);
+      const pagedMem = memOf(pagedId);
+
+      expect(naiveMem).toBeGreaterThan(0);
+      expect(pagedMem).toBeGreaterThan(0);
+      expect(pagedMem).toBeLessThan(naiveMem);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -25,8 +25,8 @@ const base = Date.now() - 60 * 60 * 1000;
 
 const TOTAL_TRACES = 800;
 const PAGE_LIMIT = 200;
-const HEAVY_INPUT = "i".repeat(2000);
-const HEAVY_OUTPUT = "o".repeat(2000); // ~80KB of payload per trace
+const HEAVY_INPUT = "i".repeat(8000);
+const HEAVY_OUTPUT = "o".repeat(8000); // ~16KB of payload per trace
 
 let ch: ClickHouseClient;
 let repo: TraceListClickHouseRepository;
@@ -64,6 +64,12 @@ function makeTraceSummaryRow(i: number, overrides: Record<string, unknown> = {})
     OutputFromRootSpan: false,
     OutputSpanEndTimeMs: 0,
     BlockedByGuardrail: false,
+    TraceName: `trace-${i}`,
+    RootSpanType: "",
+    ContainsAi: false,
+    ContainsPrompt: false,
+    AnnotationIds: [],
+    LastEventOccurredAt: new Date(base + i),
     TopicId: null,
     SubTopicId: null,
     ...overrides,

--- a/langwatch/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -25,7 +25,6 @@ interface ClickHouseSummaryRow extends TraceSummaryFieldsBase {
   AttrUserId: string;
   AttrOrigin: string;
   LastEventOccurredAt: number;
-  TotalCount: number;
 }
 
 /**
@@ -109,15 +108,30 @@ export class TraceListClickHouseRepository implements TraceListRepository {
 
     const client = await this.resolveClient(query.tenantId);
 
-    // Subquery so WHERE/ORDER BY operate on raw DateTime columns —
-    // aliasing DateTime to millis in the same scope shadows the column
-    // and breaks the WHERE comparison. The inner SELECT also lists
-    // explicit columns (no `SELECT *`) so ClickHouse doesn't read the
-    // whole `Attributes` Map off storage just to drop it on the floor.
-    // Only five attribute keys flow through to the list mapper — see
-    // `mapToTraceListItem`.
-    const result = await client.query({
-      query: `
+    // Latest-version dedup, shared by the page, the heavy read, and the count.
+    const dedupFilter = `(TenantId, TraceId, UpdatedAt) IN (
+          SELECT TenantId, TraceId, max(UpdatedAt)
+          FROM ${TABLE_NAME}
+          WHERE ${whereClause}
+          GROUP BY TenantId, TraceId
+        )`;
+
+    // Page the matching TraceIds first (key + sort columns only), then read
+    // the heavy columns (ComputedInput/ComputedOutput and the rest) for that
+    // bounded page alone. The previous single query materialized those
+    // payloads for every deduped trace in the window before ORDER BY ... LIMIT
+    // trimmed it, and `count() OVER ()` forced the whole deduped set to buffer
+    // — together the dominant read-bytes cost on this list. The total is now a
+    // separate light count that never touches the payload columns.
+    //
+    // The inner subquery keeps WHERE/ORDER BY on raw DateTime columns —
+    // aliasing DateTime to millis in the same scope shadows the column and
+    // breaks the comparison. It also lists explicit columns (no `SELECT *`) so
+    // ClickHouse skips reading the full `Attributes` Map; only five keys flow
+    // through to the list mapper (see `mapToTraceListItem`).
+    const [result, countResult] = await Promise.all([
+      client.query({
+        query: `
         SELECT
           TraceId,
           TenantId,
@@ -161,8 +175,7 @@ export class TraceListClickHouseRepository implements TraceListRepository {
           TopicId,
           SubTopicId,
           AnnotationIds,
-          toUnixTimestamp64Milli(LastEventOccurredAt) AS LastEventOccurredAt,
-          TotalCount
+          toUnixTimestamp64Milli(LastEventOccurredAt) AS LastEventOccurredAt
         FROM (
           SELECT
             TraceId,
@@ -207,31 +220,46 @@ export class TraceListClickHouseRepository implements TraceListRepository {
             TopicId,
             SubTopicId,
             AnnotationIds,
-            LastEventOccurredAt,
-            count() OVER () AS TotalCount
+            LastEventOccurredAt
           FROM ${TABLE_NAME}
           WHERE ${whereClause}
-            AND (TenantId, TraceId, UpdatedAt) IN (
-              SELECT TenantId, TraceId, max(UpdatedAt)
+            AND TraceId IN (
+              SELECT TraceId
               FROM ${TABLE_NAME}
               WHERE ${whereClause}
-              GROUP BY TenantId, TraceId
+                AND ${dedupFilter}
+              ORDER BY ${sortExpression} ${sortDir}
+              LIMIT {limit:UInt32}
+              OFFSET {offset:UInt32}
             )
+            AND ${dedupFilter}
           ORDER BY ${sortExpression} ${sortDir}
           LIMIT {limit:UInt32}
-          OFFSET {offset:UInt32}
         )
       `,
-      query_params: {
-        ...params,
-        limit: query.limit,
-        offset: query.offset,
-      },
-      format: "JSONEachRow",
-    });
+        query_params: {
+          ...params,
+          limit: query.limit,
+          offset: query.offset,
+        },
+        format: "JSONEachRow",
+      }),
+      client.query({
+        query: `
+        SELECT count() AS totalHits
+        FROM ${TABLE_NAME}
+        WHERE ${whereClause}
+          AND ${dedupFilter}
+      `,
+        query_params: { ...params },
+        format: "JSONEachRow",
+      }),
+    ]);
 
     const rows = await result.json<ClickHouseSummaryRow>();
-    const totalHits = rows.length > 0 ? Number(rows[0]!.TotalCount) : 0;
+    const countRows = await countResult.json<{ totalHits: number | string }>();
+    const totalHits =
+      countRows.length > 0 ? Number(countRows[0]!.totalHits) : 0;
 
     return {
       rows: rows.map((row) => this.toTraceSummaryData(row)),


### PR DESCRIPTION
## Evidence

Sourced from prod CloudWatch (read-only, last 24h). Redacted; no raw tenant values.

`findAll` powers the main traces list. In the codebase slow-query warnings (Signal A) it is the worst sustained read-bytes offender that is not already covered by an open PR:

- ~140 warnings in a 5,000-row sample, **p95 read bytes ~617MB per list page load**, p95 duration ~1s.
- Same heavy-column-before-LIMIT shape that produced `MEMORY_LIMIT_EXCEEDED` on the topic-clustering and single-trace-span paths.

## Suspected cause

`findAll` selects the heavy `ComputedInput` / `ComputedOutput` (full trace input/output text) and the rest of the trace columns for **every** deduped trace matching the time window, then `ORDER BY <sort> LIMIT/OFFSET` trims to one page. ClickHouse materializes those payloads for the entire deduped window before the `LIMIT` applies. On top of that, `count() OVER ()` (used to return the page total) forces the whole post-dedup row set to buffer in memory rather than streaming.

So a list page over a busy window reads hundreds of MB of payload it then discards, and buffers the full result for the window count.

## Proposed fix

Page the matching `TraceId`s first in an inner subquery that reads only the key plus the sort columns (all light), `ORDER BY <sort> LIMIT/OFFSET`. Then read the heavy columns in the outer scan for that bounded `TraceId` set only. The latest-version dedup (`max(UpdatedAt)` GROUP BY IN-tuple) is preserved in both the page and the read, so version selection, ordering, and offset paging are unchanged.

`count() OVER ()` is removed; the page total is now a separate, parallel `count()` query that applies the same dedup filter but never selects a payload column.

No `LIMIT 1 BY` is introduced (covered by the `trace-dedup-oom-safety` structural guard).

## Expected impact

- Heavy-column reads bounded to one page (`limit`) of traces instead of the full deduped window, so read bytes and peak memory on the list drop sharply on busy windows.
- The total no longer forces a full-result buffer; it scans light columns only.
- One extra lightweight key-only scan and one parallel count query per page load; both avoid the payload columns.
- Result rows, ordering, dedup semantics, and `totalHits` are unchanged.

## Test plan

`src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts` (new), real ClickHouse testcontainer on the production schema:

- Seeds 800 traces (more than one 200-row page), each with ~80KB of `ComputedInput`/`ComputedOutput`, plus a stale earlier version of the newest trace.
- Asserts one page is returned newest-first, `totalHits` reports the full deduped total (800, the stale duplicate not double-counted), the latest version (not the stale payload) is returned, and offset paging does not overlap.
- Runs the naive single-scan SQL (heavy read for all + `count() OVER ()`) and the paged SQL under stable `query_id`s, flushes `system.query_log`, and asserts the paged query's peak `memory_usage` is strictly lower. Both run to completion (no intentional OOM), so neither leaves an undrained socket.

Local run: integration 5/5 passing, OOM-safety guard 24/24 passing, typecheck clean.

## EXPLAIN check (self-validated via the read-only `/api/ops/clickhouse/explain` endpoint, real tenant)

Ran `EXPLAIN PLAN` / `PIPELINE` / `INDEXES` against prod ClickHouse using a real known-large tenant (~900k spans / ~60k traces over 7 days) and a 7-day `OccurredAt` window. `INDEXES` now works end-to-end (server rewrites to `EXPLAIN PLAN indexes = 1, actions = 1`). Tenant id and the deduped key-set sizes are redacted below.

`INDEXES`, heavy read path (`trace_summaries`):

```
old (count() OVER (), payload read for the whole deduped window):
  ReadFromMergeTree -> PrimaryKey (TraceId in <deduped-set> AND TenantId = <redacted>)
  Parts: 11   Granules: 39

new (page the TraceIds first, payload read for the 200-row page only):
  ReadFromMergeTree -> PrimaryKey (TraceId in <deduped-set> AND TraceId in <200-set> AND TenantId = <redacted>)
  Parts: 4    Granules: 6
```

The heavy `ComputedInput`/`ComputedOutput` read drops from **39 granules across 11 parts to 6 granules across 4 parts (~6.5x fewer granules)** because the page limits to the 200 newest traces, which are temporally concentrated. The `OccurredAt` range prunes partitions (`toYearWeek`) in both shapes (407/9327 granules at the partition stage).

`PLAN` / `PIPELINE`: the old plan has a `Window (Window step for window '')` node and a `WindowTransform` between the read and the sort/limit (it buffers the full deduped set); the new plan has neither. The separated count is a light `Aggregating` over the same 39 granules but reads count-only (no payload columns).

Caveat: prune ratios depend on the sort column. On the default `OccurredAt DESC` (recency) sort the newest page is temporally concentrated, as above; a sort on `TotalDurationMs`/`TotalCost` spreads the page across more parts, so the granule win is smaller there (the `Window` removal and the bounded heavy-row sort still apply).

Reviewer: re-run `EXPLAIN` / `ANALYZE` on a busy tenant/window before merge.