### PR TITLE
fix(evaluations): cap evaluation_runs payload columns at write time

### DIFF
--- a/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.payload-cap.unit.test.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/__tests__/evaluation-run.payload-cap.unit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_EVALUATION_PAYLOAD_BYTES,
+  capInputs,
+  capPayloadText,
+} from "../evaluation-run.payload-cap";
+
+const ctx = { tenantId: "tenant-1", evaluationId: "eval-1" };
+const overCap = (extra: number) =>
+  "a".repeat(MAX_EVALUATION_PAYLOAD_BYTES + extra);
+
+describe("capPayloadText", () => {
+  it("passes null through unchanged", () => {
+    expect(capPayloadText(null, "Details", ctx)).toBeNull();
+  });
+
+  it("returns small values unchanged", () => {
+    expect(capPayloadText("hello", "Error", ctx)).toBe("hello");
+  });
+
+  it("returns values exactly at the cap unchanged", () => {
+    const atCap = "a".repeat(MAX_EVALUATION_PAYLOAD_BYTES);
+    expect(capPayloadText(atCap, "Details", ctx)).toBe(atCap);
+  });
+
+  it("truncates oversized values to a bounded, observable marker", () => {
+    const result = capPayloadText(overCap(1), "Details", ctx)!;
+    expect(result).toContain("[truncated: evaluation_runs Details was");
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThan(
+      MAX_EVALUATION_PAYLOAD_BYTES,
+    );
+  });
+
+  it("uses byte length, not char count, for multibyte strings", () => {
+    // "✓" is 3 UTF-8 bytes; just over the cap by bytes, under it by char count.
+    const value = "✓".repeat(Math.ceil(MAX_EVALUATION_PAYLOAD_BYTES / 3) + 1);
+    expect(value.length).toBeLessThan(MAX_EVALUATION_PAYLOAD_BYTES);
+    expect(capPayloadText(value, "ErrorDetails", ctx)).toContain("[truncated");
+  });
+});
+
+describe("capInputs", () => {
+  it("returns null for null/undefined inputs", () => {
+    expect(capInputs(null, ctx)).toBeNull();
+    expect(capInputs(undefined as never, ctx)).toBeNull();
+  });
+
+  it("serializes small inputs as-is", () => {
+    expect(capInputs({ a: 1, b: "x" }, ctx)).toBe('{"a":1,"b":"x"}');
+  });
+
+  it("replaces oversized inputs with a valid-JSON marker object", () => {
+    const result = capInputs({ blob: overCap(100) }, ctx)!;
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    expect(parsed.__truncated).toBe(true);
+    expect(parsed.field).toBe("Inputs");
+    expect(parsed.cap).toBe(MAX_EVALUATION_PAYLOAD_BYTES);
+    expect(parsed.originalBytes as number).toBeGreaterThan(
+      MAX_EVALUATION_PAYLOAD_BYTES,
+    );
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThan(
+      MAX_EVALUATION_PAYLOAD_BYTES,
+    );
+  });
+});

--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.clickhouse.repository.ts
@@ -7,6 +7,7 @@ import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
 import { createLogger } from "~/utils/logger/server";
 import { validateBatchTenants } from "../../_shared/clickhouse-batch";
 import type { EvalSummary, EvaluationRunData } from "../types";
+import { capInputs, capPayloadText } from "./evaluation-run.payload-cap";
 import type { EvaluationRunRepository, GetByEvaluationIdParams } from "./evaluation-run.repository";
 
 const TABLE_NAME = "evaluation_runs" as const;
