### PR TITLE
fix(tokenizer): bound tiktoken remote BPE fetch with a timeout (unblocks CI shard-3 wedge)

### DIFF
--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -67,6 +67,11 @@ API_TOKEN_JWT_SECRET="change me to a random string"
 # curl -o langwatch/tiktoken/o200k_base.tiktoken https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken
 # # Download additional tiktoken files as needed for other models
 TIKTOKENS_PATH=langwatch/tiktoken
+# Timeout (ms) for the tiktoken BPE remote-fetch fallback used when a local file
+# is absent. Without a bound the fetch can hang indefinitely on a
+# network-restricted host; on timeout, tokenization is skipped (best-effort).
+# Default: 10000.
+# TIKTOKEN_FETCH_TIMEOUT_MS=10000
 
 # SERVICES AND INFRASTRUCTURE
 

--- a/langwatch/src/server/app-layer/clients/tokenizer/__tests__/tiktoken.client.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/tokenizer/__tests__/tiktoken.client.unit.test.ts
@@ -231,8 +231,11 @@ describe("TiktokenClient", () => {
       // Best-effort tokenization: the bounded fetch times out, loadEncoder's
       // catch turns the throw into `undefined`, and token counting is skipped.
       expect(result).toBe(undefined);
-      // Proves we hit the timeout path, not an instant unrelated failure, and
-      // that we did not hang (generous upper bound for slow CI runners).
+      // Prove the timeout branch was actually exercised: the fetch was invoked
+      // (so we reached remoteFetch, not an instant unrelated failure) and
+      // elapsed cleared the 50ms timeout floor — yet stayed well under a hang.
+      expect(globalThis.fetch).toHaveBeenCalled();
+      expect(elapsed).toBeGreaterThanOrEqual(40);
       expect(elapsed).toBeLessThan(5000);
     });
   });

--- a/langwatch/src/server/app-layer/clients/tokenizer/__tests__/tiktoken.client.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/tokenizer/__tests__/tiktoken.client.unit.test.ts
@@ -1,11 +1,125 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TiktokenClient } from "../tiktoken.client";
 import { NullTokenizerClient } from "../tokenizer.client";
 
