### PR TITLE
feat(simulations): cap per-message Content/Rest size in projection (defensive seatbelt)

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
@@ -263,6 +263,69 @@ describe("simulationRunStateFoldProjection", () => {
       expect(state.Status).toBe("IN_PROGRESS");
     });
 
+    it("caps oversized message Content (defence vs SDKs shipping inline media that wasn't externalised)", () => {
+      // 80 KiB string — over the 64 KiB cap. Models the symptom we hit when a
+      // voice SDK ships full base64 audio inline because the stored-objects
+      // pipeline failed to externalise the file part. Without this cap the
+      // bytes land verbatim in ClickHouse Messages.Content and re-leak on
+      // every list query.
+      const oversizedContent = "x".repeat(80 * 1024);
+      const state = foldEvents([
+        createRunStartedEvent(),
+        createMessageSnapshotEvent({
+          messages: [{ role: "user", content: oversizedContent }],
+        }),
+      ]);
+
+      expect(state.Messages).toHaveLength(1);
+      const persisted = state.Messages[0]!.Content;
+      // Truncated to a clearly-marked placeholder, not the original payload.
+      expect(persisted.length).toBeLessThan(oversizedContent.length);
+      expect(persisted).toContain("[truncated:");
+      expect(persisted).toContain("inline media");
+    });
+
+    it("preserves normal-sized Content unchanged (no false-positive truncation)", () => {
+      // Below the cap — a long but reasonable assistant reply.
+      const longButReasonable = "a sentence. ".repeat(2000); // ~24 KiB
+      const state = foldEvents([
+        createRunStartedEvent(),
+        createMessageSnapshotEvent({
+          messages: [{ role: "assistant", content: longButReasonable }],
+        }),
+      ]);
+
+      expect(state.Messages[0]!.Content).toBe(longButReasonable);
+    });
+
+    it("caps oversized Rest (covers array-content paths that route audio into Rest)", () => {
+      // Array content gets duplicated into Rest by buildMessageRestJson; cap
+      // there too so a misbehaving SDK can't punt the leak into Rest while
+      // Content stays small.
+      const oversizedPart = "y".repeat(80 * 1024);
+      const state = foldEvents([
+        createRunStartedEvent(),
+        createMessageSnapshotEvent({
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "hi" },
+                // The actual symptom is a file/input_audio part with base64 in
+                // `data`; an oversized text part is the simplest way to model
+                // the byte volume without coupling the test to a wire shape.
+                { type: "text", text: oversizedPart },
+              ],
+            },
+          ],
+        }),
+      ]);
+
+      const rest = state.Messages[0]!.Rest;
+      expect(rest.length).toBeLessThan(oversizedPart.length);
+      expect(rest).toContain("[truncated:");
+    });
+
     it("ignores snapshots with older timestamps (out-of-order protection)", () => {
       const state = foldEvents([
         createRunStartedEvent(),
@@ -513,6 +576,22 @@ describe("simulationRunStateFoldProjection", () => {
       ]);
 
       expect(state.Messages[0]!.Rest).toContain("toolCalls");
+    });
+
+    it("caps oversized Content on TextMessageEnd (same defence as snapshot path)", () => {
+      const oversized = "z".repeat(80 * 1024);
+      const state = foldEvents([
+        createRunStartedEvent(),
+        createTextMessageEndEvent({
+          messageId: "msg-leak",
+          role: "assistant",
+          content: oversized,
+        }),
+      ]);
+
+      const persisted = state.Messages[0]!.Content;
+      expect(persisted.length).toBeLessThan(oversized.length);
+      expect(persisted).toContain("[truncated:");
     });
   });
 

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
@@ -285,6 +285,26 @@ describe("simulationRunStateFoldProjection", () => {
       expect(persisted).toContain("inline media");
     });
 
