### PR TITLE
feat(langy): make Langy a real, user-managed VirtualKey

### DIFF
--- a/langwatch/scripts/backfill-langy-virtual-keys.ts
+++ b/langwatch/scripts/backfill-langy-virtual-keys.ts
@@ -1,0 +1,45 @@
+/**
+ * Backfill script: mint the auto-managed Langy VirtualKey for every existing
+ * application project that doesn't already have one.
+ *
+ * Symmetric with `backfill-langy-api-keys.ts`. Project creation eagerly
+ * provisions both now (#4275), so this is for projects that pre-date the
+ * eager hook AND projects whose runtime provision was skipped (no actor).
+ *
+ * Idempotent — re-running only provisions VKs for projects still missing one.
+ * Hidden internal_governance projects are excluded.
+ *
+ * Run with:
+ *   DATABASE_URL=... npx tsx scripts/backfill-langy-virtual-keys.ts
+ *   DATABASE_URL=... npx tsx scripts/backfill-langy-virtual-keys.ts --dry-run
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { backfillLangyVirtualKeys } from "../src/server/services/langy/LangyCredentialService";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN" : "LIVE"}\n`);
+
+  const { provisioned, skipped, failed } = await backfillLangyVirtualKeys(
+    prisma,
+    { dryRun: DRY_RUN },
+  );
+
+  console.log(
+    `Langy VK backfill: ${DRY_RUN ? "would provision" : "provisioned"} ${provisioned}, skipped ${skipped} (already had one or no admin to attribute), failed ${failed}`,
+  );
+
+  await prisma.$disconnect();
+
+  if (failed > 0) process.exit(1);
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect().catch(() => {});
+  process.exit(1);
+});

--- a/langwatch/src/components/ModelMultiSelect.tsx
+++ b/langwatch/src/components/ModelMultiSelect.tsx
@@ -1,0 +1,132 @@
+import { Box, HStack, Input, Skeleton, Text, VStack } from "@chakra-ui/react";
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { titleCase } from "../utils/stringCasing";
+import { MODEL_ICON_SIZE } from "./llmPromptConfigs/constants";
+import { allModelOptions, useModelSelectionOptions } from "./ModelSelector";
+import { Checkbox } from "./ui/checkbox";
+import { InputGroup } from "./ui/input-group";
+
+/**
+ * Grouped, searchable multi-select over the project's available models.
+ *
+ * Shares `useModelSelectionOptions` with the single-select <ModelSelector>,
+ * so the option set is always exactly the models the project's enabled
+ * providers can serve — there is one source of truth for "what models exist
+ * here", not two. Selection is a flat string[] of `provider/model` ids
+ * (the shape `VirtualKey.config.modelsAllowed` stores and the gateway
+ * enforces). Empty array = caller's convention for "all eligible models".
+ */
+export function ModelMultiSelect({
+  value,
+  onChange,
+  mode = "chat",
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+  mode?: "chat" | "embedding";
+}) {
+  const { groupedByProvider, isLoading, isEmpty } = useModelSelectionOptions(
+    allModelOptions,
+    "",
+    mode,
+  );
+  const [search, setSearch] = useState("");
+  const selected = useMemo(() => new Set(value), [value]);
+
+  const toggle = (modelValue: string) => {
+    const next = new Set(selected);
+    if (next.has(modelValue)) next.delete(modelValue);
+    else next.add(modelValue);
+    onChange([...next]);
+  };
+
+  const filteredGroups = useMemo(() => {
+    const needle = search.toLowerCase();
+    return groupedByProvider
+      .map((group) => ({
+        ...group,
+        models: group.models.filter(
+          (m) =>
+            m.label.toLowerCase().includes(needle) ||
+            m.value.toLowerCase().includes(needle),
+        ),
+      }))
+      .filter((group) => group.models.length > 0);
+  }, [groupedByProvider, search]);
+
+  if (isLoading) {
+    return <Skeleton height="180px" borderRadius="md" />;
+  }
+  if (isEmpty) {
+    return (
+      <Text fontSize="sm" color="fg.muted">
+        No models available — configure a model provider first.
+      </Text>
+    );
+  }
+
+  return (
+    <VStack align="stretch" gap={2}>
+      <InputGroup startElement={<Search size={14} />}>
+        <Input
+          size="sm"
+          placeholder="Search models"
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </InputGroup>
+      <Box
+        maxHeight="240px"
+        overflowY="auto"
+        borderWidth="1px"
+        borderColor="border"
+        borderRadius="md"
+        padding={2}
+      >
+        {filteredGroups.length === 0 ? (
+          <Text fontSize="xs" color="fg.muted" padding={1}>
+            No models match “{search}”.
+          </Text>
+        ) : (
+          filteredGroups.map((group) => (
+            <Box key={group.provider} mb={2}>
+              <Text
+                fontSize="xs"
+                fontWeight="semibold"
+                color="fg.muted"
+                mb={1}
+                paddingX={1}
+              >
+                {titleCase(group.provider)}
+              </Text>
+              <VStack align="stretch" gap={1}>
+                {group.models.map((m) => (
+                  <Checkbox
+                    key={m.value}
+                    size="sm"
+                    checked={selected.has(m.value)}
+                    onCheckedChange={() => toggle(m.value)}
+                  >
+                    <HStack gap={2}>
+                      {m.icon && (
+                        <Box width={MODEL_ICON_SIZE} minWidth={MODEL_ICON_SIZE}>
+                          {m.icon}
+                        </Box>
+                      )}
+                      <Text fontSize="13px" fontFamily="mono">
+                        {m.label}
+                      </Text>
+                    </HStack>
+                  </Checkbox>
+                ))}
+              </VStack>
+            </Box>
+          ))
+        )}
+      </Box>
+    </VStack>
+  );
+}

