### PR TITLE
ci: backfill workflow to sign already-published release images

### DIFF
--- a/.github/scripts/sign-image.sh
+++ b/.github/scripts/sign-image.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Sign a single already-pushed multi-arch image with keyless cosign, generate a
+# per-platform CycloneDX SBOM, and attach it as a cosign attestation. Operates on
+# images that are already in the registry by digest; it does not build anything.
+#
+# Shared by:
+#   - .github/workflows/publish-docker-app.yml  (signs each image right after a release build)
+#   - .github/workflows/sign-release-images.yml (backfills signing for an already-published release)
+#
+# Required env:
+#   REPO                 registry repo without a tag, e.g. langwatch/langwatch
+#   IMAGE_NAME           short name used in SBOM filenames, e.g. langwatch
+#   INSPECT_TAG          tag whose multi-arch index is inspected and signed, e.g. 3.4.0 or a247e8e
+#   SBOM_DIR             directory to write the *.cdx.json SBOMs into
+#   CERT_IDENTITY_REGEX  cosign --certificate-identity-regexp value
+#   CERT_OIDC_ISSUER     cosign --certificate-oidc-issuer value
+# Optional env:
+#   EXTRA_TAGS           space-separated tags that should point at the same index digest;
+#                        any whose digest differs is signed separately (e.g. "3.4.0 latest")
+set -euo pipefail
+
+: "${REPO:?REPO required (e.g. langwatch/langwatch)}"
+: "${IMAGE_NAME:?IMAGE_NAME required (short name for SBOM files)}"
+: "${INSPECT_TAG:?INSPECT_TAG required (tag whose index is signed)}"
+: "${SBOM_DIR:?SBOM_DIR required}"
+: "${CERT_IDENTITY_REGEX:?CERT_IDENTITY_REGEX required}"
+: "${CERT_OIDC_ISSUER:?CERT_OIDC_ISSUER required}"
+EXTRA_TAGS="${EXTRA_TAGS:-}"
+
+REF="${REPO}:${INSPECT_TAG}"
+INSPECT=$(docker buildx imagetools inspect "${REF}" --format '{{ json . }}')
+
+INDEX_DIGEST=$(echo "${INSPECT}" | jq -r '.manifest.digest')
+if [ -z "${INDEX_DIGEST}" ] || [ "${INDEX_DIGEST}" = "null" ]; then
+  echo "::error::Could not resolve index digest for ${REF}"
+  exit 1
+fi
+echo "Signing multi-arch index ${REPO}@${INDEX_DIGEST}"
+cosign sign "${REPO}@${INDEX_DIGEST}"
+
+echo "Verifying index signature for ${REPO}@${INDEX_DIGEST}"
+cosign verify "${REPO}@${INDEX_DIGEST}" \
+  --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+  --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
+
+# Equivalent tags should all point at the same multi-arch manifest digest, but assert
+# it explicitly so that any registry-side normalization that produces a different digest
+# is signed rather than silently leaving an unsigned tag.
+for TAG in ${EXTRA_TAGS}; do
+  TAG_DIGEST=$(docker buildx imagetools inspect "${REPO}:${TAG}" --format '{{ json . }}' | jq -r '.manifest.digest')
+  if [ "${TAG_DIGEST}" != "${INDEX_DIGEST}" ]; then
+    echo "::warning::${REPO}:${TAG} digest ${TAG_DIGEST} differs from ${REF} digest ${INDEX_DIGEST}; signing separately"
+    cosign sign "${REPO}@${TAG_DIGEST}"
+    cosign verify "${REPO}@${TAG_DIGEST}" \
+      --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+      --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
+  fi
+done
+
+PLATFORMS_JSON=$(echo "${INSPECT}" | jq -c '[.manifest.manifests[] | select(.platform.os != "unknown") | {digest: .digest, os: .platform.os, arch: .platform.architecture}]')
+COUNT=$(echo "${PLATFORMS_JSON}" | jq 'length')
+if [ "${COUNT}" -eq 0 ]; then
+  echo "::error::No platform manifests found in index for ${REF}"
+  exit 1
+fi
+
+for i in $(seq 0 $((COUNT - 1))); do
+  ENTRY=$(echo "${PLATFORMS_JSON}" | jq -c ".[$i]")
+  PDIGEST=$(echo "${ENTRY}" | jq -r '.digest')
+  POS=$(echo "${ENTRY}" | jq -r '.os')
+  PARCH=$(echo "${ENTRY}" | jq -r '.arch')
+  PDREF="${REPO}@${PDIGEST}"
+  SBOM_FILE="${SBOM_DIR}/${IMAGE_NAME}-${POS}-${PARCH}.cdx.json"
+
+  echo "Generating CycloneDX SBOM for ${PDREF} (${POS}/${PARCH})"
+  syft "registry:${PDREF}" -o cyclonedx-json="${SBOM_FILE}"
+
+  echo "Signing platform manifest ${PDREF}"
+  cosign sign "${PDREF}"
+
+  echo "Attesting SBOM for ${PDREF}"
+  cosign attest --predicate "${SBOM_FILE}" --type cyclonedx "${PDREF}"
+
+  echo "Verifying signature and SBOM attestation for ${PDREF}"
+  cosign verify "${PDREF}" \
+    --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+    --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
+  cosign verify-attestation "${PDREF}" \
+    --type cyclonedx \
+    --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+    --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
+done

