### PR TITLE
fix(governance): SaaS CLI gateway default points at parked .com host

### DIFF
--- a/langwatch/ee/governance/services/__tests__/gatewayUrl.unit.test.ts
+++ b/langwatch/ee/governance/services/__tests__/gatewayUrl.unit.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+import { describe, expect, it } from "vitest";
+
+import {
+  LOCAL_GATEWAY_URL,
+  SAAS_GATEWAY_URL,
+  resolveGatewayBaseUrl,
+} from "../gatewayUrl";
+
+describe("resolveGatewayBaseUrl", () => {
+  describe("given no explicit gateway env vars", () => {
+    describe("when the deployment is SaaS", () => {
+      it("resolves the canonical .ai gateway host", () => {
+        expect(resolveGatewayBaseUrl({ isSaas: true })).toBe(
+          "https://gateway.langwatch.ai",
+        );
+      });
+
+      it("never resolves the parked .com host", () => {
+        // Regression: a stale `gateway.langwatch.com` default routed SaaS
+        // CLI traffic at a parked DigitalOcean IP whose TLS cert didn't
+        // match the host, surfacing as `fetch failed` on `langwatch claude`.
+        expect(resolveGatewayBaseUrl({ isSaas: true })).not.toContain(".com");
+        expect(SAAS_GATEWAY_URL).toBe("https://gateway.langwatch.ai");
+      });
+    });
+
+    describe("when the deployment is self-hosted", () => {
+      it("resolves the local Go gateway port", () => {
+        expect(resolveGatewayBaseUrl({ isSaas: false })).toBe(
+          LOCAL_GATEWAY_URL,
+        );
+      });
+    });
+  });
+
+  describe("given LW_GATEWAY_PUBLIC_URL is set", () => {
+    it("wins over both the legacy base url and the SaaS default", () => {
+      expect(
+        resolveGatewayBaseUrl({
+          publicUrl: "https://gw.acme.example",
+          baseUrl: "https://legacy.acme.example",
+          isSaas: true,
+        }),
+      ).toBe("https://gw.acme.example");
+    });
+  });
+
+  describe("given only the legacy LW_GATEWAY_BASE_URL is set", () => {
+    it("falls back to the legacy base url over the SaaS default", () => {
+      expect(
+        resolveGatewayBaseUrl({
+          baseUrl: "https://legacy.acme.example",
+          isSaas: true,
+        }),
+      ).toBe("https://legacy.acme.example");
+    });
+  });
+});

--- a/langwatch/ee/governance/services/cliBootstrap.service.ts
+++ b/langwatch/ee/governance/services/cliBootstrap.service.ts
@@ -35,6 +35,7 @@ import {
   getProviderModelOptions,
   modelProviders as modelProviderRegistry,
 } from "~/server/modelProviders/registry";
+import { resolveGatewayBaseUrl } from "./gatewayUrl";
 import { PersonalVirtualKeyService } from "./personalVirtualKey.service";
 import { PersonalWorkspaceService } from "./personalWorkspace.service";
 
