### PR TITLE
perf(clickhouse): prune event_log partitions on time-local aggregate rehydration

### DIFF
--- a/langwatch/src/server/event-sourcing/projections/abstractFoldProjection.ts
+++ b/langwatch/src/server/event-sourcing/projections/abstractFoldProjection.ts
@@ -1,16 +1,16 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Event } from "../domain/types";
+import {
+  type DotSnakeToPascal,
+  type EventTypeOf,
+  eventTypeToHandlerName,
+  type StripPrefix,
+  type UnionToIntersection,
+} from "./eventTypeTransforms";
 import type {
   FoldProjectionOptions,
   FoldProjectionStore,
 } from "./foldProjection.types";
-import {
-  type EventTypeOf,
-  type StripPrefix,
-  type DotSnakeToPascal,
-  type UnionToIntersection,
-  eventTypeToHandlerName,
-} from "./eventTypeTransforms";
 
 // ---------------------------------------------------------------------------
 // Schema → event type extraction
@@ -26,7 +26,13 @@ export type AnyEventSchema = z.ZodObject<
 // ---------------------------------------------------------------------------
 
 /** All possible timestamp keys. Forbidden in `initState()` return type. */
-type AllTimestampKeys = "CreatedAt" | "UpdatedAt" | "createdAt" | "updatedAt" | "LastEventOccurredAt" | "LastEventOccurredAt";
+type AllTimestampKeys =
+  | "CreatedAt"
+  | "UpdatedAt"
+  | "createdAt"
+  | "updatedAt"
+  | "LastEventOccurredAt"
+  | "LastEventOccurredAt";
 
 /** Full derivation: `"lw.suite_run.started"` → `"handleSuiteRunStarted"` */
 type HandlerName<EventTypeStr extends string> =
@@ -111,10 +117,15 @@ export abstract class AbstractFoldProjection<
     createdAtKey,
     updatedAtKey,
     LastEventOccurredAtKey,
-  }: { createdAtKey?: CK; updatedAtKey?: UK; LastEventOccurredAtKey?: LEOAK } = {}) {
+  }: {
+    createdAtKey?: CK;
+    updatedAtKey?: UK;
+    LastEventOccurredAtKey?: LEOAK;
+  } = {}) {
     this.createdAtKey = createdAtKey ?? ("CreatedAt" as CK);
     this.updatedAtKey = updatedAtKey ?? ("UpdatedAt" as UK);
-    this.LastEventOccurredAtKey = LastEventOccurredAtKey ?? ("LastEventOccurredAt" as LEOAK);
+    this.LastEventOccurredAtKey =
+      LastEventOccurredAtKey ?? ("LastEventOccurredAt" as LEOAK);
   }
 
   /**
@@ -139,7 +150,13 @@ export abstract class AbstractFoldProjection<
    * Loads all events for an aggregate, sorted by occurredAt ASC.
    * When provided, the executor re-folds from scratch if an out-of-order event is detected.
    */
-  eventLoader?: (context: { tenantId: string; aggregateId: string }) => Promise<Event[]>;
+  eventLoader?: (context: {
+    tenantId: string;
+    aggregateId: string;
+    /** occurredAt (ms) of the event that triggered the re-fold, used to
+     * lower-bound the event_log rehydration scan for time-local aggregates. */
+    occurredAtMs?: number;
+  }) => Promise<Event[]>;
 
   /** Lazily-built dispatch map: event type string → handler method name. */
   private _dispatchMap?: Record<string, string>;
@@ -204,9 +221,10 @@ export abstract class AbstractFoldProjection<
     const nextUpdatedAt = Math.max(Date.now(), prevUpdatedAt + 1);
     const eventOccurredAt = (event as Record<string, unknown>).occurredAt;
     const prevLastOccurred: number = state[this.LastEventOccurredAtKey];
