### PR TITLE
feat(langy): default release_langy_enabled ON so everyone sees Langy

### DIFF
--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -150,9 +150,9 @@ export const FEATURE_FLAGS = [
   {
     key: "release_langy_enabled",
     scope: "PRODUCT",
-    defaultValue: false,
+    defaultValue: true,
     description:
-      "Opens the Langy in-product assistant to non-staff. LangWatch staff (isLangwatchStaff()) always have access regardless of this flag; flipping it on extends Langy to the targeted non-staff users.",
+      "Opens the Langy in-product assistant. Default flipped to on: Langy now ships to everyone with project access, and disabling is the opt-out path (set a PostHog rule, an operator-store row via /ops/feature-flags, or RELEASE_LANGY_ENABLED=false to turn it off). LangWatch staff (isLangwatchStaff()) always have access regardless of this flag, so a kill switch still leaves staff able to debug.",
   },
 ] as const satisfies readonly FeatureFlagDefinition[];
 


### PR DESCRIPTION
## What

Flips the `release_langy_enabled` registry default from `false` → `true` so Langy is visible to **everyone with project access**, not just LangWatch staff.

```diff
-    defaultValue: false,
+    defaultValue: true,
```

## Why this actually turns it on (not a no-op)

`release_langy_enabled` is a `PRODUCT`-scoped flag. Resolver order is:
`env override → operator-store (postgres) → PostHog → registry default`.

I checked prod PostHog (project 66212): **no feature flag named `release_langy_enabled` exists**. So `posthog.isFeatureEnabled(...)` returns `undefined`, the backend does `undefined ?? defaultValue`, and the **registry default governs**. Flipping it to `true` reliably opens Langy to all users.

## Kill switch is preserved

This is a default flip, not a removal. Langy can still be disabled at runtime without a redeploy:
- a PostHog rule named `release_langy_enabled`,
- an operator-store row via `/ops/feature-flags`, or
- `RELEASE_LANGY_ENABLED=false`.

The staff bypass (`isLangwatchStaff() || flag`) in `langy.ts` and `DashboardLayout.tsx` is left in place, so even if the flag is killed, LangWatch staff retain access for debugging.

This mirrors the existing repo pattern for `release_nlp_go_engine_enabled` and `release_ui_ai_gateway_menu_enabled`, which both default ON with PostHog/operator-store as the opt-out.

## Scope / base
Stacked on `feat/langy-staff-bypass` (where the gate lives), so this PR's diff is just the flag flip. Per-project `evaluations:view` RBAC is untouched. No tests pin this default; the route-gate test mocks `isEnabled` directly and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)