### PR TITLE
feat(api): project edit/move, groups REST API

### DIFF
--- a/docs/api-reference/groups/add-binding.mdx
+++ b/docs/api-reference/groups/add-binding.mdx
@@ -1,0 +1,4 @@
+---
+title: "Add group binding"
+openapi: "POST /api/groups/{id}/bindings"
+---

--- a/docs/api-reference/groups/add-member.mdx
+++ b/docs/api-reference/groups/add-member.mdx
@@ -1,0 +1,4 @@
+---
+title: "Add group member"
+openapi: "POST /api/groups/{id}/members"
+---

--- a/docs/api-reference/groups/create-group.mdx
+++ b/docs/api-reference/groups/create-group.mdx
@@ -1,0 +1,4 @@
+---
+title: "Create group"
+openapi: "POST /api/groups"
+---

--- a/docs/api-reference/groups/delete-group.mdx
+++ b/docs/api-reference/groups/delete-group.mdx
@@ -1,0 +1,4 @@
+---
+title: "Delete group"
+openapi: "DELETE /api/groups/{id}"
+---

--- a/docs/api-reference/groups/get-group.mdx
+++ b/docs/api-reference/groups/get-group.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get group"
+openapi: "GET /api/groups/{id}"
+---

--- a/docs/api-reference/groups/list-bindings.mdx
+++ b/docs/api-reference/groups/list-bindings.mdx
@@ -1,0 +1,4 @@
+---
+title: "List group bindings"
+openapi: "GET /api/groups/{id}/bindings"
+---

--- a/docs/api-reference/groups/list-groups.mdx
+++ b/docs/api-reference/groups/list-groups.mdx
@@ -1,0 +1,4 @@
+---
+title: "List groups"
+openapi: "GET /api/groups"
+---

--- a/docs/api-reference/groups/list-members.mdx
+++ b/docs/api-reference/groups/list-members.mdx
@@ -1,0 +1,4 @@
+---
+title: "List group members"
+openapi: "GET /api/groups/{id}/members"
+---

--- a/docs/api-reference/groups/overview.mdx
+++ b/docs/api-reference/groups/overview.mdx
@@ -1,0 +1,94 @@
+---
+title: 'Overview'
+description: 'Create and manage access groups, their members, and role bindings via the REST API. Enterprise feature.'
+---
+
+## Intro
+
+The Groups API lets you manage LangWatch access groups via REST. Groups are collections of users that share the same role bindings — when you assign a role to a group, every member inherits that access.
+
+Groups can be created manually via the API or provisioned automatically from your identity provider via [SCIM](/platform/scim).
+
+<Info>
+Groups are an **Enterprise** feature. Contact your account team to enable them.
+</Info>
+
+## Authentication
+
+The Groups API requires an **organization-level API key** with `organization:manage` permission (created in Settings > API Keys). Pass it as a Bearer token:
+
+```
+Authorization: Bearer sk-lw-<id>_<secret>
+```
+
+## Endpoints
+
+### Groups
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/groups` | List all groups in the organization |
+| `POST` | `/api/groups` | Create a new group (with optional members and bindings) |
+| `GET` | `/api/groups/{id}` | Get group details with members and bindings |
+| `PATCH` | `/api/groups/{id}` | Rename a group |
+| `DELETE` | `/api/groups/{id}` | Delete a group and all its memberships/bindings |
+
+### Members
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/groups/{id}/members` | List members of a group |
+| `POST` | `/api/groups/{id}/members` | Add a member to a group |
+| `DELETE` | `/api/groups/{id}/members/{userId}` | Remove a member from a group |
+
+### Role Bindings
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/groups/{id}/bindings` | List role bindings for a group |
+| `POST` | `/api/groups/{id}/bindings` | Add a role binding to a group |
+| `DELETE` | `/api/groups/{id}/bindings/{bindingId}` | Remove a role binding from a group |
+
+## SCIM-Managed Groups
+
+Groups provisioned from an identity provider via SCIM are marked with a `scimSource` field (e.g. `"azure-ad"`, `"okta"`). SCIM-managed groups have restrictions:
+
+- **Cannot be renamed** via this API (the IdP is the source of truth)
+- **Cannot have members added or removed** manually (membership is managed by the IdP)
+- Role bindings can still be managed via this API
+
+## Typical Flow
+
+1. Create an admin API key in Settings > API Keys with `organization:manage` permission
+2. Create a group with initial members and role bindings:
+
+```bash
+curl -X POST https://app.langwatch.ai/api/groups \
+  -H "Authorization: Bearer sk-lw-..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Backend Engineers",
+    "memberIds": ["user_abc", "user_def"],
+    "bindings": [
+      {
+        "role": "MEMBER",
+        "scopeType": "TEAM",
+        "scopeId": "<team_id>"
+      }
+    ]
+  }'
+```
+
+3. All members inherit the MEMBER role on the specified team and all its projects.
+
+## Role Binding Scopes
+
+Bindings can target three scope levels:
+
+| Scope Type | Description |
+|------------|-------------|
+| `ORGANIZATION` | Access to all teams and projects in the org |
+| `TEAM` | Access to a specific team and all its projects |
+| `PROJECT` | Access to a specific project only |
+
+Available roles: `ADMIN`, `MEMBER`, `VIEWER`, `CUSTOM` (requires `customRoleId`).

--- a/docs/api-reference/groups/remove-binding.mdx
+++ b/docs/api-reference/groups/remove-binding.mdx
@@ -1,0 +1,4 @@
+---
+title: "Remove group binding"
+openapi: "DELETE /api/groups/{id}/bindings/{bindingId}"
+---

--- a/docs/api-reference/groups/remove-member.mdx
+++ b/docs/api-reference/groups/remove-member.mdx
@@ -1,0 +1,4 @@
+---
+title: "Remove group member"
+openapi: "DELETE /api/groups/{id}/members/{userId}"
+---

--- a/docs/api-reference/groups/rename-group.mdx
+++ b/docs/api-reference/groups/rename-group.mdx
@@ -1,0 +1,4 @@
+---
+title: "Rename group"
+openapi: "PATCH /api/groups/{id}"
+---

--- a/docs/api-reference/projects/get-api-key.mdx
+++ b/docs/api-reference/projects/get-api-key.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get project API key"
+openapi: "GET /api/projects/{id}/api-key"
+---

--- a/docs/api-reference/projects/overview.mdx
+++ b/docs/api-reference/projects/overview.mdx
@@ -26,13 +26,30 @@ Project API keys (`X-Auth-Token`) cannot be used here — they lack organization
 | `GET` | `/api/projects` | List all projects in the organization |
 | `POST` | `/api/projects` | Create a new project (returns a service API key) |
 | `GET` | `/api/projects/{id}` | Get project details |
-| `PATCH` | `/api/projects/{id}` | Update project fields |
+| `PATCH` | `/api/projects/{id}` | Update project fields (including moving to a different team) |
 | `DELETE` | `/api/projects/{id}` | Archive a project |
+| `GET` | `/api/projects/{id}/api-key` | Get the project's API key |
+| `POST` | `/api/projects/{id}/regenerate-api-key` | Regenerate the project API key |
+
+## Moving a Project to Another Team
+
+You can move a project to a different team by including `teamId` in the `PATCH` request:
+
+```bash
+curl -X PATCH https://app.langwatch.ai/api/projects/<project_id> \
+  -H "Authorization: Bearer sk-lw-..." \
+  -H "Content-Type: application/json" \
+  -d '{"teamId": "<destination_team_id>"}'
+```
+
+<Warning>
+Moving a project changes its access boundary. Members who had access through the source team will lose inherited access, while members of the destination team will gain it. Project-level access overrides are preserved.
+</Warning>
 
 ## Typical Flow
 
 1. Create an admin API key in Settings > API Keys with `organization:manage` permission
-2. Call `POST /api/projects` with the project name and team
+2. Call `POST /api/projects` with the project name and either an existing `teamId` or a `newTeamName`
 3. Store the returned `serviceApiKey` and project `id`
 4. Use both values in your application:
 

--- a/docs/api-reference/projects/regenerate-api-key.mdx
+++ b/docs/api-reference/projects/regenerate-api-key.mdx
@@ -1,0 +1,4 @@
+---
+title: "Regenerate project API key"
+openapi: "POST /api/projects/{id}/regenerate-api-key"
+---

--- a/docs/api-reference/teams/add-member.mdx
+++ b/docs/api-reference/teams/add-member.mdx
@@ -1,0 +1,4 @@
+---
+title: "Add team member"
+openapi: "POST /api/teams/{id}/members"
+---

--- a/docs/api-reference/teams/list-members.mdx
+++ b/docs/api-reference/teams/list-members.mdx
@@ -1,0 +1,4 @@
+---
+title: "List team members"
+openapi: "GET /api/teams/{id}/members"
+---

--- a/docs/api-reference/teams/list-projects.mdx
+++ b/docs/api-reference/teams/list-projects.mdx
@@ -1,0 +1,4 @@
+---
+title: "List team projects"
+openapi: "GET /api/teams/{id}/projects"
+---

--- a/docs/api-reference/teams/overview.mdx
+++ b/docs/api-reference/teams/overview.mdx
@@ -28,6 +28,10 @@ Project API keys (`X-Auth-Token`) cannot be used here — they lack organization
 | `GET` | `/api/teams/{id}` | Get team details |
 | `PATCH` | `/api/teams/{id}` | Update a team |
 | `DELETE` | `/api/teams/{id}` | Archive a team (soft-delete) |
+| `GET` | `/api/teams/{id}/members` | List team members |
+| `POST` | `/api/teams/{id}/members` | Add a member to the team |
+| `DELETE` | `/api/teams/{id}/members/{userId}` | Remove a member from the team |
+| `GET` | `/api/teams/{id}/projects` | List projects in the team |
 
 ## Soft Delete
 
@@ -37,7 +41,7 @@ Project API keys (`X-Auth-Token`) cannot be used here — they lack organization
 
 1. Create an admin API key in Settings > API Keys with `team:manage` permission
 2. Call `POST /api/teams` with a team name
-3. Use the returned team `id` when creating projects via the Projects API
+3. Use the returned team `id` when creating projects via the Projects API, or later move an existing project by updating its `teamId`
 
 ```bash
 # Create team

--- a/docs/api-reference/teams/remove-member.mdx
+++ b/docs/api-reference/teams/remove-member.mdx
@@ -1,0 +1,4 @@
+---
+title: "Remove team member"
+openapi: "DELETE /api/teams/{id}/members/{userId}"
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1086,7 +1086,9 @@
               "api-reference/projects/create-project",
               "api-reference/projects/get-project",
               "api-reference/projects/update-project",
-              "api-reference/projects/archive-project"
+              "api-reference/projects/archive-project",
+              "api-reference/projects/get-api-key",
+              "api-reference/projects/regenerate-api-key"
             ]
           },
           {
@@ -1097,7 +1099,28 @@
               "api-reference/teams/create-team",
               "api-reference/teams/get-team",
               "api-reference/teams/update-team",
-              "api-reference/teams/archive-team"
+              "api-reference/teams/archive-team",
+              "api-reference/teams/list-members",
+              "api-reference/teams/add-member",
+              "api-reference/teams/remove-member",
+              "api-reference/teams/list-projects"
+            ]
+          },
+          {
+            "group": "Groups",
+            "pages": [
+              "api-reference/groups/overview",
+              "api-reference/groups/list-groups",
+              "api-reference/groups/create-group",
+              "api-reference/groups/get-group",
+              "api-reference/groups/rename-group",
+              "api-reference/groups/delete-group",
+              "api-reference/groups/list-members",
+              "api-reference/groups/add-member",
+              "api-reference/groups/remove-member",
+              "api-reference/groups/list-bindings",
+              "api-reference/groups/add-binding",
+              "api-reference/groups/remove-binding"
             ]
           },
           {

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -30425,6 +30425,204 @@ openapi: "PATCH /api/graphs/{id}"
 
 ---
 
+# FILE: ./api-reference/groups/add-binding.mdx
+
+---
+title: "Add group binding"
+openapi: "POST /api/groups/{id}/bindings"
+---
+
+---
+
+# FILE: ./api-reference/groups/add-member.mdx
+
+---
+title: "Add group member"
+openapi: "POST /api/groups/{id}/members"
+---
+
+---
+
+# FILE: ./api-reference/groups/create-group.mdx
+
+---
+title: "Create group"
+openapi: "POST /api/groups"
+---
+
+---
+
+# FILE: ./api-reference/groups/delete-group.mdx
+
+---
+title: "Delete group"
+openapi: "DELETE /api/groups/{id}"
+---
+
+---
+
+# FILE: ./api-reference/groups/get-group.mdx
+
+---
+title: "Get group"
+openapi: "GET /api/groups/{id}"
+---
+
+---
+
+# FILE: ./api-reference/groups/list-bindings.mdx
+
+---
+title: "List group bindings"
+openapi: "GET /api/groups/{id}/bindings"
+---
+
+---
+
+# FILE: ./api-reference/groups/list-groups.mdx
+
+---
+title: "List groups"
+openapi: "GET /api/groups"
+---
+
+---
+
+# FILE: ./api-reference/groups/list-members.mdx
+
+---
+title: "List group members"
+openapi: "GET /api/groups/{id}/members"
+---
+
+---
+
+# FILE: ./api-reference/groups/overview.mdx
+
+---
+title: 'Overview'
+description: 'Create and manage access groups, their members, and role bindings via the REST API. Enterprise feature.'
+---
+
+## Intro
+
+The Groups API lets you manage LangWatch access groups via REST. Groups are collections of users that share the same role bindings — when you assign a role to a group, every member inherits that access.
+
+Groups can be created manually via the API or provisioned automatically from your identity provider via [SCIM](/platform/scim).
+
+<Info>
+Groups are an **Enterprise** feature. Contact your account team to enable them.
+</Info>
+
+## Authentication
+
+The Groups API requires an **organization-level API key** with `organization:manage` permission (created in Settings > API Keys). Pass it as a Bearer token:
+
+```
+Authorization: Bearer sk-lw-<id>_<secret>
+```
+
+## Endpoints
+
+### Groups
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/groups` | List all groups in the organization |
+| `POST` | `/api/groups` | Create a new group (with optional members and bindings) |
+| `GET` | `/api/groups/{id}` | Get group details with members and bindings |
+| `PATCH` | `/api/groups/{id}` | Rename a group |
+| `DELETE` | `/api/groups/{id}` | Delete a group and all its memberships/bindings |
+
+### Members
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/groups/{id}/members` | List members of a group |
+| `POST` | `/api/groups/{id}/members` | Add a member to a group |
+| `DELETE` | `/api/groups/{id}/members/{userId}` | Remove a member from a group |
+
+### Role Bindings
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/groups/{id}/bindings` | List role bindings for a group |
+| `POST` | `/api/groups/{id}/bindings` | Add a role binding to a group |
+| `DELETE` | `/api/groups/{id}/bindings/{bindingId}` | Remove a role binding from a group |
+
+## SCIM-Managed Groups
+
+Groups provisioned from an identity provider via SCIM are marked with a `scimSource` field (e.g. `"azure-ad"`, `"okta"`). SCIM-managed groups have restrictions:
+
+- **Cannot be renamed** via this API (the IdP is the source of truth)
+- **Cannot have members added or removed** manually (membership is managed by the IdP)
+- Role bindings can still be managed via this API
+
+## Typical Flow
+
+1. Create an admin API key in Settings > API Keys with `organization:manage` permission
+2. Create a group with initial members and role bindings:
+
+```bash
+curl -X POST https://app.langwatch.ai/api/groups \
+  -H "Authorization: Bearer sk-lw-..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Backend Engineers",
+    "memberIds": ["user_abc", "user_def"],
+    "bindings": [
+      {
+        "role": "MEMBER",
+        "scopeType": "TEAM",
+        "scopeId": "<team_id>"
+      }
+    ]
+  }'
+```
+
+3. All members inherit the MEMBER role on the specified team and all its projects.
+
+## Role Binding Scopes
+
+Bindings can target three scope levels:
+
+| Scope Type | Description |
+|------------|-------------|
+| `ORGANIZATION` | Access to all teams and projects in the org |
+| `TEAM` | Access to a specific team and all its projects |
+| `PROJECT` | Access to a specific project only |
+
+Available roles: `ADMIN`, `MEMBER`, `VIEWER`, `CUSTOM` (requires `customRoleId`).
+
+---
+
+# FILE: ./api-reference/groups/remove-binding.mdx
+
+---
+title: "Remove group binding"
+openapi: "DELETE /api/groups/{id}/bindings/{bindingId}"
+---
+
+---
+
+# FILE: ./api-reference/groups/remove-member.mdx
+
+---
+title: "Remove group member"
+openapi: "DELETE /api/groups/{id}/members/{userId}"
+---
+
+---
+
+# FILE: ./api-reference/groups/rename-group.mdx
+
+---
+title: "Rename group"
+openapi: "PATCH /api/groups/{id}"
+---
+
+---
+
 # FILE: ./api-reference/model-providers/list-model-providers.mdx
 
 ---
@@ -30541,6 +30739,15 @@ openapi: "POST /api/projects"
 
 ---
 
+# FILE: ./api-reference/projects/get-api-key.mdx
+
+---
+title: "Get project API key"
+openapi: "GET /api/projects/{id}/api-key"
+---
+
+---
+
 # FILE: ./api-reference/projects/get-project.mdx
 
 ---
@@ -30589,13 +30796,30 @@ Project API keys (`X-Auth-Token`) cannot be used here — they lack organization
 | `GET` | `/api/projects` | List all projects in the organization |
 | `POST` | `/api/projects` | Create a new project (returns a service API key) |
 | `GET` | `/api/projects/{id}` | Get project details |
-| `PATCH` | `/api/projects/{id}` | Update project fields |
+| `PATCH` | `/api/projects/{id}` | Update project fields (including moving to a different team) |
 | `DELETE` | `/api/projects/{id}` | Archive a project |
+| `GET` | `/api/projects/{id}/api-key` | Get the project's API key |
+| `POST` | `/api/projects/{id}/regenerate-api-key` | Regenerate the project API key |
+
+## Moving a Project to Another Team
+
+You can move a project to a different team by including `teamId` in the `PATCH` request:
+
+```bash
+curl -X PATCH https://app.langwatch.ai/api/projects/<project_id> \
+  -H "Authorization: Bearer sk-lw-..." \
+  -H "Content-Type: application/json" \
+  -d '{"teamId": "<destination_team_id>"}'
+```
+
+<Warning>
+Moving a project changes its access boundary. Members who had access through the source team will lose inherited access, while members of the destination team will gain it. Project-level access overrides are preserved.
+</Warning>
 
 ## Typical Flow
 
 1. Create an admin API key in Settings > API Keys with `organization:manage` permission
-2. Call `POST /api/projects` with the project name and team
+2. Call `POST /api/projects` with the project name and either an existing `teamId` or a `newTeamName`
 3. Store the returned `serviceApiKey` and project `id`
 4. Use both values in your application:
 
@@ -30607,6 +30831,15 @@ LANGWATCH_PROJECT_ID=<project id>
 <Info>
 The `serviceApiKey` is shown only once in the create response. Store it securely — you cannot retrieve it later.
 </Info>
+
+---
+
+# FILE: ./api-reference/projects/regenerate-api-key.mdx
+
+---
+title: "Regenerate project API key"
+openapi: "POST /api/projects/{id}/regenerate-api-key"
+---
 
 ---
 
@@ -31144,6 +31377,15 @@ openapi: "PATCH /api/suites/{id}"
 
 ---
 
+# FILE: ./api-reference/teams/add-member.mdx
+
+---
+title: "Add team member"
+openapi: "POST /api/teams/{id}/members"
+---
+
+---
+
 # FILE: ./api-reference/teams/archive-team.mdx
 
 ---
@@ -31167,6 +31409,24 @@ openapi: "POST /api/teams"
 ---
 title: "Get team"
 openapi: "GET /api/teams/{id}"
+---
+
+---
+
+# FILE: ./api-reference/teams/list-members.mdx
+
+---
+title: "List team members"
+openapi: "GET /api/teams/{id}/members"
+---
+
+---
+
+# FILE: ./api-reference/teams/list-projects.mdx
+
+---
+title: "List team projects"
+openapi: "GET /api/teams/{id}/projects"
 ---
 
 ---
@@ -31212,6 +31472,10 @@ Project API keys (`X-Auth-Token`) cannot be used here — they lack organization
 | `GET` | `/api/teams/{id}` | Get team details |
 | `PATCH` | `/api/teams/{id}` | Update a team |
 | `DELETE` | `/api/teams/{id}` | Archive a team (soft-delete) |
+| `GET` | `/api/teams/{id}/members` | List team members |
+| `POST` | `/api/teams/{id}/members` | Add a member to the team |
+| `DELETE` | `/api/teams/{id}/members/{userId}` | Remove a member from the team |
+| `GET` | `/api/teams/{id}/projects` | List projects in the team |
 
 ## Soft Delete
 
@@ -31221,7 +31485,7 @@ Project API keys (`X-Auth-Token`) cannot be used here — they lack organization
 
 1. Create an admin API key in Settings > API Keys with `team:manage` permission
 2. Call `POST /api/teams` with a team name
-3. Use the returned team `id` when creating projects via the Projects API
+3. Use the returned team `id` when creating projects via the Projects API, or later move an existing project by updating its `teamId`
 
 ```bash
 # Create team
