### PR TITLE
perf(clickhouse): add skip-index on stored_objects.id for cross-tenant lookup

### DIFF
--- a/langwatch/src/server/clickhouse/migrations/00033_add_stored_objects_id_index.sql
+++ b/langwatch/src/server/clickhouse/migrations/00033_add_stored_objects_id_index.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- stored_objects is ORDER BY (project_id, id) and PARTITION BY
+-- toYYYYMM(created_at). The cross-tenant lookup
+-- (stored-objects-cross-tenant-lookup.ts) resolves a stored object by `id`
+-- alone — by design it does NOT know the project_id — with
+--   SELECT project_id FROM stored_objects WHERE id = {id} LIMIT 1
+-- Because `id` is the SECOND sort-key column, that predicate cannot prune via
+-- the primary key, so the read falls back to a full scan of every granule in
+-- every monthly partition. On the larger ClickHouse instances this lookup was
+-- the slowest query in production (~17s for a single point lookup).
+--
+-- Add a bloom_filter skip-index on `id` (matching the existing idx_sha256 /
+-- idx_purpose granularity) so a point lookup by id skips the granule-blocks
+-- that cannot contain it, the same way idx_sha256 already accelerates the
+-- per-project content-hash lookup.
+--
+-- This ADD INDEX only attaches the index to NEW parts. To backfill existing
+-- parts, the reviewer should run (out of band, it is a heavy mutation that
+-- reads the id column across all parts — plan it for a low-traffic window):
+--   ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_objects MATERIALIZE INDEX idx_id;
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_objects
+  ADD INDEX IF NOT EXISTS idx_id id
+    TYPE bloom_filter(0.01) GRANULARITY 4;
+-- +goose StatementEnd
+
+-- +goose Down
+-- To roll back, uncomment and run manually:
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_objects DROP INDEX IF EXISTS idx_id;

