### PR TITLE
docs(self-hosting): pre-create ClickHouse Secret when autogen.enabled=false

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -26642,9 +26642,14 @@ If you are not on ArgoCD, the [Kubernetes (Helm)](/self-hosting/deployment/kuber
 
 ## Quick start
 
-The langwatch chart needs one operator-managed Secret (`langwatch-app-secrets`) in your target namespace before the first sync. It holds the app keys + the AI gateway shared-auth keys; both `langwatch-app` and the gateway pod mount from the same Secret. This is the same pre-create-then-install pattern that the Kubernetes (Helm) [production deployment](/self-hosting/deployment/kubernetes-helm#production-deployment) uses, and it is what makes the ArgoCD path trivial: the chart never renders this Secret, so Argo has nothing to reconcile and nothing rotates on subsequent syncs.
+The langwatch chart needs two operator-managed Secrets in your target namespace before the first sync:
 
-Create the namespace and the Secret:
+- `langwatch-app-secrets` holds the app keys + the AI gateway shared-auth keys. Both `langwatch-app` and the gateway pod mount from this Secret.
+- A ClickHouse credentials Secret (any name, referenced from values via `clickhouse.auth.existingSecret`) holds the ClickHouse password and the Keeper inter-node cluster secret. The deployment composes `CLICKHOUSE_URL` at runtime from the password key, so the Secret name must be a non-default name (the chart's render-time validator fails fast if you leave it at the default `<release>-clickhouse` while `autogen.enabled=false`).
+
+This is the same pre-create-then-install pattern that the Kubernetes (Helm) [production deployment](/self-hosting/deployment/kubernetes-helm#production-deployment) uses, and it is what makes the ArgoCD path trivial: the chart never renders these Secrets, so Argo has nothing to reconcile and nothing rotates on subsequent syncs.
+
+Create the namespace and the Secrets:
 
 ```bash
 kubectl create namespace langwatch
@@ -26656,9 +26661,13 @@ kubectl -n langwatch create secret generic langwatch-app-secrets \
   --from-literal=virtualKeyPepper="$(openssl rand -hex 32)" \
   --from-literal=LW_GATEWAY_INTERNAL_SECRET="$(openssl rand -hex 32)" \
   --from-literal=LW_GATEWAY_JWT_SECRET="$(openssl rand -hex 32)"
+
+kubectl -n langwatch create secret generic langwatch-clickhouse-creds \
+  --from-literal=password="$(openssl rand -hex 32)" \
+  --from-literal=clusterSecret="$(openssl rand -hex 24)"
 ```
 
-If you run with `gateway.chartManaged: false` (no AI gateway proxy), skip the two `LW_GATEWAY_*` lines.
+If you run with `gateway.chartManaged: false` (no AI gateway proxy), skip the two `LW_GATEWAY_*` lines. If you run single-replica ClickHouse (`clickhouse.replicas: 1`, the default), the `clusterSecret` key is optional because only replicated ClickHouse uses it for Keeper inter-node auth. Creating both keys upfront keeps `helm upgrade --set clickhouse.replicas=3` a one-line change later.
 
 Then apply the Application manifest:
 
@@ -26676,7 +26685,7 @@ spec:
   source:
     repoURL: https://langwatch.github.io/langwatch
     chart: langwatch
-    targetRevision: 3.3.0
+    targetRevision: 3.5.0
     helm:
       releaseName: langwatch
       values: |
@@ -26684,6 +26693,9 @@ spec:
           enabled: false
         secrets:
           existingSecret: langwatch-app-secrets
+        clickhouse:
+          auth:
+            existingSecret: langwatch-clickhouse-creds
         # Add your other overrides here. See "Production overrides" below.
   syncPolicy:
     automated:
@@ -26722,7 +26734,7 @@ spec:
   sources:
     - repoURL: https://langwatch.github.io/langwatch
       chart: langwatch
-      targetRevision: 3.3.0
+      targetRevision: 3.5.0
       helm:
         releaseName: langwatch
         valueFiles:
@@ -27210,6 +27222,17 @@ kubectl -n langwatch create secret generic langwatch-app-secrets \
 
 If you run with `gateway.chartManaged: false` (no AI gateway proxy), skip the two `LW_GATEWAY_*` lines.
 
+For chart-managed ClickHouse (the default), create the credentials Secret too. With `autogen.enabled=false` the chart will not materialise this Secret itself. The deployment composes `CLICKHOUSE_URL` at runtime from the password key:
+
+```bash
+kubectl create secret generic langwatch-clickhouse-creds \
+  --namespace langwatch \
+  --from-literal=password="$(openssl rand -hex 32)" \
+  --from-literal=clusterSecret="$(openssl rand -hex 24)"
+```
+
+The `clusterSecret` key is only used when `clickhouse.replicas > 1` (Keeper inter-node auth), but creating it upfront keeps a future `--set clickhouse.replicas=3` a one-line change. If you run external ClickHouse (`clickhouse.chartManaged: false`), skip this Secret entirely.
+
 For external databases, create additional secrets:
 
 ```bash
@@ -27281,6 +27304,12 @@ clickhouse:
   memory: "8Gi"
   storage:
     size: 100Gi
+  auth:
+    # Operator-owned Secret (created above). With autogen.enabled=false the
+    # chart will not materialise a ClickHouse Secret; point at the one you
+    # created and the deployment composes CLICKHOUSE_URL at runtime from
+    # its password key.
+    existingSecret: langwatch-clickhouse-creds
 
 # Ingress with TLS
 ingress:

--- a/docs/self-hosting/deployment/argocd.mdx
+++ b/docs/self-hosting/deployment/argocd.mdx
@@ -15,9 +15,14 @@ If you are not on ArgoCD, the [Kubernetes (Helm)](/self-hosting/deployment/kuber
 
 ## Quick start
 
-The langwatch chart needs one operator-managed Secret (`langwatch-app-secrets`) in your target namespace before the first sync. It holds the app keys + the AI gateway shared-auth keys; both `langwatch-app` and the gateway pod mount from the same Secret. This is the same pre-create-then-install pattern that the Kubernetes (Helm) [production deployment](/self-hosting/deployment/kubernetes-helm#production-deployment) uses, and it is what makes the ArgoCD path trivial: the chart never renders this Secret, so Argo has nothing to reconcile and nothing rotates on subsequent syncs.
+The langwatch chart needs two operator-managed Secrets in your target namespace before the first sync:
 
-Create the namespace and the Secret:
+- `langwatch-app-secrets` holds the app keys + the AI gateway shared-auth keys. Both `langwatch-app` and the gateway pod mount from this Secret.
+- A ClickHouse credentials Secret (any name, referenced from values via `clickhouse.auth.existingSecret`) holds the ClickHouse password and the Keeper inter-node cluster secret. The deployment composes `CLICKHOUSE_URL` at runtime from the password key, so the Secret name must be a non-default name (the chart's render-time validator fails fast if you leave it at the default `<release>-clickhouse` while `autogen.enabled=false`).
+
+This is the same pre-create-then-install pattern that the Kubernetes (Helm) [production deployment](/self-hosting/deployment/kubernetes-helm#production-deployment) uses, and it is what makes the ArgoCD path trivial: the chart never renders these Secrets, so Argo has nothing to reconcile and nothing rotates on subsequent syncs.
+
+Create the namespace and the Secrets:
 
 ```bash
 kubectl create namespace langwatch
@@ -29,9 +34,13 @@ kubectl -n langwatch create secret generic langwatch-app-secrets \
   --from-literal=virtualKeyPepper="$(openssl rand -hex 32)" \
   --from-literal=LW_GATEWAY_INTERNAL_SECRET="$(openssl rand -hex 32)" \
   --from-literal=LW_GATEWAY_JWT_SECRET="$(openssl rand -hex 32)"
+
+kubectl -n langwatch create secret generic langwatch-clickhouse-creds \
+  --from-literal=password="$(openssl rand -hex 32)" \
+  --from-literal=clusterSecret="$(openssl rand -hex 24)"
 ```
 
-If you run with `gateway.chartManaged: false` (no AI gateway proxy), skip the two `LW_GATEWAY_*` lines.
+If you run with `gateway.chartManaged: false` (no AI gateway proxy), skip the two `LW_GATEWAY_*` lines. If you run single-replica ClickHouse (`clickhouse.replicas: 1`, the default), the `clusterSecret` key is optional because only replicated ClickHouse uses it for Keeper inter-node auth. Creating both keys upfront keeps `helm upgrade --set clickhouse.replicas=3` a one-line change later.
 
 Then apply the Application manifest:
 
@@ -49,7 +58,7 @@ spec:
   source:
     repoURL: https://langwatch.github.io/langwatch
     chart: langwatch
-    targetRevision: 3.3.0
+    targetRevision: 3.5.0
     helm:
       releaseName: langwatch
       values: |
@@ -57,6 +66,9 @@ spec:
           enabled: false
         secrets:
           existingSecret: langwatch-app-secrets
+        clickhouse:
+          auth:
+            existingSecret: langwatch-clickhouse-creds
         # Add your other overrides here. See "Production overrides" below.
   syncPolicy:
     automated:
@@ -95,7 +107,7 @@ spec:
   sources:
     - repoURL: https://langwatch.github.io/langwatch
       chart: langwatch
-      targetRevision: 3.3.0
+      targetRevision: 3.5.0
       helm:
         releaseName: langwatch
         valueFiles:

--- a/docs/self-hosting/deployment/kubernetes-helm.mdx
+++ b/docs/self-hosting/deployment/kubernetes-helm.mdx
@@ -89,6 +89,17 @@ kubectl -n langwatch create secret generic langwatch-app-secrets \
 
 If you run with `gateway.chartManaged: false` (no AI gateway proxy), skip the two `LW_GATEWAY_*` lines.
 
+For chart-managed ClickHouse (the default), create the credentials Secret too. With `autogen.enabled=false` the chart will not materialise this Secret itself. The deployment composes `CLICKHOUSE_URL` at runtime from the password key:
+
+```bash
+kubectl create secret generic langwatch-clickhouse-creds \
+  --namespace langwatch \
+  --from-literal=password="$(openssl rand -hex 32)" \
+  --from-literal=clusterSecret="$(openssl rand -hex 24)"
+```
+
+The `clusterSecret` key is only used when `clickhouse.replicas > 1` (Keeper inter-node auth), but creating it upfront keeps a future `--set clickhouse.replicas=3` a one-line change. If you run external ClickHouse (`clickhouse.chartManaged: false`), skip this Secret entirely.
+
 For external databases, create additional secrets:
 
 ```bash
@@ -160,6 +171,12 @@ clickhouse:
   memory: "8Gi"
   storage:
     size: 100Gi
+  auth:
+    # Operator-owned Secret (created above). With autogen.enabled=false the
+    # chart will not materialise a ClickHouse Secret; point at the one you
+    # created and the deployment composes CLICKHOUSE_URL at runtime from
+    # its password key.
+    existingSecret: langwatch-clickhouse-creds
 
 # Ingress with TLS
 ingress:


### PR DESCRIPTION
## Summary

The public ArgoCD and production Helm guides did not document that chart-managed ClickHouse needs an operator-owned credentials Secret when `autogen.enabled=false`. The chart intentionally fails at render time without `clickhouse.auth.existingSecret`, but the documented setup only created the app Secret.

This PR documents the required ClickHouse Secret, wires `clickhouse.auth.existingSecret` into both production examples, updates the ArgoCD examples to chart version 3.5.0, and regenerates `docs/llms-full.txt`.

## Changes

- Add `langwatch-clickhouse-creds` creation commands with `password` and `clusterSecret`.
- Add `clickhouse.auth.existingSecret: langwatch-clickhouse-creds` to the ArgoCD and Helm values examples.
- Explain when `clusterSecret` is optional and when external ClickHouse does not need this Secret.
- Keep both ArgoCD examples aligned with chart version 3.5.0.

## Deployment Impact

This is a documentation-only change and does not add or change runtime environment variables, Helm values, chart templates, or BYOC dataplane behavior. No application deployment changes are introduced. A vanilla development install with `autogen.enabled=true` is unchanged. Production installs that use chart-managed ClickHouse with `autogen.enabled=false` already require the documented `clickhouse.auth.existingSecret` value and operator-owned Secret. The docs now match that existing chart validation and runtime behavior.

## Verification

- `helm template langwatch charts/langwatch --set autogen.enabled=false --set secrets.existingSecret=langwatch-app-secrets --set clickhouse.auth.existingSecret=langwatch-clickhouse-creds`
- `npx mintlify broken-links` reports no broken links.
- `node docs/llms.txt.cjs` regenerates the documentation bundle cleanly.
