### PR TITLE
fix(collector): remove 200-span-per-trace cap on REST ingestion

### DIFF
--- a/langwatch/src/server/routes/collector.ts
+++ b/langwatch/src/server/routes/collector.ts
@@ -283,23 +283,6 @@ secured.access(handlerManagedAuth("ingestion API key resolved in-handler")).post
       );
     }
 
-    if (body.spans?.length > 200) {
-      logger.info(
-        {
-          projectId: project.id,
-          spansCount: body.spans?.length,
-          traceId: nullableTraceId,
-        },
-        "[429] Too many spans",
-      );
-      return c.json(
-        {
-          message: "Too many spans, maximum of 200 per trace",
-        },
-        429,
-      );
-    }
-
     let reservedTraceMetadata: ReservedTraceMetadata = {};
     let customMetadata: CustomMetadata = {};
     try {


### PR DESCRIPTION
## Summary
Removes the hardcoded 200-span limit on `POST /api/collector` that returned HTTP 429 and rejected entire traces.

## Context
Customer report: traces with >200 spans were being rejected. The 200-span cap is a legacy artifact from when traces were stored as single Elasticsearch documents. With the event-sourcing migration, spans are processed individually via `RecordSpanCommand` — no architectural limit.

The remaining two legacy caps (BullMQ worker silent drop + ES painless script truncation) will be cleaned up in a separate PR.

Fixes #4628

## Test plan
- [x] 1 file, 17 lines removed
- [ ] Verify collector accepts >200 spans