@@ -51,17 +52,11 @@ export interface CliBootstrapResult {
   };
   /**
    * Authoritative gateway base URL for the CLI to use as `cfg.gateway_url`.
-   * Resolution order:
-   *   1. `LW_GATEWAY_PUBLIC_URL` — dedicated TS-side var, unambiguous.
-   *   2. `LW_GATEWAY_BASE_URL`   — legacy SaaS deploys where this var
-   *      still carried the public URL. In dev `scripts/start.sh`
-   *      hijacks it for the Go control-plane URL, so reading it on
-   *      dev would point the CLI at the Hono API (PORT+1000) and a
-   *      `langwatch claude` request would 404.
-   *   3. SaaS default `https://gateway.langwatch.com`.
-   *   4. Self-hosted default `http://localhost:5563`.
-   * Mirrors the same helper used by the personal-VK reveal card so /me
-   * and CLI surfaces report the same URL.
+   * Resolution lives in {@link resolveGatewayBaseUrl} — shared with the
+   * personal-VK reveal card so /me and CLI surfaces report the same URL.
+   * Note: in dev `scripts/start.sh` hijacks `LW_GATEWAY_BASE_URL` for the
+   * Go control-plane URL, so on dev the SaaS branch is what keeps a
+   * `langwatch claude` request off the Hono API (PORT+1000).
    */
   gatewayUrl: string;
   /**
@@ -75,11 +70,11 @@ export interface CliBootstrapResult {
 }
 
 function resolveGatewayUrl(): string {
-  if (env.LW_GATEWAY_PUBLIC_URL) return env.LW_GATEWAY_PUBLIC_URL;
-  if (env.LW_GATEWAY_BASE_URL) return env.LW_GATEWAY_BASE_URL;
-  return env.IS_SAAS
-    ? "https://gateway.langwatch.com"
-    : "http://localhost:5563";
+  return resolveGatewayBaseUrl({
+    publicUrl: env.LW_GATEWAY_PUBLIC_URL,
+    baseUrl: env.LW_GATEWAY_BASE_URL,
+    isSaas: env.IS_SAAS,
+  });
 }
 
 const SCOPE_RANK: Record<string, number> = {

--- a/langwatch/ee/governance/services/gatewayUrl.ts
+++ b/langwatch/ee/governance/services/gatewayUrl.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
+
+/**
+ * Single source of truth for the public AI Gateway base URL a deployment
+ * hands to CLI surfaces (login ceremony, personal-VK reveal card,
+ * cliBootstrap). Keeping the fallback in one place stops the SaaS default
+ * from drifting between call sites — a `.com`/`.ai` typo in just one copy
+ * previously routed SaaS `langwatch <tool>` calls at a parked domain whose
+ * TLS cert didn't match, surfacing as a `fetch failed` on every command.
+ *
+ * Resolution order:
+ *   1. publicUrl — `LW_GATEWAY_PUBLIC_URL`, the unambiguous TS-side var.
+ *   2. baseUrl   — `LW_GATEWAY_BASE_URL`, legacy fallback for SaaS deploys
+ *      where it still carried the public URL before the Go gateway started
+ *      hijacking the same name for control-plane discovery.
+ *   3. SaaS default `https://gateway.langwatch.ai`.
+ *   4. Self-hosted default `http://localhost:5563` (the Go AI gateway port).
+ */
+
+/** Canonical SaaS public gateway host. */
+export const SAAS_GATEWAY_URL = "https://gateway.langwatch.ai";
+/** Local Go AI gateway (per `make service svc=aigateway`). */
+export const LOCAL_GATEWAY_URL = "http://localhost:5563";
+
+export function resolveGatewayBaseUrl({
+  publicUrl,
+  baseUrl,
+  isSaas,
+}: {
+  publicUrl?: string | null;
+  baseUrl?: string | null;
+  isSaas?: boolean;
+}): string {
+  return (
+    publicUrl ?? baseUrl ?? (isSaas ? SAAS_GATEWAY_URL : LOCAL_GATEWAY_URL)
+  );
+}

--- a/langwatch/ee/governance/services/personalVirtualKey.service.ts
+++ b/langwatch/ee/governance/services/personalVirtualKey.service.ts
@@ -26,6 +26,7 @@ import { type PrismaClient } from "@prisma/client";
 import { VirtualKeyService } from "~/server/gateway/virtualKey.service";
 import type { VirtualKeyWithScopes } from "~/server/gateway/virtualKey.repository";
 
+import { resolveGatewayBaseUrl } from "./gatewayUrl";
 import { PersonalWorkspaceService } from "./personalWorkspace.service";
 import { RoutingPolicyService } from "./routingPolicy.service";
 
@@ -65,10 +66,10 @@ export class PersonalVirtualKeyService {
       prisma,
       new PersonalWorkspaceService(prisma),
       new RoutingPolicyService(prisma),
-      options?.gatewayBaseUrl ??
-        (options?.isSaas
-          ? "https://gateway.langwatch.com"
-          : "http://localhost:5563"),
+      resolveGatewayBaseUrl({
+        publicUrl: options?.gatewayBaseUrl,
+        isSaas: options?.isSaas,
+      }),
     );
   }
 

