### PR TITLE
perf(clickhouse): prune evaluation_runs trace fetch off SELECT *

### DIFF
--- a/langwatch/src/server/evaluations/__tests__/evaluation-run.mappers.test.ts
+++ b/langwatch/src/server/evaluations/__tests__/evaluation-run.mappers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Evaluation } from "~/server/tracer/types";
 import type { ClickHouseEvaluationRunRow } from "../evaluation-run.mappers";
 import {
+  EVALUATION_RUN_COLUMNS_WITH_INPUTS,
   mapClickHouseEvaluationToTraceEvaluation,
   mapEsEvaluationToTraceEvaluation,
   mapTraceEvaluationsToLegacyEvaluations,
@@ -335,5 +336,26 @@ describe("mapTraceEvaluationsToLegacyEvaluations", () => {
   it("handles empty input", () => {
     const result = mapTraceEvaluationsToLegacyEvaluations({});
     expect(result).toEqual({});
+  });
+});
+
+describe("EVALUATION_RUN_COLUMNS_WITH_INPUTS", () => {
+  const columns = EVALUATION_RUN_COLUMNS_WITH_INPUTS.split(",").map((c) =>
+    c.trim(),
+  );
+
+  it("lists exactly the columns the row mapper consumes (stays in sync with ClickHouseEvaluationRunRow)", () => {
+    expect([...columns].sort()).toEqual(Object.keys(baseCHRow).sort());
+  });
+
+  it("excludes evaluation_runs columns no reader consumes (the SELECT * over-read)", () => {
+    for (const unused of [
+      "ErrorDetails",
+      "CostId",
+      "ArchivedAt",
+      "CreatedAt",
+    ]) {
+      expect(columns).not.toContain(unused);
+    }
   });
 });

--- a/langwatch/src/server/evaluations/clickhouse-evaluation.service.ts
+++ b/langwatch/src/server/evaluations/clickhouse-evaluation.service.ts
@@ -6,42 +6,19 @@ import type { Protections } from "~/server/elasticsearch/protections";
 import { createLogger } from "~/utils/logger/server";
 import { safeJsonParse } from "~/utils/safeJsonParse";
 import type { ClickHouseEvaluationRunRow } from "./evaluation-run.mappers";
-import { mapClickHouseEvaluationToTraceEvaluation } from "./evaluation-run.mappers";
+import {
+  EVALUATION_RUN_COLUMNS_LIGHT,
+  EVALUATION_RUN_COLUMNS_WITH_INPUTS,
+  mapClickHouseEvaluationToTraceEvaluation,
+} from "./evaluation-run.mappers";
 import type { TraceEvaluation } from "./evaluation-run.types";
 
-/**
- * Columns the evaluation mapper actually reads, minus the heavy `Inputs`
- * blob. `evaluation_runs` is `ORDER BY (TenantId, EvaluationId)`, so a
- * `TraceId` filter can't prune granules — ClickHouse reads whole granules
- * to evaluate the predicate, and when `Inputs` holds multi-MB payloads
- * (RAG contexts, full conversations) materialising one granule blows past
- * the per-query memory ceiling. The light projection lets us still return
- * verdicts/scores when the heavy read would OOM.
- */
-const EVAL_COLUMNS_LIGHT = [
-  "ProjectionId",
-  "TenantId",
-  "EvaluationId",
-  "Version",
-  "EvaluatorId",
-  "EvaluatorType",
-  "EvaluatorName",
-  "TraceId",
-  "IsGuardrail",
-  "Status",
-  "Score",
-  "Passed",
-  "Label",
-  "Details",
-  "Error",
-  "ScheduledAt",
-  "StartedAt",
-  "CompletedAt",
-  "LastProcessedEventId",
-  "UpdatedAt",
-].join(", ");
-
-const EVAL_COLUMNS_WITH_INPUTS = `${EVAL_COLUMNS_LIGHT}, Inputs`;
+// `evaluation_runs` is `ORDER BY (TenantId, EvaluationId)`, so a `TraceId`
+// filter can't prune granules — ClickHouse reads whole granules to evaluate the
+// predicate, and when `Inputs` holds multi-MB payloads (RAG contexts, full
+// conversations) materialising one granule blows past the per-query memory
+// ceiling. EVALUATION_RUN_COLUMNS_WITH_INPUTS/LIGHT (the light projection drops
+// `Inputs`) let us still return verdicts/scores when the heavy read would OOM.
 
 /**
  * ClickHouse raises this when a query would exceed `max_memory_usage`.
@@ -134,7 +111,7 @@ export class ClickHouseEvaluationService {
         };
 
         try {
-          const rows = await runQuery(EVAL_COLUMNS_WITH_INPUTS);
+          const rows = await runQuery(EVALUATION_RUN_COLUMNS_WITH_INPUTS);
           return rows.map(mapClickHouseEvaluationToTraceEvaluation);
         } catch (error) {
           if (isMemoryLimitError(error)) {
@@ -146,7 +123,7 @@ export class ClickHouseEvaluationService {
               "Evaluations read hit the ClickHouse memory limit; retrying without Inputs",
             );
             try {
-              const rows = await runQuery(EVAL_COLUMNS_LIGHT);
+              const rows = await runQuery(EVALUATION_RUN_COLUMNS_LIGHT);
               return rows.map(mapClickHouseEvaluationToTraceEvaluation);
             } catch (retryError) {
               this.logger.error(
@@ -261,7 +238,9 @@ export class ClickHouseEvaluationService {
         };
 
         try {
-          return groupByTrace(await runQuery(EVAL_COLUMNS_WITH_INPUTS));
+          return groupByTrace(
+            await runQuery(EVALUATION_RUN_COLUMNS_WITH_INPUTS),
+          );
         } catch (error) {
           if (isMemoryLimitError(error)) {
             // Heavy `Inputs` blobs blew the memory ceiling — retry without
@@ -272,7 +251,7 @@ export class ClickHouseEvaluationService {
               "Evaluations read hit the ClickHouse memory limit; retrying without Inputs",
             );
             try {
-              return groupByTrace(await runQuery(EVAL_COLUMNS_LIGHT));
+              return groupByTrace(await runQuery(EVALUATION_RUN_COLUMNS_LIGHT));
             } catch (retryError) {
               this.logger.error(
                 {
@@ -285,7 +264,9 @@ export class ClickHouseEvaluationService {
                 },
                 "Failed to fetch evaluations for multiple traces from ClickHouse after light-projection retry",
               );
-              throw new Error("Failed to fetch evaluations for multiple traces");
+              throw new Error(
+                "Failed to fetch evaluations for multiple traces",
+              );
             }
           }
           this.logger.error(
@@ -349,9 +330,7 @@ export class ClickHouseEvaluationService {
           });
           const rows = (await result.json()) as { Inputs: string | null }[];
           const parsed = safeJsonParse(rows[0]?.Inputs ?? null);
-          return parsed &&
-            typeof parsed === "object" &&
-            !Array.isArray(parsed)
+          return parsed && typeof parsed === "object" && !Array.isArray(parsed)
             ? (parsed as Record<string, unknown>)
             : null;
         } catch (error) {

--- a/langwatch/src/server/evaluations/evaluation-run.mappers.ts
+++ b/langwatch/src/server/evaluations/evaluation-run.mappers.ts
@@ -30,6 +30,39 @@ export interface ClickHouseEvaluationRunRow {
 }
 
 /**
+ * evaluation_runs columns that back {@link ClickHouseEvaluationRunRow}, minus the
+ * heavy `Inputs` payload. Keep in sync with the interface above. Reading these
+ * explicitly avoids `SELECT *`, which also pulls columns no reader consumes
+ * (ErrorDetails, CostId, ArchivedAt, CreatedAt) — and, on the deduped read path,
+ * pulls them across every version before the IN-tuple discards the stale ones.
+ */
+export const EVALUATION_RUN_COLUMNS_LIGHT = [
+  "ProjectionId",
+  "TenantId",
+  "EvaluationId",
+  "Version",
+  "EvaluatorId",
+  "EvaluatorType",
+  "EvaluatorName",
+  "TraceId",
+  "IsGuardrail",
+  "Status",
+  "Score",
+  "Passed",
+  "Label",
+  "Details",
+  "Error",
+  "ScheduledAt",
+  "StartedAt",
+  "CompletedAt",
+  "LastProcessedEventId",
+  "UpdatedAt",
+].join(", ");
+
+/** Light columns plus the heavy `Inputs` payload. */
+export const EVALUATION_RUN_COLUMNS_WITH_INPUTS = `${EVALUATION_RUN_COLUMNS_LIGHT}, Inputs`;
+
+/**
  * Maps a ClickHouse evaluation_runs row to the canonical TraceEvaluation type.
  *
  * @param record - A row from the evaluation_runs table

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -10,6 +10,7 @@ import { prisma as defaultPrisma } from "~/server/db";
 import type { Protections } from "~/server/elasticsearch/protections";
 import {
   type ClickHouseEvaluationRunRow,
+  EVALUATION_RUN_COLUMNS_WITH_INPUTS,
   mapClickHouseEvaluationToTraceEvaluation,
   mapTraceEvaluationsToLegacyEvaluations,
 } from "~/server/evaluations/evaluation-run.mappers";
@@ -2088,7 +2089,7 @@ export class ClickHouseTraceService {
     const runQuery = async (ids: string[]) => {
       const result = await clickHouseClient.query({
         query: `
-          SELECT *
+          SELECT ${EVALUATION_RUN_COLUMNS_WITH_INPUTS}
           FROM evaluation_runs
           WHERE TenantId = {tenantId:String}
             AND TraceId IN ({traceIds:Array(String)})


### PR DESCRIPTION
## Evidence

In the last 24h app-side slow-query log, the dominant **uncovered** evaluation_runs read is the trace-detail evaluations fetch (`fetchEvaluationRows` in `clickhouse-trace.service.ts`):

```
SELECT * FROM evaluation_runs WHERE TenantId = {…} AND TraceId IN ({…}) AND (TenantId, EvaluationId, UpdatedAt) IN (… max(UpdatedAt) …)
```

~390 warns/24h, p50 ~290ms. (The per-trace evaluation service uses an explicit column list already; this trace-service path was the missed `SELECT *`.)

## Suspected cause

`SELECT *` reads every column of `evaluation_runs` for the matched rows. The consumer (`ClickHouseEvaluationRunRow`) only uses 21 columns; `SELECT *` additionally pulls `ErrorDetails`, `CostId`, `ArchivedAt` and `CreatedAt`. `ErrorDetails` in particular is an unbounded error/JSON blob. On this deduped read path the `(TenantId, EvaluationId, UpdatedAt) IN (max-subquery)` predicate materializes those columns across **every version** of each evaluation before the IN filter discards the stale ones.

## Proposed fix

Select the explicit column set the mapper actually reads instead of `SELECT *`. The canonical column list moves next to its row type in `evaluation-run.mappers.ts` (single source of truth, `EVALUATION_RUN_COLUMNS_WITH_INPUTS`) and is reused by both the per-trace evaluation service (which previously had its own copy) and the trace service — so there is now one list, not three. The repo already enforces "no `SELECT *` on evaluation_runs" for the analytics subquery (`analytics/clickhouse/__tests__/column-pruning.test.ts`); this extends the same discipline to the trace-detail path.

## Expected impact

- Stops reading `ErrorDetails`/`CostId`/`ArchivedAt`/`CreatedAt` (across all versions) for every trace-detail evaluations fetch; read bytes drop, most when `ErrorDetails` is large.
- Results unchanged: the explicit list is exactly the columns the mapper consumes, asserted in sync with the row type by a test.

## EXPLAIN check

This is a column-projection change; it does not alter partition/granule pruning, so `EXPLAIN INDEXES` granule counts are identical for both shapes (the win is bytes read per granule, which the read-only EXPLAIN endpoint cannot quantify — ANALYZE is blocked). `EXPLAIN SYNTAX` confirms the new shape selects the 21 explicit columns and is otherwise identical.

## Test plan

- `evaluation-run.mappers.test.ts`: asserts `EVALUATION_RUN_COLUMNS_WITH_INPUTS` lists exactly the keys of `ClickHouseEvaluationRunRow` (stays in sync with the type) and excludes the unused columns. **25/25 pass.**
- Existing `clickhouse-evaluation.fallback`/`inputs` unit tests (which now consume the shared constants) still pass: **29/29.**
- `tsgo` typecheck clean for the changed files.

Advisory PR from the ClickHouse slow-query optimizer. A human should review and ship.
