### PR TITLE
perf(clickhouse): prune trace_summaries read in RAG document and feedback analytics

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -1232,6 +1232,30 @@ describe("aggregation-builder", () => {
 
       expect(result.sql).toContain("LIMIT 10");
     });
+
+    it("prunes the deduped trace_summaries read to identity columns", () => {
+      const result = buildTopDocumentsQuery(projectId, startDate, endDate);
+
+      // The document payload comes from the stored_spans ARRAY JOIN, so the
+      // deduped trace_summaries subquery only needs identity/date columns and
+      // must not materialise the wide Attributes map.
+      expect(result.sql).toContain(
+        "SELECT TenantId, TraceId, OccurredAt, UpdatedAt FROM trace_summaries"
+      );
+    });
+
+    it("adds filter-referenced columns to the deduped read so filtered queries stay valid", () => {
+      const result = buildTopDocumentsQuery(projectId, startDate, endDate, {
+        "topics.topics": ["topic-1"],
+      });
+
+      // TopicId is referenced by the filter WHERE, so the deduped subquery must
+      // also select it (otherwise ClickHouse would reject ts.TopicId).
+      expect(result.sql).toContain(
+        "SELECT TenantId, TraceId, OccurredAt, UpdatedAt, TopicId FROM trace_summaries"
+      );
+      expect(result.sql).toContain("ts.TopicId IN");
+    });
   });
 
   describe("buildFeedbacksQuery", () => {
@@ -1298,6 +1322,29 @@ describe("aggregation-builder", () => {
       const result = buildFeedbacksQuery(projectId, startDate, endDate);
 
       expect(result.sql).toContain("ORDER BY event_timestamp DESC");
+    });
+
+    it("prunes the deduped trace_summaries read to identity columns", () => {
+      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+
+      // Feedback payload comes from the stored_spans Events arrays, so the
+      // deduped trace_summaries subquery only needs identity/date columns.
+      expect(result.sql).toContain(
+        "SELECT TenantId, TraceId, OccurredAt, UpdatedAt FROM trace_summaries"
+      );
+    });
+
+    it("adds a filter-referenced Attributes read to the deduped subquery", () => {
+      const result = buildFeedbacksQuery(projectId, startDate, endDate, {
+        "metadata.user_id": ["user-1"],
+      });
+
+      // The user_id filter references ts.Attributes[...], so Attributes must be
+      // present in the deduped subquery's column list for the query to be valid.
+      expect(result.sql).toContain(
+        "SELECT TenantId, TraceId, OccurredAt, UpdatedAt, Attributes FROM trace_summaries"
+      );
+      expect(result.sql).toContain("ts.Attributes[{metaValues_");
     });
   });
 

--- a/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings-column-extraction.unit.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/field-mappings-column-extraction.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractReferencedSpanColumns,
   extractReferencedEvaluationColumns,
