### PR TITLE
feat(outbox): wire trigger-notify dispatch end-to-end on the worker

### DIFF
--- a/langwatch/ee/governance/reactors/alertTrigger.reactor.ts
+++ b/langwatch/ee/governance/reactors/alertTrigger.reactor.ts
@@ -14,6 +14,7 @@ import type { ReactorDefinition } from "~/server/event-sourcing/reactors/reactor
 import { isDispatchError } from "~/server/event-sourcing/outbox/dispatchError";
 import {
   dispatchTriggerAction,
+  NOTIFY_TRIGGER_ACTIONS,
   type TriggerActionDispatchDeps,
 } from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
 import type { TraceProcessingEvent } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
@@ -88,7 +89,29 @@ export function createAlertTriggerReactor(
           // Skip triggers that require evaluation results (handled by evaluationAlertTrigger)
           if (hasEvaluationFilters) continue;
 
-          // Skip if no trace filters match
+          // Outbox path: notify-class triggers route through the unified
+          // outbox queue (`stage: "settle"`). The settle dispatcher re-reads
+          // the now-settled fold after `traceDebounceMs`, re-runs filters
+          // against fresh state, claims TriggerSent, and re-enqueues as
+          // cadence on match. Skip the inline filter check + claim here so
+          // a half-formed early match doesn't shoot first.
+          if (
+            deps.enqueueSettle &&
+            NOTIFY_TRIGGER_ACTIONS.has(trigger.action)
+          ) {
+            await deps.enqueueSettle({
+              projectId: tenantId,
+              triggerId: trigger.id,
+              traceId,
+              foldState,
+            });
+            continue;
+          }
+
+          // Inline path: persist-class actions (dataset, annotation queue)
+          // and the legacy unwired notify path. Filter check + claim +
+          // dispatch all happen here against the current (possibly
+          // half-formed) fold state.
           if (
             Object.keys(traceFilters).length > 0 &&
             !matchesTriggerFilters(traceData, traceFilters)

--- a/langwatch/src/server/app-layer/presets.ts
+++ b/langwatch/src/server/app-layer/presets.ts
@@ -4,6 +4,7 @@ import { prisma as globalPrisma } from "~/server/db";
 import { getClickHouseClientForProject, isClickHouseEnabled, type ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { esClient, TRACE_INDEX, traceIndexId } from "../elasticsearch";
 import { EventSourcing } from "../event-sourcing";
+import { setupOutbox } from "../event-sourcing/outbox/setup";
 import { PipelineRegistry, type AppCommands } from "../event-sourcing/pipelineRegistry";
 import type { ScenarioExecutionReactorHandle } from "../event-sourcing/pipelines/simulation-processing/reactors/scenarioExecution.reactor";
 import { App, getApp, globalForApp, initializeApp } from "./app";
@@ -397,6 +398,23 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
       }
     : undefined;
 
+  // Outbox stack: worker-only consumer loop, but the send-side handle is
+  // wired into the registry so reactors can enqueue settle payloads. Web
+  // processes don't build this (no settle traffic; no consumer to drain).
+  const outbox =
+    config.processRole === "worker"
+      ? setupOutbox({
+          prisma,
+          redis: redis ?? null,
+          processRole: config.processRole,
+          triggers,
+          projects,
+          evaluations: { runs: evaluations.runs },
+          traces: { spans: spanStorage },
+          traceSummaryRepository: repositories.traceSummaryFold,
+        })
+      : undefined;
+
   const registry = new PipelineRegistry({
     eventSourcing: es,
     repositories,
@@ -416,6 +434,7 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
     gatewayBudgetSync,
     governanceKpisSync,
     governanceOcsfEventsSync,
+    outbox,
   });
   const commands = registry.registerAll();
   (globalForApp as any).__scenarioExecutionHandle = commands.scenarioExecutionHandle;
@@ -486,6 +505,12 @@ export function initializeDefaultApp(options?: { processRole?: ProcessRole }): A
       await broadcast.close();
     },
   });
