### PR TITLE
feat(langy): trace opencode worker activity into the user's project (tagged "langy")

### DIFF
--- a/Dockerfile.langy_agent
+++ b/Dockerfile.langy_agent
@@ -14,6 +14,11 @@ FROM ubuntu:24.04
 # in lockstep with a tested release rather than tracking `latest`.
 ARG LANGWATCH_CLI_VERSION=0.31.0
 ARG LANGWATCH_MCP_VERSION=0.10.1
+# opencode has no native OpenTelemetry export, so the per-session worker loads
+# this opencode plugin to emit session/llm/tool spans over OTLP into the user's
+# LangWatch project. Pinned; opencode auto-loads it by name from the per-worker
+# config (server.js). See specs/assistant/langy-otel-tracing.feature.
+ARG OPENCODE_OTEL_PLUGIN_VERSION=1.0.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl git ca-certificates unzip build-essential python3 \
@@ -32,9 +37,16 @@ RUN curl -fsSL https://opencode.ai/install | bash && \
 
 # CLI (`langwatch`) + MCP server (`langwatch-mcp-server`) from npm. Replaces
 # the old locally-`pnpm pack`'d tarballs so the image builds reproducibly in
-# CI with no host-side build step.
+# CI with no host-side build step. The opencode OTel plugin is installed here
+# too so the pinned version is present in the image (and the build fails fast
+# if the version is bad) rather than relying solely on opencode's runtime fetch.
 RUN npm install -g "langwatch@${LANGWATCH_CLI_VERSION}" \
-    "@langwatch/mcp-server@${LANGWATCH_MCP_VERSION}"
+    "@langwatch/mcp-server@${LANGWATCH_MCP_VERSION}" \
+    "@devtheops/opencode-plugin-otel@${OPENCODE_OTEL_PLUGIN_VERSION}"
+
+# Surface the pinned plugin version to the manager (server.js) so each
+# per-worker opencode config requests the exact same version opencode loads.
+ENV OPENCODE_OTEL_PLUGIN_VERSION=${OPENCODE_OTEL_PLUGIN_VERSION}
 
 COPY services/langy-agent/entrypoint.sh /entrypoint.sh
 COPY services/langy-agent/server.js /server.js

--- a/langwatch/src/components/langy/__tests__/ProjectLangyLayout.integration.test.tsx
+++ b/langwatch/src/components/langy/__tests__/ProjectLangyLayout.integration.test.tsx
@@ -152,18 +152,21 @@ describe("ProjectLangyLayout", () => {
     });
   });
 