@@ -474,6 +475,10 @@ export class EvaluationRunClickHouseRepository
     version: string,
     retentionDays = PLATFORM_DEFAULT_RETENTION_DAYS,
   ): ClickHouseEvaluationRunWriteRecord {
+    // Cap unbounded payload columns at write time so a single oversized row
+    // (e.g. a multi-GB `Inputs`) can never produce a part that exceeds
+    // ClickHouse's merge memory budget. See evaluation-run.payload-cap.ts.
+    const capCtx = { tenantId, evaluationId: data.evaluationId };
     return {
       ProjectionId: projectionId,
       TenantId: tenantId,
@@ -488,10 +493,10 @@ export class EvaluationRunClickHouseRepository
       Score: data.score,
       Passed: data.passed === null ? null : data.passed ? 1 : 0,
       Label: data.label,
-      Details: data.details,
-      Inputs: data.inputs ? JSON.stringify(data.inputs) : null,
-      Error: data.error,
-      ErrorDetails: data.errorDetails,
+      Details: capPayloadText(data.details, "Details", capCtx),
+      Inputs: capInputs(data.inputs, capCtx),
+      Error: capPayloadText(data.error, "Error", capCtx),
+      ErrorDetails: capPayloadText(data.errorDetails, "ErrorDetails", capCtx),
       CreatedAt: new Date(data.createdAt),
       UpdatedAt: new Date(data.updatedAt),
       LastEventOccurredAt: data.LastEventOccurredAt ? new Date(data.LastEventOccurredAt) : new Date(0),

--- a/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.payload-cap.ts
+++ b/langwatch/src/server/app-layer/evaluations/repositories/evaluation-run.payload-cap.ts
@@ -1,0 +1,86 @@
+import type { EvaluationRunData } from "../types";
+
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger(
+  "langwatch:app-layer:evaluations:payload-cap",
+);
+
+/**
+ * Per-value byte ceiling for the unbounded payload columns on `evaluation_runs`
+ * (`Inputs`, `Details`, `Error`, `ErrorDetails`).
+ *
+ * Incident: a single multi-GB `Inputs` value (a full trace context
+ * JSON-stringified at write time) produced a ClickHouse part that no longer fit
+ * the merge memory budget. The partition's MERGE_PARTS task then retried for
+ * ~10 days with `MEMORY_LIMIT_EXCEEDED` (code 241, ~11 GiB against the 14 GiB
+ * server cap) and never converged, spiking memory on every backoff. ClickHouse
+ * already caps merge *blocks* at 10 MiB (`merge_max_block_size_bytes`), so the
+ * only way to force a multi-GB allocation during a merge is a single oversized
+ * *row* — which this write-time cap prevents.
+ *
+ * 8 MiB is far above any legitimate evaluator payload (the offending partition
+ * averaged well under 1 MiB/row) while keeping every row trivially mergeable.
+ * Mirrors `capOversizedString` / `MAX_MESSAGE_CONTENT_BYTES` in the simulation
+ * projection.
+ */
+export const MAX_EVALUATION_PAYLOAD_BYTES = 8 * 1024 * 1024;
+
+export interface PayloadCapContext {
+  tenantId: string;
+  evaluationId: string;
+}
+
+/**
+ * `length * 3 <= maxBytes` is the only safe length-only bypass: UTF-8 uses at
+ * most 3 bytes per UTF-16 code unit (a surrogate pair is 4 bytes but occupies
+ * two code units, so the per-code-unit ceiling stays 3). Using `length <=
+ * maxBytes` would let a multibyte string up to ~3× over the cap slip through.
+ */
+function withinCap(value: string): boolean {
+  if (value.length * 3 <= MAX_EVALUATION_PAYLOAD_BYTES) return true;
+  return Buffer.byteLength(value, "utf8") <= MAX_EVALUATION_PAYLOAD_BYTES;
+}
+
+/**
+ * Cap an oversized free-text column, leaving an observable marker and emitting a
+ * structured warn so an upstream regression doesn't silently land an
+ * unmergeable row in ClickHouse. `null` passes through unchanged.
+ */
+export function capPayloadText(
+  value: string | null,
+  field: "Details" | "Error" | "ErrorDetails",
+  ctx: PayloadCapContext,
+): string | null {
+  if (value === null || withinCap(value)) return value;
+  const byteLength = Buffer.byteLength(value, "utf8");
+  logger.warn(
+    { ...ctx, field, byteLength, maxBytes: MAX_EVALUATION_PAYLOAD_BYTES },
+    `evaluation_runs ${field} exceeds size cap — truncating; an oversized row makes the partition unmergeable`,
+  );
+  return `[truncated: evaluation_runs ${field} was ${byteLength} bytes (cap ${MAX_EVALUATION_PAYLOAD_BYTES})]`;
+}
+
+/**
+ * Serialize evaluator inputs, replacing an oversized payload with a marker
+ * object so the column stays valid JSON *and* the row stays mergeable.
+ */
+export function capInputs(
+  inputs: EvaluationRunData["inputs"],
+  ctx: PayloadCapContext,
+): string | null {
+  if (!inputs) return null;
+  const serialized = JSON.stringify(inputs);
+  if (withinCap(serialized)) return serialized;
+  const byteLength = Buffer.byteLength(serialized, "utf8");
+  logger.warn(
+    { ...ctx, field: "Inputs", byteLength, maxBytes: MAX_EVALUATION_PAYLOAD_BYTES },
+    "evaluation_runs Inputs exceeds size cap — replacing with marker; an oversized row makes the partition unmergeable",
+  );
+  return JSON.stringify({
+    __truncated: true,
+    field: "Inputs",
+    originalBytes: byteLength,
+    cap: MAX_EVALUATION_PAYLOAD_BYTES,
+  });
+}


### PR DESCRIPTION
## Why

A single `evaluation_runs` row with a multi-GB `Inputs` value (a full trace context, `JSON.stringify`'d at write time) produced a ClickHouse part that no longer fit the merge memory budget. The partition's `MERGE_PARTS` task then retried **for ~10 days** with:

```
Code 241 MEMORY_LIMIT_EXCEEDED: would use 11.02 GiB (attempt to allocate chunk of 4.00 GiB),
current RSS: 12.65 GiB, maximum: 14.00 GiB  (while reading column Inputs)
```

…and never converged — spiking memory on every exponential-backoff retry. At low baseline it's contained, but each retry eats the headroom concurrent queries need, contributing to query-side `MEMORY_LIMIT_EXCEEDED`.

## Root cause

ClickHouse already caps merge **blocks** at 10 MiB (`merge_max_block_size_bytes`, default, confirmed in prod). So a 10 MiB block budget can only be blown by a **single oversized row** — a merge must read at least one whole value, and one `Inputs` value was multiple GB. No merge/block-size setting can fix that; the fix has to be at write time.

Source: `evaluation-run.clickhouse.repository.ts` → `Inputs: data.inputs ? JSON.stringify(data.inputs) : null` with no size bound.

## Fix

Cap the unbounded payload columns (`Inputs`, `Details`, `Error`, `ErrorDetails`) at **8 MiB** on write, so every row stays trivially mergeable:

- **Free-text** (`Details`/`Error`/`ErrorDetails`) → truncated with an observable `[truncated: …]` marker.
- **`Inputs`** (JSON) → replaced with a valid-JSON marker object (`{ __truncated: true, originalBytes, cap }`) so the column stays parseable.
- Both emit a structured `warn` so a recurrence is visible, not silent.

8 MiB is far above any legitimate evaluator payload (the offending partition averaged well under 1 MiB/row) while guaranteeing mergeability. Mirrors the existing `MAX_MESSAGE_CONTENT_BYTES` / `capOversizedString` idiom in the simulation projection.

## Scope / not included

- **Prevention only.** This stops *new* unmergeable rows. The existing pre-fix partition still has the stuck merge and needs a separate, deliberate prod operation (it can't be cleared by a block-size ALTER, and identifying the giant rows reads `Inputs` → OOM). Tracked separately.

## Test plan

- New unit test `evaluation-run.payload-cap.unit.test.ts` — 8 cases: null passthrough, under/at cap unchanged, oversized text truncation (bounded + marker), multibyte byte-vs-char correctness, `Inputs` null handling, small-input serialization, oversized `Inputs` → valid-JSON marker under cap. **8/8 pass.**
- `tslsp` diagnostics clean on all changed files.