### PR TITLE
fix(governance): wire + document gateway public URL for self-hosted

### DIFF
--- a/charts/langwatch/templates/NOTES.txt
+++ b/charts/langwatch/templates/NOTES.txt
@@ -55,7 +55,7 @@ in that state.
 ──────────────────────────────────────────────────────────────────────
 Once steps 1-3 are done, share the install command with your team:
 
-  npx @langwatch/sdk@latest login --device --url https://{{ .Values.ingress.host | default "<your-host>" }}
+  npx langwatch@latest login --device --url https://{{ .Values.ingress.host | default "<your-host>" }}
 
 Then in any terminal:
 

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -190,6 +190,29 @@ spec:
                   key: LW_GATEWAY_JWT_SECRET
             {{- end }}
 
+            # LW_GATEWAY_PUBLIC_URL — the externally-reachable AI Gateway URL
+            # the control plane hands to CLI users (langwatch claude/codex/
+            # cursor) at login. Without it the CLI falls back to
+            # http://localhost:5563, which a developer laptop can't reach
+            # against a remote cluster. Prefer the explicit gateway.publicUrl
+            # knob; otherwise derive it from an operator-set gateway ingress
+            # host (the SaaS default host is skipped so a self-host install
+            # never silently points at gateway.langwatch.ai).
+            {{- $gwPublic := .Values.gateway.publicUrl | default "" }}
+            {{- if not $gwPublic }}
+            {{- $gwIngress := .Values.gateway.ingress | default dict }}
+            {{- $gwHost := $gwIngress.host | default "" }}
+            {{- if and $gwIngress.enabled $gwHost (ne $gwHost "gateway.langwatch.ai") }}
+            {{- $scheme := "http" }}
+            {{- if and $gwIngress.tls $gwIngress.tls.enabled }}{{- $scheme = "https" }}{{- end }}
+            {{- $gwPublic = printf "%s://%s" $scheme $gwHost }}
+            {{- end }}
+            {{- end }}
+            {{- if $gwPublic }}
+            - name: LW_GATEWAY_PUBLIC_URL
+              value: {{ $gwPublic | quote }}
+            {{- end }}
+
             # NextAuth configuration
             - name: NEXTAUTH_PROVIDER
               value: {{ .Values.app.nextAuth.provider | quote }}

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -1582,6 +1582,15 @@ gateway:
   ## @param gateway.chartManaged [default: true] Lift the AI gateway pod as part of this chart (false = external or off).
   chartManaged: true
 
+  ## @param gateway.publicUrl [string, default: ""] Externally-reachable URL of the AI Gateway (e.g. https://gateway.your-corp.com). The control plane hands this to CLI users (langwatch claude/codex/cursor) at login. REQUIRED for self-hosted CLI/agentic use: without it the CLI falls back to http://localhost:5563, which a developer laptop cannot reach against a remote cluster. Leave empty to auto-derive from gateway.ingress.host when you set your own host. Set LANGWATCH_GATEWAY_URL on the client to override per-user.
+  publicUrl: ""
+
+  # The gateway needs its OWN externally-reachable endpoint, separate from
+  # the main app — point a second ingress / load balancer at gateway.ingress
+  # below (the LLM clients hit the gateway, the browser hits the app). The
+  # gateway subchart ships ingress.enabled=true with a SaaS placeholder host;
+  # override gateway.ingress.host with your domain.
+
   # The gateway subchart defaults (image, probes, HPA, NetworkPolicy,
   # PDB, SecurityContext) live in charts/gateway/values.yaml. Common
   # umbrella-level overrides below; everything else inherits.

--- a/docs/ai-gateway/self-hosting/post-install-checklist.mdx
+++ b/docs/ai-gateway/self-hosting/post-install-checklist.mdx
@@ -79,7 +79,42 @@ fix is almost always `gateway.controlPlane.baseUrl`, defaults to
 `http://langwatch-app:5560` on the assumption your release name is
 `langwatch`. Adjust on a different release name or split-domain.
 
