### PR TITLE
fix(skills/scenarios): clarify per-adapter how to connect the user's agent (voice section)

### DIFF
--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -639,19 +639,20 @@ Also browse the runnable voice examples:
 
 There are dozens of patterns there (angry customer with cafe noise, password-reset trap, multi-intent rush, accent + disfluency, background cross-talk, security pressure). Match the user's domain to the closest existing example before writing one from scratch.
 
-### Step 2: Pick the right voice adapter
+### Step 2: Pick the right voice adapter — and understand how it connects to the user's agent
 
-Detect the user's transport from their codebase and pick the matching adapter:
+Detect the user's transport from their codebase and pick the matching adapter. **Critically**, every adapter has a different idea of "what is the agent under test":
 
-| User's stack | Adapter |
-| --- | --- |
-| OpenAI Realtime model is the agent | \`scenario.OpenAIRealtimeAgentAdapter\` |
-| ElevenLabs hosted ConvAI agent | \`scenario.ElevenLabsAgentAdapter\` |
-| Pipecat / Twilio Media Streams WebSocket bot | \`scenario.PipecatAgentAdapter\` |
-| Gemini Live agent | \`scenario.GeminiLiveAgentAdapter\` |
-| Twilio phone number (real PSTN) | \`scenario.TwilioAgentAdapter\` |
+| User's stack | Adapter | How it connects to the user's agent |
+| --- | --- | --- |
+| Pipecat / Twilio Media Streams WS bot deployed somewhere | \`scenario.PipecatAgentAdapter(url="ws://<your-bot>/stream", ...)\` | Opens a WebSocket to the user's **already-running** bot. The bot has to be reachable (locally on \`ws://localhost:<port>\` or remotely). |
+| ElevenLabs hosted ConvAI agent (created in the EL dashboard) | \`scenario.ElevenLabsAgentAdapter(agent_id=..., api_key=...)\` | Dials the user's hosted ConvAI agent by ID. The hosted agent owns model + voice + instructions + tools. |
+| Twilio phone number (real PSTN, agent answers via Media Streams) | \`scenario.TwilioAgentAdapter\` (via \`TwilioHarness(phone_number=...)\`) | Accepts a real inbound call on the user's Twilio number. The deployed agent picks up. |
+| Gemini Live model is the agent | \`scenario.GeminiLiveAgentAdapter(model=..., system_instruction=..., voice=...)\` | The **adapter IS the agent**. It opens a Gemini Live session with these params — there is no separate "user's agent" being connected to. Copy the user's prod model, system instruction, voice, and tools into the constructor or the test is testing Gemini defaults, not the user's agent. |
+| OpenAI Realtime model is the agent | \`scenario.OpenAIRealtimeAgentAdapter(model=..., instructions=..., voice=..., tools=...)\` | Same shape as Gemini Live — the **adapter IS the agent**. Copy prod \`model\`, \`instructions\`, \`voice\`, and \`tools\` into the constructor. Without those, you're testing OpenAI defaults, not the user's agent. |
+| Text-only stack (chat completions, LangGraph, Mastra, plain SDK) with no deployed voice transport yet | \`scenario.ComposableVoiceAgent(stt=..., llm=<wrap their agent>, tts=...)\` | Wraps the user's existing text agent in STT → agent → TTS. **Be explicit in your reply** that this tests a *voice wrapper* around their text logic, not a production voice transport. If they want to test a real deployed voice transport, they need to ship one first (Pipecat, Twilio, ElevenLabs hosted, OpenAI Realtime). |
 
-If the user's stack is text-only and they want voice anyway, default to \`OpenAIRealtimeAgentAdapter\` (lowest setup: just an OpenAI key) and note the swap in your reply.
+If you can't tell from the codebase which path the user is on, ASK before generating a test. Picking the wrong adapter means the test exercises something the user hasn't deployed — and they will (rightly) call it useless.
 
 ### Step 3: Seed a VOICE on the user simulator
 
@@ -683,16 +684,23 @@ The default \`UserSimulatorAgent\` system prompt encodes a text-chat style ("ver
 
 > "You are SPEAKING ON A PHONE, not typing. Talk in natural spoken sentences (full clauses with subjects and verbs), not telegraphic phrases. Real callers don't speak like google queries."
 
-### Worked example (Python)
+### Worked example (Python, Pipecat WS — adapter connects to the user's deployed bot)
 
 \`\`\`python
+import os
 import pytest
 import scenario
 
 scenario.configure(default_model="openai/gpt-5-mini")
 
+# The user's Pipecat bot must be reachable at this URL when the test runs.
+# Typical setups: spin it up in a fixture, point at a staging deployment,
+# or \`make bot\` in another terminal. The adapter does NOT start the bot.
+BOT_WS_URL = os.environ.get("PIPECAT_BOT_URL", "ws://localhost:8765/stream")
+
 @pytest.mark.agent_test
 @pytest.mark.asyncio
+@pytest.mark.timeout(300)
 async def test_angry_customer_billing_error():
     result = await scenario.run(
         name="angry billing error in a noisy cafe",
@@ -702,9 +710,10 @@ async def test_angry_customer_billing_error():
             "logistics, stay calm, and queue a refund."
         ),
         agents=[
-            scenario.OpenAIRealtimeAgentAdapter(
-                model="gpt-realtime-mini",
-                instructions="...your agent's system prompt...",
+            scenario.PipecatAgentAdapter(
+                url=BOT_WS_URL,
+                audio_format="mulaw",
+                sample_rate=8000,
             ),
             scenario.UserSimulatorAgent(
                 voice="elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -739,6 +748,50 @@ async def test_angry_customer_billing_error():
     assert result.success, result.reasoning
 \`\`\`
 
+### Worked example (Python, OpenAI Realtime — adapter IS the agent, mirror prod config)
+
+Use this shape when the user's production agent IS an OpenAI Realtime model. Copy their prod \`model\`, \`voice\`, \`instructions\`, and \`tools\` into the constructor — anything you leave as a placeholder is what you are testing.
+
+\`\`\`python
+import pytest
+import scenario
+from scenario.config.voice_models import OPENAI_REALTIME_MODEL
+from scenario.types import AgentRole
+
+# Mirror the user's PROD config — same model, same system prompt,
+# same voice, same tools. Otherwise this exercises OpenAI defaults,
+# not their agent.
+PROD_MODEL = OPENAI_REALTIME_MODEL
+PROD_INSTRUCTIONS = "<copy the EXACT prod system prompt here>"
+PROD_VOICE = "alloy"
+PROD_TOOLS: list = []  # paste the same function-calling schemas as prod
+
+@pytest.mark.agent_test
+@pytest.mark.asyncio
+@pytest.mark.timeout(300)
+async def test_realtime_greeting():
+    result = await scenario.run(
+        name="realtime greeting smoke",
+        description="Caller says hi; agent greets and stays helpful.",
+        agents=[
+            scenario.OpenAIRealtimeAgentAdapter(
+                model=PROD_MODEL,
+                voice=PROD_VOICE,
+                instructions=PROD_INSTRUCTIONS,
+                tools=PROD_TOOLS,
+                role=AgentRole.AGENT,
+            ),
+            scenario.UserSimulatorAgent(voice="openai/nova"),
+            scenario.JudgeAgent(criteria=[
+                "The agent greeted the caller helpfully",
+                "Real audio was exchanged in both directions",
+            ]),
+        ],
+        script=[scenario.user("Hi, can you help me?"), scenario.agent(), scenario.judge()],
+    )
+    assert result.success, result.reasoning
+\`\`\`
+
 ### Worked example (TypeScript)
 
 \`\`\`typescript
@@ -754,9 +807,13 @@ describe("Voice agent — angry billing", () => {
         "The agent must acknowledge the frustration before pivoting to " +
         "logistics, stay calm, and queue a refund.",
       agents: [
+        // The adapter IS the agent. Mirror the user's PROD model,
+        // voice, instructions, and tools here — anything you leave as
+        // a placeholder is what you're actually testing.
         scenario.openAIRealtimeAgent({
           voice: "alloy",
-          instructions: "...your agent's system prompt...",
+          instructions: "<paste the EXACT prod system prompt here>",
+          // tools: [...prod tool schemas...],
         }),
         scenario.userSimulatorAgent({
           voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -850,7 +907,9 @@ Do NOT ask permission before Phase 1 and 2 — deliver value first. Do NOT ask g
 
 ### Voice Agents
 
-- Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\`
+- Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\` / \`ComposableVoiceAgent\`
+- Do NOT instantiate \`OpenAIRealtimeAgentAdapter\` or \`GeminiLiveAgentAdapter\` with placeholder \`instructions=...\` / \`model=...\` / \`tools=...\` — those adapters ARE the agent, so a placeholder constructor tests OpenAI/Gemini defaults, not the user's agent. Either mirror the user's prod config exactly, or pick a different adapter (Pipecat/Twilio/ElevenLabs hosted) that connects to their already-deployed transport.
+- Do NOT point \`PipecatAgentAdapter(url=...)\` / \`ElevenLabsAgentAdapter(agent_id=...)\` / \`TwilioAgentAdapter\` at a transport the user hasn't deployed — those adapters only connect, they don't spin anything up. If the user is text-only and has no voice transport, say so and offer \`ComposableVoiceAgent\` as a voice wrapper around their existing text logic.
 - Do NOT forget the \`voice="elevenlabs/..."\` (or \`"openai/..."\`) on \`UserSimulatorAgent\` — a silent simulator turns the voice scenario into a text scenario with audio frame headers
 - Do NOT bake an empathy persona into a calm voice — use ElevenLabs tonal markers (\`[shouting]\`, \`[angry]\`, \`[stressed]\`) in the persona prompt so the TTS renders audible emotion
 - Do NOT script multi-turn \`user()\` audio against \`ElevenLabsAgentAdapter\` — it's server-VAD-driven and the second \`agent()\` reliably times out; keep hosted-ConvAI scripts to ONE exchange
@@ -2306,19 +2365,20 @@ Also browse the runnable voice examples:
 
 There are dozens of patterns there (angry customer with cafe noise, password-reset trap, multi-intent rush, accent + disfluency, background cross-talk, security pressure). Match the user's domain to the closest existing example before writing one from scratch.
 
-### Step 2: Pick the right voice adapter
+### Step 2: Pick the right voice adapter — and understand how it connects to the user's agent
 
-Detect the user's transport from their codebase and pick the matching adapter:
+Detect the user's transport from their codebase and pick the matching adapter. **Critically**, every adapter has a different idea of "what is the agent under test":
 
-| User's stack | Adapter |
-| --- | --- |
-| OpenAI Realtime model is the agent | \`scenario.OpenAIRealtimeAgentAdapter\` |
-| ElevenLabs hosted ConvAI agent | \`scenario.ElevenLabsAgentAdapter\` |
-| Pipecat / Twilio Media Streams WebSocket bot | \`scenario.PipecatAgentAdapter\` |
-| Gemini Live agent | \`scenario.GeminiLiveAgentAdapter\` |
-| Twilio phone number (real PSTN) | \`scenario.TwilioAgentAdapter\` |
+| User's stack | Adapter | How it connects to the user's agent |
+| --- | --- | --- |
+| Pipecat / Twilio Media Streams WS bot deployed somewhere | \`scenario.PipecatAgentAdapter(url="ws://<your-bot>/stream", ...)\` | Opens a WebSocket to the user's **already-running** bot. The bot has to be reachable (locally on \`ws://localhost:<port>\` or remotely). |
+| ElevenLabs hosted ConvAI agent (created in the EL dashboard) | \`scenario.ElevenLabsAgentAdapter(agent_id=..., api_key=...)\` | Dials the user's hosted ConvAI agent by ID. The hosted agent owns model + voice + instructions + tools. |
+| Twilio phone number (real PSTN, agent answers via Media Streams) | \`scenario.TwilioAgentAdapter\` (via \`TwilioHarness(phone_number=...)\`) | Accepts a real inbound call on the user's Twilio number. The deployed agent picks up. |
+| Gemini Live model is the agent | \`scenario.GeminiLiveAgentAdapter(model=..., system_instruction=..., voice=...)\` | The **adapter IS the agent**. It opens a Gemini Live session with these params — there is no separate "user's agent" being connected to. Copy the user's prod model, system instruction, voice, and tools into the constructor or the test is testing Gemini defaults, not the user's agent. |
+| OpenAI Realtime model is the agent | \`scenario.OpenAIRealtimeAgentAdapter(model=..., instructions=..., voice=..., tools=...)\` | Same shape as Gemini Live — the **adapter IS the agent**. Copy prod \`model\`, \`instructions\`, \`voice\`, and \`tools\` into the constructor. Without those, you're testing OpenAI defaults, not the user's agent. |
+| Text-only stack (chat completions, LangGraph, Mastra, plain SDK) with no deployed voice transport yet | \`scenario.ComposableVoiceAgent(stt=..., llm=<wrap their agent>, tts=...)\` | Wraps the user's existing text agent in STT → agent → TTS. **Be explicit in your reply** that this tests a *voice wrapper* around their text logic, not a production voice transport. If they want to test a real deployed voice transport, they need to ship one first (Pipecat, Twilio, ElevenLabs hosted, OpenAI Realtime). |
 
-If the user's stack is text-only and they want voice anyway, default to \`OpenAIRealtimeAgentAdapter\` (lowest setup: just an OpenAI key) and note the swap in your reply.
+If you can't tell from the codebase which path the user is on, ASK before generating a test. Picking the wrong adapter means the test exercises something the user hasn't deployed — and they will (rightly) call it useless.
 
 ### Step 3: Seed a VOICE on the user simulator
 
@@ -2350,16 +2410,23 @@ The default \`UserSimulatorAgent\` system prompt encodes a text-chat style ("ver
 
 > "You are SPEAKING ON A PHONE, not typing. Talk in natural spoken sentences (full clauses with subjects and verbs), not telegraphic phrases. Real callers don't speak like google queries."
 
-### Worked example (Python)
+### Worked example (Python, Pipecat WS — adapter connects to the user's deployed bot)
 
 \`\`\`python
+import os
 import pytest
 import scenario
 
 scenario.configure(default_model="openai/gpt-5-mini")
 
+# The user's Pipecat bot must be reachable at this URL when the test runs.
+# Typical setups: spin it up in a fixture, point at a staging deployment,
+# or \`make bot\` in another terminal. The adapter does NOT start the bot.
+BOT_WS_URL = os.environ.get("PIPECAT_BOT_URL", "ws://localhost:8765/stream")
+
 @pytest.mark.agent_test
 @pytest.mark.asyncio
+@pytest.mark.timeout(300)
 async def test_angry_customer_billing_error():
     result = await scenario.run(
         name="angry billing error in a noisy cafe",
@@ -2369,9 +2436,10 @@ async def test_angry_customer_billing_error():
             "logistics, stay calm, and queue a refund."
         ),
         agents=[
-            scenario.OpenAIRealtimeAgentAdapter(
-                model="gpt-realtime-mini",
-                instructions="...your agent's system prompt...",
+            scenario.PipecatAgentAdapter(
+                url=BOT_WS_URL,
+                audio_format="mulaw",
+                sample_rate=8000,
             ),
             scenario.UserSimulatorAgent(
                 voice="elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -2406,6 +2474,50 @@ async def test_angry_customer_billing_error():
     assert result.success, result.reasoning
 \`\`\`
 
+### Worked example (Python, OpenAI Realtime — adapter IS the agent, mirror prod config)
+
+Use this shape when the user's production agent IS an OpenAI Realtime model. Copy their prod \`model\`, \`voice\`, \`instructions\`, and \`tools\` into the constructor — anything you leave as a placeholder is what you are testing.
+
+\`\`\`python
+import pytest
+import scenario
+from scenario.config.voice_models import OPENAI_REALTIME_MODEL
+from scenario.types import AgentRole
+
+# Mirror the user's PROD config — same model, same system prompt,
+# same voice, same tools. Otherwise this exercises OpenAI defaults,
+# not their agent.
+PROD_MODEL = OPENAI_REALTIME_MODEL
+PROD_INSTRUCTIONS = "<copy the EXACT prod system prompt here>"
+PROD_VOICE = "alloy"
+PROD_TOOLS: list = []  # paste the same function-calling schemas as prod
+
+@pytest.mark.agent_test
+@pytest.mark.asyncio
+@pytest.mark.timeout(300)
+async def test_realtime_greeting():
+    result = await scenario.run(
+        name="realtime greeting smoke",
+        description="Caller says hi; agent greets and stays helpful.",
+        agents=[
+            scenario.OpenAIRealtimeAgentAdapter(
+                model=PROD_MODEL,
+                voice=PROD_VOICE,
+                instructions=PROD_INSTRUCTIONS,
+                tools=PROD_TOOLS,
+                role=AgentRole.AGENT,
+            ),
+            scenario.UserSimulatorAgent(voice="openai/nova"),
+            scenario.JudgeAgent(criteria=[
+                "The agent greeted the caller helpfully",
+                "Real audio was exchanged in both directions",
+            ]),
+        ],
+        script=[scenario.user("Hi, can you help me?"), scenario.agent(), scenario.judge()],
+    )
+    assert result.success, result.reasoning
+\`\`\`
+
 ### Worked example (TypeScript)
 
 \`\`\`typescript
@@ -2421,9 +2533,13 @@ describe("Voice agent — angry billing", () => {
         "The agent must acknowledge the frustration before pivoting to " +
         "logistics, stay calm, and queue a refund.",
       agents: [
+        // The adapter IS the agent. Mirror the user's PROD model,
+        // voice, instructions, and tools here — anything you leave as
+        // a placeholder is what you're actually testing.
         scenario.openAIRealtimeAgent({
           voice: "alloy",
-          instructions: "...your agent's system prompt...",
+          instructions: "<paste the EXACT prod system prompt here>",
+          // tools: [...prod tool schemas...],
         }),
         scenario.userSimulatorAgent({
           voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -2509,7 +2625,9 @@ Once tests are green, summarize what you delivered and suggest 2-3 domain-specif
 
 ### Voice Agents
 
-- Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\`
+- Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\` / \`ComposableVoiceAgent\`
+- Do NOT instantiate \`OpenAIRealtimeAgentAdapter\` or \`GeminiLiveAgentAdapter\` with placeholder \`instructions=...\` / \`model=...\` / \`tools=...\` — those adapters ARE the agent, so a placeholder constructor tests OpenAI/Gemini defaults, not the user's agent. Either mirror the user's prod config exactly, or pick a different adapter (Pipecat/Twilio/ElevenLabs hosted) that connects to their already-deployed transport.
+- Do NOT point \`PipecatAgentAdapter(url=...)\` / \`ElevenLabsAgentAdapter(agent_id=...)\` / \`TwilioAgentAdapter\` at a transport the user hasn't deployed — those adapters only connect, they don't spin anything up. If the user is text-only and has no voice transport, say so and offer \`ComposableVoiceAgent\` as a voice wrapper around their existing text logic.
 - Do NOT forget the \`voice="elevenlabs/..."\` (or \`"openai/..."\`) on \`UserSimulatorAgent\` — a silent simulator turns the voice scenario into a text scenario with audio frame headers
 - Do NOT bake an empathy persona into a calm voice — use ElevenLabs tonal markers (\`[shouting]\`, \`[angry]\`, \`[stressed]\`) in the persona prompt so the TTS renders audible emotion
 - Do NOT script multi-turn \`user()\` audio against \`ElevenLabsAgentAdapter\` — it's server-VAD-driven and the second \`agent()\` reliably times out; keep hosted-ConvAI scripts to ONE exchange
@@ -3580,19 +3698,20 @@ Also browse the runnable voice examples:
 
 There are dozens of patterns there (angry customer with cafe noise, password-reset trap, multi-intent rush, accent + disfluency, background cross-talk, security pressure). Match the user's domain to the closest existing example before writing one from scratch.
 
-### Step 2: Pick the right voice adapter
+### Step 2: Pick the right voice adapter — and understand how it connects to the user's agent
 
-Detect the user's transport from their codebase and pick the matching adapter:
+Detect the user's transport from their codebase and pick the matching adapter. **Critically**, every adapter has a different idea of "what is the agent under test":
 
-| User's stack | Adapter |
-| --- | --- |
-| OpenAI Realtime model is the agent | \`scenario.OpenAIRealtimeAgentAdapter\` |
-| ElevenLabs hosted ConvAI agent | \`scenario.ElevenLabsAgentAdapter\` |
-| Pipecat / Twilio Media Streams WebSocket bot | \`scenario.PipecatAgentAdapter\` |
-| Gemini Live agent | \`scenario.GeminiLiveAgentAdapter\` |
-| Twilio phone number (real PSTN) | \`scenario.TwilioAgentAdapter\` |
+| User's stack | Adapter | How it connects to the user's agent |
+| --- | --- | --- |
+| Pipecat / Twilio Media Streams WS bot deployed somewhere | \`scenario.PipecatAgentAdapter(url="ws://<your-bot>/stream", ...)\` | Opens a WebSocket to the user's **already-running** bot. The bot has to be reachable (locally on \`ws://localhost:<port>\` or remotely). |
+| ElevenLabs hosted ConvAI agent (created in the EL dashboard) | \`scenario.ElevenLabsAgentAdapter(agent_id=..., api_key=...)\` | Dials the user's hosted ConvAI agent by ID. The hosted agent owns model + voice + instructions + tools. |
+| Twilio phone number (real PSTN, agent answers via Media Streams) | \`scenario.TwilioAgentAdapter\` (via \`TwilioHarness(phone_number=...)\`) | Accepts a real inbound call on the user's Twilio number. The deployed agent picks up. |
+| Gemini Live model is the agent | \`scenario.GeminiLiveAgentAdapter(model=..., system_instruction=..., voice=...)\` | The **adapter IS the agent**. It opens a Gemini Live session with these params — there is no separate "user's agent" being connected to. Copy the user's prod model, system instruction, voice, and tools into the constructor or the test is testing Gemini defaults, not the user's agent. |
+| OpenAI Realtime model is the agent | \`scenario.OpenAIRealtimeAgentAdapter(model=..., instructions=..., voice=..., tools=...)\` | Same shape as Gemini Live — the **adapter IS the agent**. Copy prod \`model\`, \`instructions\`, \`voice\`, and \`tools\` into the constructor. Without those, you're testing OpenAI defaults, not the user's agent. |
+| Text-only stack (chat completions, LangGraph, Mastra, plain SDK) with no deployed voice transport yet | \`scenario.ComposableVoiceAgent(stt=..., llm=<wrap their agent>, tts=...)\` | Wraps the user's existing text agent in STT → agent → TTS. **Be explicit in your reply** that this tests a *voice wrapper* around their text logic, not a production voice transport. If they want to test a real deployed voice transport, they need to ship one first (Pipecat, Twilio, ElevenLabs hosted, OpenAI Realtime). |
 
-If the user's stack is text-only and they want voice anyway, default to \`OpenAIRealtimeAgentAdapter\` (lowest setup: just an OpenAI key) and note the swap in your reply.
+If you can't tell from the codebase which path the user is on, ASK before generating a test. Picking the wrong adapter means the test exercises something the user hasn't deployed — and they will (rightly) call it useless.
 
 ### Step 3: Seed a VOICE on the user simulator
 
@@ -3624,16 +3743,23 @@ The default \`UserSimulatorAgent\` system prompt encodes a text-chat style ("ver
 
 > "You are SPEAKING ON A PHONE, not typing. Talk in natural spoken sentences (full clauses with subjects and verbs), not telegraphic phrases. Real callers don't speak like google queries."
 
-### Worked example (Python)
+### Worked example (Python, Pipecat WS — adapter connects to the user's deployed bot)
 
 \`\`\`python
+import os
 import pytest
 import scenario
 
 scenario.configure(default_model="openai/gpt-5-mini")
 
+# The user's Pipecat bot must be reachable at this URL when the test runs.
+# Typical setups: spin it up in a fixture, point at a staging deployment,
+# or \`make bot\` in another terminal. The adapter does NOT start the bot.
+BOT_WS_URL = os.environ.get("PIPECAT_BOT_URL", "ws://localhost:8765/stream")
+
 @pytest.mark.agent_test
 @pytest.mark.asyncio
+@pytest.mark.timeout(300)
 async def test_angry_customer_billing_error():
     result = await scenario.run(
         name="angry billing error in a noisy cafe",
@@ -3643,9 +3769,10 @@ async def test_angry_customer_billing_error():
             "logistics, stay calm, and queue a refund."
         ),
         agents=[
-            scenario.OpenAIRealtimeAgentAdapter(
-                model="gpt-realtime-mini",
-                instructions="...your agent's system prompt...",
+            scenario.PipecatAgentAdapter(
+                url=BOT_WS_URL,
+                audio_format="mulaw",
+                sample_rate=8000,
             ),
             scenario.UserSimulatorAgent(
                 voice="elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -3680,6 +3807,50 @@ async def test_angry_customer_billing_error():
     assert result.success, result.reasoning
 \`\`\`
 
+### Worked example (Python, OpenAI Realtime — adapter IS the agent, mirror prod config)
+
+Use this shape when the user's production agent IS an OpenAI Realtime model. Copy their prod \`model\`, \`voice\`, \`instructions\`, and \`tools\` into the constructor — anything you leave as a placeholder is what you are testing.
+
+\`\`\`python
+import pytest
+import scenario
+from scenario.config.voice_models import OPENAI_REALTIME_MODEL
+from scenario.types import AgentRole
+
+# Mirror the user's PROD config — same model, same system prompt,
+# same voice, same tools. Otherwise this exercises OpenAI defaults,
+# not their agent.
+PROD_MODEL = OPENAI_REALTIME_MODEL
+PROD_INSTRUCTIONS = "<copy the EXACT prod system prompt here>"
+PROD_VOICE = "alloy"
+PROD_TOOLS: list = []  # paste the same function-calling schemas as prod
+
+@pytest.mark.agent_test
+@pytest.mark.asyncio
+@pytest.mark.timeout(300)
+async def test_realtime_greeting():
+    result = await scenario.run(
+        name="realtime greeting smoke",
+        description="Caller says hi; agent greets and stays helpful.",
+        agents=[
+            scenario.OpenAIRealtimeAgentAdapter(
+                model=PROD_MODEL,
+                voice=PROD_VOICE,
+                instructions=PROD_INSTRUCTIONS,
+                tools=PROD_TOOLS,
+                role=AgentRole.AGENT,
+            ),
+            scenario.UserSimulatorAgent(voice="openai/nova"),
+            scenario.JudgeAgent(criteria=[
+                "The agent greeted the caller helpfully",
+                "Real audio was exchanged in both directions",
+            ]),
+        ],
+        script=[scenario.user("Hi, can you help me?"), scenario.agent(), scenario.judge()],
+    )
+    assert result.success, result.reasoning
+\`\`\`
+
 ### Worked example (TypeScript)
 
 \`\`\`typescript
@@ -3695,9 +3866,13 @@ describe("Voice agent — angry billing", () => {
         "The agent must acknowledge the frustration before pivoting to " +
         "logistics, stay calm, and queue a refund.",
       agents: [
+        // The adapter IS the agent. Mirror the user's PROD model,
+        // voice, instructions, and tools here — anything you leave as
+        // a placeholder is what you're actually testing.
         scenario.openAIRealtimeAgent({
           voice: "alloy",
-          instructions: "...your agent's system prompt...",
+          instructions: "<paste the EXACT prod system prompt here>",
+          // tools: [...prod tool schemas...],
         }),
         scenario.userSimulatorAgent({
           voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -3791,7 +3966,9 @@ Do NOT ask permission before Phase 1 and 2 — deliver value first. Do NOT ask g
 
 ### Voice Agents
 
-- Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\`
+- Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\` / \`ComposableVoiceAgent\`
+- Do NOT instantiate \`OpenAIRealtimeAgentAdapter\` or \`GeminiLiveAgentAdapter\` with placeholder \`instructions=...\` / \`model=...\` / \`tools=...\` — those adapters ARE the agent, so a placeholder constructor tests OpenAI/Gemini defaults, not the user's agent. Either mirror the user's prod config exactly, or pick a different adapter (Pipecat/Twilio/ElevenLabs hosted) that connects to their already-deployed transport.
+- Do NOT point \`PipecatAgentAdapter(url=...)\` / \`ElevenLabsAgentAdapter(agent_id=...)\` / \`TwilioAgentAdapter\` at a transport the user hasn't deployed — those adapters only connect, they don't spin anything up. If the user is text-only and has no voice transport, say so and offer \`ComposableVoiceAgent\` as a voice wrapper around their existing text logic.
 - Do NOT forget the \`voice="elevenlabs/..."\` (or \`"openai/..."\`) on \`UserSimulatorAgent\` — a silent simulator turns the voice scenario into a text scenario with audio frame headers
 - Do NOT bake an empathy persona into a calm voice — use ElevenLabs tonal markers (\`[shouting]\`, \`[angry]\`, \`[stressed]\`) in the persona prompt so the TTS renders audible emotion
 - Do NOT script multi-turn \`user()\` audio against \`ElevenLabsAgentAdapter\` — it's server-VAD-driven and the second \`agent()\` reliably times out; keep hosted-ConvAI scripts to ONE exchange

--- a/skills/_tests/README.md
+++ b/skills/_tests/README.md
@@ -1,0 +1,47 @@
+# Skills dogfood tests
+
+These are LangWatch Scenario tests that drive a real sub Claude Code session against each skill in `skills/<skill>/SKILL.mdx`, and assert that the agent picked up on the skill's instructions and produced the expected output (a test file, a CLI run, a piece of code). They prove the SKILL prompt is good enough that a fresh agent acts on it correctly.
+
+## Run locally before every SKILL change — always
+
+Every test file here is gated with `it.skipIf(isCI)` because each run:
+
+- Spins up a real `claude` sub-process per scenario step.
+- Talks to the live LLM (OpenAI, Anthropic) — both in the agent and in the judge.
+- For voice tests, also reaches out to TTS providers.
+- Costs real money per run and takes 5-15 min for the heavy ones (voice dogfood is ~10 min).
+
+CI cannot gate on these. **You can.** If you change a `SKILL.mdx`, or anything in `skills/_tests/fixtures/`, or anything the SKILL references (LangWatch CLI flags, docs page slugs, adapter names), you MUST run the affected dogfood locally and read the generated artifact before opening a PR.
+
+### Quick commands
+
+```bash
+# From repo root.
+cd skills
+
+# All skill tests (long, hits live LLMs, costs money). Don't.
+pnpm vitest run _tests
+
+# One specific skill test (the right grain — pick the one your change touches).
+pnpm vitest run _tests/scenarios.scenario.test.ts
+
+# One specific scenario inside a test file.
+pnpm vitest run _tests/scenarios.scenario.test.ts -t "creates voice scenario tests"
+```
+
+### What "passing" actually means
+
+Green dot is necessary, not sufficient.
+
+1. Run the test.
+2. Open the temp folder printed at the top of the run (`[voice dogfood] working dir: /tmp/langwatch-skill-scenarios-voice-py-XXX`).
+3. **Read the generated file the agent produced** (e.g. `test_voice_agent.py`). The regex guardrails inside the test only check structural shape — they cannot tell you whether the agent picked the right adapter for the user's stack, used the right model, or wrote anything that would actually run.
+4. If the generated file would not solve the user's stated problem, the SKILL is wrong. Fix the SKILL and re-run.
+
+If you skip step 3, you're trusting the regex. The regex doesn't know about your domain. The regex is happy with `OpenAIRealtimeAgentAdapter(instructions="<placeholder>")` even when the user has a Pipecat bot. You have to read.
+
+### Common failure modes
+
+- `Error: Command failed with exit code 1` inside `callAgent` — the sub `claude` process crashed or rate-limited. Re-run; if it persists, check `~/.claude/projects/` for the agent's transcript.
+- Test times out without a generated file — the SKILL didn't give Claude enough to act, or pointed it at a docs page that no longer exists. Read what Claude actually tried in its transcript.
+- Test passes the regex but the generated file is nonsense — the regex is too loose. Tighten it AND fix the SKILL guidance that led to the nonsense.

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -268,19 +268,20 @@ Also browse the runnable voice examples:
 
 There are dozens of patterns there (angry customer with cafe noise, password-reset trap, multi-intent rush, accent + disfluency, background cross-talk, security pressure). Match the user's domain to the closest existing example before writing one from scratch.
 
-### Step 2: Pick the right voice adapter
+### Step 2: Pick the right voice adapter — and understand how it connects to the user's agent
 
-Detect the user's transport from their codebase and pick the matching adapter:
+Detect the user's transport from their codebase and pick the matching adapter. **Critically**, every adapter has a different idea of "what is the agent under test":
 
-| User's stack | Adapter |
-| --- | --- |
-| OpenAI Realtime model is the agent | `scenario.OpenAIRealtimeAgentAdapter` |
-| ElevenLabs hosted ConvAI agent | `scenario.ElevenLabsAgentAdapter` |
-| Pipecat / Twilio Media Streams WebSocket bot | `scenario.PipecatAgentAdapter` |
-| Gemini Live agent | `scenario.GeminiLiveAgentAdapter` |
-| Twilio phone number (real PSTN) | `scenario.TwilioAgentAdapter` |
+| User's stack | Adapter | How it connects to the user's agent |
+| --- | --- | --- |
+| Pipecat / Twilio Media Streams WS bot deployed somewhere | `scenario.PipecatAgentAdapter(url="ws://<your-bot>/stream", ...)` | Opens a WebSocket to the user's **already-running** bot. The bot has to be reachable (locally on `ws://localhost:<port>` or remotely). |
+| ElevenLabs hosted ConvAI agent (created in the EL dashboard) | `scenario.ElevenLabsAgentAdapter(agent_id=..., api_key=...)` | Dials the user's hosted ConvAI agent by ID. The hosted agent owns model + voice + instructions + tools. |
+| Twilio phone number (real PSTN, agent answers via Media Streams) | `scenario.TwilioAgentAdapter` (via `TwilioHarness(phone_number=...)`) | Accepts a real inbound call on the user's Twilio number. The deployed agent picks up. |
+| Gemini Live model is the agent | `scenario.GeminiLiveAgentAdapter(model=..., system_instruction=..., voice=...)` | The **adapter IS the agent**. It opens a Gemini Live session with these params — there is no separate "user's agent" being connected to. Copy the user's prod model, system instruction, voice, and tools into the constructor or the test is testing Gemini defaults, not the user's agent. |
+| OpenAI Realtime model is the agent | `scenario.OpenAIRealtimeAgentAdapter(model=..., instructions=..., voice=..., tools=...)` | Same shape as Gemini Live — the **adapter IS the agent**. Copy prod `model`, `instructions`, `voice`, and `tools` into the constructor. Without those, you're testing OpenAI defaults, not the user's agent. |
+| Text-only stack (chat completions, LangGraph, Mastra, plain SDK) with no deployed voice transport yet | `scenario.ComposableVoiceAgent(stt=..., llm=<wrap their agent>, tts=...)` | Wraps the user's existing text agent in STT → agent → TTS. **Be explicit in your reply** that this tests a *voice wrapper* around their text logic, not a production voice transport. If they want to test a real deployed voice transport, they need to ship one first (Pipecat, Twilio, ElevenLabs hosted, OpenAI Realtime). |
 
