### PR TITLE
feat(langy): dedicated per-project Langy API key (+ backfill)

### DIFF
--- a/langwatch/scripts/backfill-langy-api-keys.ts
+++ b/langwatch/scripts/backfill-langy-api-keys.ts
@@ -1,0 +1,40 @@
+/**
+ * Backfill script: mint the dedicated "Langy" API key for every existing
+ * application project that doesn't already have one.
+ *
+ * Idempotent — re-running only provisions keys for projects still missing one.
+ * Hidden internal_governance projects are excluded.
+ *
+ * Run with:
+ *   DATABASE_URL=... npx tsx scripts/backfill-langy-api-keys.ts
+ *   DATABASE_URL=... npx tsx scripts/backfill-langy-api-keys.ts --dry-run
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { backfillLangyApiKeys } from "../src/server/services/langy/langyApiKey";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE"}\n`);
+
+  const { provisioned, skipped, failed } = await backfillLangyApiKeys(prisma, {
+    dryRun: DRY_RUN,
+  });
+
+  console.log(
+    `Langy key backfill: ${DRY_RUN ? "would provision" : "provisioned"} ${provisioned}, skipped ${skipped} (already had one), failed ${failed}`,
+  );
+
+  await prisma.$disconnect();
+
+  if (failed > 0) process.exit(1);
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect().catch(() => {});
+  process.exit(1);
+});

--- a/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
@@ -160,6 +160,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
   }
 
   describe("when a new project is created", () => {
+    /** @scenario "Creating a project provisions a dedicated Langy key" */
     it("provisions a dedicated Langy key that is a service key", async () => {
       const project = await createProjectViaApi("Provisions Langy Key");
 
@@ -191,6 +192,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
       expect(keys[0]!.lookupId).not.toBe(project.apiKey);
     });
 
+    /** @scenario "The Langy key is scoped to only its own project" */
     it("scopes the Langy key to only its own project", async () => {
       const project = await createProjectViaApi("Project Scoped");
 
@@ -208,6 +210,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
       }
     });
 
