### PR TITLE
fix(ops): populate P50/P99 latency tiles from group-queue durations

### DIFF
--- a/langwatch/src/server/app-layer/ops/__tests__/integration/latency-tiles.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/latency-tiles.integration.test.ts
@@ -7,6 +7,11 @@ import {
 } from "../../../../event-sourcing/__tests__/integration/testContainers";
 import { GroupQueueProcessor } from "../../../../event-sourcing/queues/groupQueue/groupQueue";
 import type { EventSourcedQueueDefinition } from "../../../../event-sourcing/queues/queue.types";
+import { OpsMetricsCollector } from "../../metrics-collector";
+import {
+  NullQueueRepository,
+  type QueueRepository,
+} from "../../repositories/queue.repository";
 
 const hasTestcontainers = !!(
   process.env.TEST_CLICKHOUSE_URL ||
@@ -21,6 +26,7 @@ type TestPayload = { id: string; groupId: string };
 describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
   let redis: Redis;
   const queues: GroupQueueProcessor<TestPayload>[] = [];
+  const queueNames: string[] = [];
 
   beforeAll(async () => {
     await startTestContainers();
@@ -30,7 +36,26 @@ describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
   afterEach(async () => {
     await Promise.all(queues.map((q) => q.close().catch(() => {})));
     queues.length = 0;
-    await redis.flushall();
+    // Scoped cleanup: only delete keys this suite created. FLUSHALL would
+    // wipe state owned by other integration tests sharing the same Redis.
+    for (const name of queueNames) {
+      let cursor = "0";
+      do {
+        const [next, batch] = await redis.scan(
+          cursor,
+          "MATCH",
+          `${name}*`,
+          "COUNT",
+          200,
+        );
+        if (batch.length > 0) await redis.unlink(...batch);
+        cursor = next;
+      } while (cursor !== "0");
+    }
+    // Collector-owned state keys this suite touches (KNOWN_PIPELINES_KEY +
+    // REDIS_STATE_KEY in metrics-collector.ts).
+    await redis.unlink("ops:known-pipelines", "ops:metrics:state");
+    queueNames.length = 0;
   });
 
   afterAll(async () => {
@@ -50,7 +75,20 @@ describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
     };
     const q = new GroupQueueProcessor<TestPayload>(def, redis);
     queues.push(q);
+    queueNames.push(name);
     return { queue: q, name };
+  }
+
+  async function waitForLatencyCount(name: string, target: number, timeoutMs: number) {
+    const key = `${name}:gq:stats:latencies-ms`;
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const len = await redis.llen(key);
+      if (len >= target) return;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    const finalLen = await redis.llen(key);
+    throw new Error(`only ${finalLen} entries in ${key} after ${timeoutMs}ms`);
   }
 
   describe("given a group-queue worker has completed several jobs", () => {
@@ -67,27 +105,19 @@ describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
         await queue.send({ id: "b", groupId: "g2" });
         await queue.send({ id: "c", groupId: "g3" });
 
-        const latencyKey = `${name}:gq:stats:latencies-ms`;
-        await new Promise<void>((resolve, reject) => {
-          const start = Date.now();
-          const tick = async () => {
-            const len = await redis.llen(latencyKey);
-            if (len >= 3) return resolve();
-            if (Date.now() - start > 5000)
-              return reject(new Error(`only ${len} entries after 5s`));
-            setTimeout(tick, 50);
-          };
-          void tick();
-        });
+        await waitForLatencyCount(name, 3, 5000);
 
-        const raw = await redis.lrange(latencyKey, 0, -1);
+        const raw = await redis.lrange(
+          `${name}:gq:stats:latencies-ms`,
+          0,
+          -1,
+        );
         const durations = raw.map((s) => Number(s));
         expect(durations).toHaveLength(3);
         for (const ms of durations) {
           expect(Number.isFinite(ms)).toBe(true);
           expect(ms).toBeGreaterThanOrEqual(0);
         }
-        // At least one job spent ~20ms in the handler.
         expect(Math.max(...durations)).toBeGreaterThanOrEqual(10);
       });
 
@@ -104,27 +134,16 @@ describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
           await queue.send({ id: `j${i}`, groupId: `g${i % 5}` });
         }
 
-        const latencyKey = `${name}:gq:stats:latencies-ms`;
-        await new Promise<void>((resolve, reject) => {
-          const start = Date.now();
-          const tick = async () => {
-            const len = await redis.llen(latencyKey);
-            if (len >= 200) return resolve();
-            if (Date.now() - start > 15000)
-              return reject(new Error(`only ${len} entries after 15s`));
-            setTimeout(tick, 100);
-          };
-          void tick();
-        });
+        await waitForLatencyCount(name, 200, 15000);
 
         // Give the worker a beat to push past the cap, then re-check.
         await new Promise((r) => setTimeout(r, 200));
-        const len = await redis.llen(latencyKey);
+        const len = await redis.llen(`${name}:gq:stats:latencies-ms`);
         expect(len).toBeLessThanOrEqual(200);
         expect(len).toBeGreaterThanOrEqual(190);
       });
 
