### PR TITLE
perf(clickhouse): cap topic-clustering page-fetch read streams

### DIFF
--- a/langwatch/src/server/topicClustering/__tests__/fetchTraces-memory-guard.unit.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchTraces-memory-guard.unit.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Guards the bounded-memory setting on the topic-clustering page fetch.
+ *
+ * The outer page query reads ComputedInput (a potentially large payload) for
+ * up to 2000 traces. Peak memory scales with the number of read streams holding
+ * a ComputedInput block at once; for tenants with large inputs that peak crossed
+ * max_memory_usage_per_query (MEMORY_LIMIT_EXCEEDED). This is a background
+ * clustering batch, so the read is capped to a small max_threads to keep peak
+ * memory under the per-query limit. Correctness under the cap is covered by
+ * fetchTracesFromClickHouse.integration.test.ts; this guards the setting itself.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("topicClustering page fetch memory guard", () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, "..", "topicClustering.ts"),
+    "utf-8",
+  );
+
+  it("caps the page fetch read streams with a small max_threads", () => {
+    expect(source).toMatch(/clickhouse_settings:\s*\{\s*max_threads:\s*[1-4]\s*\}/);
+  });
+});

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -343,6 +343,15 @@ export async function fetchTracesFromClickHouse(
         : {}),
     },
     format: "JSONEachRow",
+    // The outer query reads ComputedInput (a potentially large payload) for the
+    // page of <=2000 traces. Even though rows stream (no outer sort/LIMIT), the
+    // dedup still resolves the latest version per trace, and peak memory scales
+    // with the number of read streams holding a ComputedInput block at once. For
+    // tenants with large inputs that peak crossed max_memory_usage_per_query
+    // (MEMORY_LIMIT_EXCEEDED). This is a background clustering batch, not a
+    // latency-critical path, so cap the read streams to keep peak memory well
+    // under the per-query limit; the returned rows are unchanged.
+    clickhouse_settings: { max_threads: 2 },
   });
 
   const rawRows = (await result.json()) as Array<{


### PR DESCRIPTION
## Evidence

In the last 24h ClickHouse server log, the topic-clustering page fetch appears in the `Code: 241 MEMORY_LIMIT_EXCEEDED` set, reading the heavy `ComputedInput` column:

```
WITH page AS (
  SELECT TraceId FROM trace_summaries WHERE TenantId = {…} AND OccurredAt >= {…}
  GROUP BY TenantId, TraceId ORDER BY argMax(OccurredAt, UpdatedAt) DESC, TraceId ASC LIMIT 2000
)
SELECT t.TraceId, t.ComputedInput, t.TopicId, t.SubTopicId, …
FROM trace_summaries t
WHERE TenantId = {…} AND OccurredAt >= {…}
  AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (… max(UpdatedAt) … TraceId IN (SELECT TraceId FROM page))
```

Redacted server error: `would use ~3.5 GiB … maximum: 3.50 GiB … (while reading column ComputedInput) … in table trace_summaries`. The clustering fetch fails for tenants with large inputs.

## Suspected cause

#4496 already removed the outer `ORDER BY … LIMIT`, so the rows stream (`ComputedInput` read in adaptive blocks and released) rather than buffering a full top-N. What remains is that peak memory still scales with the number of **concurrent read streams**, each holding a `ComputedInput` block while resolving the latest version per trace. At the default thread count that peak sits right at the 3.5 GiB per-query limit, so the largest-input tenants tip over.

## Proposed fix

Cap the page fetch to `max_threads = 2`. Fewer parallel streams → the streaming `ComputedInput` buffers stay well under the per-query limit, so the read succeeds. This is the topic-clustering batch job (background, not user-facing latency), so trading parallelism for a bounded footprint is the right call. The returned rows are byte-identical; only execution parallelism changes.

A `max_memory_usage` cap was not added: the per-query limit is already 3.5 GiB, so a lower ceiling would only make borderline tenants fail sooner. `max_threads` is the lever that makes the read fit.

## Expected impact

- Eliminates this Code 241 shape for large-input tenants; topic clustering stops failing mid-batch.
- No change to results or to tenants with small inputs.
- Slightly higher latency on a background batch query, which is acceptable.

## EXPLAIN check

`EXPLAIN PIPELINE` of the page fetch at the default thread count shows the parallel read fan-out the cap reduces:

```
ExpressionTransform × 4
  …
    MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 4 0 → 1
```

The read-only EXPLAIN endpoint runs without custom settings and can't quantify per-column read bytes (ANALYZE is blocked), so the bounded-memory effect is shown by the prod OOM (3.5 GiB per-query exceeded reading `ComputedInput`) plus the `× N` stream count the cap lowers.

## Test plan

- `fetchTracesFromClickHouse.integration.test.ts` (real ClickHouse, inserts a 2000-trace page with non-empty `ComputedInput`): asserts the fetch still returns all 2000 traces and paginates correctly **with the cap applied**. **3/3 pass locally.**
- `fetchTraces-memory-guard.unit.test.ts`: structural guard asserting the page fetch carries a small `max_threads` cap. **1/1 pass.**
- `tsgo` typecheck clean for the changed file.

Advisory PR from the ClickHouse slow-query optimizer. A human should review and ship.
