### PR TITLE
fix(retention): anchor evaluation_runs TTL on UpdatedAt (non-null, partition-aligned)

### DIFF
--- a/langwatch/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/retentionTtl.unit.test.ts
@@ -29,6 +29,19 @@ describe("buildRetentionTTLExpression", () => {
         "IF(_retention_days > 0, toDateTime(EventOccurredAt / 1000) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE",
       );
     });
+
+    // Regression: ScheduledAt and StartedAt on evaluation_runs are both
+    // Nullable(DateTime64(3)), which CH rejects in TTL expressions with
+    // BAD_TTL_EXPRESSION (code 450). The anchor must be UpdatedAt — non-null
+    // and partition-aligned with `toYearWeek(UpdatedAt)`.
+    it("evaluation_runs anchors retention on the non-null partition key", () => {
+      const config = TABLE_TTL_CONFIG.find((c) => c.table === "evaluation_runs")!;
+      expect(config.retentionTTLColumn).toBe("UpdatedAt");
+      const expr = buildRetentionTTLExpression(config);
+      expect(expr).toBe(
+        "IF(_retention_days > 0, toDateTime(UpdatedAt) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE",
+      );
+    });
   });
 
   describe("when retentionTTLColumn is not set", () => {

--- a/langwatch/src/server/clickhouse/__tests__/rmtTtlCompatibility.integration.test.ts
+++ b/langwatch/src/server/clickhouse/__tests__/rmtTtlCompatibility.integration.test.ts
@@ -110,6 +110,40 @@ describe("ReplacingMergeTree + TTL retention compatibility", () => {
     expect(indefiniteRow?._retention_days).toBe(0);
   });
 
+  // Regression: a retention anchor on a Nullable(DateTime) column makes CH reject
+  // MODIFY TTL with BAD_TTL_EXPRESSION (code 450), which crashed the prod app
+  // pod's clickhouse:migrate step on the first deploy of the retention feature
+  // because evaluation_runs.ScheduledAt was Nullable. This locks in the
+  // non-null-anchor rule.
+  it("rejects MODIFY TTL when the anchor column is Nullable(DateTime)", async () => {
+    const NULLABLE_TABLE = "test_rmt_ttl_nullable_anchor";
+    await client.command({
+      query: `CREATE TABLE IF NOT EXISTS ${database}.${NULLABLE_TABLE} (
+        TenantId String,
+        TraceId String,
+        ScheduledAt Nullable(DateTime64(3)),
+        UpdatedAt DateTime64(3),
+        _retention_days UInt16 DEFAULT 0
+      ) ENGINE = ReplacingMergeTree(UpdatedAt)
+      PARTITION BY toYearWeek(UpdatedAt)
+      ORDER BY (TenantId, TraceId)`,
+    });
+
+    try {
+      await expect(
+        client.command({
+          query: `ALTER TABLE ${database}.${NULLABLE_TABLE} MODIFY TTL
+            IF(_retention_days > 0, toDateTime(ScheduledAt) + toIntervalDay(_retention_days), toDateTime('2106-01-01')) DELETE
+            SETTINGS materialize_ttl_after_modify = 0`,
+        }),
+      ).rejects.toMatchObject({ code: "450" });
+    } finally {
+      await client.command({
+        query: `DROP TABLE IF EXISTS ${database}.${NULLABLE_TABLE}`,
+      });
+    }
+  });
+
   it("handles mixed-tenant partitions correctly", async () => {
     const threeDaysAgo = new Date(Date.now() - 3 * 86400000);
 

--- a/langwatch/src/server/clickhouse/ttlReconciler.ts
+++ b/langwatch/src/server/clickhouse/ttlReconciler.ts
@@ -49,7 +49,13 @@ export const TABLE_TTL_CONFIG: readonly TableTTLEntry[] = [
   {
     table: "evaluation_runs",
     ttlColumn: "UpdatedAt",
-    retentionTTLColumn: "ScheduledAt",
+    // Retention anchors on UpdatedAt (= partition key `toYearWeek(UpdatedAt)`),
+    // not ScheduledAt/StartedAt. Both of those are Nullable(DateTime64) on this
+    // table and ClickHouse rejects Nullable in TTL expressions with
+    // BAD_TTL_EXPRESSION (code 450). UpdatedAt is non-null and partition-aligned,
+    // so TTL drops whole weekly partitions at the part level instead of running
+    // row-level mutations across still-warm parts.
+    retentionTTLColumn: "UpdatedAt",
     envVar: "CLICKHOUSE_COLD_STORAGE_EVALUATION_RUNS_TTL_DAYS",
     hardcodedDefault: 49,
   },


### PR DESCRIPTION
## Why

PR #4147 (retention) crashes the app pod at startup on the first deploy. The migration itself succeeds (goose `current version: 32`), but the immediately-following `reconcileTTL` step fails with ClickHouse `BAD_TTL_EXPRESSION` (code 450):

```
TTL expression result column should have Date, Date32, DateTime or DateTime64 type, but has Nullable(DateTime).
```

…on `evaluation_runs`. Pod exits 1 → `CrashLoopBackOff`. Prod was rolled back to the previous revision while this fix lands. CD will redeploy the broken image until this PR merges.

## Root cause

`evaluation_runs.ScheduledAt` is `Nullable(DateTime64(3))` (and so is `StartedAt`). ClickHouse refuses Nullable in TTL expressions, so the reconciler's `MODIFY TTL IF(_retention_days > 0, toDateTime(ScheduledAt) + …, …) DELETE` is rejected before it runs.

## Fix

Anchor `evaluation_runs` retention on **`UpdatedAt`**:

- **Non-null** — CH accepts.
- **Partition-aligned** with `toYearWeek(UpdatedAt)`, so the DELETE TTL drops whole weekly partitions at the part level instead of running row-level mutations across still-warm parts. Same anchor as cold-storage on this table → single source of truth.
- **Zero schema disruption** — `ALTER … MODIFY TTL … SETTINGS materialize_ttl_after_modify = 0` is metadata-only.

### Trade-off and follow-ups (deferred)

`UpdatedAt` is not the business date — a re-fold or backfill resets the retention clock. The structurally cleaner answer is to re-partition `evaluation_runs` on a true business date (e.g. `CreatedAt`) and anchor TTL there too, but that is a heavier schema change on a hot table. Discussed with @sergioestebance; decision is to keep partition-aligned now and revisit alignment + biz-date partitioning together as a follow-up.

## Audit: partition-key alignment for all 11 retention-managed tables

Cross-checked prod schema vs `TABLE_TTL_CONFIG` — `evaluation_runs` is the only mismatch and is fixed here:

| Table | Partition key | Retention anchor | Aligned? |
|---|---|---|---|
| dspy_steps | CreatedAt | CreatedAt | yes |
| evaluation_runs | **UpdatedAt** | ~~ScheduledAt~~ → **UpdatedAt** | yes (after this PR) |
| event_log | EventOccurredAt | EventOccurredAt | yes |
| experiment_run_items | OccurredAt | OccurredAt | yes |
| experiment_runs | StartedAt | StartedAt | yes |
| simulation_runs | StartedAt | StartedAt | yes |
| stored_log_records | TimeUnixMs | TimeUnixMs | yes |
| stored_metric_records | TimeUnixMs | TimeUnixMs | yes |
| stored_spans | StartTime | StartTime | yes |
| suite_runs | StartedAt | StartedAt | yes |
| trace_summaries | OccurredAt | OccurredAt | yes |

Aside (out of scope): `stored_spans` cold-storage TTL anchors on `EndTime` while the partition is `StartTime`. Spans almost always start and end in the same week, so part-level moves work in practice — worth a follow-up but does not block this fix.

## Test plan

- Unit: lock in `evaluation_runs` anchor = `UpdatedAt` in `retentionTtl.unit.test.ts`.
- Integration: `rmtTtlCompatibility.integration.test.ts` now asserts `ALTER … MODIFY TTL` against a `Nullable(DateTime)` anchor is rejected with code 450 — this class of bug now fails CI.
- 47/47 unit tests pass for the reconciler suite.

## Follow-ups (separate PRs)

- Re-partition `evaluation_runs` on a true business date and switch TTL anchor accordingly so retention is biz-time semantically and remains part-level.
- `stored_spans` cold-storage TTL anchor mismatch (`EndTime` vs partition `StartTime`).