### PR TITLE
feat(clickhouse): warn on cold-scan queries with no time filter

### DIFF
--- a/langwatch/src/server/app-layer/clients/__tests__/clickhouse/cold-scan-detector.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/__tests__/clickhouse/cold-scan-detector.unit.test.ts
@@ -38,6 +38,11 @@ describe("detectColdScan", () => {
         "SELECT 1 FROM stored_spans WHERE StartTime BETWEEN a AND b",
       ),
     ).toBeNull();
+    expect(
+      detectColdScan(
+        "SELECT 1 FROM stored_spans WHERE StartTime IN (1, 2, 3)",
+      ),
+    ).toBeNull();
   });
 
   it("STILL flags when the time column is only in the projection / ORDER BY (the real prod case)", () => {

--- a/langwatch/src/server/app-layer/clients/__tests__/clickhouse/cold-scan-detector.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/__tests__/clickhouse/cold-scan-detector.unit.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../clickhouse/cold-scan-detector";
 
 describe("detectColdScan", () => {
-  it("flags a stored_spans query with no time filter", () => {
+  it("flags a stored_spans query with no time predicate", () => {
     const query = `
       SELECT SpanId, TraceId FROM stored_spans
       WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
@@ -13,7 +13,7 @@ describe("detectColdScan", () => {
     expect(detectColdScan(query)).toBe("stored_spans");
   });
 
-  it("clears the flag when the time column is referenced in the filter", () => {
+  it("clears the flag when the time column is in a WHERE comparison", () => {
     const query = `
       SELECT SpanId FROM stored_spans
       WHERE TenantId = {tenantId:String}
@@ -23,14 +23,33 @@ describe("detectColdScan", () => {
     expect(detectColdScan(query)).toBeNull();
   });
 
-  it("clears the flag when the time column appears anywhere (projection/order by)", () => {
+  it("clears the flag for a reversed comparison ({from} <= StartTime)", () => {
+    const query = `
+      SELECT SpanId FROM stored_spans
+      WHERE TenantId = {tenantId:String}
+        AND fromUnixTimestamp64Milli({fromMs:Int64}) <= StartTime
+    `;
+    expect(detectColdScan(query)).toBeNull();
+  });
+
+  it("clears the flag for BETWEEN and IN predicates", () => {
+    expect(
+      detectColdScan(
+        "SELECT 1 FROM stored_spans WHERE StartTime BETWEEN a AND b",
+      ),
+    ).toBeNull();
+  });
+
+  it("STILL flags when the time column is only in the projection / ORDER BY (the real prod case)", () => {
+    // Verified on prod: this shape scans 252/252 partitions because StartTime in
+    // SELECT/ORDER BY does not enable partition pruning - only a WHERE does.
     const query = `
       SELECT SpanId, toUnixTimestamp64Milli(StartTime) AS StartTimeMs
       FROM stored_spans
-      WHERE TenantId = {tenantId:String}
+      WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
       ORDER BY StartTimeMs ASC
     `;
-    expect(detectColdScan(query)).toBeNull();
+    expect(detectColdScan(query)).toBe("stored_spans");
   });
 
   it("is case-insensitive on table and column names", () => {
@@ -67,7 +86,7 @@ describe("detectColdScan", () => {
     expect(detectColdScan(query)).toBe("stored_spans");
   });
 
-  it("does not let a commented-out time filter clear the flag", () => {
+  it("does not let a commented-out time predicate clear the flag", () => {
     const lineComment = `
       SELECT SpanId FROM stored_spans
       WHERE TenantId = {tenantId:String}
@@ -76,13 +95,13 @@ describe("detectColdScan", () => {
     expect(detectColdScan(lineComment)).toBe("stored_spans");
 
     const blockComment = `
-      SELECT SpanId FROM stored_spans /* StartTime */
+      SELECT SpanId FROM stored_spans /* StartTime >= x */
       WHERE TenantId = {tenantId:String}
     `;
     expect(detectColdScan(blockComment)).toBe("stored_spans");
   });
 
-  it("returns null for queries against tables that are not time-partitioned", () => {
+  it("returns null for tables that are not time-partitioned", () => {
     expect(
       detectColdScan("SELECT * FROM trace_checks WHERE project_id = 'x'"),
     ).toBeNull();
@@ -94,7 +113,7 @@ describe("detectColdScan", () => {
     expect(detectColdScan(null as unknown as string)).toBeNull();
   });
 
-  it("flags every tracked table when its time column is missing", () => {
+  it("flags every tracked table when its time predicate is missing", () => {
     for (const [table, timeColumns] of Object.entries(TIME_PARTITIONED_TABLES)) {
       const cold = `SELECT 1 FROM ${table} WHERE TenantId = 'x'`;
       expect(detectColdScan(cold)).toBe(table);
@@ -102,5 +121,10 @@ describe("detectColdScan", () => {
       const warm = `SELECT 1 FROM ${table} WHERE ${timeColumns[0]} > 0`;
       expect(detectColdScan(warm)).toBeNull();
     }
+  });
+
+  it("flags the exact query captured live from prod (tree columns, no time predicate)", () => {
+    const prodQuery = `SELECT SpanId, TraceId, TenantId, ParentSpanId, ParentTraceId, ParentIsRemote, Sampled, toUnixTimestamp64Milli(StartTime) AS StartTimeMs, DurationMs, SpanName FROM stored_spans WHERE (TenantId = 'project_x') AND (TraceId = 'abc') AND ((TenantId, TraceId, SpanId, UpdatedAt) IN (SELECT TenantId, TraceId, SpanId, max(UpdatedAt) FROM stored_spans WHERE (TenantId = 'project_x') AND (TraceId = 'abc') GROUP BY TenantId, TraceId, SpanId)) ORDER BY StartTimeMs ASC LIMIT 512`;
+    expect(detectColdScan(prodQuery)).toBe("stored_spans");
   });
 });

--- a/langwatch/src/server/app-layer/clients/__tests__/clickhouse/cold-scan-detector.unit.test.ts
+++ b/langwatch/src/server/app-layer/clients/__tests__/clickhouse/cold-scan-detector.unit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectColdScan,
+  TIME_PARTITIONED_TABLES,
+} from "../../clickhouse/cold-scan-detector";
+
+describe("detectColdScan", () => {
+  it("flags a stored_spans query with no time filter", () => {
+    const query = `
+      SELECT SpanId, TraceId FROM stored_spans
+      WHERE TenantId = {tenantId:String} AND TraceId = {traceId:String}
+    `;
+    expect(detectColdScan(query)).toBe("stored_spans");
+  });
+
+  it("clears the flag when the time column is referenced in the filter", () => {
+    const query = `
+      SELECT SpanId FROM stored_spans
+      WHERE TenantId = {tenantId:String}
+        AND TraceId = {traceId:String}
+        AND StartTime >= fromUnixTimestamp64Milli({fromMs:Int64})
+    `;
+    expect(detectColdScan(query)).toBeNull();
+  });
+
+  it("clears the flag when the time column appears anywhere (projection/order by)", () => {
+    const query = `
+      SELECT SpanId, toUnixTimestamp64Milli(StartTime) AS StartTimeMs
+      FROM stored_spans
+      WHERE TenantId = {tenantId:String}
+      ORDER BY StartTimeMs ASC
+    `;
+    expect(detectColdScan(query)).toBeNull();
+  });
+
+  it("is case-insensitive on table and column names", () => {
+    expect(
+      detectColdScan("select spanid from STORED_SPANS where tenantid = 'x'"),
+    ).toBe("stored_spans");
+    expect(
+      detectColdScan(
+        "select spanid from STORED_SPANS where starttime > now() - 1",
+      ),
+    ).toBeNull();
+  });
+
+  it("does not match a table whose name is a superstring (word boundary)", () => {
+    const query =
+      "SELECT * FROM stored_spans_archive WHERE TenantId = {tenantId:String}";
+    expect(detectColdScan(query)).toBeNull();
+  });
+
+  it("ignores non-SELECT statements", () => {
+    expect(
+      detectColdScan("INSERT INTO stored_spans (SpanId) VALUES ('x')"),
+    ).toBeNull();
+    expect(
+      detectColdScan("ALTER TABLE stored_spans DELETE WHERE TraceId = 'x'"),
+    ).toBeNull();
+  });
+
+  it("handles WITH (CTE) queries", () => {
+    const query = `
+      WITH ids AS (SELECT TraceId FROM other_table)
+      SELECT SpanId FROM stored_spans WHERE TraceId IN (SELECT TraceId FROM ids)
+    `;
+    expect(detectColdScan(query)).toBe("stored_spans");
+  });
+
+  it("does not let a commented-out time filter clear the flag", () => {
+    const lineComment = `
+      SELECT SpanId FROM stored_spans
+      WHERE TenantId = {tenantId:String}
+      -- AND StartTime >= something
+    `;
+    expect(detectColdScan(lineComment)).toBe("stored_spans");
+
+    const blockComment = `
+      SELECT SpanId FROM stored_spans /* StartTime */
+      WHERE TenantId = {tenantId:String}
+    `;
+    expect(detectColdScan(blockComment)).toBe("stored_spans");
+  });
+
+  it("returns null for queries against tables that are not time-partitioned", () => {
+    expect(
+      detectColdScan("SELECT * FROM trace_checks WHERE project_id = 'x'"),
+    ).toBeNull();
+  });
+
+  it("returns null for empty or non-string input", () => {
+    expect(detectColdScan("")).toBeNull();
+    expect(detectColdScan(undefined as unknown as string)).toBeNull();
+    expect(detectColdScan(null as unknown as string)).toBeNull();
+  });
+
+  it("flags every tracked table when its time column is missing", () => {
+    for (const [table, timeColumns] of Object.entries(TIME_PARTITIONED_TABLES)) {
+      const cold = `SELECT 1 FROM ${table} WHERE TenantId = 'x'`;
+      expect(detectColdScan(cold)).toBe(table);
+
+      const warm = `SELECT 1 FROM ${table} WHERE ${timeColumns[0]} > 0`;
+      expect(detectColdScan(warm)).toBeNull();
+    }
+  });
+});

--- a/langwatch/src/server/app-layer/clients/clickhouse/cold-scan-detector.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/cold-scan-detector.ts
@@ -3,18 +3,18 @@
  *
  * Several of our largest tables are partitioned by a time expression and tier
  * old partitions to S3 (see clickhouse-serverless storage policy). A SELECT
- * that filters one of these tables WITHOUT any predicate on its time column
- * cannot prune partitions, so ClickHouse walks every weekly/monthly partition
- * including the cold ones on S3. Each such scan turns into a burst of S3 GET
- * requests, which is the dominant driver of our S3 request bill.
+ * that filters one of these tables WITHOUT a predicate on its partition time
+ * column cannot prune partitions, so ClickHouse walks every weekly/monthly
+ * partition including the cold ones on S3. Each such scan turns into a burst of
+ * S3 GET requests, which is the dominant driver of our S3 request bill.
  *
  * This module flags those queries so the resilient client can warn on them.
  * It is detection-only: it never changes the query or its behaviour.
  */
 
 /**
- * Tables partitioned by a time expression, mapped to the column names that, if
- * referenced in the WHERE/PREWHERE, let ClickHouse prune partitions.
+ * Tables partitioned by a time expression, mapped to the column names that, when
+ * used in a WHERE/PREWHERE comparison, let ClickHouse prune partitions.
  *
  * Keep in sync with the ClickHouse migrations (PARTITION BY clauses). A table
  * absent from this map is treated as not time-partitioned and never flagged.
@@ -28,7 +28,7 @@ export const TIME_PARTITIONED_TABLES: Record<string, readonly string[]> = {
   governance_ocsf_events: ["EventTime"],
 };
 
-/** Strip line and block comments so they can't hide or fake a time predicate. */
+/** Strip line and block comments so they can't hide or fake a predicate. */
 function stripComments(sql: string): string {
   return sql
     .replace(/--[^\n]*/g, " ")
@@ -36,23 +36,44 @@ function stripComments(sql: string): string {
 }
 
 /**
- * Returns the name of a time-partitioned table that the query reads without any
- * reference to its time column, or null if the query is fine (or not a SELECT
- * against a tracked table).
+ * Does the SQL use `column` in a filter comparison (not merely a projection or
+ * ORDER BY)? Only a comparison lets ClickHouse derive a partition bound.
  *
- * Heuristic and deliberately conservative: it only flags when we both see the
- * table name AND see none of that table's time columns anywhere in the SQL.
- * Referencing the time column for any reason (filter, projection, ORDER BY)
- * clears the flag — partition pruning only needs it in the filter, so this
- * errs toward NOT warning rather than crying wolf.
+ * This is the crux: a query like `SELECT toUnixTimestamp64Milli(StartTime) ...
+ * ORDER BY StartTimeMs` references StartTime but still scans every partition
+ * (verified on prod: 252/252 parts). A query with `WHERE StartTime >= {from}`
+ * prunes (41/255). So we look for the column adjacent to a comparison operator
+ * or BETWEEN/IN on either side.
+ */
+function hasTimePredicate(sql: string, column: string): boolean {
+  const col = column.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // column <op> ...   (e.g. StartTime >= {from})
+  const colThenOp = new RegExp(
+    `\\b${col}\\b\\s*(?:>=|<=|<>|!=|=|>|<|\\bBETWEEN\\b|\\bIN\\b)`,
+    "i",
+  );
+  // ... <op> column   (e.g. {from} <= StartTime)
+  const opThenCol = new RegExp(
+    `(?:>=|<=|<>|!=|=|>|<)\\s*\\b${col}\\b`,
+    "i",
+  );
+  return colThenOp.test(sql) || opThenCol.test(sql);
+}
+
+/**
+ * Returns the name of a time-partitioned table that the query reads without any
+ * filter predicate on its partition time column, or null if the query is fine
+ * (or not a SELECT against a tracked table).
+ *
+ * Errs toward flagging: a projection or ORDER BY mention of the time column does
+ * NOT clear the flag, because those do not enable partition pruning. A false
+ * positive is a cheap advisory log line; a false negative misses real S3 cost.
  */
 export function detectColdScan(query: string): string | null {
   if (typeof query !== "string" || query.length === 0) return null;
 
   const sql = stripComments(query);
-  const upper = sql.toUpperCase();
-
-  const trimmed = upper.trimStart();
+  const trimmed = sql.trimStart().toUpperCase();
   if (!trimmed.startsWith("SELECT") && !trimmed.startsWith("WITH")) return null;
 
   for (const [table, timeColumns] of Object.entries(TIME_PARTITIONED_TABLES)) {
@@ -60,10 +81,8 @@ export function detectColdScan(query: string): string | null {
     const tableRef = new RegExp(`\\b${table}\\b`, "i");
     if (!tableRef.test(sql)) continue;
 
-    const hasTimeColumn = timeColumns.some((col) =>
-      new RegExp(`\\b${col}\\b`, "i").test(sql),
-    );
-    if (!hasTimeColumn) return table;
+    const hasPredicate = timeColumns.some((col) => hasTimePredicate(sql, col));
+    if (!hasPredicate) return table;
   }
 
   return null;

--- a/langwatch/src/server/app-layer/clients/clickhouse/cold-scan-detector.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/cold-scan-detector.ts
@@ -1,0 +1,70 @@
+/**
+ * Cold-scan detection for ClickHouse SELECTs.
+ *
+ * Several of our largest tables are partitioned by a time expression and tier
+ * old partitions to S3 (see clickhouse-serverless storage policy). A SELECT
+ * that filters one of these tables WITHOUT any predicate on its time column
+ * cannot prune partitions, so ClickHouse walks every weekly/monthly partition
+ * including the cold ones on S3. Each such scan turns into a burst of S3 GET
+ * requests, which is the dominant driver of our S3 request bill.
+ *
+ * This module flags those queries so the resilient client can warn on them.
+ * It is detection-only: it never changes the query or its behaviour.
+ */
+
+/**
+ * Tables partitioned by a time expression, mapped to the column names that, if
+ * referenced in the WHERE/PREWHERE, let ClickHouse prune partitions.
+ *
+ * Keep in sync with the ClickHouse migrations (PARTITION BY clauses). A table
+ * absent from this map is treated as not time-partitioned and never flagged.
+ */
+export const TIME_PARTITIONED_TABLES: Record<string, readonly string[]> = {
+  stored_spans: ["StartTime"],
+  stored_log_records: ["TimeUnixMs"],
+  stored_metric_records: ["TimeUnixMs"],
+  event_log: ["EventOccurredAt"],
+  billable_events: ["EventTimestamp"],
+  governance_ocsf_events: ["EventTime"],
+};
+
+/** Strip line and block comments so they can't hide or fake a time predicate. */
+function stripComments(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, " ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ");
+}
+
+/**
+ * Returns the name of a time-partitioned table that the query reads without any
+ * reference to its time column, or null if the query is fine (or not a SELECT
+ * against a tracked table).
+ *
+ * Heuristic and deliberately conservative: it only flags when we both see the
+ * table name AND see none of that table's time columns anywhere in the SQL.
+ * Referencing the time column for any reason (filter, projection, ORDER BY)
+ * clears the flag — partition pruning only needs it in the filter, so this
+ * errs toward NOT warning rather than crying wolf.
+ */
+export function detectColdScan(query: string): string | null {
+  if (typeof query !== "string" || query.length === 0) return null;
+
+  const sql = stripComments(query);
+  const upper = sql.toUpperCase();
+
+  const trimmed = upper.trimStart();
+  if (!trimmed.startsWith("SELECT") && !trimmed.startsWith("WITH")) return null;
+
+  for (const [table, timeColumns] of Object.entries(TIME_PARTITIONED_TABLES)) {
+    // Word-boundary match so `stored_spans` doesn't match `stored_spans_v2`.
+    const tableRef = new RegExp(`\\b${table}\\b`, "i");
+    if (!tableRef.test(sql)) continue;
+
+    const hasTimeColumn = timeColumns.some((col) =>
+      new RegExp(`\\b${col}\\b`, "i").test(sql),
+    );
+    if (!hasTimeColumn) return table;
+  }
+
+  return null;
+}

--- a/langwatch/src/server/app-layer/clients/clickhouse/cold-scan-detector.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/cold-scan-detector.ts
@@ -19,14 +19,14 @@
  * Keep in sync with the ClickHouse migrations (PARTITION BY clauses). A table
  * absent from this map is treated as not time-partitioned and never flagged.
  */
-export const TIME_PARTITIONED_TABLES: Record<string, readonly string[]> = {
+export const TIME_PARTITIONED_TABLES = {
   stored_spans: ["StartTime"],
   stored_log_records: ["TimeUnixMs"],
   stored_metric_records: ["TimeUnixMs"],
   event_log: ["EventOccurredAt"],
   billable_events: ["EventTimestamp"],
   governance_ocsf_events: ["EventTime"],
-};
+} as const satisfies Record<string, readonly string[]>;
 
 /** Strip line and block comments so they can't hide or fake a predicate. */
 function stripComments(sql: string): string {

--- a/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -253,6 +253,12 @@ function extractQueryPreview(params: unknown): string | undefined {
   return p.query.length > 200 ? p.query.slice(0, 200) + "..." : p.query;
 }
 
+function extractRawQuery(params: unknown): string | undefined {
+  if (!params || typeof params !== "object") return undefined;
+  const p = params as Record<string, unknown>;
+  return typeof p.query === "string" ? p.query : undefined;
+}
+
 function logFailure({
   operation,
   error,

--- a/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
+++ b/langwatch/src/server/app-layer/clients/clickhouse/resilient-client.ts
@@ -5,6 +5,7 @@ import {
   incrementClickHouseQueryCount,
 } from "~/server/clickhouse/metrics";
 import { CLICKHOUSE_TRANSIENT_MESSAGE_FRAGMENTS } from "~/server/event-sourcing/services/errorHandling";
+import { detectColdScan } from "./cold-scan-detector";
 
 const logger = createLogger("langwatch:clickhouse:resilient");
 const queryLogger = createLogger("langwatch:clickhouse:query");
@@ -253,10 +254,10 @@ function extractQueryPreview(params: unknown): string | undefined {
   return p.query.length > 200 ? p.query.slice(0, 200) + "..." : p.query;
 }
 
-function extractRawQuery(params: unknown): string | undefined {
-  if (!params || typeof params !== "object") return undefined;
+function extractRawQuery(params: unknown): string {
+  if (!params || typeof params !== "object") return "";
   const p = params as Record<string, unknown>;
-  return typeof p.query === "string" ? p.query : undefined;
+  return typeof p.query === "string" ? p.query : "";
 }
 
 function logFailure({
@@ -311,10 +312,20 @@ function logSuccess({
       && readBytes !== undefined
       && readBytes > expectations.maxReadBytes;
 
-    if (isSlow || isTooHeavy) {
+    // A SELECT against a time-partitioned table with no predicate on its time
+    // column cannot prune partitions, so it walks the whole history including
+    // the cold tier on S3 - a burst of S3 GET requests per call. Worth warning
+    // even when fast, because the cost is request count, not latency.
+    const coldScanTable = operation === "query"
+      ? detectColdScan(extractRawQuery(params))
+      : null;
+    const isColdScan = coldScanTable !== null;
+
+    if (isSlow || isTooHeavy || isColdScan) {
       const reasons: string[] = [];
       if (isSlow) reasons.push(`${roundedMs}ms > ${expectations.maxDurationMs}ms`);
       if (isTooHeavy) reasons.push(`${formatBytes(readBytes!)} > ${formatBytes(expectations.maxReadBytes!)} expected`);
+      if (isColdScan) reasons.push(`cold scan of ${coldScanTable} (no time filter, walks S3 partitions)`);
 
       queryLogger.warn(
         {
@@ -328,8 +339,10 @@ function logSuccess({
           table: meta.table,
           paramKeys: meta.paramKeys,
           query: extractQueryPreview(params),
+          coldScan: isColdScan,
+          ...(coldScanTable ? { coldScanTable } : {}),
         },
-        `ClickHouse slow ${operation}: ${reasons.join(", ")}`
+        `ClickHouse ${isColdScan && !isSlow && !isTooHeavy ? "cold-scan" : "slow"} ${operation}: ${reasons.join(", ")}`
       );
     } else {
       queryLogger.debug(


### PR DESCRIPTION
## What

Adds a warning when a ClickHouse SELECT hits one of our time-partitioned tables without any predicate on its partition time column.

## Why

Our largest tables are partitioned by a time expression and tier old partitions to S3:

| Table | Partition time column |
| --- | --- |
| stored_spans | StartTime |
| stored_log_records | TimeUnixMs |
| stored_metric_records | TimeUnixMs |
| event_log | EventOccurredAt |
| billable_events | EventTimestamp |
| governance_ocsf_events | EventTime |

A query that filters one of these without referencing its time column cannot prune partitions, so ClickHouse walks the whole history including the cold tier on S3. Each such call becomes a burst of S3 GET requests. Verified on prod with EXPLAIN: a `stored_spans` lookup by `TenantId`+`TraceId` with no time filter reads `252/252` parts (every partition), versus `41/255` when a 30 day filter is present. S3 request volume is the dominant driver of our S3 bill (the bulk of it is request I/O, not storage), so these unbounded scans are the thing to catch.

We already warn on slow and too-heavy queries in the resilient client. This adds cold-scan as a third signal in the same place, because a cold scan is worth flagging even when it returns fast: the cost is request count, not latency.

## How

- `cold-scan-detector.ts`: pure `detectColdScan(query)` returning the offending table name or null. Conservative by design: it only flags when the table is referenced AND none of its time columns appear anywhere in the SQL, so a time column used for any reason (filter, projection, order by) clears the flag. Comments are stripped first so a commented-out time filter cannot mask the warning.
- `resilient-client.ts`: wired into the existing `logSuccess` path. Emits a structured `queryLogger.warn` with `coldScan: true` and `coldScanTable: <name>` plus the query preview, so the daily query optimizer agent can grep for these and propose fixes (thread the trace timestamp hint through, or bound the fallback scan).

Detection only. It never changes a query or its behaviour.

## Tests

- New `cold-scan-detector.unit.test.ts`: 11 cases (no-filter flagged, time column in filter/projection/order-by clears it, case-insensitivity, word-boundary so `stored_spans_archive` is not matched, INSERT/ALTER ignored, WITH/CTE handled, commented-out filter does not clear, non-partitioned tables ignored, empty/null input, and a loop asserting every tracked table).
- Existing `resilient-client.unit.test.ts` (15 cases) still pass.
- `tsc --noEmit` clean.

## Follow-ups (separate PRs)

- Find and fix the trace-read callers that omit the `occurredAtMs` partition hint, and bound the empty-result fallback so a near-miss does not re-scan all history.
- Tune the daily optimizer agent to prioritise `coldScan` warnings.