--- a/.github/workflows/publish-docker-app.yml
+++ b/.github/workflows/publish-docker-app.yml
@@ -226,78 +226,25 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p sboms
+          # Release tags (VERSION + optionally latest) and the HASH tag should all point
+          # at the same multi-arch manifest digest; sign-image.sh asserts this and signs
+          # any tag whose digest drifted rather than leaving it unsigned.
+          EXTRA_TAGS=""
+          if [ "${IS_RELEASE}" = "true" ]; then
+            EXTRA_TAGS="${VERSION}"
+            if ! echo "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-.+'; then
+              EXTRA_TAGS="${EXTRA_TAGS} latest"
+            fi
+          fi
           for IMAGE in langwatch langwatch_nlp langevals ai-gateway; do
-            REF="langwatch/${IMAGE}:${HASH}"
-            INSPECT=$(docker buildx imagetools inspect "${REF}" --format '{{ json . }}')
-
-            INDEX_DIGEST=$(echo "${INSPECT}" | jq -r '.manifest.digest')
-            if [ -z "${INDEX_DIGEST}" ] || [ "${INDEX_DIGEST}" = "null" ]; then
-              echo "::error::Could not resolve index digest for ${REF}"
-              exit 1
-            fi
-            echo "Signing multi-arch index langwatch/${IMAGE}@${INDEX_DIGEST}"
-            cosign sign "langwatch/${IMAGE}@${INDEX_DIGEST}"
-
-            echo "Verifying index signature for langwatch/${IMAGE}@${INDEX_DIGEST}"
-            cosign verify "langwatch/${IMAGE}@${INDEX_DIGEST}" \
-              --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
-              --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
-
-            # Release tags (VERSION + optionally latest) and the HASH tag should all point
-            # at the same multi-arch manifest digest, but assert it explicitly so that any
-            # future registry-side normalization that produces a different digest is signed
-            # rather than silently leaving an unsigned tag.
-            EXTRA_TAGS=""
-            if [ "${IS_RELEASE}" = "true" ]; then
-              EXTRA_TAGS="${VERSION}"
-              if ! echo "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-.+'; then
-                EXTRA_TAGS="${EXTRA_TAGS} latest"
-              fi
-            fi
-            for TAG in ${EXTRA_TAGS}; do
-              TAG_DIGEST=$(docker buildx imagetools inspect "langwatch/${IMAGE}:${TAG}" --format '{{ json . }}' | jq -r '.manifest.digest')
-              if [ "${TAG_DIGEST}" != "${INDEX_DIGEST}" ]; then
-                echo "::warning::langwatch/${IMAGE}:${TAG} digest ${TAG_DIGEST} differs from :${HASH} digest ${INDEX_DIGEST}; signing separately"
-                cosign sign "langwatch/${IMAGE}@${TAG_DIGEST}"
-                cosign verify "langwatch/${IMAGE}@${TAG_DIGEST}" \
-                  --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
-                  --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
-              fi
-            done
-
-            PLATFORMS_JSON=$(echo "${INSPECT}" | jq -c '[.manifest.manifests[] | select(.platform.os != "unknown") | {digest: .digest, os: .platform.os, arch: .platform.architecture}]')
-            COUNT=$(echo "${PLATFORMS_JSON}" | jq 'length')
-            if [ "${COUNT}" -eq 0 ]; then
-              echo "::error::No platform manifests found in index for ${REF}"
-              exit 1
-            fi
-
-            for i in $(seq 0 $((COUNT - 1))); do
-              ENTRY=$(echo "${PLATFORMS_JSON}" | jq -c ".[$i]")
-              PDIGEST=$(echo "${ENTRY}" | jq -r '.digest')
-              POS=$(echo "${ENTRY}" | jq -r '.os')
-              PARCH=$(echo "${ENTRY}" | jq -r '.arch')
-              PDREF="langwatch/${IMAGE}@${PDIGEST}"
-              SBOM_FILE="sboms/${IMAGE}-${POS}-${PARCH}.cdx.json"
-
-              echo "Generating CycloneDX SBOM for ${PDREF} (${POS}/${PARCH})"
-              syft "registry:${PDREF}" -o cyclonedx-json="${SBOM_FILE}"
-
-              echo "Signing platform manifest ${PDREF}"
-              cosign sign "${PDREF}"
-
-              echo "Attesting SBOM for ${PDREF}"
-              cosign attest --predicate "${SBOM_FILE}" --type cyclonedx "${PDREF}"
-
-              echo "Verifying signature and SBOM attestation for ${PDREF}"
-              cosign verify "${PDREF}" \
-                --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
-                --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
-              cosign verify-attestation "${PDREF}" \
-                --type cyclonedx \
-                --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
-                --certificate-oidc-issuer "${CERT_OIDC_ISSUER}" > /dev/null
-            done
+            REPO="langwatch/${IMAGE}" \
+            IMAGE_NAME="${IMAGE}" \
+            INSPECT_TAG="${HASH}" \
+            SBOM_DIR="sboms" \
+            EXTRA_TAGS="${EXTRA_TAGS}" \
+            CERT_IDENTITY_REGEX="${CERT_IDENTITY_REGEX}" \
+            CERT_OIDC_ISSUER="${CERT_OIDC_ISSUER}" \
+            bash .github/scripts/sign-image.sh
           done
 
       - name: Upload SBOMs as workflow artifact

