### PR TITLE
feat(langy): add adaptive setup modal for model readiness

### DIFF
--- a/langwatch/scripts/backfill-langy-api-keys.ts
+++ b/langwatch/scripts/backfill-langy-api-keys.ts
@@ -1,0 +1,40 @@
+/**
+ * Backfill script: mint the dedicated "Langy" API key for every existing
+ * application project that doesn't already have one.
+ *
+ * Idempotent — re-running only provisions keys for projects still missing one.
+ * Hidden internal_governance projects are excluded.
+ *
+ * Run with:
+ *   DATABASE_URL=... npx tsx scripts/backfill-langy-api-keys.ts
+ *   DATABASE_URL=... npx tsx scripts/backfill-langy-api-keys.ts --dry-run
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { backfillLangyApiKeys } from "../src/server/services/langy/langyApiKey";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE"}\n`);
+
+  const { provisioned, skipped, failed } = await backfillLangyApiKeys(prisma, {
+    dryRun: DRY_RUN,
+  });
+
+  console.log(
+    `Langy key backfill: ${DRY_RUN ? "would provision" : "provisioned"} ${provisioned}, skipped ${skipped} (already had one), failed ${failed}`,
+  );
+
+  await prisma.$disconnect();
+
+  if (failed > 0) process.exit(1);
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect().catch(() => {});
+  process.exit(1);
+});

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -39,6 +39,8 @@ import { useTypewriterPlaceholder } from "~/features/traces-v2/components/ai/use
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
+import { api } from "~/utils/api";
+import { SetUpLangyModal } from "./SetUpLangyModal";
 import {
   useLangyConversations,
   type LangyConversationSummary,
@@ -418,6 +420,27 @@ function LangyPanel({
   );
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  // "Set up Langy" modal state + readiness. Langy's chat gate is
+  // getVercelAIModel(projectId) → resolves the DEFAULT role (feature key
+  // prompt.create_default) and 409s when nothing resolves.
+  // getResolvedDefault returns null in exactly that case, so we treat
+  // `data === null` as "not ready" and open the modal instead of failing.
+  const [setupOpen, setSetupOpen] = useState(false);
+  const modelReadinessQuery = api.modelProvider.getResolvedDefault.useQuery(
+    { projectId: projectId ?? "", featureKey: "prompt.create_default" },
+    { enabled: !!projectId, refetchOnWindowFocus: true },
+  );
+  const modelReady =
+    modelReadinessQuery.data === undefined
+      ? undefined
+      : modelReadinessQuery.data !== null;
+  // onError closes over the useChat config created once; read readiness via a
+  // ref so the backstop sees the current value, not a stale render's.
+  const modelReadyRef = useRef(modelReady);
+  useEffect(() => {
+    modelReadyRef.current = modelReady;
+  }, [modelReady]);
+
   const transport = useMemo(
     () => new DefaultChatTransport({ api: "/api/langy/chat" }),
     [],
@@ -426,6 +449,13 @@ function LangyPanel({
     transport,
     onError: (error) => {
       if (isHandledByGlobalHandler(error)) return;
+      // Race backstop: if the project has no usable default model, the chat
+      // failed the model gate (409). Open the setup modal instead of a
+      // dead-end toast. (send() intercepts the common, already-loaded case.)
+      if (modelReadyRef.current === false) {
+        setSetupOpen(true);
+        return;
+      }
       toaster.create({
         title: "Langy error",
         description: error.message,
@@ -484,6 +514,12 @@ function LangyPanel({
 
   const send = async (text: string) => {
     if (!text.trim() || !projectId || isBusy) return;
+    // No usable model yet → open the setup modal instead of firing a request
+    // that would 409. Leave the text in the input so it survives setup.
+    if (modelReady === false) {
+      setSetupOpen(true);
+      return;
+    }
     setInput("");
     await sendMessage(
       { role: "user", parts: [{ type: "text", text }] },
@@ -634,6 +670,12 @@ function LangyPanel({
           canSend={!!input.trim() && !isBusy && !!projectId}
         />
       </VStack>
+      <SetUpLangyModal
+        open={setupOpen}
+        projectId={projectId}
+        onClose={() => setSetupOpen(false)}
+        onReady={() => void modelReadinessQuery.refetch()}
+      />
     </Box>
   );
 }

--- a/langwatch/src/components/langy/SetUpLangyModal.tsx
+++ b/langwatch/src/components/langy/SetUpLangyModal.tsx
@@ -1,0 +1,232 @@
+import {
+  Box,
+  Button,
+  HStack,
+  Icon,
+  Separator,
+  Skeleton,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { ArrowRight, Check, Sparkles } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  ModelSelector,
+  allModelOptions,
+  useModelSelectionOptions,
+} from "~/components/ModelSelector";
+import { Dialog } from "~/components/ui/dialog";
+import { Link } from "~/components/ui/link";
+import { toaster } from "~/components/ui/toaster";
+import { api } from "~/utils/api";
+import { titleCase } from "~/utils/stringCasing";
+import { computeLangyModelSetup } from "./langyModelSetup";
+
+// Plain deep-link to the real provider form — the single source of truth for
+// adding/validating a provider (no duplicated validation here). Opened in a
+// new tab so this modal stays mounted; the providers query refetches on focus
+// when the user returns, advancing branch C → A/B automatically.
+const MODEL_PROVIDERS_SETTINGS_PATH = "/settings/model-providers";
+
+export interface SetUpLangyModalProps {
+  open: boolean;
+  projectId: string | undefined;
+  onClose: () => void;
+  /**
+   * Fired once a usable default model has been persisted. The host should
+   * re-check Langy readiness (and may retry the user's pending message).
+   */
+  onReady: () => void;
+}
+
+/**
+ * Adaptive "Set up Langy" modal (#4274). One surface that takes a project from
+ * "Langy can't run" to "Langy works", with no dead ends:
+ *
+ *   ① Langy key — informational; PR1 (#4273) already auto-provisions it.
+ *   ② Model — server-derived branch:
+ *       A  Anthropic enabled    → one-click "Use Anthropic"
+ *       B  other provider only  → one-click "Use your <provider>" + Anthropic nudge
+ *       C  nothing enabled      → "Add a model →" deep-link to provider settings
+ *
+ * Confirming persists the chosen model as the project's DEFAULT-role default
+ * (the key Langy's gate, getVercelAIModel → prompt.create_default, resolves).
+ */
+export function SetUpLangyModal({
+  open,
+  projectId,
+  onClose,
+  onReady,
+}: SetUpLangyModalProps) {
+  const utils = api.useContext();
+  const providersQuery = api.modelProvider.getAllForProjectForFrontend.useQuery(
+    { projectId: projectId ?? "" },
+    { enabled: !!projectId && open, refetchOnWindowFocus: true },
+  );
+  const saveMutation = api.modelProvider.saveDefaultModelsConfig.useMutation();
+
+  // getAllForProjectForFrontend returns { providers, modelMetadata }; the
+  // enabled-provider map we branch on lives under `.providers`.
+  const setup = computeLangyModelSetup(providersQuery.data?.providers);
+
+  // The chat model the confirm action will persist. Seeded from the branch's
+  // primary provider once options load; the dropdown lets the user override.
+  const [selectedModel, setSelectedModel] = useState("");
+  const { selectOptions } = useModelSelectionOptions(
+    allModelOptions,
+    selectedModel,
+    "chat",
+  );
+
+  // Pre-select a model so branches A/B are genuinely one-click. Prefer the
+  // branch's primary provider; fall back to the first available option so the
+  // confirm button is never stranded disabled when models exist but none match
+  // the primary (e.g. a provider counts as "enabled" but offers no chat model
+  // in the picker). The user can still change it.
+  useEffect(() => {
+    if (selectedModel || selectOptions.length === 0) return;
+    const primary = setup.primaryProviderKey;
+    const preferred = primary
+      ? selectOptions.find((o) => o.value.startsWith(`${primary}/`))
+      : undefined;
+    setSelectedModel((preferred ?? selectOptions[0]!).value);
+  }, [selectedModel, setup.primaryProviderKey, selectOptions]);
+
+  const handleConfirm = async () => {
+    if (!projectId || !selectedModel) return;
+    try {
+      await saveMutation.mutateAsync({
+        config: { DEFAULT: selectedModel },
+        scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+      });
+      // Refresh the gate readiness + the settings snapshot so the host (and
+      // the Default Models page) reflect the new default immediately.
+      await Promise.all([
+        utils.modelProvider.getResolvedDefault.invalidate(),
+        utils.modelProvider.getDefaultModelsForProject.invalidate(),
+      ]);
+      toaster.create({
+        title: "Langy is ready",
+        description: `Using ${selectedModel}`,
+        type: "success",
+        duration: 4000,
+        meta: { closable: true },
+      });
+      onReady();
+      onClose();
+    } catch (error) {
+      toaster.create({
+        title: "Couldn't set the model",
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+        type: "error",
+        duration: 6000,
+        meta: { closable: true },
+      });
+    }
+  };
+
+  // Label names the provider that will actually be saved (derived from the
+  // selected model), so the button never promises "Use Anthropic" while a
+  // different model is selected.
+  const selectedProvider = selectedModel.split("/")[0] ?? "";
+  const confirmLabel = selectedProvider
+    ? `Use ${titleCase(selectedProvider)}`
+    : "Use this model";
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(d) => !d.open && onClose()}>
+      <Dialog.Content bg="bg">
+        <Dialog.CloseTrigger />
+        <Dialog.Header>
+          <HStack gap={2}>
+            <Icon as={Sparkles} color="purple.500" boxSize={5} />
+            <Dialog.Title>Set up Langy</Dialog.Title>
+          </HStack>
+        </Dialog.Header>
+        <Dialog.Body>
+          <VStack align="stretch" gap={5} py={2}>
+            {/* ① Langy key — informational (PR1 auto-provisions it). */}
+            <HStack gap={2} align="center">
+              <Icon as={Check} color="green.500" boxSize={5} />
+              <Text fontSize="sm">
+                A dedicated Langy key is ready for this project.
+              </Text>
+            </HStack>
+
+            <Separator />
+
+            {/* ② Model. */}
+            {providersQuery.isLoading ? (
+              <Skeleton height="40px" borderRadius="md" />
+            ) : setup.branch === "none" ? (
+              <VStack align="stretch" gap={3}>
+                <Text fontSize="sm" color="fg.muted">
+                  Langy needs an AI model to run. Add a model provider to
+                  continue — we recommend Anthropic.
+                </Text>
+                <Button colorPalette="purple" alignSelf="flex-start" asChild>
+                  <a
+                    data-testid="langy-add-model"
+                    href={MODEL_PROVIDERS_SETTINGS_PATH}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: "white" }}
+                  >
+                    <HStack gap={2}>
+                      <Text>Add a model</Text>
+                      <Icon as={ArrowRight} boxSize={4} />
+                    </HStack>
+                  </a>
+                </Button>
+                <Text fontSize="xs" color="fg.subtle">
+                  Opens settings in a new tab. Come back here when you&apos;re
+                  done — Langy picks it up automatically.
+                </Text>
+              </VStack>
+            ) : (
+              <VStack align="stretch" gap={3}>
+                <Text fontSize="sm" color="fg.muted">
+                  Choose the model Langy will use:
+                </Text>
+                <Box>
+                  <ModelSelector
+                    model={selectedModel}
+                    options={allModelOptions}
+                    onChange={setSelectedModel}
+                    mode="chat"
+                    size="full"
+                    showConfigureAction
+                  />
+                </Box>
+                {setup.showAnthropicNudge && (
+                  <Link
+                    href={MODEL_PROVIDERS_SETTINGS_PATH}
+                    isExternal
+                    fontSize="xs"
+                    color="purple.500"
+                  >
+                    Add Anthropic for the best Langy experience →
+                  </Link>
+                )}
+              </VStack>
+            )}
+          </VStack>
+        </Dialog.Body>
+        <Dialog.Footer>
+          {setup.branch !== "none" && (
+            <Button
+              data-testid="langy-confirm-model"
+              colorPalette="purple"
+              onClick={() => void handleConfirm()}
+              loading={saveMutation.isPending}
+              disabled={!selectedModel}
+            >
+              {confirmLabel}
+            </Button>
+          )}
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/langwatch/src/components/langy/__tests__/langyModelSetup.unit.test.ts
+++ b/langwatch/src/components/langy/__tests__/langyModelSetup.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { computeLangyModelSetup } from "../langyModelSetup";
+
+describe("computeLangyModelSetup", () => {
+  it("branch A: Anthropic enabled takes priority even with other providers", () => {
+    const result = computeLangyModelSetup({
+      anthropic: { enabled: true },
+      openai: { enabled: true },
+    });
+    expect(result.branch).toBe("anthropic");
+    expect(result.primaryProviderKey).toBe("anthropic");
+    expect(result.showAnthropicNudge).toBe(false);
+  });
+
+  it("branch B: only a non-Anthropic provider enabled → use it + nudge", () => {
+    const result = computeLangyModelSetup({
+      openai: { enabled: true },
+      anthropic: { enabled: false },
+    });
+    expect(result.branch).toBe("other");
+    expect(result.primaryProviderKey).toBe("openai");
+    expect(result.showAnthropicNudge).toBe(true);
+  });
+
+  it("branch B: picks a deterministic (sorted) primary among several others", () => {
+    const result = computeLangyModelSetup({
+      openai: { enabled: true },
+      azure: { enabled: true },
+    });
+    expect(result.branch).toBe("other");
+    // sorted: ["azure", "openai"] → azure is primary
+    expect(result.primaryProviderKey).toBe("azure");
+    expect(result.enabledProviderKeys).toEqual(["azure", "openai"]);
+  });
+
+  it("branch C: nothing enabled", () => {
+    const result = computeLangyModelSetup({
+      openai: { enabled: false },
+      anthropic: { enabled: false },
+    });
+    expect(result.branch).toBe("none");
+    expect(result.primaryProviderKey).toBeNull();
+    expect(result.showAnthropicNudge).toBe(false);
+  });
+
+  it("branch C: empty / nullish provider maps are safe", () => {
+    expect(computeLangyModelSetup({}).branch).toBe("none");
+    expect(computeLangyModelSetup(undefined).branch).toBe("none");
+    expect(computeLangyModelSetup(null).branch).toBe("none");
+  });
+
+  it("ignores disabled providers when listing enabled keys", () => {
+    const result = computeLangyModelSetup({
+      anthropic: { enabled: true },
+      openai: { enabled: false },
+      gemini: { enabled: true },
+    });
+    expect(result.enabledProviderKeys).toEqual(["anthropic", "gemini"]);
+  });
+});

