### PR TITLE
fix(retention): orphan-sweep jobId must be ':'-free; never run the sweep inline

### DIFF
--- a/dev/docs/adr/023-orphan-sweep-reactor-chain.md
+++ b/dev/docs/adr/023-orphan-sweep-reactor-chain.md
@@ -69,7 +69,7 @@ worker.on("completed") listener  ───────────┘
 | Component | File | Owns |
 |---|---|---|
 | `createRetentionOrphanSweepReactor` | `data-retention/orphan-sweep/retentionOrphanSweep.reactor.ts` | Fires on every trace event. Seeds the chain only — does not sweep. Short-circuits on `INDEFINITE_RETENTION_DAYS` (nothing will TTL → nothing to sweep). |
-| `seedOrphanSweepChain(tenantId, { delayMs? })` | `background/queues/orphanSweepChainQueue.ts` | Adds a chain job with stable `jobId = orphan-sweep-chain:${tenantId}`. Dedup-by-jobId is the canonical 24h gate. |
+| `seedOrphanSweepChain(tenantId, { delayMs? })` | `background/queues/orphanSweepChainQueue.ts` | Adds a chain job with stable `jobId = orphan-sweep-chain-${tenantId}` (':'-free — BullMQ rejects ':' in custom job ids). Dedup-by-jobId is the canonical 24h gate. Best-effort: a failed enqueue is logged and dropped, never run inline (the queue is configured `fallbackToInline: false`). |
 | `runOrphanSweepChainJob` | `background/workers/orphanSweepChainWorker.ts` | One step: project lookup → archive/deleted check → `sweepProject`. Returns `{ stopChain }`. |
 | `handleChainStepCompleted` | same file | Self-perpetuates: on `stopChain=false`, re-seeds with `delay=24h`. Extracted from the worker listener for unit testability. |
 | `OrphanSweepService.sweepProject` | `data-retention/orphan-sweep/orphanSweep.service.ts` | Cursor-paginated candidate walk; per-tenant; bounded batches. |

--- a/langwatch/src/server/background/queues/__tests__/orphanSweepChainQueue.unit.test.ts
+++ b/langwatch/src/server/background/queues/__tests__/orphanSweepChainQueue.unit.test.ts
@@ -28,10 +28,17 @@ describe("orphanSweepChainJobId", () => {
     expect(orphanSweepChainJobId("abc123")).toContain("abc123");
   });
 
-  // Regression: ':' made BullMQ reject the add ("Custom Ids cannot contain :"),
+  // Regression: ':' made BullMQ reject the add ("Custom Id cannot contain :"),
   // which fell back to running the sweep inline per ingestion event.
   it("contains no ':' character", () => {
     expect(orphanSweepChainJobId("tenant-1")).not.toContain(":");
+  });
+
+  // TenantIdSchema only trims + requires non-empty; it does NOT forbid ':'.
+  // A tenantId that ever contained ':' would otherwise reintroduce the rejected
+  // add. The jobId must stay ':'-free regardless of the tenantId's contents.
+  it("stays ':'-free even when the tenant id contains ':'", () => {
+    expect(orphanSweepChainJobId("ten:ant:1")).not.toContain(":");
   });
 });
 

