### PR TITLE
feat(outbox): scheduledFor + leaseGroup + group dispatcher for digest cadence

### DIFF
--- a/dev/docs/adr/021-transactional-outbox-for-stake-sensitive-dispatch.md
+++ b/dev/docs/adr/021-transactional-outbox-for-stake-sensitive-dispatch.md
@@ -1,8 +1,8 @@
 # ADR-021: Transactional outbox for stake-sensitive reactor dispatch
 
-**Date:** 2026-05-28
+**Date:** 2026-05-28 (revised 2026-06-01 — see "Revision" below)
 
-**Status:** Accepted
+**Status:** Accepted (revised)
 
 ## Context
 
@@ -19,17 +19,32 @@ The reactor framework currently makes no distinction between these two reactor c
 
 ## Decision
 
-Introduce a **transactional outbox** as the durable substrate for stake-sensitive reactor dispatch.
+Introduce a **transactional outbox** as the durable substrate for stake-sensitive reactor dispatch — implemented as a **dedicated GroupQueue (the source of truth for scheduling and execution) plus a PG audit projection (the source of truth for history and operator visibility)**.
 
 Concretely:
 
-- A new PG table `ReactorOutbox` holds one row per pending or recently-completed dispatch, with lifecycle `queued → dispatching → dispatched | failed_retryable | dead`.
+- A dedicated `outboxDispatchQueue` (a `GroupQueueProcessor`, separate from the main event-sourcing queue) owns dispatch **execution**: dedup, per-trigger FIFO via groupKey, delayed dispatch for cadence windows (via `delay` + `processBatch` for coalescing), per-tenant fairness, lease/heartbeat, retry-with-backoff. The queue's `process` callback **is** the dispatcher. Reactors registered via `.withOutbox` use this path going forward.
+- A PG table `ReactorOutbox` holds one row per dispatch, **maintained by a queue-side audit adapter**. The adapter receives every queue lifecycle event (`onEnqueue`, `onLeased`, `onDispatched`, `onFailed`, `onDead`) and writes the corresponding row state. Operators query PG for activity feeds, stuck-state alerts, retry buttons — never Redis.
 - A new framework primitive `.withOutbox(...)` on the pipeline builder lets reactors opt into this path (see [ADR-024](./024-withoutbox-pipeline-builder-primitive.md)).