--- a/langwatch/src/components/langy/langyModelSetup.ts
+++ b/langwatch/src/components/langy/langyModelSetup.ts
@@ -1,0 +1,67 @@
+/**
+ * Branch detection for the "Set up Langy" modal's model section.
+ *
+ * The modal adapts to what the project already has configured. This is the
+ * pure decision — given the provider map the frontend already loads via
+ * `api.modelProvider.getAllForProjectForFrontend`, decide which of the three
+ * branches to render. Kept free of React/Chakra so it can be unit-tested
+ * without a DOM and so the component stays a dumb renderer.
+ *
+ * Note: "enabled" here means a provider is usable (saved row or env-fed
+ * system provider). It is INDEPENDENT of whether a default model is saved —
+ * a project can have Anthropic enabled and still fail Langy's model gate
+ * because no DEFAULT-role default is set. This branch only chooses the copy
+ * and the suggested provider; satisfying the gate is the confirm action's job.
+ */
+
+export const ANTHROPIC_PROVIDER_KEY = "anthropic";
+
+export type LangyModelBranch = "anthropic" | "other" | "none";
+
+export interface LangyModelSetup {
+  /** Which model section to render. */
+  branch: LangyModelBranch;
+  /** Provider keys that are enabled, sorted for deterministic display. */
+  enabledProviderKeys: string[];
+  /** Provider whose flagship the one-click action confirms (null in branch "none"). */
+  primaryProviderKey: string | null;
+  /** Show the soft "add Anthropic for the best experience" nudge (branch "other" only). */
+  showAnthropicNudge: boolean;
+}
+
+/** Minimal shape we read off each provider; matches MaybeStoredModelProvider. */
+type ProviderLike = { enabled?: boolean | null };
+
+export function computeLangyModelSetup(
+  providers: Record<string, ProviderLike> | undefined | null,
+): LangyModelSetup {
+  const enabledProviderKeys = Object.entries(providers ?? {})
+    .filter(([, p]) => p?.enabled === true)
+    .map(([key]) => key)
+    .sort();
+
+  if (enabledProviderKeys.includes(ANTHROPIC_PROVIDER_KEY)) {
+    return {
+      branch: "anthropic",
+      enabledProviderKeys,
+      primaryProviderKey: ANTHROPIC_PROVIDER_KEY,
+      showAnthropicNudge: false,
+    };
+  }
+
+  if (enabledProviderKeys.length > 0) {
+    return {
+      branch: "other",
+      enabledProviderKeys,
+      primaryProviderKey: enabledProviderKeys[0]!,
+      showAnthropicNudge: true,
+    };
+  }
+
+  return {
+    branch: "none",
+    enabledProviderKeys,
+    primaryProviderKey: null,
+    showAnthropicNudge: false,
+  };
+}