+  extractReferencedTraceColumns,
 } from "../field-mappings";
 
 describe("extractReferencedSpanColumns", () => {
@@ -189,6 +190,50 @@ describe("extractReferencedEvaluationColumns", () => {
     it("matches Status at end of string", () => {
       const result = extractReferencedEvaluationColumns(["es.Status"]);
       expect(result).toContain("Status");
+    });
+  });
+});
+
+describe("extractReferencedTraceColumns", () => {
+  describe("when expression references trace columns", () => {
+    it("extracts the Attributes map for ts-qualified bracket access", () => {
+      const result = extractReferencedTraceColumns([
+        "ts.Attributes['langwatch.user_id'] = {v:String}",
+      ]);
+      expect(result).toContain("Attributes");
+    });
+
+    it("extracts TopicId from a filter predicate", () => {
+      const result = extractReferencedTraceColumns(["ts.TopicId IN ('a')"]);
+      expect(result).toContain("TopicId");
+      expect(result).not.toContain("SubTopicId");
+    });
+  });
+
+  describe("when expression only references span attributes", () => {
+    it("does not match trace Attributes inside SpanAttributes", () => {
+      // Suffix collision: "Attributes" is the tail of "SpanAttributes".
+      const result = extractReferencedTraceColumns([
+        "ss.SpanAttributes['gen_ai.request.model'] = {v:String}",
+      ]);
+      expect(result).not.toContain("Attributes");
+    });
+
+    it('does not match trace Attributes inside quoted "Events.Attributes"', () => {
+      const result = extractReferencedTraceColumns([
+        'mapContains(ss."Events.Attributes", \'x\')',
+      ]);
+      expect(result).not.toContain("Attributes");
+    });
+  });
+
+  describe("when expression references no trace columns", () => {
+    it("returns an empty set", () => {
+      const result = extractReferencedTraceColumns([
+        "ss.DurationMs > 100",
+        "1=1",
+      ]);
+      expect(result.size).toBe(0);
     });
   });
 });

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -13,8 +13,10 @@ import {
   buildJoinClause,
   tableAliases,
   TRACE_ANALYTICS_COLUMNS,
+  TRACE_IDENTITY_COLUMNS,
   extractReferencedSpanColumns,
   extractReferencedEvaluationColumns,
+  extractReferencedTraceColumns,
 } from "./field-mappings";
 import { snakeCase } from "../../../utils/stringCasing";
 import {
@@ -2459,14 +2461,27 @@ export function buildTopDocumentsQuery(
       : "";
 
   // Build query to get top documents from RAG contexts
-  // Documents are stored in SpanAttributes['langwatch.rag.contexts'] as JSON
+  // Documents are stored in SpanAttributes['langwatch.rag.contexts'] as JSON.
+  // The document payload comes entirely from the stored_spans ARRAY JOIN; the
+  // fixed part of this query only uses trace_summaries identity/date columns
+  // (the JOIN keys and the OccurredAt filter). So the deduped subquery reads
+  // just the identity columns plus whatever the user filters reference, instead
+  // of the full analytics set, which avoids materialising the heavy Attributes
+  // map for every deduped trace.
+  const traceColumns = Array.from(
+    new Set([
+      ...TRACE_IDENTITY_COLUMNS,
+      ...extractReferencedTraceColumns([filterWhere]),
+    ]),
+  );
+
   const sql = `
     WITH document_refs AS (
       SELECT
         ${ts}.TraceId,
         toString(context.document_id) AS document_id,
         toString(context.content) AS content
-      FROM ${dedupedTraceSummaries(ts, undefined, DATE_FILTER_START_END)}
+      FROM ${dedupedTraceSummaries(ts, traceColumns, DATE_FILTER_START_END)}
       JOIN stored_spans ${ss} ON ${ts}.TenantId = ${ss}.TenantId AND ${ts}.TraceId = ${ss}.TraceId
       ARRAY JOIN JSONExtract(${ss}.SpanAttributes['langwatch.rag.contexts'], 'Array(JSON)') AS context
       WHERE ${ts}.TenantId = {tenantId:String}
@@ -2489,7 +2504,7 @@ export function buildTopDocumentsQuery(
 
   const totalSql = `
     SELECT uniq(toString(context.document_id)) AS total
-    FROM ${dedupedTraceSummaries(ts, undefined, DATE_FILTER_START_END)}
+    FROM ${dedupedTraceSummaries(ts, traceColumns, DATE_FILTER_START_END)}
     JOIN stored_spans ${ss} ON ${ts}.TenantId = ${ss}.TenantId AND ${ts}.TraceId = ${ss}.TraceId
     ARRAY JOIN JSONExtract(${ss}.SpanAttributes['langwatch.rag.contexts'], 'Array(JSON)') AS context
     WHERE ${ts}.TenantId = {tenantId:String}
@@ -2537,7 +2552,18 @@ export function buildFeedbacksQuery(
       : "";
 
   // Build query to get feedback events
-  // Events are stored in stored_spans as parallel arrays
+  // Events are stored in stored_spans as parallel arrays. As with the documents
+  // query, the fixed part uses only trace_summaries identity/date columns, so
+  // the deduped subquery reads just the identity columns plus whatever the user
+  // filters reference rather than the full analytics set, skipping the heavy
+  // Attributes map.
+  const traceColumns = Array.from(
+    new Set([
+      ...TRACE_IDENTITY_COLUMNS,
+      ...extractReferencedTraceColumns([filterWhere]),
+    ]),
+  );
+
   const sql = `
     SELECT
       ${ts}.TraceId AS trace_id,
@@ -2545,7 +2571,7 @@ export function buildFeedbacksQuery(
       toUnixTimestamp64Milli(event_timestamp) AS started_at,
       event_name AS event_type,
       event_attrs AS attributes
-    FROM ${dedupedTraceSummaries(ts, undefined, DATE_FILTER_START_END)}
+    FROM ${dedupedTraceSummaries(ts, traceColumns, DATE_FILTER_START_END)}
     JOIN stored_spans ${ss} ON ${ts}.TenantId = ${ss}.TenantId AND ${ts}.TraceId = ${ss}.TraceId
     ARRAY JOIN
       ${ss}."Events.Timestamp" AS event_timestamp,

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -634,6 +634,32 @@ export function extractReferencedEvaluationColumns(
 }
 
 /**
+ * Extract which trace_summaries columns are referenced in a set of SQL
+ * expressions.
+ *
+ * Scans the expressions for references to known trace analytics column names
+ * (including through the table alias `ts.`). Returns the set of column names
+ * suitable for passing to `dedupedTraceSummaries` so the deduped subquery only
+ * reads the columns actually used, instead of the full analytics set with its
+ * wide Attributes map.
+ */
+export function extractReferencedTraceColumns(
+  expressions: string[],
+): ReadonlySet<string> {
+  const joined = expressions.join(" ");
+  const columns = new Set<string>();
+  const alias = tableAliases.trace_summaries;
+
+  for (const col of TRACE_ANALYTICS_COLUMNS) {
+    if (buildColumnPattern(col, alias).test(joined)) {
+      columns.add(col);
+    }
+  }
+
+  return columns;
+}
+
+/**
  * Build a qualified column reference with table alias
  */
 export function qualifiedColumn(esField: string): string {

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -582,8 +582,12 @@ function buildColumnPattern(col: string, alias: string): RegExp {
   const rawCol = col.replace(/"/g, "");
   // Escape special regex chars in the column name (e.g. dots in "Events.Name")
   const escaped = rawCol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Match alias.Column or unqualified Column, followed by a boundary
-  const pattern = `(?:${alias}\\.)?(?:"?${escaped}"?)${COLUMN_BOUNDARY.source}`;
+  // Match alias.Column or an unqualified column token, but not a suffix inside
+  // another identifier. The left boundary applies to the whole match (before
+  // the optional alias too), so neither "Attributes" matches the tail of
+  // "SpanAttributes", nor "ts." matches the tail of "Events." in
+  // "Events.Attributes".
+  const pattern = `(?<![\\w."])(?:${alias}\\.)?(?:"?${escaped}"?)${COLUMN_BOUNDARY.source}`;
   return new RegExp(pattern);
 }
 


### PR DESCRIPTION
## Evidence

Two analytics query shapes against `trace_summaries` show up in the prod ClickHouse logs (last 24h):

- **Signal B (failed in prod):** `SELECT uniq(toString(context.document_id)) ... FROM (SELECT <all analytics columns> FROM trace_summaries WHERE ... IN (dedup)) JOIN stored_spans ...` failed with `Code: 241 MEMORY_LIMIT_EXCEEDED` (3.5 GiB per-query cap). The deduped subquery materialises the wide `Attributes` map for every trace in the window.
- **Signal C (cold-scan cost):** the same `document_refs` shape appears among the `stored_spans`/`trace_summaries` cold-scan reads.

## Suspected cause

`buildTopDocumentsQuery` and `buildFeedbacksQuery` (in `analytics/clickhouse/aggregation-builder.ts`) JOIN `trace_summaries` to `stored_spans` and pull their actual payload from the `stored_spans` ARRAY JOIN (RAG contexts JSON / Events arrays). From `trace_summaries` they use only identity columns (`TenantId`, `TraceId` for the JOIN) and `OccurredAt` (date filter).

But both pass `undefined` for the column list of `dedupedTraceSummaries(...)`, which defaults to the full `TRACE_ANALYTICS_COLUMNS` set, including the heavy `Attributes` `Map(String, String)`. So the deduped subquery reads ~20 columns (with the wide map) per deduped trace when it needs 4. That heavy read is what tips the documents query over the per-query memory limit.

There was no `trace_summaries` column extractor (only `extractReferencedSpanColumns` / `extractReferencedEvaluationColumns` existed), so the existing `columns` parameter of `dedupedTraceSummaries` was never used by any caller.

## Proposed fix

- Add `extractReferencedTraceColumns(expressions)` to `field-mappings.ts`, mirroring the span / evaluation extractors: it scans expressions for `trace_summaries` columns referenced through the `ts.` alias.
- In both builders, read only `TRACE_IDENTITY_COLUMNS` (`TenantId`, `TraceId`, `OccurredAt`, `UpdatedAt`) union the columns the active filters reference (extracted from the translated filter WHERE), and pass that set to `dedupedTraceSummaries`.

This is the safe part of the broader over-read: the fixed body of these two queries provably uses only identity columns, and filter-referenced columns are added back so filtered queries stay valid. No schema, migration, or infra change.

## Expected impact

- Unfiltered: the deduped `trace_summaries` read drops from ~20 columns (incl. the wide `Attributes` map) to 4 identity columns. The documents query stops materialising the map that pushed it past the 3.5 GiB cap, so the Code 241 failures stop.
- Filtered: reads exactly the extra columns the WHERE needs (e.g. `TopicId` for a topic filter, `Attributes` for a metadata facet), so behaviour is unchanged.
- Cost: fewer bytes read per granule on both hot and S3-tiered partitions for these shapes. User-visible latency may move only slightly; the headline is removing the OOM and cutting read volume.

## Test plan

`aggregation-builder.test.ts` (unit), 87 passed including 4 new:
- documents / feedbacks unfiltered: deduped subquery is `SELECT TenantId, TraceId, OccurredAt, UpdatedAt FROM trace_summaries` (no `Attributes`).
- documents with a topic filter: subquery list gains `TopicId` and the WHERE still has `ts.TopicId IN` (valid).
- feedbacks with a `metadata.user_id` filter: subquery list gains `Attributes` and the WHERE still has `ts.Attributes[{metaValues_...}]` (valid).

## EXPLAIN check

Validated via the read-only `/api/ops/clickhouse/explain` endpoint against a real large tenant (id redacted), `stored_spans` + `trace_summaries` JOIN.

- The **new** pruned `totalSql` plans successfully against the live schema (no missing-column error), confirming the prune preserves the IN-tuple dedup and the JOIN/ARRAY JOIN. PLAN top: `Expression -> Aggregating -> ArrayJoin -> Join -> {ReadFromMergeTree trace_summaries, ReadFromMergeTree stored_spans}`.
- `INDEXES` on the new shape shows partition pruning intact on `trace_summaries` (`Parts: 10/278`). Column pruning reduces bytes-read-per-granule (the `Attributes` map is no longer deserialised) rather than granule count, so granule numbers are unchanged by design; the mechanism is the eliminated wide-column read, corroborated by the prod Code 241 on the old shape.
