### PR TITLE
perf(clickhouse): stop topic-clustering OOM on trace_summaries ComputedInput

### DIFF
--- a/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchTracesFromClickHouse.integration.test.ts
@@ -2,19 +2,21 @@
  * Integration coverage for the topic-clustering trace fetch against a real
  * ClickHouse.
  *
- * The pre-fix query read `ComputedInput` (a potentially large payload) for the
- * entire deduped 12-month trace set before `ORDER BY ... LIMIT 2000` trimmed
- * it, tipping busy tenants into MEMORY_LIMIT_EXCEEDED. The fix pages the 2000
- * most-recent trace keys first (lightweight columns only) and reads
- * `ComputedInput` for that bounded set alone.
+ * The query pages the 2000 most-recent trace keys first (lightweight columns
+ * only) and reads `ComputedInput` (a potentially large payload) for that
+ * bounded set alone. It also carries NO outer `ORDER BY`: an `ORDER BY ...
+ * LIMIT` makes ClickHouse buffer a top-N of full rows, retaining every row's
+ * `ComputedInput` at once, which tipped busy tenants into
+ * MEMORY_LIMIT_EXCEEDED. Ordering is reapplied in JS over the small result set
+ * instead, so these tests double as the regression guard that the JS ordering
+ * matches what the SQL sort used to produce.
  *
  * These tests exercise the real `fetchTracesFromClickHouse` and lock in the
  * behaviour that matters for correctness and pagination:
  *  - a full page returns the newest traces, newest first;
  *  - the cursor advances to strictly older, non-overlapping traces;
  *  - empty-input traces still occupy page slots so the cursor reaches older
- *    eligible traces instead of stalling (the heavy-column read stays bounded
- *    to the page either way — verified separately during development).
+ *    eligible traces instead of stalling.
  */
 
 import type { ClickHouseClient } from "@clickhouse/client";

