### PR TITLE
fix(langy): hoist release_langy_enabled hook above early returns (React #310)

### DIFF
--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -412,6 +412,19 @@ export const DashboardLayout = ({
     { organizationId: organization?.id, enabled: !!organization?.id },
   );
 
+  // Resolve the Langy flag HERE, above the loading / not-found early returns
+  // below. A hook placed after those returns is skipped on the first
+  // (loading) render and runs once data resolves — a changing hook count
+  // across renders, which is React error #310 ("Rendered more hooks than
+  // during the previous render") and crashes the whole dashboard. The derived
+  // `showLangy` (which also needs `user` + route checks) stays lower; only the
+  // hook itself must be unconditional/top-level.
+  const { enabled: langyFlagEnabled } = useFeatureFlag("release_langy_enabled", {
+    projectId: project?.id,
+    organizationId: organization?.id,
+    enabled: !!project,
+  });
+
   usePostHogIdentify({
     session: session ?? null,
     organization,
@@ -535,14 +548,6 @@ export const DashboardLayout = ({
   const isProjectRoute =
     router.pathname === "/[project]" ||
     router.pathname.startsWith("/[project]/");
-  const { enabled: langyFlagEnabled } = useFeatureFlag(
-    "release_langy_enabled",
-    {
-      projectId: project?.id,
-      organizationId: organization?.id,
-      enabled: !!project,
-    },
-  );
   const showLangy =
     !publicPage &&
     userIsPartOfTeam &&


### PR DESCRIPTION
## Problem
Enabling Langy (`release_langy_enabled`, as `@langwatch.ai` staff) crashes the **whole dashboard** with React error **#310** ("Rendered more hooks than during the previous render") on every `/[project]` route — the error boundary shows "Something went wrong".

**Repro**
1. Log in as an `@langwatch.ai` user (so `isLangwatchStaff()` is true).
2. Enable `release_langy_enabled`.
3. Open any `/[project]` route → dashboard crashes (#310).

## Root cause
In `DashboardLayout.tsx`, `useFeatureFlag("release_langy_enabled")` was placed **below** the `<NotFoundScene/>` and `<LoadingScreen/>` early returns:

```
410  useFeatureFlag(governance)        // hook
422  return <NotFoundScene />          // conditional early return
501  return <LoadingScreen />          // conditional early return
538  useFeatureFlag("release_langy_enabled")   // ← hook AFTER the returns
```

While the layout is loading it returns `<LoadingScreen/>` early, so the langy flag hook is **skipped**; once data resolves the component falls through and the hook **runs** → the hook count changes between renders → #310. This is precisely why *enabling the flag* is what triggers the crash.

> The original report pointed at `LangySidebar.tsx`, but those components are hooks-compliant — `RecentList`/`MessageContent` have **no** hooks after their `return null`, and `ThinkingIndicator`/`Composer` call their hooks at the top. The real violation is this flag-hook placement in `DashboardLayout`.

## Fix
Hoist the `useFeatureFlag("release_langy_enabled")` call up next to the other top-level hooks, **above** the early returns. The derived `showLangy` (which also needs `user` + route checks) stays where it was — only the *hook* must be unconditional, so hook count is now constant every render.

✅ `pnpm typecheck` clean.

## Note (out of scope)
A pre-existing `recordWorkspaceView` `useMutation` + `useEffect` also sit after the `<NotFoundScene/>` return. That only toggles on the project-not-found path, predates the langy work, and isn't addressed here.

## Verify
Enable the flag locally as staff (`pnpm dev`) and open a project route — the Langy drawer should render without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)