### PR TITLE
fix(governance): prod blackhole on OTLP ingestion + personal VK without default routing policy

### DIFF
--- a/langwatch/ee/governance/dashboard/pages/ingestion-source-detail.tsx
+++ b/langwatch/ee/governance/dashboard/pages/ingestion-source-detail.tsx
@@ -629,16 +629,21 @@ function SecretRevealModal({
   const usesWebhookUrl = sourceType === "workato";
   const isClaudeCode = sourceType === "claude_code";
 
-  // Claude Code's monitoring-usage doc requires both
-  // CLAUDE_CODE_ENABLE_TELEMETRY=1 and the standard OTEL_*_EXPORTER
-  // env vars before any signals are emitted. Pre-build the shell
-  // export block so admins paste once instead of stitching six lines
-  // off the docs page. SDK suffixes /v1/logs + /v1/metrics off the
-  // base endpoint (Ariana's 2026-05-06 capture confirmed the
-  // SDK-side suffixing — admins paste the bare base).
+  // Claude Code's monitoring-usage doc requires CLAUDE_CODE_ENABLE_TELEMETRY=1
+  // plus the standard OTEL_*_EXPORTER env vars before any signals are emitted.
+  // We also recommend OTEL_TRACES_EXPORTER=otlp so any spans Claude Code does
+  // instrument propagate to LangWatch and any logs/metrics emitted INSIDE a
+  // span get correlated. Standalone records still arrive without trace context
+  // (logs emitted outside spans always will, per OTLP proto v1.0.0 where
+  // trace_id/span_id are optional on LogRecord), but the receiver synthesizes
+  // a stable trace id from service.name + service.instance.id so each session
+  // surfaces as one named trace in the listing. Pre-build the shell export
+  // block so admins paste once instead of stitching seven lines off the docs
+  // page.
   const claudeCodeEnvBlock = isClaudeCode
     ? [
         `export CLAUDE_CODE_ENABLE_TELEMETRY=1`,
+        `export OTEL_TRACES_EXPORTER=otlp`,
         `export OTEL_LOGS_EXPORTER=otlp`,
         `export OTEL_METRICS_EXPORTER=otlp`,
         `export OTEL_EXPORTER_OTLP_PROTOCOL=http/json`,

--- a/langwatch/ee/governance/dashboard/pages/ingestion-sources.tsx
+++ b/langwatch/ee/governance/dashboard/pages/ingestion-sources.tsx
@@ -1341,16 +1341,19 @@ function SecretModal({
   const usesWebhookUrl = details?.sourceType === "workato";
   const isClaudeCode = details?.sourceType === "claude_code";
 
-  // Claude Code's monitoring-usage doc requires both
-  // CLAUDE_CODE_ENABLE_TELEMETRY=1 and the standard OTEL_*_EXPORTER
-  // env vars before any signals are emitted. Pre-build the shell
-  // export block so admins paste once instead of stitching six lines
-  // off the docs page. SDK suffixes /v1/logs + /v1/metrics off the
-  // base endpoint.
+  // Claude Code's monitoring-usage doc requires CLAUDE_CODE_ENABLE_TELEMETRY=1
+  // plus the standard OTEL_*_EXPORTER env vars. We recommend
+  // OTEL_TRACES_EXPORTER=otlp so spans claude-code instruments propagate to
+  // LangWatch and logs/metrics emitted inside those spans get correlated;
+  // the session.id resource attribute is then mapped to gen_ai.conversation.id
+  // by the OpenInference extractor so the UI groups the session as one thread.
+  // Pre-build the shell export block so admins paste once instead of stitching
+  // seven lines off the docs page.
   const claudeCodeEnvBlock = useMemo(() => {
     if (!isClaudeCode || !details) return "";
     return [
       `export CLAUDE_CODE_ENABLE_TELEMETRY=1`,
+      `export OTEL_TRACES_EXPORTER=otlp`,
       `export OTEL_LOGS_EXPORTER=otlp`,
       `export OTEL_METRICS_EXPORTER=otlp`,
       `export OTEL_EXPORTER_OTLP_PROTOCOL=http/json`,

--- a/langwatch/ee/governance/services/__tests__/personalVirtualKey.service.gracefulFallback.integration.test.ts
+++ b/langwatch/ee/governance/services/__tests__/personalVirtualKey.service.gracefulFallback.integration.test.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * @vitest-environment node
+ *
+ * Real-DB integration coverage for the no-default-policy graceful
+ * fallback in `PersonalVirtualKeyService.issue`. When the caller
+ * relies on default resolution and the org has no `isDefault=true`
+ * RoutingPolicy, the service used to throw and the device-flow
+ * approval silently bypassed VK minting. Customers with many
+ * ModelProviders configured at ORG scope still saw "No personal
+ * virtual key on this account" on `langwatch login`.
+ *
+ * Now: when at least one ModelProvider is reachable from the
+ * personal team via scope cascade (PROJECT / TEAM / ORGANIZATION),
+ * the VK is minted with `routingPolicyId: null` and the gateway
+ * dispatch path falls back to `fallbackPriorityGlobal` ordering.
+ * Only when the cascade is empty do we refuse the mint with the
+ * actionable `NoEligibleProvidersError`.
+ */
+
+import { nanoid } from "nanoid";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { prisma } from "~/server/db";
+
+import {
+  PersonalVirtualKeyService,
+  NoEligibleProvidersError,
+} from "../personalVirtualKey.service";
+
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+const hasCredentialsSecret = !!process.env.CREDENTIALS_SECRET;
+
+describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
+  "PersonalVirtualKeyService.issue — graceful fallback when no default policy (real DB)",
+  () => {
+    const service = PersonalVirtualKeyService.create(prisma, {
+      gatewayBaseUrl: "http://gw.test",
+    });
+
+    let suffix: string;
+    let orgId: string;
+    let userId: string;
+    let teamId: string;
+    let projectId: string;
+
+    beforeEach(async () => {
+      suffix = nanoid(8);
+      orgId = `org-fb-${suffix}`;
+      userId = `usr-fb-${suffix}`;
+      teamId = `team-fb-${suffix}`;
+      projectId = `proj-fb-${suffix}`;
+
+      await prisma.organization.create({
+        data: { id: orgId, name: `FB ${suffix}`, slug: `fb-${suffix}` },
+      });
+      await prisma.user.create({
+        data: { id: userId, email: `fb-${suffix}@example.com`, name: "FB User" },
+      });
+      await prisma.organizationUser.create({
+        data: { organizationId: orgId, userId, role: "MEMBER" },
+      });
+      await prisma.team.create({
+        data: {
+          id: teamId,
+          name: `FB Personal ${suffix}`,
+          slug: `fb-personal-${suffix}`,
+          organizationId: orgId,
+          isPersonal: true,
+          ownerUserId: userId,
+        },
+      });
+      await prisma.project.create({
+        data: {
+          id: projectId,
+          name: `FB Project ${suffix}`,
+          slug: `fb-project-${suffix}`,
+          apiKey: `fb-${suffix}`,
+          teamId,
+          language: "typescript",
+          framework: "other",
+          isPersonal: true,
+          ownerUserId: userId,
+        },
+      });
+    });
+
+    describe("given an org-scoped ModelProvider exists but no default RoutingPolicy", () => {
+      /** @scenario When org has no default RoutingPolicy but has accessible providers, personal-key issuance succeeds with no policy bound */
+      it("mints the VK with routingPolicyId=null instead of throwing", async () => {
+        const mpId = `mp-fb-${suffix}`;
+        await prisma.modelProvider.create({
+          data: {
+            id: mpId,
+            name: `fb-mp-${suffix}`,
+            provider: "anthropic",
+            enabled: true,
+            organizationId: orgId,
+            scopes: {
+              create: [{ scopeType: "ORGANIZATION", scopeId: orgId }],
+            },
+          },
+        });
+
+        const issued = await service.issue({
+          userId,
+          organizationId: orgId,
+          personalProjectId: projectId,
+          personalTeamId: teamId,
+          label: "default",
+        });
+
+        expect(issued.routingPolicyId).toBeNull();
+        expect(issued.virtualKey.id).toBeTruthy();
+        expect(issued.secret).toBeTruthy();
+      });
+    });
+
+    describe("given a default RoutingPolicy with zero providers AND a separately-scoped MP", () => {
+      it("falls back to mint with null policy rather than refusing — caller did not pin the empty policy", async () => {
+        await prisma.routingPolicy.create({
+          data: {
+            id: `rp-empty-${suffix}`,
+            organizationId: orgId,
+            name: `empty-${suffix}`,
+            isDefault: true,
+            modelProviderIds: [],
+            scopes: {
+              create: [{ scopeType: "ORGANIZATION", scopeId: orgId }],
+            },
+          },
+        });
+        await prisma.modelProvider.create({
+          data: {
+            id: `mp-fb2-${suffix}`,
+            name: `fb-mp2-${suffix}`,
+            provider: "openai",
+            enabled: true,
+            organizationId: orgId,
+            scopes: {
+              create: [{ scopeType: "ORGANIZATION", scopeId: orgId }],
+            },
+          },
+        });
+
+        const issued = await service.issue({
+          userId,
+          organizationId: orgId,
+          personalProjectId: projectId,
+          personalTeamId: teamId,
+          label: "default",
+        });
+
+        expect(issued.routingPolicyId).toBeNull();
+      });
+    });
+
+    describe("given the org has zero accessible ModelProviders", () => {
+      /** @scenario When org has no AI providers at all, personal-key issuance fails with a clear error */
+      it("rejects with NoEligibleProvidersError carrying an actionable message", async () => {
+        await expect(
+          service.issue({
+            userId,
+            organizationId: orgId,
+            personalProjectId: projectId,
+            personalTeamId: teamId,
+            label: "default",
+          }),
+        ).rejects.toBeInstanceOf(NoEligibleProvidersError);
+      });
+    });
+  },
+);

--- a/langwatch/ee/governance/services/personalVirtualKey.service.ts
+++ b/langwatch/ee/governance/services/personalVirtualKey.service.ts
@@ -174,21 +174,46 @@ export class PersonalVirtualKeyService {
       throw new PersonalVirtualKeyNotFoundError(routingPolicyId);
     }
 
-    // Spec contract (specs/ai-gateway/governance/personal-keys.feature
-    // lines 57-63): when the caller relied on default-policy resolution
-    // and the org has no default policy, the device-exchange MUST 409
-    // with `{ error: "no_default_routing_policy" }` and NO personal VK
-    // should be created.
-    if (routingPolicyId === undefined && !policy) {
-      throw new NoDefaultRoutingPolicyError(organizationId);
+    // Default-resolution path: when the caller did not pin a specific
+    // routingPolicyId AND the org has no default policy (or the
+    // default points at an empty provider list), fall back to minting
+    // the VK with `routingPolicyId: null`. The gateway's
+    // `eligibleModelProvidersForVk` already handles a null policy by
+    // ranking every scope-cascade-eligible ModelProvider on
+    // `fallbackPriorityGlobal` ASC then `createdAt` ASC — so the VK
+    // dispatches correctly as long as at least one provider is
+    // reachable. Only when truly zero providers are reachable does the
+    // mint fail with an actionable error.
+    //
+    // When the caller pinned an explicit routingPolicyId, the empty-
+    // policy invariant from G34 still applies — they asked for THIS
+    // policy and we refuse to silently substitute a different shape.
+    const defaultResolution = routingPolicyId === undefined;
+    const policyIsEmpty =
+      !!policy && extractModelProviderIds(policy).length === 0;
+
+    if (defaultResolution && (!policy || policyIsEmpty)) {
+      const eligibleCount = await this.countEligibleProviders({
+        organizationId,
+        personalTeamId,
+        personalProjectId,
+      });
+      if (eligibleCount === 0) {
+        throw new NoEligibleProvidersError(organizationId);
+      }
+      // Fall through with policy = null (gateway uses cascade order).
+      // Important: clear `policy` so the create call below writes
+      // routingPolicyId: null instead of the stale empty-default.
+      // The local rebind is fine — `policy` is only read by the
+      // `policy?.id` accessors after this point.
+    } else if (policyIsEmpty) {
+      // Caller pinned an empty policy explicitly — preserve the
+      // validate-before-mint contract from G34.
+      throw new RoutingPolicyHasNoProvidersError(policy!.id, policy!.name);
     }
 
-    // G34: validate the resolved policy has at least one eligible
-    // ModelProvider before minting, otherwise the user copy-pastes a
-    // curl that 504s at the gateway.
-    if (policy && extractModelProviderIds(policy).length === 0) {
-      throw new RoutingPolicyHasNoProvidersError(policy.id, policy.name);
-    }
+    const resolvedPolicyId =
+      defaultResolution && (!policy || policyIsEmpty) ? null : policy?.id ?? null;
 
     const vkService = VirtualKeyService.create(this.prisma);
     const { virtualKey, secret } = await vkService.create({
@@ -198,14 +223,14 @@ export class PersonalVirtualKeyService {
       principalUserId: userId,
       actorUserId: userId,
       scopes: [{ scopeType: "PROJECT", scopeId: personalProjectId }],
-      routingPolicyId: policy?.id ?? null,
+      routingPolicyId: resolvedPolicyId,
     });
 
     return {
       virtualKey,
       secret,
       baseUrl: this.gatewayBaseUrl,
-      routingPolicyId: policy?.id ?? null,
+      routingPolicyId: resolvedPolicyId,
       id: virtualKey.id,
       label: virtualKey.name,
     };
@@ -284,6 +309,41 @@ export class PersonalVirtualKeyService {
   }
 
   /**
+   * Count ModelProviders that a personal VK at the given personal team /
+   * project would see via scope cascade (PROJECT → TEAM → ORGANIZATION).
+   * Used as the gate for the no-default-policy graceful-fallback path:
+   * if any provider is reachable, mint with routingPolicyId=null instead
+   * of refusing the request. Mirrors the scope predicates in
+   * `eligibleModelProvidersForVk`.
+   */
+  private async countEligibleProviders({
+    organizationId,
+    personalTeamId,
+    personalProjectId,
+  }: {
+    organizationId: string;
+    personalTeamId?: string;
+    personalProjectId: string;
+  }): Promise<number> {
+    const scopePredicates: Array<{
+      scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+      scopeId: string;
+    }> = [{ scopeType: "ORGANIZATION", scopeId: organizationId }];
+    if (personalTeamId) {
+      scopePredicates.push({ scopeType: "TEAM", scopeId: personalTeamId });
+    }
+    scopePredicates.push({ scopeType: "PROJECT", scopeId: personalProjectId });
+
+    return await this.prisma.modelProvider.count({
+      where: {
+        enabled: true,
+        disabledAt: null,
+        scopes: { some: { OR: scopePredicates } },
+      },
+    });
+  }
+
+  /**
    * Cascade revoke every personal VK belonging to a user.
    * Called from the user-deactivation path (out of scope for this
    * iteration — wiring point exists for follow-up).
@@ -332,18 +392,25 @@ export class PersonalVirtualKeyNotFoundError extends Error {
 }
 
 /**
- * Thrown by `issue()` when the caller relied on default-policy resolution
- * (no `routingPolicyId` argument) and the organisation has no
- * RoutingPolicy with `isDefault=true`. Routes / tRPC handlers should
- * translate this to HTTP 409 with `{ error: "no_default_routing_policy" }`
- * per specs/ai-gateway/governance/personal-keys.feature.
+ * Thrown by `issue()` when the caller relied on default-policy
+ * resolution (no `routingPolicyId` argument) and the organization has
+ * NO ModelProvider reachable from the user's personal team via scope
+ * cascade. Without any eligible provider the gateway would have
+ * nothing to route to, so the mint is refused with a clear
+ * "configure a provider" message. Routes / tRPC handlers translate
+ * this to HTTP 409 with `{ error: "no_eligible_providers" }`.
+ *
+ * Distinct from `RoutingPolicyHasNoProvidersError`: that one fires
+ * when the caller pinned an empty policy explicitly (G34 invariant).
+ * This one fires when no policy was requested AND the cascade is
+ * empty — i.e. the org genuinely has no providers configured yet.
  */
-export class NoDefaultRoutingPolicyError extends Error {
+export class NoEligibleProvidersError extends Error {
   constructor(public readonly organizationId: string) {
     super(
-      `Your organization admin must publish a default routing policy before personal keys can be issued.`,
+      `Your organization has no AI providers configured. Ask an admin to add one at Settings → Model Providers.`,
     );
-    this.name = "NoDefaultRoutingPolicyError";
+    this.name = "NoEligibleProvidersError";
   }
 }
 

--- a/langwatch/ee/governance/services/personalVirtualKey.service.ts
+++ b/langwatch/ee/governance/services/personalVirtualKey.service.ts
@@ -188,11 +188,19 @@ export class PersonalVirtualKeyService {
     // When the caller pinned an explicit routingPolicyId, the empty-
     // policy invariant from G34 still applies — they asked for THIS
     // policy and we refuse to silently substitute a different shape.
-    const defaultResolution = routingPolicyId === undefined;
+    // Both "no policy id provided" (undefined → default-resolution) and
+    // "no policy requested" (explicit null) collapse into the same
+    // mint-with-null-policy branch — they both end up with a VK whose
+    // routingPolicyId is null and rely on the gateway's cascade
+    // ordering. Either way we still owe the caller the no-provider
+    // guard, otherwise an empty org could mint a broken VK by passing
+    // `routingPolicyId: null` explicitly.
+    const noPolicyRequested =
+      routingPolicyId === undefined || routingPolicyId === null;
     const policyIsEmpty =
       !!policy && extractModelProviderIds(policy).length === 0;
 
-    if (defaultResolution && (!policy || policyIsEmpty)) {
+    if (noPolicyRequested && (!policy || policyIsEmpty)) {
       const eligibleCount = await this.countEligibleProviders({
         organizationId,
         personalTeamId,
@@ -202,10 +210,6 @@ export class PersonalVirtualKeyService {
         throw new NoEligibleProvidersError(organizationId);
       }
       // Fall through with policy = null (gateway uses cascade order).
-      // Important: clear `policy` so the create call below writes
-      // routingPolicyId: null instead of the stale empty-default.
-      // The local rebind is fine — `policy` is only read by the
-      // `policy?.id` accessors after this point.
     } else if (policyIsEmpty) {
       // Caller pinned an empty policy explicitly — preserve the
       // validate-before-mint contract from G34.
@@ -213,7 +217,7 @@ export class PersonalVirtualKeyService {
     }
 
     const resolvedPolicyId =
-      defaultResolution && (!policy || policyIsEmpty) ? null : policy?.id ?? null;
+      noPolicyRequested && (!policy || policyIsEmpty) ? null : policy?.id ?? null;
 
     const vkService = VirtualKeyService.create(this.prisma);
     const { virtualKey, secret } = await vkService.create({

--- a/langwatch/ee/governance/services/routingPolicy.service.ts
+++ b/langwatch/ee/governance/services/routingPolicy.service.ts
@@ -307,8 +307,10 @@ export class RoutingPolicyService {
    * the TEAM-default-beats-ORG-default rule from the spec.
    *
    * Returns null if the org has no default policy at any tier — caller
-   * is expected to translate to a 409 `no_default_routing_policy`
-   * (see `NoDefaultRoutingPolicyError` in personalVirtualKey.service).
+   * (currently `PersonalVirtualKeyService.issue`) falls back to minting
+   * the VK with `routingPolicyId: null`, which the gateway resolves via
+   * scope cascade + `fallbackPriorityGlobal` ordering on every eligible
+   * ModelProvider.
    */
   async resolveDefaultForUser({
     organizationId,

--- a/langwatch/src/components/me/IngestionTemplateInstallDrawer.tsx
+++ b/langwatch/src/components/me/IngestionTemplateInstallDrawer.tsx
@@ -24,7 +24,11 @@ import { toaster } from "~/components/ui/toaster";
 
 const SECRET_MASK = "•".repeat(48);
 
-function buildEnvSnippet(slug: string, endpoint: string, token: string): string {
+export function buildEnvSnippet(
+  slug: string,
+  endpoint: string,
+  token: string,
+): string {
   const base = `export OTEL_EXPORTER_OTLP_ENDPOINT="${endpoint}"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${token}"`;
   if (slug === "claude_code") {

--- a/langwatch/src/components/me/IngestionTemplateInstallDrawer.tsx
+++ b/langwatch/src/components/me/IngestionTemplateInstallDrawer.tsx
@@ -30,6 +30,7 @@ export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${token}"`;
   if (slug === "claude_code") {
     return [
       `export CLAUDE_CODE_ENABLE_TELEMETRY=1`,
+      `export OTEL_TRACES_EXPORTER=otlp`,
       `export OTEL_LOGS_EXPORTER=otlp`,
       `export OTEL_METRICS_EXPORTER=otlp`,
       `export OTEL_EXPORTER_OTLP_PROTOCOL=http/json`,
@@ -142,10 +143,15 @@ export function IngestionTemplateInstallDrawer({
 
   // Claude Code only emits OTLP when CLAUDE_CODE_ENABLE_TELEMETRY=1 plus
   // the OTEL_LOGS_EXPORTER + OTEL_METRICS_EXPORTER + OTEL_EXPORTER_OTLP_PROTOCOL
-  // trio. Without those four, Claude Code silently does nothing even with
-  // a valid endpoint + token. Other ingestion sources (cursor, claude_cowork,
-  // raw OTLP) need only the endpoint + bearer header — they enable
-  // telemetry through their own configuration.
+  // trio. Without those, Claude Code silently does nothing even with a valid
+  // endpoint + token. OTEL_TRACES_EXPORTER=otlp is recommended too so any
+  // spans Claude Code does instrument propagate to LangWatch and any logs or
+  // metrics emitted inside a span get correlated; standalone records still
+  // arrive context-less and the receiver synthesizes a stable trace id per
+  // service.instance.id so each session surfaces as one named trace. Other
+  // ingestion sources (cursor, claude_cowork, raw OTLP) need only the
+  // endpoint + bearer header, they enable telemetry through their own
+  // configuration.
   const envVarsSnippet = installResult
     ? buildEnvSnippet(template.slug, installResult.endpoint, renderedToken)
     : "";

--- a/langwatch/src/components/me/__tests__/IngestionTemplateInstallDrawer.buildEnvSnippet.unit.test.ts
+++ b/langwatch/src/components/me/__tests__/IngestionTemplateInstallDrawer.buildEnvSnippet.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEnvSnippet } from "../IngestionTemplateInstallDrawer";
+
+const ENDPOINT = "https://app.langwatch.ai/api/otel";
+const TOKEN = "ik-lw-TEST_TOKEN";
+
+describe("buildEnvSnippet", () => {
+  describe("when the template slug is claude_code", () => {
+    const snippet = buildEnvSnippet("claude_code", ENDPOINT, TOKEN);
+
+    it("includes the claude-code telemetry switch", () => {
+      expect(snippet).toContain("export CLAUDE_CODE_ENABLE_TELEMETRY=1");
+    });
+
+    it("recommends OTEL_TRACES_EXPORTER=otlp", () => {
+      // Without traces exporter, claude-code never emits spans, every log
+      // arrives without trace context, and the fold-skip in
+      // traceSummary.foldProjection drops them from /messages.
+      expect(snippet).toContain("export OTEL_TRACES_EXPORTER=otlp");
+    });
+
+    it("recommends OTEL_LOGS_EXPORTER=otlp", () => {
+      expect(snippet).toContain("export OTEL_LOGS_EXPORTER=otlp");
+    });
+
+    it("recommends OTEL_METRICS_EXPORTER=otlp", () => {
+      expect(snippet).toContain("export OTEL_METRICS_EXPORTER=otlp");
+    });
+
+    it("uses http/json protocol", () => {
+      expect(snippet).toContain("export OTEL_EXPORTER_OTLP_PROTOCOL=http/json");
+    });
+
+    it("interpolates the endpoint and token", () => {
+      expect(snippet).toContain(`OTEL_EXPORTER_OTLP_ENDPOINT="${ENDPOINT}"`);
+      expect(snippet).toContain(
+        `OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${TOKEN}"`,
+      );
+    });
+  });
+
+  describe("when the template slug is anything else", () => {
+    const snippet = buildEnvSnippet("cursor", ENDPOINT, TOKEN);
+
+    it("emits only the endpoint and bearer header", () => {
+      // Non-claude-code sources enable telemetry through their own config.
+      expect(snippet).not.toContain("CLAUDE_CODE_ENABLE_TELEMETRY");
+      expect(snippet).not.toContain("OTEL_TRACES_EXPORTER");
+      expect(snippet).not.toContain("OTEL_LOGS_EXPORTER");
+      expect(snippet).toContain(`OTEL_EXPORTER_OTLP_ENDPOINT="${ENDPOINT}"`);
+      expect(snippet).toContain(
+        `OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer ${TOKEN}"`,
+      );
+    });
+  });
+});

--- a/langwatch/src/components/me/tiles/ModelProviderTile.tsx
+++ b/langwatch/src/components/me/tiles/ModelProviderTile.tsx
@@ -48,9 +48,6 @@ function articleFor(word: string): "a" | "an" {
   return VOWEL_SOUNDS.includes(first) ? "an" : "a";
 }
 
-const NO_DEFAULT_POLICY_HINT =
-  "no default routing policy"; // matches `NoDefaultRoutingPolicyError.message` (lowercased compare)
-
 interface Props {
   displayName: string;
   config: ModelProviderConfig;
@@ -290,21 +287,6 @@ export function ModelProviderTile({
               <Text fontSize="xs" color="red.700">
                 {errorMessage}
               </Text>
-              {errorMessage.toLowerCase().includes(NO_DEFAULT_POLICY_HINT) && (
-                <Text fontSize="xs" color="red.700" marginTop={1}>
-                  <Link
-                    href="/settings/routing-policies"
-                    color="red.700"
-                    fontWeight="medium"
-                  >
-                    Configure routing policy →
-                  </Link>{" "}
-                  <Text as="span" color="fg.muted">
-                    (admin only — non-admins should ask their organization
-                    admin to publish a default)
-                  </Text>
-                </Text>
-              )}
             </Box>
           )}
         </VStack>

--- a/langwatch/src/pages/settings/routing-policies.tsx
+++ b/langwatch/src/pages/settings/routing-policies.tsx
@@ -376,14 +376,15 @@ function RoutingPoliciesPage() {
                     : "Publish a default policy to unblock end-user keys"}
                 </Text>
                 <Text fontSize="xs" color="fg.muted">
-                  Without an applicable default, {`'langwatch login'`} (and
-                  every personal-key issue path) returns 409{" "}
+                  Without a default, personal keys still mint and the
+                  gateway picks providers in {" "}
                   <Text as="span" fontFamily="mono">
-                    no_default_routing_policy
-                  </Text>
-                  . Start with an Organization default that points at
-                  whichever model providers your team should use, then
-                  override per-team or per-project as needed.
+                    fallbackPriorityGlobal
+                  </Text>{" "}
+                  order — useful as a quick start. Publish an explicit
+                  default to pin a deterministic chain at the
+                  organization level, then override per-team or
+                  per-project as needed.
                 </Text>
                 <HStack gap={3} paddingTop={1}>
                   <Button
@@ -527,7 +528,7 @@ function RoutingPoliciesPage() {
         }
         message={
           policyToDelete?.isDefault
-            ? "This is the default policy at this scope. Personal-key issue paths and 'langwatch login' will return 409 no_default_routing_policy until another default is published. Virtual keys that resolved through this policy will fail closed at the next request."
+            ? "This is the default policy at this scope. Personal-key issue paths fall back to fallbackPriorityGlobal ordering across all scope-eligible providers until another default is published; existing VKs that resolved through this policy lose the pinned chain and follow the same fallback on the next request."
             : "Virtual keys that explicitly reference this policy will lose the reference and fail closed at the next request. Re-publish or pick another policy on the affected VKs to restore routing."
         }
         confirmLabel="Delete policy"

--- a/langwatch/src/pages/settings/routing-policies.tsx
+++ b/langwatch/src/pages/settings/routing-policies.tsx
@@ -376,15 +376,17 @@ function RoutingPoliciesPage() {
                     : "Publish a default policy to unblock end-user keys"}
                 </Text>
                 <Text fontSize="xs" color="fg.muted">
-                  Without a default, personal keys still mint and the
-                  gateway picks providers in {" "}
+                  When at least one model provider is reachable from a
+                  user's personal team, personal keys still mint
+                  without a default and the gateway picks providers in {" "}
                   <Text as="span" fontFamily="mono">
                     fallbackPriorityGlobal
                   </Text>{" "}
-                  order — useful as a quick start. Publish an explicit
-                  default to pin a deterministic chain at the
-                  organization level, then override per-team or
-                  per-project as needed.
+                  order. Orgs with zero accessible providers still hit
+                  a 409 at issue time; configure a model provider first.
+                  Publish an explicit default to pin a deterministic
+                  chain at the organization level, then override
+                  per-team or per-project as needed.
                 </Text>
                 <HStack gap={3} paddingTop={1}>
                   <Button
@@ -528,7 +530,7 @@ function RoutingPoliciesPage() {
         }
         message={
           policyToDelete?.isDefault
-            ? "This is the default policy at this scope. Personal-key issue paths fall back to fallbackPriorityGlobal ordering across all scope-eligible providers until another default is published; existing VKs that resolved through this policy lose the pinned chain and follow the same fallback on the next request."
+            ? "This is the default policy at this scope. NEW personal-key issuance falls back to fallbackPriorityGlobal ordering across scope-eligible providers until another default is published. Existing VKs that already reference this policy keep the persisted routingPolicyId and will fail closed on the next request until you re-bind them to another policy."
             : "Virtual keys that explicitly reference this policy will lose the reference and fail closed at the next request. Re-publish or pick another policy on the affected VKs to restore routing."
         }
         confirmLabel="Delete policy"

--- a/langwatch/src/server/api/routers/personalVirtualKeys.ts
+++ b/langwatch/src/server/api/routers/personalVirtualKeys.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 import {
   PersonalVirtualKeyService,
   PersonalVirtualKeyNotFoundError,
-  NoDefaultRoutingPolicyError,
+  NoEligibleProvidersError,
   RoutingPolicyHasNoProvidersError,
 } from "@ee/governance/services/personalVirtualKey.service";
 import { PersonalWorkspaceService } from "@ee/governance/services/personalWorkspace.service";
@@ -206,24 +206,22 @@ export const personalVirtualKeysRouter = createTRPCRouter({
           routingPolicyId: input.routingPolicyId,
         });
       } catch (err) {
-        // Spec contract — no_default_routing_policy maps to 409 so the
-        // CLI / device-flow client can surface the actionable
-        // "ask your admin to publish a default policy" message.
-        if (err instanceof NoDefaultRoutingPolicyError) {
+        // Default-resolution path with zero accessible providers — the
+        // user genuinely has nothing to route through. Map to 409 so
+        // the CLI / /me UI can surface the actionable "ask your admin
+        // to add a provider" message at mint time instead of letting
+        // the user discover the gap via a copy-pasted curl that 504s.
+        if (err instanceof NoEligibleProvidersError) {
           throw new TRPCError({
             code: "CONFLICT",
             message: err.message,
             cause: err,
           });
         }
-        // G34 — empty routing policy (provider list is []). Mapping to
-        // 422 (UNPROCESSABLE_CONTENT) per master_orchestrator's
-        // contract for validate-before-mint: the request is
-        // syntactically fine but the org's state doesn't yet support
-        // processing it. /me consumes the actionable
-        // "ask your admin to add providers" message at mint time
-        // instead of letting the user discover the gap via a
-        // copy-pasted curl that 504s.
+        // G34 — empty routing policy (provider list is []) when the
+        // caller explicitly pinned that policy. Mapping to 422
+        // (UNPROCESSABLE_CONTENT) — the request is syntactically fine
+        // but the pinned policy does not yet support processing it.
         if (err instanceof RoutingPolicyHasNoProvidersError) {
           throw new TRPCError({
             code: "UNPROCESSABLE_CONTENT",

--- a/langwatch/src/server/app-layer/traces/__tests__/log-request-collection.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/log-request-collection.service.unit.test.ts
@@ -78,7 +78,7 @@ describe("LogRequestCollectionService", () => {
               resource: { attributes: [] },
               scopeLogs: [
                 {
-                  scope: { name: "test", version: null },
+                  scope: { name: "test", version: undefined },
                   logRecords: [
                     {
                       timeUnixNano: "1700000000000000000",
@@ -117,7 +117,7 @@ describe("LogRequestCollectionService", () => {
               resource: { attributes: [] },
               scopeLogs: [
                 {
-                  scope: { name: "test", version: null },
+                  scope: { name: "test", version: undefined },
                   logRecords: [
                     {
                       timeUnixNano: "1700000000000000000",

--- a/langwatch/src/server/app-layer/traces/__tests__/log-request-collection.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/log-request-collection.service.unit.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RecordLogCommandData } from "../../../event-sourcing/pipelines/trace-processing/schemas/commands";
+import { LogRequestCollectionService } from "../log-request-collection.service";
+
+function makeService() {
+  const recordLog = vi.fn<(data: RecordLogCommandData) => Promise<void>>(
+    () => Promise.resolve(),
+  );
+  const service = new LogRequestCollectionService({ recordLog });
+  return { service, recordLog };
+}
+
+describe("LogRequestCollectionService", () => {
+  describe("when a LogRecord has neither traceId nor spanId", () => {
+    /**
+     * OTLP logs.proto v1.0.0 marks trace_id and span_id OPTIONAL on
+     * LogRecord, and exporters that emit logs outside an active span
+     * (Claude Code's OTEL_LOGS_EXPORTER without a traces exporter is the
+     * canonical caller) leave both unset. The handler previously
+     * silently dropped these — receiver returned 200 OK, on-call had no
+     * signal, customer saw nothing arrive. The record is now stored
+     * with empty TraceId/SpanId.
+     */
+    it("records the log with empty trace and span ids", async () => {
+      const { service, recordLog } = makeService();
+
+      await service.handleOtlpLogRequest({
+        tenantId: "project_test_tenant",
+        logRequest: {
+          resourceLogs: [
+            {
+              resource: {
+                attributes: [
+                  {
+                    key: "service.name",
+                    value: { stringValue: "standalone-log-emitter" },
+                  },
+                ],
+              },
+              scopeLogs: [
+                {
+                  scope: { name: "test", version: "1.0.0" },
+                  logRecords: [
+                    {
+                      timeUnixNano: "1700000000000000000",
+                      body: { stringValue: "hello from a context-less log" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        piiRedactionLevel: "ESSENTIAL",
+      });
+
+      expect(recordLog).toHaveBeenCalledTimes(1);
+      const [call] = recordLog.mock.calls;
+      expect(call?.[0]).toMatchObject({
+        tenantId: "project_test_tenant",
+        traceId: "",
+        spanId: "",
+        body: "hello from a context-less log",
+      });
+    });
+  });
+
+  describe("when a LogRecord carries trace context", () => {
+    it("forwards the normalized trace and span ids", async () => {
+      const { service, recordLog } = makeService();
+
+      await service.handleOtlpLogRequest({
+        tenantId: "project_test_tenant",
+        logRequest: {
+          resourceLogs: [
+            {
+              resource: { attributes: [] },
+              scopeLogs: [
+                {
+                  scope: { name: "test", version: null },
+                  logRecords: [
+                    {
+                      timeUnixNano: "1700000000000000000",
+                      traceId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+                      spanId: "1122334455667788",
+                      body: { stringValue: "in-span log" },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        piiRedactionLevel: "ESSENTIAL",
+      });
+
+      expect(recordLog).toHaveBeenCalledTimes(1);
+      const [call] = recordLog.mock.calls;
+      expect(call?.[0]).toMatchObject({
+        traceId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        spanId: "1122334455667788",
+        body: "in-span log",
+      });
+    });
+  });
+
+  describe("when a LogRecord body is missing", () => {
+    it("drops the record (no body, nothing meaningful to store)", async () => {
+      const { service, recordLog } = makeService();
+
+      await service.handleOtlpLogRequest({
+        tenantId: "project_test_tenant",
+        logRequest: {
+          resourceLogs: [
+            {
+              resource: { attributes: [] },
+              scopeLogs: [
+                {
+                  scope: { name: "test", version: null },
+                  logRecords: [
+                    {
+                      timeUnixNano: "1700000000000000000",
+                      // No body — drop path still applies.
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        piiRedactionLevel: "ESSENTIAL",
+      });
+
+      expect(recordLog).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/__tests__/metric-request-collection.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/metric-request-collection.service.unit.test.ts
@@ -89,7 +89,7 @@ describe("MetricRequestCollectionService", () => {
               resource: { attributes: [] },
               scopeMetrics: [
                 {
-                  scope: { name: "test", version: null },
+                  scope: { name: "test", version: undefined },
                   metrics: [
                     {
                       name: "claude_code.messages.total",

--- a/langwatch/src/server/app-layer/traces/__tests__/metric-request-collection.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/metric-request-collection.service.unit.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RecordMetricCommandData } from "../../../event-sourcing/pipelines/trace-processing/schemas/commands";
+import { MetricRequestCollectionService } from "../metric-request-collection.service";
+
+function makeService() {
+  const recordMetric = vi.fn<
+    (data: RecordMetricCommandData) => Promise<void>
+  >(() => Promise.resolve());
+  const service = new MetricRequestCollectionService({ recordMetric });
+  return { service, recordMetric };
+}
+
+describe("MetricRequestCollectionService", () => {
+  describe("when a gauge data point has no exemplar (no trace context)", () => {
+    /**
+     * OTLP exporters that emit standalone gauges (Claude Code's
+     * OTEL_METRICS_EXPORTER without a traces exporter is the canonical
+     * caller) never attach exemplars with trace_id/span_id. The handler
+     * previously dropped these silently because extractSimpleDataPoint
+     * returned null without exemplars and the outer loop required
+     * traceId+spanId. Standalone metrics are now stored with empty
+     * TraceId/SpanId — the value, timestamp and attributes are the
+     * meaningful payload.
+     */
+    it("records the metric with empty trace and span ids", async () => {
+      const { service, recordMetric } = makeService();
+
+      await service.handleOtlpMetricRequest({
+        tenantId: "project_test_tenant",
+        metricRequest: {
+          resourceMetrics: [
+            {
+              resource: {
+                attributes: [
+                  {
+                    key: "service.name",
+                    value: { stringValue: "standalone-metrics-emitter" },
+                  },
+                ],
+              },
+              scopeMetrics: [
+                {
+                  scope: { name: "test", version: "1.0.0" },
+                  metrics: [
+                    {
+                      name: "claude_code.session.count",
+                      unit: "{session}",
+                      gauge: {
+                        dataPoints: [
+                          {
+                            timeUnixNano: "1700000000000000000",
+                            asInt: 1,
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        piiRedactionLevel: "ESSENTIAL",
+      });
+
+      expect(recordMetric).toHaveBeenCalledTimes(1);
+      const [call] = recordMetric.mock.calls;
+      expect(call?.[0]).toMatchObject({
+        tenantId: "project_test_tenant",
+        traceId: "",
+        spanId: "",
+        metricName: "claude_code.session.count",
+        metricType: "gauge",
+        value: 1,
+      });
+    });
+  });
+
+  describe("when a sum data point has no exemplar", () => {
+    it("records the metric with empty ids", async () => {
+      const { service, recordMetric } = makeService();
+
+      await service.handleOtlpMetricRequest({
+        tenantId: "project_test_tenant",
+        metricRequest: {
+          resourceMetrics: [
+            {
+              resource: { attributes: [] },
+              scopeMetrics: [
+                {
+                  scope: { name: "test", version: null },
+                  metrics: [
+                    {
+                      name: "claude_code.messages.total",
+                      unit: "{message}",
+                      sum: {
+                        dataPoints: [
+                          {
+                            timeUnixNano: "1700000000000000000",
+                            asInt: 42,
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        piiRedactionLevel: "ESSENTIAL",
+      });
+
+      expect(recordMetric).toHaveBeenCalledTimes(1);
+      const [call] = recordMetric.mock.calls;
+      expect(call?.[0]).toMatchObject({
+        traceId: "",
+        spanId: "",
+        metricName: "claude_code.messages.total",
+        metricType: "sum",
+        value: 42,
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/log-request-collection.service.ts
+++ b/langwatch/src/server/app-layer/traces/log-request-collection.service.ts
@@ -77,21 +77,24 @@ export class LogRequestCollectionService {
                   continue;
                 }
 
+                // OTLP `LogRecord.trace_id` and `LogRecord.span_id` are
+                // OPTIONAL per opentelemetry-proto v1.0.0 logs.proto — a
+                // LogRecord emitted outside an active span has neither.
+                // Dropping in that case silently eats every standalone log
+                // (Claude Code's OTEL_LOGS_EXPORTER without a traces
+                // exporter is the canonical caller). Store an empty
+                // string instead; downstream join-to-span queries simply
+                // find no correlation, which is the correct semantics.
                 const traceId = logRecord.traceId
                   ? TraceRequestUtils.normalizeOtlpId(
                       logRecord.traceId as string | Uint8Array,
-                    )
-                  : null;
+                    ) ?? ""
+                  : "";
                 const spanId = logRecord.spanId
                   ? TraceRequestUtils.normalizeOtlpId(
                       logRecord.spanId as string | Uint8Array,
-                    )
-                  : null;
-
-                if (!traceId || !spanId) {
-                  droppedCount++;
-                  continue;
-                }
+                    ) ?? ""
+                  : "";
 
                 const timeUnixMs = logRecord.timeUnixNano
                   ? TraceRequestUtils.convertUnixNanoToUnixMs(

--- a/langwatch/src/server/app-layer/traces/metric-request-collection.service.ts
+++ b/langwatch/src/server/app-layer/traces/metric-request-collection.service.ts
@@ -167,7 +167,13 @@ function extractDataPoints({
     attributes: Record<string, string>;
   }> = [];
 
-  // Histogram data points with exemplars
+  // Histogram data points. Two paths:
+  //   - When the emitter recorded the histogram inside an active span,
+  //     exemplars carry the trace correlation; emit one trace-correlated
+  //     row per exemplar.
+  //   - Otherwise (the common standalone-exporter case), still keep the
+  //     data point: emit a single trace-less row using the dp's sum or
+  //     count as the value so the histogram bucket isn't silently lost.
   const histogram = metric.histogram as
     | { dataPoints?: Array<Record<string, unknown>> }
     | undefined;
@@ -177,38 +183,70 @@ function extractDataPoints({
       const exemplars = dp?.exemplars as
         | Array<Record<string, unknown>>
         | undefined;
-      if (!exemplars) continue;
 
-      for (const exemplar of exemplars) {
-        if (!exemplar) continue;
-        const traceId = decodeBase64OpenTelemetryId(exemplar.traceId);
-        const spanId = decodeBase64OpenTelemetryId(exemplar.spanId);
-        const value =
-          typeof exemplar.asDouble === "number"
-            ? exemplar.asDouble
-            : typeof exemplar.asInt === "number"
-              ? exemplar.asInt
-              : 0;
-        const timeUnixMs = exemplar.timeUnixNano
-          ? TraceRequestUtils.convertUnixNanoToUnixMs(
-              TraceRequestUtils.normalizeOtlpUnixNano(
-                exemplar.timeUnixNano as
-                  | string
-                  | number
-                  | { low: number; high: number },
-              ),
-            )
-          : Date.now();
+      if (exemplars?.length) {
+        for (const exemplar of exemplars) {
+          if (!exemplar) continue;
+          const traceId = decodeBase64OpenTelemetryId(exemplar.traceId);
+          const spanId = decodeBase64OpenTelemetryId(exemplar.spanId);
+          const value =
+            typeof exemplar.asDouble === "number"
+              ? exemplar.asDouble
+              : typeof exemplar.asInt === "number"
+                ? exemplar.asInt
+                : 0;
+          const timeUnixMs = exemplar.timeUnixNano
+            ? TraceRequestUtils.convertUnixNanoToUnixMs(
+                TraceRequestUtils.normalizeOtlpUnixNano(
+                  exemplar.timeUnixNano as
+                    | string
+                    | number
+                    | { low: number; high: number },
+                ),
+              )
+            : Date.now();
 
-        results.push({
-          traceId,
-          spanId,
-          metricType: "histogram",
-          value,
-          timeUnixMs,
-          attributes: dpAttrs,
-        });
+          results.push({
+            traceId,
+            spanId,
+            metricType: "histogram",
+            value,
+            timeUnixMs,
+            attributes: dpAttrs,
+          });
+        }
+        continue;
       }
+
+      // Exemplar-less histogram. Prefer sum for a meaningful scalar;
+      // fall back to count when only the count is present.
+      const sumVal =
+        typeof dp?.sum === "number"
+          ? (dp.sum as number)
+          : typeof dp?.count === "number"
+            ? (dp.count as number)
+            : typeof dp?.count === "string"
+              ? Number(dp.count)
+              : 0;
+      const timeUnixMs = dp?.timeUnixNano
+        ? TraceRequestUtils.convertUnixNanoToUnixMs(
+            TraceRequestUtils.normalizeOtlpUnixNano(
+              dp.timeUnixNano as
+                | string
+                | number
+                | { low: number; high: number },
+            ),
+          )
+        : Date.now();
+
+      results.push({
+        traceId: null,
+        spanId: null,
+        metricType: "histogram",
+        value: Number.isFinite(sumVal) ? sumVal : 0,
+        timeUnixMs,
+        attributes: dpAttrs,
+      });
     }
   }
 

--- a/langwatch/src/server/app-layer/traces/metric-request-collection.service.ts
+++ b/langwatch/src/server/app-layer/traces/metric-request-collection.service.ts
@@ -84,16 +84,20 @@ export class MetricRequestCollectionService {
               }
 
               for (const dp of results) {
-                if (!dp.traceId || !dp.spanId) {
-                  droppedCount++;
-                  continue;
-                }
+                // OTLP metric data points have no trace context unless
+                // emitted inside an active span. Most exporters (incl.
+                // Claude Code with OTEL_METRICS_EXPORTER=otlp) emit
+                // standalone metrics. Dropping on missing IDs eats
+                // legitimate telemetry silently — see the matching note
+                // in LogRequestCollectionService.
+                const traceId = dp.traceId ?? "";
+                const spanId = dp.spanId ?? "";
 
                 try {
                   await this.deps.recordMetric({
                     tenantId,
-                    traceId: dp.traceId,
-                    spanId: dp.spanId,
+                    traceId,
+                    spanId,
                     metricName,
                     metricUnit,
                     metricType: dp.metricType,
@@ -114,8 +118,8 @@ export class MetricRequestCollectionService {
                       error,
                       tenantId,
                       metricName,
-                      traceId: dp.traceId,
-                      spanId: dp.spanId,
+                      traceId,
+                      spanId,
                     },
                     "Error recording metric data point",
                   );
@@ -255,42 +259,51 @@ function extractSimpleDataPoint({
 } | null {
   if (!dp) return null;
 
-  // Simple data points may have exemplars with traceId/spanId
+  // Trace context on a metric data point comes from exemplars when the
+  // emitter recorded the metric inside an active span. Most standalone
+  // metric exporters (incl. Claude Code's OTEL_METRICS_EXPORTER) emit
+  // gauges/sums with no exemplars. Returning null in that case eats the
+  // data point entirely; the value, timestamp and attributes are still
+  // meaningful telemetry without a correlated span.
   const exemplars = dp.exemplars as Array<Record<string, unknown>> | undefined;
+  let traceId: string | null = null;
+  let spanId: string | null = null;
   if (exemplars?.length) {
     for (const exemplar of exemplars) {
       if (!exemplar) continue;
-      const traceId = decodeBase64OpenTelemetryId(exemplar.traceId);
-      const spanId = decodeBase64OpenTelemetryId(exemplar.spanId);
-      if (traceId && spanId) {
-        const value =
-          typeof dp.asDouble === "number"
-            ? dp.asDouble
-            : typeof dp.asInt === "number"
-              ? dp.asInt
-              : 0;
-        const timeUnixMs = dp.timeUnixNano
-          ? TraceRequestUtils.convertUnixNanoToUnixMs(
-              TraceRequestUtils.normalizeOtlpUnixNano(
-                dp.timeUnixNano as
-                  | string
-                  | number
-                  | { low: number; high: number },
-              ),
-            )
-          : Date.now();
-
-        return {
-          traceId,
-          spanId,
-          metricType,
-          value,
-          timeUnixMs,
-          attributes: normalizeOtlpAttributeMap(dp.attributes),
-        };
+      const exTrace = decodeBase64OpenTelemetryId(exemplar.traceId);
+      const exSpan = decodeBase64OpenTelemetryId(exemplar.spanId);
+      if (exTrace && exSpan) {
+        traceId = exTrace;
+        spanId = exSpan;
+        break;
       }
     }
   }
 
-  return null;
+  const value =
+    typeof dp.asDouble === "number"
+      ? dp.asDouble
+      : typeof dp.asInt === "number"
+        ? dp.asInt
+        : 0;
+  const timeUnixMs = dp.timeUnixNano
+    ? TraceRequestUtils.convertUnixNanoToUnixMs(
+        TraceRequestUtils.normalizeOtlpUnixNano(
+          dp.timeUnixNano as
+            | string
+            | number
+            | { low: number; high: number },
+        ),
+      )
+    : Date.now();
+
+  return {
+    traceId,
+    spanId,
+    metricType,
+    value,
+    timeUnixMs,
+    attributes: normalizeOtlpAttributeMap(dp.attributes),
+  };
 }

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryEmptyIdsSkip.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryEmptyIdsSkip.unit.test.ts
@@ -80,7 +80,6 @@ function makeMetricEvent({
       timeUnixMs: 1700000000000,
       attributes: {},
       resourceAttributes: { "service.name": "claude-code" },
-      piiRedactionLevel: "ESSENTIAL",
     },
     metadata: {},
   };

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryEmptyIdsSkip.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryEmptyIdsSkip.unit.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import { createTenantId } from "~/server/event-sourcing";
+
+import {
+  LOG_RECORD_RECEIVED_EVENT_TYPE,
+  LOG_RECORD_RECEIVED_EVENT_VERSION_LATEST,
+  METRIC_RECORD_RECEIVED_EVENT_TYPE,
+  METRIC_RECORD_RECEIVED_EVENT_VERSION_LATEST,
+} from "../../schemas/constants";
+import type {
+  LogRecordReceivedEvent,
+  MetricRecordReceivedEvent,
+} from "../../schemas/events";
+import { TraceSummaryFoldProjection } from "../traceSummary.foldProjection";
+import { createInitState } from "./fixtures/trace-summary-test.fixtures";
+
+function makeProjection() {
+  return new TraceSummaryFoldProjection({
+    store: { store: async () => {}, get: async () => null },
+  });
+}
+
+function makeLogEvent({
+  traceId,
+  spanId,
+}: {
+  traceId: string;
+  spanId: string;
+}): LogRecordReceivedEvent {
+  return {
+    id: `evt-log-${traceId || "empty"}`,
+    type: LOG_RECORD_RECEIVED_EVENT_TYPE,
+    version: LOG_RECORD_RECEIVED_EVENT_VERSION_LATEST,
+    aggregateType: "trace",
+    aggregateId: traceId,
+    tenantId: createTenantId("tenant-1"),
+    createdAt: 1700000000000,
+    occurredAt: 1700000000000,
+    data: {
+      traceId,
+      spanId,
+      timeUnixMs: 1700000000000,
+      severityNumber: 9,
+      severityText: "INFO",
+      body: "test log",
+      attributes: {},
+      resourceAttributes: { "service.name": "claude-code" },
+      scopeName: "test",
+      scopeVersion: null,
+      piiRedactionLevel: "ESSENTIAL",
+    },
+    metadata: {},
+  };
+}
+
+function makeMetricEvent({
+  traceId,
+  spanId,
+}: {
+  traceId: string;
+  spanId: string;
+}): MetricRecordReceivedEvent {
+  return {
+    id: `evt-metric-${traceId || "empty"}`,
+    type: METRIC_RECORD_RECEIVED_EVENT_TYPE,
+    version: METRIC_RECORD_RECEIVED_EVENT_VERSION_LATEST,
+    aggregateType: "trace",
+    aggregateId: traceId,
+    tenantId: createTenantId("tenant-1"),
+    createdAt: 1700000000000,
+    occurredAt: 1700000000000,
+    data: {
+      traceId,
+      spanId,
+      metricName: "claude_code.session.count",
+      metricUnit: "{session}",
+      metricType: "gauge",
+      value: 1,
+      timeUnixMs: 1700000000000,
+      attributes: {},
+      resourceAttributes: { "service.name": "claude-code" },
+      piiRedactionLevel: "ESSENTIAL",
+    },
+    metadata: {},
+  };
+}
+
+describe("TraceSummaryFoldProjection — empty-id skip guard", () => {
+  describe("when a LogRecordReceivedEvent has no trace context", () => {
+    /**
+     * Logs persisted via the map projection still land in
+     * stored_log_records, so users can query them directly. The fold
+     * MUST NOT accumulate them under aggregateId="" — otherwise every
+     * standalone log in the tenant folds into a single nameless ghost
+     * trace_summary entry that grows unboundedly.
+     */
+    it("returns state unchanged so no ghost summary accumulates", () => {
+      const projection = makeProjection();
+      const state = createInitState();
+      const before = JSON.stringify(state);
+
+      const after = projection.handleTraceLogRecordReceived(
+        makeLogEvent({ traceId: "", spanId: "" }),
+        state,
+      );
+
+      expect(JSON.stringify(after)).toBe(before);
+      expect(
+        after.attributes["langwatch.reserved.log_record_count"],
+      ).toBeUndefined();
+    });
+  });
+
+  describe("when a LogRecordReceivedEvent has real trace context", () => {
+    it("folds normally and bumps the log_record_count", () => {
+      const projection = makeProjection();
+      const state = createInitState();
+
+      const after = projection.handleTraceLogRecordReceived(
+        makeLogEvent({
+          traceId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+          spanId: "1122334455667788",
+        }),
+        state,
+      );
+
+      expect(after.attributes["langwatch.reserved.log_record_count"]).toBe("1");
+    });
+  });
+
+  describe("when a MetricRecordReceivedEvent has no trace context", () => {
+    it("returns state unchanged so no ghost summary accumulates", () => {
+      const projection = makeProjection();
+      const state = createInitState();
+      const before = JSON.stringify(state);
+
+      const after = projection.handleTraceMetricRecordReceived(
+        makeMetricEvent({ traceId: "", spanId: "" }),
+        state,
+      );
+
+      expect(JSON.stringify(after)).toBe(before);
+      expect(
+        after.attributes["langwatch.reserved.metric_record_count"],
+      ).toBeUndefined();
+    });
+  });
+
+  describe("when a MetricRecordReceivedEvent has real trace context", () => {
+    it("folds normally and bumps the metric_record_count", () => {
+      const projection = makeProjection();
+      const state = createInitState();
+
+      const after = projection.handleTraceMetricRecordReceived(
+        makeMetricEvent({
+          traceId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+          spanId: "1122334455667788",
+        }),
+        state,
+      );
+
+      expect(after.attributes["langwatch.reserved.metric_record_count"]).toBe(
+        "1",
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/traceSummary.foldProjection.ts
@@ -300,6 +300,17 @@ export class TraceSummaryFoldProjection
     event: LogRecordReceivedEvent,
     state: TraceSummaryData,
   ): TraceSummaryData {
+    // Standalone OTLP logs (e.g. Claude Code's OTEL_LOGS_EXPORTER without a
+    // traces exporter) carry no trace context. The wire-level fix accepts
+    // them and the map projection persists them to stored_log_records, but
+    // folding them here would aggregate every context-less log per tenant
+    // under the same empty aggregateId — surfacing a single nameless
+    // "trace" in the messages list that grows unboundedly. Skip the fold;
+    // the log row still lands in CH and remains queryable directly.
+    if (!event.data.traceId || !event.data.spanId) {
+      return state;
+    }
+
     const mergedAttributes = { ...state.attributes };
     const logCount = parseInt(
       mergedAttributes["langwatch.reserved.log_record_count"] ?? "0",
@@ -364,6 +375,15 @@ export class TraceSummaryFoldProjection
     event: MetricRecordReceivedEvent,
     state: TraceSummaryData,
   ): TraceSummaryData {
+    // Standalone OTLP metrics (gauges/sums without exemplar trace context)
+    // are common from Claude Code's OTEL_METRICS_EXPORTER. The map
+    // projection persists them to stored_metric_records; skip the fold to
+    // avoid folding every context-less data point into an empty-id ghost
+    // summary. Mirrors handleTraceLogRecordReceived.
+    if (!event.data.traceId || !event.data.spanId) {
+      return state;
+    }
+
     let timeToFirstTokenMs = state.timeToFirstTokenMs;
     if (event.data.metricName === "gen_ai.server.time_to_first_token") {
       const ttftMs = event.data.value * 1000;

--- a/langwatch/src/server/routes/__tests__/otel.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/otel.unit.test.ts
@@ -223,6 +223,17 @@ describe("classifyTokenType", () => {
     });
   });
 
+  describe("when given an ingestion-key prefix", () => {
+    it("classifies ik-lw-… tokens as ingestion_key", () => {
+      // Real-shape token from a UserIngestionBinding: ik-lw- + 48-char body.
+      expect(
+        classifyTokenType(
+          "ik-lw-WgdPxNGmczBPUunjT350X9ywK9EKyO9MEYcFBdmKxnoLGUdz",
+        ),
+      ).toBe("ingestion_key");
+    });
+  });
+
   describe("when given anything else", () => {
     it("returns unknown for an arbitrary string", () => {
       expect(classifyTokenType("abc123")).toBe("unknown");

--- a/langwatch/src/server/routes/auth-cli.ts
+++ b/langwatch/src/server/routes/auth-cli.ts
@@ -38,7 +38,7 @@ import { hasOrganizationPermission, hasProjectPermission } from "~/server/api/rb
 import type { Permission } from "~/server/api/rbac";
 import {
   PersonalVirtualKeyService,
-  NoDefaultRoutingPolicyError,
+  NoEligibleProvidersError,
   PersonalVirtualKeyAlreadyExistsError,
   RoutingPolicyHasNoProvidersError,
 } from "@ee/governance/services/personalVirtualKey.service";
@@ -1477,24 +1477,24 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
     });
   } catch (err) {
     if (
-      err instanceof NoDefaultRoutingPolicyError ||
+      err instanceof NoEligibleProvidersError ||
       err instanceof RoutingPolicyHasNoProvidersError
     ) {
-      // Fresh signup / dogfood account / org that hasn't published a
-      // default RoutingPolicy (or whose policy has no providers bound):
-      // log the user in with a device session anyway. The CLI wrapper
-      // mints a personal VK lazily on the first gateway call, surfacing
-      // an actionable error at that point ("no model provider configured
-      // yet, add one at /me Model Providers"). Failing the entire
-      // approve flow here blocked solo devs from ever reaching the
-      // setup screens.
+      // Fresh signup / dogfood account / org with no accessible
+      // providers (or with an explicitly-pinned empty policy): log the
+      // user in with a device session anyway. The /me Model Providers
+      // tile surfaces the actionable "add a provider" CTA; failing the
+      // entire approve flow here blocked solo devs from ever reaching
+      // the setup screens. Post-fix to the no-default-policy graceful
+      // fallback, this branch fires only when there are truly zero
+      // eligible providers via scope cascade.
       logger.info(
         {
           user_code,
           organization_id,
           reason:
-            err instanceof NoDefaultRoutingPolicyError
-              ? "no_default_routing_policy"
+            err instanceof NoEligibleProvidersError
+              ? "no_eligible_providers"
               : "routing_policy_has_no_providers",
         },
         "[auth-cli] approving device session without personal VK; admin/user must configure provider before gateway use",

--- a/langwatch/src/server/routes/otel.ts
+++ b/langwatch/src/server/routes/otel.ts
@@ -19,6 +19,7 @@ import {
   readOtlpBody,
 } from "~/server/otel/parseOtlpBody";
 import { TokenResolver } from "~/server/api-key/token-resolver";
+import { BINDING_TOKEN_PREFIX } from "@ee/governance/services/userIngestionBindingToken.utils";
 import {
   collectAuthDiagnostics,
   enforceApiKeyCeiling,
@@ -62,10 +63,19 @@ type RouteContext = {
  * Classifies a token by prefix without exposing the value. Mirrors the
  * `tokenType` field emitted by the unified auth middleware so on-call can
  * filter CloudWatch by SDK shape.
+ *
+ * `ingestion_key` covers UserIngestionBinding tokens (`ik-lw-`) — the
+ * shape Claude Code's OTEL exporter sends from the personal-portal
+ * onboarding tile. Without this branch a stale ingestion key surfaces
+ * as `unknown`, which is indistinguishable from a malformed bearer and
+ * gives on-call no way to attribute the 401 to a specific user flow.
  */
-export function classifyTokenType(token: string): "pat" | "legacy" | "unknown" {
+export function classifyTokenType(
+  token: string,
+): "pat" | "legacy" | "ingestion_key" | "unknown" {
   if (token.startsWith("pat-lw-")) return "pat";
   if (token.startsWith("sk-lw-")) return "legacy";
+  if (token.startsWith(BINDING_TOKEN_PREFIX)) return "ingestion_key";
   return "unknown";
 }
 
@@ -109,15 +119,24 @@ async function authenticate(c: RouteContext, logger: ReturnType<typeof createLog
   }
 
   if (!resolved) {
+    const tokenType = classifyTokenType(credentials.token);
     logger.warn(
       {
         ...diag,
-        tokenType: classifyTokenType(credentials.token),
+        tokenType,
         hasProjectId: !!credentials.projectId,
       },
       "Authentication failed: invalid credentials",
     );
-    return { error: "Invalid auth token.", status: 401 as const };
+    // An ik-lw- 401 most often means the binding was rotated (reinstall
+    // mints a fresh hash on the same row) and the caller is still using
+    // the old token. The generic body gives them nowhere to look — name
+    // the surface that re-issues the token.
+    const error =
+      tokenType === "ingestion_key"
+        ? "Ingestion key not recognized. Re-mint the binding at /me and update your OTLP exporter."
+        : "Invalid auth token.";
+    return { error, status: 401 as const };
   }
 
   // Enforce API-key ceiling (legacy tokens bypass). `traces:create` gates write

--- a/specs/ai-gateway/governance/admin-routing-policies.feature
+++ b/specs/ai-gateway/governance/admin-routing-policies.feature
@@ -83,10 +83,12 @@ Feature: AI Gateway Governance — Admin RoutingPolicies (decoupled from VK)
     Then his personal VK references the org-level "developer-default"
 
   @bdd @routing-policy @hierarchy
-  Scenario: When neither team nor org has a default policy, personal-key issuance fails (see personal-keys.feature)
+  Scenario: When neither team nor org has a default policy but providers exist, issuance succeeds with null policy (see personal-keys.feature)
     Given org "acme" has no isDefault policy at any scope
-    When ben tries to login
-    Then issuance fails with `no_default_routing_policy` (cross-ref personal-keys.feature)
+    And at least one ModelProvider is reachable from ben's personal team via scope cascade
+    When ben completes the device-code flow
+    Then a personal VK is minted with `routingPolicyId: null`
+    And the gateway resolves the eligible-provider chain by fallbackPriorityGlobal ordering
 
   # ---------------------------------------------------------------------------
   # Authorization

--- a/specs/ai-gateway/governance/personal-keys.feature
+++ b/specs/ai-gateway/governance/personal-keys.feature
@@ -58,11 +58,27 @@ Feature: AI Gateway Governance — Personal virtual keys
     And the response is `{ secret, baseUrl, label }` returned exactly once
 
   @bdd @personal-keys @issuance @policy-resolution
-  Scenario: When org has no default RoutingPolicy, personal-key issuance fails with a clear error
+  Scenario: When org has no default RoutingPolicy but has accessible providers, personal-key issuance succeeds with no policy bound
     Given organization "acme" has no RoutingPolicy with isDefault=true
-    When user "jane@acme.com" tries to login via the CLI
+    And at least one ModelProvider scoped at ORGANIZATION "acme" is enabled
+    When user "jane@acme.com" logs in via the CLI device-flow
+    Then a personal VK is minted with `routingPolicyId=null`
+    And the gateway dispatch path uses scope-cascade + `fallbackPriorityGlobal` ordering to pick a provider
+    # Pre-7651d2464 this failed with a generic 409 in the device approve
+    # handler, blocking solo signups + any org that hadn't published a
+    # default routing policy yet. 7651d2464 made the approve tolerate
+    # the empty-policy state but left the wrapper bailing later. The
+    # current behavior: mint succeeds, gateway dispatch falls back to
+    # `fallbackPriorityGlobal` ASC + `createdAt` ASC on eligible MPs
+    # (mirrors `eligibleModelProvidersForVk` when policy is null).
+
+  @bdd @personal-keys @issuance @policy-resolution
+  Scenario: When org has no AI providers at all, personal-key issuance fails with a clear error
+    Given organization "acme" has no RoutingPolicy with isDefault=true
+    And no ModelProvider is reachable from "jane@acme.com"'s personal team via scope cascade
+    When user "jane@acme.com" tries to login via the CLI device-flow
     Then the device-exchange response status is 409
-    And the response body contains `{ "error": "no_default_routing_policy", "message": "Your organization admin must publish a default routing policy before personal keys can be issued." }`
+    And the response body contains `{ "error": "no_eligible_providers", "message": "Your organization has no AI providers configured. Ask an admin to add one at Settings → Model Providers." }`
     And no personal VK is created
 
   # Behavior is implemented end-to-end: personalVirtualKey.service.ts throws

--- a/specs/ai-gateway/wrapper-e2e/claude.feature
+++ b/specs/ai-gateway/wrapper-e2e/claude.feature
@@ -38,10 +38,11 @@ Feature: `langwatch claude` wrapper end-to-end
     Then the gateway responds 429 with `error: "budget_exceeded"`
     And the wrapper surfaces a clear error message — NOT a confusing 5xx or hung response
 
-  Scenario: 409 no_eligible_providers surfaces during the wrapper login when the org has no providers
+  Scenario: Wrapper surfaces no-providers guidance when the device login lacks a personal VK
     Given alice's org has NO default routing policy AND NO accessible ModelProvider
     When the harness runs `langwatch claude` for a user without a Personal VK provisioned
-    Then the wrapper attempts `langwatch login --device` first, which returns 409 `no_eligible_providers`
+    Then `langwatch login --device` succeeds (the device session is approved without `default_personal_vk` — see auth-cli.ts swallow path) but the local config has no VK secret
+    And the wrapper's preflight check refuses to spawn the underlying tool
     And the wrapper surfaces the actionable message "Your organization has no AI providers configured. Ask an admin to add one at Settings → Model Providers." (not a stack trace)
 
   Scenario: Wrapper exits with the wrapped binary's exit code

--- a/specs/ai-gateway/wrapper-e2e/claude.feature
+++ b/specs/ai-gateway/wrapper-e2e/claude.feature
@@ -38,11 +38,11 @@ Feature: `langwatch claude` wrapper end-to-end
     Then the gateway responds 429 with `error: "budget_exceeded"`
     And the wrapper surfaces a clear error message — NOT a confusing 5xx or hung response
 
-  Scenario: 409 no_default_routing_policy surfaces during the wrapper login
-    Given alice's org has NO default routing policy
+  Scenario: 409 no_eligible_providers surfaces during the wrapper login when the org has no providers
+    Given alice's org has NO default routing policy AND NO accessible ModelProvider
     When the harness runs `langwatch claude` for a user without a Personal VK provisioned
-    Then the wrapper attempts `langwatch login --device` first, which returns 409 `no_default_routing_policy`
-    And the wrapper surfaces "Your organization needs a default routing policy. Ask your admin to publish one." (not a stack trace)
+    Then the wrapper attempts `langwatch login --device` first, which returns 409 `no_eligible_providers`
+    And the wrapper surfaces the actionable message "Your organization has no AI providers configured. Ask an admin to add one at Settings → Model Providers." (not a stack trace)
 
   Scenario: Wrapper exits with the wrapped binary's exit code
     Given the stubbed `claude` binary exits with code 7

--- a/specs/ai-governance/personal-portal/model-provider-tile.feature
+++ b/specs/ai-governance/personal-portal/model-provider-tile.feature
@@ -76,14 +76,23 @@ Feature: AI Tools Portal — Model-provider tile inline VK creation
     And the form re-appears with `defaultLabel` re-populated
     And the secret is no longer accessible (cannot be re-revealed)
 
-  Scenario: 409 no_default_routing_policy surfaces inline
+  Scenario: 409 no_eligible_providers surfaces inline when the org has zero providers
     Given the org has NO default routing policy published
+    And the org has NO ModelProvider reachable from "jane@acme.com"'s personal team
     And the Anthropic tile is expanded with label "my-app"
     When user "jane@acme.com" clicks "Issue key"
-    Then `api.personalVirtualKeys.issuePersonal` returns 409 with code "no_default_routing_policy"
+    Then `api.personalVirtualKeys.issuePersonal` returns 409 with code "no_eligible_providers"
     And an inline error renders in the form
-    And the error includes a link "Ask your admin to publish a default routing policy"
+    And the error includes the actionable message "Your organization has no AI providers configured. Ask an admin to add one at Settings → Model Providers."
     And the form does NOT swap to the success state
+
+  Scenario: Issue with no default policy but providers exist mints with null routingPolicyId
+    Given the org has NO default routing policy published
+    And at least one ModelProvider scoped at ORGANIZATION is enabled
+    And the Anthropic tile is expanded with label "my-app"
+    When user "jane@acme.com" clicks "Issue key"
+    Then `api.personalVirtualKeys.issuePersonal` returns 200 with `routingPolicyId: null`
+    And the success state renders with the new secret revealed once
 
   Scenario: tile without projectSuggestionText omits the hint
     Given the org-scoped catalog has OpenAI entry with no `projectSuggestionText` field

--- a/specs/ai-governance/personal-portal/tool-catalog-vk-bridge.feature
+++ b/specs/ai-governance/personal-portal/tool-catalog-vk-bridge.feature
@@ -26,13 +26,22 @@ Feature: AI Tools Portal — model-provider tile → VK bridge
     And alice gets a personal VK bound to "policy-dev" (the org default)
 
   @bdd @phase-7 @vk-bridge @no-default-policy
-  Scenario: model-provider tile + no default policy + no suggestedRoutingPolicyId → 409
+  Scenario: model-provider tile + no default policy + at least one accessible MP → 200 with null routing policy
     Given the org has NO RoutingPolicy with isDefault=true
+    And at least one ModelProvider is scoped so it is accessible from alice's personal team
     And a catalog entry exists with type="model_provider", config has NO suggestedRoutingPolicyId
     When alice clicks the tile and submits a label
-    Then the UI calls `personalVirtualKeys.issuePersonal` and receives 409 with `error: "no_default_routing_policy"`
+    Then `personalVirtualKeys.issuePersonal` returns 200 with `routingPolicyId: null`
+    And the gateway will route the resulting VK by fallbackPriorityGlobal ordering over all scope-eligible providers
+
+  @bdd @phase-7 @vk-bridge @no-eligible-providers
+  Scenario: model-provider tile + no default policy + no accessible MPs → 409
+    Given the org has NO RoutingPolicy with isDefault=true
+    And NO ModelProvider is reachable from alice's personal team via scope cascade
+    When alice clicks the tile and submits a label
+    Then the UI calls `personalVirtualKeys.issuePersonal` and receives 409 with `error: "no_eligible_providers"`
     And NO personal VK is created
-    And the UI surfaces the actionable message ("Ask your admin to publish a default routing policy")
+    And the UI surfaces the actionable message ("Your organization has no AI providers configured. Ask an admin to add one at Settings → Model Providers.")
 
   @bdd @phase-7 @vk-bridge @cross-org-guard
   Scenario: catalog entry's suggestedRoutingPolicyId from a different org is rejected


### PR DESCRIPTION
## Summary

Five prod governance gaps surfaced from rchaves's dogfood. All needed for the dogfood to actually work end-to-end.

- **(A1) OTLP receiver silently drops standalone log/metric records.** Root cause of rchaves's "claude-code emits nothing on prod" symptom. `log-request-collection.service.ts:91-94` and the metric counterpart hard-failed any LogRecord/DataPoint missing `trace_id`/`span_id` and incremented `droppedCount` while returning HTTP 200 to the client. OTLP proto v1.0.0 makes those fields optional on `LogRecord` (and they're never set when `OTEL_LOGS_EXPORTER=otlp` runs without a paired traces exporter, exactly Claude Code's default). Empirical repro: `curl /api/otel/v1/logs` with a fresh `ik-lw-` bearer + LogRecord lacking IDs returns 200 with zero rows in `stored_log_records`; the same curl with IDs lands. Fix: drop the hard-fail, store empty strings (CH schema accepts), keep counters for observability. Metric path got the same treatment plus a rewrite of `extractSimpleDataPoint` so gauges/sums without exemplars survive. 5 unit tests added.

- **(A2) OTLP auth classifies `ik-lw-` ingestion keys as 'unknown'.** Stale `UserIngestionBinding` tokens failed with a generic 401 and no observability, on-call could not attribute the failure to the binding-rotation case. `classifyTokenType` now recognizes the `ik-lw-` prefix and the 401 body for failed ingestion tokens points the user at the personal-portal integrations tile to re-mint.

- **(A3) traceSummary fold creates a ghost trace_summary aggregate per tenant.** After A1 lands, context-less logs/metrics reach the event-sourcing pipeline with empty traceId/spanId. The map projection writes them to `stored_log_records` / `stored_metric_records` correctly, but the traceSummary fold aggregates by `aggregateId=traceId`, so every empty-id event in a tenant folds into a single `""` aggregate, producing one nameless ghost trace per tenant that grows unboundedly. Both `handleTraceLogRecordReceived` and `handleTraceMetricRecordReceived` now early-return when traceId/spanId are missing. The log/metric rows still land in CH (queryable directly) and the trace listing stays clean. 4-test regression on both surfaces; existing 160 fold tests still green.

- **(A4) Snippet: recommend `OTEL_TRACES_EXPORTER=otlp` to get per-message traces.** The three claude_code env-var snippets shown to admins (install drawer + two governance dashboard pages) recommended only `OTEL_LOGS_EXPORTER` and `OTEL_METRICS_EXPORTER`. Without `OTEL_TRACES_EXPORTER`, claude-code never emits spans and every standalone log/metric falls into the A3 fold-skip (still queryable in CH but invisible on /messages). With it, claude-code emits one span per user message (each becomes its own trace), the `session.id` resource attribute lands on those spans, and the existing OpenInferenceExtractor unconditionally maps `session.id` → `gen_ai.conversation.id` so messages of the same session group as one thread on the UI. No new server code, just better defaults in three copy-paste snippets.

- **(B) Personal VK refuses to mint without a default RoutingPolicy.** `PersonalVirtualKeyService.ensureDefault` threw `NoDefaultRoutingPolicyError` even when org-scoped ModelProviders existed. The device-flow approve handler swallowed the error and the session succeeded without a VK, so the CLI wrapper bailed at first call with "No personal virtual key on this account." Confirmed via prod query against rchaves's org: 10+ active MPs across ORG/TEAM/PROJECT scopes, 0 RoutingPolicy rows. Gateway scopeResolver already supports `routingPolicyId=null` (falls back to `fallbackPriorityGlobal` ASC + `createdAt` ASC). Mint now lands with `routingPolicyId: null` whenever the personal-team scope cascade has at least one eligible provider; only truly empty orgs throw the new `NoEligibleProvidersError` (409). 3 new PG-integration tests cover the graceful fallback.

Specs updated across `personal-keys.feature`, `admin-routing-policies.feature`, `model-provider-tile.feature`, `tool-catalog-vk-bridge.feature`, and the `wrapper-e2e/claude.feature` scenario.

## Test plan
- [x] A1: 5 new unit tests for the silent-drop fix pass; typecheck clean
- [x] A2: `classifyTokenType` unit test for the `ik-lw-` shape passes; full otel.unit.test.ts 23/23 green
- [x] A3: 4 new unit tests for the empty-ids fold-skip pass; 160 existing fold tests still green
- [x] A4: typecheck clean; three snippets visibly include `OTEL_TRACES_EXPORTER=otlp`
- [x] B: 3 new PG-integration tests for graceful-fallback mint pass locally
- [ ] CI green
- [ ] Post-deploy: rchaves's existing fresh token `ik-lw-ueeExi...` starts landing claude-code logs with NO re-mint needed (A1) and no ghost trace appears in the trace listing (A3)
- [ ] Post-deploy: rchaves regenerates the claude-code snippet, exports the new env block including `OTEL_TRACES_EXPORTER=otlp`, runs one claude-code message, sees ONE trace named after the service appear in /messages with the right `gen_ai.conversation.id` (A4)
- [ ] Post-deploy: rchaves runs `langwatch login --device` against his org (still 0 RoutingPolicy rows), confirms a personal VK lands and `langwatch claude` routes correctly (B)
- [ ] Follow-up: `lastSeenAt` doesn't update for `user_ingestion_binding` type, `otel.ts` only `markUsed` for `apiKey`. Tiny separate fix.