--- a/langwatch/src/server/api/routers/__tests__/langySetupModal.modelGate.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/langySetupModal.modelGate.integration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for the Langy model gate that the "Set up Langy" modal
+ * exists to satisfy. Real database — no mocks.
+ *
+ * Langy's chat route (src/server/routes/langy.ts) calls getVercelAIModel,
+ * which delegates to resolveModelForFeature("prompt.create_default"). When
+ * nothing resolves for the DEFAULT role at any scope, that throws
+ * ModelNotConfiguredError and the route answers HTTP 409 — the failure the
+ * modal recovers from. The modal's "confirm a model" action persists the
+ * chosen model as the project's DEFAULT-role default via
+ * modelProvider.setRoleAssignmentForScope.
+ *
+ * These tests pin that exact contract end-to-end: gate throws with no
+ * default, resolves after the modal's write, and the write is idempotent at
+ * project scope.
+ *
+ * Spec: specs/assistant/langy-setup-modal.feature (the @integration scenarios)
+ * Requires: PostgreSQL database (Prisma)
+ */
+import {
+  OrganizationUserRole,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "../../../db";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+import { resolveModelForFeature } from "~/server/modelProviders/resolveModelForFeature";
+import { ModelNotConfiguredError } from "~/server/modelProviders/modelNotConfiguredError";
+
+// The Langy chat route resolves with no explicit feature key, which defaults
+// to "prompt.create_default" (DEFAULT role). Keep these in lockstep with
+// getVercelAIModel's default so the test guards the real gate.
+const LANGY_GATE_FEATURE_KEY = "prompt.create_default";
+
+// describe.skipIf(isTestcontainersOnly): the testcontainers run sets
+// TEST_CLICKHOUSE_URL and is reserved for ClickHouse-backed suites. This is a
+// Postgres-only suite, so it must run when that var is ABSENT. If you see this
+// suite skipped, you ran it in the wrong mode — unset TEST_CLICKHOUSE_URL.
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+
+describe.skipIf(isTestcontainersOnly)("Langy model gate (Set up Langy modal)", () => {
+  const testNamespace = `langy-gate-${nanoid(8)}`;
+  let organizationId: string;
+  let teamId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Langy Gate Org", slug: `--test-org-${testNamespace}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: {
+        name: "Langy Gate Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+
+    const user = await prisma.user.create({
+      data: { name: "Langy Gate User", email: `${testNamespace}@example.com` },
+    });
+    userId = user.id;
+
+    await prisma.organizationUser.create({
+      data: { userId, organizationId, role: OrganizationUserRole.ADMIN },
+    });
+    await prisma.teamUser.create({
+      data: { userId, teamId, role: TeamUserRole.ADMIN },
+    });
+  });
+
+  afterAll(async () => {
+    const projects = await prisma.project.findMany({
+      where: { teamId },
+      select: { id: true },
+    });
+    const projectIds = projects.map((p) => p.id);
+    // Default-model configs are attached to scopes (project/team/org) via a
+    // join table; delete the configs first so their scope rows cascade.
+    await prisma.modelDefaultConfig
+      .deleteMany({
+        where: {
+          scopes: {
+            some: {
+              OR: [
+                { scopeType: "ORGANIZATION", scopeId: organizationId },
+                { scopeType: "TEAM", scopeId: teamId },
+                ...projectIds.map((id) => ({
+                  scopeType: "PROJECT" as const,
+                  scopeId: id,
+                })),
+              ],
+            },
+          },
+        },
+      })
+      .catch(() => {});
+    await prisma.roleBinding.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.apiKey.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.project.deleteMany({ where: { teamId } }).catch(() => {});
+    await prisma.teamUser.deleteMany({ where: { teamId } }).catch(() => {});
+    await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
+    await prisma.organizationUser.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.organization.deleteMany({ where: { id: organizationId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
+  });
+
+  function createCaller() {
+    const ctx = createInnerTRPCContext({
+      session: { user: { id: userId }, expires: "1" },
+    });
+    return appRouter.createCaller(ctx);
+  }
+
+  // A fresh project with no default-model config of its own. We do NOT mint a
+  // Langy key here (that's PR1's concern); these tests are purely about the
+  // model gate.
+  async function createBareProject(name: string) {
+    return prisma.project.create({
+      data: {
+        name,
+        slug: `--gate-${testNamespace}-${nanoid(6)}`,
+        apiKey: `sk-lw-test-${nanoid()}`,
+        teamId,
+        language: "en",
+        framework: "test",
+      },
+    });
+  }
+
+  // The modal's confirm action: persist the chosen model as the project's
+  // DEFAULT-role default. We use saveDefaultModelsConfig (the same writer the
+  // Model Providers settings drawer uses) rather than setRoleAssignmentForScope
+  // so we exercise the production-proven, guard-safe path.
+  function persistDefaultModel(projectId: string, model: string) {
+    return createCaller().modelProvider.saveDefaultModelsConfig({
+      config: { DEFAULT: model },
+      scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+    });
+  }
+
+  it("fails the gate when the project has no default model configured", async () => {
+    const project = await createBareProject("No Default");
+
+    await expect(
+      resolveModelForFeature(LANGY_GATE_FEATURE_KEY, {
+        prisma,
+        projectId: project.id,
+      }),
+    ).rejects.toBeInstanceOf(ModelNotConfiguredError);
+  });
+
+  it("satisfies the gate after the modal persists the chosen model", async () => {
+    const project = await createBareProject("Confirms Model");
+    const chosen = "anthropic/claude-3-5-sonnet-20241022";
+
+    await persistDefaultModel(project.id, chosen);
+
+    const resolved = await resolveModelForFeature(LANGY_GATE_FEATURE_KEY, {
+      prisma,
+      projectId: project.id,
+    });
+    expect(resolved.model).toBe(chosen);
+    expect(resolved.scope).toBe("project");
+  });
+
+  it("resolves to the latest choice when a different model is re-confirmed", async () => {
+    const project = await createBareProject("Confirms Twice");
+    const first = "anthropic/claude-3-5-sonnet-20241022";
+    const second = "openai/gpt-4o";
+
+    await persistDefaultModel(project.id, first);
+    await persistDefaultModel(project.id, second);
+
+    // The resolver picks the newest config at the project tier, so the most
+    // recently confirmed model wins.
+    const resolved = await resolveModelForFeature(LANGY_GATE_FEATURE_KEY, {
+      prisma,
+      projectId: project.id,
+    });
+    expect(resolved.model).toBe(second);
+    expect(resolved.scope).toBe("project");
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration tests for dedicated Langy API key provisioning.
+ * Real database — mocks only the planProvider / usageLimits system boundary
+ * (so project.create runs without a real subscription).
+ *
+ * Spec: specs/assistant/langy-api-key-provisioning.feature
+ * Requires: PostgreSQL database (Prisma)
+ */
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { nanoid } from "nanoid";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { prisma } from "../../../db";
+import { appRouter } from "../../root";
+import { createInnerTRPCContext } from "../../trpc";
+import { createTestApp } from "~/server/app-layer/presets";
+import { globalForApp, resetApp } from "~/server/app-layer/app";
+import {
+  PlanProviderService,
+  type PlanProvider,
+} from "~/server/app-layer/subscription/plan-provider";
+import { FREE_PLAN } from "../../../../../ee/licensing/constants";
+import {
+  LANGY_API_KEY_NAME,
+  backfillLangyApiKeys,
+} from "~/server/services/langy/langyApiKey";
+
+const isTestcontainersOnly = !!process.env.TEST_CLICKHOUSE_URL;
+
+describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
+  const testNamespace = `langy-key-${nanoid(8)}`;
+  let organizationId: string;
+  let teamId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    const organization = await prisma.organization.create({
+      data: { name: "Langy Key Org", slug: `--test-org-${testNamespace}` },
+    });
+    organizationId = organization.id;
+
+    const team = await prisma.team.create({
+      data: {
+        name: "Langy Key Team",
+        slug: `--test-team-${testNamespace}`,
+        organizationId,
+      },
+    });
+    teamId = team.id;
+
+    const user = await prisma.user.create({
+      data: { name: "Langy Key User", email: `${testNamespace}@example.com` },
+    });
+    userId = user.id;
+
+    await prisma.organizationUser.create({
+      data: { userId, organizationId, role: OrganizationUserRole.ADMIN },
+    });
+    await prisma.teamUser.create({
+      data: { userId, teamId, role: TeamUserRole.ADMIN },
+    });
+  });
+
+  beforeEach(() => {
+    resetApp();
+    globalForApp.__langwatch_app = createTestApp({
+      planProvider: PlanProviderService.create({
+        getActivePlan: vi.fn().mockResolvedValue({
+          ...FREE_PLAN,
+          maxProjects: 50,
+          overrideAddingLimitations: true,
+        }) as PlanProvider["getActivePlan"],
+      }),
+      usageLimits: {
+        notifyResourceLimitReached: vi.fn().mockResolvedValue(undefined),
+        checkAndSendWarning: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    });
+  });
+
+  afterEach(() => resetApp());
+
+  afterAll(async () => {
+    // RoleBindings + ApiKeys are org-scoped; delete them before the org.
+    await prisma.roleBinding.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.apiKey.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.project.deleteMany({ where: { teamId } }).catch(() => {});
+    await prisma.teamUser.deleteMany({ where: { teamId } }).catch(() => {});
+    await prisma.team.deleteMany({ where: { id: teamId } }).catch(() => {});
+    await prisma.organizationUser.deleteMany({ where: { organizationId } }).catch(() => {});
+    await prisma.organization.deleteMany({ where: { id: organizationId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
+  });
+
+  function createCaller() {
+    const ctx = createInnerTRPCContext({
+      session: { user: { id: userId }, expires: "1" },
+    });
+    return appRouter.createCaller(ctx);
+  }
+
+  async function findLangyKeys(projectId: string) {
+    return prisma.apiKey.findMany({
+      where: {
+        name: LANGY_API_KEY_NAME,
+        revokedAt: null,
+        roleBindings: {
+          some: {
+            scopeType: RoleBindingScopeType.PROJECT,
+            scopeId: projectId,
+          },
+        },
+      },
+      include: { roleBindings: true },
+    });
+  }
+
+  async function createProjectViaApi(name: string) {
+    const caller = createCaller();
+    const result = await caller.project.create({
+      organizationId,
+      teamId,
+      name,
+      language: "en",
+      framework: "test",
+    });
+    const project = await prisma.project.findUniqueOrThrow({
+      where: { slug: result.projectSlug },
+    });
+    return project;
+  }
+
+  // Helper to create a project directly in the DB (no Langy key) — simulates a
+  // project that predates Langy keys, for backfill tests.
+  async function createLegacyProject(name: string) {
+    return prisma.project.create({
+      data: {
+        name,
+        slug: `--legacy-${testNamespace}-${nanoid(6)}`,
+        apiKey: `sk-lw-test-${nanoid()}`,
+        teamId,
+        language: "en",
+        framework: "test",
+      },
+    });
+  }
+
+  describe("when a new project is created", () => {
+    it("provisions a dedicated Langy key that is a service key", async () => {
+      const project = await createProjectViaApi("Provisions Langy Key");
+
+      // Best-effort provisioning happens after creation — wait for it.
+      const keys = await vi.waitFor(
+        async () => {
+          const found = await findLangyKeys(project.id);
+          expect(found).toHaveLength(1);
+          return found;
+        },
+        { timeout: 5000, interval: 100 },
+      );
+
+      const langyKey = keys[0]!;
+      expect(langyKey.userId).toBeNull(); // service key, owned by no human
+      expect(langyKey.name).toBe(LANGY_API_KEY_NAME);
+    });
+
+    it("provisions a key distinct from the project's own ingestion apiKey", async () => {
+      const project = await createProjectViaApi("Distinct From Ingestion Key");
+
+      const keys = await vi.waitFor(async () => {
+        const found = await findLangyKeys(project.id);
+        expect(found).toHaveLength(1);
+        return found;
+      });
+
+      // The Langy key is a separate ApiKey row, not the project.apiKey string.
+      expect(keys[0]!.lookupId).not.toBe(project.apiKey);
+    });
+
+    it("scopes the Langy key to only its own project", async () => {
+      const project = await createProjectViaApi("Project Scoped");
+
+      const keys = await vi.waitFor(async () => {
+        const found = await findLangyKeys(project.id);
+        expect(found).toHaveLength(1);
+        return found;
+      });
+
+      const bindings = keys[0]!.roleBindings;
+      expect(bindings.length).toBeGreaterThan(0);
+      for (const b of bindings) {
+        expect(b.scopeType).toBe(RoleBindingScopeType.PROJECT);
+        expect(b.scopeId).toBe(project.id);
+      }
+    });
+
+    it("grants least-privilege (no organization-level admin)", async () => {
+      const project = await createProjectViaApi("Least Privilege");
+
+      const keys = await vi.waitFor(async () => {
+        const found = await findLangyKeys(project.id);
+        expect(found).toHaveLength(1);
+        return found;
+      });
+
+      const langyKey = keys[0]!;
+      // restricted mode = scoped to an explicit permission set, not "all"/admin.
+      expect(langyKey.permissionMode).toBe("restricted");
+      // No org-wide binding of any kind.
+      const orgBindings = langyKey.roleBindings.filter(
+        (b) => b.scopeType === RoleBindingScopeType.ORGANIZATION,
+      );
+      expect(orgBindings).toHaveLength(0);
+    });
+  });
+
+  describe("when backfilling existing projects", () => {
+    it("provisions a Langy key for a project that has none", async () => {
+      const project = await createLegacyProject("Backfill Target");
+      expect(await findLangyKeys(project.id)).toHaveLength(0);
+
+      await backfillLangyApiKeys(prisma);
+
+      expect(await findLangyKeys(project.id)).toHaveLength(1);
+    });
+
+    it("does not create duplicates when run again", async () => {
+      const project = await createLegacyProject("Idempotent Backfill");
+
+      await backfillLangyApiKeys(prisma);
+      await backfillLangyApiKeys(prisma);
+
+      expect(await findLangyKeys(project.id)).toHaveLength(1);
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -37,6 +37,7 @@ import {
   skipPermissionCheckProjectCreation,
 } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
+import { provisionLangyApiKey } from "~/server/services/langy/langyApiKey";
 
 export const projectRouter = createTRPCRouter({
   publicGetById: publicProcedure
@@ -221,6 +222,25 @@ export const projectRouter = createTRPCRouter({
             ProjectSensitiveDataVisibilityLevel.VISIBLE_TO_ALL,
         },
       });
+
+      // Best-effort: mint Langy's dedicated, least-privilege service key so the
+      // assistant works the moment the project exists. A failure here must never
+      // block project creation — the backfill reconciler mints any that slip through.
+      try {
+        await provisionLangyApiKey({
+          prisma,
+          projectId: project.id,
+          organizationId: input.organizationId,
+          createdByUserId: userId,
+        });
+      } catch (error) {
+        captureException(error, {
+          extra: {
+            projectId: project.id,
+            context: "provisionLangyApiKey:project.create",
+          },
+        });
+      }
 
       return { success: true, projectSlug: project.slug };
     }),

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 
 import { encrypt, decrypt } from "~/utils/encryption";
 import { VirtualKeyService } from "~/server/gateway/virtualKey.service";
+import { provisionLangyApiKey, getLangyApiKeyToken } from "./langyApiKey";
 
 /**
  * Name under which the auto-provisioned Langy VK secret is stored in
@@ -88,6 +89,18 @@ export class LangyCredentialService {
       );
     }
 
+    // Prefer the dedicated, least-privilege "Langy" key over the human's
+    // ingestion key. Provision-on-first-use makes it self-healing if project
+    // creation / backfill missed it; we fall back to project.apiKey only when
+    // no token could be stored (e.g. no resolvable user to attribute it to).
+    await provisionLangyApiKey({
+      prisma: this.prisma,
+      projectId,
+      organizationId: project.team.organizationId,
+      createdByUserId: actorUserId,
+    });
+    const langyApiKeyToken = await getLangyApiKeyToken(this.prisma, projectId);
+
     const llmVirtualKey = await this.getOrProvisionVirtualKey({
       projectId,
       organizationId: project.team.organizationId,
@@ -95,7 +108,7 @@ export class LangyCredentialService {
     });
 
     return {
-      langwatchApiKey: project.apiKey,
+      langwatchApiKey: langyApiKeyToken ?? project.apiKey,
       llmVirtualKey,
       langwatchEndpoint,
       gatewayBaseUrl,

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -124,10 +124,12 @@ export class LangyCredentialService {
     organizationId: string;
     actorUserId: string;
   }): Promise<string> {
-    const existing = await this.prisma.projectSecret.findUnique({
-      where: {
-        projectId_name: { projectId, name: LANGY_VK_SECRET_NAME },
-      },
+    // findFirst with a plain `projectId` (not findUnique-by-`projectId_name`):
+    // the guarded prisma client's multitenancy middleware doesn't recognize the
+    // `projectId_name` compound key and throws. ProjectSecret is unique on
+    // (projectId, name), so this is still a single-row read.
+    const existing = await this.prisma.projectSecret.findFirst({
+      where: { projectId, name: LANGY_VK_SECRET_NAME },
       select: { encryptedValue: true },
     });
     if (existing) {
@@ -171,10 +173,8 @@ export class LangyCredentialService {
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === "P2002"
       ) {
-        const winner = await this.prisma.projectSecret.findUnique({
-          where: {
-            projectId_name: { projectId, name: LANGY_VK_SECRET_NAME },
-          },
+        const winner = await this.prisma.projectSecret.findFirst({
+          where: { projectId, name: LANGY_VK_SECRET_NAME },
           select: { encryptedValue: true },
         });
         if (winner) return decrypt(winner.encryptedValue);

--- a/langwatch/src/server/services/langy/langyApiKey.ts
+++ b/langwatch/src/server/services/langy/langyApiKey.ts
@@ -1,0 +1,222 @@
+import type { PrismaClient } from "@prisma/client";
+import { Prisma, RoleBindingScopeType } from "@prisma/client";
+import { ApiKeyService } from "~/server/api-key/api-key.service";
+import {
+  computePermissionsFromSelections,
+  type AccessLevel,
+} from "~/server/api-key/permission-categories";
+import { encrypt, decrypt } from "~/utils/encryption";
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:langy:api-key");
+
+export const LANGY_API_KEY_NAME = "Langy";
+
+// ProjectSecret name under which the dedicated Langy key's one-time token is
+// stored (encrypted). The ApiKey row only keeps a hash of the secret, so the
+// usable token MUST be captured at mint time for the runtime (the worker's MCP
+// server) to retrieve it later — same pattern as the Langy virtual key.
+export const LANGY_API_KEY_SECRET_NAME = "langy_api_key_secret";
+
+// Least-privilege surface for the Langy assistant, expressed in the same
+// permission categories the API-key UI uses so it stays valid and auditable.
+// Deliberately omits secrets, project/team management, and the audit log — a
+// leaked Langy key must not be able to administer the project or read secrets.
+const LANGY_PERMISSION_SELECTIONS: Record<string, AccessLevel | "none"> = {
+  traces: "write",
+  evaluations: "write",
+  datasets: "write",
+  scenarios: "write",
+  annotations: "write",
+  analytics: "write",
+  prompts: "write",
+  triggers: "write",
+  workflows: "write",
+  cost: "read",
+};
+
+const LANGY_PERMISSIONS = computePermissionsFromSelections(
+  LANGY_PERMISSION_SELECTIONS,
+);
+
+async function hasLangyKey(
+  prisma: PrismaClient,
+  projectId: string,
+): Promise<boolean> {
+  const existing = await prisma.apiKey.findFirst({
+    where: {
+      name: LANGY_API_KEY_NAME,
+      revokedAt: null,
+      roleBindings: {
+        some: {
+          scopeType: RoleBindingScopeType.PROJECT,
+          scopeId: projectId,
+        },
+      },
+    },
+    select: { id: true },
+  });
+  return existing !== null;
+}
+
+/**
+ * Returns the decrypted, ready-to-use dedicated Langy key token for a project,
+ * or null if it hasn't been provisioned yet. This is the token the worker's MCP
+ * server uses as LANGWATCH_API_KEY.
+ */
+export async function getLangyApiKeyToken(
+  prisma: PrismaClient,
+  projectId: string,
+): Promise<string | null> {
+  const secret = await prisma.projectSecret.findUnique({
+    where: {
+      projectId_name: { projectId, name: LANGY_API_KEY_SECRET_NAME },
+    },
+    select: { encryptedValue: true },
+  });
+  return secret ? decrypt(secret.encryptedValue) : null;
+}
+
+/**
+ * ProjectSecret.createdById is non-null, so the stored token must be attributed
+ * to a user: the explicit actor when we have one (project creation / runtime),
+ * else the organization's first admin (the backfill path, which has no actor).
+ */
+async function resolveCreatorId(
+  prisma: PrismaClient,
+  organizationId: string,
+  createdByUserId: string | null,
+): Promise<string | null> {
+  if (createdByUserId) return createdByUserId;
+  const admin = await prisma.organizationUser.findFirst({
+    where: { organizationId, role: "ADMIN" },
+    orderBy: { createdAt: "asc" },
+    select: { userId: true },
+  });
+  return admin?.userId ?? null;
+}
+
+/**
+ * Mints the dedicated Langy key for a project — a service key (no human owner),
+ * named "Langy", restricted to a least-privilege permission set, bound to the
+ * project scope only — AND stores its one-time token (encrypted) so the runtime
+ * can hand it to the worker.
+ *
+ * Idempotent: a no-op once the usable token is stored. The "provisioned" gate is
+ * the stored token (not just the ApiKey row), because a key whose token wasn't
+ * captured is useless to the worker.
+ */
+export async function provisionLangyApiKey({
+  prisma,
+  projectId,
+  organizationId,
+  createdByUserId = null,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  organizationId: string;
+  createdByUserId?: string | null;
+}): Promise<void> {
+  if (await getLangyApiKeyToken(prisma, projectId)) return;
+
+  const creatorId = await resolveCreatorId(
+    prisma,
+    organizationId,
+    createdByUserId,
+  );
+  if (!creatorId) {
+    logger.warn(
+      { projectId },
+      "no user to attribute the Langy key token to; skipping — the runtime falls back to the project ingestion key",
+    );
+    return;
+  }
+
+  const service = ApiKeyService.create(prisma);
+  const { token } = await service.create({
+    name: LANGY_API_KEY_NAME,
+    description:
+      "Dedicated key for the Langy in-product assistant. Scoped to this project; revoke to cut off Langy's access.",
+    userId: null, // service key — owned by no individual user
+    createdByUserId: creatorId,
+    organizationId,
+    permissionMode: "restricted",
+    permissions: LANGY_PERMISSIONS,
+    bindings: [{ role: "CUSTOM", scopeType: "PROJECT", scopeId: projectId }],
+  });
+
+  try {
+    await prisma.projectSecret.create({
+      data: {
+        projectId,
+        name: LANGY_API_KEY_SECRET_NAME,
+        encryptedValue: encrypt(token),
+        createdById: creatorId,
+        updatedById: creatorId,
+      },
+    });
+  } catch (error) {
+    // Race: another provision stored the token first. The key we just minted is
+    // an orphan (harmless, revocable later); the winner's stored token is the
+    // authoritative one. Acceptable for v1.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Reconciles existing projects: provisions the Langy key + token for every
+ * project that lacks one. Idempotent — safe to run repeatedly. Per-project
+ * failures are logged and skipped so one bad project never aborts the sweep.
+ */
+export async function backfillLangyApiKeys(
+  prisma: PrismaClient,
+  { dryRun = false }: { dryRun?: boolean } = {},
+): Promise<{ provisioned: number; skipped: number; failed: number }> {
+  // Only real user workspaces. Hidden "internal_governance" routing projects
+  // are not user-facing and must never receive a Langy key.
+  const projects = await prisma.project.findMany({
+    where: { kind: "application" },
+    select: { id: true, team: { select: { organizationId: true } } },
+  });
+
+  let provisioned = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const project of projects) {
+    if (await getLangyApiKeyToken(prisma, project.id)) {
+      skipped++;
+      continue;
+    }
+    if (dryRun) {
+      provisioned++; // would-provision count
+      continue;
+    }
+    try {
+      await provisionLangyApiKey({
+        prisma,
+        projectId: project.id,
+        organizationId: project.team.organizationId,
+      });
+      provisioned++;
+    } catch (err) {
+      failed++;
+      logger.error(
+        { err, projectId: project.id },
+        "failed to backfill Langy key for project",
+      );
+    }
+  }
+
+  logger.info(
+    { provisioned, skipped, failed, dryRun },
+    "Langy key backfill complete",
+  );
+  return { provisioned, skipped, failed };
+}

--- a/langwatch/src/server/services/langy/langyApiKey.ts
+++ b/langwatch/src/server/services/langy/langyApiKey.ts
@@ -68,10 +68,14 @@ export async function getLangyApiKeyToken(
   prisma: PrismaClient,
   projectId: string,
 ): Promise<string | null> {
-  const secret = await prisma.projectSecret.findUnique({
-    where: {
-      projectId_name: { projectId, name: LANGY_API_KEY_SECRET_NAME },
-    },
+  // findFirst with an explicit `projectId` (NOT findUnique-by-`projectId_name`):
+  // the request-scoped prisma client runs a multitenancy guard that recognizes a
+  // plain `projectId` predicate but NOT the `projectId_name` compound key, and
+  // would otherwise throw "requires a 'projectId' in the where clause". This is
+  // why the creation-hook mint silently failed under ctx.prisma. ProjectSecret is
+  // unique on (projectId, name), so this still returns exactly the one row.
+  const secret = await prisma.projectSecret.findFirst({
+    where: { projectId, name: LANGY_API_KEY_SECRET_NAME },
     select: { encryptedValue: true },
   });
   return secret ? decrypt(secret.encryptedValue) : null;

--- a/specs/assistant/langy-api-key-provisioning.feature
+++ b/specs/assistant/langy-api-key-provisioning.feature
@@ -1,0 +1,60 @@
+Feature: Dedicated Langy API key provisioning
+  As a project owner
+  I want each of my projects to have its own dedicated, least-privilege Langy key
+  So that the Langy assistant can act on my project without reusing my personal key,
+  and so that a leaked key exposes only this project and only what Langy needs
+
+  Background:
+    Given I am signed in as an admin of my organization
+
+  # ---------------------------------------------------------------------------
+  # New projects
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Creating a project provisions a dedicated Langy key
+    When I create a new project
+    Then the project has a dedicated API key named "Langy"
+    And the Langy key is separate from the project's own ingestion API key
+    And the Langy key is not owned by any individual user
+
+  @integration
+  Scenario: The Langy key is scoped to only its own project
+    Given I have two projects "Alpha" and "Beta"
+    When a Langy key is provisioned for "Alpha"
+    Then the Langy key for "Alpha" can act only within "Alpha"
+    And the Langy key for "Alpha" cannot access "Beta"
+
+  @integration
+  Scenario: The Langy key grants only the access Langy needs
+    When I create a new project
+    Then the Langy key cannot perform organization-level administration
+    And the Langy key can perform only the actions the Langy assistant requires
+
+  # ---------------------------------------------------------------------------
+  # Existing projects (backfill)
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Existing projects without a Langy key are backfilled
+    Given a project that was created before Langy keys existed
+    And that project has no Langy key
+    When the Langy key backfill runs
+    Then that project has a dedicated Langy key named "Langy"
+
+  @integration
+  Scenario: Backfill does not create duplicates
+    Given a project that already has a Langy key
+    When the Langy key backfill runs again
+    Then the project still has exactly one Langy key
+
+  # ---------------------------------------------------------------------------
+  # Lifecycle
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: An admin can revoke the Langy key
+    Given my project has a Langy key
+    When I revoke the Langy key
+    Then the Langy key can no longer act on my project
+    And my project's other API keys are unaffected

--- a/specs/assistant/langy-keys-plan.md
+++ b/specs/assistant/langy-keys-plan.md
@@ -1,0 +1,170 @@
+# Langy zero-friction onboarding — implementation plan
+
+> **Epic:** #4528 · **Sub-issues:** #4273 → #4274 → #4275
+> **Branch:** `issue4273/langy-api-key` · **Base:** `langy/per-session-manager` (PR #4272)
+> **Worktree:** `~/langwatch_codebase/langy-keys`
+
+## Goal
+
+Make Langy *just work* — no manual key wrangling, no "configure a provider first" dead end.
+Two credentials power Langy end-to-end; this epic makes both seamless:
+
+1. **LangWatch API key** → Langy reads project data (MCP + outbound calls into LangWatch).
+2. **AI Gateway `VirtualKey`** → Langy calls an LLM on the user's behalf, model chosen from a **dropdown**.
+
+Target: new projects auto-mint the key; existing projects are backfilled; the key flows to the
+Langy worker for traces + MCP automatically; model selection routes through the gateway VirtualKey.
+
+## Target flow
+
+```
+  new project ─┐                          ┌─ backfill reconciler (existing projects)
+               ▼                          ▼
+        provisionLangyApiKey()  ◄── idempotent ──►  mint "Langy" key for any project missing one
+               │                                            (#4273)
+               ▼
+     dedicated "Langy" ApiKey (service key, PROJECT-scoped, least-privilege)
+               │
+               ▼
+   open Langy ─► "Set up Langy" modal (#4274)
+                 (1) key:   (•) dedicated Langy key   ( ) project's own key
+                 (2) model: [ dropdown / 1-click "use <provider>" ]
+                            none configured? → guided add → return to modal
+               │
+               ▼
+   Langy worker (per-session, from #4272)
+     • MCP server   ← LangWatch API key            (traces / MCP)
+     • opencode LLM ← VirtualKey → AI Gateway      (#4275)
+```
+
+## What already exists — reuse, do not rebuild
+
+**From the #4272 base (`langy/per-session-manager`):**
+- Per-session OpenCode workers + `LangyCredentialService.getOrProvision()`
+  (`src/server/services/langy/LangyCredentialService.ts`) — already reads `project.apiKey`,
+  **already auto-provisions a per-project Langy VirtualKey** (`langy_vk_secret` in `ProjectSecret`),
+  and passes `langwatchApiKey` + `llmVirtualKey` + `gatewayBaseUrl` to the worker env.
+  → A chunk of PR3's plumbing is already here; #4275 is mostly *flipping the gate* (see below).
+- `ApiKeyService.create(...)` — signature verified to match the helper:
+  `{ name, description, userId, createdByUserId, organizationId, permissionMode, permissions, bindings }`.
+- `permission-categories.computePermissionsFromSelections()` and `Project.kind` (`@default("application")`).
+
+**WIP to port from `~/langwatch_codebase/langy-full-rebase` (branch `issue4273/langy-default-api-key`):**
+These were written on the diverged `langy/full` base but their dependencies all exist on #4272, so they
+port cleanly (adapt imports/line refs only):
+- `src/server/services/langy/langyApiKey.ts` — `provisionLangyApiKey()` + `backfillLangyApiKeys()` (idempotent, least-privilege, excludes hidden `kind != "application"` projects).
+- `scripts/backfill-langy-api-keys.ts` — runnable backfill (`--dry-run` supported).
+- `specs/assistant/langy-api-key-provisioning.feature` — BDD spec (6 scenarios).
+- `src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts` — real-DB integration test.
+
+## Locked decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Where the key lives | Reuse `ApiKey` + `ApiKeyService` — **no new schema** | Already supports named, hashed, revocable, scope-bound **service keys** (`userId: null`). |
+| Key identity | Service key (`userId: null`), `name: "Langy"` | Not tied to a human; attributable via `createdByUserId`. |
+| Key scope | PROJECT-scoped, least-privilege | A leak exposes one project + only Langy's actions. |
+| When minted | Best-effort after project creation; **backfill reconciles** | Keeps project creation decoupled from `ApiKeyService`; eventual consistency. |
+| Gateway key | A `VirtualKey` (already auto-provisioned in #4272) | Implies "whose budget / which provider" → made real in #4275. |
+| No new REST endpoints | Extend services + existing Langy routes only | Project constraint. |
+
+---
+
+## PR 1 — dedicated Langy API key (#4273)  ·  *foundation*  ·  **CODE COMPLETE, typecheck green**
+
+Spec: `specs/assistant/langy-api-key-provisioning.feature`.
+
+- [x] **Spec-first** — `.feature` in `specs/assistant/` (6 scenarios).
+- [x] **Integration tests** (real DB, no mocks) — `src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts`:
+  - new project → a `Langy` service key exists, distinct from `Project.apiKey`
+  - key bound only to its project · no org-admin (least-privilege) · `permissionMode: "restricted"`
+  - backfill mints for a project lacking one · backfill twice → exactly one key (idempotent)
+- [x] **`langyApiKey.ts`** → `src/server/services/langy/langyApiKey.ts` (`provisionLangyApiKey` + `backfillLangyApiKeys`).
+- [x] **Hook the live creation path** (best-effort, awaited + caught, never blocks creation):
+  - tRPC `project.create` → `src/server/api/routers/project.ts` (after `prisma.project.create`).
+  - **Finding (deviation from original plan):** the app-layer `ProjectService.create`
+    (`project.service.ts:137`) is **not invoked anywhere** for real project creation —
+    onboarding goes `onboarding.router.ts:62 → projectRouter.createCaller(ctx).create()` (the tRPC path).
+    Hooking the app-layer service would be **dead code** *and* break the repository abstraction
+    (the service holds `this.repo`, not a `PrismaClient`). So it's intentionally **not** hooked;
+    the **backfill reconciler** is the safety net for any path that ever bypasses provisioning.
+- [x] **Backfill script** → `scripts/backfill-langy-api-keys.ts` (idempotent; `--dry-run`).
+- [x] `pnpm typecheck` → exit 0 (whole project).
+- [ ] **Run integration tests end-to-end** — NOT yet run. The worktree `.env` `DATABASE_URL` points at the
+      **shared dev RDS**; do NOT run create/delete tests against it. Bring up a local PG and override:
+      ```bash
+      make quickstart migration            # local postgres on host :5432
+      cd langwatch
+      DATABASE_URL="postgresql://prisma:prisma@localhost:5432/mydb?schema=langwatch_db" \
+        pnpm prisma migrate deploy
+      DATABASE_URL="postgresql://prisma:prisma@localhost:5432/mydb?schema=langwatch_db" \
+        pnpm test:integration src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
+      ```
+
+**Open question (still):** finalize the least-privilege permission set (current: traces/evaluations/datasets/
+scenarios/annotations/analytics/prompts/triggers/workflows = write, cost = read; no secrets/admin/audit).
+Validate against what `langy.ts` + Langy's MCP tools actually call; trim to smallest viable.
+
+## PR 2 — adaptive "Set up Langy" modal (#4274)  ·  *needs #4273*
+
+One modal, server picks the branch:
+
+```
+① Langy key:  (•) Create dedicated Langy key ⭐   ( ) Use existing project key
+② Model:
+     A  Anthropic configured → "✓ Use Anthropic" (1-click)
+     B  other provider only  → "✓ Use your <provider>" (default) + soft Anthropic nudge
+     C  none configured      → [Add a model →] deep-link to Settings → Model Providers
+                               (Anthropic prefilled), return-URL continuation back to the modal
+```
+
+- [ ] Reuse `src/components/scenarios/ModelProviderRequiredModal.tsx` as the pattern.
+- [ ] **Gate (this PR):** the existing `ModelProvider` 409 in `src/server/routes/langy.ts:235`
+      (`getVercelAIModel` → 409 at :244) — Langy's *real* failure today.
+- [ ] Branch C reuses the real model-provider form (one source of truth, no duplicated validation).
+
+### Execution map (researched — ready to build)
+- **New component** `src/components/langy/SetUpLangyModal.tsx` — Chakra `Dialog` (same shape as `ModelProviderRequiredModal`).
+- **Readiness / branch detection:** `api.modelProvider.getAllForProjectForFrontend.useQuery({ projectId })`
+  → inspect enabled providers; Anthropic present = branch A, other-only = branch B, none = branch C.
+- **Model dropdown:** reuse the existing `<ModelSelector model options={allModelOptions} onChange mode="chat" showConfigureAction />`
+  from `src/components/ModelSelector.tsx` — it already renders grouped options *and* the branch-C
+  "No models configured" callout via `useModelSelectionOptions` (its `isEmpty`).
+- **Persist the pick:** `api.modelProvider.saveDefaultModelsConfig` mutation (feature key for Langy's default
+  chat model; confirm key — likely `prompt.create_default` or a new `langy.*` role in `featureRegistry.ts`).
+- **Wire the trigger:** `LangySidebar.tsx:427` `useChat({ onError })` — detect the 409 (status/`error` body)
+  and open the modal instead of (or before) the toast. Optional: proactively open on mount when
+  `getAllForProjectForFrontend` shows not-ready (more seamless than waiting for the error).
+- **Key section:** PR1 already auto-mints the dedicated Langy key, so ① is a confirmation line
+  ("✓ dedicated Langy key ready"), not an action.
+- **Return-URL continuation (branch C):** deep-link `/settings/model-providers?return=<langy>` and reopen the
+  modal on return (mirror an OAuth `redirect_uri`).
+
+## PR 3 — route Langy LLM through the gateway / VirtualKey (#4275)  ·  *needs #4274*
+
+Note: #4272 already provisions the VirtualKey and points the worker's opencode at `gatewayBaseUrl`.
+This PR makes the **control-plane gate** honest and binds the VK to a provider chain.
+
+- [ ] Ensure the Langy `VirtualKey` (already minted by `LangyCredentialService`) is bound to a
+      `GatewayProviderCredential` fallback chain (reuse `src/server/gateway/virtualKey.service.ts`).
+- [ ] Rewire / replace the `getVercelAIModel` availability check at `langy.ts:235` so the gate reflects
+      **VirtualKey readiness** rather than the legacy `ModelProvider` path.
+- [ ] Flip the modal's gate (from #4274): "ModelProvider configured?" → "VirtualKey configured?"
+      (UI unchanged, only the underlying check).
+
+## Dev env / verify
+
+```bash
+cd ~/langwatch_codebase/langy-keys/langwatch
+pnpm install                       # match repo pnpm (corepack may pull the wrong major — see memory)
+pnpm start:prepare:files           # regenerate Prisma/zod/generated types after worktree creation
+pnpm typecheck
+pnpm test:integration <file>       # real DB, no mocks
+make quickstart migration          # postgres + clickhouse on host ports, for prisma + integration tests
+```
+
+## Conventions (from CLAUDE.md)
+- Spec → test → code (outside-in TDD). Update the `.feature` *before* changing behavior.
+- Always include `projectId` in Prisma WHERE clauses for project-level models.
+- Each PR body: `Refs #4528` + tick the relevant sub-issue checkbox.
+- No re-exports for back-compat; no new REST endpoints.

--- a/specs/assistant/langy-setup-modal.feature
+++ b/specs/assistant/langy-setup-modal.feature
@@ -1,0 +1,99 @@
+Feature: Adaptive "Set up Langy" modal
+  As a project member opening Langy for the first time
+  I want a single modal that gets me from "Langy can't run" to "Langy works"
+  So that I never hit a dead end when a model isn't configured yet
+
+  # Langy fails today with an HTTP 409 from POST /api/langy/chat when
+  # getVercelAIModel(projectId) cannot resolve a model for the DEFAULT role
+  # (feature key prompt.create_default). This modal is the recovery surface
+  # for that 409: it confirms the dedicated Langy key (already minted in
+  # #4273), lets the user pick / confirm a chat model, and persists it as the
+  # project's DEFAULT-role default so the next send resolves and streams.
+
+  Background:
+    Given I am signed in and Langy is enabled for my account
+    And I am a member of a project with permission to use Langy
+
+  # ---------------------------------------------------------------------------
+  # Trigger — the modal replaces the dead-end error
+  # ---------------------------------------------------------------------------
+
+  @ui
+  Scenario: Opening Langy with no model configured opens the setup modal
+    Given my project has no usable model provider configured
+    When I open Langy and send a message
+    Then the "Set up Langy" modal opens instead of a generic error toast
+
+  @ui
+  Scenario: The key section is informational, not an action
+    When the "Set up Langy" modal is open
+    Then it confirms that a dedicated Langy key is ready
+    And it does not ask me to create or paste any key
+
+  # ---------------------------------------------------------------------------
+  # Model section — the server picks the branch from configured providers
+  # ---------------------------------------------------------------------------
+
+  @ui
+  Scenario: Branch A — Anthropic already configured
+    Given my project has the Anthropic provider enabled
+    When the "Set up Langy" modal is open
+    Then it offers a one-click "Use Anthropic" action
+    And the model dropdown is preset to an Anthropic chat model
+
+  @ui
+  Scenario: Branch B — only another provider is configured
+    Given my project has only the OpenAI provider enabled
+    When the "Set up Langy" modal is open
+    Then it offers a one-click "Use your OpenAI" action
+    And it shows a soft nudge to add Anthropic for the best experience
+    And the model dropdown is preset to an OpenAI chat model
+
+  @ui
+  Scenario: Branch C — no provider configured
+    Given my project has no model provider configured
+    When the "Set up Langy" modal is open
+    Then it shows an "Add a model" action that deep-links to Model Providers settings
+    And no model can be confirmed until a provider is added
+
+  @ui
+  Scenario: Branch C returns to a ready modal after adding a provider
+    Given the "Set up Langy" modal is open with no provider configured
+    When I add the Anthropic provider in the settings tab and return to Langy
+    Then the modal re-checks providers and advances to the "Use Anthropic" action
+
+  @ui
+  Scenario: I can pick a different chat model from the dropdown
+    Given my project has more than one chat model available
+    When the "Set up Langy" modal is open
+    And I choose a different model from the dropdown
+    Then that model becomes the one that will be confirmed
+
+  @ui
+  Scenario: Confirming a model closes the modal and Langy works
+    Given my project has the Anthropic provider enabled but no default model
+    When I confirm "Use Anthropic" in the "Set up Langy" modal
+    Then the modal closes
+    And my original message is sent and Langy streams a reply
+
+  # ---------------------------------------------------------------------------
+  # The gate — real server behavior the modal must satisfy (real DB)
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: A project with no default model fails the Langy model gate
+    Given a project with no model provider configured
+    Then resolving the Langy chat model for that project fails with "not configured"
+
+  @integration
+  Scenario: Confirming a model satisfies the Langy model gate
+    Given a project with the Anthropic provider enabled but no default model
+    When the modal persists the chosen model as the project's default
+    Then resolving the Langy chat model for that project returns that model
+
+  @integration
+  Scenario: Re-confirming a different model resolves to the latest choice
+    Given a project with the Anthropic provider enabled
+    When the modal persists a chosen default model
+    And the modal later persists a different chosen default model
+    Then resolving the Langy chat model returns the most recently chosen one


### PR DESCRIPTION
## What
A single adaptive **"Set up Langy"** modal that takes a project from "Langy can't run" to "Langy works" with no dead ends. It's the recovery surface for Langy's model gate: when `getVercelAIModel(projectId)` can't resolve a DEFAULT-role model (feature key `prompt.create_default`) the chat route returns **409** — this modal opens instead of a dead-end toast.

```
 user opens Langy ─► send ─► gate ready?  ──no──► [ Set up Langy modal ]
                                  │ yes                     │ pick/confirm model
                                  ▼                          ▼ saveDefaultModelsConfig (DEFAULT @ project)
                              stream reply  ◄──────── gate now resolves
```

**① Langy key** — informational ("✓ dedicated Langy key ready"); PR langwatch/tasks#65 auto-provisions it.
**② Model** — server-derived branch:
- **A** Anthropic enabled → one-click *Use Anthropic*
- **B** other provider only → one-click *Use your <provider>* + soft Anthropic nudge
- **C** none enabled → **Add a model →** deep-link to Settings (new tab; providers refetch on focus → auto-advances back to A/B)

## How
- `SetUpLangyModal.tsx` — Chakra `Dialog` (shape of `ModelProviderRequiredModal`), reuses `<ModelSelector mode="chat">` for the dropdown. Confirm persists the pick as the project DEFAULT via `modelProvider.saveDefaultModelsConfig` — **no new endpoints**.
- `langyModelSetup.ts` — pure branch decision (`anthropic | other | none`), unit-tested.
- `LangySidebar.tsx` — `getResolvedDefault` drives readiness; `send()` intercepts when no model and opens the modal instead of firing a doomed request; `onError` is a 409 backstop.

## Tests
- Spec-first: `specs/assistant/langy-setup-modal.feature`.
- Unit: `langyModelSetup.unit.test.ts` (6/6) — branch A/B/C.
- Real-DB integration: `langySetupModal.modelGate.integration.test.ts` (3/3) — gate throws with no default → resolves after the modal's persist → latest-choice wins.
- `pnpm typecheck` green (whole project).

## QA
Browser-verified on localhost: modal triggers on no-model, branch C renders with the deep-link, branch A renders with the dropdown + confirm. QA also caught & fixed a real bug — `getAllForProjectForFrontend` returns `{ providers, modelMetadata }`, so branch detection must read `.providers` (TS didn't catch it: an all-optional index signature matches almost any object).

> Note: the final auto-seed visual re-check (button pre-enabled after the 1-click fix) is pending local ClickHouse coming back up; logic is covered by typecheck + the unit/integration suites.

Stacked on langwatch/tasks#65 (base = `issue4273/langy-api-key`).

Refs langwatch/tasks#103 · langwatch/tasks#66

🤖 Generated with [Claude Code](https://claude.com/claude-code)