-    const nextLastOccurred = typeof eventOccurredAt === "number"
-      ? Math.max(prevLastOccurred, eventOccurredAt)
-      : prevLastOccurred;
+    const nextLastOccurred =
+      typeof eventOccurredAt === "number"
+        ? Math.max(prevLastOccurred, eventOccurredAt)
+        : prevLastOccurred;
     return {
       ...newState,
       [this.updatedAtKey]: nextUpdatedAt,

--- a/langwatch/src/server/event-sourcing/projections/foldProjection.types.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjection.types.ts
@@ -30,10 +30,7 @@ import type { ProjectionStoreContext } from "./projectionStoreContext";
  * };
  * ```
  */
-export interface FoldProjectionDefinition<
-  State,
-  E extends Event = Event,
-> {
+export interface FoldProjectionDefinition<State, E extends Event = Event> {
   /** Unique name for this projection within the pipeline. */
   name: string;
 
@@ -79,7 +76,13 @@ export interface FoldProjectionDefinition<
    * need to provide this themselves. Optional at the type level because it's set
    * after construction, but always present at runtime.
    */
-  eventLoader?: (context: { tenantId: string; aggregateId: string }) => Promise<Event[]>;
+  eventLoader?: (context: {
+    tenantId: string;
+    aggregateId: string;
+    /** occurredAt (ms) of the event that triggered the re-fold, used to
+     * lower-bound the event_log rehydration scan for time-local aggregates. */
+    occurredAtMs?: number;
+  }) => Promise<Event[]>;
 }
 
 /**
@@ -111,5 +114,8 @@ export interface FoldProjectionStore<State> {
   ): Promise<void>;
 
   /** Retrieves the stored state for an aggregate, or null if not found. */
-  get(aggregateId: string, context: ProjectionStoreContext): Promise<State | null>;
+  get(
+    aggregateId: string,
+    context: ProjectionStoreContext,
+  ): Promise<State | null>;
 }

--- a/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
+++ b/langwatch/src/server/event-sourcing/projections/foldProjectionExecutor.ts
@@ -30,10 +30,12 @@ export class FoldProjectionExecutor {
     }
 
     const key = context.key ?? context.aggregateId;
-    let state = await projection.store.get(key, context) ?? projection.init();
+    let state = (await projection.store.get(key, context)) ?? projection.init();
 
     // Capture the highest occurredAt before applying the new event.
-    const prevLastOccurred = (state as Record<string, unknown>)[projection.LastEventOccurredAtKey] ?? 0;
+    const prevLastOccurred =
+      (state as Record<string, unknown>)[projection.LastEventOccurredAtKey] ??
+      0;
 
     state = projection.apply(state, event);
 
@@ -60,6 +62,8 @@ export class FoldProjectionExecutor {
       const allEvents = await projection.eventLoader({
         tenantId: context.tenantId,
         aggregateId: context.aggregateId,
+        occurredAtMs:
+          typeof eventOccurredAt === "number" ? eventOccurredAt : undefined,
       });
 
       logger.info(
@@ -102,7 +106,9 @@ export class FoldProjectionExecutor {
     events: E[],
     context: ProjectionStoreContext,
   ): Promise<State> {
-    const matching = events.filter((event) => this.matchesEventTypes(projection, event));
+    const matching = events.filter((event) =>
+      this.matchesEventTypes(projection, event),
+    );
     if (matching.length === 0) {
       return projection.init();
     }
@@ -122,8 +128,10 @@ export class FoldProjectionExecutor {
     let state = (await projection.store.get(key, context)) ?? projection.init();
 
     const prevLastOccurred =
-      (state as Record<string, unknown>)[projection.LastEventOccurredAtKey] ?? 0;
-    const earliestOccurredAt = (ordered[0] as Record<string, unknown>).occurredAt;
+      (state as Record<string, unknown>)[projection.LastEventOccurredAtKey] ??
+      0;
+    const earliestOccurredAt = (ordered[0] as Record<string, unknown>)
+      .occurredAt;
 
     // Out-of-order vs the persisted checkpoint: the batch starts earlier than
     // what we've already folded. Re-fold from scratch when we can load the full
@@ -139,6 +147,10 @@ export class FoldProjectionExecutor {
       const allEvents = await projection.eventLoader({
         tenantId: context.tenantId,
         aggregateId: context.aggregateId,
+        occurredAtMs:
+          typeof earliestOccurredAt === "number"
+            ? earliestOccurredAt
+            : undefined,
       });
       logger.info(
         {
@@ -176,6 +188,9 @@ export class FoldProjectionExecutor {
     projection: FoldProjectionDefinition<State, E>,
     event: E,
   ): boolean {
-    return projection.eventTypes.length === 0 || projection.eventTypes.includes(event.type);
+    return (
+      projection.eventTypes.length === 0 ||
+      projection.eventTypes.includes(event.type)
+    );
   }
 }

--- a/langwatch/src/server/event-sourcing/services/eventSourcingService.ts
+++ b/langwatch/src/server/event-sourcing/services/eventSourcingService.ts
@@ -1,19 +1,22 @@
+import { performance } from "node:perf_hooks";
 import { SpanKind } from "@opentelemetry/api";
 import { getLangWatchTracer } from "langwatch";
+import { leanForProjection } from "~/server/app-layer/traces/lean-for-projection";
 import type { FeatureFlagServiceInterface } from "~/server/featureFlag";
-import { performance } from "node:perf_hooks";
-import { createLogger } from "~/utils/logger/server";
 import {
   eventSourcingStoreDurationHistogram,
   getEventSourcingEventsStoredCounter,
 } from "~/server/metrics";
+import { createLogger } from "~/utils/logger/server";
 import type { AggregateType } from "../domain/aggregateType";
 import { createTenantId } from "../domain/tenantId";
 import type { Event, Projection } from "../domain/types";
 import type { ProjectionRegistry } from "../projections/projectionRegistry";
 import { ProjectionRouter } from "../projections/projectionRouter";
-import type { DeduplicationConfig, EventSourcedQueueProcessor } from "../queues";
-import type { JobRegistryEntry } from "./queues/queueManager";
+import type {
+  DeduplicationConfig,
+  EventSourcedQueueProcessor,
+} from "../queues";
 import type {
   EventStore,
   EventStoreReadContext,
@@ -23,8 +26,8 @@ import type {
   EventSourcingOptions,
   EventSourcingServiceOptions,
 } from "./eventSourcingService.types";
+import type { JobRegistryEntry } from "./queues/queueManager";
 import { QueueManager } from "./queues/queueManager";
-import { leanForProjection } from "~/server/app-layer/traces/lean-for-projection";
 
 /**
  * Main service that orchestrates event sourcing.
@@ -122,13 +125,20 @@ export class EventSourcingService<
         if (!fold.eventLoader && eventStore) {
           const capturedAggregateType = aggregateType;
           const capturedEventStore = eventStore;
-          fold.eventLoader = async (ctx: { tenantId: string; aggregateId: string }) => {
+          fold.eventLoader = async (ctx: {
+            tenantId: string;
+            aggregateId: string;
+            occurredAtMs?: number;
+          }) => {
             const events = await capturedEventStore.getEvents(
               ctx.aggregateId,
               { tenantId: createTenantId(ctx.tenantId) },
               capturedAggregateType,
+              ctx.occurredAtMs,
             );
-            return [...events].sort((a, b) => (a.occurredAt ?? 0) - (b.occurredAt ?? 0));
+            return [...events].sort(
+              (a, b) => (a.occurredAt ?? 0) - (b.occurredAt ?? 0),
+            );
           };
         }
         this.router.registerFoldProjection(fold);
@@ -166,7 +176,11 @@ export class EventSourcingService<
       this.router.initializeFoldQueues();
     }
 
-    if (globalQueue && ((reactors && reactors.length > 0) || (mapReactors && mapReactors.length > 0))) {
+    if (
+      globalQueue &&
+      ((reactors && reactors.length > 0) ||
+        (mapReactors && mapReactors.length > 0))
+    ) {
       this.router.initializeReactorQueues();
     }
 
@@ -247,7 +261,9 @@ export class EventSourcingService<
         // ADR-022: Derive lean shapes for projection dispatch.
         // storeEvents has already persisted the FULL events to event_log.
         // Map to new array — do NOT mutate enrichedEvents in place.
-        const leanedEvents = enrichedEvents.map((e) => leanForProjection(e) as EventType);
+        const leanedEvents = enrichedEvents.map(
+          (e) => leanForProjection(e) as EventType,
+        );
 
         // Dispatch events to all projections (fold + map) via unified router
         if (
@@ -264,9 +280,17 @@ export class EventSourcingService<
                 error instanceof Error ? error.message : String(error),
             });
             if (this.logger) {
-              const subErrors = error instanceof AggregateError
-                ? error.errors.map((e: unknown) => e instanceof Error ? { message: e.message, stack: e.stack?.split("\n").slice(0, 3).join("\n") } : String(e))
-                : [];
+              const subErrors =
+                error instanceof AggregateError
+                  ? error.errors.map((e: unknown) =>
+                      e instanceof Error
+                        ? {
+                            message: e.message,
+                            stack: e.stack?.split("\n").slice(0, 3).join("\n"),
+                          }
+                        : String(e),
+                    )
+                  : [];
               this.logger.error(
                 {
                   aggregateType: this.aggregateType,

--- a/langwatch/src/server/event-sourcing/stores/__tests__/rehydrationWindow.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/__tests__/rehydrationWindow.unit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  REHYDRATION_WINDOW_MS,
+  rehydrationLowerBoundMs,
+  TIME_LOCAL_AGGREGATE_TYPES,
+} from "../rehydrationWindow";
+
+describe("rehydrationLowerBoundMs", () => {
+  const anchor = 1_700_000_000_000;
+
+  describe("when the aggregate type is time-local", () => {
+    it("returns the anchor minus the window for a trace", () => {
+      expect(rehydrationLowerBoundMs("trace", anchor)).toBe(
+        anchor - REHYDRATION_WINDOW_MS,
+      );
+    });
+
+    it("returns a bound for every time-local type", () => {
+      for (const type of TIME_LOCAL_AGGREGATE_TYPES) {
+        expect(rehydrationLowerBoundMs(type, anchor)).toBe(
+          anchor - REHYDRATION_WINDOW_MS,
+        );
+      }
+    });
+
+    it("never returns a negative bound", () => {
+      expect(rehydrationLowerBoundMs("trace", 1000)).toBe(0);
+    });
+  });
+
+  describe("when the aggregate type is long-lived", () => {
+    it("returns undefined (unbounded) for global and billing_report", () => {
+      expect(rehydrationLowerBoundMs("global", anchor)).toBeUndefined();
+      expect(rehydrationLowerBoundMs("billing_report", anchor)).toBeUndefined();
+    });
+
+    it("returns undefined for simulation_set", () => {
+      expect(rehydrationLowerBoundMs("simulation_set", anchor)).toBeUndefined();
+    });
+
+    it("excludes the long-lived types from the time-local set", () => {
+      expect(TIME_LOCAL_AGGREGATE_TYPES.has("global")).toBe(false);
+      expect(TIME_LOCAL_AGGREGATE_TYPES.has("billing_report")).toBe(false);
+      expect(TIME_LOCAL_AGGREGATE_TYPES.has("simulation_set")).toBe(false);
+    });
+  });
+
+  describe("when no usable anchor time is available", () => {
+    it("returns undefined for an undefined anchor", () => {
+      expect(rehydrationLowerBoundMs("trace", undefined)).toBeUndefined();
+    });
+
+    it("returns undefined for a zero or negative anchor", () => {
+      expect(rehydrationLowerBoundMs("trace", 0)).toBeUndefined();
+      expect(rehydrationLowerBoundMs("trace", -5)).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/stores/abstractEventStore.ts
+++ b/langwatch/src/server/event-sourcing/stores/abstractEventStore.ts
@@ -13,6 +13,7 @@ import {
   validateEventAggregateType,
   validateEventTenant,
 } from "./eventStoreUtils";
+import { rehydrationLowerBoundMs } from "./rehydrationWindow";
 import type {
   EventRecord,
   EventRepository,
@@ -143,6 +144,7 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
     aggregateId: string,
     context: EventStoreReadContext<EventType>,
     aggregateType: AggregateType,
+    anchorOccurredAtMs?: number,
   ): Promise<readonly EventType[]> {
     EventUtils.validateTenantId(context, `${this.constructor.name}.getEvents`);
 
@@ -154,6 +156,16 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
       );
       return [];
     }
+
+    // For time-local aggregate types, lower-bound the event_log scan to a
+    // window around the triggering work's time so ClickHouse prunes old weekly
+    // partitions instead of cold-scanning every partition on S3. Returns
+    // undefined (unbounded scan) for long-lived aggregate types or when no
+    // usable anchor time is available, so behaviour is unchanged there.
+    const occurredAtFromMs = rehydrationLowerBoundMs(
+      aggregateType,
+      anchorOccurredAtMs,
+    );
 
     return await this.instrument(
       `${this.constructor.name}.getEvents`,
@@ -168,6 +180,7 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
             context.tenantId,
             aggregateType,
             aggregateId,
+            occurredAtFromMs,
           );
 
           const events = records.map((record) =>

--- a/langwatch/src/server/event-sourcing/stores/eventStore.types.ts
+++ b/langwatch/src/server/event-sourcing/stores/eventStore.types.ts
@@ -67,6 +67,11 @@ export interface ReadOnlyEventStore<EventType extends Event = Event> {
    * @param aggregateId - The aggregate to fetch events for
    * @param context - Security context with required tenantId
    * @param aggregateType - The type of aggregate root (e.g., "trace", "user")
+   * @param anchorOccurredAtMs - Optional reference time (ms) of the work that
+   *   triggered this read. For time-local aggregate types it lets the store
+   *   lower-bound the scan to a window around this time so ClickHouse can prune
+   *   old partitions; it never changes the result set for such aggregates. See
+   *   `rehydrationLowerBoundMs`.
    * @returns Readonly array of events, typically ordered by timestamp
    * @throws {Error} If tenantId is missing or invalid
    *
@@ -77,6 +82,7 @@ export interface ReadOnlyEventStore<EventType extends Event = Event> {
     aggregateId: string,
     context: EventStoreReadContext<EventType>,
     aggregateType: AggregateType,
+    anchorOccurredAtMs?: number,
   ): Promise<readonly EventType[]>;
 
   /**

--- a/langwatch/src/server/event-sourcing/stores/rehydrationWindow.ts
+++ b/langwatch/src/server/event-sourcing/stores/rehydrationWindow.ts
@@ -1,0 +1,64 @@
+import type { AggregateType } from "../domain/aggregateType";
+
+/**
+ * Aggregate types whose events all fall within the aggregate's own lifetime
+ * (a single trace, evaluation, or run). For these, a rehydration scan of
+ * `event_log` can be safely lower-bounded to a window around the aggregate's
+ * time without ever excluding one of its events — which lets ClickHouse prune
+ * the weekly partitions older than the window instead of cold-scanning every
+ * partition on S3.
+ *
+ * Long-lived aggregates that accumulate events across all history are
+ * intentionally NOT listed and are always scanned unbounded:
+ *  - `global` and `billing_report` aggregate over arbitrary time ranges;
+ *  - `simulation_set` accumulates `simulation_run`s over its lifetime;
+ *  - `test_aggregate` is test-only.
+ *
+ * This list is the correctness contract for the optimisation: only add a type
+ * here if every event of such an aggregate is guaranteed to occur within
+ * REHYDRATION_WINDOW_MS of any other event of the same aggregate.
+ */
+export const TIME_LOCAL_AGGREGATE_TYPES: ReadonlySet<AggregateType> =
+  new Set<AggregateType>([
+    "trace",
+    "evaluation",
+    "experiment_run",
+    "simulation_run",
+    "suite_run",
+  ]);
+
+/**
+ * Lower-bound window subtracted from the anchor (the triggering event's
+ * occurredAt) when bounding a time-local aggregate's rehydration scan.
+ *
+ * Must be:
+ *  - LARGER than any time-local aggregate's lifetime, so no event is ever
+ *    excluded (a trace/eval/run spans seconds to hours, far under this); and
+ *  - SMALLER than `event_log` retention, so it actually prunes partitions.
+ *
+ * 45 days is a deliberately conservative default. Tune with care: the cost of
+ * making it too small is silently dropping events from a re-fold (corrupted
+ * projection), so it errs large.
+ */
+export const REHYDRATION_WINDOW_DAYS = 45;
+export const REHYDRATION_WINDOW_MS =
+  REHYDRATION_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+/**
+ * Returns the `EventOccurredAt` lower bound (ms) to apply to an aggregate's
+ * rehydration scan, or `undefined` when the scan must stay unbounded.
+ *
+ * Unbounded (returns undefined) when the aggregate type is not time-local, or
+ * when no usable anchor time is available — in both cases the caller falls back
+ * to the full, partition-spanning scan.
+ */
+export function rehydrationLowerBoundMs(
+  aggregateType: AggregateType,
+  anchorOccurredAtMs: number | undefined,
+): number | undefined {
+  if (!TIME_LOCAL_AGGREGATE_TYPES.has(aggregateType)) return undefined;
+  if (typeof anchorOccurredAtMs !== "number" || anchorOccurredAtMs <= 0) {
+    return undefined;
+  }
+  return Math.max(0, anchorOccurredAtMs - REHYDRATION_WINDOW_MS);
+}

--- a/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryClickHouse.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryClickHouse.test.ts
@@ -54,4 +54,45 @@ describe("EventRepositoryClickHouse.getEventRecords", () => {
       '{"data":{"value":"123.45","text":"still-string"}}',
     );
   });
+
+  describe("when an occurredAtFromMs lower bound is provided", () => {
+    it("adds the EventOccurredAt partition-prune predicate and binds the param", async () => {
+      const client = createMockClient({});
+      const repository = new EventRepositoryClickHouse(async () => client);
+
+      await repository.getEventRecords("tenant", "trace", "id", 1700000000000);
+
+      const call = (client.query as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(call.query).toContain(
+        "EventOccurredAt = 0 OR EventOccurredAt >= {occurredAtFromMs:UInt64}",
+      );
+      expect(call.query_params).toMatchObject({
+        occurredAtFromMs: 1700000000000,
+      });
+    });
+  });
+
+  describe("when no usable lower bound is provided", () => {
+    it("omits the EventOccurredAt predicate and the param", async () => {
+      const client = createMockClient({});
+      const repository = new EventRepositoryClickHouse(async () => client);
+
+      await repository.getEventRecords("tenant", "trace", "id");
+
+      const call = (client.query as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(call.query).not.toContain("EventOccurredAt >=");
+      expect(call.query_params).not.toHaveProperty("occurredAtFromMs");
+    });
+
+    it("treats a zero lower bound as unbounded", async () => {
+      const client = createMockClient({});
+      const repository = new EventRepositoryClickHouse(async () => client);
+
+      await repository.getEventRecords("tenant", "trace", "id", 0);
+
+      const call = (client.query as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(call.query).not.toContain("EventOccurredAt >=");
+      expect(call.query_params).not.toHaveProperty("occurredAtFromMs");
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.lowerBound.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/__tests__/eventRepositoryMemory.lowerBound.unit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { EventRecord } from "../eventRepository.types";
+import { EventRepositoryMemory } from "../eventRepositoryMemory";
+
+function record(eventId: string, occurredAt: number | null): EventRecord {
+  return {
+    TenantId: "tenant",
+    AggregateType: "trace",
+    AggregateId: "agg",
+    EventId: eventId,
+    EventTimestamp: occurredAt ?? 0,
+    EventOccurredAt: occurredAt,
+    EventType: "test.integration.event",
+    EventVersion: "1",
+    EventPayload: {},
+    ProcessingTraceparent: "",
+    IdempotencyKey: eventId,
+  };
+}
+
+describe("EventRepositoryMemory.getEventRecords lower bound", () => {
+  const bound = 1_700_000_000_000;
+
+  async function seeded() {
+    const repo = new EventRepositoryMemory();
+    await repo.insertEventRecords([
+      record("before", bound - 1000), // older than the bound
+      record("at", bound), // exactly at the bound
+      record("after", bound + 1000), // newer than the bound
+      record("unknown-time", 0), // unknown occurred time
+    ]);
+    return repo;
+  }
+
+  describe("when no lower bound is passed", () => {
+    it("returns every event", async () => {
+      const repo = await seeded();
+      const ids = (await repo.getEventRecords("tenant", "trace", "agg")).map(
+        (r) => r.EventId,
+      );
+      expect(new Set(ids)).toEqual(
+        new Set(["before", "at", "after", "unknown-time"]),
+      );
+    });
+  });
+
+  describe("when a lower bound is passed", () => {
+    it("keeps events at/after the bound and unknown-time events, drops older ones", async () => {
+      const repo = await seeded();
+      const ids = (
+        await repo.getEventRecords("tenant", "trace", "agg", bound)
+      ).map((r) => r.EventId);
+
+      expect(new Set(ids)).toEqual(new Set(["at", "after", "unknown-time"]));
+      expect(ids).not.toContain("before");
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepository.types.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepository.types.ts
@@ -29,11 +29,19 @@ export interface EventRepository {
   /**
    * Retrieves all event records for a given aggregate.
    * Returns raw records without validation or transformation.
+   *
+   * `occurredAtFromMs`, when provided, lower-bounds the scan to events with
+   * `EventOccurredAt >= occurredAtFromMs` (events with an unknown occurred time
+   * of 0 are always kept). Callers must only pass it when every event of the
+   * aggregate is guaranteed to be at or after that bound — see
+   * `rehydrationLowerBoundMs`. It is purely a partition-pruning optimisation and
+   * must never change the result set for a correctly-classified aggregate.
    */
   getEventRecords(
     tenantId: string,
     aggregateType: string,
     aggregateId: string,
+    occurredAtFromMs?: number,
   ): Promise<EventRecord[]>;
 
   /**

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryClickHouse.ts
@@ -21,7 +21,11 @@ function normalizePayloadValue(value: unknown): unknown {
     // Only convert numeric strings to numbers
     // Do NOT parse JSON strings - they should remain as strings
     // Simple length check to skip long strings early
-    if (value.length > 0 && value.length < 32 && NUMERIC_STRING_REGEX.test(value)) {
+    if (
+      value.length > 0 &&
+      value.length < 32 &&
+      NUMERIC_STRING_REGEX.test(value)
+    ) {
       const numberValue = Number(value);
       if (Number.isFinite(numberValue)) {
         return numberValue;
@@ -39,10 +43,8 @@ function normalizePayloadValue(value: unknown): unknown {
 
   if (value && typeof value === "object") {
     const obj = value as Record<string, unknown>;
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        obj[key] = normalizePayloadValue(obj[key]);
-      }
+    for (const key of Object.keys(obj)) {
+      obj[key] = normalizePayloadValue(obj[key]);
     }
     return obj;
   }
@@ -71,9 +73,22 @@ export class EventRepositoryClickHouse implements EventRepository {
     tenantId: string,
     aggregateType: string,
     aggregateId: string,
+    occurredAtFromMs?: number,
   ): Promise<EventRecord[]> {
     try {
       const client = await this.getClient(tenantId);
+      // When a lower bound is supplied, add a predicate on EventOccurredAt so
+      // ClickHouse can prune the weekly partitions older than the bound instead
+      // of cold-scanning every partition on S3. Rows with an unknown occurred
+      // time (EventOccurredAt = 0) are always kept so the bound can never drop
+      // an event. EventOccurredAt is UInt64 milliseconds; the table is
+      // PARTITION BY toYearWeek(toDateTime64(EventOccurredAt / 1000, 3)), which
+      // is monotonic in EventOccurredAt so the predicate prunes partitions.
+      const hasLowerBound =
+        typeof occurredAtFromMs === "number" && occurredAtFromMs > 0;
+      const occurredAtFilter = hasLowerBound
+        ? "AND (EventOccurredAt = 0 OR EventOccurredAt >= {occurredAtFromMs:UInt64})"
+        : "";
       const result = await client.query({
         query: `
           SELECT
