### PR TITLE
feat(batch-evaluation-results): fields + row height controls for the results table

### DIFF
--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
@@ -20,6 +20,7 @@ import {
 import { type Experiment, ExperimentType, type Project } from "@prisma/client";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocalStorage } from "usehooks-ts";
 import { BarChart2, Download, ExternalLink } from "react-feather";
 
 import { Link } from "~/components/ui/link";
@@ -31,6 +32,9 @@ import {
   BatchEvaluationResultsTable,
   ColumnVisibilityButton,
   DEFAULT_HIDDEN_COLUMNS,
+  DEFAULT_VIEW_SECTIONS,
+  ViewLensButton,
+  type ViewSections,
 } from "./BatchEvaluationResultsTable";
 import { type BatchRunSummary, BatchRunsSidebar } from "./BatchRunsSidebar";
 import { ComparisonCharts } from "./ComparisonCharts";
@@ -77,6 +81,12 @@ export function BatchEvaluationResults({
   // Column visibility state - initialize with defaults
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(
     () => new Set(DEFAULT_HIDDEN_COLUMNS),
+  );
+
+  // View lens state - which result sections to render (persisted across sessions)
+  const [viewSections, setViewSections] = useLocalStorage<ViewSections>(
+    "batch-results-view-sections",
+    DEFAULT_VIEW_SECTIONS,
   );
 
   // Toggle column visibility
@@ -498,6 +508,12 @@ export function BatchEvaluationResults({
               Charts
             </Button>
           )}
+          {transformedData && transformedData.targetColumns.length > 0 && (
+            <ViewLensButton
+              sections={viewSections}
+              onChange={setViewSections}
+            />
+          )}
           {transformedData && transformedData.datasetColumns.length > 0 && (
             <ColumnVisibilityButton
               datasetColumns={transformedData.datasetColumns}
@@ -576,6 +592,8 @@ export function BatchEvaluationResults({
                   onToggleColumn={toggleColumn}
                   comparisonData={comparisonData}
                   targetColors={targetColors}
+                  showOutputs={viewSections.outputs}
+                  showEvaluations={viewSections.evaluations}
                 />
               </Card.Body>
             </Card.Root>

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
@@ -20,8 +20,8 @@ import {
 import { type Experiment, ExperimentType, type Project } from "@prisma/client";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useLocalStorage } from "usehooks-ts";
 import { BarChart2, Download, ExternalLink } from "react-feather";
+import { useLocalStorage } from "usehooks-ts";
 
 import { Link } from "~/components/ui/link";
 import { useLiteMemberGuard } from "~/hooks/useLiteMemberGuard";

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
@@ -21,7 +21,6 @@ import { type Experiment, ExperimentType, type Project } from "@prisma/client";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { BarChart2, Download, ExternalLink } from "react-feather";
-import { useLocalStorage } from "usehooks-ts";
 
 import { Link } from "~/components/ui/link";
 import { useLiteMemberGuard } from "~/hooks/useLiteMemberGuard";
@@ -33,7 +32,6 @@ import {
   ColumnVisibilityButton,
   DEFAULT_HIDDEN_COLUMNS,
   FieldsButton,
-  type ResultField,
   RowHeightButton,
 } from "./BatchEvaluationResultsTable";
 import { type BatchRunSummary, BatchRunsSidebar } from "./BatchRunsSidebar";
@@ -42,20 +40,13 @@ import { downloadCsv } from "./csvExport";
 import { getRunDisplayName } from "./getRunDisplayName";
 import { isRunFinished } from "./isRunFinished";
 import { TableSkeleton } from "./TableSkeleton";
-import { DEFAULT_ROW_HEIGHT, type RowHeight } from "./tableUtils";
 import {
   type BatchEvaluationData,
   transformBatchEvaluationData,
 } from "./types";
 import { useComparisonMode } from "./useComparisonMode";
 import { RUN_COLORS, useMultiRunData } from "./useMultiRunData";
-
-/** Every target field shown by default. */
-const DEFAULT_RESULT_FIELDS: Record<ResultField, boolean> = {
-  outputs: true,
-  scores: true,
-  costAndLatency: true,
-};
+import { useResultDisplayPreferences } from "./useResultDisplayPreferences";
 
 type BatchEvaluationResultsProps = {
   project?: Project;
@@ -91,24 +82,11 @@ export function BatchEvaluationResults({
     () => new Set(DEFAULT_HIDDEN_COLUMNS),
   );
 
-  // Fields state - which target details to render. Deliberately NOT
-  // persisted: a section hidden on a previous visit should never silently
-  // explain "no results" on a different run.
-  const [fields, setFields] = useState<Record<ResultField, boolean>>(
-    DEFAULT_RESULT_FIELDS,
-  );
-
-  // Row height - how much of each cell's content shows before it needs
-  // expanding. Nothing is hidden here, only resized, so unlike field
-  // visibility this is safe to persist across sessions.
-  const [rowHeight, setRowHeight] = useLocalStorage<RowHeight>(
-    "batch-results-row-height",
-    DEFAULT_ROW_HEIGHT,
-  );
-
-  const toggleField = useCallback((field: ResultField) => {
-    setFields((prev) => ({ ...prev, [field]: !prev[field] }));
-  }, []);
+  // Which target fields render, and how much of each cell's content shows —
+  // see useResultDisplayPreferences for why fields reset per session while
+  // row height persists.
+  const { fields, toggleField, rowHeight, setRowHeight } =
+    useResultDisplayPreferences();
 
   // Toggle column visibility
   const toggleColumn = useCallback((columnName: string) => {

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResults.tsx
@@ -32,9 +32,9 @@ import {
   BatchEvaluationResultsTable,
   ColumnVisibilityButton,
   DEFAULT_HIDDEN_COLUMNS,
-  DEFAULT_VIEW_SECTIONS,
-  ViewLensButton,
-  type ViewSections,
+  FieldsButton,
+  type ResultField,
+  RowHeightButton,
 } from "./BatchEvaluationResultsTable";
 import { type BatchRunSummary, BatchRunsSidebar } from "./BatchRunsSidebar";
 import { ComparisonCharts } from "./ComparisonCharts";
@@ -42,12 +42,20 @@ import { downloadCsv } from "./csvExport";
 import { getRunDisplayName } from "./getRunDisplayName";
 import { isRunFinished } from "./isRunFinished";
 import { TableSkeleton } from "./TableSkeleton";
+import { DEFAULT_ROW_HEIGHT, type RowHeight } from "./tableUtils";
 import {
   type BatchEvaluationData,
   transformBatchEvaluationData,
 } from "./types";
 import { useComparisonMode } from "./useComparisonMode";
 import { RUN_COLORS, useMultiRunData } from "./useMultiRunData";
+
+/** Every target field shown by default. */
+const DEFAULT_RESULT_FIELDS: Record<ResultField, boolean> = {
+  outputs: true,
+  scores: true,
+  costAndLatency: true,
+};
 
 type BatchEvaluationResultsProps = {
   project?: Project;
@@ -83,11 +91,24 @@ export function BatchEvaluationResults({
     () => new Set(DEFAULT_HIDDEN_COLUMNS),
   );
 
-  // View lens state - which result sections to render (persisted across sessions)
-  const [viewSections, setViewSections] = useLocalStorage<ViewSections>(
-    "batch-results-view-sections",
-    DEFAULT_VIEW_SECTIONS,
+  // Fields state - which target details to render. Deliberately NOT
+  // persisted: a section hidden on a previous visit should never silently
+  // explain "no results" on a different run.
+  const [fields, setFields] = useState<Record<ResultField, boolean>>(
+    DEFAULT_RESULT_FIELDS,
   );
+
+  // Row height - how much of each cell's content shows before it needs
+  // expanding. Nothing is hidden here, only resized, so unlike field
+  // visibility this is safe to persist across sessions.
+  const [rowHeight, setRowHeight] = useLocalStorage<RowHeight>(
+    "batch-results-row-height",
+    DEFAULT_ROW_HEIGHT,
+  );
+
+  const toggleField = useCallback((field: ResultField) => {
+    setFields((prev) => ({ ...prev, [field]: !prev[field] }));
+  }, []);
 
   // Toggle column visibility
   const toggleColumn = useCallback((columnName: string) => {
@@ -509,10 +530,10 @@ export function BatchEvaluationResults({
             </Button>
           )}
           {transformedData && transformedData.targetColumns.length > 0 && (
-            <ViewLensButton
-              sections={viewSections}
-              onChange={setViewSections}
-            />
+            <>
+              <RowHeightButton value={rowHeight} onChange={setRowHeight} />
+              <FieldsButton fields={fields} onToggle={toggleField} />
+            </>
           )}
           {transformedData && transformedData.datasetColumns.length > 0 && (
             <ColumnVisibilityButton
@@ -592,8 +613,10 @@ export function BatchEvaluationResults({
                   onToggleColumn={toggleColumn}
                   comparisonData={comparisonData}
                   targetColors={targetColors}
-                  showOutputs={viewSections.outputs}
-                  showEvaluations={viewSections.evaluations}
+                  showOutputs={fields.outputs}
+                  showEvaluations={fields.scores}
+                  showCostAndLatency={fields.costAndLatency}
+                  rowHeight={rowHeight}
                 />
               </Card.Body>
             </Card.Root>

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
@@ -30,6 +30,7 @@ import type {
   BatchEvaluationData,
   ComparisonRunData,
 } from "./types";
+import type { ResultField } from "./useResultDisplayPreferences";
 
 type BatchEvaluationResultsTableProps = {
   /** Transformed batch evaluation data (single run mode) */
@@ -108,12 +109,6 @@ export const ColumnVisibilityButton = ({
   );
 };
 
-/**
- * A target detail the results table can show or hide, independently of the
- * others. Dataset columns stay controlled by {@link ColumnVisibilityButton}.
- */
-export type ResultField = "outputs" | "scores" | "costAndLatency";
-
 const FIELD_LABELS: Record<ResultField, string> = {
   outputs: "Outputs",
   scores: "Scores",
@@ -175,8 +170,8 @@ export const FieldsButton = ({ fields, onToggle }: FieldsButtonProps) => (
 /**
  * Row height control — how much of each cell's content shows before it
  * needs expanding. Unlike field visibility, nothing is hidden here, only
- * resized, so it's safe (and useful) to persist across sessions — see the
- * `useLocalStorage` call in {@link BatchEvaluationResults}.
+ * resized, so it's safe (and useful) to persist across sessions — see
+ * {@link useResultDisplayPreferences}.
  */
 export type RowHeightButtonProps = {
   value: RowHeight;

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
@@ -7,8 +7,8 @@
  *
  * The actual table implementations are in separate files for better maintainability.
  */
-import { Button, HStack, Text } from "@chakra-ui/react";
-import { Columns3 } from "lucide-react";
+import { Box, Button, HStack, Text, VStack } from "@chakra-ui/react";
+import { Columns3, Eye } from "lucide-react";
 import { Checkbox } from "~/components/ui/checkbox";
 import {
   PopoverArrow,
@@ -38,6 +38,10 @@ type BatchEvaluationResultsTableProps = {
   comparisonData?: ComparisonRunData[] | null;
   /** Target colors for when X-axis is "target" in charts */
   targetColors?: Record<string, string>;
+  /** Whether to render target output values (default true) */
+  showOutputs?: boolean;
+  /** Whether to render evaluator score chips (default true) */
+  showEvaluations?: boolean;
   /** Disable virtualization (for tests) */
   disableVirtualization?: boolean;
 };
@@ -95,6 +99,105 @@ export const ColumnVisibilityButton = ({
 };
 
 /**
+ * Which result sections the table renders. Lets users dial the detail level
+ * up or down — e.g. read outputs without the evaluator-score noise, or scan
+ * scores without the outputs. Dataset columns stay controlled by
+ * {@link ColumnVisibilityButton}.
+ */
+export type ViewSections = {
+  /** Show the target/model output values */
+  outputs: boolean;
+  /** Show the evaluator score chips */
+  evaluations: boolean;
+};
+
+export const DEFAULT_VIEW_SECTIONS: ViewSections = {
+  outputs: true,
+  evaluations: true,
+};
+
+/** Quick "lenses" that map to common section combinations. */
+const VIEW_PRESETS: { id: string; label: string; sections: ViewSections }[] = [
+  { id: "all", label: "Everything", sections: { outputs: true, evaluations: true } },
+  { id: "data", label: "Data only", sections: { outputs: true, evaluations: false } },
+  { id: "scores", label: "Scores only", sections: { outputs: false, evaluations: true } },
+];
+
+/**
+ * View lens control — quick presets plus per-section toggles for tuning how
+ * much detail the results table shows. Exported for use in the page header.
+ */
+export type ViewLensButtonProps = {
+  sections: ViewSections;
+  onChange: (sections: ViewSections) => void;
+};
+
+export const ViewLensButton = ({ sections, onChange }: ViewLensButtonProps) => {
+  const activePreset = VIEW_PRESETS.find(
+    (preset) =>
+      preset.sections.outputs === sections.outputs &&
+      preset.sections.evaluations === sections.evaluations,
+  );
+
+  return (
+    <PopoverRoot>
+      <PopoverTrigger asChild>
+        <Button size="sm" variant="outline" aria-label="Change results view">
+          <Eye size={16} />
+          {activePreset?.label ?? "View"}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent width="220px">
+        <PopoverArrow />
+        <PopoverBody>
+          <VStack align="stretch" gap={2}>
+            <Text fontSize="xs" color="fg.muted" fontWeight="medium">
+              Quick views
+            </Text>
+            <HStack gap={1} flexWrap="wrap">
+              {VIEW_PRESETS.map((preset) => (
+                <Button
+                  key={preset.id}
+                  size="xs"
+                  variant={activePreset?.id === preset.id ? "solid" : "outline"}
+                  onClick={() => onChange(preset.sections)}
+                >
+                  {preset.label}
+                </Button>
+              ))}
+            </HStack>
+            <Box borderTopWidth="1px" borderColor="border" marginY={1} />
+            <Text fontSize="xs" color="fg.muted" fontWeight="medium">
+              Sections
+            </Text>
+            <HStack paddingY={1}>
+              <Checkbox
+                checked={sections.outputs}
+                onCheckedChange={() =>
+                  onChange({ ...sections, outputs: !sections.outputs })
+                }
+              >
+                <Text fontSize="sm">Outputs</Text>
+              </Checkbox>
+            </HStack>
+            <HStack paddingY={1}>
+              <Checkbox
+                checked={sections.evaluations}
+                onCheckedChange={() =>
+                  onChange({ ...sections, evaluations: !sections.evaluations })
+                }
+              >
+                <Text fontSize="sm">Evaluations</Text>
+              </Checkbox>
+            </HStack>
+          </VStack>
+        </PopoverBody>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+};
+
+/**
  * Main table component that chooses between single run and comparison modes
  */
 export function BatchEvaluationResultsTable({
@@ -103,6 +206,8 @@ export function BatchEvaluationResultsTable({
   hiddenColumns = new Set(),
   comparisonData,
   targetColors = {},
+  showOutputs = true,
+  showEvaluations = true,
   disableVirtualization = false,
 }: BatchEvaluationResultsTableProps) {
   // Determine if we're in comparison mode
@@ -114,6 +219,8 @@ export function BatchEvaluationResultsTable({
         comparisonData={comparisonData}
         isLoading={isLoading}
         hiddenColumns={hiddenColumns}
+        showOutputs={showOutputs}
+        showEvaluations={showEvaluations}
         disableVirtualization={disableVirtualization}
       />
     );
@@ -125,6 +232,8 @@ export function BatchEvaluationResultsTable({
       isLoading={isLoading}
       hiddenColumns={hiddenColumns}
       targetColors={targetColors}
+      showOutputs={showOutputs}
+      showEvaluations={showEvaluations}
       disableVirtualization={disableVirtualization}
     />
   );

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
@@ -118,9 +118,21 @@ export const DEFAULT_VIEW_SECTIONS: ViewSections = {
 
 /** Quick "lenses" that map to common section combinations. */
 const VIEW_PRESETS: { id: string; label: string; sections: ViewSections }[] = [
-  { id: "all", label: "Everything", sections: { outputs: true, evaluations: true } },
-  { id: "data", label: "Data only", sections: { outputs: true, evaluations: false } },
-  { id: "scores", label: "Scores only", sections: { outputs: false, evaluations: true } },
+  {
+    id: "all",
+    label: "Everything",
+    sections: { outputs: true, evaluations: true },
+  },
+  {
+    id: "data",
+    label: "Data only",
+    sections: { outputs: true, evaluations: false },
+  },
+  {
+    id: "scores",
+    label: "Scores only",
+    sections: { outputs: false, evaluations: true },
+  },
 ];
 
 /**

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
@@ -132,6 +132,22 @@ export type ViewLensButtonProps = {
   onChange: (sections: ViewSections) => void;
 };
 
+const SectionToggle = ({
+  label,
+  checked,
+  onToggle,
+}: {
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+}) => (
+  <HStack paddingY={1}>
+    <Checkbox checked={checked} onCheckedChange={onToggle}>
+      <Text fontSize="sm">{label}</Text>
+    </Checkbox>
+  </HStack>
+);
+
 export const ViewLensButton = ({ sections, onChange }: ViewLensButtonProps) => {
   const activePreset = VIEW_PRESETS.find(
     (preset) =>
@@ -170,26 +186,20 @@ export const ViewLensButton = ({ sections, onChange }: ViewLensButtonProps) => {
             <Text fontSize="xs" color="fg.muted" fontWeight="medium">
               Sections
             </Text>
-            <HStack paddingY={1}>
-              <Checkbox
-                checked={sections.outputs}
-                onCheckedChange={() =>
-                  onChange({ ...sections, outputs: !sections.outputs })
-                }
-              >
-                <Text fontSize="sm">Outputs</Text>
-              </Checkbox>
-            </HStack>
-            <HStack paddingY={1}>
-              <Checkbox
-                checked={sections.evaluations}
-                onCheckedChange={() =>
-                  onChange({ ...sections, evaluations: !sections.evaluations })
-                }
-              >
-                <Text fontSize="sm">Evaluations</Text>
-              </Checkbox>
-            </HStack>
+            <SectionToggle
+              label="Outputs"
+              checked={sections.outputs}
+              onToggle={() =>
+                onChange({ ...sections, outputs: !sections.outputs })
+              }
+            />
+            <SectionToggle
+              label="Evaluations"
+              checked={sections.evaluations}
+              onToggle={() =>
+                onChange({ ...sections, evaluations: !sections.evaluations })
+              }
+            />
           </VStack>
         </PopoverBody>
       </PopoverContent>

--- a/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchEvaluationResultsTable.tsx
@@ -7,8 +7,8 @@
  *
  * The actual table implementations are in separate files for better maintainability.
  */
-import { Box, Button, HStack, Text, VStack } from "@chakra-ui/react";
-import { Columns3, Eye } from "lucide-react";
+import { Button, HStack, Text, VStack } from "@chakra-ui/react";
+import { Columns3, Rows3, SlidersHorizontal } from "lucide-react";
 import { Checkbox } from "~/components/ui/checkbox";
 import {
   PopoverArrow,
@@ -17,8 +17,14 @@ import {
   PopoverRoot,
   PopoverTrigger,
 } from "~/components/ui/popover";
+import { Radio, RadioGroup } from "~/components/ui/radio";
 import { ComparisonTable } from "./ComparisonTable";
 import { SingleRunTable } from "./SingleRunTable";
+import {
+  DEFAULT_ROW_HEIGHT,
+  ROW_HEIGHT_OPTIONS,
+  type RowHeight,
+} from "./tableUtils";
 import type {
   BatchDatasetColumn,
   BatchEvaluationData,
@@ -42,6 +48,10 @@ type BatchEvaluationResultsTableProps = {
   showOutputs?: boolean;
   /** Whether to render evaluator score chips (default true) */
   showEvaluations?: boolean;
+  /** Whether to render the cost/latency readout (default true) */
+  showCostAndLatency?: boolean;
+  /** How much of each cell's collapsed content to show (default "m") */
+  rowHeight?: RowHeight;
   /** Disable virtualization (for tests) */
   disableVirtualization?: boolean;
 };
@@ -99,125 +109,110 @@ export const ColumnVisibilityButton = ({
 };
 
 /**
- * Which result sections the table renders. Lets users dial the detail level
- * up or down — e.g. read outputs without the evaluator-score noise, or scan
- * scores without the outputs. Dataset columns stay controlled by
- * {@link ColumnVisibilityButton}.
+ * A target detail the results table can show or hide, independently of the
+ * others. Dataset columns stay controlled by {@link ColumnVisibilityButton}.
  */
-export type ViewSections = {
-  /** Show the target/model output values */
-  outputs: boolean;
-  /** Show the evaluator score chips */
-  evaluations: boolean;
+export type ResultField = "outputs" | "scores" | "costAndLatency";
+
+const FIELD_LABELS: Record<ResultField, string> = {
+  outputs: "Outputs",
+  scores: "Scores",
+  costAndLatency: "Latency and cost",
 };
 
-export const DEFAULT_VIEW_SECTIONS: ViewSections = {
-  outputs: true,
-  evaluations: true,
-};
-
-/** Quick "lenses" that map to common section combinations. */
-const VIEW_PRESETS: { id: string; label: string; sections: ViewSections }[] = [
-  {
-    id: "all",
-    label: "Everything",
-    sections: { outputs: true, evaluations: true },
-  },
-  {
-    id: "data",
-    label: "Data only",
-    sections: { outputs: true, evaluations: false },
-  },
-  {
-    id: "scores",
-    label: "Scores only",
-    sections: { outputs: false, evaluations: true },
-  },
-];
-
-/**
- * View lens control — quick presets plus per-section toggles for tuning how
- * much detail the results table shows. Exported for use in the page header.
- */
-export type ViewLensButtonProps = {
-  sections: ViewSections;
-  onChange: (sections: ViewSections) => void;
-};
-
-const SectionToggle = ({
-  label,
+const FieldToggle = ({
+  field,
   checked,
   onToggle,
 }: {
-  label: string;
+  field: ResultField;
   checked: boolean;
-  onToggle: () => void;
+  onToggle: (field: ResultField) => void;
 }) => (
   <HStack paddingY={1}>
-    <Checkbox checked={checked} onCheckedChange={onToggle}>
-      <Text fontSize="sm">{label}</Text>
+    <Checkbox checked={checked} onCheckedChange={() => onToggle(field)}>
+      <Text fontSize="sm">{FIELD_LABELS[field]}</Text>
     </Checkbox>
   </HStack>
 );
 
-export const ViewLensButton = ({ sections, onChange }: ViewLensButtonProps) => {
-  const activePreset = VIEW_PRESETS.find(
-    (preset) =>
-      preset.sections.outputs === sections.outputs &&
-      preset.sections.evaluations === sections.evaluations,
-  );
-
-  return (
-    <PopoverRoot>
-      <PopoverTrigger asChild>
-        <Button size="sm" variant="outline" aria-label="Change results view">
-          <Eye size={16} />
-          {activePreset?.label ?? "View"}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent width="220px">
-        <PopoverArrow />
-        <PopoverBody>
-          <VStack align="stretch" gap={2}>
-            <Text fontSize="xs" color="fg.muted" fontWeight="medium">
-              Quick views
-            </Text>
-            <HStack gap={1} flexWrap="wrap">
-              {VIEW_PRESETS.map((preset) => (
-                <Button
-                  key={preset.id}
-                  size="xs"
-                  variant={activePreset?.id === preset.id ? "solid" : "outline"}
-                  onClick={() => onChange(preset.sections)}
-                >
-                  {preset.label}
-                </Button>
-              ))}
-            </HStack>
-            <Box borderTopWidth="1px" borderColor="border" marginY={1} />
-            <Text fontSize="xs" color="fg.muted" fontWeight="medium">
-              Sections
-            </Text>
-            <SectionToggle
-              label="Outputs"
-              checked={sections.outputs}
-              onToggle={() =>
-                onChange({ ...sections, outputs: !sections.outputs })
-              }
-            />
-            <SectionToggle
-              label="Evaluations"
-              checked={sections.evaluations}
-              onToggle={() =>
-                onChange({ ...sections, evaluations: !sections.evaluations })
-              }
-            />
-          </VStack>
-        </PopoverBody>
-      </PopoverContent>
-    </PopoverRoot>
-  );
+/**
+ * Fields control — independent checkboxes for which target details render.
+ * The trigger label is always "Fields": it never mutates to reflect the
+ * current selection, so there's no state it can't name (unlike a preset
+ * button whose label degrades to a generic fallback once the selection
+ * doesn't match any preset). Exported for use in the page header.
+ */
+export type FieldsButtonProps = {
+  fields: Record<ResultField, boolean>;
+  onToggle: (field: ResultField) => void;
 };
+
+export const FieldsButton = ({ fields, onToggle }: FieldsButtonProps) => (
+  <PopoverRoot>
+    <PopoverTrigger asChild>
+      <Button size="sm" variant="outline" aria-label="Choose result fields">
+        <SlidersHorizontal size={16} />
+        Fields
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent width="200px">
+      <PopoverArrow />
+      <PopoverBody>
+        {(Object.keys(FIELD_LABELS) as ResultField[]).map((field) => (
+          <FieldToggle
+            key={field}
+            field={field}
+            checked={fields[field]}
+            onToggle={onToggle}
+          />
+        ))}
+      </PopoverBody>
+    </PopoverContent>
+  </PopoverRoot>
+);
+
+/**
+ * Row height control — how much of each cell's content shows before it
+ * needs expanding. Unlike field visibility, nothing is hidden here, only
+ * resized, so it's safe (and useful) to persist across sessions — see the
+ * `useLocalStorage` call in {@link BatchEvaluationResults}.
+ */
+export type RowHeightButtonProps = {
+  value: RowHeight;
+  onChange: (value: RowHeight) => void;
+};
+
+export const RowHeightButton = ({ value, onChange }: RowHeightButtonProps) => (
+  <PopoverRoot>
+    <PopoverTrigger asChild>
+      <Button size="sm" variant="outline" aria-label="Change row height">
+        <Rows3 size={16} />
+        Row height
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent width="160px">
+      <PopoverArrow />
+      <PopoverBody>
+        <RadioGroup
+          value={value}
+          onValueChange={(d: { value: string | null }) => {
+            if (d.value) onChange(d.value as RowHeight);
+          }}
+          size="sm"
+        >
+          <VStack align="stretch" gap={1.5}>
+            {ROW_HEIGHT_OPTIONS.map((option) => (
+              <Radio key={option.value} value={option.value}>
+                <Text fontSize="sm">{option.label}</Text>
+              </Radio>
+            ))}
+          </VStack>
+        </RadioGroup>
+      </PopoverBody>
+    </PopoverContent>
+  </PopoverRoot>
+);
 
 /**
  * Main table component that chooses between single run and comparison modes
@@ -230,6 +225,8 @@ export function BatchEvaluationResultsTable({
   targetColors = {},
   showOutputs = true,
   showEvaluations = true,
+  showCostAndLatency = true,
+  rowHeight = DEFAULT_ROW_HEIGHT,
   disableVirtualization = false,
 }: BatchEvaluationResultsTableProps) {
   // Determine if we're in comparison mode
@@ -243,6 +240,8 @@ export function BatchEvaluationResultsTable({
         hiddenColumns={hiddenColumns}
         showOutputs={showOutputs}
         showEvaluations={showEvaluations}
+        showCostAndLatency={showCostAndLatency}
+        rowHeight={rowHeight}
         disableVirtualization={disableVirtualization}
       />
     );
@@ -256,6 +255,8 @@ export function BatchEvaluationResultsTable({
       targetColors={targetColors}
       showOutputs={showOutputs}
       showEvaluations={showEvaluations}
+      showCostAndLatency={showCostAndLatency}
+      rowHeight={rowHeight}
       disableVirtualization={disableVirtualization}
     />
   );

--- a/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Box, Button, HStack, Portal, Text, VStack } from "@chakra-ui/react";
-import { useCallback, useRef, useState } from "react";
+import { type ReactNode, useCallback, useRef, useState } from "react";
 import { LuCheck, LuCircleAlert, LuCopy, LuListTree } from "react-icons/lu";
 import { EvaluatorResultChip } from "~/components/shared/EvaluatorResultChip";
 import { formatCost, formatLatency } from "~/components/shared/formatters";
@@ -50,6 +50,33 @@ type BatchTargetCellProps = {
   /** How much of the collapsed output to show before it needs expanding */
   rowHeight?: RowHeight;
 };
+
+/** A single cost/latency readout in the action bar — same tooltip + text shell either way. */
+const MetricBadge = ({
+  testId,
+  tooltipLabel,
+  children,
+}: {
+  testId: string;
+  tooltipLabel: string;
+  children: ReactNode;
+}) => (
+  <Tooltip
+    content={tooltipLabel}
+    positioning={{ placement: "top" }}
+    openDelay={100}
+  >
+    <Text
+      fontSize="11px"
+      color="fg.muted"
+      whiteSpace="nowrap"
+      px={1}
+      data-testid={testId}
+    >
+      {children}
+    </Text>
+  </Tooltip>
+);
 
 export function BatchTargetCell({
   targetOutput,
@@ -341,39 +368,21 @@ export function BatchTargetCell({
     >
       {/* Cost display */}
       {showCostAndLatency && targetOutput.cost !== null && (
-        <Tooltip
-          content={`Cost: ${formatCost(targetOutput.cost)}`}
-          positioning={{ placement: "top" }}
-          openDelay={100}
+        <MetricBadge
+          testId={`cost-${targetOutput.targetId}`}
+          tooltipLabel={`Cost: ${formatCost(targetOutput.cost)}`}
         >
-          <Text
-            fontSize="11px"
-            color="fg.muted"
-            whiteSpace="nowrap"
-            px={1}
-            data-testid={`cost-${targetOutput.targetId}`}
-          >
-            {formatCost(targetOutput.cost)}
-          </Text>
-        </Tooltip>
+          {formatCost(targetOutput.cost)}
+        </MetricBadge>
       )}
       {/* Latency display */}
       {showCostAndLatency && targetOutput.duration !== null && (
-        <Tooltip
-          content={`Latency: ${formatLatency(targetOutput.duration)}`}
-          positioning={{ placement: "top" }}
-          openDelay={100}
+        <MetricBadge
+          testId={`latency-${targetOutput.targetId}`}
+          tooltipLabel={`Latency: ${formatLatency(targetOutput.duration)}`}
         >
-          <Text
-            fontSize="11px"
-            color="fg.muted"
-            whiteSpace="nowrap"
-            px={1}
-            data-testid={`latency-${targetOutput.targetId}`}
-          >
-            {formatLatency(targetOutput.duration)}
-          </Text>
-        </Tooltip>
+          {formatLatency(targetOutput.duration)}
+        </MetricBadge>
       )}
       {/* Trace link button */}
       {showOutput && targetOutput.traceId && (

--- a/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
@@ -39,12 +39,18 @@ type BatchTargetCellProps = {
    * single source of truth passed down from the transform step.
    */
   suppressedEvaluatorIds?: Set<string>;
+  /** Whether to render the target's output (default true) */
+  showOutput?: boolean;
+  /** Whether to render the evaluator score chips (default true) */
+  showEvaluations?: boolean;
 };
 
 export function BatchTargetCell({
   targetOutput,
   getEvaluatorResult,
   suppressedEvaluatorIds,
+  showOutput = true,
+  showEvaluations = true,
 }: BatchTargetCellProps) {
   const { openDrawer } = useDrawer();
 
@@ -394,9 +400,9 @@ export function BatchTargetCell({
         gap={2}
         css={{ "&:hover .cell-action-btn": { opacity: 1 } }}
       >
-        {renderActionButtons(false)}
-        {renderOutput(false)}
-        {renderEvaluatorChips()}
+        {showOutput && renderActionButtons(false)}
+        {showOutput && renderOutput(false)}
+        {showEvaluations && renderEvaluatorChips()}
       </VStack>
 
       {/* Expanded cell overlay */}
@@ -431,9 +437,9 @@ export function BatchTargetCell({
             }}
           >
             <VStack align="stretch" gap={2} height="100%" position="relative">
-              {renderActionButtons(true)}
-              {renderOutput(true)}
-              {renderEvaluatorChips()}
+              {showOutput && renderActionButtons(true)}
+              {showOutput && renderOutput(true)}
+              {showEvaluations && renderEvaluatorChips()}
             </VStack>
           </Box>
         </Portal>

--- a/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
+++ b/langwatch/src/components/batch-evaluation-results/BatchTargetCell.tsx
@@ -9,20 +9,22 @@ import { Box, Button, HStack, Portal, Text, VStack } from "@chakra-ui/react";
 import { useCallback, useRef, useState } from "react";
 import { LuCheck, LuCircleAlert, LuCopy, LuListTree } from "react-icons/lu";
 import { EvaluatorResultChip } from "~/components/shared/EvaluatorResultChip";
-import { formatLatency } from "~/components/shared/formatters";
+import { formatCost, formatLatency } from "~/components/shared/formatters";
 import { Tooltip } from "~/components/ui/tooltip";
 import { describeCellFailure } from "~/experiments-v3/utils/cellFailure";
 import { TraceIdPeek } from "~/features/traces-v2/components/TraceIdPeek";
 import { useDrawer } from "~/hooks/useDrawer";
 import { formatTargetOutput } from "~/utils/formatTargetOutput";
 import { isTextLikelyOverflowing } from "~/utils/textOverflowHeuristic";
+import {
+  COLLAPSED_CELL_HEIGHT_PX,
+  DEFAULT_ROW_HEIGHT,
+  type RowHeight,
+} from "./tableUtils";
 import type { BatchEvaluatorResult, BatchTargetOutput } from "./types";
 
 // Max characters to display for performance
 const MAX_DISPLAY_CHARS = 10000;
-
-// Max height for collapsed output
-const OUTPUT_MAX_HEIGHT = 120;
 
 type BatchTargetCellProps = {
   /** Target output data for this row */
@@ -43,6 +45,10 @@ type BatchTargetCellProps = {
   showOutput?: boolean;
   /** Whether to render the evaluator score chips (default true) */
   showEvaluations?: boolean;
+  /** Whether to render the cost/latency readout (default true) */
+  showCostAndLatency?: boolean;
+  /** How much of the collapsed output to show before it needs expanding */
+  rowHeight?: RowHeight;
 };
 
 export function BatchTargetCell({
@@ -51,7 +57,10 @@ export function BatchTargetCell({
   suppressedEvaluatorIds,
   showOutput = true,
   showEvaluations = true,
+  showCostAndLatency = true,
+  rowHeight = DEFAULT_ROW_HEIGHT,
 }: BatchTargetCellProps) {
+  const outputMaxHeight = COLLAPSED_CELL_HEIGHT_PX[rowHeight];
   const { openDrawer } = useDrawer();
 
   // State for expanded output view
@@ -232,7 +241,8 @@ export function BatchTargetCell({
       return (
         <Box position="relative">
           <Box
-            maxHeight={`${OUTPUT_MAX_HEIGHT}px`}
+            maxHeight={`${outputMaxHeight}px`}
+            data-row-height={rowHeight}
             overflow="hidden"
             cursor={isLikelyOverflowing ? "pointer" : undefined}
             onClick={isLikelyOverflowing ? handleExpandOutput : undefined}
@@ -329,8 +339,26 @@ export function BatchTargetCell({
       borderRadius="md"
       px={0.5}
     >
+      {/* Cost display */}
+      {showCostAndLatency && targetOutput.cost !== null && (
+        <Tooltip
+          content={`Cost: ${formatCost(targetOutput.cost)}`}
+          positioning={{ placement: "top" }}
+          openDelay={100}
+        >
+          <Text
+            fontSize="11px"
+            color="fg.muted"
+            whiteSpace="nowrap"
+            px={1}
+            data-testid={`cost-${targetOutput.targetId}`}
+          >
+            {formatCost(targetOutput.cost)}
+          </Text>
+        </Tooltip>
+      )}
       {/* Latency display */}
-      {targetOutput.duration !== null && (
+      {showCostAndLatency && targetOutput.duration !== null && (
         <Tooltip
           content={`Latency: ${formatLatency(targetOutput.duration)}`}
           positioning={{ placement: "top" }}
@@ -348,7 +376,7 @@ export function BatchTargetCell({
         </Tooltip>
       )}
       {/* Trace link button */}
-      {targetOutput.traceId && (
+      {showOutput && targetOutput.traceId && (
         <Tooltip
           content="View trace"
           positioning={{ placement: "top" }}
@@ -365,9 +393,11 @@ export function BatchTargetCell({
           </Button>
         </Tooltip>
       )}
-      {targetOutput.traceId && <TraceIdPeek traceId={targetOutput.traceId} />}
+      {showOutput && targetOutput.traceId && (
+        <TraceIdPeek traceId={targetOutput.traceId} />
+      )}
       {/* Copy button */}
-      {rawOutput && (
+      {showOutput && rawOutput && (
         <Tooltip
           content={hasCopied ? "Copied!" : "Copy to clipboard"}
           positioning={{ placement: "top" }}
@@ -400,7 +430,7 @@ export function BatchTargetCell({
         gap={2}
         css={{ "&:hover .cell-action-btn": { opacity: 1 } }}
       >
-        {showOutput && renderActionButtons(false)}
+        {(showOutput || showCostAndLatency) && renderActionButtons(false)}
         {showOutput && renderOutput(false)}
         {showEvaluations && renderEvaluatorChips()}
       </VStack>
@@ -437,7 +467,7 @@ export function BatchTargetCell({
             }}
           >
             <VStack align="stretch" gap={2} height="100%" position="relative">
-              {showOutput && renderActionButtons(true)}
+              {(showOutput || showCostAndLatency) && renderActionButtons(true)}
               {showOutput && renderOutput(true)}
               {showEvaluations && renderEvaluatorChips()}
             </VStack>

--- a/langwatch/src/components/batch-evaluation-results/ComparisonTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/ComparisonTable.tsx
@@ -37,6 +37,10 @@ type ComparisonTableProps = {
   isLoading?: boolean;
   /** Hidden column names */
   hiddenColumns?: Set<string>;
+  /** Whether to render target output values (default true) */
+  showOutputs?: boolean;
+  /** Whether to render evaluator score chips (default true) */
+  showEvaluations?: boolean;
   /** Disable virtualization (for tests) */
   disableVirtualization?: boolean;
 };
@@ -63,6 +67,8 @@ const comparisonColumnHelper = createColumnHelper<ComparisonRow>();
 const buildComparisonColumns = (
   comparisonData: ComparisonRunData[],
   hiddenColumns: Set<string>,
+  showOutputs: boolean,
+  showEvaluations: boolean,
 ) => {
   const columns = [];
 
@@ -153,8 +159,12 @@ const buildComparisonColumns = (
     );
   }
 
-  // Target columns with diff values
-  for (const [targetId, targetCol] of allTargetColumns) {
+  // Target columns with diff values.
+  // Skip them entirely when neither outputs nor evaluations are shown.
+  const showTargetColumns = showOutputs || showEvaluations;
+  for (const [targetId, targetCol] of showTargetColumns
+    ? allTargetColumns
+    : new Map<string, BatchTargetColumn>()) {
     columns.push(
       comparisonColumnHelper.accessor((row) => row.targetsByRun, {
         id: `target_${targetId}`,
@@ -177,7 +187,11 @@ const buildComparisonColumns = (
                 color: run.color,
                 isLoading: run.isLoading,
                 value: targetOutput ? (
-                  <BatchTargetCell targetOutput={targetOutput} />
+                  <BatchTargetCell
+                    targetOutput={targetOutput}
+                    showOutput={showOutputs}
+                    showEvaluations={showEvaluations}
+                  />
                 ) : (
                   <Text fontSize="13px" color="fg.subtle">
                     -
@@ -245,12 +259,19 @@ export function ComparisonTable({
   comparisonData,
   isLoading,
   hiddenColumns = new Set(),
+  showOutputs = true,
+  showEvaluations = true,
   disableVirtualization = false,
 }: ComparisonTableProps) {
   // Build columns for comparison mode
   const columns = useMemo(() => {
-    return buildComparisonColumns(comparisonData, hiddenColumns);
-  }, [comparisonData, hiddenColumns]);
+    return buildComparisonColumns(
+      comparisonData,
+      hiddenColumns,
+      showOutputs,
+      showEvaluations,
+    );
+  }, [comparisonData, hiddenColumns, showOutputs, showEvaluations]);
 
   // Build comparison rows
   const comparisonRows = useMemo(() => {
@@ -321,7 +342,10 @@ export function ComparisonTable({
     firstRunWithData?.data?.datasetColumns.filter(
       (c) => !hiddenColumns.has(c.name),
     ).length ?? 0;
-  const targetColCount = firstRunWithData?.data?.targetColumns.length ?? 0;
+  const targetColCount =
+    showOutputs || showEvaluations
+      ? (firstRunWithData?.data?.targetColumns.length ?? 0)
+      : 0;
   const minTableWidth = calculateMinTableWidth(datasetColCount, targetColCount);
 
   const tableStyles = getTableStyles(minTableWidth);

--- a/langwatch/src/components/batch-evaluation-results/ComparisonTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/ComparisonTable.tsx
@@ -20,8 +20,10 @@ import { ExpandableDatasetCell } from "./ExpandableDatasetCell";
 import { TableSkeleton } from "./TableSkeleton";
 import {
   calculateMinTableWidth,
+  DEFAULT_ROW_HEIGHT,
+  ESTIMATED_ROW_HEIGHT_PX,
   getTableStyles,
-  ROW_HEIGHT,
+  type RowHeight,
 } from "./tableUtils";
 import type {
   BatchDatasetColumn,
@@ -41,6 +43,10 @@ type ComparisonTableProps = {
   showOutputs?: boolean;
   /** Whether to render evaluator score chips (default true) */
   showEvaluations?: boolean;
+  /** Whether to render the cost/latency readout (default true) */
+  showCostAndLatency?: boolean;
+  /** How much of each cell's collapsed content to show (default "m") */
+  rowHeight?: RowHeight;
   /** Disable virtualization (for tests) */
   disableVirtualization?: boolean;
 };
@@ -61,15 +67,26 @@ type ComparisonRow = {
 // Column helper for comparison rows
 const comparisonColumnHelper = createColumnHelper<ComparisonRow>();
 
+type BuildComparisonColumnsOptions = {
+  comparisonData: ComparisonRunData[];
+  hiddenColumns: Set<string>;
+  showOutputs: boolean;
+  showEvaluations: boolean;
+  showCostAndLatency: boolean;
+  rowHeight: RowHeight;
+};
+
 /**
  * Build columns for comparison mode
  */
-const buildComparisonColumns = (
-  comparisonData: ComparisonRunData[],
-  hiddenColumns: Set<string>,
-  showOutputs: boolean,
-  showEvaluations: boolean,
-) => {
+const buildComparisonColumns = ({
+  comparisonData,
+  hiddenColumns,
+  showOutputs,
+  showEvaluations,
+  showCostAndLatency,
+  rowHeight,
+}: BuildComparisonColumnsOptions) => {
   const columns = [];
 
   // Get a merged view of all columns from all runs
@@ -136,7 +153,11 @@ const buildComparisonColumns = (
                 runId: run.runId,
                 color: run.color,
                 value: (
-                  <ExpandableDatasetCell value={value} columnName={colName} />
+                  <ExpandableDatasetCell
+                    value={value}
+                    columnName={colName}
+                    rowHeight={rowHeight}
+                  />
                 ),
               };
             });
@@ -160,8 +181,9 @@ const buildComparisonColumns = (
   }
 
   // Target columns with diff values.
-  // Skip them entirely when neither outputs nor evaluations are shown.
-  const showTargetColumns = showOutputs || showEvaluations;
+  // Skip them entirely when no target field is shown.
+  const showTargetColumns =
+    showOutputs || showEvaluations || showCostAndLatency;
   for (const [targetId, targetCol] of showTargetColumns
     ? allTargetColumns
     : new Map<string, BatchTargetColumn>()) {
@@ -191,6 +213,8 @@ const buildComparisonColumns = (
                     targetOutput={targetOutput}
                     showOutput={showOutputs}
                     showEvaluations={showEvaluations}
+                    showCostAndLatency={showCostAndLatency}
+                    rowHeight={rowHeight}
                   />
                 ) : (
                   <Text fontSize="13px" color="fg.subtle">
@@ -261,17 +285,28 @@ export function ComparisonTable({
   hiddenColumns = new Set(),
   showOutputs = true,
   showEvaluations = true,
+  showCostAndLatency = true,
+  rowHeight = DEFAULT_ROW_HEIGHT,
   disableVirtualization = false,
 }: ComparisonTableProps) {
   // Build columns for comparison mode
   const columns = useMemo(() => {
-    return buildComparisonColumns(
+    return buildComparisonColumns({
       comparisonData,
       hiddenColumns,
       showOutputs,
       showEvaluations,
-    );
-  }, [comparisonData, hiddenColumns, showOutputs, showEvaluations]);
+      showCostAndLatency,
+      rowHeight,
+    });
+  }, [
+    comparisonData,
+    hiddenColumns,
+    showOutputs,
+    showEvaluations,
+    showCostAndLatency,
+    rowHeight,
+  ]);
 
   // Build comparison rows
   const comparisonRows = useMemo(() => {
@@ -306,7 +341,11 @@ export function ComparisonTable({
     () => scrollContainer,
     [scrollContainer],
   );
-  const estimateSize = useCallback(() => ROW_HEIGHT, []);
+  const estimatedRowHeight = ESTIMATED_ROW_HEIGHT_PX[rowHeight];
+  const estimateSize = useCallback(
+    () => estimatedRowHeight,
+    [estimatedRowHeight],
+  );
 
   // Set up row virtualization with dynamic measurement
   const rowVirtualizer = useVirtualizer({
@@ -318,7 +357,8 @@ export function ComparisonTable({
     // Enable dynamic measurement - measures actual row heights as they render
     measureElement:
       typeof window !== "undefined"
-        ? (element) => element?.getBoundingClientRect().height ?? ROW_HEIGHT
+        ? (element) =>
+            element?.getBoundingClientRect().height ?? estimatedRowHeight
         : undefined,
   });
 
@@ -343,7 +383,7 @@ export function ComparisonTable({
       (c) => !hiddenColumns.has(c.name),
     ).length ?? 0;
   const targetColCount =
-    showOutputs || showEvaluations
+    showOutputs || showEvaluations || showCostAndLatency
       ? (firstRunWithData?.data?.targetColumns.length ?? 0)
       : 0;
   const minTableWidth = calculateMinTableWidth(datasetColCount, targetColCount);

--- a/langwatch/src/components/batch-evaluation-results/ExpandableDatasetCell.tsx
+++ b/langwatch/src/components/batch-evaluation-results/ExpandableDatasetCell.tsx
@@ -11,18 +11,22 @@ import { LuCheck, LuCopy } from "react-icons/lu";
 
 import { Tooltip } from "~/components/ui/tooltip";
 import { isTextLikelyOverflowing } from "~/utils/textOverflowHeuristic";
+import {
+  COLLAPSED_CELL_HEIGHT_PX,
+  DEFAULT_ROW_HEIGHT,
+  type RowHeight,
+} from "./tableUtils";
 
 // Max characters to display for performance
 const MAX_DISPLAY_CHARS = 10000;
-
-// Max height for collapsed output - used in CSS
-const CELL_MAX_HEIGHT = 180;
 
 type ExpandableDatasetCellProps = {
   /** The value to display */
   value: unknown;
   /** Optional column name for test IDs */
   columnName?: string;
+  /** How much of the collapsed value to show before it needs expanding */
+  rowHeight?: RowHeight;
 };
 
 /**
@@ -37,7 +41,9 @@ const stringify = (value: unknown): string => {
 export function ExpandableDatasetCell({
   value,
   columnName = "dataset",
+  rowHeight = DEFAULT_ROW_HEIGHT,
 }: ExpandableDatasetCellProps) {
+  const cellMaxHeight = COLLAPSED_CELL_HEIGHT_PX[rowHeight];
   // State for expanded view
   const [isExpanded, setIsExpanded] = useState(false);
   const [hasCopied, setHasCopied] = useState(false);
@@ -131,7 +137,8 @@ export function ExpandableDatasetCell({
     return (
       <Box position="relative">
         <Box
-          maxHeight={`${CELL_MAX_HEIGHT}px`}
+          maxHeight={`${cellMaxHeight}px`}
+          data-row-height={rowHeight}
           overflow="hidden"
           cursor={isLikelyOverflowing ? "pointer" : undefined}
           onClick={isLikelyOverflowing ? handleExpand : undefined}

--- a/langwatch/src/components/batch-evaluation-results/SingleRunTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/SingleRunTable.tsx
@@ -49,6 +49,10 @@ type SingleRunTableProps = {
   hiddenColumns?: Set<string>;
   /** Target colors for when X-axis is "target" in charts */
   targetColors?: Record<string, string>;
+  /** Whether to render target output values (default true) */
+  showOutputs?: boolean;
+  /** Whether to render evaluator score chips (default true) */
+  showEvaluations?: boolean;
   /** Disable virtualization (for tests) */
   disableVirtualization?: boolean;
 };
@@ -66,6 +70,8 @@ const buildColumns = (
   aggregatesMap: Map<string, BatchTargetAggregate>,
   rows: BatchResultRow[],
   hiddenColumns: Set<string>,
+  showOutputs: boolean,
+  showEvaluations: boolean,
   targetColors?: Record<string, string>,
 ) => {
   // Evaluator ids whose per-row chip is redundant with the dedicated Winner
@@ -159,11 +165,17 @@ const buildColumns = (
     comparisonColumns.map((p) => [p.evaluatorId, p]),
   );
 
-  // Target columns with headers that include summary
+  // Target columns with headers that include summary.
+  // Skip a column entirely when neither outputs nor evaluations are shown —
+  // unless it hosts a comparison verdict (Winner cell), which is independent
+  // of the output/evaluation section toggles and would otherwise vanish
+  // along with them, silently dropping the comparison result.
+  const showTargetColumns = showOutputs || showEvaluations;
   for (const targetCol of targetColumns) {
+    const comparisonMeta = comparisonByTargetId.get(targetCol.id);
+    if (!showTargetColumns && !comparisonMeta) continue;
     const aggregates = aggregatesMap.get(targetCol.id) ?? null;
     const targetColor = targetColors?.[targetCol.id];
-    const comparisonMeta = comparisonByTargetId.get(targetCol.id);
 
     columns.push(
       columnHelper.accessor((row) => row.targets[targetCol.id], {
@@ -203,6 +215,8 @@ const buildColumns = (
             <BatchTargetCell
               targetOutput={targetOutput}
               suppressedEvaluatorIds={comparisonEvaluatorIds}
+              showOutput={showOutputs}
+              showEvaluations={showEvaluations}
             />
           );
         },
@@ -261,6 +275,8 @@ export function SingleRunTable({
   isLoading,
   hiddenColumns = new Set(),
   targetColors = {},
+  showOutputs = true,
+  showEvaluations = true,
   disableVirtualization = false,
 }: SingleRunTableProps) {
   // Check if target colors should be shown (non-empty means X-axis is "target")
@@ -282,9 +298,19 @@ export function SingleRunTable({
       aggregatesMap,
       data.rows,
       hiddenColumns,
+      showOutputs,
+      showEvaluations,
       showTargetColors ? targetColors : undefined,
     );
-  }, [data, aggregatesMap, hiddenColumns, showTargetColors, targetColors]);
+  }, [
+    data,
+    aggregatesMap,
+    hiddenColumns,
+    showOutputs,
+    showEvaluations,
+    showTargetColors,
+    targetColors,
+  ]);
 
   // Memoize getCoreRowModel to prevent React scheduling loops
   const coreRowModel = useMemo(() => getCoreRowModel(), []);
@@ -349,7 +375,16 @@ export function SingleRunTable({
   const datasetColCount = data.datasetColumns.filter(
     (c) => !hiddenColumns.has(c.name),
   ).length;
-  const targetColCount = data.targetColumns.length;
+  // Target columns that don't host a comparison verdict collapse away when
+  // both output/evaluation sections are hidden — see the matching skip in
+  // buildColumns above.
+  const comparisonTargetIds = new Set(
+    (data.comparisonColumns ?? []).map((p) => p.evaluatorId),
+  );
+  const showTargetColumns = showOutputs || showEvaluations;
+  const targetColCount = showTargetColumns
+    ? data.targetColumns.length
+    : data.targetColumns.filter((t) => comparisonTargetIds.has(t.id)).length;
   // Only the comparisons that get their own trailing column add width; one
   // rendered inside a target column is already paid for by that column.
   const comparisonColCount = trailingComparisonColumns(

--- a/langwatch/src/components/batch-evaluation-results/SingleRunTable.tsx
+++ b/langwatch/src/components/batch-evaluation-results/SingleRunTable.tsx
@@ -28,9 +28,11 @@ import { ExpandableDatasetCell } from "./ExpandableDatasetCell";
 import { TableSkeleton } from "./TableSkeleton";
 import {
   calculateMinTableWidth,
+  DEFAULT_ROW_HEIGHT,
+  ESTIMATED_ROW_HEIGHT_PX,
   getTableStyles,
   inferColumnType,
-  ROW_HEIGHT,
+  type RowHeight,
 } from "./tableUtils";
 import type {
   BatchComparisonColumn,
@@ -53,6 +55,10 @@ type SingleRunTableProps = {
   showOutputs?: boolean;
   /** Whether to render evaluator score chips (default true) */
   showEvaluations?: boolean;
+  /** Whether to render the cost/latency readout (default true) */
+  showCostAndLatency?: boolean;
+  /** How much of each cell's collapsed content to show (default "m") */
+  rowHeight?: RowHeight;
   /** Disable virtualization (for tests) */
   disableVirtualization?: boolean;
 };
@@ -60,20 +66,36 @@ type SingleRunTableProps = {
 // Column helper for type-safe column definitions
 const columnHelper = createColumnHelper<BatchResultRow>();
 
+type BuildColumnsOptions = {
+  datasetColumns: BatchDatasetColumn[];
+  targetColumns: BatchTargetColumn[];
+  comparisonColumns: BatchComparisonColumn[];
+  aggregatesMap: Map<string, BatchTargetAggregate>;
+  rows: BatchResultRow[];
+  hiddenColumns: Set<string>;
+  showOutputs: boolean;
+  showEvaluations: boolean;
+  showCostAndLatency: boolean;
+  rowHeight: RowHeight;
+  targetColors?: Record<string, string>;
+};
+
 /**
  * Build columns for single run mode
  */
-const buildColumns = (
-  datasetColumns: BatchDatasetColumn[],
-  targetColumns: BatchTargetColumn[],
-  comparisonColumns: BatchComparisonColumn[],
-  aggregatesMap: Map<string, BatchTargetAggregate>,
-  rows: BatchResultRow[],
-  hiddenColumns: Set<string>,
-  showOutputs: boolean,
-  showEvaluations: boolean,
-  targetColors?: Record<string, string>,
-) => {
+const buildColumns = ({
+  datasetColumns,
+  targetColumns,
+  comparisonColumns,
+  aggregatesMap,
+  rows,
+  hiddenColumns,
+  showOutputs,
+  showEvaluations,
+  showCostAndLatency,
+  rowHeight,
+  targetColors,
+}: BuildColumnsOptions) => {
   // Evaluator ids whose per-row chip is redundant with the dedicated Winner
   // column below — the generic `EvaluatorResultChip` renders the comparison
   // verdict as `<target_XYZ> 1.00`, which reads as noise to users (dogfood
@@ -151,7 +173,13 @@ const buildColumns = (
           }
 
           // Use expandable cell for text content
-          return <ExpandableDatasetCell value={value} columnName={col.name} />;
+          return (
+            <ExpandableDatasetCell
+              value={value}
+              columnName={col.name}
+              rowHeight={rowHeight}
+            />
+          );
         },
       }),
     );
@@ -166,11 +194,12 @@ const buildColumns = (
   );
 
   // Target columns with headers that include summary.
-  // Skip a column entirely when neither outputs nor evaluations are shown —
-  // unless it hosts a comparison verdict (Winner cell), which is independent
-  // of the output/evaluation section toggles and would otherwise vanish
-  // along with them, silently dropping the comparison result.
-  const showTargetColumns = showOutputs || showEvaluations;
+  // Skip a column entirely when no target field is shown — unless it hosts
+  // a comparison verdict (Winner cell), which is independent of the field
+  // toggles and would otherwise vanish along with them, silently dropping
+  // the comparison result.
+  const showTargetColumns =
+    showOutputs || showEvaluations || showCostAndLatency;
   for (const targetCol of targetColumns) {
     const comparisonMeta = comparisonByTargetId.get(targetCol.id);
     if (!showTargetColumns && !comparisonMeta) continue;
@@ -217,6 +246,8 @@ const buildColumns = (
               suppressedEvaluatorIds={comparisonEvaluatorIds}
               showOutput={showOutputs}
               showEvaluations={showEvaluations}
+              showCostAndLatency={showCostAndLatency}
+              rowHeight={rowHeight}
             />
           );
         },
@@ -277,6 +308,8 @@ export function SingleRunTable({
   targetColors = {},
   showOutputs = true,
   showEvaluations = true,
+  showCostAndLatency = true,
+  rowHeight = DEFAULT_ROW_HEIGHT,
   disableVirtualization = false,
 }: SingleRunTableProps) {
   // Check if target colors should be shown (non-empty means X-axis is "target")
@@ -291,23 +324,27 @@ export function SingleRunTable({
   // Build columns from data
   const columns = useMemo(() => {
     if (!data) return [];
-    return buildColumns(
-      data.datasetColumns,
-      data.targetColumns,
-      data.comparisonColumns ?? [],
+    return buildColumns({
+      datasetColumns: data.datasetColumns,
+      targetColumns: data.targetColumns,
+      comparisonColumns: data.comparisonColumns ?? [],
       aggregatesMap,
-      data.rows,
+      rows: data.rows,
       hiddenColumns,
       showOutputs,
       showEvaluations,
-      showTargetColors ? targetColors : undefined,
-    );
+      showCostAndLatency,
+      rowHeight,
+      targetColors: showTargetColors ? targetColors : undefined,
+    });
   }, [
     data,
     aggregatesMap,
     hiddenColumns,
     showOutputs,
     showEvaluations,
+    showCostAndLatency,
+    rowHeight,
     showTargetColors,
     targetColors,
   ]);
@@ -341,7 +378,11 @@ export function SingleRunTable({
     () => scrollContainer,
     [scrollContainer],
   );
-  const estimateSize = useCallback(() => ROW_HEIGHT, []);
+  const estimatedRowHeight = ESTIMATED_ROW_HEIGHT_PX[rowHeight];
+  const estimateSize = useCallback(
+    () => estimatedRowHeight,
+    [estimatedRowHeight],
+  );
 
   // Set up row virtualization with dynamic measurement
   const rowVirtualizer = useVirtualizer({
@@ -353,7 +394,8 @@ export function SingleRunTable({
     // Enable dynamic measurement - measures actual row heights as they render
     measureElement:
       typeof window !== "undefined"
-        ? (element) => element?.getBoundingClientRect().height ?? ROW_HEIGHT
+        ? (element) =>
+            element?.getBoundingClientRect().height ?? estimatedRowHeight
         : undefined,
   });
 
@@ -381,7 +423,8 @@ export function SingleRunTable({
   const comparisonTargetIds = new Set(
     (data.comparisonColumns ?? []).map((p) => p.evaluatorId),
   );
-  const showTargetColumns = showOutputs || showEvaluations;
+  const showTargetColumns =
+    showOutputs || showEvaluations || showCostAndLatency;
   const targetColCount = showTargetColumns
     ? data.targetColumns.length
     : data.targetColumns.filter((t) => comparisonTargetIds.has(t.id)).length;

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResultsTable.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResultsTable.test.tsx
@@ -431,4 +431,63 @@ describe("BatchEvaluationResultsTable", () => {
       expect(screen.getByText("Test input")).toBeInTheDocument();
     });
   });
+
+  describe("View Lens (section visibility)", () => {
+    /** @scenario Hide evaluation scores to focus on outputs */
+    it("hides evaluator chips but keeps outputs when showEvaluations is false", () => {
+      const data = createTestData();
+
+      render(
+        <BatchEvaluationResultsTable
+          data={data}
+          showEvaluations={false}
+          disableVirtualization
+        />,
+        { wrapper: Wrapper },
+      );
+
+      // Output stays (rendered as JSON containing the "response" field)
+      expect(screen.getByText(/response/)).toBeInTheDocument();
+      // Evaluator score chip is gone
+      expect(screen.queryByText("Exact Match")).not.toBeInTheDocument();
+    });
+
+    /** @scenario Hide outputs to focus on evaluation scores */
+    it("hides outputs but keeps evaluator chips when showOutputs is false", () => {
+      const data = createTestData();
+
+      render(
+        <BatchEvaluationResultsTable
+          data={data}
+          showOutputs={false}
+          disableVirtualization
+        />,
+        { wrapper: Wrapper },
+      );
+
+      // Evaluator score chip stays
+      expect(screen.getByText("Exact Match")).toBeInTheDocument();
+      // Output is gone
+      expect(screen.queryByText(/response/)).not.toBeInTheDocument();
+    });
+
+    /** @scenario Hide the target column when no target sections are shown */
+    it("removes the target column when both sections are off", () => {
+      const data = createTestData();
+
+      render(
+        <BatchEvaluationResultsTable
+          data={data}
+          showOutputs={false}
+          showEvaluations={false}
+          disableVirtualization
+        />,
+        { wrapper: Wrapper },
+      );
+
+      // Target header is gone, but dataset content remains
+      expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
+      expect(screen.getByText("What is 2+2?")).toBeInTheDocument();
+    });
+  });
 });

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResultsTable.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResultsTable.test.tsx
@@ -432,8 +432,8 @@ describe("BatchEvaluationResultsTable", () => {
     });
   });
 
-  describe("when changing visible result sections", () => {
-    /** @scenario Hide evaluation scores to focus on outputs */
+  describe("when changing visible result fields", () => {
+    /** @scenario Hide scores to focus on outputs */
     it("hides evaluator chips but keeps outputs when showEvaluations is false", () => {
       const data = createTestData();
 
@@ -451,7 +451,7 @@ describe("BatchEvaluationResultsTable", () => {
       expect(screen.queryByText("Exact Match")).not.toBeInTheDocument();
     });
 
-    /** @scenario Hide outputs to focus on evaluation scores */
+    /** @scenario Hide outputs to focus on scores */
     it("hides outputs but keeps evaluator chips when showOutputs is false", () => {
       const data = createTestData();
 
@@ -468,8 +468,26 @@ describe("BatchEvaluationResultsTable", () => {
       expect(screen.queryByText(/response/)).not.toBeInTheDocument();
     });
 
-    /** @scenario Hide the target column when no target sections are shown */
-    it("removes the target column when both sections are off", () => {
+    /** @scenario Hide cost and latency to reduce clutter */
+    it("hides cost and latency but keeps output when showCostAndLatency is false", () => {
+      const data = createTestData();
+
+      render(
+        <BatchEvaluationResultsTable
+          data={data}
+          showCostAndLatency={false}
+          disableVirtualization
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.getByText(/response/)).toBeInTheDocument();
+      expect(screen.queryByTestId("cost-target-1")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("latency-target-1")).not.toBeInTheDocument();
+    });
+
+    /** @scenario Hide the target column when no fields are shown */
+    it("removes the target column when all fields are off", () => {
       const data = createTestData();
 
       render(
@@ -477,6 +495,7 @@ describe("BatchEvaluationResultsTable", () => {
           data={data}
           showOutputs={false}
           showEvaluations={false}
+          showCostAndLatency={false}
           disableVirtualization
         />,
         { wrapper: Wrapper },
@@ -504,7 +523,7 @@ describe("BatchEvaluationResultsTable", () => {
         },
       ];
 
-      /** @scenario Hide evaluation scores to focus on outputs */
+      /** @scenario Hide scores to focus on outputs */
       it("hides evaluator chips but keeps outputs when showEvaluations is false", () => {
         render(
           <BatchEvaluationResultsTable
@@ -520,7 +539,7 @@ describe("BatchEvaluationResultsTable", () => {
         expect(screen.queryAllByText("Exact Match")).toHaveLength(0);
       });
 
-      /** @scenario Hide outputs to focus on evaluation scores */
+      /** @scenario Hide outputs to focus on scores */
       it("hides outputs but keeps evaluator chips when showOutputs is false", () => {
         render(
           <BatchEvaluationResultsTable
@@ -536,14 +555,15 @@ describe("BatchEvaluationResultsTable", () => {
         expect(screen.queryAllByText(/response/)).toHaveLength(0);
       });
 
-      /** @scenario Hide the target column when no target sections are shown */
-      it("removes the target column when both sections are off", () => {
+      /** @scenario Hide the target column when no fields are shown */
+      it("removes the target column when all fields are off", () => {
         render(
           <BatchEvaluationResultsTable
             data={null}
             comparisonData={createComparisonRuns()}
             showOutputs={false}
             showEvaluations={false}
+            showCostAndLatency={false}
             disableVirtualization
           />,
           { wrapper: Wrapper },
@@ -552,6 +572,29 @@ describe("BatchEvaluationResultsTable", () => {
         expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
         expect(screen.getAllByText("What is 2+2?").length).toBeGreaterThan(0);
       });
+    });
+  });
+
+  describe("when changing row height", () => {
+    /** @scenario Increase row height to see more of a long output before expanding */
+    it("threads the selected tier down to each cell", () => {
+      const data = createTestData();
+
+      render(
+        <BatchEvaluationResultsTable
+          data={data}
+          rowHeight="l"
+          disableVirtualization
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(
+        screen.getByText("What is 2+2?").closest("[data-row-height]"),
+      ).toHaveAttribute("data-row-height", "l");
+      expect(
+        screen.getByText(/response/).closest("[data-row-height]"),
+      ).toHaveAttribute("data-row-height", "l");
     });
   });
 });

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResultsTable.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResultsTable.test.tsx
@@ -9,7 +9,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BatchEvaluationResultsTable } from "../BatchEvaluationResultsTable";
-import type { BatchEvaluationData } from "../types";
+import type { BatchEvaluationData, ComparisonRunData } from "../types";
 
 // Mock the drawer hook
 vi.mock("~/hooks/useDrawer", () => ({
@@ -432,7 +432,7 @@ describe("BatchEvaluationResultsTable", () => {
     });
   });
 
-  describe("View Lens (section visibility)", () => {
+  describe("when changing visible result sections", () => {
     /** @scenario Hide evaluation scores to focus on outputs */
     it("hides evaluator chips but keeps outputs when showEvaluations is false", () => {
       const data = createTestData();
@@ -446,9 +446,8 @@ describe("BatchEvaluationResultsTable", () => {
         { wrapper: Wrapper },
       );
 
-      // Output stays (rendered as JSON containing the "response" field)
+      // The output is rendered as JSON, so it is matched via its "response" field.
       expect(screen.getByText(/response/)).toBeInTheDocument();
-      // Evaluator score chip is gone
       expect(screen.queryByText("Exact Match")).not.toBeInTheDocument();
     });
 
@@ -465,9 +464,7 @@ describe("BatchEvaluationResultsTable", () => {
         { wrapper: Wrapper },
       );
 
-      // Evaluator score chip stays
       expect(screen.getByText("Exact Match")).toBeInTheDocument();
-      // Output is gone
       expect(screen.queryByText(/response/)).not.toBeInTheDocument();
     });
 
@@ -485,9 +482,76 @@ describe("BatchEvaluationResultsTable", () => {
         { wrapper: Wrapper },
       );
 
-      // Target header is gone, but dataset content remains
       expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
       expect(screen.getByText("What is 2+2?")).toBeInTheDocument();
+    });
+
+    describe("when comparing runs side by side", () => {
+      const createComparisonRuns = (): ComparisonRunData[] => [
+        {
+          runId: "run-a",
+          runName: "Run A",
+          color: "#3182ce",
+          data: createTestData({ runId: "run-a" }),
+          isLoading: false,
+        },
+        {
+          runId: "run-b",
+          runName: "Run B",
+          color: "#dd6b20",
+          data: createTestData({ runId: "run-b" }),
+          isLoading: false,
+        },
+      ];
+
+      /** @scenario Hide evaluation scores to focus on outputs */
+      it("hides evaluator chips but keeps outputs when showEvaluations is false", () => {
+        render(
+          <BatchEvaluationResultsTable
+            data={null}
+            comparisonData={createComparisonRuns()}
+            showEvaluations={false}
+            disableVirtualization
+          />,
+          { wrapper: Wrapper },
+        );
+
+        expect(screen.getAllByText(/response/).length).toBeGreaterThan(0);
+        expect(screen.queryAllByText("Exact Match")).toHaveLength(0);
+      });
+
+      /** @scenario Hide outputs to focus on evaluation scores */
+      it("hides outputs but keeps evaluator chips when showOutputs is false", () => {
+        render(
+          <BatchEvaluationResultsTable
+            data={null}
+            comparisonData={createComparisonRuns()}
+            showOutputs={false}
+            disableVirtualization
+          />,
+          { wrapper: Wrapper },
+        );
+
+        expect(screen.getAllByText("Exact Match").length).toBeGreaterThan(0);
+        expect(screen.queryAllByText(/response/)).toHaveLength(0);
+      });
+
+      /** @scenario Hide the target column when no target sections are shown */
+      it("removes the target column when both sections are off", () => {
+        render(
+          <BatchEvaluationResultsTable
+            data={null}
+            comparisonData={createComparisonRuns()}
+            showOutputs={false}
+            showEvaluations={false}
+            disableVirtualization
+          />,
+          { wrapper: Wrapper },
+        );
+
+        expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
+        expect(screen.getAllByText("What is 2+2?").length).toBeGreaterThan(0);
+      });
     });
   });
 });

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResultsTable.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchEvaluationResultsTable.test.tsx
@@ -504,74 +504,74 @@ describe("BatchEvaluationResultsTable", () => {
       expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
       expect(screen.getByText("What is 2+2?")).toBeInTheDocument();
     });
+  });
 
-    describe("when comparing runs side by side", () => {
-      const createComparisonRuns = (): ComparisonRunData[] => [
-        {
-          runId: "run-a",
-          runName: "Run A",
-          color: "#3182ce",
-          data: createTestData({ runId: "run-a" }),
-          isLoading: false,
-        },
-        {
-          runId: "run-b",
-          runName: "Run B",
-          color: "#dd6b20",
-          data: createTestData({ runId: "run-b" }),
-          isLoading: false,
-        },
-      ];
+  describe("when changing visible result fields in comparison mode", () => {
+    const createComparisonRuns = (): ComparisonRunData[] => [
+      {
+        runId: "run-a",
+        runName: "Run A",
+        color: "#3182ce",
+        data: createTestData({ runId: "run-a" }),
+        isLoading: false,
+      },
+      {
+        runId: "run-b",
+        runName: "Run B",
+        color: "#dd6b20",
+        data: createTestData({ runId: "run-b" }),
+        isLoading: false,
+      },
+    ];
 
-      /** @scenario Hide scores to focus on outputs */
-      it("hides evaluator chips but keeps outputs when showEvaluations is false", () => {
-        render(
-          <BatchEvaluationResultsTable
-            data={null}
-            comparisonData={createComparisonRuns()}
-            showEvaluations={false}
-            disableVirtualization
-          />,
-          { wrapper: Wrapper },
-        );
+    /** @scenario Hide scores to focus on outputs */
+    it("hides evaluator chips but keeps outputs when showEvaluations is false", () => {
+      render(
+        <BatchEvaluationResultsTable
+          data={null}
+          comparisonData={createComparisonRuns()}
+          showEvaluations={false}
+          disableVirtualization
+        />,
+        { wrapper: Wrapper },
+      );
 
-        expect(screen.getAllByText(/response/).length).toBeGreaterThan(0);
-        expect(screen.queryAllByText("Exact Match")).toHaveLength(0);
-      });
+      expect(screen.getAllByText(/response/).length).toBeGreaterThan(0);
+      expect(screen.queryAllByText("Exact Match")).toHaveLength(0);
+    });
 
-      /** @scenario Hide outputs to focus on scores */
-      it("hides outputs but keeps evaluator chips when showOutputs is false", () => {
-        render(
-          <BatchEvaluationResultsTable
-            data={null}
-            comparisonData={createComparisonRuns()}
-            showOutputs={false}
-            disableVirtualization
-          />,
-          { wrapper: Wrapper },
-        );
+    /** @scenario Hide outputs to focus on scores */
+    it("hides outputs but keeps evaluator chips when showOutputs is false", () => {
+      render(
+        <BatchEvaluationResultsTable
+          data={null}
+          comparisonData={createComparisonRuns()}
+          showOutputs={false}
+          disableVirtualization
+        />,
+        { wrapper: Wrapper },
+      );
 
-        expect(screen.getAllByText("Exact Match").length).toBeGreaterThan(0);
-        expect(screen.queryAllByText(/response/)).toHaveLength(0);
-      });
+      expect(screen.getAllByText("Exact Match").length).toBeGreaterThan(0);
+      expect(screen.queryAllByText(/response/)).toHaveLength(0);
+    });
 
-      /** @scenario Hide the target column when no fields are shown */
-      it("removes the target column when all fields are off", () => {
-        render(
-          <BatchEvaluationResultsTable
-            data={null}
-            comparisonData={createComparisonRuns()}
-            showOutputs={false}
-            showEvaluations={false}
-            showCostAndLatency={false}
-            disableVirtualization
-          />,
-          { wrapper: Wrapper },
-        );
+    /** @scenario Hide the target column when no fields are shown */
+    it("removes the target column when all fields are off", () => {
+      render(
+        <BatchEvaluationResultsTable
+          data={null}
+          comparisonData={createComparisonRuns()}
+          showOutputs={false}
+          showEvaluations={false}
+          showCostAndLatency={false}
+          disableVirtualization
+        />,
+        { wrapper: Wrapper },
+      );
 
-        expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
-        expect(screen.getAllByText("What is 2+2?").length).toBeGreaterThan(0);
-      });
+      expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
+      expect(screen.getAllByText("What is 2+2?").length).toBeGreaterThan(0);
     });
   });
 

--- a/langwatch/src/components/batch-evaluation-results/__tests__/BatchTargetCell.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/BatchTargetCell.test.tsx
@@ -246,6 +246,48 @@ describe("BatchTargetCell", () => {
       expect(screen.getByTestId("latency-target-1")).toBeInTheDocument();
       expect(screen.getByText("1.5s")).toBeInTheDocument();
     });
+
+    it("displays cost when present", () => {
+      const targetOutput = createTargetOutput({ cost: 0.05 });
+
+      render(<BatchTargetCell targetOutput={targetOutput} />, {
+        wrapper: Wrapper,
+      });
+
+      expect(screen.getByTestId("cost-target-1")).toBeInTheDocument();
+      expect(screen.getByText("$0.0500")).toBeInTheDocument();
+    });
+
+    /** @scenario Hide cost and latency to reduce clutter */
+    it("hides cost and latency when showCostAndLatency is false", () => {
+      const targetOutput = createTargetOutput({ cost: 0.05, duration: 1500 });
+
+      render(
+        <BatchTargetCell
+          targetOutput={targetOutput}
+          showCostAndLatency={false}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(screen.queryByTestId("cost-target-1")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("latency-target-1")).not.toBeInTheDocument();
+      // Output stays — cost/latency is independent of the output toggle.
+      expect(screen.getByText(/Test output/)).toBeInTheDocument();
+    });
+
+    /** @scenario Increase row height to see more of a long output before expanding */
+    it("applies the row-height tier to the collapsed output box", () => {
+      const targetOutput = createTargetOutput();
+
+      render(<BatchTargetCell targetOutput={targetOutput} rowHeight="l" />, {
+        wrapper: Wrapper,
+      });
+
+      expect(
+        screen.getByText(/Test output/).closest("[data-row-height]"),
+      ).toHaveAttribute("data-row-height", "l");
+    });
   });
 
   describe("Output Unwrapping", () => {

--- a/langwatch/src/components/batch-evaluation-results/__tests__/useResultDisplayPreferences.test.ts
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/useResultDisplayPreferences.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for useResultDisplayPreferences
+ *
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useResultDisplayPreferences } from "../useResultDisplayPreferences";
+
+describe("useResultDisplayPreferences", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  describe("when toggling a field", () => {
+    it("flips only the requested field", () => {
+      const { result } = renderHook(() => useResultDisplayPreferences());
+
+      act(() => result.current.toggleField("scores"));
+
+      expect(result.current.fields.scores).toBe(false);
+      expect(result.current.fields.outputs).toBe(true);
+      expect(result.current.fields.costAndLatency).toBe(true);
+    });
+  });
+
+  describe("when a new session starts", () => {
+    /** @scenario Field visibility does not persist across reloads */
+    it("resets field visibility to defaults", () => {
+      const first = renderHook(() => useResultDisplayPreferences());
+      act(() => first.result.current.toggleField("scores"));
+      expect(first.result.current.fields.scores).toBe(false);
+      first.unmount();
+
+      // A fresh hook instance stands in for a reload — fields hold no
+      // storage key, so nothing carries over.
+      const second = renderHook(() => useResultDisplayPreferences());
+      expect(second.result.current.fields.scores).toBe(true);
+    });
+
+    /** @scenario Row height choice persists across reloads */
+    it("keeps the row height choice", () => {
+      const first = renderHook(() => useResultDisplayPreferences());
+      act(() => first.result.current.setRowHeight("l"));
+      expect(first.result.current.rowHeight).toBe("l");
+      first.unmount();
+
+      const second = renderHook(() => useResultDisplayPreferences());
+      expect(second.result.current.rowHeight).toBe("l");
+    });
+  });
+});

--- a/langwatch/src/components/batch-evaluation-results/index.ts
+++ b/langwatch/src/components/batch-evaluation-results/index.ts
@@ -12,6 +12,11 @@ export {
   ColumnVisibilityButton,
   type ColumnVisibilityButtonProps,
   DEFAULT_HIDDEN_COLUMNS,
+  FieldsButton,
+  type FieldsButtonProps,
+  type ResultField,
+  RowHeightButton,
+  type RowHeightButtonProps,
 } from "./BatchEvaluationResultsTable";
 export { type BatchRunSummary, BatchRunsSidebar } from "./BatchRunsSidebar";
 // BatchSummaryFooter is still used by ResultsPanel for stop button functionality
@@ -40,9 +45,11 @@ export { SingleRunTable } from "./SingleRunTable";
 // Table utilities
 export {
   calculateMinTableWidth,
+  DEFAULT_ROW_HEIGHT,
   getTableStyles,
   inferColumnType,
-  ROW_HEIGHT,
+  ROW_HEIGHT_OPTIONS,
+  type RowHeight,
 } from "./tableUtils";
 // Types
 export {

--- a/langwatch/src/components/batch-evaluation-results/index.ts
+++ b/langwatch/src/components/batch-evaluation-results/index.ts
@@ -14,7 +14,6 @@ export {
   DEFAULT_HIDDEN_COLUMNS,
   FieldsButton,
   type FieldsButtonProps,
-  type ResultField,
   RowHeightButton,
   type RowHeightButtonProps,
 } from "./BatchEvaluationResultsTable";
@@ -62,3 +61,9 @@ export {
   isImageUrlHeuristic,
   transformBatchEvaluationData,
 } from "./types";
+// Result display preferences (fields visibility + row height)
+export {
+  DEFAULT_RESULT_FIELDS,
+  type ResultField,
+  useResultDisplayPreferences,
+} from "./useResultDisplayPreferences";

--- a/langwatch/src/components/batch-evaluation-results/tableUtils.ts
+++ b/langwatch/src/components/batch-evaluation-results/tableUtils.ts
@@ -4,8 +4,42 @@
 import type { SystemStyleObject } from "@chakra-ui/react";
 import { getImageUrl } from "~/components/ExternalImage";
 
-/** Estimated row height for virtualization */
-export const ROW_HEIGHT = 180;
+/**
+ * How much of a cell's content shows before it needs expanding. Applies
+ * uniformly to every cell in a row (dataset columns via
+ * {@link ExpandableDatasetCell}, target columns via {@link BatchTargetCell})
+ * so a row's cells all clip at the same height.
+ */
+export type RowHeight = "s" | "m" | "l";
+
+export const ROW_HEIGHT_OPTIONS: ReadonlyArray<{
+  value: RowHeight;
+  label: string;
+}> = [
+  { value: "s", label: "Small" },
+  { value: "m", label: "Medium" },
+  { value: "l", label: "Large" },
+];
+
+export const DEFAULT_ROW_HEIGHT: RowHeight = "m";
+
+/** Max height (px) for a cell's collapsed content, per row-height tier. */
+export const COLLAPSED_CELL_HEIGHT_PX: Record<RowHeight, number> = {
+  s: 60,
+  m: 140,
+  l: 360,
+};
+
+/**
+ * Estimated row height for virtualization, per tier — keeps the
+ * virtualizer's first-paint guess close to the real height so switching
+ * tiers doesn't visibly jump before dynamic measurement catches up.
+ */
+export const ESTIMATED_ROW_HEIGHT_PX: Record<RowHeight, number> = {
+  s: 100,
+  m: 180,
+  l: 400,
+};
 
 /**
  * Calculate minimum table width based on column counts

--- a/langwatch/src/components/batch-evaluation-results/useResultDisplayPreferences.ts
+++ b/langwatch/src/components/batch-evaluation-results/useResultDisplayPreferences.ts
@@ -1,0 +1,37 @@
+/**
+ * Result-display preferences for the batch evaluation results table.
+ *
+ * Row height persists across sessions — density is a reading preference,
+ * not tied to any one run. Field visibility deliberately does not: a field
+ * hidden on a previous visit should never silently explain "no results" on
+ * a different run, so it always starts from the defaults.
+ */
+import { useCallback, useState } from "react";
+import { useLocalStorage } from "usehooks-ts";
+import { DEFAULT_ROW_HEIGHT, type RowHeight } from "./tableUtils";
+
+export type ResultField = "outputs" | "scores" | "costAndLatency";
+
+export const DEFAULT_RESULT_FIELDS: Record<ResultField, boolean> = {
+  outputs: true,
+  scores: true,
+  costAndLatency: true,
+};
+
+const ROW_HEIGHT_STORAGE_KEY = "batch-results-row-height";
+
+export function useResultDisplayPreferences() {
+  const [fields, setFields] = useState<Record<ResultField, boolean>>(
+    DEFAULT_RESULT_FIELDS,
+  );
+  const [rowHeight, setRowHeight] = useLocalStorage<RowHeight>(
+    ROW_HEIGHT_STORAGE_KEY,
+    DEFAULT_ROW_HEIGHT,
+  );
+
+  const toggleField = useCallback((field: ResultField) => {
+    setFields((prev) => ({ ...prev, [field]: !prev[field] }));
+  }, []);
+
+  return { fields, toggleField, rowHeight, setRowHeight };
+}

--- a/specs/batch-evaluation-results/batch-evaluation-results.feature
+++ b/specs/batch-evaluation-results/batch-evaluation-results.feature
@@ -144,6 +144,31 @@ Feature: Batch Evaluation Results Visualization
     And I see the evaluation details/reasoning
 
   # ============================================================================
+  # View Lens / Focus Filter
+  # ============================================================================
+  # A "View" control in the results header lets users dial the detail level up
+  # or down by toggling which sections render. Dataset columns stay controlled
+  # by the separate column-visibility popover.
+
+  Scenario: Hide evaluation scores to focus on outputs
+    Given an evaluation run with target outputs and evaluator score chips
+    When I switch the results view to "Data only"
+    Then the target outputs remain visible
+    And the evaluator score chips are hidden
+
+  Scenario: Hide outputs to focus on evaluation scores
+    Given an evaluation run with target outputs and evaluator score chips
+    When I switch the results view to "Scores only"
+    Then the evaluator score chips remain visible
+    And the target outputs are hidden
+
+  Scenario: Hide the target column when no target sections are shown
+    Given an evaluation run with a target column
+    When I turn off both the outputs and evaluations sections
+    Then the target column is removed from the table
+    And the dataset columns remain visible
+
+  # ============================================================================
   # Trace Links
   # ============================================================================
 

--- a/specs/batch-evaluation-results/batch-evaluation-results.feature
+++ b/specs/batch-evaluation-results/batch-evaluation-results.feature
@@ -96,7 +96,7 @@ Feature: Batch Evaluation Results Visualization
 
   @unimplemented
   Scenario: Expand long target output
-    Given a target output is longer than the cell max height (120px)
+    Given a target output is longer than the cell's collapsed height
     When the results table renders
     Then a fade overlay appears at the bottom of the cell
     When I click on the cell
@@ -144,29 +144,54 @@ Feature: Batch Evaluation Results Visualization
     And I see the evaluation details/reasoning
 
   # ============================================================================
-  # View Lens / Focus Filter
+  # Fields / Row Height
   # ============================================================================
-  # A "View" control in the results header lets users dial the detail level up
-  # or down by toggling which sections render. Dataset columns stay controlled
-  # by the separate column-visibility popover.
+  # A "Fields" control in the results header lets users toggle which target
+  # details render — outputs, scores, and latency/cost — independently of
+  # each other. A separate "Row height" control changes how much of each
+  # cell's content is visible before it needs expanding. Dataset columns stay
+  # controlled by the separate column-visibility popover. Field choices reset
+  # on reload — a hidden section left on from a previous visit should never
+  # silently explain "no results" on a different run.
 
-  Scenario: Hide evaluation scores to focus on outputs
+  Scenario: Hide scores to focus on outputs
     Given an evaluation run with target outputs and evaluator score chips
-    When I switch the results view to "Data only"
+    When I turn off the "Scores" field
     Then the target outputs remain visible
     And the evaluator score chips are hidden
 
-  Scenario: Hide outputs to focus on evaluation scores
+  Scenario: Hide outputs to focus on scores
     Given an evaluation run with target outputs and evaluator score chips
-    When I switch the results view to "Scores only"
+    When I turn off the "Outputs" field
     Then the evaluator score chips remain visible
     And the target outputs are hidden
 
-  Scenario: Hide the target column when no target sections are shown
+  Scenario: Hide cost and latency to reduce clutter
+    Given a target produced output with a cost and a latency
+    When I turn off the "Latency and cost" field
+    Then the cost and latency are hidden
+    And the target output remains visible
+
+  Scenario: Hide the target column when no fields are shown
     Given an evaluation run with a target column
-    When I turn off both the outputs and evaluations sections
+    When I turn off the outputs, scores, and latency and cost fields
     Then the target column is removed from the table
     And the dataset columns remain visible
+
+  Scenario: Field visibility does not persist across reloads
+    Given I have turned off the "Scores" field
+    When I reload the page
+    Then all fields are shown again
+
+  Scenario: Increase row height to see more of a long output before expanding
+    Given a target output long enough to be clipped at the default row height
+    When I switch the row height to "Large"
+    Then more of the output is visible without expanding the cell
+
+  Scenario: Row height choice persists across reloads
+    Given I have switched the row height to "Large"
+    When I reload the page
+    Then the row height is still "Large"
 
   # ============================================================================
   # Trace Links


### PR DESCRIPTION
## What & why

The results table always renders the full target cell — model **output**, evaluator **score chips**, and now **cost/latency** — stacked together, with no way to dial the detail level up or down. That's a real problem the moment a run has more than 2-3 targets: with 5 targets side by side, a support-quality N-way run renders as five columns of dense paragraph text plus chips, and the thing you're actually trying to do — scan scores, or read one output in full — gets buried in the others'. This PR was a straight port of that idea, shipped as a single "View" button with three presets (`Everything`/`Data only`/`Scores only`) plus two checkboxes underneath.

**That version had two real problems**, caught in review before merge:
1. **An unnamed state.** Toggling the checkboxes independently of the presets could land on a combination no preset named, and the button's own label degraded to a generic `"View"` — a control that can reach a state it can't name is the wrong model.
2. **It solved the wrong half of the problem.** Hiding sections is *destructive* — you lose the score chips entirely to make room. The actual complaint ("I can't read this without scrolling forever") is a **density** problem, not a **visibility** problem, and this PR had no answer for that at all.

The fix is to split "what shows" from "how much fits" into two independent controls, instead of one control trying to do both:

- **`Fields`** — plain, independent checkboxes: `Outputs`, `Scores`, `Latency and cost`. No presets, no derived label — the button always says "Fields." Deliberately **not** persisted: a section left off from a previous visit should never silently explain "no results" on a *different* run.
- **`Row height`** — `Small` / `Medium` / `Large`, controlling how much of each cell's content shows before it needs expanding. This is the non-destructive fix for the actual density complaint: nothing is hidden, more just fits, or you get more room to read one thing in full. **Persisted** — density is a "how I like to read tables" preference, not something tied to one run.
- **Cost is now shown per-row**, next to latency (previously latency-only, despite `BatchTargetOutput.cost` already existing in the data model and being aggregated in the column header as "Total Cost"). Bundled into one "Latency and cost" toggle, since they're both resource metrics a reader wants together.

## Screenshots

Captured against a real 5-target comparison run (`support-nway-showdown`, 1,620 result rows) on a local stack.

**Before / after, side by side** — one button that could reach a state it couldn't name, replaced by two that can't:

| Before — shipped first | After — reworked to this |
|---|---|
| ![old header](https://raw.githubusercontent.com/langwatch/langwatch/assets/pr4623-view-lens/old-header.png) | ![new header](https://raw.githubusercontent.com/langwatch/langwatch/assets/pr4623-view-lens/new-header.png) |
| `Everything` — three presets + two checkboxes; the label falls back to a bare `"View"` the moment the checkboxes disagree with every preset | `Row height` + `Fields` — two controls, two jobs, neither can degrade into a state it can't describe |

**Fields** — flat checkboxes, no presets, stable label:

![fields open](https://raw.githubusercontent.com/langwatch/langwatch/assets/pr4623-view-lens/2-fields-open.png)

**Row height** — three named tiers:

![row height open](https://raw.githubusercontent.com/langwatch/langwatch/assets/pr4623-view-lens/4-rowheight-open.png)

**Same run, same viewport, two tiers** — `Small` fits more rows on screen at once; `Large` gives one response room to read start to finish without opening the expanded view. Neither hides a single evaluator chip:

| `Small` — 57 chips on screen | `Large` — 49 chips on screen |
|---|---|
| ![small](https://raw.githubusercontent.com/langwatch/langwatch/assets/pr4623-view-lens/5-rowheight-small.png) | ![large](https://raw.githubusercontent.com/langwatch/langwatch/assets/pr4623-view-lens/6-rowheight-large.png) |

**After reload** — row height (`Large`) survived; a field hidden before the reload (`Outputs`) came back:

![persistence](https://raw.githubusercontent.com/langwatch/langwatch/assets/pr4623-view-lens/7-rowheight-persists-after-reload.png)

## Verification

DOM/virtualizer state, not just eyeballing the images — the chip counts prove the virtualizer is actually re-measuring rows at each tier, not just applying a CSS clip:

| State | Chips rendered | Cost/latency els | Table columns | Row-height tier |
|---|---|---|---|---|
| Default | 53 | 52 | 8 | `m` |
| Latency/cost hidden | 53 (unchanged) | **0** | 8 | `m` |
| Row height → Small | **57** (more rows fit) | 56 | 8 | `s` |
| Row height → Large | **49** (fewer rows fit) | 48 | 8 | `l` |
| Outputs off (still Large) | 53 (row shrinks w/o output text) | 52 | 8 | `l` |
| After reload | 49 | 48 | 8 | `l` (persisted) |
| — Fields reset | — | — | — | outputs back on |

The Small→Large swing in chip count (57→49) is the virtualizer genuinely re-measuring row heights per tier, not a cosmetic-only change.

## Implementation

- New `rowHeight.ts`-style constants in `tableUtils.ts`: `RowHeight` type, `COLLAPSED_CELL_HEIGHT_PX` (shared by `BatchTargetCell` and `ExpandableDatasetCell` so a row's cells all clip at the same height — previously these were two different hardcoded values, 120px and 180px, with no explanation for the mismatch), and `ESTIMATED_ROW_HEIGHT_PX` (keeps the virtualizer's first-paint guess close to the real height per tier).
- `showOutputs`/`showEvaluations` (kept, minimal churn) plus a new `showCostAndLatency`, threaded through `BatchEvaluationResultsTable` → `SingleRunTable`/`ComparisonTable` → `BatchTargetCell`. The action-bar gate is split: cost/latency renders independently of the output toggle (previously bundled — hiding output also silently hid latency, unrelated to the actual toggle you touched).
- `buildColumns`/`buildComparisonColumns` converted from 9 positional args to a single options object — CI's Biome delta-gate enforces a 3-param max, and I was about to push both over it anyway.

## Tests / spec

- Spec section renamed `Fields / Row Height`; 3 scenarios reworded from preset names to field names, 4 new scenarios added (row height, and that each of fields/row-height does or doesn't survive a reload) — `check:feature-parity` reports **9/9 bound**.
- 191/191 tests pass across the directory. New coverage: cost display, the cost/latency-independent-of-output toggle, row-height threading (`data-row-height` attribute), all in both single-run and comparison modes.
- The two reload-persistence scenarios were initially only verified by hand in the browser (screenshots above) — moved into `useResultDisplayPreferences`, a small extracted hook, and bound to `renderHook` tests against jsdom's real `localStorage`, so they're enforced in CI, not just observed once.
- Mutation-verified throughout: forcing `showTargetColumns = true` in `ComparisonTable` fails exactly the "removes target column" test; forcing `fields` onto `useLocalStorage` fails exactly the "resets to defaults" test; forcing `rowHeight` onto plain `useState` fails exactly the "keeps the choice" test. Each mutation fails only its own test.

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
