### PR TITLE
perf(clickhouse): bound storage-metering query memory to stop _size_bytes OOM

### DIFF
--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { StorageMeterService } from "../storageMeter.service";
+
+/**
+ * The metering reads sum a lazily-recomputed MATERIALIZED byteSize(...) column
+ * across heavy payload columns, which exceeded the ClickHouse per-query memory
+ * limit for large tenants. Every metering query must carry the bounded-memory
+ * settings (capped read streams) so the recompute stays within budget instead
+ * of failing the read.
+ */
+describe("StorageMeterService memory guard", () => {
+  function makeService() {
+    const query = vi.fn().mockResolvedValue({
+      json: async () => [{ total: "42" }],
+    });
+    const client = { query } as const;
+    const service = new StorageMeterService(async () => client as any);
+    return { service, query };
+  }
+
+  function assertGuarded(call: { clickhouse_settings?: Record<string, unknown> }) {
+    expect(call.clickhouse_settings).toBeDefined();
+    expect(call.clickhouse_settings!.max_threads).toBe(2);
+  }
+
+  describe("when computing the per-category storage breakdown", () => {
+    it("passes the bounded-memory settings on every per-table query", async () => {
+      const { service, query } = makeService();
+
+      await service.getStorageBreakdown({ tenantId: "project-1" });
+
+      expect(query.mock.calls.length).toBeGreaterThan(0);
+      for (const [arg] of query.mock.calls) {
+        assertGuarded(arg);
+      }
+    });
+  });
+
+  describe("when computing the total storage bytes", () => {
+    it("passes the bounded-memory settings on the aggregate query", async () => {
+      const { service, query } = makeService();
+
+      await service.getTotalStorageBytes({ tenantId: "project-total" });
+
+      expect(query).toHaveBeenCalledTimes(1);
+      assertGuarded(query.mock.calls[0]![0]);
+    });
+  });
+});

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -11,6 +11,26 @@ const logger = createLogger("langwatch:data-retention:metering");
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
+// Storage metering sums `_size_bytes`, a `UInt32 MATERIALIZED byteSize(...)`
+// column over each table's payload columns. On parts written before that
+// column existed, ClickHouse has no stored value and recomputes it lazily on
+// read by scanning the heavy source columns (Messages.*, Inputs, Details,
+// EventPayload, ...). Summing across a large tenant therefore reads those
+// payload columns for every row; at the default thread count the parallel
+// per-stream column buffers exceeded the per-query memory limit (Code 241,
+// e.g. ~6.6 GiB reading column `Inputs` against the 3.5 GiB cap), so the
+// metering read failed outright.
+//
+// These are cached (5 min), background metering reads, so we trade parallelism
+// for a bounded peak: capping the read streams keeps the recompute's footprint
+// well under the per-query limit so the query succeeds, and lowers its share of
+// total server memory so it can't help tip the box into a server-wide OOM. The
+// common case (parts where `_size_bytes` is already materialized) reads a tiny
+// UInt32 column and is unaffected.
+const METERING_CLICKHOUSE_SETTINGS = {
+  max_threads: 2,
+} as const;
+
 interface StorageBreakdown {
   totalBytes: number;
   byCategory: Record<RetentionCategory, number>;
@@ -63,6 +83,7 @@ export class StorageMeterService {
           query: `SELECT sum(_size_bytes) AS total FROM ${table} WHERE TenantId = {tenantId:String}`,
           query_params: { tenantId },
           format: "JSONEachRow",
+          clickhouse_settings: METERING_CLICKHOUSE_SETTINGS,
         });
         const rows = (await result.json()) as Array<{ total: string }>;
         const tableBytes = Number(rows[0]?.total ?? 0);
@@ -94,6 +115,7 @@ export class StorageMeterService {
       query: `SELECT sum(t) AS total FROM (\n  ${unions}\n)`,
       query_params: { tenantId },
       format: "JSONEachRow",
+      clickhouse_settings: METERING_CLICKHOUSE_SETTINGS,
     });
     const rows = (await result.json()) as Array<{ total: string }>;
     return Number(rows[0]?.total ?? 0);

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -45,6 +45,11 @@ export class StorageMeterService {
     this.cache = new TtlCache(CACHE_TTL_MS, "storage-meter:");
   }
 
