### PR TITLE
fix(retention): drop _size_bytes MATERIALIZED column to relieve merge memory pressure

### DIFF
--- a/langwatch/src/server/clickhouse/migrations/00033_drop_retention_size_bytes_materialized.sql
+++ b/langwatch/src/server/clickhouse/migrations/00033_drop_retention_size_bytes_materialized.sql
@@ -1,0 +1,120 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- Drop _size_bytes MATERIALIZED column from all retention-managed tables.
+--
+-- The column was added in 00032 as `MATERIALIZED byteSize(<payload cols>)`.
+-- ClickHouse evaluates that expression on the heavy payload columns
+-- (EventPayload, SpanAttributes, ResourceAttributes, ComputedInput/Output,
+-- Inputs, …) during background merges as it drifts the value onto disk for
+-- pre-existing parts. On heavy-payload tables this materially increased
+-- merge memory usage and combined with already-large parts to push merges
+-- past the per-server memory cap, producing MEMORY_LIMIT_EXCEEDED failures
+-- on MERGE_PARTS replication queue entries and an exponential-backoff
+-- retry loop that pressured the cluster.
+--
+-- Retention enforcement itself does NOT depend on `_size_bytes` — only
+-- `_retention_days` is referenced by the TTL DELETE expression. The storage
+-- metering surface that used `SUM(_size_bytes)` is reworked alongside this
+-- migration to a path that does not require a per-row byteSize column.
+--
+-- DROP COLUMN is metadata-only at ALTER time and reads no row data; the
+-- column files are removed from each part on disk lazily.
+
+-- event_log
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.event_log
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- stored_spans
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_spans
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- stored_log_records
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- stored_metric_records
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- trace_summaries
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- evaluation_runs
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.evaluation_runs
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- experiment_runs
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.experiment_runs
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- experiment_run_items
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.experiment_run_items
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- simulation_runs
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.simulation_runs
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- suite_runs
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.suite_runs
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- dspy_steps
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.dspy_steps
+  DROP COLUMN IF EXISTS `_size_bytes`
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- To roll back, uncomment and run manually. Re-adding the MATERIALIZED column
+-- re-introduces the byteSize() merge-memory cost that motivated dropping it,
+-- so a rollback must be followed by either raising the CH per-server memory
+-- cap or accepting merge OOM risk on heavy-payload tables.
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.event_log ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(EventPayload, ProcessingTraceparent) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_spans ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(ResourceAttributes, SpanAttributes, StatusMessage, ScopeName, ScopeVersion, `Events.Timestamp`, `Events.Name`, `Events.Attributes`, `Links.TraceId`, `Links.SpanId`, `Links.Attributes`) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(Body, Attributes, ResourceAttributes, ScopeName, ScopeVersion) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(MetricUnit, Attributes, ResourceAttributes) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(Attributes, ComputedInput, ComputedOutput, ErrorMessage, Models, TopicId, SubTopicId, AnnotationIds, SelectedPromptId, SelectedPromptSpanId, LastUsedPromptId, LastUsedPromptVersionId, LastUsedPromptSpanId, TraceName, SourceId) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.evaluation_runs ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(EvaluatorName, TraceId, Label, Details, Error, ErrorDetails, Inputs) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.experiment_runs ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(WorkflowVersionId, Targets) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.experiment_run_items ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(DatasetEntry, Predicted, TargetError, TraceId, EvaluatorId, EvaluatorName, Label, EvaluationDetails, EvaluationInputs) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.simulation_runs ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(Status, Name, Description, `Messages.Id`, `Messages.Role`, `Messages.Content`, `Messages.TraceId`, `Messages.Rest`, TraceIds, Verdict, Reasoning, MetCriteria, UnmetCriteria, Error, Metadata, RoleCosts, RoleLatencies, TraceMetricsJson) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.suite_runs ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(Status) CODEC(Delta(4), ZSTD(1));
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.dspy_steps ADD COLUMN IF NOT EXISTS `_size_bytes` UInt32 MATERIALIZED byteSize(Label, OptimizerName, OptimizerParameters, Predictors, Examples, LlmCalls) CODEC(Delta(4), ZSTD(1));
+-- +goose StatementEnd

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -1,101 +1,44 @@
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
-import { TtlCache } from "~/server/utils/ttlCache";
 import { createLogger } from "~/utils/logger/server";
