### PR TITLE
feat(langy): staff always have Langy; flag only opens it to non-staff

### DIFF
--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -552,8 +552,9 @@ export const DashboardLayout = ({
     !publicPage &&
     userIsPartOfTeam &&
     isProjectRoute &&
-    isLangwatchStaff(user?.email) &&
-    langyFlagEnabled;
+    // Staff always see Langy; the flag only extends it to non-staff. Mirrors
+    // the server gate in src/server/routes/langy.ts.
+    (isLangwatchStaff(user?.email) || langyFlagEnabled);
 
   return (
     <LangyProvider>

--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -152,7 +152,7 @@ export const FEATURE_FLAGS = [
     scope: "PRODUCT",
     defaultValue: false,
     description:
-      "Enables the Langy in-product assistant. Staff-only gate is layered on top via isLangwatchStaff(); flag off = hidden for everyone including staff.",
+      "Opens the Langy in-product assistant to non-staff. LangWatch staff (isLangwatchStaff()) always have access regardless of this flag; flipping it on extends Langy to the targeted non-staff users.",
   },
 ] as const satisfies readonly FeatureFlagDefinition[];
 

--- a/langwatch/src/server/routes/__tests__/langy-route-auth.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy-route-auth.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment node
+ *
+ * @see specs/assistant/langy-baseline.feature — Access and rollout gating
+ *
+ * Binds the Langy access contract:
+ *   - LangWatch staff always reach Langy, even with the rollout flag OFF.
+ *   - Non-staff are blocked unless the rollout flag is on for them.
+ *
+ * The flag is the lever for opening Langy beyond staff; it can never lock
+ * staff out. A future re-introduction of a hard "staff AND flag" gate would
+ * fail the staff scenario here.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getServerAuthSession = vi.fn();
+const isEnabled = vi.fn();
+
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: (...args: unknown[]) => getServerAuthSession(...args),
+}));
+vi.mock("~/server/featureFlag", () => ({
+  featureFlagService: {
+    isEnabled: (...args: unknown[]) => isEnabled(...args),
+  },
+}));
+
+// The 403 the access middleware emits when neither staff nor rollout lets the
+// caller through. Pass-through cases assert the answer is NOT this string —
+// downstream handler errors (no DB in this env) are fine; only the gate is
+// under test here.
+const GATE_BLOCKED = "Langy is not currently enabled";
+
+async function requestLangy() {
+  const { app } = await import("../langy");
+  return app.request(
+    "http://localhost/api/langy/conversations?projectId=p1",
+    { method: "GET" },
+  );
+}
+
+describe("Langy access gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when the user is LangWatch staff", () => {
+    describe("and Langy has not been rolled out beyond staff", () => {
+      it("is not blocked by the rollout gate", async () => {
+        getServerAuthSession.mockResolvedValue({
+          user: { email: "dev@langwatch.ai", id: "u1" },
+        });
+        isEnabled.mockResolvedValue(false);
+
+        const res = await requestLangy();
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+
+        expect(body.error).not.toBe(GATE_BLOCKED);
+        // Staff must never trigger the flag lookup at all.
+        expect(isEnabled).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when the user is not staff", () => {
+    describe("and Langy has not been rolled out to them", () => {
+      it("is rejected with a 403", async () => {
+        getServerAuthSession.mockResolvedValue({
+          user: { email: "user@acme.com", id: "u2" },
+        });
+        isEnabled.mockResolvedValue(false);
+
+        const res = await requestLangy();
+
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { error?: string };
+        expect(body.error).toBe(GATE_BLOCKED);
+      });
+    });
+
+    describe("and Langy has been rolled out to them", () => {
+      it("is not blocked by the rollout gate", async () => {
+        getServerAuthSession.mockResolvedValue({
+          user: { email: "user@acme.com", id: "u3" },
+        });
+        isEnabled.mockResolvedValue(true);
+
+        const res = await requestLangy();
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+
+        expect(body.error).not.toBe(GATE_BLOCKED);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -14,8 +14,9 @@
  *                                              conversations for a project.
  *   GET    /langy/memory/export              — GDPR export of conversations.
  *
- * Every route is gated by `isLangwatchStaff(email)` AND
- * `release_langy_enabled` (see the middleware below).
+ * Access: LangWatch staff always have Langy. For everyone else it is gated by
+ * `release_langy_enabled`, which is the lever for opening Langy beyond staff
+ * (see the middleware below). Staff therefore bypass the flag entirely.
  */
 import {
   createUIMessageStream,
@@ -129,12 +130,13 @@ const secured = createServiceApp({ basePath: "/api" });
 
 secured.hono.use("/langy/*", async (c, next) => {
   const session = await getServerAuthSession({ req: c.req.raw as any });
-  if (!isLangwatchStaff(session?.user?.email)) {
-    return c.json({ error: "Langy is not available for your account" }, 403);
-  }
-  const enabled = await featureFlagService.isEnabled("release_langy_enabled", {
-    distinctId: session?.user?.id ?? "",
-  });
+  // Staff always have Langy; the flag only opens it to non-staff. The `||`
+  // short-circuits for staff, so the flag is never read for them.
+  const enabled =
+    isLangwatchStaff(session?.user?.email) ||
+    (await featureFlagService.isEnabled("release_langy_enabled", {
+      distinctId: session?.user?.id ?? "",
+    }));
   if (!enabled) {
     return c.json({ error: "Langy is not currently enabled" }, 403);
   }

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -48,6 +48,29 @@ Feature: Langy in-product AI assistant — baseline (v1)
     Then the request is rejected with a 403
 
   # ============================================================================
+  # Access and rollout gating
+  # Covered by src/server/routes/__tests__/langy-route-auth.test.ts
+  # ============================================================================
+
+  Scenario: Staff always have Langy regardless of rollout
+    Given I am a LangWatch staff member
+    And Langy has not been rolled out beyond staff
+    When I send a message to Langy in project "demo"
+    Then the request is not rejected by the rollout gate
+
+  Scenario: Non-staff without rollout are blocked
+    Given I am not a LangWatch staff member
+    And Langy has not been rolled out to my account
+    When I send a message to Langy in project "demo"
+    Then the request is rejected with a 403
+
+  Scenario: Rollout opens Langy to non-staff
+    Given I am not a LangWatch staff member
+    And Langy has been rolled out to my account
+    When I send a message to Langy in project "demo"
+    Then the request is not rejected by the rollout gate
+
+  # ============================================================================
   # Read-only tools (information retrieval)
   # ============================================================================
 


### PR DESCRIPTION
## What
Staff (`@langwatch.ai`) now get Langy automatically — no flag flip. The `release_langy_enabled` flag now only controls extending Langy to **non-staff** users.

## Changes
- `routes/langy.ts` — server guard: `isLangwatchStaff(email) || flag` (staff short-circuit the flag lookup)
- `DashboardLayout.tsx` — UI gate mirrors the server: `isLangwatchStaff(email) || langyFlagEnabled`
- `registry.ts` — flag description updated to reflect new semantics
- `+ langy-route-auth.test.ts` — covers all three access cases (staff-no-flag, non-staff-no-flag, non-staff-flag)
- `langy-baseline.feature` — 3 BDD scenarios for the access/rollout gating

## Notes
Targets `langy/per-session-manager` (#4272) per request. Local test run blocked by a degraded dev env (node-version + stale Prisma client); the identical test passed 3/3 on the langy/full base and typecheck is clean for the touched files — CI will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)