### PR TITLE
perf(clickhouse): add time predicate to evaluation span fetch (stop cold scan)

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
@@ -86,4 +86,22 @@ describe("ExecuteEvaluationCommand", () => {
       });
     });
   });
+
+  describe("when it reads spans for the trace", () => {
+    /** @scenario the span read carries occurredAt so it can prune partitions */
+    it("passes the event occurredAt as the partition hint", async () => {
+      const deps = buildDeps();
+      const command = new ExecuteEvaluationCommand(deps);
+      const cmd = buildCommand();
+
+      await command.handle(cmd);
+
+      expect(deps.spanStorage.getSpansByTraceId).toHaveBeenCalledWith(
+        expect.objectContaining({
+          traceId: cmd.data.traceId,
+          occurredAtMs: cmd.data.occurredAt,
+        }),
+      );
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/__tests__/executeEvaluation.skip-thread.unit.test.ts
@@ -88,7 +88,6 @@ describe("ExecuteEvaluationCommand", () => {
   });
 
   describe("when it reads spans for the trace", () => {
-    /** @scenario the span read carries occurredAt so it can prune partitions */
     it("passes the event occurredAt as the partition hint", async () => {
       const deps = buildDeps();
       const command = new ExecuteEvaluationCommand(deps);

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/commands/executeEvaluation.command.ts
@@ -42,7 +42,7 @@ const logger = createLogger(
 
 export interface ExecuteEvaluationCommandDeps {
   monitors: MonitorService;
-  spanStorage: { getSpansByTraceId(params: { tenantId: string; traceId: string }): Promise<Span[]> };
+  spanStorage: { getSpansByTraceId(params: { tenantId: string; traceId: string; occurredAtMs?: number }): Promise<Span[]> };
   traceEvents: { getEventsByTraceId(params: { tenantId: string; traceId: string }): Promise<ElasticSearchEvent[]> };
   evaluationExecution: EvaluationExecutionService;
   costRecorder: EvaluationCostRecorder;
@@ -174,8 +174,15 @@ export class ExecuteEvaluationCommand implements CommandHandler<
       return [];
     }
 
-    // 3. Read spans from CH, check evaluator required fields + preconditions
-    const spans = await this.deps.spanStorage.getSpansByTraceId({ tenantId, traceId: data.traceId });
+    // 3. Read spans from CH, check evaluator required fields + preconditions.
+    // Pass the event's occurredAt so the span read can prune stored_spans to the
+    // trace's weekly partition instead of cold-scanning every partition on S3
+    // (the read falls back to an unconstrained scan if the window misses).
+    const spans = await this.deps.spanStorage.getSpansByTraceId({
+      tenantId,
+      traceId: data.traceId,
+      occurredAtMs: data.occurredAt,
+    });
 
     // Check evaluator required fields first
     const requiredFieldsMet = checkEvaluatorRequiredFields({


### PR DESCRIPTION
## Evidence

Sourced from prod CloudWatch (read-only, last 24h). Redacted; no raw tenant values.

The new cold-scan signal (`coldScan:true`) shows `stored_spans` cold scans split into two shapes; this PR targets the single-trace one:

- `paramKeys: [tenantId, traceId, limit]` — ~343 of a 5,000-line sample (~2k/day scaled). The query reads a trace's spans (`FULL_SPAN_SELECT`) with no `StartTime` predicate, so it walks every weekly `stored_spans` partition including cold S3 tiers. The msg: `cold scan of stored_spans (no time filter, walks S3 partitions)`. Latency is fine (the row set is small); the cost is the S3 GET burst per call.

The backend caller responsible is the evaluation command, which fetched spans as `getSpansByTraceId({ tenantId, traceId })` — no `occurredAt`.

## Suspected cause

`stored_spans` is `PARTITION BY toYearWeek(StartTime)`. The repository's `getSpansByTraceId` already supports a `±2-day StartTime` partition hint via `withPartitionHint(occurredAtMs, …)`, but the evaluation command never passed `occurredAtMs`, so the read fell through to the unconstrained path and opened every partition.

## Proposed fix

Pass `occurredAtMs: data.occurredAt` (already present on the evaluation command's event data) into `getSpansByTraceId`. The existing `withPartitionHint` then bounds the scan to the trace's week and falls back to an unconstrained scan only if the window returns nothing — so correctness is unchanged for late/out-of-window data.

No query-string change; this is a caller-side plumbing fix, the intended remedy for a cold scan.

## Expected impact

- Partitions opened for the evaluation span read drop from "all parts" to the 1–2 weeks around the trace, cutting S3 GETs on the evaluation path. **This is a cost (S3 request) fix, not a latency fix** — user-visible evaluation time should not change.
- No change to results: same spans, same dedup; unconstrained fallback preserves completeness when the hint misses.

## EXPLAIN check (self-validated via the read-only `/api/ops/clickhouse/explain`, real tenant)

`EXPLAIN INDEXES` on `stored_spans` for a real known-large tenant (redacted), single-trace span read:

```
no time predicate (current):
  MinMax / Partition stage   Parts: 255/255   Granules: 130126/130126   (every partition opened)

with ±2-day StartTime window (this fix, via withPartitionHint):
  MinMax     Condition: StartTime in [window]      Parts: 5/256     Granules: 5057/130127
  Partition  Condition: toYearWeek(StartTime) in [..]  Parts: 5/5    (pruned to the 2 relevant weeks)
```

255 parts → 5 parts opened (~51x fewer), confirming the partition prune. (Probe trace id was synthetic so the final SpanId set is empty; the partition-prune stage is what this fix moves and it is unambiguous.)

## Test plan

`executeEvaluation.skip-thread.unit.test.ts`: added an assertion that the command calls `getSpansByTraceId` with `occurredAtMs` set to the event's `occurredAt`. Existing evaluation-processing unit + integration tests cover behavior; `withPartitionHint` itself is already integration-tested against a real ClickHouse container, so the partition-hint mechanics are not re-tested here.

Local run: typecheck clean, unit 2/2 in the touched file.