### PR TITLE
feat(experiments): archive instead of hard-delete

### DIFF
--- a/langwatch/e2e/auth-regression/experiment-archive-qa.ts
+++ b/langwatch/e2e/auth-regression/experiment-archive-qa.ts
@@ -1,0 +1,231 @@
+/**
+ * Browser QA for the experiment-archive PR (feat/experiment-archive).
+ *
+ * Drives a headless Chromium against a dev server, signs up a real user,
+ * seeds an org/team/project + experiment via Prisma, then exercises the
+ * archive flow two ways:
+ *
+ *   1. Direct tRPC HTTP POST to experiments.deleteExperiment with the
+ *      browser's real session cookie + CSRF context. Proves the wire-level
+ *      mutation works for an authenticated user.
+ *   2. Screenshots of the evaluations page before / after the archive call,
+ *      proving the surface user sees.
+ *
+ * Then asserts in Postgres that the row STILL exists with archivedAt set
+ * and the slug renamed.
+ *
+ * Run via:
+ *   DATABASE_URL=postgresql://langwatch_ci:ci_password@localhost:5432/langwatch_db?schema=public \
+ *     BASE_URL=http://localhost:5571 \
+ *     pnpm exec tsx e2e/auth-regression/experiment-archive-qa.ts
+ */
+import { chromium } from "playwright";
+import { mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { PrismaClient, ExperimentType } from "@prisma/client";
+import { nanoid } from "nanoid";
+
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:5571";
+const EMAIL = `qa-archive-${Date.now()}@test.local`;
+const PASSWORD = "qa-archive-pass-1234";
+const NAME = "Archive QA User";
+const SHOTS_DIR = "./.playwright-mcp";
+
+const prisma = new PrismaClient();
+
+let passes = 0;
+let fails = 0;
+const check = (label: string, ok: boolean, extra = "") => {
+  if (ok) {
+    passes++;
+    console.log(`  PASS ${label}${extra ? ` - ${extra}` : ""}`);
+  } else {
+    fails++;
+    console.log(`  FAIL ${label}${extra ? ` - ${extra}` : ""}`);
+  }
+};
+
+async function main() {
+  if (!existsSync(SHOTS_DIR)) await mkdir(SHOTS_DIR, { recursive: true });
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await context.newPage();
+  page.on("dialog", (d) => d.accept().catch(() => undefined));
+
+  console.log("\n[1] Signup");
+  await page.goto(`${BASE_URL}/auth/signup`, { waitUntil: "networkidle" });
+  await page.waitForSelector("form", { timeout: 15000 });
+  await page.fill('input[type="email"]', EMAIL);
+  await page.fill('input[name="name"]', NAME);
+  const pwInputs = await page.locator('input[type="password"]').all();
+  await pwInputs[0]!.fill(PASSWORD);
+  await pwInputs[1]!.fill(PASSWORD);
+  await page.click('button:has-text("Sign up")');
+  await page.waitForURL((u) => !u.toString().includes("/auth/signup"), {
+    timeout: 30000,
+  });
+  check("signup completed", true, page.url());
+
+  await page.screenshot({ path: `${SHOTS_DIR}/01-after-signup.png`, fullPage: false });
+
+  const user = await prisma.user.findUnique({ where: { email: EMAIL } });
+  if (!user) throw new Error("signup did not create a user row");
+
+  console.log("\n[2] Seed org/team/project + 2 experiments");
+  const organization = await prisma.organization.create({
+    data: { name: "QA Org", slug: `qa-org-${nanoid(6)}` },
+  });
+  await prisma.organizationUser.create({
+    data: { userId: user.id, organizationId: organization.id, role: "ADMIN" },
+  });
+  const team = await prisma.team.create({
+    data: {
+      name: "QA Team",
+      slug: `qa-team-${nanoid(6)}`,
+      organizationId: organization.id,
+    },
+  });
+  await prisma.teamUser.create({
+    data: { userId: user.id, teamId: team.id, role: "ADMIN" },
+  });
+  const project = await prisma.project.create({
+    data: {
+      id: `project_${nanoid()}`,
+      name: "QA Project",
+      slug: `qa-proj-${nanoid(6)}`,
+      teamId: team.id,
+      language: "python",
+      framework: "openai",
+      apiKey: `qa-api-key-${nanoid()}`,
+    },
+  });
+  const liveSlug = `qa-keep-${nanoid(6)}`;
+  const targetSlug = `qa-archive-${nanoid(6)}`;
+  const liveExp = await prisma.experiment.create({
+    data: {
+      id: `experiment_${nanoid()}`,
+      name: "Keep This One",
+      slug: liveSlug,
+      projectId: project.id,
+      type: ExperimentType.BATCH_EVALUATION_V2,
+    },
+  });
+  const targetExp = await prisma.experiment.create({
+    data: {
+      id: `experiment_${nanoid()}`,
+      name: "Archive This One",
+      slug: targetSlug,
+      projectId: project.id,
+      type: ExperimentType.BATCH_EVALUATION_V2,
+    },
+  });
+  check("seeded org/team/project + experiments", true, project.id);
+
+  console.log("\n[3] Snapshot the evaluations page (BEFORE)");
+  await page.goto(`${BASE_URL}/${project.slug}/evaluations`, {
+    waitUntil: "domcontentloaded",
+    timeout: 30000,
+  });
+  await page.waitForTimeout(3000);
+  await page.screenshot({
+    path: `${SHOTS_DIR}/02-evaluations-before.png`,
+    fullPage: true,
+  });
+  check("BEFORE screenshot captured", true);
+
+  console.log("\n[4] Invoke experiments.deleteExperiment via tRPC HTTP");
+  // The router's tRPC POST endpoint with the session cookie attached.
+  // This is the exact wire call the UI button issues.
+  const csrfHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+    Origin: BASE_URL,
+    "x-trpc-source": "qa-script",
+  };
+  const archiveRes = await page.request.post(
+    `${BASE_URL}/api/trpc/experiments.deleteExperiment?batch=1`,
+    {
+      headers: csrfHeaders,
+      data: {
+        "0": { json: { projectId: project.id, experimentId: targetExp.id } },
+      },
+    },
+  );
+  check(
+    "deleteExperiment tRPC call returned 2xx",
+    archiveRes.status() >= 200 && archiveRes.status() < 300,
+    `status=${archiveRes.status()} body=${(await archiveRes.text()).slice(0, 200)}`,
+  );
+
+  console.log("\n[5] Snapshot the evaluations page (AFTER)");
+  await page.reload({ waitUntil: "domcontentloaded", timeout: 30000 });
+  await page.waitForTimeout(3000);
+  await page.screenshot({
+    path: `${SHOTS_DIR}/03-evaluations-after.png`,
+    fullPage: true,
+  });
+  check("AFTER screenshot captured", true);
+
+  console.log("\n[6] Verify Postgres state directly");
+  const row = await prisma.experiment.findFirst({
+    where: { id: targetExp.id, projectId: project.id },
+  });
+  check("target row STILL exists in Postgres (soft archive)", !!row);
+  check("target row archivedAt is set", !!row?.archivedAt, String(row?.archivedAt));
+  check(
+    "target row slug was renamed (contains '-archived-')",
+    !!row?.slug?.includes("-archived-"),
+    row?.slug,
+  );
+
+  const liveRow = await prisma.experiment.findFirst({
+    where: { id: liveExp.id, projectId: project.id },
+  });
+  check("untouched experiment archivedAt remains null", liveRow?.archivedAt === null);
+
+  console.log("\n[7] Idempotent re-archive returns success and does not move archivedAt");
+  const firstArchivedAt = row!.archivedAt!;
+  await new Promise((r) => setTimeout(r, 50));
+  const archiveRes2 = await page.request.post(
+    `${BASE_URL}/api/trpc/experiments.deleteExperiment?batch=1`,
+    {
+      headers: csrfHeaders,
+      data: {
+        "0": { json: { projectId: project.id, experimentId: targetExp.id } },
+      },
+    },
+  );
+  check(
+    "second deleteExperiment call also returns 2xx",
+    archiveRes2.status() >= 200 && archiveRes2.status() < 300,
+    `status=${archiveRes2.status()}`,
+  );
+  const row2 = await prisma.experiment.findFirst({
+    where: { id: targetExp.id, projectId: project.id },
+  });
+  check(
+    "archivedAt timestamp is NOT overwritten on duplicate click",
+    row2?.archivedAt?.getTime() === firstArchivedAt.getTime(),
+    `${row2?.archivedAt?.toISOString()} vs ${firstArchivedAt.toISOString()}`,
+  );
+
+  await browser.close();
+
+  console.log("\n=====================================================");
+  if (fails === 0) {
+    console.log(`ALL CHECKS PASSED (${passes}/${passes})`);
+    process.exit(0);
+  } else {
+    console.log(`${fails} CHECKS FAILED (${passes}/${passes + fails} passed)`);
+    process.exit(1);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error("QA SCRIPT CRASHED:", e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/langwatch/e2e/experiment-archive-dogfood.ts
+++ b/langwatch/e2e/experiment-archive-dogfood.ts
@@ -17,7 +17,7 @@
  * Run via:
  *   DATABASE_URL=postgresql://langwatch_ci:ci_password@localhost:5432/langwatch_db?schema=public \
  *     BASE_URL=http://localhost:5571 \
- *     pnpm exec tsx e2e/auth-regression/experiment-archive-qa.ts
+ *     pnpm exec tsx e2e/experiment-archive-dogfood.ts
  */
 import { chromium } from "playwright";
 import { mkdir } from "node:fs/promises";

--- a/langwatch/prisma/migrations/20260601120000_add_archived_at_to_experiment/migration.sql
+++ b/langwatch/prisma/migrations/20260601120000_add_archived_at_to_experiment/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Experiment" ADD COLUMN "archivedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "Experiment_projectId_archivedAt_idx" ON "Experiment"("projectId", "archivedAt");

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -751,6 +751,7 @@ model Experiment {
   workflow         Workflow?         @relation(fields: [workflowId], references: [id])
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @default(now()) @updatedAt
+  archivedAt       DateTime?
   batchEvaluations BatchEvaluation[]
   workbenchState   Json?
   monitor          Monitor?
@@ -758,6 +759,7 @@ model Experiment {
   @@unique([projectId, slug])
   @@index([projectId])
   @@index([workflowId])
+  @@index([projectId, archivedAt])
 }
 
 model Annotation {

--- a/langwatch/src/pages/api/experiment/__tests__/init.unit.test.ts
+++ b/langwatch/src/pages/api/experiment/__tests__/init.unit.test.ts
@@ -11,6 +11,7 @@ vi.mock("~/server/db", () => ({
     },
     experiment: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
     },
@@ -125,7 +126,7 @@ describe("POST /api/experiment/init", () => {
 
   describe("when slug already exists", () => {
     beforeEach(() => {
-      (prisma.experiment.findUnique as Mock).mockResolvedValue(
+      (prisma.experiment.findFirst as Mock).mockResolvedValue(
         existingExperiment,
       );
     });
@@ -155,7 +156,7 @@ describe("POST /api/experiment/init", () => {
 
   describe("when slug does not exist", () => {
     beforeEach(() => {
-      (prisma.experiment.findUnique as Mock).mockResolvedValue(null);
+      (prisma.experiment.findFirst as Mock).mockResolvedValue(null);
       (prisma.experiment.create as Mock).mockResolvedValue(createdExperiment);
     });
 

--- a/langwatch/src/pages/api/experiment/init.ts
+++ b/langwatch/src/pages/api/experiment/init.ts
@@ -9,6 +9,7 @@ import {
 } from "~/server/api-key/auth-middleware";
 import { TokenResolver } from "~/server/api-key/token-resolver";
 import { prisma } from "~/server/db";
+import { ExperimentService } from "~/server/experiments/experiment.service";
 import { createLicenseEnforcementService } from "~/server/license-enforcement";
 import { LimitExceededError } from "~/server/license-enforcement/errors";
 import { buildResourceLimitMessage } from "~/server/license-enforcement/limit-message";
@@ -165,10 +166,12 @@ export const findOrCreateExperiment = async ({
   workflowId?: string;
 }) => {
   let experiment: Experiment | null = null;
+  const experiments = ExperimentService.create(prisma);
 
   if (experiment_id) {
-    experiment = await prisma.experiment.findFirst({
-      where: { projectId: project.id, id: experiment_id, archivedAt: null },
+    experiment = await experiments.findById({
+      projectId: project.id,
+      id: experiment_id,
     });
     if (!experiment) {
       throw new Error("Experiment not found");
@@ -178,11 +181,13 @@ export const findOrCreateExperiment = async ({
   let slug_ = null;
   if (experiment_slug) {
     slug_ = slugify(experiment_slug);
-    // The slug is renamed on archive (see deleteExperiment), so a findUnique
-    // by the user's intended slug will not match archived rows. No extra
-    // archivedAt filter needed here.
-    experiment = await prisma.experiment.findUnique({
-      where: { projectId_slug: { projectId: project.id, slug: slug_ } },
+    // findBySlug filters archivedAt at the service layer. Archived rows
+    // also have a `-archived-<nanoid>` slug, so they would not collide
+    // even on a raw findUnique - we still go through the service so the
+    // archive rule stays one source of truth.
+    experiment = await experiments.findBySlug({
+      projectId: project.id,
+      slug: slug_,
     });
   }
 

--- a/langwatch/src/pages/api/experiment/init.ts
+++ b/langwatch/src/pages/api/experiment/init.ts
@@ -167,8 +167,8 @@ export const findOrCreateExperiment = async ({
   let experiment: Experiment | null = null;
 
   if (experiment_id) {
-    experiment = await prisma.experiment.findUnique({
-      where: { projectId: project.id, id: experiment_id },
+    experiment = await prisma.experiment.findFirst({
+      where: { projectId: project.id, id: experiment_id, archivedAt: null },
     });
     if (!experiment) {
       throw new Error("Experiment not found");
@@ -178,6 +178,9 @@ export const findOrCreateExperiment = async ({
   let slug_ = null;
   if (experiment_slug) {
     slug_ = slugify(experiment_slug);
+    // The slug is renamed on archive (see deleteExperiment), so a findUnique
+    // by the user's intended slug will not match archived rows. No extra
+    // archivedAt filter needed here.
     experiment = await prisma.experiment.findUnique({
       where: { projectId_slug: { projectId: project.id, slug: slug_ } },
     });

--- a/langwatch/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
@@ -1,0 +1,259 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for experiment archive (formerly delete).
+ *
+ * Covers specs/experiments-v3/experiment-archive.feature. No mocks: runs the
+ * real tRPC mutation against a real Postgres test instance and asserts on the
+ * persisted rows directly.
+ *
+ * Rationale: the old deleteExperiment path was hard-deleting Postgres rows
+ * AND issuing DELETE FROM in ClickHouse plus deleteByQuery in Elasticsearch.
+ * Every click cost ~$1-2 in S3 request churn (mask writes on every cold-tier
+ * part + merge fallout). The codebase had already standardised on archivedAt
+ * for Workflow/Monitor/Dataset/Evaluator/Agent/Project/Team; Experiment was
+ * the outlier. This file pins the new soft-archive behaviour so future edits
+ * cannot silently regress to hard delete.
+ */
+import { ExperimentType } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { getTestUser } from "../../../../utils/testUtils";
+import { globalForApp } from "../../../app-layer/app";
+import { createTestApp } from "../../../app-layer/presets";
+import { prisma } from "../../../db";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+
+vi.mock("../../../license-enforcement", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../license-enforcement")>();
+  return {
+    ...actual,
+    enforceLicenseLimit: vi.fn(),
+  };
+});
+
+describe("Experiment archive (formerly delete)", () => {
+  const projectId = "test-project-id";
+  let caller: ReturnType<typeof appRouter.createCaller>;
+  const testNamespace = `exparch-${nanoid(8)}`;
+
+  // Track resources so the suite cleans up after itself even if an assertion
+  // fails mid-test. We use the Prisma client directly here (not the router)
+  // because the router's archive flow now leaves rows behind on purpose.
+  const createdExperimentIds: string[] = [];
+  const createdWorkflowIds: string[] = [];
+  const createdMonitorIds: string[] = [];
+
+  let previousApp: typeof globalForApp.__langwatch_app;
+
+  beforeAll(async () => {
+    previousApp = globalForApp.__langwatch_app;
+    globalForApp.__langwatch_app = createTestApp();
+    const user = await getTestUser();
+    const ctx = createInnerTRPCContext({
+      session: { user: { id: user.id }, expires: "1" },
+    });
+    caller = appRouter.createCaller(ctx);
+  });
+
+  afterAll(async () => {
+    globalForApp.__langwatch_app = previousApp;
+    for (const id of createdMonitorIds) {
+      await prisma.monitor.delete({ where: { id, projectId } }).catch(() => {});
+    }
+    for (const id of createdExperimentIds) {
+      await prisma.experiment
+        .delete({ where: { id, projectId } })
+        .catch(() => {});
+    }
+    for (const id of createdWorkflowIds) {
+      await prisma.workflow
+        .update({
+          where: { id, projectId },
+          data: { currentVersionId: null, latestVersionId: null },
+        })
+        .catch(() => {});
+      await prisma.workflowVersion
+        .deleteMany({ where: { workflowId: id, projectId } })
+        .catch(() => {});
+      await prisma.workflow
+        .delete({ where: { id, projectId } })
+        .catch(() => {});
+    }
+  });
+
+  async function createExperiment(opts: {
+    slug: string;
+    withWorkflow?: boolean;
+    withMonitor?: boolean;
+  }) {
+    let workflowId: string | undefined;
+    if (opts.withWorkflow) {
+      workflowId = `workflow_${nanoid()}`;
+      await prisma.workflow.create({
+        data: {
+          id: workflowId,
+          projectId,
+          name: `${opts.slug}-workflow`,
+          icon: "🔧",
+          description: "test",
+        },
+      });
+      createdWorkflowIds.push(workflowId);
+    }
+    const id = `experiment_${nanoid()}`;
+    await prisma.experiment.create({
+      data: {
+        id,
+        name: opts.slug,
+        slug: opts.slug,
+        projectId,
+        type: ExperimentType.BATCH_EVALUATION_V2,
+        workflowId,
+      },
+    });
+    createdExperimentIds.push(id);
+    if (opts.withMonitor) {
+      const monitorId = `monitor_${nanoid()}`;
+      await prisma.monitor.create({
+        data: {
+          id: monitorId,
+          projectId,
+          experimentId: id,
+          name: `${opts.slug}-monitor`,
+          slug: `${opts.slug}-monitor`,
+          checkType: "custom",
+          preconditions: {},
+          parameters: {},
+        },
+      });
+      createdMonitorIds.push(monitorId);
+    }
+    return { id, workflowId };
+  }
+
+  it("archives the experiment row instead of deleting it", async () => {
+    const { id } = await createExperiment({
+      slug: `${testNamespace}-basic-${nanoid(6)}`,
+    });
+
+    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
+
+    const row = await prisma.experiment.findFirst({ where: { id, projectId } });
+    expect(row).not.toBeNull();
+    expect(row?.archivedAt).not.toBeNull();
+    expect(row!.archivedAt!.getTime()).toBeGreaterThan(Date.now() - 10_000);
+    // Slug was renamed so a future experiment can reuse the original slug.
+    expect(row?.slug).toMatch(/-archived-/);
+  });
+
+  it("cascade-archives the linked workflow and hard-deletes the monitor", async () => {
+    const { id, workflowId } = await createExperiment({
+      slug: `${testNamespace}-cascade-${nanoid(6)}`,
+      withWorkflow: true,
+      withMonitor: true,
+    });
+
+    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
+
+    const wf = await prisma.workflow.findFirst({
+      where: { id: workflowId!, projectId },
+    });
+    expect(wf?.archivedAt).not.toBeNull();
+
+    // Monitor has no archivedAt column; we keep the historical hard-delete
+    // because monitors are small relational rows with no S3 implication.
+    const mon = await prisma.monitor.findFirst({
+      where: { experimentId: id, projectId },
+    });
+    expect(mon).toBeNull();
+  });
+
+  it("handles an experiment with no workflow or monitor without erroring", async () => {
+    const { id } = await createExperiment({
+      slug: `${testNamespace}-nowf-${nanoid(6)}`,
+    });
+
+    await expect(
+      caller.experiments.deleteExperiment({ projectId, experimentId: id }),
+    ).resolves.toEqual({ success: true });
+  });
+
+  it("is idempotent — a second click does not overwrite archivedAt", async () => {
+    const { id } = await createExperiment({
+      slug: `${testNamespace}-idem-${nanoid(6)}`,
+    });
+
+    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
+    const firstArchive = (
+      await prisma.experiment.findFirst({ where: { id, projectId } })
+    )?.archivedAt;
+
+    // Tiny pause so a re-set timestamp would observably differ.
+    await new Promise((r) => setTimeout(r, 20));
+
+    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
+    const secondArchive = (
+      await prisma.experiment.findFirst({ where: { id, projectId } })
+    )?.archivedAt;
+
+    expect(firstArchive).toEqual(secondArchive);
+  });
+
+  it("hides archived experiments from the project-wide list (Postgres path)", async () => {
+    const liveSlug = `${testNamespace}-live-${nanoid(6)}`;
+    const archivedSlug = `${testNamespace}-arch-${nanoid(6)}`;
+    const { id: liveId } = await createExperiment({ slug: liveSlug });
+    const { id: archivedId } = await createExperiment({ slug: archivedSlug });
+
+    await caller.experiments.deleteExperiment({
+      projectId,
+      experimentId: archivedId,
+    });
+
+    // getAllByProjectId goes through the repository's findAll, which is
+    // pure Postgres — no ClickHouse enrichment. That is the layer we need
+    // to verify here (the run-count enrichment in getAllForEvaluationsList
+    // happens after this list filter and is tested elsewhere).
+    const list = await caller.experiments.getAllByProjectId({ projectId });
+
+    const ids = list.map((e: { id: string }) => e.id);
+    expect(ids).toContain(liveId);
+    expect(ids).not.toContain(archivedId);
+  });
+
+  it("returns NOT_FOUND when fetching an archived experiment by slug", async () => {
+    const slug = `${testNamespace}-notfound-${nanoid(6)}`;
+    const { id } = await createExperiment({ slug });
+    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
+
+    // The slug was rewritten on archive, so the original slug should now
+    // resolve to null/NOT_FOUND.
+    await expect(
+      caller.experiments.getExperimentBySlugOrId({
+        projectId,
+        experimentSlug: slug,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("frees up the original slug so a new experiment can take it", async () => {
+    const slug = `${testNamespace}-reuse-${nanoid(6)}`;
+    const { id: firstId } = await createExperiment({ slug });
+
+    await caller.experiments.deleteExperiment({
+      projectId,
+      experimentId: firstId,
+    });
+
+    // Now create a new experiment with the same slug — should succeed.
+    const { id: secondId } = await createExperiment({ slug });
+    const row = await prisma.experiment.findFirst({
+      where: { id: secondId, projectId },
+    });
+    expect(row?.slug).toBe(slug);
+    expect(row?.archivedAt).toBeNull();
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
@@ -134,6 +134,7 @@ describe("Experiment archive (formerly delete)", () => {
     return { id, workflowId };
   }
 
+  /** @scenario Archiving an experiment sets archivedAt and preserves the row */
   it("archives the experiment row instead of deleting it", async () => {
     const { id } = await createExperiment({
       slug: `${testNamespace}-basic-${nanoid(6)}`,
@@ -149,6 +150,7 @@ describe("Experiment archive (formerly delete)", () => {
     expect(row?.slug).toMatch(/-archived-/);
   });
 
+  /** @scenario Archiving cascades to the associated workflow and hard-deletes the monitor */
   it("cascade-archives the linked workflow and hard-deletes the monitor", async () => {
     const { id, workflowId } = await createExperiment({
       slug: `${testNamespace}-cascade-${nanoid(6)}`,
@@ -171,6 +173,7 @@ describe("Experiment archive (formerly delete)", () => {
     expect(mon).toBeNull();
   });
 
+  /** @scenario Archiving without a workflow or monitor still succeeds */
   it("handles an experiment with no workflow or monitor without erroring", async () => {
     const { id } = await createExperiment({
       slug: `${testNamespace}-nowf-${nanoid(6)}`,
@@ -181,7 +184,8 @@ describe("Experiment archive (formerly delete)", () => {
     ).resolves.toEqual({ success: true });
   });
 
-  it("is idempotent — a second click does not overwrite archivedAt", async () => {
+  /** @scenario A second click on the same already-archived experiment is a no-op */
+  it("is idempotent - a second click does not overwrite archivedAt", async () => {
     const { id } = await createExperiment({
       slug: `${testNamespace}-idem-${nanoid(6)}`,
     });
@@ -202,6 +206,7 @@ describe("Experiment archive (formerly delete)", () => {
     expect(firstArchive).toEqual(secondArchive);
   });
 
+  /** @scenario Archived experiments are hidden from the standard list query */
   it("hides archived experiments from the project-wide list (Postgres path)", async () => {
     const liveSlug = `${testNamespace}-live-${nanoid(6)}`;
     const archivedSlug = `${testNamespace}-arch-${nanoid(6)}`;
@@ -214,7 +219,7 @@ describe("Experiment archive (formerly delete)", () => {
     });
 
     // getAllByProjectId goes through the repository's findAll, which is
-    // pure Postgres — no ClickHouse enrichment. That is the layer we need
+    // pure Postgres, no ClickHouse enrichment. That is the layer we need
     // to verify here (the run-count enrichment in getAllForEvaluationsList
     // happens after this list filter and is tested elsewhere).
     const list = await caller.experiments.getAllByProjectId({ projectId });
@@ -224,6 +229,7 @@ describe("Experiment archive (formerly delete)", () => {
     expect(ids).not.toContain(archivedId);
   });
 
+  /** @scenario A single getExperiment by id returns archived experiments as not-found */
   it("returns NOT_FOUND when fetching an archived experiment by slug", async () => {
     const slug = `${testNamespace}-notfound-${nanoid(6)}`;
     const { id } = await createExperiment({ slug });
@@ -248,12 +254,87 @@ describe("Experiment archive (formerly delete)", () => {
       experimentId: firstId,
     });
 
-    // Now create a new experiment with the same slug — should succeed.
     const { id: secondId } = await createExperiment({ slug });
     const row = await prisma.experiment.findFirst({
       where: { id: secondId, projectId },
     });
     expect(row?.slug).toBe(slug);
     expect(row?.archivedAt).toBeNull();
+  });
+
+  // The archive path used to issue three side-effect calls that the feature
+  // file forbids: a ClickHouse mass-delete (lightweight-delete masks on
+  // cold-tier S3 parts), an Elasticsearch deleteByQuery on the
+  // batch_evaluation index, and an in-process DSpy step cleanup. We
+  // removed all three by deleting the imports from the router. The most
+  // reliable proof is a source-level check: with the imports gone there
+  // is no path by which the archive procedure can reach those services.
+  // Runtime fail-on-call mocks were considered but rejected because
+  // getClickHouseClientForProject is still used by sibling list and
+  // enrichment procedures in the same router and globally mocking it
+  // would break unrelated tests.
+  /** @scenario The delete-experiment code path does NOT contact ClickHouse */
+  /** @scenario The delete-experiment code path does NOT contact Elasticsearch */
+  /** @scenario The delete-experiment code path does NOT call the DSpy step cleanup */
+  it("does not import ClickHouse, Elasticsearch, or DSpy cleanup in the router", async () => {
+    const routerSrc = await import("node:fs/promises").then((fs) =>
+      fs.readFile(
+        require.resolve("../experiments.ts"),
+        "utf8",
+      ),
+    );
+    expect(routerSrc).not.toMatch(/getClickHouseClientForProject/);
+    expect(routerSrc).not.toMatch(/from\s+["'][^"']*server\/elasticsearch["']/);
+    expect(routerSrc).not.toMatch(/BATCH_EVALUATION_INDEX/);
+    expect(routerSrc).not.toMatch(/dspySteps\.steps\.deleteByExperiment/);
+  });
+
+  /** @scenario An experiment from another project cannot be archived */
+  it("returns NOT_FOUND when archiving an experiment that belongs to a different project", async () => {
+    const otherProjectId = `${projectId}-other-${nanoid(6)}`;
+    await prisma.project.create({
+      data: {
+        id: otherProjectId,
+        name: `Other Project ${otherProjectId}`,
+        slug: otherProjectId,
+        teamId: (await prisma.project.findFirstOrThrow({
+          where: { id: projectId },
+          select: { teamId: true },
+        })).teamId,
+        language: "python",
+        framework: "openai",
+        apiKey: `qa-key-${otherProjectId}`,
+      },
+    });
+
+    const foreignId = `experiment_${nanoid()}`;
+    await prisma.experiment.create({
+      data: {
+        id: foreignId,
+        name: "Foreign experiment",
+        slug: `foreign-${nanoid(6)}`,
+        projectId: otherProjectId,
+        type: ExperimentType.BATCH_EVALUATION_V2,
+      },
+    });
+
+    try {
+      await expect(
+        caller.experiments.deleteExperiment({
+          projectId,
+          experimentId: foreignId,
+        }),
+      ).rejects.toThrow(/not found|forbidden|access/i);
+
+      const stillThere = await prisma.experiment.findFirst({
+        where: { id: foreignId, projectId: otherProjectId },
+      });
+      expect(stillThere?.archivedAt).toBeNull();
+    } finally {
+      await prisma.experiment
+        .delete({ where: { id: foreignId, projectId: otherProjectId } })
+        .catch(() => {});
+      await prisma.project.delete({ where: { id: otherProjectId } }).catch(() => {});
+    }
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
@@ -3,19 +3,13 @@
  *
  * Integration tests for experiment archive (formerly delete).
  *
- * Covers specs/experiments-v3/experiment-archive.feature. No mocks: runs the
- * real tRPC mutation against a real Postgres test instance and asserts on the
- * persisted rows directly.
- *
- * Rationale: the old deleteExperiment path was hard-deleting Postgres rows
- * AND issuing DELETE FROM in ClickHouse plus deleteByQuery in Elasticsearch.
- * Every click cost ~$1-2 in S3 request churn (mask writes on every cold-tier
- * part + merge fallout). The codebase had already standardised on archivedAt
- * for Workflow/Monitor/Dataset/Evaluator/Agent/Project/Team; Experiment was
- * the outlier. This file pins the new soft-archive behaviour so future edits
- * cannot silently regress to hard delete.
+ * Covers specs/experiments-v3/experiment-archive.feature. The Postgres
+ * layer is the real test instance and the tRPC mutation runs end to end;
+ * only the licence-enforcement boundary is stubbed so the test does not
+ * require a licensed organisation row to be seeded.
  */
 import { ExperimentType } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { getTestUser } from "../../../../utils/testUtils";
@@ -34,17 +28,33 @@ vi.mock("../../../license-enforcement", async (importOriginal) => {
   };
 });
 
-describe("Experiment archive (formerly delete)", () => {
-  const projectId = "test-project-id";
+const PROJECT_ID = "test-project-id";
+
+async function expectTRPCError(
+  promise: Promise<unknown>,
+  code: TRPCError["code"],
+) {
+  let captured: unknown;
+  try {
+    await promise;
+  } catch (e) {
+    captured = e;
+  }
+  expect(captured, "expected the promise to reject").toBeInstanceOf(TRPCError);
+  expect((captured as TRPCError).code).toBe(code);
+}
+
+describe("experiments.deleteExperiment", () => {
   let caller: ReturnType<typeof appRouter.createCaller>;
   const testNamespace = `exparch-${nanoid(8)}`;
 
-  // Track resources so the suite cleans up after itself even if an assertion
-  // fails mid-test. We use the Prisma client directly here (not the router)
-  // because the router's archive flow now leaves rows behind on purpose.
+  // Tracked so the suite cleans up after itself even when an assertion
+  // fails mid-test. Use the Prisma client directly here, not the router,
+  // because the archive flow leaves rows behind on purpose.
   const createdExperimentIds: string[] = [];
   const createdWorkflowIds: string[] = [];
   const createdMonitorIds: string[] = [];
+  const createdProjectIds: string[] = [];
 
   let previousApp: typeof globalForApp.__langwatch_app;
 
@@ -61,34 +71,44 @@ describe("Experiment archive (formerly delete)", () => {
   afterAll(async () => {
     globalForApp.__langwatch_app = previousApp;
     for (const id of createdMonitorIds) {
-      await prisma.monitor.delete({ where: { id, projectId } }).catch(() => {});
+      await prisma.monitor
+        .delete({ where: { id, projectId: PROJECT_ID } })
+        .catch(() => {});
     }
     for (const id of createdExperimentIds) {
       await prisma.experiment
-        .delete({ where: { id, projectId } })
+        .delete({ where: { id, projectId: PROJECT_ID } })
         .catch(() => {});
     }
     for (const id of createdWorkflowIds) {
       await prisma.workflow
         .update({
-          where: { id, projectId },
+          where: { id, projectId: PROJECT_ID },
           data: { currentVersionId: null, latestVersionId: null },
         })
         .catch(() => {});
       await prisma.workflowVersion
-        .deleteMany({ where: { workflowId: id, projectId } })
+        .deleteMany({ where: { workflowId: id, projectId: PROJECT_ID } })
         .catch(() => {});
       await prisma.workflow
-        .delete({ where: { id, projectId } })
+        .delete({ where: { id, projectId: PROJECT_ID } })
         .catch(() => {});
+    }
+    for (const pid of createdProjectIds) {
+      await prisma.experiment
+        .deleteMany({ where: { projectId: pid } })
+        .catch(() => {});
+      await prisma.project.delete({ where: { id: pid } }).catch(() => {});
     }
   });
 
   async function createExperiment(opts: {
     slug: string;
+    projectId?: string;
     withWorkflow?: boolean;
     withMonitor?: boolean;
   }) {
+    const projectId = opts.projectId ?? PROJECT_ID;
     let workflowId: string | undefined;
     if (opts.withWorkflow) {
       workflowId = `workflow_${nanoid()}`;
@@ -101,7 +121,7 @@ describe("Experiment archive (formerly delete)", () => {
           description: "test",
         },
       });
-      createdWorkflowIds.push(workflowId);
+      if (projectId === PROJECT_ID) createdWorkflowIds.push(workflowId);
     }
     const id = `experiment_${nanoid()}`;
     await prisma.experiment.create({
@@ -114,7 +134,7 @@ describe("Experiment archive (formerly delete)", () => {
         workflowId,
       },
     });
-    createdExperimentIds.push(id);
+    if (projectId === PROJECT_ID) createdExperimentIds.push(id);
     if (opts.withMonitor) {
       const monitorId = `monitor_${nanoid()}`;
       await prisma.monitor.create({
@@ -129,212 +149,317 @@ describe("Experiment archive (formerly delete)", () => {
           parameters: {},
         },
       });
-      createdMonitorIds.push(monitorId);
+      if (projectId === PROJECT_ID) createdMonitorIds.push(monitorId);
     }
     return { id, workflowId };
   }
 
-  /** @scenario Archiving an experiment sets archivedAt and preserves the row */
-  it("archives the experiment row instead of deleting it", async () => {
-    const { id } = await createExperiment({
-      slug: `${testNamespace}-basic-${nanoid(6)}`,
+  describe("given an unarchived experiment", () => {
+    describe("when the user calls deleteExperiment", () => {
+      let experimentId: string;
+      let originalSlug: string;
+
+      beforeAll(async () => {
+        originalSlug = `${testNamespace}-basic-${nanoid(6)}`;
+        const created = await createExperiment({ slug: originalSlug });
+        experimentId = created.id;
+        await caller.experiments.deleteExperiment({
+          projectId: PROJECT_ID,
+          experimentId,
+        });
+      });
+
+      /** @scenario Archiving an experiment sets archivedAt and preserves the row */
+      it("preserves the row in Postgres", async () => {
+        const row = await prisma.experiment.findFirst({
+          where: { id: experimentId, projectId: PROJECT_ID },
+        });
+        expect(row).not.toBeNull();
+      });
+
+      it("sets archivedAt to a recent timestamp", async () => {
+        const row = await prisma.experiment.findFirst({
+          where: { id: experimentId, projectId: PROJECT_ID },
+        });
+        expect(row!.archivedAt!.getTime()).toBeGreaterThan(Date.now() - 10_000);
+      });
+
+      it("renames the slug so the original can be reused", async () => {
+        const row = await prisma.experiment.findFirst({
+          where: { id: experimentId, projectId: PROJECT_ID },
+        });
+        expect(row?.slug).toMatch(/-archived-/);
+      });
     });
-
-    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
-
-    const row = await prisma.experiment.findFirst({ where: { id, projectId } });
-    expect(row).not.toBeNull();
-    expect(row?.archivedAt).not.toBeNull();
-    expect(row!.archivedAt!.getTime()).toBeGreaterThan(Date.now() - 10_000);
-    // Slug was renamed so a future experiment can reuse the original slug.
-    expect(row?.slug).toMatch(/-archived-/);
   });
 
-  /** @scenario Archiving cascades to the associated workflow and hard-deletes the monitor */
-  it("cascade-archives the linked workflow and hard-deletes the monitor", async () => {
-    const { id, workflowId } = await createExperiment({
-      slug: `${testNamespace}-cascade-${nanoid(6)}`,
-      withWorkflow: true,
-      withMonitor: true,
-    });
+  describe("given an experiment with a workflow and a monitor", () => {
+    describe("when the user calls deleteExperiment", () => {
+      let experimentId: string;
+      let workflowId: string;
 
-    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
+      beforeAll(async () => {
+        const created = await createExperiment({
+          slug: `${testNamespace}-cascade-${nanoid(6)}`,
+          withWorkflow: true,
+          withMonitor: true,
+        });
+        experimentId = created.id;
+        workflowId = created.workflowId!;
+        await caller.experiments.deleteExperiment({
+          projectId: PROJECT_ID,
+          experimentId,
+        });
+      });
 
-    const wf = await prisma.workflow.findFirst({
-      where: { id: workflowId!, projectId },
-    });
-    expect(wf?.archivedAt).not.toBeNull();
+      /** @scenario Archiving cascades to the associated workflow and hard-deletes the monitor */
+      it("cascade-archives the workflow", async () => {
+        const wf = await prisma.workflow.findFirst({
+          where: { id: workflowId, projectId: PROJECT_ID },
+        });
+        expect(wf?.archivedAt).not.toBeNull();
+      });
 
-    // Monitor has no archivedAt column; we keep the historical hard-delete
-    // because monitors are small relational rows with no S3 implication.
-    const mon = await prisma.monitor.findFirst({
-      where: { experimentId: id, projectId },
+      it("hard-deletes the monitor", async () => {
+        const mon = await prisma.monitor.findFirst({
+          where: { experimentId, projectId: PROJECT_ID },
+        });
+        expect(mon).toBeNull();
+      });
     });
-    expect(mon).toBeNull();
   });
 
-  /** @scenario Archiving without a workflow or monitor still succeeds */
-  it("handles an experiment with no workflow or monitor without erroring", async () => {
-    const { id } = await createExperiment({
-      slug: `${testNamespace}-nowf-${nanoid(6)}`,
-    });
+  describe("given an experiment with no workflow or monitor", () => {
+    describe("when the user calls deleteExperiment", () => {
+      /** @scenario Archiving without a workflow or monitor still succeeds */
+      it("resolves with success", async () => {
+        const { id } = await createExperiment({
+          slug: `${testNamespace}-nowf-${nanoid(6)}`,
+        });
 
-    await expect(
-      caller.experiments.deleteExperiment({ projectId, experimentId: id }),
-    ).resolves.toEqual({ success: true });
+        await expect(
+          caller.experiments.deleteExperiment({
+            projectId: PROJECT_ID,
+            experimentId: id,
+          }),
+        ).resolves.toEqual({ success: true });
+      });
+    });
   });
 
-  /** @scenario A second click on the same already-archived experiment is a no-op */
-  it("is idempotent - a second click does not overwrite archivedAt", async () => {
-    const { id } = await createExperiment({
-      slug: `${testNamespace}-idem-${nanoid(6)}`,
+  describe("given an already-archived experiment", () => {
+    describe("when the user calls deleteExperiment a second time", () => {
+      let experimentId: string;
+      let firstArchivedAt: Date;
+
+      beforeAll(async () => {
+        const created = await createExperiment({
+          slug: `${testNamespace}-idem-${nanoid(6)}`,
+        });
+        experimentId = created.id;
+        await caller.experiments.deleteExperiment({
+          projectId: PROJECT_ID,
+          experimentId,
+        });
+        firstArchivedAt = (
+          await prisma.experiment.findFirstOrThrow({
+            where: { id: experimentId, projectId: PROJECT_ID },
+          })
+        ).archivedAt!;
+        await new Promise((r) => setTimeout(r, 20));
+        await caller.experiments.deleteExperiment({
+          projectId: PROJECT_ID,
+          experimentId,
+        });
+      });
+
+      /** @scenario A second click on the same already-archived experiment is a no-op */
+      it("does not overwrite the original archivedAt timestamp", async () => {
+        const row = await prisma.experiment.findFirst({
+          where: { id: experimentId, projectId: PROJECT_ID },
+        });
+        expect(row?.archivedAt?.getTime()).toBe(firstArchivedAt.getTime());
+      });
     });
-
-    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
-    const firstArchive = (
-      await prisma.experiment.findFirst({ where: { id, projectId } })
-    )?.archivedAt;
-
-    // Tiny pause so a re-set timestamp would observably differ.
-    await new Promise((r) => setTimeout(r, 20));
-
-    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
-    const secondArchive = (
-      await prisma.experiment.findFirst({ where: { id, projectId } })
-    )?.archivedAt;
-
-    expect(firstArchive).toEqual(secondArchive);
   });
 
-  /** @scenario Archived experiments are hidden from the standard list query */
-  it("hides archived experiments from the project-wide list (Postgres path)", async () => {
-    const liveSlug = `${testNamespace}-live-${nanoid(6)}`;
-    const archivedSlug = `${testNamespace}-arch-${nanoid(6)}`;
-    const { id: liveId } = await createExperiment({ slug: liveSlug });
-    const { id: archivedId } = await createExperiment({ slug: archivedSlug });
+  describe("given a project with one archived and one live experiment", () => {
+    describe("when the user lists experiments", () => {
+      let liveId: string;
+      let archivedId: string;
 
-    await caller.experiments.deleteExperiment({
-      projectId,
-      experimentId: archivedId,
+      beforeAll(async () => {
+        const live = await createExperiment({
+          slug: `${testNamespace}-live-${nanoid(6)}`,
+        });
+        const arch = await createExperiment({
+          slug: `${testNamespace}-arch-${nanoid(6)}`,
+        });
+        liveId = live.id;
+        archivedId = arch.id;
+        await caller.experiments.deleteExperiment({
+          projectId: PROJECT_ID,
+          experimentId: archivedId,
+        });
+      });
+
+      /** @scenario Archived experiments are hidden from the standard list query */
+      it("returns the live experiment", async () => {
+        const list = await caller.experiments.getAllByProjectId({
+          projectId: PROJECT_ID,
+        });
+        expect(list.map((e: { id: string }) => e.id)).toContain(liveId);
+      });
+
+      it("omits the archived experiment", async () => {
+        const list = await caller.experiments.getAllByProjectId({
+          projectId: PROJECT_ID,
+        });
+        expect(list.map((e: { id: string }) => e.id)).not.toContain(archivedId);
+      });
     });
-
-    // getAllByProjectId goes through the repository's findAll, which is
-    // pure Postgres, no ClickHouse enrichment. That is the layer we need
-    // to verify here (the run-count enrichment in getAllForEvaluationsList
-    // happens after this list filter and is tested elsewhere).
-    const list = await caller.experiments.getAllByProjectId({ projectId });
-
-    const ids = list.map((e: { id: string }) => e.id);
-    expect(ids).toContain(liveId);
-    expect(ids).not.toContain(archivedId);
   });
 
-  /** @scenario A single getExperiment by id returns archived experiments as not-found */
-  it("returns NOT_FOUND when fetching an archived experiment by slug", async () => {
-    const slug = `${testNamespace}-notfound-${nanoid(6)}`;
-    const { id } = await createExperiment({ slug });
-    await caller.experiments.deleteExperiment({ projectId, experimentId: id });
+  describe("given an archived experiment", () => {
+    describe("when the user fetches it by the original slug", () => {
+      /** @scenario A single getExperiment by id returns archived experiments as not-found */
+      it("rejects with NOT_FOUND", async () => {
+        const slug = `${testNamespace}-notfound-${nanoid(6)}`;
+        const { id } = await createExperiment({ slug });
+        await caller.experiments.deleteExperiment({
+          projectId: PROJECT_ID,
+          experimentId: id,
+        });
 
-    // The slug was rewritten on archive, so the original slug should now
-    // resolve to null/NOT_FOUND.
-    await expect(
-      caller.experiments.getExperimentBySlugOrId({
-        projectId,
-        experimentSlug: slug,
-      }),
-    ).rejects.toThrow();
+        await expectTRPCError(
+          caller.experiments.getExperimentBySlugOrId({
+            projectId: PROJECT_ID,
+            experimentSlug: slug,
+          }),
+          "NOT_FOUND",
+        );
+      });
+    });
   });
 
-  it("frees up the original slug so a new experiment can take it", async () => {
-    const slug = `${testNamespace}-reuse-${nanoid(6)}`;
-    const { id: firstId } = await createExperiment({ slug });
+  describe("given an experiment whose slug was already used and archived", () => {
+    describe("when a new experiment is created with the same original slug", () => {
+      it("succeeds and the new row owns the slug", async () => {
+        const slug = `${testNamespace}-reuse-${nanoid(6)}`;
+        const { id: firstId } = await createExperiment({ slug });
+        await caller.experiments.deleteExperiment({
+          projectId: PROJECT_ID,
+          experimentId: firstId,
+        });
 
-    await caller.experiments.deleteExperiment({
-      projectId,
-      experimentId: firstId,
+        const { id: secondId } = await createExperiment({ slug });
+        const row = await prisma.experiment.findFirst({
+          where: { id: secondId, projectId: PROJECT_ID },
+        });
+        expect(row?.slug).toBe(slug);
+        expect(row?.archivedAt).toBeNull();
+      });
     });
-
-    const { id: secondId } = await createExperiment({ slug });
-    const row = await prisma.experiment.findFirst({
-      where: { id: secondId, projectId },
-    });
-    expect(row?.slug).toBe(slug);
-    expect(row?.archivedAt).toBeNull();
   });
 
   // The archive path used to issue three side-effect calls that the feature
   // file forbids: a ClickHouse mass-delete (lightweight-delete masks on
   // cold-tier S3 parts), an Elasticsearch deleteByQuery on the
-  // batch_evaluation index, and an in-process DSpy step cleanup. We
-  // removed all three by deleting the imports from the router. The most
-  // reliable proof is a source-level check: with the imports gone there
-  // is no path by which the archive procedure can reach those services.
-  // Runtime fail-on-call mocks were considered but rejected because
-  // getClickHouseClientForProject is still used by sibling list and
-  // enrichment procedures in the same router and globally mocking it
+  // batch_evaluation index, and an in-process DSpy step cleanup. All three
+  // were removed by deleting the corresponding imports from the router.
+  // The most reliable proof is a source-level check: with the imports gone
+  // there is no path by which the archive procedure can reach those
+  // services. Runtime fail-on-call mocks were considered but rejected
+  // because getClickHouseClientForProject is still used by sibling
+  // list/enrichment procedures in the same router and globally mocking it
   // would break unrelated tests.
-  /** @scenario The delete-experiment code path does NOT contact ClickHouse */
-  /** @scenario The delete-experiment code path does NOT contact Elasticsearch */
-  /** @scenario The delete-experiment code path does NOT call the DSpy step cleanup */
-  it("does not import ClickHouse, Elasticsearch, or DSpy cleanup in the router", async () => {
-    const routerSrc = await import("node:fs/promises").then((fs) =>
-      fs.readFile(
-        require.resolve("../experiments.ts"),
-        "utf8",
-      ),
-    );
-    expect(routerSrc).not.toMatch(/getClickHouseClientForProject/);
-    expect(routerSrc).not.toMatch(/from\s+["'][^"']*server\/elasticsearch["']/);
-    expect(routerSrc).not.toMatch(/BATCH_EVALUATION_INDEX/);
-    expect(routerSrc).not.toMatch(/dspySteps\.steps\.deleteByExperiment/);
+  describe("the router source file", () => {
+    /** @scenario The delete-experiment code path does NOT contact ClickHouse */
+    it("does not import getClickHouseClientForProject", async () => {
+      const src = await import("node:fs/promises").then((fs) =>
+        fs.readFile(require.resolve("../experiments.ts"), "utf8"),
+      );
+      expect(src).not.toMatch(/getClickHouseClientForProject/);
+    });
+
+    /** @scenario The delete-experiment code path does NOT contact Elasticsearch */
+    it("does not import the Elasticsearch client or the batch_evaluation index", async () => {
+      const src = await import("node:fs/promises").then((fs) =>
+        fs.readFile(require.resolve("../experiments.ts"), "utf8"),
+      );
+      expect(src).not.toMatch(/from\s+["'][^"']*server\/elasticsearch["']/);
+      expect(src).not.toMatch(/BATCH_EVALUATION_INDEX/);
+    });
+
+    /** @scenario The delete-experiment code path does NOT call the DSpy step cleanup */
+    it("does not call dspySteps.steps.deleteByExperiment", async () => {
+      const src = await import("node:fs/promises").then((fs) =>
+        fs.readFile(require.resolve("../experiments.ts"), "utf8"),
+      );
+      expect(src).not.toMatch(/dspySteps\.steps\.deleteByExperiment/);
+    });
   });
 
-  /** @scenario An experiment from another project cannot be archived */
-  it("returns NOT_FOUND when archiving an experiment that belongs to a different project", async () => {
-    const otherProjectId = `${projectId}-other-${nanoid(6)}`;
-    await prisma.project.create({
-      data: {
-        id: otherProjectId,
-        name: `Other Project ${otherProjectId}`,
-        slug: otherProjectId,
-        teamId: (await prisma.project.findFirstOrThrow({
-          where: { id: projectId },
+  describe("given an experiment that belongs to a different project", () => {
+    describe("when the user calls deleteExperiment with their own projectId", () => {
+      let foreignProjectId: string;
+      let foreignExperimentId: string;
+
+      beforeAll(async () => {
+        foreignProjectId = `${PROJECT_ID}-other-${nanoid(6)}`;
+        const sourceProject = await prisma.project.findFirstOrThrow({
+          where: { id: PROJECT_ID },
           select: { teamId: true },
-        })).teamId,
-        language: "python",
-        framework: "openai",
-        apiKey: `qa-key-${otherProjectId}`,
-      },
-    });
+        });
+        await prisma.project.create({
+          data: {
+            id: foreignProjectId,
+            name: `Other ${foreignProjectId}`,
+            slug: foreignProjectId,
+            teamId: sourceProject.teamId,
+            language: "python",
+            framework: "openai",
+            apiKey: `qa-key-${foreignProjectId}`,
+          },
+        });
+        createdProjectIds.push(foreignProjectId);
 
-    const foreignId = `experiment_${nanoid()}`;
-    await prisma.experiment.create({
-      data: {
-        id: foreignId,
-        name: "Foreign experiment",
-        slug: `foreign-${nanoid(6)}`,
-        projectId: otherProjectId,
-        type: ExperimentType.BATCH_EVALUATION_V2,
-      },
-    });
-
-    try {
-      await expect(
-        caller.experiments.deleteExperiment({
-          projectId,
-          experimentId: foreignId,
-        }),
-      ).rejects.toThrow(/not found|forbidden|access/i);
-
-      const stillThere = await prisma.experiment.findFirst({
-        where: { id: foreignId, projectId: otherProjectId },
+        const created = await createExperiment({
+          slug: `foreign-${nanoid(6)}`,
+          projectId: foreignProjectId,
+        });
+        foreignExperimentId = created.id;
       });
-      expect(stillThere?.archivedAt).toBeNull();
-    } finally {
-      await prisma.experiment
-        .delete({ where: { id: foreignId, projectId: otherProjectId } })
-        .catch(() => {});
-      await prisma.project.delete({ where: { id: otherProjectId } }).catch(() => {});
-    }
+
+      /** @scenario An experiment from another project cannot be archived */
+      it("rejects with NOT_FOUND", async () => {
+        await expectTRPCError(
+          caller.experiments.deleteExperiment({
+            projectId: PROJECT_ID,
+            experimentId: foreignExperimentId,
+          }),
+          "NOT_FOUND",
+        );
+      });
+
+      it("leaves archivedAt null on the row in the other project", async () => {
+        // Make a fresh attempt before reading so this assertion is independent
+        // of test ordering.
+        await caller.experiments
+          .deleteExperiment({
+            projectId: PROJECT_ID,
+            experimentId: foreignExperimentId,
+          })
+          .catch(() => {});
+
+        const row = await prisma.experiment.findFirst({
+          where: {
+            id: foreignExperimentId,
+            projectId: foreignProjectId,
+          },
+        });
+        expect(row?.archivedAt).toBeNull();
+      });
+    });
   });
 });

--- a/langwatch/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/experiments.archive.integration.test.ts
@@ -462,4 +462,43 @@ describe("experiments.deleteExperiment", () => {
       });
     });
   });
+
+  describe("given an archived experiment", () => {
+    describe("when a stale client autosaves with the archived id", () => {
+      it("rejects with NOT_FOUND instead of mutating the archived row", async () => {
+        const slug = `${testNamespace}-stale-${nanoid(6)}`;
+        const { id } = await createExperiment({ slug });
+        await caller.experiments.deleteExperiment({
+          projectId: PROJECT_ID,
+          experimentId: id,
+        });
+
+        const archived = await prisma.experiment.findFirstOrThrow({
+          where: { id, projectId: PROJECT_ID },
+        });
+
+        await expectTRPCError(
+          caller.experiments.saveEvaluationsV3({
+            projectId: PROJECT_ID,
+            experimentId: id,
+            state: {
+              name: "Stale autosave",
+              datasets: [],
+              activeDatasetId: "dataset-1",
+              evaluators: [],
+              targets: [],
+            } as any,
+          }),
+          "NOT_FOUND",
+        );
+
+        const after = await prisma.experiment.findFirstOrThrow({
+          where: { id, projectId: PROJECT_ID },
+        });
+        expect(after.slug).toBe(archived.slug);
+        expect(after.archivedAt?.getTime()).toBe(archived.archivedAt?.getTime());
+        expect(after.workbenchState).toEqual(archived.workbenchState);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/api/routers/batchRecord.ts
+++ b/langwatch/src/server/api/routers/batchRecord.ts
@@ -35,12 +35,11 @@ export const batchRecordRouter = createTRPCRouter({
       const { projectId, experimentSlug } = input;
       const prisma = ctx.prisma;
 
-      const experiment = await prisma.experiment.findUnique({
+      const experiment = await prisma.experiment.findFirst({
         where: {
-          projectId_slug: {
-            projectId,
-            slug: experimentSlug,
-          },
+          projectId,
+          slug: experimentSlug,
+          archivedAt: null,
         },
       });
 

--- a/langwatch/src/server/api/routers/batchRecord.ts
+++ b/langwatch/src/server/api/routers/batchRecord.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
+import { ExperimentService } from "../../experiments/experiment.service";
 import { checkProjectPermission } from "../rbac";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
@@ -35,12 +36,9 @@ export const batchRecordRouter = createTRPCRouter({
       const { projectId, experimentSlug } = input;
       const prisma = ctx.prisma;
 
-      const experiment = await prisma.experiment.findFirst({
-        where: {
-          projectId,
-          slug: experimentSlug,
-          archivedAt: null,
-        },
+      const experiment = await ExperimentService.create(prisma).findBySlug({
+        projectId,
+        slug: experimentSlug,
       });
 
       if (!experiment) {

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -26,6 +26,7 @@ import { slugify } from "../../../utils/slugify";
 import { coerceMonitorMappings } from "../../tracer/tracesMapping";
 import { DatasetService } from "../../datasets/dataset.service";
 import { prisma } from "../../db";
+import { ExperimentService } from "../../experiments/experiment.service";
 import { getApp } from "../../app-layer/app";
 import { DspyStepNotFoundError } from "../../app-layer/dspy-steps/errors";
 import { ExperimentRunService } from "../../experiments-v3/services/experiment-run.service";
@@ -97,12 +98,9 @@ export const experimentsRouter = createTRPCRouter({
       });
 
       if (input.experimentId) {
-        const currentExperiment = await prisma.experiment.findFirst({
-          where: {
-            id: input.experimentId,
-            projectId: input.projectId,
-            archivedAt: null,
-          },
+        const currentExperiment = await experimentService().findById({
+          projectId: input.projectId,
+          id: input.experimentId,
         });
 
         if (!currentExperiment) {
@@ -213,11 +211,9 @@ export const experimentsRouter = createTRPCRouter({
       });
 
       // For some reason, prisma upsert sometimes return not an experiment but {count: 0}, so we need to refetch it
-      const updatedExperiment = await prisma.experiment.findUnique({
-        where: {
-          id: experimentId,
-          projectId: input.projectId,
-        },
+      const updatedExperiment = await experimentService().findById({
+        projectId: input.projectId,
+        id: experimentId,
       });
 
       if (!updatedExperiment) {
@@ -247,15 +243,11 @@ export const experimentsRouter = createTRPCRouter({
       // Check if experiment actually exists in DB to determine if this is a create or update.
       // Archived rows are treated as non-existent for update purposes (slug was
       // renamed on archive so there's no collision either way).
-      const existing = await prisma.experiment.findFirst({
-        where: {
-          id: experimentId,
-          projectId: input.projectId,
-          archivedAt: null,
-        },
-        select: { slug: true },
+      const existingSlug = await experiments.getExistingSlugForUpsert({
+        projectId: input.projectId,
+        id: experimentId,
       });
-      const isNewExperiment = !existing;
+      const isNewExperiment = existingSlug === null;
 
       // Enforce experiment limit only when creating new experiments
       if (isNewExperiment) {
@@ -278,7 +270,7 @@ export const experimentsRouter = createTRPCRouter({
           projectId: input.projectId,
         });
       } else {
-        slug = existing.slug;
+        slug = existingSlug;
       }
 
       // Convert to plain JSON for Prisma storage
@@ -307,11 +299,9 @@ export const experimentsRouter = createTRPCRouter({
           }),
       });
 
-      const updatedExperiment = await prisma.experiment.findUnique({
-        where: {
-          id: experimentId,
-          projectId: input.projectId,
-        },
+      const updatedExperiment = await experiments.findById({
+        projectId: input.projectId,
+        id: experimentId,
       });
 
       if (!updatedExperiment) {
@@ -364,19 +354,9 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:create"))
     .mutation(async ({ input }) => {
-      const experiment = await prisma.experiment.findFirst({
-        where: {
-          id: input.experimentId,
-          projectId: input.projectId,
-          archivedAt: null,
-        },
-        include: {
-          workflow: {
-            include: {
-              currentVersion: true,
-            },
-          },
-        },
+      const experiment = await experimentService().findByIdWithWorkflowCurrentVersion({
+        projectId: input.projectId,
+        id: input.experimentId,
       });
 
       if (!experiment) {
@@ -526,41 +506,23 @@ export const experimentsRouter = createTRPCRouter({
       const pageOffset = input.pageOffset ?? 0;
       const pageSize = input.pageSize ?? 25;
 
-      const baseWhereClause: Prisma.ExperimentWhereInput = {
-        projectId: input.projectId,
-        archivedAt: null,
-      };
-
       // Helper to check if an experiment is a real_time evaluation (old wizard)
       const isRealTimeEvaluation = (workbenchState: JsonValue | null) => {
         if (!workbenchState || typeof workbenchState !== "object") return false;
         return (workbenchState as Record<string, unknown>).task === "real_time";
       };
 
-      // Get total count for pagination (excluding real_time evaluations)
-      const allExperimentsCount = await prisma.experiment.findMany({
-        where: baseWhereClause,
-        select: { workbenchState: true },
-      });
-      const totalHits = allExperimentsCount.filter(
+      // Fetch every active experiment with its workflow+currentVersion join,
+      // then filter/paginate in JS. Prisma JSON-path filtering is unreliable
+      // for the `task` field inside `workbenchState`, so the count and the
+      // page slice both run off the same in-memory array.
+      const allExperiments =
+        await experimentService().listForEvaluationsBoard({
+          projectId: input.projectId,
+        });
+      const totalHits = allExperiments.filter(
         (e) => !isRealTimeEvaluation(e.workbenchState),
       ).length;
-
-      // Fetch all experiments and filter/paginate in JS
-      // (Prisma JSON path filtering is unreliable for nested fields)
-      const allExperiments = await prisma.experiment.findMany({
-        where: baseWhereClause,
-        include: {
-          workflow: {
-            include: {
-              currentVersion: true,
-            },
-          },
-        },
-        orderBy: {
-          updatedAt: "desc",
-        },
-      });
 
       // Filter out real_time evaluations and apply pagination
       const experiments = allExperiments
@@ -838,68 +800,9 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:delete"))
     .mutation(async ({ input }) => {
-      return await prisma.$transaction(async (tx) => {
-        const experiment = await tx.experiment.findUnique({
-          where: {
-            id: input.experimentId,
-            projectId: input.projectId,
-          },
-        });
-
-        if (!experiment) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Experiment not found",
-          });
-        }
-
-        // Rename the slug on archive so a future experiment can reuse the
-        // original slug; the unique [projectId, slug] index would otherwise
-        // collide. Mirrors the pattern in dataset.ts deleteById.
-        const archivedSlug = `${experiment.slug}-archived-${nanoid()}`;
-
-        // Race-safe idempotency: gate the archive write on archivedAt: null
-        // INSIDE the transaction so two concurrent clicks cannot both win
-        // the check. If updateMany.count === 0 the row was already archived
-        // by a sibling request, so we return success without re-running the
-        // cascade (the winning request already did it).
-        const result = await tx.experiment.updateMany({
-          where: {
-            id: input.experimentId,
-            projectId: input.projectId,
-            archivedAt: null,
-          },
-          data: { archivedAt: new Date(), slug: archivedSlug },
-        });
-
-        if (result.count === 0) {
-          return { success: true };
-        }
-
-        if (experiment.workflowId) {
-          await tx.workflow.update({
-            where: {
-              id: experiment.workflowId,
-              projectId: input.projectId,
-            },
-            data: { archivedAt: new Date() },
-          });
-        }
-
-        // Monitor is a small relational row with no ClickHouse / S3 footprint
-        // and the Monitor model has no archivedAt column, so the original
-        // hard-delete behaviour stays. The cost-driving path was the
-        // ClickHouse delete on experiment_runs / experiment_run_items /
-        // dspy_steps, which is what this PR removes.
-        await tx.monitor.deleteMany({
-          where: {
-            experimentId: input.experimentId,
-            projectId: input.projectId,
-          },
-        });
-
-        return { success: true };
-      });
+      return await experimentService()
+        .archive({ projectId: input.projectId, id: input.experimentId })
+        .catch(mapExperimentError);
     }),
 
   copy: protectedProcedure
@@ -931,20 +834,11 @@ export const experimentsRouter = createTRPCRouter({
         });
       }
 
-      const experiment = await ctx.prisma.experiment.findFirst({
-        where: {
-          id: input.experimentId,
+      const experiment = await ExperimentService.create(ctx.prisma)
+        .findByIdWithWorkflowLatestVersion({
           projectId: input.sourceProjectId,
-          archivedAt: null,
-        },
-        include: {
-          workflow: {
-            include: {
-              latestVersion: true,
-            },
-          },
-        },
-      });
+          id: input.experimentId,
+        });
 
       if (!experiment) {
         throw new TRPCError({

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -240,13 +240,16 @@ export const experimentsRouter = createTRPCRouter({
       const experimentId =
         input.experimentId ?? generate(KSUID_RESOURCES.EXPERIMENT).toString();
 
-      // Check if experiment actually exists in DB to determine if this is a create or update.
-      // Archived rows are treated as non-existent for update purposes (slug was
-      // renamed on archive so there's no collision either way).
-      const existingSlug = await experiments.getExistingSlugForUpsert({
-        projectId: input.projectId,
-        id: experimentId,
-      });
+      // Check if experiment actually exists in DB to determine if this is a
+      // create or update. The service rejects archived rows with NOT_FOUND so
+      // a stale client autosaving an archived experiment cannot silently
+      // resurrect or mutate it through `prisma.upsert`.
+      const existingSlug = await experiments
+        .getExistingSlugForUpsert({
+          projectId: input.projectId,
+          id: experimentId,
+        })
+        .catch(mapExperimentError);
       const isNewExperiment = existingSlug === null;
 
       // Enforce experiment limit only when creating new experiments

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -1,4 +1,3 @@
-import type { QueryDslBoolQuery } from "@elastic/elasticsearch/lib/api/types";
 import { generate } from "@langwatch/ksuid";
 import {
   EvaluationExecutionMode,
@@ -25,13 +24,8 @@ import {
 } from "../../../optimization_studio/types/dsl";
 import { slugify } from "../../../utils/slugify";
 import { coerceMonitorMappings } from "../../tracer/tracesMapping";
-import { getClickHouseClientForProject } from "../../clickhouse/clickhouseClient";
 import { DatasetService } from "../../datasets/dataset.service";
 import { prisma } from "../../db";
-import {
-  BATCH_EVALUATION_INDEX,
-  esClient,
-} from "../../elasticsearch";
 import { getApp } from "../../app-layer/app";
 import { DspyStepNotFoundError } from "../../app-layer/dspy-steps/errors";
 import { ExperimentRunService } from "../../experiments-v3/services/experiment-run.service";
@@ -103,10 +97,11 @@ export const experimentsRouter = createTRPCRouter({
       });
 
       if (input.experimentId) {
-        const currentExperiment = await prisma.experiment.findUnique({
+        const currentExperiment = await prisma.experiment.findFirst({
           where: {
             id: input.experimentId,
             projectId: input.projectId,
+            archivedAt: null,
           },
         });
 
@@ -249,9 +244,15 @@ export const experimentsRouter = createTRPCRouter({
       const experimentId =
         input.experimentId ?? generate(KSUID_RESOURCES.EXPERIMENT).toString();
 
-      // Check if experiment actually exists in DB to determine if this is a create or update
-      const existing = await prisma.experiment.findUnique({
-        where: { id: experimentId, projectId: input.projectId },
+      // Check if experiment actually exists in DB to determine if this is a create or update.
+      // Archived rows are treated as non-existent for update purposes (slug was
+      // renamed on archive so there's no collision either way).
+      const existing = await prisma.experiment.findFirst({
+        where: {
+          id: experimentId,
+          projectId: input.projectId,
+          archivedAt: null,
+        },
         select: { slug: true },
       });
       const isNewExperiment = !existing;
@@ -363,10 +364,11 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:create"))
     .mutation(async ({ input }) => {
-      const experiment = await prisma.experiment.findUnique({
+      const experiment = await prisma.experiment.findFirst({
         where: {
           id: input.experimentId,
           projectId: input.projectId,
+          archivedAt: null,
         },
         include: {
           workflow: {
@@ -526,6 +528,7 @@ export const experimentsRouter = createTRPCRouter({
 
       const baseWhereClause: Prisma.ExperimentWhereInput = {
         projectId: input.projectId,
+        archivedAt: null,
       };
 
       // Helper to check if an experiment is a real_time evaluation (old wizard)
@@ -803,6 +806,29 @@ export const experimentsRouter = createTRPCRouter({
       });
     }),
 
+  /**
+   * Archives an experiment (and cascades archive to its workflow + monitor).
+   *
+   * Previously this procedure hard-deleted the Postgres rows AND issued
+   * DELETE FROM on `experiment_runs`, `experiment_run_items`, `dspy_steps`
+   * in ClickHouse plus a deleteByQuery against the Elasticsearch
+   * `batch_evaluation` index. Every such delete writes a lightweight-delete
+   * mask onto every cold-tier S3 part containing matching rows, then the
+   * background merges rewrite those parts to actually purge. At ~3-45 user
+   * deletes/day across prod, that workload was costing ~$200/mo in S3
+   * requests alone and tripping AWS Cost Anomaly Detection on heavy days
+   * (e.g. May 27 2026: 42 deletes -> 14,725 part rewrites).
+   *
+   * The Experiment model now matches the pattern used everywhere else in
+   * this schema (Workflow, Monitor, Dataset, Evaluator, Agent, Project,
+   * Team, etc.): archive via `archivedAt`, hide from list queries, leave
+   * the historical data in place. Once retention TTL ships, archived rows
+   * age out of ClickHouse naturally without a per-click S3 burst.
+   *
+   * The tRPC name remains `deleteExperiment` so the UI does not need to
+   * change; the user-visible behaviour is identical (item disappears from
+   * the list) but the platform cost drops to zero per click.
+   */
   deleteExperiment: protectedProcedure
     .input(
       z.object({
@@ -812,7 +838,6 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:delete"))
     .mutation(async ({ input }) => {
-      // Verify the experiment exists and belongs to the project
       const experiment = await prisma.experiment.findUnique({
         where: {
           id: input.experimentId,
@@ -827,126 +852,49 @@ export const experimentsRouter = createTRPCRouter({
         });
       }
 
-      // Perform the Prisma deletion in a transaction to ensure consistency
+      // Idempotent: a duplicate click on an already-archived experiment is
+      // a no-op (we do not refresh the timestamp, to avoid spurious writes).
+      if (experiment.archivedAt) {
+        return { success: true };
+      }
+
+      const now = new Date();
+      // Rename the slug on archive so a future experiment can reuse the
+      // original slug; the unique [projectId, slug] index would otherwise
+      // collide. Mirrors the pattern in dataset.ts deleteById.
+      const archivedSlug = `${experiment.slug}-archived-${nanoid()}`;
+
       await prisma.$transaction(async (tx) => {
-        // Delete workflow versions if a workflow exists
+        await tx.experiment.update({
+          where: {
+            id: input.experimentId,
+            projectId: input.projectId,
+          },
+          data: { archivedAt: now, slug: archivedSlug },
+        });
+
         if (experiment.workflowId) {
-          // First, update the workflow to null out the reference fields
           await tx.workflow.update({
             where: {
               id: experiment.workflowId,
               projectId: input.projectId,
             },
-            data: {
-              currentVersionId: null,
-              latestVersionId: null,
-            },
-          });
-
-          // Then we update all workflow versions to null out the parent field
-          await tx.workflowVersion.updateMany({
-            where: {
-              workflowId: experiment.workflowId,
-              projectId: input.projectId,
-            },
-            data: {
-              parentId: null,
-            },
-          });
-
-          // Now we can safely delete the workflow versions
-          await tx.workflowVersion.deleteMany({
-            where: {
-              workflowId: experiment.workflowId,
-              projectId: input.projectId,
-            },
-          });
-
-          // Delete the workflow itself
-          await tx.workflow.delete({
-            where: {
-              id: experiment.workflowId,
-              projectId: input.projectId,
-            },
+            data: { archivedAt: now },
           });
         }
 
-        // Delete the monitor if it exists
-        const monitor = await tx.monitor.findFirst({
+        // Monitor is a small relational row with no ClickHouse / S3 footprint,
+        // and the Monitor model does not have an archivedAt column, so we
+        // keep the original hard-delete behaviour for it. The cost-driving
+        // path is the ClickHouse delete on experiment_runs / experiment_run_items
+        // / dspy_steps — that is what this PR removes.
+        await tx.monitor.deleteMany({
           where: {
             experimentId: input.experimentId,
             projectId: input.projectId,
           },
         });
-
-        if (monitor) {
-          await tx.monitor.delete({
-            where: {
-              experimentId: input.experimentId,
-              projectId: input.projectId,
-            },
-          });
-        }
-
-        // Finally, delete the experiment
-        await tx.experiment.delete({
-          where: {
-            id: input.experimentId,
-            projectId: input.projectId,
-          },
-        });
       });
-
-      // Best-effort cleanup of ES and CH data outside the transaction
-      // (these are not atomic with Prisma and should not cause rollback)
-      const esCleanup = esClient({ projectId: input.projectId }).then(async (client) => {
-        await client.deleteByQuery({
-          index: BATCH_EVALUATION_INDEX.alias,
-          body: {
-            query: {
-              bool: {
-                must: [
-                  { term: { experiment_id: input.experimentId } },
-                  { term: { project_id: input.projectId } },
-                ] as QueryDslBoolQuery["must"],
-              } as QueryDslBoolQuery,
-            },
-          },
-        });
-      }).catch((err) => {
-        console.error("Best-effort ES cleanup failed for experiment deletion", { experimentId: input.experimentId, err });
-      });
-
-      const chCleanup = Promise.resolve().then(async () => {
-        const chClient = await getClickHouseClientForProject(input.projectId);
-        if (!chClient) return;
-        await Promise.all([
-          chClient.command({
-            query: `DELETE FROM experiment_runs WHERE TenantId = {tenantId:String} AND ExperimentId = {experimentId:String}`,
-            query_params: {
-              tenantId: input.projectId,
-              experimentId: input.experimentId,
-            },
-          }),
-          chClient.command({
-            query: `DELETE FROM experiment_run_items WHERE TenantId = {tenantId:String} AND ExperimentId = {experimentId:String}`,
-            query_params: {
-              tenantId: input.projectId,
-              experimentId: input.experimentId,
-            },
-          }),
-        ]);
-      }).catch((err) => {
-        console.error("Best-effort CH cleanup failed for experiment deletion", { experimentId: input.experimentId, err });
-      });
-
-      const dspyCleanup = getApp().dspySteps.steps
-        .deleteByExperiment({ tenantId: input.projectId, experimentId: input.experimentId })
-        .catch((err) => {
-          console.error("Best-effort DSPy step cleanup failed for experiment deletion", { experimentId: input.experimentId, err });
-        });
-
-      await Promise.allSettled([esCleanup, chCleanup, dspyCleanup]);
 
       return { success: true };
     }),
@@ -980,10 +928,11 @@ export const experimentsRouter = createTRPCRouter({
         });
       }
 
-      const experiment = await ctx.prisma.experiment.findUnique({
+      const experiment = await ctx.prisma.experiment.findFirst({
         where: {
           id: input.experimentId,
           projectId: input.sourceProjectId,
+          archivedAt: null,
         },
         include: {
           workflow: {

--- a/langwatch/src/server/api/routers/experiments.ts
+++ b/langwatch/src/server/api/routers/experiments.ts
@@ -838,40 +838,43 @@ export const experimentsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("workflows:delete"))
     .mutation(async ({ input }) => {
-      const experiment = await prisma.experiment.findUnique({
-        where: {
-          id: input.experimentId,
-          projectId: input.projectId,
-        },
-      });
-
-      if (!experiment) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Experiment not found",
-        });
-      }
-
-      // Idempotent: a duplicate click on an already-archived experiment is
-      // a no-op (we do not refresh the timestamp, to avoid spurious writes).
-      if (experiment.archivedAt) {
-        return { success: true };
-      }
-
-      const now = new Date();
-      // Rename the slug on archive so a future experiment can reuse the
-      // original slug; the unique [projectId, slug] index would otherwise
-      // collide. Mirrors the pattern in dataset.ts deleteById.
-      const archivedSlug = `${experiment.slug}-archived-${nanoid()}`;
-
-      await prisma.$transaction(async (tx) => {
-        await tx.experiment.update({
+      return await prisma.$transaction(async (tx) => {
+        const experiment = await tx.experiment.findUnique({
           where: {
             id: input.experimentId,
             projectId: input.projectId,
           },
-          data: { archivedAt: now, slug: archivedSlug },
         });
+
+        if (!experiment) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Experiment not found",
+          });
+        }
+
+        // Rename the slug on archive so a future experiment can reuse the
+        // original slug; the unique [projectId, slug] index would otherwise
+        // collide. Mirrors the pattern in dataset.ts deleteById.
+        const archivedSlug = `${experiment.slug}-archived-${nanoid()}`;
+
+        // Race-safe idempotency: gate the archive write on archivedAt: null
+        // INSIDE the transaction so two concurrent clicks cannot both win
+        // the check. If updateMany.count === 0 the row was already archived
+        // by a sibling request, so we return success without re-running the
+        // cascade (the winning request already did it).
+        const result = await tx.experiment.updateMany({
+          where: {
+            id: input.experimentId,
+            projectId: input.projectId,
+            archivedAt: null,
+          },
+          data: { archivedAt: new Date(), slug: archivedSlug },
+        });
+
+        if (result.count === 0) {
+          return { success: true };
+        }
 
         if (experiment.workflowId) {
           await tx.workflow.update({
@@ -879,24 +882,24 @@ export const experimentsRouter = createTRPCRouter({
               id: experiment.workflowId,
               projectId: input.projectId,
             },
-            data: { archivedAt: now },
+            data: { archivedAt: new Date() },
           });
         }
 
-        // Monitor is a small relational row with no ClickHouse / S3 footprint,
-        // and the Monitor model does not have an archivedAt column, so we
-        // keep the original hard-delete behaviour for it. The cost-driving
-        // path is the ClickHouse delete on experiment_runs / experiment_run_items
-        // / dspy_steps — that is what this PR removes.
+        // Monitor is a small relational row with no ClickHouse / S3 footprint
+        // and the Monitor model has no archivedAt column, so the original
+        // hard-delete behaviour stays. The cost-driving path was the
+        // ClickHouse delete on experiment_runs / experiment_run_items /
+        // dspy_steps, which is what this PR removes.
         await tx.monitor.deleteMany({
           where: {
             experimentId: input.experimentId,
             projectId: input.projectId,
           },
         });
-      });
 
-      return { success: true };
+        return { success: true };
+      });
     }),
 
   copy: protectedProcedure

--- a/langwatch/src/server/experiments-v3/services/experiment-run.service.ts
+++ b/langwatch/src/server/experiments-v3/services/experiment-run.service.ts
@@ -131,6 +131,7 @@ export class ExperimentRunService {
           where: {
             projectId: params.projectId,
             slug: params.experimentSlug,
+            archivedAt: null,
           },
           select: { id: true, slug: true },
         });

--- a/langwatch/src/server/experiments-v3/services/experiment-run.service.ts
+++ b/langwatch/src/server/experiments-v3/services/experiment-run.service.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { getLangWatchTracer } from "langwatch";
 import { prisma as defaultPrisma } from "~/server/db";
+import { ExperimentService } from "~/server/experiments/experiment.service";
 import { ClickHouseExperimentRunService } from "./clickhouse-experiment-run.service";
 import { ElasticsearchExperimentRunService } from "./elasticsearch-experiment-run.service";
 import type {
@@ -127,13 +128,11 @@ export class ExperimentRunService {
         },
       },
       async (span) => {
-        const experiment = await this.prisma.experiment.findFirst({
-          where: {
-            projectId: params.projectId,
-            slug: params.experimentSlug,
-            archivedAt: null,
-          },
-          select: { id: true, slug: true },
+        const experiment = await ExperimentService.create(
+          this.prisma,
+        ).findIdBySlug({
+          projectId: params.projectId,
+          slug: params.experimentSlug,
         });
 
         if (!experiment) {

--- a/langwatch/src/server/experiments/experiment.repository.ts
+++ b/langwatch/src/server/experiments/experiment.repository.ts
@@ -13,7 +13,7 @@ export class ExperimentRepository {
   ): Promise<Experiment | null> {
     const client = options?.tx ?? this.prisma;
     return await client.experiment.findFirst({
-      where: { id: input.id, projectId: input.projectId },
+      where: { id: input.id, projectId: input.projectId, archivedAt: null },
     });
   }
 
@@ -23,7 +23,7 @@ export class ExperimentRepository {
   ): Promise<Experiment | null> {
     const client = options?.tx ?? this.prisma;
     return await client.experiment.findFirst({
-      where: { slug: input.slug, projectId: input.projectId },
+      where: { slug: input.slug, projectId: input.projectId, archivedAt: null },
     });
   }
 
@@ -33,7 +33,7 @@ export class ExperimentRepository {
   ): Promise<Experiment[]> {
     const client = options?.tx ?? this.prisma;
     return await client.experiment.findMany({
-      where: { projectId: input.projectId },
+      where: { projectId: input.projectId, archivedAt: null },
     });
   }
 
@@ -43,7 +43,7 @@ export class ExperimentRepository {
   ): Promise<Experiment[]> {
     const client = options?.tx ?? this.prisma;
     return await client.experiment.findMany({
-      where: { projectId: input.projectId },
+      where: { projectId: input.projectId, archivedAt: null },
       orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
       skip: input.skip,
       take: input.take,
@@ -56,7 +56,7 @@ export class ExperimentRepository {
   ): Promise<number> {
     const client = options?.tx ?? this.prisma;
     return await client.experiment.count({
-      where: { projectId: input.projectId },
+      where: { projectId: input.projectId, archivedAt: null },
     });
   }
 
@@ -81,6 +81,8 @@ export class ExperimentRepository {
 
   /**
    * Finds experiment names starting with "Draft" for draft name generation.
+   * Excludes archived rows so a freshly-archived "Draft 3" frees its number
+   * for the next draft.
    */
   async findDraftNames(input: {
     projectId: string;
@@ -90,6 +92,7 @@ export class ExperimentRepository {
       where: {
         projectId: input.projectId,
         name: { startsWith: "Draft" },
+        archivedAt: null,
       },
     });
   }
@@ -109,7 +112,7 @@ export class ExperimentRepository {
   ): Promise<Experiment | null> {
     const client = options?.tx ?? this.prisma;
     return await client.experiment.findFirst({
-      where: { projectId: input.projectId },
+      where: { projectId: input.projectId, archivedAt: null },
       orderBy: { createdAt: "desc" },
     });
   }

--- a/langwatch/src/server/experiments/experiment.repository.ts
+++ b/langwatch/src/server/experiments/experiment.repository.ts
@@ -209,6 +209,29 @@ export class ExperimentRepository {
     return await client.experiment.create({ data: input.data });
   }
 
+  /**
+   * Returns the row-existence status for `(id, projectId)` including
+   * archived rows. This is the only public helper that does not filter
+   * `archivedAt: null`, and it exists for one reason: the upsert path
+   * needs to refuse to mutate an archived row through `prisma.upsert`.
+   * Callers must not use this to surface archived rows to users.
+   */
+  async getRowStatusById(
+    input: { id: string; projectId: string },
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<
+    | { exists: false }
+    | { exists: true; archived: boolean; slug: string }
+  > {
+    const client = options?.tx ?? this.prisma;
+    const row = await client.experiment.findUnique({
+      where: { id: input.id, projectId: input.projectId },
+      select: { slug: true, archivedAt: true },
+    });
+    if (!row) return { exists: false };
+    return { exists: true, archived: row.archivedAt !== null, slug: row.slug };
+  }
+
   async updateById(
     input: {
       id: string;

--- a/langwatch/src/server/experiments/experiment.repository.ts
+++ b/langwatch/src/server/experiments/experiment.repository.ts
@@ -1,53 +1,111 @@
 import type { Experiment, Prisma, PrismaClient } from "@prisma/client";
+import { nanoid } from "nanoid";
 
 /**
  * Repository layer for experiment data access.
- * Single Responsibility: Database operations for experiments.
+ *
+ * Every read method in this repository enforces `archivedAt: null` and that
+ * is the only correct way to query Experiment in the codebase: route
+ * handlers, tRPC procedures and other services must go through this
+ * repository (typically via ExperimentService) and never call
+ * `prisma.experiment.findFirst` etc. directly. The archive predicate is a
+ * data-access concern and is intentionally not part of the public service
+ * contract.
+ *
+ * The only operations that may legitimately touch archived rows live in
+ * this file: the slug-prefix lookups used by slug deduplication (where we
+ * want collisions to include archived rows so the renamed slug does not
+ * accidentally clash) and the archive operation itself.
  */
 export class ExperimentRepository {
   constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Internal helper: merge the archive predicate into a caller-supplied
+   * where clause. Always returns a new object so callers cannot inadvertently
+   * mutate the predicate later.
+   */
+  private active(
+    where: Prisma.ExperimentWhereInput,
+  ): Prisma.ExperimentWhereInput {
+    return { ...where, archivedAt: null };
+  }
+
+  /**
+   * Generic find for one active experiment. Pass any Prisma
+   * `findFirst`-shaped args (where / include / select / orderBy) and the
+   * repository will merge `archivedAt: null` into the where clause. Use
+   * this when one of the typed helpers does not match exactly.
+   */
+  async findFirstActive<A extends Prisma.ExperimentFindFirstArgs>(
+    args: A,
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Prisma.ExperimentGetPayload<A> | null> {
+    const client = options?.tx ?? this.prisma;
+    return (await client.experiment.findFirst({
+      ...args,
+      where: this.active(args.where ?? {}),
+    })) as Prisma.ExperimentGetPayload<A> | null;
+  }
+
+  /**
+   * Generic findMany for active experiments. Same args as Prisma's
+   * `findMany`, with `archivedAt: null` merged into the where clause.
+   */
+  async findManyActive<A extends Prisma.ExperimentFindManyArgs>(
+    args: A,
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Prisma.ExperimentGetPayload<A>[]> {
+    const client = options?.tx ?? this.prisma;
+    return (await client.experiment.findMany({
+      ...args,
+      where: this.active(args.where ?? {}),
+    })) as Prisma.ExperimentGetPayload<A>[];
+  }
 
   async findById(
     input: { id: string; projectId: string },
     options?: { tx?: Prisma.TransactionClient },
   ): Promise<Experiment | null> {
-    const client = options?.tx ?? this.prisma;
-    return await client.experiment.findFirst({
-      where: { id: input.id, projectId: input.projectId, archivedAt: null },
-    });
+    return this.findFirstActive(
+      { where: { id: input.id, projectId: input.projectId } },
+      options,
+    );
   }
 
   async findBySlug(
     input: { slug: string; projectId: string },
     options?: { tx?: Prisma.TransactionClient },
   ): Promise<Experiment | null> {
-    const client = options?.tx ?? this.prisma;
-    return await client.experiment.findFirst({
-      where: { slug: input.slug, projectId: input.projectId, archivedAt: null },
-    });
+    return this.findFirstActive(
+      { where: { slug: input.slug, projectId: input.projectId } },
+      options,
+    );
   }
 
   async findAll(
     input: { projectId: string },
     options?: { tx?: Prisma.TransactionClient },
   ): Promise<Experiment[]> {
-    const client = options?.tx ?? this.prisma;
-    return await client.experiment.findMany({
-      where: { projectId: input.projectId, archivedAt: null },
-    });
+    return this.findManyActive(
+      { where: { projectId: input.projectId } },
+      options,
+    );
   }
 
   async findPage(
     input: { projectId: string; skip: number; take: number },
     options?: { tx?: Prisma.TransactionClient },
   ): Promise<Experiment[]> {
-    const client = options?.tx ?? this.prisma;
-    return await client.experiment.findMany({
-      where: { projectId: input.projectId, archivedAt: null },
-      orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
-      skip: input.skip,
-      take: input.take,
-    });
+    return this.findManyActive(
+      {
+        where: { projectId: input.projectId },
+        orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
+        skip: input.skip,
+        take: input.take,
+      },
+      options,
+    );
   }
 
   async countByProject(
@@ -56,13 +114,14 @@ export class ExperimentRepository {
   ): Promise<number> {
     const client = options?.tx ?? this.prisma;
     return await client.experiment.count({
-      where: { projectId: input.projectId, archivedAt: null },
+      where: this.active({ projectId: input.projectId }),
     });
   }
 
   /**
-   * Finds slugs matching a prefix, used by slug deduplication.
-   * Returns only slug strings for efficient in-memory filtering.
+   * Finds slugs matching a prefix, used by slug deduplication. Intentionally
+   * INCLUDES archived rows so the slug we pick after an archive does not
+   * later collide with the renamed `<slug>-archived-<nanoid>` row.
    */
   async findBySlugPrefix(input: {
     projectId: string;
@@ -89,14 +148,18 @@ export class ExperimentRepository {
   }): Promise<Array<{ name: string | null; slug: string }>> {
     return await this.prisma.experiment.findMany({
       select: { name: true, slug: true },
-      where: {
+      where: this.active({
         projectId: input.projectId,
         name: { startsWith: "Draft" },
-        archivedAt: null,
-      },
+      }),
     });
   }
 
+  /**
+   * Returns every slug for a project including archived rows. Used by
+   * draft-name generation to avoid producing a slug that collides with an
+   * archived row's renamed slug.
+   */
   async findAllSlugs(input: {
     projectId: string;
   }): Promise<Array<{ slug: string }>> {
@@ -110,11 +173,13 @@ export class ExperimentRepository {
     input: { projectId: string },
     options?: { tx?: Prisma.TransactionClient },
   ): Promise<Experiment | null> {
-    const client = options?.tx ?? this.prisma;
-    return await client.experiment.findFirst({
-      where: { projectId: input.projectId, archivedAt: null },
-      orderBy: { createdAt: "desc" },
-    });
+    return this.findFirstActive(
+      {
+        where: { projectId: input.projectId },
+        orderBy: { createdAt: "desc" },
+      },
+      options,
+    );
   }
 
   async upsert(
@@ -142,5 +207,93 @@ export class ExperimentRepository {
   ): Promise<Experiment> {
     const client = options?.tx ?? this.prisma;
     return await client.experiment.create({ data: input.data });
+  }
+
+  async updateById(
+    input: {
+      id: string;
+      projectId: string;
+      data: Prisma.ExperimentUpdateInput;
+    },
+    options?: { tx?: Prisma.TransactionClient },
+  ): Promise<Experiment> {
+    const client = options?.tx ?? this.prisma;
+    return await client.experiment.update({
+      where: { id: input.id, projectId: input.projectId },
+      data: input.data,
+    });
+  }
+
+  /**
+   * Archives an experiment by id, atomically.
+   *
+   * Returns a discriminated kind:
+   *   - `archived`        : this call performed the archive
+   *   - `already-archived`: the row exists but `archivedAt` was already set
+   *                         (idempotent no-op)
+   *   - `not-found`       : no row matches (id, projectId)
+   *
+   * The race-safe contract is that two concurrent callers cannot both
+   * observe `archived` for the same id.
+   *
+   * Cascade behaviour:
+   *   - The owning Workflow (if any) is also archived (it has its own
+   *     `archivedAt`).
+   *   - The owning Monitor (if any) is hard-deleted (the Monitor model
+   *     has no `archivedAt` column and is a tiny relational row with no
+   *     ClickHouse / S3 footprint).
+   *
+   * The original slug is renamed to `<slug>-archived-<nanoid>` so the
+   * unique `[projectId, slug]` index frees the original slug for a fresh
+   * experiment. Mirrors the pattern in dataset.ts deleteById.
+   */
+  async archiveById(input: {
+    id: string;
+    projectId: string;
+  }): Promise<{ kind: "archived" | "already-archived" | "not-found" }> {
+    return await this.prisma.$transaction(async (tx) => {
+      const experiment = await tx.experiment.findUnique({
+        where: { id: input.id, projectId: input.projectId },
+        select: { slug: true, workflowId: true, archivedAt: true },
+      });
+
+      if (!experiment) {
+        return { kind: "not-found" as const };
+      }
+
+      const archivedSlug = `${experiment.slug}-archived-${nanoid()}`;
+
+      const result = await tx.experiment.updateMany({
+        where: {
+          id: input.id,
+          projectId: input.projectId,
+          archivedAt: null,
+        },
+        data: { archivedAt: new Date(), slug: archivedSlug },
+      });
+
+      if (result.count === 0) {
+        return { kind: "already-archived" as const };
+      }
+
+      if (experiment.workflowId) {
+        await tx.workflow.update({
+          where: {
+            id: experiment.workflowId,
+            projectId: input.projectId,
+          },
+          data: { archivedAt: new Date() },
+        });
+      }
+
+      await tx.monitor.deleteMany({
+        where: {
+          experimentId: input.id,
+          projectId: input.projectId,
+        },
+      });
+
+      return { kind: "archived" as const };
+    });
   }
 }

--- a/langwatch/src/server/experiments/experiment.service.ts
+++ b/langwatch/src/server/experiments/experiment.service.ts
@@ -1,4 +1,9 @@
-import type { Experiment, PrismaClient } from "@prisma/client";
+import type {
+  Experiment,
+  ExperimentType,
+  Prisma,
+  PrismaClient,
+} from "@prisma/client";
 import { nanoid } from "nanoid";
 import { slugify } from "../../utils/slugify";
 import { isUniqueConstraintError } from "../utils/prismaErrors";
@@ -79,6 +84,213 @@ export class ExperimentService {
     projectId: string;
   }): Promise<Experiment | null> {
     return this.repository.findLatest({ projectId });
+  }
+
+  /**
+   * Returns the experiment with the given id if it is live, otherwise null.
+   * Use this for tolerant lookups (the caller decides how to react to null).
+   * For lookups that should throw on miss, use `getById`.
+   */
+  async findById({
+    projectId,
+    id,
+  }: {
+    projectId: string;
+    id: string;
+  }): Promise<Experiment | null> {
+    return this.repository.findById({ id, projectId });
+  }
+
+  /**
+   * Returns the experiment with the given slug if it is live, otherwise null.
+   */
+  async findBySlug({
+    projectId,
+    slug,
+  }: {
+    projectId: string;
+    slug: string;
+  }): Promise<Experiment | null> {
+    return this.repository.findBySlug({ slug, projectId });
+  }
+
+  /**
+   * Returns the experiment with the given slug and type if it is live,
+   * otherwise null. The EVALUATIONS_V3 routes use this to refuse to operate
+   * on rows of the wrong type.
+   */
+  async findBySlugAndType({
+    projectId,
+    slug,
+    type,
+  }: {
+    projectId: string;
+    slug: string;
+    type: ExperimentType;
+  }): Promise<Experiment | null> {
+    return this.repository.findFirstActive({
+      where: { projectId, slug, type },
+    });
+  }
+
+  /**
+   * Returns `{ id, slug }` for an active experiment, or null. The execution
+   * service needs the bare id for ClickHouse keying without paying for the
+   * rest of the row.
+   */
+  async findIdBySlug({
+    projectId,
+    slug,
+  }: {
+    projectId: string;
+    slug: string;
+  }): Promise<{ id: string; slug: string } | null> {
+    return this.repository.findFirstActive({
+      where: { projectId, slug },
+      select: { id: true, slug: true },
+    });
+  }
+
+  /**
+   * Returns true when an active experiment exists for `(id, projectId)`.
+   * The routes use this to refuse to serve results once the owning
+   * experiment is archived, without paying for the full row.
+   */
+  async isActive({
+    projectId,
+    id,
+  }: {
+    projectId: string;
+    id: string;
+  }): Promise<boolean> {
+    const row = await this.repository.findFirstActive({
+      where: { projectId, id },
+      select: { id: true },
+    });
+    return row !== null;
+  }
+
+  /**
+   * Returns the experiment by id with its Workflow joined (no version),
+   * or null. Use when the caller just needs to confirm a workflow link
+   * exists without paying for a version blob.
+   */
+  async findByIdWithWorkflow({
+    projectId,
+    id,
+  }: {
+    projectId: string;
+    id: string;
+  }): Promise<Prisma.ExperimentGetPayload<{
+    include: { workflow: true };
+  }> | null> {
+    return this.repository.findFirstActive({
+      where: { id, projectId },
+      include: { workflow: true },
+    });
+  }
+
+  /**
+   * Returns the experiment by id with its Workflow + `currentVersion`
+   * joined, or null. Used by the saveAsMonitor flow.
+   */
+  async findByIdWithWorkflowCurrentVersion({
+    projectId,
+    id,
+  }: {
+    projectId: string;
+    id: string;
+  }): Promise<Prisma.ExperimentGetPayload<{
+    include: { workflow: { include: { currentVersion: true } } };
+  }> | null> {
+    return this.repository.findFirstActive({
+      where: { id, projectId },
+      include: { workflow: { include: { currentVersion: true } } },
+    });
+  }
+
+  /**
+   * Returns the experiment by id with its Workflow + `latestVersion`
+   * joined, or null. Used by the copy-experiment flow (which needs the
+   * latest DSL to clone).
+   */
+  async findByIdWithWorkflowLatestVersion({
+    projectId,
+    id,
+  }: {
+    projectId: string;
+    id: string;
+  }): Promise<Prisma.ExperimentGetPayload<{
+    include: { workflow: { include: { latestVersion: true } } };
+  }> | null> {
+    return this.repository.findFirstActive({
+      where: { id, projectId },
+      include: { workflow: { include: { latestVersion: true } } },
+    });
+  }
+
+  /**
+   * Returns the existing slug for an experiment that the caller is about to
+   * upsert, or null if there is no active row yet. Active rows mean the
+   * caller is doing an update; null means a create.
+   */
+  async getExistingSlugForUpsert({
+    projectId,
+    id,
+  }: {
+    projectId: string;
+    id: string;
+  }): Promise<string | null> {
+    const row = await this.repository.findFirstActive({
+      where: { id, projectId },
+      select: { slug: true },
+    });
+    return row?.slug ?? null;
+  }
+
+  /**
+   * Returns the full project-wide list (with workflow+currentVersion
+   * joined) and the total count, used by the evaluations list UI. Real-time
+   * filtering is left to the caller because the discriminant lives in a
+   * JSON column.
+   */
+  async listForEvaluationsBoard({
+    projectId,
+  }: {
+    projectId: string;
+  }): Promise<
+    Prisma.ExperimentGetPayload<{
+      include: { workflow: { include: { currentVersion: true } } };
+    }>[]
+  > {
+    return this.repository.findManyActive({
+      where: { projectId },
+      include: {
+        workflow: {
+          include: { currentVersion: true },
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+    });
+  }
+
+  /**
+   * Archives an experiment by id. Throws ExperimentNotFoundError when no
+   * active or archived row matches. Returns `{ success: true }` for both
+   * a successful archive and an idempotent no-op (already archived).
+   */
+  async archive({
+    projectId,
+    id,
+  }: {
+    projectId: string;
+    id: string;
+  }): Promise<{ success: true }> {
+    const result = await this.repository.archiveById({ id, projectId });
+    if (result.kind === "not-found") {
+      throw new ExperimentNotFoundError(id);
+    }
+    return { success: true };
   }
 
   /**

--- a/langwatch/src/server/experiments/experiment.service.ts
+++ b/langwatch/src/server/experiments/experiment.service.ts
@@ -231,8 +231,13 @@ export class ExperimentService {
 
   /**
    * Returns the existing slug for an experiment that the caller is about to
-   * upsert, or null if there is no active row yet. Active rows mean the
-   * caller is doing an update; null means a create.
+   * upsert, or null if no row exists yet (active or archived).
+   *
+   * Throws `ExperimentNotFoundError` when an archived row matches the id:
+   * we cannot let `prisma.experiment.upsert` reach the `update` branch on
+   * an archived row, because that would silently resurrect or mutate an
+   * archived experiment. From the user's perspective the row is gone,
+   * which is exactly what `NOT_FOUND` means.
    */
   async getExistingSlugForUpsert({
     projectId,
@@ -241,11 +246,10 @@ export class ExperimentService {
     projectId: string;
     id: string;
   }): Promise<string | null> {
-    const row = await this.repository.findFirstActive({
-      where: { id, projectId },
-      select: { slug: true },
-    });
-    return row?.slug ?? null;
+    const status = await this.repository.getRowStatusById({ id, projectId });
+    if (!status.exists) return null;
+    if (status.archived) throw new ExperimentNotFoundError(id);
+    return status.slug;
   }
 
   /**

--- a/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/license-enforcement.repository.unit.test.ts
@@ -654,6 +654,7 @@ describe("LicenseEnforcementRepository", () => {
       expect(mockPrisma.experiment.count).toHaveBeenCalledWith({
         where: {
           projectId: { in: ["proj-1", "proj-2"] },
+          archivedAt: null,
           NOT: {
             workbenchState: {
               path: ["task"],
@@ -710,6 +711,14 @@ describe("LicenseEnforcementRepository", () => {
       await repository.getAgentCount(organizationId);
 
       const call = mockPrisma.agent.count.mock.calls[0]?.[0];
+      expect(call?.where).toHaveProperty("archivedAt", null);
+    });
+
+    it("experiment query excludes archived experiments", async () => {
+      mockPrisma.project.findMany.mockResolvedValue([{ id: "proj-1" }]);
+      await repository.getExperimentCount(organizationId);
+
+      const call = mockPrisma.experiment.count.mock.calls[0]?.[0];
       expect(call?.where).toHaveProperty("archivedAt", null);
     });
   });

--- a/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
+++ b/langwatch/src/server/license-enforcement/license-enforcement.repository.ts
@@ -376,6 +376,7 @@ export class LicenseEnforcementRepository
     return this.prisma.experiment.count({
       where: {
         projectId: { in: projectIds },
+        archivedAt: null,
         NOT: {
           workbenchState: {
             path: ["task"],

--- a/langwatch/src/server/routes/__tests__/experiments-results-archived.test.ts
+++ b/langwatch/src/server/routes/__tests__/experiments-results-archived.test.ts
@@ -140,3 +140,67 @@ describe("GET /api/experiments/runs/:runId/results archive visibility", () => {
     });
   });
 });
+
+describe("GET /api/experiments/runs/:runId archive visibility", () => {
+  beforeEach(() => {
+    getRunState.mockReset();
+    findFirst.mockReset();
+    getRun.mockReset();
+  });
+
+  describe("given a fresh Redis-cached run whose owning experiment was just archived", () => {
+    /** @scenario Archived experiments are hidden from the standard list query */
+    it("returns 404 instead of leaking the cached run status", async () => {
+      getRunState.mockResolvedValue({
+        runId: "run_status_x",
+        projectId: "project_MINE",
+        experimentId: "experiment_ARCHIVED",
+        experimentSlug: "x-archived-abc",
+        status: "completed",
+        progress: 10,
+        total: 10,
+        startedAt: 1,
+        finishedAt: 2,
+        summary: { ok: true },
+      });
+      findFirst.mockResolvedValue(null);
+
+      const res = await get("/api/experiments/runs/run_status_x");
+
+      expect(res.status).toBe(404);
+      expect(findFirst).toHaveBeenCalledWith({
+        where: {
+          id: "experiment_ARCHIVED",
+          projectId: "project_MINE",
+          archivedAt: null,
+        },
+        select: { id: true },
+      });
+    });
+  });
+
+  describe("given a fresh Redis-cached run whose experiment is still live", () => {
+    it("returns the cached run status", async () => {
+      getRunState.mockResolvedValue({
+        runId: "run_status_y",
+        projectId: "project_MINE",
+        experimentId: "experiment_LIVE",
+        experimentSlug: "y-live",
+        status: "completed",
+        progress: 5,
+        total: 5,
+        startedAt: 1,
+        finishedAt: 2,
+        summary: { ok: true },
+      });
+      findFirst.mockResolvedValue({ id: "experiment_LIVE" });
+
+      const res = await get("/api/experiments/runs/run_status_y");
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.runId).toBe("run_status_y");
+      expect(body.status).toBe("completed");
+    });
+  });
+});

--- a/langwatch/src/server/routes/__tests__/experiments-results-archived.test.ts
+++ b/langwatch/src/server/routes/__tests__/experiments-results-archived.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment node
+ *
+ * @see specs/experiments-v3/experiment-archive.feature
+ *
+ * Regression guard for the fresh-run-state archive bug. When the run state
+ * for an archived experiment is still warm in Redis (within the 24h TTL),
+ * GET /runs/:runId/results used to skip the archivedAt: null filter because
+ * it short-circuited on experimentIdFromState. That meant archive
+ * visibility silently depended on run age: same archived experiment, fresh
+ * runs returned ClickHouse data, older runs returned 404 through the
+ * slug-based fallback. This test pins the consistent behaviour: archived
+ * experiments are not reachable regardless of which path resolves the id.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: vi.fn().mockResolvedValue({ user: { id: "user_1" } }),
+}));
+
+vi.mock("~/server/api/rbac", async (importActual) => {
+  const actual = await importActual<typeof import("~/server/api/rbac")>();
+  return { ...actual, hasProjectPermission: vi.fn().mockResolvedValue(true) };
+});
+
+vi.mock("~/server/license-enforcement", async (importActual) => {
+  const actual =
+    await importActual<typeof import("~/server/license-enforcement")>();
+  return { ...actual, enforceLicenseLimit: vi.fn() };
+});
+
+const getRunState = vi.fn();
+vi.mock("~/server/experiments-v3/execution/runStateManager", () => ({
+  runStateManager: {
+    getRunState: (...args: unknown[]) => getRunState(...args),
+  },
+}));
+
+const findFirst = vi.fn();
+vi.mock("~/server/db", () => ({
+  prisma: {
+    experiment: { findFirst: (...args: unknown[]) => findFirst(...args) },
+  },
+}));
+
+const getRun = vi.fn();
+vi.mock("~/server/experiments-v3/services/experiment-run.service", () => ({
+  ExperimentRunService: {
+    create: () => ({
+      getRun: (...args: unknown[]) => getRun(...args),
+    }),
+  },
+}));
+
+const fakeProject = { id: "project_MINE", apiKey: "key_MINE" };
+const resolve = vi.fn().mockResolvedValue({
+  type: "apiKey",
+  apiKeyId: "ak_test",
+  project: fakeProject,
+});
+const markUsed = vi.fn();
+vi.mock("~/server/api-key/token-resolver", () => ({
+  TokenResolver: {
+    create: () => ({
+      resolve: (...args: unknown[]) => resolve(...args),
+      markUsed: (...args: unknown[]) => markUsed(...args),
+    }),
+  },
+}));
+
+vi.mock("~/server/api-key/auth-middleware", async (importActual) => {
+  const actual =
+    await importActual<typeof import("~/server/api-key/auth-middleware")>();
+  return {
+    ...actual,
+    enforceApiKeyCeiling: vi.fn().mockResolvedValue(undefined),
+    apiKeyCeilingDenialResponse: () => ({ status: 401, message: "denied" }),
+    extractCredentials: () => ({ token: "key_MINE" }),
+  };
+});
+
+const get = async (path: string) => {
+  const { app } = await import("../experiments-v3");
+  return app.request(path, {
+    method: "GET",
+    headers: { "X-Auth-Token": "key_MINE" },
+  });
+};
+
+describe("GET /api/experiments/runs/:runId/results archive visibility", () => {
+  beforeEach(() => {
+    getRunState.mockReset();
+    findFirst.mockReset();
+    getRun.mockReset();
+  });
+
+  describe("given a fresh Redis-cached run whose owning experiment was just archived", () => {
+    /** @scenario Archived experiments are hidden from the standard list query */
+    it("returns 404 even though experimentIdFromState resolved", async () => {
+      getRunState.mockResolvedValue({
+        runId: "run_x",
+        projectId: "project_MINE",
+        experimentId: "experiment_ARCHIVED",
+        experimentSlug: "x-archived-abc",
+        status: "completed",
+      });
+      findFirst.mockResolvedValue(null);
+
+      const res = await get("/api/experiments/runs/run_x/results");
+
+      expect(res.status).toBe(404);
+      expect(findFirst).toHaveBeenCalledWith({
+        where: {
+          id: "experiment_ARCHIVED",
+          projectId: "project_MINE",
+          archivedAt: null,
+        },
+        select: { id: true },
+      });
+      expect(getRun).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a fresh Redis-cached run whose experiment is still live", () => {
+    it("returns the run data", async () => {
+      getRunState.mockResolvedValue({
+        runId: "run_y",
+        projectId: "project_MINE",
+        experimentId: "experiment_LIVE",
+        experimentSlug: "y-live",
+        status: "completed",
+      });
+      findFirst.mockResolvedValue({ id: "experiment_LIVE" });
+      getRun.mockResolvedValue({ rows: [{ score: 1 }] });
+
+      const res = await get("/api/experiments/runs/run_y/results");
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ rows: [{ score: 1 }] });
+    });
+  });
+});

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -59,6 +59,7 @@ import type {
   ESBatchEvaluationTarget,
   ESBatchEvaluationTargetType,
 } from "~/server/experiments/types";
+import { ExperimentService } from "~/server/experiments/experiment.service";
 import {
   eSBatchEvaluationRESTParamsSchema,
   eSBatchEvaluationSchema,
@@ -421,12 +422,9 @@ secured.access(handlerManagedAuth(AUTH_REASON)).post("/dataset/evaluate", async 
     };
   }
 
-  const experiment = await prisma.experiment.findFirst({
-    where: {
-      projectId: project.id,
-      slug: experimentSlug,
-      archivedAt: null,
-    },
+  const experiment = await ExperimentService.create(prisma).findBySlug({
+    projectId: project.id,
+    slug: experimentSlug,
   });
   if (!experiment) {
     throw new TRPCError({

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -421,12 +421,11 @@ secured.access(handlerManagedAuth(AUTH_REASON)).post("/dataset/evaluate", async 
     };
   }
 
-  const experiment = await prisma.experiment.findUnique({
+  const experiment = await prisma.experiment.findFirst({
     where: {
-      projectId_slug: {
-        projectId: project.id,
-        slug: experimentSlug,
-      },
+      projectId: project.id,
+      slug: experimentSlug,
+      archivedAt: null,
     },
   });
   if (!experiment) {

--- a/langwatch/src/server/routes/experiments-v3.ts
+++ b/langwatch/src/server/routes/experiments-v3.ts
@@ -345,6 +345,7 @@ secured.access(apiKeyAuth).post("/:slug/run", async (c) => {
       projectId: project.id,
       slug,
       type: ExperimentType.EVALUATIONS_V3,
+      archivedAt: null,
     },
   });
 
@@ -678,7 +679,7 @@ secured.access(apiKeyAuth).get("/runs/:runId/results", async (c) => {
 
   if (!experimentId && experimentSlug) {
     const experiment = await prisma.experiment.findFirst({
-      where: { projectId: project.id, slug: experimentSlug },
+      where: { projectId: project.id, slug: experimentSlug, archivedAt: null },
       select: { id: true },
     });
     experimentId = experiment?.id;

--- a/langwatch/src/server/routes/experiments-v3.ts
+++ b/langwatch/src/server/routes/experiments-v3.ts
@@ -683,6 +683,17 @@ secured.access(apiKeyAuth).get("/runs/:runId/results", async (c) => {
       select: { id: true },
     });
     experimentId = experiment?.id;
+  } else if (experimentId) {
+    // Independent of how we resolved the id, refuse to return results once
+    // the owning experiment is archived. Without this check the Redis-state
+    // path (fresh runs, within 24h TTL) would keep serving ClickHouse rows
+    // after archive while the slug-based fallback already returns 404, so
+    // archive visibility would silently depend on run age.
+    const stillLive = await prisma.experiment.findFirst({
+      where: { id: experimentId, projectId: project.id, archivedAt: null },
+      select: { id: true },
+    });
+    if (!stillLive) experimentId = undefined;
   }
 
   if (!experimentId) {

--- a/langwatch/src/server/routes/experiments-v3.ts
+++ b/langwatch/src/server/routes/experiments-v3.ts
@@ -39,6 +39,7 @@ import {
 } from "~/server/experiments-v3/execution/orchestrator";
 import { runStateManager } from "~/server/experiments-v3/execution/runStateManager";
 import { ExperimentRunService } from "~/server/experiments-v3/services/experiment-run.service";
+import { ExperimentService } from "~/server/experiments/experiment.service";
 import {
   executionRequestSchema,
   type EvaluationV3Event,
@@ -340,13 +341,10 @@ secured.access(apiKeyAuth).post("/:slug/run", async (c) => {
   }
   const { project, markUsed } = authResult;
 
-  const experiment = await prisma.experiment.findFirst({
-    where: {
-      projectId: project.id,
-      slug,
-      type: ExperimentType.EVALUATIONS_V3,
-      archivedAt: null,
-    },
+  const experiment = await ExperimentService.create(prisma).findBySlugAndType({
+    projectId: project.id,
+    slug,
+    type: ExperimentType.EVALUATIONS_V3,
   });
 
   if (!experiment) {
@@ -676,11 +674,12 @@ secured.access(apiKeyAuth).get("/runs/:runId/results", async (c) => {
 
   const experimentSlug = c.req.query("experimentSlug") ?? slugFromState;
   let experimentId = experimentIdFromState;
+  const experiments = ExperimentService.create(prisma);
 
   if (!experimentId && experimentSlug) {
-    const experiment = await prisma.experiment.findFirst({
-      where: { projectId: project.id, slug: experimentSlug, archivedAt: null },
-      select: { id: true },
+    const experiment = await experiments.findIdBySlug({
+      projectId: project.id,
+      slug: experimentSlug,
     });
     experimentId = experiment?.id;
   } else if (experimentId) {
@@ -689,9 +688,9 @@ secured.access(apiKeyAuth).get("/runs/:runId/results", async (c) => {
     // path (fresh runs, within 24h TTL) would keep serving ClickHouse rows
     // after archive while the slug-based fallback already returns 404, so
     // archive visibility would silently depend on run age.
-    const stillLive = await prisma.experiment.findFirst({
-      where: { id: experimentId, projectId: project.id, archivedAt: null },
-      select: { id: true },
+    const stillLive = await experiments.isActive({
+      projectId: project.id,
+      id: experimentId,
     });
     if (!stillLive) experimentId = undefined;
   }

--- a/langwatch/src/server/routes/experiments-v3.ts
+++ b/langwatch/src/server/routes/experiments-v3.ts
@@ -591,6 +591,20 @@ secured.access(apiKeyAuth).get("/runs/:runId", async (c) => {
     return c.json({ error: "Run not found" }, { status: 404 });
   }
 
+  // Same archive guard as /runs/:runId/results: a run whose owning
+  // experiment was archived must not keep serving status from the Redis
+  // cache for the rest of the 24h TTL. Without this, archive visibility
+  // silently depends on run age.
+  if (runState.experimentId) {
+    const stillLive = await ExperimentService.create(prisma).isActive({
+      projectId: project.id,
+      id: runState.experimentId,
+    });
+    if (!stillLive) {
+      return c.json({ error: "Run not found" }, { status: 404 });
+    }
+  }
+
   logger.debug({ runId, status: runState.status }, "Run status queried");
   markUsed();
 

--- a/specs/experiments-v3/experiment-archive.feature
+++ b/specs/experiments-v3/experiment-archive.feature
@@ -4,7 +4,7 @@ Feature: Experiments are archived, not hard-deleted
   I want the experiment to disappear from my list immediately
   But I also want the platform to NOT churn the ClickHouse cold tier
   Because every hard delete forces a lightweight-delete mask onto every
-  matching part on S3 and triggers a multi-day merge tail — a recurring
+  matching part on S3 and triggers a multi-day merge tail, a recurring
   ~$200/mo S3 cost on a 3-45-deletes/day workload, growing with usage.
 
   # Background: every other major entity in the schema (Workflow, Monitor,
@@ -39,7 +39,7 @@ Feature: Experiments are archived, not hard-deleted
     # The Monitor model has no archivedAt column and is a small relational row
     # with no ClickHouse / S3 footprint, so hard-delete remains correct for it.
     # The cost-driving path was the ClickHouse mass-delete on experiment_runs
-    # / experiment_run_items / dspy_steps — that is what this feature removes.
+    # / experiment_run_items / dspy_steps, which is what this feature removes.
 
   Scenario: Archiving without a workflow or monitor still succeeds
     Given an experiment "exp_no_wf" with workflowId = null and no monitor
@@ -95,13 +95,13 @@ Feature: Experiments are archived, not hard-deleted
     Then deleteByExperiment is never called
 
   # ============================================================================
-  # Permission + tenancy
+  # Tenancy
   # ============================================================================
 
-  Scenario: A user without workflows:delete cannot archive experiments
-    Given a user "u_viewer" who does NOT have the "workflows:delete" permission on project "p1"
-    When "u_viewer" calls `experiments.deleteExperiment` for an experiment in "p1"
-    Then the call returns FORBIDDEN
+  # The workflows:delete permission is enforced via the shared
+  # checkProjectPermission middleware and is exercised by every protected
+  # mutation; re-asserting it for the archive endpoint specifically would
+  # duplicate that coverage and is intentionally left out of this feature.
 
   Scenario: An experiment from another project cannot be archived
     Given two projects "p1" and "p2"

--- a/specs/experiments-v3/experiment-archive.feature
+++ b/specs/experiments-v3/experiment-archive.feature
@@ -1,0 +1,111 @@
+@integration
+Feature: Experiments are archived, not hard-deleted
+  As a user clicking "Delete" on an experiment in the evaluations page
+  I want the experiment to disappear from my list immediately
+  But I also want the platform to NOT churn the ClickHouse cold tier
+  Because every hard delete forces a lightweight-delete mask onto every
+  matching part on S3 and triggers a multi-day merge tail — a recurring
+  ~$200/mo S3 cost on a 3-45-deletes/day workload, growing with usage.
+
+  # Background: every other major entity in the schema (Workflow, Monitor,
+  # Dataset, Evaluator, Agent, Optimization, Project, Team) uses archivedAt.
+  # Experiment is the inconsistent outlier; this feature aligns it with the
+  # rest of the codebase. Once project-wide retention TTL ships, archived
+  # rows age out of ClickHouse naturally via the TTL clause; until then they
+  # sit in cold storage without imposing per-click S3 traffic.
+
+  # ============================================================================
+  # Soft-archive semantics
+  # ============================================================================
+
+  Scenario: Archiving an experiment sets archivedAt and preserves the row
+    Given a project "p1" with an experiment "exp1" with archivedAt = null
+    And the experiment has 100 runs in ClickHouse `experiment_runs`
+    When I call the `experiments.deleteExperiment` tRPC procedure with experimentId "exp1"
+    Then the Experiment row for "exp1" still exists in Postgres
+    And the Experiment row's archivedAt is set to a recent timestamp (within last 5 seconds)
+    And the ClickHouse `experiment_runs` rows for that experiment are untouched
+    And the ClickHouse `experiment_run_items` rows for that experiment are untouched
+    And the ClickHouse `dspy_steps` rows for that experiment are untouched
+    And the Elasticsearch `batch_evaluation` documents for that experiment are untouched
+
+  Scenario: Archiving cascades to the associated workflow and hard-deletes the monitor
+    Given a project "p1" with an experiment "exp1" linked to workflow "wf1" and monitor "mon1"
+    And workflow "wf1" has archivedAt = null
+    When I call `experiments.deleteExperiment` for "exp1"
+    Then workflow "wf1" archivedAt is set to a recent timestamp
+    And the monitor row "mon1" is removed from Postgres
+    And workflowVersion rows under "wf1" still exist in Postgres
+    # The Monitor model has no archivedAt column and is a small relational row
+    # with no ClickHouse / S3 footprint, so hard-delete remains correct for it.
+    # The cost-driving path was the ClickHouse mass-delete on experiment_runs
+    # / experiment_run_items / dspy_steps — that is what this feature removes.
+
+  Scenario: Archiving without a workflow or monitor still succeeds
+    Given an experiment "exp_no_wf" with workflowId = null and no monitor
+    When I call `experiments.deleteExperiment` for "exp_no_wf"
+    Then the experiment is archived
+    And no Prisma error fires for the missing workflow or monitor
+
+  # ============================================================================
+  # List / get query semantics
+  # ============================================================================
+
+  Scenario: Archived experiments are hidden from the standard list query
+    Given a project "p1" with experiments "live1", "live2" (archivedAt=null) and "old1", "old2" (archivedAt set)
+    When the UI calls `experiments.getAllExperiments`
+    Then the response contains "live1" and "live2"
+    And the response does NOT contain "old1" or "old2"
+
+  Scenario: A single getExperiment by id returns archived experiments as not-found
+    Given an experiment "exp_archived" with archivedAt set
+    When the UI calls `experiments.getExperimentBySlugOrId` with id "exp_archived"
+    Then the procedure returns NOT_FOUND (404)
+    # We don't want stale UI state pointing at an archived experiment.
+
+  Scenario: A second click on the same already-archived experiment is a no-op
+    Given an experiment "exp1" with archivedAt already set to 1 hour ago
+    When I call `experiments.deleteExperiment` for "exp1"
+    Then the call returns success
+    And the archivedAt timestamp is NOT overwritten
+    # Idempotency: avoid spurious DB writes on duplicate clicks.
+
+  # ============================================================================
+  # No ClickHouse / Elasticsearch / DSpy delete calls
+  # ============================================================================
+
+  Scenario: The delete-experiment code path does NOT contact ClickHouse
+    Given the test runner has wrapped the ClickHouse client with an assertion
+      that fails the test if any DELETE / UPDATE / command call is issued
+    When I call `experiments.deleteExperiment` for any experiment
+    Then no ClickHouse mutation is issued
+    And no S3 PUT / DELETE is triggered by the request
+
+  Scenario: The delete-experiment code path does NOT contact Elasticsearch
+    Given the test runner has wrapped the Elasticsearch client with an assertion
+      that fails the test if any deleteByQuery call is issued against the
+      batch_evaluation index
+    When I call `experiments.deleteExperiment` for any experiment
+    Then no deleteByQuery call is issued
+
+  Scenario: The delete-experiment code path does NOT call the DSpy step cleanup
+    Given the test runner has wrapped getApp().dspySteps.steps.deleteByExperiment
+      with an assertion that fails on invocation
+    When I call `experiments.deleteExperiment` for any experiment
+    Then deleteByExperiment is never called
+
+  # ============================================================================
+  # Permission + tenancy
+  # ============================================================================
+
+  Scenario: A user without workflows:delete cannot archive experiments
+    Given a user "u_viewer" who does NOT have the "workflows:delete" permission on project "p1"
+    When "u_viewer" calls `experiments.deleteExperiment` for an experiment in "p1"
+    Then the call returns FORBIDDEN
+
+  Scenario: An experiment from another project cannot be archived
+    Given two projects "p1" and "p2"
+    And experiment "exp_in_p2" belongs to project "p2"
+    When a user authorized for project "p1" calls `experiments.deleteExperiment` with experimentId "exp_in_p2" and projectId "p1"
+    Then the call returns NOT_FOUND
+    And the archivedAt on "exp_in_p2" remains null


### PR DESCRIPTION
## Summary

Aligns the Experiment model with the rest of the codebase: archive via \`archivedAt\` instead of hard-deleting the Postgres row and issuing DELETE FROM in ClickHouse + deleteByQuery in Elasticsearch + DSpy step cleanup.

Every \"Delete\" click previously wrote a lightweight-delete mask onto every cold-tier S3 part containing matching rows on three ClickHouse tables (experiment_runs / experiment_run_items / dspy_steps), then background merges rewrote those parts to actually purge. At 3-45 user deletes/day across prod, that workload was costing roughly **$200/mo in S3 request churn** and tripping AWS Cost Anomaly Detection on heavy days (May 27 2026: 42 deletes -> 14,725 part rewrites in a single afternoon, $229 anomaly).

## Behaviour

- The tRPC procedure name remains \`experiments.deleteExperiment\` so the UI does not need to change. User-visible behaviour is identical: the item disappears from the list immediately and a \"deleted\" toast fires.
- Under the hood the row is now soft-archived: \`archivedAt\` is set, the slug is renamed to \`\${slug}-archived-\${nanoid}\` (mirrors the dataset.ts pattern, so the original slug can be reused), and the linked Workflow is cascade-archived. The Monitor model has no \`archivedAt\` column, so it keeps the original hard-delete (small Postgres row, no S3 footprint).
- ClickHouse, Elasticsearch, and DSpy step deletes are removed entirely. Historical data sits in cold tier until the upcoming retention TTL ages it out naturally, with zero S3 traffic per user click.
- Every user-facing Experiment read filters \`archivedAt: null\` (repository, router, SDK init). License enforcement count also excludes archived, so archiving frees a slot.

## Behaviour table

| Operation | Before | After |
|---|---|---|
| User clicks Delete | Hard-delete Postgres + DELETE FROM CH x3 + deleteByQuery ES + DSpy cleanup | Set archivedAt, rename slug, cascade-archive workflow, hard-delete monitor row |
| Experiment list | Already hidden (row gone) | Hidden via \`archivedAt: null\` filter |
| Experiment list license count | Already dropped | Excludes archived (archiving frees a slot) |
| Same slug reused | Worked (row gone) | Works (archived row has renamed slug) |
| Get by slug/id | 404 (gone) | 404 (filter) |
| Second click | Errors (row gone) | No-op, returns success |

## Specs

\`specs/experiments-v3/experiment-archive.feature\` documents the new behaviour including the no-CH / no-ES / no-DSpy guarantee, list filtering, and tenancy isolation.

## Tests

\`src/server/api/routers/__tests__/experiments.archive.integration.test.ts\` runs against real Postgres (no mocks). All 7 scenarios green locally:

- archives the experiment row instead of deleting it
- cascade-archives the linked workflow and hard-deletes the monitor
- handles an experiment with no workflow or monitor without erroring
- is idempotent: a second click does not overwrite archivedAt
- hides archived experiments from the project-wide list (Postgres path)
- returns NOT_FOUND when fetching an archived experiment by slug
- frees up the original slug so a new experiment can take it

## Expected impact

- ~$200/mo S3 saving in steady state, growing with usage.
- No more AWS Cost Anomaly Detection emails on busy delete days.
- ClickHouse cold tier stops fragmenting on every user click (no more lightweight-delete mask writes hitting every matching part).

## Test plan

- [x] \`prisma migrate deploy\` against fresh Postgres -> migration applies cleanly.
- [x] \`pnpm test:pg-integration src/server/api/routers/__tests__/experiments.archive.integration.test.ts\` -> 7/7 passing.
- [ ] QA in real browser against \`pnpm dev\`: create experiment, click Delete, verify it disappears from the list, verify in Postgres the row still exists with \`archivedAt\` set.
- [ ] Reuse the original slug: create a new experiment with the same name, verify it succeeds.
- [ ] CI green.