### PR TITLE
fix(ci): unit-test hard-floor for the vitest finalize-wedge

### DIFF
--- a/langwatch/src/test-unit-global-setup.ts
+++ b/langwatch/src/test-unit-global-setup.ts
@@ -1,0 +1,44 @@
+/**
+ * Global setup for the UNIT test config (vitest.config.ts).
+ *
+ * This file exists solely to mirror the hard-floor that already lives in the
+ * integration globalSetup (see
+ * src/server/event-sourcing/__tests__/integration/globalSetup.ts). Unit tests
+ * need no containers or other setup, so the hard-floor is the only thing here.
+ *
+ * Why a hard-floor on unit too: `langwatch-app-ci` runs `test-unit` (4 shards)
+ * and `test-integration` (6 shards). A vitest finalize wedge — diagnosed at
+ * length as living in vitest's own shard/reporter finalize path, NOT an
+ * application handle leak — makes a *random* shard hang after its last test
+ * passes, until the job timeout cap. Integration shards already survive this
+ * via the hard-floor in their globalSetup; unit shards had no globalSetup at
+ * all, so when the wedge lands on a unit shard the step runs to the 25-min job
+ * timeout, gets cancelled, and fails the `langwatch-app-complete` required
+ * check (observed cancelling app-ci repeatedly). Extending the same accepted
+ * mask to unit lets a wedged unit shard force-exit(0) and unblock the check.
+ */
+export async function setup(): Promise<void> {
+  // Hard floor: a vitest finalize wedge can reproducibly hang a CI shard after
+  // the last test of the last file passes. Every diagnostic the team has run
+  // (handle dumps, --no-coverage, --no-json-reporter, pool=threads vs
+  // pool=forks) shows the worker reaches steady state with no application
+  // handles open, then the vitest main process sits idle for the full job
+  // timeout cap. The wedge appears to be in vitest's own shard / reporter
+  // finalize path and we cannot fix it from inside a test. Schedule a hard
+  // process.exit(0) so the step at least completes and the rest of the
+  // langwatch-app-complete required check unblocks. Unref'd so a healthy
+  // shard exits immediately on its own; the timer only fires on the wedge.
+  // Mirrors the integration globalSetup hard-floor; unit shards otherwise lack
+  // one. Unit never legitimately runs 20 min, so this only fires on a wedge.
+  if (process.env.CI) {
+    const HARD_FLOOR_MS = 20 * 60 * 1000;
+    const timer = setTimeout(() => {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[unit globalSetup] hard floor reached at ${HARD_FLOOR_MS / 60_000} min — forcing process.exit(0) to release the CI step from a vitest finalize wedge`,
+      );
+      process.exit(0);
+    }, HARD_FLOOR_MS);
+    timer.unref();
+  }
+}

--- a/langwatch/vitest.config.ts
+++ b/langwatch/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
     maxWorkers: "50%", // Low default for local dev; CI overrides with VITEST_MAX_WORKERS
     vmMemoryLimit: "512MB", // Recycle workers aggressively — vmThreads leaks memory by design
     testTimeout: 30000, // 30s default to handle slower CI runners
+    // Global setup runs once before all tests. Unit needs no containers; this
+    // only carries a CI-gated hard-floor that mirrors the integration
+    // globalSetup, releasing the vitest finalize wedge on unit shards (which
+    // otherwise lack a hard-floor → 25-min job timeout → app-ci cancel).
+    globalSetup: ["./src/test-unit-global-setup.ts"],
     setupFiles: ["./test-setup.ts"],
     exclude: [
       ...configDefaults.exclude,


### PR DESCRIPTION
## Symptom

`langwatch-app-ci` intermittently **cancels** and fails the `langwatch-app-complete` required check. It happens whenever a non-deterministic vitest finalize-wedge lands on a `test-unit` shard (e.g. `test-unit (2)`). Observed repeatedly cancelling app-ci on PR #4216.

## Root cause

`langwatch-app-ci` runs `test-unit` (4 shards) and `test-integration` (6 shards). A known vitest finalize-wedge — diagnosed at length as living in **vitest's own shard/reporter finalize path**, not an application handle leak (handle dumps, `--no-coverage`, `--no-json-reporter`, `pool=threads` vs `pool=forks` all confirmed steady-state-with-no-open-handles) — makes a *random* shard hang after its last test passes, until the 25-min job timeout cap.

The **integration** config already survives this. Its globalSetup schedules an unref'd 20-min `setTimeout` that force-exits `0` when `process.env.CI` is set, so a wedged integration shard completes green:

> `langwatch/src/server/event-sourcing/__tests__/integration/globalSetup.ts` (the `HARD_FLOOR_MS = 20 * 60 * 1000` block)

The **unit** config (`langwatch/vitest.config.ts`) only wired `setupFiles: ["./test-setup.ts"]` — **no `globalSetup`, no hard-floor**. So when the wedge hits a unit shard, the step runs to the 25-min job timeout → cancelled → `langwatch-app-complete` fails.

## Fix

Add a unit globalSetup (`langwatch/src/test-unit-global-setup.ts`) that carries **only** the same CI-gated hard-floor, and wire it into `vitest.config.ts` via `globalSetup: ["./src/test-unit-global-setup.ts"]`.

- **Mirrors** `integration/globalSetup.ts` — same 20-min unref'd `setTimeout` → `process.exit(0)`, same `if (process.env.CI)` guard, same rationale.
- Unit needs no containers/other setup, so the hard-floor is the only logic in the new file.
- **Only fires in CI on a wedge.** The guard means it's never scheduled locally; unref'd means a healthy shard exits on its own and the timer never fires; unit tests never legitimately run 20 minutes, so a fire unambiguously means the wedge.

This extends the team's already-accepted mask (chosen after the wedge was diagnosed as vitest-internal and unfixable from inside a test) to unit, and unblocks PRs like #4216 whose app-ci kept cancelling.

## Local validation

Confirmed the wiring doesn't break unit tests (the hard-floor itself only arms under `CI`):

```
$ pnpm test:unit src/server/app-layer/clients/tokenizer/__tests__/tiktoken.client.unit.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  8.37s
# exit 0 — vitest exited cleanly (not in CI ⇒ hard-floor never scheduled)

$ pnpm typecheck
> ./node_modules/.bin/tsgo --noEmit --project ./tsconfig.tsgo.json
# exit 0, no output — clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)