### PR TITLE
fix(ci): pin cosign to 2.x so release image signing works on Docker Hub

### DIFF
--- a/.github/workflows/publish-docker-app.yml
+++ b/.github/workflows/publish-docker-app.yml
@@ -200,6 +200,12 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin to cosign 2.x. cosign 3.x defaults to the new bundle format (OCI 1.1
+          # referrers), which Docker Hub does not reliably serve, so cosign verify
+          # reports "no signatures found" immediately after a successful cosign sign.
+          # The 2.x line writes the tag-based signature format Docker Hub supports.
+          cosign-release: v2.6.3
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0


### PR DESCRIPTION
## What

Pins cosign to `v2.6.3` in the `sign-and-attest` job of `publish-docker-app`.

## Why

The langwatch@v3.4.0 release run failed at "Sign manifests and attach per-platform CycloneDX SBOMs" with:

```
Signing artifact...
Verifying index signature for langwatch/langwatch@sha256:50bd...
Error: no signatures found
error during command execution: no signatures found
```

`cosign sign` succeeded but the immediately-following `cosign verify` could not find the signature. Root cause: `cosign-installer@v4.1.2` installs cosign **3.0.6** by default, and cosign 3.x defaults to the new bundle format (OCI 1.1 referrers). Docker Hub does not reliably serve the referrers API, so the signature is written in a form `cosign verify` cannot read back, producing "no signatures found".

This job was added in #4155 and v3.4.0 is the first langwatch app release to actually exercise it (the intervening releases were SDK/MCP ones that skip this job), so this never surfaced before.

cosign 2.x writes the tag-based (`sha256-<digest>.sig` / `.att`) signature format that Docker Hub supports, which is what the verify/attest steps already expect. All flags the workflow uses exist in 2.x. v2.6.3 is the latest 2.x and is still maintained alongside the 3.x line.

## Note

This is a durable fix for future releases. The v3.4.0 publish run cannot retroactively pick up this change (release events use the workflow file at the tag commit), so the helm chart release for 3.4.0 is being unblocked manually via the chart workflow's `workflow_dispatch`.