+  /**
+   * Total stored bytes for a tenant across all retention-managed tables,
+   * served from a short-lived cache and computed via {@link queryTotalBytes}
+   * on a miss.
+   */
   async getTotalStorageBytes({
     tenantId,
   }: {
@@ -58,6 +63,11 @@ export class StorageMeterService {
     return total;
   }
 
+  /**
+   * Stored bytes for a tenant grouped by retention category. Each table is
+   * queried independently so a single table's failure degrades that category
+   * to zero rather than failing the whole breakdown.
+   */
   async getStorageBreakdown({
     tenantId,
   }: {
@@ -98,6 +108,11 @@ export class StorageMeterService {
     return { totalBytes, byCategory };
   }
 
+  /**
+   * Sums per-table `_size_bytes` totals for a tenant in a single query. Each
+   * table is pre-aggregated inside a UNION ALL so only the 11 scalar subtotals
+   * (not every row's `_size_bytes`) reach the outer sum.
+   */
   private async queryTotalBytes(tenantId: string): Promise<number> {
     if (!this.resolveClickHouseClient) return 0;
 


### PR DESCRIPTION
## Evidence

Prod ClickHouse exceptions over the last 24h: **26 `Code: 241` MEMORY_LIMIT_EXCEEDED**. The second-largest shape (**9 of 26**) is the data-retention storage meter:

```
SELECT sum(_size_bytes) AS total FROM evaluation_runs WHERE TenantId = {…}    -- 7
SELECT sum(_size_bytes) AS t     FROM event_log       WHERE TenantId = {…}    -- 2 (inside the UNION ALL)
```

Redacted server errors: `would use 6.64 GiB … maximum: 3.50 GiB … (while reading column Inputs) … in table evaluation_runs` (the evaluation_runs reads hit the **per-query 3.5 GiB limit**; the event_log reads showed `maximum: 14.00 GiB`, the server total). The metering read fails, so the storage-usage number on the data-retention settings page comes back wrong (the per-table failure is swallowed and counted as 0).

## Suspected cause

`_size_bytes` is `UInt32 MATERIALIZED byteSize(<payload columns>)` (migration `00032`), e.g. `byteSize(EvaluatorName, TraceId, Label, Details, Error, ErrorDetails, Inputs)` for `evaluation_runs`. Per that migration's own note, **old parts (written before the column existed) compute the value lazily on read** by scanning the heavy source columns. `sum(_size_bytes)` over a large tenant therefore reads `Inputs`/`Details`/`Messages.*`/`EventPayload` for every row, and at the default thread count the parallel per-stream column buffers blow past the memory limit.

## Proposed fix

Run the metering queries with `max_threads = 2`. These are cached (5 min), background reads behind the data-retention settings UI, so trading parallelism for a bounded footprint is the right call:

- Fewer parallel heavy-column streams → peak memory drops roughly linearly, back under the 3.5 GiB per-query limit, so the query **succeeds** instead of failing.
- A smaller share of total server memory → the metering read can't help tip the box into a server-wide OOM that degrades user traffic.

A `max_memory_usage` cap was intentionally **not** added: the per-query limit is already 3.5 GiB, so any lower ceiling would only make borderline tenants fail sooner rather than succeed. `max_threads` is the lever that makes the read fit.

## Expected impact

- Eliminates this Code 241 shape (9/24h); storage breakdown returns real numbers for large tenants instead of silently undercounting.
- No change for tenants whose parts already have `_size_bytes` materialized (reads a tiny UInt32 column either way).
- Results are byte-identical; only execution parallelism changes. Slightly higher latency on a cached background query is acceptable.

## EXPLAIN check

`EXPLAIN PIPELINE` of the metering query (`sum(_size_bytes) … WHERE TenantId = …`) at the default thread count shows the parallel read fan-out the cap reduces:

```
ExpressionTransform × 4
  AggregatingTransform × 4
    …
      MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 4 0 → 1
```

The read-only EXPLAIN endpoint runs without custom settings and cannot quantify per-column read bytes (ANALYZE is blocked), so the bounded-memory effect is demonstrated by the prod OOM (per-query 3.5 GiB exceeded reading `Inputs`) plus the `byteSize(...)` column definition; the fix lowers the `× N` stream count that multiplies that read.

## Test plan

- `storageMeter.service.unit.test.ts`: drives `getStorageBreakdown` and `getTotalStorageBytes` through a mock ClickHouse client and asserts every issued query carries `max_threads: 2` (executes the real path, observes the settings passed). **2/2 pass.**
- `tsgo` typecheck clean for the changed file.

Advisory PR from the ClickHouse slow-query optimizer. A human should review and ship.
