### PR TITLE
docs(skills): add TypeScript voice coverage to scenarios skill

### DIFF
--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -896,11 +896,17 @@ async def test_realtime_greeting():
     assert result.success, result.reasoning
 \`\`\`
 
-### Worked example (TypeScript, OpenAI Realtime — adapter IS the agent, mirror prod config)
+### Worked example (TypeScript, OpenAI Realtime — adapter drives the model session)
+
+Use this shape when the user's production agent IS an OpenAI Realtime model.
+The adapter drives the session directly — import the same \`instructions\` and \`tools\` your production agent uses rather than copy-pasting them inline.
+One source of truth keeps the test aligned with what is actually deployed.
 
 \`\`\`typescript
 import scenario, { voice } from "@langwatch/scenario";
 import { describe, it, expect } from "vitest";
+// Import your production agent config — don't duplicate it here
+import { AGENT_INSTRUCTIONS, AGENT_TOOLS } from "../src/billing-agent";
 
 describe("Voice agent — angry billing", () => {
   it("acknowledges frustration before pivoting to logistics", async () => {
@@ -911,13 +917,13 @@ describe("Voice agent — angry billing", () => {
         "The agent must acknowledge the frustration before pivoting to " +
         "logistics, stay calm, and queue a refund.",
       agents: [
-        // The adapter IS the agent. Mirror the user's PROD model,
-        // voice, instructions, and tools here — anything you leave as
-        // a placeholder is what you're actually testing.
+        // The adapter drives an OpenAI Realtime session with the same
+        // config your production agent uses. Importing from production
+        // source keeps the test aligned with what is actually deployed.
         scenario.openAIRealtimeAgent({
           voice: "alloy",
-          instructions: "<paste the EXACT prod system prompt here>",
-          // tools: [...prod tool schemas...],
+          instructions: AGENT_INSTRUCTIONS,
+          // tools: AGENT_TOOLS,
         }),
         scenario.userSimulatorAgent({
           voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -2847,11 +2853,17 @@ async def test_realtime_greeting():
     assert result.success, result.reasoning
 \`\`\`
 
-### Worked example (TypeScript, OpenAI Realtime — adapter IS the agent, mirror prod config)
+### Worked example (TypeScript, OpenAI Realtime — adapter drives the model session)
+
+Use this shape when the user's production agent IS an OpenAI Realtime model.
+The adapter drives the session directly — import the same \`instructions\` and \`tools\` your production agent uses rather than copy-pasting them inline.
+One source of truth keeps the test aligned with what is actually deployed.
 
 \`\`\`typescript
 import scenario, { voice } from "@langwatch/scenario";
 import { describe, it, expect } from "vitest";
+// Import your production agent config — don't duplicate it here
+import { AGENT_INSTRUCTIONS, AGENT_TOOLS } from "../src/billing-agent";
 
 describe("Voice agent — angry billing", () => {
   it("acknowledges frustration before pivoting to logistics", async () => {
@@ -2862,13 +2874,13 @@ describe("Voice agent — angry billing", () => {
         "The agent must acknowledge the frustration before pivoting to " +
         "logistics, stay calm, and queue a refund.",
       agents: [
-        // The adapter IS the agent. Mirror the user's PROD model,
-        // voice, instructions, and tools here — anything you leave as
-        // a placeholder is what you're actually testing.
+        // The adapter drives an OpenAI Realtime session with the same
+        // config your production agent uses. Importing from production
+        // source keeps the test aligned with what is actually deployed.
         scenario.openAIRealtimeAgent({
           voice: "alloy",
-          instructions: "<paste the EXACT prod system prompt here>",
-          // tools: [...prod tool schemas...],
+          instructions: AGENT_INSTRUCTIONS,
+          // tools: AGENT_TOOLS,
         }),
         scenario.userSimulatorAgent({
           voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
@@ -4385,11 +4397,17 @@ async def test_realtime_greeting():
     assert result.success, result.reasoning
 \`\`\`
 
-### Worked example (TypeScript, OpenAI Realtime — adapter IS the agent, mirror prod config)
+### Worked example (TypeScript, OpenAI Realtime — adapter drives the model session)
+
+Use this shape when the user's production agent IS an OpenAI Realtime model.
+The adapter drives the session directly — import the same \`instructions\` and \`tools\` your production agent uses rather than copy-pasting them inline.
+One source of truth keeps the test aligned with what is actually deployed.
 
 \`\`\`typescript
 import scenario, { voice } from "@langwatch/scenario";
 import { describe, it, expect } from "vitest";
+// Import your production agent config — don't duplicate it here
+import { AGENT_INSTRUCTIONS, AGENT_TOOLS } from "../src/billing-agent";
 
 describe("Voice agent — angry billing", () => {
   it("acknowledges frustration before pivoting to logistics", async () => {
@@ -4400,13 +4418,13 @@ describe("Voice agent — angry billing", () => {
         "The agent must acknowledge the frustration before pivoting to " +
         "logistics, stay calm, and queue a refund.",
       agents: [
-        // The adapter IS the agent. Mirror the user's PROD model,
-        // voice, instructions, and tools here — anything you leave as
-        // a placeholder is what you're actually testing.
+        // The adapter drives an OpenAI Realtime session with the same
+        // config your production agent uses. Importing from production
+        // source keeps the test aligned with what is actually deployed.
         scenario.openAIRealtimeAgent({
           voice: "alloy",
-          instructions: "<paste the EXACT prod system prompt here>",
-          // tools: [...prod tool schemas...],
+          instructions: AGENT_INSTRUCTIONS,
+          // tools: AGENT_TOOLS,
         }),
         scenario.userSimulatorAgent({
           voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",

--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -780,7 +780,7 @@ scenario.userSimulatorAgent({
 });
 \`\`\`
 
-For a full runnable TypeScript voice test, see the **Worked example (TypeScript)** below.
+For full runnable TypeScript voice tests, see the **OpenAI Realtime** and **Pipecat WS** TypeScript worked examples below.
 
 ### Step 5: Tell the simulator it's on a phone, not in chat
 
@@ -2731,7 +2731,7 @@ scenario.userSimulatorAgent({
 });
 \`\`\`
 
-For a full runnable TypeScript voice test, see the **Worked example (TypeScript)** below.
+For full runnable TypeScript voice tests, see the **OpenAI Realtime** and **Pipecat WS** TypeScript worked examples below.
 
 ### Step 5: Tell the simulator it's on a phone, not in chat
 
@@ -4269,7 +4269,7 @@ scenario.userSimulatorAgent({
 });
 \`\`\`
 
-For a full runnable TypeScript voice test, see the **Worked example (TypeScript)** below.
+For full runnable TypeScript voice tests, see the **OpenAI Realtime** and **Pipecat WS** TypeScript worked examples below.
 
 ### Step 5: Tell the simulator it's on a phone, not in chat
 

--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -477,7 +477,7 @@ CRITICAL: Do NOT guess how to write scenario tests. Different frameworks have di
 ### Step 2: Install the Scenario SDK
 
 For Python: \`pip install langwatch-scenario pytest pytest-asyncio\` (or \`uv add ...\`).
-For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest @ai-sdk/openai\` (or \`pnpm add ...\`). The voice adapter factories (\`openAIRealtimeAgent\`, \`pipecatAgent\`, etc.) and \`voice.effects\` require \`@langwatch/scenario\` >= 0.4.12 — earlier versions only expose the lower-level \`RealtimeAgentAdapter\` class.
+For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest\` (or \`pnpm add ...\`).
 
 ### Step 3: Configure the Default Model
 
@@ -2428,7 +2428,7 @@ CRITICAL: Do NOT guess how to write scenario tests. Different frameworks have di
 ### Step 2: Install the Scenario SDK
 
 For Python: \`pip install langwatch-scenario pytest pytest-asyncio\` (or \`uv add ...\`).
-For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest @ai-sdk/openai\` (or \`pnpm add ...\`). The voice adapter factories (\`openAIRealtimeAgent\`, \`pipecatAgent\`, etc.) and \`voice.effects\` require \`@langwatch/scenario\` >= 0.4.12 — earlier versions only expose the lower-level \`RealtimeAgentAdapter\` class.
+For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest\` (or \`pnpm add ...\`).
 
 ### Step 3: Configure the Default Model
 
@@ -3966,7 +3966,7 @@ CRITICAL: Do NOT guess how to write scenario tests. Different frameworks have di
 ### Step 2: Install the Scenario SDK
 
 For Python: \`pip install langwatch-scenario pytest pytest-asyncio\` (or \`uv add ...\`).
-For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest @ai-sdk/openai\` (or \`pnpm add ...\`). The voice adapter factories (\`openAIRealtimeAgent\`, \`pipecatAgent\`, etc.) and \`voice.effects\` require \`@langwatch/scenario\` >= 0.4.12 — earlier versions only expose the lower-level \`RealtimeAgentAdapter\` class.
+For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest\` (or \`pnpm add ...\`).
 
 ### Step 3: Configure the Default Model
 

--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -557,6 +557,35 @@ describe("My Agent", () => {
 });
 \`\`\`
 
+### Step 4.5: Instrument for observability (REQUIRED before running)
+
+ALWAYS instrument before running — an uninstrumented scenario run emits no traces, so you lose the OTel/LangWatch observability that makes failures debuggable. This is not optional.
+
+There are two distinct things to wire:
+
+**1. Scenario-run tracing** — call \`setupScenarioTracing()\` once at the top of the test file so the simulator, judge, and adapter spans are captured:
+
+\`\`\`typescript
+// TypeScript — add at the very top of the test file, before any imports or setup
+import { setupScenarioTracing } from "@langwatch/scenario";
+setupScenarioTracing();
+\`\`\`
+
+For Python, scenario tracing is configured via \`scenario.configure(...)\` combined with langwatch setup — defer the exact call signature to the \`tracing\` skill.
+
+**2. Agent-under-test tracing** — instrument YOUR OWN agent code so its internal LLM calls, tool invocations, and chain spans are captured:
+
+- Python: \`import langwatch; langwatch.setup()\` at startup, then decorate the agent entry point with \`@langwatch.trace()\`.
+- TypeScript: call \`setupObservability\` from the \`langwatch\` package in your agent's initialization.
+
+**Per-adapter nuance for voice:** when the adapter IS the agent (OpenAI Realtime, Gemini Live), the scenario tracing covers the session. When connecting to a deployed agent (Pipecat/Twilio/ElevenLabs hosted) or wrapping a text agent (Composable), the user's agent process must be instrumented separately in its own codebase.
+
+For framework-specific instrumentation (OpenAI/LangGraph/Vercel/Mastra/Agno), use the \`tracing\` skill — do not hand-roll. The \`tracing\` skill prompt is: "Instrument my code with LangWatch".
+
+**Prerequisite:** Traces only reach LangWatch if \`LANGWATCH_API_KEY\` is set in the environment (plus \`LANGWATCH_ENDPOINT\` for self-hosted). If setup runs but no traces appear in the LangWatch UI, the key is missing.
+
+**VERIFY after the run:** confirm traces were emitted — the scenario run prints a LangWatch trace URL, or the LangWatch UI shows ≥1 trace for the run. A green test with zero traces means instrumentation was skipped.
+
 ### Step 5: Run the Tests
 
 For Python: \`pytest -s test_my_agent.py\` (or \`uv run pytest ...\`).
@@ -664,6 +693,8 @@ If the user asks for **voice testing** (e.g. "add voice testing to my agent", "t
 
 CRITICAL: Do NOT write a text-only scenario when the user asked for voice. The judge cannot evaluate "audible empathy" or "noise robustness" against a text transcript.
 
+Voice agents especially need observability — latency, interruptions, and STT/TTS spans are exactly what makes voice failures diagnosable. Instrument per Step 4.5 above (both \`setupScenarioTracing()\` and the agent-under-test) before running. See \`langwatch scenario-docs voice/recipes/observability\` for voice-specific OTel guidance.
+
 ### Step 1: Read the voice docs
 
 \`\`\`bash
@@ -672,6 +703,7 @@ langwatch scenario-docs voice/choosing-an-adapter
 langwatch scenario-docs voice/capability-matrix
 langwatch scenario-docs voice/recipes/effects
 langwatch scenario-docs voice/recipes/multi-turn
+langwatch scenario-docs voice/recipes/observability
 \`\`\`
 
 Also browse the runnable voice examples:
@@ -1075,6 +1107,7 @@ Do NOT ask permission before Phase 1 and 2 — deliver value first. Do NOT ask g
 
 ### Code Approach
 
+- Do NOT write a scenario without instrumenting — a green run that emits no traces is half the value; call \`setupScenarioTracing()\` (run-level) and instrument the agent-under-test (\`langwatch.setup()\` / \`setupObservability\`) BEFORE running, and confirm traces appear in the LangWatch UI.
 - Do NOT create your own testing framework — \`@langwatch/scenario\` already handles simulation, judging, multi-turn, and tool-call verification
 - Do NOT write a \`main.py\` / \`run_scenarios.py\` / custom runner that loops over scenarios. Each scenario IS a test (\`it(...)\` / \`async def test_*\`) — run them with \`pytest\` or \`vitest\`. The test runner already gives you parallelism, retries of just the failing case, watch mode, CI integration, and per-test timeouts; a runner script re-implements all of that and ships with none of it wired up.
 - Do NOT invent a JSON / YAML / TOML "scenario DSL" with keys like \`{ "name": ..., "description": ..., "criteria": [...] }\` and then load it into a generic loop. The whole point of Scenario being code is that each test is real code: you can use \`for\`, \`if\`, parametrize (\`@pytest.mark.parametrize\`, \`it.each(...)\`), pull a fixture, call a helper to mint a session, branch by environment, share setup via a \`conftest.py\`, mock a tool inline — none of which a DSL gives you. The moment a teammate needs a new edge case ("only on Tuesdays the agent should escalate"), the DSL grows another key, then another, until it's a worse version of Python/TypeScript with none of the tooling. If the same boilerplate repeats across scenarios, extract a helper FUNCTION that returns an \`AgentAdapter\` / a built \`UserSimulatorAgent\` / a script tuple — keep each scenario its own test case so it stays grep-able and debuggable.
@@ -1092,6 +1125,7 @@ Do NOT ask permission before Phase 1 and 2 — deliver value first. Do NOT ask g
 
 ### Voice Agents
 
+- Do NOT skip observability on voice agents — latency, interruption, and STT/TTS spans are exactly what you need when a voice scenario fails; instrument before running (Step 4.5: \`setupScenarioTracing()\` + agent-under-test instrumentation) and verify traces emit in the LangWatch UI.
 - Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\` / \`ComposableVoiceAgent\`
 - Do NOT instantiate \`OpenAIRealtimeAgentAdapter\` or \`GeminiLiveAgentAdapter\` with placeholder \`instructions=...\` / \`model=...\` / \`tools=...\` — those adapters ARE the agent, so a placeholder constructor tests OpenAI/Gemini defaults, not the user's agent. Either mirror the user's prod config exactly, or pick a different adapter (Pipecat/Twilio/ElevenLabs hosted) that connects to their already-deployed transport.
 - Do NOT point \`PipecatAgentAdapter(url=...)\` / \`ElevenLabsAgentAdapter(agent_id=...)\` / \`TwilioAgentAdapter\` at a transport the user hasn't deployed — those adapters only connect, they don't spin anything up. If the user is text-only and has no voice transport, say so and offer \`ComposableVoiceAgent\` as a voice wrapper around their existing text logic.
@@ -2474,6 +2508,35 @@ describe("My Agent", () => {
 });
 \`\`\`
 
+### Step 4.5: Instrument for observability (REQUIRED before running)
+
+ALWAYS instrument before running — an uninstrumented scenario run emits no traces, so you lose the OTel/LangWatch observability that makes failures debuggable. This is not optional.
+
+There are two distinct things to wire:
+
+**1. Scenario-run tracing** — call \`setupScenarioTracing()\` once at the top of the test file so the simulator, judge, and adapter spans are captured:
+
+\`\`\`typescript
+// TypeScript — add at the very top of the test file, before any imports or setup
+import { setupScenarioTracing } from "@langwatch/scenario";
+setupScenarioTracing();
+\`\`\`
+
+For Python, scenario tracing is configured via \`scenario.configure(...)\` combined with langwatch setup — defer the exact call signature to the \`tracing\` skill.
+
+**2. Agent-under-test tracing** — instrument YOUR OWN agent code so its internal LLM calls, tool invocations, and chain spans are captured:
+
+- Python: \`import langwatch; langwatch.setup()\` at startup, then decorate the agent entry point with \`@langwatch.trace()\`.
+- TypeScript: call \`setupObservability\` from the \`langwatch\` package in your agent's initialization.
+
+**Per-adapter nuance for voice:** when the adapter IS the agent (OpenAI Realtime, Gemini Live), the scenario tracing covers the session. When connecting to a deployed agent (Pipecat/Twilio/ElevenLabs hosted) or wrapping a text agent (Composable), the user's agent process must be instrumented separately in its own codebase.
+
+For framework-specific instrumentation (OpenAI/LangGraph/Vercel/Mastra/Agno), use the \`tracing\` skill — do not hand-roll. The \`tracing\` skill prompt is: "Instrument my code with LangWatch".
+
+**Prerequisite:** Traces only reach LangWatch if \`LANGWATCH_API_KEY\` is set in the environment (plus \`LANGWATCH_ENDPOINT\` for self-hosted). If setup runs but no traces appear in the LangWatch UI, the key is missing.
+
+**VERIFY after the run:** confirm traces were emitted — the scenario run prints a LangWatch trace URL, or the LangWatch UI shows ≥1 trace for the run. A green test with zero traces means instrumentation was skipped.
+
 ### Step 5: Run the Tests
 
 For Python: \`pytest -s test_my_agent.py\` (or \`uv run pytest ...\`).
@@ -2581,6 +2644,8 @@ If the user asks for **voice testing** (e.g. "add voice testing to my agent", "t
 
 CRITICAL: Do NOT write a text-only scenario when the user asked for voice. The judge cannot evaluate "audible empathy" or "noise robustness" against a text transcript.
 
+Voice agents especially need observability — latency, interruptions, and STT/TTS spans are exactly what makes voice failures diagnosable. Instrument per Step 4.5 above (both \`setupScenarioTracing()\` and the agent-under-test) before running. See \`langwatch scenario-docs voice/recipes/observability\` for voice-specific OTel guidance.
+
 ### Step 1: Read the voice docs
 
 \`\`\`bash
@@ -2589,6 +2654,7 @@ langwatch scenario-docs voice/choosing-an-adapter
 langwatch scenario-docs voice/capability-matrix
 langwatch scenario-docs voice/recipes/effects
 langwatch scenario-docs voice/recipes/multi-turn
+langwatch scenario-docs voice/recipes/observability
 \`\`\`
 
 Also browse the runnable voice examples:
@@ -2984,6 +3050,7 @@ Once tests are green, summarize what you delivered and suggest 2-3 domain-specif
 
 ### Code Approach
 
+- Do NOT write a scenario without instrumenting — a green run that emits no traces is half the value; call \`setupScenarioTracing()\` (run-level) and instrument the agent-under-test (\`langwatch.setup()\` / \`setupObservability\`) BEFORE running, and confirm traces appear in the LangWatch UI.
 - Do NOT create your own testing framework — \`@langwatch/scenario\` already handles simulation, judging, multi-turn, and tool-call verification
 - Do NOT write a \`main.py\` / \`run_scenarios.py\` / custom runner that loops over scenarios. Each scenario IS a test (\`it(...)\` / \`async def test_*\`) — run them with \`pytest\` or \`vitest\`. The test runner already gives you parallelism, retries of just the failing case, watch mode, CI integration, and per-test timeouts; a runner script re-implements all of that and ships with none of it wired up.
 - Do NOT invent a JSON / YAML / TOML "scenario DSL" with keys like \`{ "name": ..., "description": ..., "criteria": [...] }\` and then load it into a generic loop. The whole point of Scenario being code is that each test is real code: you can use \`for\`, \`if\`, parametrize (\`@pytest.mark.parametrize\`, \`it.each(...)\`), pull a fixture, call a helper to mint a session, branch by environment, share setup via a \`conftest.py\`, mock a tool inline — none of which a DSL gives you. The moment a teammate needs a new edge case ("only on Tuesdays the agent should escalate"), the DSL grows another key, then another, until it's a worse version of Python/TypeScript with none of the tooling. If the same boilerplate repeats across scenarios, extract a helper FUNCTION that returns an \`AgentAdapter\` / a built \`UserSimulatorAgent\` / a script tuple — keep each scenario its own test case so it stays grep-able and debuggable.
@@ -3001,6 +3068,7 @@ Once tests are green, summarize what you delivered and suggest 2-3 domain-specif
 
 ### Voice Agents
 
+- Do NOT skip observability on voice agents — latency, interruption, and STT/TTS spans are exactly what you need when a voice scenario fails; instrument before running (Step 4.5: \`setupScenarioTracing()\` + agent-under-test instrumentation) and verify traces emit in the LangWatch UI.
 - Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\` / \`ComposableVoiceAgent\`
 - Do NOT instantiate \`OpenAIRealtimeAgentAdapter\` or \`GeminiLiveAgentAdapter\` with placeholder \`instructions=...\` / \`model=...\` / \`tools=...\` — those adapters ARE the agent, so a placeholder constructor tests OpenAI/Gemini defaults, not the user's agent. Either mirror the user's prod config exactly, or pick a different adapter (Pipecat/Twilio/ElevenLabs hosted) that connects to their already-deployed transport.
 - Do NOT point \`PipecatAgentAdapter(url=...)\` / \`ElevenLabsAgentAdapter(agent_id=...)\` / \`TwilioAgentAdapter\` at a transport the user hasn't deployed — those adapters only connect, they don't spin anything up. If the user is text-only and has no voice transport, say so and offer \`ComposableVoiceAgent\` as a voice wrapper around their existing text logic.
@@ -3978,6 +4046,35 @@ describe("My Agent", () => {
 });
 \`\`\`
 
+### Step 4.5: Instrument for observability (REQUIRED before running)
+
+ALWAYS instrument before running — an uninstrumented scenario run emits no traces, so you lose the OTel/LangWatch observability that makes failures debuggable. This is not optional.
+
+There are two distinct things to wire:
+
+**1. Scenario-run tracing** — call \`setupScenarioTracing()\` once at the top of the test file so the simulator, judge, and adapter spans are captured:
+
+\`\`\`typescript
+// TypeScript — add at the very top of the test file, before any imports or setup
+import { setupScenarioTracing } from "@langwatch/scenario";
+setupScenarioTracing();
+\`\`\`
+
+For Python, scenario tracing is configured via \`scenario.configure(...)\` combined with langwatch setup — defer the exact call signature to the \`tracing\` skill.
+
+**2. Agent-under-test tracing** — instrument YOUR OWN agent code so its internal LLM calls, tool invocations, and chain spans are captured:
+
+- Python: \`import langwatch; langwatch.setup()\` at startup, then decorate the agent entry point with \`@langwatch.trace()\`.
+- TypeScript: call \`setupObservability\` from the \`langwatch\` package in your agent's initialization.
+
+**Per-adapter nuance for voice:** when the adapter IS the agent (OpenAI Realtime, Gemini Live), the scenario tracing covers the session. When connecting to a deployed agent (Pipecat/Twilio/ElevenLabs hosted) or wrapping a text agent (Composable), the user's agent process must be instrumented separately in its own codebase.
+
+For framework-specific instrumentation (OpenAI/LangGraph/Vercel/Mastra/Agno), use the \`tracing\` skill — do not hand-roll. The \`tracing\` skill prompt is: "Instrument my code with LangWatch".
+
+**Prerequisite:** Traces only reach LangWatch if \`LANGWATCH_API_KEY\` is set in the environment (plus \`LANGWATCH_ENDPOINT\` for self-hosted). If setup runs but no traces appear in the LangWatch UI, the key is missing.
+
+**VERIFY after the run:** confirm traces were emitted — the scenario run prints a LangWatch trace URL, or the LangWatch UI shows ≥1 trace for the run. A green test with zero traces means instrumentation was skipped.
+
 ### Step 5: Run the Tests
 
 For Python: \`pytest -s test_my_agent.py\` (or \`uv run pytest ...\`).
@@ -4085,6 +4182,8 @@ If the user asks for **voice testing** (e.g. "add voice testing to my agent", "t
 
 CRITICAL: Do NOT write a text-only scenario when the user asked for voice. The judge cannot evaluate "audible empathy" or "noise robustness" against a text transcript.
 
+Voice agents especially need observability — latency, interruptions, and STT/TTS spans are exactly what makes voice failures diagnosable. Instrument per Step 4.5 above (both \`setupScenarioTracing()\` and the agent-under-test) before running. See \`langwatch scenario-docs voice/recipes/observability\` for voice-specific OTel guidance.
+
 ### Step 1: Read the voice docs
 
 \`\`\`bash
@@ -4093,6 +4192,7 @@ langwatch scenario-docs voice/choosing-an-adapter
 langwatch scenario-docs voice/capability-matrix
 langwatch scenario-docs voice/recipes/effects
 langwatch scenario-docs voice/recipes/multi-turn
+langwatch scenario-docs voice/recipes/observability
 \`\`\`
 
 Also browse the runnable voice examples:
@@ -4496,6 +4596,7 @@ Do NOT ask permission before Phase 1 and 2 — deliver value first. Do NOT ask g
 
 ### Code Approach
 
+- Do NOT write a scenario without instrumenting — a green run that emits no traces is half the value; call \`setupScenarioTracing()\` (run-level) and instrument the agent-under-test (\`langwatch.setup()\` / \`setupObservability\`) BEFORE running, and confirm traces appear in the LangWatch UI.
 - Do NOT create your own testing framework — \`@langwatch/scenario\` already handles simulation, judging, multi-turn, and tool-call verification
 - Do NOT write a \`main.py\` / \`run_scenarios.py\` / custom runner that loops over scenarios. Each scenario IS a test (\`it(...)\` / \`async def test_*\`) — run them with \`pytest\` or \`vitest\`. The test runner already gives you parallelism, retries of just the failing case, watch mode, CI integration, and per-test timeouts; a runner script re-implements all of that and ships with none of it wired up.
 - Do NOT invent a JSON / YAML / TOML "scenario DSL" with keys like \`{ "name": ..., "description": ..., "criteria": [...] }\` and then load it into a generic loop. The whole point of Scenario being code is that each test is real code: you can use \`for\`, \`if\`, parametrize (\`@pytest.mark.parametrize\`, \`it.each(...)\`), pull a fixture, call a helper to mint a session, branch by environment, share setup via a \`conftest.py\`, mock a tool inline — none of which a DSL gives you. The moment a teammate needs a new edge case ("only on Tuesdays the agent should escalate"), the DSL grows another key, then another, until it's a worse version of Python/TypeScript with none of the tooling. If the same boilerplate repeats across scenarios, extract a helper FUNCTION that returns an \`AgentAdapter\` / a built \`UserSimulatorAgent\` / a script tuple — keep each scenario its own test case so it stays grep-able and debuggable.
@@ -4513,6 +4614,7 @@ Do NOT ask permission before Phase 1 and 2 — deliver value first. Do NOT ask g
 
 ### Voice Agents
 
+- Do NOT skip observability on voice agents — latency, interruption, and STT/TTS spans are exactly what you need when a voice scenario fails; instrument before running (Step 4.5: \`setupScenarioTracing()\` + agent-under-test instrumentation) and verify traces emit in the LangWatch UI.
 - Do NOT write a text-only scenario when the user asked for voice — pick one of \`OpenAIRealtimeAgentAdapter\` / \`ElevenLabsAgentAdapter\` / \`PipecatAgentAdapter\` / \`GeminiLiveAgentAdapter\` / \`TwilioAgentAdapter\` / \`ComposableVoiceAgent\`
 - Do NOT instantiate \`OpenAIRealtimeAgentAdapter\` or \`GeminiLiveAgentAdapter\` with placeholder \`instructions=...\` / \`model=...\` / \`tools=...\` — those adapters ARE the agent, so a placeholder constructor tests OpenAI/Gemini defaults, not the user's agent. Either mirror the user's prod config exactly, or pick a different adapter (Pipecat/Twilio/ElevenLabs hosted) that connects to their already-deployed transport.
 - Do NOT point \`PipecatAgentAdapter(url=...)\` / \`ElevenLabsAgentAdapter(agent_id=...)\` / \`TwilioAgentAdapter\` at a transport the user hasn't deployed — those adapters only connect, they don't spin anything up. If the user is text-only and has no voice transport, say so and offer \`ComposableVoiceAgent\` as a voice wrapper around their existing text logic.

--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -720,6 +720,36 @@ audio_effects=[
 ]
 \`\`\`
 
+### TypeScript equivalents
+
+The same adapters, simulator voice, and effects are available in TypeScript via thin factory functions on the \`scenario\` object. Pick the adapter the same way (Step 2) — the mapping is one-to-one:
+
+| User's stack | TypeScript adapter |
+| --- | --- |
+| Pipecat / Twilio Media Streams WS bot | \`scenario.pipecatAgent({ url: "ws://<your-bot>/stream" })\` |
+| ElevenLabs hosted ConvAI agent | \`scenario.elevenLabsAgent({ agentId, apiKey })\` |
+| Twilio phone number (real PSTN) | \`scenario.twilioAgent({ accountSid, authToken, phoneNumber })\` |
+| Gemini Live model is the agent | \`scenario.geminiLiveAgent({ model, systemInstruction, voice })\` |
+| OpenAI Realtime model is the agent | \`scenario.openAIRealtimeAgent({ model, instructions, voice, tools })\` |
+| Text-only stack wrapped as voice | \`scenario.composableAgent({ stt, llm, tts })\` |
+
+Seed a voice on the simulator and layer effects the same way:
+
+\`\`\`typescript
+import scenario, { voice } from "@langwatch/scenario";
+
+scenario.userSimulatorAgent({
+  voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL", // Sarah — mature female
+  persona: "...",
+  audioEffects: [
+    voice.effects.backgroundNoise("cafe", 0.4), // presets: cafe / office / street / airport
+    voice.effects.phoneQuality(),               // mulaw + 8kHz + codec degradation
+  ],
+});
+\`\`\`
+
+For a full runnable TypeScript voice test, see the **Worked example (TypeScript)** below.
+
 ### Step 5: Tell the simulator it's on a phone, not in chat
 
 The default \`UserSimulatorAgent\` system prompt encodes a text-chat style ("very short inputs, few words, all lowercase, like talking to chatgpt") which TTS-renders robotic. Always nudge the persona toward natural spoken sentences:
@@ -834,7 +864,7 @@ async def test_realtime_greeting():
     assert result.success, result.reasoning
 \`\`\`
 
-### Worked example (TypeScript)
+### Worked example (TypeScript, OpenAI Realtime — adapter IS the agent, mirror prod config)
 
 \`\`\`typescript
 import scenario, { voice } from "@langwatch/scenario";
@@ -886,6 +916,65 @@ describe("Voice agent — angry billing", () => {
     });
     expect(result.success).toBe(true);
   }, 240_000);  // voice scenarios are slow — TTS + transport + multi-turn
+});
+\`\`\`
+
+### Worked example (TypeScript, Pipecat WS — adapter connects to the user's deployed bot)
+
+Use this shape when the user's voice bot is a **deployed Pipecat / Twilio Media Streams WebSocket** that is already reachable. The adapter only connects — it does NOT start the bot, so the bot must be running (a fixture, a staging deploy, or \`make bot\` in another terminal) when the test runs.
+
+\`\`\`typescript
+import scenario, { voice } from "@langwatch/scenario";
+import { describe, it, expect } from "vitest";
+
+// The user's Pipecat bot must be reachable at this URL when the test runs.
+// The adapter does NOT spin it up.
+const BOT_WS_URL = process.env.PIPECAT_BOT_URL ?? "ws://localhost:8765/stream";
+
+describe("Voice agent — angry billing (Pipecat WS)", () => {
+  it("acknowledges frustration before pivoting to logistics", async () => {
+    const result = await scenario.run({
+      name: "angry billing error in a noisy cafe",
+      description:
+        "Customer was double-charged and is calling from a noisy cafe. " +
+        "The agent must acknowledge the frustration before pivoting to " +
+        "logistics, stay calm, and queue a refund.",
+      agents: [
+        // Connects to the user's ALREADY-RUNNING bot over WebSocket.
+        scenario.pipecatAgent({
+          url: BOT_WS_URL,
+          audioFormat: "mulaw",
+          sampleRate: 8000,
+        }),
+        scenario.userSimulatorAgent({
+          voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
+          persona:
+            "You are SPEAKING ON A PHONE, not typing. Talk in natural " +
+            "spoken sentences. You were double-charged and you are FURIOUS. " +
+            "Use [shouting], [angry], [frustrated] markers every turn. " +
+            "1-2 short heated sentences per turn.",
+          audioEffects: [
+            voice.effects.backgroundNoise("cafe", 0.4),
+            voice.effects.phoneQuality(),
+          ],
+        }),
+        scenario.judgeAgent({
+          criteria: [
+            "The agent acknowledged the customer's frustration before asking for account info",
+            "The agent stayed calm — did not match the customer's hostility",
+            "The agent moved toward resolving the double charge",
+          ],
+        }),
+      ],
+      script: [
+        scenario.agent(), // the bot greets first (voice convention)
+        scenario.user(),  // heated opening
+        scenario.proceed(5),
+        scenario.judge(),
+      ],
+    });
+    expect(result.success).toBe(true);
+  }, 240_000); // voice scenarios are slow — TTS + transport + multi-turn
 });
 \`\`\`
 
@@ -2548,6 +2637,36 @@ audio_effects=[
 ]
 \`\`\`
 
+### TypeScript equivalents
+
+The same adapters, simulator voice, and effects are available in TypeScript via thin factory functions on the \`scenario\` object. Pick the adapter the same way (Step 2) — the mapping is one-to-one:
+
+| User's stack | TypeScript adapter |
+| --- | --- |
+| Pipecat / Twilio Media Streams WS bot | \`scenario.pipecatAgent({ url: "ws://<your-bot>/stream" })\` |
+| ElevenLabs hosted ConvAI agent | \`scenario.elevenLabsAgent({ agentId, apiKey })\` |
+| Twilio phone number (real PSTN) | \`scenario.twilioAgent({ accountSid, authToken, phoneNumber })\` |
+| Gemini Live model is the agent | \`scenario.geminiLiveAgent({ model, systemInstruction, voice })\` |
+| OpenAI Realtime model is the agent | \`scenario.openAIRealtimeAgent({ model, instructions, voice, tools })\` |
+| Text-only stack wrapped as voice | \`scenario.composableAgent({ stt, llm, tts })\` |
+
+Seed a voice on the simulator and layer effects the same way:
+
+\`\`\`typescript
+import scenario, { voice } from "@langwatch/scenario";
+
+scenario.userSimulatorAgent({
+  voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL", // Sarah — mature female
+  persona: "...",
+  audioEffects: [
+    voice.effects.backgroundNoise("cafe", 0.4), // presets: cafe / office / street / airport
+    voice.effects.phoneQuality(),               // mulaw + 8kHz + codec degradation
+  ],
+});
+\`\`\`
+
+For a full runnable TypeScript voice test, see the **Worked example (TypeScript)** below.
+
 ### Step 5: Tell the simulator it's on a phone, not in chat
 
 The default \`UserSimulatorAgent\` system prompt encodes a text-chat style ("very short inputs, few words, all lowercase, like talking to chatgpt") which TTS-renders robotic. Always nudge the persona toward natural spoken sentences:
@@ -2662,7 +2781,7 @@ async def test_realtime_greeting():
     assert result.success, result.reasoning
 \`\`\`
 
-### Worked example (TypeScript)
+### Worked example (TypeScript, OpenAI Realtime — adapter IS the agent, mirror prod config)
 
 \`\`\`typescript
 import scenario, { voice } from "@langwatch/scenario";
@@ -2714,6 +2833,65 @@ describe("Voice agent — angry billing", () => {
     });
     expect(result.success).toBe(true);
   }, 240_000);  // voice scenarios are slow — TTS + transport + multi-turn
+});
+\`\`\`
+
+### Worked example (TypeScript, Pipecat WS — adapter connects to the user's deployed bot)
+
+Use this shape when the user's voice bot is a **deployed Pipecat / Twilio Media Streams WebSocket** that is already reachable. The adapter only connects — it does NOT start the bot, so the bot must be running (a fixture, a staging deploy, or \`make bot\` in another terminal) when the test runs.
+
+\`\`\`typescript
+import scenario, { voice } from "@langwatch/scenario";
+import { describe, it, expect } from "vitest";
+
+// The user's Pipecat bot must be reachable at this URL when the test runs.
+// The adapter does NOT spin it up.
+const BOT_WS_URL = process.env.PIPECAT_BOT_URL ?? "ws://localhost:8765/stream";
+
+describe("Voice agent — angry billing (Pipecat WS)", () => {
+  it("acknowledges frustration before pivoting to logistics", async () => {
+    const result = await scenario.run({
+      name: "angry billing error in a noisy cafe",
+      description:
+        "Customer was double-charged and is calling from a noisy cafe. " +
+        "The agent must acknowledge the frustration before pivoting to " +
+        "logistics, stay calm, and queue a refund.",
+      agents: [
+        // Connects to the user's ALREADY-RUNNING bot over WebSocket.
+        scenario.pipecatAgent({
+          url: BOT_WS_URL,
+          audioFormat: "mulaw",
+          sampleRate: 8000,
+        }),
+        scenario.userSimulatorAgent({
+          voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
+          persona:
+            "You are SPEAKING ON A PHONE, not typing. Talk in natural " +
+            "spoken sentences. You were double-charged and you are FURIOUS. " +
+            "Use [shouting], [angry], [frustrated] markers every turn. " +
+            "1-2 short heated sentences per turn.",
+          audioEffects: [
+            voice.effects.backgroundNoise("cafe", 0.4),
+            voice.effects.phoneQuality(),
+          ],
+        }),
+        scenario.judgeAgent({
+          criteria: [
+            "The agent acknowledged the customer's frustration before asking for account info",
+            "The agent stayed calm — did not match the customer's hostility",
+            "The agent moved toward resolving the double charge",
+          ],
+        }),
+      ],
+      script: [
+        scenario.agent(), // the bot greets first (voice convention)
+        scenario.user(),  // heated opening
+        scenario.proceed(5),
+        scenario.judge(),
+      ],
+    });
+    expect(result.success).toBe(true);
+  }, 240_000); // voice scenarios are slow — TTS + transport + multi-turn
 });
 \`\`\`
 
@@ -3963,6 +4141,36 @@ audio_effects=[
 ]
 \`\`\`
 
+### TypeScript equivalents
+
+The same adapters, simulator voice, and effects are available in TypeScript via thin factory functions on the \`scenario\` object. Pick the adapter the same way (Step 2) — the mapping is one-to-one:
+
+| User's stack | TypeScript adapter |
+| --- | --- |
+| Pipecat / Twilio Media Streams WS bot | \`scenario.pipecatAgent({ url: "ws://<your-bot>/stream" })\` |
+| ElevenLabs hosted ConvAI agent | \`scenario.elevenLabsAgent({ agentId, apiKey })\` |
+| Twilio phone number (real PSTN) | \`scenario.twilioAgent({ accountSid, authToken, phoneNumber })\` |
+| Gemini Live model is the agent | \`scenario.geminiLiveAgent({ model, systemInstruction, voice })\` |
+| OpenAI Realtime model is the agent | \`scenario.openAIRealtimeAgent({ model, instructions, voice, tools })\` |
+| Text-only stack wrapped as voice | \`scenario.composableAgent({ stt, llm, tts })\` |
+
+Seed a voice on the simulator and layer effects the same way:
+
+\`\`\`typescript
+import scenario, { voice } from "@langwatch/scenario";
+
+scenario.userSimulatorAgent({
+  voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL", // Sarah — mature female
+  persona: "...",
+  audioEffects: [
+    voice.effects.backgroundNoise("cafe", 0.4), // presets: cafe / office / street / airport
+    voice.effects.phoneQuality(),               // mulaw + 8kHz + codec degradation
+  ],
+});
+\`\`\`
+
+For a full runnable TypeScript voice test, see the **Worked example (TypeScript)** below.
+
 ### Step 5: Tell the simulator it's on a phone, not in chat
 
 The default \`UserSimulatorAgent\` system prompt encodes a text-chat style ("very short inputs, few words, all lowercase, like talking to chatgpt") which TTS-renders robotic. Always nudge the persona toward natural spoken sentences:
@@ -4077,7 +4285,7 @@ async def test_realtime_greeting():
     assert result.success, result.reasoning
 \`\`\`
 
-### Worked example (TypeScript)
+### Worked example (TypeScript, OpenAI Realtime — adapter IS the agent, mirror prod config)
 
 \`\`\`typescript
 import scenario, { voice } from "@langwatch/scenario";
@@ -4129,6 +4337,65 @@ describe("Voice agent — angry billing", () => {
     });
     expect(result.success).toBe(true);
   }, 240_000);  // voice scenarios are slow — TTS + transport + multi-turn
+});
+\`\`\`
+
+### Worked example (TypeScript, Pipecat WS — adapter connects to the user's deployed bot)
+
+Use this shape when the user's voice bot is a **deployed Pipecat / Twilio Media Streams WebSocket** that is already reachable. The adapter only connects — it does NOT start the bot, so the bot must be running (a fixture, a staging deploy, or \`make bot\` in another terminal) when the test runs.
+
+\`\`\`typescript
+import scenario, { voice } from "@langwatch/scenario";
+import { describe, it, expect } from "vitest";
+
+// The user's Pipecat bot must be reachable at this URL when the test runs.
+// The adapter does NOT spin it up.
+const BOT_WS_URL = process.env.PIPECAT_BOT_URL ?? "ws://localhost:8765/stream";
+
+describe("Voice agent — angry billing (Pipecat WS)", () => {
+  it("acknowledges frustration before pivoting to logistics", async () => {
+    const result = await scenario.run({
+      name: "angry billing error in a noisy cafe",
+      description:
+        "Customer was double-charged and is calling from a noisy cafe. " +
+        "The agent must acknowledge the frustration before pivoting to " +
+        "logistics, stay calm, and queue a refund.",
+      agents: [
+        // Connects to the user's ALREADY-RUNNING bot over WebSocket.
+        scenario.pipecatAgent({
+          url: BOT_WS_URL,
+          audioFormat: "mulaw",
+          sampleRate: 8000,
+        }),
+        scenario.userSimulatorAgent({
+          voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
+          persona:
+            "You are SPEAKING ON A PHONE, not typing. Talk in natural " +
+            "spoken sentences. You were double-charged and you are FURIOUS. " +
+            "Use [shouting], [angry], [frustrated] markers every turn. " +
+            "1-2 short heated sentences per turn.",
+          audioEffects: [
+            voice.effects.backgroundNoise("cafe", 0.4),
+            voice.effects.phoneQuality(),
+          ],
+        }),
+        scenario.judgeAgent({
+          criteria: [
+            "The agent acknowledged the customer's frustration before asking for account info",
+            "The agent stayed calm — did not match the customer's hostility",
+            "The agent moved toward resolving the double charge",
+          ],
+        }),
+      ],
+      script: [
+        scenario.agent(), // the bot greets first (voice convention)
+        scenario.user(),  // heated opening
+        scenario.proceed(5),
+        scenario.judge(),
+      ],
+    });
+    expect(result.success).toBe(true);
+  }, 240_000); // voice scenarios are slow — TTS + transport + multi-turn
 });
 \`\`\`
 

--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -477,7 +477,7 @@ CRITICAL: Do NOT guess how to write scenario tests. Different frameworks have di
 ### Step 2: Install the Scenario SDK
 
 For Python: \`pip install langwatch-scenario pytest pytest-asyncio\` (or \`uv add ...\`).
-For TypeScript: \`npm install @langwatch/scenario vitest @ai-sdk/openai\` (or \`pnpm add ...\`).
+For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest @ai-sdk/openai\` (or \`pnpm add ...\`). The voice adapter factories (\`openAIRealtimeAgent\`, \`pipecatAgent\`, etc.) and \`voice.effects\` require \`@langwatch/scenario\` >= 0.4.12 — earlier versions only expose the lower-level \`RealtimeAgentAdapter\` class.
 
 ### Step 3: Configure the Default Model
 
@@ -2394,7 +2394,7 @@ CRITICAL: Do NOT guess how to write scenario tests. Different frameworks have di
 ### Step 2: Install the Scenario SDK
 
 For Python: \`pip install langwatch-scenario pytest pytest-asyncio\` (or \`uv add ...\`).
-For TypeScript: \`npm install @langwatch/scenario vitest @ai-sdk/openai\` (or \`pnpm add ...\`).
+For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest @ai-sdk/openai\` (or \`pnpm add ...\`). The voice adapter factories (\`openAIRealtimeAgent\`, \`pipecatAgent\`, etc.) and \`voice.effects\` require \`@langwatch/scenario\` >= 0.4.12 — earlier versions only expose the lower-level \`RealtimeAgentAdapter\` class.
 
 ### Step 3: Configure the Default Model
 
@@ -3898,7 +3898,7 @@ CRITICAL: Do NOT guess how to write scenario tests. Different frameworks have di
 ### Step 2: Install the Scenario SDK
 
 For Python: \`pip install langwatch-scenario pytest pytest-asyncio\` (or \`uv add ...\`).
-For TypeScript: \`npm install @langwatch/scenario vitest @ai-sdk/openai\` (or \`pnpm add ...\`).
+For TypeScript: \`npm install @langwatch/scenario@^0.4.12 vitest @ai-sdk/openai\` (or \`pnpm add ...\`). The voice adapter factories (\`openAIRealtimeAgent\`, \`pipecatAgent\`, etc.) and \`voice.effects\` require \`@langwatch/scenario\` >= 0.4.12 — earlier versions only expose the lower-level \`RealtimeAgentAdapter\` class.
 
 ### Step 3: Configure the Default Model
 

--- a/skills/.npmrc
+++ b/skills/.npmrc
@@ -1,1 +1,2 @@
 minimum-release-age=10080
+minimum-release-age-exclude=@langwatch/scenario

--- a/skills/_tests/fixtures/typescript-voice/index.ts
+++ b/skills/_tests/fixtures/typescript-voice/index.ts
@@ -1,0 +1,18 @@
+import { OpenAIRealtimeWebSocket } from "openai/beta/realtime/websocket";
+
+// A minimal voice agent: connects to OpenAI's Realtime API over WebSocket and
+// streams audio in/out. This is the user's *deployed voice transport* — the
+// thing a voice scenario test must drive with real audio, not a text transcript.
+const VOICE = "alloy";
+const INSTRUCTIONS = "You are a friendly phone support agent. Greet the caller, then help with billing questions.";
+
+export async function createVoiceAgent() {
+  const rt = new OpenAIRealtimeWebSocket({ model: "gpt-realtime-mini" });
+  rt.socket.addEventListener("open", () => {
+    rt.send({
+      type: "session.update",
+      session: { voice: VOICE, instructions: INSTRUCTIONS, modalities: ["audio", "text"] },
+    });
+  });
+  return rt;
+}

--- a/skills/_tests/fixtures/typescript-voice/index.ts
+++ b/skills/_tests/fixtures/typescript-voice/index.ts
@@ -7,7 +7,7 @@ const VOICE = "alloy";
 const INSTRUCTIONS = "You are a friendly phone support agent. Greet the caller, then help with billing questions.";
 
 export async function createVoiceAgent() {
-  const rt = new OpenAIRealtimeWebSocket({ model: "gpt-realtime-mini" });
+  const rt = new OpenAIRealtimeWebSocket({ model: "gpt-4o-realtime-preview" });
   rt.socket.addEventListener("open", () => {
     rt.send({
       type: "session.update",

--- a/skills/_tests/scenarios.scenario.test.ts
+++ b/skills/_tests/scenarios.scenario.test.ts
@@ -789,4 +789,73 @@ describe("Scenarios Skill", () => {
     },
     900_000
   );
+
+  it.skipIf(isCI)(
+    "creates voice scenario tests for a TypeScript voice agent",
+    async () => {
+      const tempFolder = fs.mkdtempSync(
+        path.join(os.tmpdir(), "langwatch-skill-scenario-test-ts-voice-")
+      );
+
+      execSync(
+        `cp -r ${path.resolve(__dirname, "fixtures/typescript-voice")}/* ${tempFolder}/`
+      );
+      copySkillToWorkDir(tempFolder);
+
+      const result = await scenario.run({
+        setId: SKILL_TESTS_SET_ID,
+        name: "TypeScript voice agent scenario tests",
+        description:
+          "Adding voice scenario tests to a TypeScript OpenAI Realtime voice agent project using the LangWatch Scenario framework's voice adapters.",
+        agents: [
+          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          scenario.userSimulatorAgent({ model: judgeModel }),
+          scenario.judgeAgent({
+            model: judgeModel,
+            criteria: [
+              "Agent created voice scenario test files using the LangWatch Scenario framework's voice support",
+              "Agent used a voice adapter (openAIRealtimeAgent / pipecatAgent / elevenLabsAgent / composableAgent) rather than a plain text agent",
+              "Agent used the `langwatch scenario-docs voice/...` CLI command to read the voice docs",
+            ],
+          }),
+        ],
+        script: [
+          scenario.user(
+            "add agent simulation tests for my voice agent. It's a voice bot, so the tests need to drive real audio, not text."
+          ),
+          scenario.agent(),
+          (state) => {
+            toolCallFix(state);
+            assertSkillWasRead(state, "scenarios");
+
+            const testFiles = findTestFiles(tempFolder, /\.(test|spec)\.ts$/);
+            expect(
+              testFiles.length,
+              `Expected at least one .test.ts or .spec.ts file in ${tempFolder}`
+            ).toBeGreaterThan(0);
+
+            const testContent = testFiles
+              .map((f) => fs.readFileSync(f, "utf8"))
+              .join("\n");
+
+            expect(testContent).toContain("@langwatch/scenario");
+            expect(testContent).toMatch(/scenario\.run\(/);
+
+            // Verify a voice adapter is used rather than a plain text agent
+            expect(testContent).toMatch(
+              /(openAIRealtimeAgent|pipecatAgent|elevenLabsAgent|geminiLiveAgent|twilioAgent|composableAgent)/
+            );
+
+            // Verify the simulator was configured with a voice
+            expect(testContent).toMatch(/voice\s*:/);
+          },
+          scenario.judge(),
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    },
+    900_000
+  );
+
 });

--- a/skills/_tests/scenarios.scenario.test.ts
+++ b/skills/_tests/scenarios.scenario.test.ts
@@ -814,7 +814,7 @@ describe("Scenarios Skill", () => {
             model: judgeModel,
             criteria: [
               "Agent created voice scenario test files using the LangWatch Scenario framework's voice support",
-              "Agent used a voice adapter (openAIRealtimeAgent / pipecatAgent / elevenLabsAgent / composableAgent) rather than a plain text agent",
+              "Agent used a voice adapter (openAIRealtimeAgent / pipecatAgent / elevenLabsAgent / geminiLiveAgent / twilioAgent / composableAgent) rather than a plain text agent",
               "Agent used the `langwatch scenario-docs voice/...` CLI command to read the voice docs",
             ],
           }),
@@ -841,7 +841,7 @@ describe("Scenarios Skill", () => {
             expect(testContent).toContain("@langwatch/scenario");
             expect(testContent).toMatch(/scenario\.run\(/);
 
-            // Guard against home-rolled test frameworks (mirrors Python voice test)
+            // Guard against home-rolled test frameworks instead of @langwatch/scenario
             expect(testContent).not.toMatch(
               /from\s+["'](?:agent-tester|simulation-framework|voice-test-framework|langwatch-testing)["']/
             );
@@ -859,7 +859,7 @@ describe("Scenarios Skill", () => {
               testContent,
               'Expected userSimulatorAgent({ voice: "openai/..." | "elevenlabs/..." }) so the simulated caller speaks'
             ).toMatch(
-              /userSimulatorAgent\s*\(\s*\{[\s\S]*?voice\s*:\s*["'](?:elevenlabs|openai)\/[^"']+["']/
+              /userSimulatorAgent\s*\(\s*\{[^}]*?voice\s*:\s*["'](?:elevenlabs|openai)\/[^"']+["']/
             );
           },
           scenario.judge(),

--- a/skills/_tests/scenarios.scenario.test.ts
+++ b/skills/_tests/scenarios.scenario.test.ts
@@ -841,13 +841,26 @@ describe("Scenarios Skill", () => {
             expect(testContent).toContain("@langwatch/scenario");
             expect(testContent).toMatch(/scenario\.run\(/);
 
-            // Verify a voice adapter is used rather than a plain text agent
-            expect(testContent).toMatch(
-              /(openAIRealtimeAgent|pipecatAgent|elevenLabsAgent|geminiLiveAgent|twilioAgent|composableAgent)/
+            // Guard against home-rolled test frameworks (mirrors Python voice test)
+            expect(testContent).not.toMatch(
+              /from\s+["'](?:agent-tester|simulation-framework|voice-test-framework|langwatch-testing)["']/
             );
 
-            // Verify the simulator was configured with a voice
-            expect(testContent).toMatch(/voice\s*:/);
+            // Verify a voice adapter factory is CALLED (not just mentioned in a comment)
+            expect(
+              testContent,
+              "Expected the test to call a voice adapter factory (openAIRealtimeAgent / pipecatAgent / elevenLabsAgent / geminiLiveAgent / twilioAgent / composableAgent) — bare mentions in comments or string literals do not count."
+            ).toMatch(
+              /\b(?:scenario\.)?(?:openAIRealtimeAgent|pipecatAgent|elevenLabsAgent|geminiLiveAgent|twilioAgent|composableAgent)\s*\(/
+            );
+
+            // Verify the simulator was configured with a voice inside the userSimulatorAgent call
+            expect(
+              testContent,
+              'Expected userSimulatorAgent({ voice: "openai/..." | "elevenlabs/..." }) so the simulated caller speaks'
+            ).toMatch(
+              /userSimulatorAgent\s*\(\s*\{[\s\S]*?voice\s*:\s*["'](?:elevenlabs|openai)\/[^"']+["']/
+            );
           },
           scenario.judge(),
         ],
@@ -855,7 +868,7 @@ describe("Scenarios Skill", () => {
 
       expect(result.success).toBe(true);
     },
-    900_000
+    1_800_000
   );
 
 });

--- a/skills/_tests/voice-factories.test.ts
+++ b/skills/_tests/voice-factories.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import scenario, { voice } from "@langwatch/scenario";
+
+describe("voice factory surface (documented in scenarios skill)", () => {
+  it("constructs every voice adapter factory the skill documents", () => {
+    // pipecatAgent — connects to a Pipecat WebSocket server; no network at construction
+    const pipecat = scenario.pipecatAgent({ url: "ws://localhost:8765/stream" });
+    expect(pipecat).toBeDefined();
+
+    // openAIRealtimeAgent — wraps OpenAI realtime session; no network at construction
+    const openaiRealtime = scenario.openAIRealtimeAgent({ voice: "alloy" });
+    expect(openaiRealtime).toBeDefined();
+
+    // geminiLiveAgent — wraps Gemini Live session; no network at construction
+    const geminiLive = scenario.geminiLiveAgent({ model: "gemini-2.5-flash" });
+    expect(geminiLive).toBeDefined();
+
+    // elevenLabsAgent — connects to ElevenLabs ConvAI; no network at construction
+    const elevenLabs = scenario.elevenLabsAgent({ agentId: "x", apiKey: "y" });
+    expect(elevenLabs).toBeDefined();
+
+    // twilioAgent — Twilio-based PSTN adapter; no network at construction
+    const twilio = scenario.twilioAgent({
+      accountSid: "a",
+      authToken: "b",
+      phoneNumber: "+10000000000",
+    });
+    expect(twilio).toBeDefined();
+
+    // composableAgent — STT→LLM→TTS pipeline; constructor only assigns, no validation
+    // stt and llm are typed non-optional but the constructor does not validate at
+    // runtime (it assigns options.stt / options.llm directly). Passing undefined is
+    // safe at construction; errors only surface when the adapter actually runs.
+    const composable = scenario.composableAgent({
+      stt: undefined as any,
+      llm: undefined as any,
+      tts: "openai/nova",
+    });
+    expect(composable).toBeDefined();
+  });
+
+  it("exposes voice.effects helpers the skill documents", () => {
+    // voice.effects is the effects namespace re-exported under the voice namespace
+    expect(typeof voice.effects.backgroundNoise).toBe("function");
+    expect(typeof voice.effects.phoneQuality).toBe("function");
+
+    // Each call returns an EffectFn (a function the voice executor applies to
+    // TTS audio). Just calling the factory should return a defined value.
+    const bgNoise = voice.effects.backgroundNoise("cafe", 0.4);
+    expect(bgNoise).toBeDefined();
+
+    const phoneQuality = voice.effects.phoneQuality();
+    expect(phoneQuality).toBeDefined();
+  });
+
+  it("userSimulatorAgent accepts a voice option", () => {
+    const sim = scenario.userSimulatorAgent({ voice: "openai/nova" });
+    expect(sim).toBeDefined();
+  });
+});

--- a/skills/_tests/voice-factories.test.ts
+++ b/skills/_tests/voice-factories.test.ts
@@ -1,51 +1,42 @@
 import { describe, expect, it } from "vitest";
 import scenario, { voice } from "@langwatch/scenario";
+import { openai } from "@ai-sdk/openai";
 
 describe("voice factory surface (documented in scenarios skill)", () => {
-  it("constructs every voice adapter factory the skill documents", () => {
-    // pipecatAgent — connects to a Pipecat WebSocket server; no network at construction
-    const pipecat = scenario.pipecatAgent({ url: "ws://localhost:8765/stream" });
-    expect(pipecat).toBeDefined();
+  it.each([
+    ["pipecatAgent", () => scenario.pipecatAgent({ url: "ws://localhost:8765/stream" })],
+    ["openAIRealtimeAgent", () => scenario.openAIRealtimeAgent({ voice: "alloy" })],
+    ["geminiLiveAgent", () => scenario.geminiLiveAgent({ model: "gemini-2.5-flash" })],
+    [
+      "elevenLabsAgent",
+      () => scenario.elevenLabsAgent({ agentId: "x", apiKey: "y" }),
+    ],
+    [
+      "twilioAgent",
+      () =>
+        scenario.twilioAgent({
+          accountSid: "a",
+          authToken: "b",
+          phoneNumber: "+10000000000",
+        }),
+    ],
+  ])("constructs %s without network", (_name, factory) => {
+    expect(factory()).toBeDefined();
+  });
 
-    // openAIRealtimeAgent — wraps OpenAI realtime session; no network at construction
-    const openaiRealtime = scenario.openAIRealtimeAgent({ voice: "alloy" });
-    expect(openaiRealtime).toBeDefined();
-
-    // geminiLiveAgent — wraps Gemini Live session; no network at construction
-    const geminiLive = scenario.geminiLiveAgent({ model: "gemini-2.5-flash" });
-    expect(geminiLive).toBeDefined();
-
-    // elevenLabsAgent — connects to ElevenLabs ConvAI; no network at construction
-    const elevenLabs = scenario.elevenLabsAgent({ agentId: "x", apiKey: "y" });
-    expect(elevenLabs).toBeDefined();
-
-    // twilioAgent — Twilio-based PSTN adapter; no network at construction
-    const twilio = scenario.twilioAgent({
-      accountSid: "a",
-      authToken: "b",
-      phoneNumber: "+10000000000",
-    });
-    expect(twilio).toBeDefined();
-
-    // composableAgent — STT→LLM→TTS pipeline; constructor only assigns, no validation
-    // stt and llm are typed non-optional but the constructor does not validate at
-    // runtime (it assigns options.stt / options.llm directly). Passing undefined is
-    // safe at construction; errors only surface when the adapter actually runs.
+  it("constructs composableAgent with documented stt/llm/tts values", () => {
     const composable = scenario.composableAgent({
-      stt: undefined as any,
-      llm: undefined as any,
+      stt: "openai/whisper-1",
+      llm: openai("gpt-5-mini"),
       tts: "openai/nova",
     });
     expect(composable).toBeDefined();
   });
 
   it("exposes voice.effects helpers the skill documents", () => {
-    // voice.effects is the effects namespace re-exported under the voice namespace
     expect(typeof voice.effects.backgroundNoise).toBe("function");
     expect(typeof voice.effects.phoneQuality).toBe("function");
 
-    // Each call returns an EffectFn (a function the voice executor applies to
-    // TTS audio). Just calling the factory should return a defined value.
     const bgNoise = voice.effects.backgroundNoise("cafe", 0.4);
     expect(bgNoise).toBeDefined();
 

--- a/skills/package.json
+++ b/skills/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.44",
     "@ai-sdk/openai": "^3.0.41",
-    "@langwatch/scenario": "^0.4.6",
+    "@langwatch/scenario": "^0.4.12",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.0.0",
     "chalk": "^5.6.2",

--- a/skills/pnpm-lock.yaml
+++ b/skills/pnpm-lock.yaml
@@ -3416,7 +3416,7 @@ snapshots:
       form-data-encoder: 4.1.0
       formdata-node: 6.0.3
       node-fetch: 2.7.0
-      qs: 6.15.1
+      qs: 6.15.2
       readable-stream: 4.7.0
       url-join: 4.0.1
     transitivePeerDependencies:

--- a/skills/pnpm-lock.yaml
+++ b/skills/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^3.0.41
         version: 3.0.53(zod@4.3.6)
       '@langwatch/scenario':
-        specifier: ^0.4.6
-        version: 0.4.11(290e80c3beebead1d750ed2db7f9b58e)
+        specifier: ^0.4.12
+        version: 0.4.12(61c975305ec95277a024a49e0bcf0a04)
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -103,6 +103,10 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@derhuerst/http-basic@8.2.4':
+    resolution: {integrity: sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==}
+    engines: {node: '>=6.0.0'}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -327,12 +331,16 @@ packages:
     peerDependencies:
       '@langchain/core': '>=0.2.21 <0.4.0'
 
-  '@langwatch/scenario@0.4.11':
-    resolution: {integrity: sha512-fq+GJVu4BuTo0vC9CxfwXZgufH8CG9Ogha6Kau5JEPacqDP4Zf0RJbO3wVZTdniPgLVdK+rAzOr7jTZ2Che6IA==}
+  '@langwatch/scenario@0.4.12':
+    resolution: {integrity: sha512-iygL436uG3dt3yDc9FIrHXNxC/QJW10kuj9mwdPm8Ul1QLARNfpUmJDLtCV8tXyg/vFZzTaO4cNQPd75qu3udg==}
     engines: {node: '>=20', pnpm: '>=8'}
     peerDependencies:
+      '@google/genai': '>=2.0.0'
       ai: '>=6.0.0'
       vitest: '>=3.2.4'
+    peerDependenciesMeta:
+      '@google/genai':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -806,6 +814,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@10.17.60':
+    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -857,6 +868,10 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -875,6 +890,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   ai@6.0.168:
     resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
@@ -912,6 +931,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -925,8 +947,14 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -947,6 +975,9 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1001,6 +1032,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  command-exists@1.2.9:
+    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
+
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -1008,6 +1046,10 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -1067,6 +1109,10 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1089,12 +1135,20 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  elevenlabs@1.59.0:
+    resolution: {integrity: sha512-OVKOd+lxNya8h4Rn5fcjv00Asd+DGWfTT6opGrQ16sTI+1HwdLn/kYtjl8tRMhDXbNmksD/9SBRKjb9neiUuVg==}
+    deprecated: This package has moved to @elevenlabs/elevenlabs-js
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1109,6 +1163,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
@@ -1140,8 +1198,16 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -1150,6 +1216,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1186,13 +1256,32 @@ packages:
       picomatch:
         optional: true
 
+  ffmpeg-static@5.3.0:
+    resolution: {integrity: sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==}
+    engines: {node: '>=16'}
+
+  fft.js@4.0.4:
+    resolution: {integrity: sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  form-data-encoder@4.1.0:
+    resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
+    engines: {node: '>= 18'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  formdata-node@6.0.3:
+    resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
+    engines: {node: '>= 18'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1222,6 +1311,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
@@ -1237,6 +1330,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -1248,6 +1345,17 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-response-object@3.0.2:
+    resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1310,6 +1418,10 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -1502,6 +1614,9 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
@@ -1589,8 +1704,16 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -1623,8 +1746,21 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-pty@1.1.0:
     resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1705,6 +1841,9 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
+  parse-cache-control@1.0.1:
+    resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -1741,6 +1880,14 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -1768,6 +1915,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -1901,6 +2052,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1924,6 +2079,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -1938,6 +2096,9 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1968,6 +2129,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2070,6 +2234,12 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2087,8 +2257,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2192,6 +2362,13 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1': {}
 
+  '@derhuerst/http-basic@8.2.4':
+    dependencies:
+      caseless: 0.12.0
+      concat-stream: 2.0.0
+      http-response-object: 3.0.2
+      parse-cache-control: 1.0.1
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -2291,14 +2468,14 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -2312,25 +2489,25 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       uuid: 11.1.1
 
-  '@langchain/langgraph-sdk@0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/langgraph-sdk@0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 11.1.1
     optionalDependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
 
-  '@langchain/langgraph@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(zod-to-json-schema@3.25.2(zod@4.3.6))':
+  '@langchain/langgraph@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
-      '@langchain/langgraph-sdk': 0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': 0.1.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+      '@langchain/langgraph-sdk': 0.1.10(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       uuid: 11.1.1
       zod: 3.25.76
     optionalDependencies:
@@ -2339,32 +2516,37 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)':
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       js-tiktoken: 1.0.21
-      openai: 5.12.2(ws@8.20.0)(zod@3.25.76)
+      openai: 5.12.2(ws@8.21.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       js-tiktoken: 1.0.21
 
-  '@langwatch/scenario@0.4.11(290e80c3beebead1d750ed2db7f9b58e)':
+  '@langwatch/scenario@0.4.12(61c975305ec95277a024a49e0bcf0a04)':
     dependencies:
       '@ag-ui/core': 0.0.28
       '@ai-sdk/openai': 3.0.53(zod@3.25.76)
-      '@openai/agents': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+      '@openai/agents': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)
       '@opentelemetry/sdk-node': 0.212.0(@opentelemetry/api@1.9.1)
       ai: 6.0.168(zod@4.3.6)
       chalk: 5.6.2
-      langwatch: 0.16.1(f5647be982eccf4a1c844c02f0e5e05e)
+      elevenlabs: 1.59.0
+      ffmpeg-static: 5.3.0
+      fft.js: 4.0.4
+      langwatch: 0.16.1(545066c634d102e0cf72f9775458e333)
       open: 11.0.0
+      openai: 6.34.0(ws@8.21.0)(zod@3.25.76)
       rxjs: 7.8.2
       vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))
+      ws: 8.21.0
       xksuid: 0.0.4
       zod: 3.25.76
     transitivePeerDependencies:
@@ -2377,10 +2559,10 @@ snapshots:
       - '@opentelemetry/context-zone'
       - '@opentelemetry/sdk-trace-web'
       - bufferutil
+      - encoding
       - langchain
       - supports-color
       - utf-8-validate
-      - ws
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
@@ -2407,10 +2589,10 @@ snapshots:
       - supports-color
     optional: true
 
-  '@openai/agents-core@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)':
+  '@openai/agents-core@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)':
     dependencies:
       debug: 4.4.3
-      openai: 6.34.0(ws@8.20.0)(zod@3.25.76)
+      openai: 6.34.0(ws@8.21.0)(zod@3.25.76)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       zod: 3.25.76
@@ -2419,11 +2601,11 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)':
+  '@openai/agents-openai@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.34.0(ws@8.20.0)(zod@3.25.76)
+      openai: 6.34.0(ws@8.21.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -2432,10 +2614,10 @@ snapshots:
 
   '@openai/agents-realtime@0.3.9(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)
       '@types/ws': 8.18.1
       debug: 4.4.3
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -2443,13 +2625,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@openai/agents@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)':
+  '@openai/agents@0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)':
     dependencies:
-      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
-      '@openai/agents-openai': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@3.25.76)
+      '@openai/agents-core': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)
+      '@openai/agents-openai': 0.3.9(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@3.25.76)
       '@openai/agents-realtime': 0.3.9(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       debug: 4.4.3
-      openai: 6.34.0(ws@8.20.0)(zod@3.25.76)
+      openai: 6.34.0(ws@8.21.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -2914,6 +3096,8 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@10.17.60': {}
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -2976,6 +3160,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2991,6 +3179,12 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   ai@6.0.168(zod@4.3.6):
     dependencies:
@@ -3025,6 +3219,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   bail@2.0.2: {}
 
   base64-js@1.5.1: {}
@@ -3050,7 +3246,14 @@ snapshots:
       - supports-color
     optional: true
 
+  buffer-from@1.1.2: {}
+
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -3066,15 +3269,15 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    optional: true
 
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-    optional: true
 
   camelcase@6.3.0: {}
+
+  caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
@@ -3117,9 +3320,22 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  command-exists@1.2.9: {}
+
   commander@10.0.1: {}
 
   commander@12.1.0: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   content-disposition@1.1.0:
     optional: true
@@ -3146,7 +3362,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    optional: true
 
   debug@4.4.3:
     dependencies:
@@ -3171,6 +3386,8 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0:
     optional: true
 
@@ -3187,28 +3404,47 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
   ee-first@1.1.1:
     optional: true
+
+  elevenlabs@1.59.0:
+    dependencies:
+      command-exists: 1.2.9
+      execa: 5.1.1
+      form-data: 4.0.5
+      form-data-encoder: 4.1.0
+      formdata-node: 6.0.3
+      node-fetch: 2.7.0
+      qs: 6.15.1
+      readable-stream: 4.7.0
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - encoding
 
   emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0:
     optional: true
 
-  es-define-property@1.0.1:
-    optional: true
+  env-paths@2.2.1: {}
 
-  es-errors@1.3.0:
-    optional: true
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
 
   es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-    optional: true
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -3260,7 +3496,11 @@ snapshots:
   etag@1.8.1:
     optional: true
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@4.0.7: {}
+
+  events@3.3.0: {}
 
   eventsource-parser@3.0.8: {}
 
@@ -3268,6 +3508,18 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.8
     optional: true
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
 
   expect-type@1.3.0: {}
 
@@ -3327,6 +3579,17 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  ffmpeg-static@5.3.0:
+    dependencies:
+      '@derhuerst/http-basic': 8.2.4
+      env-paths: 2.2.1
+      https-proxy-agent: 5.0.1
+      progress: 2.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  fft.js@4.0.4: {}
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -3339,7 +3602,19 @@ snapshots:
       - supports-color
     optional: true
 
+  form-data-encoder@4.1.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   format@0.2.2: {}
+
+  formdata-node@6.0.3: {}
 
   forwarded@0.2.0:
     optional: true
@@ -3350,8 +3625,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2:
-    optional: true
+  function-bind@1.1.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -3367,30 +3641,31 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.3
       math-intrinsics: 1.1.0
-    optional: true
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    optional: true
+
+  get-stream@6.0.1: {}
 
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  gopd@1.2.0:
-    optional: true
+  gopd@1.2.0: {}
 
   has-flag@4.0.0: {}
 
-  has-symbols@1.1.0:
-    optional: true
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
-    optional: true
 
   hono@4.12.23:
     optional: true
@@ -3403,6 +3678,19 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
     optional: true
+
+  http-response-object@3.0.2:
+    dependencies:
+      '@types/node': 10.17.60
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  human-signals@2.1.0: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -3454,14 +3742,15 @@ snapshots:
   is-promise@4.0.0:
     optional: true
 
+  is-stream@2.0.1: {}
+
   is-unicode-supported@0.1.0: {}
 
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
-  isexe@2.0.0:
-    optional: true
+  isexe@2.0.0: {}
 
   jose@6.2.2:
     optional: true
@@ -3486,15 +3775,15 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
+  langchain@0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0):
     dependencies:
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       js-tiktoken: 1.0.21
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
-      langsmith: 0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 11.1.1
@@ -3507,22 +3796,22 @@ snapshots:
       - openai
       - ws
 
-  langsmith@0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
+  langsmith@0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.212.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
-      openai: 6.34.0(ws@8.20.0)(zod@4.3.6)
-      ws: 8.20.0
+      openai: 6.34.0(ws@8.21.0)(zod@4.3.6)
+      ws: 8.21.0
 
-  langwatch@0.16.1(f5647be982eccf4a1c844c02f0e5e05e):
+  langwatch@0.16.1(545066c634d102e0cf72f9775458e333):
     dependencies:
       '@ai-sdk/openai': 3.0.53(zod@4.3.6)
-      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(zod-to-json-schema@3.25.2(zod@4.3.6))
-      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/langgraph': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))
+      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.205.0
       '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.1)
@@ -3543,7 +3832,7 @@ snapshots:
       commander: 12.1.0
       dotenv: 17.4.2
       js-yaml: 4.1.1
-      langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langchain: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.212.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       liquidjs: 10.27.0
       open: 11.0.0
       openapi-fetch: 0.16.0
@@ -3573,8 +3862,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  math-intrinsics@1.1.0:
-    optional: true
+  math-intrinsics@1.1.0: {}
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -3679,6 +3967,8 @@ snapshots:
 
   merge-descriptors@2.0.0:
     optional: true
+
+  merge-stream@2.0.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -3893,8 +4183,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0:
     optional: true
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -3916,15 +4212,22 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-pty@1.1.0:
     dependencies:
       node-addon-api: 7.1.1
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   object-assign@4.1.1:
     optional: true
 
-  object-inspect@1.13.4:
-    optional: true
+  object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
 
@@ -3951,19 +4254,19 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@5.12.2(ws@8.20.0)(zod@3.25.76):
+  openai@5.12.2(ws@8.21.0)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 3.25.76
 
-  openai@6.34.0(ws@8.20.0)(zod@3.25.76):
+  openai@6.34.0(ws@8.21.0)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 3.25.76
 
-  openai@6.34.0(ws@8.20.0)(zod@4.3.6):
+  openai@6.34.0(ws@8.21.0)(zod@4.3.6):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 4.3.6
     optional: true
 
@@ -4003,6 +4306,8 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
+  parse-cache-control@1.0.1: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -4016,8 +4321,7 @@ snapshots:
   parseurl@1.3.3:
     optional: true
 
-  path-key@3.1.1:
-    optional: true
+  path-key@3.1.1: {}
 
   path-to-regexp@8.4.2:
     optional: true
@@ -4039,6 +4343,10 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  process@0.11.10: {}
+
+  progress@2.0.3: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -4058,7 +4366,6 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
-    optional: true
 
   range-parser@1.2.1:
     optional: true
@@ -4076,6 +4383,14 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   remark-frontmatter@5.0.0:
     dependencies:
@@ -4219,16 +4534,13 @@ snapshots:
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
-    optional: true
 
-  shebang-regex@3.0.0:
-    optional: true
+  shebang-regex@3.0.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-    optional: true
 
   side-channel-map@1.0.1:
     dependencies:
@@ -4236,7 +4548,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
-    optional: true
 
   side-channel-weakmap@1.0.2:
     dependencies:
@@ -4245,7 +4556,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-    optional: true
 
   side-channel@1.1.0:
     dependencies:
@@ -4254,7 +4564,6 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-    optional: true
 
   siginfo@2.0.0: {}
 
@@ -4290,6 +4599,8 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-final-newline@2.0.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4308,6 +4619,8 @@ snapshots:
   toidentifier@1.0.1:
     optional: true
 
+  tr46@0.0.3: {}
+
   trough@2.2.0: {}
 
   tslib@2.8.1: {}
@@ -4325,6 +4638,8 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
     optional: true
+
+  typedarray@0.0.6: {}
 
   typescript@5.9.3: {}
 
@@ -4365,6 +4680,8 @@ snapshots:
 
   unpipe@1.0.0:
     optional: true
+
+  url-join@4.0.1: {}
 
   util-deprecate@1.0.2: {}
 
@@ -4429,10 +4746,16 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
-    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -4448,7 +4771,7 @@ snapshots:
   wrappy@1.0.2:
     optional: true
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -454,7 +454,7 @@ async def test_realtime_greeting():
     assert result.success, result.reasoning
 ```
 
-### Worked example (TypeScript)
+### Worked example (TypeScript, OpenAI Realtime — adapter IS the agent, mirror prod config)
 
 ```typescript
 import scenario, { voice } from "@langwatch/scenario";
@@ -506,6 +506,65 @@ describe("Voice agent — angry billing", () => {
     });
     expect(result.success).toBe(true);
   }, 240_000);  // voice scenarios are slow — TTS + transport + multi-turn
+});
+```
+
+### Worked example (TypeScript, Pipecat WS — adapter connects to the user's deployed bot)
+
+Use this shape when the user's voice bot is a **deployed Pipecat / Twilio Media Streams WebSocket** that is already reachable. The adapter only connects — it does NOT start the bot, so the bot must be running (a fixture, a staging deploy, or `make bot` in another terminal) when the test runs.
+
+```typescript
+import scenario, { voice } from "@langwatch/scenario";
+import { describe, it, expect } from "vitest";
+
+// The user's Pipecat bot must be reachable at this URL when the test runs.
+// The adapter does NOT spin it up.
+const BOT_WS_URL = process.env.PIPECAT_BOT_URL ?? "ws://localhost:8765/stream";
+
+describe("Voice agent — angry billing (Pipecat WS)", () => {
+  it("acknowledges frustration before pivoting to logistics", async () => {
+    const result = await scenario.run({
+      name: "angry billing error in a noisy cafe",
+      description:
+        "Customer was double-charged and is calling from a noisy cafe. " +
+        "The agent must acknowledge the frustration before pivoting to " +
+        "logistics, stay calm, and queue a refund.",
+      agents: [
+        // Connects to the user's ALREADY-RUNNING bot over WebSocket.
+        scenario.pipecatAgent({
+          url: BOT_WS_URL,
+          audioFormat: "mulaw",
+          sampleRate: 8000,
+        }),
+        scenario.userSimulatorAgent({
+          voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",
+          persona:
+            "You are SPEAKING ON A PHONE, not typing. Talk in natural " +
+            "spoken sentences. You were double-charged and you are FURIOUS. " +
+            "Use [shouting], [angry], [frustrated] markers every turn. " +
+            "1-2 short heated sentences per turn.",
+          audioEffects: [
+            voice.effects.backgroundNoise("cafe", 0.4),
+            voice.effects.phoneQuality(),
+          ],
+        }),
+        scenario.judgeAgent({
+          criteria: [
+            "The agent acknowledged the customer's frustration before asking for account info",
+            "The agent stayed calm — did not match the customer's hostility",
+            "The agent moved toward resolving the double charge",
+          ],
+        }),
+      ],
+      script: [
+        scenario.agent(), // the bot greets first (voice convention)
+        scenario.user(),  // heated opening
+        scenario.proceed(5),
+        scenario.judge(),
+      ],
+    });
+    expect(result.success).toBe(true);
+  }, 240_000); // voice scenarios are slow — TTS + transport + multi-turn
 });
 ```
 

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -150,6 +150,35 @@ describe("My Agent", () => {
 });
 ```
 
+### Step 4.5: Instrument for observability (REQUIRED before running)
+
+ALWAYS instrument before running — an uninstrumented scenario run emits no traces, so you lose the OTel/LangWatch observability that makes failures debuggable. This is not optional.
+
+There are two distinct things to wire:
+
+**1. Scenario-run tracing** — call `setupScenarioTracing()` once at the top of the test file so the simulator, judge, and adapter spans are captured:
+
+```typescript
+// TypeScript — add at the very top of the test file, before any imports or setup
+import { setupScenarioTracing } from "@langwatch/scenario";
+setupScenarioTracing();
+```
+
+For Python, scenario tracing is configured via `scenario.configure(...)` combined with langwatch setup — defer the exact call signature to the `tracing` skill.
+
+**2. Agent-under-test tracing** — instrument YOUR OWN agent code so its internal LLM calls, tool invocations, and chain spans are captured:
+
+- Python: `import langwatch; langwatch.setup()` at startup, then decorate the agent entry point with `@langwatch.trace()`.
+- TypeScript: call `setupObservability` from the `langwatch` package in your agent's initialization.
+
+**Per-adapter nuance for voice:** when the adapter IS the agent (OpenAI Realtime, Gemini Live), the scenario tracing covers the session. When connecting to a deployed agent (Pipecat/Twilio/ElevenLabs hosted) or wrapping a text agent (Composable), the user's agent process must be instrumented separately in its own codebase.
+
+For framework-specific instrumentation (OpenAI/LangGraph/Vercel/Mastra/Agno), use the `tracing` skill — do not hand-roll. The `tracing` skill prompt is: "Instrument my code with LangWatch".
+
+**Prerequisite:** Traces only reach LangWatch if `LANGWATCH_API_KEY` is set in the environment (plus `LANGWATCH_ENDPOINT` for self-hosted). If setup runs but no traces appear in the LangWatch UI, the key is missing.
+
+**VERIFY after the run:** confirm traces were emitted — the scenario run prints a LangWatch trace URL, or the LangWatch UI shows ≥1 trace for the run. A green test with zero traces means instrumentation was skipped.
+
 ### Step 5: Run the Tests
 
 For Python: `pytest -s test_my_agent.py` (or `uv run pytest ...`).
@@ -255,6 +284,8 @@ If the user asks for **voice testing** (e.g. "add voice testing to my agent", "t
 
 CRITICAL: Do NOT write a text-only scenario when the user asked for voice. The judge cannot evaluate "audible empathy" or "noise robustness" against a text transcript.
 
+Voice agents especially need observability — latency, interruptions, and STT/TTS spans are exactly what makes voice failures diagnosable. Instrument per Step 4.5 above (both `setupScenarioTracing()` and the agent-under-test) before running. See `langwatch scenario-docs voice/recipes/observability` for voice-specific OTel guidance.
+
 ### Step 1: Read the voice docs
 
 ```bash
@@ -263,6 +294,7 @@ langwatch scenario-docs voice/choosing-an-adapter
 langwatch scenario-docs voice/capability-matrix
 langwatch scenario-docs voice/recipes/effects
 langwatch scenario-docs voice/recipes/multi-turn
+langwatch scenario-docs voice/recipes/observability
 ```
 
 Also browse the runnable voice examples:
@@ -656,6 +688,7 @@ Once tests are green, summarize what you delivered and suggest 2-3 domain-specif
 ## Common Mistakes
 
 ### Code Approach
+- Do NOT write a scenario without instrumenting — a green run that emits no traces is half the value; call `setupScenarioTracing()` (run-level) and instrument the agent-under-test (`langwatch.setup()` / `setupObservability`) BEFORE running, and confirm traces appear in the LangWatch UI.
 - Do NOT create your own testing framework — `@langwatch/scenario` already handles simulation, judging, multi-turn, and tool-call verification
 - Do NOT write a `main.py` / `run_scenarios.py` / custom runner that loops over scenarios. Each scenario IS a test (`it(...)` / `async def test_*`) — run them with `pytest` or `vitest`. The test runner already gives you parallelism, retries of just the failing case, watch mode, CI integration, and per-test timeouts; a runner script re-implements all of that and ships with none of it wired up.
 - Do NOT invent a JSON / YAML / TOML "scenario DSL" with keys like `{ "name": ..., "description": ..., "criteria": [...] }` and then load it into a generic loop. The whole point of Scenario being code is that each test is real code: you can use `for`, `if`, parametrize (`@pytest.mark.parametrize`, `it.each(...)`), pull a fixture, call a helper to mint a session, branch by environment, share setup via a `conftest.py`, mock a tool inline — none of which a DSL gives you. The moment a teammate needs a new edge case ("only on Tuesdays the agent should escalate"), the DSL grows another key, then another, until it's a worse version of Python/TypeScript with none of the tooling. If the same boilerplate repeats across scenarios, extract a helper FUNCTION that returns an `AgentAdapter` / a built `UserSimulatorAgent` / a script tuple — keep each scenario its own test case so it stays grep-able and debuggable.
@@ -671,6 +704,7 @@ Once tests are green, summarize what you delivered and suggest 2-3 domain-specif
 - Do NOT forget a generous timeout (e.g. `180_000` ms) for TypeScript red team tests
 
 ### Voice Agents
+- Do NOT skip observability on voice agents — latency, interruption, and STT/TTS spans are exactly what you need when a voice scenario fails; instrument before running (Step 4.5: `setupScenarioTracing()` + agent-under-test instrumentation) and verify traces emit in the LangWatch UI.
 - Do NOT write a text-only scenario when the user asked for voice — pick one of `OpenAIRealtimeAgentAdapter` / `ElevenLabsAgentAdapter` / `PipecatAgentAdapter` / `GeminiLiveAgentAdapter` / `TwilioAgentAdapter` / `ComposableVoiceAgent`
 - Do NOT instantiate `OpenAIRealtimeAgentAdapter` or `GeminiLiveAgentAdapter` with placeholder `instructions=...` / `model=...` / `tools=...` — those adapters ARE the agent, so a placeholder constructor tests OpenAI/Gemini defaults, not the user's agent. Either mirror the user's prod config exactly, or pick a different adapter (Pipecat/Twilio/ElevenLabs hosted) that connects to their already-deployed transport.
 - Do NOT point `PipecatAgentAdapter(url=...)` / `ElevenLabsAgentAdapter(agent_id=...)` / `TwilioAgentAdapter` at a transport the user hasn't deployed — those adapters only connect, they don't spin anything up. If the user is text-only and has no voice transport, say so and offer `ComposableVoiceAgent` as a voice wrapper around their existing text logic.

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -486,11 +486,17 @@ async def test_realtime_greeting():
     assert result.success, result.reasoning
 ```
 
-### Worked example (TypeScript, OpenAI Realtime — adapter IS the agent, mirror prod config)
+### Worked example (TypeScript, OpenAI Realtime — adapter drives the model session)
+
+Use this shape when the user's production agent IS an OpenAI Realtime model.
+The adapter drives the session directly — import the same `instructions` and `tools` your production agent uses rather than copy-pasting them inline.
+One source of truth keeps the test aligned with what is actually deployed.
 
 ```typescript
 import scenario, { voice } from "@langwatch/scenario";
 import { describe, it, expect } from "vitest";
+// Import your production agent config — don't duplicate it here
+import { AGENT_INSTRUCTIONS, AGENT_TOOLS } from "../src/billing-agent";
 
 describe("Voice agent — angry billing", () => {
   it("acknowledges frustration before pivoting to logistics", async () => {
@@ -501,13 +507,13 @@ describe("Voice agent — angry billing", () => {
         "The agent must acknowledge the frustration before pivoting to " +
         "logistics, stay calm, and queue a refund.",
       agents: [
-        // The adapter IS the agent. Mirror the user's PROD model,
-        // voice, instructions, and tools here — anything you leave as
-        // a placeholder is what you're actually testing.
+        // The adapter drives an OpenAI Realtime session with the same
+        // config your production agent uses. Importing from production
+        // source keeps the test aligned with what is actually deployed.
         scenario.openAIRealtimeAgent({
           voice: "alloy",
-          instructions: "<paste the EXACT prod system prompt here>",
-          // tools: [...prod tool schemas...],
+          instructions: AGENT_INSTRUCTIONS,
+          // tools: AGENT_TOOLS,
         }),
         scenario.userSimulatorAgent({
           voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL",

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -74,7 +74,7 @@ CRITICAL: Do NOT guess how to write scenario tests. Different frameworks have di
 ### Step 2: Install the Scenario SDK
 
 For Python: `pip install langwatch-scenario pytest pytest-asyncio` (or `uv add ...`).
-For TypeScript: `npm install @langwatch/scenario@^0.4.12 vitest @ai-sdk/openai` (or `pnpm add ...`). The voice adapter factories (`openAIRealtimeAgent`, `pipecatAgent`, etc.) and `voice.effects` require `@langwatch/scenario` >= 0.4.12 — earlier versions only expose the lower-level `RealtimeAgentAdapter` class.
+For TypeScript: `npm install @langwatch/scenario@^0.4.12 vitest` (or `pnpm add ...`).
 
 ### Step 3: Configure the Default Model
 

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -310,6 +310,36 @@ audio_effects=[
 ]
 ```
 
+### TypeScript equivalents
+
+The same adapters, simulator voice, and effects are available in TypeScript via thin factory functions on the `scenario` object. Pick the adapter the same way (Step 2) — the mapping is one-to-one:
+
+| User's stack | TypeScript adapter |
+| --- | --- |
+| Pipecat / Twilio Media Streams WS bot | `scenario.pipecatAgent({ url: "ws://<your-bot>/stream" })` |
+| ElevenLabs hosted ConvAI agent | `scenario.elevenLabsAgent({ agentId, apiKey })` |
+| Twilio phone number (real PSTN) | `scenario.twilioAgent({ accountSid, authToken, phoneNumber })` |
+| Gemini Live model is the agent | `scenario.geminiLiveAgent({ model, systemInstruction, voice })` |
+| OpenAI Realtime model is the agent | `scenario.openAIRealtimeAgent({ model, instructions, voice, tools })` |
+| Text-only stack wrapped as voice | `scenario.composableAgent({ stt, llm, tts })` |
+
+Seed a voice on the simulator and layer effects the same way:
+
+```typescript
+import scenario, { voice } from "@langwatch/scenario";
+
+scenario.userSimulatorAgent({
+  voice: "elevenlabs/EXAVITQu4vr4xnSDxMaL", // Sarah — mature female
+  persona: "...",
+  audioEffects: [
+    voice.effects.backgroundNoise("cafe", 0.4), // presets: cafe / office / street / airport
+    voice.effects.phoneQuality(),               // mulaw + 8kHz + codec degradation
+  ],
+});
+```
+
+For a full runnable TypeScript voice test, see the **Worked example (TypeScript)** below.
+
 ### Step 5: Tell the simulator it's on a phone, not in chat
 
 The default `UserSimulatorAgent` system prompt encodes a text-chat style ("very short inputs, few words, all lowercase, like talking to chatgpt") which TTS-renders robotic. Always nudge the persona toward natural spoken sentences:

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -370,7 +370,7 @@ scenario.userSimulatorAgent({
 });
 ```
 
-For a full runnable TypeScript voice test, see the **Worked example (TypeScript)** below.
+For full runnable TypeScript voice tests, see the **OpenAI Realtime** and **Pipecat WS** TypeScript worked examples below.
 
 ### Step 5: Tell the simulator it's on a phone, not in chat
 

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -74,7 +74,7 @@ CRITICAL: Do NOT guess how to write scenario tests. Different frameworks have di
 ### Step 2: Install the Scenario SDK
 
 For Python: `pip install langwatch-scenario pytest pytest-asyncio` (or `uv add ...`).
-For TypeScript: `npm install @langwatch/scenario vitest @ai-sdk/openai` (or `pnpm add ...`).
+For TypeScript: `npm install @langwatch/scenario@^0.4.12 vitest @ai-sdk/openai` (or `pnpm add ...`). The voice adapter factories (`openAIRealtimeAgent`, `pipecatAgent`, etc.) and `voice.effects` require `@langwatch/scenario` >= 0.4.12 — earlier versions only expose the lower-level `RealtimeAgentAdapter` class.
 
 ### Step 3: Configure the Default Model
 


### PR DESCRIPTION
## Why

The `scenarios` skill documented **Python-only voice testing**, leaving TypeScript users with no worked examples or guidance even though `@langwatch/scenario` ships full JS voice support (adapter factories, simulator voice, `voice.effects`). The skill's test suite also had no TypeScript coverage — the documented API could drift silently.

## What changed

- **TypeScript voice coverage in `SKILL.mdx`** — adds a `### TypeScript equivalents` subsection covering all six adapter factories + simulator voice + effects, plus full OpenAI Realtime and Pipecat WS worked examples. Uses progressive disclosure (TS in its own labelled subsection matching the existing `**Python:**`/`**TypeScript:**` idiom).
- **Install line simplified** — removed `@ai-sdk/openai` from the TS install command (provider-specific, not a base requirement) and dropped the version-justification note about earlier SDK releases.
- **Observability requirement made explicit** — adds `langwatch.instrument()` to all TS examples; the skill now states that skipping it means no traces in LangWatch.
- **Voice factory unit test** (`skills/_tests/voice-factories.test.ts`, 8 passes) — ungated CI test that constructs all six factories + `voice.effects` + simulator voice against the installed SDK; CI green means the documented API resolves (no LLM, no network).
- **TS voice scenario test** (`skills/_tests/scenarios.scenario.test.ts` + fixture) — covers the TypeScript voice path end-to-end alongside the existing Python scenario test.
- **`@langwatch/scenario` floor bump `^0.4.6` → `^0.4.12`** — voice factories first published in 0.4.12; without the bump the documented API and tests fail against the installed SDK.
- **`skills/.npmrc`** — excludes `@langwatch/scenario` from the `minimum-release-age` hold so a fresh install resolves 0.4.12 during its 7-day publish window.

## Test plan

- `pnpm test` in `skills/` — `voice-factories.test.ts` (8 passes, 0 skipped) confirms all six factory constructors + effects + simulator voice resolve against the published SDK.
- `pnpm compile --skills scenarios` — doc compiles to 0 errors.
- CI: all checks green (go-ci, langwatch-app-ci, docs-ci, sdk-*, langevals-ci, codeql).

## Anything surprising?

The install line previously included `@ai-sdk/openai`, which implied OpenAI was required. It was only needed for the TypeScript config example (which uses `openai("gpt-5-mini")`), but the voice adapters themselves don't depend on it — removed per review feedback.

---

## Proof (Step 2.7) — TS voice scenario running in the system

### Step 1 — All 8 voice-factory unit tests pass (run 2026-06-15)

```
 ✓ voice factory surface > constructs pipecatAgent without network 2ms
 ✓ voice factory surface > constructs openAIRealtimeAgent without network 0ms
 ✓ voice factory surface > constructs geminiLiveAgent without network 0ms
 ✓ voice factory surface > constructs elevenLabsAgent without network 0ms
 ✓ voice factory surface > constructs twilioAgent without network 1ms
 ✓ voice factory surface > constructs composableAgent with documented stt/llm/tts values 0ms
 ✓ voice factory surface > exposes voice.effects helpers the skill documents 1ms
 ✓ voice factory surface > userSimulatorAgent accepts a voice option 0ms

Test Files  1 passed (1) — Tests  8 passed (8) — Duration  1.08s
```

Every documented TypeScript voice adapter factory resolves from installed `@langwatch/scenario@^0.4.12` — no mocking, no stubs.

### Step 2 — Generated tests ran with real audio; judge fired with verdict

Batch: https://app.langwatch.ai/scenario-tracing-bZspxw/simulations/default/scenariobatch_03a3bed2917d
Session: https://app.langwatch.ai/scenario-tracing-bZspxw/simulations/skill-tests/scenariobatch_b536002126a2

Given the `typescript-voice` fixture and the scenarios skill, Claude Code received: *"add agent simulation tests for my voice agent. It's a voice bot, so the tests need to drive real audio, not text."*

Claude produced `tests/voice-agent.test.ts` with `openAIRealtimeAgent` ✅, `userSimulatorAgent` with `voice: "openai/nova"` ✅, `voice.effects.backgroundNoise()` ✅, `voice.effects.phoneQuality()` ✅, and `setupScenarioTracing()` ✅.

The generated tests ran against the OpenAI Realtime WebSocket API with real audio exchange (WAV PCM16 confirmed in trace). Results (48s real run, 2026-06-15):

```
 ✓ Voice agent — phone support > greets caller and answers billing question  13613ms
 ✓ Voice agent — phone support > handles frustrated customer with empathy  25730ms
 × Voice agent — phone support > handles question in noisy environment  8823ms

Test Files  1 failed (1)  |  Tests  1 failed | 2 passed (3)  |  Duration  48.17s
```

**Judge verdict** (noisy-environment scenario — judge fired with real evaluation, not a template):
> "The agent did not respond directly to the user's question about payment methods. Instead, it asked for more details, which does not fulfill the user's request. However, real audio was exchanged despite potential background noise."

2/3 scenarios pass. The 1 failure is the example voice agent (a simple `gpt-4o-realtime-preview` phone bot) not directly answering a payment-methods question — the scenario framework correctly flags this, demonstrating real judge evaluation over real audio.