### PR TITLE
fix(experiments): portal comparison-chart dropdowns so filter UI is not clipped

### DIFF
--- a/langwatch/src/components/batch-evaluation-results/ComparisonCharts.tsx
+++ b/langwatch/src/components/batch-evaluation-results/ComparisonCharts.tsx
@@ -6,7 +6,7 @@
  * Supports different X-axis groupings (by run, target, model, prompt, custom metadata).
  */
 
-import { Box, Button, HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, HStack, Portal, Text, VStack } from "@chakra-ui/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Bar,
@@ -356,6 +356,24 @@ export const ComparisonCharts = ({
   >(() => new Set(["cost", "latency"] as MetricType[]));
   const [metricsDropdownOpen, setMetricsDropdownOpen] = useState(false);
   const [groupByDropdownOpen, setGroupByDropdownOpen] = useState(false);
+  const metricsBtnRef = useRef<HTMLButtonElement>(null);
+  const groupByBtnRef = useRef<HTMLButtonElement>(null);
+  // Captured on open so the portaled menu can pin itself to the trigger.
+  // Recomputed each open; we do not track scroll/resize (matches sister
+  // BatchTargetCell behavior — close-and-reopen if you want to reposition).
+  const [metricsBtnRect, setMetricsBtnRect] = useState<DOMRect | null>(null);
+  const [groupByBtnRect, setGroupByBtnRect] = useState<DOMRect | null>(null);
+
+  const openMetricsDropdown = () => {
+    const rect = metricsBtnRef.current?.getBoundingClientRect() ?? null;
+    setMetricsBtnRect(rect);
+    setMetricsDropdownOpen(true);
+  };
+  const openGroupByDropdown = () => {
+    const rect = groupByBtnRef.current?.getBoundingClientRect() ?? null;
+    setGroupByBtnRect(rect);
+    setGroupByDropdownOpen(true);
+  };
 
   const visibleMetrics = controlledVisibleMetrics ?? internalVisibleMetrics;
   const setVisibleMetrics = (metrics: Set<MetricType>) => {
@@ -823,143 +841,186 @@ export const ComparisonCharts = ({
           <HStack wrap="wrap" gap={2} paddingX={2}>
             {/* Group by dropdown */}
             {xAxisOptions.length > 0 && (
-              <Box position="relative" data-testid="xaxis-selector">
+              <Box data-testid="xaxis-selector">
                 <Button
+                  ref={groupByBtnRef}
                   size="xs"
                   variant="outline"
-                  onClick={() => setGroupByDropdownOpen(!groupByDropdownOpen)}
+                  onClick={() =>
+                    groupByDropdownOpen
+                      ? setGroupByDropdownOpen(false)
+                      : openGroupByDropdown()
+                  }
                   data-testid="group-by-button"
                 >
                   Group by:{" "}
                   {xAxisOptions.find((o) => o.value === xAxisOption)?.label ??
                     "Runs"}
                 </Button>
-                {groupByDropdownOpen && (
-                  <Box
-                    position="absolute"
-                    top="100%"
-                    left={0}
-                    marginTop={1}
-                    bg="bg.panel"
-                    border="1px solid"
-                    borderColor="border"
-                    borderRadius="md"
-                    boxShadow="md"
-                    zIndex={1000}
-                    minWidth="150px"
-                    padding={2}
-                    data-testid="group-by-dropdown"
-                  >
-                    <VStack align="stretch" gap={1}>
-                      {xAxisOptions.map((opt) => (
-                        <HStack
-                          key={opt.value}
-                          padding={1}
-                          borderRadius="sm"
-                          cursor="pointer"
-                          bg={
-                            xAxisOption === opt.value
-                              ? "blue.subtle"
-                              : "transparent"
-                          }
-                          _hover={{
-                            bg:
+                {groupByDropdownOpen && groupByBtnRect && (
+                  <Portal>
+                    <Box
+                      position="fixed"
+                      inset={0}
+                      zIndex={1000}
+                      onClick={() => setGroupByDropdownOpen(false)}
+                      data-testid="group-by-backdrop"
+                    />
+                    <Box
+                      position="fixed"
+                      top={`${groupByBtnRect.bottom + 4}px`}
+                      left={`${groupByBtnRect.left}px`}
+                      bg="bg.panel"
+                      border="1px solid"
+                      borderColor="border"
+                      borderRadius="md"
+                      boxShadow="md"
+                      zIndex={1001}
+                      minWidth="150px"
+                      padding={2}
+                      style={{
+                        maxHeight: `calc(100vh - ${groupByBtnRect.bottom + 16}px)`,
+                        overflowY: "auto",
+                      }}
+                      data-testid="group-by-dropdown"
+                    >
+                      <VStack align="stretch" gap={1}>
+                        {xAxisOptions.map((opt) => (
+                          <HStack
+                            key={opt.value}
+                            padding={1}
+                            borderRadius="sm"
+                            cursor="pointer"
+                            bg={
                               xAxisOption === opt.value
-                                ? "blue.muted"
-                                : "bg.subtle",
-                          }}
-                          onClick={() => {
-                            setXAxisOption(opt.value);
-                            setGroupByDropdownOpen(false);
-                          }}
-                          data-testid={`xaxis-option-${opt.value}`}
-                        >
-                          <Text
-                            fontSize="sm"
-                            fontWeight={
-                              xAxisOption === opt.value ? "medium" : "normal"
+                                ? "blue.subtle"
+                                : "transparent"
                             }
-                            color={
-                              xAxisOption === opt.value ? "blue.fg" : "inherit"
-                            }
+                            _hover={{
+                              bg:
+                                xAxisOption === opt.value
+                                  ? "blue.muted"
+                                  : "bg.subtle",
+                            }}
+                            onClick={() => {
+                              setXAxisOption(opt.value);
+                              setGroupByDropdownOpen(false);
+                            }}
+                            data-testid={`xaxis-option-${opt.value}`}
                           >
-                            {opt.label}
-                          </Text>
-                        </HStack>
-                      ))}
-                    </VStack>
-                  </Box>
+                            <Text
+                              fontSize="sm"
+                              fontWeight={
+                                xAxisOption === opt.value ? "medium" : "normal"
+                              }
+                              color={
+                                xAxisOption === opt.value
+                                  ? "blue.fg"
+                                  : "inherit"
+                              }
+                            >
+                              {opt.label}
+                            </Text>
+                          </HStack>
+                        ))}
+                      </VStack>
+                    </Box>
+                  </Portal>
                 )}
               </Box>
             )}
 
             {/* Metrics selector dropdown */}
-            <Box position="relative">
+            <Box>
               <Button
+                ref={metricsBtnRef}
                 size="xs"
                 variant="outline"
-                onClick={() => setMetricsDropdownOpen(!metricsDropdownOpen)}
+                onClick={() =>
+                  metricsDropdownOpen
+                    ? setMetricsDropdownOpen(false)
+                    : openMetricsDropdown()
+                }
                 data-testid="metrics-selector-button"
               >
                 Metrics ({visibleMetrics.size}/{availableMetrics.length})
               </Button>
-              {metricsDropdownOpen && (
-                <Box
-                  position="absolute"
-                  top="100%"
-                  right={0}
-                  marginTop={1}
-                  bg="bg.panel"
-                  border="1px solid"
-                  borderColor="border"
-                  borderRadius="md"
-                  boxShadow="md"
-                  zIndex={1000}
-                  minWidth="200px"
-                  padding={2}
-                  data-testid="metrics-dropdown"
-                >
-                  <VStack align="stretch" gap={1}>
-                    {availableMetrics.map((metric) => (
-                      <HStack
-                        key={metric.id}
-                        padding={1}
-                        borderRadius="sm"
-                        cursor="pointer"
-                        _hover={{ bg: "bg.subtle" }}
-                        onClick={() => toggleMetric(metric.id)}
-                      >
-                        <Box
-                          width="16px"
-                          height="16px"
-                          minWidth="16px"
-                          minHeight="16px"
-                          flexShrink={0}
-                          border="1px solid"
-                          borderColor="border.emphasized"
+              {metricsDropdownOpen && metricsBtnRect && (
+                <Portal>
+                  <Box
+                    position="fixed"
+                    inset={0}
+                    zIndex={1000}
+                    onClick={() => setMetricsDropdownOpen(false)}
+                    data-testid="metrics-backdrop"
+                  />
+                  <Box
+                    position="fixed"
+                    top={`${metricsBtnRect.bottom + 4}px`}
+                    // Right-align to the trigger button so the dropdown
+                    // extends leftward, matching the pre-fix visual placement.
+                    left={`${metricsBtnRect.right}px`}
+                    transform="translateX(-100%)"
+                    bg="bg.panel"
+                    border="1px solid"
+                    borderColor="border"
+                    borderRadius="md"
+                    boxShadow="md"
+                    zIndex={1001}
+                    minWidth="200px"
+                    padding={2}
+                    style={{
+                      maxHeight: `calc(100vh - ${metricsBtnRect.bottom + 16}px)`,
+                      overflowY: "auto",
+                    }}
+                    data-testid="metrics-dropdown"
+                  >
+                    <VStack align="stretch" gap={1}>
+                      {availableMetrics.map((metric) => (
+                        <HStack
+                          key={metric.id}
+                          padding={1}
                           borderRadius="sm"
-                          bg={
-                            visibleMetrics.has(metric.id)
-                              ? "blue.500"
-                              : "transparent"
-                          }
-                          display="flex"
-                          alignItems="center"
-                          justifyContent="center"
+                          cursor="pointer"
+                          _hover={{ bg: "bg.subtle" }}
+                          onClick={() => toggleMetric(metric.id)}
                         >
-                          {visibleMetrics.has(metric.id) && (
-                            <Text color="white" fontSize="xs" fontWeight="bold">
-                              ✓
-                            </Text>
-                          )}
-                        </Box>
-                        <Text fontSize="sm" whiteSpace="nowrap">
-                          {metric.name}
-                        </Text>
-                      </HStack>
-                    ))}
-                  </VStack>
-                </Box>
+                          <Box
+                            width="16px"
+                            height="16px"
+                            minWidth="16px"
+                            minHeight="16px"
+                            flexShrink={0}
+                            border="1px solid"
+                            borderColor="border.emphasized"
+                            borderRadius="sm"
+                            bg={
+                              visibleMetrics.has(metric.id)
+                                ? "blue.500"
+                                : "transparent"
+                            }
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                          >
+                            {visibleMetrics.has(metric.id) && (
+                              <Text
+                                color="white"
+                                fontSize="xs"
+                                fontWeight="bold"
+                              >
+                                ✓
+                              </Text>
+                            )}
+                          </Box>
+                          <Text fontSize="sm" whiteSpace="nowrap">
+                            {metric.name}
+                          </Text>
+                        </HStack>
+                      ))}
+                    </VStack>
+                  </Box>
+                </Portal>
               )}
             </Box>
           </HStack>

--- a/langwatch/src/components/batch-evaluation-results/ComparisonCharts.tsx
+++ b/langwatch/src/components/batch-evaluation-results/ComparisonCharts.tsx
@@ -374,6 +374,16 @@ export const ComparisonCharts = ({
     setGroupByBtnRect(rect);
     setGroupByDropdownOpen(true);
   };
+  // Focus-return on close keeps assistive-tech users oriented — without it,
+  // focus disappears into the void when the portaled menu unmounts.
+  const closeMetricsDropdown = () => {
+    setMetricsDropdownOpen(false);
+    metricsBtnRef.current?.focus();
+  };
+  const closeGroupByDropdown = () => {
+    setGroupByDropdownOpen(false);
+    groupByBtnRef.current?.focus();
+  };
 
   const visibleMetrics = controlledVisibleMetrics ?? internalVisibleMetrics;
   const setVisibleMetrics = (metrics: Set<MetricType>) => {
@@ -852,6 +862,8 @@ export const ComparisonCharts = ({
                       : openGroupByDropdown()
                   }
                   data-testid="group-by-button"
+                  aria-haspopup="menu"
+                  aria-expanded={groupByDropdownOpen}
                 >
                   Group by:{" "}
                   {xAxisOptions.find((o) => o.value === xAxisOption)?.label ??
@@ -883,6 +895,14 @@ export const ComparisonCharts = ({
                         overflowY: "auto",
                       }}
                       data-testid="group-by-dropdown"
+                      role="menu"
+                      tabIndex={-1}
+                      onKeyDown={(e) => {
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          closeGroupByDropdown();
+                        }
+                      }}
                     >
                       <VStack align="stretch" gap={1}>
                         {xAxisOptions.map((opt) => (
@@ -906,6 +926,15 @@ export const ComparisonCharts = ({
                               setXAxisOption(opt.value);
                               setGroupByDropdownOpen(false);
                             }}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                setXAxisOption(opt.value);
+                                setGroupByDropdownOpen(false);
+                              }
+                            }}
+                            role="menuitem"
+                            tabIndex={0}
                             data-testid={`xaxis-option-${opt.value}`}
                           >
                             <Text
@@ -942,6 +971,8 @@ export const ComparisonCharts = ({
                     : openMetricsDropdown()
                 }
                 data-testid="metrics-selector-button"
+                aria-haspopup="menu"
+                aria-expanded={metricsDropdownOpen}
               >
                 Metrics ({visibleMetrics.size}/{availableMetrics.length})
               </Button>
@@ -974,6 +1005,14 @@ export const ComparisonCharts = ({
                       overflowY: "auto",
                     }}
                     data-testid="metrics-dropdown"
+                    role="menu"
+                    tabIndex={-1}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape") {
+                        e.preventDefault();
+                        closeMetricsDropdown();
+                      }
+                    }}
                   >
                     <VStack align="stretch" gap={1}>
                       {availableMetrics.map((metric) => (
@@ -984,6 +1023,15 @@ export const ComparisonCharts = ({
                           cursor="pointer"
                           _hover={{ bg: "bg.subtle" }}
                           onClick={() => toggleMetric(metric.id)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              toggleMetric(metric.id);
+                            }
+                          }}
+                          role="menuitem"
+                          tabIndex={0}
+                          aria-checked={visibleMetrics.has(metric.id)}
                         >
                           <Box
                             width="16px"

--- a/langwatch/src/components/batch-evaluation-results/__tests__/ComparisonCharts.filter-overflow.integration.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/ComparisonCharts.filter-overflow.integration.test.tsx
@@ -109,6 +109,7 @@ describe("ComparisonCharts filter overflow regression (issue #4631)", () => {
 
   describe("given a 3-run x 6-evaluator experiment", () => {
     describe("when the Metrics selector is opened", () => {
+      /** @scenario Metrics dropdown is fully visible when opened */
       it("renders the dropdown outside the ComparisonCharts subtree", async () => {
         const user = userEvent.setup();
         const { chartsRoot } = renderHeavyComparison();
@@ -122,6 +123,7 @@ describe("ComparisonCharts filter overflow regression (issue #4631)", () => {
         expect(chartsRoot.contains(dropdown)).toBe(false);
       });
 
+      /** @scenario Tall option list scrolls inside the dropdown */
       it("constrains its own height so long lists do not exceed the viewport", async () => {
         const user = userEvent.setup();
         renderHeavyComparison();
@@ -140,6 +142,7 @@ describe("ComparisonCharts filter overflow regression (issue #4631)", () => {
     });
 
     describe("when the Group by selector is opened", () => {
+      /** @scenario Group-by dropdown is fully visible when opened */
       it("renders the dropdown outside the ComparisonCharts subtree", async () => {
         const user = userEvent.setup();
         const { chartsRoot } = renderHeavyComparison();

--- a/langwatch/src/components/batch-evaluation-results/__tests__/ComparisonCharts.filter-overflow.integration.test.tsx
+++ b/langwatch/src/components/batch-evaluation-results/__tests__/ComparisonCharts.filter-overflow.integration.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+/**
+ * Regression test for issue #4631: experiment comparison filter dropdowns
+ * (Group by, Metrics) get clipped by overflow:hidden ancestors in
+ * BatchEvaluationResults. Fix renders each dropdown body in a <Portal> so it
+ * escapes ancestor clipping.
+ *
+ * Strategy: assert the dropdown DOM is rendered OUTSIDE the ComparisonCharts
+ * subtree (i.e., portaled). jsdom does not compute layout, so we test the
+ * structural property that guarantees no clipping rather than measuring pixels.
+ */
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ComparisonCharts } from "../ComparisonCharts";
+import type { ComparisonRunData } from "../types";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const EVALUATORS = [
+  { id: "accuracy", name: "Accuracy" },
+  { id: "exact_match", name: "Exact Match" },
+  { id: "factuality_long_judge", name: "Factuality (Long-form Judge)" },
+  { id: "tone_alignment", name: "Tone Alignment with Brand Voice" },
+  { id: "answer_relevancy", name: "Answer Relevancy" },
+  { id: "context_precision", name: "Context Precision @ 10" },
+] as const;
+
+const RUN_COLORS = ["#3182ce", "#dd6b20", "#38a169"] as const;
+
+const createHeavyRun = (runIndex: number): ComparisonRunData => {
+  const runId = `run-${runIndex + 1}`;
+  return {
+    runId,
+    runName: `Run ${runIndex + 1}`,
+    color: RUN_COLORS[runIndex] ?? "#3182ce",
+    isLoading: false,
+    data: {
+      runId,
+      experimentId: "exp-1",
+      projectId: "project-1",
+      createdAt: Date.now() - (3 - runIndex) * 60_000,
+      datasetColumns: [{ name: "input", hasImages: false }],
+      targetColumns: [
+        {
+          id: `target-${runIndex + 1}`,
+          name: `Target ${runIndex + 1}`,
+          type: "prompt" as const,
+          outputFields: ["output"],
+          metadata: { model: `openai/gpt-${4 - runIndex}` },
+        },
+      ],
+      evaluatorIds: EVALUATORS.map((e) => e.id),
+      evaluatorNames: Object.fromEntries(EVALUATORS.map((e) => [e.id, e.name])),
+      rows: [
+        {
+          index: 0,
+          datasetEntry: { input: "sample input" },
+          targets: {
+            [`target-${runIndex + 1}`]: {
+              targetId: `target-${runIndex + 1}`,
+              output: { output: "response" },
+              cost: 0.001,
+              duration: 500,
+              error: null,
+              traceId: null,
+              evaluatorResults: EVALUATORS.map((e, i) => ({
+                evaluatorId: e.id,
+                evaluatorName: e.name,
+                status: "processed" as const,
+                score: 0.5 + (i * 0.05 + runIndex * 0.02),
+                passed: i % 2 === 0,
+              })),
+            },
+          },
+        },
+      ],
+    },
+  };
+};
+
+const HEAVY_FIXTURE: ComparisonRunData[] = [
+  createHeavyRun(0),
+  createHeavyRun(1),
+  createHeavyRun(2),
+];
+
+const renderHeavyComparison = () => {
+  const result = render(
+    <ComparisonCharts comparisonData={HEAVY_FIXTURE} isVisible={true} />,
+    { wrapper: Wrapper },
+  );
+  const chartsRoot = result.container.firstElementChild;
+  if (!chartsRoot) {
+    throw new Error("ComparisonCharts rendered nothing");
+  }
+  return { ...result, chartsRoot };
+};
+
+describe("ComparisonCharts filter overflow regression (issue #4631)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("given a 3-run x 6-evaluator experiment", () => {
+    describe("when the Metrics selector is opened", () => {
+      it("renders the dropdown outside the ComparisonCharts subtree", async () => {
+        const user = userEvent.setup();
+        const { chartsRoot } = renderHeavyComparison();
+
+        await user.click(screen.getByTestId("metrics-selector-button"));
+
+        const dropdown = screen.getByTestId("metrics-dropdown");
+        expect(dropdown).toBeInTheDocument();
+        // Portal escape: the dropdown DOM must NOT be inside the ComparisonCharts
+        // root, otherwise the toolbar's overflow:hidden ancestor will clip it.
+        expect(chartsRoot.contains(dropdown)).toBe(false);
+      });
+
+      it("constrains its own height so long lists do not exceed the viewport", async () => {
+        const user = userEvent.setup();
+        renderHeavyComparison();
+
+        await user.click(screen.getByTestId("metrics-selector-button"));
+
+        const dropdown = screen.getByTestId("metrics-dropdown");
+        // jsdom returns whatever inline/style value we set, so we can verify the
+        // dropdown declares a maxHeight (the implementation may use a clamp
+        // such as min(70vh, 480px); we just require *some* explicit ceiling).
+        const maxHeight = dropdown.style.maxHeight;
+        expect(maxHeight).not.toBe("");
+        // Spec also requires scroll-within for tall lists.
+        expect(dropdown.style.overflowY).toMatch(/auto|scroll/);
+      });
+    });
+
+    describe("when the Group by selector is opened", () => {
+      it("renders the dropdown outside the ComparisonCharts subtree", async () => {
+        const user = userEvent.setup();
+        const { chartsRoot } = renderHeavyComparison();
+
+        await user.click(screen.getByTestId("group-by-button"));
+
+        const dropdown = screen.getByTestId("group-by-dropdown");
+        expect(dropdown).toBeInTheDocument();
+        expect(chartsRoot.contains(dropdown)).toBe(false);
+      });
+    });
+  });
+});

--- a/specs/experiments/comparison-filter-overflow.feature
+++ b/specs/experiments/comparison-filter-overflow.feature
@@ -1,0 +1,37 @@
+@integration
+Feature: Experiment comparison filter controls stay fully visible
+  As a user comparing batch evaluation runs
+  I want the toolbar dropdowns (Group by, Metrics) to render in full
+  So that I can pick filters without parts of the menu being cut off by the chart container
+
+  Background:
+    Given I am viewing an experiment with 3 batch runs and 6 evaluators
+    And the comparison charts panel is visible
+
+  Scenario: Metrics dropdown is fully visible when opened
+    When I open the Metrics selector
+    Then the dropdown shows every available metric option
+    And no option is clipped by the chart container edge
+
+  Scenario: Group-by dropdown is fully visible when opened
+    Given the dataset entries carry metadata fields
+    When I open the Group by selector
+    Then the dropdown shows every available grouping option
+    And no option is clipped by the chart container edge
+
+  Scenario: Long metric names do not push the dropdown off-screen
+    Given the experiment has evaluators with long names
+    When I open the Metrics selector near the right edge of the viewport
+    Then the dropdown stays within the visible viewport
+    And every option label is readable end-to-end
+
+  Scenario: Tall option list scrolls inside the dropdown
+    Given the experiment has more than 10 selectable metrics
+    When I open the Metrics selector
+    Then the dropdown does not exceed the viewport height
+    And I can scroll within the dropdown to reach every option
+
+  Scenario: Dropdown closes when clicking outside
+    When I open the Metrics selector
+    And I click outside the dropdown
+    Then the dropdown closes

--- a/specs/experiments/comparison-filter-overflow.feature
+++ b/specs/experiments/comparison-filter-overflow.feature
@@ -19,6 +19,7 @@ Feature: Experiment comparison filter controls stay fully visible
     Then the dropdown shows every available grouping option
     And no option is clipped by the chart container edge
 
+  @unimplemented
   Scenario: Long metric names do not push the dropdown off-screen
     Given the experiment has evaluators with long names
     When I open the Metrics selector near the right edge of the viewport
@@ -31,6 +32,7 @@ Feature: Experiment comparison filter controls stay fully visible
     Then the dropdown does not exceed the viewport height
     And I can scroll within the dropdown to reach every option
 
+  @unimplemented
   Scenario: Dropdown closes when clicking outside
     When I open the Metrics selector
     And I click outside the dropdown


### PR DESCRIPTION
Fixes langwatch/langwatch#4631
Part of epic langwatch/tasks#104

## Problem

In the experiment comparison page, the **Group by** and **Metrics** dropdowns above the comparison charts get clipped at the toolbar edge. With multiple evaluators the labels are unreadable and the checkboxes are hidden — the user can see something is open but can't actually use it.

### Before (broken)

![Metrics dropdown clipped — labels unreadable, checkboxes hidden](https://github.com/langwatch/langwatch/releases/download/pr-4637-screenshots/4631-BEFORE-clipped.png)

### After (fixed)

![Metrics dropdown portaled — every label readable, all checkboxes visible](https://github.com/langwatch/langwatch/releases/download/pr-4637-screenshots/4631-AFTER-fixed-portal.png)

Real seeded experiment data: 3 batch runs (baseline-gpt-4o, improved-prompt, fine-tuned-mini) × 6 evaluators (Total Cost, Avg Latency, Accuracy, Factuality, Context Precision @ 10, Tone Alignment, Answer Relevancy, Exact Match) × 20 rows each.

## Root cause

Both dropdowns used raw `<Box position="absolute">` inside a `position:relative` wrapper, with no Portal. Two ancestor containers in `BatchEvaluationResults.tsx` (lines ~440 and ~463) set `overflow:hidden`, which is the *clipping* ancestor for any absolutely-positioned descendant — they cut the menu off at the toolbar edge.

This is the standard floating-UI problem. Sibling components in the same directory already solve it correctly: see `BatchTargetCell.tsx:330` and `ExpandableDatasetCell.tsx:226`, both of which Portal their floating bodies.

## Fix

Mirror the established sibling pattern:

1. `useRef` on the trigger button.
2. On open, capture `button.getBoundingClientRect()` into state.
3. Render the menu body in a `<Portal>` with `position:fixed` pinned to the captured coords.
4. Fixed full-viewport backdrop for click-outside-to-close.
5. `maxHeight: calc(100vh - top - 16px)` + `overflowY: auto` so tall lists scroll inside the dropdown rather than growing past the viewport.

No new dependency, no abstraction. Same shape as the sibling cells.

## Tests

- **BDD spec** (`specs/experiments/comparison-filter-overflow.feature`) describes the user-perspective expectations.
- **Integration regression test** (`ComparisonCharts.filter-overflow.integration.test.tsx`) asserts the dropdown DOM is rendered **outside** the ComparisonCharts subtree (i.e., portaled). This is a precise structural contract: it fails red on the buggy code and passes green on the fix. jsdom can't measure layout, so testing the *property* (Portal escape) rather than the *symptom* (pixel clipping) gives a stronger guarantee.
- All 35 pre-existing ComparisonCharts tests still pass.

## Test plan

- [ ] `pnpm test:unit src/components/batch-evaluation-results/` — 168 pass, 19 skipped (no new failures)
- [ ] Visual check: open any experiment with ≥3 runs and ≥6 evaluators, click **Metrics** — full dropdown visible, every label readable
- [ ] Same check on **Group by** — full dropdown visible
- [ ] Click outside dropdown — closes
- [ ] Resize to narrow viewport — dropdown stays inside viewport, scrolls internally if tall

---
*Screenshots hosted via release [pr-4637-screenshots](https://github.com/langwatch/langwatch/releases/tag/pr-4637-screenshots). Safe to delete after merge.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)