### PR TITLE
fix(nlpgo): expose project secrets as `secrets.NAME` in code blocks

### DIFF
--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock.go
@@ -87,7 +87,12 @@ type Request struct {
 	Code            string
 	Inputs          map[string]any
 	DeclaredOutputs []string
-	Timeout         time.Duration
+	// Secrets are the project's decrypted secrets (from the workflow
+	// DSL's `secrets` map). When non-empty the runner exposes them to
+	// user code as a `secrets` namespace so `secrets.NAME` works —
+	// parity with the Python executor's build_secrets_preamble.
+	Secrets map[string]string
+	Timeout time.Duration
 }
 
 // Result is what the executor returns.
@@ -130,6 +135,7 @@ func (e *Executor) Execute(ctx context.Context, req Request) (*Result, error) {
 		"code":    req.Code,
 		"inputs":  req.Inputs,
 		"outputs": req.DeclaredOutputs,
+		"secrets": req.Secrets,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("codeblock: marshal request: %w", err)

--- a/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
+++ b/services/nlpgo/app/engine/blocks/codeblock/codeblock_test.go
@@ -341,6 +341,72 @@ class Code(dspy.Module):
 	assert.Contains(t, res.Error.Message, "Example")
 }
 
+// TestCodeBlock_SecretsExposedAsNamespace pins the customer-reported
+// fix: a configured project secret rides on the request and the runner
+// exposes it as `secrets.NAME` attribute access — matching the Studio
+// code-editor hint and the Python executor's build_secrets_preamble.
+func TestCodeBlock_SecretsExposedAsNamespace(t *testing.T) {
+	requirePython(t)
+	res, err := newExec(t).Execute(context.Background(), codeblock.Request{
+		Code:            "def execute():\n    return {'token': secrets.CLOUDFLARE_ACCESS_CLIENT_ID}\n",
+		Secrets:         map[string]string{"CLOUDFLARE_ACCESS_CLIENT_ID": "id-123"},
+		DeclaredOutputs: []string{"token"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
+	assert.Equal(t, "id-123", res.Outputs["token"])
+}
+
+// TestCodeBlock_SecretsValueWithSpecialChars guards the escaping path:
+// SimpleNamespace(**secrets) takes values verbatim (no string-literal
+// interpolation), so quotes/newlines/backslashes in a secret survive
+// intact — a regression the old regex-replacement approach was prone to.
+func TestCodeBlock_SecretsValueWithSpecialChars(t *testing.T) {
+	requirePython(t)
+	tricky := "v'al\"ue\nwith\\chars"
+	res, err := newExec(t).Execute(context.Background(), codeblock.Request{
+		Code:            "def execute():\n    return {'s': secrets.WEIRD}\n",
+		Secrets:         map[string]string{"WEIRD": tricky},
+		DeclaredOutputs: []string{"s"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, res.Error, "expected no error, got %+v", res.Error)
+	assert.Equal(t, tricky, res.Outputs["s"])
+}
+
+// TestCodeBlock_UndefinedSecretRaisesAttributeError pins that a
+// reference to a secret that isn't configured fails as AttributeError
+// (the namespace exists but the attr doesn't), not a silent empty value.
+func TestCodeBlock_UndefinedSecretRaisesAttributeError(t *testing.T) {
+	requirePython(t)
+	res, err := newExec(t).Execute(context.Background(), codeblock.Request{
+		Code:            "def execute():\n    return {'x': secrets.ABSENT}\n",
+		Secrets:         map[string]string{"PRESENT": "yes"},
+		DeclaredOutputs: []string{"x"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "AttributeError", res.Error.Type)
+	assert.Contains(t, res.Error.Message, "ABSENT")
+}
+
+// TestCodeBlock_NoSecretsLeavesNamespaceUndefined pins Python parity:
+// with no secrets configured, `secrets` is undefined (NameError),
+// matching build_secrets_preamble's no-op on an empty/None map. This is
+// deliberate — we don't inject an empty namespace, so behavior is
+// identical across the Go and Python engines.
+func TestCodeBlock_NoSecretsLeavesNamespaceUndefined(t *testing.T) {
+	requirePython(t)
+	res, err := newExec(t).Execute(context.Background(), codeblock.Request{
+		Code:            "def execute():\n    return {'x': secrets.ANYTHING}\n",
+		DeclaredOutputs: []string{"x"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.Error)
+	assert.Equal(t, "NameError", res.Error.Type)
+	assert.Contains(t, res.Error.Message, "secrets")
+}
+
 func TestCodeBlock_InvocationsAreIsolated(t *testing.T) {
 	requirePython(t)
 	exec := newExec(t)

--- a/services/nlpgo/app/engine/blocks/codeblock/runner.py
+++ b/services/nlpgo/app/engine/blocks/codeblock/runner.py
@@ -51,8 +51,17 @@ Wire shape (stdin):
     {
       "code":    "<python source>",
       "inputs":  {"name": value, ...},
-      "outputs": ["name", ...]
+      "outputs": ["name", ...],
+      "secrets": {"NAME": "value", ...}
     }
+
+The optional `secrets` map is the project's decrypted secrets (rides on
+the workflow DSL as `workflow.secrets`, populated upstream by
+addEnvs.ts). When non-empty it is exposed to user code as a `secrets`
+namespace object so `secrets.NAME` resolves as attribute access —
+matching the Studio code-editor hint and the Python executor's
+`build_secrets_preamble`. When absent/empty the name is left undefined,
+mirroring the Python preamble's no-op-on-empty behavior.
 
 Wire shape (result file):
     {
@@ -78,6 +87,7 @@ import sys
 import time
 import traceback
 from contextlib import redirect_stdout, redirect_stderr
+from types import SimpleNamespace
 
 # Inject fake_dspy as the user-visible `dspy` module BEFORE any user
 # code is exec'd. We resolve it by file path so the runner stays
@@ -109,6 +119,7 @@ def main() -> int:
     code = payload.get("code", "")
     inputs = payload.get("inputs", {}) or {}
     declared_outputs = payload.get("outputs", []) or []
+    secrets = payload.get("secrets", {}) or {}
 
     stdout_buf = io.StringIO()
     stderr_buf = io.StringIO()
@@ -119,6 +130,15 @@ def main() -> int:
     try:
         with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
             module_globals: dict = {"__name__": "__user_code__"}
+            # Expose project secrets as `secrets.NAME` attribute access.
+            # Injected as a global (not a source preamble) so user-code
+            # line numbers in tracebacks stay accurate. Left undefined
+            # when there are no secrets — parity with the Python
+            # executor's build_secrets_preamble, which is a no-op on an
+            # empty/None map (so `secrets.X` with nothing configured
+            # raises NameError on both engines).
+            if secrets:
+                module_globals["secrets"] = SimpleNamespace(**secrets)
             exec(compile(code, "<code-block>", "exec"), module_globals)
             result = _invoke_user_entrypoint(module_globals, inputs)
             result = _coerce_result(result)

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -278,7 +278,7 @@ func (e *Engine) dispatch(ctx context.Context, req ExecuteRequest, node *dsl.Nod
 	case dsl.ComponentEnd:
 		return inputs, nil
 	case dsl.ComponentCode:
-		return e.runCode(ctx, node, inputs, ns)
+		return e.runCode(ctx, node, inputs, ns, req.Workflow.Secrets)
 	case dsl.ComponentHTTP:
 		return e.runHTTP(ctx, node, inputs, ns)
 	case dsl.ComponentSignature:
@@ -335,7 +335,7 @@ func (e *Engine) runEntry(node *dsl.Node, req ExecuteRequest) (map[string]any, *
 	return map[string]any{}, nil
 }
 
-func (e *Engine) runCode(ctx context.Context, node *dsl.Node, inputs map[string]any, ns *NodeState) (map[string]any, *NodeError) {
+func (e *Engine) runCode(ctx context.Context, node *dsl.Node, inputs map[string]any, ns *NodeState, secrets map[string]string) (map[string]any, *NodeError) {
 	if e.code == nil {
 		return nil, &NodeError{Type: "code_runner_unavailable", Message: "no code runner configured"}
 	}
@@ -345,6 +345,7 @@ func (e *Engine) runCode(ctx context.Context, node *dsl.Node, inputs map[string]
 		Code:            code,
 		Inputs:          inputs,
 		DeclaredOutputs: declared,
+		Secrets:         secrets,
 	})
 	if err != nil {
 		return nil, &NodeError{Type: "code_runner_error", Message: err.Error()}
@@ -754,7 +755,7 @@ func (e *Engine) runAgent(ctx context.Context, req ExecuteRequest, node *dsl.Nod
 	case "http":
 		return e.runHTTP(ctx, node, inputs, ns)
 	case "code":
-		return e.runCode(ctx, node, inputs, ns)
+		return e.runCode(ctx, node, inputs, ns, req.Workflow.Secrets)
 	case "workflow":
 		return e.runAgentWorkflow(ctx, req, node, inputs, ns)
 	case "":

--- a/services/nlpgo/tests/integration/code_block_realistic_test.go
+++ b/services/nlpgo/tests/integration/code_block_realistic_test.go
@@ -77,6 +77,62 @@ func TestSync_CodeBlock_StdlibHeavyComputation(t *testing.T) {
 	assert.Contains(t, got, `Y3VzdG9tZXItZGF0YS0yMDI2`)
 }
 
+// TestSync_CodeBlock_SecretsNamespaceFromWorkflow is the end-to-end
+// guard for the customer-reported bug: a project secret declared on the
+// workflow DSL (`workflow.secrets`, populated upstream by addEnvs.ts)
+// must reach user code as `secrets.NAME`. This proves the full thread —
+// DSL → engine.runCode → codeblock.Request → runner.py namespace — that
+// was previously broken (the Go engine dropped secrets on the floor for
+// code nodes, so `secrets.NAME` raised NameError).
+func TestSync_CodeBlock_SecretsNamespaceFromWorkflow(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+	stack := setupStack(t)
+	defer stack.close()
+
+	body := `{
+	  "type": "execute_flow",
+	  "payload": {
+	    "trace_id": "secrets-ns",
+	    "workflow": {
+	      "workflow_id":"wf","api_key":"k","spec_version":"1.3","name":"x","icon":"x","description":"x","version":"x",
+	      "template_adapter":"default",
+	      "secrets":{"CLOUDFLARE_ACCESS_CLIENT_ID":"id-123"},
+	      "nodes":[
+	        {"id":"entry","type":"entry","data":{
+	          "outputs":[{"identifier":"q","type":"str"}],
+	          "dataset":{"inline":{"records":{"q":["x"]}}},
+	          "entry_selection":0,
+	          "train_size":1.0,"test_size":0.0,"seed":1
+	        }},
+	        {"id":"useSecret","type":"code","data":{
+	          "parameters":[
+	            {"identifier":"code","type":"code","value":"def execute(q):\n    return {'token': secrets.CLOUDFLARE_ACCESS_CLIENT_ID}\n"}
+	          ],
+	          "inputs":[{"identifier":"q","type":"str"}],
+	          "outputs":[{"identifier":"token","type":"str"}]
+	        }},
+	        {"id":"end","type":"end","data":{
+	          "inputs":[{"identifier":"token","type":"str"}]
+	        }}
+	      ],
+	      "edges":[
+	        {"id":"e1","source":"entry","sourceHandle":"outputs.q","target":"useSecret","targetHandle":"inputs.q","type":"default"},
+	        {"id":"e2","source":"useSecret","sourceHandle":"outputs.token","target":"end","targetHandle":"inputs.token","type":"default"}
+	      ],
+	      "state":{}
+	    },
+	    "inputs":[{}],
+	    "origin":"workflow"
+	  }
+	}`
+
+	res := postSync(t, stack, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+	assert.Equal(t, "id-123", res.Result["token"])
+}
+
 // TestSync_CodeBlock_ThirdPartyImportSkipsCleanly proves the failure
 // mode for missing third-party packages: the user code raises
 // ImportError, the engine surfaces a structured error with the

--- a/specs/nlp-go/code-block.feature
+++ b/specs/nlp-go/code-block.feature
@@ -116,6 +116,38 @@ Feature: Code block — execute user Python with isolated subprocess and structu
       Then the node's status is "success" (today's parity — no network restriction is added by the migration)
       # Note: tightening egress is tracked as a follow-up hardening item, not blocking this PR.
 
+  Rule: Project secrets are exposed to user code as the `secrets` namespace
+
+    # Parity with the Python executor's build_secrets_preamble
+    # (langwatch_nlp/studio/utils.py): decrypted project secrets ride on
+    # the workflow DSL (`workflow.secrets`, populated by addEnvs.ts) and
+    # are surfaced to user code as attribute access on a `secrets` object,
+    # matching the Studio code-editor hint ("Use secrets.NAME syntax").
+
+    @unit @unimplemented
+    Scenario: a configured project secret is readable as secrets.NAME
+      Given the workflow carries secret "CLOUDFLARE_ACCESS_CLIENT_ID" = "id-123"
+      And a code node whose body returns {"token": secrets.CLOUDFLARE_ACCESS_CLIENT_ID}
+      When the engine invokes the node
+      Then the node's output equals {"token": "id-123"}
+      And the node's status is "success"
+
+    @unit @unimplemented
+    Scenario: referencing an undefined secret raises AttributeError, not NameError
+      Given the workflow carries secret "PRESENT" = "yes"
+      And a code node whose body returns {"x": secrets.ABSENT}
+      When the engine invokes the node
+      Then the node's status is "error"
+      And the error message contains "ABSENT"
+
+    @unit @unimplemented
+    Scenario: with no project secrets the `secrets` name is left undefined (Python parity)
+      Given the workflow carries no secrets
+      And a code node whose body returns {"x": secrets.ANYTHING}
+      When the engine invokes the node
+      Then the node's status is "error"
+      And the error message contains "secrets"
+
   Rule: Parity with Python code-node executor
 
     @integration @parity @unimplemented


### PR DESCRIPTION
## Problem

A user reported that the Studio Python code editor hints to reference project secrets as `secrets.NAME` (e.g. `secrets.CLOUDFLARE_ACCESS_CLIENT_ID`), but executing the code in a workflow fails:

```
NameError: name 'secrets' is not defined
```

`os.environ[...]` also fails.

## Root cause

There are two execution runtimes, gated by the `release_nlp_go_engine_enabled` flag:

- **Python (`langwatch_nlp`)** — injects a `secrets` namespace via `build_secrets_preamble` (`studio/utils.py`). `secrets.NAME` works. ✅
- **Go (`nlpgo`)** — the user's project is on this engine. `addEnvs.ts` *does* populate `workflow.secrets` in the DSL, and the Go DSL has the field (`dsl/types.go` `Secrets`), **but the code-block path never threaded it through**: `engine.runCode` → `codeblock.Request` → `runner.py` carried only `{code, inputs, outputs}`, and the runner exec'd user code in a bare namespace (`{"__name__": "__user_code__"}`). So `secrets` was undefined. ❌

`os.environ` fails because secrets live in the DSL, not the subprocess env. HTTP nodes were unaffected — they use the separate `{{ secrets.NAME }}` resolver (`ports.go` `SecretsResolver`), which only covers HTTP-block invocation.

This was a parity gap introduced during the dspy-rip migration to the Go engine.

## Fix

Thread `workflow.secrets` through the one path that lacked it:

1. **`engine.go`** — pass `req.Workflow.Secrets` into `runCode` (both call sites: `code` node and `agent_type: code`).
2. **`codeblock.go`** — add `Secrets` to `Request`; include it in the stdin payload.
3. **`runner.py`** — inject a `secrets` `SimpleNamespace` into the exec globals so `secrets.NAME` is real attribute access (mirrors the Python `build_secrets_preamble`).

Design notes:
- Injected as a **global**, not a source preamble — so user-code line numbers in tracebacks stay accurate.
- Left **undefined when no secrets are configured** — byte-parity with the Python preamble's no-op-on-empty behavior (so `secrets.X` with nothing configured raises `NameError` on both engines, and a missing key with secrets present raises `AttributeError`).
- `SimpleNamespace(**secrets)` takes values verbatim, so quotes/newlines/backslashes in a secret survive intact.

## Tests

- **Spec:** new Rule in `specs/nlp-go/code-block.feature` (3 scenarios: readable secret, undefined-secret → AttributeError, no-secrets → undefined parity).
- **Unit (`codeblock_test.go`):** secret exposed as namespace; special-char values; undefined secret → AttributeError; no-secrets → NameError parity.
- **Integration (`code_block_realistic_test.go`):** end-to-end — a `secrets` map on the workflow DSL reaches user code as `secrets.NAME` through `/go/studio/execute_sync`.

All green locally (`go test ./app/engine/... ./tests/integration/ -run CodeBlock`), `go vet` clean, `runner.py` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)