--- a/langwatch/src/server/background/queues/__tests__/orphanSweepChainQueue.unit.test.ts
+++ b/langwatch/src/server/background/queues/__tests__/orphanSweepChainQueue.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+// No Redis in unit env → QueueWithFallback takes its no-connection path.
+vi.mock("../../../redis", () => ({ connection: undefined }));
+
+// Keep the worker import light and observable so we can assert it is never run
+// inline when seeding fails.
+const { runOrphanSweepChainJob } = vi.hoisted(() => ({
+  runOrphanSweepChainJob: vi.fn(),
+}));
+vi.mock("../../workers/orphanSweepChainWorker", () => ({
+  runOrphanSweepChainJob,
+}));
+
+import {
+  orphanSweepChainJobId,
+  seedOrphanSweepChain,
+} from "../orphanSweepChainQueue";
+
+describe("orphanSweepChainJobId", () => {
+  it("is stable per tenant", () => {
+    expect(orphanSweepChainJobId("tenant-1")).toBe(
+      orphanSweepChainJobId("tenant-1"),
+    );
+  });
+
+  it("includes the tenant id", () => {
+    expect(orphanSweepChainJobId("abc123")).toContain("abc123");
+  });
+
+  // Regression: ':' made BullMQ reject the add ("Custom Ids cannot contain :"),
+  // which fell back to running the sweep inline per ingestion event.
+  it("contains no ':' character", () => {
+    expect(orphanSweepChainJobId("tenant-1")).not.toContain(":");
+  });
+});
+
+describe("seedOrphanSweepChain", () => {
+  it("is best-effort: swallows enqueue failure and never runs the sweep inline", async () => {
+    // No connection + fallbackToInline:false ⇒ add() throws. The seed must
+    // catch it (so it never reaches the ingestion path) and must NOT invoke the
+    // worker synchronously inline.
+    await expect(seedOrphanSweepChain("tenant-1")).resolves.toBeUndefined();
+    expect(runOrphanSweepChainJob).not.toHaveBeenCalled();
+  });
+});

--- a/langwatch/src/server/background/queues/__tests__/queueWithFallback.unit.test.ts
+++ b/langwatch/src/server/background/queues/__tests__/queueWithFallback.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Force the no-connection path so we exercise the inline-fallback decision
+// without a real Redis.
+vi.mock("../../../redis", () => ({ connection: undefined }));
+
+import { QueueWithFallback } from "../queueWithFallback";
+
+describe("QueueWithFallback inline-fallback gating", () => {
+  it("runs the worker inline when unavailable and fallback is enabled (default)", async () => {
+    const worker = vi.fn().mockResolvedValue("done");
+    const queue = new QueueWithFallback<{ x: number }, string, string>(
+      "q-default",
+      worker,
+      {},
+    );
+
+    const result = await queue.add("job", { x: 1 });
+
+    expect(worker).toHaveBeenCalledTimes(1);
+    expect(result).toBe("done");
+  });
+
+  it("throws instead of running inline when fallback is disabled", async () => {
+    const worker = vi.fn().mockResolvedValue("done");
+    const queue = new QueueWithFallback<{ x: number }, string, string>(
+      "q-no-inline",
+      worker,
+      {},
+      { fallbackToInline: false },
+    );
+
+    await expect(queue.add("job", { x: 1 })).rejects.toThrow();
+    expect(worker).not.toHaveBeenCalled();
+  });
+});

--- a/langwatch/src/server/background/queues/__tests__/queueWithFallback.unit.test.ts
+++ b/langwatch/src/server/background/queues/__tests__/queueWithFallback.unit.test.ts
@@ -1,36 +1,130 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Force the no-connection path so we exercise the inline-fallback decision
-// without a real Redis.
-vi.mock("../../../redis", () => ({ connection: undefined }));
+// Mutable Redis "connection" state. QueueWithFallback reads `connection` from
+// the redis module to decide between its enqueue path (connection present) and
+// its inline-fallback short-circuit (no connection). A getter keeps the binding
+// live so each test can flip it.
+const redisState = vi.hoisted(() => ({
+  connection: undefined as Record<string, unknown> | undefined,
+}));
+vi.mock("../../../redis", () => ({
+  get connection() {
+    return redisState.connection;
+  },
+}));
+
+// Stub BullMQ's Queue/Job so we never touch a real Redis. `enqueue` stands in
+// for the inner `Queue.add` that QueueWithFallback wraps — tests drive it to
+// reject to simulate BullMQ rejecting the job (e.g. the ":"-in-jobId rejection
+// that caused the incident). Everything else (telemetry, etc.) stays real.
+const { enqueue } = vi.hoisted(() => ({ enqueue: vi.fn() }));
+vi.mock("bullmq", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("bullmq")>();
+  class Queue {
+    name: string;
+    constructor(name: string) {
+      this.name = name;
+    }
+    add(...args: unknown[]) {
+      return enqueue(...args);
+    }
+  }
+  class Job {
+    constructor(
+      public queue: unknown,
+      public name: string,
+      public data: unknown,
+      public opts: unknown,
+    ) {}
+  }
+  return { ...actual, Queue, Job };
+});
 
 import { QueueWithFallback } from "../queueWithFallback";
 
