### PR TITLE
perf(clickhouse): scalar latest-version filter for experiment getRun

### DIFF
--- a/langwatch/src/server/experiments-v3/services/__tests__/clickhouse-experiment-run.getRun.integration.test.ts
+++ b/langwatch/src/server/experiments-v3/services/__tests__/clickhouse-experiment-run.getRun.integration.test.ts
@@ -41,15 +41,23 @@ interface RunVersion {
  * take their table defaults.
  */
 async function insertVersion(ch: ClickHouseClient, v: RunVersion) {
-  const tenant = v.tenant ?? tenantId;
-  const targets = (v.targets ?? "[]").replace(/'/g, "\\'");
   await ch.command({
     query: `
       INSERT INTO experiment_runs
         (ProjectionId, TenantId, RunId, ExperimentId, Version, Total, Progress, Targets, CreatedAt, UpdatedAt, StartedAt)
       VALUES
-        ('${nanoid()}', '${tenant}', '${v.runId}', '${v.experimentId}', 'v1', ${v.total ?? 10}, ${v.progress}, '${targets}', now64(3), now64(3) - ${v.agoSec}, now64(3))
+        ({pid:String}, {tenant:String}, {runId:String}, {experimentId:String}, 'v1', {total:UInt32}, {progress:UInt32}, {targets:String}, now64(3), now64(3) - {agoSec:UInt32}, now64(3))
     `,
+    query_params: {
+      pid: nanoid(),
+      tenant: v.tenant ?? tenantId,
+      runId: v.runId,
+      experimentId: v.experimentId,
+      total: v.total ?? 10,
+      progress: v.progress,
+      targets: v.targets ?? "[]",
+      agoSec: v.agoSec,
+    },
   });
 }
 

--- a/langwatch/src/server/experiments-v3/services/__tests__/clickhouse-experiment-run.getRun.integration.test.ts
+++ b/langwatch/src/server/experiments-v3/services/__tests__/clickhouse-experiment-run.getRun.integration.test.ts
@@ -1,0 +1,120 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { startTestContainers, stopTestContainers } from "../../../event-sourcing/__tests__/integration/testContainers";
+
+// getRun resolves its ClickHouse client through getClickHouseClientForProject;
+// point that at the testcontainer client so the real query path runs.
+let testClient: ClickHouseClient;
+vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("~/server/clickhouse/clickhouseClient")
+  >();
+  return {
+    ...actual,
+    getClickHouseClientForProject: async () => testClient,
+  };
+});
+
+// Imported after the mock is registered.
+const { ClickHouseExperimentRunService } = await import(
+  "../clickhouse-experiment-run.service"
+);
+
+const tenantId = `test-exp-getrun-${nanoid()}`;
+
+interface RunVersion {
+  tenant?: string;
+  experimentId: string;
+  runId: string;
+  progress: number;
+  total?: number;
+  targets?: string;
+  /** Seconds subtracted from now64(3) for UpdatedAt; lower = newer. */
+  agoSec: number;
+}
+
+/**
+ * Inserts one experiment_runs version using server-side now64(3) timestamps,
+ * synchronously via a command (avoids client-side Date serialization and async
+ * insert buffering). Only the columns the read path needs are set; the rest
+ * take their table defaults.
+ */
+async function insertVersion(ch: ClickHouseClient, v: RunVersion) {
+  const tenant = v.tenant ?? tenantId;
+  const targets = (v.targets ?? "[]").replace(/'/g, "\\'");
+  await ch.command({
+    query: `
+      INSERT INTO experiment_runs
+        (ProjectionId, TenantId, RunId, ExperimentId, Version, Total, Progress, Targets, CreatedAt, UpdatedAt, StartedAt)
+      VALUES
+        ('${nanoid()}', '${tenant}', '${v.runId}', '${v.experimentId}', 'v1', ${v.total ?? 10}, ${v.progress}, '${targets}', now64(3), now64(3) - ${v.agoSec}, now64(3))
+    `,
+  });
+}
+
+let ch: ClickHouseClient;
+let service: InstanceType<typeof ClickHouseExperimentRunService>;
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  testClient = ch;
+  service = new ClickHouseExperimentRunService({} as any);
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE experiment_runs DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("ClickHouseExperimentRunService.getRun (integration)", () => {
+  describe("when a run has several versions", () => {
+    it("returns the fields of the version with the greatest UpdatedAt", async () => {
+      const experimentId = `exp-latest-${nanoid()}`;
+      const runId = `run-latest-${nanoid()}`;
+      await insertVersion(ch, { experimentId, runId, progress: 1, targets: '[{"id":"stale-1"}]', agoSec: 3 });
+      await insertVersion(ch, { experimentId, runId, progress: 2, targets: '[{"id":"stale-2"}]', agoSec: 1 });
+      await insertVersion(ch, { experimentId, runId, progress: 9, targets: '[{"id":"final"}]', agoSec: 0 });
+
+      const result = await service.getRun({ projectId: tenantId, experimentId, runId });
+
+      expect(result).not.toBeNull();
+      expect(result!.progress).toBe(9);
+      expect(result!.targets).toEqual([{ id: "final" }]);
+    });
+  });
+
+  describe("when the run does not exist", () => {
+    it("returns null", async () => {
+      const result = await service.getRun({
+        projectId: tenantId,
+        experimentId: `exp-missing-${nanoid()}`,
+        runId: `run-missing-${nanoid()}`,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("when the same run id exists under another tenant", () => {
+    it("does not return the other tenant's run", async () => {
+      const experimentId = `exp-shared-${nanoid()}`;
+      const runId = `run-shared-${nanoid()}`;
+      const otherTenant = `test-exp-getrun-other-${nanoid()}`;
+      await insertVersion(ch, { tenant: otherTenant, experimentId, runId, progress: 5, agoSec: 0 });
+
+      const result = await service.getRun({ projectId: tenantId, experimentId, runId });
+      expect(result).toBeNull();
+
+      await ch.exec({
+        query: `ALTER TABLE experiment_runs DELETE WHERE TenantId = {tenantId:String}`,
+        query_params: { tenantId: otherTenant },
+      });
+    });
+  });
+});

--- a/langwatch/src/server/experiments-v3/services/__tests__/experiment-run-dedup-safety.unit.test.ts
+++ b/langwatch/src/server/experiments-v3/services/__tests__/experiment-run-dedup-safety.unit.test.ts
@@ -59,8 +59,13 @@ describe("clickhouse-experiment-run.service dedup OOM safety", () => {
     });
 
     it("does not read a single run via an experiment_runs UpdatedAt IN-tuple", () => {
+      // Order-insensitive over the three key columns, and bare (non-aliased)
+      // columns only: the legitimate multi-run listRuns dedup uses `t.`-prefixed
+      // columns (`(t.TenantId, t.RunId, t.ExperimentId, t.UpdatedAt) IN`), so a
+      // getRun regression back to a bare key+UpdatedAt IN-tuple is caught in any
+      // key order without flagging listRuns.
       expect(source).not.toMatch(
-        /\(TenantId, ExperimentId, RunId, UpdatedAt\)\s*IN/,
+        /\(\s*(?:(?:TenantId|ExperimentId|RunId)\s*,\s*){3}UpdatedAt\s*\)\s*IN/,
       );
     });
   });

--- a/langwatch/src/server/experiments-v3/services/__tests__/experiment-run-dedup-safety.unit.test.ts
+++ b/langwatch/src/server/experiments-v3/services/__tests__/experiment-run-dedup-safety.unit.test.ts
@@ -44,4 +44,24 @@ describe("clickhouse-experiment-run.service dedup OOM safety", () => {
       );
     });
   });
+
+  describe("single-run getRun latest-version read", () => {
+    // getRun fetches ONE run, so it resolves the latest version with a scalar
+    // `UpdatedAt = (SELECT max(UpdatedAt) ...)` subquery rather than the
+    // `(..., UpdatedAt) IN (max-subquery)` tuple form. The scalar equality is
+    // PREWHERE-able, so the heavy columns are materialized for only the
+    // surviving version instead of across every version of the run. The
+    // IN-tuple form stays correct for the multi-run list reads.
+    it("uses a scalar max(UpdatedAt) subquery for the single run fetch", () => {
+      expect(source).toMatch(
+        /UpdatedAt = \(\s*SELECT max\(UpdatedAt\)\s*FROM experiment_runs/,
+      );
+    });
+
+    it("does not read a single run via an experiment_runs UpdatedAt IN-tuple", () => {
+      expect(source).not.toMatch(
+        /\(TenantId, ExperimentId, RunId, UpdatedAt\)\s*IN/,
+      );
+    });
+  });
 });

--- a/langwatch/src/server/experiments-v3/services/clickhouse-experiment-run.service.ts
+++ b/langwatch/src/server/experiments-v3/services/clickhouse-experiment-run.service.ts
@@ -711,11 +711,20 @@ export class ClickHouseExperimentRunService {
         );
 
         try {
-          // IN-tuple dedup over the ReplacingMergeTree (see
-          // dev/docs/best_practices/clickhouse-queries.md). Inner SELECT
-          // scans only the sparse key tuple to find max(UpdatedAt), outer
-          // SELECT pulls the heavy run row (Total/Progress/cost rollups) for
-          // that one match.
+          // Latest-version read for a single run over the
+          // ReplacingMergeTree(UpdatedAt). The inner scalar subquery finds the
+          // newest UpdatedAt reading only the light sort-key columns; the outer
+          // `UpdatedAt = (...)` equality is PREWHERE-able, so the heavy columns
+          // (Targets and the full row) are materialized for only the surviving
+          // version.
+          //
+          // The earlier key-plus-version IN-tuple form was not applied as a
+          // PREWHERE on the version, so ClickHouse read the heavy columns across
+          // EVERY version of the run before discarding the stale ones. For a
+          // single-aggregate get the scalar form is preferable; the IN-tuple
+          // form stays the right choice for the multi-run list reads (listRuns)
+          // and for experiment_run_items below. See the sibling
+          // simulation/trace read paths which use the same scalar form.
           const runResult = await clickHouseClient.query({
             query: `
               SELECT *
@@ -723,13 +732,12 @@ export class ClickHouseExperimentRunService {
               WHERE TenantId = {tenantId:String}
                 AND ExperimentId = {experimentId:String}
                 AND RunId = {runId:String}
-                AND (TenantId, ExperimentId, RunId, UpdatedAt) IN (
-                  SELECT TenantId, ExperimentId, RunId, max(UpdatedAt)
+                AND UpdatedAt = (
+                  SELECT max(UpdatedAt)
                   FROM experiment_runs
                   WHERE TenantId = {tenantId:String}
                     AND ExperimentId = {experimentId:String}
                     AND RunId = {runId:String}
-                  GROUP BY TenantId, ExperimentId, RunId
                 )
               LIMIT 1
             `,


### PR DESCRIPTION
## Evidence

Over the last 24h the dominant **uncovered** slow-read shape in the app-side ClickHouse slow-query log (`ClickHouse slow query` warns) is the single-experiment-run fetch:

```
SELECT * FROM experiment_runs
WHERE TenantId = {…} AND ExperimentId = {…} AND RunId = {…}
  AND (TenantId, ExperimentId, RunId, UpdatedAt) IN (
    SELECT TenantId, ExperimentId, RunId, max(UpdatedAt)
    FROM experiment_runs WHERE … GROUP BY TenantId, ExperimentId, RunId
  )
LIMIT 1
```

~220 warns/24h, p50 ~1.1s (max ~3s). It is also the shape that, for runs with the largest payloads, tips into the `Code: 241 MEMORY_LIMIT_EXCEEDED` family this optimizer has been clearing all week.

## Suspected cause

`experiment_runs` is `ReplacingMergeTree(UpdatedAt)`; a single run accumulates one row per fold/snapshot. The `(TenantId, ExperimentId, RunId, UpdatedAt) IN (max-subquery)` tuple predicate is **not** applied as a PREWHERE on the version column, so ClickHouse materializes the heavy columns (`Targets` plus the rest of the `SELECT *` row) for **every version** of the run before the IN filter discards the stale ones. Read cost scales with version count, not with the one row actually returned.

## Proposed fix

Resolve the latest version with a **scalar** subquery and a plain equality:

```
WHERE TenantId = {…} AND ExperimentId = {…} AND RunId = {…}
  AND UpdatedAt = (
    SELECT max(UpdatedAt) FROM experiment_runs WHERE … 
  )
```

`UpdatedAt = <scalar>` is PREWHERE-able: ClickHouse reads the light `UpdatedAt` column first, filters to the single latest-version row, and materializes the heavy columns for only that row. This is the same single-aggregate pattern the sibling simulation/trace read paths already use. The IN-tuple form is left untouched for the multi-run `listRuns` reads and for `experiment_run_items`, where it is the correct dedup shape.

## Expected impact

- Heavy columns materialized for **1 row** instead of every version of the run; p50 drops and the read stops crossing the memory limit on large runs.
- Latest-version semantics unchanged (ReplacingMergeTree(UpdatedAt); `LIMIT 1` preserved).

## EXPLAIN check

`EXPLAIN SYNTAX`/`PLAN` confirm the new shape parses and plans as a single `ReadFromMergeTree` with the equality in WHERE (PREWHERE-eligible). As with the prior single-aggregate fixes, `EXPLAIN INDEXES` granule counts are identical for both shapes (both prune to the run's granules via the primary key); the win is **column materialization**, which the read-only EXPLAIN endpoint cannot quantify (ANALYZE is blocked). The behavioural proof is the integration test plus the prod slow-query evidence and the sibling-path precedent.

## Test plan

- `clickhouse-experiment-run.getRun.integration.test.ts` (real ClickHouse via testcontainers, drives the actual `getRun` with the CH client pointed at the container): inserts several versions of one run and asserts `getRun` returns the latest version's fields (`progress`, parsed `targets`); covers not-found and cross-tenant isolation. **3/3 pass locally.**
- `experiment-run-dedup-safety.unit.test.ts`: extended with a structural guard asserting the single-run fetch uses the scalar `max(UpdatedAt)` subquery and no `(…, UpdatedAt) IN` tuple. **5/5 pass.**
- `tsgo` typecheck clean for the changed files.

Advisory PR from the ClickHouse slow-query optimizer. A human should review and ship.