-## 5. Distribute the unified `langwatch` CLI to your team
+## 5. Expose the gateway and set its public URL
+
+The gateway needs its **own** externally-reachable endpoint, separate
+from the app. Your LLM clients (Claude Code, Codex, Cursor) hit the
+gateway; the browser hits the app. So you provision two ingresses /
+load balancers: one for `app.your-corp.com` and one for
+`gateway.your-corp.com`.
+
+Then tell the control plane where the gateway lives, so it can hand
+that URL to CLI users at login. With the Helm chart, set the gateway's
+own host and the chart derives the rest:
+
+```yaml
+gateway:
+  ingress:
+    enabled: true
+    host: gateway.your-corp.com   # your domain, not the SaaS default
+  # publicUrl: https://gateway.your-corp.com   # or set explicitly
+```
+
+This populates `LW_GATEWAY_PUBLIC_URL` on the `langwatch-app`
+container. **Without it, the control plane returns
+`http://localhost:5563` to CLI users** and every `langwatch claude` /
+`langwatch codex` call from a developer laptop fails with
+`Cannot reach AI Gateway ... fetch failed`. Do NOT reuse
+`LW_GATEWAY_BASE_URL` for this — that variable is the internal
+control-plane URL the Go gateway dials back on, a different direction.
+
+Verify it landed:
+
+```bash
+kubectl -n langwatch get deploy langwatch-app -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="LW_GATEWAY_PUBLIC_URL")].value}'
+# → https://gateway.your-corp.com
+```
+
+## 6. Distribute the unified `langwatch` CLI to your team
 
 ```bash
 # One-liner for the IT-bot Slack message:
@@ -101,7 +136,7 @@ The CLI calls `GET /api/auth/cli/budget/status` before exec'ing the
 underlying tool, a 402 short-circuits with a branded budget error
 so devs aren't surprised mid-session.
 
-## 6. Off-board cleanly when someone leaves
+## 7. Off-board cleanly when someone leaves
 
 Personal teams are deactivated through the same admin path as the
 user themselves:

--- a/docs/ai-gateway/self-hosting/post-install-checklist.mdx
+++ b/docs/ai-gateway/self-hosting/post-install-checklist.mdx
@@ -114,40 +114,6 @@ kubectl -n langwatch get deploy langwatch-app -o jsonpath='{.spec.template.spec.
 # → https://gateway.your-corp.com
 ```
 
-## 6. Distribute the unified `langwatch` CLI to your team
-
-```bash
-# One-liner for the IT-bot Slack message:
-npx @langwatch/sdk@latest login --device --url https://<your-host>
-```
-
-Devs run that once. They get a short-lived `lw_at_*` access token
-plus a personal `vk-lw-*` virtual key, both bound to their SSO
-identity. Then any of the wrapped tools "just work":
-
-```bash
-langwatch claude       # Claude Code with org-managed keys
-langwatch codex        # Codex CLI
-langwatch cursor       # Cursor with custom endpoint
-langwatch init-shell   # Eval-able shell snippet with ANTHROPIC_BASE_URL etc.
-```
-
-The CLI calls `GET /api/auth/cli/budget/status` before exec'ing the
-underlying tool, a 402 short-circuits with a branded budget error
-so devs aren't surprised mid-session.
-
-## 7. Off-board cleanly when someone leaves
-
-Personal teams are deactivated through the same admin path as the
-user themselves:
-
-- **Settings → Organization → Members → ...**, choose Remove.
-- The user's personal team and projects stay in the audit log for
-  compliance retention but every personal VK is revoked
-  synchronously. New gateway calls return `401 vk_revoked`.
-- Their refresh + access tokens in Redis are invalidated so a
-  cached CLI session can't keep working past the off-boarding.
-
 ## What to read next
 
 - [Helm chart](./helm): chart structure, secrets, upgrade procedure.

--- a/docs/ai-governance/control-plane.mdx
+++ b/docs/ai-governance/control-plane.mdx
@@ -252,7 +252,7 @@ Two important Tier 4 sub-cases:
   bearer token in the workspace settings, every Cowork install in
   the org streams to LangWatch. **No per-desktop config required.**
 - **In-house agents using the LangWatch SDKs**: the existing
-  `@langwatch/sdk` setup; nothing governance-specific needed.
+  `langwatch` SDK setup; nothing governance-specific needed.
 
 ## Tier 5: Sandboxed runtime (Open Managed Agents)
 

