### PR TITLE
fix(workflows): strip unsupported LLM params on the server-driven dispatch path

### DIFF
--- a/langwatch/src/server/workflows/runWorkflow.ts
+++ b/langwatch/src/server/workflows/runWorkflow.ts
@@ -12,6 +12,10 @@ import { getProjectModelProviders } from "../api/routers/modelProviders.utils";
 import { prisma } from "../db";
 import type { SingleEvaluationResult } from "../evaluations/evaluators.generated";
 import type { MaybeStoredModelProvider } from "../modelProviders/registry";
+import { createLogger } from "../../utils/logger";
+import { stripUnsupportedLLMParamsFromWorkflow } from "./stripUnsupportedLLMParams";
+
+const logger = createLogger("langwatch:workflows:runWorkflow");
 
 const getWorkFlow = (state: Workflow) => {
   return {
@@ -232,6 +236,33 @@ export async function runWorkflow(
       origin,
     },
   };
+
+  // Strip every sampling parameter from each LLM block that the resolved
+  // model does not list as supported. The Studio path (POST
+  // /api/workflows/post_event) already does this; this is the parallel
+  // chokepoint for every server-driven dispatch (online evaluators,
+  // evaluator-as-evaluator chains, scheduled runs). Without it, a
+  // published workflow that carries a stale top_p from before the
+  // operator disabled it on their custom-model config still ships the
+  // field to the gateway, and Bedrock newer-Claude rejects the combo
+  // with `temperature and top_p cannot both be specified`. Customer
+  // dogfood 2026-05-31 surfaced exactly this path on
+  // us.anthropic.claude-haiku-4-5-* as an online evaluator. Best-effort
+  // so a registry-lookup miss never blocks the run.
+  try {
+    await stripUnsupportedLLMParamsFromWorkflow({
+      prisma,
+      projectId,
+      workflow: messageWithoutEnvs.payload.workflow as Parameters<
+        typeof stripUnsupportedLLMParamsFromWorkflow
+      >[0]["workflow"],
+    });
+  } catch (filterError) {
+    logger.warn(
+      { err: filterError, projectId, workflowId },
+      "stripUnsupportedLLMParamsFromWorkflow failed; forwarding original payload",
+    );
+  }
 
   const event = await addEnvs(messageWithoutEnvs, projectId);
 


### PR DESCRIPTION
## Summary

The Studio path (`POST /api/workflows/post_event`) already calls `stripUnsupportedLLMParamsFromWorkflow` on every event before forwarding to nlpgo (PR #4429), so a published workflow whose prompt-config blob still carries a stale `top_p` from before the operator disabled it on their custom-model config does not ship that field to the gateway. The **server-driven dispatch path** (`runWorkflow` / `runEvaluationWorkflow`, used by online evaluators, evaluator-as-evaluator chains, and any tRPC/cron caller of `runWorkflow`) skipped that chokepoint and re-opened the bug the strip was written to close.

## Customer dogfood 2026-05-31

The classifier-relevance workflow (`temperature=1`, `top_p=1`, `model = bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0`) ran fine in Studio but failed every online-evaluation run with:

```
gateway chat/completions: provider_error ... ValidationException: The model returned the following errors: `temperature` and `top_p` cannot both be specified for this model. Please use only one.
```

because the customer had removed `top_p` from their custom model's `supportedParameters` list. The Studio path honored the model-config strip; the evaluator path did not.

## Changes

`langwatch/src/server/workflows/runWorkflow.ts`: call `stripUnsupportedLLMParamsFromWorkflow` immediately after the message payload is built and before it goes through `addEnvs + nlpgoFetch`. Mirrors the post-event wiring 1-for-1 (best-effort try/catch, never blocks the run on a registry-lookup miss).

## Why not the earlier draft

The first draft of this PR hardcoded a `bedrock+anthropic temperature+top_p` drop in `nlpgo/adapters/llmexecutor/executor.go` and `aigateway/adapters/providers/bedrock_vpce.go`. That was the wrong layer:

- It overrode the operator's model-config choices unconditionally.
- It would have stripped `top_p` even from configs that legitimately disabled `temperature` and kept `top_p`.
- It bypassed the model-config-aware filter that PR #4429 added specifically for this class of bug.

The model-config-aware filter respects every operator decision (`top_p` disabled, `top_k` removed, `seed` not supported, etc.) and is the same code path the rest of the system already trusts.

## Test plan

- [x] tsgo typecheck clean
- [ ] CI green
- [ ] Customer can rerun the failing online-evaluation against the same workflow once deployed