+    it("caps oversized multi-byte (UTF-8) Content (fast-path doesn't bypass on character count)", () => {
+      // A char-count fast-path (`value.length <= maxBytes`) would WRONGLY
+      // bypass this string: 30 KiB of chars = under the 64 KiB length, but
+      // each 4-byte UTF-8 emoji (😀) pushes the actual byte length to ~120 KiB.
+      // The safe fast-path uses `value.length * 3 <= maxBytes`, so this
+      // string falls through to the real Buffer.byteLength check and gets
+      // truncated.
+      const oversizedMultibyte = "😀".repeat(30 * 1024);
+      const state = foldEvents([
+        createRunStartedEvent(),
+        createMessageSnapshotEvent({
+          messages: [{ role: "user", content: oversizedMultibyte }],
+        }),
+      ]);
+
+      const persisted = state.Messages[0]!.Content;
+      expect(persisted.length).toBeLessThan(oversizedMultibyte.length);
+      expect(persisted).toContain("[truncated:");
+    });
+
     it("preserves normal-sized Content unchanged (no false-positive truncation)", () => {
       // Below the cap — a long but reasonable assistant reply.
       const longButReasonable = "a sentence. ".repeat(2000); // ~24 KiB

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -55,16 +55,24 @@ const MAX_MESSAGE_REST_BYTES = 64 * 1024;
  * The returned marker has a stable prefix so monitoring + retroactive scans
  * can find affected rows.
  */
-function capOversizedString(
-  value: string,
-  maxBytes: number,
-  field: "Content" | "Rest",
-  ctx: { scenarioRunId: string; messageId?: string; messageRole?: string },
-): string {
-  // String length is char-count, not bytes; rough byte check via
-  // Buffer.byteLength gives an accurate UTF-8 size. Fast path: skip the
-  // Buffer allocation when length alone already proves the string is small.
-  if (value.length <= maxBytes) return value;
+function capOversizedString({
+  value,
+  maxBytes,
+  field,
+  ctx,
+}: {
+  value: string;
+  maxBytes: number;
+  field: "Content" | "Rest";
+  ctx: { scenarioRunId: string; messageId?: string; messageRole?: string };
+}): string {
+  // String length is char-count (UTF-16 code units); UTF-8 may use up to 3
+  // bytes per code unit (4 for surrogate pairs, but a pair occupies two code
+  // units so the per-code-unit ceiling is still 3). The only safe length-only
+  // short-circuit is the inverse bound: when length*3 <= maxBytes the UTF-8
+  // byte length is guaranteed to fit. Using length <= maxBytes as the bypass
+  // would let a multibyte string ~3× over the cap slip through.
+  if (value.length * 3 <= maxBytes) return value;
   const byteLength = Buffer.byteLength(value, "utf8");
   if (byteLength <= maxBytes) return value;
   projectionLogger.warn(
@@ -287,14 +295,30 @@ export class SimulationRunStateFoldProjection
 
         const messageId = typeof m.id === "string" ? m.id : "";
         const messageRole = typeof m.role === "string" ? m.role : "";
-        const ctx = { scenarioRunId: state.ScenarioRunId, messageId, messageRole };
+        // Snapshots can arrive BEFORE the run-started event (see
+        // `StartedAt: state.StartedAt ?? event.occurredAt` two lines up); on
+        // that path state.ScenarioRunId is still empty while the event already
+        // carries the id. Fall back so an oversized first snapshot's warn log
+        // is locatable instead of arriving id-less.
+        const scenarioRunId = state.ScenarioRunId || event.data.scenarioRunId;
+        const ctx = { scenarioRunId, messageId, messageRole };
 
         return {
           Id: messageId,
           Role: messageRole,
-          Content: capOversizedString(content, MAX_MESSAGE_CONTENT_BYTES, "Content", ctx),
+          Content: capOversizedString({
+            value: content,
+            maxBytes: MAX_MESSAGE_CONTENT_BYTES,
+            field: "Content",
+            ctx,
+          }),
           TraceId: typeof m.trace_id === "string" ? m.trace_id : "",
-          Rest: capOversizedString(buildMessageRestJson(m), MAX_MESSAGE_REST_BYTES, "Rest", ctx),
+          Rest: capOversizedString({
+            value: buildMessageRestJson(m),
+            maxBytes: MAX_MESSAGE_REST_BYTES,
+            field: "Rest",
+            ctx,
+          }),
         };
       }),
       TraceIds: Array.isArray(event.data.traceIds) ? event.data.traceIds : [],
@@ -347,22 +371,30 @@ export class SimulationRunStateFoldProjection
       (m) => m.Id === event.data.messageId,
     );
 
+    // TextMessageEnd can also fold before the started event (the handler
+    // appends/pads even without a prior START); fall back to the event's
+    // scenarioRunId so the warn log carries the run identifier.
     const ctx = {
-      scenarioRunId: state.ScenarioRunId,
+      scenarioRunId: state.ScenarioRunId || event.data.scenarioRunId,
       messageId: event.data.messageId,
       messageRole: event.data.role,
     };
     const row: SimulationMessageRow = {
       Id: event.data.messageId,
       Role: event.data.role,
-      Content: capOversizedString(event.data.content, MAX_MESSAGE_CONTENT_BYTES, "Content", ctx),
-      TraceId: event.data.traceId ?? "",
-      Rest: capOversizedString(
-        buildMessageRestJson((event.data.message ?? {}) as Record<string, unknown>),
-        MAX_MESSAGE_REST_BYTES,
-        "Rest",
+      Content: capOversizedString({
+        value: event.data.content,
+        maxBytes: MAX_MESSAGE_CONTENT_BYTES,
+        field: "Content",
         ctx,
-      ),
+      }),
+      TraceId: event.data.traceId ?? "",
+      Rest: capOversizedString({
+        value: buildMessageRestJson((event.data.message ?? {}) as Record<string, unknown>),
+        maxBytes: MAX_MESSAGE_REST_BYTES,
+        field: "Rest",
+        ctx,
+      }),
     };
 
     let updatedMessages: SimulationMessageRow[];

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -29,6 +29,57 @@ import {
   SimulationRunDeletedEventSchema,
 } from "../schemas/events";
 import { ValidationError } from "~/server/event-sourcing/services/errorHandling";
+import { createLogger } from "~/utils/logger/server";
+
+const projectionLogger = createLogger("simulationRunState.foldProjection");
+
+/**
+ * Per-message size cap for `Messages.Content` / `Messages.Rest`.
+ *
+ * Set generously (64 KiB) so normal text turns — even verbose multi-paragraph
+ * assistant replies — are never truncated. Messages that exceed this are
+ * almost always the symptom of an upstream SDK shipping inline binary media
+ * that the stored-objects pipeline failed to externalise (the original
+ * symptom: scenario voice runs persisting full base64 PCM16 audio in
+ * `Messages.Content`, which then leaked into every `getSuiteRunData`
+ * response). Truncation here keeps the list path bounded and makes the
+ * regression visible (via logs + the surfaced marker) instead of silently
+ * blowing up the simulations page.
+ */
+const MAX_MESSAGE_CONTENT_BYTES = 64 * 1024;
+const MAX_MESSAGE_REST_BYTES = 64 * 1024;
+
+/**
+ * Cap an oversized message-content / rest string and emit a structured warn
+ * log so an SDK regression doesn't silently land 90+ MB rows in ClickHouse.
+ * The returned marker has a stable prefix so monitoring + retroactive scans
+ * can find affected rows.
+ */
+function capOversizedString(
+  value: string,
+  maxBytes: number,
+  field: "Content" | "Rest",
+  ctx: { scenarioRunId: string; messageId?: string; messageRole?: string },
+): string {
+  // String length is char-count, not bytes; rough byte check via
+  // Buffer.byteLength gives an accurate UTF-8 size. Fast path: skip the
+  // Buffer allocation when length alone already proves the string is small.
+  if (value.length <= maxBytes) return value;
+  const byteLength = Buffer.byteLength(value, "utf8");
+  if (byteLength <= maxBytes) return value;
+  projectionLogger.warn(
+    {
+      scenarioRunId: ctx.scenarioRunId,
+      messageId: ctx.messageId,
+      messageRole: ctx.messageRole,
+      field,
+      byteLength,
+      maxBytes,
+    },
+    `simulation message ${field} exceeds size cap — truncating (probable inline media not externalised)`,
+  );
+  return `[truncated: message ${field.toLowerCase()} was ${byteLength} bytes (cap ${maxBytes}); likely inline media that was not externalised to stored-objects]`;
+}
 
 function buildMessageRestJson(messageFields: Record<string, unknown>): string {
   // When `content` is an array, preserve it in Rest so the renderer can route
@@ -234,12 +285,16 @@ export class SimulationRunStateFoldProjection
           content = JSON.stringify(m.content);
         }
 
+        const messageId = typeof m.id === "string" ? m.id : "";
+        const messageRole = typeof m.role === "string" ? m.role : "";
+        const ctx = { scenarioRunId: state.ScenarioRunId, messageId, messageRole };
+
         return {
-          Id: typeof m.id === "string" ? m.id : "",
-          Role: typeof m.role === "string" ? m.role : "",
-          Content: content,
+          Id: messageId,
+          Role: messageRole,
+          Content: capOversizedString(content, MAX_MESSAGE_CONTENT_BYTES, "Content", ctx),
           TraceId: typeof m.trace_id === "string" ? m.trace_id : "",
-          Rest: buildMessageRestJson(m),
+          Rest: capOversizedString(buildMessageRestJson(m), MAX_MESSAGE_REST_BYTES, "Rest", ctx),
         };
       }),
       TraceIds: Array.isArray(event.data.traceIds) ? event.data.traceIds : [],