--- a/langwatch/.env.example
+++ b/langwatch/.env.example
@@ -174,6 +174,16 @@ LW_GATEWAY_INTERNAL_SECRET=
 # verifies. Same dual-value rotation pattern as LW_GATEWAY_INTERNAL_SECRET.
 LW_GATEWAY_JWT_SECRET=
 
+# Public-facing URL the AI Gateway is reachable at from OUTSIDE the
+# cluster. The control plane hands this to CLI users (langwatch claude /
+# codex / cursor) at login. REQUIRED for self-hosted CLI/agentic use: a
+# remote deploy with this unset falls back to http://localhost:5563,
+# which a developer laptop cannot reach. Point it at the gateway's own
+# ingress / load balancer (separate from the app's). NOT the same as
+# LW_GATEWAY_BASE_URL below, which is the INTERNAL control-plane URL the
+# Go gateway dials back on.
+LW_GATEWAY_PUBLIC_URL=http://localhost:5563
+
 # Base URL the Go gateway reaches the control-plane at. Defaults to
 # localhost:5560 which matches `pnpm dev`. Override for split-deploy
 # topologies (e.g. gateway in a separate pod from the app).


### PR DESCRIPTION
Follow-up to #4625 (the SaaS `.com` gateway fix). That PR fixed the SaaS default; this one closes the same class of bug for **self-hosted**, which was actually worse off.

## Problem

For self-hosted (`IS_SAAS` unset, so `false`), the control plane resolves the CLI gateway URL to `http://localhost:5563` unless `LW_GATEWAY_PUBLIC_URL` is set. That's unreachable from a developer laptop against a remote cluster, so `langwatch claude` / `codex` / `cursor` fail with `Cannot reach AI Gateway ... fetch failed` for the whole team, by default.

Audit found two gaps that made this dead-on-arrival:

1. **Helm never wired it.** `charts/gateway/` deploys the gateway (Deployment + ClusterIP Service + Ingress), but the parent `charts/langwatch` app container had no `LW_GATEWAY_PUBLIC_URL` env and no values knob for it. `grep IS_SAAS charts/` returned nothing.
2. **Docs never mentioned it.** `LW_GATEWAY_PUBLIC_URL` appeared in zero docs and was absent from `.env.example`. One doc even told self-hosted users to `export ANTHROPIC_BASE_URL="http://localhost:5563"`, which is wrong for any remote cluster.

Note: `LW_GATEWAY_BASE_URL` is **not** the right knob to repurpose. The Go gateway reads it as the internal control-plane URL (gateway to app), the opposite direction. The correct, unambiguous variable is `LW_GATEWAY_PUBLIC_URL`.

## Fix

- **`charts/langwatch`**: inject `LW_GATEWAY_PUBLIC_URL` into the app container from a new documented `gateway.publicUrl` knob, or auto-derive it from an operator-set `gateway.ingress` host (scheme from `tls.enabled`). The SaaS placeholder host (`gateway.langwatch.ai`) is deliberately skipped so a self-host install never silently points its CLI at the SaaS gateway, and nothing is emitted by default (no regression).
- **`.env.example`**: document `LW_GATEWAY_PUBLIC_URL` and disambiguate it from `LW_GATEWAY_BASE_URL`.
- **post-install-checklist**: new step explaining the gateway needs its own ingress / load balancer separate from the app, that `LW_GATEWAY_PUBLIC_URL` must be set, and the exact failure symptom if it isn't.
- **track-your-claude-code-usage**: fix the wrong `localhost:5563` guidance for remote clusters.

## Verification

`helm template` across all cases:

| values | rendered `LW_GATEWAY_PUBLIC_URL` |
|---|---|
| defaults | (absent — no regression) |
| `gateway.publicUrl=https://gw.acme` | `https://gw.acme` |
| `gateway.ingress.host=gateway.acme` + tls | `https://gateway.acme` |
| `gateway.ingress.host=gw.internal` no tls | `http://gw.internal` |
| `gateway.ingress.host=gateway.langwatch.ai` (SaaS default) | (absent — safe skip) |
| explicit `publicUrl` + ingress host | explicit wins |

`helm lint` clean.