--- a/langwatch/src/server/topicClustering/__tests__/topicClustering.unit.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/topicClustering.unit.test.ts
@@ -97,7 +97,7 @@ describe("clusterTopicsForProject", () => {
       mockClickHouseQuery.mockResolvedValueOnce({
         json: () =>
           Promise.resolve([
-            { total: "5", withInput: "3", recent: "5", assigned: "0" },
+            { total: "5", recent: "5", assigned: "0" },
           ]),
       });
 
@@ -127,7 +127,7 @@ describe("clusterTopicsForProject", () => {
       mockClickHouseQuery.mockResolvedValueOnce({
         json: () =>
           Promise.resolve([
-            { total: "100", withInput: "0", recent: "100", assigned: "0" },
+            { total: "100", recent: "100", assigned: "0" },
           ]),
       });
 
@@ -168,7 +168,7 @@ describe("clusterTopicsForProject", () => {
       mockClickHouseQuery.mockResolvedValueOnce({
         json: () =>
           Promise.resolve([
-            { total: "100", withInput: "80", recent: "100", assigned: "0" },
+            { total: "100", recent: "100", assigned: "0" },
           ]),
       });
 
@@ -217,7 +217,7 @@ describe("clusterTopicsForProject", () => {
       mockClickHouseQuery.mockResolvedValueOnce({
         json: () =>
           Promise.resolve([
-            { total: "100", withInput: "80", recent: "100", assigned: "0" },
+            { total: "100", recent: "100", assigned: "0" },
           ]),
       });
 
@@ -253,7 +253,7 @@ describe("clusterTopicsForProject", () => {
       mockClickHouseQuery.mockResolvedValueOnce({
         json: () =>
           Promise.resolve([
-            { total: "100", withInput: "80", recent: "100", assigned: "0" },
+            { total: "100", recent: "100", assigned: "0" },
           ]),
       });
 

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -255,14 +255,20 @@ export async function fetchTracesFromClickHouse(
   // by the surviving subset and could strand older eligible traces behind a
   // run of empty-input traces.
   //
-  // The outer query also has NO `ORDER BY`. The page CTE has already chosen the
-  // exact set of traces to return, so an outer sort would only re-order that
-  // fixed set — but `ORDER BY ... LIMIT` makes ClickHouse buffer a top-N of full
-  // rows, retaining every row's ComputedInput payload at once. For tenants with
-  // large inputs that buffer alone exceeded max_memory_usage_per_query (3.5 GiB)
-  // and the read failed with MEMORY_LIMIT_EXCEEDED. Without the sort the rows
-  // stream out (ComputedInput is read in small adaptive blocks and released),
-  // and the page ordering is reapplied in JS over the small result set below.
+  // The outer query also has NO `ORDER BY` and NO outer `LIMIT`. The page CTE
+  // has already chosen the exact (<=2000) set of traces to return, so an outer
+  // sort would only re-order that fixed set — but `ORDER BY ... LIMIT` makes
+  // ClickHouse buffer a top-N of full rows, retaining every row's ComputedInput
+  // payload at once. For tenants with large inputs that buffer alone exceeded
+  // max_memory_usage_per_query (3.5 GiB) and the read failed with
+  // MEMORY_LIMIT_EXCEEDED. Without the sort the rows stream out (ComputedInput
+  // is read in small adaptive blocks and released), and the page ordering is
+  // reapplied in JS over the small result set below.
+  //
+  // An outer `LIMIT 2000` is also omitted: it would cap physical rows *before*
+  // the JS TraceId de-dupe, so if a trace had duplicate latest-version rows the
+  // cap could drop other selected TraceIds and break `returnedCount`/`lastSort`
+  // pagination. The page CTE bounds the result, so the cap is unnecessary.
   const pageHaving: string[] = [];
 
   if (isIncrementalProcessing && (topicIds.length > 0 || subtopicIds.length > 0)) {
@@ -326,7 +332,6 @@ export async function fetchTracesFromClickHouse(
             AND TraceId IN (SELECT TraceId FROM page)
           GROUP BY TenantId, TraceId
         )
-      LIMIT 2000
     `,
     query_params: {
       tenantId: projectId,

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -48,14 +48,13 @@ export const clusterTopicsForProject = async (
     throw new Error(`ClickHouse client not available for project ${projectId}`);
   }
 
-  const { totalTracesCount, tracesWithInputCount, recentTracesCount, assignedTracesCount } =
+  const { totalTracesCount, recentTracesCount, assignedTracesCount } =
     await fetchCountsFromClickHouse(clickhouse, projectId);
 
   logger.info(
     {
       projectId,
       totalTraces: totalTracesCount,
-      tracesWithInput: tracesWithInputCount,
       recentTraces: recentTracesCount,
       backend: "clickhouse",
     },
@@ -179,7 +178,6 @@ export const clusterTopicsForProject = async (
 
 type TraceCounts = {
   totalTracesCount: number;
-  tracesWithInputCount: number;
   recentTracesCount: number;
   assignedTracesCount: number;
 };
@@ -201,7 +199,6 @@ async function fetchCountsFromClickHouse(
     query: `
       SELECT
         toString(count(*)) AS total,
-        toString(countIf(length(ComputedInput) > 0)) AS withInput,
         toString(countIf(OccurredAt >= fromUnixTimestamp64Milli({thirtyDaysAgo:UInt64}))) AS recent,
         toString(countIf(TopicId IS NOT NULL AND TopicId != '')) AS assigned
       FROM trace_summaries t
@@ -221,7 +218,6 @@ async function fetchCountsFromClickHouse(
 
   const rows = (await result.json()) as Array<{
     total: string;
-    withInput: string;
     recent: string;
     assigned: string;
   }>;
@@ -229,7 +225,6 @@ async function fetchCountsFromClickHouse(
 
   return {
     totalTracesCount: parseInt(row?.total ?? "0", 10),
-    tracesWithInputCount: parseInt(row?.withInput ?? "0", 10),
     recentTracesCount: parseInt(row?.recent ?? "0", 10),
     assignedTracesCount: parseInt(row?.assigned ?? "0", 10),
   };
@@ -259,6 +254,15 @@ export async function fetchTracesFromClickHouse(
   // cursor) tracks the page boundary. Filtering here would advance the cursor
   // by the surviving subset and could strand older eligible traces behind a
   // run of empty-input traces.
+  //
+  // The outer query also has NO `ORDER BY`. The page CTE has already chosen the
+  // exact set of traces to return, so an outer sort would only re-order that
+  // fixed set — but `ORDER BY ... LIMIT` makes ClickHouse buffer a top-N of full
+  // rows, retaining every row's ComputedInput payload at once. For tenants with
+  // large inputs that buffer alone exceeded max_memory_usage_per_query (3.5 GiB)
+  // and the read failed with MEMORY_LIMIT_EXCEEDED. Without the sort the rows
+  // stream out (ComputedInput is read in small adaptive blocks and released),
+  // and the page ordering is reapplied in JS over the small result set below.
   const pageHaving: string[] = [];
 
   if (isIncrementalProcessing && (topicIds.length > 0 || subtopicIds.length > 0)) {
@@ -322,7 +326,6 @@ export async function fetchTracesFromClickHouse(
             AND TraceId IN (SELECT TraceId FROM page)
           GROUP BY TenantId, TraceId
         )
-      ORDER BY t.OccurredAt DESC, t.TraceId ASC
       LIMIT 2000
     `,
     query_params: {
@@ -345,14 +348,25 @@ export async function fetchTracesFromClickHouse(
     OccurredAtMs: string;
   }>;
 
+  // Reapply the page ordering (OccurredAt DESC, TraceId ASC) in JS. The query
+  // dropped its outer ORDER BY to avoid the top-N memory buffer (see above), so
+  // rows now arrive in scan order; sort the small (<=2000) result set here so
+  // the dedup-first-row and `lastSort` cursor logic below stay correct.
+  rawRows.sort((a, b) => {
+    const aTs = parseInt(a.OccurredAtMs, 10);
+    const bTs = parseInt(b.OccurredAtMs, 10);
+    if (aTs !== bTs) return bTs - aTs; // OccurredAt DESC
+    return a.TraceId < b.TraceId ? -1 : a.TraceId > b.TraceId ? 1 : 0; // TraceId ASC
+  });
+
   // Defensive de-duplication by TraceId. The monotonic `UpdatedAt` invariant
   // should make `(TenantId, TraceId, max(UpdatedAt))` match exactly one row per
   // trace, but `returnedCount` / `lastSort` now drive pagination, so collapse
   // any same-version duplicate here in JS rather than at the SQL layer — the
   // per-key SQL dedup operator is banned in this path for OOM safety (it reads
   // heavy columns for the whole granule; see trace-dedup-oom-safety.unit.test).
-  // Rows arrive ordered by `OccurredAt DESC, TraceId ASC`, so the first row per
-  // TraceId is the one the boundary cursor should land on.
+  // Rows are ordered `OccurredAt DESC, TraceId ASC` (sorted above), so the first
+  // row per TraceId is the one the boundary cursor should land on.
   const seenTraceIds = new Set<string>();
   const rows = rawRows.filter((row) => {
     if (seenTraceIds.has(row.TraceId)) return false;


### PR DESCRIPTION
## Evidence

Prod ClickHouse server log (last 24h) shows `Code: 241 MEMORY_LIMIT_EXCEEDED` exceptions on `trace_summaries`, blowing up `(while reading column ComputedInput)`:

- `WITH page AS (...) SELECT ... t.ComputedInput ... ORDER BY t.OccurredAt DESC LIMIT 2000` (the topic-clustering trace fetch) failed repeatedly: `would use 3.67 GiB ... maximum: 3.50 GiB`.
- `SELECT count(*), countIf(length(ComputedInput) > 0), ...` (the topic-clustering counts query) failed with the same code over the 12-month window.

These are the per-query memory-limit failures (3.5 GiB cap, `infrastructure/clickhouse.tf`), i.e. the worst class of slow query: the run errors out and that clustering page never completes.

## Suspected cause

Both queries live in `src/server/topicClustering/topicClustering.ts` and both read the heavy `ComputedInput` column:

1. **`fetchTracesFromClickHouse`** pages the 2000 most-recent trace keys in a lightweight CTE (good), then reads `ComputedInput` for that bounded set. The problem is the outer `ORDER BY t.OccurredAt DESC, t.TraceId ASC LIMIT 2000`: `ORDER BY ... LIMIT` makes ClickHouse run a top-N sort that **buffers full rows**, holding every selected row's `ComputedInput` in memory at once. For tenants with large inputs that buffer alone exceeds 3.5 GiB. The sort is also redundant: the `page` CTE has already chosen the exact set of traces to return, so the outer sort only re-orders a fixed set.
2. **`fetchCountsFromClickHouse`** computes `countIf(length(ComputedInput) > 0)` across the entire deduped 12-month trace set. `length()` forces a full read of the column. The resulting number (`tracesWithInputCount`) is used **only in a debug log line** and drives no control flow.

## Proposed fix

1. Drop the outer `ORDER BY` from `fetchTracesFromClickHouse`. Rows now stream out (`ComputedInput` is read in small adaptive blocks and released as each block is formatted) instead of being buffered for a top-N. Re-apply the page ordering (`OccurredAt DESC, TraceId ASC`) in JS over the small (<=2000) result set, preserving the existing dedup-first-row and `lastSort` cursor semantics.
2. Drop `countIf(length(ComputedInput) > 0)` (and the `tracesWithInputCount` field) from `fetchCountsFromClickHouse`. The remaining counts (`total`, `recent`, `assigned`) use only light columns.

No schema, migration, or infra change.

## Expected impact

- Peak memory for the trace fetch drops from "2000 x full ComputedInput buffered for the sort" (3.6+ GiB for large-input tenants) to roughly one adaptive block's worth of `ComputedInput` at a time. The query stops hitting the 3.5 GiB cap.
- The counts query no longer reads `ComputedInput` at all, so it no longer OOMs on the 12-month window.
- No user-visible latency regression: clustering currently *fails* for these tenants, so the change turns an error into a completed page. Ordering and pagination are unchanged (now enforced in JS, covered by the integration tests).

## Test plan

- Unit (`topicClustering.unit.test.ts`): updated mocks to the new query shape; existing dedup + `lastSort` assertions pass (the JS sort reproduces the prior SQL ordering). 5 passed.
- Integration (`fetchTracesFromClickHouse.integration.test.ts`, real ClickHouse via testcontainers): full page returns the 2000 newest newest-first; cursor advances to strictly older non-overlapping traces; a full empty-input page still advances the cursor to `...-trace-001999`. 3 passed. These double as the regression guard that the JS ordering matches what the SQL sort produced.

## EXPLAIN check

Run via the read-only `/api/ops/clickhouse/explain` endpoint against a real large tenant (id redacted), 12-month window.

**PLAN** - the `Sorting` step disappears:

```
old: Limit (preliminary LIMIT) -> Sorting (Sorting for ORDER BY) -> Expression (WHERE) -> ReadFromMergeTree
new: Limit (preliminary LIMIT) -> Expression (WHERE) -> ReadFromMergeTree
```

**PIPELINE** - the top-N buffering transforms disappear:

```
old: Limit -> MergingSortedTransform 4 -> 1 -> MergeSortingTransform x4 -> LimitsCheckingTransform x4 -> PartialSortingTransform x4 -> ReadFromMergeTree
new: Limit 4 -> 4 -> ExpressionTransform x4 -> MergeTreeSelect x4 (streams, no sort buffer)
```

The removed `MergeSortingTransform` / `PartialSortingTransform` chain is exactly the buffer that retained the full `ComputedInput` payload for the whole page. The new pipeline keeps the 4 read streams parallel and streams straight through `Limit`.

The page CTE's own sort (on lightweight key columns, inside `CreatingSets`) is unchanged.
