### PR TITLE
fix(ops): stop sending client settings when using langwatch_ops (readonly profile)

### DIFF
--- a/langwatch/src/server/ops/explain-core.ts
+++ b/langwatch/src/server/ops/explain-core.ts
@@ -226,12 +226,19 @@ export function getOpsClickHouseClient(): ClickHouseClient | null {
   const url = process.env.CLICKHOUSE_OPS_URL;
   if (!url || url.trim() === "") return null;
   const parsed = parseOpsConnection(url);
+  // No client-side `clickhouse_settings` here: the langwatch_ops user runs
+  // under the `readonly_safe` profile (readonly=1) which forbids modifying
+  // any session setting client-side, so the previous default of
+  // date_time_input_format=best_effort made every request fail with
+  // "Cannot modify ... in readonly mode". EXPLAIN never parses input
+  // values anyway, so dropping the setting is also functionally correct.
+  // The execution/result/memory caps that USED to live here are enforced
+  // server-side by the profile.
   opsClickHouseClient = createClient({
     url: parsed?.url ?? url,
     username: parsed?.username || undefined,
     password: parsed?.password || undefined,
     database: parsed?.database,
-    clickhouse_settings: { date_time_input_format: "best_effort" },
     max_open_connections: 5,
     keep_alive: { enabled: true, idle_socket_ttl: 1500 },
   });

--- a/langwatch/src/server/routes/ops.ts
+++ b/langwatch/src/server/routes/ops.ts
@@ -140,10 +140,15 @@ secured
     );
 
     try {
+      // Only send guardrails when we fell back to the default-user client.
+      // The langwatch_ops user runs under the `readonly_safe` profile
+      // (readonly=1), which forbids client-side setting modifications —
+      // sending guardrails here would 400 every request. The profile
+      // already enforces the same caps server-side.
       const result = await client.query({
         query: built.wrapped!,
         format: "JSONEachRow",
-        clickhouse_settings: CLICKHOUSE_GUARDRAILS,
+        ...(usingFallback ? { clickhouse_settings: CLICKHOUSE_GUARDRAILS } : {}),
       });
       const rows = await result.json();
       return c.json({ type: built.type, rows });


### PR DESCRIPTION
## Summary
- After #4445 fixed authentication, the endpoint still 502'd from the langwatch_ops path with \`Cannot modify 'date_time_input_format' setting in readonly mode\`. The user runs under the \`readonly_safe\` profile (\`readonly=1\`), which forbids any client-side session-setting modification — even no-op re-sets.
- The settings we were sending were redundant on this path anyway: the profile pins exec_time/result_bytes/memory server-side, and EXPLAIN never parses datetime input.
- Drop \`date_time_input_format=best_effort\` from \`getOpsClickHouseClient\`, and only attach \`CLICKHOUSE_GUARDRAILS\` per-query on the fallback (default-user) path.

Why the integration test didn't catch it: testcontainers CH runs with the default user under no profile/no readonly enforcement, so client setting overrides are silently accepted. The failure only surfaces against a prod-shaped CH where users.xml pins readonly=1.

## Test plan
- [x] \`pnpm vitest run src/server/ops/__tests__/explain-core.unit.test.ts\` (33 passed)
- [ ] After deploy, re-probe from the agents box — endpoint returns 200 with a PLAN payload
- [ ] Nudge the clickhouse-optimizer to re-run the EXPLAINs from #4434