### PR TITLE
fix(ops): percent-decode CLICKHOUSE_OPS_URL userinfo for /ops/clickhouse/explain

### DIFF
--- a/langwatch/src/server/ops/__tests__/explain-core.unit.test.ts
+++ b/langwatch/src/server/ops/__tests__/explain-core.unit.test.ts
@@ -3,6 +3,7 @@ import {
   _resetOpsClickHouseClientForTesting,
   buildExplainQuery,
   getOpsClickHouseClient,
+  parseOpsConnection,
   redactQueryForAudit,
   stripCommentsAndStrings,
 } from "../explain-core";
@@ -182,6 +183,47 @@ describe("redactQueryForAudit", () => {
     const b = redactQueryForAudit("SELECT 1 FROM x");
     expect(a.sha256).toBe(b.sha256);
     expect(a.sha256).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("parseOpsConnection", () => {
+  it("splits scheme/host from userinfo/database", () => {
+    const r = parseOpsConnection("http://langwatch_ops:secret@ch.example:8123/langwatch");
+    expect(r).toEqual({
+      url: "http://ch.example:8123",
+      username: "langwatch_ops",
+      password: "secret",
+      database: "langwatch",
+    });
+  });
+
+  it("percent-decodes a password Terraform urlencode()'d (the prod failure mode)", () => {
+    // random_password override_special = "_%@" -> a real prod value would
+    // look like this once urlencode() wraps the '@' and '%' chars for the
+    // URL to parse at all. URL.password returns the encoded string, so the
+    // client used to authenticate with the literal "%40" instead of "@" —
+    // that's the "Authentication failed" we saw against prod CH.
+    const r = parseOpsConnection(
+      "http://langwatch_ops:_1a4ZZx_kpR%40%25efk_lL%40fm%25WSwa5C%40AN@ch.example:8123/langwatch",
+    );
+    expect(r?.username).toBe("langwatch_ops");
+    expect(r?.password).toBe("_1a4ZZx_kpR@%efk_lL@fm%WSwa5C@AN");
+  });
+
+  it("returns empty strings when userinfo is absent", () => {
+    const r = parseOpsConnection("http://ch.example:8123/langwatch");
+    expect(r?.username).toBe("");
+    expect(r?.password).toBe("");
+    expect(r?.database).toBe("langwatch");
+  });
+
+  it("returns undefined database when path is empty or '/'", () => {
+    expect(parseOpsConnection("http://u:p@ch:8123")?.database).toBeUndefined();
+    expect(parseOpsConnection("http://u:p@ch:8123/")?.database).toBeUndefined();
+  });
+
+  it("returns null on a non-URL string", () => {
+    expect(parseOpsConnection("not a url at all")).toBeNull();
   });
 });
 

--- a/langwatch/src/server/ops/explain-core.ts
+++ b/langwatch/src/server/ops/explain-core.ts
@@ -189,18 +189,48 @@ export function redactQueryForAudit(query: string): { shape: string; sha256: str
 let opsClickHouseClient: ClickHouseClient | null = null;
 let warnedAboutMissingOpsUrl = false;
 
+/**
+ * Parse CLICKHOUSE_OPS_URL into the pieces @clickhouse/client wants as
+ * separate config fields. We do the userinfo split + percent-decoding
+ * ourselves because the lib forwards `URL.username` / `URL.password`
+ * to the wire as-is — both getters return the URL-encoded form. With a
+ * Terraform-generated password that may contain '@' or '%' (which TF
+ * wraps via `urlencode()` to keep the URL parseable), passing the URL
+ * verbatim ends up authenticating with the encoded form (e.g. "p%40ss")
+ * and ClickHouse rejects with "Authentication failed". Decoding here
+ * means the wire password matches what users.xml hashes.
+ */
+export function parseOpsConnection(raw: string): {
+  url: string;
+  username: string;
+  password: string;
+  database?: string;
+} | null {
+  try {
+    const u = new URL(raw);
+    const username = u.username ? decodeURIComponent(u.username) : "";
+    const password = u.password ? decodeURIComponent(u.password) : "";
+    const database =
+      u.pathname && u.pathname !== "/"
+        ? decodeURIComponent(u.pathname.replace(/^\//, ""))
+        : undefined;
+    const cleanUrl = `${u.protocol}//${u.host}`;
+    return { url: cleanUrl, username, password, database };
+  } catch {
+    return null;
+  }
+}
+
 export function getOpsClickHouseClient(): ClickHouseClient | null {
   if (opsClickHouseClient) return opsClickHouseClient;
   const url = process.env.CLICKHOUSE_OPS_URL;
   if (!url || url.trim() === "") return null;
-  let parsed: URL | string = url;
-  try {
-    parsed = new URL(url);
-  } catch {
-    /* pass raw if not a valid URL */
-  }
+  const parsed = parseOpsConnection(url);
   opsClickHouseClient = createClient({
-    url: parsed,
+    url: parsed?.url ?? url,
+    username: parsed?.username || undefined,
+    password: parsed?.password || undefined,
+    database: parsed?.database,
     clickhouse_settings: { date_time_input_format: "best_effort" },
     max_open_connections: 5,
     keep_alive: { enabled: true, idle_socket_ttl: 1500 },


### PR DESCRIPTION
## Summary
- CH ops endpoint was authenticating with the URL-encoded form of the password, not the raw password. Every request to `/api/ops/clickhouse/explain` against prod returned 502 because the wrapped CH client hit "Authentication failed: password is incorrect, or there is no user with such name".
- Root cause: `getOpsClickHouseClient()` passed `new URL(CLICKHOUSE_OPS_URL)` straight to `@clickhouse/client`. The lib forwards `URL.username` / `URL.password` to the wire as-is, and both getters return the percent-encoded form. With the Terraform random_password (override_special = `_%@`) wrapped by `urlencode()` for the URL to parse, the client was authenticating with the encoded literal (e.g. `_1a4ZZx_kpR%40%25...`) instead of the original.
- Fix: parse the URL ourselves, decode the userinfo + database with `decodeURIComponent`, and pass `url` / `username` / `password` / `database` to `createClient()` as separate fields. Added `parseOpsConnection()` with unit tests including the exact prod failure-mode shape.

Why the existing integration test missed it: the testcontainers ClickHouse runs with no auth so URL.password was never on the auth path. Added a unit case that pins the prod shape (urlencoded `@` and `%`) so we cannot regress.

## Test plan
- [x] `pnpm vitest run src/server/ops/__tests__/explain-core.unit.test.ts` (33 passed)
- [ ] After deploy, re-probe from the agents box: `curl ... /api/ops/clickhouse/explain` returns 200 with a PLAN payload instead of 502
- [ ] Nudge the clickhouse-optimizer agent to re-run the EXPLAINs from its review on #4434 against the now-live endpoint