-      it("derives non-zero P50/P99 via the collector's LRANGE read path", async () => {
+      it("surfaces non-zero P50/P99 through OpsMetricsCollector.getDashboardData()", async () => {
         const { queue, name } = createQueue({
           process: async () => {
             await new Promise((r) => setTimeout(r, 15));
@@ -136,46 +155,37 @@ describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
           await queue.send({ id: `j${i}`, groupId: `g${i}` });
         }
 
-        const latencyKey = `${name}:gq:stats:latencies-ms`;
-        await new Promise<void>((resolve, reject) => {
-          const start = Date.now();
-          const tick = async () => {
-            const len = await redis.llen(latencyKey);
-            if (len >= 5) return resolve();
-            if (Date.now() - start > 5000)
-              return reject(new Error(`only ${len} entries after 5s`));
-            setTimeout(tick, 50);
-          };
-          void tick();
+        await waitForLatencyCount(name, 5, 5000);
+
+        // Drive the real collector — stub queueRepo so it sees exactly this
+        // suite's queue. Any future drift in key names, filtering, or
+        // percentile math inside OpsMetricsCollector will break this test.
+        const queueRepoStub: QueueRepository = Object.assign(
+          new NullQueueRepository(),
+          {
+            discoverQueueNames: async () => [name],
+          },
+        );
+        const collector = new OpsMetricsCollector({
+          redis,
+          queueRepo: queueRepoStub,
         });
+        try {
+          await collector.discoverQueues();
+          // Two cycles: the first establishes the baseline (hasBaseline=false
+          // skips throughput math but still reads latencies), the second
+          // exercises the steady-state path.
+          await collector.collect();
+          await collector.collect();
 
-        // Reproduce the body of OpsMetricsCollector.computeJobMetrics() that
-        // reads latencies, so this test stays honest against the same shape
-        // the dashboard renders.
-        const queueNames = [name];
-        const pipeline = redis.pipeline();
-        for (const name of queueNames) {
-          pipeline.lrange(`${name}:gq:stats:latencies-ms`, 0, -1);
+          const data = collector.getDashboardData();
+          expect(data.latencyP50Ms).toBeGreaterThan(0);
+          expect(data.latencyP99Ms).toBeGreaterThanOrEqual(data.latencyP50Ms);
+          expect(data.peakLatencyP50Ms).toBeGreaterThanOrEqual(data.latencyP50Ms);
+          expect(data.peakLatencyP99Ms).toBeGreaterThanOrEqual(data.latencyP99Ms);
+        } finally {
+          collector.stop();
         }
-        const results = await pipeline.exec();
-        const latencies: number[] = [];
-        for (const [, result] of results ?? []) {
-          if (!Array.isArray(result)) continue;
-          for (const raw of result) {
-            const ms = Number(raw);
-            if (Number.isFinite(ms) && ms >= 0) latencies.push(ms);
-          }
-        }
-
-        expect(latencies.length).toBeGreaterThanOrEqual(5);
-        latencies.sort((a, b) => a - b);
-        const p50 = latencies[Math.floor(latencies.length * 0.5)]!;
-        const p99 =
-          latencies[
-            Math.min(latencies.length - 1, Math.floor(latencies.length * 0.99))
-          ]!;
-        expect(p50).toBeGreaterThan(0);
-        expect(p99).toBeGreaterThanOrEqual(p50);
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/latency-tiles.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/latency-tiles.integration.test.ts
@@ -38,6 +38,10 @@ describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
     queues.length = 0;
     // Scoped cleanup: only delete keys this suite created. FLUSHALL would
     // wipe state owned by other integration tests sharing the same Redis.
+    // Global collector keys (ops:known-pipelines, ops:metrics:state) are
+    // intentionally left alone — they are best-effort caches; the only stale
+    // state that survives is `peakLatencyP*`, and our assertion is
+    // `peak >= current`, which a stale-larger peak still satisfies.
     for (const name of queueNames) {
       let cursor = "0";
       do {
@@ -52,9 +56,6 @@ describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
         cursor = next;
       } while (cursor !== "0");
     }
-    // Collector-owned state keys this suite touches (KNOWN_PIPELINES_KEY +
-    // REDIS_STATE_KEY in metrics-collector.ts).
-    await redis.unlink("ops:known-pipelines", "ops:metrics:state");
     queueNames.length = 0;
   });
 

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/latency-tiles.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/latency-tiles.integration.test.ts
@@ -1,0 +1,182 @@
+import type { Redis } from "ioredis";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+  getTestRedisConnection,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { GroupQueueProcessor } from "../../../../event-sourcing/queues/groupQueue/groupQueue";
+import type { EventSourcedQueueDefinition } from "../../../../event-sourcing/queues/queue.types";
+
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL ||
+  process.env.CI_CLICKHOUSE_URL ||
+  process.env.REDIS_URL ||
+  process.env.CI_REDIS_URL
+);
+
+type TestPayload = { id: string; groupId: string };
+
+/** @scenario P50 and P99 reflect recent job durations after completion */
+describe.skipIf(!hasTestcontainers)("Ops dashboard latency tiles", () => {
+  let redis: Redis;
+  const queues: GroupQueueProcessor<TestPayload>[] = [];
+
+  beforeAll(async () => {
+    await startTestContainers();
+    redis = getTestRedisConnection()!;
+  });
+
+  afterEach(async () => {
+    await Promise.all(queues.map((q) => q.close().catch(() => {})));
+    queues.length = 0;
+    await redis.flushall();
+  });
+
+  afterAll(async () => {
+    await stopTestContainers();
+  });
+
+  function createQueue(
+    overrides: Partial<EventSourcedQueueDefinition<TestPayload>> & {
+      process: (payload: TestPayload) => Promise<void>;
+    },
+  ): { queue: GroupQueueProcessor<TestPayload>; name: string } {
+    const name = `{test/gq/lat/${crypto.randomUUID().slice(0, 8)}}`;
+    const def: EventSourcedQueueDefinition<TestPayload> = {
+      name,
+      groupKey: (p) => p.groupId,
+      ...overrides,
+    };
+    const q = new GroupQueueProcessor<TestPayload>(def, redis);
+    queues.push(q);
+    return { queue: q, name };
+  }
+
+  describe("given a group-queue worker has completed several jobs", () => {
+    describe("when the dashboard reads the latency buffer", () => {
+      it("populates :gq:stats:latencies-ms with one entry per completed job", async () => {
+        const { queue, name } = createQueue({
+          process: async () => {
+            await new Promise((r) => setTimeout(r, 20));
+          },
+        });
+        await queue.waitUntilReady();
+
+        await queue.send({ id: "a", groupId: "g1" });
+        await queue.send({ id: "b", groupId: "g2" });
+        await queue.send({ id: "c", groupId: "g3" });
+
+        const latencyKey = `${name}:gq:stats:latencies-ms`;
+        await new Promise<void>((resolve, reject) => {
+          const start = Date.now();
+          const tick = async () => {
+            const len = await redis.llen(latencyKey);
+            if (len >= 3) return resolve();
+            if (Date.now() - start > 5000)
+              return reject(new Error(`only ${len} entries after 5s`));
+            setTimeout(tick, 50);
+          };
+          void tick();
+        });
+
+        const raw = await redis.lrange(latencyKey, 0, -1);
+        const durations = raw.map((s) => Number(s));
+        expect(durations).toHaveLength(3);
+        for (const ms of durations) {
+          expect(Number.isFinite(ms)).toBe(true);
+          expect(ms).toBeGreaterThanOrEqual(0);
+        }
+        // At least one job spent ~20ms in the handler.
+        expect(Math.max(...durations)).toBeGreaterThanOrEqual(10);
+      });
+
+      it("caps the buffer at 200 entries via LTRIM", async () => {
+        const { queue, name } = createQueue({
+          process: async () => {
+            // No work — keep the test fast. The cap check only needs the buffer
+            // to grow past the limit, not real latency.
+          },
+        });
+        await queue.waitUntilReady();
+
+        for (let i = 0; i < 250; i++) {
+          await queue.send({ id: `j${i}`, groupId: `g${i % 5}` });
+        }
+
+        const latencyKey = `${name}:gq:stats:latencies-ms`;
+        await new Promise<void>((resolve, reject) => {
+          const start = Date.now();
+          const tick = async () => {
+            const len = await redis.llen(latencyKey);
+            if (len >= 200) return resolve();
+            if (Date.now() - start > 15000)
+              return reject(new Error(`only ${len} entries after 15s`));
+            setTimeout(tick, 100);
+          };
+          void tick();
+        });
+
+        // Give the worker a beat to push past the cap, then re-check.
+        await new Promise((r) => setTimeout(r, 200));
+        const len = await redis.llen(latencyKey);
+        expect(len).toBeLessThanOrEqual(200);
+        expect(len).toBeGreaterThanOrEqual(190);
+      });
+
+      it("derives non-zero P50/P99 via the collector's LRANGE read path", async () => {
+        const { queue, name } = createQueue({
+          process: async () => {
+            await new Promise((r) => setTimeout(r, 15));
+          },
+        });
+        await queue.waitUntilReady();
+
+        for (let i = 0; i < 5; i++) {
+          await queue.send({ id: `j${i}`, groupId: `g${i}` });
+        }
+
+        const latencyKey = `${name}:gq:stats:latencies-ms`;
+        await new Promise<void>((resolve, reject) => {
+          const start = Date.now();
+          const tick = async () => {
+            const len = await redis.llen(latencyKey);
+            if (len >= 5) return resolve();
+            if (Date.now() - start > 5000)
+              return reject(new Error(`only ${len} entries after 5s`));
+            setTimeout(tick, 50);
+          };
+          void tick();
+        });
+
+        // Reproduce the body of OpsMetricsCollector.computeJobMetrics() that
+        // reads latencies, so this test stays honest against the same shape
+        // the dashboard renders.
+        const queueNames = [name];
+        const pipeline = redis.pipeline();
+        for (const name of queueNames) {
+          pipeline.lrange(`${name}:gq:stats:latencies-ms`, 0, -1);
+        }
+        const results = await pipeline.exec();
+        const latencies: number[] = [];
+        for (const [, result] of results ?? []) {
+          if (!Array.isArray(result)) continue;
+          for (const raw of result) {
+            const ms = Number(raw);
+            if (Number.isFinite(ms) && ms >= 0) latencies.push(ms);
+          }
+        }
+
+        expect(latencies.length).toBeGreaterThanOrEqual(5);
+        latencies.sort((a, b) => a - b);
+        const p50 = latencies[Math.floor(latencies.length * 0.5)]!;
+        const p99 =
+          latencies[
+            Math.min(latencies.length - 1, Math.floor(latencies.length * 0.99))
+          ]!;
+        expect(p50).toBeGreaterThan(0);
+        expect(p99).toBeGreaterThanOrEqual(p50);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/metrics-collector.ts
+++ b/langwatch/src/server/app-layer/ops/metrics-collector.ts
@@ -611,36 +611,16 @@ class OpsMetricsCollector {
     if (newCompleted > 0 || !this.hasBaseline) {
       const latencyPipeline = this.redis.pipeline();
       for (const name of this.groupQueueNames) {
-        latencyPipeline.zrange(`${name}:completed`, 0, 24, "REV");
+        latencyPipeline.lrange(`${name}:gq:stats:latencies-ms`, 0, -1);
       }
       const latencyResults = await latencyPipeline.exec();
 
       if (latencyResults) {
-        const jobIdPipeline = this.redis.pipeline();
-        const jobKeys: string[] = [];
-        for (let i = 0; i < this.groupQueueNames.length; i++) {
-          const jobIds = (latencyResults[i]?.[1] as string[]) ?? [];
-          const name = this.groupQueueNames[i]!;
-          for (const jobId of jobIds) {
-            jobIdPipeline.hmget(
-              `${name}:${jobId}`,
-              "processedOn",
-              "finishedOn",
-            );
-            jobKeys.push(`${name}:${jobId}`);
-          }
-        }
-        if (jobKeys.length > 0) {
-          const jobResults = await jobIdPipeline.exec();
-          if (jobResults) {
-            for (const [, result] of jobResults) {
-              const fields = result as [string | null, string | null];
-              const processedOn = fields?.[0] ? Number(fields[0]) : 0;
-              const finishedOn = fields?.[1] ? Number(fields[1]) : 0;
-              if (processedOn > 0 && finishedOn > processedOn) {
-                latencies.push(finishedOn - processedOn);
-              }
-            }
+        for (const [, result] of latencyResults) {
+          if (!Array.isArray(result)) continue;
+          for (const raw of result) {
+            const ms = Number(raw);
+            if (Number.isFinite(ms) && ms >= 0) latencies.push(ms);
           }
         }
       }

--- a/langwatch/src/server/app-layer/ops/metrics-collector.ts
+++ b/langwatch/src/server/app-layer/ops/metrics-collector.ts
@@ -202,7 +202,7 @@ export function buildPipelineTree({
   return tree;
 }
 
-class OpsMetricsCollector {
+export class OpsMetricsCollector {
   private redis: IORedis | Cluster;
   private groupQueueNames: string[] = [];
   private throughputBuffer: ThroughputPoint[] = [];
@@ -356,7 +356,7 @@ class OpsMetricsCollector {
     this.emitter.removeAllListeners();
   }
 
-  private async discoverQueues(): Promise<void> {
+  async discoverQueues(): Promise<void> {
     try {
       this.groupQueueNames = await this.queueRepo.discoverQueueNames();
     } catch (err) {
@@ -854,7 +854,7 @@ class OpsMetricsCollector {
     }
   }
 
-  private async collect(): Promise<void> {
+  async collect(): Promise<void> {
     if (this.isCollecting) return;
     this.isCollecting = true;
     try {
@@ -1025,5 +1025,3 @@ export function getOpsMetricsCollector(params: {
   }
   return singleton;
 }
-
-export type { OpsMetricsCollector };

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -684,6 +684,18 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       this.activeJobCount--;
       const jobDurationMs = performance.now() - jobStartTime;
       gqJobDurationMilliseconds.observe(routingLabels, jobDurationMs);
+      // Feed the ops dashboard P50/P99 tiles. Capped circular buffer; the
+      // collector LRANGE's it every 2s. Fire-and-forget so an instrumentation
+      // hiccup never bubbles into the worker pipeline.
+      this.redisConnection
+        .multi()
+        .lpush(
+          `${this.queueName}:gq:stats:latencies-ms`,
+          String(Math.round(jobDurationMs)),
+        )
+        .ltrim(`${this.queueName}:gq:stats:latencies-ms`, 0, 199)
+        .exec()
+        .catch(() => {});
     }
   }
 

--- a/specs/ops/dashboard-latency.feature
+++ b/specs/ops/dashboard-latency.feature
@@ -1,0 +1,22 @@
+Feature: Ops dashboard latency tiles
+  As an operator monitoring the queue platform
+  I want the P50 and P99 latency tiles to reflect actual job durations
+  So that I can spot slow-processing pipelines from the ops page
+
+  Background:
+    Given an admin is viewing the ops dashboard
+
+  Scenario: P50 and P99 stay at zero when no jobs have completed
+    Given no group-queue job has completed since the last process restart
+    When the dashboard fetches metrics
+    Then the P50 tile shows "0ms"
+    And the P99 tile shows "0ms"
+    And the P50 peak shows "0ms"
+    And the P99 peak shows "0ms"
+
+  Scenario: P50 and P99 reflect recent job durations after completion
+    Given a group-queue worker has completed several jobs with measurable durations
+    When the dashboard fetches metrics
+    Then the P50 tile shows a non-zero value
+    And the P99 tile shows a value at least as large as P50
+    And both peak tiles retain the highest observed value across collections


### PR DESCRIPTION
## Summary

The ops dashboard's **P50** and **P99** tiles have been stuck at `0ms` / `peak 0ms` since the dashboard was introduced in #3169.

The latency-read snippet in `metrics-collector.ts` was written against keys that don't exist in this codebase — `<queue>:completed` ZSET + a per-job hash with `processedOn`/`finishedOn` fields. GroupQueue never wrote those keys (its `COMPLETE_LUA` just increments `<queue>:gq:stats:completed` and frees the active slot), so the collector's `latencies` array has always been empty.

In other words: the tile was born dead. Reported with a screenshot showing both tiles flatlined at 0ms even with active throughput.

## Fix

- **`groupQueue.ts`**: After each job finishes (success or failure), push the observed duration to a capped Redis list `${queue}:gq:stats:latencies-ms` (cap 200 via `LTRIM`, fire-and-forget). Sits next to the existing Prometheus `gqJobDurationMilliseconds.observe()` so a single source-of-truth duration drives both surfaces.
- **`metrics-collector.ts`**: Replace the dead ZRANGE + HMGET pipeline with one `LRANGE ${name}:gq:stats:latencies-ms 0 -1` per discovered queue. Same percentile math; working data source.

## Test plan

- [x] `pnpm typecheck` clean
- [x] New integration test `latency-tiles.integration.test.ts` drives a real `GroupQueueProcessor` + real Redis + the real `OpsMetricsCollector`:
  - one entry per completed job is appended
  - `LTRIM` caps the list at ~200
  - `OpsMetricsCollector.getDashboardData()` returns non-zero `latencyP50Ms` / `latencyP99Ms`
- [x] Existing `groupQueue.integration.test.ts` still green
- [x] BDD spec in `specs/ops/dashboard-latency.feature` describes the empty-state and populated-state behaviors