-- The **match** half of the reactor runs in-band on the event-sourcing queue (inheriting `_originGuardedReactor`'s loop-prevention guards) and writes one outbox row per match.
-- The **dispatch** half runs out-of-band on a separate worker that reads outbox rows and invokes the registered dispatch handler. Failures transition the row, not silently log.
+- The **match** half of the reactor runs in-band on the main event-sourcing queue (inheriting `_originGuardedReactor`'s loop-prevention guards) and calls `outboxQueue.send(payload, …)` per match. The queue's dedup config absorbs replay.
+- The **dispatch** half runs in the outbox queue's `process` callback. Failures throw `DispatchError` ([ADR-027](./027-typed-dispatcherror-contract.md)); the queue's retry semantics handle backoff, and the adapter mirrors each transition to PG.
 - Best-effort reactors stay on `.withReactor` — no change to their execution model.
 
-The outbox table is the **source of truth** for dispatch state. Operator surfaces (activity tab, retry buttons, Grafana alarms) read from it. Replay safety comes from the unique constraint + `createMany skipDuplicates` pattern already used by `TriggerSent`.
+**The queue is the source of truth for dispatch execution.** **The PG row is the source of truth for dispatch audit.** Both must agree on every transition, which is why the adapter lives inside the GroupQueue rather than alongside it — every lifecycle event publishes through one hook that cannot be bypassed.
+
+Replay safety comes from the queue's dedup config (`(reactorName, dedupKey)` collapses replayed enqueues onto the existing pending job) plus, for trigger reactors, `TriggerSent` as the cross-pipeline match claim ([ADR-022](./022-two-tier-dedup-triggersent-reactor-outbox.md)).
+
+### Revision (2026-06-01)
+
+This ADR was originally written with **PG as the source of truth for both scheduling and audit** — `OutboxRepository.leaseGroup` / `leaseNext` / `markDispatched` polled and mutated PG rows directly, and a separate "wakeup queue" only signaled when rows were ready. That meant we re-implemented scheduling (delays, retries, leasing, FIFO) on top of PG when the in-house `GroupQueue` already had every one of those primitives.
+
+The revised design (above) keeps the same external behavior — durable retry, operator visibility, replay safety — but consolidates execution on the GroupQueue and lets PG go back to being a write-mostly audit log. Less code, one queue primitive instead of two, and the dual-state-sync hazard goes away because the adapter is the only writer of `ReactorOutbox` from runtime.
+
+**Phased rollout.** The Phase-0 outbox infrastructure (`OutboxDrainer`, `OutboxRepository.leaseNext` / `markDispatched` / `markRetry` / `recoverExpiredLeases`, the `wakeupQueue` carrying wakeup-only payloads) was deployed alongside this ADR's original draft. Removing it now would risk leaving any in-flight Phase-0 dispatch behind. So the queue-driven path **coexists** with the Phase-0 path:
+
+- New reactors register via the queue-driven path with `auditAdapter` wired.
+- Existing Phase-0 code stays in place; `OutboxDrainer` becomes dead code once every reactor that used to register with it has migrated.
+- A follow-up cleanup PR (out of scope here) drops the Phase-0 drainer + lease* methods + the `leasedUntil` / `nextAttemptAt` columns from `ReactorOutbox`. That migration converts the schema to its end state — `scheduledAt` replaces `nextAttemptAt` as the audit field, and `leasedUntil` goes away because the queue owns the lease.
 
 ## Rationale
 
@@ -47,15 +62,25 @@ Rejected because:
 
 Each reactor adds its own retry loop, its own error categorization, its own status tracking column. Rejected because every reactor would re-implement the same wheel slightly differently, there'd be no shared operator surface, and the retention/cleanup story would diverge per-reactor.
 
-### Why outbox-as-table
+### Why outbox-as-table (audit projection, not source of truth)
 
-A PG table gives us durability (outlives Redis), queryability (operator UI reads rows directly), and replay safety (unique constraint absorbs duplicate inserts from reactor replay). The state-machine semantics of a table — atomic UPDATEs, explicit transitions — match the reasoning model better than an append-only event log when the question is "is this dispatch done or not?"
+A PG table gives us durability (outlives Redis), queryability (operator UI reads rows directly), and the structured `status` enum operator dashboards key off of. The state-machine semantics of a table — atomic UPDATEs, explicit transitions — match the reasoning model better than an append-only event log when the question is "is this dispatch done or not?"
+
+What it does **not** need to do — and what the revised design removes — is own the scheduling primitive. The GroupQueue already has dedup, per-group FIFO, delay, retry with backoff, lease/heartbeat, and per-tenant fairness. The original ADR re-implemented all of that as PG queries (`leaseNext`, `leaseGroup`, `markFailedRetryable` with `nextAttemptAt` arithmetic) because the queue's role was scoped to "wake the drainer when something is ready." The revised design promotes the queue to source-of-truth for execution and demotes the table to audit projection — the wins are: ~40% less framework code, no `leaseGroup` race against the queue, and no opportunity for the two views to drift.
+
+### Why the audit adapter lives inside the GroupQueue
+
+The adapter mirrors **every** queue lifecycle event into PG. If it lived as a sibling consumer (a second subscriber to queue events, or worse a polling reconciler), there'd be windows where the queue has dispatched a job but PG still says `enqueued` — exactly the dual-state-sync hazard the revision is supposed to remove. Embedding the adapter as a `QueueAuditAdapter?` field on `GroupQueueProcessor` means every lifecycle hook fires through it before the queue considers the transition complete; the queue cannot mark a job dispatched without the adapter having seen it.
+
+Adapter writes are still best-effort relative to dispatch: a PG outage logs and metrics but does not block Redis-side execution (the queue keeps running, the adapter retries, the projection catches up). Operator dashboards alert on adapter-lag metrics when reconciliation falls behind.
 
 ## Consequences
 
-- **New schema surface:** `ReactorOutbox` table in PG (defined in [ADR-022](./022-two-tier-dedup-triggersent-reactor-outbox.md)). Bounded size at steady state (one row per pending or recently-completed dispatch, 30-day retention for `dispatched` rows, 90 days for `dead`).
+- **`ReactorOutbox` table in PG** (defined in [ADR-022](./022-two-tier-dedup-triggersent-reactor-outbox.md)) — written exclusively by the adapter on the queue-driven path, read by operator surfaces. Bounded size at steady state (one row per pending or recently-completed dispatch, 30-day retention for `dispatched` rows, 90 days for `dead`). The end-state schema (no `leasedUntil`, `scheduledAt` in place of `nextAttemptAt`) is finalised in the follow-up Phase-0 cleanup PR, not this one.
 - **New framework primitive:** `.withOutbox` on `StaticPipelineBuilder`, framework code under `src/server/event-sourcing/outbox/` (covered by ADR-024).
-- **New worker infrastructure:** outbox dispatch worker, scheduled via existing `GroupQueue` (covered by [ADR-023](./023-groupqueue-wakeup-pattern-for-outbox.md)).
+- **New worker infrastructure:** a dedicated `outboxDispatchQueue` (a `GroupQueueProcessor`, separate from the main event-sourcing queue) whose `process` callback dispatches and whose `auditAdapter` writes audit rows. Coexists with the Phase-0 wakeup queue + drainer; new reactors use the new path.
+- **`QueueAuditAdapter` interface** on `GroupQueueProcessor` — a reusable hook that any queue can opt into for PG-backed audit. The `PgOutboxAuditAdapter` is the first implementation; future queues (e.g., a future stake-sensitive command queue) can wire their own.
+- **Phase-0 outbox primitives (`OutboxDrainer`, `OutboxRepository.leaseNext` / `markDispatched` / `markRetry` / `recoverExpiredLeases`, `wakeupQueue`) are deprecated but still present.** Removed in a follow-up cleanup PR once no reactor is registered on them.
 - **New error contract:** dispatch endpoints throw a typed `DispatchError` so the worker can branch on retryable vs dead (covered by [ADR-027](./027-typed-dispatcherror-contract.md)).
 - **Two reactor classes now exist** in the system: best-effort (`.withReactor`) and stake-sensitive (`.withOutbox`). Authors and reviewers must choose at definition time. The default for new reactors should be `.withReactor` unless the side effect is auditable.
 - **Operator surfaces** (activity tab, retry buttons, Grafana alarms on stuck-queue depth) become possible and necessary. Without them the outbox is just an extra hop.

--- a/dev/docs/adr/022-two-tier-dedup-triggersent-reactor-outbox.md
+++ b/dev/docs/adr/022-two-tier-dedup-triggersent-reactor-outbox.md
@@ -1,8 +1,8 @@
-# ADR-022: Two-tier dedup — `TriggerSent` as match-claim, `ReactorOutbox` as dispatch state
+# ADR-022: Two-tier dedup — `TriggerSent` as match-claim, `ReactorOutbox` as dispatch audit
 
-**Date:** 2026-05-28
+**Date:** 2026-05-28 (revised 2026-06-01 alongside [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md))
 
-**Status:** Accepted
+**Status:** Accepted (revised)
 
 ## Context
 
@@ -14,7 +14,7 @@ The trigger dispatch path needs to answer two distinct questions:
 [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) introduces `ReactorOutbox` for question 2. There's an obvious temptation to merge them — keep one table for "this trigger has fired" — but the two semantics behave differently:
 
 - `TriggerSent` is **domain** state, scoped to triggers, with the cross-pipeline race winner property baked in via the unique constraint.
-- `ReactorOutbox` is **framework** state, scoped per-reactor (the table will hold rows for `customerIoTraceSync`, future auditable reactors etc. in Phase 7), with dispatch lifecycle columns (status, attemptCount, leasedUntil, lastError).
+- `ReactorOutbox` is **framework** audit state, scoped per-reactor (the table will hold rows for `customerIoTraceSync`, future auditable reactors etc. in Phase 7), with the dispatch lifecycle columns operators query against (status, attemptCount, lastError, scheduledAt, dispatchedAt). Rows are maintained by the outbox queue's audit adapter ([ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) revision), not by application code — `leaseGroup` / `markDispatched` etc. are gone, the queue mirrors transitions through the adapter.
 
 A separate decision is how `ReactorOutbox` rows relate to matches and to digest windows. Two competing shapes:
 
@@ -28,15 +28,15 @@ Row-per-window seems compact but means 1000 simultaneous matches `UPDATE` the sa
 Keep **two separate tables** with distinct roles:
 
 - `TriggerSent` remains the **match-claim ledger**. Unchanged. Continues to serve as the cross-reactor race winner via its unique constraint.
-- `ReactorOutbox` is the **dispatch-state table**. Row-per-match (one row per match-subject for trigger outbox reactors). Unique constraint is `(reactorName, dedupKey)` where:
+- `ReactorOutbox` is the **dispatch audit table** — written exclusively by the queue's `PgOutboxAuditAdapter` on every lifecycle transition, read by operator surfaces. Row-per-match (one row per match-subject for trigger outbox reactors). Unique constraint is `(reactorName, dedupKey)` where:
   - Trace/evaluation triggers: `dedupKey = ${projectId}/${triggerId}:trace:${traceId}`.
   - Custom-graph alerts: `dedupKey = ${projectId}/${triggerId}:graph:${customGraphId}` (the subject is the graph, not a trace — alerts can re-fire across resolution cycles, so the dedupKey is scoped per claim, not lifetime).
 
   The `${projectId}/` prefix mirrors the `groupKey` convention from [ADR-023](./023-groupqueue-wakeup-pattern-for-outbox.md) and makes tenant scoping structural in the key itself — `triggerId` is a globally-unique cuid so the prefix isn't load-bearing for uniqueness, but it keeps every dedup/group identifier in the outbox layer self-describing for an operator scanning rows. The `:trace:` / `:graph:` discriminator keeps the two subject types in separate namespaces so a future trigger type cannot collide.
 
-Outbox row insertion is **gated on `TriggerSent` claim succeeding**: the reactor's match phase first calls `TriggerSent.claimSend`; only on a successful claim does it write the corresponding `ReactorOutbox` row.
+Outbox **queue enqueue** is **gated on `TriggerSent` claim succeeding**: the reactor's match phase first calls `TriggerSent.claimSend`; only on a successful claim does it call `outboxQueue.send(...)`, which then writes the corresponding `ReactorOutbox` audit row via the adapter's `onEnqueue` hook.
 
-Digest grouping is a **read-time concern**, not a write-time concern: when the outbox worker fires for a given trigger, it `SELECT … WHERE reactorName=X AND groupKey=Y AND status='queued' AND scheduledFor <= now()` (the indexed key defined in [ADR-023](./023-groupqueue-wakeup-pattern-for-outbox.md), with `groupKey = ${projectId}/${reactorName}:${triggerId}`) and batches whatever rows are returned into one dispatch call.
+Digest grouping is owned by the **queue**, not by an application-level `SELECT … FOR UPDATE`: the outbox dispatch queue uses `processBatch` + `coalesceMaxBatch` to fold same-`groupKey` jobs that are ready at the same time into a single dispatch invocation ([ADR-023](./023-groupqueue-wakeup-pattern-for-outbox.md) revision). The audit adapter then mirrors the batch's outcome to each individual row in PG.
 
 ## Rationale
 

--- a/dev/docs/adr/023-groupqueue-wakeup-pattern-for-outbox.md
+++ b/dev/docs/adr/023-groupqueue-wakeup-pattern-for-outbox.md
@@ -26,17 +26,26 @@ The naive alternative is a polling drainer (a 30-second cron that `SELECT … FO
 
 ## Decision
 
-Use the existing `GroupQueue` infrastructure for outbox dispatch. Define a single dedicated queue, `outboxDispatchQueue` — **separate from the main event-sourcing queue** — registered globally (not inside any one domain pipeline) under `src/server/event-sourcing/outbox/outboxDispatchQueue.ts`.
+Use the existing `GroupQueue` infrastructure for outbox dispatch. Define one dedicated queue, `langwatch:outbox` — **separate from the main event-sourcing queue** — registered globally (not inside any one domain pipeline) under `src/server/event-sourcing/outbox/setup.ts`.
 
-**Queue payload is the full dispatch context** (trigger identity, target identity, the matched-trace identity, alert metadata — everything the dispatcher needs to fire). The queue is the source of truth for dispatch scheduling and execution; PG is the audit projection (see [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) revision).
+The queue carries **two stages as a discriminated payload union**, not two queues:
 
-**Per-trigger FIFO** is guaranteed by setting `groupKey = ${projectId}/${reactorName}:${triggerId}` (or, for non-trigger reactors, whatever stable identifier the reactor defines after the `${projectId}/` prefix). The `${projectId}/` prefix is mandatory: the outbox dispatch queue is a free-standing global queue, not a pipeline command/projection, so `queueManager`'s automatic `${tenantId}/` wrapping does not apply — the producer must include the prefix itself so `tenantIdFromGroupId` (see `src/server/observability/tenantRateTracker.ts`) can extract the tenant and per-tenant fairness via `TenantRateTracker` works.
+- `SettleStagePayload { stage: "settle", projectId, triggerId, traceId, … }` — per-(trigger, trace) Debounce Mode entry. The trace-readiness debounce from ADR-030 lives here. New events on the same (trigger, trace) collapse onto the existing pending job and reset the TTL. When the TTL elapses, the dispatcher re-reads the now-settled fold, runs filters, claims `TriggerSent`, and on match re-enqueues as `cadence`.
+- `CadenceStagePayload { stage: "cadence", projectId, triggerId, match, … }` — per-trigger group, windowed delay snapped to the next wall-clock cadence boundary. The queue's `processBatch` + `coalesceMaxBatch` fold every cadence job for the same trigger landing in the same boundary into one digest invocation.
+
+Per-stage queue behavior (dedup mode, delay, group key, coalescing) is driven by the payload's `stage` discriminator so one queue serves both timing primitives without merging them — the operator's `traceDebounceMs` and `notificationCadence` knobs stay independently tunable.
+
+The earlier draft of this ADR proposed two separate queues for this. They were merged on 2026-06-01 because the maintenance surface (Redis prefixes, metrics, deploy gates, audit adapter wiring) doubles with no behavior gain — a `stage:` field in the payload achieves the same thing with one queue.
+
+**Queue payload is the full dispatch context** (trigger identity, trace identity, alert metadata — everything the dispatcher needs to fire). The queue is the source of truth for dispatch scheduling and execution; PG is the audit projection (see [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) revision).
+
+**Per-trigger FIFO** is guaranteed by setting `groupKey = ${projectId}/${reactorName}:${triggerId}` (or, for non-trigger reactors, whatever stable identifier the reactor defines after the `${projectId}/` prefix). The `${projectId}/` prefix is mandatory: the outbox queue is a free-standing global queue, not a pipeline command/projection, so `queueManager`'s automatic `${tenantId}/` wrapping does not apply — the producer must include the prefix itself so `tenantIdFromGroupId` (see `src/server/observability/tenantRateTracker.ts`) can extract the tenant and per-tenant fairness via `TenantRateTracker` works.
 
 **Cadence windows** are handled natively by setting `delay = scheduledFor - now()` on send. The queue dispatches the job when the delay elapses; no polling needed.
 
 **Digest coalescing** is handled by the queue's `processBatch` + `coalesceMaxBatch` configuration: when the cadence window flushes for a trigger, the queue invokes the dispatcher with every same-`groupKey` job currently ready, in one batch. The dispatcher renders one digest from the array of payloads. No application-level `SELECT … FOR UPDATE` against PG.
 
-**Replay dedup** is handled by `deduplication: { makeId: payload => '${reactorName}:${dedupKey}', extend: false, replace: false }`. The original event re-firing (from a replay or a cross-pipeline race) collapses onto the existing pending job; the cadence window stays anchored to the first match's enqueue time.
+**Dedup is stage-aware.** The settle stage uses Debounce Mode (`makeId: settleDedupId, extend: true, replace: true`) — every new event on the same (projectId, triggerId, traceId) collapses onto the pending job and resets the TTL, so an in-flight trace stays uncommitted as long as spans keep arriving. The cadence stage uses a different `makeId` so digest members don't dedup against each other; the cadence window stays anchored to the boundary, not to the first match. Both modes are configured in the one `deduplication.makeId` resolver via the `stage` discriminator.
 
 **Audit projection.** The queue is constructed with a `PgOutboxAuditAdapter` (see [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) revision) so every lifecycle event (`onEnqueue`, `onLeased`, `onDispatched`, `onFailed`, `onDead`) writes/updates a row in `ReactorOutbox`. Operator dashboards read PG, not Redis.
 
@@ -64,15 +73,13 @@ Reasons for the flip:
 
 The cost is that the queue payload is bigger and Redis is now load-bearing for payload durability — but the GroupQueue's existing heartbeat + recovery already cover that, and `PgOutboxAuditAdapter` provides a parallel durable record for the cases where Redis loses a job (the adapter's `onEnqueue` ran, no subsequent transition fires within a configurable timeout → operator gets paged).
 
-### Why `deduplication: { extend: false, replace: false }`
+### Why two dedup modes share one queue
 
-The dispatch window is anchored at **first-match time + cadence**. Subsequent matches must join that existing window, not push it out. `extend: true` (the debounce default) would extend the window every time a match arrives, indefinitely. `replace: true` would replace the existing job's payload, which we don't want for cadence: each match is its own logical row in the digest, so we need the *batch* of matches at flush time, not the latest. `extend: false, replace: false` means "first match opens the window; subsequent matches enqueue alongside, the queue's `processBatch` folds them at flush" — exactly what we want.
-
-If runtime testing in Phase 1 reveals that `extend: false` doesn't behave as the docs imply, fall back to emulating it in app code: check via a small per-trigger Redis SETNX before calling `groupQueue.send`.
+Settle and cadence want opposite dedup semantics: settle wants Debounce Mode (collapse + reset TTL on every new span), cadence wants no dedup across digest members (each match is its own row in the digest). Sharing one queue would be a problem only if dedup were globally configured — but `DeduplicationConfig.makeId` is a function of payload, so the same queue can return Debounce Mode keys for settle payloads and per-job keys for cadence payloads. The earlier draft of this ADR side-stepped this by using two queues; the unification on 2026-06-01 dropped that constraint.
 
 ## Consequences
 
-- **Operational consistency.** Outbox dispatch shares queue infrastructure with the rest of event sourcing — same Redis, same Grafana panels, same crash recovery code paths. The outbox dispatch queue and the main event-sourcing queue are distinct `GroupQueueProcessor` instances; they share the runtime but not state.
+- **Operational consistency.** Outbox dispatch shares queue infrastructure with the rest of event sourcing — same Redis, same Grafana panels, same crash recovery code paths. The outbox queue and the main event-sourcing queue are distinct `GroupQueueProcessor` instances; they share the runtime but not state. The outbox queue itself carries both stages — one queue, not two.
 - **Redis outage halts new dispatches.** Audit rows do not accumulate (no producer side, no consumer side) — the prior "PG keeps a backlog" property goes away with wakeup-only payloads. The compensation is that Redis outages are short and the queue's recovery semantics handle resume cleanly; long outages page operators via the audit-lag metric.
 - **PG outage degrades the audit projection but does not block dispatch.** The queue keeps running; the `PgOutboxAuditAdapter` retries adapter writes and the projection eventually catches up. Operator dashboards show audit lag when reconciliation falls behind.
 - **The dispatch worker is a `GroupQueue` processor with an audit adapter**, not a standalone polling drainer. Its process role is `worker` (same as other event-sourcing workers).

--- a/dev/docs/adr/023-groupqueue-wakeup-pattern-for-outbox.md
+++ b/dev/docs/adr/023-groupqueue-wakeup-pattern-for-outbox.md
@@ -1,8 +1,8 @@
-# ADR-023: GroupQueue wakeup pattern for outbox scheduling
+# ADR-023: GroupQueue as the outbox dispatch substrate
 
-**Date:** 2026-05-28
+**Date:** 2026-05-28 (revised 2026-06-01 alongside [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md))
 
-**Status:** Accepted
+**Status:** Accepted (revised)
 
 ## Context
 
@@ -26,17 +26,21 @@ The naive alternative is a polling drainer (a 30-second cron that `SELECT … FO
 
 ## Decision
 
-Use the existing `GroupQueue` infrastructure for outbox scheduling. Define a single new queue, `outboxDispatchQueue`, registered globally (not inside any one domain pipeline) under `src/server/event-sourcing/outbox/outboxDispatchQueue.ts`.
+Use the existing `GroupQueue` infrastructure for outbox dispatch. Define a single dedicated queue, `outboxDispatchQueue` — **separate from the main event-sourcing queue** — registered globally (not inside any one domain pipeline) under `src/server/event-sourcing/outbox/outboxDispatchQueue.ts`.
 
-**Queue payload is a wakeup only**: `{ reactorName, groupKey }`. The worker reads the actual outbox rows from PG when it fires. The queue is a scheduling primitive; PG is the source of truth.
+**Queue payload is the full dispatch context** (trigger identity, target identity, the matched-trace identity, alert metadata — everything the dispatcher needs to fire). The queue is the source of truth for dispatch scheduling and execution; PG is the audit projection (see [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) revision).
 
 **Per-trigger FIFO** is guaranteed by setting `groupKey = ${projectId}/${reactorName}:${triggerId}` (or, for non-trigger reactors, whatever stable identifier the reactor defines after the `${projectId}/` prefix). The `${projectId}/` prefix is mandatory: the outbox dispatch queue is a free-standing global queue, not a pipeline command/projection, so `queueManager`'s automatic `${tenantId}/` wrapping does not apply — the producer must include the prefix itself so `tenantIdFromGroupId` (see `src/server/observability/tenantRateTracker.ts`) can extract the tenant and per-tenant fairness via `TenantRateTracker` works.
 
 **Cadence windows** are handled natively by setting `delay = scheduledFor - now()` on send. The queue dispatches the job when the delay elapses; no polling needed.
 
-**One wakeup per cadence window per trigger** is enforced by setting `deduplication: { makeId: () => 'wakeup:' + reactorName + ':' + groupKey, ttlMs: cadenceWindowMs, extend: false, replace: false }`. Subsequent matches within the window dedupe to the existing wakeup; they don't push the dispatch time out.
+**Digest coalescing** is handled by the queue's `processBatch` + `coalesceMaxBatch` configuration: when the cadence window flushes for a trigger, the queue invokes the dispatcher with every same-`groupKey` job currently ready, in one batch. The dispatcher renders one digest from the array of payloads. No application-level `SELECT … FOR UPDATE` against PG.
 
-**Crash recovery** is handled by GroupQueue's existing heartbeat + Lua scripts. The outbox's two-phase status transitions (`queued → dispatching → dispatched`) with `leasedUntil` are a secondary safety net for the rare case where the queue itself loses a job.
+**Replay dedup** is handled by `deduplication: { makeId: payload => '${reactorName}:${dedupKey}', extend: false, replace: false }`. The original event re-firing (from a replay or a cross-pipeline race) collapses onto the existing pending job; the cadence window stays anchored to the first match's enqueue time.
+
+**Audit projection.** The queue is constructed with a `PgOutboxAuditAdapter` (see [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) revision) so every lifecycle event (`onEnqueue`, `onLeased`, `onDispatched`, `onFailed`, `onDead`) writes/updates a row in `ReactorOutbox`. Operator dashboards read PG, not Redis.
+
+**Crash recovery** is handled by GroupQueue's existing heartbeat + Lua scripts. The audit adapter's `onLeased` / `onFailed` hooks keep the PG `status` in sync; an "audit-lag" metric (jobs the queue considers in-flight that the adapter has not yet acked) alerts when PG falls behind.
 
 ## Rationale
 
@@ -48,26 +52,32 @@ LangWatch removed BullMQ in PR #4114 ("Skynet BullMQ removal"). GroupQueue is th
 
 A polling drainer (`setInterval(30_000)` + `FOR UPDATE SKIP LOCKED`) would work — but it re-implements scheduling (delays), fairness (round-robin per tenant), and ordering (FIFO per trigger) that GroupQueue already provides natively. It also introduces a new metric/alarm surface in parallel with the existing one. The polling approach was the initial sketch in the design; the GroupQueue capabilities discovered during code review obsoleted it.
 
-### Why wakeup-only payloads
+### Why full-payload queue jobs (revised)
 
-Putting the full match payload in the queue would duplicate state with PG (the outbox row already has it) and grow queue memory with match volume. With wakeup-only payloads, the queue holds a constant ~50 bytes per pending trigger regardless of match count. PG holds the variable-sized payload data.
+The original design used **wakeup-only payloads** — the queue stored ~50 bytes per pending trigger and the dispatcher re-read the variable-size payload from PG. The 2026-06-01 revision flipped that: the queue carries the full payload, PG holds an audit projection.
 
-The trade-off is an extra PG read on each wakeup — but the read is a single indexed query (`WHERE reactorName=X AND groupKey=Y AND status='queued' AND scheduledFor <= now()`), sub-millisecond at expected volumes.
+Reasons for the flip:
+
+- **One source of truth for scheduling.** Wakeup-only meant the queue knew "something is ready" and PG knew "what." Two sources of truth always disagree under failure — a job dispatched from the queue but lost during PG read meant the dispatcher saw `queued` rows that the queue had already considered done, and `leaseGroup` re-fired them.
+- **Coalescing is in the queue layer where the locking already lives.** `processBatch` + `coalesceMaxBatch` give us digest grouping for free; the previous design re-implemented it as `SELECT … FOR UPDATE SKIP LOCKED` and had to defend against the queue racing the database.
+- **Queue memory is not the bottleneck.** Per-tenant fairness already caps in-flight job counts; payloads of ~1 KB × low thousands of concurrent jobs is well within Redis envelope. The "queue grows with match volume" worry was theoretical at our scale.
+
+The cost is that the queue payload is bigger and Redis is now load-bearing for payload durability — but the GroupQueue's existing heartbeat + recovery already cover that, and `PgOutboxAuditAdapter` provides a parallel durable record for the cases where Redis loses a job (the adapter's `onEnqueue` ran, no subsequent transition fires within a configurable timeout → operator gets paged).
 
 ### Why `deduplication: { extend: false, replace: false }`
 
-The dispatch window is anchored at **first-match time + cadence**. Subsequent matches must join that existing window, not push it out. `extend: true` (the debounce default) would extend the window every time a match arrives, indefinitely. `replace: true` would replace the existing wakeup's payload, which we don't need because payloads are wakeup-only. `extend: false, replace: false` means "first wakeup wins; subsequent dedupes drop the new wakeup silently" — exactly what we want.
+The dispatch window is anchored at **first-match time + cadence**. Subsequent matches must join that existing window, not push it out. `extend: true` (the debounce default) would extend the window every time a match arrives, indefinitely. `replace: true` would replace the existing job's payload, which we don't want for cadence: each match is its own logical row in the digest, so we need the *batch* of matches at flush time, not the latest. `extend: false, replace: false` means "first match opens the window; subsequent matches enqueue alongside, the queue's `processBatch` folds them at flush" — exactly what we want.
 
 If runtime testing in Phase 1 reveals that `extend: false` doesn't behave as the docs imply, fall back to emulating it in app code: check via a small per-trigger Redis SETNX before calling `groupQueue.send`.
 
 ## Consequences
 
-- **Operational consistency.** Outbox dispatch shares queue infrastructure with the rest of event sourcing — same Redis, same Grafana panels, same crash recovery code paths.
-- **Redis outage stops new wakeups from being scheduled** but outbox rows continue to accumulate in PG. On Redis recovery, a backfill script (`scripts/outbox-rewake.ts`) re-queues wakeups for rows where `status='queued' AND scheduledFor < now()`. Documented in the Phase 0 runbook.
-- **PG outage stops dispatch entirely.** Acceptable — PG is the durable record; no other behavior is correct.
-- **The dispatch worker is a `GroupQueue` processor**, not a standalone polling cron. Its process role is `worker` (same as other event-sourcing workers).
+- **Operational consistency.** Outbox dispatch shares queue infrastructure with the rest of event sourcing — same Redis, same Grafana panels, same crash recovery code paths. The outbox dispatch queue and the main event-sourcing queue are distinct `GroupQueueProcessor` instances; they share the runtime but not state.
+- **Redis outage halts new dispatches.** Audit rows do not accumulate (no producer side, no consumer side) — the prior "PG keeps a backlog" property goes away with wakeup-only payloads. The compensation is that Redis outages are short and the queue's recovery semantics handle resume cleanly; long outages page operators via the audit-lag metric.
+- **PG outage degrades the audit projection but does not block dispatch.** The queue keeps running; the `PgOutboxAuditAdapter` retries adapter writes and the projection eventually catches up. Operator dashboards show audit lag when reconciliation falls behind.
+- **The dispatch worker is a `GroupQueue` processor with an audit adapter**, not a standalone polling drainer. Its process role is `worker` (same as other event-sourcing workers).
 - **Per-tenant fairness comes for free** via `TenantRateTracker`. No hand-rolled "LIMIT 100 per tenantId" logic.
-- **One wakeup per cadence window per trigger** is the structural property that lets a single dispatch handler invocation see all queued matches for that trigger in one batch — the digest semantic.
+- **Digest grouping is `processBatch` + `coalesceMaxBatch`,** not application-level `SELECT … FOR UPDATE`. The dispatcher receives a single invocation per cadence window per trigger with every coalesced match's payload.
 - **GroupQueue wakeup is a cadence primitive, not a deadline primitive.** "Cadence" = open a window at first match, flush whatever accumulated when the window expires (what this ADR designs). "Deadline" = at +Nmin, re-read state and decide whether to fire — the shape needed by regression-confirmation triggers ("evaluation score dropped; wait 5 min, only fire if it hasn't recovered"). A deadline re-reads source state when it fires; a cadence just drains an inbox. Out of scope here; flagged so a future deadline primitive isn't conflated with `extend: false` wakeups (which would just delay the existing batch flush, not re-query state).
 
 ## References

--- a/dev/docs/adr/024-withoutbox-pipeline-builder-primitive.md
+++ b/dev/docs/adr/024-withoutbox-pipeline-builder-primitive.md
@@ -1,8 +1,8 @@
 # ADR-024: `.withOutbox` as a pipeline-builder primitive
 
-**Date:** 2026-05-28
+**Date:** 2026-05-28 (revised 2026-06-01 alongside [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md))
 
-**Status:** Accepted
+**Status:** Accepted (revised)
 
 ## Context
 
@@ -67,11 +67,14 @@ src/server/event-sourcing/
 The framework wrapper invoked by `.withOutbox` is responsible for:
 
 1. Wrapping `match` in `_originGuardedReactor` guards.
-2. Gating outbox row insertion on `TriggerSent.claimSend` (or equivalent reactor-defined claim).
-3. Writing rows via `createMany skipDuplicates`.
-4. Enqueueing a `GroupQueue` wakeup with the cadence-window delay and `extend: false` dedup.
+2. Gating queue enqueue on `TriggerSent.claimSend` (or equivalent reactor-defined claim).
+3. Calling `outboxDispatchQueue.send(payload, { delay: cadenceWindowMs, deduplication: { makeId: dedupKey, extend: false, replace: false } })`.
+
+   The queue's `PgOutboxAuditAdapter` writes the `ReactorOutbox` row via its `onEnqueue` hook ([ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) revision). There is **no** separate `createMany skipDuplicates` step in the wrapper — the queue's dedup config is the replay-safety mechanism, and the adapter mirrors the resulting transition to PG.
 
 The reactor author writes `match` and `dispatch`; everything else is provided.
+
+The wrapper itself is unchanged at the call-site level (reactor authors don't care which side of the queue/PG boundary writes the audit row), but the implementation behind it is queue-driven post-revision rather than PG-polled.
 
 ## Rationale
 

--- a/dev/docs/adr/030-trace-readiness-debounce-for-trigger-evaluation.md
+++ b/dev/docs/adr/030-trace-readiness-debounce-for-trigger-evaluation.md
@@ -1,0 +1,299 @@
+# ADR-030: Trace-readiness debounce for trigger evaluation
+
+**Date:** 2026-06-01
+
+**Status:** Proposed
+
+## Context
+
+A trace in LangWatch is assembled from many spans that arrive over time —
+the root span first, internal LLM and tool spans next, evaluation spans
+last, sometimes seconds or minutes apart. We **do not have a terminal
+signal** ("this trace is now complete"): there is no end-of-trace event,
+no per-trace "expected span count" we could compare against, and OTel
+exporters do not flush at consistent times. Adopting an explicit
+terminal signal is a separate, larger change — out of scope for this ADR.
+
+Today the two trigger reactors (`alertTrigger` on the trace pipeline,
+`evaluationAlertTrigger` on the evaluation pipeline) fire on **every**
+event into their pipeline. They re-evaluate every active trigger's
+filters against the current fold state and, if they match, dispatch.
+This eager evaluation produces three classes of problem:
+
+1. **Half-formed dispatch.** A trigger that filters on
+   `output.matches: "refund granted"` will fire as soon as the first
+   matching span is folded — even if the trace's *final* output (a span
+   that arrives 10 seconds later) walks the refund back. The operator
+   sees a notification for a state the trace never actually reached.
+2. **Half-formed persist.** `ADD_TO_DATASET` snapshots the trace at
+   dispatch time. Today the row written to the dataset is truncated
+   relative to what an operator browsing the trace UI sees a minute
+   later. The dataset diverges from the trace.
+3. **Wasted re-evaluation.** A 50-span trace evaluates every active
+   trigger ~50 times even though the verdict almost always stabilises
+   on the last few spans. Cheap per-trigger but quadratic in the number
+   of active triggers, and the early evaluations are by definition
+   wrong-or-equal-to the final one.
+
+The dedup hop on `TriggerSent` makes (2) and (3) survivable — once a
+trigger has fired for a (trigger, trace) pair, subsequent matches
+no-op. But "first match wins" is exactly the half-formed problem.
+
+[ADR-025](./025-notify-persistent-action-classification.md) added
+cadence digest windows on the dispatch side: once a match fires,
+matches inside the same cadence window coalesce into one digest. That
+solves notification-storm pain but is **not** trace-readiness; the
+first half-formed match still opens the window.
+
+## Decision
+
+Add a **per-trigger trace-readiness debounce** that gates trigger
+evaluation: when a trace receives an event, the trigger does not
+evaluate filters until `debounceMs` of silence has elapsed for that
+(trigger, trace) pair. Implemented on the in-house `GroupQueue`'s
+existing "Debounce Mode" deduplication primitive (`extend: true,
+replace: true` in `DeduplicationConfig`).
+
+### Schema
+
+A new column on `Trigger`:
+
+```sql
+ALTER TABLE "Trigger"
+  ADD COLUMN "evaluationDebounceMs" INTEGER NOT NULL DEFAULT 30000;
+-- Allowed values surfaced in the UI: 0 (off), 15000, 30000, 60000, 120000, 300000.
+```
+
+Stored as an integer ms, not an enum, so a future "10s" or "10min" addition
+is just a UI change. The value **must** be configurable per-trigger and
+**must** default to a non-zero value — every existing trigger and every
+new trigger starts with a real debounce window so the half-formed-dispatch
+default goes away on day one.
+
+**Default: 30 seconds.** Short enough that operators expecting
+near-real-time still see notifications well inside the SLO most teams
+quote for their LLM apps, long enough that the common "LLM trace with
+retries plus an evaluation step" envelope is fully assembled before the
+filter runs. The closest alternative considered was 15 seconds — viable
+for chat-style traces that almost always finish under 10s, but cuts it
+fine once you add a re-ranking step or a synchronous evaluation, so 30s
+wins as the broadly-safe default and 15s is offered as a first-class
+option for teams that have measured their P99 trace-completion latency
+and want to tighten up.
+
+The migration default of 30s is a behavior change for existing triggers
+(they previously evaluated on every event). A migration banner /
+changelog notes this and links to the trigger settings page so anyone
+who wants today's eager behavior can flip the trigger to 0.
+
+### Evaluation queue
+
+A new GroupQueue, `trigger-evaluation`, with this definition:
+
+```ts
+defineEventSourcedQueue<TriggerEvaluationRequest>({
+  name: "langwatch:trigger-evaluation",
+  process: async (req) => {
+    // Settled — evaluate filters now, dispatch on match.
+    await evaluateAndDispatchTrigger(req);
+  },
+  groupKey: (req) => `${req.projectId}/${req.triggerId}`,
+  deduplication: {
+    makeId: (req) => `${req.projectId}:${req.triggerId}:${req.traceId}`,
+    ttlMs: 30_000,              // overridden per-trigger via req.debounceMs at enqueue time
+    extend: true,               // every new event resets the timer
+    replace: true,              // latest payload (latest event ref) wins
+  },
+});
+```
+
+The reactor's job collapses to **enqueue an evaluation request** for
+every (active trigger × incoming event). It no longer evaluates
+filters or dispatches inline:
+
+```ts
+// inside alertTrigger / evaluationAlertTrigger:
+for (const trigger of triggers) {
+  await triggerEvaluationQueue.send(
+    { projectId: tenantId, triggerId: trigger.id, traceId },
+    { deduplication: { ttlMs: trigger.evaluationDebounceMs } },
+  );
+}
+```
+
+The GroupQueue's Debounce Mode ensures:
+
+- A re-fired event for the same (trigger, trace) replaces the pending
+  request and **resets** the TTL — so an in-flight trace stays
+  uncommitted as long as spans keep arriving.
+- After `debounceMs` of silence, the dispatcher fires once with the
+  latest payload — guaranteed exactly one evaluation per settled trace
+  per trigger, regardless of how many spans the trace produced.
+- The deduplication key is `(projectId, triggerId, traceId)` so two
+  different triggers on the same trace settle independently with
+  potentially different debounce windows.
+
+### Where filter evaluation moves
+
+`evaluateAndDispatchTrigger(req)` becomes the single owner of:
+1. Re-reading the (now-settled) trace fold state.
+2. Running `matchesTriggerFilters` / `matchesEvaluationFilters`.
+3. Calling `triggers.claimSend(...)` for the
+   ADR-022 at-most-once gate.
+4. Calling `dispatchTriggerAction(...)` — which itself routes to the
+   ADR-025 outbox or inline path based on action class.
+
+The two reactors (`alertTrigger`, `evaluationAlertTrigger`) keep doing
+the pre-filter scan that decides *which* triggers are candidates for a
+given event (trace-only vs evaluation-required), but they no longer
+own the evaluation itself — they only emit enqueue requests.
+
+### UI
+
+`EvaluationDebounceField` on the staged authoring drawer
+([ADR-028](./028-staged-automation-authoring-drawer.md)), rendered as
+its own stage between Conditions and Configuration. Required field
+(no "leave blank to inherit"), surfaced visibly so the latency
+trade-off is part of the authoring conversation:
+
+> **Wait for trace to settle**  
+> Don't evaluate this automation until the trace has been quiet for…  
+> ▢ Off (evaluate on every span)  
+> ▢ 15 seconds  
+> ▢ 30 seconds (default)  
+> ▢ 1 minute  
+> ▢ 2 minutes  
+> ▢ 5 minutes
+
+The stage is **visible for every action class** — persist triggers
+benefit even more than notify, because a dataset row captured before
+the trace settles diverges from the trace UI permanently. The current
+value is also shown as a column on the automations settings list
+([ADR-029](./029-automation-management-and-health-surface.md)) so an
+operator scanning the list can see at a glance which triggers are
+trading latency for completeness.
+
+## Rationale
+
+### Why GroupQueue Debounce Mode, not a new primitive
+
+The deduplication-with-TTL pattern is already implemented in
+`src/server/event-sourcing/queues/queue.types.ts:DeduplicationConfig`
+and battle-tested by the projection-coalescing path. Reusing it
+means:
+
+- No new Redis key shape, no new Lua scripts, no new metrics surface
+  for the ops dashboard — the existing `*:gq:*` keys cover it.
+- The TTL-reset-on-overwrite semantics are exactly what
+  "trace is still arriving" requires; we do not need to invent a
+  custom "I saw a new span, please push the timer out" mechanic.
+- The dispatcher latency for a settled trace is a single fastq tick,
+  not a bespoke timer thread.
+
+A bespoke per-trace "expected span count" or "OTel batch end"
+signal would be more accurate but significantly more invasive —
+it touches the ingestion path, the fold projection, and the SDK
+contract. Debounce is the cheapest first step that meaningfully
+reduces half-formed dispatch.
+
+### Why a per-trigger setting, not a per-project default
+
+Different triggers have different latency budgets. A pager-style
+"high latency on critical path" trigger wants 0ms debounce. A
+"capture for the eval dataset" trigger can afford 5 minutes. A
+single per-project default forces every team to compromise.
+
+The trigger model already has a per-trigger
+`notificationCadence` ([ADR-025](./025-notify-persistent-action-classification.md));
+adding a sibling field keeps the per-trigger configuration shape
+consistent.
+
+### Why default 30 seconds, not 0 (and not 15)
+
+`0` (no debounce) is current behavior, and current behavior is what
+the half-formed-dispatch problem looks like — picking it as the
+default ships the bug as the default. The default must be non-zero.
+
+Between the two realistic candidates:
+
+- **15s** is enough for the typical synchronous chat trace (root +
+  one LLM call + maybe a tool call, all under 5s wall time) but cuts
+  it close once you add a re-ranker, a synchronous evaluation step,
+  or a tool that makes its own network call. A trace that legitimately
+  takes 18s to assemble would dispatch from a partial fold.
+- **30s** absorbs the common "agent with a few tool calls and a
+  trailing evaluation" envelope while still landing well inside the
+  latency operators tolerate for non-paging notifications.
+
+30s wins as the default. 15s is offered as a first-class option (not
+hidden behind a custom-ms field) so teams that have measured their
+P99 trace-completion latency and know it stays well under 15s can
+tighten up without a code change. Teams that need urgent (≤ 1s)
+notifications still flip the field to 0 explicitly — the visible
+setting in the drawer makes that trade-off legible at authoring time.
+
+### Why this is orthogonal to ADR-025 cadence
+
+Two debounce-shaped knobs sit at different points in the pipeline:
+
+| Knob | When it fires | What it does |
+|---|---|---|
+| ADR-030 `evaluationDebounceMs` | Before filter evaluation | Wait for trace to settle so the filter sees the final state |
+| ADR-025 `notificationCadence` | After dispatch decision | Batch matches inside a wall-clock window into one digest |
+
+A trigger configured `evaluationDebounceMs: 60000` +
+`notificationCadence: 5min_digest` means "wait 60s for the trace to
+settle, then if it matches, hold the notification for the next
+5-minute digest boundary." Each knob solves a different operator
+pain — bundling them would force a worse default for at least one
+class of trigger.
+
+### Why all action classes, not notify-only
+
+`ADD_TO_DATASET` and `ADD_TO_ANNOTATION_QUEUE` rows are
+*more* sensitive to half-formed traces than notify actions — a
+truncated dataset row corrupts the customer's eval set in a way that
+is invisible until someone tries to use it. The cadence-vs-immediate
+split (ADR-025) is notify-only because batching makes no sense for
+persist; debounce makes sense for both.
+
+## Consequences
+
+- **New `Trigger.evaluationDebounceMs` column.** Single `ALTER TABLE`
+  with a default; instant on PG ≥ 11.
+- **Existing triggers default to 30s.** Operators who were depending
+  on eager evaluation see a one-time change — flip to 0 if needed.
+  The drawer surfaces the value on the next edit.
+- **Reactor shape changes.** `alertTrigger` /
+  `evaluationAlertTrigger` no longer evaluate filters; they emit
+  `triggerEvaluationQueue.send(...)`. The unit tests for those
+  reactors collapse to "the right number of enqueues for the right
+  triggers" — the heavy filter-matching tests move onto the new
+  `evaluateAndDispatchTrigger` function.
+- **Worker-only.** The trigger-evaluation queue is part of the
+  outbox-adjacent worker stack
+  ([feedback-outbox-worker-only](../../feedback-outbox-worker-only.md)),
+  so web is unaffected.
+- **Latency floor.** Operators who set 5min debounce + 1h digest
+  cadence will see notifications up to ~65 minutes after the trace
+  start. This is a deliberate trade-off — settings UI surfaces both
+  numbers so the total budget is visible.
+- **Memory pressure on the dedup index.** Each in-flight (trigger,
+  trace) pair holds one Redis entry for `debounceMs`. At 5-minute
+  debounce + 100K active traces × N triggers, the dedup-index size
+  grows linearly. The existing GroupQueue ops dashboard
+  (`gq:dedup-index:*`) already exposes this — wire an alert on the
+  count, not just a hard cap.
+- **Replay safety unchanged.** ADR-022's `TriggerSent` claim still
+  gates the actual side effect, so a re-fired event after the
+  debounce window (e.g. on a re-ingested trace) still no-ops if the
+  dispatch already happened.
+
+## References
+
+- [ADR-021](./021-transactional-outbox-for-stake-sensitive-dispatch.md) — outbox layer the dispatch flows through
+- [ADR-022](./022-two-tier-dedup-triggersent-reactor-outbox.md) — `TriggerSent` claim that gates side effects
+- [ADR-023](./023-groupqueue-wakeup-pattern-for-outbox.md) — GroupQueue primitive
+- [ADR-025](./025-notify-persistent-action-classification.md) — cadence digest, the *other* trigger-side debounce
+- `src/server/event-sourcing/queues/queue.types.ts` — `DeduplicationConfig` + Debounce Mode
+- `src/server/event-sourcing/queues/groupQueue/scripts.ts` — TTL-reset Lua underlying the dedup

--- a/dev/docs/adr/030-trace-readiness-debounce-for-trigger-evaluation.md
+++ b/dev/docs/adr/030-trace-readiness-debounce-for-trigger-evaluation.md
@@ -60,7 +60,7 @@ A new column on `Trigger`:
 
 ```sql
 ALTER TABLE "Trigger"
-  ADD COLUMN "evaluationDebounceMs" INTEGER NOT NULL DEFAULT 30000;
+  ADD COLUMN "traceDebounceMs" INTEGER NOT NULL DEFAULT 30000;
 -- Allowed values surfaced in the UI: 0 (off), 15000, 30000, 60000, 120000, 300000.
 ```
 
@@ -88,35 +88,47 @@ who wants today's eager behavior can flip the trigger to 0.
 
 ### Evaluation queue
 
-A new GroupQueue, `trigger-evaluation`, with this definition:
+The debounce lives on the **unified outbox queue** (`langwatch:outbox`,
+ADR-023 revision) as its `stage: "settle"` payload. There is **not**
+a separate `langwatch:trigger-evaluation` queue — folding both stages
+onto one queue halves the operational surface (one Redis prefix, one
+audit adapter, one Grafana panel, one consumer loop) without losing
+the per-stage tuning: stage-specific group key, coalescing, and dedup
+mode are driven by the payload discriminator. See ADR-023 for the
+full queue definition.
+
+The settle payload uses Debounce Mode keyed on
+`(projectId, triggerId, traceId)`:
 
 ```ts
-defineEventSourcedQueue<TriggerEvaluationRequest>({
-  name: "langwatch:trigger-evaluation",
-  process: async (req) => {
-    // Settled — evaluate filters now, dispatch on match.
-    await evaluateAndDispatchTrigger(req);
-  },
-  groupKey: (req) => `${req.projectId}/${req.triggerId}`,
-  deduplication: {
-    makeId: (req) => `${req.projectId}:${req.triggerId}:${req.traceId}`,
-    ttlMs: 30_000,              // overridden per-trigger via req.debounceMs at enqueue time
-    extend: true,               // every new event resets the timer
-    replace: true,              // latest payload (latest event ref) wins
-  },
-});
+// Inside the unified outbox queue's deduplication.makeId resolver:
+makeId: (payload) =>
+  isSettle(payload)
+    ? settleDedupId(payload)            // per-(trigger, trace)
+    : `${payload.projectId}/cadence/${payload.auditDedupKey}`,
+// extend: true, replace: true — Debounce Mode.
+// ttlMs defaults to DEFAULT_TRACE_DEBOUNCE_MS, overridden per trigger
+// via the per-send `deduplication.ttlMs` override.
 ```
 
-The reactor's job collapses to **enqueue an evaluation request** for
-every (active trigger × incoming event). It no longer evaluates
-filters or dispatches inline:
+The reactor's job collapses to **enqueue a settle payload** for every
+(active trigger × incoming event). It no longer evaluates filters or
+dispatches inline:
 
 ```ts
 // inside alertTrigger / evaluationAlertTrigger:
 for (const trigger of triggers) {
-  await triggerEvaluationQueue.send(
-    { projectId: tenantId, triggerId: trigger.id, traceId },
-    { deduplication: { ttlMs: trigger.evaluationDebounceMs } },
+  await outboxQueue.send(
+    {
+      stage: "settle",
+      projectId: tenantId,
+      triggerId: trigger.id,
+      traceId,
+      reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+      auditDedupKey: auditDedupKey({ projectId: tenantId, triggerId: trigger.id, traceId }),
+      foldSnapshotAtEnqueue: { computedInput, computedOutput },
+    },
+    { deduplication: { ttlMs: trigger.traceDebounceMs } },
   );
 }
 ```
@@ -132,6 +144,12 @@ The GroupQueue's Debounce Mode ensures:
 - The deduplication key is `(projectId, triggerId, traceId)` so two
   different triggers on the same trace settle independently with
   potentially different debounce windows.
+
+When the settle process callback matches, it re-enqueues a
+`stage: "cadence"` payload with `delay = computeScheduledFor(
+trigger.action, trigger.notificationCadence, now) - now`. The same
+queue carries it; the audit row identified by `auditDedupKey` follows
+it through the cadence boundary.
 
 ### Where filter evaluation moves
 
@@ -238,10 +256,10 @@ Two debounce-shaped knobs sit at different points in the pipeline:
 
 | Knob | When it fires | What it does |
 |---|---|---|
-| ADR-030 `evaluationDebounceMs` | Before filter evaluation | Wait for trace to settle so the filter sees the final state |
+| ADR-030 `traceDebounceMs` | Before filter evaluation | Wait for trace to settle so the filter sees the final state |
 | ADR-025 `notificationCadence` | After dispatch decision | Batch matches inside a wall-clock window into one digest |
 
-A trigger configured `evaluationDebounceMs: 60000` +
+A trigger configured `traceDebounceMs: 60000` +
 `notificationCadence: 5min_digest` means "wait 60s for the trace to
 settle, then if it matches, hold the notification for the next
 5-minute digest boundary." Each knob solves a different operator
@@ -259,18 +277,18 @@ persist; debounce makes sense for both.
 
 ## Consequences
 
-- **New `Trigger.evaluationDebounceMs` column.** Single `ALTER TABLE`
+- **New `Trigger.traceDebounceMs` column.** Single `ALTER TABLE`
   with a default; instant on PG ≥ 11.
 - **Existing triggers default to 30s.** Operators who were depending
   on eager evaluation see a one-time change — flip to 0 if needed.
   The drawer surfaces the value on the next edit.
 - **Reactor shape changes.** `alertTrigger` /
   `evaluationAlertTrigger` no longer evaluate filters; they emit
-  `triggerEvaluationQueue.send(...)`. The unit tests for those
+  `outboxQueue.send({ stage: "settle", … })`. The unit tests for those
   reactors collapse to "the right number of enqueues for the right
   triggers" — the heavy filter-matching tests move onto the new
   `evaluateAndDispatchTrigger` function.
-- **Worker-only.** The trigger-evaluation queue is part of the
+- **Worker-only.** The settle stage runs on the unified outbox queue, which is part of the
   outbox-adjacent worker stack
   ([feedback-outbox-worker-only](../../feedback-outbox-worker-only.md)),
   so web is unaffected.

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -1,0 +1,334 @@
+import { TriggerAction } from "@prisma/client";
+import type { EvaluationRunService } from "~/server/app-layer/evaluations/evaluation-run.service";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import type { ProjectService } from "~/server/app-layer/projects/project.service";
+import type { TriggerService } from "~/server/app-layer/triggers/trigger.service";
+import {
+  buildPreconditionTraceDataFromFoldState,
+  classifyTriggerFilters,
+  matchesEvaluationFilters,
+  matchesTriggerFilters,
+  triggerFiltersReferenceEvents,
+} from "~/server/filters/triggerFilter.matcher";
+import { sendTriggerEmail } from "~/server/mailer/triggerEmail";
+import { sendSlackWebhook } from "~/server/triggers/sendSlackWebhook";
+import type { Trace } from "~/server/tracer/types";
+import { createLogger } from "~/utils/logger/server";
+import { captureException } from "~/utils/posthogErrorCapture";
+import { createTenantId } from "../domain/tenantId";
+import { DispatchError, isDispatchError } from "./dispatchError";
+import type { DerivedTraceEvent } from "../pipelines/trace-processing/projections/services/trace-events.derivation";
+import {
+  computeScheduledFor,
+  NOTIFY_TRIGGER_ACTIONS,
+} from "../pipelines/shared/triggerActionDispatch";
+import type { FoldProjectionStore } from "../projections/foldProjection.types";
+import {
+  TRIGGER_NOTIFY_REACTOR_NAME,
+  type CadenceStagePayload,
+  type OutboxJob,
+  type SettleStagePayload,
+} from "./payload";
+
+const logger = createLogger("langwatch:outbox:dispatcher");
+
+interface ActionParams {
+  members?: string[] | null;
+  slackWebhook?: string | null;
+}
+
+export interface OutboxDispatcherDeps {
+  triggers: TriggerService;
+  projects: ProjectService;
+  traceSummaryStore: FoldProjectionStore<TraceSummaryData>;
+  evaluationRuns: EvaluationRunService;
+  deriveEvents: (params: {
+    tenantId: string;
+    traceId: string;
+    occurredAtMs?: number;
+    foldVersion?: number;
+  }) => Promise<DerivedTraceEvent[]>;
+  traceById: (
+    projectId: string,
+    traceId: string,
+  ) => Promise<Trace | undefined>;
+  /**
+   * Late-bound — settle stage's match-confirmed branch calls this to
+   * re-enqueue as `cadence`. The queue ref is filled in by `setupOutbox`
+   * after the queue is constructed, since the queue's `process`
+   * callback (this function) holds the only reference to itself.
+   *
+   * `delayMs` is the wall-clock distance from now to the cadence
+   * boundary the dispatcher just resolved from `trigger.notificationCadence`.
+   */
+  enqueueCadence: (
+    payload: CadenceStagePayload,
+    options: { delayMs: number },
+  ) => Promise<void>;
+}
+
+/**
+ * Unified outbox process callback. Branches on `stage` so one queue
+ * carries both ADR-030 settle and ADR-025 cadence digest stages with
+ * the operator's two knobs (`traceDebounceMs`, `notificationCadence`)
+ * still independently tunable.
+ *
+ * `process(payload)` is invoked by the GroupQueue for single-job
+ * paths (settle is never coalesced). `processBatch(payloads)` is
+ * invoked when `coalesceMaxBatch` opens a digest — only cadence-stage
+ * payloads coalesce.
+ */
+export function createOutboxDispatcher(deps: OutboxDispatcherDeps): {
+  process: (payload: OutboxJob) => Promise<void>;
+  processBatch: (payloads: OutboxJob[]) => Promise<void>;
+} {
+  return {
+    process: async (payload) => {
+      if (payload.stage === "settle") {
+        await handleSettle(deps, payload);
+      } else {
+        // Single-job cadence path (no coalescing this round) — render
+        // and send a one-match digest.
+        await handleCadenceBatch(deps, [payload]);
+      }
+    },
+    processBatch: async (payloads) => {
+      if (payloads.length === 0) return;
+      // Settle stage's coalesceMaxBatch returns 1 so we never see a
+      // settle-stage batch here; defensive split anyway.
+      const cadence: CadenceStagePayload[] = [];
+      for (const p of payloads) {
+        if (p.stage === "settle") {
+          await handleSettle(deps, p);
+        } else {
+          cadence.push(p);
+        }
+      }
+      if (cadence.length > 0) {
+        await handleCadenceBatch(deps, cadence);
+      }
+    },
+  };
+}
+
+/**
+ * Settle stage: trace has been quiet for `traceDebounceMs`. Re-read
+ * the fold, re-run filters against the now-settled state, claim
+ * `TriggerSent` if it matches, and re-enqueue as cadence so the
+ * digest window can coalesce.
+ */
+async function handleSettle(
+  deps: OutboxDispatcherDeps,
+  payload: SettleStagePayload,
+): Promise<void> {
+  const { projectId, triggerId, traceId } = payload;
+
+  const triggers =
+    await deps.triggers.getActiveTraceTriggersForProject(projectId);
+  const trigger = triggers.find((t) => t.id === triggerId);
+  if (!trigger) {
+    logger.debug(
+      { projectId, triggerId, traceId },
+      "Trigger missing / deactivated during settle — skipping",
+    );
+    return;
+  }
+
+  const brandedTenantId = createTenantId(projectId);
+  const foldState = await deps.traceSummaryStore.get(traceId, {
+    tenantId: brandedTenantId,
+    aggregateId: traceId,
+  });
+  if (!foldState) {
+    logger.debug(
+      { projectId, triggerId, traceId },
+      "Trace fold gone during settle — skipping",
+    );
+    return;
+  }
+
+  const { traceFilters, evaluationFilters, hasEvaluationFilters } =
+    classifyTriggerFilters(trigger.filters);
+
+  const events = triggerFiltersReferenceEvents(traceFilters)
+    ? await deps.deriveEvents({
+        tenantId: projectId,
+        traceId,
+        occurredAtMs: foldState.occurredAt,
+        foldVersion: foldState.spanCount,
+      })
+    : null;
+  const traceData = buildPreconditionTraceDataFromFoldState(foldState, events);
+
+  if (
+    Object.keys(traceFilters).length > 0 &&
+    !matchesTriggerFilters(traceData, traceFilters)
+  ) {
+    return;
+  }
+
+  if (hasEvaluationFilters) {
+    const allEvaluations = await deps.evaluationRuns.findByTraceId(
+      projectId,
+      traceId,
+    );
+    if (!matchesEvaluationFilters(allEvaluations, evaluationFilters)) {
+      return;
+    }
+  }
+
+  if (!NOTIFY_TRIGGER_ACTIONS.has(trigger.action)) {
+    // Persist actions don't take the outbox path — the inline
+    // dispatchTriggerAction caller routed them separately.
+    return;
+  }
+
+  const claimed = await deps.triggers.claimSend({
+    triggerId: trigger.id,
+    traceId,
+    projectId,
+  });
+  if (!claimed) return;
+
+  const cadencePayload: CadenceStagePayload = {
+    stage: "cadence",
+    projectId,
+    triggerId,
+    reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+    auditDedupKey: payload.auditDedupKey,
+    match: {
+      traceId,
+      input: foldState.computedInput ?? "",
+      output: foldState.computedOutput ?? "",
+    },
+  };
+
+  const now = new Date();
+  const scheduledFor = computeScheduledFor({
+    action: trigger.action,
+    cadence: trigger.notificationCadence,
+    now,
+  });
+  const delayMs = Math.max(0, scheduledFor.getTime() - now.getTime());
+
+  await deps.enqueueCadence(cadencePayload, { delayMs });
+}
+
+/**
+ * Cadence stage: one or more matched (trigger, trace) pairs landed in
+ * the same wall-clock cadence boundary. Renders one digest and sends.
+ * The group invariant (single triggerId per batch) is enforced by the
+ * queue's `groupKey` configuration.
+ */
+async function handleCadenceBatch(
+  deps: OutboxDispatcherDeps,
+  payloads: CadenceStagePayload[],
+): Promise<void> {
+  const projectId = payloads[0]!.projectId;
+  const triggerId = payloads[0]!.triggerId;
+
+  for (const p of payloads) {
+    if (p.triggerId !== triggerId || p.projectId !== projectId) {
+      throw new DispatchError({
+        message: `cadence batch has mixed identity (${projectId}/${triggerId} vs ${p.projectId}/${p.triggerId})`,
+        retryable: false,
+      });
+    }
+  }
+
+  const triggersForProject =
+    await deps.triggers.getActiveTraceTriggersForProject(projectId);
+  const trigger = triggersForProject.find((t) => t.id === triggerId);
+  if (!trigger) {
+    logger.info(
+      { projectId, triggerId, batchSize: payloads.length },
+      "Trigger gone / deactivated since enqueue — dropping digest",
+    );
+    return;
+  }
+
+  const project = await deps.projects.getById(projectId);
+  if (!project) {
+    throw new DispatchError({
+      message: `project ${projectId} not found at dispatch time`,
+      retryable: false,
+    });
+  }
+
+  const params = (trigger.actionParams ?? {}) as ActionParams;
+  const triggerData = await Promise.all(
+    payloads.map(async (p) => {
+      const fullTrace =
+        (await deps.traceById(projectId, p.match.traceId)) ??
+        ({ trace_id: p.match.traceId } as Trace);
+      return {
+        traceId: p.match.traceId,
+        input: p.match.input,
+        output: p.match.output,
+        projectId,
+        fullTrace,
+      };
+    }),
+  );
+
+  try {
+    switch (trigger.action) {
+      case TriggerAction.SEND_EMAIL:
+        await sendTriggerEmail({
+          triggerEmails: params.members ?? [],
+          triggerData,
+          triggerName: trigger.name,
+          projectSlug: project.slug,
+          triggerType: trigger.alertType,
+          triggerMessage: trigger.message ?? "",
+        });
+        break;
+      case TriggerAction.SEND_SLACK_MESSAGE:
+        await sendSlackWebhook({
+          triggerWebhook: params.slackWebhook ?? "",
+          triggerData,
+          triggerName: trigger.name,
+          projectSlug: project.slug,
+          triggerType: trigger.alertType,
+          triggerMessage: trigger.message ?? "",
+        });
+        break;
+      default:
+        throw new DispatchError({
+          message: `cadence stage cannot dispatch action ${trigger.action} — settle stage misrouted`,
+          retryable: false,
+        });
+    }
+  } catch (error) {
+    const retryable = isDispatchError(error) ? error.retryable : true;
+    logger.error(
+      {
+        projectId,
+        triggerId,
+        retryable,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Cadence dispatch failed",
+    );
+    captureException(error, {
+      extra: { projectId, triggerId, triggerAction: trigger.action },
+    });
+    throw error;
+  }
+
+  await deps.triggers.updateLastRunAt(triggerId, projectId);
+  logger.info(
+    {
+      projectId,
+      triggerId,
+      action: trigger.action,
+      cadence: trigger.notificationCadence,
+      digestSize: payloads.length,
+    },
+    "Outbox cadence digest dispatched",
+  );
+}
+
+// Re-export so callers building cadence payloads from outside (e.g. a
+// test) reach computeScheduledFor through the same module surface.
+export { computeScheduledFor };

--- a/langwatch/src/server/event-sourcing/outbox/payload.ts
+++ b/langwatch/src/server/event-sourcing/outbox/payload.ts
@@ -1,0 +1,145 @@
+/**
+ * Single queue, two stages (ADR-021 revision + ADR-025 + ADR-030).
+ *
+ * The unified outbox queue carries both trace-readiness settling and
+ * cadence digest dispatch in one `process` callback via the `stage`
+ * discriminator. Per-stage queue behavior (dedup, delay, group key,
+ * coalescing) is driven by `stage` so one queue serves both timing
+ * primitives without merging them — the operator's `traceDebounceMs`
+ * and `notificationCadence` knobs stay independently tunable.
+ *
+ * - **settle**: per-(trigger, trace). Sent on every event the reactor
+ *   sees as a candidate match. Dedup mode is debounce (extend + replace
+ *   TTL) keyed on `(projectId, triggerId, traceId)`, so subsequent
+ *   spans on the same trace reset the timer and carry the latest fold.
+ *   When TTL elapses without a new event, the process callback loads
+ *   fresh fold, runs filters, claims `TriggerSent`, and — on match —
+ *   re-enqueues as a `cadence` job.
+ * - **cadence**: per-trigger. Carries one matched (trigger, trace)
+ *   pair. Delay snaps to the next wall-clock cadence boundary; the
+ *   queue's `processBatch` + `coalesceMaxBatch` groups every cadence
+ *   job for the same trigger landing in the same boundary into one
+ *   dispatcher invocation — that's the digest.
+ *
+ * Audit projection (PG `ReactorOutbox`) is written for BOTH stages,
+ * sharing one row via `auditDedupKey` so operators see the full
+ * lifecycle:
+ *   settle.onEnqueue → status="queued", scheduledAt=settle end
+ *   settle.onLeased → status="dispatching"
+ *   settle.onDispatched (no match) → status="dispatched",
+ *     lastError="settle: no match"
+ *   settle.onDispatched (matched + cadence re-enqueued) → cadence's
+ *     onEnqueue has already moved the row back to "queued"; settle's
+ *     terminal update no-ops via a `WHERE status='dispatching'` CAS
+ *   cadence.onEnqueue → UPDATE → status="queued", new scheduledAt
+ *   cadence.onLeased → status="dispatching"
+ *   cadence.onDispatched → status="dispatched"
+ */
+
+export const TRIGGER_NOTIFY_REACTOR_NAME = "triggerNotify" as const;
+
+/**
+ * Both stages carry the SAME `auditDedupKey` so they project onto one
+ * `ReactorOutbox` row through the lifecycle: settle's INSERT,
+ * settle's leased/dispatched-or-noMatch, cadence's UPDATE, cadence's
+ * leased/dispatched. The GroupQueue's own dedup id is different per
+ * stage (settle uses Debounce Mode, cadence does not) — that key is
+ * for queue-level collapse, not PG row identity.
+ */
+interface CommonStagePayload {
+  projectId: string;
+  triggerId: string;
+  reactorName: typeof TRIGGER_NOTIFY_REACTOR_NAME;
+  auditDedupKey: string;
+}
+
+export interface SettleStagePayload
+  extends CommonStagePayload,
+    Record<string, unknown> {
+  stage: "settle";
+  traceId: string;
+  /**
+   * Fold snapshot at enqueue time. The settle process callback
+   * **re-reads** the fold from the projection store at fire time so a
+   * 30-second-old snapshot doesn't drive the filter check — the
+   * snapshot here is only a debugging breadcrumb.
+   */
+  foldSnapshotAtEnqueue: {
+    computedInput: string;
+    computedOutput: string;
+  };
+}
+
+export interface CadenceStagePayload
+  extends CommonStagePayload,
+    Record<string, unknown> {
+  stage: "cadence";
+  match: {
+    traceId: string;
+    input: string;
+    output: string;
+  };
+}
+
+export type OutboxJob = SettleStagePayload | CadenceStagePayload;
+
+export function isSettle(job: OutboxJob): job is SettleStagePayload {
+  return job.stage === "settle";
+}
+
+export function isCadence(job: OutboxJob): job is CadenceStagePayload {
+  return job.stage === "cadence";
+}
+
+/**
+ * Per-(trigger, trace) dedup key for the settle stage. Identity for
+ * the GroupQueue Debounce Mode entry — repeat sends within the TTL
+ * collapse onto the existing pending job.
+ */
+export function settleDedupId(params: {
+  projectId: string;
+  triggerId: string;
+  traceId: string;
+}): string {
+  return `${params.projectId}/${params.triggerId}/${params.traceId}`;
+}
+
+/**
+ * Per-(trigger, trace) audit row identity. Both settle and cadence
+ * payloads carry this on `auditDedupKey` so they target one row in
+ * `ReactorOutbox` through the full lifecycle. Collisions are the
+ * replay-safe claim primitive (ADR-022).
+ */
+export function auditDedupKey(params: {
+  projectId: string;
+  triggerId: string;
+  traceId: string;
+}): string {
+  return `${params.projectId}/${params.triggerId}:trace:${params.traceId}`;
+}
+
+/**
+ * Per-(trigger, trace) group key for the settle stage. Per-trace FIFO
+ * so a noisy trace doesn't head-of-line block other traces' settle
+ * windows.
+ */
+export function settleGroupKey(params: {
+  projectId: string;
+  triggerId: string;
+  traceId: string;
+}): string {
+  return `${params.projectId}/${TRIGGER_NOTIFY_REACTOR_NAME}:${params.triggerId}:${params.traceId}`;
+}
+
+/**
+ * Per-trigger group key for the cadence stage. All matched traces for
+ * a trigger landing in the same wall-clock cadence boundary group
+ * together via the queue's `processBatch` — one dispatcher invocation,
+ * one digest send.
+ */
+export function cadenceGroupKey(params: {
+  projectId: string;
+  triggerId: string;
+}): string {
+  return `${params.projectId}/${TRIGGER_NOTIFY_REACTOR_NAME}:${params.triggerId}`;
+}

--- a/langwatch/src/server/event-sourcing/outbox/pgAuditAdapter.ts
+++ b/langwatch/src/server/event-sourcing/outbox/pgAuditAdapter.ts
@@ -1,0 +1,260 @@
+import type { PrismaClient } from "@prisma/client";
+import { createLogger } from "~/utils/logger/server";
+import type { QueueAuditAdapter } from "../queues/queue.types";
+import { isCadence, isSettle, type OutboxJob } from "./payload";
+
+const logger = createLogger("langwatch:outbox:pg-audit-adapter");
+
+const SETTLE_NO_MATCH_REASON = "settle: no match";
+
+/**
+ * Projects every outbox queue lifecycle event into a `ReactorOutbox`
+ * row (ADR-021 revision).
+ *
+ * One row per (trigger, trace) — both settle and cadence stages
+ * target the same row via the shared `auditDedupKey` on the payload.
+ * Lifecycle:
+ *
+ *   settle.onEnqueue   → INSERT status="queued", scheduledAt=settle end
+ *   settle.onLeased    → status="dispatching"
+ *   settle.onDispatched
+ *     matched + cadence re-enqueued → cadence.onEnqueue already moved
+ *       the row back to status="queued"; settle's terminal update is a
+ *       no-op via the `WHERE status='dispatching'` filter
+ *     no match → status="dispatched", lastError="settle: no match"
+ *   settle.onFailed/onDead → conditional terminal (same WHERE filter)
+ *   cadence.onEnqueue  → UPDATE existing row: status="queued",
+ *                        scheduledAt=cadence boundary, attempts reset
+ *   cadence.onLeased   → status="dispatching"
+ *   cadence.onDispatched → status="dispatched"
+ *   cadence.onFailed/onDead → standard retry/dead
+ *
+ * The CAS-style `WHERE status='dispatching'` on settle's terminal
+ * hooks is what makes the lifecycle race-safe: by the time settle's
+ * onDispatched fires, cadence's onEnqueue may have already updated
+ * the row back to "queued"; the conditional update sees no matching
+ * row and no-ops.
+ *
+ * Adapter writes are non-fatal — see `runAudit` in `GroupQueueProcessor`.
+ */
+export class PgOutboxAuditAdapter implements QueueAuditAdapter<OutboxJob> {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async onEnqueue(event: {
+    payload: OutboxJob;
+    groupKey: string;
+    dedupKey: string | undefined;
+    scheduledAt: Date;
+    maxAttempts?: number;
+  }): Promise<void> {
+    const p = event.payload;
+    if (isSettle(p)) {
+      // Settle is the first stage — INSERT (idempotent via the
+      // (reactorName, auditDedupKey) unique constraint). A replayed
+      // settle for the same (trigger, trace) collapses.
+      await this.write(() =>
+        this.prisma.reactorOutbox.createMany({
+          data: [
+            {
+              projectId: p.projectId,
+              reactorName: p.reactorName,
+              dedupKey: p.auditDedupKey,
+              groupKey: event.groupKey,
+              payload: p as object,
+              status: "queued",
+              attempts: 0,
+              maxAttempts: event.maxAttempts ?? 8,
+              nextAttemptAt: event.scheduledAt,
+            },
+          ],
+          skipDuplicates: true,
+        }),
+      );
+      return;
+    }
+
+    if (isCadence(p)) {
+      // Cadence is the second stage — UPDATE the row settle wrote,
+      // moving status back to "queued" with the new scheduled time.
+      // attempts resets because cadence is a fresh dispatch attempt
+      // independent of settle's filter check.
+      const updated = await this.write(() =>
+        this.prisma.reactorOutbox.updateMany({
+          where: {
+            reactorName: p.reactorName,
+            dedupKey: p.auditDedupKey,
+          },
+          data: {
+            status: "queued",
+            attempts: 0,
+            nextAttemptAt: event.scheduledAt,
+            groupKey: event.groupKey,
+            payload: p as object,
+          },
+        }),
+      );
+      // Defensive: if no settle row exists (e.g. caller wired cadence
+      // directly without a settle stage), INSERT instead. Keeps the
+      // adapter robust against partial-rollout misconfigurations.
+      if (updated === 0) {
+        await this.write(() =>
+          this.prisma.reactorOutbox.createMany({
+            data: [
+              {
+                projectId: p.projectId,
+                reactorName: p.reactorName,
+                dedupKey: p.auditDedupKey,
+                groupKey: event.groupKey,
+                payload: p as object,
+                status: "queued",
+                attempts: 0,
+                maxAttempts: event.maxAttempts ?? 8,
+                nextAttemptAt: event.scheduledAt,
+              },
+            ],
+            skipDuplicates: true,
+          }),
+        );
+      }
+    }
+  }
+
+  async onLeased(event: { payload: OutboxJob }): Promise<void> {
+    const p = event.payload;
+    if (!isSettle(p) && !isCadence(p)) return;
+    await this.write(() =>
+      this.prisma.reactorOutbox.updateMany({
+        where: { reactorName: p.reactorName, dedupKey: p.auditDedupKey },
+        data: { status: "dispatching", attempts: { increment: 1 } },
+      }),
+    );
+  }
+
+  async onDispatched(event: {
+    payload: OutboxJob;
+    at: Date;
+  }): Promise<void> {
+    const p = event.payload;
+    if (isSettle(p)) {
+      // Conditional CAS: only mark dispatched if the row is still in
+      // "dispatching". If cadence already re-enqueued (settle matched
+      // + claimed), status is back to "queued" and the WHERE doesn't
+      // match — this becomes a no-op, which is correct.
+      await this.write(() =>
+        this.prisma.reactorOutbox.updateMany({
+          where: {
+            reactorName: p.reactorName,
+            dedupKey: p.auditDedupKey,
+            status: "dispatching",
+          },
+          data: {
+            status: "dispatched",
+            dispatchedAt: event.at,
+            lastError: SETTLE_NO_MATCH_REASON,
+          },
+        }),
+      );
+      return;
+    }
+    if (isCadence(p)) {
+      await this.write(() =>
+        this.prisma.reactorOutbox.updateMany({
+          where: { reactorName: p.reactorName, dedupKey: p.auditDedupKey },
+          data: {
+            status: "dispatched",
+            dispatchedAt: event.at,
+            lastError: null,
+          },
+        }),
+      );
+    }
+  }
+
+  async onFailed(event: {
+    payload: OutboxJob;
+    error: string;
+    willRetry: boolean;
+    nextAttemptAt?: Date;
+  }): Promise<void> {
+    const p = event.payload;
+    if (!isSettle(p) && !isCadence(p)) return;
+    const baseWhere = {
+      reactorName: p.reactorName,
+      dedupKey: p.auditDedupKey,
+    };
+    // Settle's onFailed is conditional (only update if still leased).
+    // Cadence's onFailed is unconditional (it owns the row at that point).
+    const where = isSettle(p)
+      ? { ...baseWhere, status: "dispatching" as const }
+      : baseWhere;
+    await this.write(() =>
+      this.prisma.reactorOutbox.updateMany({
+        where,
+        data: {
+          status: event.willRetry ? "failed_retryable" : "dead",
+          lastError: event.error,
+          lastErrorAt: new Date(),
+          ...(event.willRetry && event.nextAttemptAt
+            ? { nextAttemptAt: event.nextAttemptAt }
+            : { nextAttemptAt: null }),
+        },
+      }),
+    );
+  }
+
+  async onDead(event: {
+    payload: OutboxJob;
+    lastError: string;
+  }): Promise<void> {
+    const p = event.payload;
+    if (!isSettle(p) && !isCadence(p)) return;
+    const baseWhere = {
+      reactorName: p.reactorName,
+      dedupKey: p.auditDedupKey,
+    };
+    const where = isSettle(p)
+      ? { ...baseWhere, status: "dispatching" as const }
+      : baseWhere;
+    await this.write(() =>
+      this.prisma.reactorOutbox.updateMany({
+        where,
+        data: {
+          status: "dead",
+          lastError: event.lastError,
+          lastErrorAt: new Date(),
+          nextAttemptAt: null,
+        },
+      }),
+    );
+  }
+
+  /**
+   * Adapter writes are best-effort relative to the queue's own state.
+   * A PG error logs+continues; the queue keeps running and the next
+   * transition's write brings the projection back into sync. Returns
+   * the rowsAffected count (for `onEnqueue`'s settle-fallback path) or
+   * 0 on failure.
+   */
+  private async write(
+    op: () => Promise<{ count: number } | unknown>,
+  ): Promise<number> {
+    try {
+      const result = await op();
+      if (
+        result &&
+        typeof result === "object" &&
+        "count" in result &&
+        typeof (result as { count: unknown }).count === "number"
+      ) {
+        return (result as { count: number }).count;
+      }
+      return 0;
+    } catch (error) {
+      logger.warn(
+        { error: error instanceof Error ? error.message : String(error) },
+        "PgOutboxAuditAdapter write failed; queue keeps running, audit lags",
+      );
+      return 0;
+    }
+  }
+}

--- a/langwatch/src/server/event-sourcing/outbox/setup.ts
+++ b/langwatch/src/server/event-sourcing/outbox/setup.ts
@@ -1,0 +1,168 @@
+import type { PrismaClient } from "@prisma/client";
+import type { Cluster, Redis } from "ioredis";
+import type { ProcessRole } from "~/server/app-layer/config";
+import type { EvaluationRunService } from "~/server/app-layer/evaluations/evaluation-run.service";
+import type { ProjectService } from "~/server/app-layer/projects/project.service";
+import type { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
+import type { TraceSummaryRepository } from "~/server/app-layer/traces/repositories/trace-summary.repository";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import type { TriggerService } from "~/server/app-layer/triggers/trigger.service";
+import { TraceReadDerivationService } from "~/server/app-layer/traces/trace-read-derivation.service";
+import { getProtectionsForProject } from "~/server/api/utils";
+import { TraceService } from "~/server/traces/trace.service";
+import { DEFAULT_TRACE_DEBOUNCE_MS } from "../pipelines/shared/triggerActionDispatch";
+import { TraceSummaryStore } from "../pipelines/trace-processing/projections/traceSummary.store";
+import type { FoldProjectionStore } from "../projections/foldProjection.types";
+import { RedisCachedFoldStore } from "../projections/redisCachedFoldStore";
+import { GroupQueueProcessor } from "../queues/groupQueue/groupQueue";
+import { EventSourcedQueueProcessorMemory } from "../queues/memory";
+import type {
+  EventSourcedQueueDefinition,
+  EventSourcedQueueProcessor,
+} from "../queues/queue.types";
+import { createOutboxDispatcher } from "./dispatcher";
+import {
+  cadenceGroupKey,
+  isSettle,
+  settleDedupId,
+  settleGroupKey,
+  type CadenceStagePayload,
+  type OutboxJob,
+} from "./payload";
+import { PgOutboxAuditAdapter } from "./pgAuditAdapter";
+
+export const OUTBOX_QUEUE_NAME = "langwatch:outbox";
+
+export interface OutboxStack {
+  queue: EventSourcedQueueProcessor<OutboxJob>;
+  auditAdapter: PgOutboxAuditAdapter;
+}
+
+/**
+ * Composition root for the unified outbox stack (ADR-021 revision +
+ * ADR-025 + ADR-030).
+ *
+ * One queue, two stages:
+ *   - settle: per-(trigger, trace) Debounce Mode dedup; the timer
+ *     elapses without new spans → process callback re-reads fold,
+ *     runs filters, claims `TriggerSent`, re-enqueues as cadence.
+ *   - cadence: per-trigger group, windowed `delay`; `processBatch`
+ *     coalesces same-trigger jobs landing in the same wall-clock
+ *     cadence boundary into one digest.
+ *
+ * Audit projection (PG `ReactorOutbox`) is written by the queue's
+ * `auditAdapter` — onEnqueue / onLeased / onDispatched / onFailed /
+ * onDead hooks fire as the queue moves jobs through their lifecycle,
+ * but only for cadence-stage payloads (settle is ephemeral).
+ *
+ * Consumer loop only runs on `processRole === "worker"`. Web can
+ * still `queue.send` (the send-side is producer-only) but never
+ * drains. Web should still skip calling `setupOutbox` entirely —
+ * gate the call site on processRole to avoid the Redis-client cost.
+ */
+export function setupOutbox({
+  prisma,
+  redis,
+  processRole,
+  triggers,
+  projects,
+  evaluations,
+  traces,
+  traceSummaryRepository,
+}: {
+  prisma: PrismaClient;
+  redis: Redis | Cluster | null;
+  processRole: ProcessRole;
+  triggers: TriggerService;
+  projects: ProjectService;
+  evaluations: { runs: EvaluationRunService };
+  traces: { spans: SpanStorageService };
+  traceSummaryRepository: TraceSummaryRepository;
+}): OutboxStack {
+  const auditAdapter = new PgOutboxAuditAdapter(prisma);
+
+  // Shared trace fold store — settle stage cross-reads it to drive the
+  // post-settle filter check against fresh state.
+  const traceSummaryStore: FoldProjectionStore<TraceSummaryData> = redis
+    ? new RedisCachedFoldStore(
+        new TraceSummaryStore(traceSummaryRepository),
+        redis,
+        { keyPrefix: "trace_summaries" },
+      )
+    : new TraceSummaryStore(traceSummaryRepository);
+
+  const traceReadDerivation = new TraceReadDerivationService(traces.spans);
+
+  // Late-bound: the settle-stage process callback needs to re-enqueue
+  // as cadence, but the queue handle is built _after_ the dispatcher.
+  // A holder pattern lets the dispatcher reach into the constructed
+  // queue without circular-import gymnastics.
+  const queueHolder: { current?: EventSourcedQueueProcessor<OutboxJob> } = {};
+
+  const dispatcher = createOutboxDispatcher({
+    triggers,
+    projects,
+    traceSummaryStore,
+    evaluationRuns: evaluations.runs,
+    deriveEvents: (params) => traceReadDerivation.deriveEvents(params),
+    traceById: async (projectId, traceId) => {
+      const traceService = TraceService.create(prisma);
+      const protections = await getProtectionsForProject(prisma, { projectId });
+      return traceService.getById(projectId, traceId, protections);
+    },
+    enqueueCadence: async (
+      payload: CadenceStagePayload,
+      { delayMs }: { delayMs: number },
+    ) => {
+      if (!queueHolder.current) {
+        throw new Error(
+          "Outbox queue not yet wired — enqueueCadence called before setupOutbox returned",
+        );
+      }
+      await queueHolder.current.send(payload, {
+        delay: delayMs > 0 ? delayMs : undefined,
+      });
+    },
+  });
+
+  const definition: EventSourcedQueueDefinition<OutboxJob> = {
+    name: OUTBOX_QUEUE_NAME,
+    process: dispatcher.process,
+    processBatch: dispatcher.processBatch,
+    // Coalesce only cadence-stage jobs — settle is per-(trigger, trace),
+    // batching it doesn't make sense.
+    coalesceMaxBatch: (payload) => (isSettle(payload) ? 1 : 100),
+    // Per-stage group key: per-trace for settle (so noisy traces don't
+    // head-of-line block other traces), per-trigger for cadence (so
+    // processBatch can coalesce a digest).
+    groupKey: (payload) =>
+      isSettle(payload)
+        ? settleGroupKey(payload)
+        : cadenceGroupKey(payload),
+    deduplication: {
+      // Settle stage: per-(trigger, trace) Debounce Mode (extend +
+      // replace TTL on every send so the latest event wins). Cadence
+      // stage uses a per-job id so it doesn't dedup across digest
+      // members — the digest grouping is done by `groupKey` +
+      // `coalesceMaxBatch`, not by dedup.
+      makeId: (payload) =>
+        isSettle(payload)
+          ? settleDedupId(payload)
+          : `${payload.projectId}/cadence/${payload.auditDedupKey}`,
+      ttlMs: DEFAULT_TRACE_DEBOUNCE_MS,
+      extend: true,
+      replace: true,
+    },
+    auditAdapter,
+  };
+
+  const queue: EventSourcedQueueProcessor<OutboxJob> = redis
+    ? new GroupQueueProcessor(definition, redis, {
+        consumerEnabled: processRole === "worker",
+      })
+    : new EventSourcedQueueProcessorMemory(definition);
+
+  queueHolder.current = queue;
+
+  return { queue, auditAdapter };
+}

--- a/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
@@ -39,6 +39,20 @@ export const PERSIST_TRIGGER_ACTIONS = new Set<TriggerAction>([
   TriggerAction.ADD_TO_ANNOTATION_QUEUE,
 ]);
 
+/**
+ * How long a trace stays in the settle stage before its filters are
+ * re-evaluated. Sized to absorb the typical drip of late spans on an
+ * in-flight trace without making "immediate" cadence visibly delayed.
+ * The unified outbox queue uses Debounce Mode keyed on
+ * `(projectId, triggerId, traceId)` with this as the TTL — every new
+ * candidate event on the same trace extends + replaces the pending job.
+ *
+ * Per-trigger override lives on `Monitor.traceDebounceMs` (ADR-030),
+ * the application reads this as the floor / default when the trigger
+ * has no explicit value.
+ */
+export const DEFAULT_TRACE_DEBOUNCE_MS = 30_000;
+
 export const NOTIFICATION_CADENCES = [
   "immediate",
   "5min_digest",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -17,6 +17,7 @@ import type {
   DeduplicationConfig,
   EventSourcedQueueDefinition,
   EventSourcedQueueProcessor,
+  QueueAuditAdapter,
   QueueSendOptions,
 } from "../../queues";
 import { categorizeError, ConfigurationError, ErrorCategory, QueueError } from "../../services/errorHandling";
@@ -102,6 +103,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   private readonly deduplication?: DeduplicationConfig<Payload>;
   private readonly groupKey: (payload: Payload) => string;
   private readonly score?: (payload: Payload) => number;
+  private readonly auditAdapter?: QueueAuditAdapter<Payload>;
   private readonly redisConnection: IORedis | Cluster;
   private readonly blockingConnection: IORedis | Cluster;
   private readonly scripts: GroupStagingScripts;
@@ -131,6 +133,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       deduplication,
       groupKey,
       score,
+      auditAdapter,
     } = definition;
 
     const effectiveConnection = redisConnection ?? connection;
@@ -168,6 +171,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     this.process = process;
     this.processBatch = processBatch;
     this.coalesceMaxBatch = coalesceMaxBatch;
+    this.auditAdapter = auditAdapter;
     this.globalConcurrency =
       defOptions?.globalConcurrency ??
       GROUP_QUEUE_CONFIG.defaultGlobalConcurrency;
@@ -317,6 +321,17 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       if (tenantId) {
         void this.rateTracker.record(tenantId);
       }
+      // Audit hook (ADR-021 revision): only on the new-stage path, not on
+      // dedup-collapse. The adapter's audit row already exists for the
+      // first send under this dedup ID.
+      await this.runAudit(() =>
+        this.auditAdapter?.onEnqueue({
+          payload,
+          groupKey: groupId,
+          dedupKey: dedupId || undefined,
+          scheduledAt: new Date(dispatchAfterMs),
+        }),
+      );
     } else {
       gqJobsDedupedTotal.inc({ queue_name: this.queueName });
     }
@@ -419,6 +434,23 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       gqJobsDedupedTotal.inc({ queue_name: this.queueName }, dedupedCount);
     }
 
+    // Audit hooks (ADR-021 revision). The Lua's stageBatch returns a count,
+    // not a per-payload new/dedup map, so we fire onEnqueue for every
+    // payload and let the adapter's idempotency (createMany skipDuplicates)
+    // absorb dedup-collapsed duplicates.
+    if (this.auditAdapter) {
+      for (const job of jobsToStage) {
+        await this.runAudit(() =>
+          this.auditAdapter?.onEnqueue({
+            payload: payloads[jobsToStage.indexOf(job)]!,
+            groupKey: job.groupId,
+            dedupKey: job.dedupId || undefined,
+            scheduledAt: new Date(job.dispatchAfterMs),
+          }),
+        );
+      }
+    }
+
     this.logger.debug(
       {
         queueName: this.queueName,
@@ -428,6 +460,26 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       },
       "Batch of jobs staged",
     );
+  }
+
+  /**
+   * Best-effort audit-adapter invocation. PG outages log + continue;
+   * the queue stays available. See ADR-021 revision for the "audit lags
+   * but never blocks dispatch" property.
+   */
+  private async runAudit(op: () => Promise<unknown> | undefined): Promise<void> {
+    if (!this.auditAdapter) return;
+    try {
+      await op();
+    } catch (err) {
+      this.logger.warn(
+        {
+          queueName: this.queueName,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        "Audit adapter hook failed; queue continues, projection lags",
+      );
+    }
   }
 
   /**
@@ -559,6 +611,20 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
             }
 
             try {
+              // Audit hook: onLeased fires once per leased payload (including
+              // each drained sibling in a coalesced batch). Best-effort —
+              // PG outage logs+continues.
+              await this.runAudit(() =>
+                this.auditAdapter?.onLeased({ payload }),
+              );
+              if (batchPayloads && this.auditAdapter) {
+                for (const sibling of batchPayloads.slice(1)) {
+                  await this.runAudit(() =>
+                    this.auditAdapter?.onLeased({ payload: sibling }),
+                  );
+                }
+              }
+
               // Run the actual handler with request context propagation
               const requestContext = createContextFromJobData(contextMetadata);
               await runWithContext(requestContext, async () => {
@@ -575,6 +641,23 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               // dispatched job is enough to free the group.
               await this.scripts.complete({ groupId, stagedJobId, jobName });
               gqJobsCompletedTotal.inc(routingLabels);
+
+              // Audit hook: onDispatched fires once per dispatched payload
+              // (dispatched + every drained sibling on success).
+              const dispatchedAt = new Date();
+              await this.runAudit(() =>
+                this.auditAdapter?.onDispatched({ payload, at: dispatchedAt }),
+              );
+              if (batchPayloads && this.auditAdapter) {
+                for (const sibling of batchPayloads.slice(1)) {
+                  await this.runAudit(() =>
+                    this.auditAdapter?.onDispatched({
+                      payload: sibling,
+                      at: dispatchedAt,
+                    }),
+                  );
+                }
+              }
 
               this.logger.debug(
                 {
@@ -621,6 +704,30 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   backoffMs,
                 });
 
+                // Audit hook: willRetry=true. Fires for the dispatched
+                // payload + every drained sibling (they all get re-staged).
+                const nextAttemptAt = new Date(Date.now() + backoffMs);
+                await this.runAudit(() =>
+                  this.auditAdapter?.onFailed({
+                    payload,
+                    error: error.message,
+                    willRetry: true,
+                    nextAttemptAt,
+                  }),
+                );
+                if (batchPayloads && this.auditAdapter) {
+                  for (const sibling of batchPayloads.slice(1)) {
+                    await this.runAudit(() =>
+                      this.auditAdapter?.onFailed({
+                        payload: sibling,
+                        error: error.message,
+                        willRetry: true,
+                        nextAttemptAt,
+                      }),
+                    );
+                  }
+                }
+
                 this.logger.warn(
                   {
                     queueName: this.queueName,
@@ -661,6 +768,25 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   contextMetadata,
                   routingLabels,
                 });
+
+                // Audit hook: terminal — onDead fires for the dispatched
+                // payload + every drained sibling.
+                await this.runAudit(() =>
+                  this.auditAdapter?.onDead({
+                    payload,
+                    lastError: error.message,
+                  }),
+                );
+                if (batchPayloads && this.auditAdapter) {
+                  for (const sibling of batchPayloads.slice(1)) {
+                    await this.runAudit(() =>
+                      this.auditAdapter?.onDead({
+                        payload: sibling,
+                        lastError: error.message,
+                      }),
+                    );
+                  }
+                }
               }
             }
           },

--- a/langwatch/src/server/event-sourcing/queues/queue.types.ts
+++ b/langwatch/src/server/event-sourcing/queues/queue.types.ts
@@ -157,6 +157,57 @@ export interface EventSourcedQueueDefinition<Payload extends Record<string, unkn
    * Used by GroupQueue to ensure global ordering across nodes.
    */
   score?: (payload: Payload) => number;
+
+  /**
+   * Optional audit adapter that mirrors every job lifecycle event to a
+   * durable side-store (typically PG). Used by the outbox dispatch queue
+   * per ADR-021 revision: the queue owns scheduling and execution, and
+   * the adapter projects each transition into a row that operator
+   * dashboards query against.
+   *
+   * Adapter calls are best-effort relative to the queue's own state: a
+   * PG outage logs+metrics, the queue keeps running, the next
+   * transition's write resyncs the projection. Each call writes the
+   * latest projection, not an event log.
+   */
+  auditAdapter?: QueueAuditAdapter<Payload>;
+}
+
+/**
+ * Lifecycle hooks for queues that want to project state into a durable
+ * side-store. Used by the outbox dispatch queue (ADR-021 revision).
+ *
+ * The queue invokes:
+ *   - `onEnqueue` on a successful new-stage `send` (skipped on a
+ *     dedup-collapsed send — the row already exists from the first
+ *     send).
+ *   - `onLeased` / `onDispatched` / `onFailed` / `onDead` around the
+ *     `process` / `processBatch` callback execution.
+ *
+ * Adapter writes do not block dispatch — a thrown hook is caught and
+ * logged so a PG outage cannot stall the Redis-side queue.
+ */
+export interface QueueAuditAdapter<Payload> {
+  onEnqueue(event: {
+    payload: Payload;
+    groupKey: string;
+    dedupKey: string | undefined;
+    scheduledAt: Date;
+    maxAttempts?: number;
+  }): Promise<void>;
+
+  onLeased(event: { payload: Payload }): Promise<void>;
+
+  onDispatched(event: { payload: Payload; at: Date }): Promise<void>;
+
+  onFailed(event: {
+    payload: Payload;
+    error: string;
+    willRetry: boolean;
+    nextAttemptAt?: Date;
+  }): Promise<void>;
+
+  onDead(event: { payload: Payload; lastError: string }): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Stacked on #4458 (Phase 4a cadence foundation). Adds the outbox-layer
primitives the digest dispatch needs:

- **`computeScheduledFor` is windowed**: two matches inside the same
  cadence window now share a `nextAttemptAt` (snap to next wall-clock
  boundary), so the drainer can lease them together as one digest. The
  pre-existing unit test still passes because `12:00:00.000Z` is
  already on every cadence boundary; new tests cover mid-window
  coalescing and boundary crossing.
- **`OutboxService.enqueue` accepts an optional `nextAttemptAt`**,
  threaded through `OutboxInsertRow` → Prisma row insert. Existing
  callers pass nothing and keep the default-`now()` behavior.
- **`OutboxRepository.leaseGroup`** atomically leases every ready row
  for `(projectId, reactorName, groupKey)` — same `FOR UPDATE SKIP
  LOCKED` race-safety as `leaseNext`, bounded by an explicit `limit`.
- **`OutboxDrainer.registerGroupDispatcher`** is a parallel registry
  to per-row dispatchers; `handleWakeup` branches on which kind is
  registered. The group path applies one success/retry/dead verdict
  to the whole batch.

No production code path wires these yet — the next stack on top
(`feat/outbox-digest-notify`, in progress) plugs the trigger-notify
reactor into them. Splitting it this way keeps the outbox contract
changes reviewable independently from the dispatch-path migration.

Refs: `dev/docs/adr/021-transactional-outbox-for-stake-sensitive-dispatch.md`,
`dev/docs/adr/023-groupqueue-wakeup-pattern-for-outbox.md`,
`dev/docs/adr/025-notify-persistent-action-classification.md`.

## Test plan

- [ ] \`pnpm test:unit outbox.service.unit\` — new \`leaseGroup\`
      describe block covers ready batch, future-window exclusion,
      empty group.
- [ ] \`pnpm test:unit drainer.unit\` — new group dispatcher describe
      block covers happy path, empty lease, retryable failure
      (every row marked retryable + follow-up wakeup), non-retryable
      failure (every row marked dead).
- [ ] \`pnpm test:unit triggerActionDispatch.unit\` — new
      coalescing + boundary-crossing scenarios verify windowed
      \`computeScheduledFor\` semantics.