### PR TITLE
perf(clickhouse): zero-copy + zstd + PreferClose to cut cross-AZ cost

### DIFF
--- a/charts/clickhouse-serverless/templates/services.yaml
+++ b/charts/clickhouse-serverless/templates/services.yaml
@@ -9,6 +9,13 @@ metadata:
     {{- include "clickhouse-serverless.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  # Prefer same-AZ ClickHouse endpoint when one is ready, falling back to any endpoint
+  # otherwise. Eliminates the random cross-AZ hop on the app→ClickHouse query path —
+  # the main controllable driver of cross-AZ data-transfer cost on a multi-AZ replicated
+  # cluster. PreferClose is stable from Kubernetes 1.31.
+  {{- if .Values.service.preferCloseTrafficDistribution }}
+  trafficDistribution: PreferClose
+  {{- end }}
   ports:
     - name: http
       port: 8123

--- a/charts/clickhouse-serverless/values.yaml
+++ b/charts/clickhouse-serverless/values.yaml
@@ -89,6 +89,15 @@ preflight:
 # Advanced: override any computed value (applied last)
 env: {}
 
+# Kubernetes Service settings
+service:
+  # Set the ClusterIP Service's trafficDistribution to PreferClose so kube-proxy
+  # routes in-cluster app→ClickHouse traffic to a same-AZ endpoint when one is
+  # ready. Cuts cross-AZ data transfer cost on multi-AZ replicated clusters.
+  # Requires Kubernetes 1.31+ (stable from 1.31). Disable on older clusters —
+  # the field is rejected by older kube-apiservers.
+  preferCloseTrafficDistribution: true
+
 # Keeper resources (only used when replicas > 1)
 keeper:
   resources:

--- a/clickhouse-serverless/internal/config/compute.go
+++ b/clickhouse-serverless/internal/config/compute.go
@@ -45,6 +45,12 @@ type Computed struct {
 	PoolFreeEntryLowerMerge        int   `env:"NUMBER_OF_FREE_ENTRIES_IN_POOL_TO_LOWER_MAX_SIZE_OF_MERGE"`
 	PoolFreeEntryOptimizePartition int   `env:"NUMBER_OF_FREE_ENTRIES_IN_POOL_TO_EXECUTE_OPTIMIZE_ENTIRE_PARTITION"`
 
+	// Zero-copy replication for S3-backed parts. Replicas share S3 objects with
+	// refcounts in Keeper rather than each re-uploading merged parts and cross-AZ
+	// transferring them. Largest cost lever on S3-backed multi-replica clusters.
+	// 1 = enabled (default), 0 = disabled.
+	AllowRemoteFsZeroCopyReplication int `env:"ALLOW_REMOTE_FS_ZERO_COPY_REPLICATION"`
+
 	// Async Insert
 	AsyncInsertEnabled       int `env:"ASYNC_INSERT_ENABLED"`
 	AsyncInsertWait          int `env:"ASYNC_INSERT_WAIT"`
@@ -130,6 +136,11 @@ func ComputeFromResources(cpu int, ramBytes int64, input *Input) *Computed {
 	c.PoolFreeEntryMutation = max(1, c.BackgroundPoolSize/2)
 	c.PoolFreeEntryLowerMerge = max(1, c.BackgroundPoolSize/4)
 	c.PoolFreeEntryOptimizePartition = max(1, c.BackgroundPoolSize/2)
+
+	// Zero-copy S3 replication on by default. Only meaningful when the cluster
+	// is replicated AND a remote object-storage disk is configured; ClickHouse
+	// ignores it for purely local MergeTrees so it's safe to enable globally.
+	c.AllowRemoteFsZeroCopyReplication = 1
 
 	// --- Async Insert (constants) ---
 	c.AsyncInsertEnabled = 1

--- a/clickhouse-serverless/internal/render/clickhouse.go
+++ b/clickhouse-serverless/internal/render/clickhouse.go
@@ -86,12 +86,19 @@ func renderLogging(input *config.Input, configD string) error {
 }
 
 // renderNetwork writes network.yaml with connection and timeout settings.
+//
+// network_compression_method=zstd compresses inter-server traffic — replication
+// INSERTs and distributed query payloads. ClickHouse columnar payloads typically
+// hit 5-8x with zstd, which directly reduces cross-AZ data-transfer bytes on the
+// mandatory replication write path. Level 3 trades a little CPU for high ratio.
 func renderNetwork(c *config.Computed, configD string) error {
 	return writeYAML(filepath.Join(configD, "network.yaml"), map[string]any{
-		"listen_host":        "0.0.0.0",
-		"max_connections":    c.MaxConnections,
-		"keep_alive_timeout": c.KeepAliveTimeout,
-		"listen_backlog":     c.ListenBacklog,
+		"listen_host":                   "0.0.0.0",
+		"max_connections":               c.MaxConnections,
+		"keep_alive_timeout":            c.KeepAliveTimeout,
+		"listen_backlog":                c.ListenBacklog,
+		"network_compression_method":    "zstd",
+		"network_zstd_compression_level": 3,
 	})
 }
 

--- a/clickhouse-serverless/internal/render/limits.go
+++ b/clickhouse-serverless/internal/render/limits.go
@@ -23,6 +23,7 @@ type mergeTreeConfig struct {
 	FreeEntriesMutation               int   `yaml:"number_of_free_entries_in_pool_to_execute_mutation"`
 	FreeEntriesLowerMerge             int   `yaml:"number_of_free_entries_in_pool_to_lower_max_size_of_merge"`
 	FreeEntriesOptimize               int   `yaml:"number_of_free_entries_in_pool_to_execute_optimize_entire_partition"`
+	AllowRemoteFsZeroCopyReplication  int   `yaml:"allow_remote_fs_zero_copy_replication"`
 }
 
 // systemLogDef defines a ClickHouse system log table with its configuration knobs.
@@ -52,6 +53,7 @@ func renderLimits(input *config.Input, c *config.Computed, configD string) error
 			FreeEntriesMutation:               c.PoolFreeEntryMutation,
 			FreeEntriesLowerMerge:             c.PoolFreeEntryLowerMerge,
 			FreeEntriesOptimize:               c.PoolFreeEntryOptimizePartition,
+			AllowRemoteFsZeroCopyReplication:  c.AllowRemoteFsZeroCopyReplication,
 		},
 		"max_server_memory_usage":                       c.MaxServerMemoryUsage,
 		"max_server_memory_usage_to_ram_ratio":          c.MaxServerMemoryRatio,


### PR DESCRIPTION
## Summary
Cross-AZ data transfer (`EUC1-DataTransfer-Regional-Bytes`, billed as "EC2 - Other") jumped from **\$406 in April → \$1,802 in May** (+343%). That's ~140 TB of cross-AZ movement, almost entirely ClickHouse replication and app→ClickHouse routing on a 2-AZ replicated cluster — the structural minimum for the durability we want, but with three controllable cost levers that we're not currently pulling.

Three changes, three different points on the cost curve, no durability impact:

- **Zero-copy S3 replication** (`allow_remote_fs_zero_copy_replication=1`) on the merge_tree section. Replicas share S3 objects via Keeper refcounts instead of each re-uploading merged parts and cross-AZ-transferring them to peers. Largest single lever on an S3-backed multi-replica cluster — on a 14 TB cluster, a 50 GB merge stops costing 50 GB cross-AZ + 100 GB duplicate S3 PUTs and becomes a few KB of metadata in Keeper.
- **zstd inter-server compression** (`network_compression_method=zstd`, level 3) at the server level. Replication INSERTs and distributed query payloads compress 5–8× on ClickHouse columnar data, directly cutting the bytes on the mandatory replication write path.
- **`trafficDistribution: PreferClose`** on the ClusterIP Service. Kube-proxy routes in-cluster app→ClickHouse traffic to a same-AZ endpoint when one is ready, falling back to any endpoint otherwise. Eliminates the random cross-AZ hop on the app→ClickHouse query path. Requires Kubernetes 1.31+; gated by `service.preferCloseTrafficDistribution` for older consumers.

## Where it lands
- `charts/clickhouse-serverless/templates/services.yaml` + `values.yaml` — `trafficDistribution: PreferClose`, gated.
- `clickhouse-serverless/internal/config/compute.go` — `AllowRemoteFsZeroCopyReplication` field, default 1.
- `clickhouse-serverless/internal/render/limits.go` — emits `allow_remote_fs_zero_copy_replication` into the `merge_tree` block.
- `clickhouse-serverless/internal/render/clickhouse.go` — `renderNetwork` emits `network_compression_method: zstd` + `network_zstd_compression_level: 3`.

The matching changes for the actually-deployed prod image config templates and Terraform Service land in `langwatch/langwatch-saas` (linked separately).

## Caveats
- Zero-copy tracks refcounts in Keeper. Losing Keeper state can leak S3 objects. Configure a bucket lifecycle to GC orphans (separate follow-up). ClickHouse historically marked zero-copy "experimental"; it's stable on 24.x+ and is the standard answer for S3-backed deployments.
- `trafficDistribution: PreferClose` was rejected by kube-apiservers <1.31. Both EKS clusters here are on 1.35; the values flag lets older consumers of the chart opt out.

## Test plan
- [x] `go test ./...` passes (`internal/config`, `internal/render`, `internal/storage`).
- [x] `helm template charts/clickhouse-serverless --set replicas=3 --set autogen.enabled=true` renders the new `trafficDistribution: PreferClose` line on the ClusterIP Service.
- [ ] Roll the new image to staging; verify `SELECT value FROM system.merge_tree_settings WHERE name = 'allow_remote_fs_zero_copy_replication'` returns `1`.
- [ ] Verify `SELECT value FROM system.server_settings WHERE name = 'network_compression_method'` returns `zstd`.
- [ ] After Service change rolls, sample EndpointSlice hints and confirm app pods are talking to same-AZ ClickHouse pods (`kubectl get endpointslices -o yaml` + check `kube-proxy` config).
- [ ] Watch `EUC1-DataTransfer-Regional-Bytes` daily for a week post-deploy.