--- a/langwatch/src/server/stored-objects/__tests__/stored-objects-id-index.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/stored-objects-id-index.integration.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * Verifies the bloom_filter skip-index on stored_objects.id (migration 00033):
+ *  - the migration actually attaches idx_id to the table, and
+ *  - the cross-tenant lookup shape (`WHERE id = {id}`, no project_id) still
+ *    returns the correct row.
+ *
+ * The lookup is by `id` alone — the second ORDER BY column — so without a skip
+ * index it falls back to a full scan. The index lets ClickHouse skip granule
+ * blocks that cannot contain the id; correctness is identical either way, which
+ * is what this test pins.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startTestContainers, stopTestContainers } from "../../event-sourcing/__tests__/integration/testContainers";
+
+let ch: ClickHouseClient;
+const tag = nanoid();
+
+async function insertObject(projectId: string, id: string) {
+  await ch.command({
+    query: `
+      INSERT INTO stored_objects
+        (id, project_id, purpose, owner_kind, owner_id, media_type, size_bytes, sha256, storage_uri, created_at, inserted_at)
+      VALUES
+        ({id:String}, {projectId:String}, 'input', 'trace', {id:String}, 'application/json', 10, {id:String}, 's3://b/k', now64(3), now64(3))
+    `,
+    query_params: { id, projectId },
+  });
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE stored_objects DELETE WHERE startsWith(id, {tag:String})`,
+      query_params: { tag },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("stored_objects id skip-index (migration 00033)", () => {
+  it("attaches a bloom_filter index on id", async () => {
+    const ddl = await (
+      await ch.query({ query: "SHOW CREATE TABLE stored_objects", format: "TabSeparatedRaw" })
+    ).text();
+    expect(ddl).toMatch(/INDEX\s+idx_id\s+id\s+TYPE\s+bloom_filter/i);
+  });
+
+  describe("when looking up an object by id alone (cross-tenant)", () => {
+    it("returns the owning project_id", async () => {
+      const id = `${tag}-obj-a`;
+      const projectId = `${tag}-project-a`;
+      await insertObject(projectId, id);
+      await insertObject(`${tag}-project-b`, `${tag}-obj-b`);
+
+      const rows = await (
+        await ch.query({
+          query: "SELECT project_id FROM stored_objects WHERE id = {id:String} LIMIT 1",
+          query_params: { id },
+          format: "JSONEachRow",
+        })
+      ).json<{ project_id: string }>();
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.project_id).toBe(projectId);
+    });
+
+    it("returns nothing for an id that does not exist", async () => {
+      const rows = await (
+        await ch.query({
+          query: "SELECT project_id FROM stored_objects WHERE id = {id:String} LIMIT 1",
+          query_params: { id: `${tag}-missing` },
+          format: "JSONEachRow",
+        })
+      ).json<{ project_id: string }>();
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Evidence

In the last 24h app-side slow-query log, the two slowest shapes by per-query latency are both `stored_objects` point lookups:

```
SELECT project_id FROM stored_objects WHERE id = {id} LIMIT 1   -- ~17s  (cross-tenant lookup)
SELECT id FROM stored_objects WHERE project_id = {…} AND sha256 = {…} LIMIT 1   -- ~7s (content-hash dedup; already uses idx_sha256)
```

The `WHERE id` lookup (the cross-tenant resolver, `stored-objects-cross-tenant-lookup.ts`) was the single slowest query observed (~17s for one point lookup; it also fans out across instances). The sha256 lookup already prunes via the primary key + `idx_sha256` bloom filter, so this PR targets only the `id` lookup.

## Suspected cause

`stored_objects` is `ORDER BY (project_id, id)`, `PARTITION BY toYYYYMM(created_at)`. The cross-tenant lookup matches on `id` alone — by design it does not know the `project_id`. Because `id` is the **second** sort-key column, the predicate cannot prune via the primary key, and there is no skip-index on `id` (only `idx_sha256` and `idx_purpose` exist). So the read degrades to a full scan of every granule in every monthly partition.

## Proposed fix

Add a `bloom_filter(0.01) GRANULARITY 4` skip-index on `id` (matching the existing `idx_sha256`/`idx_purpose`). For a point lookup `id = {id}` the bloom filter lets ClickHouse skip the granule blocks that cannot contain the id — turning the full scan into a handful of granules, exactly as `idx_sha256` already does for the per-project content-hash lookup.

Migration `00033_add_stored_objects_id_index.sql` does `ADD INDEX IF NOT EXISTS` (attaches to new parts). Backfilling existing parts needs a one-off `ALTER TABLE … MATERIALIZE INDEX idx_id` — called out in the migration comment for the reviewer to schedule, since it is a heavy mutation (reads the `id` column across all parts). This follows the existing `idx_source_id` precedent (migration `00028`), which also added a bloom_filter without an inline MATERIALIZE.

## Expected impact

- Cross-tenant `WHERE id` lookup: full-partition scan → granule-skip point read. On the large instance this should take the ~17s lookup down to the tens-of-ms range once the index is materialized.
- No change to write path beyond the small per-part bloom_filter (id is already stored). No change to query results.

## EXPLAIN check

The read-only `/ops` EXPLAIN endpoint reaches only the shared instance, where `stored_objects` is tiny (3 granules), so it cannot reproduce the large-instance full scan or show the post-index granule reduction. On that instance the old shape already reads all 3 granules:

```
ReadFromMergeTree … WHERE id = … → Parts 2/3, Granules 2/3  (primary key gives no useful prune on id)
```

The reviewer should re-run `EXPLAIN INDEXES` for the `WHERE id` shape on the large instance after `MATERIALIZE INDEX idx_id` to confirm the granule prune (expected: from all-granules to a small fraction, like the `idx_sha256` skip already visible in the plan).

## Test plan

- `stored-objects-id-index.integration.test.ts` (real ClickHouse via testcontainers, which applies the new migration): asserts `SHOW CREATE TABLE stored_objects` now contains `INDEX idx_id id TYPE bloom_filter`, and that the cross-tenant `WHERE id` lookup returns the correct owning `project_id` (and nothing for a missing id). **3/3 pass locally.**
- `clickhouseMigrations.unit.test.ts` (migration format validator) passes with `00033` added.

Advisory PR from the ClickHouse slow-query optimizer. A human should review, and schedule the `MATERIALIZE INDEX` on the large instance, before/after merge.
