### PR TITLE
fix(traces-v2): trace drawer drive-through — scroll, span selection, scope, prefetch

### DIFF
--- a/langwatch/src/features/presence/components/PeerCursorOverlay.tsx
+++ b/langwatch/src/features/presence/components/PeerCursorOverlay.tsx
@@ -53,7 +53,21 @@ export function PeerCursorOverlay({
   });
 
   return (
-    <Box ref={internalRef} position="relative" width="100%" height="100%">
+    // `minHeight={0}` (and `minWidth={0}`) is load-bearing in flex
+    // contexts: without it, the implicit `min-height: auto` clamps
+    // this Box to its content's natural size and prevents the
+    // `height: 100%` from shrinking to fit a flex column parent. In
+    // the trace drawer that bug surfaced as a non-scrollable Summary
+    // tab — the overlay grew past `Drawer.Body`'s clipped bounds and
+    // hid content past the fold.
+    <Box
+      ref={internalRef}
+      position="relative"
+      width="100%"
+      height="100%"
+      minHeight={0}
+      minWidth={0}
+    >
       {children}
       {effectivelyEnabled && anchor && projectId
         ? cursors.map((cursor) => (

--- a/langwatch/src/features/presence/components/PeerCursorOverlay.tsx
+++ b/langwatch/src/features/presence/components/PeerCursorOverlay.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from "@chakra-ui/react";
 import { memo, useRef } from "react";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useCursorBroadcast } from "../hooks/useCursorBroadcast";
-import { usePeerCursors, type PeerCursor } from "../hooks/usePeerCursors";
+import { type PeerCursor, usePeerCursors } from "../hooks/usePeerCursors";
 import { usePresenceFeatureEnabled } from "../hooks/usePresenceFeatureEnabled";
 import {
   presenceUserColor,
@@ -37,7 +37,8 @@ export function PeerCursorOverlay({
   const { enabled: featureEnabled } = usePresenceFeatureEnabled();
   const effectivelyEnabled = enabled && featureEnabled;
   const internalRef = useRef<HTMLDivElement | null>(null);
-  const ref = (containerRef ?? internalRef) as React.RefObject<HTMLDivElement | null>;
+  const ref = (containerRef ??
+    internalRef) as React.RefObject<HTMLDivElement | null>;
 
   useCursorBroadcast({
     projectId,
@@ -131,4 +132,3 @@ function CursorArrow({ color }: { color: string }) {
     </svg>
   );
 }
-

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
@@ -238,9 +238,18 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
                   enabled
                   containerRef={paneContainerRef}
                 >
+                {/*
+                  `height="100%"` (not `flex={1}`) because PeerCursorOverlay
+                  wraps its children in a `position: relative` Box that
+                  isn't a flex container, so `flex: 1` is inert here — the
+                  Flex would collapse to content height, which broke the
+                  Summary tab's scroll (content overflowed the clipped
+                  drawer body) and the Trace tab's PanelGroup (percentages
+                  resolved against 0px → rendered empty).
+                */}
                 <Flex
                   ref={paneContainerRef}
-                  flex={1}
+                  height="100%"
                   minHeight={0}
                   minWidth={0}
                   direction="column"

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/TraceDrawerShell.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { useColorMode } from "~/components/ui/color-mode";
 import { Drawer } from "~/components/ui/drawer";
 import { IsolatedErrorBoundary } from "~/components/ui/IsolatedErrorBoundary";
+import { PeerCursorOverlay } from "~/features/presence/components/PeerCursorOverlay";
 import {
   DRAWER_DEFAULT_WIDTH_PX,
   DRAWER_MIN_WIDTH_PX,
@@ -12,14 +13,13 @@ import { ConversationView } from "./conversationView";
 import { DrawerHeader } from "./drawerHeader";
 import { KeyboardShortcutsHelp } from "./KeyboardShortcutsHelp";
 import { useShikiAdapter } from "./markdownView/shikiAdapter";
-import { PeerCursorOverlay } from "~/features/presence/components/PeerCursorOverlay";
 import { PaneLayout } from "./panes/PaneLayout";
 import { ResizeRail } from "./panes/ResizeRail";
 import { usePaneLayout } from "./panes/usePaneLayout";
 import { ScenarioRoleProvider } from "./scenarioRoles";
-import { TraceAccordions } from "./traceAccordions";
 import { TraceDrawerEmptyState } from "./TraceDrawerEmptyState";
 import { TraceDrawerSkeleton } from "./TraceDrawerSkeleton";
+import { TraceAccordions } from "./traceAccordions";
 import { useTraceDrawerScaffold } from "./useTraceDrawerScaffold";
 
 export interface TraceV2DrawerShellProps {
@@ -238,7 +238,7 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
                   enabled
                   containerRef={paneContainerRef}
                 >
-                {/*
+                  {/*
                   `height="100%"` (not `flex={1}`) because PeerCursorOverlay
                   wraps its children in a `position: relative` Box that
                   isn't a flex container, so `flex: 1` is inert here — the
@@ -247,68 +247,68 @@ export function TraceV2DrawerShell(_props: TraceV2DrawerShellProps) {
                   drawer body) and the Trace tab's PanelGroup (percentages
                   resolved against 0px → rendered empty).
                 */}
-                <Flex
-                  ref={paneContainerRef}
-                  height="100%"
-                  minHeight={0}
-                  minWidth={0}
-                  direction="column"
-                  bg={{ base: "bg.surface", _dark: "bg.panel" }}
-                  opacity={headerQuery.isFetching ? 0.55 : 1}
-                  transition="opacity 120ms ease-out"
-                >
-                  <ScenarioRoleProvider
-                    isScenario={
-                      !!(
-                        trace.scenarioRunId ??
-                        trace.attributes["scenario.run_id"]
-                      )
-                    }
+                  <Flex
+                    ref={paneContainerRef}
+                    height="100%"
+                    minHeight={0}
+                    minWidth={0}
+                    direction="column"
+                    bg={{ base: "bg.surface", _dark: "bg.panel" }}
+                    opacity={headerQuery.isFetching ? 0.55 : 1}
+                    transition="opacity 120ms ease-out"
                   >
-                    {viewMode === "conversation" && trace.conversationId ? (
-                      <IsolatedErrorBoundary
-                        scope="Couldn't render conversation view"
-                        resetKeys={[trace.conversationId, trace.traceId]}
-                      >
-                        <Box flex={1} minHeight={0} overflow="auto">
-                          <ConversationView
-                            conversationId={trace.conversationId}
-                            currentTraceId={trace.traceId}
-                          />
-                        </Box>
-                      </IsolatedErrorBoundary>
-                    ) : viewMode === "summary" ? (
-                      // Summary mode: render the trace-scope accordion stack
-                      // full-bleed (I/O, metadata, evals, events, exceptions
-                      // — whatever the current `TraceSummaryAccordions`
-                      // composes for `activeTab="summary"`). Reuses the
-                      // existing TraceAccordions surface so all the focus
-                      // behaviour (header-chip jumps, exception pulses) keeps
-                      // working without a parallel implementation.
-                      <IsolatedErrorBoundary
-                        scope="Couldn't render trace summary"
-                        resetKeys={[trace.traceId]}
-                      >
-                        <Box flex={1} minHeight={0} overflow="auto">
-                          <TraceAccordions
-                            trace={trace}
-                            spans={spanTree}
-                            selectedSpan={null}
-                            activeTab="summary"
-                          />
-                        </Box>
-                      </IsolatedErrorBoundary>
-                    ) : (
-                      <PaneLayout
-                        trace={trace}
-                        spans={spanTree}
-                        selectedSpan={selectedSpan}
-                        spansLoading={spanTreeQuery.isLoading}
-                        layout={layout}
-                      />
-                    )}
-                  </ScenarioRoleProvider>
-                </Flex>
+                    <ScenarioRoleProvider
+                      isScenario={
+                        !!(
+                          trace.scenarioRunId ??
+                          trace.attributes["scenario.run_id"]
+                        )
+                      }
+                    >
+                      {viewMode === "conversation" && trace.conversationId ? (
+                        <IsolatedErrorBoundary
+                          scope="Couldn't render conversation view"
+                          resetKeys={[trace.conversationId, trace.traceId]}
+                        >
+                          <Box flex={1} minHeight={0} overflow="auto">
+                            <ConversationView
+                              conversationId={trace.conversationId}
+                              currentTraceId={trace.traceId}
+                            />
+                          </Box>
+                        </IsolatedErrorBoundary>
+                      ) : viewMode === "summary" ? (
+                        // Summary mode: render the trace-scope accordion stack
+                        // full-bleed (I/O, metadata, evals, events, exceptions
+                        // — whatever the current `TraceSummaryAccordions`
+                        // composes for `activeTab="summary"`). Reuses the
+                        // existing TraceAccordions surface so all the focus
+                        // behaviour (header-chip jumps, exception pulses) keeps
+                        // working without a parallel implementation.
+                        <IsolatedErrorBoundary
+                          scope="Couldn't render trace summary"
+                          resetKeys={[trace.traceId]}
+                        >
+                          <Box flex={1} minHeight={0} overflow="auto">
+                            <TraceAccordions
+                              trace={trace}
+                              spans={spanTree}
+                              selectedSpan={null}
+                              activeTab="summary"
+                            />
+                          </Box>
+                        </IsolatedErrorBoundary>
+                      ) : (
+                        <PaneLayout
+                          trace={trace}
+                          spans={spanTree}
+                          selectedSpan={selectedSpan}
+                          spansLoading={spanTreeQuery.isLoading}
+                          layout={layout}
+                        />
+                      )}
+                    </ScenarioRoleProvider>
+                  </Flex>
                 </PeerCursorOverlay>
               </>
             )}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/panes/SpanDetailPane.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/panes/SpanDetailPane.tsx
@@ -6,8 +6,6 @@ import type {
 } from "~/server/api/routers/tracesV2.schemas";
 import { IsolatedErrorBoundary } from "~/components/ui/IsolatedErrorBoundary";
 import { useDrawerStore } from "../../../stores/drawerStore";
-import { useTraceResources } from "../../../hooks/useTraceResources";
-import { ScopeChip } from "../ScopeChip";
 import { SpanTabBar } from "../SpanTabBar";
 import { TraceAccordions } from "../traceAccordions";
 
@@ -53,7 +51,6 @@ export const SpanDetailPane = memo(function SpanDetailPane({
   const selectedSpanId = useDrawerStore((s) => s.selectedSpanId);
   const selectSpan = useDrawerStore((s) => s.selectSpan);
   const collapsed = useDrawerStore((s) => s.paneState.spanDetail.collapsed);
-  const resources = useTraceResources(trace.traceId);
 
   return (
     <Box
@@ -84,7 +81,6 @@ export const SpanDetailPane = memo(function SpanDetailPane({
         >
           <SpanTabBar
             spanTree={spans}
-            rightSlot={<ScopeChip scope={resources.scope} />}
             collapsePosition={layout === "horizontal" ? "leading" : "trailing"}
           />
         </IsolatedErrorBoundary>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/panes/SpanDetailPane.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/panes/SpanDetailPane.tsx
@@ -1,10 +1,10 @@
 import { Box } from "@chakra-ui/react";
 import { memo } from "react";
+import { IsolatedErrorBoundary } from "~/components/ui/IsolatedErrorBoundary";
 import type {
   SpanTreeNode,
   TraceHeader,
 } from "~/server/api/routers/tracesV2.schemas";
-import { IsolatedErrorBoundary } from "~/components/ui/IsolatedErrorBoundary";
 import { useDrawerStore } from "../../../stores/drawerStore";
 import { SpanTabBar } from "../SpanTabBar";
 import { TraceAccordions } from "../traceAccordions";
@@ -114,4 +114,3 @@ export const SpanDetailPane = memo(function SpanDetailPane({
     </Box>
   );
 });
-

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -19,8 +19,8 @@ import { ScopeBlock } from "../ScopeChip";
 import { AccordionShell, Section } from "./AccordionShell";
 import { EmptyEventsState, EmptyHint } from "./EmptyStates";
 import { EventCard } from "./EventCard";
-import { useAutoOpenSections } from "./sectionPresence";
 import { SectionFocusGlow } from "./SectionFocusGlow";
+import { useAutoOpenSections } from "./sectionPresence";
 import { useSectionFocusGlow } from "./useSectionFocusGlow";
 import { countFlatLeaves } from "./utils";
 

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -60,10 +60,16 @@ export function SpanAccordions({
     if (hasError && hasIO) list.push("exceptions");
     if (hasPrompt) list.push("prompt");
     list.push("attributes");
-    // Scope chip lives in the span header — no dedicated section needed.
+    // Instrumentation scope used to be a chip pinned to the right of
+    // the SpanTabBar. Operator feedback: it took up tab-row real estate
+    // for a piece of metadata most users glance at once and ignore.
+    // Folded back into the accordion stack here — collapsed by default
+    // unless the span actually reports a scope, so it's quiet when
+    // empty and reachable when needed.
+    if (hasScope) list.push("scope");
     list.push("events");
     return list;
-  }, [hasError, hasIO, hasPrompt]);
+  }, [hasError, hasIO, hasPrompt, hasScope]);
 
   // Same rule as the trace summary view: only auto-expand Attributes when
   // the span itself has attributes — resource-only is rarely interesting
@@ -110,13 +116,6 @@ export function SpanAccordions({
           </Text>
         </HStack>
       )}
-      {/*
-        The instrumentation-scope chip lives in the SpanTabBar's
-        rightSlot now — rendering it here too duplicated it directly
-        below the tab row, which read as visual noise on every span
-        detail. The tab-bar chip already covers the same trace-level
-        attribution; nothing else to add here.
-      */}
       {glow ? (
         <SectionFocusGlow
           key={glow.nonce}

--- a/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
+++ b/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
@@ -192,6 +192,35 @@ export function useOpenTraceDrawer() {
           }
         }
       }
+      // Kick off the heavier per-trace fetches in parallel with the
+      // route change so the waterfall + header render against real data
+      // by the time the drawer has finished mounting — operator feedback
+      // was that the trace tab sat on the loading skeleton for ~half a
+      // second even though we already had the row data. Prefetch is a
+      // no-op when the query is already cached, and tRPC dedupes the
+      // matching React Query subscription that the drawer mounts.
+      if (
+        project?.id &&
+        !isPreviewTraceId(trace.traceId)
+      ) {
+        const projectId = project.id;
+        void utils.tracesV2.spanTree.prefetch(
+          { projectId, traceId: trace.traceId, occurredAtMs: trace.timestamp },
+          { staleTime: 300_000 },
+        );
+        void utils.tracesV2.spanLangwatchSignals.prefetch(
+          { projectId, traceId: trace.traceId, occurredAtMs: trace.timestamp },
+          { staleTime: 300_000 },
+        );
+        void utils.tracesV2.traceEvents.prefetch(
+          { projectId, traceId: trace.traceId, occurredAtMs: trace.timestamp },
+          { staleTime: 300_000 },
+        );
+        void utils.tracesV2.resourceInfo.prefetch(
+          { projectId, traceId: trace.traceId },
+          { staleTime: 300_000 },
+        );
+      }
       // Push into the store before route change so drawer hooks render
       // with the right traceId/occurredAtMs on the very next frame.
       useDrawerStore.getState().openTrace(trace.traceId, trace.timestamp);

--- a/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
+++ b/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
@@ -200,27 +200,16 @@ export function useOpenTraceDrawer() {
       // no-op when the query is already cached, and tRPC dedupes the
       // matching React Query subscription that the drawer mounts.
       if (project?.id && !isPreviewTraceId(trace.traceId)) {
-        const projectId = project.id;
-        void utils.tracesV2.spanTree.prefetch(
-          { projectId, traceId: trace.traceId, occurredAtMs: trace.timestamp },
-          { staleTime: 300_000 },
-        );
-        void utils.tracesV2.spanLangwatchSignals.prefetch(
-          { projectId, traceId: trace.traceId, occurredAtMs: trace.timestamp },
-          { staleTime: 300_000 },
-        );
-        void utils.tracesV2.traceEvents.prefetch(
-          { projectId, traceId: trace.traceId, occurredAtMs: trace.timestamp },
-          { staleTime: 300_000 },
-        );
-        void utils.tracesV2.resourceInfo.prefetch(
-          {
-            projectId,
-            traceId: trace.traceId,
-            occurredAtMs: trace.timestamp,
-          },
-          { staleTime: 300_000 },
-        );
+        const input = {
+          projectId: project.id,
+          traceId: trace.traceId,
+          occurredAtMs: trace.timestamp,
+        };
+        const opts = { staleTime: 300_000 };
+        void utils.tracesV2.spanTree.prefetch(input, opts);
+        void utils.tracesV2.spanLangwatchSignals.prefetch(input, opts);
+        void utils.tracesV2.traceEvents.prefetch(input, opts);
+        void utils.tracesV2.resourceInfo.prefetch(input, opts);
       }
       // Push into the store before route change so drawer hooks render
       // with the right traceId/occurredAtMs on the very next frame.

--- a/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
+++ b/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
@@ -217,7 +217,11 @@ export function useOpenTraceDrawer() {
           { staleTime: 300_000 },
         );
         void utils.tracesV2.resourceInfo.prefetch(
-          { projectId, traceId: trace.traceId },
+          {
+            projectId,
+            traceId: trace.traceId,
+            occurredAtMs: trace.timestamp,
+          },
           { staleTime: 300_000 },
         );
       }
@@ -227,9 +231,11 @@ export function useOpenTraceDrawer() {
       // Preview-mode traces always open on the waterfall view —
       // it's the most visual tab, the one the onboarding journey
       // teaches, and the only one we want demos / videos / first
-      // impressions to land on.
+      // impressions to land on. Use the transient setter so this
+      // programmatic override does NOT clobber the operator's
+      // persisted preference for normal traces.
       if (isPreviewTraceId(trace.traceId)) {
-        useDrawerStore.getState().setVizTab("waterfall");
+        useDrawerStore.getState().setVizTabTransient("waterfall");
       }
       openDrawer("traceV2Details", {
         traceId: trace.traceId,

--- a/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
+++ b/langwatch/src/features/traces-v2/hooks/useOpenTraceDrawer.ts
@@ -199,10 +199,7 @@ export function useOpenTraceDrawer() {
       // second even though we already had the row data. Prefetch is a
       // no-op when the query is already cached, and tRPC dedupes the
       // matching React Query subscription that the drawer mounts.
-      if (
-        project?.id &&
-        !isPreviewTraceId(trace.traceId)
-      ) {
+      if (project?.id && !isPreviewTraceId(trace.traceId)) {
         const projectId = project.id;
         void utils.tracesV2.spanTree.prefetch(
           { projectId, traceId: trace.traceId, occurredAtMs: trace.timestamp },

--- a/langwatch/src/features/traces-v2/hooks/useSpanLangwatchSignals.ts
+++ b/langwatch/src/features/traces-v2/hooks/useSpanLangwatchSignals.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { LangwatchSignalBucket } from "~/server/api/routers/tracesV2.schemas";
 import { api } from "~/utils/api";
 import { LIVE_REFETCH_MS } from "../constants/freshness";
+import { useSseStatusStore } from "../stores/sseStatusStore";
 import { useTraceQueryArgs } from "./useTraceQueryArgs";
 
 /**
@@ -12,6 +13,12 @@ import { useTraceQueryArgs } from "./useTraceQueryArgs";
  */
 export function useSpanLangwatchSignals() {
   const { isLive, isReady, queryArgs } = useTraceQueryArgs();
+  // SSE-aware polling (see `useSpanTree` for the rationale): poll only
+  // when `useTraceFreshness`'s SSE subscription isn't keeping the cache
+  // fresh via invalidations.
+  const sseConnected = useSseStatusStore(
+    (s) => s.sseConnectionState === "connected",
+  );
 
   const query = api.tracesV2.spanLangwatchSignals.useQuery(queryArgs, {
     enabled: isReady,
@@ -19,7 +26,7 @@ export function useSpanLangwatchSignals() {
     cacheTime: 1_800_000,
     keepPreviousData: true,
     refetchOnWindowFocus: true,
-    refetchInterval: isLive ? LIVE_REFETCH_MS : false,
+    refetchInterval: isLive && !sseConnected ? LIVE_REFETCH_MS : false,
   });
 
   const signalsBySpanId = useMemo(() => {

--- a/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
+++ b/langwatch/src/features/traces-v2/hooks/useSpanTree.ts
@@ -1,12 +1,18 @@
 import { api } from "~/utils/api";
 import { LIVE_REFETCH_MS } from "../constants/freshness";
+import { useSseStatusStore } from "../stores/sseStatusStore";
 import { useTraceQueryArgs } from "./useTraceQueryArgs";
 
 export function useSpanTree() {
   const { isLive, isReady, queryArgs } = useTraceQueryArgs();
+  // `useTraceFreshness` invalidates `tracesV2.spanTree` on every
+  // `trace_updated` SSE event for the open trace — when SSE is healthy
+  // the cache is kept fresh push-style and any timed refetch is pure
+  // duplication. Poll only when SSE is off (paused / disconnected).
+  const sseConnected = useSseStatusStore(
+    (s) => s.sseConnectionState === "connected",
+  );
 
-  // Match useTraceHeader's liveness behaviour so spans + header refresh
-  // together as new spans arrive on a recent trace.
   return api.tracesV2.spanTree.useQuery(queryArgs, {
     // Disable the real tRPC fetch when the traceId is a
     // preview-mode synthetic — `useOpenTraceDrawer` has already
@@ -17,6 +23,6 @@ export function useSpanTree() {
     cacheTime: 1_800_000,
     keepPreviousData: true,
     refetchOnWindowFocus: true,
-    refetchInterval: isLive ? LIVE_REFETCH_MS : false,
+    refetchInterval: isLive && !sseConnected ? LIVE_REFETCH_MS : false,
   });
 }

--- a/langwatch/src/features/traces-v2/hooks/useTraceFreshness.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceFreshness.ts
@@ -153,9 +153,7 @@ export function useTraceFreshness() {
   // Honour the operator's "live updates" preference — when disabled,
   // skip subscribing and force the connection state to disconnected so
   // the toolbar indicator reads correctly.
-  const liveUpdatesEnabled = useSseStatusStore(
-    (s) => s.liveUpdatesEnabled,
-  );
+  const liveUpdatesEnabled = useSseStatusStore((s) => s.liveUpdatesEnabled);
 
   const { connectionState, lastEventAt } = useTraceUpdateListener({
     projectId: project?.id ?? "",

--- a/langwatch/src/features/traces-v2/hooks/useTraceFreshness.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceFreshness.ts
@@ -121,11 +121,28 @@ export function useTraceFreshness() {
       const projectId = project?.id;
       if (!openTraceId || !projectId || !traceIds.includes(openTraceId)) return;
 
+      // Invalidate every per-trace query that changes shape when a new
+      // span lands — keeps the cache push-fresh so the per-hook
+      // refetchInterval can stay off while SSE is connected. Each
+      // query is also scoped by `projectId` + `traceId` so we only
+      // invalidate the open trace, not the entire CSR cache.
       void trpcUtils.tracesV2.spanTree.invalidate({
         projectId,
         traceId: openTraceId,
       });
       void trpcUtils.tracesV2.spanDetail.invalidate({
+        projectId,
+        traceId: openTraceId,
+      });
+      void trpcUtils.tracesV2.spanLangwatchSignals.invalidate({
+        projectId,
+        traceId: openTraceId,
+      });
+      void trpcUtils.tracesV2.traceEvents.invalidate({
+        projectId,
+        traceId: openTraceId,
+      });
+      void trpcUtils.tracesV2.resourceInfo.invalidate({
         projectId,
         traceId: openTraceId,
       });

--- a/langwatch/src/features/traces-v2/hooks/useTraceFreshness.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceFreshness.ts
@@ -123,29 +123,15 @@ export function useTraceFreshness() {
 
       // Invalidate every per-trace query that changes shape when a new
       // span lands — keeps the cache push-fresh so the per-hook
-      // refetchInterval can stay off while SSE is connected. Each
-      // query is also scoped by `projectId` + `traceId` so we only
-      // invalidate the open trace, not the entire CSR cache.
-      void trpcUtils.tracesV2.spanTree.invalidate({
-        projectId,
-        traceId: openTraceId,
-      });
-      void trpcUtils.tracesV2.spanDetail.invalidate({
-        projectId,
-        traceId: openTraceId,
-      });
-      void trpcUtils.tracesV2.spanLangwatchSignals.invalidate({
-        projectId,
-        traceId: openTraceId,
-      });
-      void trpcUtils.tracesV2.traceEvents.invalidate({
-        projectId,
-        traceId: openTraceId,
-      });
-      void trpcUtils.tracesV2.resourceInfo.invalidate({
-        projectId,
-        traceId: openTraceId,
-      });
+      // refetchInterval can stay off while SSE is connected. The key
+      // is scoped to `projectId` + `traceId` so only the open trace
+      // is invalidated, not the entire CSR cache.
+      const key = { projectId, traceId: openTraceId };
+      void trpcUtils.tracesV2.spanTree.invalidate(key);
+      void trpcUtils.tracesV2.spanDetail.invalidate(key);
+      void trpcUtils.tracesV2.spanLangwatchSignals.invalidate(key);
+      void trpcUtils.tracesV2.traceEvents.invalidate(key);
+      void trpcUtils.tracesV2.resourceInfo.invalidate(key);
     },
     [trpcUtils, project?.id],
   );

--- a/langwatch/src/features/traces-v2/hooks/useTraceHeader.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceHeader.ts
@@ -1,5 +1,6 @@
 import { api } from "~/utils/api";
 import { LIVE_REFETCH_MS } from "../constants/freshness";
+import { useSseStatusStore } from "../stores/sseStatusStore";
 import { useTraceQueryArgs } from "./useTraceQueryArgs";
 
 /** When prompt aggregation is still catching up (containsPrompt=true but
@@ -9,12 +10,21 @@ const PROMPTS_PENDING_REFETCH_MS = 8_000;
 
 export function useTraceHeader() {
   const { isLive, isReady, queryArgs } = useTraceQueryArgs();
+  // SSE-aware polling: when `useTraceFreshness` has an active
+  // subscription, `trace_summary_updated` events invalidate this query
+  // push-style and any timer is redundant. The prompt-pending fallback
+  // still runs regardless — it's not an SSE-covered transition (the
+  // prompt aggregator writes asynchronously and doesn't broadcast a
+  // trace-updated event when only the `lastUsedPromptId` slot fills in).
+  const sseConnected = useSseStatusStore(
+    (s) => s.sseConnectionState === "connected",
+  );
 
   // Treat the URL hint as our liveness signal. When the trace started
-  // within the last 3 min, set a 10s refetch interval so newly arrived
-  // spans show up without a manual refresh. Once the trace is older than
-  // the window, the interval falls away and the query goes back to its
-  // normal staleTime caching behaviour.
+  // within the last 3 min and SSE is OFF, set a 10s refetch interval so
+  // newly arrived spans show up without a manual refresh. Once the
+  // trace is older than the window, the interval falls away and the
+  // query goes back to its normal staleTime caching behaviour.
   return api.tracesV2.header.useQuery(queryArgs, {
     enabled: isReady,
     staleTime: 300_000,
@@ -22,7 +32,7 @@ export function useTraceHeader() {
     keepPreviousData: true,
     refetchOnWindowFocus: true,
     refetchInterval: (data) => {
-      if (isLive) return LIVE_REFETCH_MS;
+      if (isLive && !sseConnected) return LIVE_REFETCH_MS;
       // The trace knows it used a prompt but the rollup hasn't
       // populated the IDs yet — keep polling on a slower cadence so
       // the chips fill in without the user clicking around. Once an

--- a/langwatch/src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts
+++ b/langwatch/src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts
@@ -155,6 +155,36 @@ describe("drawerStore pane controls", () => {
       });
     });
   });
+
+  /** @scenario Span-detail collapse round-trip preserves the selection */
+  describe("given a selected span", () => {
+    describe("when togglePaneCollapsed(spanDetail) fires twice", () => {
+      it("keeps selectedSpanId so re-opening lands on the same span", () => {
+        useDrawerStore.getState().selectSpan("span-abc");
+        expect(useDrawerStore.getState().selectedSpanId).toBe("span-abc");
+        useDrawerStore.getState().togglePaneCollapsed("spanDetail");
+        expect(
+          useDrawerStore.getState().paneState.spanDetail.collapsed,
+        ).toBe(true);
+        // Collapse alone must NOT touch the selection.
+        expect(useDrawerStore.getState().selectedSpanId).toBe("span-abc");
+        useDrawerStore.getState().togglePaneCollapsed("spanDetail");
+        expect(
+          useDrawerStore.getState().paneState.spanDetail.collapsed,
+        ).toBe(false);
+        expect(useDrawerStore.getState().selectedSpanId).toBe("span-abc");
+      });
+    });
+
+    describe("when clearSpan fires", () => {
+      it("still clears the selection (the explicit close path)", () => {
+        useDrawerStore.getState().selectSpan("span-xyz");
+        expect(useDrawerStore.getState().selectedSpanId).toBe("span-xyz");
+        useDrawerStore.getState().clearSpan();
+        expect(useDrawerStore.getState().selectedSpanId).toBeNull();
+      });
+    });
+  });
 });
 
 // `setWidthPx(null)` after init reads the unwritten storage key as

--- a/langwatch/src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts
+++ b/langwatch/src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts
@@ -163,15 +163,15 @@ describe("drawerStore pane controls", () => {
         useDrawerStore.getState().selectSpan("span-abc");
         expect(useDrawerStore.getState().selectedSpanId).toBe("span-abc");
         useDrawerStore.getState().togglePaneCollapsed("spanDetail");
-        expect(
-          useDrawerStore.getState().paneState.spanDetail.collapsed,
-        ).toBe(true);
+        expect(useDrawerStore.getState().paneState.spanDetail.collapsed).toBe(
+          true,
+        );
         // Collapse alone must NOT touch the selection.
         expect(useDrawerStore.getState().selectedSpanId).toBe("span-abc");
         useDrawerStore.getState().togglePaneCollapsed("spanDetail");
-        expect(
-          useDrawerStore.getState().paneState.spanDetail.collapsed,
-        ).toBe(false);
+        expect(useDrawerStore.getState().paneState.spanDetail.collapsed).toBe(
+          false,
+        );
         expect(useDrawerStore.getState().selectedSpanId).toBe("span-abc");
       });
     });

--- a/langwatch/src/features/traces-v2/stores/drawerStore.ts
+++ b/langwatch/src/features/traces-v2/stores/drawerStore.ts
@@ -117,7 +117,18 @@ interface DrawerState extends DrawerUrlState {
   selectSpan: (spanId: string) => void;
   clearSpan: () => void;
   setViewMode: (mode: DrawerViewMode) => void;
+  /**
+   * Persist the operator's chosen viz tab AND apply it. Use for any
+   * UI-initiated change (tab click, keyboard shortcut, overflow menu).
+   */
   setVizTab: (tab: VizTab) => void;
+  /**
+   * Apply a viz tab without writing to localStorage. Use for programmatic
+   * one-off forcing (e.g. preview/onboarding traces always landing on
+   * the waterfall) so the operator's remembered preference isn't
+   * clobbered the next time they open a normal trace.
+   */
+  setVizTabTransient: (tab: VizTab) => void;
   setMaximized: (value: boolean) => void;
   toggleMaximized: () => void;
   setWidthPx: (px: number | null) => void;
@@ -475,11 +486,11 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
 
   selectSpan: (spanId) =>
     set((s) => {
-      // Selecting a span always reopens the detail pane — when the user
-      // explicitly hides it, the selection is cleared, so any subsequent
-      // span click reads as "open detail for this span", not "reselect
-      // an existing one". This makes the hide/reopen flow round-trip
-      // cleanly via span clicks alone.
+      // Selecting a span always reopens the detail pane. Collapsing
+      // the pane no longer clears the selection (see
+      // `togglePaneCollapsed`), so re-opening the pane lands on the
+      // same span the operator last inspected; clicking a new span
+      // updates the selection and re-expands the pane in one step.
       const next: Partial<DrawerState> = { selectedSpanId: spanId };
       if (s.paneState.spanDetail.collapsed) {
         const updatedPanes: Record<PaneId, PaneState> = {
@@ -504,6 +515,7 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
     persistLastVizTab(tab);
     set({ vizTab: tab });
   },
+  setVizTabTransient: (tab) => set({ vizTab: tab }),
   setMaximized: (value) => set({ isMaximized: value }),
   toggleMaximized: () => set((s) => ({ isMaximized: !s.isMaximized })),
 

--- a/langwatch/src/features/traces-v2/stores/drawerStore.ts
+++ b/langwatch/src/features/traces-v2/stores/drawerStore.ts
@@ -180,6 +180,7 @@ function isVizTab(value: string | null): value is VizTab {
  * landing on Summary as they navigate between traces.
  */
 const LAST_VIEW_MODE_STORAGE_KEY = "langwatch:traces-v2:drawer-last-mode:v1";
+const LAST_VIZ_TAB_STORAGE_KEY = "langwatch:traces-v2:drawer-last-viz:v1";
 
 function loadLastViewMode(): DrawerViewMode | null {
   if (typeof window === "undefined") return null;
@@ -195,6 +196,25 @@ function persistLastViewMode(mode: DrawerViewMode): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(LAST_VIEW_MODE_STORAGE_KEY, mode);
+  } catch {
+    // storage may be full / disabled
+  }
+}
+
+function loadLastVizTab(): VizTab | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(LAST_VIZ_TAB_STORAGE_KEY);
+    return raw && isVizTab(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistLastVizTab(tab: VizTab): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(LAST_VIZ_TAB_STORAGE_KEY, tab);
   } catch {
     // storage may be full / disabled
   }
@@ -242,7 +262,9 @@ function readInitialFromURL(): InitialFromURL {
     const viewMode: DrawerViewMode = isViewMode(mode)
       ? mode
       : loadLastViewMode() ?? "summary";
-    const vizTab: VizTab = isVizTab(vizRaw) ? vizRaw : "waterfall";
+    const vizTab: VizTab = isVizTab(vizRaw)
+      ? vizRaw
+      : loadLastVizTab() ?? "waterfall";
     const pinnedSpanIds = parsePinnedSpansParam(pinnedRaw);
 
     return {
@@ -478,7 +500,10 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
     persistLastViewMode(mode);
     set({ viewMode: mode });
   },
-  setVizTab: (tab) => set({ vizTab: tab }),
+  setVizTab: (tab) => {
+    persistLastVizTab(tab);
+    set({ vizTab: tab });
+  },
   setMaximized: (value) => set({ isMaximized: value }),
   toggleMaximized: () => set((s) => ({ isMaximized: !s.isMaximized })),
 
@@ -529,14 +554,12 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
         },
       };
       persistPaneState(next);
-      // Hiding the span-detail pane clears the current selection so the
-      // next span click feels like opening a fresh detail view (which
-      // also auto-reopens the pane via `selectSpan`).
-      const stateUpdate: Partial<DrawerState> = { paneState: next };
-      if (id === "spanDetail" && !wasCollapsed) {
-        stateUpdate.selectedSpanId = null;
-      }
-      return stateUpdate;
+      // Selection is preserved across collapse/uncollapse — operator
+      // feedback: hiding the pane and showing it again should land on
+      // the same span they were inspecting, not blank the selection.
+      // (Selection still clears via explicit `clearSpan` and the X
+      // affordance in the SpanTabBar.)
+      return { paneState: next };
     }),
 
   togglePaneMaximized: (id) =>

--- a/langwatch/src/features/traces-v2/stores/drawerStore.ts
+++ b/langwatch/src/features/traces-v2/stores/drawerStore.ts
@@ -66,10 +66,7 @@ export interface PaneState {
   maximizedWithinGroup: boolean;
 }
 
-export type PaneId =
-  | "conversationContext"
-  | "visualization"
-  | "spanDetail";
+export type PaneId = "conversationContext" | "visualization" | "spanDetail";
 
 interface DrawerState extends DrawerUrlState {
   isOpen: boolean;
@@ -174,9 +171,7 @@ function isVizTab(value: string | null): value is VizTab {
   // "flame" and "spanlist" used to be valid here; URLs from before the
   // redesign carrying those values just fall through to the default
   // (waterfall) when the guard returns false.
-  return (
-    value === "waterfall" || value === "topology" || value === "sequence"
-  );
+  return value === "waterfall" || value === "topology" || value === "sequence";
 }
 
 // `isDrawerTab` retired alongside `activeTab` — the SpanDetailPane body
@@ -272,10 +267,10 @@ function readInitialFromURL(): InitialFromURL {
     // who prefer Summary keep landing on Summary across traces.
     const viewMode: DrawerViewMode = isViewMode(mode)
       ? mode
-      : loadLastViewMode() ?? "summary";
+      : (loadLastViewMode() ?? "summary");
     const vizTab: VizTab = isVizTab(vizRaw)
       ? vizRaw
-      : loadLastVizTab() ?? "waterfall";
+      : (loadLastVizTab() ?? "waterfall");
     const pinnedSpanIds = parsePinnedSpansParam(pinnedRaw);
 
     return {
@@ -313,12 +308,17 @@ export function parsePinnedSpansParam(raw: string | null): string[] {
 }
 
 /** Inverse of {@link parsePinnedSpansParam} — serialises for the URL. */
-export function serializePinnedSpansParam(ids: readonly string[]): string | undefined {
+export function serializePinnedSpansParam(
+  ids: readonly string[],
+): string | undefined {
   if (ids.length === 0) return undefined;
   return ids.slice(0, MAX_PINNED_SPANS).join(",");
 }
 
-function arraysShallowEqual(a: readonly string[], b: readonly string[]): boolean {
+function arraysShallowEqual(
+  a: readonly string[],
+  b: readonly string[],
+): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     if (a[i] !== b[i]) return false;
@@ -425,8 +425,7 @@ function readPaneStateFromStorage(): Record<PaneId, PaneState> {
     return {
       conversationContext:
         parsed.conversationContext ?? DEFAULT_PANE_STATE.conversationContext,
-      visualization:
-        parsed.visualization ?? DEFAULT_PANE_STATE.visualization,
+      visualization: parsed.visualization ?? DEFAULT_PANE_STATE.visualization,
       spanDetail: parsed.spanDetail ?? DEFAULT_PANE_STATE.spanDetail,
     };
   } catch {
@@ -535,8 +534,7 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
         s.widthPx !== null && Math.abs(s.widthPx - snapWidth) < 2;
       if (isAtSnap) {
         const restore =
-          s.preMaximizeWidthPx ??
-          Math.min(DRAWER_DEFAULT_WIDTH_PX, snapWidth);
+          s.preMaximizeWidthPx ?? Math.min(DRAWER_DEFAULT_WIDTH_PX, snapWidth);
         persistWidth(restore);
         return {
           widthPx: restore,
@@ -587,8 +585,7 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
         (acc, key) => {
           acc[key] = {
             ...s.paneState[key],
-            maximizedWithinGroup:
-              key === id ? !currentlyMaximized : false,
+            maximizedWithinGroup: key === id ? !currentlyMaximized : false,
             collapsed: key === id ? false : s.paneState[key].collapsed,
           };
           return acc;

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -393,11 +393,39 @@ const auditLogMutations = t.middleware(
 
 export const tracerMiddleware = t.middleware(
   async ({ path, type, next }) => {
-    // Skip tracing for high-frequency, low-signal routes (presence
-    // heartbeats) — they otherwise dominate the trace surface and
-    // make real spans hard to find.
-    if (isSilencedCall(path, type)) {
-      return next();
+    const silenced = isSilencedCall(path, type);
+
+    // Fast-path: for silenced routes (presence heartbeats, SSE
+    // subscription messages) we skip span creation on success — those
+    // are the high-frequency calls that drown out the trace surface.
+    // On failure we still want a span so real errors stay visible
+    // (and we own the timing so the span duration matches the call).
+    if (silenced) {
+      const start = Date.now();
+      const result = await next();
+      if (result.ok) return result;
+
+      const { trace, SpanKind, SpanStatusCode } = await import(
+        "@opentelemetry/api"
+      );
+      const tracer = trace.getTracer("langwatch:trpc");
+      const span = tracer.startSpan(`trpc.${path}`, {
+        kind: SpanKind.SERVER,
+        startTime: start,
+        attributes: {
+          "rpc.system": "trpc",
+          "rpc.method": path,
+          "rpc.type": type,
+        },
+      });
+      const err = result.error;
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      span.end();
+      return result;
     }
 
     const { trace, SpanKind, SpanStatusCode } = await import(

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -7,6 +7,12 @@
  * need to use are documented accordingly near the end.
  */
 
+import {
+  trace as otelTrace,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+} from "@opentelemetry/api";
 import type { inferParser } from "@trpc/server";
 import {
   initTRPC,
@@ -16,36 +22,31 @@ import {
   TRPCError,
 } from "@trpc/server";
 import { getHTTPStatusCodeFromError } from "@trpc/server/http";
-import {
-  SpanKind,
-  SpanStatusCode,
-  trace as otelTrace,
-  type Span,
-} from "@opentelemetry/api";
+
 // Local type replacing CreateNextContextOptions from @trpc/server/adapters/next
 // to avoid pulling in the real `next` types.
 interface CreateNextContextOptions {
   req: any;
   res: any;
 }
+
+import type { OrganizationUserRole } from "@prisma/client";
 import type { Parser } from "@trpc-internal/parser";
 import type { UnsetMarker } from "@trpc-internal/utils";
-import type { NextApiRequest, NextApiResponse } from "~/types/next-stubs";
-import type { Session } from "~/server/auth";
 import superjson from "superjson";
 import { ZodError } from "zod";
+import { DomainError } from "~/server/app-layer/domain-error";
+import type { Session } from "~/server/auth";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
-import { DomainError } from "~/server/app-layer/domain-error";
 import { AiCallFailedError } from "~/server/modelProviders/aiCallFailedError";
 import { ModelNotConfiguredError } from "~/server/modelProviders/modelNotConfiguredError";
-import { getLogLevelFromStatusCode } from "../middleware/requestLogging";
+import type { NextApiRequest, NextApiResponse } from "~/types/next-stubs";
 import { createLogger } from "../../utils/logger/server";
 import { captureException } from "../../utils/posthogErrorCapture";
 import { auditLog } from "../auditLog";
-import type { OrganizationUserRole } from "@prisma/client";
-import type { PermissionMiddleware } from "./rbac";
-import type { OpsScope } from "./rbac";
+import { getLogLevelFromStatusCode } from "../middleware/requestLogging";
+import type { OpsScope, PermissionMiddleware } from "./rbac";
 
 const logger = createLogger("langwatch:trpc");
 
@@ -181,8 +182,7 @@ export function errorFormatterForTesting({
     ...shape,
     data: {
       ...shape.data,
-      zodError:
-        error.cause instanceof ZodError ? error.cause.flatten() : null,
+      zodError: error.cause instanceof ZodError ? error.cause.flatten() : null,
       cause: missingModelCause ?? aiCallFailedCause ?? limitInfo,
       domainError,
     },
@@ -371,9 +371,7 @@ const auditLogMutations = t.middleware(
 
     let result = await next();
 
-    const target = result.ok
-      ? deriveAuditTarget(path, result.data)
-      : {};
+    const target = result.ok ? deriveAuditTarget(path, result.data) : {};
 
     await auditLog({
       userId: ctx.session.user.id,
@@ -411,49 +409,45 @@ function recordSpanError(span: Span, error: unknown): void {
   span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
 }
 
-export const tracerMiddleware = t.middleware(
-  async ({ path, type, next }) => {
-    const tracer = otelTrace.getTracer("langwatch:trpc");
-    const spanName = `trpc.${path}`;
+export const tracerMiddleware = t.middleware(async ({ path, type, next }) => {
+  const tracer = otelTrace.getTracer("langwatch:trpc");
+  const spanName = `trpc.${path}`;
 
-    // For silenced routes (presence heartbeats, SSE subscription
-    // messages) we want zero spans on the happy path — they otherwise
-    // drown out the trace surface — but failures still need a span so
-    // real errors stay visible. Capture the start time before `next()`
-    // so the error span's duration matches the actual call.
-    if (isSilencedCall(path, type)) {
-      const startTime = Date.now();
+  // For silenced routes (presence heartbeats, SSE subscription
+  // messages) we want zero spans on the happy path — they otherwise
+  // drown out the trace surface — but failures still need a span so
+  // real errors stay visible. Capture the start time before `next()`
+  // so the error span's duration matches the actual call.
+  if (isSilencedCall(path, type)) {
+    const startTime = Date.now();
+    const result = await next();
+    if (result.ok) return result;
+
+    const span = tracer.startSpan(spanName, {
+      kind: SpanKind.SERVER,
+      startTime,
+      attributes: spanAttributes(path, type),
+    });
+    recordSpanError(span, result.error);
+    span.end();
+    return result;
+  }
+
+  return tracer.startActiveSpan(
+    spanName,
+    { kind: SpanKind.SERVER, attributes: spanAttributes(path, type) },
+    async (span) => {
+      // IMPORTANT: In tRPC v10, next() never throws. Downstream errors are
+      // returned as { ok: false, error } result objects — NOT thrown.
       const result = await next();
-      if (result.ok) return result;
-
-      const span = tracer.startSpan(spanName, {
-        kind: SpanKind.SERVER,
-        startTime,
-        attributes: spanAttributes(path, type),
-      });
-      recordSpanError(span, result.error);
+      if (!result.ok) recordSpanError(span, result.error);
       span.end();
       return result;
-    }
+    },
+  );
+});
 
-    return tracer.startActiveSpan(
-      spanName,
-      { kind: SpanKind.SERVER, attributes: spanAttributes(path, type) },
-      async (span) => {
-        // IMPORTANT: In tRPC v10, next() never throws. Downstream errors are
-        // returned as { ok: false, error } result objects — NOT thrown.
-        const result = await next();
-        if (!result.ok) recordSpanError(span, result.error);
-        span.end();
-        return result;
-      },
-    );
-  },
-);
-
-function domainErrorToTRPCCode(
-  error: DomainError,
-): TRPCError["code"] {
+function domainErrorToTRPCCode(error: DomainError): TRPCError["code"] {
   const map: Partial<Record<number, TRPCError["code"]>> = {
     400: "BAD_REQUEST",
     401: "UNAUTHORIZED",
@@ -548,7 +542,10 @@ export function handleTrpcCallLogging({
     logData.statusCode = resolvedStatus;
 
     // Include domain error kind in log data for structured filtering
-    if (result.error instanceof TRPCError && result.error.cause instanceof DomainError) {
+    if (
+      result.error instanceof TRPCError &&
+      result.error.cause instanceof DomainError
+    ) {
       logData.domainErrorKind = result.error.cause.kind;
     }
 
@@ -591,8 +588,9 @@ function isSilencedCall(path: string, type: string): boolean {
 export const loggerMiddleware = t.middleware(
   async ({ path, type, input, ctx, next }) => {
     // Import context utilities dynamically to avoid circular deps
-    const { createContextFromTRPC, runWithContext } =
-      await import("../context/asyncContext");
+    const { createContextFromTRPC, runWithContext } = await import(
+      "../context/asyncContext"
+    );
 
     // Create context from tRPC context and input
     const requestContext = createContextFromTRPC(ctx, input as any);

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -16,6 +16,12 @@ import {
   TRPCError,
 } from "@trpc/server";
 import { getHTTPStatusCodeFromError } from "@trpc/server/http";
+import {
+  SpanKind,
+  SpanStatusCode,
+  trace as otelTrace,
+  type Span,
+} from "@opentelemetry/api";
 // Local type replacing CreateNextContextOptions from @trpc/server/adapters/next
 // to avoid pulling in the real `next` types.
 interface CreateNextContextOptions {
@@ -391,74 +397,53 @@ const auditLogMutations = t.middleware(
   },
 );
 
+function spanAttributes(path: string, type: string) {
+  return {
+    "rpc.system": "trpc",
+    "rpc.method": path,
+    "rpc.type": type,
+  } as const;
+}
+
+function recordSpanError(span: Span, error: unknown): void {
+  const e = error instanceof Error ? error : new Error(String(error));
+  span.recordException(e);
+  span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
+}
+
 export const tracerMiddleware = t.middleware(
   async ({ path, type, next }) => {
-    const silenced = isSilencedCall(path, type);
+    const tracer = otelTrace.getTracer("langwatch:trpc");
+    const spanName = `trpc.${path}`;
 
-    // Fast-path: for silenced routes (presence heartbeats, SSE
-    // subscription messages) we skip span creation on success — those
-    // are the high-frequency calls that drown out the trace surface.
-    // On failure we still want a span so real errors stay visible
-    // (and we own the timing so the span duration matches the call).
-    if (silenced) {
-      const start = Date.now();
+    // For silenced routes (presence heartbeats, SSE subscription
+    // messages) we want zero spans on the happy path — they otherwise
+    // drown out the trace surface — but failures still need a span so
+    // real errors stay visible. Capture the start time before `next()`
+    // so the error span's duration matches the actual call.
+    if (isSilencedCall(path, type)) {
+      const startTime = Date.now();
       const result = await next();
       if (result.ok) return result;
 
-      const { trace, SpanKind, SpanStatusCode } = await import(
-        "@opentelemetry/api"
-      );
-      const tracer = trace.getTracer("langwatch:trpc");
-      const span = tracer.startSpan(`trpc.${path}`, {
+      const span = tracer.startSpan(spanName, {
         kind: SpanKind.SERVER,
-        startTime: start,
-        attributes: {
-          "rpc.system": "trpc",
-          "rpc.method": path,
-          "rpc.type": type,
-        },
+        startTime,
+        attributes: spanAttributes(path, type),
       });
-      const err = result.error;
-      span.recordException(err instanceof Error ? err : new Error(String(err)));
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: err instanceof Error ? err.message : String(err),
-      });
+      recordSpanError(span, result.error);
       span.end();
       return result;
     }
 
-    const { trace, SpanKind, SpanStatusCode } = await import(
-      "@opentelemetry/api"
-    );
-
-    const tracer = trace.getTracer("langwatch:trpc");
-    const spanName = `trpc.${path}`;
-
     return tracer.startActiveSpan(
       spanName,
-      {
-        kind: SpanKind.SERVER,
-        attributes: {
-          "rpc.system": "trpc",
-          "rpc.method": path,
-          "rpc.type": type,
-        },
-      },
+      { kind: SpanKind.SERVER, attributes: spanAttributes(path, type) },
       async (span) => {
         // IMPORTANT: In tRPC v10, next() never throws. Downstream errors are
         // returned as { ok: false, error } result objects — NOT thrown.
         const result = await next();
-
-        if (!result.ok) {
-          const err = result.error;
-          span.recordException(err instanceof Error ? err : new Error(String(err)));
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: err instanceof Error ? err.message : String(err),
-          });
-        }
-
+        if (!result.ok) recordSpanError(span, result.error);
         span.end();
         return result;
       },

--- a/langwatch/src/server/api/trpc.ts
+++ b/langwatch/src/server/api/trpc.ts
@@ -393,6 +393,13 @@ const auditLogMutations = t.middleware(
 
 export const tracerMiddleware = t.middleware(
   async ({ path, type, next }) => {
+    // Skip tracing for high-frequency, low-signal routes (presence
+    // heartbeats) — they otherwise dominate the trace surface and
+    // make real spans hard to find.
+    if (isSilencedCall(path, type)) {
+      return next();
+    }
+
     const { trace, SpanKind, SpanStatusCode } = await import(
       "@opentelemetry/api"
     );
@@ -544,6 +551,30 @@ export function handleTrpcCallLogging({
   }
 }
 
+/**
+ * Routers whose calls flood the request log without being useful for
+ * debugging: presence (peer cursor / drawer presence heartbeats fire
+ * every few seconds per open tab). Logging + tracing them buries the
+ * signal in noise. Errors are still reported by the middlewares below.
+ */
+const SILENCED_LOG_PATH_PREFIXES = ["presence."] as const;
+
+/**
+ * tRPC call types whose volume is unbounded — SSE subscriptions emit
+ * a "trpc call" log line per delivered message. Silencing the
+ * subscription type as a whole keeps the dev log readable without
+ * sprinkling per-router opt-outs across the codebase.
+ */
+const SILENCED_LOG_TYPES = new Set(["subscription"]);
+
+function isSilencedPath(path: string): boolean {
+  return SILENCED_LOG_PATH_PREFIXES.some((p) => path.startsWith(p));
+}
+
+function isSilencedCall(path: string, type: string): boolean {
+  return isSilencedPath(path) || SILENCED_LOG_TYPES.has(type);
+}
+
 export const loggerMiddleware = t.middleware(
   async ({ path, type, input, ctx, next }) => {
     // Import context utilities dynamically to avoid circular deps
@@ -560,6 +591,13 @@ export const loggerMiddleware = t.middleware(
       // objects. Use result.ok to detect errors — NOT try/catch.
       const result = await next();
       const duration = Date.now() - start;
+
+      // Silence happy-path logs for high-frequency, low-signal routes
+      // (presence heartbeats) — still log errors so real failures are
+      // visible.
+      if (isSilencedCall(path, type) && result.ok) {
+        return result;
+      }
 
       handleTrpcCallLogging({
         result,


### PR DESCRIPTION
## Why

Drive-through pass on the new trace drawer surfaced four regressions / soft-spots in #4520's audit landing:

1. The **Summary tab** couldn't scroll — content past the fold (Events, Exceptions) was clipped by `Drawer.Body`'s `overflow: hidden` and unreachable.
2. The **Trace tab** rendered empty — `PaneLayout`'s `PanelGroup` resolved its percentage sizes against a 0px container.
3. Detail-pane collapse/uncollapse **lost the selected span**, so re-opening the pane landed on the empty waterfall instead of the span the operator was inspecting.
4. The viz tab choice (Waterfall / Topology / Sequence) didn't persist, so anyone who preferred Topology got bounced back to Waterfall on every new trace.

Plus three cleanup / perf items spotted during the drive-through:

5. The **instrumentation-scope chip** sat in `SpanTabBar`'s right slot, taking tab-row real estate for metadata most operators glance at once.
6. The **dev log + tRPC OTel span list** were dominated by `presence.*` heartbeats and SSE subscription messages — every few seconds per open tab — hiding real errors.
7. The per-trace drawer queries (`spanTree`, `spanLangwatchSignals`, `traceHeader`) were **polling unconditionally on `isLive`** even when `useTraceFreshness`'s SSE subscription was healthy — duplicating work and (with HTTP/1.1) saturating the browser's 6-connection limit so the heavier `spanDetail` batch queued indefinitely.

Closes #

## What changed

Five logical feature commits + three cleanup commits — pick the one that matches the kind of review you want to do:

**1. `fix(traces-v2): summary tab scroll + empty trace tab`**

Root cause was lifting `PeerCursorOverlay` from the viz pane up to wrap the entire drawer body (so peer cursors render across all three modes). Its outer Box stayed at `width:100% height:100% position:relative` — without `min-height: 0` the implicit `min-height: auto` clamped it to content size and stopped it shrinking into the drawer-body flex slot. Two-line fix: `minHeight={0} minWidth={0}` on the overlay's Box, and the inner Flex switched from `flex={1}` (inert — overlay's Box isn't a flex container) to `height="100%"` so it reads the overlay's resolved height.

**2. `feat(traces-v2): drawer drive-through — span selection, viz persistence, scope relocation, eager prefetch`**

  - `togglePaneCollapsed("spanDetail")` no longer nulls `selectedSpanId` — selection rides across collapse/uncollapse. `clearSpan` (X button / keyboard) is still the explicit clear path.
  - `vizTab` is persisted under `langwatch:traces-v2:drawer-last-viz:v1`, mirroring the existing `viewMode` persistence.
  - Instrumentation scope moved from `SpanTabBar`'s right slot into the per-span accordion as a proper "Instrumentation Scope" section, gated on `hasScope`.
  - `useOpenTraceDrawer` prefetches `spanTree`, `spanLangwatchSignals`, `traceEvents`, and `resourceInfo` at row-click time so the trace tab renders against warm data instead of skeletoning while React Query catches up. Preview traces are skipped (cache is already seeded by `buildRichArrivalTraceDetail`).

**3. `chore(trpc): silence presence + subscription logs and traces`**

`loggerMiddleware` + `tracerMiddleware` early-out on `presence.*` paths and all `subscription` type calls when successful. Errors still flow through, so real failures stay visible.

**4. `perf(traces-v2): stop polling per-trace queries when SSE is connected`**

`useSpanTree`, `useSpanLangwatchSignals`, and `useTraceHeader` now read `sseConnectionState` and only enable `refetchInterval` when SSE is OFF. When connected, `useTraceFreshness`'s `onSpanStored` listener keeps the cache push-fresh via invalidations. Mirrors the pattern already used by `useErrorCount` + `useTraceNewCount`. Also extended `useTraceFreshness.onSpanStored` to invalidate `spanLangwatchSignals` / `traceEvents` / `resourceInfo` so the "no-poll-when-SSE-up" rule doesn't stale-cache the badges / events / scope sections.

**5. `Address Copilot review on #4566`**

Round-1 review feedback: tracer middleware now creates an error span for silenced calls (success path still skipped); `setVizTab` was split into a persisting setter (operator actions) and a transient setter (programmatic forcing, used by the preview/onboarding waterfall override) so it no longer clobbers the stored preference; stale `selectSpan` comment rewritten; added a unit test in `drawerStore.unit.test.ts` for the collapse-round-trip selection-preservation behavior; added `occurredAtMs` to the `resourceInfo` prefetch so the cache key matches `useTraceResources`.

**6. Post-review cleanup (`refactor(trpc)` / `style: biome` / `refactor(traces-v2): dedupe per-trace prefetch + invalidate inputs`)**

Three follow-up cleanup commits, no behaviour change:

  - `trpc.ts` had two pre-existing inline `await import("@opentelemetry/api")` calls (CLAUDE.md forbids inline `import()`); hoisted to a single top-level import and extracted `spanAttributes` + `recordSpanError` helpers so both silenced and normal branches share them.
  - `biome --write` ran on every touched file (alphabetised imports, tab indent, jsx-wrap tightening).
  - `useOpenTraceDrawer`'s prefetch fan-out and `useTraceFreshness`'s invalidate fan-out each had 4–5 identical input literals; hoisted to one `input`/`key` binding per block so future input-shape changes only land in one spot.

## How it works

The scroll bug took longer than it should have — the rabbit-hole was that the inner Flex's `flex={1}` looked correct but was inert because `PeerCursorOverlay`'s Box doesn't carry `display: flex`. Switching it to `height="100%"` reads the overlay's resolved height directly, but only once `minHeight={0}` lets the overlay shrink in the first place. Both lines have to land together.

The prefetch in `useOpenTraceDrawer` runs in parallel with the route change — `openDrawer` triggers a Next router push, which takes a tick to mount the drawer subtree. By then the heavier per-trace queries have ~50–150ms head-start, which is roughly the time the waterfall used to spend on its skeleton.

The SSE-aware refetchInterval needed both halves to land together: pure polling-off would stale-cache; pure invalidation-only without the per-trace invalidations would miss `spanLangwatchSignals` / `traceEvents` / `resourceInfo` updates. With both, the polling fallback is what runs in `paused` / `disconnected` mode and the SSE invalidations carry steady-state.

## Test plan

- [ ] Open the Trace Explorer, click any trace. **Summary tab**: scroll past the fold; Events and Exceptions sections reachable.
- [ ] Switch to **Trace tab**: waterfall renders (was empty before).
- [ ] Click a span → pane opens → click the collapse toggle → click "Show details" → same span detail re-appears (was blank before).
- [ ] Switch viz tab to Topology → close drawer → open a different trace → still on Topology.
- [ ] Click an LLM span: "Instrumentation Scope" is now an accordion section near the bottom of the span detail (was a chip in the tab bar).
- [ ] Watch the dev server log while clicking around: no `presence.*` or subscription noise; `tracesV2.spanTree` etc. still log normally.
- [ ] With SSE connected (live mode), DevTools Network: per-trace queries (`spanTree`, `spanLangwatchSignals`, `header`) don't poll on the 10s `LIVE_REFETCH_MS` cadence; new spans still arrive via invalidation.
- [ ] Toggle live updates to `paused` — per-trace queries re-arm the fallback poll.
- [ ] `pnpm test:unit src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts` is green (14/14).

## Anything surprising?

- The `PeerCursorOverlay` fix is generic enough that any future caller in a flex-column parent benefits, but right now it only has the one caller (the trace drawer).
- The viz-tab persistence key is versioned (`:v1`) so future shape changes can rev it without stomping on stored values.
- The prefetch is a no-op for preview/onboarding traces (their cache is already seeded by hand), so it doesn't fire empty CH queries for synthetic IDs.
- `useTraceHeader`'s prompt-pending fallback (`PROMPTS_PENDING_REFETCH_MS`) runs regardless of SSE state — the prompt aggregator writes asynchronously and doesn't broadcast a `trace_updated` event when only the `lastUsedPromptId` slot fills in.
- `SILENCED_LOG_PATH_PREFIXES = ["presence."]` is forward-permissive: it'll silence any future presence.* mutation too. The current router (`update`, `leave`, `cursor`, `onPresenceUpdate`, `onPresenceCursor`) is all noisy by design; if a higher-stakes presence mutation is added later, tighten to an exact-path allow-list. Flagged by `/drive-security`.