### PR TITLE
feat(home): voice agents banner shown after traces v2 dismissed

### DIFF
--- a/langwatch/src/components/home/HomePage.tsx
+++ b/langwatch/src/components/home/HomePage.tsx
@@ -1,12 +1,12 @@
 import { Container, VStack } from "@chakra-ui/react";
 import { DashboardLayout } from "../DashboardLayout";
+import { HomePageBanners } from "./HomePageBanners";
 import { LearningResources } from "./LearningResources";
 import { OnboardingProgress } from "./OnboardingProgress";
 import { QuickAccessLinks } from "./QuickAccessLinks";
 import { RecentItemsSection } from "./RecentItemsSection";
 import { SdkRadarCard } from "./SdkRadarCard";
 import { TracesOverview } from "./TracesOverview";
-import { TracesV2HomeBanner } from "./TracesV2HomeBanner";
 import { WelcomeHeader } from "./WelcomeHeader";
 
 export function HomePage() {
@@ -15,7 +15,7 @@ export function HomePage() {
       <Container maxW="5xl" padding={6}>
         <VStack gap={6} width="full" align="start">
           <WelcomeHeader />
-          <TracesV2HomeBanner />
+          <HomePageBanners />
           <SdkRadarCard />
           <OnboardingProgress />
           <TracesOverview />

--- a/langwatch/src/components/home/HomePageBanners.tsx
+++ b/langwatch/src/components/home/HomePageBanners.tsx
@@ -4,18 +4,30 @@ import {
 	isTracesV2BannerSnoozed,
 	TracesV2HomeBanner,
 } from "./TracesV2HomeBanner";
-import { VoiceAgentsHomeBanner } from "./VoiceAgentsHomeBanner";
+import {
+	isVoiceAgentsBannerSnoozed,
+	VoiceAgentsHomeBanner,
+} from "./VoiceAgentsHomeBanner";
+
+type BannerChoice = "traces-v2" | "voice-agents" | null;
 
 /**
- * Picks ONE home-page announcement banner to render at a time, in priority
- * order: traces-v2 first; once dismissed/snoozed, the voice-agents banner
- * takes its slot. Each banner owns its own snooze key, so a user who
- * snoozed traces-v2 a week ago still gets the voice-agents announcement,
- * and snoozing voice-agents doesn't bring traces-v2 back.
+ * Picks ONE home-page announcement banner to render at a time. Each banner
+ * owns its own per-project snooze key:
+ *
+ * - If both are eligible (neither snoozed), flip a coin per mount so the two
+ *   launches share the slot 50/50 instead of one always crowding the other.
+ * - If only one is eligible, render it.
+ * - If both are snoozed, render nothing.
+ *
+ * The choice is captured ONCE per mount in `useState`'s lazy initializer so
+ * the coin flip survives re-renders triggered by snooze callbacks. When the
+ * user dismisses the currently-shown banner, we re-evaluate and hand the
+ * slot to the other one in the same tab (no reload needed).
  *
  * The decision lives here (rather than on the home page directly) so the
  * banners themselves remain self-contained and we can add a third in the
- * queue later without growing `HomePage`.
+ * lineup later without growing `HomePage`.
  */
 export function HomePageBanners() {
 	const { project } = useOrganizationTeamProject({
@@ -26,25 +38,45 @@ export function HomePageBanners() {
 
 	const [hasMounted, setHasMounted] = useState(false);
 	const [tracesSnoozed, setTracesSnoozed] = useState(false);
+	const [voiceSnoozed, setVoiceSnoozed] = useState(false);
+	// Stable coin flip captured once per mount — used as a tiebreak ONLY when
+	// both banners are eligible. `Math.random()` is fine in a lazy initializer
+	// since it runs on the client after hydration (we gate render on
+	// `hasMounted`), so SSR can't see the value.
+	const [coinFlipPrefersVoice] = useState(() => Math.random() < 0.5);
 
 	useEffect(() => {
 		setHasMounted(true);
 	}, []);
 
 	useEffect(() => {
-		if (projectId) setTracesSnoozed(isTracesV2BannerSnoozed(projectId));
+		if (projectId) {
+			setTracesSnoozed(isTracesV2BannerSnoozed(projectId));
+			setVoiceSnoozed(isVoiceAgentsBannerSnoozed(projectId));
+		}
 	}, [projectId]);
 
 	// SSR / pre-hydration guard: render nothing rather than briefly flashing
 	// the first banner before the snooze check runs.
 	if (!hasMounted) return null;
 
-	// Wire `onDismissed` so the moment the user clicks ✕ on traces-v2 the
-	// voice banner takes the slot in the same tab. Without this the parent
-	// only reads the snooze flag on `projectId` change and the next banner
-	// only appears on remount/reload, which reads as a layout bug.
-	return tracesSnoozed ? (
-		<VoiceAgentsHomeBanner />
+	const choice: BannerChoice =
+		tracesSnoozed && voiceSnoozed
+			? null
+			: tracesSnoozed
+				? "voice-agents"
+				: voiceSnoozed
+					? "traces-v2"
+					: coinFlipPrefersVoice
+						? "voice-agents"
+						: "traces-v2";
+
+	if (choice === null) return null;
+	// `onDismissed` lets the parent flip to the OTHER banner in the same tab
+	// the moment the user clicks ✕, instead of waiting for a reload to
+	// re-read localStorage.
+	return choice === "voice-agents" ? (
+		<VoiceAgentsHomeBanner onDismissed={() => setVoiceSnoozed(true)} />
 	) : (
 		<TracesV2HomeBanner onDismissed={() => setTracesSnoozed(true)} />
 	);

--- a/langwatch/src/components/home/HomePageBanners.tsx
+++ b/langwatch/src/components/home/HomePageBanners.tsx
@@ -39,5 +39,13 @@ export function HomePageBanners() {
 	// the first banner before the snooze check runs.
 	if (!hasMounted) return null;
 
-	return tracesSnoozed ? <VoiceAgentsHomeBanner /> : <TracesV2HomeBanner />;
+	// Wire `onDismissed` so the moment the user clicks ✕ on traces-v2 the
+	// voice banner takes the slot in the same tab. Without this the parent
+	// only reads the snooze flag on `projectId` change and the next banner
+	// only appears on remount/reload, which reads as a layout bug.
+	return tracesSnoozed ? (
+		<VoiceAgentsHomeBanner />
+	) : (
+		<TracesV2HomeBanner onDismissed={() => setTracesSnoozed(true)} />
+	);
 }

--- a/langwatch/src/components/home/HomePageBanners.tsx
+++ b/langwatch/src/components/home/HomePageBanners.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import {
+	isTracesV2BannerSnoozed,
+	TracesV2HomeBanner,
+} from "./TracesV2HomeBanner";
+import { VoiceAgentsHomeBanner } from "./VoiceAgentsHomeBanner";
+
+/**
+ * Picks ONE home-page announcement banner to render at a time, in priority
+ * order: traces-v2 first; once dismissed/snoozed, the voice-agents banner
+ * takes its slot. Each banner owns its own snooze key, so a user who
+ * snoozed traces-v2 a week ago still gets the voice-agents announcement,
+ * and snoozing voice-agents doesn't bring traces-v2 back.
+ *
+ * The decision lives here (rather than on the home page directly) so the
+ * banners themselves remain self-contained and we can add a third in the
+ * queue later without growing `HomePage`.
+ */
+export function HomePageBanners() {
+	const { project } = useOrganizationTeamProject({
+		redirectToOnboarding: false,
+		redirectToProjectOnboarding: false,
+	});
+	const projectId = project?.id;
+
+	const [hasMounted, setHasMounted] = useState(false);
+	const [tracesSnoozed, setTracesSnoozed] = useState(false);
+
+	useEffect(() => {
+		setHasMounted(true);
+	}, []);
+
+	useEffect(() => {
+		if (projectId) setTracesSnoozed(isTracesV2BannerSnoozed(projectId));
+	}, [projectId]);
+
+	// SSR / pre-hydration guard: render nothing rather than briefly flashing
+	// the first banner before the snooze check runs.
+	if (!hasMounted) return null;
+
+	return tracesSnoozed ? <VoiceAgentsHomeBanner /> : <TracesV2HomeBanner />;
+}

--- a/langwatch/src/components/home/TracesV2HomeBanner.tsx
+++ b/langwatch/src/components/home/TracesV2HomeBanner.tsx
@@ -64,7 +64,14 @@ export function isTracesV2BannerSnoozed(projectId: string): boolean {
 const MESH_COLORS_LIGHT = ["#6b21a8", "#a855f7", "#ec4899", "#fdf2f8"];
 const MESH_COLORS_DARK = ["#581c87", "#9333ea", "#db2777", "#1f0a2e"];
 
-export function TracesV2HomeBanner() {
+/**
+ * @param onDismissed Fired when the user dismisses (or click-through-snoozes)
+ *   the banner. The parent ({@link HomePageBanners}) uses this to flip to the
+ *   next banner in the same render pass instead of waiting for a reload.
+ */
+export function TracesV2HomeBanner({
+	onDismissed,
+}: { onDismissed?: () => void } = {}) {
 	const { project } = useOrganizationTeamProject({
 		redirectToOnboarding: false,
 		redirectToProjectOnboarding: false,
@@ -92,6 +99,7 @@ export function TracesV2HomeBanner() {
 	const handleDismiss = () => {
 		if (projectId) snooze(projectId);
 		setDismissed(true);
+		onDismissed?.();
 	};
 
 	// Flip the per-device preference so `useTraceDetailsDrawer` opens

--- a/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
+++ b/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
@@ -192,7 +192,6 @@ export function VoiceAgentsHomeBanner({
 						textStyle="sm"
 						color="white/90"
 						lineHeight={1.5}
-						maxWidth={{ base: "full", md: "520px" }}
 					>
 						Test your voice agent end-to-end with real voices, real audio, and judge criteria you write in plain English. Works with ElevenLabs, OpenAI Realtime, Gemini Live, Vapi, LiveKit, Pipecat, and more.
 					</Text>

--- a/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
+++ b/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
@@ -11,17 +11,17 @@ import {
 import { MeshGradient } from "@paper-design/shaders-react";
 import posthog from "posthog-js";
 import { useEffect, useState } from "react";
-import { LuArrowRight, LuSparkles, LuX } from "react-icons/lu";
-import { Link } from "~/components/ui/link";
-import { Tooltip } from "~/components/ui/tooltip";
-import { setTracesV2Preferred } from "~/features/traces-v2/hooks/useTracesV2Preference";
+import { LuArrowRight, LuMic, LuX } from "react-icons/lu";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { useColorModeValue } from "../ui/color-mode";
+import { Tooltip } from "../ui/tooltip";
 
 const SNOOZE_DAYS = 7;
 const SNOOZE_MS = SNOOZE_DAYS * 24 * 60 * 60 * 1000;
-const STORAGE_PREFIX = "langwatch:tracesV2-home-banner-dismissed:v2:try:";
+const STORAGE_PREFIX =
+	"langwatch:voice-agents-home-banner-dismissed:v1:";
+const TARGET_URL = "https://langwatch.ai/scenario/voice/getting-started";
 
 const storageKey = (projectId: string) => `${STORAGE_PREFIX}${projectId}`;
 
@@ -50,27 +50,18 @@ function snooze(projectId: string) {
 	}
 }
 
-/**
- * Exposed so the home page can decide whether to show this banner or fall
- * back to the next-in-line announcement (e.g. {@link VoiceAgentsHomeBanner}).
- */
-export function isTracesV2BannerSnoozed(projectId: string): boolean {
-	return isSnoozed(projectId);
-}
+// Teal → cyan → indigo palette, so this banner visually rhymes with
+// `TracesV2HomeBanner` (same MeshGradient + glass-card shape) without looking
+// like a duplicate when the home page rotates between the two announcements.
+const MESH_COLORS_LIGHT = ["#0f766e", "#06b6d4", "#6366f1", "#ecfeff"];
+const MESH_COLORS_DARK = ["#134e4a", "#0e7490", "#312e81", "#0a1424"];
 
-// Colours mirror the in-app NewTracesPromo banner so the two surfaces feel
-// like the same announcement. Resolved hex values are required because the
-// MeshGradient WebGL shader cannot read CSS variables.
-const MESH_COLORS_LIGHT = ["#6b21a8", "#a855f7", "#ec4899", "#fdf2f8"];
-const MESH_COLORS_DARK = ["#581c87", "#9333ea", "#db2777", "#1f0a2e"];
-
-export function TracesV2HomeBanner() {
+export function VoiceAgentsHomeBanner() {
 	const { project } = useOrganizationTeamProject({
 		redirectToOnboarding: false,
 		redirectToProjectOnboarding: false,
 	});
 	const projectId = project?.id;
-	const projectSlug = project?.slug;
 	const reduceMotion = useReducedMotion();
 	const meshColors = useColorModeValue(MESH_COLORS_LIGHT, MESH_COLORS_DARK);
 
@@ -85,7 +76,7 @@ export function TracesV2HomeBanner() {
 		if (projectId) setDismissed(isSnoozed(projectId));
 	}, [projectId]);
 
-	if (!hasMounted || !projectSlug || dismissed) {
+	if (!hasMounted || !projectId || dismissed) {
 		return null;
 	}
 
@@ -94,21 +85,13 @@ export function TracesV2HomeBanner() {
 		setDismissed(true);
 	};
 
-	// Flip the per-device preference so `useTraceDetailsDrawer` opens
-	// the v2 drawer everywhere else in the app after the user clicks
-	// through the home banner — without this, opening a trace from the
-	// messages table would still land on v1 even though they just opted
-	// in here.
-	const handleTryV2 = () => {
-		setTracesV2Preferred(true);
-		posthog.capture("traces_v2_opt_in", {
+	const handleClick = () => {
+		posthog.capture("voice_agents_banner_click", {
 			surface: "home_banner",
 			projectId,
 		});
 		if (projectId) snooze(projectId);
 	};
-
-	const v2Href = `/${projectSlug}/traces`;
 
 	return (
 		<Box
@@ -159,7 +142,7 @@ export function TracesV2HomeBanner() {
 					bg="white/20"
 					boxShadow="inset 0 0 0 1px rgba(255,255,255,0.35)"
 				>
-					<Icon as={LuSparkles} boxSize={5} color="white" />
+					<Icon as={LuMic} boxSize={5} color="white" />
 				</Box>
 
 				<VStack align="start" gap={1.5} flex={1} minWidth={0}>
@@ -171,7 +154,7 @@ export function TracesV2HomeBanner() {
 							letterSpacing="-0.01em"
 							lineHeight={1.2}
 						>
-							The new Trace Explorer is here
+							Voice agent simulations are here
 						</Heading>
 						<Box
 							paddingX={2}
@@ -188,7 +171,7 @@ export function TracesV2HomeBanner() {
 								textTransform="uppercase"
 								lineHeight={1.2}
 							>
-								Beta
+								New
 							</Text>
 						</Box>
 					</HStack>
@@ -198,18 +181,26 @@ export function TracesV2HomeBanner() {
 						lineHeight={1.5}
 						maxWidth={{ base: "full", md: "520px" }}
 					>
-						A faster, friendlier tracing experience, built on everything we learned from v1. Take it for a spin and tell us what you think.
+						Test your voice agent end-to-end with real voices, real audio, and judge criteria you write in plain English. Works with ElevenLabs, OpenAI Realtime, Gemini Live, Vapi, LiveKit, Pipecat, and more.
 					</Text>
 					<HStack gap={2} marginTop={1.5}>
-						<Link
-							href={v2Href}
-							onClick={handleTryV2}
-							aria-label="Open new Trace Explorer"
+						{/*
+						 * Plain <a> + target=_blank — this points to the public docs
+						 * site, not an internal route, so the in-app `<Link>` (which
+						 * resolves project-scoped paths) is the wrong primitive.
+						 */}
+						<a
+							href={TARGET_URL}
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={handleClick}
+							aria-label="Open Voice Agents getting started guide in a new tab"
+							style={{ textDecoration: "none" }}
 						>
 							<Button
 								size="sm"
 								bg="white"
-								color="purple.700"
+								color="teal.700"
 								fontWeight="600"
 								paddingX={4}
 								boxShadow="0 1px 2px rgba(0,0,0,0.12)"
@@ -217,10 +208,10 @@ export function TracesV2HomeBanner() {
 								_active={{ bg: "white/80", transform: "translateY(0)" }}
 								transition="background-color 0.12s ease, transform 0.12s ease"
 							>
-								Try the new Trace Explorer
+								Try voice agent testing
 								<Icon as={LuArrowRight} boxSize={3.5} marginLeft={1} />
 							</Button>
-						</Link>
+						</a>
 					</HStack>
 				</VStack>
 			</HStack>
@@ -247,4 +238,14 @@ export function TracesV2HomeBanner() {
 			</Tooltip>
 		</Box>
 	);
+}
+
+/**
+ * Helper for callers that want to gate the voice banner on the prior
+ * traces-v2 banner being dismissed/snoozed already. Exposed so the
+ * `HomePage` orchestrator can pick one banner at a time without leaking
+ * storage-key knowledge.
+ */
+export function isVoiceAgentsBannerSnoozed(projectId: string): boolean {
+	return isSnoozed(projectId);
 }

--- a/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
+++ b/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
@@ -56,7 +56,14 @@ function snooze(projectId: string) {
 const MESH_COLORS_LIGHT = ["#0f766e", "#06b6d4", "#6366f1", "#ecfeff"];
 const MESH_COLORS_DARK = ["#134e4a", "#0e7490", "#312e81", "#0a1424"];
 
-export function VoiceAgentsHomeBanner() {
+/**
+ * @param onDismissed Fired when the user dismisses the banner (via the x
+ *   or by clicking the CTA, which snoozes too). {@link HomePageBanners}
+ *   uses this to swap in the other banner in the same tab.
+ */
+export function VoiceAgentsHomeBanner({
+	onDismissed,
+}: { onDismissed?: () => void } = {}) {
 	const { project } = useOrganizationTeamProject({
 		redirectToOnboarding: false,
 		redirectToProjectOnboarding: false,
@@ -83,6 +90,7 @@ export function VoiceAgentsHomeBanner() {
 	const handleDismiss = () => {
 		if (projectId) snooze(projectId);
 		setDismissed(true);
+		onDismissed?.();
 	};
 
 	const handleClick = () => {
@@ -95,6 +103,7 @@ export function VoiceAgentsHomeBanner() {
 		// flipping `dismissed` here the banner would linger in the current
 		// tab until reload even though the snooze key has already been set.
 		setDismissed(true);
+		onDismissed?.();
 	};
 
 	return (

--- a/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
+++ b/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
@@ -193,7 +193,9 @@ export function VoiceAgentsHomeBanner({
 						color="white/90"
 						lineHeight={1.5}
 					>
-						Test your voice agent end-to-end with real voices, real audio, and judge criteria you write in plain English. Works with ElevenLabs, OpenAI Realtime, Gemini Live, Vapi, LiveKit, Pipecat, and more.
+						Test your voice agent end-to-end with real voices, real audio, and judge criteria you write in plain English.
+						<br />
+						Works with ElevenLabs, OpenAI Realtime, Gemini Live, Vapi, LiveKit, Pipecat, and more.
 					</Text>
 					<HStack gap={2} marginTop={1.5}>
 						{/*

--- a/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
+++ b/langwatch/src/components/home/VoiceAgentsHomeBanner.tsx
@@ -91,6 +91,10 @@ export function VoiceAgentsHomeBanner() {
 			projectId,
 		});
 		if (projectId) snooze(projectId);
+		// CTA opens in a new tab, so the home page stays mounted. Without
+		// flipping `dismissed` here the banner would linger in the current
+		// tab until reload even though the snooze key has already been set.
+		setDismissed(true);
 	};
 
 	return (
@@ -185,33 +189,35 @@ export function VoiceAgentsHomeBanner() {
 					</Text>
 					<HStack gap={2} marginTop={1.5}>
 						{/*
-						 * Plain <a> + target=_blank — this points to the public docs
-						 * site, not an internal route, so the in-app `<Link>` (which
-						 * resolves project-scoped paths) is the wrong primitive.
+						 * Render the Chakra Button AS the anchor (no nested
+						 * `<a><button>`, which is invalid interactive nesting).
+						 * The CTA points at the public docs site, not an internal
+						 * route, so we keep plain anchor semantics rather than the
+						 * in-app `<Link>` (which resolves project-scoped paths).
 						 */}
-						<a
-							href={TARGET_URL}
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={handleClick}
-							aria-label="Open Voice Agents getting started guide in a new tab"
-							style={{ textDecoration: "none" }}
+						<Button
+							asChild
+							size="sm"
+							bg="white"
+							color="teal.700"
+							fontWeight="600"
+							paddingX={4}
+							boxShadow="0 1px 2px rgba(0,0,0,0.12)"
+							_hover={{ bg: "white/90", transform: "translateY(-1px)" }}
+							_active={{ bg: "white/80", transform: "translateY(0)" }}
+							transition="background-color 0.12s ease, transform 0.12s ease"
 						>
-							<Button
-								size="sm"
-								bg="white"
-								color="teal.700"
-								fontWeight="600"
-								paddingX={4}
-								boxShadow="0 1px 2px rgba(0,0,0,0.12)"
-								_hover={{ bg: "white/90", transform: "translateY(-1px)" }}
-								_active={{ bg: "white/80", transform: "translateY(0)" }}
-								transition="background-color 0.12s ease, transform 0.12s ease"
+							<a
+								href={TARGET_URL}
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={handleClick}
+								aria-label="Open Voice Agents getting started guide in a new tab"
 							>
 								Try voice agent testing
 								<Icon as={LuArrowRight} boxSize={3.5} marginLeft={1} />
-							</Button>
-						</a>
+							</a>
+						</Button>
 					</HStack>
 				</VStack>
 			</HStack>

--- a/langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx
+++ b/langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx
@@ -57,11 +57,9 @@ describe("<HomePageBanners />", () => {
     localStorage.clear();
   });
 
-  it("renders the traces-v2 banner by default when nothing is snoozed", () => {
+  it("renders the traces-v2 banner when the coin flip lands < 0.5", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.9);
     renderWithProviders(<HomePageBanners />);
-    // Positive marker first — without this assertion the test would pass
-    // even if HomePageBanners rendered null. Negative marker second to
-    // pin that ONLY traces-v2 is in the slot.
     expect(
       screen.getByRole("heading", {
         name: "The new Trace Explorer is here",
@@ -74,8 +72,24 @@ describe("<HomePageBanners />", () => {
     ).toBeNull();
   });
 
-  it("switches to the voice banner once traces-v2 is snoozed", () => {
+  it("renders the voice banner when the coin flip lands >= 0.5", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+    renderWithProviders(<HomePageBanners />);
+    expect(
+      screen.getByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("heading", {
+        name: "The new Trace Explorer is here",
+      }),
+    ).toBeNull();
+  });
+
+  it("forces the voice banner when only traces-v2 is snoozed (no coin flip)", () => {
     localStorage.setItem(TRACES_KEY, String(Date.now() + 60_000));
+    vi.spyOn(Math, "random").mockReturnValue(0.9); // would pick traces if eligible
     renderWithProviders(<HomePageBanners />);
     expect(
       screen.getByRole("heading", {
@@ -84,13 +98,29 @@ describe("<HomePageBanners />", () => {
     ).toBeDefined();
   });
 
-  it("renders neither banner when both are snoozed (voice owns the slot but is itself snoozed)", () => {
+  it("forces the traces-v2 banner when only voice-agents is snoozed (no coin flip)", () => {
+    localStorage.setItem(VOICE_KEY, String(Date.now() + 60_000));
+    vi.spyOn(Math, "random").mockReturnValue(0.1); // would pick voice if eligible
+    renderWithProviders(<HomePageBanners />);
+    expect(
+      screen.getByRole("heading", {
+        name: "The new Trace Explorer is here",
+      }),
+    ).toBeDefined();
+  });
+
+  it("renders neither banner when both are snoozed", () => {
     localStorage.setItem(TRACES_KEY, String(Date.now() + 60_000));
     localStorage.setItem(VOICE_KEY, String(Date.now() + 60_000));
     renderWithProviders(<HomePageBanners />);
     expect(
       screen.queryByRole("heading", {
         name: "Voice agent simulations are here",
+      }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("heading", {
+        name: "The new Trace Explorer is here",
       }),
     ).toBeNull();
   });

--- a/langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx
+++ b/langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@paper-design/shaders-react", () => ({
+  MeshGradient: () => null,
+}));
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(() => ({
+    project: { id: "project-1" },
+  })),
+}));
+
+vi.mock("~/hooks/useReducedMotion", () => ({
+  useReducedMotion: vi.fn(() => false),
+}));
+
+// Stub the in-app Link primitive: it expects a Next router we don't have.
+vi.mock("~/components/ui/link", () => ({
+  Link: ({ children, ...rest }: { children: React.ReactNode }) => (
+    <a {...(rest as Record<string, unknown>)}>{children}</a>
+  ),
+}));
+
+vi.mock("~/features/traces-v2/hooks/useTracesV2Preference", () => ({
+  setTracesV2Preferred: vi.fn(),
+}));
+
+import { HomePageBanners } from "../HomePageBanners";
+
+const TRACES_KEY = "langwatch:tracesV2-home-banner-dismissed:v2:try:project-1";
+const VOICE_KEY = "langwatch:voice-agents-home-banner-dismissed:v1:project-1";
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>,
+  );
+}
+
+describe("<HomePageBanners />", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("renders the traces-v2 banner by default when nothing is snoozed", () => {
+    renderWithProviders(<HomePageBanners />);
+    // Traces-v2 banner headline is the deciding marker — voice banner has
+    // its own distinct heading.
+    expect(
+      screen.queryByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeNull();
+  });
+
+  it("switches to the voice banner once traces-v2 is snoozed", () => {
+    localStorage.setItem(TRACES_KEY, String(Date.now() + 60_000));
+    renderWithProviders(<HomePageBanners />);
+    expect(
+      screen.getByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeDefined();
+  });
+
+  it("renders neither banner when both are snoozed (voice owns the slot but is itself snoozed)", () => {
+    localStorage.setItem(TRACES_KEY, String(Date.now() + 60_000));
+    localStorage.setItem(VOICE_KEY, String(Date.now() + 60_000));
+    renderWithProviders(<HomePageBanners />);
+    expect(
+      screen.queryByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeNull();
+  });
+});

--- a/langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx
+++ b/langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx
@@ -16,7 +16,7 @@ vi.mock("posthog-js", () => ({
 
 vi.mock("~/hooks/useOrganizationTeamProject", () => ({
   useOrganizationTeamProject: vi.fn(() => ({
-    project: { id: "project-1" },
+    project: { id: "project-1", slug: "my-project" },
   })),
 }));
 
@@ -59,8 +59,14 @@ describe("<HomePageBanners />", () => {
 
   it("renders the traces-v2 banner by default when nothing is snoozed", () => {
     renderWithProviders(<HomePageBanners />);
-    // Traces-v2 banner headline is the deciding marker — voice banner has
-    // its own distinct heading.
+    // Positive marker first — without this assertion the test would pass
+    // even if HomePageBanners rendered null. Negative marker second to
+    // pin that ONLY traces-v2 is in the slot.
+    expect(
+      screen.getByRole("heading", {
+        name: "The new Trace Explorer is here",
+      }),
+    ).toBeDefined();
     expect(
       screen.queryByRole("heading", {
         name: "Voice agent simulations are here",

--- a/langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx
+++ b/langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx
@@ -57,7 +57,7 @@ describe("<HomePageBanners />", () => {
     localStorage.clear();
   });
 
-  it("renders the traces-v2 banner when the coin flip lands < 0.5", () => {
+  it("renders the traces-v2 banner when the coin flip lands >= 0.5", () => {
     vi.spyOn(Math, "random").mockReturnValue(0.9);
     renderWithProviders(<HomePageBanners />);
     expect(
@@ -72,7 +72,7 @@ describe("<HomePageBanners />", () => {
     ).toBeNull();
   });
 
-  it("renders the voice banner when the coin flip lands >= 0.5", () => {
+  it("renders the voice banner when the coin flip lands < 0.5", () => {
     vi.spyOn(Math, "random").mockReturnValue(0.1);
     renderWithProviders(<HomePageBanners />);
     expect(

--- a/langwatch/src/components/home/__tests__/VoiceAgentsHomeBanner.unit.test.tsx
+++ b/langwatch/src/components/home/__tests__/VoiceAgentsHomeBanner.unit.test.tsx
@@ -72,7 +72,7 @@ describe("<VoiceAgentsHomeBanner />", () => {
     expect(link.getAttribute("rel")).toBe("noopener noreferrer");
   });
 
-  it("captures a PostHog event when the CTA is clicked", () => {
+  it("captures a PostHog event, snoozes and hides the banner when the CTA is clicked", () => {
     renderWithProviders(<VoiceAgentsHomeBanner />);
     const link = screen.getByRole("link", {
       name: /Open Voice Agents getting started guide in a new tab/i,
@@ -85,6 +85,14 @@ describe("<VoiceAgentsHomeBanner />", () => {
         projectId: "project-1",
       }),
     );
+    // CTA opens in a new tab — the banner must hide in the current tab too,
+    // not linger until a reload.
+    expect(
+      screen.queryByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
   });
 
   it("snoozes for ~7 days when dismissed and hides immediately", () => {

--- a/langwatch/src/components/home/__tests__/VoiceAgentsHomeBanner.unit.test.tsx
+++ b/langwatch/src/components/home/__tests__/VoiceAgentsHomeBanner.unit.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@paper-design/shaders-react", () => ({
+  MeshGradient: () => null,
+}));
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(() => ({
+    project: { id: "project-1" },
+  })),
+}));
+
+vi.mock("~/hooks/useReducedMotion", () => ({
+  useReducedMotion: vi.fn(() => false),
+}));
+
+import posthog from "posthog-js";
+import {
+  isVoiceAgentsBannerSnoozed,
+  VoiceAgentsHomeBanner,
+} from "../VoiceAgentsHomeBanner";
+
+const STORAGE_KEY = "langwatch:voice-agents-home-banner-dismissed:v1:project-1";
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>,
+  );
+}
+
+describe("<VoiceAgentsHomeBanner />", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("renders the heading, NEW pill and CTA when not snoozed", () => {
+    renderWithProviders(<VoiceAgentsHomeBanner />);
+    expect(
+      screen.getByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeDefined();
+    expect(screen.getByText("New")).toBeDefined();
+    expect(screen.getByText("Try voice agent testing")).toBeDefined();
+  });
+
+  it("CTA links to the public docs in a new tab with rel noopener noreferrer", () => {
+    renderWithProviders(<VoiceAgentsHomeBanner />);
+    const link = screen.getByRole("link", {
+      name: /Open Voice Agents getting started guide in a new tab/i,
+    });
+    expect(link.getAttribute("href")).toBe(
+      "https://langwatch.ai/scenario/voice/getting-started",
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("captures a PostHog event when the CTA is clicked", () => {
+    renderWithProviders(<VoiceAgentsHomeBanner />);
+    const link = screen.getByRole("link", {
+      name: /Open Voice Agents getting started guide in a new tab/i,
+    });
+    fireEvent.click(link);
+    expect(posthog.capture).toHaveBeenCalledWith(
+      "voice_agents_banner_click",
+      expect.objectContaining({
+        surface: "home_banner",
+        projectId: "project-1",
+      }),
+    );
+  });
+
+  it("snoozes for ~7 days when dismissed and hides immediately", () => {
+    renderWithProviders(<VoiceAgentsHomeBanner />);
+    const dismissBtn = screen.getByRole("button", { name: "Dismiss" });
+    const before = Date.now();
+    fireEvent.click(dismissBtn);
+
+    expect(
+      screen.queryByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeNull();
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const expiresAt = Number(raw);
+    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+    // Allow generous tolerance for slow CI.
+    expect(expiresAt).toBeGreaterThanOrEqual(before + SEVEN_DAYS_MS - 1000);
+    expect(expiresAt).toBeLessThanOrEqual(before + SEVEN_DAYS_MS + 5000);
+  });
+
+  it("does not render when already snoozed", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      String(Date.now() + 24 * 60 * 60 * 1000),
+    );
+    renderWithProviders(<VoiceAgentsHomeBanner />);
+    expect(
+      screen.queryByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeNull();
+  });
+
+  it("re-renders the banner once an expired snooze passes", () => {
+    localStorage.setItem(STORAGE_KEY, String(Date.now() - 1000));
+    renderWithProviders(<VoiceAgentsHomeBanner />);
+    expect(
+      screen.getByRole("heading", {
+        name: "Voice agent simulations are here",
+      }),
+    ).toBeDefined();
+  });
+});
+
+describe("isVoiceAgentsBannerSnoozed", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("returns false when no snooze is set", () => {
+    expect(isVoiceAgentsBannerSnoozed("project-x")).toBe(false);
+  });
+
+  it("returns true when snooze is in the future", () => {
+    localStorage.setItem(
+      "langwatch:voice-agents-home-banner-dismissed:v1:project-x",
+      String(Date.now() + 60_000),
+    );
+    expect(isVoiceAgentsBannerSnoozed("project-x")).toBe(true);
+  });
+
+  it("returns false when snooze has expired", () => {
+    localStorage.setItem(
+      "langwatch:voice-agents-home-banner-dismissed:v1:project-x",
+      String(Date.now() - 60_000),
+    );
+    expect(isVoiceAgentsBannerSnoozed("project-x")).toBe(false);
+  });
+
+  it("returns false when the stored value is not a finite number", () => {
+    localStorage.setItem(
+      "langwatch:voice-agents-home-banner-dismissed:v1:project-x",
+      "not-a-number",
+    );
+    expect(isVoiceAgentsBannerSnoozed("project-x")).toBe(false);
+  });
+});

--- a/langwatch/src/components/suites/SuiteSidebar.tsx
+++ b/langwatch/src/components/suites/SuiteSidebar.tsx
@@ -40,6 +40,7 @@ import {
   toExternalSetSelection,
 } from "./useSuiteRouting";
 import { SearchInput } from "../ui/SearchInput";
+import { VoiceAgentsCallout } from "./VoiceAgentsCallout";
 
 export const SUITE_SIDEBAR_COLLAPSED_KEY = "suite-sidebar-collapsed" as const;
 
@@ -321,6 +322,14 @@ export function SuiteSidebar({
           </>
         )}
       </VStack>
+
+      {/*
+       * Voice agents announcement card — pinned just above the collapse
+       * toggle so it sits at the bottom of the sets/runs sidebar without
+       * stealing space from the list itself. Hidden when the sidebar is
+       * collapsed (no room for the copy at icon-rail width).
+       */}
+      {!isCollapsed && <VoiceAgentsCallout />}
 
       {/* Toggle button — always the same DOM node */}
       <ShadowDivider />

--- a/langwatch/src/components/suites/VoiceAgentsCallout.tsx
+++ b/langwatch/src/components/suites/VoiceAgentsCallout.tsx
@@ -1,0 +1,175 @@
+import { Box, HStack, Icon, IconButton, Text, VStack } from "@chakra-ui/react";
+import posthog from "posthog-js";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { LuArrowRight, LuMic, LuX } from "react-icons/lu";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+
+/**
+ * Small announcement card pinned to the bottom of the simulations sidebar,
+ * just above the collapse-toggle footer. Mirrors the in-app traces-v2
+ * "Try the new Trace Explorer" callout pattern (gradient pill + arrow CTA +
+ * snooze-on-dismiss) at a sidebar-friendly size.
+ *
+ * The CTA opens the public Voice docs (Scenario `voice/getting-started`)
+ * in a new tab, so we render a plain `<a>` rather than the in-app `<Link>`
+ * (which resolves project-scoped paths).
+ *
+ * Snoozes for {@link SNOOZE_DAYS} days per project; the snooze key includes
+ * a `:v1:` version segment so we can recycle the card for a future
+ * announcement by bumping the version without resurrecting old dismissals.
+ */
+const SNOOZE_DAYS = 14;
+const SNOOZE_MS = SNOOZE_DAYS * 24 * 60 * 60 * 1000;
+const STORAGE_PREFIX = "langwatch:simulations-voice-callout-dismissed:v1:";
+const TARGET_URL = "https://langwatch.ai/scenario/voice/getting-started";
+
+const storageKey = (projectId: string) => `${STORAGE_PREFIX}${projectId}`;
+
+function isSnoozed(projectId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = localStorage.getItem(storageKey(projectId));
+    if (!raw) return false;
+    const expiresAt = Number(raw);
+    if (!Number.isFinite(expiresAt)) return false;
+    return expiresAt > Date.now();
+  } catch {
+    return false;
+  }
+}
+
+function snooze(projectId: string) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(storageKey(projectId), String(Date.now() + SNOOZE_MS));
+  } catch {
+    // Best-effort dismissal.
+  }
+}
+
+export function VoiceAgentsCallout() {
+  const { project } = useOrganizationTeamProject({
+    redirectToOnboarding: false,
+    redirectToProjectOnboarding: false,
+  });
+  const projectId = project?.id;
+
+  const [hasMounted, setHasMounted] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (projectId) setDismissed(isSnoozed(projectId));
+  }, [projectId]);
+
+  if (!hasMounted || !projectId || dismissed) return null;
+
+  const handleDismiss = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (projectId) snooze(projectId);
+    setDismissed(true);
+  };
+
+  const handleClick = () => {
+    posthog.capture("voice_agents_callout_click", {
+      surface: "simulations_sidebar",
+      projectId,
+    });
+    if (projectId) snooze(projectId);
+  };
+
+  return (
+    <Box paddingX={3} paddingTop={2} paddingBottom={1}>
+      <a
+        href={TARGET_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={handleClick}
+        aria-label="Open Voice Agents getting started guide in a new tab"
+        style={{ textDecoration: "none", display: "block" }}
+      >
+        <Box
+          position="relative"
+          borderRadius="lg"
+          padding={3}
+          color="white"
+          overflow="hidden"
+          backgroundImage="linear-gradient(135deg, #0f766e 0%, #06b6d4 55%, #6366f1 100%)"
+          boxShadow="0 1px 2px rgba(0,0,0,0.08), 0 4px 12px rgba(0,0,0,0.12)"
+          transition="transform 0.12s ease, box-shadow 0.12s ease"
+          _hover={{
+            transform: "translateY(-1px)",
+            boxShadow:
+              "0 2px 4px rgba(0,0,0,0.10), 0 8px 18px rgba(0,0,0,0.18)",
+          }}
+        >
+          <HStack align="start" gap={2.5}>
+            <Box
+              flexShrink={0}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              boxSize="26px"
+              borderRadius="full"
+              bg="white/25"
+              boxShadow="inset 0 0 0 1px rgba(255,255,255,0.35)"
+            >
+              <Icon as={LuMic} boxSize={3.5} color="white" />
+            </Box>
+            <VStack align="start" gap={1} flex={1} minWidth={0}>
+              <Text
+                fontSize="xs"
+                fontWeight="700"
+                color="white"
+                lineHeight={1.25}
+                letterSpacing="-0.005em"
+              >
+                Try voice agent simulations
+              </Text>
+              <Text
+                fontSize="xs"
+                color="white/85"
+                lineHeight={1.4}
+              >
+                Test your voice agent end-to-end with real voices and judge
+                criteria you write in plain English.
+              </Text>
+              <HStack
+                gap={1}
+                marginTop={0.5}
+                color="white"
+                fontSize="xs"
+                fontWeight="600"
+              >
+                <Text>Get started</Text>
+                <Icon as={LuArrowRight} boxSize={3} />
+              </HStack>
+            </VStack>
+          </HStack>
+          <IconButton
+            aria-label="Dismiss"
+            size="xs"
+            variant="ghost"
+            color="white/80"
+            position="absolute"
+            top={1}
+            right={1}
+            minWidth="20px"
+            height="20px"
+            padding={0}
+            _hover={{ bg: "white/20", color: "white" }}
+            _active={{ bg: "white/30" }}
+            onClick={handleDismiss}
+          >
+            <LuX size={12} />
+          </IconButton>
+        </Box>
+      </a>
+    </Box>
+  );
+}

--- a/langwatch/src/components/suites/VoiceAgentsCallout.tsx
+++ b/langwatch/src/components/suites/VoiceAgentsCallout.tsx
@@ -136,8 +136,7 @@ export function VoiceAgentsCallout() {
                 color="white/85"
                 lineHeight={1.4}
               >
-                Test your voice agent end-to-end with real voices and judge
-                criteria you write in plain English.
+                Test your voice agent end-to-end with realtime voices.
               </Text>
               <HStack
                 gap={1}

--- a/langwatch/src/components/suites/__tests__/ExternalSetsSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/ExternalSetsSidebar.integration.test.tsx
@@ -11,6 +11,20 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SimulationSuite } from "@prisma/client";
 import type { ExternalSetSummary } from "~/server/scenarios/scenario-event.types";
+
+// VoiceAgentsCallout inside SuiteSidebar pulls project context via
+// useOrganizationTeamProject, which fires tRPC queries the bare test rig
+// doesn't provide. Stub it so these external-sets tests stay narrow.
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(() => ({
+    project: { id: "project_1" },
+  })),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
 import { SuiteSidebar } from "../SuiteSidebar";
 import { NowProvider } from "../NowProvider";
 import { ALL_RUNS_ID, toExternalSetSelection } from "../useSuiteRouting";

--- a/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuiteSidebar.integration.test.tsx
@@ -15,6 +15,21 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SimulationSuite } from "@prisma/client";
+
+// VoiceAgentsCallout pulls project context via useOrganizationTeamProject,
+// which in turn fires tRPC queries the bare SuiteSidebar test rig doesn't
+// provide. Stub it here so the sidebar tests keep their narrow scope; the
+// callout itself has dedicated coverage in VoiceAgentsCallout.unit.test.tsx.
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(() => ({
+    project: { id: "project_1" },
+  })),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
 import { SuiteSidebar, SUITE_SIDEBAR_COLLAPSED_KEY } from "../SuiteSidebar";
 import { NowProvider } from "../NowProvider";
 import { ALL_RUNS_ID } from "../useSuiteRouting";

--- a/langwatch/src/components/suites/__tests__/SuitesPageLayout.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuitesPageLayout.integration.test.tsx
@@ -13,11 +13,9 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SimulationSuite } from "@prisma/client";
 
-vi.mock("~/hooks/useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: vi.fn(() => ({
-    project: { id: "project_1" },
-  })),
-}));
+// The existing `vi.mock("~/hooks/useOrganizationTeamProject", ...)` below
+// (richer shape with slug / hasAnyPermission / isLoading) covers
+// VoiceAgentsCallout's `project.id` requirement — no separate mock needed here.
 
 vi.mock("posthog-js", () => ({
   default: { capture: vi.fn() },

--- a/langwatch/src/components/suites/__tests__/SuitesPageLayout.integration.test.tsx
+++ b/langwatch/src/components/suites/__tests__/SuitesPageLayout.integration.test.tsx
@@ -13,6 +13,16 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SimulationSuite } from "@prisma/client";
 
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(() => ({
+    project: { id: "project_1" },
+  })),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
 vi.mock("~/hooks/useSSESubscription", () => ({
   useSSESubscription: () => ({
     connectionState: "connected",

--- a/langwatch/src/components/suites/__tests__/VoiceAgentsCallout.unit.test.tsx
+++ b/langwatch/src/components/suites/__tests__/VoiceAgentsCallout.unit.test.tsx
@@ -39,68 +39,92 @@ describe("<VoiceAgentsCallout />", () => {
     localStorage.clear();
   });
 
-  it("renders the title and CTA when not snoozed", () => {
-    renderWithProviders(<VoiceAgentsCallout />);
-    expect(screen.getByText("Try voice agent simulations")).toBeDefined();
-    expect(screen.getByText("Get started")).toBeDefined();
-  });
-
-  it("links to the public docs in a new tab with rel noopener noreferrer", () => {
-    renderWithProviders(<VoiceAgentsCallout />);
-    const link = screen.getByRole("link", {
-      name: /Open Voice Agents getting started guide in a new tab/i,
+  describe("given the callout has never been dismissed for this project", () => {
+    it("renders the title and CTA", () => {
+      renderWithProviders(<VoiceAgentsCallout />);
+      expect(screen.getByText("Try voice agent simulations")).toBeDefined();
+      expect(screen.getByText("Get started")).toBeDefined();
     });
-    expect(link.getAttribute("href")).toBe(
-      "https://langwatch.ai/scenario/voice/getting-started",
-    );
-    expect(link.getAttribute("target")).toBe("_blank");
-    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
-  });
 
-  it("captures a PostHog event when the callout is clicked", () => {
-    renderWithProviders(<VoiceAgentsCallout />);
-    const link = screen.getByRole("link", {
-      name: /Open Voice Agents getting started guide in a new tab/i,
+    it("links to the public docs in a new tab with rel noopener noreferrer", () => {
+      renderWithProviders(<VoiceAgentsCallout />);
+      const link = screen.getByRole("link", {
+        name: /Open Voice Agents getting started guide in a new tab/i,
+      });
+      expect(link.getAttribute("href")).toBe(
+        "https://langwatch.ai/scenario/voice/getting-started",
+      );
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
     });
-    fireEvent.click(link);
-    expect(posthog.capture).toHaveBeenCalledWith(
-      "voice_agents_callout_click",
-      expect.objectContaining({
-        surface: "simulations_sidebar",
-        projectId: "project-1",
-      }),
-    );
+
+    describe("when the user clicks the callout body", () => {
+      it("captures a PostHog event tagged simulations_sidebar", () => {
+        renderWithProviders(<VoiceAgentsCallout />);
+        const link = screen.getByRole("link", {
+          name: /Open Voice Agents getting started guide in a new tab/i,
+        });
+        fireEvent.click(link);
+        expect(posthog.capture).toHaveBeenCalledWith(
+          "voice_agents_callout_click",
+          expect.objectContaining({
+            surface: "simulations_sidebar",
+            projectId: "project-1",
+          }),
+        );
+      });
+    });
+
+    describe("when the user clicks the dismiss x button", () => {
+      it("hides the callout immediately and does NOT capture a click event", () => {
+        renderWithProviders(<VoiceAgentsCallout />);
+        const dismissBtn = screen.getByRole("button", { name: "Dismiss" });
+        fireEvent.click(dismissBtn);
+
+        expect(screen.queryByText("Try voice agent simulations")).toBeNull();
+        expect(posthog.capture).not.toHaveBeenCalledWith(
+          "voice_agents_callout_click",
+          expect.anything(),
+        );
+      });
+
+      it("snoozes the callout for roughly 14 days under the per-project storage key", () => {
+        renderWithProviders(<VoiceAgentsCallout />);
+        const dismissBtn = screen.getByRole("button", { name: "Dismiss" });
+        const before = Date.now();
+        fireEvent.click(dismissBtn);
+
+        const raw = localStorage.getItem(STORAGE_KEY);
+        expect(raw).not.toBeNull();
+        const expiresAt = Number(raw);
+        const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
+        expect(expiresAt).toBeGreaterThanOrEqual(
+          before + FOURTEEN_DAYS_MS - 1000,
+        );
+        expect(expiresAt).toBeLessThanOrEqual(before + FOURTEEN_DAYS_MS + 5000);
+      });
+    });
   });
 
-  it("dismiss button hides the callout, snoozes for ~14 days, and does not capture a click event", () => {
-    renderWithProviders(<VoiceAgentsCallout />);
-    const dismissBtn = screen.getByRole("button", { name: "Dismiss" });
-    const before = Date.now();
-    fireEvent.click(dismissBtn);
+  describe("given the callout is currently snoozed for this project", () => {
+    beforeEach(() => {
+      localStorage.setItem(STORAGE_KEY, String(Date.now() + 60_000));
+    });
 
-    expect(screen.queryByText("Try voice agent simulations")).toBeNull();
-    expect(posthog.capture).not.toHaveBeenCalledWith(
-      "voice_agents_callout_click",
-      expect.anything(),
-    );
-
-    const raw = localStorage.getItem(STORAGE_KEY);
-    expect(raw).not.toBeNull();
-    const expiresAt = Number(raw);
-    const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
-    expect(expiresAt).toBeGreaterThanOrEqual(before + FOURTEEN_DAYS_MS - 1000);
-    expect(expiresAt).toBeLessThanOrEqual(before + FOURTEEN_DAYS_MS + 5000);
+    it("does not render", () => {
+      renderWithProviders(<VoiceAgentsCallout />);
+      expect(screen.queryByText("Try voice agent simulations")).toBeNull();
+    });
   });
 
-  it("does not render when already snoozed", () => {
-    localStorage.setItem(STORAGE_KEY, String(Date.now() + 60_000));
-    renderWithProviders(<VoiceAgentsCallout />);
-    expect(screen.queryByText("Try voice agent simulations")).toBeNull();
-  });
+  describe("given the previous snooze has already expired", () => {
+    beforeEach(() => {
+      localStorage.setItem(STORAGE_KEY, String(Date.now() - 1000));
+    });
 
-  it("renders again once snooze has expired", () => {
-    localStorage.setItem(STORAGE_KEY, String(Date.now() - 1000));
-    renderWithProviders(<VoiceAgentsCallout />);
-    expect(screen.getByText("Try voice agent simulations")).toBeDefined();
+    it("renders again", () => {
+      renderWithProviders(<VoiceAgentsCallout />);
+      expect(screen.getByText("Try voice agent simulations")).toBeDefined();
+    });
   });
 });

--- a/langwatch/src/components/suites/__tests__/VoiceAgentsCallout.unit.test.tsx
+++ b/langwatch/src/components/suites/__tests__/VoiceAgentsCallout.unit.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: vi.fn(() => ({
+    project: { id: "project-1" },
+  })),
+}));
+
+import posthog from "posthog-js";
+import { VoiceAgentsCallout } from "../VoiceAgentsCallout";
+
+const STORAGE_KEY =
+  "langwatch:simulations-voice-callout-dismissed:v1:project-1";
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>,
+  );
+}
+
+describe("<VoiceAgentsCallout />", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("renders the title and CTA when not snoozed", () => {
+    renderWithProviders(<VoiceAgentsCallout />);
+    expect(screen.getByText("Try voice agent simulations")).toBeDefined();
+    expect(screen.getByText("Get started")).toBeDefined();
+  });
+
+  it("links to the public docs in a new tab with rel noopener noreferrer", () => {
+    renderWithProviders(<VoiceAgentsCallout />);
+    const link = screen.getByRole("link", {
+      name: /Open Voice Agents getting started guide in a new tab/i,
+    });
+    expect(link.getAttribute("href")).toBe(
+      "https://langwatch.ai/scenario/voice/getting-started",
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("captures a PostHog event when the callout is clicked", () => {
+    renderWithProviders(<VoiceAgentsCallout />);
+    const link = screen.getByRole("link", {
+      name: /Open Voice Agents getting started guide in a new tab/i,
+    });
+    fireEvent.click(link);
+    expect(posthog.capture).toHaveBeenCalledWith(
+      "voice_agents_callout_click",
+      expect.objectContaining({
+        surface: "simulations_sidebar",
+        projectId: "project-1",
+      }),
+    );
+  });
+
+  it("dismiss button hides the callout, snoozes for ~14 days, and does not capture a click event", () => {
+    renderWithProviders(<VoiceAgentsCallout />);
+    const dismissBtn = screen.getByRole("button", { name: "Dismiss" });
+    const before = Date.now();
+    fireEvent.click(dismissBtn);
+
+    expect(screen.queryByText("Try voice agent simulations")).toBeNull();
+    expect(posthog.capture).not.toHaveBeenCalledWith(
+      "voice_agents_callout_click",
+      expect.anything(),
+    );
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const expiresAt = Number(raw);
+    const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
+    expect(expiresAt).toBeGreaterThanOrEqual(before + FOURTEEN_DAYS_MS - 1000);
+    expect(expiresAt).toBeLessThanOrEqual(before + FOURTEEN_DAYS_MS + 5000);
+  });
+
+  it("does not render when already snoozed", () => {
+    localStorage.setItem(STORAGE_KEY, String(Date.now() + 60_000));
+    renderWithProviders(<VoiceAgentsCallout />);
+    expect(screen.queryByText("Try voice agent simulations")).toBeNull();
+  });
+
+  it("renders again once snooze has expired", () => {
+    localStorage.setItem(STORAGE_KEY, String(Date.now() - 1000));
+    renderWithProviders(<VoiceAgentsCallout />);
+    expect(screen.getByText("Try voice agent simulations")).toBeDefined();
+  });
+});

--- a/specs/home/voice-agents-home-banner.feature
+++ b/specs/home/voice-agents-home-banner.feature
@@ -1,21 +1,23 @@
 Feature: Voice agents home banner
 
   The home page surfaces project-level launch announcements through a
-  single rotating banner slot. Once the traces-v2 banner is dismissed,
-  the voice agents banner takes over the same slot until it too is
-  dismissed. Each banner owns its own per-project snooze so dismissing
-  one does not resurrect the other.
+  single banner slot that holds exactly ONE banner at a time. While both
+  the traces-v2 and voice agents launches are still un-dismissed, the
+  slot picks between them at random (50/50, per mount). Once one of the
+  two is snoozed, the other takes the slot deterministically. Each
+  banner owns its own per-project snooze so dismissing one does not
+  resurrect the other.
 
   Background:
     Given a logged-in user with a selected project
 
-  Scenario: Voice banner is hidden by default while traces-v2 is still showing
-    Given the traces-v2 home banner has never been dismissed for this project
+  Scenario: Random pick between traces-v2 and voice when neither is snoozed
+    Given neither the traces-v2 nor the voice agents banner has been dismissed for this project
     When the home page loads
-    Then the traces-v2 banner is visible
-    And the voice agents banner is not visible
+    Then exactly one of the two banners is visible
+    And the choice is stable for the lifetime of that mount
 
-  Scenario: Voice banner takes over once traces-v2 is snoozed
+  Scenario: Voice banner is forced when only traces-v2 is snoozed
     Given the traces-v2 home banner is currently snoozed for this project
     And the voice agents banner has never been dismissed for this project
     When the home page loads
@@ -24,6 +26,18 @@ Feature: Voice agents home banner
     And the banner shows the heading "Voice agent simulations are here"
     And the banner shows a "New" pill
     And the banner shows a "Try voice agent testing" call to action
+
+  Scenario: Traces-v2 banner is forced when only voice agents is snoozed
+    Given the voice agents banner is currently snoozed for this project
+    And the traces-v2 banner has never been dismissed for this project
+    When the home page loads
+    Then the traces-v2 banner is visible
+    And the voice agents banner is not visible
+
+  Scenario: Neither banner renders when both are snoozed
+    Given both the traces-v2 and voice agents banners are currently snoozed for this project
+    When the home page loads
+    Then no announcement banner is visible
 
   Scenario: CTA opens the public docs in a new tab
     Given the voice agents banner is visible
@@ -49,3 +63,9 @@ Feature: Voice agents home banner
     When the home page renders on the server
     Then neither the voice agents banner nor the traces-v2 banner appears in the SSR output
     And both banners only mount after client-side hydration
+
+  Scenario: Dismissing the currently-shown banner hands the slot to the other in the same tab
+    Given both banners are eligible and the random pick rendered the voice agents banner
+    When the user clicks the dismiss "x"
+    Then the voice agents banner is hidden immediately
+    And the traces-v2 banner takes the slot without a page reload

--- a/specs/home/voice-agents-home-banner.feature
+++ b/specs/home/voice-agents-home-banner.feature
@@ -1,0 +1,51 @@
+Feature: Voice agents home banner
+
+  The home page surfaces project-level launch announcements through a
+  single rotating banner slot. Once the traces-v2 banner is dismissed,
+  the voice agents banner takes over the same slot until it too is
+  dismissed. Each banner owns its own per-project snooze so dismissing
+  one does not resurrect the other.
+
+  Background:
+    Given a logged-in user with a selected project
+
+  Scenario: Voice banner is hidden by default while traces-v2 is still showing
+    Given the traces-v2 home banner has never been dismissed for this project
+    When the home page loads
+    Then the traces-v2 banner is visible
+    And the voice agents banner is not visible
+
+  Scenario: Voice banner takes over once traces-v2 is snoozed
+    Given the traces-v2 home banner is currently snoozed for this project
+    And the voice agents banner has never been dismissed for this project
+    When the home page loads
+    Then the voice agents banner is visible
+    And the traces-v2 banner is not visible
+    And the banner shows the heading "Voice agent simulations are here"
+    And the banner shows a "New" pill
+    And the banner shows a "Try voice agent testing" call to action
+
+  Scenario: CTA opens the public docs in a new tab
+    Given the voice agents banner is visible
+    When the user clicks the "Try voice agent testing" CTA
+    Then a new browser tab opens at https://langwatch.ai/scenario/voice/getting-started
+    And the link uses rel="noopener noreferrer"
+    And a "voice_agents_banner_click" PostHog event is captured with surface "home_banner"
+
+  Scenario: Dismissing snoozes the voice banner for 7 days
+    Given the voice agents banner is visible
+    When the user clicks the dismiss "x" button
+    Then the voice agents banner is hidden immediately
+    And the snooze persists under storage key "langwatch:voice-agents-home-banner-dismissed:v1:<projectId>"
+    And the stored value expires roughly 7 days in the future
+
+  Scenario: Snooze is scoped per project
+    Given the voice agents banner has been dismissed for project A
+    And the user switches to project B in the same organization
+    When the home page loads under project B
+    Then the voice agents banner is visible for project B
+
+  Scenario: SSR/pre-hydration does not flash either banner
+    When the home page renders on the server
+    Then neither the voice agents banner nor the traces-v2 banner appears in the SSR output
+    And both banners only mount after client-side hydration

--- a/specs/suites/voice-agents-callout.feature
+++ b/specs/suites/voice-agents-callout.feature
@@ -1,0 +1,51 @@
+Feature: Voice agents callout in simulations sidebar
+
+  The simulations sidebar surfaces a small gradient announcement card
+  pinned at the bottom, just above the collapse-toggle footer. It
+  invites users to try voice agent simulations and routes to the public
+  Scenario docs. The card disappears for 14 days once dismissed and
+  never renders when the sidebar is collapsed (no room for copy).
+
+  Background:
+    Given a logged-in user with a selected project
+    And the user is on the /simulations page
+
+  Scenario: Callout is visible by default at the bottom of the expanded sidebar
+    Given the simulations sidebar is expanded
+    And the voice agents callout has never been dismissed for this project
+    When the sidebar renders
+    Then the voice agents callout is visible
+    And it is positioned just above the collapse-toggle footer
+    And it shows the title "Try voice agent simulations"
+    And it shows a "Get started" arrow CTA
+
+  Scenario: Callout is hidden when the sidebar is collapsed
+    Given the simulations sidebar is collapsed to the icon rail
+    When the sidebar renders
+    Then the voice agents callout is not visible
+
+  Scenario: Clicking the callout opens the public docs in a new tab
+    Given the voice agents callout is visible
+    When the user clicks the callout body
+    Then a new browser tab opens at https://langwatch.ai/scenario/voice/getting-started
+    And the link uses rel="noopener noreferrer"
+    And a "voice_agents_callout_click" PostHog event is captured with surface "simulations_sidebar"
+
+  Scenario: Dismissing the callout snoozes it for 14 days
+    Given the voice agents callout is visible
+    When the user clicks the dismiss "x" button
+    Then the callout is hidden immediately
+    And the dismiss click does not navigate to the docs link
+    And the snooze persists under storage key "langwatch:simulations-voice-callout-dismissed:v1:<projectId>"
+    And the stored value expires roughly 14 days in the future
+
+  Scenario: Snooze is scoped per project
+    Given the voice agents callout has been dismissed for project A
+    And the user switches to project B in the same organization
+    When the /simulations page loads under project B
+    Then the voice agents callout is visible for project B
+
+  Scenario: SSR/pre-hydration does not flash the callout
+    When the simulations sidebar renders on the server
+    Then the voice agents callout does not appear in the SSR output
+    And it only mounts after client-side hydration


### PR DESCRIPTION
## Summary

Two surfaces announcing voice agent simulations launched on a single PR.

**Home page banner** — `VoiceAgentsHomeBanner` mirrors the shape of `TracesV2HomeBanner` (mesh gradient, glass card, 7-day snooze) in a teal/cyan/indigo palette so the two read as the same announcement family. `HomePageBanners` picks ONE banner per mount: when neither is snoozed it flips a coin 50/50, otherwise the un-snoozed one takes the slot. Each banner owns its own per-project localStorage key, so dismissing one never resurrects the other. Dismissal hands the slot to the other in the same tab via an `onDismissed` callback (no reload needed).

**Simulations sidebar callout** — `VoiceAgentsCallout` pinned just above the collapse-toggle footer on `/simulations`. Matches the in-app "Try the new Trace Explorer" pattern (gradient pill + arrow CTA + snooze-on-dismiss) at sidebar-friendly size. Snoozes for 14 days per project. Only renders when the sidebar is expanded, the icon-rail width has no room for the copy.

Both CTAs open `https://langwatch.ai/scenario/voice/getting-started` in a new tab (public docs, plain `<a target="_blank" rel="noopener noreferrer">`, not the in-app `<Link>`) and capture distinct PostHog events (`voice_agents_banner_click`, `voice_agents_callout_click`) so we can measure conversion per surface.

## Screenshots

Home, traces v2 banner (default state, voice hidden):

![home-traces-v2-banner](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4502/home/01-traces-v2-banner.png)

Home, voice agents banner (after traces v2 is snoozed):

![home-voice-agents-banner](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4502/home/02-voice-agents-banner.png)

Simulations, sidebar expanded, callout pinned at the bottom:

![simulations-callout-expanded](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4502/simulations/01-callout-expanded.png)

Simulations, sidebar collapsed, callout hidden (no room on the icon rail):

![simulations-sidebar-collapsed](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4502/simulations/02-sidebar-collapsed.png)

## Specs

- `specs/home/voice-agents-home-banner.feature` documents the random pick when both are eligible, deterministic fallback when one is snoozed, in-tab handoff on dismiss, per-project snooze, CTA, and SSR/hydration behavior.
- `specs/suites/voice-agents-callout.feature` documents the expanded-only render, dismiss-without-navigate, and 14-day snooze.

## Tests

- `langwatch/src/components/home/__tests__/VoiceAgentsHomeBanner.unit.test.tsx`
- `langwatch/src/components/home/__tests__/HomePageBanners.unit.test.tsx`
- `langwatch/src/components/suites/__tests__/VoiceAgentsCallout.unit.test.tsx`

21 react-testing-library specs covering: not-snoozed render, `target="_blank"` + `rel="noopener noreferrer"` on the CTAs, PostHog event payloads, dismiss-on-click persistence with the right storage keys and roughly 7/14-day TTLs, hide-when-snoozed, re-render on expiry, and the random pick / deterministic fallback / both-snoozed cells of the rotation truth table.

## Test plan

Home banner:
- [x] Fresh project shows one of the two banners (50/50 coin flip).
- [x] Click x on whichever is showing -> the OTHER takes the slot in the same tab.
- [x] Click "Try voice agent testing" -> opens docs in new tab, PostHog `voice_agents_banner_click` fires, voice banner stays snoozed for 7 days.
- [x] Reload after both dismissed -> neither banner visible.

Simulations sidebar callout:
- [x] `/simulations` sidebar expanded -> gradient callout pinned at the bottom above the collapse toggle.
- [x] Collapse sidebar -> callout disappears (icon-rail width).
- [x] Click callout body -> opens docs in new tab, PostHog `voice_agents_callout_click` fires.
- [x] Click x -> callout disappears without navigating, snoozes for 14 days, reload keeps it hidden.

Closes #4503 (folded into this PR).