-  describe("given the visibility gate is not satisfied", () => {
-    it("does not render Langy when the feature flag is off", () => {
+  // #4558 dropped the staff + rollout-flag visibility gate; Langy is shown to
+  // every team member regardless of those inputs. These pin that contract so
+  // re-introducing either gate would fail loudly.
+  describe("given the staff / rollout-flag gates were removed in #4558", () => {
+    it("renders Langy for a team member even when the rollout flag is off", () => {
       gate.flagEnabled = false;
       renderAt("/demo/traces");
       expect(screen.getByText("traces page")).toBeTruthy();
-      expect(drawer()).toBeNull();
+      expect(drawer()).not.toBeNull();
     });
 
-    it("does not render Langy for non-staff users", () => {
+    it("renders Langy for a non-staff team member", () => {
       gate.staff = false;
       renderAt("/demo/traces");
-      expect(drawer()).toBeNull();
+      expect(drawer()).not.toBeNull();
     });
   });
 });

--- a/langwatch/src/server/routes/__tests__/langy-route-auth.test.ts
+++ b/langwatch/src/server/routes/__tests__/langy-route-auth.test.ts
@@ -1,15 +1,14 @@
 /**
  * @vitest-environment node
  *
- * @see specs/assistant/langy-baseline.feature — Access and rollout gating
+ * Anti-regression for the Langy access-gate removal (#4558): the route used to
+ * gate non-staff behind `release_langy_enabled`, returning 403 with the literal
+ * "Langy is not currently enabled" when the flag was off. That gate is gone;
+ * Langy ships unconditionally to any authenticated session. These tests pin
+ * that contract so a re-introduction of the staff/flag gate would fail loudly.
  *
- * Binds the Langy access contract:
- *   - LangWatch staff always reach Langy, even with the rollout flag OFF.
- *   - Non-staff are blocked unless the rollout flag is on for them.
- *
- * The flag is the lever for opening Langy beyond staff; it can never lock
- * staff out. A future re-introduction of a hard "staff AND flag" gate would
- * fail the staff scenario here.
+ * The downstream handler still 500s in this env (no DB), which is fine — the
+ * gate is what's under test, not the handler.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -25,11 +24,9 @@ vi.mock("~/server/featureFlag", () => ({
   },
 }));
 
-// The 403 the access middleware emits when neither staff nor rollout lets the
-// caller through. Pass-through cases assert the answer is NOT this string —
-// downstream handler errors (no DB in this env) are fine; only the gate is
-// under test here.
-const GATE_BLOCKED = "Langy is not currently enabled";
+// The 403 string the old access middleware emitted. Must never reappear in any
+// response — its presence means the gate has crept back.
+const REMOVED_GATE_MESSAGE = "Langy is not currently enabled";
 
 async function requestLangy() {
   const { app } = await import("../langy");
@@ -39,57 +36,52 @@ async function requestLangy() {
   );
 }
 
-describe("Langy access gating", () => {
+describe("Langy access (post-#4558: no staff or rollout gate)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe("when the user is LangWatch staff", () => {
-    describe("and Langy has not been rolled out beyond staff", () => {
-      it("is not blocked by the rollout gate", async () => {
-        getServerAuthSession.mockResolvedValue({
-          user: { email: "dev@langwatch.ai", id: "u1" },
-        });
-        isEnabled.mockResolvedValue(false);
-
-        const res = await requestLangy();
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-
-        expect(body.error).not.toBe(GATE_BLOCKED);
-        // Staff must never trigger the flag lookup at all.
-        expect(isEnabled).not.toHaveBeenCalled();
+    it("reaches the handler regardless of the rollout flag", async () => {
+      getServerAuthSession.mockResolvedValue({
+        user: { email: "dev@langwatch.ai", id: "u1" },
       });
+      isEnabled.mockResolvedValue(false);
+
+      const res = await requestLangy();
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+
+      expect(body.error).not.toBe(REMOVED_GATE_MESSAGE);
+      // The removed gate is the only thing that ever called isEnabled here.
+      expect(isEnabled).not.toHaveBeenCalled();
     });
   });
 
   describe("when the user is not staff", () => {
-    describe("and Langy has not been rolled out to them", () => {
-      it("is rejected with a 403", async () => {
-        getServerAuthSession.mockResolvedValue({
-          user: { email: "user@acme.com", id: "u2" },
-        });
-        isEnabled.mockResolvedValue(false);
-
-        const res = await requestLangy();
-
-        expect(res.status).toBe(403);
-        const body = (await res.json()) as { error?: string };
-        expect(body.error).toBe(GATE_BLOCKED);
+    it("reaches the handler with the rollout flag OFF", async () => {
+      getServerAuthSession.mockResolvedValue({
+        user: { email: "user@acme.com", id: "u2" },
       });
+      isEnabled.mockResolvedValue(false);
+
+      const res = await requestLangy();
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+
+      expect(body.error).not.toBe(REMOVED_GATE_MESSAGE);
+      expect(isEnabled).not.toHaveBeenCalled();
     });
 
-    describe("and Langy has been rolled out to them", () => {
-      it("is not blocked by the rollout gate", async () => {
-        getServerAuthSession.mockResolvedValue({
-          user: { email: "user@acme.com", id: "u3" },
-        });
-        isEnabled.mockResolvedValue(true);
-
-        const res = await requestLangy();
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-
-        expect(body.error).not.toBe(GATE_BLOCKED);
+    it("reaches the handler with the rollout flag ON", async () => {
+      getServerAuthSession.mockResolvedValue({
+        user: { email: "user@acme.com", id: "u3" },
       });
+      isEnabled.mockResolvedValue(true);
+
+      const res = await requestLangy();
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+
+      expect(body.error).not.toBe(REMOVED_GATE_MESSAGE);
+      expect(isEnabled).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/server/tracer/__tests__/metadataLabels.integration.test.ts
+++ b/langwatch/src/server/tracer/__tests__/metadataLabels.integration.test.ts
@@ -859,3 +859,101 @@ describe("Integration - Real-world SDK scenarios", () => {
     expect(trace.spans[0]?.type).toBe("llm");
   });
 });
+
+/**
+ * Helper to create a minimal OTEL trace request with the given OTLP *resource*
+ * attributes (as opposed to span attributes). This mirrors how an OTel SDK
+ * serialises OTEL_RESOURCE_ATTRIBUTES — flat string-valued key/value pairs on
+ * the resource shared by every span. Used to verify that reserved metadata
+ * keys are mapped from resource attributes, not only span attributes.
+ */
+function createOtelTraceWithResourceAttributes(
+  resourceAttributes: Array<{ key: string; value: { stringValue?: string } }>,
+  traceId = "dGVzdC10cmFjZS1pZDEyMzQ=",
+): DeepPartial<IExportTraceServiceRequest> {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: resourceAttributes },
+        scopeSpans: [
+          {
+            scope: { name: "test.instrumentation", version: "1.0.0" },
+            spans: [
+              {
+                traceId,
+                spanId: "c3Bhbi1pZC0xMjM0NTY=",
+                name: "test-span",
+                kind: "SPAN_KIND_INTERNAL" as unknown as ESpanKind,
+                startTimeUnixNano: "1700000000000000000",
+                endTimeUnixNano: "1700000001000000000",
+                attributes: [],
+                status: { code: "STATUS_CODE_OK" as unknown as EStatusCode },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("Metadata Mapping - resource attributes", () => {
+  // The opencode OTel plugin (Langy worker) sets tags via OTLP *resource*
+  // attributes, so reserved keys must be hoisted from the resource the same
+  // way they are from span attributes. See specs/assistant/langy-otel-tracing.feature.
+
+  it("maps tag.tags from resource attributes to labels", async () => {
+    const request = createOtelTraceWithResourceAttributes([
+      { key: "tag.tags", value: { stringValue: "langy" } },
+    ]);
+
+    const traces = await openTelemetryTraceRequestToTracesForCollection(request);
+    expect(traces).toHaveLength(1);
+
+    const trace = traces[0]!;
+    expect(trace.reservedTraceMetadata.labels).toEqual(["langy"]);
+  });
+
+  it("maps langwatch.thread.id from resource attributes to thread_id", async () => {
+    const request = createOtelTraceWithResourceAttributes([
+      { key: "langwatch.thread.id", value: { stringValue: "conv-123" } },
+    ]);
+
+    const traces = await openTelemetryTraceRequestToTracesForCollection(request);
+    expect(traces).toHaveLength(1);
+
+    const trace = traces[0]!;
+    expect(trace.reservedTraceMetadata.thread_id).toBe("conv-123");
+  });
+
+  it("keeps non-reserved resource attributes as custom metadata", async () => {
+    const request = createOtelTraceWithResourceAttributes([
+      { key: "service.name", value: { stringValue: "langy-agent" } },
+    ]);
+
+    const traces = await openTelemetryTraceRequestToTracesForCollection(request);
+    expect(traces).toHaveLength(1);
+
+    const trace = traces[0]!;
+    expect(trace.customMetadata["service.name"]).toBe("langy-agent");
+    expect(trace.reservedTraceMetadata).not.toHaveProperty("service.name");
+  });
+
+  it("maps the Langy worker's resource attributes end to end", async () => {
+    // Exactly what services/langy-agent/server.js sets via
+    // OPENCODE_RESOURCE_ATTRIBUTES for a conversation.
+    const request = createOtelTraceWithResourceAttributes([
+      { key: "tag.tags", value: { stringValue: "langy" } },
+      { key: "service.name", value: { stringValue: "langy-agent" } },
+      { key: "langwatch.thread.id", value: { stringValue: "conv-123" } },
+    ]);
+
+    const traces = await openTelemetryTraceRequestToTracesForCollection(request);
+    expect(traces).toHaveLength(1);
+
+    const trace = traces[0]!;
+    expect(trace.reservedTraceMetadata.labels).toEqual(["langy"]);
+    expect(trace.reservedTraceMetadata.thread_id).toBe("conv-123");
+    expect(trace.customMetadata["service.name"]).toBe("langy-agent");
+  });
+});

--- a/langwatch/src/server/tracer/otel.traces.ts
+++ b/langwatch/src/server/tracer/otel.traces.ts
@@ -175,11 +175,25 @@ const openTelemetryTraceRequestToTraceForCollection = (
         );
         const otelTrace = cloneDeep(otelTrace_);
 
+        // Collect OTLP resource attributes (shared by every span in the
+        // request). Reserved keys (tag.tags -> labels, langwatch.thread.id ->
+        // thread_id, ...) are hoisted to reserved trace metadata exactly as
+        // they are from span attributes — Langy's opencode OTel plugin sets
+        // them on the resource, so this is what makes its traces land labeled
+        // "langy" and grouped by conversation. Everything else stays custom.
         const customMetadata: Record<string, any> = {};
+        const resourceReservedSource: Record<string, any> = {};
         for (const resourceSpan of otelTrace.resourceSpans ?? []) {
           for (const attribute of resourceSpan?.resource?.attributes ?? []) {
-            if (attribute?.key) {
-              customMetadata[attribute.key] = attribute?.value?.stringValue;
+            if (!attribute?.key) continue;
+            const value = attribute?.value?.stringValue;
+            if (
+              attribute.key in openTelemetryToLangWatchMetadataMapping &&
+              value != null
+            ) {
+              resourceReservedSource[attribute.key] = value;
+            } else {
+              customMetadata[attribute.key] = value;
             }
           }
         }
@@ -191,6 +205,35 @@ const openTelemetryTraceRequestToTraceForCollection = (
           reservedTraceMetadata: {},
           customMetadata,
         };
+
+        if (Object.keys(resourceReservedSource).length > 0) {
+          // tag.tags maps to labels (string[]); a resource attribute carries
+          // it as a single string (OTEL_RESOURCE_ATTRIBUTES can't express
+          // arrays), so coerce to an array before the reserved schema
+          // validates it.
+          if (typeof resourceReservedSource["tag.tags"] === "string") {
+            resourceReservedSource["tag.tags"] = resourceReservedSource[
+              "tag.tags"
+            ]
+              .split(",")
+              .map((tag: string) => tag.trim())
+              .filter(Boolean);
+          }
+          try {
+            const { reservedTraceMetadata, customMetadata: extraCustom } =
+              extractReservedAndCustomMetadata(
+                applyMappingsToMetadata(resourceReservedSource),
+              );
+            trace.reservedTraceMetadata = reservedTraceMetadata;
+            // Any reserved-source key the schema didn't claim falls back to
+            // custom metadata rather than being dropped.
+            Object.assign(trace.customMetadata, extraCustom);
+          } catch {
+            // Defensive: never let a malformed resource attribute break
+            // ingestion — keep the raw values as custom metadata.
+            Object.assign(trace.customMetadata, resourceReservedSource);
+          }
+        }
 
         for (const resourceSpan of otelTrace.resourceSpans ?? []) {
           for (const scopeSpan of resourceSpan?.scopeSpans ?? []) {

--- a/langwatch/src/server/tracer/otel.traces.ts
+++ b/langwatch/src/server/tracer/otel.traces.ts
@@ -189,6 +189,12 @@ const openTelemetryTraceRequestToTraceForCollection = (
             const value = attribute?.value?.stringValue;
             if (
               attribute.key in openTelemetryToLangWatchMetadataMapping &&
+              // telemetry.sdk.* are standard SDK-provenance resource attributes
+              // present on every OTLP trace, which LangWatch has always
+              // surfaced as custom metadata. Leave them there to preserve that
+              // behaviour and keep this change scoped to the trace-identity
+              // keys Langy relies on (tag.tags, langwatch.thread.id, ...).
+              !attribute.key.startsWith("telemetry.sdk.") &&
               value != null
             ) {
               resourceReservedSource[attribute.key] = value;

--- a/services/langy-agent/server.js
+++ b/services/langy-agent/server.js
@@ -50,6 +50,15 @@ const REAPER_INTERVAL_MS = 30_000;
 const SESSIONS_ROOT = "/workspace/sessions";
 const MAX_BODY_BYTES = 1_000_000; // 1MB — cap /chat body to avoid memory exhaustion.
 
+// opencode has no native OpenTelemetry export, so each worker loads this
+// opencode plugin to emit session/llm/tool spans over OTLP. Version is pinned
+// by the Dockerfile (OPENCODE_OTEL_PLUGIN_VERSION) so the version opencode
+// loads matches the one baked into the image; the literal default keeps the
+// manager runnable outside the image.
+const OPENCODE_OTEL_PLUGIN = `@devtheops/opencode-plugin-otel@${
+  process.env.OPENCODE_OTEL_PLUGIN_VERSION || "1.0.0"
+}`;
+
 if (!INTERNAL_SECRET) {
   console.error("fatal: LANGY_INTERNAL_SECRET is required");
   process.exit(1);
@@ -128,6 +137,9 @@ function setupWorkerHome(workerHome, credentials) {
   const config = {
     $schema: "https://opencode.ai/config.json",
     model: "openai/gpt-5-mini",
+    // OTel plugin: opencode auto-loads it by name and exports spans using the
+    // OPENCODE_OTLP_* env injected at spawn time (see spawnWorker).
+    plugin: [OPENCODE_OTEL_PLUGIN],
     mcp: {
       langwatch: {
         type: "local",
@@ -319,6 +331,22 @@ async function spawnWorker(conversationId, credentials) {
         OPENAI_API_KEY: credentials.llmVirtualKey,
         LANGWATCH_API_KEY: credentials.langwatchApiKey,
         LANGWATCH_ENDPOINT: credentials.langwatchEndpoint,
+        // OTel export (consumed by the opencode OTel plugin, not opencode
+        // itself). The plugin appends "/v1/traces" to the endpoint, so we point
+        // it at the "/api/otel" base — LangWatch ingests at /api/otel/v1/traces.
+        // http/protobuf is what that endpoint accepts; auth is the dedicated
+        // Langy key as a Bearer token (resolves its own project, no X-Project-Id
+        // needed). tag.tags=langy becomes the trace label and the conversation
+        // id groups the chat's turns as one thread. conversationId is charset-
+        // validated upstream, so it is safe in the comma/= delimited value.
+        OPENCODE_ENABLE_TELEMETRY: "1",
+        OPENCODE_OTLP_ENDPOINT: `${credentials.langwatchEndpoint.replace(
+          /\/+$/,
+          "",
+        )}/api/otel`,
+        OPENCODE_OTLP_PROTOCOL: "http/protobuf",
+        OPENCODE_OTLP_HEADERS: `Authorization=Bearer ${credentials.langwatchApiKey}`,
+        OPENCODE_RESOURCE_ATTRIBUTES: `tag.tags=langy,service.name=langy-agent,langwatch.thread.id=${conversationId}`,
       },
       cwd: workerHome,
       stdio: ["ignore", "inherit", "inherit"],

--- a/specs/assistant/langy-otel-tracing.feature
+++ b/specs/assistant/langy-otel-tracing.feature
@@ -1,0 +1,81 @@
+@unimplemented
+Feature: Langy agent activity is traced into the user's project
+  As a LangWatch user running Langy
+  I want Langy's agent activity (reasoning, LLM calls, MCP tool calls) captured as traces
+  So that I can observe and debug what Langy did, in my own project, tagged "langy"
+
+  # Part of epic #4528 (issue #4536).
+  #
+  # The Langy worker spawns one `opencode serve` subprocess per conversation
+  # (services/langy-agent/server.js). opencode has NO native OpenTelemetry
+  # export, so an opencode telemetry plugin (@devtheops/opencode-plugin-otel,
+  # pinned) emits session/llm/tool spans over OTLP http/protobuf, authenticated
+  # with the project's dedicated Langy API key, into LangWatch's existing
+  # ingest endpoint POST /api/otel/v1/traces. No new REST endpoints.
+  #
+  # The plugin tags traces via OTLP *resource* attributes. LangWatch already
+  # maps reserved keys (tag.tags -> labels, langwatch.thread.id -> thread_id)
+  # from *span* attributes; this feature also maps them from resource
+  # attributes so the "langy" label and conversation grouping survive.
+
+  Background:
+    Given a project with a provisioned dedicated Langy API key
+    And the Langy worker is configured with the opencode OTel plugin
+
+  # ============================================================================
+  # End-to-end: a Langy chat becomes a labeled trace
+  # ============================================================================
+
+  Scenario: A Langy chat produces a trace in the user's project
+    When I send a message to Langy in my project
+    Then a trace appears in that same project
+    And the trace's labels contain "langy"
+
+  Scenario: The trace captures the agent's activity as spans
+    When Langy answers using an LLM and at least one MCP tool
+    Then the trace contains a span for the LLM call
+    And the trace contains a span for the MCP tool call
+
+  Scenario: Turns of one conversation are grouped together
+    Given a Langy conversation with id "conv-123"
+    When I send two messages in that conversation
+    Then both resulting traces share thread_id "conv-123"
+
+  # ============================================================================
+  # OTLP export wiring (services/langy-agent)
+  # ============================================================================
+
+  Scenario: The worker exports over a protocol LangWatch accepts
+    Given the worker spawns an opencode subprocess for a conversation
+    Then the subprocess environment enables the OTel plugin
+    And the OTLP endpoint resolves to "<LANGWATCH_ENDPOINT>/api/otel/v1/traces"
+    And the OTLP protocol is "http/protobuf"
+    And the OTLP headers authenticate with the dedicated Langy API key as a Bearer token
+    And the OTLP resource attributes include "tag.tags=langy" and the conversation id
+
+  Scenario: opencode without the plugin exports nothing
+    # Guards against the silent no-op: standard OTEL_* env on opencode is ignored.
+    Given an opencode subprocess without the OTel plugin enabled
+    When it runs a turn
+    Then no traces are exported
+
+  # ============================================================================
+  # Ingestion: reserved metadata keys in OTLP resource attributes
+  # Covered by src/server/tracer/__tests__/metadataLabels.integration.test.ts
+  # ============================================================================
+
+  Scenario: tag.tags in resource attributes becomes trace labels
+    Given an OTLP trace whose resource attributes include "tag.tags=langy"
+    When the trace is ingested at /api/otel/v1/traces
+    Then the stored trace's labels contain "langy"
+
+  Scenario: langwatch.thread.id in resource attributes becomes thread_id
+    Given an OTLP trace whose resource attributes include "langwatch.thread.id=conv-123"
+    When the trace is ingested
+    Then the stored trace's thread_id is "conv-123"
+
+  Scenario: Non-reserved resource attributes stay as custom metadata
+    Given an OTLP trace whose resource attributes include "service.name=langy-agent"
+    When the trace is ingested
+    Then "service.name" is preserved in the trace's custom metadata
+    And it is not promoted to a reserved field


### PR DESCRIPTION
Closes langwatch/tasks#70. Part of epic langwatch/tasks#103. Stacked on langwatch/tasks#65 (dedicated Langy API key).

## What
Langy's per-session OpenCode worker now emits OpenTelemetry traces — agent `session` / `llm` / `tool` spans — into the **user's own LangWatch project**, tagged **`langy`** and grouped by conversation.

## Why this shape (verified, not guessed)
- **opencode has NO native OTel export.** Confirmed by open upstream requests anomalyco/opencode#12142, #14246, #14697 (they ask for the standard `OTEL_*` env that Claude Code honours). Setting `OTEL_EXPORTER_OTLP_*` on the subprocess would be a **silent no-op** — so we use the `@devtheops/opencode-plugin-otel` plugin (pinned `1.0.0`), which emits session/llm/tool spans and reads `OPENCODE_*` env.
- **Endpoint:** the plugin appends `/v1/traces` to `OPENCODE_OTLP_ENDPOINT` (its `buildHttpSignalUrl` sets `pathname = ${base}/v1/${signal}`), so we point it at `${LANGWATCH_ENDPOINT}/api/otel` → `…/api/otel/v1/traces`, LangWatch's real ingest path.
- **Protocol/auth:** `http/protobuf` (what `/api/otel/v1/traces` accepts) + `Authorization: Bearer <dedicated Langy key>`. The key resolves its own project, so no `X-Project-Id` is needed (same as the MCP server already does).
- **Tagging gap fixed:** the plugin tags via OTLP **resource** attributes, but ingestion only mapped reserved keys (`tag.tags`→`labels`, `langwatch.thread.id`→`thread_id`) from **span** attributes — resource attributes were dumped raw into customMetadata. `otel.traces.ts` now also hoists reserved keys from **resource** attributes (coercing `tag.tags` to a `string[]`). The change is **additive** (only string-valued keys already in the reserved mapping are hoisted; everything else stays as today) and wrapped in try/catch so a malformed resource attribute can never break ingestion for any sender.

## Changes
- `langwatch/src/server/tracer/otel.traces.ts` — map reserved metadata keys from OTLP resource attributes.
- `langwatch/src/server/tracer/__tests__/metadataLabels.integration.test.ts` — resource-attribute cases incl. the exact Langy end-to-end resource set.
- `Dockerfile.langy_agent` — pin + install the plugin (`OPENCODE_OTEL_PLUGIN_VERSION` ARG → ENV).
- `services/langy-agent/server.js` — reference the plugin in each worker's `config.json`; inject `OPENCODE_*` OTLP env at spawn.
- `specs/assistant/langy-otel-tracing.feature` — BDD spec.

No new REST endpoints (reuses `/api/otel/v1/traces`).

## Verified locally
- ✅ Ingestion logic: resource-attr `tag.tags=langy` → `labels:["langy"]`, `langwatch.thread.id` → `thread_id`, `service.name` stays custom. TDD red→green (the integration cases run under `pnpm test:integration` in CI; verified locally via the unit runner since this box has no Docker/ClickHouse).
- ✅ `pnpm typecheck` clean.
- ✅ Plugin URL/header/protocol/resource-attr behaviour read from plugin source.

## Needs pod QA (couldn't run full pod locally — no Docker here)
- [ ] In a running langy-agent pod: send a Langy chat, confirm a trace appears in the project with `labels` containing `langy`, grouped by conversation, with LLM + MCP tool spans.
- [ ] Confirm the plugin **loads** in the locked-down pod — opencode auto-installs plugins via Bun at startup into `~/.cache/opencode`; verify the pod has npm egress for that first fetch (or pre-warm/bake the cache). This is the one link not exercisable in this dev env and the most likely silent-failure point.