@@ -292,12 +347,22 @@ export class SimulationRunStateFoldProjection
       (m) => m.Id === event.data.messageId,
     );
 
+    const ctx = {
+      scenarioRunId: state.ScenarioRunId,
+      messageId: event.data.messageId,
+      messageRole: event.data.role,
+    };
     const row: SimulationMessageRow = {
       Id: event.data.messageId,
       Role: event.data.role,
-      Content: event.data.content,
+      Content: capOversizedString(event.data.content, MAX_MESSAGE_CONTENT_BYTES, "Content", ctx),
       TraceId: event.data.traceId ?? "",
-      Rest: buildMessageRestJson((event.data.message ?? {}) as Record<string, unknown>),
+      Rest: capOversizedString(
+        buildMessageRestJson((event.data.message ?? {}) as Record<string, unknown>),
+        MAX_MESSAGE_REST_BYTES,
+        "Rest",
+        ctx,
+      ),
     };
 
     let updatedMessages: SimulationMessageRow[];


### PR DESCRIPTION
## Summary

- Caps `Messages.Content` and `Messages.Rest` at 64 KiB per message in the simulation-run fold projection (both MessageSnapshot and TextMessageEnd handlers).
- Oversized values become a clearly-marked truncation placeholder (`[truncated: message content was N bytes (cap M); likely inline media that was not externalised to stored-objects]`).
- Emits a structured `warn` log on every truncation: `{scenarioRunId, messageId, messageRole, field, byteLength, maxBytes}` — alertable in production.
- 4 new unit tests; 26 existing still pass.

