### PR TITLE
fix(billing): show real monthly event count on usage page for metered seat plans

### DIFF
--- a/langwatch/src/components/sidebar/UsageIndicator.tsx
+++ b/langwatch/src/components/sidebar/UsageIndicator.tsx
@@ -2,9 +2,9 @@ import { Box, HStack, Progress, Text, VStack } from "@chakra-ui/react";
 import { PricingModel } from "@prisma/client";
 import { Info } from "lucide-react";
 import { UNLIMITED_MESSAGES } from "../../../ee/billing/planLimits";
-import type { UsageUnit } from "../../server/app-layer/usage/usage-meter-policy";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { usePublicEnv } from "../../hooks/usePublicEnv";
+import type { UsageUnit } from "../../server/app-layer/usage/usage-meter-policy";
 import { api } from "../../utils/api";
 import { Link } from "../ui/link";
 import { Tooltip } from "../ui/tooltip";
@@ -94,9 +94,7 @@ export const UsageIndicator = ({ showLabel = true }: UsageIndicatorProps) => {
   }
 
   const percentage = Math.min(
-    (currentCount /
-      usage.data.activePlan.maxMessagesPerMonth) *
-      100,
+    (currentCount / usage.data.activePlan.maxMessagesPerMonth) * 100,
     100,
   );
 
@@ -133,7 +131,10 @@ export const UsageIndicator = ({ showLabel = true }: UsageIndicatorProps) => {
                 </Text>
               </HStack>
               <Progress.Root
-                value={Math.min(currentCount, usage.data.activePlan.maxMessagesPerMonth)}
+                value={Math.min(
+                  currentCount,
+                  usage.data.activePlan.maxMessagesPerMonth,
+                )}
                 max={usage.data.activePlan.maxMessagesPerMonth}
                 colorPalette="orange"
                 width="full"

--- a/langwatch/src/components/sidebar/UsageIndicator.tsx
+++ b/langwatch/src/components/sidebar/UsageIndicator.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack, Progress, Text, VStack } from "@chakra-ui/react";
 import { PricingModel } from "@prisma/client";
 import { Info } from "lucide-react";
+import { UNLIMITED_MESSAGES } from "../../../ee/billing/planLimits";
 import type { UsageUnit } from "../../server/app-layer/usage/usage-meter-policy";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { usePublicEnv } from "../../hooks/usePublicEnv";
@@ -79,9 +80,18 @@ export const UsageIndicator = ({ showLabel = true }: UsageIndicatorProps) => {
   });
   if (!display.visible) return null;
 
-  // When currentMonthMessagesCount is null (unlimited plan), don't show the usage bar
+  // Unlimited plans have no cap to draw a progress bar against, so hide the
+  // sidebar bar (the actual usage volume is still surfaced on /settings/usage).
+  // currentMonthMessagesCount is null for legacy/unlimited responses; the
+  // maxMessagesPerMonth check also covers metered plans that now return a real
+  // count.
   const currentCount = usage.data.currentMonthMessagesCount;
