### PR TITLE
feat(automations): per-trigger digest cadence (ADR-025 foundation)

### DIFF
--- a/langwatch/prisma/migrations/20260601000000_add_trigger_notification_cadence/migration.sql
+++ b/langwatch/prisma/migrations/20260601000000_add_trigger_notification_cadence/migration.sql
@@ -1,0 +1,16 @@
+-- Per-trigger notification cadence for digest batching of notify actions
+-- (SEND_EMAIL, SEND_SLACK_MESSAGE). Persist actions (ADD_TO_DATASET,
+-- ADD_TO_ANNOTATION_QUEUE) always dispatch immediately and ignore this column.
+--
+-- See dev/docs/adr/025-notify-persistent-action-classification.md.
+--
+-- Default is 'immediate' so every existing trigger keeps firing without a
+-- digest delay. The app-layer default for *new* notify triggers is
+-- '5min_digest' — that policy lives in code, not in the schema default, so
+-- existing rows are not surprised by a behavior change.
+
+-- AlterTable
+ALTER TABLE "Trigger" ADD COLUMN "notificationCadence" TEXT NOT NULL DEFAULT 'immediate';
+
+-- To roll back, uncomment and run manually:
+-- ALTER TABLE "Trigger" DROP COLUMN "notificationCadence";

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -705,6 +705,9 @@ model Trigger {
   slackTemplate        String?
   emailSubjectTemplate String?
   emailBodyTemplate    String?
+  // Per-trigger digest cadence; see ADR-025. Ignored for persist actions.
+  // Values: 'immediate' | '5min_digest' | '15min_digest' | 'hourly_digest'.
+  notificationCadence  String        @default("immediate")
   TriggerSent   TriggerSent[]
   customGraphId String?       @unique
   customGraph   CustomGraph?  @relation(fields: [customGraphId], references: [id], onDelete: Cascade)

--- a/langwatch/src/features/automations/AutomationDrawer.tsx
+++ b/langwatch/src/features/automations/AutomationDrawer.tsx
@@ -28,6 +28,10 @@ import {
 } from "~/shared/templating/templateContext";
 import { api } from "~/utils/api";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
+import {
+  NOTIFICATION_CADENCES,
+  type NotificationCadence,
+} from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
 import { MainSectionList } from "./components/MainSectionList";
 import { ConfigurationSecondaryDrawer } from "./components/secondaries/ConfigurationSecondaryDrawer";
 import { FiltersSecondaryDrawer } from "./components/secondaries/FiltersSecondaryDrawer";
@@ -140,6 +144,12 @@ export function AutomationDrawer({
       source: row.customGraphId ? "customGraph" : "trace",
       customGraphId: row.customGraphId,
       filters: sanitized as Partial<Record<FilterField, FilterParam>>,
+      // Defensive narrow: column is a free-form TEXT (see the repo parser).
+      notificationCadence: (NOTIFICATION_CADENCES as readonly string[]).includes(
+        row.notificationCadence,
+      )
+        ? (row.notificationCadence as NotificationCadence)
+        : "immediate",
       slices: {
         ...INITIAL_DRAFT.slices,
         [action]: provider.client.fromTriggerRow({
@@ -341,6 +351,7 @@ export function AutomationDrawer({
           draft.source === "customGraph" ? draft.customGraphId : null,
         actionParams: actionParamsFromDraft(draft) as never,
         templates: templatesFromDraft(draft),
+        notificationCadence: draft.notificationCadence,
       },
       {
         onSuccess: () => {

--- a/langwatch/src/features/automations/components/CadenceField.tsx
+++ b/langwatch/src/features/automations/components/CadenceField.tsx
@@ -1,0 +1,75 @@
+import { createListCollection, Field, Text } from "@chakra-ui/react";
+import { useMemo } from "react";
+import { Select } from "~/components/ui/select";
+import {
+  NOTIFICATION_CADENCES,
+  type NotificationCadence,
+} from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
+import { isNotifyAction } from "../logic/draftReducer";
+import { useAutomationStore } from "../state/automationStore";
+import { useDraft } from "../state/selectors";
+
+const CADENCE_LABELS: Record<NotificationCadence, string> = {
+  immediate: "Immediate",
+  "5min_digest": "Every 5 minutes",
+  "15min_digest": "Every 15 minutes",
+  hourly_digest: "Every hour",
+};
+
+const CADENCE_OPTIONS = NOTIFICATION_CADENCES.map((value) => ({
+  value,
+  label: CADENCE_LABELS[value],
+}));
+
+/**
+ * Per-trigger digest cadence (ADR-025). Notify actions only — hidden
+ * entirely for persist actions, which always dispatch immediately. The
+ * router silently coerces persist-action cadence writes to "immediate",
+ * so omitting the field here matches the storage contract.
+ */
+export function CadenceField() {
+  const draft = useDraft();
+  const dispatch = useAutomationStore((s) => s.dispatch);
+
+  const collection = useMemo(
+    () => createListCollection({ items: CADENCE_OPTIONS }),
+    [],
+  );
+
+  if (!isNotifyAction(draft)) return null;
+
+  return (
+    <Field.Root>
+      <Field.Label>Cadence</Field.Label>
+      <Select.Root
+        collection={collection}
+        value={[draft.notificationCadence]}
+        onValueChange={({ value }) => {
+          const next = value[0];
+          if (next) {
+            dispatch({
+              type: "SET_CADENCE",
+              value: next as NotificationCadence,
+            });
+          }
+        }}
+      >
+        <Select.Trigger>
+          <Select.ValueText />
+        </Select.Trigger>
+        <Select.Content>
+          {CADENCE_OPTIONS.map((opt) => (
+            <Select.Item key={opt.value} item={opt}>
+              {opt.label}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+      <Text textStyle="xs" color="fg.muted" mt={1}>
+        {draft.notificationCadence === "immediate"
+          ? "Fires one notification per matching trace."
+          : "Batches matches in the window into a single digest."}
+      </Text>
+    </Field.Root>
+  );
+}

--- a/langwatch/src/features/automations/components/MainSectionList.tsx
+++ b/langwatch/src/features/automations/components/MainSectionList.tsx
@@ -8,6 +8,7 @@ import {
   useDraft,
   useSummariseConditions,
 } from "../state/selectors";
+import { CadenceField } from "./CadenceField";
 import { IdentityFields } from "./IdentityFields";
 import { SectionRow } from "./SectionRow";
 import { TestFireSection } from "./TestFireSection";
@@ -77,6 +78,7 @@ export function MainSectionList({
         disabled={!draft.action}
         onClick={() => setSection("configuration")}
       />
+      <CadenceField />
       <TestFireSection loading={testFireLoading} onFire={onTestFire} />
     </VStack>
   );

--- a/langwatch/src/features/automations/logic/draftReducer.ts
+++ b/langwatch/src/features/automations/logic/draftReducer.ts
@@ -7,6 +7,7 @@ import {
 } from "~/automations/providers/client";
 import { isNotifyEntry } from "~/automations/providers/types";
 import type { FilterField, FilterParam } from "~/hooks/useFilterParams";
+import type { NotificationCadence } from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
 
 /**
  * Pure state machine for the staged automation drawer (ADR-028). Lives
@@ -32,6 +33,10 @@ export interface AutomationDraft {
   source: ConditionSource;
   filters: Partial<Record<FilterField, FilterParam>>;
   customGraphId: string | null;
+  /** Per-trigger digest cadence (ADR-025). Ignored at storage and dispatch
+   *  time for persist actions, so the draft value can sit dormant while the
+   *  user is type-switching. */
+  notificationCadence: NotificationCadence;
   /** Per-provider slice — all present, so type-switching never loses the
    *  slice the user was on. */
   slices: AllSlices;
@@ -44,6 +49,7 @@ export type DraftAction =
   | { type: "SET_SOURCE"; value: ConditionSource }
   | { type: "SET_CUSTOM_GRAPH_ID"; value: string | null }
   | { type: "SET_FILTERS"; value: Partial<Record<FilterField, FilterParam>> }
+  | { type: "SET_CADENCE"; value: NotificationCadence }
   | {
       type: "SET_SLICE";
       action: TriggerAction;
@@ -58,6 +64,10 @@ export const INITIAL_DRAFT: AutomationDraft = {
   source: "trace",
   filters: {},
   customGraphId: null,
+  // Matches the app-layer create-default for notify triggers (ADR-025).
+  // Persist actions ignore this at the router boundary, so leaving it set
+  // here while the user is picking an action is safe.
+  notificationCadence: "5min_digest",
   slices: initialSlices(),
 };
 
@@ -85,6 +95,8 @@ export function reducer(
       return { ...state, customGraphId: action.value };
     case "SET_FILTERS":
       return { ...state, filters: action.value };
+    case "SET_CADENCE":
+      return { ...state, notificationCadence: action.value };
     case "SET_SLICE":
       return {
         ...state,

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -7,6 +7,11 @@ import { KSUID_RESOURCES } from "~/utils/constants";
 import { getApp } from "~/server/app-layer/app";
 import { DomainError } from "~/server/app-layer/domain-error";
 import {
+  NOTIFICATION_CADENCES,
+  NOTIFY_TRIGGER_ACTIONS,
+  type NotificationCadence,
+} from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
+import {
   InvalidEmailRecipientError,
   MissingAnnotatorError,
   MissingSlackWebhookError,
@@ -33,6 +38,29 @@ const templateDraftSchema = z.object({
   emailSubjectTemplate: z.string().nullable().optional(),
   emailBodyTemplate: z.string().nullable().optional(),
 });
+
+const notificationCadenceSchema = z.enum(NOTIFICATION_CADENCES);
+
+// ADR-025: cadence applies to notify actions only. New notify triggers default
+// to a 5-minute digest (operator-friendly storm protection); persist actions
+// are pinned to immediate at the storage boundary so a stale value can't leak
+// into the dispatch path.
+function resolveCadenceForCreate(
+  action: TriggerAction,
+  requested: NotificationCadence | undefined,
+): NotificationCadence {
+  if (!NOTIFY_TRIGGER_ACTIONS.has(action)) return "immediate";
+  return requested ?? "5min_digest";
+}
+
+function resolveCadenceForUpdate(
+  action: TriggerAction,
+  requested: NotificationCadence | undefined,
+): NotificationCadence | undefined {
+  if (requested === undefined) return undefined;
+  if (!NOTIFY_TRIGGER_ACTIONS.has(action)) return "immediate";
+  return requested;
+}
 
 const triggerIdentitySchema = z.object({
   name: z.string(),
@@ -129,6 +157,7 @@ export const automationRouter = createTRPCRouter({
         name: z.string(),
         action: z.nativeEnum(TriggerAction),
         filters: triggerFiltersSchema,
+        notificationCadence: notificationCadenceSchema.optional(),
         actionParams: z.object({
           createdByUserId: z.string().optional(),
           members: z.string().array().optional(),
@@ -218,6 +247,10 @@ export const automationRouter = createTRPCRouter({
           filters: JSON.stringify(input.filters),
           projectId: input.projectId,
           lastRunAt: new Date().getTime(),
+          notificationCadence: resolveCadenceForCreate(
+            input.action,
+            input.notificationCadence,
+          ),
         },
       });
 
@@ -409,6 +442,7 @@ export const automationRouter = createTRPCRouter({
         customGraphId: z.string().nullable().optional(),
         actionParams: actionParamsSchema,
         templates: templateDraftSchema,
+        notificationCadence: notificationCadenceSchema.optional(),
       }),
     )
     .use(checkProjectPermission("triggers:update"))
@@ -454,9 +488,18 @@ export const automationRouter = createTRPCRouter({
 
       let trigger;
       if (input.triggerId) {
+        const cadenceUpdate = resolveCadenceForUpdate(
+          input.action,
+          input.notificationCadence,
+        );
         trigger = await ctx.prisma.trigger.update({
           where: { id: input.triggerId, projectId: input.projectId },
-          data,
+          data: {
+            ...data,
+            ...(cadenceUpdate !== undefined
+              ? { notificationCadence: cadenceUpdate }
+              : {}),
+          },
         });
       } else {
         await enforceLicenseLimit(ctx, input.projectId, "automations");
@@ -465,6 +508,10 @@ export const automationRouter = createTRPCRouter({
             id: ksuid(KSUID_RESOURCES.TRIGGER).toString(),
             projectId: input.projectId,
             lastRunAt: new Date().getTime(),
+            notificationCadence: resolveCadenceForCreate(
+              input.action,
+              input.notificationCadence,
+            ),
             ...data,
           },
         });

--- a/langwatch/src/server/app-layer/triggers/repositories/trigger.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/triggers/repositories/trigger.prisma.repository.ts
@@ -1,4 +1,8 @@
 import type { PrismaClient } from "@prisma/client";
+import {
+  NOTIFICATION_CADENCES,
+  type NotificationCadence,
+} from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
 import type { TriggerFilters } from "~/server/filters/types";
 import type {
   TriggerRepository,
@@ -21,6 +25,7 @@ export class PrismaTriggerRepository implements TriggerRepository {
         alertType: true,
         message: true,
         customGraphId: true,
+        notificationCadence: true,
       },
     });
 
@@ -28,6 +33,7 @@ export class PrismaTriggerRepository implements TriggerRepository {
       ...t,
       actionParams: t.actionParams ?? {},
       filters: parseFilters(t.filters),
+      notificationCadence: parseCadence(t.notificationCadence),
     }));
   }
 
@@ -73,4 +79,13 @@ function parseFilters(raw: unknown): TriggerFilters {
     return raw as TriggerFilters;
   }
   return {};
+}
+
+// Defensive narrow: column is a free-form TEXT so an upstream write of an
+// unknown value (e.g. a future cadence not yet shipped) must not throw —
+// fall back to "immediate" so the trigger keeps firing.
+function parseCadence(raw: string): NotificationCadence {
+  return (NOTIFICATION_CADENCES as readonly string[]).includes(raw)
+    ? (raw as NotificationCadence)
+    : "immediate";
 }

--- a/langwatch/src/server/app-layer/triggers/repositories/trigger.repository.ts
+++ b/langwatch/src/server/app-layer/triggers/repositories/trigger.repository.ts
@@ -1,4 +1,5 @@
 import type { AlertType, TriggerAction } from "@prisma/client";
+import type { NotificationCadence } from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
 import type { TriggerFilters } from "~/server/filters/types";
 
 export interface TriggerSummary {
@@ -11,6 +12,7 @@ export interface TriggerSummary {
   alertType: AlertType | null;
   message: string | null;
   customGraphId: string | null;
+  notificationCadence: NotificationCadence;
 }
 
 export interface TriggerRepository {

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/evaluationAlertTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/evaluationAlertTrigger.reactor.unit.test.ts
@@ -138,6 +138,7 @@ function createTrigger(
     alertType: "WARNING",
     message: "Evaluation passed",
     customGraphId: null,
+    notificationCadence: "immediate",
     ...overrides,
   };
 }

--- a/specs/automations/digest-cadence.feature
+++ b/specs/automations/digest-cadence.feature
@@ -1,0 +1,78 @@
+Feature: Digest cadence for notification triggers
+
+  Notification triggers (email and Slack) can batch matches into a digest
+  window so a burst of matching traces does not produce a notification storm.
+  Persist triggers (dataset / annotation queue) always write each match
+  immediately, regardless of cadence.
+
+  See dev/docs/adr/025-notify-persistent-action-classification.md.
+
+  Background:
+    Given a project with notifications enabled
+    And an automation that notifies on traces matching a filter
+
+  Scenario: Existing triggers keep firing immediately after the upgrade
+    Given an automation that existed before the cadence feature shipped
+    When a matching trace arrives
+    Then the notification is sent immediately
+    And the trigger's cadence is shown as "Immediate" in settings
+
+  Scenario: New notification automations default to a 5-minute digest
+    When the user creates a new email or Slack automation
+    Then its cadence is "Every 5 minutes" by default
+    And the cadence dropdown is visible in the automation settings
+
+  Scenario: Persist automations do not expose a cadence
+    When the user creates an automation that adds matches to a dataset
+    Then the cadence dropdown is not shown
+    And every matching trace is written to the dataset as it arrives
+
+  Scenario Outline: A single match in the window sends one notification
+    Given an automation with cadence "<cadence>"
+    When one matching trace arrives within the window
+    Then one notification is sent at the end of the window
+    And the notification body references one trace
+
+    Examples:
+      | cadence              |
+      | Every 5 minutes      |
+      | Every 15 minutes     |
+      | Every hour           |
+
+  Scenario Outline: Multiple matches in the window are coalesced into one digest
+    Given an automation with cadence "<cadence>"
+    When <count> matching traces arrive within the window
+    Then exactly one notification is sent at the end of the window
+    And the notification body references all <count> traces
+
+    Examples:
+      | cadence              | count |
+      | Every 5 minutes      | 3     |
+      | Every 15 minutes     | 12    |
+      | Every hour           | 50    |
+
+  Scenario: Matches arriving after the window opens a new digest
+    Given an automation with cadence "Every 5 minutes"
+    And two matching traces arrive that get coalesced into one digest
+    When a third matching trace arrives after the digest has been sent
+    Then a new digest window opens for the third trace
+    And the third trace is delivered in its own notification at the end of that window
+
+  Scenario: Changing the cadence applies to future matches only
+    Given an automation with cadence "Every hour"
+    And matching traces are already queued inside the hour window
+    When the user changes the cadence to "Immediate"
+    Then in-flight matches still dispatch at the end of the original window
+    And matches arriving after the change dispatch immediately
+
+  Scenario: The same trace does not appear in two digests
+    Given an automation with cadence "Every 5 minutes"
+    When the same trace matches the filter twice within the window
+    Then it appears once in the next digest
+    And the per-(trigger, trace) dedup rule is preserved
+
+  Scenario: Cadence does not affect dataset writes on a mixed-action automation
+    Given a dataset automation and an email automation share the same filter
+    When 10 matching traces arrive within 5 minutes
+    Then all 10 rows are written to the dataset immediately
+    And the email automation sends one digest at the end of the 5-minute window


### PR DESCRIPTION
## Summary

Stack 5 / Phase 4a of the trigger-outbox initiative (ADRs 021–029). Adds
per-trigger **notification cadence** so operators can opt notify-class
automations (email, Slack) into 5min / 15min / hourly digest windows
instead of one-message-per-match. Persist-class automations (dataset,
annotation queue) ignore the field and always dispatch immediately.

- Schema: `Trigger.notificationCadence TEXT NOT NULL DEFAULT 'immediate'`.
  Existing rows get `'immediate'` (no behavior change); new notify
  triggers default to `'5min_digest'` at the app-layer.
- Router: `notificationCadenceSchema` on `automation.create` /
  `automation.upsert`; persist-action writes are silently coerced to
  `'immediate'` at the storage boundary so a stale draft value can't
  leak into the dispatch path.
- Repository: `TriggerSummary.notificationCadence` with a defensive
  narrow on read — an unknown column value falls back to `'immediate'`
  rather than throwing.
- UI: new `CadenceField` in the staged authoring drawer; visible only
  when the active action is in `NOTIFY_TRIGGER_ACTIONS`. Hydration
  reads the row's cadence (defensive narrow), save round-trips it.
- BDD spec: `specs/automations/digest-cadence.feature` covers the
  user-visible behavior (defaults, coalescing, dedup, cadence change).

Phase 4b — the outbox-backed dispatch that actually honors the window
(`computeScheduledFor` is on the base branch but has no caller; inline
`dispatchTriggerAction` still fires on every match) — lands as a
follow-up stack on top of this one.

Refs: `dev/docs/adr/025-notify-persistent-action-classification.md`.

## Test plan

- [ ] Apply migration locally; existing triggers report cadence
      `"Immediate"` in the drawer.
- [ ] Create a new email automation; cadence dropdown defaults to
      "Every 5 minutes" and persists round-trip.
- [ ] Create an "Add to dataset" automation; cadence dropdown is
      hidden; DB row stores `'immediate'`.
- [ ] Change cadence on an existing notify trigger; round-trip works.
- [ ] Switch action from notify to persist in the drawer; saving
      stores `'immediate'` regardless of the draft cadence value.
- [ ] Reactor unit tests pass (`evaluationAlertTrigger.reactor.unit.test.ts`).