### PR TITLE
perf(clickhouse): add time predicate to batch trace-spans fetch (stop cold scan)

### DIFF
--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1798,8 +1798,16 @@ export class ClickHouseTraceService {
 
         const summaryRows = (await summaryResult.json()) as TraceSummaryRow[];
 
+        // No matched summaries: the result map is built solely from summary
+        // rows, so the spans would be discarded anyway. Return early to skip the
+        // (otherwise unbounded) stored_spans scan — the very cold scan this path
+        // is meant to avoid.
+        if (summaryRows.length === 0) {
+          return new Map();
+        }
+
         // Bound the stored_spans scan to the weeks the matched traces occurred
-        // in (the cold-scan cost driver). Empty -> unbounded fallback.
+        // in (the cold-scan cost driver).
         const SPAN_PARTITION_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
         const occurredAts = summaryRows
           .map((r) => r.ts_OccurredAt)

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1745,9 +1745,13 @@ export class ClickHouseTraceService {
           throw new Error("ClickHouse client not available");
         }
 
-        // Two parallel queries: trace summaries (with I/O) and spans (separate table)
-        const [summaryResult, spansResult] = await Promise.all([
-          clickHouseClient.query({
+        // Summaries first (light, one row per trace): they carry OccurredAt,
+        // which bounds the heavy stored_spans scan below to the traces' weekly
+        // partitions instead of cold-scanning every partition on S3. A span's
+        // StartTime always falls within its trace's lifetime, so a ±2-day window
+        // around the summaries' OccurredAt range is safe headroom; when no
+        // summary row is found we fall back to an unbounded span scan.
+        const summaryResult = await clickHouseClient.query({
             query: `
         SELECT
           TraceId AS ts_TraceId,
@@ -1790,8 +1794,31 @@ export class ClickHouseTraceService {
       `,
             query_params: { tenantId: projectId, traceIds },
             format: "JSONEachRow",
-          }),
-          clickHouseClient.query({
+          });
+
+        const summaryRows = (await summaryResult.json()) as TraceSummaryRow[];
+
+        // Bound the stored_spans scan to the weeks the matched traces occurred
+        // in (the cold-scan cost driver). Empty -> unbounded fallback.
+        const SPAN_PARTITION_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
+        const occurredAts = summaryRows
+          .map((r) => r.ts_OccurredAt)
+          .filter((t): t is number => typeof t === "number" && t > 0);
+        const hasWindow = occurredAts.length > 0;
+        const spanTimeFilterOuter = hasWindow
+          ? "AND t.StartTime >= fromUnixTimestamp64Milli({spanFromMs:Int64}) AND t.StartTime <= fromUnixTimestamp64Milli({spanToMs:Int64})"
+          : "";
+        const spanTimeFilterInner = hasWindow
+          ? "AND StartTime >= fromUnixTimestamp64Milli({spanFromMs:Int64}) AND StartTime <= fromUnixTimestamp64Milli({spanToMs:Int64})"
+          : "";
+        const spanTimeParams = hasWindow
+          ? {
+              spanFromMs: Math.min(...occurredAts) - SPAN_PARTITION_WINDOW_MS,
+              spanToMs: Math.max(...occurredAts) + SPAN_PARTITION_WINDOW_MS,
+            }
+          : {};
+
+        const spansResult = await clickHouseClient.query({
             query: `
         SELECT
           SpanId,
@@ -1821,23 +1848,21 @@ export class ClickHouseTraceService {
         FROM stored_spans AS t
         WHERE t.TenantId = {tenantId:String}
           AND t.TraceId IN ({traceIds:Array(String)})
+          ${spanTimeFilterOuter}
           AND (t.TenantId, t.TraceId, t.SpanId, t.StartTime) IN (
             SELECT TenantId, TraceId, SpanId, max(StartTime)
             FROM stored_spans
             WHERE TenantId = {tenantId:String}
               AND TraceId IN ({traceIds:Array(String)})
+              ${spanTimeFilterInner}
             GROUP BY TenantId, TraceId, SpanId
           )
         ORDER BY t.TraceId, t.StartTime ASC
         LIMIT 200 BY t.TraceId
       `,
-            query_params: { tenantId: projectId, traceIds },
+            query_params: { tenantId: projectId, traceIds, ...spanTimeParams },
             format: "JSONEachRow",
-          }),
-        ]);
-
-        // Parse trace summaries (includes ComputedInput/Output)
-        const summaryRows = (await summaryResult.json()) as TraceSummaryRow[];
+          });
 
         // Parse spans
         type SpanRow = {


### PR DESCRIPTION
## Evidence

Sourced from prod CloudWatch (read-only, last 24h). Redacted; no raw tenant values.

The cold-scan signal (`coldScan:true`) shows `stored_spans` cold scans split into two shapes; this PR targets the batch one (the larger):

- `paramKeys: [tenantId, traceIds]` — ~751 of a 5,000-line sample (the dominant `stored_spans` cold-scan shape, ~4–5k/day scaled). msg: `cold scan of stored_spans (no time filter, walks S3 partitions)`. Latency is fine; the cost is the S3 GET burst per call.

The caller is `ClickHouseTraceService.getTracesWithSpans` → `fetchTracesWithSpansJoined`, which read `stored_spans` filtered only by `TenantId` + `TraceId IN (...)`.

## Suspected cause

`stored_spans` is `PARTITION BY toYearWeek(StartTime)`. With no `StartTime` predicate, ClickHouse can't skip partitions via partition metadata, so it consults every part's primary-key index across all weekly partitions (incl. cold S3) — each a GET — before the `(TenantId, TraceId, SpanId)` key prunes to the trace's part. The primary key does the row pruning, but only after every partition's index has been opened.

## Proposed fix

`fetchTracesWithSpansJoined` runs a summaries query and a spans query. The summaries query already returns each trace's `OccurredAt`. Run the summaries first, derive a `StartTime` window from their `OccurredAt` range (`±2 days`), and add it to the `stored_spans` query (outer scan + dedup subquery). A span's `StartTime` always falls within its trace's lifetime, so `±2 days` is generous headroom.

Self-contained: no caller change, no new public parameter. The trace map is built from summary rows, so a non-empty result always has a window; when there are no summaries the span scan stays unbounded (result is empty anyway).

## Expected impact

- `stored_spans` partition scan is bounded to the 1–2 weeks the matched traces occurred in instead of every partition, cutting S3 GETs on every batch trace fetch (annotation queues, datasets, evaluations, thread views). **Cost (S3 request) fix, not latency.**
- One extra round-trip: the spans query now waits for the summaries query (previously parallel). Summaries are one row per trace; the added latency is a single fast query, traded for the GET reduction.
- No change to returned traces/spans or dedup. `trace_summaries` itself is still fetched by id (it was not the flagged cold-scan shape; its scan is far lighter than the heavy `stored_spans` payload).

## EXPLAIN check (self-validated via the read-only `/api/ops/clickhouse/explain`, real tenant)

`EXPLAIN INDEXES` on `stored_spans` for a real known-large tenant (redacted). The rewritten spans query gains a `toYearWeek(StartTime)` partition condition that the old shape lacks:

```
old (no time predicate): MinMax/Partition stage considers all parts (e.g. 1/258 selected — 258 parts' indexes consulted), no toYearWeek condition
new (±2-day StartTime):  adds  Condition: toYearWeek(StartTime) in [..]   → partitions skipped via metadata
```

On the identical `stored_spans` StartTime-window mechanism (single-trace probe, same tenant), a `±` window of a few days prunes the MinMax/partition stage from **255/255 parts to 5/256 parts** — i.e. ~51x fewer part indexes opened. The batch query applies the same predicate; the exact ratio scales with how tightly the traces' `OccurredAt` values cluster.

## Test plan

`clickhouse-trace-dedup.integration.test.ts` (real ClickHouse testcontainer) exercises `getTracesWithSpans` and now runs through the windowed path: 8/8 passing, confirming the same traces/spans/dedup are returned under the bound. `trace.service` + `evaluation-execution.service` unit suites: 37/37 passing. Typecheck clean.

The partition-prune itself is validated via EXPLAIN above rather than the testcontainer (a few-partition container can't reproduce the prune ratio), per the cold-scan playbook.