### PR TITLE
feat(langy): default release_langy_enabled ON so everyone sees Langy

### DIFF
--- a/langwatch/src/server/featureFlag/registry.ts
+++ b/langwatch/src/server/featureFlag/registry.ts
@@ -150,9 +150,9 @@ export const FEATURE_FLAGS = [
   {
     key: "release_langy_enabled",
     scope: "PRODUCT",
-    defaultValue: false,
+    defaultValue: true,
     description:
-      "Opens the Langy in-product assistant to non-staff. LangWatch staff (isLangwatchStaff()) always have access regardless of this flag; flipping it on extends Langy to the targeted non-staff users.",
+      "Opens the Langy in-product assistant. Default flipped to on: Langy now ships to everyone with project access, and disabling is the opt-out path (set a PostHog rule, an operator-store row via /ops/feature-flags, or RELEASE_LANGY_ENABLED=false to turn it off). LangWatch staff (isLangwatchStaff()) always have access regardless of this flag, so a kill switch still leaves staff able to debug.",
   },
 ] as const satisfies readonly FeatureFlagDefinition[];
 


### PR DESCRIPTION
Sub-PR into #4272. Flips the `release_langy_enabled` registry default `false` → `true` so Langy is visible to **everyone with project access**, not just staff.

```diff
-    defaultValue: false,
+    defaultValue: true,
```

## Why this actually turns it on (not a no-op)

`release_langy_enabled` is a `PRODUCT`-scoped flag. Resolver order:
`env override → operator-store (postgres) → PostHog → registry default`.

Checked prod PostHog (project 66212): **no flag named `release_langy_enabled` exists**, so `isFeatureEnabled(...)` returns `undefined`, the backend does `undefined ?? defaultValue`, and the **registry default governs**. Flipping it to `true` reliably opens Langy to all users.

## Kill switch preserved

Default flip, not a removal. Disable at runtime without a redeploy via a PostHog rule, an `/ops/feature-flags` row, or `RELEASE_LANGY_ENABLED=false`. The staff bypass (`isLangwatchStaff() || flag`) stays, so even if the flag is killed, staff retain access to debug. Mirrors `release_nlp_go_engine_enabled` / `release_ui_ai_gateway_menu_enabled`, which both default ON with PostHog/operator-store as the opt-out.

Per-project `evaluations:view` RBAC untouched. No tests pin this default; the route-gate test mocks `isEnabled` directly and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)