-If the user's stack is text-only and they want voice anyway, default to `OpenAIRealtimeAgentAdapter` (lowest setup: just an OpenAI key) and note the swap in your reply.
+If you can't tell from the codebase which path the user is on, ASK before generating a test. Picking the wrong adapter means the test exercises something the user hasn't deployed — and they will (rightly) call it useless.
 
 ### Step 3: Seed a VOICE on the user simulator
 
@@ -312,16 +313,23 @@ The default `UserSimulatorAgent` system prompt encodes a text-chat style ("very 
 
 > "You are SPEAKING ON A PHONE, not typing. Talk in natural spoken sentences (full clauses with subjects and verbs), not telegraphic phrases. Real callers don't speak like google queries."
 
-### Worked example (Python)
+### Worked example (Python, Pipecat WS — adapter connects to the user's deployed bot)
 
 ```python
+import os
 import pytest
 import scenario
 
 scenario.configure(default_model="openai/gpt-5-mini")
 
+# The user's Pipecat bot must be reachable at this URL when the test runs.
+# Typical setups: spin it up in a fixture, point at a staging deployment,
+# or `make bot` in another terminal. The adapter does NOT start the bot.
+BOT_WS_URL = os.environ.get("PIPECAT_BOT_URL", "ws://localhost:8765/stream")
+
 @pytest.mark.agent_test
 @pytest.mark.asyncio
+@pytest.mark.timeout(300)
 async def test_angry_customer_billing_error():
     result = await scenario.run(
         name="angry billing error in a noisy cafe",
@@ -331,9 +339,10 @@ async def test_angry_customer_billing_error():
             "logistics, stay calm, and queue a refund."
         ),
         agents=[
-            scenario.OpenAIRealtimeAgentAdapter(
-                model="gpt-realtime-mini",
-                instructions="...your agent's system prompt...",
+            scenario.PipecatAgentAdapter(
+                url=BOT_WS_URL,
+                audio_format="mulaw",
+                sample_rate=8000,
             ),
             scenario.UserSimulatorAgent(
                 voice="elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -368,6 +377,50 @@ async def test_angry_customer_billing_error():
     assert result.success, result.reasoning
 ```
 
+### Worked example (Python, OpenAI Realtime — adapter IS the agent, mirror prod config)
+
+Use this shape when the user's production agent IS an OpenAI Realtime model. Copy their prod `model`, `voice`, `instructions`, and `tools` into the constructor — anything you leave as a placeholder is what you are testing.
+
+```python
+import pytest
+import scenario
+from scenario.config.voice_models import OPENAI_REALTIME_MODEL
+from scenario.types import AgentRole
+
+# Mirror the user's PROD config — same model, same system prompt,
+# same voice, same tools. Otherwise this exercises OpenAI defaults,
+# not their agent.
+PROD_MODEL = OPENAI_REALTIME_MODEL
+PROD_INSTRUCTIONS = "<copy the EXACT prod system prompt here>"
+PROD_VOICE = "alloy"
+PROD_TOOLS: list = []  # paste the same function-calling schemas as prod
+
+@pytest.mark.agent_test
+@pytest.mark.asyncio
+@pytest.mark.timeout(300)
+async def test_realtime_greeting():
+    result = await scenario.run(
+        name="realtime greeting smoke",
+        description="Caller says hi; agent greets and stays helpful.",
+        agents=[
+            scenario.OpenAIRealtimeAgentAdapter(
+                model=PROD_MODEL,
+                voice=PROD_VOICE,
+                instructions=PROD_INSTRUCTIONS,
+                tools=PROD_TOOLS,
+                role=AgentRole.AGENT,
+            ),
+            scenario.UserSimulatorAgent(voice="openai/nova"),
+            scenario.JudgeAgent(criteria=[
+                "The agent greeted the caller helpfully",
+                "Real audio was exchanged in both directions",
+            ]),
+        ],
+        script=[scenario.user("Hi, can you help me?"), scenario.agent(), scenario.judge()],
+    )
+    assert result.success, result.reasoning
+```
+
 ### Worked example (TypeScript)
 
 ```typescript
@@ -383,9 +436,13 @@ describe("Voice agent — angry billing", () => {
         "The agent must acknowledge the frustration before pivoting to " +
         "logistics, stay calm, and queue a refund.",
       agents: [
+        // The adapter IS the agent. Mirror the user's PROD model,
+        // voice, instructions, and tools here — anything you leave as
+        // a placeholder is what you're actually testing.
         scenario.openAIRealtimeAgent({
           voice: "alloy",
-          instructions: "...your agent's system prompt...",
+          instructions: "<paste the EXACT prod system prompt here>",
+          // tools: [...prod tool schemas...],
         }),
         scenario.userSimulatorAgent({
           voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -468,7 +525,9 @@ Once tests are green, summarize what you delivered and suggest 2-3 domain-specif
 - Do NOT forget a generous timeout (e.g. `180_000` ms) for TypeScript red team tests
 
 ### Voice Agents
-- Do NOT write a text-only scenario when the user asked for voice — pick one of `OpenAIRealtimeAgentAdapter` / `ElevenLabsAgentAdapter` / `PipecatAgentAdapter` / `GeminiLiveAgentAdapter` / `TwilioAgentAdapter`
+- Do NOT write a text-only scenario when the user asked for voice — pick one of `OpenAIRealtimeAgentAdapter` / `ElevenLabsAgentAdapter` / `PipecatAgentAdapter` / `GeminiLiveAgentAdapter` / `TwilioAgentAdapter` / `ComposableVoiceAgent`
+- Do NOT instantiate `OpenAIRealtimeAgentAdapter` or `GeminiLiveAgentAdapter` with placeholder `instructions=...` / `model=...` / `tools=...` — those adapters ARE the agent, so a placeholder constructor tests OpenAI/Gemini defaults, not the user's agent. Either mirror the user's prod config exactly, or pick a different adapter (Pipecat/Twilio/ElevenLabs hosted) that connects to their already-deployed transport.
+- Do NOT point `PipecatAgentAdapter(url=...)` / `ElevenLabsAgentAdapter(agent_id=...)` / `TwilioAgentAdapter` at a transport the user hasn't deployed — those adapters only connect, they don't spin anything up. If the user is text-only and has no voice transport, say so and offer `ComposableVoiceAgent` as a voice wrapper around their existing text logic.
 - Do NOT forget the `voice="elevenlabs/..."` (or `"openai/..."`) on `UserSimulatorAgent` — a silent simulator turns the voice scenario into a text scenario with audio frame headers
 - Do NOT bake an empathy persona into a calm voice — use ElevenLabs tonal markers (`[shouting]`, `[angry]`, `[stressed]`) in the persona prompt so the TTS renders audible emotion
 - Do NOT script multi-turn `user()` audio against `ElevenLabsAgentAdapter` — it's server-VAD-driven and the second `agent()` reliably times out; keep hosted-ConvAI scripts to ONE exchange


### PR DESCRIPTION
## Why

Verbal review on the just-merged #4504 dogfood output: the skill led Claude to write a voice scenario where

```python
scenario.OpenAIRealtimeAgentAdapter(
    model="gpt-realtime-mini",
    instructions="...your agent's system prompt...",
)
```

was the only "agent under test". That doesn't connect to anything the user actually deployed; it spins up a fresh OpenAI Realtime instance with a placeholder system prompt and tests OpenAI defaults, not the user's agent. The Step 2 table only listed adapter names, so a fresh agent had no way to know which adapters CONNECT to a deployed transport vs which adapters ARE the agent vs what to do for a text-only stack.

## What

- Add a "how it connects to the user's agent" column to the Step 2 adapter table.
- Pipecat / Twilio / ElevenLabs hosted → connect (URL / phone number / agent_id) to a transport the user already deployed.
- OpenAI Realtime / Gemini Live → the adapter IS the agent; mirror prod model + voice + instructions + tools or you're testing the foundation model's defaults.
- Text-only stack → ComposableVoiceAgent wraps their existing LLM in STT+LLM+TTS, and the agent's reply has to be explicit that this is a voice wrapper, not a production voice transport.
- Replace the Python worked example with a Pipecat WS example whose `url=BOT_WS_URL` makes the "your bot has to be running at this URL" contract obvious. Keep a second OpenAI Realtime example that explicitly labels itself as "adapter IS the agent, mirror prod config" with named `PROD_*` constants.
- Annotate the TypeScript example the same way.
- Add two Common Mistakes bullets: against placeholder constructors on the adapter-IS-the-agent shapes, and against pointing connection adapters at transports the user hasn't deployed.
- Drop the misleading "text-only stacks default to OpenAIRealtimeAgentAdapter" line.

Also adds `skills/_tests/README.md` documenting that the `it.skipIf(isCI)` skill-dogfood tests have to be run locally before any SKILL change, and that reading the generated file is part of "passing" (the regex guardrails can't catch domain mismatches like this one).

## Test plan

- [ ] Re-run the voice dogfood locally and read the generated `test_voice_agent.py` for the text-only python-openai fixture. Expect either a `ComposableVoiceAgent`-wrapped scenario with an explicit "voice wrapper" reply, or a refusal that explains the user needs to ship a voice transport first.
- [ ] Run the red-teaming dogfood unchanged (no SKILL changes outside the voice section).