--- a/langwatch/src/server/api/routers/personalVirtualKeys.ts
+++ b/langwatch/src/server/api/routers/personalVirtualKeys.ts
@@ -32,7 +32,7 @@ import { createTRPCRouter, protectedProcedure } from "../trpc";
  * Service options for VK lifecycle calls. Forwards the gateway-URL
  * env signal so the service can pick the right default for the
  * deployment shape: explicit `LW_GATEWAY_BASE_URL` always wins,
- * otherwise SaaS gets `gateway.langwatch.com` and self-hosted falls
+ * otherwise SaaS gets `gateway.langwatch.ai` and self-hosted falls
  * back to `http://localhost:5563` (the Docker port the AI gateway
  * binds to). Without this, fresh self-hosted installs displayed the
  * production gateway URL on the VK reveal card and the user's curl

--- a/typescript-sdk/src/cli/utils/governance/login-flow.ts
+++ b/typescript-sdk/src/cli/utils/governance/login-flow.ts
@@ -96,7 +96,7 @@ export async function runUnifiedLoginFlow(
 
       // Pick up the server's authoritative gateway URL. Without this,
       // self-hosted CLI users would see the SaaS default
-      // (https://gateway.langwatch.com) on whoami / login output even
+      // (https://gateway.langwatch.ai) on whoami / login output even
       // though the actual gateway is on localhost:5563. The server's
       // `gatewayUrl` reflects `LW_GATEWAY_BASE_URL` or the IS_SAAS-
       // aware fallback. Backwards-compatible: older servers (without


### PR DESCRIPTION
## Problem

`langwatch claude` (and `codex` / `cursor`) fail immediately on SaaS with:

```
Cannot reach AI Gateway at https://gateway.langwatch.com
  fetch failed
```

even though the login ceremony succeeds and the gateway pods are healthy.

## Root cause

The SaaS gateway lives at **`gateway.langwatch.ai`** (that's already the CLI's own default in `config.ts`, the VK usage snippets, and the existing tests). But two server-side files hardcoded **`gateway.langwatch.com`** as the SaaS fallback:

- `cliBootstrap.service.ts` (login bootstrap) writes `gateway_url` into the user's `~/.langwatch/config.json`. This is the one users hit.
- `personalVirtualKey.service.ts` (personal-VK reveal card).

Prod runs `IS_SAAS=true` with **no `LW_GATEWAY_PUBLIC_URL` and no `LW_GATEWAY_BASE_URL`** set (verified on the live `langwatch` deployment), so both fell through to the hardcoded default and persisted the wrong host.

`gateway.langwatch.com` resolves to a parked IP (`167.71.201.99`) whose TLS cert does not match the hostname, so Node's `fetch` rejects the connection and the wrapper reports `fetch failed`. `gateway.langwatch.ai` is the real gateway:

```
$ curl -sI https://gateway.langwatch.ai/
X-Langwatch-Gateway-Version: git-cdc5e65
```

## Fix

- Correct the SaaS default to `https://gateway.langwatch.ai`.
- Extract the duplicated `public ?? base ?? (isSaas ? saas : local)` resolution into a single `resolveGatewayBaseUrl` helper (`ee/governance/services/gatewayUrl.ts`) so the defaults live in one tested place and can't drift between call sites again.
- Update two stale `.com` doc-comment references.

No env change is required for the fix to land, but setting `LW_GATEWAY_PUBLIC_URL=https://gateway.langwatch.ai` on prod would be belt-and-suspenders.

## Note on already-logged-in users

Users who logged in before this deploys have `gateway.langwatch.com` cached in `~/.langwatch/config.json`. After this ships they can either re-run `langwatch login` or edit `gateway_url` to `https://gateway.langwatch.ai`.

## Tests

Added `gatewayUrl.unit.test.ts` covering the SaaS default, the self-hosted default, the explicit-URL precedence, and a regression assertion that the SaaS default never resolves a `.com` host.