### PR TITLE
fix(ci/skills-publish): skip devDep postinstalls so node-pty doesn't break the workflow

### DIFF
--- a/.github/workflows/skills-publish.yml
+++ b/.github/workflows/skills-publish.yml
@@ -40,7 +40,12 @@ jobs:
 
       - name: Install skill tooling
         working-directory: skills
-        run: pnpm install --frozen-lockfile
+        # `--ignore-scripts` skips devDep postinstalls (notably node-pty's
+        # rebuild on linux-x64, which needs node-gyp / python and isn't
+        # installed on ubuntu-latest by default). Publish only needs to run
+        # `pnpm sync` (TS transformer over MDX), which doesn't touch any of
+        # the native deps node-pty pulls in.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Sync skills
         working-directory: skills


### PR DESCRIPTION
## Why

The skills-publish workflow has been **failing on every push to main since mid-May** (7 consecutive failures, last success was April 28). That's why \`langwatch/skills\` hasn't updated past v0.4.1 even though we've cut multiple skills releases (currently 0.6.0) through release-please.

Root cause: \`skills/package.json\` pulls \`node-pty@^1.0.0\` in devDependencies for the dogfood tests. node-pty@1.1.0 has no prebuilt binary for linux-x64 in this version range, so its postinstall falls back to a node-gyp rebuild, and \`node-gyp\` is not on the default \`ubuntu-latest\` runner. Install dies with \`sh: 1: node-gyp: not found\` before \`pnpm sync\` ever runs.

## What

Add \`--ignore-scripts\` to the publish workflow's \`pnpm install\`. The publish job only needs to run \`pnpm sync\` (a TS transformer over MDX) and doesn't touch any of the native binaries node-pty pulls in, so skipping every postinstall (node-pty's rebuild included) costs nothing and unblocks the sync.

Local dev (where the dogfood tests actually exercise node-pty) is unchanged — devs still run \`pnpm install\` normally with full postinstalls.

## Test plan

- [ ] After merge, the next push to main (or a \`workflow_dispatch\`) should publish to \`langwatch/skills\` and tag \`v0.6.0\`.
- [ ] Verify the recent SKILL changes (voice "how connects to my agent" table, no-runner / no-JSON-DSL nudges) land in \`langwatch/skills/scenarios/SKILL.mdx\` on the public mirror.