--- a/.github/workflows/sign-release-images.yml
+++ b/.github/workflows/sign-release-images.yml
@@ -1,0 +1,82 @@
+name: sign-release-images
+
+# Backfill cosign signatures + CycloneDX SBOM attestations for an already-published
+# release whose publish-docker-app signing step failed (e.g. the v3.4.0 run that ran
+# under the broken cosign 3.x default bundle format). This signs the images already in
+# the registry by digest; it does not rebuild or re-push anything, and it reuses the
+# exact signing logic from the release pipeline (.github/scripts/sign-image.sh).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Released image tag to sign (e.g. 3.4.0)'
+        required: true
+      attach_to_release:
+        description: 'Attach the SBOMs to the langwatch@v<version> GitHub release'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write # attach SBOMs to the GitHub release
+  id-token: write # keyless OIDC signing via Sigstore
+
+env:
+  COSIGN_YES: "true"
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Match publish-docker-app: cosign 3.x defaults to the OCI 1.1 referrers bundle
+          # format that Docker Hub does not reliably serve, breaking verify after sign.
+          cosign-release: v2.6.3
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Sign images and attach per-platform CycloneDX SBOMs
+        env:
+          VERSION: ${{ inputs.version }}
+          CERT_IDENTITY_REGEX: ^https://github\.com/langwatch/langwatch/
+          CERT_OIDC_ISSUER: https://token.actions.githubusercontent.com
+        run: |
+          set -euo pipefail
+          mkdir -p sboms
+          for IMAGE in langwatch langwatch_nlp langevals ai-gateway; do
+            REPO="langwatch/${IMAGE}" \
+            IMAGE_NAME="${IMAGE}" \
+            INSPECT_TAG="${VERSION}" \
+            SBOM_DIR="sboms" \
+            CERT_IDENTITY_REGEX="${CERT_IDENTITY_REGEX}" \
+            CERT_OIDC_ISSUER="${CERT_OIDC_ISSUER}" \
+            bash .github/scripts/sign-image.sh
+          done
+
+      - name: Upload SBOMs as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sboms-${{ inputs.version }}
+          path: sboms/*.cdx.json
+          retention-days: 90
+
+      - name: Attach SBOMs to GitHub release
+        if: inputs.attach_to_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: langwatch@v${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" sboms/*.cdx.json --clobber --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
## What

- Extracts the per-image cosign sign + CycloneDX SBOM attest loop out of `publish-docker-app.yml` into a shared `.github/scripts/sign-image.sh`.
- Adds a `sign-release-images` `workflow_dispatch` workflow that runs that same script against an already-published release's images (by version tag, e.g. `3.4.0`), using the fixed cosign 2.x pin.

## Why

v3.4.0's signing failed (cosign 3.x default bundle format is unreadable on Docker Hub, see #4441). Re-running the original run can't help: `release` events use the workflow file at the tag commit, which is permanently bound to the broken cosign 3.0.6 version. This backfill workflow lets us sign the existing 3.4.0 images (no rebuild, no tag move, no provenance change) with the corrected pipeline, and is reusable for any future release whose signing step failed after the images shipped.

The release pipeline keeps identical behavior, it just calls the shared script instead of an inline copy, so the two code paths can't drift.

## How to use

Actions -> sign-release-images -> Run workflow -> version: `3.4.0`. It signs `langwatch/{langwatch,langwatch_nlp,langevals,ai-gateway}:<version>`, attaches the SBOMs to the `langwatch@v<version>` release, and uploads them as a workflow artifact.