-  if (currentCount === null) return null;
+  if (
+    currentCount === null ||
+    usage.data.activePlan.maxMessagesPerMonth >= UNLIMITED_MESSAGES
+  ) {
+    return null;
+  }
 
   const percentage = Math.min(
     (currentCount /

--- a/langwatch/src/server/api/routers/__tests__/limits.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/limits.integration.test.ts
@@ -4,22 +4,52 @@
  * Integration tests for Limits tRPC endpoints.
  * Tests the router layer including message limit status calculation.
  */
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OrganizationUserRole } from "@prisma/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { FREE_PLAN } from "../../../../../ee/licensing/constants";
+import { globalForApp, resetApp } from "../../../app-layer/app";
+import { createTestApp } from "../../../app-layer/presets";
+import { PlanProviderService } from "../../../app-layer/subscription/plan-provider";
+import { UsageService } from "../../../app-layer/usage/usage.service";
 import { prisma } from "../../../db";
 import { appRouter } from "../../root";
 import { createInnerTRPCContext } from "../../trpc";
-import { OrganizationUserRole } from "@prisma/client";
-import { createTestApp } from "../../../app-layer/presets";
-import { globalForApp, resetApp } from "../../../app-layer/app";
-import { PlanProviderService } from "../../../app-layer/subscription/plan-provider";
-import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 
-// Hoisted mocks for deterministic control (must use vi.hoisted to survive vi.mock hoisting)
-const { mockGetCurrentMonthCount, mockGetActivePlan } = vi.hoisted(() => ({
-  mockGetCurrentMonthCount: vi.fn(),
+// Hoisted so it survives vi.mock hoisting if a factory ever needs it.
+const { mockGetActivePlan } = vi.hoisted(() => ({
   mockGetActivePlan: vi.fn(),
 }));
 
+const PRO_PLAN = {
+  ...FREE_PLAN,
+  planSource: "subscription",
+  type: "PRO",
+  name: "Pro",
+  free: false,
+  maxMessagesPerMonth: 1000,
+} as const;
+
+/**
+ * Controls the monthly usage the page reads. getUsage → UsageStatsService reads
+ * getApp().usage.getCurrentMonthCountForDisplay(); spying the real prototype
+ * method keeps the stub type-checked against UsageService (no casts) and fails
+ * to compile if the method is renamed.
+ */
+function stubMonthlyUsage(count: number) {
+  return vi
+    .spyOn(UsageService.prototype, "getCurrentMonthCountForDisplay")
+    .mockResolvedValue(count);
+}
 
 describe("Limits Router Integration", () => {
   const testOrgSlug = "limits-router-test-org";
@@ -27,21 +57,11 @@ describe("Limits Router Integration", () => {
   let caller: ReturnType<typeof appRouter.createCaller>;
 
   beforeAll(async () => {
-    mockGetActivePlan.mockResolvedValue({
-      ...FREE_PLAN,
-      planSource: "subscription",
-      type: "PRO",
-      name: "Pro",
-      free: false,
-      maxMessagesPerMonth: 1000,
-    });
+    mockGetActivePlan.mockResolvedValue(PRO_PLAN);
 
-    // Wire App singleton so UsageStatsService.create() can call getApp().usage
+    // Wire App singleton so UsageStatsService.create() can call getApp().usage.
+    // usage is the real service; tests stub one method via stubMonthlyUsage().
     globalForApp.__langwatch_app = createTestApp({
-      usage: {
-        getCurrentMonthCount: mockGetCurrentMonthCount,
-        getCurrentMonthCountForDisplay: mockGetCurrentMonthCount,
-      } as any,
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan,
       }),
@@ -91,6 +111,7 @@ describe("Limits Router Integration", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await resetApp();
   });
 
@@ -109,21 +130,9 @@ describe("Limits Router Integration", () => {
 
   describe("getUsage", () => {
     beforeEach(async () => {
-      mockGetCurrentMonthCount.mockReset();
-      mockGetActivePlan.mockResolvedValue({
-        ...FREE_PLAN,
-        planSource: "subscription",
-        type: "PRO",
-        name: "Pro",
-        free: false,
-        maxMessagesPerMonth: 1000,
-      });
+      mockGetActivePlan.mockResolvedValue(PRO_PLAN);
       await resetApp();
       globalForApp.__langwatch_app = createTestApp({
-        usage: {
-        getCurrentMonthCount: mockGetCurrentMonthCount,
-        getCurrentMonthCountForDisplay: mockGetCurrentMonthCount,
-      } as any,
         planProvider: PlanProviderService.create({
           getActivePlan: mockGetActivePlan,
         }),
@@ -133,7 +142,7 @@ describe("Limits Router Integration", () => {
     describe("when usage is below 80% threshold", () => {
       // Skipped: env.mjs requires DATABASE_URL, BASE_HOST, NEXTAUTH_SECRET etc. which are not available in this test environment.
       it.skip("returns messageLimitInfo with status ok", async () => {
-        mockGetCurrentMonthCount.mockResolvedValue(500);
+        stubMonthlyUsage(500);
 
         const result = await caller.limits.getUsage({ organizationId });
 
@@ -146,7 +155,7 @@ describe("Limits Router Integration", () => {
     describe("when usage is between 80% and 100%", () => {
       // Skipped: env.mjs requires DATABASE_URL, BASE_HOST, NEXTAUTH_SECRET etc. which are not available in this test environment.
       it.skip("returns messageLimitInfo with status warning and percentage", async () => {
-        mockGetCurrentMonthCount.mockResolvedValue(850);
+        stubMonthlyUsage(850);
 
         const result = await caller.limits.getUsage({ organizationId });
 
@@ -159,7 +168,7 @@ describe("Limits Router Integration", () => {
     describe("when usage reaches or exceeds limit", () => {
       // Skipped: env.mjs requires DATABASE_URL, BASE_HOST, NEXTAUTH_SECRET etc. which are not available in this test environment.
       it.skip("returns messageLimitInfo with status exceeded", async () => {
-        mockGetCurrentMonthCount.mockResolvedValue(1000);
+        stubMonthlyUsage(1000);
 
         const result = await caller.limits.getUsage({ organizationId });
 
@@ -169,7 +178,7 @@ describe("Limits Router Integration", () => {
 
       // Skipped: env.mjs requires DATABASE_URL, BASE_HOST, NEXTAUTH_SECRET etc. which are not available in this test environment.
       it.skip("keeps enforcement behavior when plan provider returns a copied FREE plan object", async () => {
-        mockGetCurrentMonthCount.mockResolvedValue(1500);
+        stubMonthlyUsage(1500);
         mockGetActivePlan.mockResolvedValue({
           ...FREE_PLAN,
           maxMessagesPerMonth: 1000,

--- a/langwatch/src/server/api/routers/__tests__/limits.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/limits.integration.test.ts
@@ -38,7 +38,10 @@ describe("Limits Router Integration", () => {
 
     // Wire App singleton so UsageStatsService.create() can call getApp().usage
     globalForApp.__langwatch_app = createTestApp({
-      usage: { getCurrentMonthCount: mockGetCurrentMonthCount } as any,
+      usage: {
+        getCurrentMonthCount: mockGetCurrentMonthCount,
+        getCurrentMonthCountForDisplay: mockGetCurrentMonthCount,
+      } as any,
       planProvider: PlanProviderService.create({
         getActivePlan: mockGetActivePlan,
       }),
@@ -117,7 +120,10 @@ describe("Limits Router Integration", () => {
       });
       await resetApp();
       globalForApp.__langwatch_app = createTestApp({
-        usage: { getCurrentMonthCount: mockGetCurrentMonthCount } as any,
+        usage: {
+        getCurrentMonthCount: mockGetCurrentMonthCount,
+        getCurrentMonthCountForDisplay: mockGetCurrentMonthCount,
+      } as any,
         planProvider: PlanProviderService.create({
           getActivePlan: mockGetActivePlan,
         }),

--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PricingModel } from "@prisma/client";
 import { TtlCache } from "~/server/utils/ttlCache";
 import type { PlanResolver } from "../../subscription/plan-provider";
 import type { OrganizationService } from "../../organizations/organization.service";
 import { UsageService } from "../usage.service";
 import { FREE_PLAN } from "../../../../../ee/licensing/constants";
+import { UNLIMITED_MESSAGES } from "../../../../../ee/billing/planLimits";
 import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
 
 const ENTERPRISE_LICENSE_PLAN: PlanInfo = {
@@ -23,6 +25,17 @@ const PAID_TIERED_PLAN: PlanInfo = {
   name: "Team",
   free: false,
   maxMessagesPerMonth: 10_000,
+};
+
+// Seat-based plan (GROWTH_SEAT_*): events are metered/billed via Stripe with no
+// monthly cap, so maxMessagesPerMonth is the UNLIMITED_MESSAGES sentinel.
+const SEAT_UNLIMITED_PLAN: PlanInfo = {
+  ...FREE_PLAN,
+  planSource: "subscription",
+  type: "GROWTH_SEAT_EUR_MONTHLY",
+  name: "Growth",
+  free: false,
+  maxMessagesPerMonth: UNLIMITED_MESSAGES,
 };
 
 const { mockRedisStore } = vi.hoisted(() => {
@@ -575,6 +588,54 @@ describe("UsageService", () => {
         expect(
           mockTraceUsageService.getCountByProjects,
         ).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Display count vs enforcement count for seat-based (metered) plans
+  // ==========================================================================
+
+  describe("getCurrentMonthCountForDisplay", () => {
+    describe("given a seat-based plan with no message cap (metered events)", () => {
+      beforeEach(() => {
+        mockOrgRepo.getPricingModel.mockResolvedValue(PricingModel.SEAT_EVENT);
+        (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue({
+          ...SEAT_UNLIMITED_PLAN,
+        });
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
+          "proj-1",
+          "proj-2",
+        ]);
+        mockEventUsageService.getCountByProjects.mockResolvedValue([
+          { projectId: "proj-1", count: 30_000 },
+          { projectId: "proj-2", count: 7_924 },
+        ]);
+      });
+
+      it("short-circuits getCurrentMonthCount to 'unlimited' without querying (enforcement)", async () => {
+        const result = await service.getCurrentMonthCount({
+          organizationId: "org-123",
+        });
+
+        expect(result).toBe("unlimited");
+        expect(
+          mockEventUsageService.getCountByProjects,
+        ).not.toHaveBeenCalled();
+      });
+
+      it("returns the real metered event total from getCurrentMonthCountForDisplay", async () => {
+        const result = await service.getCurrentMonthCountForDisplay({
+          organizationId: "org-123",
+        });
+
+        expect(result).toBe(37_924);
+        expect(
+          mockEventUsageService.getCountByProjects,
+        ).toHaveBeenCalledWith({
+          organizationId: "org-123",
+          projectIds: ["proj-1", "proj-2"],
+        });
       });
     });
   });

--- a/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/usage/__tests__/usage.service.unit.test.ts
@@ -1,12 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PricingModel } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TtlCache } from "~/server/utils/ttlCache";
-import type { PlanResolver } from "../../subscription/plan-provider";
-import type { OrganizationService } from "../../organizations/organization.service";
-import { UsageService } from "../usage.service";
-import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import { UNLIMITED_MESSAGES } from "../../../../../ee/billing/planLimits";
+import { FREE_PLAN } from "../../../../../ee/licensing/constants";
 import type { PlanInfo } from "../../../../../ee/licensing/planInfo";
+import type { OrganizationService } from "../../organizations/organization.service";
+import type { PlanResolver } from "../../subscription/plan-provider";
+import { UsageService } from "../usage.service";
 
 const ENTERPRISE_LICENSE_PLAN: PlanInfo = {
   ...FREE_PLAN,
@@ -49,7 +49,9 @@ vi.mock("~/server/redis", () => {
     setex: vi.fn(async (_key: string, _ttl: number, value: string) => {
       mockRedisStore.set(_key, value);
     }),
-    del: vi.fn(async (key: string) => { mockRedisStore.delete(key); }),
+    del: vi.fn(async (key: string) => {
+      mockRedisStore.delete(key);
+    }),
   };
   return { isBuildOrNoRedis: false, connection: fakeRedis };
 });
@@ -123,9 +125,9 @@ describe("UsageService", () => {
   describe("checkLimit", () => {
     describe("when team has no organization", () => {
       it("throws OrganizationNotFoundForTeamError", async () => {
-        vi.mocked(
-          mockOrgService.getOrganizationIdByTeamId,
-        ).mockResolvedValue(null);
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          null,
+        );
 
         await expect(
           service.checkLimit({ teamId: "team-123" }),
@@ -136,12 +138,10 @@ describe("UsageService", () => {
     describe("when free-tier org exceeds limit on SaaS", () => {
       beforeEach(() => {
         mockEnv.IS_SAAS = true;
-        vi.mocked(
-          mockOrgService.getOrganizationIdByTeamId,
-        ).mockResolvedValue("org-123");
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          "org-123",
+        );
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         mockEventUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 50_000 },
         ]);
@@ -155,9 +155,7 @@ describe("UsageService", () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
         expect(result.exceeded).toBe(true);
-        expect(result.message).toContain(
-          "Free limit of 50000 events reached",
-        );
+        expect(result.message).toContain("Free limit of 50000 events reached");
         expect(result.message).toContain(
           "upgrade your plan at https://app.langwatch.ai/settings/subscription",
         );
@@ -168,12 +166,10 @@ describe("UsageService", () => {
       beforeEach(() => {
         mockEnv.IS_SAAS = false;
         mockEnv.BASE_HOST = "https://my-langwatch.example.com";
-        vi.mocked(
-          mockOrgService.getOrganizationIdByTeamId,
-        ).mockResolvedValue("org-123");
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          "org-123",
+        );
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         mockEventUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 50_000 },
         ]);
@@ -187,9 +183,7 @@ describe("UsageService", () => {
         const result = await service.checkLimit({ teamId: "team-123" });
 
         expect(result.exceeded).toBe(true);
-        expect(result.message).toContain(
-          "Free limit of 50000 events reached",
-        );
+        expect(result.message).toContain("Free limit of 50000 events reached");
         expect(result.message).toContain(
           "buy a license at https://my-langwatch.example.com/settings/license",
         );
@@ -199,12 +193,10 @@ describe("UsageService", () => {
     describe("when paid TIERED org exceeds limit on SaaS", () => {
       beforeEach(() => {
         mockEnv.IS_SAAS = true;
-        vi.mocked(
-          mockOrgService.getOrganizationIdByTeamId,
-        ).mockResolvedValue("org-123");
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          "org-123",
+        );
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         mockTraceUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 10_000 },
         ]);
@@ -231,12 +223,10 @@ describe("UsageService", () => {
       beforeEach(() => {
         mockEnv.IS_SAAS = false;
         mockEnv.BASE_HOST = "https://my-langwatch.example.com";
-        vi.mocked(
-          mockOrgService.getOrganizationIdByTeamId,
-        ).mockResolvedValue("org-123");
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          "org-123",
+        );
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         mockTraceUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 10_000 },
         ]);
@@ -261,12 +251,10 @@ describe("UsageService", () => {
 
     describe("when count >= maxMessagesPerMonth", () => {
       beforeEach(() => {
-        vi.mocked(
-          mockOrgService.getOrganizationIdByTeamId,
-        ).mockResolvedValue("org-123");
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          "org-123",
+        );
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         // Free plan resolves to events counter
         mockEventUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 1000 },
@@ -295,12 +283,10 @@ describe("UsageService", () => {
 
     describe("when count < maxMessagesPerMonth", () => {
       it("returns exceeded: false", async () => {
-        vi.mocked(
-          mockOrgService.getOrganizationIdByTeamId,
-        ).mockResolvedValue("org-123");
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getOrganizationIdByTeamId).mockResolvedValue(
+          "org-123",
+        );
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         // Free plan resolves to events counter
         mockEventUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 500 },
@@ -334,9 +320,7 @@ describe("UsageService", () => {
       });
 
       expect(result).toBe(100);
-      expect(
-        mockEventUsageService.getCountByProjects,
-      ).toHaveBeenCalledWith({
+      expect(mockEventUsageService.getCountByProjects).toHaveBeenCalledWith({
         organizationId: "org-123",
         projectIds: ["proj-1", "proj-2"],
       });
@@ -360,9 +344,7 @@ describe("UsageService", () => {
       });
 
       expect(result).toBe(100);
-      expect(
-        mockTraceUsageService.getCountByProjects,
-      ).toHaveBeenCalledWith({
+      expect(mockTraceUsageService.getCountByProjects).toHaveBeenCalledWith({
         organizationId: "org-123",
         projectIds: ["proj-1", "proj-2"],
       });
@@ -377,20 +359,14 @@ describe("UsageService", () => {
         });
 
         expect(result).toBe(0);
-        expect(
-          mockTraceUsageService.getCountByProjects,
-        ).not.toHaveBeenCalled();
-        expect(
-          mockEventUsageService.getCountByProjects,
-        ).not.toHaveBeenCalled();
+        expect(mockTraceUsageService.getCountByProjects).not.toHaveBeenCalled();
+        expect(mockEventUsageService.getCountByProjects).not.toHaveBeenCalled();
       });
     });
 
     describe("when result is cached", () => {
       it("returns cached value within TTL", async () => {
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         // Free plan (default) resolves to events counter
         mockEventUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 42 },
@@ -412,9 +388,7 @@ describe("UsageService", () => {
 
     describe("cache key includes usage unit", () => {
       it("caches separately for different meter decisions", async () => {
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         // Default free plan uses events counter
         mockEventUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 42 },
@@ -474,9 +448,7 @@ describe("UsageService", () => {
         { projectId: "proj-2", count: 20 },
       ]);
       expect(mockEventUsageService.getCountByProjects).toHaveBeenCalled();
-      expect(
-        mockTraceUsageService.getCountByProjects,
-      ).not.toHaveBeenCalled();
+      expect(mockTraceUsageService.getCountByProjects).not.toHaveBeenCalled();
     });
 
     it("delegates to TraceUsageService for paid plan", async () => {
@@ -498,9 +470,7 @@ describe("UsageService", () => {
         { projectId: "proj-2", count: 20 },
       ]);
       expect(mockTraceUsageService.getCountByProjects).toHaveBeenCalled();
-      expect(
-        mockEventUsageService.getCountByProjects,
-      ).not.toHaveBeenCalled();
+      expect(mockEventUsageService.getCountByProjects).not.toHaveBeenCalled();
     });
 
     describe("when meter decision is events", () => {
@@ -521,15 +491,11 @@ describe("UsageService", () => {
         });
 
         expect(result).toEqual([{ projectId: "proj-1", count: 50 }]);
-        expect(
-          mockEventUsageService.getCountByProjects,
-        ).toHaveBeenCalledWith({
+        expect(mockEventUsageService.getCountByProjects).toHaveBeenCalledWith({
           organizationId: "org-123",
           projectIds: ["proj-1"],
         });
-        expect(
-          mockTraceUsageService.getCountByProjects,
-        ).not.toHaveBeenCalled();
+        expect(mockTraceUsageService.getCountByProjects).not.toHaveBeenCalled();
       });
     });
   });
@@ -544,9 +510,7 @@ describe("UsageService", () => {
         (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue({
           ...PAID_TIERED_PLAN,
         });
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         mockTraceUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 100 },
         ]);
@@ -559,9 +523,7 @@ describe("UsageService", () => {
 
         expect(result).toBe(100);
         expect(mockTraceUsageService.getCountByProjects).toHaveBeenCalled();
-        expect(
-          mockEventUsageService.getCountByProjects,
-        ).not.toHaveBeenCalled();
+        expect(mockEventUsageService.getCountByProjects).not.toHaveBeenCalled();
       });
     });
 
@@ -570,9 +532,7 @@ describe("UsageService", () => {
         (mockPlanResolver as ReturnType<typeof vi.fn>).mockResolvedValue({
           ...ENTERPRISE_LICENSE_PLAN,
         });
-        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue([
-          "proj-1",
-        ]);
+        vi.mocked(mockOrgService.getProjectIds).mockResolvedValue(["proj-1"]);
         mockEventUsageService.getCountByProjects.mockResolvedValue([
           { projectId: "proj-1", count: 200 },
         ]);
@@ -585,9 +545,7 @@ describe("UsageService", () => {
 
         expect(result).toBe(200);
         expect(mockEventUsageService.getCountByProjects).toHaveBeenCalled();
-        expect(
-          mockTraceUsageService.getCountByProjects,
-        ).not.toHaveBeenCalled();
+        expect(mockTraceUsageService.getCountByProjects).not.toHaveBeenCalled();
       });
     });
   });
@@ -619,9 +577,7 @@ describe("UsageService", () => {
         });
 
         expect(result).toBe("unlimited");
-        expect(
-          mockEventUsageService.getCountByProjects,
-        ).not.toHaveBeenCalled();
+        expect(mockEventUsageService.getCountByProjects).not.toHaveBeenCalled();
       });
 
       it("returns the real metered event total from getCurrentMonthCountForDisplay", async () => {
@@ -630,9 +586,7 @@ describe("UsageService", () => {
         });
 
         expect(result).toBe(37_924);
-        expect(
-          mockEventUsageService.getCountByProjects,
-        ).toHaveBeenCalledWith({
+        expect(mockEventUsageService.getCountByProjects).toHaveBeenCalledWith({
           organizationId: "org-123",
           projectIds: ["proj-1", "proj-2"],
         });

--- a/langwatch/src/server/app-layer/usage/usage.service.ts
+++ b/langwatch/src/server/app-layer/usage/usage.service.ts
@@ -1,19 +1,19 @@
-import { TraceUsageService } from "../../traces/trace-usage.service";
-import { EventUsageService } from "../../traces/event-usage.service";
-import type { PlanResolver } from "../subscription/plan-provider";
+import { UNLIMITED_MESSAGES } from "../../../../ee/billing/planLimits";
+import type { OrganizationRepository } from "../../repositories/organization.repository";
+import type { EventUsageService } from "../../traces/event-usage.service";
+import type { TraceUsageService } from "../../traces/trace-usage.service";
 import { TtlCache } from "../../utils/ttlCache";
 import { OrganizationNotFoundForTeamError } from "../organizations/errors";
 import type { OrganizationService } from "../organizations/organization.service";
+import type { SimulationRunService } from "../simulations/simulation-run.service";
+import type { PlanResolver } from "../subscription/plan-provider";
+import { ScenarioSetLimitExceededError } from "./errors";
+import { buildLimitMessage } from "./limit-message";
 import {
-  resolveUsageMeter,
   type MeterDecision,
+  resolveUsageMeter,
   type UsageUnit,
 } from "./usage-meter-policy";
-import { buildLimitMessage } from "./limit-message";
-import { OrganizationRepository } from "../../repositories/organization.repository";
-import { ScenarioSetLimitExceededError } from "./errors";
-import type { SimulationRunService } from "../simulations/simulation-run.service";
-import { UNLIMITED_MESSAGES } from "../../../../ee/billing/planLimits";
 
 const CACHE_TTL_MS = 30_000; // 30 seconds
 const MAX_FREE_SCENARIO_SETS = 3;
@@ -45,12 +45,24 @@ export class UsageService {
     private readonly eventUsageService: EventUsageService,
     private readonly planResolver: PlanResolver,
     private readonly organizationRepository: OrganizationRepository | null,
-    private readonly simulationRunService: Pick<SimulationRunService, "getDistinctExternalSetIds">,
+    private readonly simulationRunService: Pick<
+      SimulationRunService,
+      "getDistinctExternalSetIds"
+    >,
     private readonly clickhouseAvailable: boolean,
   ) {
-    this.countCache = new TtlCache<number>(CACHE_TTL_MS, "ttlcache:usage:count:");
-    this.decisionCache = new TtlCache<MeterDecision>(CACHE_TTL_MS, "ttlcache:usage:decision:");
-    this.scenarioSetCache = new TtlCache<string[]>(CACHE_TTL_MS, "ttlcache:usage:scenarioSets:");
+    this.countCache = new TtlCache<number>(
+      CACHE_TTL_MS,
+      "ttlcache:usage:count:",
+    );
+    this.decisionCache = new TtlCache<MeterDecision>(
+      CACHE_TTL_MS,
+      "ttlcache:usage:decision:",
+    );
+    this.scenarioSetCache = new TtlCache<string[]>(
+      CACHE_TTL_MS,
+      "ttlcache:usage:scenarioSets:",
+    );
   }
 
   async checkLimit({ teamId }: { teamId: string }): Promise<UsageLimitResult> {
@@ -130,7 +142,9 @@ export class UsageService {
       }
 
       const fromService =
-        await this.simulationRunService.getDistinctExternalSetIds({ projectIds });
+        await this.simulationRunService.getDistinctExternalSetIds({
+          projectIds,
+        });
       knownSetIds = [...fromService];
       await this.scenarioSetCache.set(organizationId, knownSetIds);
     }
@@ -142,7 +156,10 @@ export class UsageService {
 
     // This is a new set -- check against limit
     if (knownSetIds.length >= maxScenarioSets) {
-      throw new ScenarioSetLimitExceededError(knownSetIds.length, maxScenarioSets);
+      throw new ScenarioSetLimitExceededError(
+        knownSetIds.length,
+        maxScenarioSets,
+      );
     }
 
     // Allowed: record the new set in the cache
@@ -297,6 +314,4 @@ export class UsageService {
 
     return decision;
   }
-
 }
-

--- a/langwatch/src/server/app-layer/usage/usage.service.ts
+++ b/langwatch/src/server/app-layer/usage/usage.service.ts
@@ -169,13 +169,41 @@ export class UsageService {
     organizationId: string;
   }): Promise<number | "unlimited"> {
     // Skip the heavy ClickHouse query for unlimited plans (e.g. seat-based pricing).
-    // The count would never exceed the limit, so querying is wasted work.
-    // Returns "unlimited" so callers can distinguish from actual 0 usage.
+    // The count would never exceed the limit, so querying is wasted work for
+    // ENFORCEMENT. Returns "unlimited" so callers can distinguish from actual 0
+    // usage. Display callers that need the real volume regardless of the cap use
+    // getCurrentMonthCountForDisplay instead.
     const plan = await this.planResolver(organizationId);
     if (plan.maxMessagesPerMonth >= UNLIMITED_MESSAGES) {
       return "unlimited";
     }
 
+    return this.computeCurrentMonthCount({ organizationId });
+  }
+
+  /**
+   * Always computes the real current-month usage count (events or traces per
+   * the resolved meter), regardless of whether the plan caps usage.
+   *
+   * Seat-based / metered plans (GROWTH_SEAT_*) have no monthly message cap but
+   * still accrue billable events that are metered and billed via Stripe. The
+   * usage page must surface that volume, so it cannot use getCurrentMonthCount
+   * (which short-circuits unlimited plans to "unlimited" for enforcement and
+   * would otherwise render as "0").
+   */
+  async getCurrentMonthCountForDisplay({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<number> {
+    return this.computeCurrentMonthCount({ organizationId });
+  }
+
+  private async computeCurrentMonthCount({
+    organizationId,
+  }: {
+    organizationId: string;
+  }): Promise<number> {
     const decision = await this.getCachedMeterDecision(organizationId);
     const cacheKey = `${organizationId}:${decision.usageUnit}`;
 

--- a/langwatch/src/server/license-enforcement/__tests__/usage-stats.service.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/usage-stats.service.unit.test.ts
@@ -42,8 +42,11 @@ describe("UsageStatsService", () => {
       getExperimentCount: vi.fn().mockResolvedValue(0),
     } as unknown as ILicenseEnforcementRepository;
 
+    // Distinct values so the suite fails if getUsageStats regresses to the
+    // enforcement counter: display drives the surfaced count, enforcement must
+    // not be called.
     mockTraceUsage = {
-      getCurrentMonthCount: vi.fn().mockResolvedValue(500),
+      getCurrentMonthCount: vi.fn().mockResolvedValue(123),
       getCurrentMonthCountForDisplay: vi.fn().mockResolvedValue(500),
     } as unknown as ITraceUsageService;
 
@@ -97,6 +100,15 @@ describe("UsageStatsService", () => {
       expect(stats.currentMonthMessagesCount).toBe(500);
       expect(stats.usageUnit).toBe("traces");
       expect(stats.messageLimitInfo).toBeDefined();
+    });
+
+    it("surfaces the display count and never the enforcement counter", async () => {
+      await service.getUsageStats("org-123", testUser);
+
+      expect(
+        mockTraceUsage.getCurrentMonthCountForDisplay,
+      ).toHaveBeenCalledWith({ organizationId: "org-123" });
+      expect(mockTraceUsage.getCurrentMonthCount).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/server/license-enforcement/__tests__/usage-stats.service.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/usage-stats.service.unit.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  UsageStatsService,
-  type IUsageUnitResolver,
-  type ITraceUsageService,
-} from "../usage-stats.service";
-import type { ILicenseEnforcementRepository } from "../license-enforcement.repository";
-import type { PlanProvider } from "../../app-layer/subscription/plan-provider";
-import type { PlanInfo } from "../../../../ee/licensing/planInfo";
 import { FREE_PLAN } from "../../../../ee/licensing/constants";
+import type { PlanInfo } from "../../../../ee/licensing/planInfo";
+import type { PlanProvider } from "../../app-layer/subscription/plan-provider";
+import type { ILicenseEnforcementRepository } from "../license-enforcement.repository";
+import {
+  type ITraceUsageService,
+  type IUsageUnitResolver,
+  UsageStatsService,
+} from "../usage-stats.service";
 
 const TEST_PLAN: PlanInfo = {
   ...FREE_PLAN,

--- a/langwatch/src/server/license-enforcement/__tests__/usage-stats.service.unit.test.ts
+++ b/langwatch/src/server/license-enforcement/__tests__/usage-stats.service.unit.test.ts
@@ -44,6 +44,7 @@ describe("UsageStatsService", () => {
 
     mockTraceUsage = {
       getCurrentMonthCount: vi.fn().mockResolvedValue(500),
+      getCurrentMonthCountForDisplay: vi.fn().mockResolvedValue(500),
     } as unknown as ITraceUsageService;
 
     mockPlanProvider = {

--- a/langwatch/src/server/license-enforcement/usage-stats.service.ts
+++ b/langwatch/src/server/license-enforcement/usage-stats.service.ts
@@ -1,11 +1,11 @@
 import type { PrismaClient } from "@prisma/client";
 import { UNLIMITED_MESSAGES } from "../../../ee/billing/planLimits";
 import type { PlanInfo } from "../../../ee/licensing/planInfo";
-import type { PlanProvider } from "../app-layer/subscription/plan-provider";
-import type { UsageUnit } from "../app-layer/usage/usage-meter-policy";
 import { env } from "../../env.mjs";
 import { formatNumber, formatPercent } from "../../utils/formatNumber";
 import { getApp } from "../app-layer/app";
+import type { PlanProvider } from "../app-layer/subscription/plan-provider";
+import type { UsageUnit } from "../app-layer/usage/usage-meter-policy";
 import {
   type ILicenseEnforcementRepository,
   LicenseEnforcementRepository,
@@ -79,12 +79,16 @@ export function buildMessageLimitInfo(
  * Follows Interface Segregation Principle - only what we need.
  */
 export interface ITraceUsageService {
-  getCurrentMonthCount(params: { organizationId: string }): Promise<number | "unlimited">;
+  getCurrentMonthCount(params: {
+    organizationId: string;
+  }): Promise<number | "unlimited">;
   /**
    * Real current-month usage count for display, computed even for unlimited
    * (seat-based / metered) plans where getCurrentMonthCount returns "unlimited".
    */
-  getCurrentMonthCountForDisplay(params: { organizationId: string }): Promise<number>;
+  getCurrentMonthCountForDisplay(params: {
+    organizationId: string;
+  }): Promise<number>;
 }
 
 /**
@@ -92,9 +96,7 @@ export interface ITraceUsageService {
  * Follows Interface Segregation Principle.
  */
 export interface IUsageUnitResolver {
-  getResolvedUsageUnit(params: {
-    organizationId: string;
-  }): Promise<UsageUnit>;
+  getResolvedUsageUnit(params: { organizationId: string }): Promise<UsageUnit>;
 }
 
 /**

--- a/langwatch/src/server/license-enforcement/usage-stats.service.ts
+++ b/langwatch/src/server/license-enforcement/usage-stats.service.ts
@@ -80,6 +80,11 @@ export function buildMessageLimitInfo(
  */
 export interface ITraceUsageService {
   getCurrentMonthCount(params: { organizationId: string }): Promise<number | "unlimited">;
+  /**
+   * Real current-month usage count for display, computed even for unlimited
+   * (seat-based / metered) plans where getCurrentMonthCount returns "unlimited".
+   */
+  getCurrentMonthCountForDisplay(params: { organizationId: string }): Promise<number>;
 }
 
 /**
@@ -173,7 +178,7 @@ export class UsageStatsService {
       usageUnit,
     ] = await Promise.all([
       this.repository.getProjectCount(organizationId),
-      this.traceUsageService.getCurrentMonthCount({ organizationId }),
+      this.traceUsageService.getCurrentMonthCountForDisplay({ organizationId }),
       this.repository.getCurrentMonthCost(organizationId),
       this.planProvider.getActivePlan({ organizationId, user }),
       this.getMaxMonthlyUsageLimit(organizationId),
@@ -189,10 +194,12 @@ export class UsageStatsService {
       this.usageUnitResolver.getResolvedUsageUnit({ organizationId }),
     ]);
 
-    const resolvedCount = currentMonthMessagesCount === "unlimited" ? null : currentMonthMessagesCount;
+    // Real metered/trace volume for the month — surfaced even for unlimited
+    // (seat-based) plans so the usage page shows actual billable events.
+    const resolvedCount = currentMonthMessagesCount;
 
     const messageLimitInfo = buildMessageLimitInfo(
-      resolvedCount ?? 0,
+      resolvedCount,
       activePlan.maxMessagesPerMonth,
     );
 


### PR DESCRIPTION
## Problem

A paying customer on a seat-based plan (`GROWTH_SEAT_*`) saw **Events / Month: 0** on `/settings/usage`, while their events were being metered and billed correctly via Stripe (~7K/day). Customer report surfaced the discrepancy.

This was **not** a ClickHouse query bug — both backing tables hold the data for the period. The count was simply never queried.

## Root cause

`UsageService.getCurrentMonthCount()` short-circuits:

```ts
if (plan.maxMessagesPerMonth >= UNLIMITED_MESSAGES) return "unlimited";
```

Seat plans have no monthly message cap (`maxMessagesPerMonth = UNLIMITED_MESSAGES`) because events are metered and billed per-event. So `getUsageStats` received `"unlimited"`, mapped it to `null`, and the UI rendered `?? 0`. The real billable volume was never fetched.

Stripe was always correct — it reports from a separate `billable_events` pipeline, independent of this display path.

## Fix

Separate **display** from **enforcement**:

- **`usage.service.ts`** — add `getCurrentMonthCountForDisplay()` that always computes the real count (events → `billable_events`, traces → `trace_summaries`, per the meter policy), reusing the existing cache. `getCurrentMonthCount()` keeps its short-circuit for limit enforcement (`checkLimit`), so the hot path does no extra work.
- **`usage-stats.service.ts`** — `getUsageStats()` now uses the display count, so the card shows the actual metered volume instead of 0.
- **`UsageIndicator.tsx`** — the sidebar bar previously relied on the `null` count to hide itself for unlimited plans. Now that the count is a real number, re-guard on `maxMessagesPerMonth >= UNLIMITED_MESSAGES` so uncapped plans (e.g. self-hosted unlimited license) don't render a meaningless ~0% progress bar. Seat customers were already hidden via the existing `SEAT_EVENT` guard.

No behavior change for capped (tiered/free) plans or for enforcement.

## Verification

- `pnpm typecheck`: clean.
- 284 related unit tests pass, including a new regression test asserting enforcement still returns `"unlimited"` while display returns the real metered total.
- Confirmed against production data for the reporting org (seat plan): `billable_events` for the month is non-zero and now surfaces on the usage page.

## Review follow-ups

- **CodeRabbit**: made the usage-stats test doubles distinct and asserted `getUsageStats` invokes `getCurrentMonthCountForDisplay` (not the enforcement counter), so the regression test can't silently pass if the wiring reverts.
- **Lint/format**: applied biome (import order, `import type`, wrapping) to the changed files so the `lint` job passes.
- **Test typing**: replaced the `usage: {...} as any` `createTestApp` override in `limits.integration.test.ts` with `vi.spyOn(UsageService.prototype, "getCurrentMonthCountForDisplay")` — no casts; the stub is type-checked against the real class and fails to compile if the method is renamed.

> Note: a transient CI failure during review was an unrelated flaky ClickHouse dedup test (`span-storage … returns the latest version of a duplicated span`, async ReplacingMergeTree merge timing); it passed on re-run.
