### PR TITLE
refactor(retention): split data-retention page + round presets up

### DIFF
--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -189,6 +189,13 @@ LW_GATEWAY_PUBLIC_URL=http://localhost:5563
 # topologies (e.g. gateway in a separate pod from the app).
 LW_GATEWAY_BASE_URL=http://localhost:5560
 
+# Public gateway URL shown to users (CLI + /me virtual-key cards).
+LW_GATEWAY_PUBLIC_URL=http://localhost:5563
+
+# Control-plane to gateway URL for the internal HMAC-signed routes.
+# In Docker use http://host.docker.internal:5563.
+LW_GATEWAY_INTERNAL_URL=http://localhost:5563
+
 # AI Gateway auth-cache stale-while-error knobs (Go gateway only).
 # When the control plane is briefly unreachable, the gateway extends the
 # cached entry's soft expiry by SOFT_BUMP each transport-class refresh

--- a/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
+++ b/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
@@ -1,0 +1,266 @@
+import {
+  Button,
+  createListCollection,
+  Field,
+  Heading,
+  HStack,
+  Input,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  ScopeChipPicker,
+  type ScopeTriadEntry,
+} from "~/components/settings/ScopeChipPicker";
+import { Drawer } from "~/components/ui/drawer";
+import { Select } from "~/components/ui/select";
+import { Switch } from "~/components/ui/switch";
+import {
+  DEFAULT_RETENTION_DAYS,
+  INDEFINITE_RETENTION_DAYS,
+  MAX_RETENTION_DAYS,
+  MIN_RETENTION_DAYS,
+  RETENTION_WEEK_DAYS,
+} from "~/server/data-retention/retentionPolicy.schema";
+import {
+  CUSTOM_PRESET_VALUE,
+  DAYS_PER_UNIT,
+  INDEFINITE_PRESET_VALUE,
+  RETENTION_PRESETS,
+  retentionUnitCollection,
+  type RetentionUnit,
+} from "./constants";
+
+export function AddOverrideDrawer({
+  open,
+  onClose,
+  available,
+  currentOrganizationId,
+  currentTeamId,
+  currentProjectId,
+  isPlatformAdmin,
+  isSaving,
+  onSave,
+}: {
+  open: boolean;
+  onClose: () => void;
+  available: {
+    organization: { id: string; name: string } | null;
+    teams: { id: string; name: string }[];
+    projects: { id: string; name: string; teamId: string }[];
+  };
+  currentOrganizationId: string | undefined;
+  currentTeamId: string | undefined;
+  currentProjectId: string;
+  isPlatformAdmin: boolean;
+  isSaving: boolean;
+  onSave: (
+    scopes: ScopeTriadEntry[],
+    retentionDays: number,
+    applyToExisting: boolean,
+  ) => void;
+}) {
+  const [scopes, setScopes] = useState<ScopeTriadEntry[]>([]);
+  const [preset, setPreset] = useState<string>(String(DEFAULT_RETENTION_DAYS));
+  const [customAmount, setCustomAmount] = useState<string>("");
+  const [customUnit, setCustomUnit] = useState<RetentionUnit>("weeks");
+  const [applyToExisting, setApplyToExisting] = useState<boolean>(true);
+
+  // Platform admins get an extra "No retention (keep forever)" option. The 0
+  // sentinel is structurally valid input; the route authorizes it admin-only.
+  const presetCollection = useMemo(
+    () =>
+      createListCollection({
+        items: [
+          ...RETENTION_PRESETS.map((p) => ({ value: p.value, label: p.label })),
+          ...(isPlatformAdmin
+            ? [
+                {
+                  value: INDEFINITE_PRESET_VALUE,
+                  label: "No retention (keep forever)",
+                },
+              ]
+            : []),
+          { value: CUSTOM_PRESET_VALUE, label: "Custom…" },
+        ],
+      }),
+    [isPlatformAdmin],
+  );
+
+  useEffect(() => {
+    if (open) {
+      // Default to the current project so the picker opens on the user's
+      // working scope, mirroring the API-key drawer pattern.
+      setScopes(
+        available.projects.some((p) => p.id === currentProjectId)
+          ? [{ scopeType: "PROJECT", scopeId: currentProjectId }]
+          : [],
+      );
+      setPreset(String(DEFAULT_RETENTION_DAYS));
+      setCustomAmount("");
+      setCustomUnit("weeks");
+      setApplyToExisting(true);
+    }
+  }, [open, currentProjectId, available.projects]);
+
+  const resolvedDays = (() => {
+    if (preset === CUSTOM_PRESET_VALUE) {
+      const n = Number(customAmount);
+      if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return NaN;
+      return n * DAYS_PER_UNIT[customUnit];
+    }
+    return Number(preset);
+  })();
+
+  const daysValid =
+    // Indefinite (0) is only reachable via the admin-only preset; the route
+    // re-checks the capability, so the UI just needs to treat it as valid.
+    resolvedDays === INDEFINITE_RETENTION_DAYS ||
+    (Number.isFinite(resolvedDays) &&
+      Number.isInteger(resolvedDays) &&
+      resolvedDays >= MIN_RETENTION_DAYS &&
+      resolvedDays <= MAX_RETENTION_DAYS &&
+      resolvedDays % RETENTION_WEEK_DAYS === 0);
+
+  const canSave = scopes.length > 0 && daysValid && !isSaving;
+
+  return (
+    <Drawer.Root
+      placement="end"
+      size="md"
+      open={open}
+      onOpenChange={({ open: isOpen }) => {
+        if (!isOpen) onClose();
+      }}
+    >
+      <Drawer.Content bg="bg">
+        <Drawer.Header>
+          <Heading size="md">Add retention policy</Heading>
+          <Drawer.CloseTrigger />
+        </Drawer.Header>
+        <Drawer.Body>
+          <VStack gap={5} align="stretch">
+            <VStack gap={1.5} align="start" width="full">
+              <Text fontWeight="600" fontSize="sm">
+                Scope
+              </Text>
+              <ScopeChipPicker
+                value={scopes}
+                onChange={setScopes}
+                organizationId={available.organization?.id}
+                organizationName={available.organization?.name}
+                availableTeams={available.teams}
+                availableProjects={available.projects}
+                label=""
+                currentOrganizationId={
+                  available.organization ? currentOrganizationId : undefined
+                }
+                currentTeamId={currentTeamId}
+                currentProjectId={currentProjectId}
+              />
+            </VStack>
+
+            <Field.Root>
+              <Field.Label>Retention</Field.Label>
+              <Select.Root
+                collection={presetCollection}
+                value={[preset]}
+                onValueChange={(details) => {
+                  const v = details.value[0];
+                  if (v) setPreset(v);
+                }}
+              >
+                <Select.Trigger background="bg">
+                  <Select.ValueText placeholder="Pick a retention" />
+                </Select.Trigger>
+                <Select.Content>
+                  {presetCollection.items.map((item) => (
+                    <Select.Item key={item.value} item={item}>
+                      {item.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
+              {preset === CUSTOM_PRESET_VALUE && (
+                <HStack gap={2} marginTop={2} align="start">
+                  <Input
+                    type="number"
+                    min={1}
+                    value={customAmount}
+                    onChange={(e) => setCustomAmount(e.target.value)}
+                    width="120px"
+                    placeholder="e.g. 8"
+                  />
+                  <Select.Root
+                    collection={retentionUnitCollection}
+                    value={[customUnit]}
+                    onValueChange={(details) => {
+                      const v = details.value[0] as RetentionUnit | undefined;
+                      if (v) setCustomUnit(v);
+                    }}
+                  >
+                    <Select.Trigger background="bg" width="140px">
+                      <Select.ValueText />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {retentionUnitCollection.items.map((item) => (
+                        <Select.Item key={item.value} item={item}>
+                          {item.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Root>
+                </HStack>
+              )}
+              <Field.HelperText>
+                {preset === INDEFINITE_PRESET_VALUE
+                  ? "Data will be kept indefinitely — exempt from automatic deletion."
+                  : preset === CUSTOM_PRESET_VALUE && customAmount && daysValid
+                    ? `Stored as ${resolvedDays} days.`
+                    : preset === CUSTOM_PRESET_VALUE &&
+                        customAmount &&
+                        !daysValid
+                      ? `Must be between ${MIN_RETENTION_DAYS} and ${MAX_RETENTION_DAYS} days.`
+                      : `Minimum ${MIN_RETENTION_DAYS} days (7 weeks). Retention is partition-aligned and rounded to whole weeks under the hood.`}
+              </Field.HelperText>
+            </Field.Root>
+
+            <HStack gap={3} align="start">
+              <Switch
+                checked={applyToExisting}
+                onCheckedChange={({ checked }) =>
+                  setApplyToExisting(checked === true)
+                }
+              />
+              <VStack align="start" gap={0}>
+                <Text fontWeight="600" fontSize="sm">
+                  Apply this change to existing data
+                </Text>
+                <Text fontSize="xs" color="fg.muted">
+                  Rewrites this project's existing rows so the new retention
+                  takes effect immediately, not just for new ingestion.
+                </Text>
+              </VStack>
+            </HStack>
+          </VStack>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <HStack width="full" justify="end" gap={2}>
+            <Button variant="outline" onClick={onClose} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button
+              colorPalette="blue"
+              disabled={!canSave}
+              loading={isSaving}
+              onClick={() => onSave(scopes, resolvedDays, applyToExisting)}
+            >
+              Create
+            </Button>
+          </HStack>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer.Root>
+  );
+}

--- a/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
+++ b/langwatch/src/components/data-retention/AddOverrideDrawer.tsx
@@ -28,8 +28,8 @@ import {
   DAYS_PER_UNIT,
   INDEFINITE_PRESET_VALUE,
   RETENTION_PRESETS,
-  retentionUnitCollection,
   type RetentionUnit,
+  retentionUnitCollection,
 } from "./constants";
 
 export function AddOverrideDrawer({

--- a/langwatch/src/components/data-retention/ApplyToExistingConfirmDialog.tsx
+++ b/langwatch/src/components/data-retention/ApplyToExistingConfirmDialog.tsx
@@ -1,0 +1,91 @@
+import { Alert, Button, Text, VStack } from "@chakra-ui/react";
+import { Dialog } from "~/components/ui/dialog";
+import { INDEFINITE_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
+
+export function ApplyToExistingConfirmDialog({
+  pending,
+  isApplying,
+  onCancel,
+  onConfirm,
+}: {
+  pending: {
+    retentionDays: number;
+    savedScopeWiderThanCurrentProject: boolean;
+  } | null;
+  isApplying: boolean;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+}) {
+  return (
+    <Dialog.Root
+      open={!!pending}
+      onOpenChange={({ open }) => {
+        if (!open) onCancel();
+      }}
+    >
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>Apply retention to existing data?</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
+          {pending && (
+            <VStack align="stretch" gap={3}>
+              {pending.retentionDays === INDEFINITE_RETENTION_DAYS ? (
+                <Text>
+                  We will rewrite <strong>this project's</strong> existing data
+                  to be kept indefinitely. No rows are deleted — this removes
+                  the retention limit from already-stored data.
+                </Text>
+              ) : (
+                // We don't name a specific day count here because the server
+                // applies the project's RESOLVED effective retention
+                // (PROJECT > TEAM > ORGANIZATION > platform default), which
+                // may differ from the value the user just selected (e.g. when
+                // saving an org-wide rule but the project has a closer
+                // override). The toast that fires after the apply shows the
+                // value that was actually used.
+                <Text>
+                  We will rewrite <strong>this project's</strong> existing data
+                  to use its currently resolved retention policy. Rows older
+                  than the resolved retention become eligible for deletion on
+                  the next background merge. After deletion, this cannot be
+                  undone.
+                </Text>
+              )}
+              {pending.savedScopeWiderThanCurrentProject && (
+                <Alert.Root status="warning">
+                  <Alert.Indicator />
+                  <Alert.Content>
+                    <Alert.Description>
+                      You also saved an organization or team policy. New rows
+                      across those scopes will use the new retention, but
+                      existing rows in other projects keep their current
+                      retention until each project is visited and applied
+                      individually.
+                    </Alert.Description>
+                  </Alert.Content>
+                </Alert.Root>
+              )}
+            </VStack>
+          )}
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            colorPalette={
+              pending?.retentionDays === INDEFINITE_RETENTION_DAYS
+                ? "blue"
+                : "red"
+            }
+            loading={isApplying}
+            onClick={() => void onConfirm()}
+          >
+            Apply to existing data
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/langwatch/src/components/data-retention/RetentionAndUsageCard.tsx
+++ b/langwatch/src/components/data-retention/RetentionAndUsageCard.tsx
@@ -1,0 +1,81 @@
+import {
+  Card,
+  Heading,
+  HStack,
+  Spinner,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import {
+  RETENTION_CATEGORIES,
+  type RetentionCategory,
+} from "~/server/data-retention/retentionPolicy.schema";
+import { CATEGORY_LABELS } from "./constants";
+import { formatBytes, formatDays } from "./format";
+import { renderPolicySummary } from "./grouping";
+
+export function RetentionAndUsageCard({
+  effective,
+  isLoading,
+  data,
+}: {
+  effective: Partial<Record<RetentionCategory, number>>;
+  isLoading: boolean;
+  data?: { totalBytes: number; byCategory: Record<RetentionCategory, number> };
+}) {
+  const summary = renderPolicySummary(effective);
+  return (
+    <Card.Root width="full">
+      <Card.Header>
+        <HStack width="full" justify="space-between" align="start">
+          <VStack align="start" gap={0}>
+            <Heading as="h3" fontSize="lg">
+              Data Retention
+            </Heading>
+            <Text fontSize="sm" color="fg.muted">
+              How long this project's data is kept before deletion.
+            </Text>
+          </VStack>
+          <Text fontWeight="semibold" flexShrink={0}>
+            {summary}
+          </Text>
+        </HStack>
+      </Card.Header>
+      <Card.Body>
+        <VStack gap={5} align="stretch">
+          {summary === "Mixed" && (
+            <VStack gap={2} align="stretch">
+              {RETENTION_CATEGORIES.map((category) => (
+                <HStack key={category} justifyContent="space-between">
+                  <Text color="fg.muted">{CATEGORY_LABELS[category]}</Text>
+                  <Text>
+                    {effective[category] !== undefined
+                      ? formatDays(effective[category]!)
+                      : "—"}
+                  </Text>
+                </HStack>
+              ))}
+            </VStack>
+          )}
+          <HStack width="full" justify="space-between" align="start">
+            <VStack align="start" gap={0}>
+              <Heading as="h3" fontSize="lg">
+                Data Storage
+              </Heading>
+              <Text fontSize="sm" color="fg.muted">
+                How much space this project's data uses today.
+              </Text>
+            </VStack>
+            {isLoading ? (
+              <Spinner size="sm" />
+            ) : data ? (
+              <Text fontWeight="semibold" flexShrink={0}>
+                {formatBytes(data.totalBytes)}
+              </Text>
+            ) : null}
+          </HStack>
+        </VStack>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/langwatch/src/components/data-retention/RetentionAndUsageCard.tsx
+++ b/langwatch/src/components/data-retention/RetentionAndUsageCard.tsx
@@ -1,11 +1,4 @@
-import {
-  Card,
-  Heading,
-  HStack,
-  Spinner,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { Card, Heading, HStack, Spinner, Text, VStack } from "@chakra-ui/react";
 import {
   RETENTION_CATEGORIES,
   type RetentionCategory,

--- a/langwatch/src/components/data-retention/RetroactiveProgressCard.tsx
+++ b/langwatch/src/components/data-retention/RetroactiveProgressCard.tsx
@@ -1,0 +1,69 @@
+import {
+  Button,
+  Card,
+  Heading,
+  HStack,
+  Progress,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import type { MutationProgress } from "~/server/data-retention/retroactive/retroactiveUpdate.service";
+import { CATEGORY_LABELS } from "./constants";
+
+export function RetroactiveProgressCard({
+  mutations,
+  onCancel,
+  isCancelling,
+}: {
+  mutations: MutationProgress[];
+  onCancel: (mutationId: string) => void;
+  isCancelling: boolean;
+}) {
+  if (mutations.length === 0) return null;
+  return (
+    <Card.Root width="full">
+      <Card.Header>
+        <Heading as="h3" fontSize="lg">
+          Applying retention to existing data
+        </Heading>
+        <Text fontSize="sm" color="fg.muted">
+          ClickHouse rewrites the affected parts during background merges. Large
+          datasets can take a while; the count below is parts still pending.
+        </Text>
+      </Card.Header>
+      <Card.Body>
+        <VStack gap={4} align="stretch">
+          {mutations.map((m) => (
+            <VStack key={m.mutationId} gap={1} align="stretch">
+              <HStack justifyContent="space-between">
+                <Text>
+                  {m.table}
+                  {m.category ? ` · ${CATEGORY_LABELS[m.category]}` : ""}
+                </Text>
+                <HStack gap={3}>
+                  <Text fontSize="sm" color="fg.muted">
+                    {m.partsToDo} parts remaining
+                  </Text>
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    colorPalette="red"
+                    loading={isCancelling}
+                    onClick={() => onCancel(m.mutationId)}
+                  >
+                    Cancel
+                  </Button>
+                </HStack>
+              </HStack>
+              <Progress.Root value={null} size="xs" colorPalette="blue">
+                <Progress.Track>
+                  <Progress.Range />
+                </Progress.Track>
+              </Progress.Root>
+            </VStack>
+          ))}
+        </VStack>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/langwatch/src/components/data-retention/constants.ts
+++ b/langwatch/src/components/data-retention/constants.ts
@@ -1,0 +1,69 @@
+import { createListCollection } from "@chakra-ui/react";
+import { Building2, Folder, Users } from "lucide-react";
+import type { ScopeTriadType } from "~/components/settings/ScopeChipPicker";
+import {
+  INDEFINITE_RETENTION_DAYS,
+  type RetentionCategory,
+} from "~/server/data-retention/retentionPolicy.schema";
+
+export const CATEGORY_LABELS: Record<RetentionCategory, string> = {
+  traces: "Traces & Spans",
+  scenarios: "Scenarios",
+  experiments: "Experiments",
+};
+
+export const SCOPE_ICON: Record<ScopeTriadType, typeof Building2> = {
+  ORGANIZATION: Building2,
+  TEAM: Users,
+  PROJECT: Folder,
+};
+
+// Retention is always stored in days, but the picker speaks human time. All
+// units round-trip through whole weeks so the resulting day count is always
+// a valid 7-multiple — 1 month = 4 weeks (28 days), 1 year = 52 weeks (364
+// days). This is the same calendar arithmetic ClickHouse partition pruning
+// expects.
+export const DAYS_PER_UNIT = { weeks: 7, months: 28, years: 364 } as const;
+export type RetentionUnit = keyof typeof DAYS_PER_UNIT;
+
+export const RETENTION_UNIT_LABELS: Record<RetentionUnit, string> = {
+  weeks: "weeks",
+  months: "months",
+  years: "years",
+};
+
+export const retentionUnitCollection = createListCollection({
+  items: (Object.keys(DAYS_PER_UNIT) as RetentionUnit[]).map((u) => ({
+    value: u,
+    label: RETENTION_UNIT_LABELS[u],
+  })),
+});
+
+// Presets round UP relative to the human label so the selection covers the
+// full period plus a small buffer (e.g. "1 year" = 371d, not 364d). Avoids
+// underselling: a user who picks "1 year" expects at least a full year.
+export const RETENTION_PRESETS: Array<{
+  value: string;
+  label: string;
+  days: number;
+}> = [
+  { value: "49", label: "7 weeks", days: 49 },
+  { value: "91", label: "3 months", days: 91 },
+  { value: "182", label: "6 months", days: 182 },
+  { value: "371", label: "1 year", days: 371 },
+  { value: "735", label: "2 years", days: 735 },
+  { value: "1827", label: "5 years", days: 1827 },
+];
+
+export const CUSTOM_PRESET_VALUE = "custom";
+
+/** The "keep forever" option's select value — the stringified indefinite
+ *  sentinel. Only offered to platform admins (see AddOverrideDrawer); the
+ *  mutation route authorizes it independently. */
+export const INDEFINITE_PRESET_VALUE = String(INDEFINITE_RETENTION_DAYS);
+
+export const SCOPE_TIER_ORDER: Record<ScopeTriadType, number> = {
+  ORGANIZATION: 0,
+  TEAM: 1,
+  PROJECT: 2,
+};

--- a/langwatch/src/components/data-retention/format.ts
+++ b/langwatch/src/components/data-retention/format.ts
@@ -1,0 +1,11 @@
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(2)} ${units[i]}`;
+}
+
+export function formatDays(days: number): string {
+  return days === 0 ? "Indefinite" : `${days} days`;
+}

--- a/langwatch/src/components/data-retention/format.ts
+++ b/langwatch/src/components/data-retention/format.ts
@@ -1,7 +1,10 @@
 export function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const units = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
   const value = bytes / Math.pow(1024, i);
   return `${value.toFixed(2)} ${units[i]}`;
 }

--- a/langwatch/src/components/data-retention/grouping.ts
+++ b/langwatch/src/components/data-retention/grouping.ts
@@ -1,0 +1,92 @@
+import type { ScopeTriadType } from "~/components/settings/ScopeChipPicker";
+import {
+  RETENTION_CATEGORIES,
+  type RetentionCategory,
+} from "~/server/data-retention/retentionPolicy.schema";
+import { CATEGORY_LABELS } from "./constants";
+import { formatDays } from "./format";
+
+export type RetentionRuleRow = {
+  scopeType: ScopeTriadType;
+  scopeId: string;
+  name: string;
+  category: RetentionCategory;
+  retentionDays: number;
+};
+
+export type RetentionScopeGroup = {
+  scopeType: ScopeTriadType;
+  scopeId: string;
+  name: string;
+  byCategory: Partial<Record<RetentionCategory, number>>;
+  rules: RetentionRuleRow[];
+};
+
+/** Groups override rows by (scopeType, scopeId), preserving first-seen order.
+ *  We collapse the three category rows per scope into a single logical group
+ *  so the Scope|Policy table renders one row per scope — categories almost
+ *  always share the same value in practice. */
+export function groupRulesByScope(
+  rules: RetentionRuleRow[],
+): RetentionScopeGroup[] {
+  const groups: RetentionScopeGroup[] = [];
+  const indexByKey = new Map<string, number>();
+  for (const r of rules) {
+    const key = `${r.scopeType}:${r.scopeId}`;
+    const idx = indexByKey.get(key);
+    if (idx === undefined) {
+      indexByKey.set(key, groups.length);
+      groups.push({
+        scopeType: r.scopeType,
+        scopeId: r.scopeId,
+        name: r.name,
+        byCategory: { [r.category]: r.retentionDays },
+        rules: [r],
+      });
+    } else {
+      const group = groups[idx]!;
+      group.rules.push(r);
+      group.byCategory[r.category] = r.retentionDays;
+    }
+  }
+  return groups;
+}
+
+/** Render a single Policy cell value. If all three categories share the same
+ *  retention, show one number ("1820 days"). Otherwise show the per-category
+ *  breakdown so a divergent legacy override is still legible. */
+export function renderPolicyValue(
+  byCategory: Partial<Record<RetentionCategory, number>>,
+): string {
+  const present = RETENTION_CATEGORIES.filter(
+    (c) => byCategory[c] !== undefined,
+  );
+  if (present.length === 0) return "—";
+  const values = present.map((c) => byCategory[c]!);
+  const allSame = values.every((v) => v === values[0]);
+  if (allSame && present.length === RETENTION_CATEGORIES.length) {
+    return formatDays(values[0]!);
+  }
+  return present
+    .map((c) => `${CATEGORY_LABELS[c]}: ${formatDays(byCategory[c]!)}`)
+    .join(" · ");
+}
+
+/** Top-line summary used in the Retention + Usage card. When all three
+ *  categories share the same value we show that number; when they diverge
+ *  the per-category rows below already carry the detail, so the summary
+ *  collapses to "Mixed" instead of repeating the breakdown twice. */
+export function renderPolicySummary(
+  byCategory: Partial<Record<RetentionCategory, number>>,
+): string {
+  const present = RETENTION_CATEGORIES.filter(
+    (c) => byCategory[c] !== undefined,
+  );
+  if (present.length === 0) return "—";
+  const values = present.map((c) => byCategory[c]!);
+  const allSame = values.every((v) => v === values[0]);
+  if (allSame && present.length === RETENTION_CATEGORIES.length) {
+    return formatDays(values[0]!);
+  }
+  return "Mixed";
+}

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -16,12 +16,15 @@ import { DatabaseBackup, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AddOverrideDrawer } from "~/components/data-retention/AddOverrideDrawer";
 import { ApplyToExistingConfirmDialog } from "~/components/data-retention/ApplyToExistingConfirmDialog";
-import { SCOPE_ICON, SCOPE_TIER_ORDER } from "~/components/data-retention/constants";
+import {
+  SCOPE_ICON,
+  SCOPE_TIER_ORDER,
+} from "~/components/data-retention/constants";
 import { formatDays } from "~/components/data-retention/format";
 import {
   groupRulesByScope,
-  renderPolicyValue,
   type RetentionScopeGroup,
+  renderPolicyValue,
 } from "~/components/data-retention/grouping";
 import { RetentionAndUsageCard } from "~/components/data-retention/RetentionAndUsageCard";
 import { RetroactiveProgressCard } from "~/components/data-retention/RetroactiveProgressCard";
@@ -508,7 +511,10 @@ function DataRetentionPage({
                             category,
                           })
                           .then(
-                            (res) => ({ ok: true as const, applied: res.appliedRetentionDays }),
+                            (res) => ({
+                              ok: true as const,
+                              applied: res.appliedRetentionDays,
+                            }),
                             (error: Error) => ({
                               ok: false as const,
                               error,
@@ -522,9 +528,7 @@ function DataRetentionPage({
                         new Set(
                           triggerResults
                             .filter(
-                              (
-                                r,
-                              ): r is { ok: true; applied: number } => r.ok,
+                              (r): r is { ok: true; applied: number } => r.ok,
                             )
                             .map((r) => r.applied),
                         ),

--- a/langwatch/src/pages/settings/data-retention.tsx
+++ b/langwatch/src/pages/settings/data-retention.tsx
@@ -3,39 +3,30 @@ import {
   Badge,
   Button,
   Card,
-  createListCollection,
   EmptyState,
-  Field,
   Heading,
   HStack,
-  Input,
-  Progress,
   Spacer,
   Spinner,
   Table,
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { DatabaseBackup, Plus, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { AddOverrideDrawer } from "~/components/data-retention/AddOverrideDrawer";
+import { ApplyToExistingConfirmDialog } from "~/components/data-retention/ApplyToExistingConfirmDialog";
+import { SCOPE_ICON, SCOPE_TIER_ORDER } from "~/components/data-retention/constants";
+import { formatDays } from "~/components/data-retention/format";
 import {
-  Building2,
-  DatabaseBackup,
-  Folder,
-  Plus,
-  Trash2,
-  Users,
-} from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+  groupRulesByScope,
+  renderPolicyValue,
+  type RetentionScopeGroup,
+} from "~/components/data-retention/grouping";
+import { RetentionAndUsageCard } from "~/components/data-retention/RetentionAndUsageCard";
+import { RetroactiveProgressCard } from "~/components/data-retention/RetroactiveProgressCard";
 import SettingsLayout from "~/components/SettingsLayout";
-import {
-  ScopeChipPicker,
-  type ScopeTriadEntry,
-  type ScopeTriadType,
-} from "~/components/settings/ScopeChipPicker";
 import { ScopeFilter as ScopeFilterComponent } from "~/components/settings/ScopeFilter";
-import { Dialog } from "~/components/ui/dialog";
-import { Drawer } from "~/components/ui/drawer";
-import { Select } from "~/components/ui/select";
-import { Switch } from "~/components/ui/switch";
 import { toaster } from "~/components/ui/toaster";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
 import { useAvailableScopes } from "~/hooks/useAvailableScopes";
@@ -43,170 +34,14 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useUrlScopeFilter } from "~/hooks/useUrlScopeFilter";
 import {
   DEFAULT_RETENTION_DAYS,
-  INDEFINITE_RETENTION_DAYS,
-  MAX_RETENTION_DAYS,
-  MIN_RETENTION_DAYS,
   RETENTION_CATEGORIES,
-  RETENTION_WEEK_DAYS,
   type RetentionCategory,
 } from "~/server/data-retention/retentionPolicy.schema";
-import type { MutationProgress } from "~/server/data-retention/retroactive/retroactiveUpdate.service";
 import { api } from "~/utils/api";
 import {
   isScopeInFilter,
   resolveScopeFilter,
 } from "~/utils/filterProvidersByScope";
-
-const CATEGORY_LABELS: Record<RetentionCategory, string> = {
-  traces: "Traces & Spans",
-  scenarios: "Scenarios",
-  experiments: "Experiments",
-};
-
-const SCOPE_ICON: Record<ScopeTriadType, typeof Building2> = {
-  ORGANIZATION: Building2,
-  TEAM: Users,
-  PROJECT: Folder,
-};
-
-// Retention is always stored in days, but the picker speaks human time. All
-// units round-trip through whole weeks so the resulting day count is always
-// a valid 7-multiple - 1 month = 4 weeks (28 days), 1 year = 52 weeks (364
-// days). This is the same calendar arithmetic ClickHouse partition pruning
-// expects.
-const DAYS_PER_UNIT = { weeks: 7, months: 28, years: 364 } as const;
-type RetentionUnit = keyof typeof DAYS_PER_UNIT;
-
-const RETENTION_UNIT_LABELS: Record<RetentionUnit, string> = {
-  weeks: "weeks",
-  months: "months",
-  years: "years",
-};
-
-const retentionUnitCollection = createListCollection({
-  items: (Object.keys(DAYS_PER_UNIT) as RetentionUnit[]).map((u) => ({
-    value: u,
-    label: RETENTION_UNIT_LABELS[u],
-  })),
-});
-
-const RETENTION_PRESETS: Array<{ value: string; label: string; days: number }> =
-  [
-    { value: "49", label: "7 weeks", days: 49 },
-    { value: "91", label: "3 months", days: 91 },
-    { value: "182", label: "6 months", days: 182 },
-    { value: "364", label: "1 year", days: 364 },
-    { value: "728", label: "2 years", days: 728 },
-    { value: "1820", label: "5 years", days: 1820 },
-  ];
-
-const CUSTOM_PRESET_VALUE = "custom";
-
-/** The "keep forever" option's select value - the stringified indefinite
- *  sentinel. Only offered to platform admins (see AddOverrideDrawer); the
- *  mutation route authorizes it independently. */
-const INDEFINITE_PRESET_VALUE = String(INDEFINITE_RETENTION_DAYS);
-
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-  const value = bytes / Math.pow(1024, i);
-  return `${value.toFixed(2)} ${units[i]}`;
-}
-
-function formatDays(days: number): string {
-  return days === 0 ? "Indefinite" : `${days} days`;
-}
-
-type RetentionRuleRow = {
-  scopeType: ScopeTriadType;
-  scopeId: string;
-  name: string;
-  category: RetentionCategory;
-  retentionDays: number;
-};
-
-type RetentionScopeGroup = {
-  scopeType: ScopeTriadType;
-  scopeId: string;
-  name: string;
-  byCategory: Partial<Record<RetentionCategory, number>>;
-  rules: RetentionRuleRow[];
-};
-
-/** Groups override rows by (scopeType, scopeId), preserving first-seen order.
- *  We collapse the three category rows per scope into a single logical group
- *  so the Scope|Policy table renders one row per scope - categories almost
- *  always share the same value in practice. */
-function groupRulesByScope(rules: RetentionRuleRow[]): RetentionScopeGroup[] {
-  const groups: RetentionScopeGroup[] = [];
-  const indexByKey = new Map<string, number>();
-  for (const r of rules) {
-    const key = `${r.scopeType}:${r.scopeId}`;
-    const idx = indexByKey.get(key);
-    if (idx === undefined) {
-      indexByKey.set(key, groups.length);
-      groups.push({
-        scopeType: r.scopeType,
-        scopeId: r.scopeId,
-        name: r.name,
-        byCategory: { [r.category]: r.retentionDays },
-        rules: [r],
-      });
-    } else {
-      const group = groups[idx]!;
-      group.rules.push(r);
-      group.byCategory[r.category] = r.retentionDays;
-    }
-  }
-  return groups;
-}
-
-const SCOPE_TIER_ORDER: Record<ScopeTriadType, number> = {
-  ORGANIZATION: 0,
-  TEAM: 1,
-  PROJECT: 2,
-};
-
-/** Render a single Policy cell value. If all three categories share the same
- *  retention, show one number ("1820 days"). Otherwise show the per-category
- *  breakdown so a divergent legacy override is still legible. */
-function renderPolicyValue(
-  byCategory: Partial<Record<RetentionCategory, number>>,
-): string {
-  const present = RETENTION_CATEGORIES.filter(
-    (c) => byCategory[c] !== undefined,
-  );
-  if (present.length === 0) return "-";
-  const values = present.map((c) => byCategory[c]!);
-  const allSame = values.every((v) => v === values[0]);
-  if (allSame && present.length === RETENTION_CATEGORIES.length) {
-    return formatDays(values[0]!);
-  }
-  return present
-    .map((c) => `${CATEGORY_LABELS[c]}: ${formatDays(byCategory[c]!)}`)
-    .join(" · ");
-}
-
-/** Top-line summary used in the Retention + Usage card. When all three
- *  categories share the same value we show that number; when they diverge
- *  the per-category rows below already carry the detail, so the summary
- *  collapses to "Mixed" instead of repeating the breakdown twice. */
-function renderPolicySummary(
-  byCategory: Partial<Record<RetentionCategory, number>>,
-): string {
-  const present = RETENTION_CATEGORIES.filter(
-    (c) => byCategory[c] !== undefined,
-  );
-  if (present.length === 0) return "-";
-  const values = present.map((c) => byCategory[c]!);
-  const allSame = values.every((v) => v === values[0]);
-  if (allSame && present.length === RETENTION_CATEGORIES.length) {
-    return formatDays(values[0]!);
-  }
-  return "Mixed";
-}
 
 function DataRetentionSettings() {
   const { project, organization, team } = useOrganizationTeamProject();
@@ -266,7 +101,7 @@ function DataRetentionPage({
   const invalidate = () =>
     utils.dataRetention.getRules.invalidate({ projectId });
 
-  // Per-call toasts are intentionally omitted - the Add-policy drawer fans
+  // Per-call toasts are intentionally omitted — the Add-policy drawer fans
   // out one setForScope per (scope × category) pair and stacks the toaster
   // column with identical "saved" messages. The drawer's onSave emits a
   // single aggregated toast after the batch resolves.
@@ -280,7 +115,7 @@ function DataRetentionPage({
   // Retroactive apply: stamp the project's EXISTING ClickHouse rows with the
   // effective retention. We don't know the stored _retention_days values
   // without an extra query (they could still be the migration default), so we
-  // always route through the confirm dialog before mutating CH - the action is
+  // always route through the confirm dialog before mutating CH — the action is
   // irreversible if it contracts.
   const [pendingConfirm, setPendingConfirm] = useState<{
     retentionDays: number;
@@ -306,7 +141,7 @@ function DataRetentionPage({
     setPollMs(activeMutations.length > 0 ? 3000 : false);
   }, [activeMutations.length]);
 
-  // Per-call toasts intentionally omitted - the drawer flow fans this out one
+  // Per-call toasts intentionally omitted — the drawer flow fans this out one
   // call per category. Call sites emit a single aggregated toast.
   const triggerUpdate = api.dataRetention.triggerRetroactiveUpdate.useMutation({
     onSuccess: () => {
@@ -344,7 +179,7 @@ function DataRetentionPage({
   const snapshot = rulesQuery.data;
   const available = snapshot?.available;
   const canConfigureRetention = !!snapshot?.canConfigureRetention;
-  // Configurable retention is a paid-plan feature - even an org admin on
+  // Configurable retention is a paid-plan feature — even an org admin on
   // the free plan can't add overrides. Both gates must pass.
   const canWrite =
     canConfigureRetention &&
@@ -736,450 +571,5 @@ function DataRetentionPage({
         />
       </VStack>
     </SettingsLayout>
-  );
-}
-
-function RetroactiveProgressCard({
-  mutations,
-  onCancel,
-  isCancelling,
-}: {
-  mutations: MutationProgress[];
-  onCancel: (mutationId: string) => void;
-  isCancelling: boolean;
-}) {
-  if (mutations.length === 0) return null;
-  return (
-    <Card.Root width="full">
-      <Card.Header>
-        <Heading as="h3" fontSize="lg">
-          Applying retention to existing data
-        </Heading>
-        <Text fontSize="sm" color="fg.muted">
-          ClickHouse rewrites the affected parts during background merges. Large
-          datasets can take a while; the count below is parts still pending.
-        </Text>
-      </Card.Header>
-      <Card.Body>
-        <VStack gap={4} align="stretch">
-          {mutations.map((m) => (
-            <VStack key={m.mutationId} gap={1} align="stretch">
-              <HStack justifyContent="space-between">
-                <Text>
-                  {m.table}
-                  {m.category ? ` · ${CATEGORY_LABELS[m.category]}` : ""}
-                </Text>
-                <HStack gap={3}>
-                  <Text fontSize="sm" color="fg.muted">
-                    {m.partsToDo} parts remaining
-                  </Text>
-                  <Button
-                    size="xs"
-                    variant="ghost"
-                    colorPalette="red"
-                    loading={isCancelling}
-                    onClick={() => onCancel(m.mutationId)}
-                  >
-                    Cancel
-                  </Button>
-                </HStack>
-              </HStack>
-              <Progress.Root value={null} size="xs" colorPalette="blue">
-                <Progress.Track>
-                  <Progress.Range />
-                </Progress.Track>
-              </Progress.Root>
-            </VStack>
-          ))}
-        </VStack>
-      </Card.Body>
-    </Card.Root>
-  );
-}
-
-function ApplyToExistingConfirmDialog({
-  pending,
-  isApplying,
-  onCancel,
-  onConfirm,
-}: {
-  pending: {
-    retentionDays: number;
-    savedScopeWiderThanCurrentProject: boolean;
-  } | null;
-  isApplying: boolean;
-  onCancel: () => void;
-  onConfirm: () => void | Promise<void>;
-}) {
-  return (
-    <Dialog.Root
-      open={!!pending}
-      onOpenChange={({ open }) => {
-        if (!open) onCancel();
-      }}
-    >
-      <Dialog.Content>
-        <Dialog.Header>
-          <Dialog.Title>Apply retention to existing data?</Dialog.Title>
-        </Dialog.Header>
-        <Dialog.Body>
-          {pending && (
-            <VStack align="stretch" gap={3}>
-              {pending.retentionDays === INDEFINITE_RETENTION_DAYS ? (
-                <Text>
-                  We will rewrite <strong>this project's</strong> existing data
-                  to be kept indefinitely. No rows are deleted - this removes
-                  the retention limit from already-stored data.
-                </Text>
-              ) : (
-                // We don't name a specific day count here because the server
-                // applies the project's RESOLVED effective retention
-                // (PROJECT > TEAM > ORGANIZATION > platform default), which
-                // may differ from the value the user just selected (e.g. when
-                // saving an org-wide rule but the project has a closer
-                // override). The toast that fires after the apply shows the
-                // value that was actually used.
-                <Text>
-                  We will rewrite <strong>this project's</strong> existing data
-                  to use its currently resolved retention policy. Rows older
-                  than the resolved retention become eligible for deletion on
-                  the next background merge. After deletion, this cannot be
-                  undone.
-                </Text>
-              )}
-              {pending.savedScopeWiderThanCurrentProject && (
-                <Alert.Root status="warning">
-                  <Alert.Indicator />
-                  <Alert.Content>
-                    <Alert.Description>
-                      You also saved an organization or team policy. New rows
-                      across those scopes will use the new retention, but
-                      existing rows in other projects keep their current
-                      retention until each project is visited and applied
-                      individually.
-                    </Alert.Description>
-                  </Alert.Content>
-                </Alert.Root>
-              )}
-            </VStack>
-          )}
-        </Dialog.Body>
-        <Dialog.Footer>
-          <Button variant="outline" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button
-            colorPalette={
-              pending?.retentionDays === INDEFINITE_RETENTION_DAYS
-                ? "blue"
-                : "red"
-            }
-            loading={isApplying}
-            onClick={() => void onConfirm()}
-          >
-            Apply to existing data
-          </Button>
-        </Dialog.Footer>
-      </Dialog.Content>
-    </Dialog.Root>
-  );
-}
-
-function RetentionAndUsageCard({
-  effective,
-  isLoading,
-  data,
-}: {
-  effective: Partial<Record<RetentionCategory, number>>;
-  isLoading: boolean;
-  data?: { totalBytes: number; byCategory: Record<RetentionCategory, number> };
-}) {
-  const summary = renderPolicySummary(effective);
-  return (
-    <Card.Root width="full">
-      <Card.Header>
-        <HStack width="full" justify="space-between" align="start">
-          <VStack align="start" gap={0}>
-            <Heading as="h3" fontSize="lg">
-              Data Retention
-            </Heading>
-            <Text fontSize="sm" color="fg.muted">
-              How long this project's data is kept before deletion.
-            </Text>
-          </VStack>
-          <Text fontWeight="semibold" flexShrink={0}>
-            {summary}
-          </Text>
-        </HStack>
-      </Card.Header>
-      <Card.Body>
-        <VStack gap={5} align="stretch">
-          {summary === "Mixed" && (
-            <VStack gap={2} align="stretch">
-              {RETENTION_CATEGORIES.map((category) => (
-                <HStack key={category} justifyContent="space-between">
-                  <Text color="fg.muted">{CATEGORY_LABELS[category]}</Text>
-                  <Text>
-                    {effective[category] !== undefined
-                      ? formatDays(effective[category]!)
-                      : "-"}
-                  </Text>
-                </HStack>
-              ))}
-            </VStack>
-          )}
-          <HStack width="full" justify="space-between" align="start">
-            <VStack align="start" gap={0}>
-              <Heading as="h3" fontSize="lg">
-                Data Storage
-              </Heading>
-              <Text fontSize="sm" color="fg.muted">
-                How much space this project's data uses today.
-              </Text>
-            </VStack>
-            {isLoading ? (
-              <Spinner size="sm" />
-            ) : data ? (
-              <Text fontWeight="semibold" flexShrink={0}>
-                {formatBytes(data.totalBytes)}
-              </Text>
-            ) : null}
-          </HStack>
-        </VStack>
-      </Card.Body>
-    </Card.Root>
-  );
-}
-
-function AddOverrideDrawer({
-  open,
-  onClose,
-  available,
-  currentOrganizationId,
-  currentTeamId,
-  currentProjectId,
-  isPlatformAdmin,
-  isSaving,
-  onSave,
-}: {
-  open: boolean;
-  onClose: () => void;
-  available: {
-    organization: { id: string; name: string } | null;
-    teams: { id: string; name: string }[];
-    projects: { id: string; name: string; teamId: string }[];
-  };
-  currentOrganizationId: string | undefined;
-  currentTeamId: string | undefined;
-  currentProjectId: string;
-  isPlatformAdmin: boolean;
-  isSaving: boolean;
-  onSave: (
-    scopes: ScopeTriadEntry[],
-    retentionDays: number,
-    applyToExisting: boolean,
-  ) => void;
-}) {
-  const [scopes, setScopes] = useState<ScopeTriadEntry[]>([]);
-  const [preset, setPreset] = useState<string>(String(DEFAULT_RETENTION_DAYS));
-  const [customAmount, setCustomAmount] = useState<string>("");
-  const [customUnit, setCustomUnit] = useState<RetentionUnit>("weeks");
-  const [applyToExisting, setApplyToExisting] = useState<boolean>(true);
-
-  // Platform admins get an extra "No retention (keep forever)" option. The 0
-  // sentinel is structurally valid input; the route authorizes it admin-only.
-  const presetCollection = useMemo(
-    () =>
-      createListCollection({
-        items: [
-          ...RETENTION_PRESETS.map((p) => ({ value: p.value, label: p.label })),
-          ...(isPlatformAdmin
-            ? [
-                {
-                  value: INDEFINITE_PRESET_VALUE,
-                  label: "No retention (keep forever)",
-                },
-              ]
-            : []),
-          { value: CUSTOM_PRESET_VALUE, label: "Custom…" },
-        ],
-      }),
-    [isPlatformAdmin],
-  );
-
-  useEffect(() => {
-    if (open) {
-      // Default to the current project so the picker opens on the user's
-      // working scope, mirroring the API-key drawer pattern.
-      setScopes(
-        available.projects.some((p) => p.id === currentProjectId)
-          ? [{ scopeType: "PROJECT", scopeId: currentProjectId }]
-          : [],
-      );
-      setPreset(String(DEFAULT_RETENTION_DAYS));
-      setCustomAmount("");
-      setCustomUnit("weeks");
-      setApplyToExisting(true);
-    }
-  }, [open, currentProjectId, available.projects]);
-
-  const resolvedDays = (() => {
-    if (preset === CUSTOM_PRESET_VALUE) {
-      const n = Number(customAmount);
-      if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return NaN;
-      return n * DAYS_PER_UNIT[customUnit];
-    }
-    return Number(preset);
-  })();
-
-  const daysValid =
-    // Indefinite (0) is only reachable via the admin-only preset; the route
-    // re-checks the capability, so the UI just needs to treat it as valid.
-    resolvedDays === INDEFINITE_RETENTION_DAYS ||
-    (Number.isFinite(resolvedDays) &&
-      Number.isInteger(resolvedDays) &&
-      resolvedDays >= MIN_RETENTION_DAYS &&
-      resolvedDays <= MAX_RETENTION_DAYS &&
-      resolvedDays % RETENTION_WEEK_DAYS === 0);
-
-  const canSave = scopes.length > 0 && daysValid && !isSaving;
-
-  return (
-    <Drawer.Root
-      placement="end"
-      size="md"
-      open={open}
-      onOpenChange={({ open: isOpen }) => {
-        if (!isOpen) onClose();
-      }}
-    >
-      <Drawer.Content bg="bg">
-        <Drawer.Header>
-          <Heading size="md">Add retention policy</Heading>
-          <Drawer.CloseTrigger />
-        </Drawer.Header>
-        <Drawer.Body>
-          <VStack gap={5} align="stretch">
-            <VStack gap={1.5} align="start" width="full">
-              <Text fontWeight="600" fontSize="sm">
-                Scope
-              </Text>
-              <ScopeChipPicker
-                value={scopes}
-                onChange={setScopes}
-                organizationId={available.organization?.id}
-                organizationName={available.organization?.name}
-                availableTeams={available.teams}
-                availableProjects={available.projects}
-                label=""
-                currentOrganizationId={
-                  available.organization ? currentOrganizationId : undefined
-                }
-                currentTeamId={currentTeamId}
-                currentProjectId={currentProjectId}
-              />
-            </VStack>
-
-            <Field.Root>
-              <Field.Label>Retention</Field.Label>
-              <Select.Root
-                collection={presetCollection}
-                value={[preset]}
-                onValueChange={(details) => {
-                  const v = details.value[0];
-                  if (v) setPreset(v);
-                }}
-              >
-                <Select.Trigger background="bg">
-                  <Select.ValueText placeholder="Pick a retention" />
-                </Select.Trigger>
-                <Select.Content>
-                  {presetCollection.items.map((item) => (
-                    <Select.Item key={item.value} item={item}>
-                      {item.label}
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select.Root>
-              {preset === CUSTOM_PRESET_VALUE && (
-                <HStack gap={2} marginTop={2} align="start">
-                  <Input
-                    type="number"
-                    min={1}
-                    value={customAmount}
-                    onChange={(e) => setCustomAmount(e.target.value)}
-                    width="120px"
-                    placeholder="e.g. 8"
-                  />
-                  <Select.Root
-                    collection={retentionUnitCollection}
-                    value={[customUnit]}
-                    onValueChange={(details) => {
-                      const v = details.value[0] as RetentionUnit | undefined;
-                      if (v) setCustomUnit(v);
-                    }}
-                  >
-                    <Select.Trigger background="bg" width="140px">
-                      <Select.ValueText />
-                    </Select.Trigger>
-                    <Select.Content>
-                      {retentionUnitCollection.items.map((item) => (
-                        <Select.Item key={item.value} item={item}>
-                          {item.label}
-                        </Select.Item>
-                      ))}
-                    </Select.Content>
-                  </Select.Root>
-                </HStack>
-              )}
-              <Field.HelperText>
-                {preset === INDEFINITE_PRESET_VALUE
-                  ? "Data will be kept indefinitely - exempt from automatic deletion."
-                  : preset === CUSTOM_PRESET_VALUE && customAmount && daysValid
-                    ? `Stored as ${resolvedDays} days.`
-                    : preset === CUSTOM_PRESET_VALUE &&
-                        customAmount &&
-                        !daysValid
-                      ? `Must be between ${MIN_RETENTION_DAYS} and ${MAX_RETENTION_DAYS} days.`
-                      : `Minimum ${MIN_RETENTION_DAYS} days (7 weeks). Retention is partition-aligned and rounded to whole weeks under the hood.`}
-              </Field.HelperText>
-            </Field.Root>
-
-            <HStack gap={3} align="start">
-              <Switch
-                checked={applyToExisting}
-                onCheckedChange={({ checked }) =>
-                  setApplyToExisting(checked === true)
-                }
-              />
-              <VStack align="start" gap={0}>
-                <Text fontWeight="600" fontSize="sm">
-                  Apply this change to existing data
-                </Text>
-                <Text fontSize="xs" color="fg.muted">
-                  Rewrites this project's existing rows so the new retention
-                  takes effect immediately, not just for new ingestion.
-                </Text>
-              </VStack>
-            </HStack>
-          </VStack>
-        </Drawer.Body>
-        <Drawer.Footer>
-          <HStack width="full" justify="end" gap={2}>
-            <Button variant="outline" onClick={onClose} disabled={isSaving}>
-              Cancel
-            </Button>
-            <Button
-              colorPalette="blue"
-              disabled={!canSave}
-              loading={isSaving}
-              onClick={() => onSave(scopes, resolvedDays, applyToExisting)}
-            >
-              Create
-            </Button>
-          </HStack>
-        </Drawer.Footer>
-      </Drawer.Content>
-    </Drawer.Root>
   );
 }


### PR DESCRIPTION
Follow-up to langwatch/langwatch#4147. Closes two of the items tracked in langwatch/tasks#69.

## Summary

- **Round retention presets UP** so selection covers the full human-label period plus a small buffer instead of underselling by 1-10 days. "1 year" was 364d, now 371d. Reviewer ask on langwatch/langwatch#4147 thread.
- **Split `src/pages/settings/data-retention.tsx`** (1185 lines) into a slim page shell + per-concern modules under `src/components/data-retention/`. Page is now 575 lines (-51%). Reviewer ask on langwatch/langwatch#4147 thread.

## File layout

```
src/components/data-retention/
├─ constants.ts                       (category/scope labels, presets, units, sentinels)
├─ format.ts                          (formatBytes, formatDays)
├─ grouping.ts                        (RetentionRuleRow/Group + group/render helpers)
├─ AddOverrideDrawer.tsx
├─ RetroactiveProgressCard.tsx
├─ ApplyToExistingConfirmDialog.tsx
└─ RetentionAndUsageCard.tsx

src/pages/settings/data-retention.tsx (shell + data orchestration only)
```

No behavior change. Existing tests pass unmodified.

## Items from langwatch/tasks#69 NOT addressed here

- **Item 1** (drop legacy `PinButton`): kept in both views per latest direction — pin should remain in legacy `TraceDetails.tsx` and v2 overflow.
- **Item 3** (reply on `DEFAULT 308` bot thread): already replied + resolved on langwatch/langwatch#4147 before merge.
- **Item 5** (single `RetentionPolicyCache` in `createTestApp`): already correct in `presets.ts:647` — CodeRabbit snapshot was stale.
- **Item 6** (per-entry context in batch projection writes): already guarded via `isUniformContext` in `repositoryFoldStore.ts:65-98` — CodeRabbit snapshot was stale.
- **Item 7** (align cascade with langwatch/langwatch#4281): out of scope for this PR — needs separate investigation of the standard pattern.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit src/server/data-retention` — 8 files, 66 tests pass
- [ ] Manually verify Retention Policies settings page renders + drawers work
- [ ] CI green