### PR TITLE
fix(chart): gate clickhouse Secrets on autogen.enabled (Argo drift, subchart + parent)

### DIFF
--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -4,8 +4,13 @@ Deploy ClickHouse with auto-tuning from CPU/RAM, tiered S3-compatible cold stora
 
 ## Quick Start
 
+The chart defaults to `autogen.enabled=false` (production-safe). Pick a credentials path before installing.
+
+**Dev / stock install — chart materialises the password Secret:**
+
 ```bash
 helm install clickhouse ./charts/clickhouse-serverless \
+  --set autogen.enabled=true \
   --set cpu=4 \
   --set memory=16Gi
 ```
@@ -14,10 +19,28 @@ For a 3-node replicated cluster with Keeper:
 
 ```bash
 helm install clickhouse ./charts/clickhouse-serverless \
+  --set autogen.enabled=true \
   --set cpu=4 \
   --set memory=16Gi \
   --set replicas=3
 ```
+
+**Production / GitOps install — operator owns the credentials Secret:**
+
+```bash
+# Pre-create the Secret (single-node needs only password; replicated also needs clusterSecret).
+kubectl create secret generic my-ch-creds \
+  --from-literal=password=$(openssl rand -hex 32) \
+  --from-literal=clusterSecret=$(openssl rand -hex 24)
+
+helm install clickhouse ./charts/clickhouse-serverless \
+  --set auth.existingSecret=my-ch-creds \
+  --set cpu=4 \
+  --set memory=16Gi \
+  --set replicas=3
+```
+
+A pre-install / pre-upgrade preflight Job verifies the required keys exist in the operator-owned Secret before pods roll. See [Secret Management](#secret-management) for the rationale.
 
 ## How It Works
 
@@ -90,9 +113,15 @@ Shared by cold storage and backups. Required when either `cold.enabled` or `back
 
 | Name | Description | Default |
 |------|-------------|---------|
-| `auth.password` | Default user password (auto-generated when empty + no existingSecret) | `""` |
-| `auth.existingSecret` | Name of existing secret containing the password | `""` |
-| `auth.secretKeys.passwordKey` | Key within the secret | `password` |
+| `autogen.enabled` | Chart materialises the credentials Secret via per-key `lookup-or-rand` (existing values reused on upgrade). Must be enabled unless `auth.existingSecret` is set. | `false` |
+| `auth.password` | Seed value when `autogen.enabled=true` and you want a deterministic password instead of `randAlphaNum`. Ignored when `auth.existingSecret` is set. | `""` |
+| `auth.clusterSecret` | Seed value for the Keeper inter-node cluster secret (only used when `replicas>1`). Ignored when `auth.existingSecret` is set. | `""` |
+| `auth.existingSecret` | Name of an operator-owned Secret. When set, the chart skips its own Secret render and a preflight Job verifies the required keys exist before pods roll. | `""` |
+| `auth.secretKeys.passwordKey` | Key name for the password in both autogen and existingSecret paths | `password` |
+| `auth.secretKeys.clusterSecretKey` | Key name for the Keeper cluster secret | `clusterSecret` |
+| `preflight.enabled` | Run the pre-install/pre-upgrade Secret-keys Job when `auth.existingSecret` is set | `true` |
+| `preflight.image` | Container image (needs `sh` + `kubectl` + `jq`) | `alpine/k8s:1.30.0` |
+| `preflight.activeDeadlineSeconds` | Hard timeout for the preflight Job | `60` |
 
 ### Users
 
@@ -150,9 +179,23 @@ This creates two users: `analyst` with read-only access to all databases, and `e
 
 ## Secret Management
 
-When `auth.password` is empty and no `auth.existingSecret` is set, the chart auto-generates a password and stores it in `<release>-clickhouse` secret. The password is preserved across `helm upgrade` via `lookup`.
+Two explicit paths, picked at install time:
 
-> **Note:** `helm template` always shows freshly-generated passwords since `lookup` returns empty without cluster access. The actual deployed secret will be preserved.
+**Autogen (`autogen.enabled=true`)**
+
+The chart materialises a `<release>-clickhouse` Secret on first install via `randAlphaNum` (or the values you supply for `auth.password` / `auth.clusterSecret`). On every subsequent `helm upgrade`, each required key is independently `lookup`-ed and the existing value reused verbatim — no rotation, no roll. A partially-populated Secret (e.g. an operator imported `password` but not `clusterSecret` during a single→replicated migration) is healed in place. The Secret carries `helm.sh/resource-policy: keep` so a `helm uninstall` does not drop the credentials.
+
+> **Important:** `helm lookup` returns empty for any renderer that lacks cluster access — most notably the ArgoCD repo-server. If your install runs under such a renderer, **do not use the autogen path**: the chart will render a fresh random password on every reconcile and rotate the credentials underneath your running pods. Use the operator-owned path below instead.
+
+**Operator-owned (`autogen.enabled=false`, the default)**
+
+You pre-create a Secret in the namespace with the required keys (`password`, plus `clusterSecret` when `replicas>1`), point `auth.existingSecret` at its name, and the chart skips materialising its own Secret entirely. A pre-install / pre-upgrade preflight Job runs as a Helm hook and verifies the required keys exist before the StatefulSet rolls — catches the trap where a chart bump adds a new required key or the operator imported the Secret without all the keys.
+
+This is the drift-safe path under GitOps controllers.
+
+**Neither set**
+
+Chart-render hard-fails with an actionable error naming both opt-ins. The chart never silently materialises a Secret it could later rotate.
 
 ## Examples
 

--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -120,7 +120,7 @@ Shared by cold storage and backups. Required when either `cold.enabled` or `back
 | `auth.secretKeys.passwordKey` | Key name for the password in both autogen and existingSecret paths | `password` |
 | `auth.secretKeys.clusterSecretKey` | Key name for the Keeper cluster secret | `clusterSecret` |
 | `preflight.enabled` | Run the pre-install/pre-upgrade Secret-keys Job when `auth.existingSecret` is set | `true` |
-| `preflight.image` | Container image (needs `sh` + `kubectl` + `jq`) | `alpine/k8s:1.30.0` |
+| `preflight.image` | Container image (needs `sh` + `kubectl` + `jq`; the Job fails fast if `jq` is missing) | `alpine/k8s:1.30.0` |
 | `preflight.activeDeadlineSeconds` | Hard timeout for the preflight Job | `60` |
 
 ### Users

--- a/charts/clickhouse-serverless/templates/_helpers.tpl
+++ b/charts/clickhouse-serverless/templates/_helpers.tpl
@@ -78,6 +78,7 @@ app.kubernetes.io/component: keeper
 
 {{/* Validation: fail early on invalid configuration */}}
 {{- define "clickhouse-serverless.validate" -}}
+  {{- include "clickhouse-serverless.validateAuth" . }}
   {{- if and (or .Values.cold.enabled .Values.backup.enabled) (not .Values.objectStorage.bucket) }}
     {{- fail "objectStorage.bucket is required when cold.enabled or backup.enabled is true" }}
   {{- end }}
@@ -89,21 +90,28 @@ app.kubernetes.io/component: keeper
   {{- end }}
 {{- end -}}
 
-{{/* Password secret key */}}
-{{- define "clickhouse-serverless.secretKey" -}}
-  {{- if .Values.auth.existingSecret -}}
-    {{- .Values.auth.secretKeys.passwordKey -}}
-  {{- else -}}
-    {{- "password" -}}
-  {{- end -}}
+{{/* Auth wiring fail-fast: hard-stop the render when neither path to a
+     credentials Secret is configured. Either autogen.enabled=true (the
+     chart materialises the Secret via lookup-or-rand) or
+     auth.existingSecret points at an operator-owned Secret. With both
+     unset the StatefulSet would mount a Secret name that never gets
+     created and the ClickHouse pods would crashloop with
+     CreateContainerConfigError. Catch it at chart-render time instead. */}}
+{{- define "clickhouse-serverless.validateAuth" -}}
+  {{- if and (not .Values.autogen.enabled) (empty .Values.auth.existingSecret) }}
+    {{- fail "clickhouse-serverless: no credentials Secret configured. Either set autogen.enabled=true (chart materialises the Secret on first install via lookup-or-rand) OR pre-create a Secret with `password` (and `clusterSecret` when replicas>1) and set auth.existingSecret to its name." -}}
+  {{- end }}
 {{- end -}}
 
-{{/* Cluster secret key */}}
+{{/* Password secret key (uses auth.secretKeys.passwordKey for both the
+     autogen and existing-secret paths so the StatefulSet env mapping
+     and the rendered Secret data key always agree). */}}
+{{- define "clickhouse-serverless.secretKey" -}}
+{{- default "password" .Values.auth.secretKeys.passwordKey -}}
+{{- end -}}
+
+{{/* Cluster secret key (same shape as secretKey above). */}}
 {{- define "clickhouse-serverless.clusterSecretKey" -}}
-  {{- if .Values.auth.existingSecret -}}
-    {{- .Values.auth.secretKeys.clusterSecretKey -}}
-  {{- else -}}
-    {{- "clusterSecret" -}}
-  {{- end -}}
+{{- default "clusterSecret" .Values.auth.secretKeys.clusterSecretKey -}}
 {{- end -}}
 

--- a/charts/clickhouse-serverless/templates/preflight-secrets-job.yaml
+++ b/charts/clickhouse-serverless/templates/preflight-secrets-job.yaml
@@ -1,0 +1,136 @@
+{{/*
+  Pre-install / pre-upgrade preflight: verifies the operator-owned
+  ClickHouse credentials Secret has every key the StatefulSet mounts
+  before pods roll. Catches the trap where a chart bump renames a
+  required key (or the operator imported the Secret without setting
+  clusterSecret on a single→replicated migration) and the upgrade
+  would otherwise crashloop the new pods with CreateContainerConfigError.
+
+  Scope: only renders when the operator owns the Secret out-of-band
+  (autogen.enabled=false AND auth.existingSecret is set). When the
+  chart materialises the Secret on the autogen path, both keys land
+  in the same release as the StatefulSet so there is nothing to
+  verify ahead of time — checking would race the materialiser and
+  fail the upgrade before the Secret is rendered.
+
+  Validates `password` always, and `clusterSecret` only when
+  replicas>1 (single-replica clusters don't need inter-node auth).
+
+  Helm hook contract: pre-install + pre-upgrade. pre-install catches a
+  fresh-install operator who forgot to seed the Secret keys before
+  `helm install`; pre-upgrade catches operator-key drift introduced by
+  subsequent chart bumps. hook-delete-policy keeps failed runs around
+  for post-mortem; succeeded runs get cleaned up automatically.
+*/}}
+{{- if and .Values.preflight.enabled (not .Values.autogen.enabled) .Values.auth.existingSecret }}
+{{- $secretName := tpl .Values.auth.existingSecret . }}
+{{- $passwordKey := default "password" .Values.auth.secretKeys.passwordKey }}
+{{- $clusterSecretKey := default "clusterSecret" .Values.auth.secretKeys.clusterSecretKey }}
+{{- $replicas := .Values.replicas | int }}
+{{- $fullname := include "clickhouse-serverless.fullname" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullname }}-preflight
+  labels:
+    {{- include "clickhouse-serverless.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullname }}-preflight
+  labels:
+    {{- include "clickhouse-serverless.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $secretName | quote }}]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullname }}-preflight
+  labels:
+    {{- include "clickhouse-serverless.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}-preflight
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ $fullname }}-preflight
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullname }}-preflight-secrets
+  labels:
+    {{- include "clickhouse-serverless.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ .Values.preflight.activeDeadlineSeconds | default 60 }}
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "clickhouse-serverless.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $fullname }}-preflight
+      containers:
+        - name: preflight
+          image: {{ .Values.preflight.image }}
+          imagePullPolicy: {{ .Values.preflight.imagePullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -u
+              ns={{ .Release.Namespace | quote }}
+              secret={{ $secretName | quote }}
+              missing=""
+              check_key() {
+                key="$1"
+                v=$(kubectl -n "$ns" get secret "$secret" -o jsonpath="{.data.$key}" 2>/dev/null || printf '')
+                if [ -z "$v" ]; then
+                  missing="$(printf '%s\n  - %s / %s' "$missing" "$secret" "$key")"
+                fi
+              }
+              check_key {{ $passwordKey | quote }}
+              {{- if gt $replicas 1 }}
+              check_key {{ $clusterSecretKey | quote }}
+              {{- end }}
+              if [ -n "$missing" ]; then
+                printf 'preflight: required Secret keys missing in namespace %s:%s\n\n' "$ns" "$missing" >&2
+                printf 'Each missing key blocks the upgrade. Either add it to the existing Secret\n' >&2
+                printf 'or switch to chart-managed via autogen.enabled=true. See NOTES.txt for\n' >&2
+                printf 'the kubectl create commands.\n' >&2
+                exit 1
+              fi
+              printf 'preflight: all required Secret keys present on %s in namespace %s\n' "$secret" "$ns"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+{{- end }}

--- a/charts/clickhouse-serverless/templates/preflight-secrets-job.yaml
+++ b/charts/clickhouse-serverless/templates/preflight-secrets-job.yaml
@@ -115,6 +115,15 @@ spec:
           args:
             - |
               set -u
+              # Fail fast when the operator overrode preflight.image with one
+              # that doesn't ship jq. Without this guard a missing jq would
+              # degrade silently into the generic "required Secret keys
+              # missing" path and the real cause (wrong image) would be
+              # buried in container start failures.
+              if ! command -v jq >/dev/null 2>&1; then
+                printf 'preflight: jq is required in preflight.image (got %s); use the default alpine/k8s image or a mirror that ships jq\n' {{ .Values.preflight.image | quote }} >&2
+                exit 1
+              fi
               ns={{ .Release.Namespace | quote }}
               secret={{ $secretName | quote }}
               missing=""

--- a/charts/clickhouse-serverless/templates/preflight-secrets-job.yaml
+++ b/charts/clickhouse-serverless/templates/preflight-secrets-job.yaml
@@ -22,7 +22,18 @@
   subsequent chart bumps. hook-delete-policy keeps failed runs around
   for post-mortem; succeeded runs get cleaned up automatically.
 */}}
-{{- if and .Values.preflight.enabled (not .Values.autogen.enabled) .Values.auth.existingSecret }}
+{{/* Gate: render whenever the operator has supplied an existingSecret, even
+     if autogen.enabled is also true. The two flags are not mutually exclusive
+     at the chart-render layer: secret.yaml's gate skips rendering when
+     existingSecret is set (no point materialising over operator-owned data),
+     so any time existingSecret is set the operator is the source of truth and
+     the preflight Job must validate the keys are present before pods roll —
+     otherwise an autogen=true + existingSecret combination silently mounts a
+     Secret that might be missing keys and crashloops with CreateContainer-
+     ConfigError. The skip-render-when-autogen-true case is the
+     no-existingSecret-at-all case, where there's nothing for the preflight to
+     verify. */}}
+{{- if and .Values.preflight.enabled .Values.auth.existingSecret }}
 {{- $secretName := tpl .Values.auth.existingSecret . }}
 {{- $passwordKey := default "password" .Values.auth.secretKeys.passwordKey }}
 {{- $clusterSecretKey := default "clusterSecret" .Values.auth.secretKeys.clusterSecretKey }}
@@ -107,9 +118,15 @@ spec:
               ns={{ .Release.Namespace | quote }}
               secret={{ $secretName | quote }}
               missing=""
+              # One kubectl call upfront, then dispatch each required key
+              # against the local JSON via jq (alpine/k8s ships jq). Using
+              # kubectl's jsonpath `.data.$key` here would treat dots in
+              # operator-configured key names (e.g. `clickhouse.password`)
+              # as nested traversal and report present keys as missing.
+              json=$(kubectl -n "$ns" get secret "$secret" -o json 2>/dev/null || printf '{}')
               check_key() {
                 key="$1"
-                v=$(kubectl -n "$ns" get secret "$secret" -o jsonpath="{.data.$key}" 2>/dev/null || printf '')
+                v=$(printf '%s' "$json" | jq -r --arg k "$key" '.data[$k] // empty')
                 if [ -z "$v" ]; then
                   missing="$(printf '%s\n  - %s / %s' "$missing" "$secret" "$key")"
                 fi

--- a/charts/clickhouse-serverless/templates/secret.yaml
+++ b/charts/clickhouse-serverless/templates/secret.yaml
@@ -1,5 +1,50 @@
-{{- if not .Values.auth.existingSecret }}
+{{/*
+  Materialise the ClickHouse credentials Secret (password +
+  clusterSecret) only when the operator opts into chart-managed
+  generation via autogen.enabled=true. Mirrors the parent langwatch
+  chart's gateway-auth-secret + app-secrets gating shape so this
+  subchart behaves the same way under ArgoCD: with autogen off, no
+  Secret is rendered, the operator provides one out-of-band via
+  auth.existingSecret, and the preflight Job validates the keys
+  before pods roll.
+
+  HISTORY: prior to this gating change the Secret rendered whenever
+  auth.existingSecret was empty, and the inner block fell back to
+  randAlphaNum when helm lookup returned no in-cluster Secret. Under
+  ArgoCD, helm lookup returns nil at every sync (the repo-server has
+  no cluster access), so every reconcile re-rolled both keys and
+  rotated the ClickHouse password underneath the running pods. This
+  is the postmortem trap action item #3.
+
+  Each key is checked against the existing Secret data independently
+  via lookup so partial-key rotation works on the autogen path: on
+  first install both keys generate; on every helm upgrade the
+  rendered Secret reuses the existing values verbatim, so the
+  ClickHouse pods do not roll. A partially-populated Secret (e.g.
+  operator imported password but not clusterSecret) is healed in
+  place: only the missing key is generated.
+
+  REINSTALL HAZARD: helm.sh/resource-policy=keep deliberately leaves
+  this Secret behind on `helm uninstall` so a subsequent reinstall
+  in the same namespace reuses the credentials (otherwise the
+  ClickHouse pods would force a full rotation on every reinstall,
+  which under replication breaks Keeper auth too). The cost: a
+  reinstall in the same namespace will hit
+    "exists and cannot be imported into the current release: invalid
+     ownership metadata"
+  because the abandoned Secret no longer carries the new release's
+  meta.helm.sh/release-* annotations. NOTES.txt documents the
+  kubectl annotate / label ownership handoff used to rejoin it.
+*/}}
+{{- if and .Values.autogen.enabled (not .Values.auth.existingSecret) }}
 {{- $fullname := include "clickhouse-serverless.fullname" . }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $fullname }}
+{{- $existingData := dict }}
+{{- if and $existing $existing.data }}
+{{-   $existingData = $existing.data }}
+{{- end }}
+{{- $passwordKey := default "password" .Values.auth.secretKeys.passwordKey }}
+{{- $clusterSecretKey := default "clusterSecret" .Values.auth.secretKeys.clusterSecretKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,25 +52,22 @@ metadata:
   labels:
     {{- include "clickhouse-serverless.selectorLabels" . | nindent 4 }}
     {{- include "clickhouse-serverless.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 data:
-  {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $fullname }}
-  {{- if $existingSecret }}
-  # Reuse existing secret data (preserves password across upgrades)
-  {{- range $key, $value := $existingSecret.data }}
-  {{ $key }}: {{ $value }}
-  {{- end }}
+  {{- if hasKey $existingData $passwordKey }}
+  {{ $passwordKey }}: {{ index $existingData $passwordKey }}
+  {{- else if .Values.auth.password }}
+  {{ $passwordKey }}: {{ .Values.auth.password | b64enc | quote }}
   {{- else }}
-  # Generate new credentials on first install
-  {{- if .Values.auth.password }}
-  password: {{ .Values.auth.password | b64enc | quote }}
-  {{- else }}
-  password: {{ randAlphaNum 32 | b64enc | quote }}
+  {{ $passwordKey }}: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
-  {{- if .Values.auth.clusterSecret }}
-  clusterSecret: {{ .Values.auth.clusterSecret | b64enc | quote }}
+  {{- if hasKey $existingData $clusterSecretKey }}
+  {{ $clusterSecretKey }}: {{ index $existingData $clusterSecretKey }}
+  {{- else if .Values.auth.clusterSecret }}
+  {{ $clusterSecretKey }}: {{ .Values.auth.clusterSecret | b64enc | quote }}
   {{- else }}
-  clusterSecret: {{ randAlphaNum 48 | b64enc | quote }}
-  {{- end }}
+  {{ $clusterSecretKey }}: {{ randAlphaNum 48 | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/clickhouse-serverless/tests/e2e.sh
+++ b/charts/clickhouse-serverless/tests/e2e.sh
@@ -180,21 +180,30 @@ test_existing_secret_missing_key() {
     --from-literal=wrongkey="not-the-password"
 
   # helm install should FAIL: preflight detects the password key is missing.
+  # NOTE: the actionable error message lives in the preflight Job's pod logs,
+  # not in helm's stdout (helm just reports the hook exited non-zero). The
+  # chart's hook-delete-policy=before-hook-creation,hook-succeeded keeps the
+  # failed Job around so we can fetch its logs here.
   if helm_install \
     -f "$CHART_DIR/tests/values-single.yaml" \
     --set autogen.enabled=false \
     --set auth.existingSecret=ch-creds-broken \
     --set auth.secretKeys.passwordKey=password \
-    --set auth.password="" 2>&1 | tee /tmp/ch-preflight-out; then
+    --set auth.password="" 2>&1; then
     fail "Expected helm install to fail when preflight detects missing key"
   else
     pass "Preflight blocked install on missing key"
   fi
 
+  # Drain the preflight Job's pod logs (job/<name> selector covers all pods
+  # the Job ever spawned, regardless of which one currently exists). The
+  # --tail=-1 forces the full buffer rather than the kubectl default tail.
+  kc logs --tail=-1 "job/ch-clickhouse-preflight-secrets" > /tmp/ch-preflight-out 2>/dev/null || true
+
   if grep -q "preflight: required Secret keys missing" /tmp/ch-preflight-out; then
     pass "Preflight surfaced the missing-key error to the operator"
   else
-    fail "Preflight error message not found in helm output"
+    fail "Preflight error message not found in Job logs"
   fi
 
   # Clean up any partial release state so the next suite starts fresh.

--- a/charts/clickhouse-serverless/tests/e2e.sh
+++ b/charts/clickhouse-serverless/tests/e2e.sh
@@ -367,6 +367,17 @@ build_and_load_image() {
   docker build -t "$IMAGE" "$DOCKER_DIR"
   info "Loading image into Kind cluster: $CLUSTER_NAME"
   kind load docker-image "$IMAGE" --name "$CLUSTER_NAME"
+
+  # Pre-pull the preflight Job's image into Kind so the (cold) pull does not
+  # eat the Job's activeDeadlineSeconds budget on first run. alpine/k8s is
+  # ~200MB; on a fresh Kind node the first pull regularly exceeds 60s on
+  # slower connections. On EKS / managed clusters the image is typically
+  # cached at the node group, so the chart default of 60s is fine in prod.
+  local preflight_image
+  preflight_image="${PREFLIGHT_IMAGE:-alpine/k8s:1.30.0}"
+  info "Pre-pulling preflight image: $preflight_image"
+  docker pull "$preflight_image" >/dev/null
+  kind load docker-image "$preflight_image" --name "$CLUSTER_NAME"
 }
 
 main() {

--- a/charts/clickhouse-serverless/tests/e2e.sh
+++ b/charts/clickhouse-serverless/tests/e2e.sh
@@ -122,8 +122,12 @@ test_existing_secret() {
   kc create secret generic ch-creds \
     --from-literal=password="externally-managed" 2>/dev/null || true
 
+  # Exercise the production-shape operator-owned path: autogen.enabled=false
+  # gates off the chart-managed Secret render entirely AND triggers the
+  # preflight Job that validates the operator's Secret has the required keys.
   helm_install \
     -f "$CHART_DIR/tests/values-single.yaml" \
+    --set autogen.enabled=false \
     --set auth.existingSecret=ch-creds \
     --set auth.secretKeys.passwordKey=password \
     --set auth.password=""
@@ -136,6 +140,14 @@ test_existing_secret() {
   else
     pass "No chart-managed secret created"
   fi
+
+  # Helm's hook contract guarantees the pre-install preflight Job ran (and
+  # succeeded) before this point — helm install blocks until the Job
+  # completes, and the chart's hook-delete-policy=hook-succeeded cleans up
+  # the Job + Role + RoleBinding + ServiceAccount immediately afterwards.
+  # A failed preflight would have aborted helm_install with a non-zero exit
+  # before this assertion ran. The negative case is exercised separately
+  # by test_existing_secret_missing_key.
 
   # Verify the external secret is actually mounted and contains the expected value
   local pod="${RELEASE}-clickhouse-0"
@@ -152,6 +164,62 @@ test_existing_secret() {
   assert_eq "Query with external password succeeds" "$query_result" "1"
 
   helm_uninstall
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE: existing secret missing the required key (preflight blocks)
+# Verifies: preflight Job hard-fails helm install when the operator-owned
+# Secret is missing a key the StatefulSet would mount.
+# ─────────────────────────────────────────────────────────────────────────────
+test_existing_secret_missing_key() {
+  sep; info "Suite: existing secret missing required key (preflight blocks)"
+
+  kubectl --context "$KUBE_CTX" create namespace "$NAMESPACE" 2>/dev/null || true
+  kc delete secret ch-creds-broken 2>/dev/null || true
+  kc create secret generic ch-creds-broken \
+    --from-literal=wrongkey="not-the-password"
+
+  # helm install should FAIL: preflight detects the password key is missing.
+  if helm_install \
+    -f "$CHART_DIR/tests/values-single.yaml" \
+    --set autogen.enabled=false \
+    --set auth.existingSecret=ch-creds-broken \
+    --set auth.secretKeys.passwordKey=password \
+    --set auth.password="" 2>&1 | tee /tmp/ch-preflight-out; then
+    fail "Expected helm install to fail when preflight detects missing key"
+  else
+    pass "Preflight blocked install on missing key"
+  fi
+
+  if grep -q "preflight: required Secret keys missing" /tmp/ch-preflight-out; then
+    pass "Preflight surfaced the missing-key error to the operator"
+  else
+    fail "Preflight error message not found in helm output"
+  fi
+
+  # Clean up any partial release state so the next suite starts fresh.
+  helm_uninstall || true
+  kc delete secret ch-creds-broken 2>/dev/null || true
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE: stock install without autogen or existingSecret fails at render
+# Verifies: chart-time validateAuth catches the "no Secret configured" footgun.
+# ─────────────────────────────────────────────────────────────────────────────
+test_no_auth_config_fails() {
+  sep; info "Suite: no auth configured → chart-time render fail"
+
+  if helm template ch "$CHART_DIR" 2>&1 | tee /tmp/ch-validate-out; then
+    fail "Expected helm template to fail when neither autogen nor existingSecret is set"
+  else
+    pass "Chart render hard-failed on missing auth config"
+  fi
+
+  if grep -q "no credentials Secret configured" /tmp/ch-validate-out; then
+    pass "validateAuth surfaced the actionable error"
+  else
+    fail "validateAuth error message not found in helm template output"
+  fi
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -299,6 +367,8 @@ main() {
   test_single
   test_upgrade
   test_existing_secret
+  test_existing_secret_missing_key
+  test_no_auth_config_fails
   test_cold_storage
   test_backup
 

--- a/charts/clickhouse-serverless/tests/values-replicated.yaml
+++ b/charts/clickhouse-serverless/tests/values-replicated.yaml
@@ -13,6 +13,9 @@ auth:
   password: "e2etest"
   clusterSecret: "e2e-cluster-secret"
 
+autogen:
+  enabled: true
+
 keeper:
   resources:
     requests:

--- a/charts/clickhouse-serverless/tests/values-single.yaml
+++ b/charts/clickhouse-serverless/tests/values-single.yaml
@@ -11,3 +11,11 @@ storage:
 
 auth:
   password: "e2etest"
+
+# E2E exercises both the autogen and existing-secret paths. The
+# autogen-on default here covers test_single / test_upgrade /
+# test_cold_storage / test_backup; test_existing_secret overrides
+# auth.existingSecret on the CLI and the chart-time validator
+# accepts the existing-secret path.
+autogen:
+  enabled: true

--- a/charts/clickhouse-serverless/values.yaml
+++ b/charts/clickhouse-serverless/values.yaml
@@ -42,13 +42,46 @@ backup:
 
 # Authentication
 auth:
-  password: ""         # Auto-generated when empty
-  clusterSecret: ""    # Inter-node cluster secret; auto-generated when empty
-  existingSecret: ""
+  password: ""         # Used as autogen seed when autogen.enabled=true and this is unset
+  clusterSecret: ""    # Used as autogen seed when autogen.enabled=true and this is unset
+  existingSecret: ""   # Operator-owned Secret name. Required when autogen.enabled=false.
   secretKeys:
     passwordKey: "password"
     clusterSecretKey: "clusterSecret"
 
+# Chart-managed Secret materialisation. Default false matches the prod-safe
+# behaviour of the parent langwatch chart's autogen.enabled.
+#
+# autogen.enabled=true: the chart renders the credentials Secret on first
+# install via the lookup-or-rand pattern (subsequent helm upgrades reuse the
+# existing keys verbatim, so ClickHouse pods don't roll). Convenient for
+# stock installs and dev quickstart.
+#
+# autogen.enabled=false: the chart does NOT render a Secret. The operator
+# pre-creates a Secret out-of-band and points auth.existingSecret at it.
+# This is the only mode that is drift-free under GitOps controllers whose
+# render step has no cluster access (ArgoCD's repo-server returns nil from
+# helm lookup every sync, so the autogen path would rotate credentials on
+# every reconcile). The preflight Job validates the configured keys exist
+# before pods roll.
+#
+# Either way, when both flags are unset the chart-time validator fails with
+# a clear message instructing the operator to pick one path.
+autogen:
+  enabled: false
+
+# Preflight Job that runs pre-install + pre-upgrade and verifies the
+# operator-owned Secret has every key the StatefulSet mounts. Only renders
+# when autogen.enabled=false and auth.existingSecret is set (when the chart
+# materialises the Secret there is nothing to validate ahead of time).
+#
+# Image needs sh + kubectl. alpine/k8s ships both; registry.k8s.io/kubectl
+# is distroless and has no /bin/sh, which the script requires.
+preflight:
+  enabled: true
+  image: alpine/k8s:1.30.0
+  imagePullPolicy: IfNotPresent
+  activeDeadlineSeconds: 60
 
 # Advanced: override any computed value (applied last)
 env: {}

--- a/charts/clickhouse-serverless/values.yaml
+++ b/charts/clickhouse-serverless/values.yaml
@@ -75,8 +75,11 @@ autogen:
 # when autogen.enabled=false and auth.existingSecret is set (when the chart
 # materialises the Secret there is nothing to validate ahead of time).
 #
-# Image needs sh + kubectl. alpine/k8s ships both; registry.k8s.io/kubectl
-# is distroless and has no /bin/sh, which the script requires.
+# Image needs sh + kubectl + jq. alpine/k8s ships all three. The script
+# does a single `kubectl get -o json` per Secret + `jq` lookups so dotted
+# operator-configured key names resolve correctly. registry.k8s.io/kubectl
+# is distroless and has no /bin/sh; bitnami/kubectl has /bin/sh but no jq.
+# A startup guard inside the Job fails fast if jq is missing from the image.
 preflight:
   enabled: true
   image: alpine/k8s:1.30.0

--- a/charts/langwatch/templates/_helpers.tpl
+++ b/charts/langwatch/templates/_helpers.tpl
@@ -251,7 +251,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if and (gt $replicas 1) (eq (mod $replicas 2) 0) }}
     {{- $errors = append $errors "clickhouse.replicas must be odd (1, 3, 5, 7) for Keeper quorum" }}
   {{- end }}
-  {{/* ClickHouse subchart auto-generates its password via lookup/randAlphaNum — no autogen gate needed */}}
+  {{/* Gate the chart-managed ClickHouse Secret on autogen.enabled, same shape
+       as app-secrets / gateway-auth. When autogen=true the chart materialises
+       it via per-key lookup-or-rand. When autogen=false the operator owns
+       the Secret out-of-band and MUST set clickhouse.auth.existingSecret to a
+       name different from the default <release>-clickhouse — the deployment's
+       runtime CLICKHOUSE_URL composition only kicks in for the override path,
+       so the default-named case requires the chart-managed url-secret to
+       still render. */}}
+  {{- $chSecretName := include "langwatch.clickhouse.secretName" . }}
+  {{- $chDefaultName := printf "%s-clickhouse" .Release.Name }}
+  {{- if and (not .Values.autogen.enabled) (eq $chSecretName $chDefaultName) }}
+    {{- $errors = append $errors (printf "clickhouse.chartManaged=true with autogen.enabled=false requires clickhouse.auth.existingSecret to be set to an operator-owned Secret name different from the default %q. The deployment composes CLICKHOUSE_URL at runtime from the password key when a custom name is used; with the default name the deployment expects the chart-rendered url key, which is gated off when autogen.enabled=false. Either set autogen.enabled=true OR override clickhouse.auth.existingSecret." $chDefaultName) }}
+  {{- end }}
   {{- if or $chValues.cold.enabled $chValues.backup.enabled }}
     {{- if empty $chValues.objectStorage.bucket }}
       {{- $errors = append $errors "clickhouse.objectStorage.bucket is required when cold.enabled or backup.enabled" }}

--- a/charts/langwatch/templates/clickhouse/url-secret.yaml
+++ b/charts/langwatch/templates/clickhouse/url-secret.yaml
@@ -1,17 +1,59 @@
 {{/*
-  Create the ClickHouse credentials secret when chart-managed.
-  This secret is the single source of truth for the ClickHouse password and
-  full connection URL. The clickhouse-serverless subchart reads from this
-  secret via auth.existingSecret (set in values.yaml).
+  Materialise the chart-managed ClickHouse credentials Secret only when
+  autogen.enabled=true. Mirrors the gating shape Sarah landed on
+  charts/langwatch/templates/app/secrets.yaml + the old
+  gateway-auth-secret.yaml: with autogen off, nothing renders; the
+  operator pre-creates the Secret out-of-band, points the deployment at
+  it via a custom clickhouse.auth.existingSecret name, and the runtime
+  CLICKHOUSE_URL is composed from the Secret's `password` key (see the
+  "User-provided existingSecret" branch in _helpers.tpl :: app env).
 
-  When the user provides their own auth.existingSecret that differs from the
-  default template, they own the secret — we skip creation.
+  HISTORY: pre-fix, the gate was only chartManaged + eq $secretName
+  $defaultName. The inner block looked up the live Secret and, on lookup
+  miss, fell back to randAlphaNum. Under ArgoCD repo-server, lookup
+  returns nil at every reconcile because the renderer has no cluster
+  access, so the random branch fired on every sync, rotating the
+  ClickHouse password and the inter-Keeper clusterSecret underneath the
+  running pods (postmortem action item).
+
+  Each key is checked independently against the lookup result so a
+  partially-populated Secret (e.g. an operator imported password but
+  not clusterSecret across a single->replicated migration) is healed in
+  place — only the missing key is generated.
+
+  REINSTALL HAZARD: helm.sh/resource-policy=keep keeps the Secret
+  around on `helm uninstall` so a subsequent reinstall in the same
+  namespace reuses the credentials. Without this, every reinstall
+  rotates the password AND the Keeper clusterSecret, which breaks
+  inter-node auth in replicated clusters. The cost is the familiar
+  "exists and cannot be imported into the current release" annotation
+  hand-off on reinstall.
 */}}
-{{- if .Values.clickhouse.chartManaged }}
+{{- if and .Values.clickhouse.chartManaged .Values.autogen.enabled }}
 {{- $secretName := include "langwatch.clickhouse.secretName" . }}
 {{- $defaultName := printf "%s-clickhouse" .Release.Name }}
 {{- if eq $secretName $defaultName }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existingData := dict }}
+{{- if and $existing $existing.data }}
+{{-   $existingData = $existing.data }}
+{{- end }}
+{{- $pwB64 := "" }}
+{{- if hasKey $existingData "password" }}
+{{-   $pwB64 = index $existingData "password" }}
+{{- else if .Values.clickhouse.auth.password }}
+{{-   $pwB64 = .Values.clickhouse.auth.password | b64enc }}
+{{- else }}
+{{-   $pwB64 = randAlphaNum 32 | b64enc }}
+{{- end }}
+{{- $pw := $pwB64 | b64dec }}
+{{- $csB64 := "" }}
+{{- if hasKey $existingData "clusterSecret" }}
+{{-   $csB64 = index $existingData "clusterSecret" }}
+{{- else }}
+{{-   $csB64 = randAlphaNum 48 | b64enc }}
+{{- end }}
+{{- $url := printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,20 +61,12 @@ metadata:
   labels:
     {{- include "langwatch.labels" . | nindent 4 }}
     app.kubernetes.io/component: clickhouse
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
-{{- if $existingSecret }}
 data:
-  {{- range $key, $value := $existingSecret.data }}
-  {{ $key }}: {{ $value }}
-  {{- end }}
-  {{- $pw := index $existingSecret.data "password" | b64dec }}
-  url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | b64enc | quote }}
-{{- else }}
-  {{- $pw := .Values.clickhouse.auth.password | default (randAlphaNum 32) }}
-stringData:
-  password: {{ $pw | quote }}
-  clusterSecret: {{ randAlphaNum 48 | quote }}
-  url: {{ printf "http://default:%s@%s-clickhouse:8123/langwatch" ($pw | urlquery) .Release.Name | quote }}
-{{- end }}
+  password: {{ $pwB64 | quote }}
+  clusterSecret: {{ $csB64 | quote }}
+  url: {{ $url | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1456,6 +1456,18 @@ clickhouse:
       ## @param clickhouse.backup.incremental.schedule [string, default: "0 * * * *"] Cron schedule for incremental backups.
       schedule: "0 * * * *"
 
+  ## @extra clickhouse.preflight Subchart preflight Job override.
+  ## Disable the subchart's pre-install Secret-keys check under the umbrella:
+  ## the parent's url-secret.yaml materialises the Secret in the same release,
+  ## so the subchart preflight would run before the Secret exists and fail
+  ## with BackoffLimitExceeded. The parent chart's preflight-secrets-job.yaml
+  ## (which knows about the install ordering) is the right place to enforce
+  ## key presence for umbrella installs. Standalone subchart installs leave
+  ## preflight enabled by default.
+  preflight:
+    ## @param clickhouse.preflight.enabled [default: false] Disable subchart preflight under umbrella install.
+    enabled: false
+
   ## @extra clickhouse.auth Authentication configuration.
   ## The langwatch chart owns the ClickHouse password secret (templates/clickhouse/url-secret.yaml)
   ## and passes it to the subchart via auth.existingSecret. This ensures the full connection URL


### PR DESCRIPTION
## Summary

Mirrors the gating shape Sarah landed on gateway-auth Secret (PR #4440) onto BOTH places clickhouse credentials are materialised:

- `charts/clickhouse-serverless/templates/secret.yaml` — for standalone subchart installs
- `charts/langwatch/templates/clickhouse/url-secret.yaml` — for umbrella installs (this is the one Argo actually reconciles against for delphyr-shaped operators)

Per-key `lookup-or-rand`, `helm.sh/resource-policy: keep`, fail-fast at chart-render time when neither path is configured, plus a pre-install/pre-upgrade preflight Job inside the subchart that validates operator-owned Secret keys before pods roll.

## The drift bug

Pre-fix, both templates rendered whenever `chartManaged` was true (subchart additionally required `auth.existingSecret` empty) and fell back to `randAlphaNum` when helm `lookup` returned no in-cluster Secret. Under ArgoCD the repo-server has no cluster access, so lookup returns nil on every reconcile, the random branch fires every render, and the ClickHouse password + Keeper `clusterSecret` rotate underneath the running pods. Rotation under replication is especially bad: rotating `clusterSecret` breaks inter-Keeper auth and splits the quorum.

## The fix

Two explicit paths, picked by `autogen.enabled`:

| Path | When | What renders |
|---|---|---|
| `autogen.enabled=true` | dev / stock-install | Secret rendered via per-key lookup-or-rand. `helm.sh/resource-policy: keep`. Per-key fallback heals partial Secrets in place (single→replicated migration trap). |
| `autogen.enabled=false` (default) | production / GitOps | No Secret rendered. Operator pre-creates one out-of-band. Subchart preflight Job validates required keys before pods roll. Parent chart `validateSecrets` forces operator to override `clickhouse.auth.existingSecret` to a non-default name (so the deployment uses runtime CLICKHOUSE_URL composition). |

With both unset, the chart-time validators hard-fail with actionable errors.

## Files touched

### Subchart (`charts/clickhouse-serverless/`)
- `templates/secret.yaml` — gated on `autogen.enabled` + per-key lookup-or-rand + `helm.sh/resource-policy: keep`
- `templates/_helpers.tpl` — new `validateAuth` helper invoked from `validate`; unified `secretKey`/`clusterSecretKey` helpers to use configured keys on both paths
- `templates/preflight-secrets-job.yaml` — NEW: ServiceAccount + Role (scoped to the named Secret) + RoleBinding + Job. Runs only when `(not autogen.enabled) && auth.existingSecret`
- `values.yaml` — new `autogen.enabled` (default false) and `preflight.*` blocks
- `tests/values-{single,replicated}.yaml` — flip `autogen.enabled=true` so existing e2e suites still exercise the chart-managed Secret path
- `tests/e2e.sh` — extended `test_existing_secret` to flip `autogen.enabled=false` (exercises the production-shape operator-owned path + preflight). Added `test_existing_secret_missing_key` and `test_no_auth_config_fails`

### Parent (`charts/langwatch/`)
- `templates/clickhouse/url-secret.yaml` — gated on `autogen.enabled` + per-key lookup-or-rand + `helm.sh/resource-policy: keep`. `url` is always derived from the resolved password (never stored stale).
- `templates/_helpers.tpl` `validateSecrets` — hard-fails when `chartManaged=true && !autogen.enabled && secretName == default <release>-clickhouse`. Names the override in the error message.

## Verification

### Chart render
`helm template charts/clickhouse-serverless` (subchart standalone):
- defaults (both unset) → `clickhouse-serverless: no credentials Secret configured...` ✓
- `--set autogen.enabled=true` → Secret rendered with `helm.sh/resource-policy: keep` and both keys ✓
- `--set auth.existingSecret=my-ch-creds` → no Secret rendered, preflight Job + Role + RoleBinding + ServiceAccount render ✓
- `--set auth.existingSecret=my-ch-creds --set replicas=3` → preflight checks both `password` and `clusterSecret` ✓
- `helm lint` clean on both paths

`helm template lwparent charts/langwatch` (umbrella):
- `--set autogen.enabled=true` → `lwparent-clickhouse` renders with password+clusterSecret+url+keep annotation ✓
- `--set autogen.enabled=false --set clickhouse.chartManaged=true` → hard-fail with actionable error naming the override ✓
- `--set autogen.enabled=true --set clickhouse.auth.existingSecret=my-ch-secret` → no url-secret renders, deployment env uses CLICKHOUSE_PASSWORD + runtime CLICKHOUSE_URL composition ✓

### Live cluster
Subchart e2e suite running locally on Kind right now (`charts/clickhouse-serverless/tests/e2e.sh`). Covers:
- single-replica install + DML roundtrip
- helm upgrade password preservation (the critical timing case — verifies the lookup-or-rand reuse branch actually preserves the password across `hc upgrade`)
- operator-owned path + preflight Job validates the keys
- preflight Job blocks install when required key is missing
- chart-render hard-fails on no auth config

The umbrella chart hasn't been exercised on Kind in this PR. Argo dry-run reconcile on a dev cluster is the next confidence step — calling that out explicitly so it doesn't get skipped.

## Operator migration

Existing installs that were on the implicit autogen path (no `auth.existingSecret`, no explicit `autogen.enabled`): add `autogen.enabled=true` to your values overrides. The chart's per-key lookup-or-rand will reuse all existing keys from the in-cluster Secret on the next upgrade, so no password rotation.

Argo-driven installs that have been silently rotating credentials (the bug this PR closes): set `autogen.enabled=false`, pre-create the Secret with `password` (and `clusterSecret` when `replicas>1`), set `clickhouse.auth.existingSecret` to a custom name (parent-chart) or `auth.existingSecret` to the Secret's name (subchart). The preflight Job (subchart) or runtime CLICKHOUSE_URL composition (parent) handles the rest.

## Test plan

- [x] `helm lint` both paths
- [x] `helm template` all states locally (subchart + umbrella)
- [ ] Kind e2e suite running now (`charts/clickhouse-serverless/tests/e2e.sh`) — will update with results
- [ ] Argo reconcile loop on dev cluster — should now be steady-state with `autogen.enabled=false` + operator-owned Secret