### PR TITLE
test(langy): bind langy-api-key provisioning scenarios for feature-parity

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/project.create.langyKey.integration.test.ts
@@ -160,6 +160,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
   }
 
   describe("when a new project is created", () => {
+    /** @scenario "Creating a project provisions a dedicated Langy key" */
     it("provisions a dedicated Langy key that is a service key", async () => {
       const project = await createProjectViaApi("Provisions Langy Key");
 
@@ -191,6 +192,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
       expect(keys[0]!.lookupId).not.toBe(project.apiKey);
     });
 
+    /** @scenario "The Langy key is scoped to only its own project" */
     it("scopes the Langy key to only its own project", async () => {
       const project = await createProjectViaApi("Project Scoped");
 
@@ -208,6 +210,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
       }
     });
 
+    /** @scenario "The Langy key grants only the access Langy needs" */
     it("grants least-privilege (no organization-level admin)", async () => {
       const project = await createProjectViaApi("Least Privilege");
 
@@ -229,6 +232,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
   });
 
   describe("when backfilling existing projects", () => {
+    /** @scenario "Existing projects without a Langy key are backfilled" */
     it("provisions a Langy key for a project that has none", async () => {
       const project = await createLegacyProject("Backfill Target");
       expect(await findLangyKeys(project.id)).toHaveLength(0);
@@ -238,6 +242,7 @@ describe.skipIf(isTestcontainersOnly)("Langy API key provisioning", () => {
       expect(await findLangyKeys(project.id)).toHaveLength(1);
     });
 
+    /** @scenario "Backfill does not create duplicates" */
     it("does not create duplicates when run again", async () => {
       const project = await createLegacyProject("Idempotent Backfill");
 

--- a/specs/assistant/langy-api-key-provisioning.feature
+++ b/specs/assistant/langy-api-key-provisioning.feature
@@ -52,6 +52,9 @@ Feature: Dedicated Langy API key provisioning
   # Lifecycle
   # ---------------------------------------------------------------------------
 
+  # Not yet implemented — no Langy-key revoke flow exists yet; flagged so the
+  # feature-parity check tolerates it until the revoke behaviour is built.
+  @unimplemented
   @integration
   Scenario: An admin can revoke the Langy key
     Given my project has a Langy key


### PR DESCRIPTION
Part of epic langwatch/tasks#103. Companion to langwatch/tasks#65 (dedicated Langy API key).

## Why
`specs/assistant/langy-api-key-provisioning.feature` (added in langwatch/tasks#65) has 6 `@integration` scenarios with **no** `@scenario` test bindings, so `pnpm check:feature-parity` fails — and that red is inherited by anything stacked on langwatch/tasks#65 (e.g. the Langy OTel PR langwatch/langwatch#4541).

This PR contains **only** the binding fix — no product behaviour change — so it's not coupled to the OTel work.

## What
- Add `@scenario "<title>"` annotations to the 5 scenarios already covered by `project.create.langyKey.integration.test.ts` (provision, project-scoping, least-privilege, backfill, no-duplicates).
- Flag the not-yet-implemented "An admin can revoke the Langy key" scenario `@unimplemented` (kept `@integration` to document the intended test type). No Langy-key revoke flow exists yet.

## Verified
- `pnpm check:feature-parity` → `OK: 1536 enforced scenario(s) bound across 582 file(s)`.

Base is `issue4273/langy-api-key` because the feature file + test only exist on that branch (not on `main` yet).