-describe("TiktokenClient", () => {
-  const client = new TiktokenClient();
+/**
+ * These are UNIT tests: they must be deterministic and fully OFFLINE.
+ *
+ * The real `tiktoken` encoder fetches multi-megabyte BPE rank files over the
+ * network (see `TiktokenClient.remoteFetch`). Provisioning those files offline
+ * is impractical, so we mock at the encoder boundary instead:
+ *   - `tiktoken/lite`               -> a deterministic stub `Tiktoken` whose
+ *                                      `encode` returns a token count derived
+ *                                      purely from the input text.
+ *   - `tiktoken/load`               -> controlled per-test (no network).
+ *   - `tiktoken/registry.json` and  -> minimal fixtures so encoding resolution
+ *     `tiktoken/model_to_encoding`     works even if the real package (and its
+ *                                      WASM build) is absent from node_modules.
+ *
+ * This keeps the count assertions meaningful (positive, consistent,
+ * prefix-invariant) AND guarantees no outbound request is ever made.
+ */
 
-  describe("countTokens", () => {
+// `vi.mock` factories are hoisted ABOVE the imports and run before module
+// init, so anything they reference must be hoisted too. `vi.hoisted` is the
+// idiomatic way to share values/spies with those factories without tripping
+// the "not at the top level" warning.
+const { O200K_REGISTRY, deterministicTokenCount, loadMock } = vi.hoisted(() => {
+  const O200K_REGISTRY = {
+    load_tiktoken_bpe:
+      "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken",
+    special_tokens: { "<|endoftext|>": 199999 },
+    pat_str: "(?:)",
+  };
+
+  // Deterministic, input-proportional token count: whitespace-delimited words,
+  // at least 1 for any non-empty string. Mirrors the shape of a real tokenizer
+  // closely enough that "positive / consistent / prefix-invariant" stay honest.
+  const deterministicTokenCount = (text: string): number => {
+    const words = text.split(/\s+/).filter(Boolean).length;
+    return Math.max(1, words);
+  };
+
+  // `load` is controlled per-test. Default impl is (re)armed in beforeEach.
+  const loadMock =
+    vi.fn<
+      (
+        registry: Record<string, unknown>,
+        customFetch: (url: string) => Promise<string>,
+      ) => Promise<Record<string, unknown>>
+    >();
+
+  return { O200K_REGISTRY, deterministicTokenCount, loadMock };
+});
+
+vi.mock("tiktoken/lite", () => ({
+  Tiktoken: class {
+    constructor(
+      _bpeRanks: string,
+      _specialTokens: Record<string, number>,
+      _patStr: string,
+    ) {}
+    encode(text: string): Uint32Array {
+      return new Uint32Array(deterministicTokenCount(text));
+    }
+    free(): void {}
+  },
+}));
+
+vi.mock("tiktoken/registry.json", () => ({
+  default: { o200k_base: O200K_REGISTRY },
+}));
+
+vi.mock("tiktoken/model_to_encoding.json", () => ({
+  default: { "gpt-4o": "o200k_base" },
+}));
+
+vi.mock("tiktoken/load", () => ({
+  load: (
+    registry: Record<string, unknown>,
+    customFetch: (url: string) => Promise<string>,
+  ) => loadMock(registry, customFetch),
+}));
+
+// node-fetch-cache's cached fetch delegates to globalThis.fetch in the unit
+// env, so the no-hang test's `globalThis.fetch` stub governs the PRIMARY
+// (cached) remoteFetch path — the exact path that hangs in production. The
+// count tests never reach remoteFetch (their `load` mock returns dummy ranks),
+// so this mock is inert there.
+vi.mock("node-fetch-cache", () => ({
+  default: {
+    create() {
+      return function cachedFetch(
+        url: string,
+        init?: { signal?: AbortSignal },
+      ) {
+        return globalThis.fetch(url, init);
+      };
+    },
+  },
+  FileSystemCache: class {
+    constructor(_opts?: unknown) {}
+  },
+}));
+
+describe("TiktokenClient", () => {
+  describe("countTokens (offline, encoder stubbed)", () => {
+    let client: TiktokenClient;
+
+    beforeEach(() => {
+      // Reset call history (loadMock is module-scoped) and re-arm the default
+      // impl: no fetch, dummy ranks. Fresh client per test so the internal
+      // cache never leaks across cases.
+      loadMock.mockClear();
+      loadMock.mockImplementation(async (registry: Record<string, unknown>) => ({
+        explicit_n_vocab: undefined,
+        pat_str: registry.pat_str,
+        special_tokens: registry.special_tokens,
+        bpe_ranks: "",
+      }));
+      client = new TiktokenClient();
+    });
+
     it("returns a positive token count for non-empty text", async () => {
       const count = await client.countTokens("gpt-4o", "Hello, world!");
       expect(count).toBeGreaterThan(0);
@@ -16,6 +130,12 @@ describe("TiktokenClient", () => {
       const count1 = await client.countTokens("gpt-4o", "The quick brown fox");
       const count2 = await client.countTokens("gpt-4o", "The quick brown fox");
       expect(count1).toBe(count2);
+    });
+
+    it("caches the encoder across calls (loads BPE data once per encoding)", async () => {
+      await client.countTokens("gpt-4o", "first");
+      await client.countTokens("gpt-4o", "second");
+      expect(loadMock).toHaveBeenCalledTimes(1);
     });
 
     it("returns undefined for empty text", async () => {
@@ -38,6 +158,82 @@ describe("TiktokenClient", () => {
         "Hello, world!",
       );
       expect(count).toBeGreaterThan(0);
+    });
+  });
+
+  describe("when the remote BPE fetch never resolves", () => {
+    const ORIGINAL_TIKTOKENS_PATH = process.env.TIKTOKENS_PATH;
+    const ORIGINAL_TIMEOUT = process.env.TIKTOKEN_FETCH_TIMEOUT_MS;
+
+    beforeEach(() => {
+      // Force the remote path: with no local TIKTOKENS_PATH, fetchBpeRanks goes
+      // straight to remoteFetch.
+      delete process.env.TIKTOKENS_PATH;
+      // Tight ceiling so the test is fast but still exercises the real timer.
+      process.env.TIKTOKEN_FETCH_TIMEOUT_MS = "50";
+
+      // Drive the encoder load through the REAL single-URL path so it actually
+      // calls customFetch -> fetchBpeRanks -> remoteFetch.
+      loadMock.mockImplementation(
+        async (
+          registry: Record<string, unknown>,
+          customFetch: (url: string) => Promise<string>,
+        ) => ({
+          explicit_n_vocab: undefined,
+          pat_str: registry.pat_str,
+          special_tokens: registry.special_tokens,
+          bpe_ranks: await customFetch(registry.load_tiktoken_bpe as string),
+        }),
+      );
+
+      // The file-scope `node-fetch-cache` mock routes the cached fetch through
+      // globalThis.fetch, so stubbing globalThis.fetch governs the primary
+      // remoteFetch path. A fetch that never resolves on its own but rejects
+      // when aborted — exactly like a real fetch against a black-holed endpoint.
+      vi.spyOn(globalThis, "fetch").mockImplementation(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (signal) {
+              if (signal.aborted) {
+                reject(new Error("aborted"));
+                return;
+              }
+              signal.addEventListener("abort", () =>
+                reject(new Error("aborted")),
+              );
+            }
+          }),
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (ORIGINAL_TIKTOKENS_PATH === undefined) {
+        delete process.env.TIKTOKENS_PATH;
+      } else {
+        process.env.TIKTOKENS_PATH = ORIGINAL_TIKTOKENS_PATH;
+      }
+      if (ORIGINAL_TIMEOUT === undefined) {
+        delete process.env.TIKTOKEN_FETCH_TIMEOUT_MS;
+      } else {
+        process.env.TIKTOKEN_FETCH_TIMEOUT_MS = ORIGINAL_TIMEOUT;
+      }
+    });
+
+    it("resolves to undefined within the timeout instead of hanging", async () => {
+      const client = new TiktokenClient();
+
+      const start = Date.now();
+      const result = await client.countTokens("gpt-4o", "hello");
+      const elapsed = Date.now() - start;
+
+      // Best-effort tokenization: the bounded fetch times out, loadEncoder's
+      // catch turns the throw into `undefined`, and token counting is skipped.
+      expect(result).toBe(undefined);
+      // Proves we hit the timeout path, not an instant unrelated failure, and
+      // that we did not hang (generous upper bound for slow CI runners).
+      expect(elapsed).toBeLessThan(5000);
     });
   });
 });

--- a/langwatch/src/server/app-layer/clients/tokenizer/tiktoken.client.ts
+++ b/langwatch/src/server/app-layer/clients/tokenizer/tiktoken.client.ts
@@ -5,6 +5,8 @@ import type { TokenizerClient } from "./tokenizer.client";
 
 const logger = createLogger("langwatch:tiktoken");
 
+const DEFAULT_TIKTOKEN_FETCH_TIMEOUT_MS = 10000;
+
 type Tiktoken = { encode: (text: string) => Uint32Array; free: () => void };
 
 export class TiktokenClient implements TokenizerClient {
@@ -132,6 +134,44 @@ export class TiktokenClient implements TokenizerClient {
   }
 
   private async remoteFetch(url: string): Promise<string> {
+    const timeoutMs = this.resolveFetchTimeoutMs();
+    // A single controller/timer pair guards BOTH the cached-fetch attempt and
+    // the native-fetch fallback. The AbortController aborts fetches that honor
+    // `signal`; the Promise.race against a rejecting timer is the hard ceiling
+    // for any path that ignores the signal (e.g. some node-fetch-cache setups),
+    // so this method can never hang indefinitely.
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(
+          new Error(`tiktoken remote fetch timed out after ${timeoutMs}ms`),
+        );
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([this.doRemoteFetch(url, controller.signal), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  private resolveFetchTimeoutMs(): number {
+    const parsed = parseInt(
+      process.env.TIKTOKEN_FETCH_TIMEOUT_MS ?? "",
+      10,
+    );
+    return Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_TIKTOKEN_FETCH_TIMEOUT_MS;
+  }
+
+  private async doRemoteFetch(
+    url: string,
+    signal: AbortSignal,
+  ): Promise<string> {
     try {
       const nodeFetchCache = await import("node-fetch-cache");
       const cachedFetch = nodeFetchCache.default.create({
@@ -140,11 +180,14 @@ export class TiktokenClient implements TokenizerClient {
           ttl: 1000 * 60 * 60 * 24 * 365, // 1 year
         }),
       });
-      const res = await cachedFetch(url);
+      const res = await cachedFetch(url, { signal });
       return res.text();
-    } catch {
+    } catch (error) {
+      // Re-throw aborts (timeout) instead of falling through to a second
+      // unbounded attempt — the timer has already fired and we must reject.
+      if (signal.aborted) throw error;
       // Fall back to native fetch when node-fetch-cache is unavailable
-      const res = await globalThis.fetch(url);
+      const res = await globalThis.fetch(url, { signal });
       return res.text();
     }
   }

--- a/langwatch/src/server/app-layer/clients/tokenizer/tiktoken.client.ts
+++ b/langwatch/src/server/app-layer/clients/tokenizer/tiktoken.client.ts
@@ -180,6 +180,9 @@ export class TiktokenClient implements TokenizerClient {
           ttl: 1000 * 60 * 60 * 24 * 365, // 1 year
         }),
       });
+      // Passing { signal } changes node-fetch-cache's computed cache key, so the
+      // first call after this change re-fetches each encoding once; the key is
+      // stable thereafter and the 1-year disk cache applies as before.
       const res = await cachedFetch(url, { signal });
       return res.text();
     } catch (error) {


### PR DESCRIPTION
## Problem
`test-unit (3)` and `test-integration (3)` wedge for **100–166 min** then get cancelled — **repo-wide, on `main` itself** (runs 26650910676 @~104 min, 26642310246 @~166 min), blocking all-green CI for every PR. The other shards (1/2/4) finish in minutes.

## Root cause
`TiktokenClient.remoteFetch` (`src/server/app-layer/clients/tokenizer/tiktoken.client.ts`) makes an **unbounded** network fetch — no timeout. `TIKTOKENS_PATH=langwatch/tiktoken` is set, but those `.tiktoken` files are never provisioned (no prepare step, not in `node_modules`), so every encode falls through to `remoteFetch`. In a network-restricted CI shard the fetch never returns → the vitest process hangs → the shard wedges. `tiktoken.client.unit.test.ts` drives the real client, so it triggers this; it only "passes" locally because dev boxes have network.

## Fix
- `remoteFetch` now races the request against an `AbortController`-backed timeout (default **10 s**, override via `TIKTOKEN_FETCH_TIMEOUT_MS`), passing the signal to both the `node-fetch-cache` and native-`fetch` paths. On timeout it aborts (closing the socket) and rejects; `loadEncoder`'s existing try/catch turns that into a graceful skip — best-effort tokenization **fails fast instead of hanging forever**.
- `tiktoken.client.unit.test.ts` is now fully **offline/deterministic** (mocks the encoder + fetch) and adds a regression test asserting a never-resolving fetch yields `undefined` within the timeout rather than hanging.

## Validation
`vitest run …/tiktoken.client.unit.test.ts` → **9 passed, EXIT 0** (process exits cleanly, not 124/hang); both touched files typecheck-clean.

Closes #4437. Unblocks the shard-3 wedge for every PR (incl. #4216).

🤖 Generated with [Claude Code](https://claude.com/claude-code)