### PR TITLE
fix(gateway): forward tool_choice in bedrock VPCE intercept ToolConfig

### DIFF
--- a/services/aigateway/adapters/providers/bedrock_vpce.go
+++ b/services/aigateway/adapters/providers/bedrock_vpce.go
@@ -402,6 +402,15 @@ func mapBedrockInferenceConfig(params *bfschemas.ChatParameters) *brtypes.Infere
 
 // mapBedrockToolConfig maps the neutral tool list to Bedrock's
 // ToolConfiguration. Returns nil when no tools are present.
+//
+// Forwards the caller's tool_choice directive to Bedrock when set. Without
+// this, customer 2026-05-31 dogfood: nlpgo translates response_format to
+// tools + tool_choice(forced) for structured outputs on bedrock+anthropic
+// (executor.go shouldUseToolUseForStructuredOutput); the public-bedrock
+// path through bifrost honors that, but the VPCE intercept here dropped
+// tool_choice silently. Model received the synthetic lw_so_* tool with no
+// pin → free to ignore it and reply with text → engine prose-fallback
+// dumped the entire reasoning into the first declared output field.
 func mapBedrockToolConfig(params *bfschemas.ChatParameters) *brtypes.ToolConfiguration {
 	if params == nil || len(params.Tools) == 0 {
 		return nil
@@ -426,7 +435,55 @@ func mapBedrockToolConfig(params *bfschemas.ChatParameters) *brtypes.ToolConfigu
 	if len(tools) == 0 {
 		return nil
 	}
-	return &brtypes.ToolConfiguration{Tools: tools}
+	return &brtypes.ToolConfiguration{
+		Tools:      tools,
+		ToolChoice: mapBedrockToolChoice(params.ToolChoice),
+	}
+}
+
+// mapBedrockToolChoice maps the OpenAI/bifrost-shape tool_choice union to
+// the Bedrock Converse ToolChoice union. Returns nil when no choice was
+// specified (bedrock defaults to auto). Specific-tool pins are required
+// for the structured-output rewrite path (forced lw_so_<schema> call);
+// only Anthropic Claude 3+ and Amazon Nova models honor specific-tool
+// per the bedrockruntime SDK docs, other model families silently fall
+// back to auto.
+func mapBedrockToolChoice(tc *bfschemas.ChatToolChoice) brtypes.ToolChoice {
+	if tc == nil {
+		return nil
+	}
+	if tc.ChatToolChoiceStr != nil {
+		switch strings.ToLower(*tc.ChatToolChoiceStr) {
+		case "any", "required":
+			return &brtypes.ToolChoiceMemberAny{}
+		case "auto":
+			return &brtypes.ToolChoiceMemberAuto{}
+		default:
+			// "none" or anything unrecognised: don't pin. Bedrock's
+			// "none" semantics aren't a first-class Converse value; the
+			// caller can omit tools entirely to achieve the same.
+			return nil
+		}
+	}
+	if tc.ChatToolChoiceStruct == nil {
+		return nil
+	}
+	s := tc.ChatToolChoiceStruct
+	switch s.Type {
+	case bfschemas.ChatToolChoiceTypeAny, bfschemas.ChatToolChoiceTypeRequired:
+		return &brtypes.ToolChoiceMemberAny{}
+	case bfschemas.ChatToolChoiceTypeAuto:
+		return &brtypes.ToolChoiceMemberAuto{}
+	case bfschemas.ChatToolChoiceTypeFunction:
+		if s.Function == nil || s.Function.Name == "" {
+			return nil
+		}
+		return &brtypes.ToolChoiceMemberTool{
+			Value: brtypes.SpecificToolChoice{Name: aws.String(s.Function.Name)},
+		}
+	default:
+		return nil
+	}
 }
 
 // converseOutputToBifrost maps a Bedrock Converse response back to the

--- a/services/aigateway/adapters/providers/bedrock_vpce.go
+++ b/services/aigateway/adapters/providers/bedrock_vpce.go
@@ -459,7 +459,7 @@ func mapBedrockToolChoice(tc *bfschemas.ChatToolChoice) brtypes.ToolChoice {
 		case "auto":
 			return &brtypes.ToolChoiceMemberAuto{}
 		default:
-			// "none" or anything unrecognised: don't pin. Bedrock's
+			// "none" or anything unrecognized: don't pin. Bedrock's
 			// "none" semantics aren't a first-class Converse value; the
 			// caller can omit tools entirely to achieve the same.
 			return nil

--- a/services/aigateway/adapters/providers/bedrock_vpce_live_test.go
+++ b/services/aigateway/adapters/providers/bedrock_vpce_live_test.go
@@ -176,3 +176,136 @@ func TestBedrockVPCELive_PingStream(t *testing.T) {
 		t.Fatalf("expected a terminal finish reason; got none over %d chunks", chunks)
 	}
 }
+
+// TestBedrockVPCELive_StructuredOutputToolChoice exercises the forced
+// tool_use path that nlpgo's executor.go uses to translate
+// response_format into structured outputs for bedrock+anthropic. Customer
+// dogfood 2026-05-31: nlpgo's translation sent tools + tool_choice but
+// the VPCE intercept's mapBedrockToolConfig dropped tool_choice, so the
+// model was free to ignore the synthetic lw_so_* tool and replied with
+// text. The engine's prose-fallback then dumped the entire reasoning
+// into the first declared output field. Same prompt shape as the
+// customer's failing classifier-relevance workflow (long system
+// instructions, structured-output schema with bool + str outputs).
+//
+// Run against any VPCE-compatible endpoint:
+//
+//	AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
+//	BVPCE_ENDPOINT=https://bedrock-runtime.us-east-1.amazonaws.com \
+//	BVPCE_REGION=us-east-1 \
+//	BVPCE_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0 \
+//	go test -tags live_bedrock_vpce ./services/aigateway/adapters/providers/ \
+//	  -run BedrockVPCELive_StructuredOutputToolChoice -count=1 -v
+func TestBedrockVPCELive_StructuredOutputToolChoice(t *testing.T) {
+	endpoint := os.Getenv("BVPCE_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("BVPCE_ENDPOINT not set; skipping live Bedrock VPCE structured-output test")
+	}
+	ak := os.Getenv("AWS_ACCESS_KEY_ID")
+	sk := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if ak == "" || sk == "" {
+		t.Skip("AWS creds not set; skipping live Bedrock VPCE structured-output test")
+	}
+	region := os.Getenv("BVPCE_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	model := os.Getenv("BVPCE_MODEL")
+	if model == "" {
+		t.Fatal("BVPCE_MODEL must be set (the inference-profile id to invoke)")
+	}
+
+	extra := map[string]string{
+		"bedrock_runtime_endpoint": endpoint,
+		"access_key":               ak,
+		"secret_key":               sk,
+		"region":                   region,
+	}
+	if st := os.Getenv("AWS_SESSION_TOKEN"); st != "" {
+		extra["session_token"] = st
+	}
+
+	cred := domain.Credential{
+		ID:         "live-bedrock-vpce-so",
+		ProviderID: domain.ProviderBedrock,
+		Extra:      extra,
+	}
+	// Mirrors what nlpgo executor.go emits for a signature node with
+	// {output:bool, reason:str} outputs after translating response_format
+	// to forced tool_use (shouldUseToolUseForStructuredOutput +
+	// buildStructuredOutputTool). The synthetic tool name uses the
+	// lw_so_<schema> prefix the engine uses.
+	body := []byte(`{
+		"messages":[
+			{"role":"system","content":"You are a strict boolean evaluator. Return TRUE only when the user input describes a feature-comparison question."},
+			{"role":"user","content":"What is the difference between budget navigator and pacing monitor?"}
+		],
+		"max_tokens":1024,
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"lw_so_ClassifierRelevance",
+				"description":"Return the response as a JSON object matching the declared output schema.",
+				"parameters":{
+					"type":"object",
+					"properties":{
+						"output":{"type":"boolean"},
+						"reason":{"type":"string"}
+					},
+					"required":["output","reason"],
+					"additionalProperties":false
+				},
+				"strict":true
+			}
+		}],
+		"tool_choice":{"type":"function","function":{"name":"lw_so_ClassifierRelevance"}}
+	}`)
+	req := &domain.Request{
+		Type:  domain.RequestTypeChat,
+		Model: model,
+		Body:  body,
+	}
+
+	router := &BifrostRouter{}
+	resp, err := router.dispatchBedrockVPCE(context.Background(), req, mapProvider(cred.ProviderID), model, cred, endpoint)
+	if err != nil {
+		t.Fatalf("dispatchBedrockVPCE error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d; body=%s", resp.StatusCode, string(resp.Body))
+	}
+
+	// Post-fix: the model MUST call the forced tool. The response shape
+	// carries the structured payload on tool_calls[0].function.arguments
+	// (JSON string), with empty text content. Pre-fix (tool_choice
+	// silently dropped by mapBedrockToolConfig): the model returned text
+	// content and no tool_calls — exact pre-fix manifestation that
+	// triggered the engine's prose-fallback into the first declared
+	// output field.
+	toolName := gjson.GetBytes(resp.Body, "choices.0.message.tool_calls.0.function.name").String()
+	args := gjson.GetBytes(resp.Body, "choices.0.message.tool_calls.0.function.arguments").String()
+	textContent := gjson.GetBytes(resp.Body, "choices.0.message.content").String()
+	t.Logf("LIVE 200 via %s | model=%s | tool_name=%q | args=%q | text=%q",
+		endpoint, model, toolName, args, textContent)
+
+	if toolName != "lw_so_ClassifierRelevance" {
+		t.Fatalf("expected forced tool call to lw_so_ClassifierRelevance, got %q (text content: %q) — tool_choice was likely dropped on the VPCE intercept path",
+			toolName, textContent)
+	}
+	if args == "" {
+		t.Fatalf("expected non-empty tool_call arguments JSON; body=%s", string(resp.Body))
+	}
+	if !gjson.Valid(args) {
+		t.Fatalf("tool_call arguments must be valid JSON, got %q", args)
+	}
+	output := gjson.Get(args, "output")
+	if !output.Exists() {
+		t.Fatalf("expected `output` field in tool_call arguments; got %s", args)
+	}
+	if output.Type != gjson.True && output.Type != gjson.False {
+		t.Fatalf("expected `output` to be a real bool, got type=%v value=%v", output.Type, output.Value())
+	}
+	if reason := gjson.Get(args, "reason").String(); reason == "" {
+		t.Fatalf("expected non-empty `reason` field in tool_call arguments; got %s", args)
+	}
+}

--- a/services/aigateway/adapters/providers/bedrock_vpce_test.go
+++ b/services/aigateway/adapters/providers/bedrock_vpce_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	brtypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/tidwall/gjson"
 
 	"github.com/langwatch/langwatch/services/aigateway/domain"
@@ -241,5 +243,136 @@ func TestBedrockVPCE_DispatchHonorsAWSStyleCredentialKeys(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestMapBedrockToolChoice pins the OpenAI/bifrost tool_choice -> Bedrock
+// Converse ToolChoice mapping. Pre-fix this branch did not exist and the
+// VPCE intercept silently dropped tool_choice from the outbound request.
+// Customer dogfood 2026-05-31: nlpgo's executor.go translates
+// response_format -> tools + forced tool_choice for bedrock+anthropic
+// structured outputs; without this mapper the model was free to ignore
+// the synthetic lw_so_* tool and replied with text, which the engine's
+// prose-fallback then dumped into the first declared output field.
+func TestMapBedrockToolChoice(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		if got := mapBedrockToolChoice(nil); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("string form: any => ToolChoiceMemberAny", func(t *testing.T) {
+		s := "any"
+		got := mapBedrockToolChoice(&bfschemas.ChatToolChoice{ChatToolChoiceStr: &s})
+		if _, ok := got.(*brtypes.ToolChoiceMemberAny); !ok {
+			t.Fatalf("expected ToolChoiceMemberAny, got %T", got)
+		}
+	})
+
+	t.Run("string form: required => ToolChoiceMemberAny", func(t *testing.T) {
+		s := "required"
+		got := mapBedrockToolChoice(&bfschemas.ChatToolChoice{ChatToolChoiceStr: &s})
+		if _, ok := got.(*brtypes.ToolChoiceMemberAny); !ok {
+			t.Fatalf("expected ToolChoiceMemberAny, got %T", got)
+		}
+	})
+
+	t.Run("string form: auto => ToolChoiceMemberAuto", func(t *testing.T) {
+		s := "auto"
+		got := mapBedrockToolChoice(&bfschemas.ChatToolChoice{ChatToolChoiceStr: &s})
+		if _, ok := got.(*brtypes.ToolChoiceMemberAuto); !ok {
+			t.Fatalf("expected ToolChoiceMemberAuto, got %T", got)
+		}
+	})
+
+	t.Run("string form: none => nil (omit tools instead)", func(t *testing.T) {
+		s := "none"
+		if got := mapBedrockToolChoice(&bfschemas.ChatToolChoice{ChatToolChoiceStr: &s}); got != nil {
+			t.Fatalf("expected nil for 'none', got %#v", got)
+		}
+	})
+
+	t.Run("struct form: function with name => ToolChoiceMemberTool (the customer-fix case)", func(t *testing.T) {
+		got := mapBedrockToolChoice(&bfschemas.ChatToolChoice{
+			ChatToolChoiceStruct: &bfschemas.ChatToolChoiceStruct{
+				Type:     bfschemas.ChatToolChoiceTypeFunction,
+				Function: &bfschemas.ChatToolChoiceFunction{Name: "lw_so_ClassifierRelevance"},
+			},
+		})
+		tool, ok := got.(*brtypes.ToolChoiceMemberTool)
+		if !ok {
+			t.Fatalf("expected ToolChoiceMemberTool, got %T — without this branch the forced-tool pin is silently dropped on the VPCE intercept path", got)
+		}
+		if tool.Value.Name == nil || *tool.Value.Name != "lw_so_ClassifierRelevance" {
+			t.Fatalf("expected tool name lw_so_ClassifierRelevance, got %v", tool.Value.Name)
+		}
+	})
+
+	t.Run("struct form: function with empty name => nil", func(t *testing.T) {
+		got := mapBedrockToolChoice(&bfschemas.ChatToolChoice{
+			ChatToolChoiceStruct: &bfschemas.ChatToolChoiceStruct{
+				Type:     bfschemas.ChatToolChoiceTypeFunction,
+				Function: &bfschemas.ChatToolChoiceFunction{Name: ""},
+			},
+		})
+		if got != nil {
+			t.Fatalf("expected nil for empty function name, got %#v", got)
+		}
+	})
+
+	t.Run("struct form: any => ToolChoiceMemberAny", func(t *testing.T) {
+		got := mapBedrockToolChoice(&bfschemas.ChatToolChoice{
+			ChatToolChoiceStruct: &bfschemas.ChatToolChoiceStruct{Type: bfschemas.ChatToolChoiceTypeAny},
+		})
+		if _, ok := got.(*brtypes.ToolChoiceMemberAny); !ok {
+			t.Fatalf("expected ToolChoiceMemberAny, got %T", got)
+		}
+	})
+
+	t.Run("struct form: auto => ToolChoiceMemberAuto", func(t *testing.T) {
+		got := mapBedrockToolChoice(&bfschemas.ChatToolChoice{
+			ChatToolChoiceStruct: &bfschemas.ChatToolChoiceStruct{Type: bfschemas.ChatToolChoiceTypeAuto},
+		})
+		if _, ok := got.(*brtypes.ToolChoiceMemberAuto); !ok {
+			t.Fatalf("expected ToolChoiceMemberAuto, got %T", got)
+		}
+	})
+}
+
+// TestMapBedrockToolConfig_ForwardsForcedToolChoice pins the end-to-end
+// behavior at the public mapper boundary: when a request comes in with
+// tools + a forced tool_choice (the shape nlpgo's executor.go emits for
+// bedrock+anthropic structured outputs), the ToolConfiguration must
+// include BOTH the tools array AND the ToolChoice pin.
+func TestMapBedrockToolConfig_ForwardsForcedToolChoice(t *testing.T) {
+	params := &bfschemas.ChatParameters{
+		Tools: []bfschemas.ChatTool{
+			{
+				Function: &bfschemas.ChatToolFunction{
+					Name:        "lw_so_ClassifierRelevance",
+					Description: strPtr("Return the response as a JSON object matching the declared output schema."),
+				},
+			},
+		},
+		ToolChoice: &bfschemas.ChatToolChoice{
+			ChatToolChoiceStruct: &bfschemas.ChatToolChoiceStruct{
+				Type:     bfschemas.ChatToolChoiceTypeFunction,
+				Function: &bfschemas.ChatToolChoiceFunction{Name: "lw_so_ClassifierRelevance"},
+			},
+		},
+	}
+	cfg := mapBedrockToolConfig(params)
+	if cfg == nil {
+		t.Fatal("expected non-nil ToolConfiguration")
+	}
+	if len(cfg.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(cfg.Tools))
+	}
+	tool, ok := cfg.ToolChoice.(*brtypes.ToolChoiceMemberTool)
+	if !ok {
+		t.Fatalf("expected forced tool choice, got %T — pre-fix this was nil and the VPCE intercept dropped the pin", cfg.ToolChoice)
+	}
+	if tool.Value.Name == nil || *tool.Value.Name != "lw_so_ClassifierRelevance" {
+		t.Fatalf("expected forced tool name lw_so_ClassifierRelevance, got %v", tool.Value.Name)
 	}
 }


### PR DESCRIPTION
## Summary

Closes the customer-reported structured-output failure on managed-bedrock (#4431 follow-up).

#4431 shipped the response_format → forced tool_use translation in nlpgo's executor for bedrock+anthropic-family models. That worked on the public bedrock path (bifrost's bedrock provider honors `tool_choice` via `convertToolConfigFromFiltered`), but the VPCE intercept's `mapBedrockToolConfig` in `services/aigateway/adapters/providers/bedrock_vpce.go` emitted only the `tools` array and silently dropped `tool_choice`. So when a managed-bedrock customer's request flowed through nlpgo (with my structured-output rewrite emitting tools + tool_choice) and got dispatched via the VPCE path:

1. Gateway VPCE intercept dropped `tool_choice`
2. Bedrock received the synthetic `lw_so_<schema>` tool with no pin
3. Anthropic was free to ignore the tool and reply with text
4. nlpgo's engine `extractSignatureOutputs` prose-fallback dumped the entire model reasoning into the first declared output field

Exact reproduction matches the customer's 2026-05-31 dogfood screenshot: nlpgo path returned all reasoning collapsed into `output`, python path (LiteLLM, which uses tool_use with proper tool_choice forwarding via the SDK) returned correctly parsed `{output: false, reason: "..."}`.

## Changes

- `services/aigateway/adapters/providers/bedrock_vpce.go`
  - New `mapBedrockToolChoice` function maps the OpenAI/bifrost `ChatToolChoice` union to the bedrockruntime `ToolChoice` union:
    - string `"any"`/`"required"` or struct `{type: any|required}` → `ToolChoiceMemberAny`
    - string `"auto"` or struct `{type: auto}` → `ToolChoiceMemberAuto`
    - struct `{type: function, function.name: X}` → `ToolChoiceMemberTool{Value: SpecificToolChoice{Name: X}}` ← the customer-fix branch
    - string `"none"` / unrecognized / empty function name → `nil` (bedrock defaults to auto)
  - `mapBedrockToolConfig` now sets `ToolConfig.ToolChoice = mapBedrockToolChoice(params.ToolChoice)`. When no `tool_choice` is on the inbound request the field stays nil and bedrock defaults to auto — same observable behavior as before the fix, just with the forced-pin case actually working.

- `services/aigateway/adapters/providers/bedrock_vpce_test.go`
  - `TestMapBedrockToolChoice` covers the mapping matrix (nil, string/struct variants, empty function name, "none" fallback).
  - `TestMapBedrockToolConfig_ForwardsForcedToolChoice` pins the end-to-end public-mapper contract.

- `services/aigateway/adapters/providers/bedrock_vpce_live_test.go`
  - `TestBedrockVPCELive_StructuredOutputToolChoice` exercises the full `dispatchBedrockVPCE` path with a forced `lw_so_*` tool against any Bedrock-compatible endpoint. Build tag `live_bedrock_vpce`, env-gated `BVPCE_ENDPOINT` + AWS creds.

## Verified

- `go test ./services/aigateway/adapters/providers/` — green
- `go test ./services/aigateway/...` — green
- Live structured-output test against public bedrock (`https://bedrock-runtime.us-east-1.amazonaws.com`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`): tool invoked, JSON parsed, bool + reason fields populated
- **Live end-to-end against the actual customer VPCE** (`http://vpce-...:80`, `us-east-1`, `us.anthropic.claude-haiku-4-5-20251001-v1:0`, STS-temporary creds from the managed-bedrock proxy → cross-account chain): pre-fix returns text content + no `tool_calls`; post-fix invokes `lw_so_ClassifierRelevance` and returns `{"output": true, "reason": "<paragraph>"}`. Same behavior LiteLLM produces on the python path.

## Deploy ask

Gateway image needs a rebuild + redeploy on prod for the customer to benefit — `#4431` (in `nlp-service` / `nlp-lambda`) is already deployed via the saas submodule bump, but the gateway service has not been rebuilt since this code lived only in `aigateway`. Per rchaves "nlp-lambda and nlp-service were rebuilt (gateway was not but would that matter)?" — yes, it matters, and this PR is the reason why.

## Test plan
- [x] Unit tests pass for the new mapper + end-to-end contract
- [x] Live test passes against public bedrock with forced tool_choice
- [x] Live test passes against the actual customer managed-bedrock VPCE (off-PR, one-off verification)
- [ ] Watch CI
- [ ] Trigger gateway rebuild + redeploy after merge