## Why

A voice scenario set was leaking 90+ MB of base64 audio inline in ClickHouse `Messages.Content` because the stored-objects pipeline failed to externalise the SDK's audio file parts. `getSuiteRunData` then slurped the first 6 messages of every scenario back to the browser.

The SDK fix (langwatch/scenario PR #561) and the content-extractor fix (PR #4493) together address the root cause for the known shapes. **This patch is the defensive seatbelt** — any future shape we forget to teach the extractor about, or any upstream refactor that re-stringifies array content before it reaches the extractor, gets a hard size cap at persistence time instead of turning into a multi-megabyte list response.

## Threshold rationale

64 KiB is generous enough that no normal text turn — including verbose multi-paragraph assistant replies and long tool-call argument JSON — is ever truncated. Messages exceeding it are almost always inline binary media: that's exactly the case we want to fail-fast on.

## Test plan

- [x] `pnpm test:unit run src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts` — 30/30 pass
- [ ] Re-deploy and re-run any voice scenario from the failing project; confirm even with a misbehaving SDK upstream the list page loads in normal time and the truncation marker appears in the message row
- [ ] Set up a CloudWatch metric/alarm on the warn log `msg: "simulation message Content exceeds size cap"` — count > 0 indicates an SDK regression slipping past the extractor

## Companion PRs

- `langwatch/scenario` PR #561 — SDK side (translate file+audio → input_audio; stop pre-stringifying array content)
- langwatch PR #4493 — content-extractor side (add `file`-shape branch, normalise rewrites)