+const buildQueue = (
+  worker: () => Promise<unknown>,
+  behavior?: { fallbackToInline?: boolean },
+) =>
+  new QueueWithFallback<{ x: number }, string, string>(
+    "q",
+    worker,
+    undefined,
+    behavior,
+  );
+
 describe("QueueWithFallback inline-fallback gating", () => {
-  it("runs the worker inline when unavailable and fallback is enabled (default)", async () => {
-    const worker = vi.fn().mockResolvedValue("done");
-    const queue = new QueueWithFallback<{ x: number }, string, string>(
-      "q-default",
-      worker,
-      undefined,
-    );
-
-    const result = await queue.add("job", { x: 1 });
-
-    expect(worker).toHaveBeenCalledTimes(1);
-    expect(result).toBe("done");
+  afterEach(() => {
+    enqueue.mockReset();
   });
 
-  it("throws instead of running inline when fallback is disabled", async () => {
-    const worker = vi.fn().mockResolvedValue("done");
-    const queue = new QueueWithFallback<{ x: number }, string, string>(
-      "q-no-inline",
-      worker,
-      undefined,
-      { fallbackToInline: false },
-    );
+  describe("given the queue has no Redis connection", () => {
+    beforeEach(() => {
+      redisState.connection = undefined;
+    });
 
-    await expect(queue.add("job", { x: 1 })).rejects.toThrow();
-    expect(worker).not.toHaveBeenCalled();
+    describe("when inline fallback is enabled (default)", () => {
+      it("runs the worker inline and returns its result", async () => {
+        const worker = vi.fn().mockResolvedValue("done");
+
+        const result = await buildQueue(worker).add("job", { x: 1 });
+
+        expect(worker).toHaveBeenCalledTimes(1);
+        expect(result).toBe("done");
+        expect(enqueue).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when inline fallback is disabled", () => {
+      it("throws and never runs the worker", async () => {
+        const worker = vi.fn().mockResolvedValue("done");
+        const queue = buildQueue(worker, { fallbackToInline: false });
+
+        await expect(queue.add("job", { x: 1 })).rejects.toThrow();
+        expect(worker).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // The prod incident path: Redis WAS available, but BullMQ rejected the add
+  // because the jobId contained ":". The wrapper's catch branch then ran the
+  // heavy worker inline once per ingestion event. These cases lock that branch.
+  describe("given the queue has a Redis connection but the enqueue fails", () => {
+    beforeEach(() => {
+      // Fake-timer the 3s enqueue-timeout race so the rejection resolves via
+      // microtasks and no real timer lingers past the (instant) test.
+      vi.useFakeTimers();
+      redisState.connection = {};
+      enqueue.mockRejectedValue(new Error("Custom Id cannot contain :"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    describe("when inline fallback is enabled (default)", () => {
+      it("falls back to running the worker inline", async () => {
+        const worker = vi.fn().mockResolvedValue("done");
+
+        const result = await buildQueue(worker).add("job", { x: 1 });
+
+        expect(enqueue).toHaveBeenCalledTimes(1);
+        expect(worker).toHaveBeenCalledTimes(1);
+        expect(result).toBe("done");
+      });
+    });
+
+    describe("when inline fallback is disabled", () => {
+      it("rethrows the enqueue error and never runs the worker inline", async () => {
+        const worker = vi.fn().mockResolvedValue("done");
+        const queue = buildQueue(worker, { fallbackToInline: false });
+
+        await expect(queue.add("job", { x: 1 })).rejects.toThrow(
+          "Custom Id cannot contain :",
+        );
+        expect(enqueue).toHaveBeenCalledTimes(1);
+        expect(worker).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/langwatch/src/server/background/queues/__tests__/queueWithFallback.unit.test.ts
+++ b/langwatch/src/server/background/queues/__tests__/queueWithFallback.unit.test.ts
@@ -12,7 +12,7 @@ describe("QueueWithFallback inline-fallback gating", () => {
     const queue = new QueueWithFallback<{ x: number }, string, string>(
       "q-default",
       worker,
-      {},
+      undefined,
     );
 
     const result = await queue.add("job", { x: 1 });
@@ -26,7 +26,7 @@ describe("QueueWithFallback inline-fallback gating", () => {
     const queue = new QueueWithFallback<{ x: number }, string, string>(
       "q-no-inline",
       worker,
-      {},
+      undefined,
       { fallbackToInline: false },
     );
 

--- a/langwatch/src/server/background/queues/orphanSweepChainQueue.ts
+++ b/langwatch/src/server/background/queues/orphanSweepChainQueue.ts
@@ -21,13 +21,20 @@ export const ORPHAN_SWEEP_CHAIN_INTERVAL_MS = 24 * 60 * 60 * 1000;
 /** Stable jobId per tenant. As long as a chain step exists for a tenant in
  *  any state (waiting/delayed/active), seed attempts dedup to that one job.
  *
- *  Must stay ':'-free: BullMQ rejects custom job ids containing ':'
- *  ("Custom Ids cannot contain :"). When the add was rejected,
- *  QueueWithFallback used to fall back to running the (heavy) sweep inline on
- *  the ingestion path — a per-trace-event read storm that took down prod. The
- *  in-memory dev/test queue allows ':', so this only ever fails on BullMQ. */
+ *  Must stay ':'-free: BullMQ rejects custom job ids that contain ':' unless
+ *  they split into exactly 3 segments ("Custom Id cannot contain :"). When the
+ *  add was rejected, QueueWithFallback used to fall back to running the (heavy)
+ *  sweep inline on the ingestion path — a per-trace-event read storm that took
+ *  down prod. The in-memory dev/test queue allows ':', so this only ever fails
+ *  on BullMQ.
+ *
+ *  `tenantId` is encoded because `TenantIdSchema` only trims + requires
+ *  non-empty — it does NOT forbid ':'. encodeURIComponent maps ':' → '%3A'
+ *  while leaving the alphanumeric/`-`/`_` project ids we actually issue
+ *  untouched, so the dedup key is unchanged in practice but can never
+ *  reintroduce the rejected-add failure mode for a pathological tenantId. */
 export function orphanSweepChainJobId(tenantId: string): string {
-  return `orphan-sweep-chain-${tenantId}`;
+  return `orphan-sweep-chain-${encodeURIComponent(tenantId)}`;
 }
 
 export const orphanSweepChainQueue = new QueueWithFallback<

--- a/langwatch/src/server/background/queues/orphanSweepChainQueue.ts
+++ b/langwatch/src/server/background/queues/orphanSweepChainQueue.ts
@@ -1,6 +1,7 @@
 import type { ConnectionOptions } from "bullmq";
 import type { OrphanSweepChainJob } from "~/server/background/types";
 
+import { createLogger } from "../../../utils/logger/server";
 import { connection } from "../../redis";
 import {
   type OrphanSweepChainOutcome,
@@ -11,40 +12,57 @@ import { QueueWithFallback } from "./queueWithFallback";
 
 export { ORPHAN_SWEEP_CHAIN_QUEUE } from "./constants";
 
+const logger = createLogger("langwatch:orphanSweepChainQueue");
+
 /** 24h between chain steps. The worker re-enqueues itself with this delay
  *  on every successful run — that's why this is a chain, not a cron. */
 export const ORPHAN_SWEEP_CHAIN_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /** Stable jobId per tenant. As long as a chain step exists for a tenant in
- *  any state (waiting/delayed/active), seed attempts dedup to that one job. */
+ *  any state (waiting/delayed/active), seed attempts dedup to that one job.
+ *
+ *  Must stay ':'-free: BullMQ rejects custom job ids containing ':'
+ *  ("Custom Ids cannot contain :"). When the add was rejected,
+ *  QueueWithFallback used to fall back to running the (heavy) sweep inline on
+ *  the ingestion path — a per-trace-event read storm that took down prod. The
+ *  in-memory dev/test queue allows ':', so this only ever fails on BullMQ. */
 export function orphanSweepChainJobId(tenantId: string): string {
-  return `orphan-sweep-chain:${tenantId}`;
+  return `orphan-sweep-chain-${tenantId}`;
 }
 
 export const orphanSweepChainQueue = new QueueWithFallback<
   OrphanSweepChainJob,
   OrphanSweepChainOutcome,
   string
->(ORPHAN_SWEEP_CHAIN_QUEUE.NAME, runOrphanSweepChainJob, {
-  connection: connection as ConnectionOptions,
-  defaultJobOptions: {
-    backoff: { type: "exponential", delay: 5000 },
-    attempts: 3,
-    // Remove finished jobs atomically. BullMQ's `jobId` uniqueness spans
-    // ALL states including `completed` / `failed` — if we held the
-    // completed history with `age: …`, the listener's re-enqueue (same
-    // jobId, +24h delay) would dedup against the still-resident
-    // completed job and silently no-op, killing the chain after one run.
-    //
-    // The 24h dedup property we need for bursty ingest is still upheld:
-    // between chain steps, the next job lives in `delayed` state holding
-    // the jobId. Ingest re-seeds during that window are no-ops. Job
-    // history visibility lives in our logger + posthog capture, not the
-    // queue's retention window.
-    removeOnComplete: true,
-    removeOnFail: true,
+>(
+  ORPHAN_SWEEP_CHAIN_QUEUE.NAME,
+  runOrphanSweepChainJob,
+  {
+    connection: connection as ConnectionOptions,
+    defaultJobOptions: {
+      backoff: { type: "exponential", delay: 5000 },
+      attempts: 3,
+      // Remove finished jobs atomically. BullMQ's `jobId` uniqueness spans
+      // ALL states including `completed` / `failed` — if we held the
+      // completed history with `age: …`, the listener's re-enqueue (same
+      // jobId, +24h delay) would dedup against the still-resident
+      // completed job and silently no-op, killing the chain after one run.
+      //
+      // The 24h dedup property we need for bursty ingest is still upheld:
+      // between chain steps, the next job lives in `delayed` state holding
+      // the jobId. Ingest re-seeds during that window are no-ops. Job
+      // history visibility lives in our logger + posthog capture, not the
+      // queue's retention window.
+      removeOnComplete: true,
+      removeOnFail: true,
+    },
   },
-});
+  // The orphan sweep is a 24h-cadence maintenance reactor seeded from the
+  // ingestion path. It must NEVER run synchronously inline when an enqueue
+  // fails — doing so turns any queue failure (a bad jobId, a Redis blip) into
+  // a per-event sweep storm. Seeding is best-effort instead (see below).
+  { fallbackToInline: false },
+);
 
 /**
  * Seed (or no-op into) the per-tenant chain. Called by:
@@ -59,12 +77,23 @@ export async function seedOrphanSweepChain(
   tenantId: string,
   opts?: { delayMs?: number },
 ): Promise<void> {
-  await orphanSweepChainQueue.add(
-    ORPHAN_SWEEP_CHAIN_QUEUE.JOB,
-    { tenantId },
-    {
-      jobId: orphanSweepChainJobId(tenantId),
-      delay: opts?.delayMs ?? 0,
-    },
-  );
+  try {
+    await orphanSweepChainQueue.add(
+      ORPHAN_SWEEP_CHAIN_QUEUE.JOB,
+      { tenantId },
+      {
+        jobId: orphanSweepChainJobId(tenantId),
+        delay: opts?.delayMs ?? 0,
+      },
+    );
+  } catch (error) {
+    // Best-effort: a failed seed must never propagate into — or run inline on —
+    // the ingestion hot path. The chain self-heals: ingestion re-seeds on the
+    // next trace event, and the worker's completed-listener re-seeds the next
+    // link. Losing one seed attempt only delays a maintenance sweep.
+    logger.warn(
+      { error, tenantId },
+      "failed to seed orphan-sweep chain (best-effort; will be re-seeded next cycle)",
+    );
+  }
 }

--- a/langwatch/src/server/background/queues/queueWithFallback.ts
+++ b/langwatch/src/server/background/queues/queueWithFallback.ts
@@ -35,11 +35,26 @@ export class QueueWithFallback<
 > {
   private worker: (job: Job<DataType, ResultType, NameType>) => Promise<any>;
   private tracer = getLangWatchTracer("langwatch.queueWithFallback");
+  private fallbackToInline: boolean;
 
   constructor(
     name: string,
     worker: (job: Job<DataType, ResultType, NameType>) => Promise<any>,
     opts?: QueueOptions,
+    behavior?: {
+      /**
+       * When the queue is unavailable (no Redis connection, enqueue error or
+       * timeout), run the worker synchronously inline on the caller's path.
+       * Defaults to `true` — the resilience behaviour latency-critical queues
+       * (collector, evaluations, …) rely on.
+       *
+       * Set `false` for heavy, non-latency-critical maintenance jobs that must
+       * never run inline: inline execution turns a queue failure (a bad jobId,
+       * a Redis blip) into a per-caller-event storm. With it off, `add` throws
+       * instead of running inline, so the caller can drop the work.
+       */
+      fallbackToInline?: boolean;
+    },
   ) {
     // Add BullMQ OTel instrumentation for automatic trace context propagation
     const optsWithTelemetry: QueueOptions = {
@@ -48,6 +63,7 @@ export class QueueWithFallback<
     } as QueueOptions;
     super(name, optsWithTelemetry, connection ? undefined : (NoOpConnection as any));
     this.worker = worker;
+    this.fallbackToInline = behavior?.fallbackToInline ?? true;
   }
 
   async add(
@@ -76,6 +92,11 @@ export class QueueWithFallback<
         } as JobDataWithContext<DataType>;
 
         if (!connection) {
+          if (!this.fallbackToInline) {
+            throw new Error(
+              `Queue ${this.name} has no Redis connection and inline fallback is disabled`,
+            );
+          }
           await new Promise((resolve) => setTimeout(resolve, opts?.delay ?? 0));
           // Restore context when executing fallback worker
           const requestContext = createContextFromJobData(contextMetadata);
@@ -119,6 +140,19 @@ export class QueueWithFallback<
 
           return job as Job<DataType, ResultType, NameType>;
         } catch (error) {
+          if (!this.fallbackToInline) {
+            logger.warn(
+              {
+                error,
+                jobId: opts?.jobId,
+                queueName: this.name,
+                projectId: contextMetadata.projectId,
+              },
+              `failed sending to redis ${this.name}; inline fallback disabled, rethrowing`,
+            );
+            throw error;
+          }
+
           logger.warn(
             { error, projectId: contextMetadata.projectId },
             `failed sending to redis ${this.name} inserting trace directly, attempting to process job synchronously`,

--- a/specs/data-retention/orphan-sweep.feature
+++ b/specs/data-retention/orphan-sweep.feature
@@ -20,7 +20,8 @@ Feature: PG orphan sweep for retention-deleted traces
     Given the tenant has no orphan-sweep chain step in the queue
     When a trace event is ingested
     Then the ingestion reactor enqueues a chain step for this tenant
-    And the chain step has a stable jobId of the form "orphan-sweep-chain:<tenantId>"
+    And the chain step has a stable jobId of the form "orphan-sweep-chain-<tenantId>"
+    And the jobId contains no ":" character, which BullMQ rejects in custom job ids
 
   Scenario: Concurrent ingest from the same tenant dedups to a single chain step
     Given a chain step is already queued for the tenant


### PR DESCRIPTION
## Why

The retention orphan-sweep chain seeded a BullMQ job with:

```ts
jobId = `orphan-sweep-chain:${tenantId}`
```

**BullMQ rejects `:` in custom job ids** (`Custom Id cannot contain :`), so every `add()` threw. `QueueWithFallback.add()` caught the error and — by design, for transient Redis outages — ran the worker **synchronously inline on the caller's path**. For orphan-sweep that worker is `sweepProject` (heavy ClickHouse reads), and the caller is the **ingestion reactor**, so it ran a full sweep **once per trace event**. That hammered ClickHouse and stalled ingestion during the incident.

It slipped through because the **in-memory dev/test queue allows `:`** (`event-sourcing/queues/memory.ts` even uses `:` in its own ids) — only BullMQ (prod) rejects it. (Strictly, BullMQ rejects `:` unless the id splits into exactly 3 segments; the 2-segment `orphan-sweep-chain:<tenant>` fails.)

## Fix

1. **`jobId` is now `:`-free** — the root cause. Separator `:` → `-`, and the `tenantId` is `encodeURIComponent`-encoded. `TenantIdSchema` only trims + requires non-empty — it does **not** forbid `:`, so a pathological tenantId could otherwise reintroduce the rejected add. Encoding is a no-op for the alphanumeric/`-`/`_` project ids we actually issue, so the dedup key is unchanged in practice. Restores the intended async 24h dedup chain.
2. **`QueueWithFallback` gains an opt-in `fallbackToInline` flag** (default `true`, so collector/evaluations/etc. are unchanged). The orphan-sweep queue sets it **`false`**: a heavy, non-latency-critical maintenance reactor must never run inline when enqueue fails — that's what turns a queue hiccup (bad id, Redis blip) into a per-event storm. With it off, `add()` throws instead of running inline.
3. **`seedOrphanSweepChain` is now best-effort** — a failed seed is logged and dropped, never propagated to (or run inline on) the ingestion path. The chain self-heals: ingestion re-seeds on the next event, and the completed-listener re-seeds the next link.
4. **Spec + ADR** updated to the `:`-free jobId and the best-effort/no-inline semantics.

## Defense in depth

Fix (1) alone stops the current storm (enqueue succeeds again). Fixes (2)+(3) ensure this *failure mode* — a heavy job running inline on the hot path — can't recur from any future enqueue failure.

## Test plan

- `orphanSweepChainQueue.unit.test.ts` — jobId is `:`-free, stable per tenant, includes the tenant id, **and stays `:`-free even when the tenantId itself contains `:`**; `seedOrphanSweepChain` swallows an enqueue failure and **does not** run the worker inline.
- `queueWithFallback.unit.test.ts` — nested given/when BDD covering both failure modes: **no Redis connection** (inline by default; throws when `fallbackToInline:false`) and **Redis present but BullMQ rejects `add()`** — the actual incident path — (inline by default; rethrows + worker never runs inline when `fallbackToInline:false`). BullMQ `Queue`/`Job` are stubbed so no Redis is needed; fake timers keep the 3s enqueue-timeout race instant.
- 9/9 pass; `pnpm typecheck` clean on all changed files.

## Context

Part of the retention incident follow-ups. Independent of #4517 (evaluation_runs payload cap) and the open `_size_bytes` PR #4515. Workers are currently pinned to the pre-incident image; this is what lets them safely roll forward again.
