### PR TITLE
perf(clickhouse): fix simulation projection get OOM via scalar latest-version filter

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/__tests__/simulationRunState.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/__tests__/simulationRunState.clickhouse.repository.integration.test.ts
@@ -1,0 +1,188 @@
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import { startTestContainers, stopTestContainers } from "../../../../__tests__/integration/testContainers";
+import { createResilientClickHouseClient } from "../../../../../app-layer/clients/clickhouse";
+import { createTenantId } from "../../../../";
+import type { SimulationRunState } from "../../projections/simulationRunState.foldProjection";
+import { SimulationRunStateRepositoryClickHouse } from "../simulationRunState.clickhouse.repository";
+
+const tenantId = `test-sim-proj-${nanoid()}`;
+const now = Date.now();
+
+/**
+ * Builds one simulation_runs row. Each call defaults to a fresh ScenarioRunId;
+ * override ScenarioRunId + UpdatedAt to write multiple versions of one run.
+ */
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    ScenarioRunId: `run-${nanoid()}`,
+    ScenarioId: `scenario-${nanoid()}`,
+    BatchRunId: `batch-${nanoid()}`,
+    ScenarioSetId: `set-${nanoid()}`,
+    Version: "v1",
+    Status: "IN_PROGRESS",
+    Name: "Test run",
+    Description: "A test description",
+    Metadata: null,
+    "Messages.Id": ["msg-1"],
+    "Messages.Role": ["user"],
+    "Messages.Content": ["hello"],
+    "Messages.TraceId": ["trace-1"],
+    "Messages.Rest": ["{}"],
+    TraceIds: [],
+    Verdict: null,
+    Reasoning: null,
+    MetCriteria: [],
+    UnmetCriteria: [],
+    Error: null,
+    DurationMs: "1500",
+    TotalCost: null,
+    RoleCosts: {},
+    RoleLatencies: {},
+    TraceMetricsJson: "",
+    StartedAt: new Date(now - 5000),
+    QueuedAt: null,
+    CreatedAt: new Date(now - 5000),
+    UpdatedAt: new Date(now),
+    FinishedAt: null,
+    ArchivedAt: null,
+    CancellationRequestedAt: null,
+    LastSnapshotOccurredAt: new Date(0),
+    LastEventOccurredAt: new Date(0),
+    ...overrides,
+  };
+}
+
+async function insertRows(
+  ch: ClickHouseClient,
+  rows: ReturnType<typeof makeRow>[],
+) {
+  await ch.insert({
+    table: "simulation_runs",
+    values: rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+let ch: ClickHouseClient;
+let repo: SimulationRunStateRepositoryClickHouse<SimulationRunState>;
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  const resilient = createResilientClickHouseClient({ client: ch });
+  repo = new SimulationRunStateRepositoryClickHouse<SimulationRunState>(
+    async () => resilient,
+  );
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE simulation_runs DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("SimulationRunStateRepositoryClickHouse.getProjection (integration)", () => {
+  const context = { tenantId: createTenantId(tenantId) };
+
+  describe("when a run has several versions", () => {
+    it("returns the version with the greatest UpdatedAt", async () => {
+      const scenarioRunId = `run-latest-${nanoid()}`;
+      await insertRows(ch, [
+        makeRow({
+          ScenarioRunId: scenarioRunId,
+          Status: "IN_PROGRESS",
+          "Messages.Content": ["stale-1"],
+          UpdatedAt: new Date(now - 3000),
+        }),
+        makeRow({
+          ScenarioRunId: scenarioRunId,
+          Status: "PENDING",
+          "Messages.Content": ["stale-2"],
+          UpdatedAt: new Date(now - 1000),
+        }),
+        makeRow({
+          ScenarioRunId: scenarioRunId,
+          Status: "SUCCESS",
+          Verdict: "success",
+          "Messages.Content": ["final-answer"],
+          UpdatedAt: new Date(now),
+        }),
+      ]);
+
+      const projection = await repo.getProjection(scenarioRunId, context);
+
+      expect(projection).not.toBeNull();
+      expect(projection!.data.Status).toBe("SUCCESS");
+      expect(projection!.data.Verdict).toBe("success");
+      expect(projection!.data.Messages.map((m) => m.Content)).toEqual([
+        "final-answer",
+      ]);
+    });
+  });
+
+  describe("when a run has many heavy-payload versions", () => {
+    it("returns the latest without reading every version's heavy columns", async () => {
+      const scenarioRunId = `run-heavy-${nanoid()}`;
+      // A sizeable Messages.Content per version: the old IN-tuple dedup
+      // materialized this across every version before discarding stale ones.
+      // The scalar-UpdatedAt form must still return only the latest version.
+      const heavy = "x".repeat(20_000);
+      const versions = Array.from({ length: 25 }, (_, i) =>
+        makeRow({
+          ScenarioRunId: scenarioRunId,
+          Status: i === 24 ? "SUCCESS" : "IN_PROGRESS",
+          "Messages.Content": [`${heavy}-v${i}`],
+          UpdatedAt: new Date(now - (24 - i) * 1000),
+        }),
+      );
+      await insertRows(ch, versions);
+
+      const projection = await repo.getProjection(scenarioRunId, context);
+
+      expect(projection).not.toBeNull();
+      expect(projection!.data.Status).toBe("SUCCESS");
+      expect(projection!.data.Messages[0]!.Content).toBe(`${heavy}-v24`);
+    });
+  });
+
+  describe("when the run does not exist", () => {
+    it("returns null", async () => {
+      const projection = await repo.getProjection(
+        `run-missing-${nanoid()}`,
+        context,
+      );
+      expect(projection).toBeNull();
+    });
+  });
+
+  describe("when the same ScenarioRunId exists under another tenant", () => {
+    it("does not return the other tenant's row", async () => {
+      const scenarioRunId = `run-shared-${nanoid()}`;
+      const otherTenant = `test-sim-proj-other-${nanoid()}`;
+      await insertRows(ch, [
+        makeRow({
+          TenantId: otherTenant,
+          ScenarioRunId: scenarioRunId,
+          Status: "SUCCESS",
+        }),
+      ]);
+
+      const projection = await repo.getProjection(scenarioRunId, context);
+      expect(projection).toBeNull();
+
+      await ch.exec({
+        query: `ALTER TABLE simulation_runs DELETE WHERE TenantId = {tenantId:String}`,
+        query_params: { tenantId: otherTenant },
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/__tests__/simulationRunState.dedup-safety.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/__tests__/simulationRunState.dedup-safety.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Structural regression test for the simulation-run-state projection read.
+ *
+ * getProjection() reads the latest version of a single run from
+ * simulation_runs (ReplacingMergeTree(UpdatedAt)). It must resolve the latest
+ * version with a scalar `UpdatedAt = (SELECT max(...))` subquery, NOT the
+ * `(TenantId, ScenarioRunId, UpdatedAt) IN (max-subquery)` tuple form: the
+ * tuple form is not applied as a PREWHERE on the version, so ClickHouse read
+ * the heavy Messages.* arrays across every version before discarding the stale
+ * ones, exhausting the server memory limit (Code 241) for runs with many
+ * snapshot versions.
+ *
+ * The behavioural proof lives in the integration test
+ * (simulationRunState.clickhouse.repository.integration.test.ts); this guards
+ * the query shape so the fix can't silently regress.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("simulationRunState.clickhouse.repository getProjection OOM safety", () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, "..", "simulationRunState.clickhouse.repository.ts"),
+    "utf-8",
+  );
+
+  it("resolves the latest version with a scalar max(UpdatedAt) subquery", () => {
+    expect(source).toMatch(/t\.UpdatedAt\s*=\s*\(\s*SELECT max\(s\.UpdatedAt\)/);
+  });
+
+  it("does not read the latest version via an UpdatedAt IN-tuple subquery", () => {
+    expect(source).not.toMatch(
+      /\(t\.TenantId,\s*t\.ScenarioRunId,\s*t\.UpdatedAt\)\s*IN/,
+    );
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
@@ -184,14 +184,26 @@ export class SimulationRunStateRepositoryClickHouse<
 
     try {
       const client = await this.resolveClient(context.tenantId);
-      // IN-tuple dedup over the ReplacingMergeTree (see
-      // dev/docs/best_practices/clickhouse-queries.md). Inner SELECT scans
-      // only (TenantId, ScenarioRunId, UpdatedAt); outer SELECT pulls the
-      // heavy columns (Messages.*, TraceMetricsJson, RoleCosts, etc.) for
-      // the single matching row. Outer references UpdatedAt via table alias
-      // because the column is also projected as `toUnixTimestamp64Milli(...)
-      // AS UpdatedAt` — without the alias the IN-tuple comparison resolves
-      // to the projected UInt64 instead of the raw DateTime64.
+      // Latest-version read over the ReplacingMergeTree(UpdatedAt) for a single
+      // run. The inner scalar subquery finds the newest UpdatedAt reading only
+      // the light sort-key columns; the outer `t.UpdatedAt = (...)` equality is
+      // PREWHERE-able, so the heavy columns (Messages.*, TraceMetricsJson,
+      // RoleCosts, etc.) are materialized for only the single surviving row.
+      //
+      // The earlier `(TenantId, ScenarioRunId, UpdatedAt) IN (max-subquery)`
+      // tuple form was not applied as a PREWHERE on the version, so ClickHouse
+      // read the heavy Messages.* arrays across EVERY version of the run before
+      // discarding the stale ones. Runs with many snapshot versions exhausted
+      // the server memory limit (Code 241). For a single-aggregate get, scalar
+      // equality is preferable to the IN-tuple form (which stays the right
+      // choice for multi-key list reads); the sibling read path
+      // (simulation.clickhouse.repository.ts getScenarioRunData) already uses
+      // this scalar form for the same reason.
+      //
+      // Outer references UpdatedAt via the table alias because the column is
+      // also projected as `toUnixTimestamp64Milli(...) AS UpdatedAt` — without
+      // the alias the comparison resolves to the projected UInt64 instead of
+      // the raw DateTime64.
       const result = await client.query({
         query: `
           SELECT
@@ -225,12 +237,11 @@ export class SimulationRunStateRepositoryClickHouse<
           FROM ${TABLE_NAME} AS t
           WHERE t.TenantId = {tenantId:String}
             AND t.ScenarioRunId = {scenarioRunId:String}
-            AND (t.TenantId, t.ScenarioRunId, t.UpdatedAt) IN (
-              SELECT TenantId, ScenarioRunId, max(UpdatedAt)
-              FROM ${TABLE_NAME}
-              WHERE TenantId = {tenantId:String}
-                AND ScenarioRunId = {scenarioRunId:String}
-              GROUP BY TenantId, ScenarioRunId
+            AND t.UpdatedAt = (
+              SELECT max(s.UpdatedAt)
+              FROM ${TABLE_NAME} AS s
+              WHERE s.TenantId = {tenantId:String}
+                AND s.ScenarioRunId = {scenarioRunId:String}
             )
           LIMIT 1
         `,


### PR DESCRIPTION
## Evidence

Prod ClickHouse exceptions over the last 24h: **26 `Code: 241` MEMORY_LIMIT_EXCEEDED**, all on this cluster. The single largest shape (**14 of 26**) is the simulation-run-state projection read:

```
SELECT t.<all columns incl Messages.Content/Messages.Rest>
FROM simulation_runs AS t
WHERE t.TenantId = {…} AND t.ScenarioRunId = {…}
  AND (t.TenantId, t.ScenarioRunId, t.UpdatedAt) IN (
    SELECT TenantId, ScenarioRunId, max(UpdatedAt)
    FROM simulation_runs WHERE … GROUP BY TenantId, ScenarioRunId
  )
LIMIT 1
```

The server-side error (redacted): `(total) memory limit exceeded: would use 9.59 GiB … maximum: 14.00 GiB … (while reading column Messages.Content) … in table simulation_runs`. The read fails entirely, so the projection get errors out for runs with large/long histories.

## Suspected cause

`simulation_runs` is `ReplacingMergeTree(UpdatedAt)`; a single scenario run accumulates one row per snapshot/fold. The `(TenantId, ScenarioRunId, UpdatedAt) IN (max-subquery)` tuple predicate is **not** applied as a PREWHERE on the version column, so ClickHouse materializes the heavy `Messages.*` arrays (and `RoleCosts`, `TraceMetricsJson`, …) for **every version** of the run before the IN filter discards the stale ones. A run with many versions and sizeable message payloads blows past the memory limit.

## Proposed fix

Resolve the latest version with a **scalar** subquery and a plain equality:

```
WHERE t.TenantId = {…} AND t.ScenarioRunId = {…}
  AND t.UpdatedAt = (
    SELECT max(s.UpdatedAt) FROM simulation_runs AS s WHERE … 
  )
```

`UpdatedAt = <scalar>` is PREWHERE-able: ClickHouse reads the light `UpdatedAt` column first, filters to the single latest-version row, and materializes the heavy columns only for that one row. This is the exact pattern the sibling read path (`simulation.clickhouse.repository.ts` `getScenarioRunData`) already uses, and its comment documents the same OOM as the reason. For a single-aggregate get the scalar form is preferable; the IN-tuple form stays the right choice for multi-key list reads.

## Expected impact

- Heavy columns materialized for **1 row** instead of every version of the run.
- Eliminates this Code 241 shape (14/24h) for large simulation runs; the get stops failing.
- Latest-version semantics unchanged (ReplacingMergeTree(UpdatedAt): greatest `UpdatedAt` wins; `LIMIT 1` preserved).

## EXPLAIN check

`EXPLAIN PLAN indexes=1` against a real large tenant, both shapes prune identically via the primary key `(TenantId, …, ScenarioRunId)`:

```
old (IN-tuple):  Parts 99/150   Granules 99/1298
new (scalar):    Parts 99/150   Granules 99/1298
```

Granule counts are identical because both must scan the run's granules to find the max version. The win is **column materialization**, not granule pruning: the scalar `UpdatedAt = (…)` equality moves to PREWHERE so heavy columns are read only for the surviving row. The read-only EXPLAIN endpoint can't quantify per-column bytes (ANALYZE is blocked), so the behavioural proof is the integration test plus the prod OOM and the sibling-path precedent.

## Test plan

- `simulationRunState.clickhouse.repository.integration.test.ts` (real ClickHouse via testcontainers): inserts multiple versions of one run (incl. a 25-version case each carrying a ~20 KB `Messages.Content`) and asserts `getProjection` returns the latest version; covers not-found and cross-tenant isolation. **4/4 pass locally.**
- `simulationRunState.dedup-safety.unit.test.ts`: structural guard asserting the scalar `max(UpdatedAt)` form and no `(…, UpdatedAt) IN` tuple. **2/2 pass.**
- `tsgo` typecheck clean for the changed file.

Advisory PR from the ClickHouse slow-query optimizer. A human should review and ship.