--- a/langwatch/src/components/ModelSelector.tsx
+++ b/langwatch/src/components/ModelSelector.tsx
@@ -190,6 +190,8 @@ export const ModelSelector = React.memo(function ModelSelector({
   mode,
   showConfigureAction = false,
   forFeatureLabel,
+  open,
+  onOpenChange,
 }: {
   model: string;
   options: string[];
@@ -202,6 +204,10 @@ export const ModelSelector = React.memo(function ModelSelector({
    *  models are available — e.g. "for AI search", "for evaluators".
    *  Optional; the callout falls back to a generic message. */
   forFeatureLabel?: string;
+  /** Controlled open state. Pass with onOpenChange to drive the dropdown
+   *  from outside — e.g. force-close it when the parent collapses. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const { selectOptions, groupedByProvider, isEmpty, isLoading } =
     useModelSelectionOptions(options, model, mode);
@@ -343,6 +349,10 @@ export const ModelSelector = React.memo(function ModelSelector({
           onChange(selectedValue);
         }
       }}
+      {...(open !== undefined ? { open } : {})}
+      {...(onOpenChange
+        ? { onOpenChange: (e) => onOpenChange(e.open) }
+        : {})}
       loopFocus={true}
       highlightedValue={highlightedValue}
       onHighlightChange={(details) => {

--- a/langwatch/src/components/gateway/VirtualKeyEditDrawer.tsx
+++ b/langwatch/src/components/gateway/VirtualKeyEditDrawer.tsx
@@ -18,6 +18,7 @@ import { Drawer } from "~/components/ui/drawer";
 import { toaster } from "~/components/ui/toaster";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { api } from "~/utils/api";
+import { ModelMultiSelect } from "~/components/ModelMultiSelect";
 
 import {
   ConfigureModelProvidersLink,
@@ -39,6 +40,10 @@ type VirtualKeyDetail = {
   scopes: VirtualKeyScopeEntry[];
   routingPolicyId: string | null;
   config: {
+    // null / undefined = no allowlist = every eligible model is allowed.
+    // A non-empty list restricts the VK (and the Langy picker) to exactly
+    // these `provider/model` ids.
+    modelsAllowed?: string[] | null;
     cache?: { mode: "respect" | "force" | "disable"; ttlS: number };
     rateLimits?: {
       rpm: number | null;
@@ -76,6 +81,7 @@ export function VirtualKeyEditDrawer({
   const [tpm, setTpm] = useState<string>("");
   const [rpd, setRpd] = useState<string>("");
   const [tagsCsv, setTagsCsv] = useState<string>("");
+  const [modelsAllowed, setModelsAllowed] = useState<string[]>([]);
 
   useEffect(() => {
     if (!vk) return;
@@ -88,6 +94,7 @@ export function VirtualKeyEditDrawer({
     setRpm(vk.config.rateLimits?.rpm?.toString() ?? "");
     setTpm(vk.config.rateLimits?.tpm?.toString() ?? "");
     setRpd(vk.config.rateLimits?.rpd?.toString() ?? "");
+    setModelsAllowed(vk.config.modelsAllowed ?? []);
   }, [vk]);
 
   const availableTeams = useMemo(
@@ -141,6 +148,9 @@ export function VirtualKeyEditDrawer({
         description: description || null,
         routingPolicyId: routingPolicyId ? routingPolicyId : null,
         config: {
+          // Empty selection ⇒ null (no allowlist = all eligible models),
+          // never [] (which the gateway would read as "allow zero models").
+          modelsAllowed: modelsAllowed.length > 0 ? modelsAllowed : null,
           cache: { mode: cacheMode, ttlS: cacheTtlS },
           rateLimits: {
             rpm: rpm ? Number.parseInt(rpm, 10) : null,
@@ -269,6 +279,33 @@ export function VirtualKeyEditDrawer({
                 providers={(orgProvidersQuery.data?.providers ?? []) as any}
               />
             </Box>
+
+            <Field.Root>
+              <Field.Label>
+                Models {name ? `“${name}” ` : ""}can use
+                <FieldInfoTooltip
+                  description="Restrict this virtual key to specific models. Leave everything unchecked to allow every model the eligible providers can serve. For the Langy assistant this is exactly the set its sidebar model picker offers."
+                  docHref="/ai-gateway/virtual-keys"
+                />
+              </Field.Label>
+              {/* v1 limitation: the palette comes from the CURRENT project's
+                  providers (useModelSelectionOptions). That's correct for the
+                  current project's Langy VK — the common case — but editing a
+                  different project's VK from the org-wide list would show this
+                  project's palette. Per-VK-project sourcing is a follow-up. */}
+              <ModelMultiSelect
+                value={modelsAllowed}
+                onChange={setModelsAllowed}
+                mode="chat"
+              />
+              <Field.HelperText>
+                {modelsAllowed.length === 0
+                  ? "All eligible models allowed. Check models to restrict."
+                  : `${modelsAllowed.length} model${
+                      modelsAllowed.length === 1 ? "" : "s"
+                    } selected.`}
+              </Field.HelperText>
+            </Field.Root>
 
             {((policiesQuery.data ?? []).length > 0 || routingPolicyId) && (
               <Field.Root>

--- a/langwatch/src/components/gateway/langyVk.ts
+++ b/langwatch/src/components/gateway/langyVk.ts
@@ -1,0 +1,17 @@
+/**
+ * Client-side heuristic: is this VK row the auto-provisioned Langy VK?
+ *
+ * Matches the display name + null principal user. Source-of-truth string is
+ * LANGY_VK_DISPLAY_NAME in
+ * src/server/services/langy/LangyCredentialService.ts — kept inlined here
+ * (not imported) so this stays a client-safe module with no server deps.
+ *
+ * Shared by the gateway/virtual-keys page (badge + revoke copy) and the
+ * Langy sidebar (reading the VK's modelsAllowed to scope its picker).
+ */
+export function isLangyManagedVk(vk: {
+  name: string;
+  principalUserId: string | null;
+}): boolean {
+  return vk.name === "Langy" && vk.principalUserId === null;
+}

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -1090,14 +1090,23 @@ function Composer({
           // a descendant?" check would close the dropdown the instant the
           // user opens it. Treat anything inside any `[data-scope="select"]`
           // subtree as still-within-the-picker for blur purposes.
+          //
+          // `relatedTarget` is `EventTarget | null` — narrow with `instanceof`
+          // before calling Node/Element methods, since focus leaving to
+          // browser chrome / another window can yield a non-Element target
+          // that would throw on `.contains()`.
           onBlur={(e) => {
-            const next = e.relatedTarget as HTMLElement | null;
+            const next = e.relatedTarget;
             if (!next) {
               collapsePicker();
               return;
             }
-            if (e.currentTarget.contains(next)) return;
-            if (next.closest?.('[data-scope="select"]')) return;
+            if (next instanceof Node && e.currentTarget.contains(next)) return;
+            if (
+              next instanceof Element &&
+              next.closest('[data-scope="select"]')
+            )
+              return;
             collapsePicker();
           }}
         >

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -41,6 +41,7 @@ import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
 import { api } from "~/utils/api";
 import { ModelSelector, allModelOptions } from "~/components/ModelSelector";
+import { isLangyManagedVk } from "~/components/gateway/langyVk";
 
 // The same feature key Langy's chat route resolves against. Used to seed the
 // composer's model picker with whatever's actually resolving today — opening
@@ -411,8 +412,9 @@ function LangyPanel({
   proposalHandlers?: ProposalHandlers;
   experimentSlug?: string;
 }) {
-  const { project } = useOrganizationTeamProject();
+  const { organization, project } = useOrganizationTeamProject();
   const projectId = project?.id;
+  const organizationId = organization?.id;
 
   const [input, setInput] = useState("");
   // Per-session model override for the next send. Empty string = "use whatever
@@ -443,11 +445,60 @@ function LangyPanel({
     { projectId: projectId ?? "", featureKey: LANGY_GATE_FEATURE_KEY },
     { enabled: !!projectId },
   );
+
+  // The project's Langy VK carries an optional `modelsAllowed` allowlist
+  // (configured in the VK editor). When set, the composer's picker is
+  // narrowed to exactly those models; when null/empty it falls back to all
+  // of the project's provider models. VKs are org-scoped, so we list the
+  // org's keys and pick the auto-managed Langy VK scoped to THIS project.
+  const virtualKeysQuery = api.virtualKeys.list.useQuery(
+    { organizationId: organizationId ?? "" },
+    { enabled: !!organizationId },
+  );
+  const langyModelsAllowed = useMemo<string[] | null>(() => {
+    const langyVk = virtualKeysQuery.data?.find(
+      (vk) =>
+        isLangyManagedVk(vk) &&
+        vk.scopes.some(
+          (s) => s.scopeType === "PROJECT" && s.scopeId === projectId,
+        ),
+    );
+    const allowed = (langyVk?.config as { modelsAllowed?: string[] | null })
+      ?.modelsAllowed;
+    return allowed && allowed.length > 0 ? allowed : null;
+  }, [virtualKeysQuery.data, projectId]);
+
+  // Options the picker offers: the VK allowlist when present, else every
+  // registry model (ModelSelector further narrows that to the project's
+  // enabled providers). "Narrow to VK, fall back to all."
+  const modelOptions = useMemo(
+    () => langyModelsAllowed ?? allModelOptions,
+    [langyModelsAllowed],
+  );
+
+  // Seed the picker with the model the gate resolves to — but keep it inside
+  // the allowlist. If the resolved default isn't allowed, start on the first
+  // allowed model instead.
   useEffect(() => {
     if (modelOverride) return;
     const resolved = resolvedDefaultQuery.data?.model;
-    if (resolved) setModelOverride(resolved);
-  }, [resolvedDefaultQuery.data?.model, modelOverride]);
+    if (resolved && (!langyModelsAllowed || langyModelsAllowed.includes(resolved))) {
+      setModelOverride(resolved);
+    } else if (langyModelsAllowed) {
+      setModelOverride(langyModelsAllowed[0]!);
+    }
+  }, [resolvedDefaultQuery.data?.model, modelOverride, langyModelsAllowed]);
+
+  // Race fix: if the allowlist lands AFTER we seeded an out-of-list model,
+  // snap to the first allowed model. Safe because under an allowlist the
+  // picker only offers allowed models, so an out-of-list value can only be a
+  // stale seed, never a user choice.
+  useEffect(() => {
+    if (!langyModelsAllowed) return;
+    if (modelOverride && !langyModelsAllowed.includes(modelOverride)) {
+      setModelOverride(langyModelsAllowed[0]!);
+    }
+  }, [langyModelsAllowed, modelOverride]);
   const { messages, sendMessage, stop, status, setMessages } = useChat({
     transport,
     onError: (error) => {
@@ -663,6 +714,7 @@ function LangyPanel({
           input={input}
           onInputChange={setInput}
           model={modelOverride}
+          modelOptions={modelOptions}
           onModelChange={setModelOverride}
           onSend={() => void send(input)}
           onStop={() => void stop()}
@@ -950,6 +1002,7 @@ function Composer({
   input,
   onInputChange,
   model,
+  modelOptions,
   onModelChange,
   onSend,
   onStop,
@@ -961,6 +1014,8 @@ function Composer({
   onInputChange: (v: string) => void;
   /** The model Langy will use for the next send. "" = let the server pick. */
   model: string;
+  /** Models the picker may offer (the VK allowlist, or all registry models). */
+  modelOptions: string[];
   onModelChange: (model: string) => void;
   onSend: () => void;
   onStop: () => void;
@@ -989,7 +1044,7 @@ function Composer({
         <Box marginBottom={2} data-testid="langy-model-picker">
           <ModelSelector
             model={model}
-            options={allModelOptions}
+            options={modelOptions}
             onChange={onModelChange}
             mode="chat"
             size="sm"

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -470,9 +470,15 @@ function LangyPanel({
     return allowed && allowed.length > 0 ? allowed : null;
   }, [virtualKeysQuery.data, projectId]);
 
-  // Options the picker offers: the VK allowlist when present, else every
-  // registry model (ModelSelector further narrows that to the project's
-  // enabled providers). "Narrow to VK, fall back to all."
+  // Options the picker offers. Two-stage filter:
+  //   1. langyModelsAllowed (VK allowlist) narrows the universe to admin-
+  //      approved models when set; null = "no explicit allowlist".
+  //   2. ModelSelector internally further narrows by the project's actually-
+  //      enabled providers (getCustomModels → enabled+mode filter), so even
+  //      when the VK is unconstrained the dropdown shows ONLY models the
+  //      project can run today.
+  // The /langy/chat route mirrors the VK-allowlist check server-side so
+  // tampered clients can't pick something that's been disallowed.
   const modelOptions = useMemo(
     () => langyModelsAllowed ?? allModelOptions,
     [langyModelsAllowed],
@@ -1035,8 +1041,11 @@ function Composer({
   // Provider icon for the currently-selected model. Used by the collapsed
   // pill so we render a clean centered logo instead of clipping the full
   // ModelSelector trigger to 30px (which leaves the model name cut in half).
+  // `null` during the cold-start window (model="" before resolvedDefault
+  // lands) — used as a render gate below so we don't flash an empty pill.
   const collapsedProviderIcon = useMemo(() => {
-    const providerKey = (model ?? "").split("/")[0] ?? "";
+    const providerKey = model.split("/")[0] ?? "";
+    if (!providerKey) return null;
     return (
       modelProviderIcons[providerKey as keyof typeof modelProviderIcons] ?? null
     );
@@ -1058,15 +1067,39 @@ function Composer({
         {/* Per-send model picker. Collapsed to a small bubble showing just
             the provider logo; on hover/focus the bubble fluidly expands into
             the full picker. ModelSelector stays mounted — width animation
-            reveals the model label + caret without a remount. */}
+            reveals the model label + caret without a remount.
+
+            Hidden via visibility (not unmounted) until the model resolves
+            so we don't flash an empty 30px circle for the 50-300ms cold
+            window before the resolved-default query lands. Reserving the
+            slot keeps the composer from jumping. */}
         <Flex
           justifyContent="flex-end"
           marginBottom={1.5}
           data-testid="langy-model-picker"
           data-model={model}
+          visibility={collapsedProviderIcon ? "visible" : "hidden"}
+          aria-hidden={!collapsedProviderIcon}
           onMouseEnter={() => setPickerExpanded(true)}
           onMouseLeave={collapsePicker}
           onFocus={() => setPickerExpanded(true)}
+          // Mirror onFocus: collapse when focus moves OUT of the wrapper —
+          // BUT not when focus is moving into the Select's own portaled
+          // popover (search input, option list). Those live as siblings of
+          // <body>, not inside this wrapper, so the naive "is relatedTarget
+          // a descendant?" check would close the dropdown the instant the
+          // user opens it. Treat anything inside any `[data-scope="select"]`
+          // subtree as still-within-the-picker for blur purposes.
+          onBlur={(e) => {
+            const next = e.relatedTarget as HTMLElement | null;
+            if (!next) {
+              collapsePicker();
+              return;
+            }
+            if (e.currentTarget.contains(next)) return;
+            if (next.closest?.('[data-scope="select"]')) return;
+            collapsePicker();
+          }}
         >
           <Box
             position="relative"

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Circle,
+  Flex,
   HStack,
   IconButton,
   Separator,
@@ -25,7 +26,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Kbd } from "~/components/ops/shared/Kbd";
 import { Markdown } from "~/components/Markdown";
 import { toaster } from "~/components/ui/toaster";
@@ -41,6 +42,7 @@ import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
 import { api } from "~/utils/api";
 import { ModelSelector, allModelOptions } from "~/components/ModelSelector";
+import { modelProviderIcons } from "~/server/modelProviders/iconsMap";
 import { isLangyManagedVk } from "~/components/gateway/langyVk";
 
 // The same feature key Langy's chat route resolves against. Used to seed the
@@ -1024,10 +1026,25 @@ function Composer({
   canSend: boolean;
 }) {
   const filled = input.trim().length > 0;
+  const [pickerExpanded, setPickerExpanded] = useState(false);
+  const [pickerDropdownOpen, setPickerDropdownOpen] = useState(false);
   const typewriterPlaceholder = useTypewriterPlaceholder(
     !filled && !isBusy && !disabled,
     COMPOSER_PLACEHOLDER_EXAMPLES,
   );
+  // Provider icon for the currently-selected model. Used by the collapsed
+  // pill so we render a clean centered logo instead of clipping the full
+  // ModelSelector trigger to 30px (which leaves the model name cut in half).
+  const collapsedProviderIcon = useMemo(() => {
+    const providerKey = (model ?? "").split("/")[0] ?? "";
+    return (
+      modelProviderIcons[providerKey as keyof typeof modelProviderIcons] ?? null
+    );
+  }, [model]);
+  const collapsePicker = () => {
+    setPickerExpanded(false);
+    setPickerDropdownOpen(false);
+  };
   return (
     <>
       <Separator />
@@ -1038,18 +1055,73 @@ function Composer({
         background="bg.surface"
         flexShrink={0}
       >
-        {/* Per-send model picker. ChatGPT-style chip above the input pill.
-            Pre-seeded with the project's currently-resolved Langy model;
-            user can switch on a per-send basis. */}
-        <Box marginBottom={2} data-testid="langy-model-picker">
-          <ModelSelector
-            model={model}
-            options={modelOptions}
-            onChange={onModelChange}
-            mode="chat"
-            size="sm"
-          />
-        </Box>
+        {/* Per-send model picker. Collapsed to a small bubble showing just
+            the provider logo; on hover/focus the bubble fluidly expands into
+            the full picker. ModelSelector stays mounted — width animation
+            reveals the model label + caret without a remount. */}
+        <Flex
+          justifyContent="flex-end"
+          marginBottom={1.5}
+          data-testid="langy-model-picker"
+          data-model={model}
+          onMouseEnter={() => setPickerExpanded(true)}
+          onMouseLeave={collapsePicker}
+          onFocus={() => setPickerExpanded(true)}
+        >
+          <Box
+            position="relative"
+            width={pickerExpanded ? "180px" : "30px"}
+            height="28px"
+            borderRadius="full"
+            transition="width 220ms ease-out"
+            transformOrigin="right center"
+            _dark={{ "& svg path": { fill: "white" } }}
+            cursor="pointer"
+          >
+            {/* Collapsed view: just the provider logo, centered, sized to
+                match the icon the expanded ModelSelector renders so the
+                logo doesn't visibly grow/shrink across the transition.
+                Crossfade is short so the swap reads as a reveal, not a
+                morph. */}
+            <Flex
+              position="absolute"
+              inset={0}
+              align="center"
+              justify="center"
+              opacity={pickerExpanded ? 0 : 1}
+              transition="opacity 120ms ease-out"
+              pointerEvents={pickerExpanded ? "none" : "auto"}
+              aria-hidden={pickerExpanded}
+            >
+              <Box width="14px" height="14px" lineHeight={0}>
+                {collapsedProviderIcon}
+              </Box>
+            </Flex>
+            {/* Expanded view: full ModelSelector. Controlled open state so
+                mouse-leave can close the dropdown alongside collapsing the
+                pill — otherwise the popover floats orphaned. */}
+            <Box
+              position="absolute"
+              inset={0}
+              overflow="hidden"
+              borderRadius="full"
+              opacity={pickerExpanded ? 1 : 0}
+              transition="opacity 200ms ease-out"
+              pointerEvents={pickerExpanded ? "auto" : "none"}
+              aria-hidden={!pickerExpanded}
+            >
+              <ModelSelector
+                model={model}
+                options={modelOptions}
+                onChange={onModelChange}
+                mode="chat"
+                size="sm"
+                open={pickerDropdownOpen}
+                onOpenChange={setPickerDropdownOpen}
+              />
+            </Box>
+          </Box>
+        </Flex>
         <HStack
           gap={2}
           paddingY={1.5}
@@ -1107,8 +1179,8 @@ function Composer({
               aria-label="Send"
               onClick={onSend}
               disabled={!canSend}
-              background={canSend ? "transparent" : "#f5f5f4"}
-              color={canSend ? "white" : "var(--chakra-colors-fg-muted)"}
+              background={canSend ? "transparent" : "bg.muted"}
+              color={canSend ? "white" : "fg.muted"}
               shadow={canSend}
               cursor={canSend ? "pointer" : "default"}
               meshOverlay={canSend}

--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -39,6 +39,14 @@ import { useTypewriterPlaceholder } from "~/features/traces-v2/components/ai/use
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useReducedMotion } from "~/hooks/useReducedMotion";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
+import { api } from "~/utils/api";
+import { ModelSelector, allModelOptions } from "~/components/ModelSelector";
+
+// The same feature key Langy's chat route resolves against. Used to seed the
+// composer's model picker with whatever's actually resolving today — opening
+// Langy on a project that already has a configured default model lands on
+// THAT model, not on an unrelated branch-primary pick.
+const LANGY_GATE_FEATURE_KEY = "prompt.create_default";
 import {
   useLangyConversations,
   type LangyConversationSummary,
@@ -407,6 +415,11 @@ function LangyPanel({
   const projectId = project?.id;
 
   const [input, setInput] = useState("");
+  // Per-session model override for the next send. Empty string = "use whatever
+  // the project DEFAULT resolves to" — i.e. don't pass modelOverride. The
+  // composer's picker writes here, and `send()` reads + forwards it as the
+  // body's `modelOverride` field for the chat route to honor.
+  const [modelOverride, setModelOverride] = useState<string>("");
   const [appliedOutcomes, setAppliedOutcomes] = useState<
     Record<string, { href?: string; label?: string; onOpen?: () => void }>
   >({});
@@ -422,6 +435,19 @@ function LangyPanel({
     () => new DefaultChatTransport({ api: "/api/langy/chat" }),
     [],
   );
+
+  // Seed the picker with the model the gate currently resolves to. Once the
+  // user picks something different, we don't overwrite — they're explicitly
+  // choosing per-session. Only seed on first valid response.
+  const resolvedDefaultQuery = api.modelProvider.getResolvedDefault.useQuery(
+    { projectId: projectId ?? "", featureKey: LANGY_GATE_FEATURE_KEY },
+    { enabled: !!projectId },
+  );
+  useEffect(() => {
+    if (modelOverride) return;
+    const resolved = resolvedDefaultQuery.data?.model;
+    if (resolved) setModelOverride(resolved);
+  }, [resolvedDefaultQuery.data?.model, modelOverride]);
   const { messages, sendMessage, stop, status, setMessages } = useChat({
     transport,
     onError: (error) => {
@@ -485,9 +511,18 @@ function LangyPanel({
   const send = async (text: string) => {
     if (!text.trim() || !projectId || isBusy) return;
     setInput("");
+    // modelOverride is empty until the resolved-default query lands OR until
+    // the user picks; in either case the chat route falls back to the project
+    // DEFAULT-role resolution when this field is absent.
     await sendMessage(
       { role: "user", parts: [{ type: "text", text }] },
-      { body: { projectId, experimentSlug } },
+      {
+        body: {
+          projectId,
+          experimentSlug,
+          ...(modelOverride ? { modelOverride } : {}),
+        },
+      },
     );
   };
 
@@ -627,6 +662,8 @@ function LangyPanel({
         <Composer
           input={input}
           onInputChange={setInput}
+          model={modelOverride}
+          onModelChange={setModelOverride}
           onSend={() => void send(input)}
           onStop={() => void stop()}
           isBusy={isBusy}
@@ -912,6 +949,8 @@ function ThinkingIndicator({ messages }: { messages: UIMessage[] }) {
 function Composer({
   input,
   onInputChange,
+  model,
+  onModelChange,
   onSend,
   onStop,
   isBusy,
@@ -920,6 +959,9 @@ function Composer({
 }: {
   input: string;
   onInputChange: (v: string) => void;
+  /** The model Langy will use for the next send. "" = let the server pick. */
+  model: string;
+  onModelChange: (model: string) => void;
   onSend: () => void;
   onStop: () => void;
   isBusy: boolean;
@@ -941,6 +983,18 @@ function Composer({
         background="bg.surface"
         flexShrink={0}
       >
+        {/* Per-send model picker. ChatGPT-style chip above the input pill.
+            Pre-seeded with the project's currently-resolved Langy model;
+            user can switch on a per-send basis. */}
+        <Box marginBottom={2} data-testid="langy-model-picker">
+          <ModelSelector
+            model={model}
+            options={allModelOptions}
+            onChange={onModelChange}
+            mode="chat"
+            size="sm"
+          />
+        </Box>
         <HStack
           gap={2}
           paddingY={1.5}

--- a/langwatch/src/components/langy/__tests__/LangyConversationHistory.integration.test.tsx
+++ b/langwatch/src/components/langy/__tests__/LangyConversationHistory.integration.test.tsx
@@ -87,6 +87,34 @@ vi.mock("@paper-design/shaders-react", () => ({
   MeshGradient: () => null,
 }));
 
+// LangySidebar's per-send model picker pulls three tRPC queries — two from
+// the picker wrapper itself (getResolvedDefault + virtualKeys.list) and one
+// from the nested ModelSelector (listAllForProjectForFrontend). These tests
+// focus on the conversation-history surface, not the picker — boundary-mock
+// all three with idle-but-finished queries so React Query thinks they've
+// settled. Without this the panel throws "Unable to retrieve application
+// context" because no hook is wrapped in a tRPC provider.
+vi.mock("~/utils/api", () => ({
+  api: {
+    modelProvider: {
+      getResolvedDefault: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: { providers: [] },
+          isLoading: false,
+        }),
+      },
+    },
+    virtualKeys: {
+      list: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+  },
+}));
+
 import { LangyDrawer } from "../LangySidebar";
 import { toaster } from "~/components/ui/toaster";
 

--- a/langwatch/src/pages/settings/gateway/virtual-keys.tsx
+++ b/langwatch/src/pages/settings/gateway/virtual-keys.tsx
@@ -36,6 +36,15 @@ import { api } from "~/utils/api";
 
 type ScopeEntry = { scopeType: "ORGANIZATION" | "TEAM" | "PROJECT"; scopeId: string };
 
+// Heuristic: is this row the auto-provisioned Langy VK (project.create →
+// provisionLangyVirtualKey)? Match the display name + null principal user.
+// Source-of-truth string: LANGY_VK_DISPLAY_NAME in
+// src/server/services/langy/LangyCredentialService.ts (kept inlined here to
+// avoid importing server-only modules into the client bundle).
+function isLangyManagedVk(vk: { name: string; principalUserId: string | null }) {
+  return vk.name === "Langy" && vk.principalUserId === null;
+}
+
 type CreatedSecret = {
   id: string;
   name: string;
@@ -273,12 +282,26 @@ function VirtualKeysPage() {
                   >
                     <Table.Cell>
                       <VStack align="start" gap={1}>
-                        <Link
-                          href={`/settings/gateway/virtual-keys/${vk.id}`}
-                          fontWeight="medium"
-                        >
-                          {vk.name}
-                        </Link>
+                        <HStack gap={2} align="center">
+                          <Link
+                            href={`/settings/gateway/virtual-keys/${vk.id}`}
+                            fontWeight="medium"
+                          >
+                            {vk.name}
+                          </Link>
+                          {isLangyManagedVk(vk) && (
+                            <Tooltip content="Auto-provisioned by LangWatch for the Langy in-product assistant. You can edit its model, fallbacks, budget, and rate limits like any other virtual key. Revoking it will break Langy until you create a new one.">
+                              <Badge
+                                variant="subtle"
+                                colorPalette="purple"
+                                fontSize="2xs"
+                                data-testid="langy-vk-badge"
+                              >
+                                auto-managed
+                              </Badge>
+                            </Tooltip>
+                          )}
+                        </HStack>
                         {vk.description && (
                           <Text fontSize="xs" color="fg.muted">
                             {vk.description}
@@ -473,7 +496,15 @@ function VirtualKeysPage() {
           if (!open) setRevoking(null);
         }}
         title={`Revoke ${revoking?.name ?? "virtual key"}?`}
-        message="Clients using this key start receiving 401s within ~60 seconds. This cannot be undone — revoked keys are never reactivated."
+        message={
+          // The Langy VK is technically revocable like any other VK, but
+          // revoking it stops the in-product assistant cold. Lead with the
+          // Langy-specific consequence before the generic 401 warning so
+          // someone clicking through doesn't accidentally break Langy.
+          revoking?.name === "Langy"
+            ? "This is the auto-provisioned Langy virtual key. Revoking it will stop the in-product assistant from working until a new one is provisioned (it'll be re-created automatically on the next chat). Clients using this secret directly start receiving 401s within ~60 seconds. This cannot be undone — revoked keys are never reactivated."
+            : "Clients using this key start receiving 401s within ~60 seconds. This cannot be undone — revoked keys are never reactivated."
+        }
         confirmLabel="Revoke key"
         tone="danger"
         loading={revokeMutation.isPending}

--- a/langwatch/src/pages/settings/gateway/virtual-keys.tsx
+++ b/langwatch/src/pages/settings/gateway/virtual-keys.tsx
@@ -33,17 +33,9 @@ import { Tooltip } from "~/components/ui/tooltip";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { formatTimeAgo } from "~/utils/formatTimeAgo";
 import { api } from "~/utils/api";
+import { isLangyManagedVk } from "~/components/gateway/langyVk";
 
 type ScopeEntry = { scopeType: "ORGANIZATION" | "TEAM" | "PROJECT"; scopeId: string };
-
-// Heuristic: is this row the auto-provisioned Langy VK (project.create →
-// provisionLangyVirtualKey)? Match the display name + null principal user.
-// Source-of-truth string: LANGY_VK_DISPLAY_NAME in
-// src/server/services/langy/LangyCredentialService.ts (kept inlined here to
-// avoid importing server-only modules into the client bundle).
-function isLangyManagedVk(vk: { name: string; principalUserId: string | null }) {
-  return vk.name === "Langy" && vk.principalUserId === null;
-}
 
 type CreatedSecret = {
   id: string;

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -38,6 +38,7 @@ import {
 } from "../rbac";
 import { getUserProtectionsForProject } from "../utils";
 import { provisionLangyApiKey } from "~/server/services/langy/langyApiKey";
+import { provisionLangyVirtualKey } from "~/server/services/langy/LangyCredentialService";
 
 export const projectRouter = createTRPCRouter({
   publicGetById: publicProcedure
@@ -238,6 +239,27 @@ export const projectRouter = createTRPCRouter({
           extra: {
             projectId: project.id,
             context: "provisionLangyApiKey:project.create",
+          },
+        });
+      }
+
+      // Best-effort: mint Langy's gateway virtual key so it shows up in the
+      // user's /virtual-keys list from day 1 (configurable model + fallback
+      // chain + spend tracking like any other VK). Same best-effort contract
+      // as the API key: failure here doesn't block project creation; the
+      // credential service re-attempts on first /chat call.
+      try {
+        await provisionLangyVirtualKey({
+          prisma,
+          projectId: project.id,
+          organizationId: input.organizationId,
+          actorUserId: userId,
+        });
+      } catch (error) {
+        captureException(error, {
+          extra: {
+            projectId: project.id,
+            context: "provisionLangyVirtualKey:project.create",
           },
         });
       }

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -62,11 +62,11 @@ const chatRequestSchema = z.object({
    * (LangySidebar Composer). Optional — when absent, the agent falls back
    * to the project's DEFAULT-role model the gate resolved against.
    *
-   * Wire-level field today: forwarded to the OpenCode agent payload so the
-   * agent can pass it to the gateway as the `model` parameter. Until the
-   * agent honors it, this is effectively a hint (no behavior change, but
-   * the picker choice rides through the system). Validation is provider/-
-   * shape only here; the gateway is the final allowlist.
+   * Forwarded to the OpenCode agent payload so the agent can pass it to the
+   * gateway as the `model` parameter. Validated here in two layers: this
+   * Zod step enforces provider/model shape; the route then checks the value
+   * against the project's Langy VK `modelsAllowed` allowlist so a malicious
+   * or stale client can't pick a model the project hasn't approved.
    */
   modelOverride: z
     .string()
@@ -284,8 +284,8 @@ langyRoute().post("/langy/chat", async (c) => {
   ].join(" ");
 
   let credentials;
+  const credentialService = LangyCredentialService.create(prisma);
   try {
-    const credentialService = LangyCredentialService.create(prisma);
     credentials = await credentialService.getOrProvision({
       projectId,
       actorUserId: session.user.id,
@@ -295,6 +295,37 @@ langyRoute().post("/langy/chat", async (c) => {
       return c.json({ error: error.message }, { status: 409 });
     }
     throw error;
+  }
+
+  // Defense in depth: when a `modelOverride` rides in, enforce the project's
+  // Langy VK allowlist HERE — don't trust the picker UI to gate it. If the VK
+  // has no allowlist (modelsAllowed=null), the gateway is still the final
+  // enforcer; this check only rejects values the project has explicitly NOT
+  // allowed. Resolves the project's org via the conversation we already
+  // ensured above so we don't refetch the project.
+  if (modelOverride) {
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: { team: { select: { organizationId: true } } },
+    });
+    if (project) {
+      const modelsAllowed = await credentialService.getModelsAllowed(
+        projectId,
+        project.team.organizationId,
+      );
+      if (modelsAllowed && !modelsAllowed.includes(modelOverride)) {
+        logger.warn(
+          { projectId, modelOverride, modelsAllowed },
+          "modelOverride not in VK allowlist — rejecting",
+        );
+        return c.json(
+          {
+            error: `Model "${modelOverride}" is not allowed for this project's Langy. Pick from the configured models.`,
+          },
+          { status: 400 },
+        );
+      }
+    }
   }
 
   const agentResponse = await fetch(`${agentUrl}/chat`, {

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -301,30 +301,28 @@ langyRoute().post("/langy/chat", async (c) => {
   // Langy VK allowlist HERE — don't trust the picker UI to gate it. If the VK
   // has no allowlist (modelsAllowed=null), the gateway is still the final
   // enforcer; this check only rejects values the project has explicitly NOT
-  // allowed. Resolves the project's org via the conversation we already
-  // ensured above so we don't refetch the project.
+  // allowed. The org is taken from `credentials` (the resolver already
+  // returned it) so we don't refetch the project — no risk of a TOCTOU race
+  // silently skipping the check between calls.
   if (modelOverride) {
-    const project = await prisma.project.findUnique({
-      where: { id: projectId },
-      select: { team: { select: { organizationId: true } } },
-    });
-    if (project) {
-      const modelsAllowed = await credentialService.getModelsAllowed(
-        projectId,
-        project.team.organizationId,
+    const modelsAllowed = await credentialService.getModelsAllowed(
+      projectId,
+      credentials.organizationId,
+    );
+    if (modelsAllowed && !modelsAllowed.includes(modelOverride)) {
+      // Don't log the full allowlist on every reject — it's the project's
+      // configured-model list and travels further than the user's UI does
+      // (SIEM, support tickets). Log shape + count so we still see drift.
+      logger.warn(
+        { projectId, modelOverride, allowedCount: modelsAllowed.length },
+        "modelOverride not in VK allowlist — rejecting",
       );
-      if (modelsAllowed && !modelsAllowed.includes(modelOverride)) {
-        logger.warn(
-          { projectId, modelOverride, modelsAllowed },
-          "modelOverride not in VK allowlist — rejecting",
-        );
-        return c.json(
-          {
-            error: `Model "${modelOverride}" is not allowed for this project's Langy. Pick from the configured models.`,
-          },
-          { status: 400 },
-        );
-      }
+      return c.json(
+        {
+          error: `Model "${modelOverride}" is not allowed for this project's Langy. Pick from the configured models.`,
+        },
+        { status: 400 },
+      );
     }
   }
 

--- a/langwatch/src/server/routes/langy.ts
+++ b/langwatch/src/server/routes/langy.ts
@@ -57,6 +57,22 @@ const chatRequestSchema = z.object({
   projectId: z.string().min(1),
   conversationId: z.string().nullable().optional(),
   messages: z.array(chatMessageSchema).min(1),
+  /**
+   * Per-send model override coming from the sidebar's ChatGPT-style picker
+   * (LangySidebar Composer). Optional — when absent, the agent falls back
+   * to the project's DEFAULT-role model the gate resolved against.
+   *
+   * Wire-level field today: forwarded to the OpenCode agent payload so the
+   * agent can pass it to the gateway as the `model` parameter. Until the
+   * agent honors it, this is effectively a hint (no behavior change, but
+   * the picker choice rides through the system). Validation is provider/-
+   * shape only here; the gateway is the final allowlist.
+   */
+  modelOverride: z
+    .string()
+    .regex(/^[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+$/, "modelOverride must be in 'provider/model' shape")
+    .max(200)
+    .optional(),
 });
 type ChatMessage = z.infer<typeof chatMessageSchema>;
 
@@ -154,6 +170,7 @@ langyRoute().post("/langy/chat", async (c) => {
     messages,
     projectId,
     conversationId: requestedConversationId,
+    modelOverride,
   } = parsedBody.data;
 
   const agentUrl = process.env.OPENCODE_AGENT_URL;
@@ -291,6 +308,11 @@ langyRoute().post("/langy/chat", async (c) => {
       prompt: userText,
       system: langyOverride,
       credentials,
+      // Forwarded for the agent to thread through to the gateway as the
+      // `model` parameter when its support lands. Today the agent ignores
+      // unrecognized fields, so this is effectively a wire-up that doesn't
+      // change behavior — but the user's picker choice rides through.
+      ...(modelOverride ? { modelOverride } : {}),
     }),
     signal: AbortSignal.timeout(120_000),
   });

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -4,9 +4,18 @@ import { Prisma } from "@prisma/client";
 import { encrypt, decrypt } from "~/utils/encryption";
 import { VirtualKeyService } from "~/server/gateway/virtualKey.service";
 import { provisionLangyApiKey, getLangyApiKeyToken } from "./langyApiKey";
+import { getResolvedDefaultForFeature } from "~/server/modelProviders/modelDefaults.read";
 import { createLogger } from "~/utils/logger/server";
 
 const logger = createLogger("langwatch:langy:credential");
+
+/**
+ * Feature key whose cascade-resolved model we seed onto the Langy VK's
+ * `modelsAllowed` at provision time. Same key the sidebar picker seeds
+ * itself from (LangySidebar's LANGY_GATE_FEATURE_KEY) so the VK and the
+ * composer agree on "the model Langy uses by default".
+ */
+const LANGY_VK_MODEL_FEATURE_KEY = "prompt.create_default";
 
 /**
  * Name under which the auto-provisioned Langy VK secret is stored in
@@ -74,6 +83,24 @@ export async function provisionLangyVirtualKey(args: {
     return null;
   }
 
+  // Seed the VK's model allowlist with whatever the project currently
+  // resolves as its default chat model, so the VK "has a model in it" from
+  // day 1 and the sidebar picker starts narrowed to it. At a fresh
+  // project.create there's usually no provider yet → this resolves to null
+  // and we leave modelsAllowed null (= "all eligible models"). It fires when
+  // an org/team default is inherited, and on the self-heal / backfill paths.
+  // getResolvedDefaultForFeature returns null instead of throwing when
+  // nothing is configured, so a missing default never breaks provisioning.
+  const resolvedDefault = await getResolvedDefaultForFeature(
+    // ReadCtx wants a session, but this resolver only reads ctx.prisma;
+    // provisioning runs without a user session, so null is correct.
+    { prisma, session: null },
+    { projectId, featureKey: LANGY_VK_MODEL_FEATURE_KEY },
+  );
+  const modelsAllowed = resolvedDefault?.model
+    ? [resolvedDefault.model]
+    : null;
+
   // GatewayProviderCredential was removed in iter 110 — VKs route through the
   // project's ModelProviders. The /chat route's model gate handles "no model
   // configured" with a 409 before we get here, so we don't validate here.
@@ -86,6 +113,9 @@ export async function provisionLangyVirtualKey(args: {
     principalUserId: null,
     scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
     actorUserId,
+    // Omit config entirely when nothing resolved so the VK keeps the schema
+    // default (modelsAllowed: null = all). Only set it when we have a seed.
+    ...(modelsAllowed ? { config: { modelsAllowed } } : {}),
   });
 
   try {

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -8,8 +8,90 @@ import { provisionLangyApiKey, getLangyApiKeyToken } from "./langyApiKey";
 /**
  * Name under which the auto-provisioned Langy VK secret is stored in
  * ProjectSecret. One row per project.
+ *
+ * Exported so callers that surface "this is the Langy VK" UI (e.g. the
+ * gateway/virtual-keys page) and the backfill reconciler can detect the
+ * auto-provisioned key without reinventing the name string.
  */
-const LANGY_VK_SECRET_NAME = "langy_vk_secret";
+export const LANGY_VK_SECRET_NAME = "langy_vk_secret";
+
+/**
+ * Display name the VK row carries in the gateway/virtual-keys list. Exported
+ * for UI heuristics ("is this row the auto-managed Langy VK?").
+ */
+export const LANGY_VK_DISPLAY_NAME = "Langy";
+
+/**
+ * Idempotently provision a Langy VirtualKey for a project + persist its
+ * secret to ProjectSecret. Exported so project.create can call it eagerly
+ * (so users see the VK in /virtual-keys from day 1) AND the credential
+ * service can still self-heal on first chat. Returns the VK secret token.
+ *
+ * Safe to call multiple times for the same project — the ProjectSecret
+ * unique constraint on (projectId, name) plus race-loser retry guarantees
+ * one stored secret per project. Orphan VK rows from lost races are
+ * acceptable (#4275 v1; cleanup is an admin concern).
+ */
+export async function provisionLangyVirtualKey(args: {
+  prisma: PrismaClient;
+  projectId: string;
+  organizationId: string;
+  actorUserId: string;
+}): Promise<string> {
+  const { prisma, projectId, organizationId, actorUserId } = args;
+
+  // findFirst (not findUnique-by-projectId_name): the guarded prisma client's
+  // multitenancy middleware doesn't recognize the compound key and throws.
+  const existing = await prisma.projectSecret.findFirst({
+    where: { projectId, name: LANGY_VK_SECRET_NAME },
+    select: { encryptedValue: true },
+  });
+  if (existing) {
+    return decrypt(existing.encryptedValue);
+  }
+
+  // GatewayProviderCredential was removed in iter 110 — VKs route through the
+  // project's ModelProviders. The /chat route's model gate handles "no model
+  // configured" with a 409 before we get here, so we don't validate here.
+  const virtualKeyService = VirtualKeyService.create(prisma);
+  const created = await virtualKeyService.create({
+    organizationId,
+    name: LANGY_VK_DISPLAY_NAME,
+    description:
+      "Auto-provisioned virtual key for the Langy in-product assistant.",
+    principalUserId: null,
+    scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
+    actorUserId,
+  });
+
+  try {
+    await prisma.projectSecret.create({
+      data: {
+        projectId,
+        name: LANGY_VK_SECRET_NAME,
+        encryptedValue: encrypt(created.secret),
+        createdById: actorUserId,
+        updatedById: actorUserId,
+      },
+    });
+    return created.secret;
+  } catch (error) {
+    // Race: another caller (e.g. concurrent /chat + eager project.create)
+    // provisioned + stored first. Our just-created VK is now an orphan but
+    // does no harm. Read the winner's secret and return that.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      const winner = await prisma.projectSecret.findFirst({
+        where: { projectId, name: LANGY_VK_SECRET_NAME },
+        select: { encryptedValue: true },
+      });
+      if (winner) return decrypt(winner.encryptedValue);
+    }
+    throw error;
+  }
+}
 
 /**
  * Thrown when credential resolution can't complete — missing project,
@@ -115,71 +197,16 @@ export class LangyCredentialService {
     };
   }
 
-  private async getOrProvisionVirtualKey({
-    projectId,
-    organizationId,
-    actorUserId,
-  }: {
+  private async getOrProvisionVirtualKey(args: {
     projectId: string;
     organizationId: string;
     actorUserId: string;
   }): Promise<string> {
-    // findFirst with a plain `projectId` (not findUnique-by-`projectId_name`):
-    // the guarded prisma client's multitenancy middleware doesn't recognize the
-    // `projectId_name` compound key and throws. ProjectSecret is unique on
-    // (projectId, name), so this is still a single-row read.
-    const existing = await this.prisma.projectSecret.findFirst({
-      where: { projectId, name: LANGY_VK_SECRET_NAME },
-      select: { encryptedValue: true },
+    // Delegates to the standalone helper so /chat-time self-healing and the
+    // eager project.create path share one implementation.
+    return provisionLangyVirtualKey({
+      prisma: this.prisma,
+      ...args,
     });
-    if (existing) {
-      return decrypt(existing.encryptedValue);
-    }
-
-    // GatewayProviderCredential was removed in iter 110 — virtual keys are now
-    // scoped to a project and route through that project's ModelProviders, so
-    // there's no provider-credential row to look up or bind here. The /chat
-    // route already guards model availability via getVercelAIModel before we
-    // reach provisioning, so a project without a configured model fails there
-    // with a clear 409 rather than here.
-    const created = await this.virtualKeyService.create({
-      organizationId,
-      name: "Langy",
-      description:
-        "Auto-provisioned virtual key for the Langy in-product assistant.",
-      principalUserId: null,
-      scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
-      actorUserId,
-    });
-
-    try {
-      await this.prisma.projectSecret.create({
-        data: {
-          projectId,
-          name: LANGY_VK_SECRET_NAME,
-          encryptedValue: encrypt(created.secret),
-          createdById: actorUserId,
-          updatedById: actorUserId,
-        },
-      });
-      return created.secret;
-    } catch (error) {
-      // Race: another /chat request for the same project provisioned + stored
-      // first. The VK we just created is now an orphan (no ProjectSecret row
-      // points at it), but it does no harm — we read the winner's secret and
-      // return that. The orphan is acceptable for v1; an admin can clean it
-      // up via the gateway UI if it ever matters.
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === "P2002"
-      ) {
-        const winner = await this.prisma.projectSecret.findFirst({
-          where: { projectId, name: LANGY_VK_SECRET_NAME },
-          select: { encryptedValue: true },
-        });
-        if (winner) return decrypt(winner.encryptedValue);
-      }
-      throw error;
-    }
   }
 }

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -271,6 +271,34 @@ export class LangyCredentialService {
     }
     return secret;
   }
+
+  /**
+   * Returns the `modelsAllowed` array on the project's Langy VK. Null means
+   * "no allowlist set" — every eligible model is allowed (the gateway is the
+   * final allowlist in that case). Used by /langy/chat to validate the
+   * picker's per-send `modelOverride` server-side so the gateway isn't the
+   * only line of defense.
+   */
+  async getModelsAllowed(
+    projectId: string,
+    organizationId: string,
+  ): Promise<string[] | null> {
+    const langyVk = (
+      await this.virtualKeyService.getAllForScope({
+        scopeType: "PROJECT",
+        scopeId: projectId,
+      })
+    ).find(
+      (vk) =>
+        vk.name === LANGY_VK_DISPLAY_NAME &&
+        vk.principalUserId === null &&
+        vk.organizationId === organizationId,
+    );
+    if (!langyVk) return null;
+    const cfg = langyVk.config as { modelsAllowed?: string[] | null } | null;
+    const allowed = cfg?.modelsAllowed;
+    return allowed && allowed.length > 0 ? allowed : null;
+  }
 }
 
 async function resolveActorUserId(

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -4,6 +4,9 @@ import { Prisma } from "@prisma/client";
 import { encrypt, decrypt } from "~/utils/encryption";
 import { VirtualKeyService } from "~/server/gateway/virtualKey.service";
 import { provisionLangyApiKey, getLangyApiKeyToken } from "./langyApiKey";
+import { createLogger } from "~/utils/logger/server";
+
+const logger = createLogger("langwatch:langy:credential");
 
 /**
  * Name under which the auto-provisioned Langy VK secret is stored in
@@ -36,9 +39,14 @@ export async function provisionLangyVirtualKey(args: {
   prisma: PrismaClient;
   projectId: string;
   organizationId: string;
-  actorUserId: string;
-}): Promise<string> {
-  const { prisma, projectId, organizationId, actorUserId } = args;
+  /**
+   * The user the VK creation is attributed to. Required at runtime (project
+   * creation / first-chat self-heal). Optional in the backfill path — we
+   * fall back to the org's first admin, same shape as the API key backfill.
+   */
+  actorUserId?: string | null;
+}): Promise<string | null> {
+  const { prisma, projectId, organizationId } = args;
 
   // findFirst (not findUnique-by-projectId_name): the guarded prisma client's
   // multitenancy middleware doesn't recognize the compound key and throws.
@@ -48,6 +56,22 @@ export async function provisionLangyVirtualKey(args: {
   });
   if (existing) {
     return decrypt(existing.encryptedValue);
+  }
+
+  // ProjectSecret + VirtualKey audit fields require a user. When the caller
+  // doesn't have one (backfill), fall back to the org's first admin — same
+  // resolution the API key backfill uses (langyApiKey.ts:resolveCreatorId).
+  const actorUserId = await resolveActorUserId(
+    prisma,
+    organizationId,
+    args.actorUserId ?? null,
+  );
+  if (!actorUserId) {
+    logger.warn(
+      { projectId },
+      "no user to attribute the Langy VK to; skipping — credential service will self-heal on first chat once a user signs in",
+    );
+    return null;
   }
 
   // GatewayProviderCredential was removed in iter 110 — VKs route through the
@@ -203,10 +227,94 @@ export class LangyCredentialService {
     actorUserId: string;
   }): Promise<string> {
     // Delegates to the standalone helper so /chat-time self-healing and the
-    // eager project.create path share one implementation.
-    return provisionLangyVirtualKey({
+    // eager project.create path share one implementation. At chat time we
+    // always have an authenticated user, so the helper's null fallback path
+    // is unreachable here — assert non-null to satisfy the caller's type.
+    const secret = await provisionLangyVirtualKey({
       prisma: this.prisma,
       ...args,
     });
+    if (!secret) {
+      throw new LangyCredentialResolutionError(
+        "Failed to provision Langy virtual key — no actor user could be resolved.",
+      );
+    }
+    return secret;
   }
+}
+
+async function resolveActorUserId(
+  prisma: PrismaClient,
+  organizationId: string,
+  explicit: string | null,
+): Promise<string | null> {
+  if (explicit) return explicit;
+  const admin = await prisma.organizationUser.findFirst({
+    where: { organizationId, role: "ADMIN" },
+    orderBy: { createdAt: "asc" },
+    select: { userId: true },
+  });
+  return admin?.userId ?? null;
+}
+
+/**
+ * Idempotently provision a Langy VK for every application project that
+ * doesn't already have one. Called from `scripts/backfill-langy-virtual-keys.ts`.
+ * Mirrors the shape of `backfillLangyApiKeys` for symmetry.
+ */
+export async function backfillLangyVirtualKeys(
+  prisma: PrismaClient,
+  { dryRun = false }: { dryRun?: boolean } = {},
+): Promise<{ provisioned: number; skipped: number; failed: number }> {
+  // Only real user workspaces — hidden internal_governance routing projects
+  // are not user-facing and must never receive a Langy VK.
+  const projects = await prisma.project.findMany({
+    where: { kind: "application" },
+    select: { id: true, team: { select: { organizationId: true } } },
+  });
+
+  let provisioned = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const project of projects) {
+    const existing = await prisma.projectSecret.findFirst({
+      where: { projectId: project.id, name: LANGY_VK_SECRET_NAME },
+      select: { id: true },
+    });
+    if (existing) {
+      skipped++;
+      continue;
+    }
+    if (dryRun) {
+      provisioned++;
+      continue;
+    }
+    try {
+      const secret = await provisionLangyVirtualKey({
+        prisma,
+        projectId: project.id,
+        organizationId: project.team.organizationId,
+      });
+      if (secret) {
+        provisioned++;
+      } else {
+        // No admin to attribute the VK to — counted as skipped, not failed.
+        // First chat with a real user will heal this.
+        skipped++;
+      }
+    } catch (err) {
+      failed++;
+      logger.error(
+        { err, projectId: project.id },
+        "failed to backfill Langy VK for project",
+      );
+    }
+  }
+
+  logger.info(
+    { provisioned, skipped, failed, dryRun },
+    "Langy VK backfill complete",
+  );
+  return { provisioned, skipped, failed };
 }

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 
 import { encrypt, decrypt } from "~/utils/encryption";
 import { VirtualKeyService } from "~/server/gateway/virtualKey.service";
+import { parseVirtualKeyConfig } from "~/server/gateway/virtualKey.config";
 import { provisionLangyApiKey, getLangyApiKeyToken } from "./langyApiKey";
 import { getResolvedDefaultForFeature } from "~/server/modelProviders/modelDefaults.read";
 import { createLogger } from "~/utils/logger/server";
@@ -169,6 +170,13 @@ export type LangyCredentials = {
   langwatchEndpoint: string;
   /** AI gateway base URL — set as OPENAI_BASE_URL for opencode. */
   gatewayBaseUrl: string;
+  /**
+   * The organization the project belongs to. Returned here so callers that
+   * already resolved credentials don't re-fetch the project to discover its
+   * org (the route's allowlist-check path used to do this and risked a
+   * race where the project disappeared between calls).
+   */
+  organizationId: string;
 };
 
 /**
@@ -248,6 +256,7 @@ export class LangyCredentialService {
       llmVirtualKey,
       langwatchEndpoint,
       gatewayBaseUrl,
+      organizationId: project.team.organizationId,
     };
   }
 
@@ -278,25 +287,31 @@ export class LangyCredentialService {
    * final allowlist in that case). Used by /langy/chat to validate the
    * picker's per-send `modelOverride` server-side so the gateway isn't the
    * only line of defense.
+   *
+   * Tenancy is enforced at the DB layer (organizationId in the WHERE) rather
+   * than via a post-fetch in-memory filter, so a stray scope row pointing to
+   * the right projectId but a wrong-org VK can't reach this code path. The
+   * config blob is parsed through Zod so a corrupted/drifted VK config
+   * surfaces as a parse error instead of silently disabling enforcement.
    */
   async getModelsAllowed(
     projectId: string,
     organizationId: string,
   ): Promise<string[] | null> {
-    const langyVk = (
-      await this.virtualKeyService.getAllForScope({
-        scopeType: "PROJECT",
-        scopeId: projectId,
-      })
-    ).find(
-      (vk) =>
-        vk.name === LANGY_VK_DISPLAY_NAME &&
-        vk.principalUserId === null &&
-        vk.organizationId === organizationId,
-    );
+    const langyVk = await this.prisma.virtualKey.findFirst({
+      where: {
+        organizationId,
+        name: LANGY_VK_DISPLAY_NAME,
+        principalUserId: null,
+        scopes: {
+          some: { scopeType: "PROJECT", scopeId: projectId },
+        },
+      },
+      select: { config: true },
+    });
     if (!langyVk) return null;
-    const cfg = langyVk.config as { modelsAllowed?: string[] | null } | null;
-    const allowed = cfg?.modelsAllowed;
+    const parsed = parseVirtualKeyConfig(langyVk.config);
+    const allowed = parsed.modelsAllowed;
     return allowed && allowed.length > 0 ? allowed : null;
   }
 }

--- a/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -172,4 +172,116 @@ describe("LangyCredentialService", () => {
       });
     });
   });
+
+  // Server-side allowlist read used by /langy/chat to reject tampered
+  // `modelOverride` values before they reach the OpenCode pod. The picker
+  // UI also narrows by this list — the server check is defense in depth.
+  describe("getModelsAllowed", () => {
+    function makeVkWithScopeQuery(vks: Array<unknown>) {
+      return {
+        getAllForScope: vi.fn().mockResolvedValue(vks),
+      } as any;
+    }
+
+    describe("when the Langy VK has a modelsAllowed array configured", () => {
+      it("returns the array", async () => {
+        const prisma = makePrisma();
+        const vk = makeVkWithScopeQuery([
+          {
+            name: "Langy",
+            principalUserId: null,
+            organizationId: "org-1",
+            config: { modelsAllowed: ["anthropic/claude-opus-4-7"] },
+          },
+        ]);
+        const svc = new LangyCredentialService(prisma, vk);
+
+        const result = await svc.getModelsAllowed("p1", "org-1");
+
+        expect(result).toEqual(["anthropic/claude-opus-4-7"]);
+        expect(vk.getAllForScope).toHaveBeenCalledWith({
+          scopeType: "PROJECT",
+          scopeId: "p1",
+        });
+      });
+    });
+
+    describe("when the Langy VK has modelsAllowed=null", () => {
+      it("returns null — caller treats as 'no allowlist, gateway enforces'", async () => {
+        const prisma = makePrisma();
+        const vk = makeVkWithScopeQuery([
+          {
+            name: "Langy",
+            principalUserId: null,
+            organizationId: "org-1",
+            config: { modelsAllowed: null },
+          },
+        ]);
+        const svc = new LangyCredentialService(prisma, vk);
+
+        expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
+      });
+    });
+
+    describe("when the Langy VK has modelsAllowed=[] (empty)", () => {
+      it("returns null — empty arrays are equivalent to 'unset' for this check", async () => {
+        const prisma = makePrisma();
+        const vk = makeVkWithScopeQuery([
+          {
+            name: "Langy",
+            principalUserId: null,
+            organizationId: "org-1",
+            config: { modelsAllowed: [] },
+          },
+        ]);
+        const svc = new LangyCredentialService(prisma, vk);
+
+        expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
+      });
+    });
+
+    describe("when no Langy VK exists for the project", () => {
+      it("returns null", async () => {
+        const prisma = makePrisma();
+        const vk = makeVkWithScopeQuery([]);
+        const svc = new LangyCredentialService(prisma, vk);
+
+        expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
+      });
+    });
+
+    describe("when another VK in scope is named 'Langy' but has a principalUserId", () => {
+      it("ignores it — only the auto-managed (principalUserId=null) Langy VK counts", async () => {
+        const prisma = makePrisma();
+        const vk = makeVkWithScopeQuery([
+          {
+            name: "Langy",
+            principalUserId: "u-impersonator",
+            organizationId: "org-1",
+            config: { modelsAllowed: ["evil/model"] },
+          },
+        ]);
+        const svc = new LangyCredentialService(prisma, vk);
+
+        expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
+      });
+    });
+
+    describe("when a Langy VK belongs to a different organization", () => {
+      it("ignores it — cross-org leakage guard", async () => {
+        const prisma = makePrisma();
+        const vk = makeVkWithScopeQuery([
+          {
+            name: "Langy",
+            principalUserId: null,
+            organizationId: "org-OTHER",
+            config: { modelsAllowed: ["anthropic/claude-opus-4-7"] },
+          },
+        ]);
+        const svc = new LangyCredentialService(prisma, vk);
+
+        expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
+      });
+    });
+  });
 });

--- a/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -176,48 +176,51 @@ describe("LangyCredentialService", () => {
   // Server-side allowlist read used by /langy/chat to reject tampered
   // `modelOverride` values before they reach the OpenCode pod. The picker
   // UI also narrows by this list — the server check is defense in depth.
+  // The query happens at the DB layer (organizationId + name +
+  // principalUserId + project-scope are all in the Prisma WHERE), so the
+  // tests assert both: (a) the right WHERE was issued, and (b) the config
+  // value is returned through Zod parsing.
   describe("getModelsAllowed", () => {
-    function makeVkWithScopeQuery(vks: Array<unknown>) {
+    function makePrismaWithVk(vk: unknown) {
       return {
-        getAllForScope: vi.fn().mockResolvedValue(vks),
+        ...makePrisma(),
+        virtualKey: {
+          findFirst: vi.fn().mockResolvedValue(vk),
+        },
       } as any;
     }
 
     describe("when the Langy VK has a modelsAllowed array configured", () => {
-      it("returns the array", async () => {
-        const prisma = makePrisma();
-        const vk = makeVkWithScopeQuery([
-          {
-            name: "Langy",
-            principalUserId: null,
-            organizationId: "org-1",
-            config: { modelsAllowed: ["anthropic/claude-opus-4-7"] },
-          },
-        ]);
-        const svc = new LangyCredentialService(prisma, vk);
+      it("returns the array and queries with the full tenancy WHERE", async () => {
+        const prisma = makePrismaWithVk({
+          config: { modelsAllowed: ["anthropic/claude-opus-4-7"] },
+        });
+        const svc = new LangyCredentialService(prisma, makeVkService());
 
         const result = await svc.getModelsAllowed("p1", "org-1");
 
         expect(result).toEqual(["anthropic/claude-opus-4-7"]);
-        expect(vk.getAllForScope).toHaveBeenCalledWith({
-          scopeType: "PROJECT",
-          scopeId: "p1",
+        // Tenancy (org), identity (name + null principal), and reachability
+        // (scope row) all enforced at the DB layer — not by a post-fetch
+        // in-memory filter. Drift in any of these is a load-bearing bug.
+        expect(prisma.virtualKey.findFirst).toHaveBeenCalledWith({
+          where: {
+            organizationId: "org-1",
+            name: "Langy",
+            principalUserId: null,
+            scopes: {
+              some: { scopeType: "PROJECT", scopeId: "p1" },
+            },
+          },
+          select: { config: true },
         });
       });
     });
 
     describe("when the Langy VK has modelsAllowed=null", () => {
       it("returns null — caller treats as 'no allowlist, gateway enforces'", async () => {
-        const prisma = makePrisma();
-        const vk = makeVkWithScopeQuery([
-          {
-            name: "Langy",
-            principalUserId: null,
-            organizationId: "org-1",
-            config: { modelsAllowed: null },
-          },
-        ]);
-        const svc = new LangyCredentialService(prisma, vk);
+        const prisma = makePrismaWithVk({ config: { modelsAllowed: null } });
+        const svc = new LangyCredentialService(prisma, makeVkService());
 
         expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
       });
@@ -225,62 +228,37 @@ describe("LangyCredentialService", () => {
 
     describe("when the Langy VK has modelsAllowed=[] (empty)", () => {
       it("returns null — empty arrays are equivalent to 'unset' for this check", async () => {
-        const prisma = makePrisma();
-        const vk = makeVkWithScopeQuery([
-          {
-            name: "Langy",
-            principalUserId: null,
-            organizationId: "org-1",
-            config: { modelsAllowed: [] },
-          },
-        ]);
-        const svc = new LangyCredentialService(prisma, vk);
+        const prisma = makePrismaWithVk({ config: { modelsAllowed: [] } });
+        const svc = new LangyCredentialService(prisma, makeVkService());
 
         expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
       });
     });
 
-    describe("when no Langy VK exists for the project", () => {
-      it("returns null", async () => {
-        const prisma = makePrisma();
-        const vk = makeVkWithScopeQuery([]);
-        const svc = new LangyCredentialService(prisma, vk);
+    describe("when the tenancy WHERE excludes the VK (wrong org, principalUserId, or no scope)", () => {
+      it("returns null because findFirst itself returns null", async () => {
+        // Standing in for: cross-org leakage, impersonator-named-Langy, or
+        // a VK that's never been project-scoped. All three states collapse
+        // to "findFirst returns null" because the WHERE filters them out.
+        const prisma = makePrismaWithVk(null);
+        const svc = new LangyCredentialService(prisma, makeVkService());
 
         expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
       });
     });
 
-    describe("when another VK in scope is named 'Langy' but has a principalUserId", () => {
-      it("ignores it — only the auto-managed (principalUserId=null) Langy VK counts", async () => {
-        const prisma = makePrisma();
-        const vk = makeVkWithScopeQuery([
-          {
-            name: "Langy",
-            principalUserId: "u-impersonator",
-            organizationId: "org-1",
-            config: { modelsAllowed: ["evil/model"] },
-          },
-        ]);
-        const svc = new LangyCredentialService(prisma, vk);
+    describe("when the VK config is malformed JSON", () => {
+      it("throws (via parseVirtualKeyConfig) — silent-disable on drift would defeat the check", async () => {
+        const prisma = makePrismaWithVk({
+          config: { modelsAllowed: "not-an-array" as unknown as string[] },
+        });
+        const svc = new LangyCredentialService(prisma, makeVkService());
 
-        expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
-      });
-    });
-
-    describe("when a Langy VK belongs to a different organization", () => {
-      it("ignores it — cross-org leakage guard", async () => {
-        const prisma = makePrisma();
-        const vk = makeVkWithScopeQuery([
-          {
-            name: "Langy",
-            principalUserId: null,
-            organizationId: "org-OTHER",
-            config: { modelsAllowed: ["anthropic/claude-opus-4-7"] },
-          },
-        ]);
-        const svc = new LangyCredentialService(prisma, vk);
-
-        expect(await svc.getModelsAllowed("p1", "org-1")).toBeNull();
+        // We don't care what the error type is — only that it's not "null"
+        // (the silent-disable footgun the Zod parse is here to prevent).
+        await expect(
+          svc.getModelsAllowed("p1", "org-1"),
+        ).rejects.toThrow();
       });
     });
   });


### PR DESCRIPTION
Closes langwatch/langwatch#4275.

## What

Langy's gateway VirtualKey is now a **real, user-managed VirtualKey** — visible in `/settings/gateway/virtual-keys` from day 1, editable like any other VK (model, fallbacks, budget, rate limits, guardrails), and surfaced inline in the Langy sidebar with a ChatGPT-style per-send model picker.

Replaces the modal-driven setup path from langwatch/tasks#66 / PR langwatch/langwatch#4543: instead of a recovery surface that opens when Langy is broken, the same controls live as a normal entry in the user's key dashboard. Aligns Langy's UX with the rest of the gateway.

## Architecture shift

```
BEFORE                                      AFTER
──────                                      ─────
Langy VK auto-provisioned LAZILY            Langy VK auto-provisioned EAGERLY
  on first /chat call                         in project.create
Stored hidden in ProjectSecret              Stored in VirtualKey table (visible)
No user-facing surface for model            ChatGPT-style picker in sidebar bottom
  picking outside the rescue modal            seeded from getResolvedDefault
"Set up Langy" modal as the recovery        Rescue modal still exists from
  path (PR langwatch/langwatch#4543)                             PR langwatch/langwatch#4543 — but rarely needed now
                                              because the VK is always there
```

## Commits

1. **`feat(langy): eagerly provision Langy VK at project creation`** — extracts `provisionLangyVirtualKey()` from `LangyCredentialService` into a standalone function; calls it from `project.create` right after `provisionLangyApiKey` (same best-effort pattern).
2. **`feat(langy): badge + Langy-aware revoke confirm on /virtual-keys`** — purple `auto-managed` badge next to the Langy VK row; Langy-specific message on the revoke confirm dialog.
3. **`feat(langy): backfill Langy VK for projects that pre-date eager provision`** — symmetric with `backfill-langy-api-keys.ts`. `--dry-run` supported. Idempotent.
4. **`feat(langy): ChatGPT-style model picker above the composer`** — compact `<ModelSelector>` above the input pill in `LangySidebar`. Pre-seeded from `getResolvedDefault`. User's per-send pick rides along as `modelOverride` in the chat body.
5. **`feat(langy): accept modelOverride on /langy/chat, forward to agent`** — schema accepts an optional `modelOverride` (`provider/model` shape). Forwarded to the OpenCode agent payload. The agent currently ignores unknown fields so this is a wire-up commit; the picker choice rides through the system without behaviour change yet (full honoring needs agent support + the routing-policy follow-up).

## What's NOT in this PR (intentional)

- **Routing-policy-driven fallback chain on the Langy VK** — `RoutingPolicy.modelProviderIds` work was deemed bigger than v1 needs. Filed as a follow-up; until then the sidebar picker shows all chat models the project's providers support, which is wider than "the Langy VK's chain" but functionally equivalent.
- **Agent-side honoring of `modelOverride`** — needs an OpenCode agent change. The chat route forwards the field today; the agent will read it when its support lands.
- **The setup modal from PR langwatch/langwatch#4543** — stays as a rescue surface (for the rare case where Langy has no resolved model at all, e.g. a project where all providers got disabled). Not removed.

## Tests

⚠️ **QA yet to be done** — see follow-up comment.

Existing tests on `langy/per-session-manager` continue to pass.

## Related

- Parent epic: langwatch/tasks#103
- Master index: langwatch/langwatch#4534
- The modal this PR partially supersedes: langwatch/tasks#66 (closed by langwatch/langwatch#4543)
- Cursor-driven guided tour: langwatch/tasks#72

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model picker for individual messages in Langy chat, enabling per-send model selection
  * Model allowlist editing for virtual keys with confirmation of selected model count

* **Improvements**
  * Projects now automatically receive a managed virtual key on creation
  * Virtual key management page identifies auto-managed keys with descriptive badges and tooltips

<!-- end of auto-generated comment: release notes by coderabbit.ai -->