+  if (outbox) {
+    gracefulCloseables.push({
+      name: "outbox-queue",
+      close: () => outbox.queue.close(),
+    });
+  }
   gracefulCloseables.push({
     name: "prisma",
     close: () => prisma.$disconnect(),

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -47,7 +47,17 @@ import { RedisCachedFoldStore } from "./projections/redisCachedFoldStore";
 import { RepositoryFoldStore } from "./projections/repositoryFoldStore";
 import { SUITE_RUN_PROJECTION_VERSIONS } from "./pipelines/suite-run-processing/schemas/constants";
 import type { SuiteRunStateRepository } from "./pipelines/suite-run-processing/repositories/suiteRunState.repository";
-import type { TriggerActionDispatchDeps } from "./pipelines/shared/triggerActionDispatch";
+import {
+  auditDedupKey,
+  TRIGGER_NOTIFY_REACTOR_NAME,
+  type SettleStagePayload,
+} from "./outbox/payload";
+import type { OutboxStack } from "./outbox/setup";
+import {
+  DEFAULT_TRACE_DEBOUNCE_MS,
+  type EnqueueSettle,
+  type TriggerActionDispatchDeps,
+} from "./pipelines/shared/triggerActionDispatch";
 import { createTraceProcessingPipeline } from "./pipelines/trace-processing/pipeline";
 import { createSimulationMetricsSyncReactor } from "./pipelines/trace-processing/reactors/simulationMetricsSync.reactor";
 import { createExperimentMetricsSyncReactor } from "./pipelines/trace-processing/reactors/experimentMetricsSync.reactor";
@@ -192,6 +202,14 @@ export interface PipelineRegistryDeps {
   gatewayBudgetSync?: GatewayBudgetSyncReactorDeps;
   governanceKpisSync?: GovernanceKpisSyncReactorDeps;
   governanceOcsfEventsSync?: GovernanceOcsfEventsSyncReactorDeps;
+  /**
+   * Wired by the worker composition root (`presets.ts`) and `undefined`
+   * on the web process. When set, both trigger reactors route
+   * NOTIFY-class matches into the unified outbox queue's settle stage
+   * (ADR-021 revision + ADR-030) instead of inline-dispatching. Persist
+   * actions always run inline regardless.
+   */
+  outbox?: OutboxStack;
 }
 
 /**
@@ -221,7 +239,7 @@ export class PipelineRegistry {
    */
   private buildTraceReactorContext(): Pick<
     TriggerActionDispatchDeps,
-    "traceById" | "addToAnnotationQueue" | "addToDataset"
+    "traceById" | "addToAnnotationQueue" | "addToDataset" | "enqueueSettle"
   > & {
     deriveEvents: (params: {
       tenantId: string;
@@ -233,6 +251,36 @@ export class PipelineRegistry {
     const traceReadDerivation = new TraceReadDerivationService(
       this.deps.traces.spans,
     );
+    const outbox = this.deps.outbox;
+    const enqueueSettle: EnqueueSettle | undefined = outbox
+      ? async ({ projectId, triggerId, traceId, foldState }) => {
+          const payload: SettleStagePayload = {
+            stage: "settle",
+            projectId,
+            triggerId,
+            traceId,
+            reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+            auditDedupKey: auditDedupKey({ projectId, triggerId, traceId }),
+            foldSnapshotAtEnqueue: {
+              computedInput: foldState.computedInput ?? "",
+              computedOutput: foldState.computedOutput ?? "",
+            },
+          };
+          // Per-trigger TTL override lives on the `Monitor.traceDebounceMs`
+          // column added by ADR-030; until that migration lands the queue's
+          // default applies to every send. The send-time override below is
+          // the surface that picks the column value up once available.
+          await outbox.queue.send(payload, {
+            deduplication: {
+              makeId: () =>
+                `${projectId}/${TRIGGER_NOTIFY_REACTOR_NAME}:${triggerId}:${traceId}`,
+              ttlMs: DEFAULT_TRACE_DEBOUNCE_MS,
+              extend: true,
+              replace: true,
+            },
+          });
+        }
+      : undefined;
     return {
       traceById: async (projectId, traceId) => {
         const traceService = TraceService.create(this.deps.prisma);
@@ -248,6 +296,7 @@ export class PipelineRegistry {
         await createManyDatasetRecords(params);
       },
       deriveEvents: (params) => traceReadDerivation.deriveEvents(params),
+      enqueueSettle,
     };
   }
 

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTrigger.reactor.ts
@@ -25,6 +25,7 @@ import {
 } from "../schemas/typeGuards";
 import {
   dispatchTriggerAction,
+  NOTIFY_TRIGGER_ACTIONS,
   type TriggerActionDispatchDeps,
 } from "../../shared/triggerActionDispatch";
 
@@ -130,7 +131,56 @@ export function createEvaluationAlertTriggerReactor(
         return;
       }
 
-      // Load all evaluations for this trace
+      // Split triggers by routing. Outbox-bound triggers (notify class, settle
+      // wired) skip the inline filter + claim + dispatch path here — settle
+      // re-reads the now-settled fold *and* re-loads evaluations after
+      // `traceDebounceMs`, so we don't pay the cost of either here.
+      const outboxBound: typeof triggersWithEvalFilters = [];
+      const inlineBound: typeof triggersWithEvalFilters = [];
+      for (const t of triggersWithEvalFilters) {
+        if (deps.enqueueSettle && NOTIFY_TRIGGER_ACTIONS.has(t.action)) {
+          outboxBound.push(t);
+        } else {
+          inlineBound.push(t);
+        }
+      }
+
+      for (const trigger of outboxBound) {
+        try {
+          await deps.enqueueSettle!({
+            projectId: tenantId,
+            triggerId: trigger.id,
+            traceId,
+            foldState: traceSummary,
+          });
+        } catch (error) {
+          logger.error(
+            {
+              tenantId,
+              traceId,
+              triggerId: trigger.id,
+              evaluationId: evalRun.evaluationId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Failed to enqueue settle stage for trigger",
+          );
+          captureException(error, {
+            extra: {
+              tenantId,
+              traceId,
+              triggerId: trigger.id,
+              evaluationId: evalRun.evaluationId,
+              triggerAction: trigger.action,
+            },
+          });
+        }
+      }
+
+      // Nothing left for the inline path — skip the expensive cross-pipeline
+      // evaluation load + events derivation entirely.
+      if (inlineBound.length === 0) return;
+
+      // Load all evaluations for this trace (inline path only)
       const allEvaluations = await deps.evaluationRuns.findByTraceId(
         tenantId,
         traceId,
@@ -138,7 +188,7 @@ export function createEvaluationAlertTriggerReactor(
 
       // Derive the trace-level events list only if one of these triggers filters
       // on event fields (the trace-level half of its filter set).
-      const needsEvents = triggersWithEvalFilters.some((t) =>
+      const needsEvents = inlineBound.some((t) =>
         triggerFiltersReferenceEvents(classifyTriggerFilters(t.filters).traceFilters),
       );
       const events = needsEvents
@@ -155,7 +205,7 @@ export function createEvaluationAlertTriggerReactor(
         events,
       );
 
-      for (const trigger of triggersWithEvalFilters) {
+      for (const trigger of inlineBound) {
         try {
           const { traceFilters, evaluationFilters } =
             classifyTriggerFilters(trigger.filters);

--- a/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/shared/triggerActionDispatch.ts
@@ -89,6 +89,22 @@ export function computeScheduledFor({
   return new Date(now.getTime() + CADENCE_WINDOW_MS[cadence]);
 }
 
+/**
+ * Wired by the registry on the worker (composition root), `undefined`
+ * on the web process and in unit tests that don't care about the
+ * outbox. When set, NOTIFY-class matches route through the unified
+ * outbox queue (`stage: "settle"`) so the settle dispatcher does the
+ * filter recheck + claim + cadence enqueue. Persist-class actions
+ * always run inline regardless of this setting — they want every
+ * match to land immediately.
+ */
+export type EnqueueSettle = (params: {
+  projectId: string;
+  triggerId: string;
+  traceId: string;
+  foldState: TraceSummaryData;
+}) => Promise<void>;
+
 export interface TriggerActionDispatchDeps {
   triggers: TriggerService;
   projects: ProjectService;
@@ -104,6 +120,7 @@ export interface TriggerActionDispatchDeps {
     projectId: string;
     datasetRecords: DatasetRecordEntry[];
   }) => Promise<void>;
+  enqueueSettle?: EnqueueSettle;
 }
 
 interface ActionParams {


### PR DESCRIPTION
## Summary

Closes the loop on the ADR-025 digest cadence stack. Stacked on #4460
(outbox primitives + trigger-notify dispatcher) — once this lands, a
notify-class trigger match flows: reactor → \`enqueueTriggerNotify\` →
\`ReactorOutbox\` row with \`nextAttemptAt\` = cadence window boundary →
wakeup queue fires at boundary → drainer's \`leaseGroup\` returns the
whole batch → trigger-notify dispatcher renders ONE digest email/Slack
with every match in the window.

- **\`triggerActionDispatch.ts\`** — when \`deps.outbox\` is set and the
  action is in \`NOTIFY_TRIGGER_ACTIONS\`, dispatch becomes
  \`enqueueTriggerNotify(…)\` and returns. Persist actions (dataset,
  annotation queue) keep firing inline unchanged. Both reactors
  (trace-pipeline \`alertTrigger\` + evaluation-pipeline
  \`evaluationAlertTrigger\`) pick this up automatically because they
  both call \`dispatchTriggerAction\`.
- **\`pipelineRegistry.ts\`** — optional \`outbox: OutboxService\` on
  \`PipelineRegistryDeps\`, threaded through \`buildTraceReactorContext\`
  into both reactors' \`TriggerActionDispatchDeps\`.
- **\`outbox/setup.ts\`** — composition root for the stack: repository,
  service, drainer, group dispatcher registration, and the wakeup
  queue via \`defineOutboxWakeupQueue\`. Solves the drainer↔queue
  circular dependency via a holder the queue fills in after both
  exist. Wakeup queue is the in-house \`GroupQueueProcessor\` (Redis)
  per ADR-023 — not BullMQ.
- **\`presets.ts\`** — instantiates the stack **only when
  \`processRole === "worker"\`**. Reactors only fire on the worker, so
  web gets \`outbox: undefined\` and \`dispatchTriggerAction\` falls
  through to its legacy inline path. The wakeup queue is added to
  \`gracefulCloseables\` for clean shutdown.

Refs: \`dev/docs/adr/021\`, \`022\`, \`023\`, \`025\`, \`027\`.

## Test plan

- [ ] Apply the schema migration (Phase 4a #4458) so \`Trigger.notificationCadence\` exists.
- [ ] Boot the worker; verify the wakeup queue's GroupQueueProcessor starts in consumer mode.
- [ ] Create an email automation with \`5min_digest\` cadence; emit 5 matching traces inside a 5-minute window.
- [ ] At the next 5-minute wall-clock boundary, exactly one digest email arrives with all 5 matches.
- [ ] Same scenario with \`immediate\` cadence → 5 separate emails.
- [ ] Persist-class automation (\`ADD_TO_DATASET\`) writes every match immediately — confirms cadence is bypassed for persist.
- [ ] Stop the worker; verify the wakeup queue closes cleanly via gracefulCloseables.