### PR TITLE
feat(automations): cadence + fired-24h columns on settings list (ADR-029)

### DIFF
--- a/langwatch/src/pages/[project]/automations.tsx
+++ b/langwatch/src/pages/[project]/automations.tsx
@@ -12,6 +12,10 @@ import {
 import type { Monitor, TriggerAction } from "@prisma/client";
 import { Bell, Edit2, Filter, MoreVertical, Plus, Trash } from "react-feather";
 import { CLIENT_PROVIDERS } from "~/automations/providers/client";
+import {
+  NOTIFY_TRIGGER_ACTIONS,
+  type NotificationCadence,
+} from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
 import { HoverableBigText } from "~/components/HoverableBigText";
 import { NoDataInfoBlock } from "~/components/NoDataInfoBlock";
 import { FilterDisplay } from "~/components/automations/FilterDisplay";
@@ -27,6 +31,24 @@ import { withPermissionGuard } from "../../components/WithPermissionGuard";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
 import { formatTimeAgo } from "../../utils/formatTimeAgo";
+
+const CADENCE_LABELS: Record<NotificationCadence, string> = {
+  immediate: "Immediate",
+  "5min_digest": "Every 5 minutes",
+  "15min_digest": "Every 15 minutes",
+  hourly_digest: "Every hour",
+};
+
+function cadenceLabel(
+  action: TriggerAction,
+  cadence: string,
+): string {
+  if (!NOTIFY_TRIGGER_ACTIONS.has(action)) return "—";
+  if ((cadence as NotificationCadence) in CADENCE_LABELS) {
+    return CADENCE_LABELS[cadence as NotificationCadence];
+  }
+  return CADENCE_LABELS.immediate;
+}
 
 function Automations() {
   const { project, organizations } = useOrganizationTeamProject();
@@ -262,6 +284,12 @@ function Automations() {
                   <Table.ColumnHeader>Destination</Table.ColumnHeader>
                   <Table.ColumnHeader>Filters</Table.ColumnHeader>
                   <Table.ColumnHeader whiteSpace="nowrap">
+                    Cadence
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader whiteSpace="nowrap" textAlign="end">
+                    Fired (24h)
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader whiteSpace="nowrap">
                     Last Triggered At
                   </Table.ColumnHeader>
                   <Table.ColumnHeader>Active</Table.ColumnHeader>
@@ -271,7 +299,7 @@ function Automations() {
               <Table.Body>
               {triggers.isLoading ? (
                 <Table.Row>
-                  <Table.Cell colSpan={5}>Loading...</Table.Cell>
+                  <Table.Cell colSpan={9}>Loading...</Table.Cell>
                 </Table.Row>
               ) : (
                 triggers.data?.map((trigger) => {
@@ -304,6 +332,15 @@ function Automations() {
                             />
                           ) : null}
                         </VStack>
+                      </Table.Cell>
+                      <Table.Cell whiteSpace="nowrap">
+                        {cadenceLabel(
+                          trigger.action,
+                          trigger.notificationCadence,
+                        )}
+                      </Table.Cell>
+                      <Table.Cell whiteSpace="nowrap" textAlign="end">
+                        {trigger.firedCount24h}
                       </Table.Cell>
                       <Table.Cell whiteSpace="nowrap">
                         {formatTimeAgo(trigger.lastRunAt)}

--- a/langwatch/src/server/api/routers/automations.ts
+++ b/langwatch/src/server/api/routers/automations.ts
@@ -316,6 +316,23 @@ export const automationRouter = createTRPCRouter({
         return map;
       }, {});
 
+      // ADR-029 ship-now: per-trigger fired-count over the last 24h, sourced
+      // from TriggerSent (one row per dispatched (trigger, trace) pair so this
+      // counts every match the operator actually received). Pending / failed
+      // / dead come later, once notify dispatch flows through ReactorOutbox.
+      const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const firedCounts = await ctx.prisma.triggerSent.groupBy({
+        by: ["triggerId"],
+        where: {
+          projectId: input.projectId,
+          createdAt: { gte: since24h },
+        },
+        _count: { _all: true },
+      });
+      const firedCountByTrigger = new Map(
+        firedCounts.map((c) => [c.triggerId, c._count._all]),
+      );
+
       const enhancedTriggers = triggers.map((trigger) => {
         let triggerFilters: Record<string, any> = {};
 
@@ -330,6 +347,7 @@ export const automationRouter = createTRPCRouter({
         return {
           ...trigger,
           checks,
+          firedCount24h: firedCountByTrigger.get(trigger.id) ?? 0,
         };
       });
 


### PR DESCRIPTION
## Summary

Stacked on #4458 (Phase 4a). Ships the ADR-029 "available today"
operator signals on the automations settings list:

- **Cadence** column — pulls the per-trigger \`notificationCadence\`
  added in Phase 4a and renders the human label ("Immediate" /
  "Every 5 minutes" / "Every 15 minutes" / "Every hour"). Renders
  "—" for persist-class triggers (dataset / annotation queue) since
  cadence has no meaning for them.
- **Fired (24h)** column — count of \`TriggerSent\` rows for the
  trigger over the last 24 hours. Single \`groupBy\` aggregate added
  to \`automation.getTriggers\`; the rest of the route is unchanged.

Both columns work today against existing data. Pending / failed /
dead and template-health warnings (the ADR-029 outbox-derived
signals) ship once notify dispatch flows through \`ReactorOutbox\`
in a follow-up stack — the list shape is built so those drop in
without a second redesign.

Refs: \`dev/docs/adr/029-automation-management-and-health-surface.md\`.

## Test plan

- [ ] Settings → Automations: notify triggers show "Every 5 minutes"
      (or whichever cadence the user picked); persist triggers show
      "—".
- [ ] Fire a trigger; refetch and confirm Fired (24h) reflects
      \`TriggerSent\` rows in that window.
- [ ] Loading state colSpan covers all nine columns.