-import {
-  RETENTION_MANAGED_TABLES,
-  RETENTION_TABLE_CATEGORY_MAP,
-  type RetentionCategory,
-} from "../retentionPolicy.schema";
+import { type RetentionCategory } from "../retentionPolicy.schema";
 
 const logger = createLogger("langwatch:data-retention:metering");
-
-const CACHE_TTL_MS = 5 * 60 * 1000;
 
 interface StorageBreakdown {
   totalBytes: number;
   byCategory: Record<RetentionCategory, number>;
 }
 
-export class StorageMeterService {
-  private readonly cache: TtlCache<number>;
+const EMPTY_BREAKDOWN: StorageBreakdown = {
+  totalBytes: 0,
+  byCategory: { traces: 0, scenarios: 0, experiments: 0 },
+};
 
+/**
+ * Storage metering is currently a no-op. The previous implementation summed a
+ * `_size_bytes` MATERIALIZED `byteSize(<payload columns>)` column added in
+ * ClickHouse migration 00032; that column was dropped in 00033 because the
+ * byteSize() expression evaluated during background merges on heavy-payload
+ * tables and pushed merges over the per-server memory cap.
+ *
+ * Returning zero from this surface keeps the data-retention settings page
+ * (the only consumer) from breaking while a replacement metering strategy
+ * lands. The replacement will not require per-row materialization.
+ */
+export class StorageMeterService {
   constructor(
     private readonly resolveClickHouseClient: ClickHouseClientResolver | null,
-  ) {
-    this.cache = new TtlCache(CACHE_TTL_MS, "storage-meter:");
-  }
+  ) {}
 
-  async getTotalStorageBytes({
-    tenantId,
-  }: {
-    tenantId: string;
-  }): Promise<number> {
-    const cached = await this.cache.get(tenantId);
-    if (cached !== undefined) return cached;
-
-    const total = await this.queryTotalBytes(tenantId);
-    await this.cache.set(tenantId, total);
-    return total;
-  }
-
-  async getStorageBreakdown({
-    tenantId,
-  }: {
-    tenantId: string;
-  }): Promise<StorageBreakdown> {
-    if (!this.resolveClickHouseClient) {
-      return {
-        totalBytes: 0,
-        byCategory: { traces: 0, scenarios: 0, experiments: 0 },
-      };
-    }
-
-    const client = await this.resolveClickHouseClient(tenantId);
-    const byCategory: Record<RetentionCategory, number> = {
-      traces: 0,
-      scenarios: 0,
-      experiments: 0,
-    };
-
-    for (const table of RETENTION_MANAGED_TABLES) {
-      try {
-        const result = await client.query({
-          query: `SELECT sum(_size_bytes) AS total FROM ${table} WHERE TenantId = {tenantId:String}`,
-          query_params: { tenantId },
-          format: "JSONEachRow",
-        });
-        const rows = (await result.json()) as Array<{ total: string }>;
-        const tableBytes = Number(rows[0]?.total ?? 0);
-        const category = RETENTION_TABLE_CATEGORY_MAP[table]!;
-        byCategory[category] += tableBytes;
-      } catch (error) {
-        logger.warn({ tenantId, table, error }, "Failed to query _size_bytes");
-      }
-    }
-
-    const totalBytes = Object.values(byCategory).reduce((a, b) => a + b, 0);
-    return { totalBytes, byCategory };
-  }
-
-  private async queryTotalBytes(tenantId: string): Promise<number> {
+  async getTotalStorageBytes({ tenantId }: { tenantId: string }): Promise<number> {
     if (!this.resolveClickHouseClient) return 0;
+    logger.debug({ tenantId }, "Storage metering temporarily disabled");
+    return 0;
+  }
 
-    const client = await this.resolveClickHouseClient(tenantId);
-    // Aggregate per-table first, then sum the 11 scalars. The naive
-    // UNION ALL on raw rows materializes every _size_bytes value into the
-    // intermediate set before summing — explodes memory for tenants with
-    // tens of millions of rows.
-    const unions = RETENTION_MANAGED_TABLES.map(
-      (table) =>
-        `SELECT sum(_size_bytes) AS t FROM ${table} WHERE TenantId = {tenantId:String}`,
-    ).join("\n  UNION ALL\n  ");
-
-    const result = await client.query({
-      query: `SELECT sum(t) AS total FROM (\n  ${unions}\n)`,
-      query_params: { tenantId },
-      format: "JSONEachRow",
-    });
-    const rows = (await result.json()) as Array<{ total: string }>;
-    return Number(rows[0]?.total ?? 0);
+  async getStorageBreakdown({ tenantId }: { tenantId: string }): Promise<StorageBreakdown> {
+    if (!this.resolveClickHouseClient) return EMPTY_BREAKDOWN;
+    logger.debug({ tenantId }, "Storage breakdown temporarily disabled");
+    return EMPTY_BREAKDOWN;
   }
 }


### PR DESCRIPTION
## Why

The retention work in #4147 added a `_size_bytes` column to 11 ClickHouse tables, declared as `MATERIALIZED byteSize(<payload columns>)`. On heavy-payload tables (`event_log.EventPayload`, `stored_spans.SpanAttributes/ResourceAttributes/...`, `trace_summaries.ComputedInput/Output/...`, `evaluation_runs.Inputs`) this materially raised the memory cost of background merges on already-fat partitions.

In prod on 2026-06-02 it contributed to a merge memory ceiling outage:

- `event_log` MERGE_PARTS `new_part_name = 202622_1190507_1223359_196` failed with `MEMORY_LIMIT_EXCEEDED` ~9.5 GiB against the 14 GiB per-server cap, looping on ~23s exponential backoff, started ~2h after #4147 deployed.
- A pre-existing `evaluation_runs` merge (since 2026-05-23) was already at 559 retries with the same OOM signature — independent of #4147, but the new MATERIALIZED column compounded headroom pressure cluster-wide.
- 37–44 `trace_summaries FINAL` queries piled up holding 6–10 GiB combined, the ingestion pipeline went slow / stuck.

Per ClickHouse semantics MATERIALIZED columns are computed lazily on read and drifted onto disk as parts merge. So every merge of a pre-existing fat part now had to evaluate `byteSize()` over the entire payload column set before writing the new part. Dropping the column removes that merge-time cost.

## What changed

- New migration **`00033_drop_retention_size_bytes_materialized.sql`** drops `_size_bytes` on all 11 retention-managed tables. `DROP COLUMN` is metadata-only at ALTER time and reads no row data — column files are removed from each part on disk lazily.
- **`StorageMeterService`** now stubs both `getTotalStorageBytes` and `getStorageBreakdown` to return zero with a debug log. The data-retention settings page (the only consumer) still renders; storage usage shows as 0 B until a replacement metering strategy lands.

## What is NOT changed

- **Retention enforcement is fully preserved.** The TTL DELETE expression references only `_retention_days`, which stays as a small UInt16 column stamped at ingestion. No change to ingestion writes, no change to TTL reconciler, no change to `RETENTION_MANAGED_TABLES`.
- The retention-managed table set and category map are unchanged.

## Production triage applied alongside

To stop the active OOM-retry loop while this PR lands, `SYSTEM STOP MERGES` was applied to `langwatch.event_log` and `langwatch.evaluation_runs` on all three CH replicas. CH internal MemoryTracking dropped from ~9.1 GiB → ~7.8 GiB immediately. Once this migration applies the column is gone and merges can resume safely (`SYSTEM START MERGES`).

## Follow-ups (separate PRs)

- **Storage metering rebuild** — a strategy that does not require a per-row `byteSize` MATERIALIZED column. Options under consideration: periodic batch sampling, or `system.parts.bytes_on_disk` aggregated at table level with per-tenant proportional allocation.
- **Pre-existing `evaluation_runs` merge stuck since 2026-05-23** — separate from #4147. Likely needs raising the CH per-server memory cap (node has ~22 GiB OS-available headroom vs the 14 GiB CH cap) or narrowing the selector via per-table merge-size settings.

## Test plan

- `pnpm typecheck` clean.
- Existing retention unit/integration tests remain green (the metering surface was untested at the unit level; the consumers — authz, read, policy, TTL reconciler — are unchanged).