### PR TITLE
fix(ops): expand EXPLAIN INDEXES to the PLAN modifier form ClickHouse accepts

### DIFF
--- a/langwatch/src/server/ops/__tests__/explain-core.unit.test.ts
+++ b/langwatch/src/server/ops/__tests__/explain-core.unit.test.ts
@@ -30,6 +30,12 @@ describe("buildExplainQuery", () => {
     }
   });
 
+  it("expands INDEXES to `EXPLAIN PLAN indexes = 1, actions = 1` (CH parser quirk)", () => {
+    const r = buildExplainQuery(TENANT_OK, "INDEXES");
+    expect(r.ok).toBe(true);
+    expect(r.wrapped).toBe(`EXPLAIN PLAN indexes = 1, actions = 1 ${TENANT_OK}`);
+  });
+
   it("rejects an empty / whitespace-only query", () => {
     expect(buildExplainQuery("").ok).toBe(false);
     expect(buildExplainQuery("   ").ok).toBe(false);

--- a/langwatch/src/server/ops/explain-core.ts
+++ b/langwatch/src/server/ops/explain-core.ts
@@ -172,7 +172,14 @@ export function buildExplainQuery(query: string, type: ExplainType = "PLAN"): Pa
   if (SYSTEM_SCHEMA_RE.test(normalized)) {
     return { ok: false, reason: "references to the system.* schema are not allowed" };
   }
-  return { ok: true, wrapped: `EXPLAIN ${type} ${trimmed}`, type };
+  // `INDEXES` is not a top-level EXPLAIN type in ClickHouse — it's a
+  // modifier on `EXPLAIN PLAN` (`EXPLAIN PLAN indexes = 1 ...`). Sending
+  // `EXPLAIN INDEXES <query>` raises a parser error and the endpoint
+  // 502s. Expand it to the canonical form so callers can pass `INDEXES`
+  // as a logical type without needing to know that wrinkle.
+  const prefix =
+    type === "INDEXES" ? "EXPLAIN PLAN indexes = 1, actions = 1" : `EXPLAIN ${type}`;
+  return { ok: true, wrapped: `${prefix} ${trimmed}`, type };
 }
 
 export function redactQueryForAudit(query: string): { shape: string; sha256: string } {


### PR DESCRIPTION
## Summary
- The endpoint exposes \`INDEXES\` as an \`ExplainType\`, but \`EXPLAIN INDEXES <query>\` is not a real ClickHouse statement — \`INDEXES\` is a *modifier* on \`EXPLAIN PLAN\` (\`EXPLAIN PLAN indexes = 1 ...\`). Sending the wrong form raises a parser error on CH and the handler returns 502, which the clickhouse-optimizer agent hit during self-validation on the live endpoint.
- Translate \`INDEXES\` to the canonical \`EXPLAIN PLAN indexes = 1, actions = 1\` form so callers keep using the logical name without needing to remember that CH wrinkle. \`actions = 1\` is added because it's what gives the agent the index-prune / partition-prune visibility this type is supposed to provide.

## Test plan
- [x] \`pnpm vitest run src/server/ops/__tests__/explain-core.unit.test.ts\` (34 passed, includes a regression test pinning the rewrite)
- [ ] After deploy, agent self-validation with \`type: "INDEXES"\` returns a 200 PLAN payload instead of 502