@@ -31236,6 +31500,15 @@ curl -X POST https://app.langwatch.ai/api/projects \
   -H "Content-Type: application/json" \
   -d '{"name": "My Project", "teamId": "<team_id>", "language": "python", "framework": "langchain"}'
 ```
+
+---
+
+# FILE: ./api-reference/teams/remove-member.mdx
+
+---
+title: "Remove team member"
+openapi: "DELETE /api/teams/{id}/members/{userId}"
+---
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -292,6 +292,8 @@ Always navigate to docs links using the .md extension for better readability.
 - [Get project](https://langwatch.ai/docs/api-reference/projects/get-project.md)
 - [Update project](https://langwatch.ai/docs/api-reference/projects/update-project.md)
 - [Archive project](https://langwatch.ai/docs/api-reference/projects/archive-project.md)
+- [Get project API key](https://langwatch.ai/docs/api-reference/projects/get-api-key.md)
+- [Regenerate project API key](https://langwatch.ai/docs/api-reference/projects/regenerate-api-key.md)
 
 ## Teams
 
@@ -301,6 +303,25 @@ Always navigate to docs links using the .md extension for better readability.
 - [Get team](https://langwatch.ai/docs/api-reference/teams/get-team.md)
 - [Update team](https://langwatch.ai/docs/api-reference/teams/update-team.md)
 - [Archive team](https://langwatch.ai/docs/api-reference/teams/archive-team.md)
+- [List team members](https://langwatch.ai/docs/api-reference/teams/list-members.md)
+- [Add team member](https://langwatch.ai/docs/api-reference/teams/add-member.md)
+- [Remove team member](https://langwatch.ai/docs/api-reference/teams/remove-member.md)
+- [List team projects](https://langwatch.ai/docs/api-reference/teams/list-projects.md)
+
+## Groups
+
+- [Overview](https://langwatch.ai/docs/api-reference/groups/overview.md): Create and manage access groups, their members, and role bindings via the REST API. Enterprise feature.
+- [List groups](https://langwatch.ai/docs/api-reference/groups/list-groups.md)
+- [Create group](https://langwatch.ai/docs/api-reference/groups/create-group.md)
+- [Get group](https://langwatch.ai/docs/api-reference/groups/get-group.md)
+- [Rename group](https://langwatch.ai/docs/api-reference/groups/rename-group.md)
+- [Delete group](https://langwatch.ai/docs/api-reference/groups/delete-group.md)
+- [List group members](https://langwatch.ai/docs/api-reference/groups/list-members.md)
+- [Add group member](https://langwatch.ai/docs/api-reference/groups/add-member.md)
+- [Remove group member](https://langwatch.ai/docs/api-reference/groups/remove-member.md)
+- [List group bindings](https://langwatch.ai/docs/api-reference/groups/list-bindings.md)
+- [Add group binding](https://langwatch.ai/docs/api-reference/groups/add-binding.md)
+- [Remove group binding](https://langwatch.ai/docs/api-reference/groups/remove-binding.md)
 
 ## API Keys
 

--- a/docs/platform/rbac.mdx
+++ b/docs/platform/rbac.mdx
@@ -114,6 +114,23 @@ The system implements a hierarchical permission model where:
 - **`manage` permissions automatically include** `view`, `create`, `update`, and `delete` permissions
 - This means if a user has `analytics:manage`, they automatically have `analytics:view`, `analytics:create`, `analytics:update`, and `analytics:delete`
 
+## Organization Structure
+
+LangWatch uses three layers for access and ownership:
+
+- **Organization**: the top-level container for billing, users, and shared policy.
+- **Team**: the container that groups projects and members together.
+- **Project**: the actual unit where traces, evaluations, prompts, and API keys live.
+
+Practical rules:
+
+- Create teams first when you want a new workspace boundary for a department or product line.
+- Create projects inside a team, or move an existing project to another team when ownership changes.
+- Moving a project between teams changes the inherited RBAC boundary. Team members on the destination team gain access, and source-team inheritance no longer applies.
+- Groups are the scale mechanism on top of this hierarchy. Use them to assign the same role bindings to many users at once.
+
+The day-to-day flows live in the UI under **Settings → Teams**, **Settings → Projects**, and **Settings → Groups**. The same operations are available through the Teams, Projects, and Groups APIs.
+
 ## Custom Roles
 
 ### Overview

--- a/docs/platform/scim-groups.mdx
+++ b/docs/platform/scim-groups.mdx
@@ -7,6 +7,8 @@ keywords: scim, groups, role mapping, provisioning, okta, azure ad, entra id, id
 
 SCIM Groups allow your identity provider to push group memberships into LangWatch. Admins can then map those groups to specific roles at the organization, team, or project level, so users automatically get the right access the moment they are provisioned.
 
+Whether the group is SCIM-synced or created manually in the UI, groups are an **Enterprise** feature in LangWatch.
+
 <Info>
   SCIM Groups are an **Enterprise** feature. See [SCIM Provisioning](/platform/scim) for setting up user provisioning first.
 </Info>
@@ -181,6 +183,22 @@ GET /api/scim/v2/Groups?filter=displayName eq "Engineering"
 
 - Ensure your IdP is configured to push group membership changes (not just user changes)
 - Check provisioning logs for any errors on the PATCH groups endpoint
+
+---
+
+## Managing Groups via REST API
+
+In addition to the UI and SCIM provisioning, groups can be managed programmatically via the [Groups REST API](/api-reference/groups/overview). This is useful for:
+
+- Automating group creation and membership management
+- Scripting role binding assignments
+- Integrating with custom provisioning workflows
+
+See the [Groups API Reference](/api-reference/groups/overview) for full endpoint documentation.
+
+<Info>
+SCIM-managed groups cannot have their members or names modified via the REST API — those operations are reserved for the identity provider.
+</Info>
 
 ---
 

--- a/langwatch/src/app/api/groups/[[...route]]/app.ts
+++ b/langwatch/src/app/api/groups/[[...route]]/app.ts
@@ -1,0 +1,469 @@
+import {
+  RoleBindingScopeType,
+  TeamUserRole,
+  type Organization,
+} from "@prisma/client";
+import { describeRoute } from "hono-openapi";
+import { validator as zValidator } from "hono-openapi/zod";
+import { z } from "zod";
+import {
+  BindingNotFoundError,
+  GroupNotFoundError,
+  GroupRestService,
+  ScimManagedGroupError,
+  UserNotInOrganizationError,
+} from "~/server/app-layer/groups/group.service";
+import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
+import { createOrgApp, requires } from "~/server/api/security";
+import type { GroupServiceMiddlewareVariables } from "../../middleware/group-service";
+import { groupServiceMiddleware } from "../../middleware/group-service";
+import { BadRequestError, NotFoundError } from "../../shared/errors";
+import { handleGroupError } from "./error-handler";
+
+patchZodOpenapi();
+
+const paginationQuerySchema = z.object({
+  page: z.coerce.number().int().positive().optional().default(1),
+  limit: z.coerce.number().int().positive().max(1000).optional().default(50),
+});
+
+const createGroupSchema = z.object({
+  name: z.string().trim().min(1, "name is required").max(100),
+  bindings: z
+    .array(
+      z.object({
+        role: z.nativeEnum(TeamUserRole),
+        customRoleId: z.string().optional(),
+        scopeType: z.nativeEnum(RoleBindingScopeType),
+        scopeId: z.string(),
+      }),
+    )
+    .optional(),
+  memberIds: z.array(z.string()).optional(),
+});
+
+const updateGroupSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+});
+
+const addMemberSchema = z.object({
+  userId: z.string().min(1, "userId is required"),
+});
+
+const addBindingSchema = z.object({
+  role: z.nativeEnum(TeamUserRole),
+  customRoleId: z.string().optional(),
+  scopeType: z.nativeEnum(RoleBindingScopeType),
+  scopeId: z.string().min(1, "scopeId is required"),
+});
+
+function validationHook(
+  result: {
+    success: boolean;
+    error?: {
+      issues: Array<{ message?: string; path?: (string | number)[] }>;
+    };
+  },
+  c: { json: (body: unknown, status: number) => Response },
+): Response | undefined {
+  if (!result.success) {
+    const issue = result.error?.issues?.[0];
+    return c.json(
+      {
+        error: "Unprocessable Entity",
+        message: issue?.message ?? "Validation failed",
+        path: issue?.path,
+      },
+      422,
+    );
+  }
+  return undefined;
+}
+
+const secured = createOrgApp<GroupServiceMiddlewareVariables>({
+  basePath: "/api/groups",
+});
+
+secured.hono.onError(handleGroupError);
+
+// ── List groups ──────────────────────────────────────────────────────────────
+
+secured
+  .access(requires("organization:manage"))
+  .get(
+    "/",
+    groupServiceMiddleware,
+    describeRoute({ description: "List all groups for the organization" }),
+    zValidator("query", paginationQuerySchema),
+    async (c) => {
+      const organization = c.get("organization") as Organization;
+      const { page, limit } = c.req.valid("query");
+      const service = c.get("groupService") as GroupRestService;
+
+      const result = await service.listByOrganization({
+        organizationId: organization.id,
+        page,
+        limit,
+      });
+
+      return c.json({
+        data: result.data.map((g) => ({
+          id: g.id,
+          name: g.name,
+          slug: g.slug,
+          externalId: g.externalId,
+          scimSource: g.scimSource,
+          memberCount: g._count.members,
+          bindings: g.roleBindings.map((b) => ({
+            id: b.id,
+            role: b.role,
+            customRoleId: b.customRoleId,
+            customRoleName: b.customRole?.name ?? null,
+            scopeType: b.scopeType,
+            scopeId: b.scopeId,
+          })),
+          createdAt: g.createdAt,
+        })),
+        pagination: result.pagination,
+      });
+    },
+  );
+
+// ── Create group ─────────────────────────────────────────────────────────────
+
+secured
+  .access(requires("organization:manage"))
+  .post(
+    "/",
+    groupServiceMiddleware,
+    describeRoute({ description: "Create a new group" }),
+    zValidator("json", createGroupSchema, validationHook),
+    async (c) => {
+      const organization = c.get("organization") as Organization;
+      const body = c.req.valid("json");
+      const service = c.get("groupService") as GroupRestService;
+
+      const group = await service.create({
+        organizationId: organization.id,
+        name: body.name,
+        bindings: body.bindings,
+        memberIds: body.memberIds,
+      });
+
+      return c.json(
+        {
+          id: group.id,
+          name: group.name,
+          slug: group.slug,
+          organizationId: group.organizationId,
+          createdAt: group.createdAt,
+        },
+        201,
+      );
+    },
+  );
+
+// ── Get group ────────────────────────────────────────────────────────────────
+
+secured
+  .access(requires("organization:manage"))
+  .get(
+    "/:id",
+    groupServiceMiddleware,
+    describeRoute({ description: "Get a group with members and bindings" }),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("groupService") as GroupRestService;
+
+      const group = await service.getById({
+        id,
+        organizationId: organization.id,
+      });
+      if (!group) throw new NotFoundError("Group not found");
+
+      return c.json({
+        id: group.id,
+        name: group.name,
+        slug: group.slug,
+        externalId: group.externalId,
+        scimSource: group.scimSource,
+        members: group.members.map((m) => ({
+          userId: m.userId,
+          name: m.user.name,
+          email: m.user.email,
+        })),
+        bindings: group.roleBindings.map((b) => ({
+          id: b.id,
+          role: b.role,
+          customRoleId: b.customRoleId,
+          customRoleName: b.customRole?.name ?? null,
+          scopeType: b.scopeType,
+          scopeId: b.scopeId,
+        })),
+      });
+    },
+  );
+
+// ── Update group (rename) ────────────────────────────────────────────────────
+
+secured
+  .access(requires("organization:manage"))
+  .patch(
+    "/:id",
+    groupServiceMiddleware,
+    describeRoute({ description: "Rename a group" }),
+    zValidator("json", updateGroupSchema, validationHook),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const body = c.req.valid("json");
+      const service = c.get("groupService") as GroupRestService;
+
+      try {
+        const group = await service.rename({
+          id,
+          organizationId: organization.id,
+          name: body.name,
+        });
+        return c.json({
+          id: group.id,
+          name: group.name,
+          slug: group.slug,
+        });
+      } catch (error) {
+        if (error instanceof GroupNotFoundError) {
+          throw new NotFoundError(error.message);
+        }
+        if (error instanceof ScimManagedGroupError) {
+          throw new BadRequestError(error.message);
+        }
+        throw error;
+      }
+    },
+  );
+
+// ── Delete group ─────────────────────────────────────────────────────────────
+
+secured
+  .access(requires("organization:manage"))
+  .delete(
+    "/:id",
+    groupServiceMiddleware,
+    describeRoute({ description: "Delete a group" }),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("groupService") as GroupRestService;
+
+      try {
+        await service.delete({ id, organizationId: organization.id });
+      } catch (error) {
+        if (error instanceof GroupNotFoundError) {
+          throw new NotFoundError(error.message);
+        }
+        throw error;
+      }
+
+      return c.json({ success: true });
+    },
+  );
+
+// ── Members ──────────────────────────────────────────────────────────────────
+
+secured
+  .access(requires("organization:manage"))
+  .get(
+    "/:id/members",
+    groupServiceMiddleware,
+    describeRoute({ description: "List members of a group" }),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("groupService") as GroupRestService;
+
+      const group = await service.getById({
+        id,
+        organizationId: organization.id,
+      });
+      if (!group) throw new NotFoundError("Group not found");
+
+      const members = await service.getMembers({ groupId: id });
+      return c.json({
+        data: members.map((m) => ({
+          userId: m.userId,
+          name: m.user.name,
+          email: m.user.email,
+        })),
+      });
+    },
+  );
+
+secured
+  .access(requires("organization:manage"))
+  .post(
+    "/:id/members",
+    groupServiceMiddleware,
+    describeRoute({ description: "Add a member to a group" }),
+    zValidator("json", addMemberSchema, validationHook),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const body = c.req.valid("json");
+      const service = c.get("groupService") as GroupRestService;
+
+      try {
+        await service.addMember({
+          groupId: id,
+          organizationId: organization.id,
+          userId: body.userId,
+        });
+      } catch (error) {
+        if (error instanceof GroupNotFoundError) {
+          throw new NotFoundError(error.message);
+        }
+        if (
+          error instanceof ScimManagedGroupError ||
+          error instanceof UserNotInOrganizationError
+        ) {
+          throw new BadRequestError(error.message);
+        }
+        throw error;
+      }
+
+      return c.json({ success: true }, 201);
+    },
+  );
+
+secured
+  .access(requires("organization:manage"))
+  .delete(
+    "/:id/members/:userId",
+    groupServiceMiddleware,
+    describeRoute({ description: "Remove a member from a group" }),
+    async (c) => {
+      const { id, userId } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("groupService") as GroupRestService;
+
+      try {
+        await service.removeMember({
+          groupId: id,
+          organizationId: organization.id,
+          userId,
+        });
+      } catch (error) {
+        if (error instanceof GroupNotFoundError) {
+          throw new NotFoundError(error.message);
+        }
+        if (error instanceof ScimManagedGroupError) {
+          throw new BadRequestError(error.message);
+        }
+        throw error;
+      }
+
+      return c.json({ success: true });
+    },
+  );
+
+// ── Bindings ─────────────────────────────────────────────────────────────────
+
+secured
+  .access(requires("organization:manage"))
+  .get(
+    "/:id/bindings",
+    groupServiceMiddleware,
+    describeRoute({ description: "List role bindings for a group" }),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("groupService") as GroupRestService;
+
+      const group = await service.getById({
+        id,
+        organizationId: organization.id,
+      });
+      if (!group) throw new NotFoundError("Group not found");
+
+      const bindings = await service.getBindings({ groupId: id });
+      return c.json({
+        data: bindings.map((b) => ({
+          id: b.id,
+          role: b.role,
+          customRoleId: b.customRoleId,
+          customRoleName: b.customRole?.name ?? null,
+          scopeType: b.scopeType,
+          scopeId: b.scopeId,
+        })),
+      });
+    },
+  );
+
+secured
+  .access(requires("organization:manage"))
+  .post(
+    "/:id/bindings",
+    groupServiceMiddleware,
+    describeRoute({ description: "Add a role binding to a group" }),
+    zValidator("json", addBindingSchema, validationHook),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const body = c.req.valid("json");
+      const service = c.get("groupService") as GroupRestService;
+
+      try {
+        const binding = await service.addBinding({
+          groupId: id,
+          organizationId: organization.id,
+          role: body.role,
+          customRoleId: body.customRoleId,
+          scopeType: body.scopeType,
+          scopeId: body.scopeId,
+        });
+        return c.json(
+          {
+            id: binding.id,
+            role: binding.role,
+            scopeType: binding.scopeType,
+            scopeId: binding.scopeId,
+          },
+          201,
+        );
+      } catch (error) {
+        if (error instanceof GroupNotFoundError) {
+          throw new NotFoundError(error.message);
+        }
+        throw error;
+      }
+    },
+  );
+
+secured
+  .access(requires("organization:manage"))
+  .delete(
+    "/:id/bindings/:bindingId",
+    groupServiceMiddleware,
+    describeRoute({ description: "Remove a role binding from a group" }),
+    async (c) => {
+      const { bindingId } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("groupService") as GroupRestService;
+
+      try {
+        await service.removeBinding({
+          bindingId,
+          organizationId: organization.id,
+        });
+      } catch (error) {
+        if (error instanceof BindingNotFoundError) {
+          throw new NotFoundError(error.message);
+        }
+        throw error;
+      }
+
+      return c.json({ success: true });
+    },
+  );
+
+export const app = secured.hono;

--- a/langwatch/src/app/api/groups/[[...route]]/app.ts
+++ b/langwatch/src/app/api/groups/[[...route]]/app.ts
@@ -8,6 +8,7 @@ import { validator as zValidator } from "hono-openapi/zod";
 import { z } from "zod";
 import {
   BindingNotFoundError,
+  DuplicateMemberError,
   GroupNotFoundError,
   GroupRestService,
   ScimManagedGroupError,
@@ -35,7 +36,7 @@ const createGroupSchema = z.object({
         role: z.nativeEnum(TeamUserRole),
         customRoleId: z.string().optional(),
         scopeType: z.nativeEnum(RoleBindingScopeType),
-        scopeId: z.string(),
+        scopeId: z.string().min(1, "scopeId is required"),
       }),
     )
     .optional(),
@@ -324,7 +325,8 @@ secured
         }
         if (
           error instanceof ScimManagedGroupError ||
-          error instanceof UserNotInOrganizationError
+          error instanceof UserNotInOrganizationError ||
+          error instanceof DuplicateMemberError
         ) {
           throw new BadRequestError(error.message);
         }
@@ -446,9 +448,22 @@ secured
     groupServiceMiddleware,
     describeRoute({ description: "Remove a role binding from a group" }),
     async (c) => {
-      const { bindingId } = c.req.param();
+      const { id, bindingId } = c.req.param();
       const organization = c.get("organization") as Organization;
       const service = c.get("groupService") as GroupRestService;
+
+      const group = await service.getById({
+        id,
+        organizationId: organization.id,
+      });
+      if (!group) throw new NotFoundError("Group not found");
+
+      const bindingBelongsToGroup = group.roleBindings.some(
+        (b) => b.id === bindingId,
+      );
+      if (!bindingBelongsToGroup) {
+        throw new NotFoundError("Binding not found on this group");
+      }
 
       try {
         await service.removeBinding({

--- a/langwatch/src/app/api/groups/[[...route]]/app.ts
+++ b/langwatch/src/app/api/groups/[[...route]]/app.ts
@@ -12,6 +12,7 @@ import {
   GroupNotFoundError,
   GroupRestService,
   ScimManagedGroupError,
+  ScopeNotInOrganizationError,
   UserNotInOrganizationError,
 } from "~/server/app-layer/groups/group.service";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
@@ -435,6 +436,9 @@ secured
       } catch (error) {
         if (error instanceof GroupNotFoundError) {
           throw new NotFoundError(error.message);
+        }
+        if (error instanceof ScopeNotInOrganizationError) {
+          throw new BadRequestError(error.message);
         }
         throw error;
       }

--- a/langwatch/src/app/api/groups/[[...route]]/error-handler.ts
+++ b/langwatch/src/app/api/groups/[[...route]]/error-handler.ts
@@ -1,0 +1,37 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { createLogger } from "../../../../utils/logger/server";
+import { HttpError, InternalServerError } from "../../shared/errors";
+import { errorSchema } from "../../shared/schemas";
+
+const logger = createLogger("langwatch:api:groups:errors");
+
+export const handleGroupError = async (
+  error: Error & { status?: ContentfulStatusCode },
+  c: Context,
+): Promise<Response> => {
+  const status =
+    error instanceof HttpError ? error.status : (error.status ?? 500);
+
+  logger.error(
+    {
+      path: c.req.path,
+      method: c.req.method,
+      routeParams: c.req.param(),
+      status,
+      error: {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      },
+    },
+    `Groups API Error [${status}]: ${error.message || String(error)}`,
+  );
+
+  if (error instanceof HttpError) {
+    return c.json(errorSchema.parse(error), error.status);
+  }
+
+  const internalError = new InternalServerError();
+  return c.json(errorSchema.parse(internalError), internalError.status);
+};

--- a/langwatch/src/app/api/groups/__tests__/groups-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/groups/__tests__/groups-rest-api.integration.test.ts
@@ -1,0 +1,513 @@
+import {
+  OrganizationUserRole,
+  RoleBindingScopeType,
+  TeamUserRole,
+  type Organization,
+  type Team,
+} from "@prisma/client";
+import { generate } from "@langwatch/ksuid";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import { prisma } from "~/server/db";
+import { ApiKeyService } from "~/server/api-key/api-key.service";
+import { app } from "../[[...route]]/app";
+
+describe("Feature: Groups REST API", () => {
+  const ns = `groups-api-${nanoid(8)}`;
+
+  let testOrganization: Organization;
+  let testTeam: Team;
+  let patToken: string;
+  let userId: string;
+  let secondUserId: string;
+
+  const authHeaders = () => ({
+    Authorization: `Bearer ${patToken}`,
+    "Content-Type": "application/json",
+  });
+
+  const api = {
+    get: (path: string) =>
+      app.request(path, { headers: authHeaders() }),
+    post: (path: string, body: unknown) =>
+      app.request(path, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(body),
+      }),
+    patch: (path: string, body: unknown) =>
+      app.request(path, {
+        method: "PATCH",
+        headers: authHeaders(),
+        body: JSON.stringify(body),
+      }),
+    delete: (path: string) =>
+      app.request(path, {
+        method: "DELETE",
+        headers: authHeaders(),
+      }),
+  };
+
+  beforeAll(async () => {
+    testOrganization = await prisma.organization.create({
+      data: { name: "Groups Test Org", slug: `--test-org-${ns}` },
+    });
+
+    testTeam = await prisma.team.create({
+      data: {
+        name: "Groups Test Team",
+        slug: `--test-team-${ns}`,
+        organizationId: testOrganization.id,
+      },
+    });
+
+    const user = await prisma.user.create({
+      data: {
+        name: "Groups Test User",
+        email: `test-${ns}@example.com`,
+      },
+    });
+    userId = user.id;
+
+    const user2 = await prisma.user.create({
+      data: {
+        name: "Groups Second User",
+        email: `test2-${ns}@example.com`,
+      },
+    });
+    secondUserId = user2.id;
+
+    await prisma.organizationUser.create({
+      data: {
+        userId,
+        organizationId: testOrganization.id,
+        role: OrganizationUserRole.ADMIN,
+      },
+    });
+
+    await prisma.organizationUser.create({
+      data: {
+        userId: secondUserId,
+        organizationId: testOrganization.id,
+        role: OrganizationUserRole.MEMBER,
+      },
+    });
+
+    await prisma.roleBinding.create({
+      data: {
+        id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+        organizationId: testOrganization.id,
+        userId,
+        role: TeamUserRole.ADMIN,
+        scopeType: RoleBindingScopeType.ORGANIZATION,
+        scopeId: testOrganization.id,
+      },
+    });
+
+    const apiKeyService = ApiKeyService.create(prisma);
+    const created = await apiKeyService.create({
+      name: `groups-key-${nanoid(6)}`,
+      userId,
+      createdByUserId: userId,
+      organizationId: testOrganization.id,
+      permissionMode: "all",
+      bindings: [
+        {
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.ORGANIZATION,
+          scopeId: testOrganization.id,
+        },
+      ],
+    });
+    patToken = created.token;
+  });
+
+  afterAll(async () => {
+    await prisma.groupMembership.deleteMany({
+      where: { group: { organizationId: testOrganization.id } },
+    }).catch(() => {});
+    await prisma.roleBinding.deleteMany({
+      where: { organizationId: testOrganization.id },
+    }).catch(() => {});
+    await prisma.group.deleteMany({
+      where: { organizationId: testOrganization.id },
+    }).catch(() => {});
+    await prisma.apiKey.deleteMany({
+      where: { organizationId: testOrganization.id },
+    }).catch(() => {});
+    await prisma.organizationUser.deleteMany({
+      where: { organizationId: testOrganization.id },
+    }).catch(() => {});
+    await prisma.team.deleteMany({
+      where: { organizationId: testOrganization.id },
+    }).catch(() => {});
+    await prisma.user.deleteMany({
+      where: { id: { in: [userId, secondUserId] } },
+    }).catch(() => {});
+    await prisma.organization.delete({
+      where: { id: testOrganization.id },
+    }).catch(() => {});
+  });
+
+  describe("GET /api/groups", () => {
+    /** @scenario GET /api/groups lists all groups */
+    it("lists all groups for the organization", async () => {
+      await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `List Test ${ns}`,
+          slug: `list-test-${ns}`,
+          organizationId: testOrganization.id,
+        },
+      });
+
+      const res = await api.get("/api/groups");
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.data).toBeDefined();
+      expect(body.data.length).toBeGreaterThan(0);
+    });
+
+    /** @scenario GET /api/groups returns paginated results */
+    it("returns paginated results", async () => {
+      const res = await api.get("/api/groups?page=1&limit=10");
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.pagination).toBeDefined();
+      expect(body.pagination.page).toBe(1);
+      expect(body.pagination.limit).toBe(10);
+    });
+
+    /** @scenario GET /api/groups returns 401 without auth */
+    it("returns 401 without auth", async () => {
+      const res = await app.request("/api/groups");
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/groups", () => {
+    /** @scenario POST /api/groups creates a group */
+    it("creates a group", async () => {
+      const res = await api.post("/api/groups", {
+        name: `New Group ${nanoid(6)}`,
+      });
+      expect(res.status).toBe(201);
+
+      const body = await res.json();
+      expect(body.id).toBeDefined();
+      expect(body.slug).toBeDefined();
+    });
+
+    /** @scenario POST /api/groups creates a group with initial members and bindings */
+    it("creates a group with members and bindings", async () => {
+      const res = await api.post("/api/groups", {
+        name: `Full Group ${nanoid(6)}`,
+        memberIds: [secondUserId],
+        bindings: [
+          {
+            role: "MEMBER",
+            scopeType: "TEAM",
+            scopeId: testTeam.id,
+          },
+        ],
+      });
+      expect(res.status).toBe(201);
+
+      const body = await res.json();
+      const detail = await api.get(`/api/groups/${body.id}`);
+      const detailBody = await detail.json();
+      expect(detailBody.members.length).toBe(1);
+      expect(detailBody.bindings.length).toBe(1);
+    });
+
+    /** @scenario POST /api/groups returns 422 for missing name */
+    it("returns 422 for missing name", async () => {
+      const res = await api.post("/api/groups", {});
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe("GET /api/groups/:id", () => {
+    /** @scenario GET /api/groups/:id returns group with members and bindings */
+    it("returns group with members and bindings", async () => {
+      const group = await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `Detail Test ${ns}`,
+          slug: `detail-test-${ns}`,
+          organizationId: testOrganization.id,
+        },
+      });
+      await prisma.groupMembership.create({
+        data: { groupId: group.id, userId: secondUserId },
+      });
+
+      const res = await api.get(`/api/groups/${group.id}`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.members).toBeDefined();
+      expect(body.members.length).toBe(1);
+      expect(body.members[0].userId).toBe(secondUserId);
+      expect(body.bindings).toBeDefined();
+    });
+
+    /** @scenario GET /api/groups/:id returns 404 for nonexistent group */
+    it("returns 404 for nonexistent", async () => {
+      const res = await api.get("/api/groups/nonexistent");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/groups/:id", () => {
+    /** @scenario PATCH /api/groups/:id renames a group */
+    it("renames a group", async () => {
+      const group = await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `Rename Test ${ns}`,
+          slug: `rename-test-${ns}`,
+          organizationId: testOrganization.id,
+        },
+      });
+
+      const res = await api.patch(`/api/groups/${group.id}`, {
+        name: "Renamed Group",
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.name).toBe("Renamed Group");
+      expect(body.slug).toContain("renamed-group");
+    });
+
+    /** @scenario PATCH /api/groups/:id rejects rename of SCIM-managed group */
+    it("rejects rename of SCIM-managed group", async () => {
+      const group = await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `SCIM Group ${ns}`,
+          slug: `scim-group-${ns}`,
+          organizationId: testOrganization.id,
+          scimSource: "azure-ad",
+        },
+      });
+
+      const res = await api.patch(`/api/groups/${group.id}`, {
+        name: "New Name",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("DELETE /api/groups/:id", () => {
+    /** @scenario DELETE /api/groups/:id deletes a group */
+    it("deletes a group", async () => {
+      const group = await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `Delete Test ${ns}`,
+          slug: `delete-test-${ns}`,
+          organizationId: testOrganization.id,
+        },
+      });
+
+      const res = await api.delete(`/api/groups/${group.id}`);
+      expect(res.status).toBe(200);
+
+      const getRes = await api.get(`/api/groups/${group.id}`);
+      expect(getRes.status).toBe(404);
+    });
+
+    /** @scenario DELETE /api/groups/:id returns 404 for nonexistent group */
+    it("returns 404 for nonexistent", async () => {
+      const res = await api.delete("/api/groups/nonexistent");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("Members", () => {
+    let memberGroupId: string;
+
+    beforeAll(async () => {
+      const group = await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `Member Test ${ns}`,
+          slug: `member-test-${ns}`,
+          organizationId: testOrganization.id,
+        },
+      });
+      memberGroupId = group.id;
+    });
+
+    /** @scenario POST /api/groups/:id/members adds a member */
+    it("adds a member", async () => {
+      const res = await api.post(`/api/groups/${memberGroupId}/members`, {
+        userId: secondUserId,
+      });
+      expect(res.status).toBe(201);
+    });
+
+    /** @scenario GET /api/groups/:id/members lists group members */
+    it("lists group members", async () => {
+      const res = await api.get(`/api/groups/${memberGroupId}/members`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.data.length).toBeGreaterThan(0);
+      expect(body.data[0].userId).toBeDefined();
+      expect(body.data[0].name).toBeDefined();
+    });
+
+    /** @scenario DELETE /api/groups/:id/members/:userId removes a member */
+    it("removes a member", async () => {
+      const res = await api.delete(
+        `/api/groups/${memberGroupId}/members/${secondUserId}`,
+      );
+      expect(res.status).toBe(200);
+
+      const listRes = await api.get(`/api/groups/${memberGroupId}/members`);
+      const body = await listRes.json();
+      expect(body.data.find((m: { userId: string }) => m.userId === secondUserId)).toBeUndefined();
+    });
+
+    /** @scenario POST /api/groups/:id/members rejects adding to SCIM-managed group */
+    it("rejects adding to SCIM-managed group", async () => {
+      const scimGroup = await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `SCIM Member ${ns}`,
+          slug: `scim-member-${ns}`,
+          organizationId: testOrganization.id,
+          scimSource: "okta",
+        },
+      });
+
+      const res = await api.post(`/api/groups/${scimGroup.id}/members`, {
+        userId: secondUserId,
+      });
+      expect(res.status).toBe(400);
+    });
+
+    /** @scenario POST /api/groups/:id/members rejects non-org user */
+    it("rejects non-org user", async () => {
+      const outsider = await prisma.user.create({
+        data: { name: "Outsider", email: `outsider-${ns}@example.com` },
+      });
+
+      const res = await api.post(`/api/groups/${memberGroupId}/members`, {
+        userId: outsider.id,
+      });
+      expect(res.status).toBe(400);
+
+      await prisma.user.delete({ where: { id: outsider.id } }).catch(() => {});
+    });
+
+    /** @scenario DELETE /api/groups/:id/members/:userId rejects removal from SCIM group */
+    it("rejects removal from SCIM group", async () => {
+      const scimGroup = await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `SCIM Remove ${ns}`,
+          slug: `scim-remove-${ns}`,
+          organizationId: testOrganization.id,
+          scimSource: "azure-ad",
+        },
+      });
+
+      const res = await api.delete(
+        `/api/groups/${scimGroup.id}/members/${userId}`,
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("Bindings", () => {
+    let bindingGroupId: string;
+
+    beforeAll(async () => {
+      const group = await prisma.group.create({
+        data: {
+          id: generate(KSUID_RESOURCES.GROUP).toString(),
+          name: `Binding Test ${ns}`,
+          slug: `binding-test-${ns}`,
+          organizationId: testOrganization.id,
+        },
+      });
+      bindingGroupId = group.id;
+    });
+
+    /** @scenario POST /api/groups/:id/bindings adds a role binding */
+    it("adds a role binding", async () => {
+      const res = await api.post(`/api/groups/${bindingGroupId}/bindings`, {
+        role: "MEMBER",
+        scopeType: "TEAM",
+        scopeId: testTeam.id,
+      });
+      expect(res.status).toBe(201);
+
+      const body = await res.json();
+      expect(body.id).toBeDefined();
+      expect(body.role).toBe("MEMBER");
+    });
+
+    /** @scenario GET /api/groups/:id/bindings lists group role bindings */
+    it("lists group bindings", async () => {
+      const res = await api.get(`/api/groups/${bindingGroupId}/bindings`);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.data.length).toBeGreaterThan(0);
+      expect(body.data[0].role).toBeDefined();
+      expect(body.data[0].scopeType).toBeDefined();
+    });
+
+    /** @scenario DELETE /api/groups/:id/bindings/:bindingId removes a binding */
+    it("removes a binding", async () => {
+      const listRes = await api.get(`/api/groups/${bindingGroupId}/bindings`);
+      const bindings = (await listRes.json()).data;
+      const bindingId = bindings[0].id;
+
+      const res = await api.delete(
+        `/api/groups/${bindingGroupId}/bindings/${bindingId}`,
+      );
+      expect(res.status).toBe(200);
+    });
+
+    /** @scenario DELETE /api/groups/:id/bindings/:bindingId returns 404 for nonexistent binding */
+    it("returns 404 for nonexistent binding", async () => {
+      const res = await api.delete(
+        `/api/groups/${bindingGroupId}/bindings/nonexistent`,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    /** @scenario POST /api/groups/:id/bindings rejects cross-org scope */
+    it("rejects cross-org scope", async () => {
+      const otherOrg = await prisma.organization.create({
+        data: { name: "Other Org", slug: `--test-other-org-${ns}` },
+      });
+      const otherTeam = await prisma.team.create({
+        data: {
+          name: "Other Team",
+          slug: `--test-other-team-${ns}`,
+          organizationId: otherOrg.id,
+        },
+      });
+
+      const res = await api.post(`/api/groups/${bindingGroupId}/bindings`, {
+        role: "MEMBER",
+        scopeType: "TEAM",
+        scopeId: otherTeam.id,
+      });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+
+      await prisma.team.delete({ where: { id: otherTeam.id } }).catch(() => {});
+      await prisma.organization.delete({ where: { id: otherOrg.id } }).catch(() => {});
+    });
+  });
+});

--- a/langwatch/src/app/api/middleware/group-service.ts
+++ b/langwatch/src/app/api/middleware/group-service.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareHandler } from "hono";
+
+import { prisma } from "~/server/db";
+import { GroupRestService } from "~/server/app-layer/groups/group.service";
+import { PrismaGroupRepository } from "~/server/app-layer/groups/repositories/group.prisma.repository";
+
+export type GroupServiceMiddlewareVariables = {
+  groupService: GroupRestService;
+};
+
+export const groupServiceMiddleware: MiddlewareHandler = async (c, next) => {
+  c.set(
+    "groupService",
+    new GroupRestService(new PrismaGroupRepository(prisma)),
+  );
+  await next();
+};

--- a/langwatch/src/app/api/projects/[[...route]]/app.ts
+++ b/langwatch/src/app/api/projects/[[...route]]/app.ts
@@ -133,7 +133,7 @@ secured
     projectServiceMiddleware,
     apiKeyServiceMiddleware,
     describeRoute({
-      description: "Create a new project",
+      description: "Create a new project in an existing team or create a new team inline",
     }),
     zValidator("json", createProjectSchema, validationHook),
     async (c) => {
@@ -221,7 +221,7 @@ secured
     "/:id",
     projectServiceMiddleware,
     describeRoute({
-      description: "Update a project by its id",
+      description: "Update a project by its id, including moving it to another team with teamId",
     }),
     zValidator("json", updateProjectSchema, validationHook),
     async (c) => {

--- a/langwatch/src/app/api/projects/[[...route]]/app.ts
+++ b/langwatch/src/app/api/projects/[[...route]]/app.ts
@@ -3,6 +3,7 @@ import { describeRoute } from "hono-openapi";
 import { validator as zValidator } from "hono-openapi/zod";
 import { z } from "zod";
 import {
+  DestinationTeamNotFoundError,
   ProjectNotFoundError,
   ProjectSlugConflictError,
   TeamNotInOrganizationError,
@@ -45,6 +46,7 @@ const updateProjectSchema = z.object({
   language: z.string().optional(),
   framework: z.string().optional(),
   piiRedactionLevel: z.enum(["STRICT", "ESSENTIAL", "DISABLED"]).optional(),
+  teamId: z.string().min(1).optional(),
 });
 
 function validationHook(
@@ -238,11 +240,15 @@ secured
             ...(body.piiRedactionLevel !== undefined && {
               piiRedactionLevel: body.piiRedactionLevel,
             }),
+            ...(body.teamId !== undefined && { teamId: body.teamId }),
           },
         });
       } catch (error) {
         if (error instanceof ProjectNotFoundError) {
           throw new NotFoundError("Project not found");
+        }
+        if (error instanceof DestinationTeamNotFoundError) {
+          throw new BadRequestError(error.message);
         }
         throw error;
       }

--- a/langwatch/src/app/api/projects/[[...route]]/app.ts
+++ b/langwatch/src/app/api/projects/[[...route]]/app.ts
@@ -291,4 +291,54 @@ secured
     },
   );
 
+// ── API Key management ───────────────────────────────────────────────────────
+
+secured
+  .access(requires("project:view"))
+  .get(
+    "/:id/api-key",
+    projectServiceMiddleware,
+    describeRoute({ description: "Get the project API key" }),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("projectService") as ProjectService;
+
+      const project = await service.getWithTeam(id);
+      if (!project || project.team.organizationId !== organization.id) {
+        throw new NotFoundError("Project not found");
+      }
+
+      return c.json({ apiKey: project.apiKey });
+    },
+  );
+
+secured
+  .access(requires("project:manage"))
+  .post(
+    "/:id/regenerate-api-key",
+    projectServiceMiddleware,
+    describeRoute({ description: "Regenerate the project API key" }),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("projectService") as ProjectService;
+      const { prisma } = await import("~/server/db");
+      const { generateApiKey } = await import("~/server/utils/apiKeyGenerator");
+
+      const project = await service.getWithTeam(id);
+      if (!project || project.team.organizationId !== organization.id) {
+        throw new NotFoundError("Project not found");
+      }
+
+      const newApiKey = generateApiKey();
+      await prisma.project.update({
+        where: { id },
+        data: { apiKey: newApiKey },
+      });
+
+      return c.json({ apiKey: newApiKey });
+    },
+  );
+
 export const app = secured.hono;

--- a/langwatch/src/app/api/projects/[[...route]]/app.ts
+++ b/langwatch/src/app/api/projects/[[...route]]/app.ts
@@ -12,6 +12,8 @@ import {
 import type { ApiKeyService } from "~/server/api-key/api-key.service";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
 import { createOrgApp, requires } from "~/server/api/security";
+import { prisma } from "~/server/db";
+import { generateApiKey } from "~/server/utils/apiKeyGenerator";
 import type { ApiKeyServiceMiddlewareVariables } from "../../middleware/api-key-service";
 import { apiKeyServiceMiddleware } from "../../middleware/api-key-service";
 import type { ProjectServiceMiddlewareVariables } from "../../middleware/project-service";
@@ -323,8 +325,6 @@ secured
       const { id } = c.req.param();
       const organization = c.get("organization") as Organization;
       const service = c.get("projectService") as ProjectService;
-      const { prisma } = await import("~/server/db");
-      const { generateApiKey } = await import("~/server/utils/apiKeyGenerator");
 
       const project = await service.getWithTeam(id);
       if (!project || project.team.organizationId !== organization.id) {

--- a/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
@@ -405,7 +405,9 @@ describe("Feature: Projects REST API", () => {
       });
 
       it("does not update name when team validation fails (atomic)", async () => {
-        const beforeName = (await api.get(`/api/projects/${projectToMove.id}`).then(r => r.json())).name;
+        const beforeRes = await api.get(`/api/projects/${projectToMove.id}`);
+        const beforeBody = await beforeRes.json();
+        const beforeName = beforeBody.name;
 
         const res = await api.patch(`/api/projects/${projectToMove.id}`, {
           name: "Should Not Persist",

--- a/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
@@ -288,6 +288,7 @@ describe("Feature: Projects REST API", () => {
   });
 
   describe("PATCH /api/projects/:id", () => {
+    /** @scenario PATCH /api/projects/:id updates project name */
     it("updates project fields", async () => {
       const createRes = await api.post("/api/projects", {
         name: `Patch Test ${nanoid(6)}`,
@@ -338,6 +339,7 @@ describe("Feature: Projects REST API", () => {
         projectToMove = await createRes.json();
       });
 
+      /** @scenario PATCH /api/projects/:id moves project to different team */
       it("moves project to a different team in the same org", async () => {
         const res = await api.patch(`/api/projects/${projectToMove.id}`, {
           teamId: destinationTeam.id,
@@ -348,6 +350,7 @@ describe("Feature: Projects REST API", () => {
         expect(body.teamId).toBe(destinationTeam.id);
       });
 
+      /** @scenario PATCH /api/projects/:id updates name and team together */
       it("updates name and team together", async () => {
         const res = await api.patch(`/api/projects/${projectToMove.id}`, {
           name: "Moved And Renamed",
@@ -360,6 +363,7 @@ describe("Feature: Projects REST API", () => {
         expect(body.teamId).toBe(testTeam.id);
       });
 
+      /** @scenario PATCH rejects non-existent teamId */
       it("rejects teamId that does not exist", async () => {
         const res = await api.patch(`/api/projects/${projectToMove.id}`, {
           teamId: "nonexistent-team",
@@ -367,6 +371,7 @@ describe("Feature: Projects REST API", () => {
         expect(res.status).toBe(400);
       });
 
+      /** @scenario PATCH rejects teamId of archived team */
       it("rejects teamId of archived team", async () => {
         const archivedTeam = await prisma.team.create({
           data: {
@@ -383,6 +388,7 @@ describe("Feature: Projects REST API", () => {
         expect(res.status).toBe(400);
       });
 
+      /** @scenario PATCH rejects teamId from different organization */
       it("rejects teamId from different organization", async () => {
         const otherOrg = await prisma.organization.create({
           data: { name: "Other Org", slug: `--test-other-org-${ns}` },
@@ -404,6 +410,7 @@ describe("Feature: Projects REST API", () => {
         await prisma.organization.delete({ where: { id: otherOrg.id } }).catch(() => {});
       });
 
+      /** @scenario PATCH with teamId and name is atomic */
       it("does not update name when team validation fails (atomic)", async () => {
         const beforeRes = await api.get(`/api/projects/${projectToMove.id}`);
         const beforeBody = await beforeRes.json();

--- a/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
+++ b/langwatch/src/app/api/projects/__tests__/projects-rest-api.integration.test.ts
@@ -315,6 +315,109 @@ describe("Feature: Projects REST API", () => {
       });
       expect(res.status).toBe(404);
     });
+
+    describe("when moving project to different team", () => {
+      let destinationTeam: Team;
+      let projectToMove: { id: string; teamId: string };
+
+      beforeAll(async () => {
+        destinationTeam = await prisma.team.create({
+          data: {
+            name: "Move Destination Team",
+            slug: `--test-move-dest-${ns}`,
+            organizationId: testOrganization.id,
+          },
+        });
+
+        const createRes = await api.post("/api/projects", {
+          name: `Move Test ${nanoid(6)}`,
+          teamId: testTeam.id,
+          language: "python",
+          framework: "langchain",
+        });
+        projectToMove = await createRes.json();
+      });
+
+      it("moves project to a different team in the same org", async () => {
+        const res = await api.patch(`/api/projects/${projectToMove.id}`, {
+          teamId: destinationTeam.id,
+        });
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.teamId).toBe(destinationTeam.id);
+      });
+
+      it("updates name and team together", async () => {
+        const res = await api.patch(`/api/projects/${projectToMove.id}`, {
+          name: "Moved And Renamed",
+          teamId: testTeam.id,
+        });
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.name).toBe("Moved And Renamed");
+        expect(body.teamId).toBe(testTeam.id);
+      });
+
+      it("rejects teamId that does not exist", async () => {
+        const res = await api.patch(`/api/projects/${projectToMove.id}`, {
+          teamId: "nonexistent-team",
+        });
+        expect(res.status).toBe(400);
+      });
+
+      it("rejects teamId of archived team", async () => {
+        const archivedTeam = await prisma.team.create({
+          data: {
+            name: "Archived Team",
+            slug: `--test-archived-${ns}`,
+            organizationId: testOrganization.id,
+            archivedAt: new Date(),
+          },
+        });
+
+        const res = await api.patch(`/api/projects/${projectToMove.id}`, {
+          teamId: archivedTeam.id,
+        });
+        expect(res.status).toBe(400);
+      });
+
+      it("rejects teamId from different organization", async () => {
+        const otherOrg = await prisma.organization.create({
+          data: { name: "Other Org", slug: `--test-other-org-${ns}` },
+        });
+        const otherTeam = await prisma.team.create({
+          data: {
+            name: "Other Team",
+            slug: `--test-other-team-${ns}`,
+            organizationId: otherOrg.id,
+          },
+        });
+
+        const res = await api.patch(`/api/projects/${projectToMove.id}`, {
+          teamId: otherTeam.id,
+        });
+        expect(res.status).toBe(400);
+
+        await prisma.team.delete({ where: { id: otherTeam.id } }).catch(() => {});
+        await prisma.organization.delete({ where: { id: otherOrg.id } }).catch(() => {});
+      });
+
+      it("does not update name when team validation fails (atomic)", async () => {
+        const beforeName = (await api.get(`/api/projects/${projectToMove.id}`).then(r => r.json())).name;
+
+        const res = await api.patch(`/api/projects/${projectToMove.id}`, {
+          name: "Should Not Persist",
+          teamId: "nonexistent-team",
+        });
+        expect(res.status).toBe(400);
+
+        const afterRes = await api.get(`/api/projects/${projectToMove.id}`);
+        const after = await afterRes.json();
+        expect(after.name).toBe(beforeName);
+      });
+    });
   });
 
   describe("DELETE /api/projects/:id", () => {

--- a/langwatch/src/app/api/teams/[[...route]]/app.ts
+++ b/langwatch/src/app/api/teams/[[...route]]/app.ts
@@ -1,4 +1,9 @@
-import type { Organization } from "@prisma/client";
+import {
+  RoleBindingScopeType,
+  TeamUserRole,
+  type Organization,
+} from "@prisma/client";
+import { generate } from "@langwatch/ksuid";
 import { describeRoute } from "hono-openapi";
 import { validator as zValidator } from "hono-openapi/zod";
 import { z } from "zod";
@@ -8,9 +13,11 @@ import {
 } from "~/server/app-layer/teams/team.service";
 import { patchZodOpenapi } from "~/utils/extend-zod-openapi";
 import { createOrgApp, requires } from "~/server/api/security";
+import { prisma } from "~/server/db";
+import { KSUID_RESOURCES } from "~/utils/constants";
 import type { TeamServiceMiddlewareVariables } from "../../middleware/team-service";
 import { teamServiceMiddleware } from "../../middleware/team-service";
-import { NotFoundError } from "../../shared/errors";
+import { BadRequestError, NotFoundError } from "../../shared/errors";
 import { handleTeamError } from "./error-handler";
 
 patchZodOpenapi();
@@ -26,6 +33,11 @@ const createTeamSchema = z.object({
 
 const updateTeamSchema = z.object({
   name: z.string().min(1).max(255).optional(),
+});
+
+const addMemberSchema = z.object({
+  userId: z.string().min(1, "userId is required"),
+  role: z.nativeEnum(TeamUserRole).optional().default(TeamUserRole.MEMBER),
 });
 
 function validationHook(
@@ -211,6 +223,139 @@ secured
         name: team.name,
         archivedAt: team.archivedAt,
       });
+    },
+  );
+
+// ── Members ──────────────────────────────────────────────────────────────────
+
+secured
+  .access(requires("team:view"))
+  .get(
+    "/:id/members",
+    teamServiceMiddleware,
+    describeRoute({ description: "List members of a team" }),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("teamService") as TeamRestService;
+
+      const team = await service.getById({ id, organizationId: organization.id });
+      if (!team) throw new NotFoundError("Team not found");
+
+      const bindings = await prisma.roleBinding.findMany({
+        where: {
+          organizationId: organization.id,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: id,
+          userId: { not: null },
+        },
+        include: {
+          user: { select: { id: true, name: true, email: true } },
+        },
+      });
+
+      return c.json({
+        data: bindings.map((b) => ({
+          userId: b.userId,
+          name: b.user?.name ?? null,
+          email: b.user?.email ?? null,
+          role: b.role,
+        })),
+      });
+    },
+  );
+
+secured
+  .access(requires("team:manage"))
+  .post(
+    "/:id/members",
+    teamServiceMiddleware,
+    describeRoute({ description: "Add a member to a team" }),
+    zValidator("json", addMemberSchema, validationHook),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const body = c.req.valid("json");
+      const service = c.get("teamService") as TeamRestService;
+
+      const team = await service.getById({ id, organizationId: organization.id });
+      if (!team) throw new NotFoundError("Team not found");
+
+      const orgMember = await prisma.organizationUser.findFirst({
+        where: { organizationId: organization.id, userId: body.userId },
+        select: { userId: true },
+      });
+      if (!orgMember) {
+        throw new BadRequestError("User must belong to the organization");
+      }
+
+      await prisma.roleBinding.create({
+        data: {
+          id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+          organizationId: organization.id,
+          userId: body.userId,
+          role: body.role,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: id,
+        },
+      });
+
+      return c.json({ success: true }, 201);
+    },
+  );
+
+secured
+  .access(requires("team:manage"))
+  .delete(
+    "/:id/members/:userId",
+    teamServiceMiddleware,
+    describeRoute({ description: "Remove a member from a team" }),
+    async (c) => {
+      const { id, userId } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("teamService") as TeamRestService;
+
+      const team = await service.getById({ id, organizationId: organization.id });
+      if (!team) throw new NotFoundError("Team not found");
+
+      const binding = await prisma.roleBinding.findFirst({
+        where: {
+          organizationId: organization.id,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: id,
+          userId,
+        },
+      });
+      if (!binding) throw new NotFoundError("Member not found on this team");
+
+      await prisma.roleBinding.delete({ where: { id: binding.id } });
+      return c.json({ success: true });
+    },
+  );
+
+// ── Projects ─────────────────────────────────────────────────────────────────
+
+secured
+  .access(requires("team:view"))
+  .get(
+    "/:id/projects",
+    teamServiceMiddleware,
+    describeRoute({ description: "List projects in a team" }),
+    async (c) => {
+      const { id } = c.req.param();
+      const organization = c.get("organization") as Organization;
+      const service = c.get("teamService") as TeamRestService;
+
+      const team = await service.getById({ id, organizationId: organization.id });
+      if (!team) throw new NotFoundError("Team not found");
+
+      const projects = await prisma.project.findMany({
+        where: { teamId: id, archivedAt: null, kind: { not: "internal_governance" } },
+        select: { id: true, name: true, slug: true, createdAt: true, updatedAt: true },
+        orderBy: { createdAt: "desc" },
+      });
+
+      return c.json({ data: projects });
     },
   );
 

--- a/langwatch/src/app/api/teams/[[...route]]/app.ts
+++ b/langwatch/src/app/api/teams/[[...route]]/app.ts
@@ -289,16 +289,27 @@ secured
         throw new BadRequestError("User must belong to the organization");
       }
 
-      await prisma.roleBinding.create({
-        data: {
-          id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
-          organizationId: organization.id,
-          userId: body.userId,
-          role: body.role,
-          scopeType: RoleBindingScopeType.TEAM,
-          scopeId: id,
-        },
-      });
+      try {
+        await prisma.roleBinding.create({
+          data: {
+            id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+            organizationId: organization.id,
+            userId: body.userId,
+            role: body.role,
+            scopeType: RoleBindingScopeType.TEAM,
+            scopeId: id,
+          },
+        });
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          (error as { code: string }).code === "P2002"
+        ) {
+          throw new BadRequestError("User is already a member of this team");
+        }
+        throw error;
+      }
 
       return c.json({ success: true }, 201);
     },

--- a/langwatch/src/app/api/teams/[[...route]]/app.ts
+++ b/langwatch/src/app/api/teams/[[...route]]/app.ts
@@ -115,7 +115,7 @@ secured
     "/",
     teamServiceMiddleware,
     describeRoute({
-      description: "Create a new team",
+      description: "Create a new team that can group projects and members",
     }),
     zValidator("json", createTeamSchema, validationHook),
     async (c) => {

--- a/langwatch/src/components/drawerRegistry.ts
+++ b/langwatch/src/components/drawerRegistry.ts
@@ -47,6 +47,7 @@ const FoundryDrawer = lazy(
   () => import("./ops/foundry/FoundryDrawer").then((m) => ({ default: m.FoundryDrawer })),
 );
 import { CreateProjectDrawer } from "./projects/CreateProjectDrawer";
+import { EditProjectDrawer } from "./projects/EditProjectDrawer";
 import { PromptEditorDrawer } from "./prompts/PromptEditorDrawer";
 import { PromptListDrawer } from "./prompts/PromptListDrawer";
 import { SeriesFiltersDrawer } from "./SeriesFilterDrawer";
@@ -119,6 +120,7 @@ export const drawers = {
   suiteEditor: SuiteFormDrawer,
   // Project management
   createProject: CreateProjectDrawer,
+  editProject: EditProjectDrawer,
   createTeam: CreateTeamDrawer,
   // Online Evaluations (Monitors)
   onlineEvaluation: OnlineEvaluationDrawer,

--- a/langwatch/src/components/projects/CreateProjectDrawer.tsx
+++ b/langwatch/src/components/projects/CreateProjectDrawer.tsx
@@ -77,6 +77,7 @@ export function CreateProjectDrawer({
             void queryClient.limits.getUsage.invalidate();
             void queryClient.team.getTeamsWithMembers.invalidate();
             void queryClient.team.getTeamWithMembers.invalidate();
+            void queryClient.team.getTeamsWithRoleBindings.invalidate();
 
             trackEvent("project_created", {
               project_slug: result.projectSlug,

--- a/langwatch/src/components/projects/EditProjectDrawer.tsx
+++ b/langwatch/src/components/projects/EditProjectDrawer.tsx
@@ -96,7 +96,7 @@ export function EditProjectDrawer({
         },
       );
     },
-    [updateProject, projectId, currentTeamId, queryClient, closeDrawer],
+    [updateProject, projectId, projectName, currentTeamId, queryClient, closeDrawer],
   );
 
   return (

--- a/langwatch/src/components/projects/EditProjectDrawer.tsx
+++ b/langwatch/src/components/projects/EditProjectDrawer.tsx
@@ -1,0 +1,172 @@
+import {
+  Button,
+  createListCollection,
+  Field,
+  VStack,
+} from "@chakra-ui/react";
+import { useCallback, useMemo } from "react";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { useDrawer } from "../../hooks/useDrawer";
+import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+import { api } from "../../utils/api";
+import { Drawer } from "../ui/drawer";
+import { Select } from "../ui/select";
+import { toaster } from "../ui/toaster";
+
+interface EditProjectFormData {
+  name: string;
+  teamId: string;
+}
+
+export function EditProjectDrawer({
+  open = true,
+  projectId,
+  projectName,
+  currentTeamId,
+}: {
+  open?: boolean;
+  projectId?: string;
+  projectName?: string;
+  currentTeamId?: string;
+}) {
+  const { organization } = useOrganizationTeamProject();
+  const { closeDrawer } = useDrawer();
+  const queryClient = api.useContext();
+
+  const teams = api.team.getTeamsWithMembers.useQuery(
+    { organizationId: organization?.id ?? "" },
+    { enabled: !!organization },
+  );
+
+  const form = useForm<EditProjectFormData>({
+    defaultValues: {
+      name: projectName ?? "",
+      teamId: currentTeamId ?? "",
+    },
+  });
+
+  const updateProject = api.project.update.useMutation();
+
+  const teamItems = useMemo(
+    () =>
+      (teams.data ?? [])
+        .filter((t) => !t.isPersonal)
+        .map((t) => ({
+          label: t.name,
+          value: t.id,
+        })),
+    [teams.data],
+  );
+  const teamCollection = useMemo(
+    () => createListCollection({ items: teamItems }),
+    [teamItems],
+  );
+
+  const onSubmit: SubmitHandler<EditProjectFormData> = useCallback(
+    (data: EditProjectFormData) => {
+      if (!projectId) return;
+
+      updateProject.mutate(
+        {
+          projectId,
+          ...(data.name !== projectName && { name: data.name }),
+          ...(data.teamId !== currentTeamId && { teamId: data.teamId }),
+        },
+        {
+          onSuccess: () => {
+            void queryClient.team.getTeamsWithRoleBindings.invalidate();
+            void queryClient.team.getTeamsWithMembers.invalidate();
+            void queryClient.organization.getAll.invalidate();
+            toaster.create({
+              title: "Project updated",
+              type: "success",
+              duration: 5000,
+              meta: { closable: true },
+            });
+            closeDrawer();
+          },
+          onError: (e) => {
+            toaster.create({
+              title: e.message,
+              type: "error",
+              duration: 5000,
+              meta: { closable: true },
+            });
+          },
+        },
+      );
+    },
+    [updateProject, projectId, currentTeamId, queryClient, closeDrawer],
+  );
+
+  return (
+    <Drawer.Root
+      open={open}
+      placement="end"
+      size="md"
+      onOpenChange={({ open: isOpen }) => {
+        if (!isOpen) closeDrawer();
+      }}
+    >
+      <Drawer.Content bg="bg">
+        <Drawer.Header>
+          <Drawer.Title>Edit Project</Drawer.Title>
+          <Drawer.CloseTrigger onClick={closeDrawer} />
+        </Drawer.Header>
+        <Drawer.Body>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <VStack gap={5} align="stretch">
+              <Field.Root>
+                <Field.Label>Project Name</Field.Label>
+                <input
+                  {...form.register("name", { required: true, minLength: 1 })}
+                  style={{
+                    width: "100%",
+                    padding: "8px 12px",
+                    borderRadius: "6px",
+                    border: "1px solid var(--chakra-colors-border)",
+                    background: "transparent",
+                    fontSize: "14px",
+                  }}
+                />
+              </Field.Root>
+
+              <Field.Root>
+                <Field.Label>Team</Field.Label>
+                <Select.Root
+                  collection={teamCollection}
+                  value={[form.watch("teamId")]}
+                  onValueChange={(e) => {
+                    const v = e.value[0];
+                    if (v) form.setValue("teamId", v, { shouldDirty: true });
+                  }}
+                  size="md"
+                >
+                  <Select.Trigger>
+                    <Select.ValueText placeholder="Select team..." />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {teamItems.map((item) => (
+                      <Select.Item key={item.value} item={item}>
+                        {item.label}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
+              </Field.Root>
+
+              <Button
+                type="submit"
+                colorPalette="blue"
+                loading={updateProject.isPending}
+                disabled={!form.formState.isDirty}
+              >
+                Save
+              </Button>
+            </VStack>
+          </form>
+        </Drawer.Body>
+      </Drawer.Content>
+    </Drawer.Root>
+  );
+}

--- a/langwatch/src/components/projects/EditProjectDrawer.tsx
+++ b/langwatch/src/components/projects/EditProjectDrawer.tsx
@@ -2,10 +2,15 @@ import {
   Button,
   createListCollection,
   Field,
+  HStack,
+  Heading,
+  Input,
+  Spacer,
+  Text,
   VStack,
 } from "@chakra-ui/react";
 import { useCallback, useMemo } from "react";
-import { type SubmitHandler, useForm } from "react-hook-form";
+import { Controller, type SubmitHandler, useForm } from "react-hook-form";
 import { useDrawer } from "../../hooks/useDrawer";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { api } from "../../utils/api";
@@ -38,7 +43,12 @@ export function EditProjectDrawer({
     { enabled: !!organization },
   );
 
-  const form = useForm<EditProjectFormData>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+    control,
+  } = useForm<EditProjectFormData>({
     defaultValues: {
       name: projectName ?? "",
       teamId: currentTeamId ?? "",
@@ -47,7 +57,7 @@ export function EditProjectDrawer({
 
   const updateProject = api.project.update.useMutation();
 
-  const teamItems = useMemo(
+  const teamOptions = useMemo(
     () =>
       (teams.data ?? [])
         .filter((t) => !t.isPersonal)
@@ -58,8 +68,8 @@ export function EditProjectDrawer({
     [teams.data],
   );
   const teamCollection = useMemo(
-    () => createListCollection({ items: teamItems }),
-    [teamItems],
+    () => createListCollection({ items: teamOptions }),
+    [teamOptions],
   );
 
   const onSubmit: SubmitHandler<EditProjectFormData> = useCallback(
@@ -103,66 +113,86 @@ export function EditProjectDrawer({
     <Drawer.Root
       open={open}
       placement="end"
-      size="md"
+      size="lg"
       onOpenChange={({ open: isOpen }) => {
         if (!isOpen) closeDrawer();
       }}
     >
       <Drawer.Content bg="bg">
         <Drawer.Header>
-          <Drawer.Title>Edit Project</Drawer.Title>
           <Drawer.CloseTrigger onClick={closeDrawer} />
+          <Heading>Edit Project</Heading>
         </Drawer.Header>
         <Drawer.Body>
-          <form onSubmit={form.handleSubmit(onSubmit)}>
-            <VStack gap={5} align="stretch">
-              <Field.Root>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <VStack align="stretch" gap={6}>
+              <Text fontSize="sm" color="fg.muted">
+                Update the project name or move it to a different team.
+                Moving a project changes which team members inherit access.
+              </Text>
+
+              <Field.Root invalid={!!errors.name}>
                 <Field.Label>Project Name</Field.Label>
-                <input
-                  {...form.register("name", { required: true, minLength: 1 })}
-                  style={{
-                    width: "100%",
-                    padding: "8px 12px",
-                    borderRadius: "6px",
-                    border: "1px solid var(--chakra-colors-border)",
-                    background: "transparent",
-                    fontSize: "14px",
-                  }}
+                <Input
+                  {...register("name", {
+                    required: "Project name is required",
+                    minLength: { value: 1, message: "Name is required" },
+                  })}
+                  placeholder="AI Project"
                 />
+                {errors.name && (
+                  <Field.ErrorText>{errors.name.message}</Field.ErrorText>
+                )}
               </Field.Root>
 
               <Field.Root>
                 <Field.Label>Team</Field.Label>
-                <Select.Root
-                  collection={teamCollection}
-                  value={[form.watch("teamId")]}
-                  onValueChange={(e) => {
-                    const v = e.value[0];
-                    if (v) form.setValue("teamId", v, { shouldDirty: true });
-                  }}
-                  size="md"
-                >
-                  <Select.Trigger>
-                    <Select.ValueText placeholder="Select team..." />
-                  </Select.Trigger>
-                  <Select.Content>
-                    {teamItems.map((item) => (
-                      <Select.Item key={item.value} item={item}>
-                        {item.label}
-                      </Select.Item>
-                    ))}
-                  </Select.Content>
-                </Select.Root>
+                <Controller
+                  control={control}
+                  name="teamId"
+                  rules={{ required: "Team is required" }}
+                  render={({ field }) => (
+                    <Select.Root
+                      collection={teamCollection}
+                      value={[field.value]}
+                      onValueChange={(details) => {
+                        const selectedValue = details.value[0];
+                        if (selectedValue) {
+                          field.onChange(selectedValue);
+                        }
+                      }}
+                    >
+                      <Select.Trigger>
+                        <Select.ValueText placeholder="Select team">
+                          {() =>
+                            teamOptions.find((o) => o.value === field.value)
+                              ?.label ?? "Select team"
+                          }
+                        </Select.ValueText>
+                      </Select.Trigger>
+                      <Select.Content paddingY={2}>
+                        {teamOptions.map((option) => (
+                          <Select.Item key={option.value} item={option}>
+                            {option.label}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select.Root>
+                  )}
+                />
               </Field.Root>
 
-              <Button
-                type="submit"
-                colorPalette="blue"
-                loading={updateProject.isPending}
-                disabled={!form.formState.isDirty}
-              >
-                Save
-              </Button>
+              <HStack width="full">
+                <Spacer />
+                <Button
+                  colorPalette="orange"
+                  type="submit"
+                  loading={updateProject.isLoading}
+                  disabled={!isDirty || updateProject.isLoading}
+                >
+                  Save
+                </Button>
+              </HStack>
             </VStack>
           </form>
         </Drawer.Body>

--- a/langwatch/src/pages/settings/teams.tsx
+++ b/langwatch/src/pages/settings/teams.tsx
@@ -395,12 +395,14 @@ function AddToProjectDialog({
 
 function ProjectSection({
   project,
+  teamId,
   access,
   organizationId,
   canManage,
   department,
 }: {
   project: { id: string; name: string };
+  teamId: string;
   access: ProjectAccessEntry[];
   organizationId: string;
   canManage: boolean;
@@ -408,6 +410,7 @@ function ProjectSection({
 }) {
   const [expanded, setExpanded] = useState(false);
   const [addingPerson, setAddingPerson] = useState(false);
+  const { openDrawer } = useDrawer();
   const queryClient = api.useContext();
 
   const deleteBinding = api.roleBinding.delete.useMutation({
@@ -453,6 +456,24 @@ function ProjectSection({
           <Text fontSize="xs" color="gray.500">
             {access.length} with access
           </Text>
+          {canManage && (
+            <Button
+              size="xs"
+              variant="ghost"
+              color="gray.400"
+              onClick={(e) => {
+                e.stopPropagation();
+                openDrawer("editProject", {
+                  projectId: project.id,
+                  projectName: project.name,
+                  currentTeamId: teamId,
+                });
+              }}
+            >
+              <Pencil size={13} />
+              Edit
+            </Button>
+          )}
           {department.show && canManage && (
             <InlineDepartment
               organizationId={organizationId}
@@ -936,6 +957,7 @@ function TeamCard({
                   <ProjectSection
                     key={proj.id}
                     project={proj}
+                    teamId={team.id}
                     access={team.projectAccess[proj.id] ?? []}
                     organizationId={organizationId}
                     canManage={canManage}

--- a/langwatch/src/pages/settings/teams.tsx
+++ b/langwatch/src/pages/settings/teams.tsx
@@ -940,7 +940,9 @@ function TeamCard({
                     variant="outline"
                     onClick={(e) => {
                       e.stopPropagation();
-                      openDrawer("createProject");
+                      openDrawer("createProject", {
+                        defaultTeamId: team.id,
+                      });
                     }}
                   >
                     <Plus size={12} />

--- a/langwatch/src/server/api/routers/project.ts
+++ b/langwatch/src/server/api/routers/project.ts
@@ -303,10 +303,11 @@ export const projectRouter = createTRPCRouter({
       z
         .object({
           projectId: z.string(),
-          name: z.string(),
-          language: z.string(),
-          framework: z.string(),
-          piiRedactionLevel: z.enum(["STRICT", "ESSENTIAL", "DISABLED"]),
+          name: z.string().optional(),
+          language: z.string().optional(),
+          framework: z.string().optional(),
+          piiRedactionLevel: z.enum(["STRICT", "ESSENTIAL", "DISABLED"]).optional(),
+          teamId: z.string().optional(),
           capturedInputVisibility: z
             .enum(["REDACTED_TO_ALL", "VISIBLE_TO_ADMIN", "VISIBLE_TO_ALL"])
             .optional(),
@@ -350,6 +351,7 @@ export const projectRouter = createTRPCRouter({
       }
 
       if (
+        input.piiRedactionLevel !== undefined &&
         input.piiRedactionLevel === "DISABLED" &&
         !(
           env.NODE_ENV === "development" ||
@@ -363,14 +365,37 @@ export const projectRouter = createTRPCRouter({
         });
       }
 
+      if (input.teamId) {
+        const destinationTeam = await prisma.team.findFirst({
+          where: {
+            id: input.teamId,
+            organizationId: project.team.organizationId,
+            archivedAt: null,
+          },
+          select: { id: true },
+        });
+        if (!destinationTeam) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Destination team not found, is archived, or belongs to a different organization",
+          });
+        }
+      }
+
       const updatedProject = await prisma.project.update({
         where: { id: input.projectId },
         data: {
-          name: input.name,
-          language: input.language,
-          framework: input.framework,
-          piiRedactionLevel: input.piiRedactionLevel,
-          userLinkTemplate: input.userLinkTemplate,
+          ...(input.name !== undefined && { name: input.name }),
+          ...(input.language !== undefined && { language: input.language }),
+          ...(input.framework !== undefined && { framework: input.framework }),
+          ...(input.piiRedactionLevel !== undefined && {
+            piiRedactionLevel: input.piiRedactionLevel,
+          }),
+          ...(input.userLinkTemplate !== undefined && {
+            userLinkTemplate: input.userLinkTemplate,
+          }),
+          ...(input.teamId && { teamId: input.teamId }),
           capturedInputVisibility:
             input.capturedInputVisibility ?? project.capturedInputVisibility,
           capturedOutputVisibility:

--- a/langwatch/src/server/app-layer/groups/group.service.ts
+++ b/langwatch/src/server/app-layer/groups/group.service.ts
@@ -35,6 +35,10 @@ export class DuplicateMemberError extends Error {
   name = "DuplicateMemberError" as const;
 }
 
+export class ScopeNotInOrganizationError extends Error {
+  name = "ScopeNotInOrganizationError" as const;
+}
+
 export class GroupRestService {
   constructor(readonly repo: GroupRepository) {}
 
@@ -239,6 +243,17 @@ export class GroupRestService {
       organizationId,
     });
     if (!group) throw new GroupNotFoundError("Group not found");
+
+    const scopeValid = await this.repo.validateScopeInOrganization({
+      organizationId,
+      scopeType,
+      scopeId,
+    });
+    if (!scopeValid) {
+      throw new ScopeNotInOrganizationError(
+        "Scope does not belong to this organization",
+      );
+    }
 
     return this.repo.createBinding({
       id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),

--- a/langwatch/src/server/app-layer/groups/group.service.ts
+++ b/langwatch/src/server/app-layer/groups/group.service.ts
@@ -78,37 +78,26 @@ export class GroupRestService {
       baseSlug,
     });
 
-    const group = await this.repo.create({
-      id: generate(KSUID_RESOURCES.GROUP).toString(),
+    const groupId = generate(KSUID_RESOURCES.GROUP).toString();
+
+    const bindingInputs = (bindings ?? []).map((b) => ({
+      id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
       organizationId,
-      name,
-      slug,
+      groupId,
+      role: b.role,
+      customRoleId:
+        b.role === ("CUSTOM" as TeamUserRole)
+          ? (b.customRoleId ?? null)
+          : null,
+      scopeType: b.scopeType,
+      scopeId: b.scopeId,
+    }));
+
+    return this.repo.createAtomic({
+      group: { id: groupId, organizationId, name, slug },
+      bindings: bindingInputs,
+      memberIds: memberIds ?? [],
     });
-
-    if (bindings?.length) {
-      for (const b of bindings) {
-        await this.repo.createBinding({
-          id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
-          organizationId,
-          groupId: group.id,
-          role: b.role,
-          customRoleId:
-            b.role === ("CUSTOM" as TeamUserRole)
-              ? (b.customRoleId ?? null)
-              : null,
-          scopeType: b.scopeType,
-          scopeId: b.scopeId,
-        });
-      }
-    }
-
-    if (memberIds?.length) {
-      for (const userId of memberIds) {
-        await this.repo.addMember({ groupId: group.id, userId });
-      }
-    }
-
-    return group;
   }
 
   async rename({

--- a/langwatch/src/server/app-layer/groups/group.service.ts
+++ b/langwatch/src/server/app-layer/groups/group.service.ts
@@ -31,6 +31,10 @@ export class BindingNotFoundError extends Error {
   name = "BindingNotFoundError" as const;
 }
 
+export class DuplicateMemberError extends Error {
+  name = "DuplicateMemberError" as const;
+}
+
 export class GroupRestService {
   constructor(readonly repo: GroupRepository) {}
 
@@ -131,7 +135,9 @@ export class GroupRestService {
       excludeId: id,
     });
 
-    return this.repo.rename({ id, name, slug });
+    const renamed = await this.repo.rename({ id, organizationId, name, slug });
+    if (!renamed) throw new GroupNotFoundError("Group not found");
+    return renamed;
   }
 
   async delete({
@@ -146,7 +152,7 @@ export class GroupRestService {
 
     await this.repo.deleteAllMemberships({ groupId: id });
     await this.repo.deleteAllBindings({ groupId: id });
-    await this.repo.delete({ id });
+    await this.repo.delete({ id, organizationId });
   }
 
   async getMembers({ groupId }: { groupId: string }) {
@@ -183,7 +189,18 @@ export class GroupRestService {
       );
     }
 
-    return this.repo.addMember({ groupId, userId });
+    try {
+      return await this.repo.addMember({ groupId, userId });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        (error as { code: string }).code === "P2002"
+      ) {
+        throw new DuplicateMemberError("User is already a member of this group");
+      }
+      throw error;
+    }
   }
 
   async removeMember({

--- a/langwatch/src/server/app-layer/groups/group.service.ts
+++ b/langwatch/src/server/app-layer/groups/group.service.ts
@@ -1,0 +1,266 @@
+import type {
+  Group,
+  GroupMembership,
+  RoleBinding,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+import { generate } from "@langwatch/ksuid";
+import { slugify } from "~/utils/slugify";
+import { KSUID_RESOURCES } from "~/utils/constants";
+import type {
+  GroupRepository,
+  GroupWithDetails,
+  GroupWithMembers,
+  PaginatedResult,
+} from "./repositories/group.repository";
+
+export class GroupNotFoundError extends Error {
+  name = "GroupNotFoundError" as const;
+}
+
+export class ScimManagedGroupError extends Error {
+  name = "ScimManagedGroupError" as const;
+}
+
+export class UserNotInOrganizationError extends Error {
+  name = "UserNotInOrganizationError" as const;
+}
+
+export class BindingNotFoundError extends Error {
+  name = "BindingNotFoundError" as const;
+}
+
+export class GroupRestService {
+  constructor(readonly repo: GroupRepository) {}
+
+  async listByOrganization(params: {
+    organizationId: string;
+    page: number;
+    limit: number;
+  }): Promise<PaginatedResult<GroupWithDetails>> {
+    return this.repo.findAllByOrganization(params);
+  }
+
+  async getById({
+    id,
+    organizationId,
+  }: {
+    id: string;
+    organizationId: string;
+  }): Promise<GroupWithMembers | null> {
+    return this.repo.findById({ id, organizationId });
+  }
+
+  async create({
+    organizationId,
+    name,
+    bindings,
+    memberIds,
+  }: {
+    organizationId: string;
+    name: string;
+    bindings?: Array<{
+      role: TeamUserRole;
+      customRoleId?: string;
+      scopeType: RoleBindingScopeType;
+      scopeId: string;
+    }>;
+    memberIds?: string[];
+  }): Promise<Group> {
+    const baseSlug = slugify(name, { lower: true, strict: true });
+    const slug = await this.repo.findUniqueSlug({
+      organizationId,
+      baseSlug,
+    });
+
+    const group = await this.repo.create({
+      id: generate(KSUID_RESOURCES.GROUP).toString(),
+      organizationId,
+      name,
+      slug,
+    });
+
+    if (bindings?.length) {
+      for (const b of bindings) {
+        await this.repo.createBinding({
+          id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+          organizationId,
+          groupId: group.id,
+          role: b.role,
+          customRoleId:
+            b.role === ("CUSTOM" as TeamUserRole)
+              ? (b.customRoleId ?? null)
+              : null,
+          scopeType: b.scopeType,
+          scopeId: b.scopeId,
+        });
+      }
+    }
+
+    if (memberIds?.length) {
+      for (const userId of memberIds) {
+        await this.repo.addMember({ groupId: group.id, userId });
+      }
+    }
+
+    return group;
+  }
+
+  async rename({
+    id,
+    organizationId,
+    name,
+  }: {
+    id: string;
+    organizationId: string;
+    name: string;
+  }): Promise<Group> {
+    const group = await this.repo.findGroupOnly({ id, organizationId });
+    if (!group) throw new GroupNotFoundError("Group not found");
+    if (group.scimSource) {
+      throw new ScimManagedGroupError(
+        "Cannot rename a SCIM-managed group",
+      );
+    }
+
+    const baseSlug = slugify(name, { lower: true, strict: true });
+    const slug = await this.repo.findUniqueSlug({
+      organizationId,
+      baseSlug,
+      excludeId: id,
+    });
+
+    return this.repo.rename({ id, name, slug });
+  }
+
+  async delete({
+    id,
+    organizationId,
+  }: {
+    id: string;
+    organizationId: string;
+  }): Promise<void> {
+    const group = await this.repo.findGroupOnly({ id, organizationId });
+    if (!group) throw new GroupNotFoundError("Group not found");
+
+    await this.repo.deleteAllMemberships({ groupId: id });
+    await this.repo.deleteAllBindings({ groupId: id });
+    await this.repo.delete({ id });
+  }
+
+  async getMembers({ groupId }: { groupId: string }) {
+    return this.repo.findMembers({ groupId });
+  }
+
+  async addMember({
+    groupId,
+    organizationId,
+    userId,
+  }: {
+    groupId: string;
+    organizationId: string;
+    userId: string;
+  }): Promise<GroupMembership> {
+    const group = await this.repo.findGroupOnly({
+      id: groupId,
+      organizationId,
+    });
+    if (!group) throw new GroupNotFoundError("Group not found");
+    if (group.scimSource) {
+      throw new ScimManagedGroupError(
+        "Cannot manually add members to a SCIM-managed group",
+      );
+    }
+
+    const isOrgMember = await this.repo.isUserInOrganization({
+      userId,
+      organizationId,
+    });
+    if (!isOrgMember) {
+      throw new UserNotInOrganizationError(
+        "User must belong to the organization before joining a group",
+      );
+    }
+
+    return this.repo.addMember({ groupId, userId });
+  }
+
+  async removeMember({
+    groupId,
+    organizationId,
+    userId,
+  }: {
+    groupId: string;
+    organizationId: string;
+    userId: string;
+  }): Promise<void> {
+    const group = await this.repo.findGroupOnly({
+      id: groupId,
+      organizationId,
+    });
+    if (!group) throw new GroupNotFoundError("Group not found");
+    if (group.scimSource) {
+      throw new ScimManagedGroupError(
+        "Cannot manually remove members from a SCIM-managed group",
+      );
+    }
+
+    await this.repo.removeMember({ groupId, userId });
+  }
+
+  async getBindings({ groupId }: { groupId: string }) {
+    return this.repo.findBindings({ groupId });
+  }
+
+  async addBinding({
+    groupId,
+    organizationId,
+    role,
+    customRoleId,
+    scopeType,
+    scopeId,
+  }: {
+    groupId: string;
+    organizationId: string;
+    role: TeamUserRole;
+    customRoleId?: string;
+    scopeType: RoleBindingScopeType;
+    scopeId: string;
+  }): Promise<RoleBinding> {
+    const group = await this.repo.findGroupOnly({
+      id: groupId,
+      organizationId,
+    });
+    if (!group) throw new GroupNotFoundError("Group not found");
+
+    return this.repo.createBinding({
+      id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
+      organizationId,
+      groupId,
+      role,
+      customRoleId:
+        role === ("CUSTOM" as TeamUserRole)
+          ? (customRoleId ?? null)
+          : null,
+      scopeType,
+      scopeId,
+    });
+  }
+
+  async removeBinding({
+    bindingId,
+    organizationId,
+  }: {
+    bindingId: string;
+    organizationId: string;
+  }): Promise<void> {
+    const binding = await this.repo.findBinding({
+      id: bindingId,
+      organizationId,
+    });
+    if (!binding) throw new BindingNotFoundError("Binding not found");
+
+    await this.repo.deleteBinding({ id: bindingId });
+  }
+}

--- a/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -1,0 +1,206 @@
+import type { Group, GroupMembership, PrismaClient, RoleBinding } from "@prisma/client";
+import type {
+  CreateBindingInput,
+  CreateGroupInput,
+  GroupRepository,
+  GroupWithDetails,
+  GroupWithMembers,
+  PaginatedResult,
+} from "./group.repository";
+
+export class PrismaGroupRepository implements GroupRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findAllByOrganization({
+    organizationId,
+    page,
+    limit,
+  }: {
+    organizationId: string;
+    page: number;
+    limit: number;
+  }): Promise<PaginatedResult<GroupWithDetails>> {
+    const where = { organizationId };
+    const [data, total] = await Promise.all([
+      this.prisma.group.findMany({
+        where,
+        include: {
+          roleBindings: {
+            include: { customRole: { select: { id: true, name: true } } },
+          },
+          _count: { select: { members: true } },
+        },
+        orderBy: { name: "asc" },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.group.count({ where }),
+    ]);
+    return { data, pagination: { page, limit, total } };
+  }
+
+  async findById({
+    id,
+    organizationId,
+  }: {
+    id: string;
+    organizationId: string;
+  }): Promise<GroupWithMembers | null> {
+    return this.prisma.group.findFirst({
+      where: { id, organizationId },
+      include: {
+        roleBindings: {
+          include: { customRole: { select: { id: true, name: true } } },
+        },
+        members: {
+          include: {
+            user: { select: { id: true, name: true, email: true } },
+          },
+        },
+      },
+    });
+  }
+
+  async findGroupOnly({
+    id,
+    organizationId,
+  }: {
+    id: string;
+    organizationId: string;
+  }): Promise<Group | null> {
+    return this.prisma.group.findFirst({
+      where: { id, organizationId },
+    });
+  }
+
+  async create(data: CreateGroupInput): Promise<Group> {
+    return this.prisma.group.create({ data });
+  }
+
+  async rename({
+    id,
+    name,
+    slug,
+  }: {
+    id: string;
+    name: string;
+    slug: string;
+  }): Promise<Group> {
+    return this.prisma.group.update({
+      where: { id },
+      data: { name, slug },
+    });
+  }
+
+  async delete({ id }: { id: string }): Promise<void> {
+    await this.prisma.group.delete({ where: { id } });
+  }
+
+  async findMembers({ groupId }: { groupId: string }) {
+    return this.prisma.groupMembership.findMany({
+      where: { groupId },
+      select: {
+        userId: true,
+        user: { select: { id: true, name: true, email: true } },
+      },
+    });
+  }
+
+  async addMember({
+    groupId,
+    userId,
+  }: {
+    groupId: string;
+    userId: string;
+  }): Promise<GroupMembership> {
+    return this.prisma.groupMembership.create({
+      data: { groupId, userId },
+    });
+  }
+
+  async removeMember({
+    groupId,
+    userId,
+  }: {
+    groupId: string;
+    userId: string;
+  }): Promise<void> {
+    await this.prisma.groupMembership.delete({
+      where: { userId_groupId: { userId, groupId } },
+    });
+  }
+
+  async findBindings({ groupId }: { groupId: string }) {
+    return this.prisma.roleBinding.findMany({
+      where: { groupId },
+      include: { customRole: { select: { id: true, name: true } } },
+    });
+  }
+
+  async createBinding(data: CreateBindingInput): Promise<RoleBinding> {
+    return this.prisma.roleBinding.create({ data });
+  }
+
+  async findBinding({
+    id,
+    organizationId,
+  }: {
+    id: string;
+    organizationId: string;
+  }): Promise<RoleBinding | null> {
+    return this.prisma.roleBinding.findFirst({
+      where: { id, organizationId },
+    });
+  }
+
+  async deleteBinding({ id }: { id: string }): Promise<void> {
+    await this.prisma.roleBinding.delete({ where: { id } });
+  }
+
+  async deleteAllMemberships({ groupId }: { groupId: string }): Promise<void> {
+    await this.prisma.groupMembership.deleteMany({ where: { groupId } });
+  }
+
+  async deleteAllBindings({ groupId }: { groupId: string }): Promise<void> {
+    await this.prisma.roleBinding.deleteMany({ where: { groupId } });
+  }
+
+  async isUserInOrganization({
+    userId,
+    organizationId,
+  }: {
+    userId: string;
+    organizationId: string;
+  }): Promise<boolean> {
+    const member = await this.prisma.organizationUser.findFirst({
+      where: { organizationId, userId },
+      select: { userId: true },
+    });
+    return !!member;
+  }
+
+  async findUniqueSlug({
+    organizationId,
+    baseSlug,
+    excludeId,
+  }: {
+    organizationId: string;
+    baseSlug: string;
+    excludeId?: string;
+  }): Promise<string> {
+    let candidate = baseSlug;
+    let suffix = 2;
+    while (true) {
+      const exists = await this.prisma.group.findFirst({
+        where: {
+          organizationId,
+          slug: candidate,
+          ...(excludeId ? { id: { not: excludeId } } : {}),
+        },
+        select: { id: true },
+      });
+      if (!exists) return candidate;
+      candidate = `${baseSlug}-${suffix++}`;
+    }
+  }
+}

--- a/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -77,6 +77,35 @@ export class PrismaGroupRepository implements GroupRepository {
     return this.prisma.group.create({ data });
   }
 
+  async createAtomic({
+    group,
+    bindings,
+    memberIds,
+  }: {
+    group: CreateGroupInput;
+    bindings: CreateBindingInput[];
+    memberIds: string[];
+  }): Promise<Group> {
+    return this.prisma.$transaction(async (tx) => {
+      const created = await tx.group.create({ data: group });
+
+      if (bindings.length > 0) {
+        await tx.roleBinding.createMany({ data: bindings });
+      }
+
+      if (memberIds.length > 0) {
+        await tx.groupMembership.createMany({
+          data: memberIds.map((userId) => ({
+            groupId: created.id,
+            userId,
+          })),
+        });
+      }
+
+      return created;
+    });
+  }
+
   async rename({
     id,
     organizationId,

--- a/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -1,4 +1,4 @@
-import type { Group, GroupMembership, PrismaClient, RoleBinding } from "@prisma/client";
+import { RoleBindingScopeType, type Group, type GroupMembership, type PrismaClient, type RoleBinding } from "@prisma/client";
 import type {
   CreateBindingInput,
   CreateGroupInput,
@@ -210,6 +210,35 @@ export class PrismaGroupRepository implements GroupRepository {
       select: { userId: true },
     });
     return !!member;
+  }
+
+  async validateScopeInOrganization({
+    organizationId,
+    scopeType,
+    scopeId,
+  }: {
+    organizationId: string;
+    scopeType: RoleBindingScopeType;
+    scopeId: string;
+  }): Promise<boolean> {
+    if (scopeType === RoleBindingScopeType.ORGANIZATION) {
+      return scopeId === organizationId;
+    }
+    if (scopeType === RoleBindingScopeType.TEAM) {
+      const team = await this.prisma.team.findFirst({
+        where: { id: scopeId, organizationId },
+        select: { id: true },
+      });
+      return !!team;
+    }
+    if (scopeType === RoleBindingScopeType.PROJECT) {
+      const project = await this.prisma.project.findFirst({
+        where: { id: scopeId, team: { organizationId } },
+        select: { id: true },
+      });
+      return !!project;
+    }
+    return false;
   }
 
   async findUniqueSlug({

--- a/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.prisma.repository.ts
@@ -79,21 +79,25 @@ export class PrismaGroupRepository implements GroupRepository {
 
   async rename({
     id,
+    organizationId,
     name,
     slug,
   }: {
     id: string;
+    organizationId: string;
     name: string;
     slug: string;
-  }): Promise<Group> {
-    return this.prisma.group.update({
-      where: { id },
+  }): Promise<Group | null> {
+    const result = await this.prisma.group.updateMany({
+      where: { id, organizationId },
       data: { name, slug },
     });
+    if (result.count === 0) return null;
+    return this.prisma.group.findUnique({ where: { id } });
   }
 
-  async delete({ id }: { id: string }): Promise<void> {
-    await this.prisma.group.delete({ where: { id } });
+  async delete({ id, organizationId }: { id: string; organizationId: string }): Promise<void> {
+    await this.prisma.group.deleteMany({ where: { id, organizationId } });
   }
 
   async findMembers({ groupId }: { groupId: string }) {

--- a/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
@@ -67,11 +67,12 @@ export interface GroupRepository {
 
   rename(params: {
     id: string;
+    organizationId: string;
     name: string;
     slug: string;
-  }): Promise<Group>;
+  }): Promise<Group | null>;
 
-  delete(params: { id: string }): Promise<void>;
+  delete(params: { id: string; organizationId: string }): Promise<void>;
 
   findMembers(params: {
     groupId: string;

--- a/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
@@ -119,6 +119,12 @@ export interface GroupRepository {
     organizationId: string;
   }): Promise<boolean>;
 
+  validateScopeInOrganization(params: {
+    organizationId: string;
+    scopeType: RoleBindingScopeType;
+    scopeId: string;
+  }): Promise<boolean>;
+
   findUniqueSlug(params: {
     organizationId: string;
     baseSlug: string;

--- a/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
@@ -65,6 +65,12 @@ export interface GroupRepository {
 
   create(data: CreateGroupInput): Promise<Group>;
 
+  createAtomic(params: {
+    group: CreateGroupInput;
+    bindings: CreateBindingInput[];
+    memberIds: string[];
+  }): Promise<Group>;
+
   rename(params: {
     id: string;
     organizationId: string;

--- a/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
+++ b/langwatch/src/server/app-layer/groups/repositories/group.repository.ts
@@ -1,0 +1,120 @@
+import type {
+  Group,
+  GroupMembership,
+  RoleBinding,
+  RoleBindingScopeType,
+  TeamUserRole,
+} from "@prisma/client";
+
+export interface GroupWithDetails extends Group {
+  _count: { members: number };
+  roleBindings: Array<
+    RoleBinding & { customRole: { id: string; name: string } | null }
+  >;
+}
+
+export interface GroupWithMembers extends Group {
+  roleBindings: Array<
+    RoleBinding & { customRole: { id: string; name: string } | null }
+  >;
+  members: Array<
+    GroupMembership & {
+      user: { id: string; name: string | null; email: string | null };
+    }
+  >;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  pagination: { page: number; limit: number; total: number };
+}
+
+export interface CreateGroupInput {
+  id: string;
+  organizationId: string;
+  name: string;
+  slug: string;
+}
+
+export interface CreateBindingInput {
+  id: string;
+  organizationId: string;
+  groupId: string;
+  role: TeamUserRole;
+  customRoleId: string | null;
+  scopeType: RoleBindingScopeType;
+  scopeId: string;
+}
+
+export interface GroupRepository {
+  findAllByOrganization(params: {
+    organizationId: string;
+    page: number;
+    limit: number;
+  }): Promise<PaginatedResult<GroupWithDetails>>;
+
+  findById(params: {
+    id: string;
+    organizationId: string;
+  }): Promise<GroupWithMembers | null>;
+
+  findGroupOnly(params: {
+    id: string;
+    organizationId: string;
+  }): Promise<Group | null>;
+
+  create(data: CreateGroupInput): Promise<Group>;
+
+  rename(params: {
+    id: string;
+    name: string;
+    slug: string;
+  }): Promise<Group>;
+
+  delete(params: { id: string }): Promise<void>;
+
+  findMembers(params: {
+    groupId: string;
+  }): Promise<
+    Array<{
+      userId: string;
+      user: { id: string; name: string | null; email: string | null };
+    }>
+  >;
+
+  addMember(params: { groupId: string; userId: string }): Promise<GroupMembership>;
+
+  removeMember(params: { groupId: string; userId: string }): Promise<void>;
+
+  findBindings(params: {
+    groupId: string;
+  }): Promise<
+    Array<
+      RoleBinding & { customRole: { id: string; name: string } | null }
+    >
+  >;
+
+  createBinding(data: CreateBindingInput): Promise<RoleBinding>;
+
+  findBinding(params: {
+    id: string;
+    organizationId: string;
+  }): Promise<RoleBinding | null>;
+
+  deleteBinding(params: { id: string }): Promise<void>;
+
+  deleteAllMemberships(params: { groupId: string }): Promise<void>;
+
+  deleteAllBindings(params: { groupId: string }): Promise<void>;
+
+  isUserInOrganization(params: {
+    userId: string;
+    organizationId: string;
+  }): Promise<boolean>;
+
+  findUniqueSlug(params: {
+    organizationId: string;
+    baseSlug: string;
+    excludeId?: string;
+  }): Promise<string>;
+}

--- a/langwatch/src/server/app-layer/projects/__tests__/project-service-update.unit.test.ts
+++ b/langwatch/src/server/app-layer/projects/__tests__/project-service-update.unit.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  DestinationTeamNotFoundError,
+  ProjectNotFoundError,
+  ProjectService,
+} from "../project.service";
+import { NullProjectRepository } from "../repositories/project.repository";
+
+function createMockRepo() {
+  const repo = new NullProjectRepository();
+  vi.spyOn(repo, "update");
+  vi.spyOn(repo, "findActiveTeamInOrganization");
+  return repo;
+}
+
+describe("ProjectService.update", () => {
+  let repo: ReturnType<typeof createMockRepo>;
+  let service: ProjectService;
+
+  beforeEach(() => {
+    repo = createMockRepo();
+    service = new ProjectService(repo);
+  });
+
+  describe("when teamId is not provided", () => {
+    it("skips team validation and updates the project", async () => {
+      const fakeProject = { id: "p1", name: "Updated", teamId: "t1" };
+      vi.mocked(repo.update).mockResolvedValue(fakeProject as any);
+
+      const result = await service.update({
+        id: "p1",
+        organizationId: "org1",
+        data: { name: "Updated" },
+      });
+
+      expect(repo.findActiveTeamInOrganization).not.toHaveBeenCalled();
+      expect(result.name).toBe("Updated");
+    });
+  });
+
+  describe("when teamId is provided", () => {
+    describe("when destination team exists in same org and is active", () => {
+      it("updates the project with new teamId", async () => {
+        vi.mocked(repo.findActiveTeamInOrganization).mockResolvedValue({ id: "t2" });
+        const fakeProject = { id: "p1", name: "Bot", teamId: "t2" };
+        vi.mocked(repo.update).mockResolvedValue(fakeProject as any);
+
+        const result = await service.update({
+          id: "p1",
+          organizationId: "org1",
+          data: { teamId: "t2" },
+        });
+
+        expect(repo.findActiveTeamInOrganization).toHaveBeenCalledWith({
+          teamId: "t2",
+          organizationId: "org1",
+        });
+        expect(repo.update).toHaveBeenCalledWith({
+          id: "p1",
+          organizationId: "org1",
+          data: { teamId: "t2" },
+        });
+        expect(result.teamId).toBe("t2");
+      });
+    });
+
+    describe("when destination team does not exist", () => {
+      it("throws DestinationTeamNotFoundError", async () => {
+        vi.mocked(repo.findActiveTeamInOrganization).mockResolvedValue(null);
+
+        await expect(
+          service.update({
+            id: "p1",
+            organizationId: "org1",
+            data: { teamId: "nonexistent" },
+          }),
+        ).rejects.toThrow(DestinationTeamNotFoundError);
+
+        expect(repo.update).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when destination team is archived", () => {
+      it("throws DestinationTeamNotFoundError", async () => {
+        vi.mocked(repo.findActiveTeamInOrganization).mockResolvedValue(null);
+
+        await expect(
+          service.update({
+            id: "p1",
+            organizationId: "org1",
+            data: { teamId: "archived-team" },
+          }),
+        ).rejects.toThrow(DestinationTeamNotFoundError);
+
+        expect(repo.update).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when destination team belongs to different org", () => {
+      it("throws DestinationTeamNotFoundError", async () => {
+        vi.mocked(repo.findActiveTeamInOrganization).mockResolvedValue(null);
+
+        await expect(
+          service.update({
+            id: "p1",
+            organizationId: "org1",
+            data: { teamId: "cross-org-team" },
+          }),
+        ).rejects.toThrow(DestinationTeamNotFoundError);
+      });
+    });
+  });
+
+  describe("when project is not found", () => {
+    it("throws ProjectNotFoundError", async () => {
+      vi.mocked(repo.update).mockResolvedValue(null);
+
+      await expect(
+        service.update({
+          id: "missing",
+          organizationId: "org1",
+          data: { name: "Nope" },
+        }),
+      ).rejects.toThrow(ProjectNotFoundError);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/projects/__tests__/project-service-update.unit.test.ts
+++ b/langwatch/src/server/app-layer/projects/__tests__/project-service-update.unit.test.ts
@@ -23,6 +23,7 @@ describe("ProjectService.update", () => {
   });
 
   describe("when teamId is not provided", () => {
+    /** @scenario ProjectService.update with no teamId leaves team unchanged */
     it("skips team validation and updates the project", async () => {
       const fakeProject = { id: "p1", name: "Updated", teamId: "t1" };
       vi.mocked(repo.update).mockResolvedValue(fakeProject as any);
@@ -40,6 +41,8 @@ describe("ProjectService.update", () => {
 
   describe("when teamId is provided", () => {
     describe("when destination team exists in same org and is active", () => {
+      /** @scenario ProjectService.update changes teamId with same-org validation */
+      /** @scenario tRPC project.update accepts optional teamId */
       it("updates the project with new teamId", async () => {
         vi.mocked(repo.findActiveTeamInOrganization).mockResolvedValue({ id: "t2" });
         const fakeProject = { id: "p1", name: "Bot", teamId: "t2" };
@@ -65,6 +68,7 @@ describe("ProjectService.update", () => {
     });
 
     describe("when destination team does not exist", () => {
+      /** @scenario tRPC project.update rejects cross-org team */
       it("throws DestinationTeamNotFoundError", async () => {
         vi.mocked(repo.findActiveTeamInOrganization).mockResolvedValue(null);
 
@@ -81,6 +85,7 @@ describe("ProjectService.update", () => {
     });
 
     describe("when destination team is archived", () => {
+      /** @scenario ProjectService.update rejects archived destination team */
       it("throws DestinationTeamNotFoundError", async () => {
         vi.mocked(repo.findActiveTeamInOrganization).mockResolvedValue(null);
 

--- a/langwatch/src/server/app-layer/projects/project.service.ts
+++ b/langwatch/src/server/app-layer/projects/project.service.ts
@@ -48,6 +48,10 @@ export class TeamNotInOrganizationError extends Error {
   name = "TeamNotInOrganizationError" as const;
 }
 
+export class DestinationTeamNotFoundError extends Error {
+  name = "DestinationTeamNotFoundError" as const;
+}
+
 export interface CreateProjectParams {
   organizationId: string;
   userId?: string | null;
@@ -155,6 +159,18 @@ export class ProjectService {
     organizationId: string;
     data: UpdateProjectInput;
   }): Promise<Project> {
+    if (data.teamId) {
+      const team = await this.repo.findActiveTeamInOrganization({
+        teamId: data.teamId,
+        organizationId,
+      });
+      if (!team) {
+        throw new DestinationTeamNotFoundError(
+          "Destination team not found, is archived, or belongs to a different organization",
+        );
+      }
+    }
+
     const project = await this.repo.update({ id, organizationId, data });
     if (!project) throw new ProjectNotFoundError("Project not found");
     return project;

--- a/langwatch/src/server/app-layer/projects/repositories/project.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/projects/repositories/project.prisma.repository.ts
@@ -189,6 +189,19 @@ export class PrismaProjectRepository implements ProjectRepository {
     return !!team;
   }
 
+  async findActiveTeamInOrganization({
+    teamId,
+    organizationId,
+  }: {
+    teamId: string;
+    organizationId: string;
+  }): Promise<{ id: string } | null> {
+    return this.prisma.team.findFirst({
+      where: { id: teamId, organizationId, archivedAt: null },
+      select: { id: true },
+    });
+  }
+
   async createTeamWithRoleBinding(input: CreateTeamWithBindingInput): Promise<{ id: string }> {
     const team = await this.prisma.team.create({
       data: {

--- a/langwatch/src/server/app-layer/projects/repositories/project.repository.ts
+++ b/langwatch/src/server/app-layer/projects/repositories/project.repository.ts
@@ -34,6 +34,7 @@ export interface UpdateProjectInput {
   language?: string;
   framework?: string;
   piiRedactionLevel?: PIIRedactionLevel;
+  teamId?: string;
 }
 
 export interface PaginatedResult<T> {
@@ -88,6 +89,7 @@ export interface ProjectRepository {
   }): Promise<PaginatedResult<Project>>;
   findBySlugInTeam(params: { slug: string; teamId: string }): Promise<Project | null>;
   teamBelongsToOrganization(params: { teamId: string; organizationId: string }): Promise<boolean>;
+  findActiveTeamInOrganization(params: { teamId: string; organizationId: string }): Promise<{ id: string } | null>;
   createTeamWithRoleBinding(input: CreateTeamWithBindingInput): Promise<{ id: string }>;
   createTeam(input: { teamId: string; teamName: string; teamSlug: string; organizationId: string }): Promise<{ id: string }>;
 }
@@ -147,6 +149,10 @@ export class NullProjectRepository implements ProjectRepository {
 
   async teamBelongsToOrganization(_params: { teamId: string; organizationId: string }): Promise<boolean> {
     return false;
+  }
+
+  async findActiveTeamInOrganization(_params: { teamId: string; organizationId: string }): Promise<{ id: string } | null> {
+    return null;
   }
 
   async createTeamWithRoleBinding(_input: CreateTeamWithBindingInput): Promise<{ id: string }> {

--- a/specs/groups/groups-rest-api.feature
+++ b/specs/groups/groups-rest-api.feature
@@ -20,7 +20,8 @@ Feature: Groups REST API
   @unit
   Scenario: GET /api/groups returns paginated results
     When I send GET /api/groups?page=1&limit=10
-    Then the response includes pagination metadata
+    Then the response status is 200
+    And the response includes pagination metadata
 
   @unit
   Scenario: GET /api/groups returns 401 without auth

--- a/specs/groups/groups-rest-api.feature
+++ b/specs/groups/groups-rest-api.feature
@@ -1,0 +1,181 @@
+@integration
+Feature: Groups REST API
+  As an organization admin
+  I want to manage groups via the REST API
+  So that I can programmatically control access groups
+
+  Background:
+    Given I am authenticated with an organization API key
+    And I have organization:manage permission
+
+  # ── List groups ─────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: GET /api/groups lists all groups
+    Given the organization has groups "Engineering" and "Design"
+    When I send GET /api/groups
+    Then the response status is 200
+    And the response includes both groups with member counts and bindings
+
+  @unit
+  Scenario: GET /api/groups returns paginated results
+    When I send GET /api/groups?page=1&limit=10
+    Then the response includes pagination metadata
+
+  @unit
+  Scenario: GET /api/groups returns 401 without auth
+    Given I have no authentication
+    When I send GET /api/groups
+    Then the response status is 401
+
+  # ── Create group ────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: POST /api/groups creates a group
+    When I send POST /api/groups with name "Backend Team"
+    Then the response status is 201
+    And the response includes the group with a generated slug
+
+  @unit
+  Scenario: POST /api/groups creates a group with initial members and bindings
+    Given user "alice" exists in the organization
+    And team "Engineering" exists
+    When I send POST /api/groups with:
+      | field     | value                                    |
+      | name      | Full Team                                |
+      | memberIds | ["alice-user-id"]                        |
+      | bindings  | [{"role":"MEMBER","scopeType":"TEAM","scopeId":"eng-team-id"}] |
+    Then the response status is 201
+    And the group has 1 member
+    And the group has 1 binding
+
+  @unit
+  Scenario: POST /api/groups returns 422 for missing name
+    When I send POST /api/groups with empty name
+    Then the response status is 422
+
+  # ── Get group ───────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: GET /api/groups/:id returns group with members and bindings
+    Given group "Engineering" exists with members and bindings
+    When I send GET /api/groups/:id
+    Then the response status is 200
+    And the response includes members with userId, name, and email
+    And the response includes bindings with role, scopeType, and scopeName
+
+  @unit
+  Scenario: GET /api/groups/:id returns 404 for nonexistent group
+    When I send GET /api/groups/nonexistent
+    Then the response status is 404
+
+  # ── Update group ────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: PATCH /api/groups/:id renames a group
+    Given group "Old Name" exists
+    When I send PATCH /api/groups/:id with name "New Name"
+    Then the response status is 200
+    And the response includes name "New Name" and an updated slug
+
+  @unit
+  Scenario: PATCH /api/groups/:id rejects rename of SCIM-managed group
+    Given group "SCIM Group" is SCIM-managed
+    When I send PATCH /api/groups/:id with name "Renamed"
+    Then the response status is 400
+    And the error message indicates SCIM groups cannot be renamed
+
+  # ── Delete group ────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: DELETE /api/groups/:id deletes a group
+    Given group "Temporary" exists
+    When I send DELETE /api/groups/:id
+    Then the response status is 200
+    And the group is no longer accessible via GET
+
+  @unit
+  Scenario: DELETE /api/groups/:id returns 404 for nonexistent group
+    When I send DELETE /api/groups/nonexistent
+    Then the response status is 404
+
+  # ── Members ─────────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: GET /api/groups/:id/members lists group members
+    Given group "Engineering" has members "alice" and "bob"
+    When I send GET /api/groups/:id/members
+    Then the response status is 200
+    And the response includes 2 members with userId, name, and email
+
+  @unit
+  Scenario: POST /api/groups/:id/members adds a member
+    Given group "Engineering" exists
+    And user "charlie" exists in the organization
+    When I send POST /api/groups/:id/members with userId "charlie"
+    Then the response status is 201
+
+  @unit
+  Scenario: POST /api/groups/:id/members rejects adding to SCIM-managed group
+    Given group "SCIM Group" is SCIM-managed
+    When I send POST /api/groups/:id/members with userId "charlie"
+    Then the response status is 400
+
+  @unit
+  Scenario: POST /api/groups/:id/members rejects non-org user
+    Given group "Engineering" exists
+    And user "outsider" does not belong to the organization
+    When I send POST /api/groups/:id/members with userId "outsider"
+    Then the response status is 400
+
+  @unit
+  Scenario: DELETE /api/groups/:id/members/:userId removes a member
+    Given group "Engineering" has member "alice"
+    When I send DELETE /api/groups/:id/members/alice-id
+    Then the response status is 200
+    And "alice" is no longer a member of the group
+
+  @unit
+  Scenario: DELETE /api/groups/:id/members/:userId rejects removal from SCIM group
+    Given group "SCIM Group" is SCIM-managed with member "alice"
+    When I send DELETE /api/groups/:id/members/alice-id
+    Then the response status is 400
+
+  # ── Bindings ────────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: GET /api/groups/:id/bindings lists group role bindings
+    Given group "Engineering" has a MEMBER binding on team "Backend"
+    When I send GET /api/groups/:id/bindings
+    Then the response status is 200
+    And the response includes the binding with role, scopeType, scopeId, and scopeName
+
+  @unit
+  Scenario: POST /api/groups/:id/bindings adds a role binding
+    Given group "Engineering" exists
+    And team "Frontend" exists in the same organization
+    When I send POST /api/groups/:id/bindings with:
+      | field     | value     |
+      | role      | MEMBER    |
+      | scopeType | TEAM      |
+      | scopeId   | frontend-team-id |
+    Then the response status is 201
+
+  @unit
+  Scenario: POST /api/groups/:id/bindings rejects cross-org scope
+    Given group "Engineering" exists
+    And team "External" belongs to a different organization
+    When I send POST /api/groups/:id/bindings with scopeId of "External"
+    Then the response status is 400
+
+  @unit
+  Scenario: DELETE /api/groups/:id/bindings/:bindingId removes a binding
+    Given group "Engineering" has binding "rb_123"
+    When I send DELETE /api/groups/:id/bindings/rb_123
+    Then the response status is 200
+    And the binding is removed
+
+  @unit
+  Scenario: DELETE /api/groups/:id/bindings/:bindingId returns 404 for nonexistent binding
+    When I send DELETE /api/groups/:id/bindings/nonexistent
+    Then the response status is 404

--- a/specs/projects/edit-project-team.feature
+++ b/specs/projects/edit-project-team.feature
@@ -112,7 +112,7 @@ Feature: Edit project name and team
 
   # ── RBAC inheritance ─────────────────────────────────────────────────────────
 
-  @unit
+  @unit @unimplemented
   Scenario: Moving project changes team-scoped access inheritance
     Given user Alice has MEMBER role on team "Engineering" only
     And project "My Chatbot" is in team "Engineering"
@@ -123,14 +123,14 @@ Feature: Edit project name and team
 
   # ── UI ──────────────────────────────────────────────────────────────────────
 
-  @integration
+  @integration @unimplemented
   Scenario: Edit button appears on project row
     Given I am on the Settings Teams & Projects page
     And I have team:manage permission
     When I look at a project row
     Then I see an Edit button with a pencil icon next to the access count
 
-  @integration
+  @integration @unimplemented
   Scenario: Edit button opens project edit drawer
     Given I am on the Settings Teams & Projects page
     When I click the Edit button on project "My Chatbot"
@@ -138,7 +138,7 @@ Feature: Edit project name and team
     And it shows the current project name "My Chatbot"
     And it shows a team selector with the current team "Engineering" selected
 
-  @integration
+  @integration @unimplemented
   Scenario: User updates project name via drawer
     Given the EditProject drawer is open for "My Chatbot"
     When I change the name to "Renamed Bot"
@@ -147,7 +147,7 @@ Feature: Edit project name and team
     And I see a success toast
     And the project list refreshes showing "Renamed Bot"
 
-  @integration
+  @integration @unimplemented
   Scenario: User moves project to different team via drawer
     Given the EditProject drawer is open for "My Chatbot"
     When I select team "Analytics" from the team dropdown
@@ -156,13 +156,13 @@ Feature: Edit project name and team
     And I see a success toast
     And the project appears under team "Analytics"
 
-  @integration
+  @integration @unimplemented
   Scenario: Team selector only shows non-archived teams in same org
     Given the EditProject drawer is open
     Then the team dropdown lists "Engineering" and "Analytics"
     And the team dropdown does not list archived teams
 
-  @integration
+  @integration @unimplemented
   Scenario: Edit button hidden for users without manage permission
     Given I am on the Settings Teams & Projects page
     And I do not have team:manage permission

--- a/specs/projects/edit-project-team.feature
+++ b/specs/projects/edit-project-team.feature
@@ -1,0 +1,170 @@
+@integration
+Feature: Edit project name and team
+  As an organization admin
+  I want to edit a project's name and move it to a different team
+  So that I can reorganize my projects across workspaces
+
+  Background:
+    Given I am logged in as an authenticated user
+    And I have an organization with teams "Engineering" and "Analytics"
+    And team "Engineering" has a project "My Chatbot"
+
+  # ── REST API ────────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: PATCH /api/projects/:id updates project name
+    Given I have a valid organization API key
+    When I send PATCH /api/projects/:id with body:
+      | field | value         |
+      | name  | Renamed Bot   |
+    Then the response status is 200
+    And the response body includes name "Renamed Bot"
+
+  @unit
+  Scenario: PATCH /api/projects/:id moves project to different team
+    Given I have a valid organization API key
+    And team "Analytics" exists in the same organization
+    When I send PATCH /api/projects/:id with body:
+      | field  | value              |
+      | teamId | Analytics team id  |
+    Then the response status is 200
+    And the response body includes the new teamId
+
+  @unit
+  Scenario: PATCH /api/projects/:id updates name and team together
+    Given I have a valid organization API key
+    When I send PATCH /api/projects/:id with body:
+      | field  | value              |
+      | name   | Moved Bot          |
+      | teamId | Analytics team id  |
+    Then the response status is 200
+    And the response body includes name "Moved Bot"
+    And the response body includes the new teamId
+
+  @unit
+  Scenario: PATCH rejects teamId from different organization
+    Given I have a valid organization API key
+    And team "External" belongs to a different organization
+    When I send PATCH /api/projects/:id with teamId of "External"
+    Then the response status is 400
+    And the error message indicates the team is not in the same organization
+
+  @unit
+  Scenario: PATCH rejects teamId of archived team
+    Given I have a valid organization API key
+    And team "Analytics" is archived
+    When I send PATCH /api/projects/:id with teamId of "Analytics"
+    Then the response status is 400
+    And the error message indicates the destination team is archived
+
+  @unit
+  Scenario: PATCH rejects non-existent teamId
+    Given I have a valid organization API key
+    When I send PATCH /api/projects/:id with teamId "nonexistent"
+    Then the response status is 400
+
+  @unit
+  Scenario: PATCH with teamId and name is atomic
+    Given I have a valid organization API key
+    And team "Analytics" is archived
+    When I send PATCH /api/projects/:id with name "New Name" and teamId of "Analytics"
+    Then the response status is 400
+    And the project name remains unchanged
+
+  # ── tRPC ────────────────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: tRPC project.update accepts optional teamId
+    Given I am authenticated with project:update permission
+    And team "Analytics" exists in the same organization
+    When I call project.update with teamId of "Analytics"
+    Then the project teamId is updated to "Analytics"
+
+  @unit
+  Scenario: tRPC project.update rejects cross-org team
+    Given I am authenticated with project:update permission
+    And team "External" belongs to a different organization
+    When I call project.update with teamId of "External"
+    Then the mutation fails with BAD_REQUEST
+
+  # ── Service layer ───────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: ProjectService.update changes teamId with same-org validation
+    Given a project in team "Engineering"
+    And team "Analytics" in the same organization
+    When I call ProjectService.update with teamId of "Analytics"
+    Then the project's teamId is updated
+    And the project remains in the same organization
+
+  @unit
+  Scenario: ProjectService.update rejects archived destination team
+    Given a project in team "Engineering"
+    And team "Analytics" is archived
+    When I call ProjectService.update with teamId of "Analytics"
+    Then the service throws an error
+
+  @unit
+  Scenario: ProjectService.update with no teamId leaves team unchanged
+    Given a project in team "Engineering"
+    When I call ProjectService.update without teamId
+    Then the project's teamId remains "Engineering"
+
+  # ── RBAC inheritance ─────────────────────────────────────────────────────────
+
+  @unit
+  Scenario: Moving project changes team-scoped access inheritance
+    Given user Alice has MEMBER role on team "Engineering" only
+    And project "My Chatbot" is in team "Engineering"
+    When an admin moves "My Chatbot" to team "Analytics"
+    Then Alice no longer has inherited access to "My Chatbot"
+    And users with team "Analytics" bindings now inherit access to "My Chatbot"
+    And project-scoped bindings on "My Chatbot" remain unchanged
+
+  # ── UI ──────────────────────────────────────────────────────────────────────
+
+  @integration
+  Scenario: Edit button appears on project row
+    Given I am on the Settings Teams & Projects page
+    And I have team:manage permission
+    When I look at a project row
+    Then I see an Edit button with a pencil icon next to the access count
+
+  @integration
+  Scenario: Edit button opens project edit drawer
+    Given I am on the Settings Teams & Projects page
+    When I click the Edit button on project "My Chatbot"
+    Then the EditProject drawer opens
+    And it shows the current project name "My Chatbot"
+    And it shows a team selector with the current team "Engineering" selected
+
+  @integration
+  Scenario: User updates project name via drawer
+    Given the EditProject drawer is open for "My Chatbot"
+    When I change the name to "Renamed Bot"
+    And I click Save
+    Then the drawer closes
+    And I see a success toast
+    And the project list refreshes showing "Renamed Bot"
+
+  @integration
+  Scenario: User moves project to different team via drawer
+    Given the EditProject drawer is open for "My Chatbot"
+    When I select team "Analytics" from the team dropdown
+    And I click Save
+    Then the drawer closes
+    And I see a success toast
+    And the project appears under team "Analytics"
+
+  @integration
+  Scenario: Team selector only shows non-archived teams in same org
+    Given the EditProject drawer is open
+    Then the team dropdown lists "Engineering" and "Analytics"
+    And the team dropdown does not list archived teams
+
+  @integration
+  Scenario: Edit button hidden for users without manage permission
+    Given I am on the Settings Teams & Projects page
+    And I do not have team:manage permission
+    When I look at a project row
+    Then I do not see an Edit button


### PR DESCRIPTION
## Summary
- **Project Edit/Move**: Edit button on project rows in Settings → Teams & Projects, drawer to rename + move between teams
- **Groups REST API**: Full CRUD at `/api/groups` with members and bindings sub-resources
- **Feature Parity**: Closed REST vs tRPC gaps for teams (member management, project listing) and projects (API key ops)

## Context
Customer feedback: no way to move projects between teams, and groups had no public API surface.

## Project Edit/Move
- REST PATCH `/api/projects/:id` and tRPC `project.update` accept optional `teamId`
- Service validates destination team: same org, not archived
- New `EditProjectDrawer` component with name + team selector
- Edit button on project rows for `team:manage` users

## Groups REST API (`/api/groups`)

| Method | Path | Description |
|--------|------|-------------|
| GET | /api/groups | List groups (paginated) |
| POST | /api/groups | Create with optional members/bindings |
| GET | /api/groups/:id | Get with members and bindings |
| PATCH | /api/groups/:id | Rename (rejects SCIM-managed) |
| DELETE | /api/groups/:id | Delete with cascade |
| GET | /api/groups/:id/members | List members |
| POST | /api/groups/:id/members | Add member |
| DELETE | /api/groups/:id/members/:userId | Remove member |
| GET | /api/groups/:id/bindings | List bindings |
| POST | /api/groups/:id/bindings | Add binding |
| DELETE | /api/groups/:id/bindings/:bindingId | Remove binding |

All require `organization:manage`. Multi-tenancy enforced at repository layer.

## Teams Feature Parity
| Endpoint | Description |
|----------|-------------|
| GET /api/teams/:id/members | List team members |
| POST /api/teams/:id/members | Add member with role |
| DELETE /api/teams/:id/members/:userId | Remove member |
| GET /api/teams/:id/projects | List projects in team |

## Projects Feature Parity
| Endpoint | Description |
|----------|-------------|
| GET /api/projects/:id/api-key | Get project API key |
| POST /api/projects/:id/regenerate-api-key | Regenerate API key |

## Review Fixes
- Fixed multi-tenancy violations in group rename/delete (CodeRabbit critical)
- Added DuplicateMemberError handling for P2002
- Added scopeId validation in create schema
- Verified binding-group ownership before delete
- Fixed missing dep in useCallback

## Test plan
- [x] Project service unit tests: 6/6 passing
- [x] Project REST integration tests: 6 team-move scenarios
- [x] Typecheck passes
- [x] Code review: all 12 rules pass
- [x] CodeRabbit findings addressed