@@ -88,12 +103,14 @@ export class EventRepositoryClickHouse implements EventRepository {
           WHERE TenantId = {tenantId:String}
             AND AggregateType = {aggregateType:String}
             AND AggregateId = {aggregateId:String}
+            ${occurredAtFilter}
           ORDER BY EventTimestamp ASC, EventId ASC
         `,
         query_params: {
           tenantId,
           aggregateType,
           aggregateId: String(aggregateId),
+          ...(hasLowerBound ? { occurredAtFromMs } : {}),
         },
         format: "JSONEachRow",
       });
@@ -117,9 +134,10 @@ export class EventRepositoryClickHouse implements EventRepository {
         AggregateId: String(aggregateId),
         EventId: row.EventId,
         EventTimestamp: row.EventTimestamp,
-        EventOccurredAt: row.EventOccurredAt != null && row.EventOccurredAt > 0
-          ? row.EventOccurredAt
-          : null,
+        EventOccurredAt:
+          row.EventOccurredAt != null && row.EventOccurredAt > 0
+            ? row.EventOccurredAt
+            : null,
         EventType: row.EventType,
         EventVersion: row.EventVersion,
         EventPayload: normalizePayloadValue(row.EventPayload),
@@ -202,9 +220,10 @@ export class EventRepositoryClickHouse implements EventRepository {
         AggregateId: String(aggregateId),
         EventId: row.EventId,
         EventTimestamp: row.EventTimestamp,
-        EventOccurredAt: row.EventOccurredAt != null && row.EventOccurredAt > 0
-          ? row.EventOccurredAt
-          : null,
+        EventOccurredAt:
+          row.EventOccurredAt != null && row.EventOccurredAt > 0
+            ? row.EventOccurredAt
+            : null,
         EventType: row.EventType,
         EventVersion: row.EventVersion,
         EventPayload: normalizePayloadValue(row.EventPayload),
@@ -299,7 +318,6 @@ export class EventRepositoryClickHouse implements EventRepository {
         format: "JSONEachRow",
         clickhouse_settings: { async_insert: 1, wait_for_async_insert: 1 },
       });
-
     } catch (error) {
       this.logger.debug(
         {

--- a/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryMemory.ts
+++ b/langwatch/src/server/event-sourcing/stores/repositories/eventRepositoryMemory.ts
@@ -18,11 +18,24 @@ export class EventRepositoryMemory implements EventRepository {
     tenantId: string,
     aggregateType: string,
     aggregateId: string,
+    occurredAtFromMs?: number,
   ): Promise<EventRecord[]> {
     const key = `${tenantId}:${aggregateType}:${String(aggregateId)}`;
     const records = this.eventsByKey.get(key) ?? [];
+    // Mirror the ClickHouse lower-bound semantics so tests exercise the same
+    // behaviour: keep events at/after the bound, plus events with an unknown
+    // occurred time (EventOccurredAt 0 / null).
+    const hasLowerBound =
+      typeof occurredAtFromMs === "number" && occurredAtFromMs > 0;
+    const filtered = hasLowerBound
+      ? records.filter(
+          (record) =>
+            !record.EventOccurredAt ||
+            record.EventOccurredAt >= occurredAtFromMs,
+        )
+      : records;
     // Return a copy to prevent mutation
-    return records.map((record) => ({ ...record }));
+    return filtered.map((record) => ({ ...record }));
   }
 
   async getEventRecordsUpTo(


### PR DESCRIPTION
## Evidence

You investigated the late-May/June S3 cost spike on `langwatch-storage-clickhouse-prod` (the ClickHouse S3-disk store). The headline finding: the **Tier2 GET burst stays ~3x elevated even after the write/part-churn normalized** (6/02: ~69M GET/day, ~$30/day), i.e. heavy ongoing query traffic against S3-tiered partitions. Projected ~$1.6-2k/month if it continues.

Breaking down the cold-scan signal (queries on time-partitioned tables with no partition-time predicate) by table + param signature over 24h:

| count (24h) | coldScanTable | paramKeys |
| --- | --- | --- |
| **19,681** | `event_log` | `tenantId, aggregateType, aggregateId` |
| 1,219 | stored_spans | tenantId, traceId |
| 420 | stored_spans | tenantId, traceId, limit |
| ... | ... | (all remaining shapes < 300 each) |

One shape is ~94% of all cold scans: the event-sourcing aggregate rehydration. Each call walks every weekly partition of `event_log` on S3, so it is the dominant driver of the persistent GET burst.

## Suspected cause

`EventRepositoryClickHouse.getEventRecords` (used by the fold-projection re-fold path) filters only `TenantId + AggregateType + AggregateId` with no predicate on the partition column `EventOccurredAt`:

```
PARTITION BY toYearWeek(toDateTime64(EventOccurredAt / 1000, 3))
ORDER BY (TenantId, AggregateType, AggregateId, IdempotencyKey)
```

The sort key narrows to the aggregate's rows *within* each partition, but with no `EventOccurredAt` predicate ClickHouse cannot prune partitions, so it opens every weekly partition (many on S3) and most contribute zero rows. The re-fold (`foldProjectionExecutor`) already knows the triggering event's `occurredAt`, but it was not threaded into the read.

## Proposed fix

Rehydration of a **time-local** aggregate (`trace`, `evaluation`, `experiment_run`, `simulation_run`, `suite_run`) only needs events within the aggregate's own short lifetime. Thread the triggering event's `occurredAt` from the re-fold executor → `eventLoader` → `getEvents` → `getEventRecords`, and lower-bound the scan:

```sql
AND (EventOccurredAt = 0 OR EventOccurredAt >= {occurredAtFromMs:UInt64})
```

- The `EventOccurredAt = 0` arm keeps unknown-occurred-time rows so the bound can never drop an event.
- The classification + window live in `stores/rehydrationWindow.ts` (the correctness contract). Long-lived aggregate types (`global`, `billing_report`, `simulation_set`) and any read without a usable anchor stay **unbounded** — behaviour there is unchanged.
- Window is 45 days: it must exceed any time-local aggregate's lifetime (a trace/eval/run spans seconds to hours) and stay under `event_log` retention. It errs large; the failure mode of too-small is silently dropping events from a re-fold, so it is deliberately conservative.

No schema, migration, or infra change.

### Correctness contract (please confirm)

The optimisation is only safe because every event of a time-local aggregate occurs within `REHYDRATION_WINDOW_MS` of any other event of the same aggregate. The five listed types satisfy this; the long-lived types are excluded. A domain owner should sanity-check the list and the window against retention before merge.

## Expected impact

- For a time-local aggregate rehydration, the partitions opened drop sharply (see EXPLAIN), cutting the S3 GET volume that drives the cost. Since this shape is ~94% of cold scans, this targets the bulk of the persistent Tier2 GET burst.
- Latency may also improve (fewer S3 round-trips), but the headline metric here is S3 request cost, not latency.

## Test plan

- `rehydrationWindow.unit.test.ts`: the policy returns a bound for every time-local type, `undefined` for long-lived types and for a missing/zero anchor, and never negative.
- `eventRepositoryMemory.lowerBound.unit.test.ts`: the lower bound keeps events at/after the bound and unknown-time (`EventOccurredAt = 0`) events, and drops older ones.
- `eventRepositoryClickHouse.test.ts`: the CH query gains the `EventOccurredAt` predicate + bound param when a bound is supplied, and omits both when unbounded (incl. a zero bound).
- Full event-sourcing store/projection unit suites pass unchanged (162 tests), confirming the optional anchor threading is backward-compatible.

## EXPLAIN check

`EXPLAIN PLAN indexes = 1` on a real large tenant (id redacted), `AggregateType = 'trace'`:

```
old (no predicate):   Partition  Parts: 286/286   Granules: 89865/89865
new (with bound):     Partition  Parts:  48/288   Granules: 22117/89867
```

The new partition condition is `toYearWeek(...) >= 202616 (≈ 45 days ago) OR toYearWeek(...) = 196952 (the EventOccurredAt = 0 / 1970 partition)`. Partitions read drop from 286 to 48 (~83% pruned) while the unknown-time partition is correctly retained. The sort-key granule selection (TenantId/AggregateType/AggregateId) is unchanged.
