### PR TITLE
fix(stored-objects): externalise AI-SDK file+audio parts (scenario voice audio leak)

### DIFF
--- a/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
@@ -442,6 +442,128 @@ describe("extractInlineMediaFromEvent", () => {
     });
   });
 
+  describe("when an event has an AI-SDK file+audio part (typescript scenario SDK shape)", () => {
+    /** @scenario "file parts with audio/* mediaType are externalized to a clean input_audio reference" */
+    it("calls storeFromBytes with the audio mediaType and rewrites the part to {type:'input_audio', input_audio:{url, mimeType}}", async () => {
+      const base64Payload = makeBase64Payload("PCM16_AUDIO_BYTES");
+      const mimeType = "audio/pcm16";
+      const storedId = "stored-file-audio-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: mimeType,
+          isDuplicate: false,
+        }),
+      });
+
+      // Shape emitted by the typescript scenario SDK's `createAudioMessage`
+      // (voice/messages.ts) before the SDK-side translation patch. Older
+      // builds (and any future caller that ships raw AI-SDK file parts)
+      // hit this branch; the extractor must externalise the bytes rather
+      // than let them flow to ClickHouse Messages.Content inline.
+      const event = makeEventWithContent([
+        { type: "text", text: "Hi" },
+        {
+          type: "file",
+          mediaType: "audio/pcm16",
+          data: base64Payload,
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(service.storeFromBytes).toHaveBeenCalledOnce();
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaType: "audio/pcm16",
+          bytes: Buffer.from("PCM16_AUDIO_BYTES"),
+        }),
+      );
+
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      expect(content).toHaveLength(2);
+      expect(content[0]).toEqual({ type: "text", text: "Hi" });
+      // File-shape inputs rewrite to a clean input_audio reference — NOT a
+      // chimera of {type:"file", mediaType, input_audio:{...}}. The
+      // downstream UI MediaPart consumes the input_audio shape.
+      expect(content[1]).toEqual({
+        type: "input_audio",
+        input_audio: {
+          data: undefined,
+          url: `/api/files/${storedId}`,
+          mimeType: "audio/pcm16",
+        },
+      });
+
+      expect(refs).toHaveLength(1);
+      expect(refs[0]!.id).toBe(storedId);
+    });
+  });
+
+  describe("when an event has an AI-SDK file part with a non-audio mediaType", () => {
+    /** @scenario "non-audio file parts route through the binary handler — externalised the same way as native binary parts" */
+    it("calls storeFromBytes and rewrites the part with id and url", async () => {
+      const base64Payload = makeBase64Payload("PNG_BYTES");
+      const mimeType = "image/png";
+      const storedId = "stored-file-image-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: mimeType,
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          mediaType: "image/png",
+          data: base64Payload,
+          filename: "preview.png",
+        },
+      ]);
+
+      const { rewrittenEvent, refs } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      expect(service.storeFromBytes).toHaveBeenCalledOnce();
+      expect(service.storeFromBytes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediaType: "image/png",
+          bytes: Buffer.from("PNG_BYTES"),
+        }),
+      );
+
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      const part = content[0] as {
+        type: string;
+        id: string;
+        url: string;
+        data: unknown;
+        filename: string;
+      };
+      expect(part.type).toBe("binary");
+      expect(part.id).toBe(storedId);
+      expect(part.url).toBe(`/api/files/${storedId}`);
+      expect(part.data).toBeUndefined();
+      expect(part.filename).toBe("preview.png");
+
+      expect(refs).toHaveLength(1);
+      expect(refs[0]!.id).toBe(storedId);
+    });
+  });
+
   describe("when the same content appears twice in one event", () => {
     it("returns two refs both pointing at the same id, second isDuplicate=true", async () => {
       const base64 = makeBase64Payload("same-data");

--- a/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
@@ -443,7 +443,6 @@ describe("extractInlineMediaFromEvent", () => {
   });
 
   describe("when an event has an AI-SDK file+audio part (typescript scenario SDK shape)", () => {
-    /** @scenario "file parts with audio/* mediaType are externalized to a clean input_audio reference" */
     it("calls storeFromBytes with the audio mediaType and rewrites the part to {type:'input_audio', input_audio:{url, mimeType}}", async () => {
       const base64Payload = makeBase64Payload("PCM16_AUDIO_BYTES");
       const mimeType = "audio/pcm16";
@@ -506,8 +505,51 @@ describe("extractInlineMediaFromEvent", () => {
     });
   });
 
+  describe("when an event has an AI-SDK file+audio part with mixed-case mediaType", () => {
+    it("normalises the mediaType for the audio/* check and routes to input_audio (not binary)", async () => {
+      // MIME types are case-insensitive per RFC 2045 §5.1, so an `Audio/WAV`
+      // file part should externalise via the audio path the same as
+      // `audio/wav`. Before normalisation this fell into the binary branch
+      // and produced a `type:"binary"` rewrite — silently wrong shape.
+      const base64Payload = makeBase64Payload("WAV_BYTES");
+      const storedId = "stored-mixedcase-audio-id";
+
+      const service = makeService({
+        storeFromBytes: vi.fn().mockResolvedValue({
+          id: storedId,
+          mediaType: "audio/wav",
+          isDuplicate: false,
+        }),
+      });
+
+      const event = makeEventWithContent([
+        {
+          type: "file",
+          mediaType: "Audio/WAV",
+          data: base64Payload,
+        },
+      ]);
+
+      const { rewrittenEvent } = await extractInlineMediaFromEvent({
+        ...BASE_PARAMS,
+        event,
+        service,
+      });
+
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
+      expect(content[0]).toEqual({
+        type: "input_audio",
+        input_audio: {
+          data: undefined,
+          url: `/api/files/${storedId}`,
+          mimeType: "audio/wav",
+        },
+      });
+    });
+  });
+
   describe("when an event has an AI-SDK file part with a non-audio mediaType", () => {
-    /** @scenario "non-audio file parts route through the binary handler — externalised the same way as native binary parts" */
     it("calls storeFromBytes and rewrites the part with id and url", async () => {
       const base64Payload = makeBase64Payload("PNG_BYTES");
       const mimeType = "image/png";

--- a/langwatch/src/server/stored-objects/content-extractor.ts
+++ b/langwatch/src/server/stored-objects/content-extractor.ts
@@ -192,12 +192,30 @@ async function processContentPart({
         ownerId,
       };
 
-      const rewrittenPart = {
-        ...(part as Record<string, unknown>),
-        id: stored.id,
-        url: `/api/files/${stored.id}`,
-        data: undefined,
-      };
+      const original = part as Record<string, unknown>;
+      // AI-SDK file shape (`type:"file", mediaType, data`) is dispatched here
+      // by the visitor when mimeType is not audio/*. Normalise to a clean
+      // `binary` shape (the same canonical form the inputAudio handler
+      // produces for the audio path) so the rewrite is not a chimera of
+      // `type:"file"` + binary externalised fields.
+      const isFileShape = original.type === "file";
+      const rewrittenPart = isFileShape
+        ? {
+            type: "binary",
+            mimeType,
+            id: stored.id,
+            url: `/api/files/${stored.id}`,
+            data: undefined,
+            ...(typeof original.filename === "string"
+              ? { filename: original.filename }
+              : {}),
+          }
+        : {
+            ...original,
+            id: stored.id,
+            url: `/api/files/${stored.id}`,
+            data: undefined,
+          };
 
       return { part: rewrittenPart, ref };
     },
@@ -247,16 +265,20 @@ async function processContentPart({
 
     // OpenAI Realtime API: {type:"input_audio", input_audio:{data:"<base64>", format:"wav"}}.
     // This is the shape the langwatch python-sdk emits for scenario audio
-    // turns today. Format determines the mime type (wav -> audio/wav, mp3
-    // -> audio/mpeg, etc.); we map a small allowlist and default to
-    // application/octet-stream when the format is missing or unknown.
+    // turns today, and the shape the typescript-sdk's
+    // convert-core-messages-to-agui-messages translates AI-SDK file+audio
+    // parts to. Mime type resolution priority: explicit `mimeType` (set by
+    // the file-part dispatch path in visit-content-part for AI-SDK
+    // `audio/pcm16` etc.) > format-to-mimeType allowlist > a final
+    // `application/octet-stream` fallback when neither is recognised.
     async inputAudio(audioPart) {
       // Already-externalized: nothing to extract, pass through unchanged.
       if (!audioPart.data) return noOp;
 
       const format = audioPart.format?.toLowerCase();
       const mimeType =
-        format === "wav"
+        audioPart.mimeType ??
+        (format === "wav"
           ? "audio/wav"
           : format === "mp3"
             ? "audio/mpeg"
@@ -266,7 +288,7 @@ async function processContentPart({
                 ? "audio/ogg"
                 : format === "webm"
                   ? "audio/webm"
-                  : "application/octet-stream";
+                  : "application/octet-stream");
 
       const bytes = Buffer.from(audioPart.data, "base64");
       const stored = await service.storeFromBytes({
@@ -287,22 +309,35 @@ async function processContentPart({
       };
 
       const original = part as Record<string, unknown>;
+      const isFileShape = original.type === "file";
       const originalInputAudio =
         typeof original.input_audio === "object" && original.input_audio !== null
           ? (original.input_audio as Record<string, unknown>)
           : {};
-      // Rewrite to a shape the UI MediaPart already understands: keep the
-      // input_audio key for backward compatibility with consumers that
-      // already look at it, but swap `data` for an externalized `url`.
-      const rewrittenPart = {
-        ...original,
-        input_audio: {
-          ...originalInputAudio,
-          data: undefined,
-          url: `/api/files/${stored.id}`,
-          mimeType,
-        },
-      };
+
+      // Rewrite to the canonical externalised `input_audio` shape so the UI
+      // MediaPart renders a playable reference. When the inbound part was an
+      // AI-SDK `file` shape (`{type:"file", mediaType, data}`), drop the
+      // file-specific discriminants so the rewritten part is a clean
+      // input_audio reference rather than a chimera of both shapes.
+      const rewrittenPart = isFileShape
+        ? {
+            type: "input_audio",
+            input_audio: {
+              data: undefined,
+              url: `/api/files/${stored.id}`,
+              mimeType,
+            },
+          }
+        : {
+            ...original,
+            input_audio: {
+              ...originalInputAudio,
+              data: undefined,
+              url: `/api/files/${stored.id}`,
+              mimeType,
+            },
+          };
 
       return { part: rewrittenPart, ref };
     },

--- a/langwatch/src/server/stored-objects/visit-content-part.ts
+++ b/langwatch/src/server/stored-objects/visit-content-part.ts
@@ -166,6 +166,43 @@ export function visitContentPart<R>(
     }
   }
 
+  // AI-SDK file part: {type:"file", mediaType:"audio/...", data:"<base64>"}.
+  // The TypeScript scenario SDK emits this shape from `createAudioMessage`
+  // (see voice/messages.ts in langwatch/scenario). Newer SDK builds translate
+  // audio file parts to `input_audio` before sending, but older SDKs and
+  // first-party non-scenario callers may still ship the raw `file` shape;
+  // routing it here means the extractor externalises the bytes to stored-
+  // objects the same way it already does for `input_audio`, instead of
+  // dropping into the no-op `unknown` branch and letting full base64
+  // payloads land in ClickHouse Messages.Content. Audio mediaTypes go to
+  // `inputAudio` (preserves a playable shape downstream); other file payloads
+  // go to `binary` (generic externalisation by mimeType).
+  if (o["type"] === "file" && typeof o["mediaType"] === "string") {
+    const mimeType = o["mediaType"];
+    const data = typeof o["data"] === "string" ? o["data"] : undefined;
+    const url = typeof o["url"] === "string" ? o["url"] : undefined;
+    if (data || url) {
+      if (mimeType.startsWith("audio/")) {
+        return visitor.inputAudio
+          ? visitor.inputAudio({
+              data,
+              url,
+              format: mediaTypeToAudioFormat(mimeType),
+              mimeType,
+            })
+          : visitor.unknown?.(part);
+      }
+      return visitor.binary({
+        type: "binary",
+        mimeType,
+        data,
+        url,
+        id: typeof o["id"] === "string" ? o["id"] : undefined,
+        filename: typeof o["filename"] === "string" ? o["filename"] : undefined,
+      });
+    }
+  }
+
   // binary parts
   if (o["type"] === "binary" && o["mimeType"]) {
     return visitor.binary({
@@ -288,6 +325,43 @@ export async function visitContentPartAsync<R>(
     }
   }
 
+  // AI-SDK file part: {type:"file", mediaType:"audio/...", data:"<base64>"}.
+  // The TypeScript scenario SDK emits this shape from `createAudioMessage`
+  // (see voice/messages.ts in langwatch/scenario). Newer SDK builds translate
+  // audio file parts to `input_audio` before sending, but older SDKs and
+  // first-party non-scenario callers may still ship the raw `file` shape;
+  // routing it here means the extractor externalises the bytes to stored-
+  // objects the same way it already does for `input_audio`, instead of
+  // dropping into the no-op `unknown` branch and letting full base64
+  // payloads land in ClickHouse Messages.Content. Audio mediaTypes go to
+  // `inputAudio` (preserves a playable shape downstream); other file payloads
+  // go to `binary` (generic externalisation by mimeType).
+  if (o["type"] === "file" && typeof o["mediaType"] === "string") {
+    const mimeType = o["mediaType"];
+    const data = typeof o["data"] === "string" ? o["data"] : undefined;
+    const url = typeof o["url"] === "string" ? o["url"] : undefined;
+    if (data || url) {
+      if (mimeType.startsWith("audio/")) {
+        return visitor.inputAudio
+          ? visitor.inputAudio({
+              data,
+              url,
+              format: mediaTypeToAudioFormat(mimeType),
+              mimeType,
+            })
+          : visitor.unknown?.(part);
+      }
+      return visitor.binary({
+        type: "binary",
+        mimeType,
+        data,
+        url,
+        id: typeof o["id"] === "string" ? o["id"] : undefined,
+        filename: typeof o["filename"] === "string" ? o["filename"] : undefined,
+      });
+    }
+  }
+
   // binary parts
   if (o["type"] === "binary" && o["mimeType"]) {
     return visitor.binary({
@@ -336,4 +410,28 @@ export async function visitContentPartAsync<R>(
   }
 
   return visitor.unknown?.(part);
+}
+
+/**
+ * Best-effort `format` hint for the OpenAI Realtime `input_audio` shape based
+ * on an AI-SDK `mediaType` ("audio/wav", "audio/mpeg", etc.). Returns
+ * `undefined` for non-canonical types (e.g. "audio/pcm16") — the mimeType is
+ * still preserved on the dispatched part for downstream handling.
+ */
+function mediaTypeToAudioFormat(mediaType: string): string | undefined {
+  switch (mediaType) {
+    case "audio/wav":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/mpeg":
+      return "mp3";
+    case "audio/flac":
+      return "flac";
+    case "audio/ogg":
+      return "ogg";
+    case "audio/webm":
+      return "webm";
+    default:
+      return undefined;
+  }
 }

--- a/langwatch/src/server/stored-objects/visit-content-part.ts
+++ b/langwatch/src/server/stored-objects/visit-content-part.ts
@@ -178,7 +178,14 @@ export function visitContentPart<R>(
   // `inputAudio` (preserves a playable shape downstream); other file payloads
   // go to `binary` (generic externalisation by mimeType).
   if (o["type"] === "file" && typeof o["mediaType"] === "string") {
-    const mimeType = o["mediaType"];
+    // MIME types are case-insensitive per RFC 2045 §5.1, so an `Audio/WAV`
+    // file part should route the same as `audio/wav`. Normalise the type
+    // discriminator for the `audio/` prefix check + format mapping, but keep
+    // the original-case mimeType on the dispatched part so downstream
+    // consumers that pattern-match the exact value (e.g. an explicit
+    // allowlist) don't silently see a different string than the wire shape.
+    const mimeTypeRaw = o["mediaType"];
+    const mimeType = mimeTypeRaw.toLowerCase();
     const data = typeof o["data"] === "string" ? o["data"] : undefined;
     const url = typeof o["url"] === "string" ? o["url"] : undefined;
     if (data || url) {
@@ -337,7 +344,14 @@ export async function visitContentPartAsync<R>(
   // `inputAudio` (preserves a playable shape downstream); other file payloads
   // go to `binary` (generic externalisation by mimeType).
   if (o["type"] === "file" && typeof o["mediaType"] === "string") {
-    const mimeType = o["mediaType"];
+    // MIME types are case-insensitive per RFC 2045 §5.1, so an `Audio/WAV`
+    // file part should route the same as `audio/wav`. Normalise the type
+    // discriminator for the `audio/` prefix check + format mapping, but keep
+    // the original-case mimeType on the dispatched part so downstream
+    // consumers that pattern-match the exact value (e.g. an explicit
+    // allowlist) don't silently see a different string than the wire shape.
+    const mimeTypeRaw = o["mediaType"];
+    const mimeType = mimeTypeRaw.toLowerCase();
     const data = typeof o["data"] === "string" ? o["data"] : undefined;
     const url = typeof o["url"] === "string" ? o["url"] : undefined;
     if (data || url) {
@@ -419,7 +433,9 @@ export async function visitContentPartAsync<R>(
  * still preserved on the dispatched part for downstream handling.
  */
 function mediaTypeToAudioFormat(mediaType: string): string | undefined {
-  switch (mediaType) {
+  // Case-insensitive (RFC 2045 §5.1). Callers in this file already lowercase
+  // before passing in, but normalise here too so any future caller is safe.
+  switch (mediaType.toLowerCase()) {
     case "audio/wav":
     case "audio/x-wav":
       return "wav";


### PR DESCRIPTION
## Summary

- Adds a `file`-shape branch to the content-extractor visitor (both sync and async dispatchers). Audio mediaTypes route to `inputAudio`, non-audio file payloads route to `binary`.
- Teaches `inputAudio` to prefer an explicit `mimeType` over the format allowlist, and normalises the rewrite output so file-shape inputs produce clean `input_audio` / `binary` references (no chimera of `type:"file"` + externalised fields).
- 2 new unit tests covering the file-shape extraction paths.

## Why

`getSuiteRunData` for the scenario `voice-customer-support-demo` set was returning 90+ MB because base64 audio bytes were landing inline in ClickHouse `Messages.Content`. Root cause: the typescript scenario SDK's `createAudioMessage` emits the canonical AI-SDK shape (`{type:"file", mediaType:"audio/pcm16", data:"<base64>"}`), but the content-extractor visitor had no `file`-shape branch — so the audio dropped into the `unknown` no-op handler and was never externalised to stored-objects.

This is the **defence-in-depth** half of the fix. The companion `langwatch/scenario` PR (#561) translates file+audio parts to `input_audio` shape in the SDK before sending, AND stops pre-stringifying array content so the visitor gets a chance to walk it. With both deployed, current SDK builds hit the `input_audio` branch; older SDK builds and any future non-scenario caller shipping raw AI-SDK file parts are caught here.

## Test plan

- [x] `pnpm test:unit run src/server/stored-objects/__tests__/content-extractor.unit.test.ts` — 18/18 pass (16 existing + 2 new)
- [ ] Re-run a voice scenario from `langwatch/scenario` PR #561 after both ship; confirm `getSuiteRunData` payload drops back to expected size and `Messages.Content` for audio messages contains the externalised URL instead of inline base64
- [ ] Open `/<slug>/simulations/voice-customer-support-demo`; confirm audio plays via the externalised URL

## Companion PRs

- `langwatch/scenario` PR #561 — SDK side (translate file+audio → input_audio, stop pre-stringifying)
- Sibling langwatch PR — projection size cap as a defensive seatbelt against any future shape regression (separate review surface)