### PR TITLE
perf(clickhouse): drop FINAL from orphan-sweep trace existence check

### DIFF
--- a/langwatch/src/server/data-retention/__tests__/orphanSweep.unit.test.ts
+++ b/langwatch/src/server/data-retention/__tests__/orphanSweep.unit.test.ts
@@ -199,6 +199,65 @@ describe("OrphanSweepService", () => {
       expect(await cursorStore.load("project-1")).toBeUndefined();
     });
   });
+
+  describe("filterOrphanedTraceIds()", () => {
+    it("partitions the input into existing and orphaned by ClickHouse presence", async () => {
+      const service = new OrphanSweepService(
+        {} as any,
+        async () =>
+          ({
+            query: vi.fn().mockResolvedValue({
+              json: async () => [{ TraceId: "live" }],
+            }),
+          }) as any,
+      );
+
+      const result = await service.filterOrphanedTraceIds({
+        projectId: "project-1",
+        traceIds: ["live", "missing"],
+      });
+
+      expect(result.existing).toEqual(["live"]);
+      expect(result.orphaned).toEqual(["missing"]);
+    });
+
+    it("checks existence without FINAL (avoids the heavy replacing-merge OOM)", async () => {
+      const query = vi
+        .fn()
+        .mockResolvedValue({ json: async () => [] });
+      const service = new OrphanSweepService(
+        {} as any,
+        async () => ({ query }) as any,
+      );
+
+      await service.filterOrphanedTraceIds({
+        projectId: "project-1",
+        traceIds: ["a", "b"],
+      });
+
+      const sql: string = query.mock.calls[0]![0].query;
+      expect(sql).not.toMatch(/FINAL/);
+      expect(sql).toMatch(/SELECT DISTINCT TraceId/);
+    });
+
+    it("treats every id as existing when ClickHouse is unavailable (fail-safe, never deletes)", async () => {
+      const service = new OrphanSweepService(
+        {} as any,
+        async () =>
+          ({
+            query: vi.fn().mockRejectedValue(new Error("CH down")),
+          }) as any,
+      );
+
+      const result = await service.filterOrphanedTraceIds({
+        projectId: "project-1",
+        traceIds: ["a", "b"],
+      });
+
+      expect(result.existing).toEqual(["a", "b"]);
+      expect(result.orphaned).toEqual([]);
+    });
+  });
 });
 
 describe("createRetentionOrphanSweepReactor()", () => {

--- a/langwatch/src/server/data-retention/orphan-sweep/orphanSweep.service.ts
+++ b/langwatch/src/server/data-retention/orphan-sweep/orphanSweep.service.ts
@@ -45,10 +45,21 @@ export class OrphanSweepService {
 
     try {
       const client = await this.resolveClickHouseClient(projectId);
+      // This is purely an existence check: which of `traceIds` have at least one
+      // row in trace_summaries. trace_summaries is ReplacingMergeTree(UpdatedAt)
+      // with no soft-delete column, so FINAL only collapses duplicate versions —
+      // it never makes a TraceId appear or disappear. But FINAL forces a
+      // cross-partition replacing-merge (buffering merge state across every
+      // weekly partition that holds the tenant's data); run thousands of times a
+      // day by the sweep across many projects concurrently, that collectively
+      // exhausted the server memory limit (MEMORY_LIMIT_EXCEEDED in prod). The
+      // merge is pointless for an existence check, so drop FINAL and dedup the
+      // key with DISTINCT: the (TenantId, TraceId) sort key lets this read just
+      // the TraceId column for the matched keys, with no merge state.
       const result = await client.query({
         query: `
-          SELECT TraceId
-          FROM trace_summaries FINAL
+          SELECT DISTINCT TraceId
+          FROM trace_summaries
           WHERE TenantId = {tenantId:String} AND TraceId IN {traceIds:Array(String)}
         `,
         query_params: { tenantId: projectId, traceIds },


### PR DESCRIPTION
## Evidence

Over the last 24h, ClickHouse server `MEMORY_LIMIT_EXCEEDED` (Code 241) exceptions were dominated by a single shape — **~4,879 of ~5,000 sampled exceptions (≈98%)**:

```
SELECT TraceId FROM trace_summaries FINAL WHERE (TenantId = '<redacted>') AND (TraceId IN [<~1000 trace ids>])
```

The failures hit the **server-wide** memory ceiling (`would use ~9.9 GiB ... current RSS: 14.02 GiB, maximum: 14.00 GiB`), failing while reading sort-key columns (`TenantId` / `TraceId` / `UpdatedAt`) — i.e. the memory is `FINAL` merge state, not one heavy column. This is the orphan-sweep existence check (`OrphanSweepService.filterOrphanedTraceIds`), batching up to 1,000 traceIds and paging across many projects, so many run concurrently.

Secondary effect: when this query OOMs, the `catch` returns "all existing" (fail-safe so it never wrongly deletes), so **orphan cleanup silently stops** whenever the cluster is under memory pressure.

## Suspected cause

`filterOrphanedTraceIds` only needs to know **which of the given traceIds still have any row** in `trace_summaries` (it builds a `Set` and partitions into existing/orphaned). `trace_summaries` is `ReplacingMergeTree(UpdatedAt)` with **no soft-delete column**, so `FINAL` only collapses duplicate versions — it never makes a TraceId appear or disappear. `FINAL` therefore adds a pointless cross-partition replacing-merge that buffers merge state across every weekly partition holding the tenant's data; multiplied by the sweep's concurrency, that exhausts server memory.

## Proposed fix

Drop `FINAL` and dedup the key with `DISTINCT`:

```sql
SELECT DISTINCT TraceId
FROM trace_summaries
WHERE TenantId = {tenantId:String} AND TraceId IN {traceIds:Array(String)}
```

The `ORDER BY (TenantId, TraceId)` sort key makes this a key-only read (just the `TraceId` column for the matched keys) with no merge state. Existence semantics are identical: a TraceId present in any version is present with or without `FINAL`. No schema/infra change.

## Expected impact

- The shape stops doing a replacing-merge, removing its contribution to the server memory pressure that produced ~4.9k Code 241/day (the single largest exception shape).
- Orphan cleanup stops silently stalling under memory pressure, so dangling annotations / shares / pins / triggers for expired traces actually get swept.
- Latency for the sweep's existence check drops (key-only read vs full FINAL merge), though latency was never the headline — correctness + memory are.

## Test plan

`orphanSweep.unit.test.ts` (+3 tests, 12 pass):
- partitions input into existing/orphaned by ClickHouse presence;
- the generated SQL contains `SELECT DISTINCT TraceId` and **no** `FINAL`;
- on ClickHouse error it still returns all ids as existing (fail-safe — never deletes on a failed check).

## EXPLAIN check

`/api/ops/clickhouse/explain` against the affected tenant (id redacted). Note: synthetic trace ids prune to zero parts, so EXPLAIN understates `FINAL`'s real merge cost on matching data — the structural change is the point.

**PLAN** — `FINAL`'s read-time merge replaced by a plain key `DISTINCT`:

```
old:  Expression -> Filter (WHERE) -> ReadFromMergeTree            (FINAL applied during read)
new:  Expression -> Distinct -> Distinct (Preliminary) -> Expression (WHERE) -> ReadFromMergeTree
```

**PIPELINE** — new pipeline is `DistinctSortedStreamTransform` over a key read (the sort key gives sorted-stream distinct); no replacing-merge across partitions. The real-data memory evidence is the prod Code 241 server-limit exhaustion above.