+    /** @scenario "The Langy key grants only the access Langy needs" */
     it("grants least-privilege (no organization-level admin)", async () => {
       const project = await createProjectViaApi("Least Privilege");
 
@@ -229,6 +232,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
   });
 
   describe("when backfilling existing projects", () => {
+    /** @scenario "Existing projects without a Langy key are backfilled" */
     it("provisions a Langy key for a project that has none", async () => {
       const project = await createLegacyProject("Backfill Target");
       expect(await findLangyKeys(project.id)).toHaveLength(0);
@@ -238,6 +242,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
       expect(await findLangyKeys(project.id)).toHaveLength(1);
     });
 
+    /** @scenario "Backfill does not create duplicates" */
     it("does not create duplicates when run again", async () => {
       const project = await createLegacyProject("Idempotent Backfill");
 

--- a/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for dedicated Langy API key provisioning.
+ * Real database — mocks only the planProvider / usageLimits system boundary
+ * (so project.create runs without a real subscription).
+ *
+ * Spec: specs/assistant/langy-api-key-provisioning.feature
+ * Requires: PostgreSQL database (Prisma)
+ */
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { prisma } from "../../../db";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+import { createTestApp } from "~/server/app-layer/presets";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import {
+  PlanProviderService,
+  type PlanProvider,
+} from "~/server/app-layer/subscription/plan-provider";
+import { FREE_PLAN } from "../../../../../ee/licensing/constants";
+import {
+  LANGY_API_KEY_NAME,
+  backfillLangyApiKeys,
+} from "~/server/services/langy/langyApiKey";
+
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+
+describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
+  const testNamespace = `langy-key-${nanoid(8)}`;
+  let organizationId: string;
+  let teamId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Langy Key Org", slug: `--test-org-${testNamespace}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: {
+        name: "Langy Key Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+
+    const user = await prisma.user.create({
+      data: { name: "Langy Key User", email: `${testNamespace}@example.com` },
+    });
+    userId = user.id;
+
+    await prisma.organizationUser.create({
+      data: { userId, organizationId, role: OrganizationUserRole.ADMIN },
+    });
+    await prisma.teamUser.create({
+      data: { userId, teamId, role: TeamUserRole.ADMIN },
+    });
+  });
+
+  beforeEach(() => {
+    resetApp();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue({
+          ...FREE_PLAN,
+          maxProjects: 50,
+          overrideAddingLimitations: true,
+        }) as PlanProvider["getActivePlan"],
+      }),
+      usageLimits: {
+        notifyResourceLimitReached: vi.fn().mockResolvedValue(undefined),
+        checkAndSendWarning: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    });
+  });
+
+  afterEach(() => resetApp());
+
+  afterAll(async () => {
+    // RoleBindings + ApiKeys are org-scoped; delete them before the org.
+    await prisma.roleBinding.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.apiKey.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.project.deleteMany({ where: { teamId } }).catch(() => {});
+    await prisma.teamUser.deleteMany({ where: { teamId } }).catch(() => {});
+    await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
+    await prisma.organizationUser.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.organization.deleteMany({ where: { id: organizationId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
+  });
+
+  function createCaller() {
+    const ctx = createInnerTRPCContext({
+      session: { user: { id: userId }, expires: "1" },
+    });
+    return appRouter.createCaller(ctx);
+  }
+
+  async function findLangyKeys(projectId: string) {
+    return prisma.apiKey.findMany({
+      where: {
+        name: LANGY_API_KEY_NAME,
+        revokedAt: null,
+        roleBindings: {
+          some: {
+            scopeType: RoleBindingScopeType.PROJECT,
+            scopeId: projectId,
+          },
+        },
+      },
+      include: { roleBindings: true },
+    });
+  }
+
+  async function createProjectViaApi(name: string) {
+    const caller = createCaller();
+    const result = await caller.project.create({
+      organizationId,
+      teamId,
+      name,
+      language: "en",
+      framework: "test",
+    });
+    const project = await prisma.project.findUniqueOrThrow({
+      where: { slug: result.projectSlug },
+    });
+    return project;
+  }
+
+  // Helper to create a project directly in the DB (no Langy key) — simulates a
+  // project that predates Langy keys, for backfill tests.
+  async function createLegacyProject(name: string) {
+    return prisma.project.create({
+      data: {
+        name,
+        slug: `--legacy-${testNamespace}-${nanoid(6)}`,
+        apiKey: `sk-lw-test-${nanoid()}`,
+        teamId,
+        language: "en",
+        framework: "test",
+      },
+    });
+  }
+
+  describe("when a new project is created", () => {
+    it("provisions a dedicated Langy key that is a service key", async () => {
+      const project = await createProjectViaApi("Provisions Langy Key");
+
+      // Best-effort provisioning happens after creation — wait for it.
+      const keys = await vi.waitFor(
+        async () => {
+          const found = await findLangyKeys(project.id);
+          expect(found).toHaveLength(1);
+          return found;
+        },
+        { timeout: 5000, interval: 100 },
+      );
+
+      const langyKey = keys[0]!;
+      expect(langyKey.userId).toBeNull(); // service key, owned by no human
+      expect(langyKey.name).toBe(LANGY_API_KEY_NAME);
+    });
+
+    it("provisions a key distinct from the project's own ingestion apiKey", async () => {
+      const project = await createProjectViaApi("Distinct From Ingestion Key");
+
+      const keys = await vi.waitFor(async () => {
+        const found = await findLangyKeys(project.id);
+        expect(found).toHaveLength(1);
+        return found;
+      });
+
+      // The Langy key is a separate ApiKey row, not the project.apiKey string.
+      expect(keys[0]!.lookupId).not.toBe(project.apiKey);
+    });
+
+    it("scopes the Langy key to only its own project", async () => {
+      const project = await createProjectViaApi("Project Scoped");
+
+      const keys = await vi.waitFor(async () => {
+        const found = await findLangyKeys(project.id);
+        expect(found).toHaveLength(1);
+        return found;
+      });
+
+      const bindings = keys[0]!.roleBindings;
+      expect(bindings.length).toBeGreaterThan(0);
+      for (const b of bindings) {
+        expect(b.scopeType).toBe(RoleBindingScopeType.PROJECT);
+        expect(b.scopeId).toBe(project.id);
+      }
+    });
+
+    it("grants least-privilege (no organization-level admin)", async () => {
+      const project = await createProjectViaApi("Least Privilege");
+
+      const keys = await vi.waitFor(async () => {
+        const found = await findLangyKeys(project.id);
+        expect(found).toHaveLength(1);
+        return found;
+      });
+
+      const langyKey = keys[0]!;
+      // restricted mode = scoped to an explicit permission set, not "all"/admin.
+      expect(langyKey.permissionMode).toBe("restricted");
+      // No org-wide binding of any kind.
+      const orgBindings = langyKey.roleBindings.filter(
+        (b) => b.scopeType === RoleBindingScopeType.ORGANIZATION,
+      );
+      expect(orgBindings).toHaveLength(0);
+    });
+  });
+
+  describe("when backfilling existing projects", () => {
+    it("provisions a Langy key for a project that has none", async () => {
+      const project = await createLegacyProject("Backfill Target");
+      expect(await findLangyKeys(project.id)).toHaveLength(0);
+
+      await backfillLangyApiKeys(prisma);
+
+      expect(await findLangyKeys(project.id)).toHaveLength(1);
+    });
+
+    it("does not create duplicates when run again", async () => {
+      const project = await createLegacyProject("Idempotent Backfill");
+
+      await backfillLangyApiKeys(prisma);
+      await backfillLangyApiKeys(prisma);
+
+      expect(await findLangyKeys(project.id)).toHaveLength(1);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -37,6 +37,7 @@ import {
   skipPermissionCheckProjectCreation,
 } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
+import { provisionLangyApiKey } from "~/server/services/langy/langyApiKey";
 
 export const projectRouter = createTRPCRouter({
   publicGetById: publicProcedure
@@ -221,6 +222,25 @@ export const projectRouter = createTRPCRouter({
             ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
         },
       });
+
+      // Best-effort: mint Langy's dedicated, least-privilege service key so the
+      // assistant works the moment the project exists. A failure here must never
+      // block project creation — the backfill reconciler mints any that slip through.
+      try {
+        await provisionLangyApiKey({
+          prisma,
+          projectId: project.id,
+          organizationId: input.organizationId,
+          createdByUserId: userId,
+        });
+      } catch (error) {
+        captureException(error, {
+          extra: {
+            projectId: project.id,
+            context: "provisionLangyApiKey:project.create",
+          },
+        });
+      }
 
       return { success: true, projectSlug: project.slug };
     }),

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 
 import { encrypt, decrypt } from "~/utils/encryption";
 import { VirtualKeyService } from "~/server/gateway/virtualKey.service";
+import { provisionLangyApiKey, getLangyApiKeyToken } from "./langyApiKey";
 
 /**
  * Name under which the auto-provisioned Langy VK secret is stored in
@@ -88,6 +89,18 @@ export class LangyCredentialService {
       );
     }
 
+    // Prefer the dedicated, least-privilege "Langy" key over the human's
+    // ingestion key. Provision-on-first-use makes it self-healing if project
+    // creation / backfill missed it; we fall back to project.apiKey only when
+    // no token could be stored (e.g. no resolvable user to attribute it to).
+    await provisionLangyApiKey({
+      prisma: this.prisma,
+      projectId,
+      organizationId: project.team.organizationId,
+      createdByUserId: actorUserId,
+    });
+    const langyApiKeyToken = await getLangyApiKeyToken(this.prisma, projectId);
+
     const llmVirtualKey = await this.getOrProvisionVirtualKey({
       projectId,
       organizationId: project.team.organizationId,
@@ -95,7 +108,7 @@ export class LangyCredentialService {
     });
 
     return {
-      langwatchApiKey: project.apiKey,
+      langwatchApiKey: langyApiKeyToken ?? project.apiKey,
       llmVirtualKey,
       langwatchEndpoint,
       gatewayBaseUrl,

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -124,10 +124,12 @@ export class LangyCredentialService {
     organizationId: string;
     actorUserId: string;
   }): Promise<string> {
-    const existing = await this.prisma.projectSecret.findUnique({
-      where: {
-        projectId_name: { projectId, name: LANGY_VK_SECRET_NAME },
-      },
+    // findFirst with a plain `projectId` (not findUnique-by-`projectId_name`):
+    // the guarded prisma client's multitenancy middleware doesn't recognize the
+    // `projectId_name` compound key and throws. ProjectSecret is unique on
+    // (projectId, name), so this is still a single-row read.
+    const existing = await this.prisma.projectSecret.findFirst({
+      where: { projectId, name: LANGY_VK_SECRET_NAME },
       select: { encryptedValue: true },
     });
     if (existing) {
@@ -171,10 +173,8 @@ export class LangyCredentialService {
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === "P2002"
       ) {
-        const winner = await this.prisma.projectSecret.findUnique({
-          where: {
-            projectId_name: { projectId, name: LANGY_VK_SECRET_NAME },
-          },
+        const winner = await this.prisma.projectSecret.findFirst({
+          where: { projectId, name: LANGY_VK_SECRET_NAME },
           select: { encryptedValue: true },
         });
         if (winner) return decrypt(winner.encryptedValue);

--- a/langwatch/src/server/services/langy/langyApiKey.ts
+++ b/langwatch/src/server/services/langy/langyApiKey.ts
@@ -1,0 +1,222 @@
+import type { PrismaClient } from "@prisma/client";
+import { Prisma, RoleBindingScopeType } from "@prisma/client";
+import { ApiKeyService } from "~/server/api-key/api-key.service";
+import {
+  computePermissionsFromSelections,
+  type AccessLevel,
+} from "~/server/api-key/permission-categories";
+import { encrypt, decrypt } from "~/utils/encryption";
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:langy:api-key");
+
+export const LANGY_API_KEY_NAME = "Langy";
+
+// ProjectSecret name under which the dedicated Langy key's one-time token is
+// stored (encrypted). The ApiKey row only keeps a hash of the secret, so the
+// usable token MUST be captured at mint time for the runtime (the worker's MCP
+// server) to retrieve it later — same pattern as the Langy virtual key.
+export const LANGY_API_KEY_SECRET_NAME = "langy_api_key_secret";
+
+// Least-privilege surface for the Langy assistant, expressed in the same
+// permission categories the API-key UI uses so it stays valid and auditable.
+// Deliberately omits secrets, project/team management, and the audit log — a
+// leaked Langy key must not be able to administer the project or read secrets.
+const LANGY_PERMISSION_SELECTIONS: Record<string, AccessLevel | "none"> = {
+  traces: "write",
+  evaluations: "write",
+  datasets: "write",
+  scenarios: "write",
+  annotations: "write",
+  analytics: "write",
+  prompts: "write",
+  triggers: "write",
+  workflows: "write",
+  cost: "read",
+};
+
+const LANGY_PERMISSIONS = computePermissionsFromSelections(
+  LANGY_PERMISSION_SELECTIONS,
+);
+
+async function hasLangyKey(
+  prisma: PrismaClient,
+  projectId: string,
+): Promise<boolean> {
+  const existing = await prisma.apiKey.findFirst({
+    where: {
+      name: LANGY_API_KEY_NAME,
+      revokedAt: null,
+      roleBindings: {
+        some: {
+          scopeType: RoleBindingScopeType.PROJECT,
+          scopeId: projectId,
+        },
+      },
+    },
+    select: { id: true },
+  });
+  return existing !== null;
+}
+
+/**
+ * Returns the decrypted, ready-to-use dedicated Langy key token for a project,
+ * or null if it hasn't been provisioned yet. This is the token the worker's MCP
+ * server uses as LANGWATCH_API_KEY.
+ */
+export async function getLangyApiKeyToken(
+  prisma: PrismaClient,
+  projectId: string,
+): Promise<string | null> {
+  const secret = await prisma.projectSecret.findUnique({
+    where: {
+      projectId_name: { projectId, name: LANGY_API_KEY_SECRET_NAME },
+    },
+    select: { encryptedValue: true },
+  });
+  return secret ? decrypt(secret.encryptedValue) : null;
+}
+
+/**
+ * ProjectSecret.createdById is non-null, so the stored token must be attributed
+ * to a user: the explicit actor when we have one (project creation / runtime),
+ * else the organization's first admin (the backfill path, which has no actor).
+ */
+async function resolveCreatorId(
+  prisma: PrismaClient,
+  organizationId: string,
+  createdByUserId: string | null,
+): Promise<string | null> {
+  if (createdByUserId) return createdByUserId;
+  const admin = await prisma.organizationUser.findFirst({
+    where: { organizationId, role: "ADMIN" },
+    orderBy: { createdAt: "asc" },
+    select: { userId: true },
+  });
+  return admin?.userId ?? null;
+}
+
+/**
+ * Mints the dedicated Langy key for a project — a service key (no human owner),
+ * named "Langy", restricted to a least-privilege permission set, bound to the
+ * project scope only — AND stores its one-time token (encrypted) so the runtime
+ * can hand it to the worker.
+ *
+ * Idempotent: a no-op once the usable token is stored. The "provisioned" gate is
+ * the stored token (not just the ApiKey row), because a key whose token wasn't
+ * captured is useless to the worker.
+ */
+export async function provisionLangyApiKey({
+  prisma,
+  projectId,
+  organizationId,
+  createdByUserId = null,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  organizationId: string;
+  createdByUserId?: string | null;
+}): Promise<void> {
+  if (await getLangyApiKeyToken(prisma, projectId)) return;
+
+  const creatorId = await resolveCreatorId(
+    prisma,
+    organizationId,
+    createdByUserId,
+  );
+  if (!creatorId) {
+    logger.warn(
+      { projectId },
+      "no user to attribute the Langy key token to; skipping — the runtime falls back to the project ingestion key",
+    );
+    return;
+  }
+
+  const service = ApiKeyService.create(prisma);
+  const { token } = await service.create({
+    name: LANGY_API_KEY_NAME,
+    description:
+      "Dedicated key for the Langy in-product assistant. Scoped to this project; revoke to cut off Langy's access.",
+    userId: null, // service key — owned by no individual user
+    createdByUserId: creatorId,
+    organizationId,
+    permissionMode: "restricted",
+    permissions: LANGY_PERMISSIONS,
+    bindings: [{ role: "CUSTOM", scopeType: "PROJECT", scopeId: projectId }],
+  });
+
+  try {
+    await prisma.projectSecret.create({
+      data: {
+        projectId,
+        name: LANGY_API_KEY_SECRET_NAME,
+        encryptedValue: encrypt(token),
+        createdById: creatorId,
+        updatedById: creatorId,
+      },
+    });
+  } catch (error) {
+    // Race: another provision stored the token first. The key we just minted is
+    // an orphan (harmless, revocable later); the winner's stored token is the
+    // authoritative one. Acceptable for v1.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Reconciles existing projects: provisions the Langy key + token for every
+ * project that lacks one. Idempotent — safe to run repeatedly. Per-project
+ * failures are logged and skipped so one bad project never aborts the sweep.
+ */
+export async function backfillLangyApiKeys(
+  prisma: PrismaClient,
+  { dryRun = false }: { dryRun?: boolean } = {},
+): Promise<{ provisioned: number; skipped: number; failed: number }> {
+  // Only real user workspaces. Hidden "internal_governance" routing projects
+  // are not user-facing and must never receive a Langy key.
+  const projects = await prisma.project.findMany({
+    where: { kind: "application" },
+    select: { id: true, team: { select: { organizationId: true } } },
+  });
+
+  let provisioned = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const project of projects) {
+    if (await getLangyApiKeyToken(prisma, project.id)) {
+      skipped++;
+      continue;
+    }
+    if (dryRun) {
+      provisioned++; // would-provision count
+      continue;
+    }
+    try {
+      await provisionLangyApiKey({
+        prisma,
+        projectId: project.id,
+        organizationId: project.team.organizationId,
+      });
+      provisioned++;
+    } catch (err) {
+      failed++;
+      logger.error(
+        { err, projectId: project.id },
+        "failed to backfill Langy key for project",
+      );
+    }
+  }
+
+  logger.info(
+    { provisioned, skipped, failed, dryRun },
+    "Langy key backfill complete",
+  );
+  return { provisioned, skipped, failed };
+}

--- a/langwatch/src/server/services/langy/langyApiKey.ts
+++ b/langwatch/src/server/services/langy/langyApiKey.ts
@@ -68,10 +68,14 @@ export async function getLangyApiKeyToken(
   prisma: PrismaClient,
   projectId: string,
 ): Promise<string | null> {
-  const secret = await prisma.projectSecret.findUnique({
-    where: {
-      projectId_name: { projectId, name: LANGY_API_KEY_SECRET_NAME },
-    },
+  // findFirst with an explicit `projectId` (NOT findUnique-by-`projectId_name`):
+  // the request-scoped prisma client runs a multitenancy guard that recognizes a
+  // plain `projectId` predicate but NOT the `projectId_name` compound key, and
+  // would otherwise throw "requires a 'projectId' in the where clause". This is
+  // why the creation-hook mint silently failed under ctx.prisma. ProjectSecret is
+  // unique on (projectId, name), so this still returns exactly the one row.
+  const secret = await prisma.projectSecret.findFirst({
+    where: { projectId, name: LANGY_API_KEY_SECRET_NAME },
     select: { encryptedValue: true },
   });
   return secret ? decrypt(secret.encryptedValue) : null;

--- a/specs/assistant/langy-api-key-provisioning.feature
+++ b/specs/assistant/langy-api-key-provisioning.feature
@@ -52,6 +52,9 @@ Feature: Dedicated Langy API key provisioning
   # Lifecycle
   # ---------------------------------------------------------------------------
 
+  # Not yet implemented — no Langy-key revoke flow exists yet; flagged so the
+  # feature-parity check tolerates it until the revoke behaviour is built.
+  @unimplemented
   @integration
   Scenario: An admin can revoke the Langy key
     Given my project has a Langy key

--- a/specs/assistant/langy-api-key-provisioning.feature
+++ b/specs/assistant/langy-api-key-provisioning.feature
@@ -1,0 +1,60 @@
+Feature: Dedicated Langy API key provisioning
+  As a project owner
+  I want each of my projects to have its own dedicated, least-privilege Langy key
+  So that the Langy assistant can act on my project without reusing my personal key,
+  and so that a leaked key exposes only this project and only what Langy needs
+
+  Background:
+    Given I am signed in as an admin of my organization
+
+  # ---------------------------------------------------------------------------
+  # New projects
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Creating a project provisions a dedicated Langy key
+    When I create a new project
+    Then the project has a dedicated API key named "Langy"
+    And the Langy key is separate from the project's own ingestion API key
+    And the Langy key is not owned by any individual user
+
+  @integration
+  Scenario: The Langy key is scoped to only its own project
+    Given I have two projects "Alpha" and "Beta"
+    When a Langy key is provisioned for "Alpha"
+    Then the Langy key for "Alpha" can act only within "Alpha"
+    And the Langy key for "Alpha" cannot access "Beta"
+
+  @integration
+  Scenario: The Langy key grants only the access Langy needs
+    When I create a new project
+    Then the Langy key cannot perform organization-level administration
+    And the Langy key can perform only the actions the Langy assistant requires
+
+  # ---------------------------------------------------------------------------
+  # Existing projects (backfill)
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Existing projects without a Langy key are backfilled
+    Given a project that was created before Langy keys existed
+    And that project has no Langy key
+    When the Langy key backfill runs
+    Then that project has a dedicated Langy key named "Langy"
+
+  @integration
+  Scenario: Backfill does not create duplicates
+    Given a project that already has a Langy key
+    When the Langy key backfill runs again
+    Then the project still has exactly one Langy key
+
+  # ---------------------------------------------------------------------------
+  # Lifecycle
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: An admin can revoke the Langy key
+    Given my project has a Langy key
+    When I revoke the Langy key
+    Then the Langy key can no longer act on my project
+    And my project's other API keys are unaffected

--- a/specs/assistant/langy-keys-plan.md
+++ b/specs/assistant/langy-keys-plan.md
@@ -1,0 +1,170 @@
+# Langy zero-friction onboarding — implementation plan
+
+> **Epic:** #4528 · **Sub-issues:** #4273 → #4274 → #4275
+> **Branch:** `issue4273/langy-api-key` · **Base:** `langy/per-session-manager` (PR #4272)
+> **Worktree:** `~/langwatch_codebase/langy-keys`
+
+## Goal
+
+Make Langy *just work* — no manual key wrangling, no "configure a provider first" dead end.
+Two credentials power Langy end-to-end; this epic makes both seamless:
+
+1. **LangWatch API key** → Langy reads project data (MCP + outbound calls into LangWatch).
+2. **AI Gateway `VirtualKey`** → Langy calls an LLM on the user's behalf, model chosen from a **dropdown**.
+
+Target: new projects auto-mint the key; existing projects are backfilled; the key flows to the
+Langy worker for traces + MCP automatically; model selection routes through the gateway VirtualKey.
+
+## Target flow
+
+```
+  new project ─┐                          ┌─ backfill reconciler (existing projects)
+               ▼                          ▼
+        provisionLangyApiKey()  ◄── idempotent ──►  mint "Langy" key for any project missing one
+               │                                            (#4273)
+               ▼
+     dedicated "Langy" ApiKey (service key, PROJECT-scoped, least-privilege)
+               │
+               ▼
+   open Langy ─► "Set up Langy" modal (#4274)
+                 (1) key:   (•) dedicated Langy key   ( ) project's own key
+                 (2) model: [ dropdown / 1-click "use <provider>" ]
+                            none configured? → guided add → return to modal
+               │
+               ▼
+   Langy worker (per-session, from #4272)
+     • MCP server   ← LangWatch API key            (traces / MCP)
+     • opencode LLM ← VirtualKey → AI Gateway      (#4275)
+```
+
+## What already exists — reuse, do not rebuild
+
+**From the #4272 base (`langy/per-session-manager`):**
+- Per-session OpenCode workers + `LangyCredentialService.getOrProvision()`
+  (`src/server/services/langy/LangyCredentialService.ts`) — already reads `project.apiKey`,
+  **already auto-provisions a per-project Langy VirtualKey** (`langy_vk_secret` in `ProjectSecret`),
+  and passes `langwatchApiKey` + `llmVirtualKey` + `gatewayBaseUrl` to the worker env.
+  → A chunk of PR3's plumbing is already here; #4275 is mostly *flipping the gate* (see below).
+- `ApiKeyService.create(...)` — signature verified to match the helper:
+  `{ name, description, userId, createdByUserId, organizationId, permissionMode, permissions, bindings }`.
+- `permission-categories.computePermissionsFromSelections()` and `Project.kind` (`@default("application")`).
+
+**WIP to port from `~/langwatch_codebase/langy-full-rebase` (branch `issue4273/langy-default-api-key`):**
+These were written on the diverged `langy/full` base but their dependencies all exist on #4272, so they
+port cleanly (adapt imports/line refs only):
+- `src/server/services/langy/langyApiKey.ts` — `provisionLangyApiKey()` + `backfillLangyApiKeys()` (idempotent, least-privilege, excludes hidden `kind != "application"` projects).
+- `scripts/backfill-langy-api-keys.ts` — runnable backfill (`--dry-run` supported).
+- `specs/assistant/langy-api-key-provisioning.feature` — BDD spec (6 scenarios).
+- `src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts` — real-DB integration test.
+
+## Locked decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Where the key lives | Reuse `ApiKey` + `ApiKeyService` — **no new schema** | Already supports named, hashed, revocable, scope-bound **service keys** (`userId: null`). |
+| Key identity | Service key (`userId: null`), `name: "Langy"` | Not tied to a human; attributable via `createdByUserId`. |
+| Key scope | PROJECT-scoped, least-privilege | A leak exposes one project + only Langy's actions. |
+| When minted | Best-effort after project creation; **backfill reconciles** | Keeps project creation decoupled from `ApiKeyService`; eventual consistency. |
+| Gateway key | A `VirtualKey` (already auto-provisioned in #4272) | Implies "whose budget / which provider" → made real in #4275. |
+| No new REST endpoints | Extend services + existing Langy routes only | Project constraint. |
+
+---
+
+## PR 1 — dedicated Langy API key (#4273)  ·  *foundation*  ·  **CODE COMPLETE, typecheck green**
+
+Spec: `specs/assistant/langy-api-key-provisioning.feature`.
+
+- [x] **Spec-first** — `.feature` in `specs/assistant/` (6 scenarios).
+- [x] **Integration tests** (real DB, no mocks) — `src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts`:
+  - new project → a `Langy` service key exists, distinct from `Project.apiKey`
+  - key bound only to its project · no org-admin (least-privilege) · `permissionMode: "restricted"`
+  - backfill mints for a project lacking one · backfill twice → exactly one key (idempotent)
+- [x] **`langyApiKey.ts`** → `src/server/services/langy/langyApiKey.ts` (`provisionLangyApiKey` + `backfillLangyApiKeys`).
+- [x] **Hook the live creation path** (best-effort, awaited + caught, never blocks creation):
+  - tRPC `project.create` → `src/server/api/routers/project.ts` (after `prisma.project.create`).
+  - **Finding (deviation from original plan):** the app-layer `ProjectService.create`
+    (`project.service.ts:137`) is **not invoked anywhere** for real project creation —
+    onboarding goes `onboarding.router.ts:62 → projectRouter.createCaller(ctx).create()` (the tRPC path).
+    Hooking the app-layer service would be **dead code** *and* break the repository abstraction
+    (the service holds `this.repo`, not a `PrismaClient`). So it's intentionally **not** hooked;
+    the **backfill reconciler** is the safety net for any path that ever bypasses provisioning.
+- [x] **Backfill script** → `scripts/backfill-langy-api-keys.ts` (idempotent; `--dry-run`).
+- [x] `pnpm typecheck` → exit 0 (whole project).
+- [ ] **Run integration tests end-to-end** — NOT yet run. The worktree `.env` `DATABASE_URL` points at the
+      **shared dev RDS**; do NOT run create/delete tests against it. Bring up a local PG and override:
+      ```bash
+      make quickstart migration            # local postgres on host :5432
+      cd langwatch
+      DATABASE_URL="postgresql://prisma:prisma@localhost:5432/mydb?schema=langwatch_db" \
+        pnpm prisma migrate deploy
+      DATABASE_URL="postgresql://prisma:prisma@localhost:5432/mydb?schema=langwatch_db" \
+        pnpm test:integration src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
+      ```
+
+**Open question (still):** finalize the least-privilege permission set (current: traces/evaluations/datasets/
+scenarios/annotations/analytics/prompts/triggers/workflows = write, cost = read; no secrets/admin/audit).
+Validate against what `langy.ts` + Langy's MCP tools actually call; trim to smallest viable.
+
+## PR 2 — adaptive "Set up Langy" modal (#4274)  ·  *needs #4273*
+
+One modal, server picks the branch:
+
+```
+① Langy key:  (•) Create dedicated Langy key ⭐   ( ) Use existing project key
+② Model:
+     A  Anthropic configured → "✓ Use Anthropic" (1-click)
+     B  other provider only  → "✓ Use your <provider>" (default) + soft Anthropic nudge
+     C  none configured      → [Add a model →] deep-link to Settings → Model Providers
+                               (Anthropic prefilled), return-URL continuation back to the modal
+```
+
+- [ ] Reuse `src/components/scenarios/ModelProviderRequiredModal.tsx` as the pattern.
+- [ ] **Gate (this PR):** the existing `ModelProvider` 409 in `src/server/routes/langy.ts:235`
+      (`getVercelAIModel` → 409 at :244) — Langy's *real* failure today.
+- [ ] Branch C reuses the real model-provider form (one source of truth, no duplicated validation).
+
+### Execution map (researched — ready to build)
+- **New component** `src/components/langy/SetUpLangyModal.tsx` — Chakra `Dialog` (same shape as `ModelProviderRequiredModal`).
+- **Readiness / branch detection:** `api.modelProvider.getAllForProjectForFrontend.useQuery({ projectId })`
+  → inspect enabled providers; Anthropic present = branch A, other-only = branch B, none = branch C.
+- **Model dropdown:** reuse the existing `<ModelSelector model options={allModelOptions} onChange mode="chat" showConfigureAction />`
+  from `src/components/ModelSelector.tsx` — it already renders grouped options *and* the branch-C
+  "No models configured" callout via `useModelSelectionOptions` (its `isEmpty`).
+- **Persist the pick:** `api.modelProvider.saveDefaultModelsConfig` mutation (feature key for Langy's default
+  chat model; confirm key — likely `prompt.create_default` or a new `langy.*` role in `featureRegistry.ts`).
+- **Wire the trigger:** `LangySidebar.tsx:427` `useChat({ onError })` — detect the 409 (status/`error` body)
+  and open the modal instead of (or before) the toast. Optional: proactively open on mount when
+  `getAllForProjectForFrontend` shows not-ready (more seamless than waiting for the error).
+- **Key section:** PR1 already auto-mints the dedicated Langy key, so ① is a confirmation line
+  ("✓ dedicated Langy key ready"), not an action.
+- **Return-URL continuation (branch C):** deep-link `/settings/model-providers?return=<langy>` and reopen the
+  modal on return (mirror an OAuth `redirect_uri`).
+
+## PR 3 — route Langy LLM through the gateway / VirtualKey (#4275)  ·  *needs #4274*
+
+Note: #4272 already provisions the VirtualKey and points the worker's opencode at `gatewayBaseUrl`.
+This PR makes the **control-plane gate** honest and binds the VK to a provider chain.
+
+- [ ] Ensure the Langy `VirtualKey` (already minted by `LangyCredentialService`) is bound to a
+      `GatewayProviderCredential` fallback chain (reuse `src/server/gateway/virtualKey.service.ts`).
+- [ ] Rewire / replace the `getVercelAIModel` availability check at `langy.ts:235` so the gate reflects
+      **VirtualKey readiness** rather than the legacy `ModelProvider` path.
+- [ ] Flip the modal's gate (from #4274): "ModelProvider configured?" → "VirtualKey configured?"
+      (UI unchanged, only the underlying check).
+
+## Dev env / verify
+
+```bash
+cd ~/langwatch_codebase/langy-keys/langwatch
+pnpm install                       # match repo pnpm (corepack may pull the wrong major — see memory)
+pnpm start:prepare:files           # regenerate Prisma/zod/generated types after worktree creation
+pnpm typecheck
+pnpm test:integration <file>       # real DB, no mocks
+make quickstart migration          # postgres + clickhouse on host ports, for prisma + integration tests
+```
+
+## Conventions (from CLAUDE.md)
+- Spec → test → code (outside-in TDD). Update the `.feature` *before* changing behavior.
+- Always include `projectId` in Prisma WHERE clauses for project-level models.
+- Each PR body: `Refs #4528` + tick the relevant sub-issue checkbox.
+- No re-exports for back-compat; no new REST endpoints.


### PR DESCRIPTION
## What

Auto-provisions a dedicated, least-privilege **Langy API key** per project so the in-product assistant acts with its own credential (not the human's ingestion key), and routes it to the Langy worker.

- Mints a service `ApiKey` named **Langy** (`userId: null`), `permissionMode: restricted`, bound to **PROJECT scope only** — reuses `ApiKeyService`, no new schema.
- Captures the one-time token and stores it encrypted in `ProjectSecret("langy_api_key_secret")`. The `ApiKey` secret is hashed/unrecoverable, so the runtime must persist the usable token at mint — same pattern as the Langy virtual key.
- Provisioned three ways, all idempotent via one shared `provisionLangyApiKey`:
  - **At project creation** — tRPC `project.create` hook (best-effort; never blocks creation).
  - **Backfill** for existing projects — `scripts/backfill-langy-api-keys.ts` (org-admin attribution where there's no actor).
  - **Runtime provision-on-first-use** — `LangyCredentialService.getOrProvision` now hands the worker the dedicated key (falls back to `project.apiKey`).

## Notable fix

`ProjectSecret` lookups used `findUnique({ projectId_name })`, which the `guardProjectId` multitenancy middleware on the request-scoped prisma client rejects — it doesn't recognize the `projectId_name` compound key — so the creation-hook mint and VK provisioning silently threw in-request (swallowed by the hook's try/catch). Switched to `findFirst({ projectId, name })` (`ProjectSecret` is unique on `(projectId, name)`).

## Verification

- Integration test (real DB, no mocks): `project.create.langyKey.integration.test.ts`.
- End-to-end: a fresh browser signup → onboarding → confirmed the dedicated `Langy` key (service key, `restricted`, project-scoped only) **and** the stored token are minted by the creation hook under the real guarded client.
- `pnpm typecheck` clean.

## Notes

- Stacks on langwatch/langwatch#4272 (per-session OpenCode workers + per-request credentials); base is `langy/per-session-manager`.
- Least-privilege set: traces/evaluations/datasets/scenarios/annotations/analytics/prompts/triggers/workflows = write, cost = read; no secrets / project-admin / audit-log.
- Credentials are per-project for now (see the per-user vs per-project discussion on langwatch/langwatch#4272); conversation history is already per-user.

Closes langwatch/tasks#65
Refs langwatch/tasks#103, langwatch/langwatch#4272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
