### PR TITLE
fix(evals-v3): coerce non-string evaluator inputs + lock auto-mapping

### DIFF
--- a/langevals/evaluators/langevals/langevals_langevals/exact_match.py
+++ b/langevals/evaluators/langevals/langevals_langevals/exact_match.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import json
+from typing import Any, Optional
 from langevals_core.base_evaluator import (
     BaseEvaluator,
     EvaluatorEntry,
@@ -60,6 +61,20 @@ class ExactMatchEvaluator(
                 details=f'{output_text} == {expected_output_text}' if passed else f'Expected {output_text} to be equal to {expected_output_text}',
             )
 
+        # Recover the underlying value on each side (json.loads recovers
+        # bools and numbers from their string-coerced form) and compare with
+        # ECMA 7.2.13 loose semantics. An upstream evaluator that emits
+        # `passed: true` then surfaces as the string "true" through the
+        # coercion layer — without this layer it would mismatch a dataset
+        # golden of "1". The transform chain (trim/punct/case) is left for
+        # the genuinely-text-vs-text case so unrelated strings never collide.
+        if _js_loose_equal(output_text, expected_output_text):
+            return ExactMatchResult(
+                score=1,
+                passed=True,
+                details=f'{output_text} == {expected_output_text}',
+            )
+
         if self.settings.trim_whitespace:
             output_text = output_text.strip()
             expected_output_text = expected_output_text.strip()
@@ -88,3 +103,55 @@ class ExactMatchEvaluator(
         except ValueError:
             return False
         return True
+
+
+def _try_json(text: str) -> Any:
+    """
+    Recover a scalar's underlying value from its string-coerced form.
+
+    The coercion layer (TS routes + nlpgo + python NLP autoparse) hands the
+    scorer JSON-canonical strings: 'true' / 'false' for booleans, '42' /
+    '0.5' for numbers, raw text otherwise. json.loads inverts that mapping
+    exactly so the scorer can compare types semantically, falling back to
+    the original string when the value is plain prose.
+    """
+    if not isinstance(text, str):
+        return text
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return text
+
+
+def _js_loose_equal(a: str, b: str) -> bool:
+    """
+    ECMA 7.2.13 abstract equality, scoped to the scalar types the scorer can
+    receive (string, bool, number). Returns False for any pair that needs
+    the existing transform-chain fall-through (two free-form strings, a
+    non-scalar, or a type pairing where ECMA would say not-equal).
+    """
+    left = _try_json(a)
+    right = _try_json(b)
+
+    if isinstance(left, (list, dict)) or isinstance(right, (list, dict)):
+        return False
+
+    left_num = _to_number(left)
+    right_num = _to_number(right)
+    if left_num is not None and right_num is not None:
+        return left_num == right_num
+
+    return False
+
+
+def _to_number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None

--- a/langevals/evaluators/langevals/tests/test_exact_match.py
+++ b/langevals/evaluators/langevals/tests/test_exact_match.py
@@ -187,7 +187,7 @@ def test_langeval_exact_match_transform_chain_still_applies_for_text():
     )
     evaluator = ExactMatchEvaluator(settings=settings)
     result = evaluator.evaluate(entry)
-    assert result.passed == True
+    assert result.passed
 
 
 # @scenario "The float-equality short-circuit still applies for numeric strings"
@@ -195,4 +195,4 @@ def test_langeval_exact_match_float_short_circuit_still_applies():
     entry = ExactMatchEntry(output="1.50", expected_output="1.5")
     evaluator = ExactMatchEvaluator(settings=ExactMatchSettings())
     result = evaluator.evaluate(entry)
-    assert result.passed == True
+    assert result.passed

--- a/langevals/evaluators/langevals/tests/test_exact_match.py
+++ b/langevals/evaluators/langevals/tests/test_exact_match.py
@@ -1,3 +1,5 @@
+import pytest
+
 from langevals_langevals.exact_match import (
     ExactMatchEvaluator,
     ExactMatchEntry,
@@ -133,3 +135,60 @@ def test_langeval_exact_match_numbers_not_match():
     evaluator = ExactMatchEvaluator(settings=settings)
     result = evaluator.evaluate(entry)
     assert result.passed == False
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("true", "1"),
+        ("1", "true"),
+        ("true", "true"),
+        ("false", "0"),
+        ("0", "false"),
+        ("false", "false"),
+        ("1.0", "1"),
+        ("1", "1.0"),
+    ],
+)
+def test_langeval_exact_match_js_loose_equality_match(output, expected):
+    evaluator = ExactMatchEvaluator(settings=ExactMatchSettings())
+    result = evaluator.evaluate(ExactMatchEntry(output=output, expected_output=expected))
+    assert result.passed is True, f"expected {output!r} == {expected!r} under loose semantics"
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("true", "0"),
+        ("false", "1"),
+        ("2", "true"),
+        ("hello", "true"),
+        ("true", "hello"),
+    ],
+)
+def test_langeval_exact_match_js_loose_equality_mismatch(output, expected):
+    evaluator = ExactMatchEvaluator(settings=ExactMatchSettings())
+    result = evaluator.evaluate(ExactMatchEntry(output=output, expected_output=expected))
+    assert result.passed is False, f"expected {output!r} != {expected!r} under loose semantics"
+
+
+def test_langeval_exact_match_transform_chain_still_applies_for_text():
+    """JS-loose layer must not short-circuit the existing trim/punct/case chain
+    when both sides are free-form text."""
+    entry = ExactMatchEntry(
+        output="  Hello!  ",
+        expected_output="hello",
+    )
+    settings = ExactMatchSettings(
+        case_sensitive=False, trim_whitespace=True, remove_punctuation=True
+    )
+    evaluator = ExactMatchEvaluator(settings=settings)
+    result = evaluator.evaluate(entry)
+    assert result.passed == True
+
+
+def test_langeval_exact_match_float_short_circuit_still_applies():
+    entry = ExactMatchEntry(output="1.50", expected_output="1.5")
+    evaluator = ExactMatchEvaluator(settings=ExactMatchSettings())
+    result = evaluator.evaluate(entry)
+    assert result.passed == True

--- a/langevals/evaluators/langevals/tests/test_exact_match.py
+++ b/langevals/evaluators/langevals/tests/test_exact_match.py
@@ -137,6 +137,7 @@ def test_langeval_exact_match_numbers_not_match():
     assert result.passed == False
 
 
+# @scenario "Boolean values match their numeric and string equivalents"
 @pytest.mark.parametrize(
     "output,expected",
     [
@@ -156,6 +157,7 @@ def test_langeval_exact_match_js_loose_equality_match(output, expected):
     assert result.passed is True, f"expected {output!r} == {expected!r} under loose semantics"
 
 
+# @scenario "Mismatched values do not falsely match"
 @pytest.mark.parametrize(
     "output,expected",
     [
@@ -172,6 +174,7 @@ def test_langeval_exact_match_js_loose_equality_mismatch(output, expected):
     assert result.passed is False, f"expected {output!r} != {expected!r} under loose semantics"
 
 
+# @scenario "Non-numeric, non-boolean strings still use the existing transform chain"
 def test_langeval_exact_match_transform_chain_still_applies_for_text():
     """JS-loose layer must not short-circuit the existing trim/punct/case chain
     when both sides are free-form text."""
@@ -187,6 +190,7 @@ def test_langeval_exact_match_transform_chain_still_applies_for_text():
     assert result.passed == True
 
 
+# @scenario "The float-equality short-circuit still applies for numeric strings"
 def test_langeval_exact_match_float_short_circuit_still_applies():
     entry = ExactMatchEntry(output="1.50", expected_output="1.5")
     evaluator = ExactMatchEvaluator(settings=ExactMatchSettings())

--- a/langwatch/scripts/check-feature-parity.ts
+++ b/langwatch/scripts/check-feature-parity.ts
@@ -72,6 +72,21 @@ const DEFAULT_GO_TEST_ROOTS: string[] = [
 ];
 
 /**
+ * Roots scanned for Python `test_*.py` files. Python-side scenarios
+ * (langevals scorers, langwatch_nlp Studio executor) use the same
+ * `@scenario` token as TS/Go; binding is satisfied when the next
+ * non-blank, non-comment line is a `def test_...` function. Without
+ * this scan path, scenarios pinned to langevals scorers or the legacy
+ * python NLP service would have no way to satisfy parity short of a
+ * misleading TS stub.
+ */
+const DEFAULT_PYTHON_TEST_ROOTS: string[] = [
+  "langevals",
+  "langwatch_nlp",
+  "langwatch_server",
+];
+
+/**
  * Feature files whose unbound `@unit` / `@integration` scenarios are
  * tolerated (non-fatal) during migration. These files still parse; their
  * counts surface in the `legacy` block of `--json` output and in the
@@ -96,6 +111,7 @@ const LEGACY_UNBOUND: string[] = [
 const TEST_FILE_RE = /\.test\.tsx?$/;
 const BATS_FILE_RE = /\.bats$/;
 const GO_TEST_FILE_RE = /_test\.go$/;
+const PYTHON_TEST_FILE_RE = /^test_.+\.py$/;
 const FEATURE_FILE_RE = /\.feature$/;
 const SKIP_DIR = new Set(["node_modules", ".next", "dist", "build"]);
 
@@ -384,6 +400,111 @@ function collectGoBindings(testRoots: string[]): CollectedBinding[] {
   return bindings;
 }
 
+/**
+ * Python binding form (block-comment matching the TS form, OR a hash
+ * comment matching the Bats form — either is valid):
+ *
+ *   # @scenario "Boolean values match their numeric and string equivalents"
+ *   def test_langeval_exact_match_js_loose_equality_match(...):
+ *       ...
+ *
+ * The block-comment ANNOTATION_RE picks up `# @scenario <title>` because
+ * the regex isn't comment-syntax aware — it matches the token wherever
+ * it appears. Proximity check then requires the next non-blank,
+ * non-comment line to begin with `def test_`.
+ */
+function isFollowedByPythonTestFunc(src: string, start: number): boolean {
+  const len = src.length;
+  let i = start;
+  while (i < len) {
+    const ch = src[i];
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++;
+      continue;
+    }
+    if (ch === "#") {
+      const nl = src.indexOf("\n", i);
+      if (nl === -1) return false;
+      i = nl + 1;
+      continue;
+    }
+    if (ch === "@") {
+      // Skip Python decorators, including parenthesised multi-line forms
+      // like @pytest.mark.parametrize("a,b", [...]) that span many lines.
+      let j = i + 1;
+      while (j < len && src[j] !== "\n" && src[j] !== "(") j++;
+      if (j < len && src[j] === "(") {
+        let depth = 1;
+        j++;
+        while (j < len && depth > 0) {
+          const c = src[j];
+          if (c === "(") depth++;
+          else if (c === ")") depth--;
+          j++;
+        }
+      }
+      while (j < len && src[j] !== "\n") j++;
+      i = j + 1;
+      continue;
+    }
+    const rest = src.slice(i);
+    return /^(?:async\s+)?def\s+test_[A-Za-z0-9_]*\s*\(/.test(rest);
+  }
+  return false;
+}
+
+const PYTHON_HASH_ANNOTATION_RE =
+  /^[ \t]*#[ \t]*@scenario[ \t]+(?:"([^"\r\n]+)"|'([^'\r\n]+)')[ \t\r]*$/;
+
+function collectPythonBindings(testRoots: string[]): CollectedBinding[] {
+  const bindings: CollectedBinding[] = [];
+  const files: string[] = [];
+  for (const r of testRoots) {
+    files.push(
+      ...walkFiles(resolve(REPO_ROOT, r), (n) => PYTHON_TEST_FILE_RE.test(n))
+    );
+  }
+
+  for (const file of files) {
+    const src = readFileSync(file, "utf8");
+
+    // Block-comment form (mirrors TS / Go).
+    let m: RegExpExecArray | null;
+    ANNOTATION_RE.lastIndex = 0;
+    while ((m = ANNOTATION_RE.exec(src)) !== null) {
+      const title = (m[1] ?? m[2] ?? m[3] ?? "").trim();
+      if (!title) continue;
+      if (!isFollowedByPythonTestFunc(src, m.index + m[0].length)) continue;
+      const line = src.slice(0, m.index).split("\n").length;
+      bindings.push({
+        title,
+        ref: { file: relative(REPO_ROOT, file), line },
+      });
+    }
+
+    // Hash-comment form (mirrors Bats).
+    const lines = src.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? "";
+      const hm = line.match(PYTHON_HASH_ANNOTATION_RE);
+      if (!hm) continue;
+      const title = (hm[1] ?? hm[2] ?? "").trim();
+      if (!title) continue;
+      // Use the same proximity check as the block form. Walk from the
+      // start of the next line.
+      const lineStartOffset =
+        lines.slice(0, i + 1).reduce((acc, l) => acc + l.length + 1, 0);
+      if (!isFollowedByPythonTestFunc(src, lineStartOffset)) continue;
+      bindings.push({
+        title,
+        ref: { file: relative(REPO_ROOT, file), line: i + 1 },
+      });
+    }
+  }
+
+  return bindings;
+}
+
 function collectBatsBindings(testRoots: string[]): CollectedBinding[] {
   const bindings: CollectedBinding[] = [];
   const files: string[] = [];
@@ -539,6 +660,7 @@ function main(): void {
     ...collectAllBindings(DEFAULT_TEST_ROOTS),
     ...collectBatsBindings(DEFAULT_BATS_TEST_ROOTS),
     ...collectGoBindings(DEFAULT_GO_TEST_ROOTS),
+    ...collectPythonBindings(DEFAULT_PYTHON_TEST_ROOTS),
   ];
   const bindingsByTitle = indexByTitle(bindings);
 

--- a/langwatch/src/experiments-v3/utils/__tests__/mappingInference.test.ts
+++ b/langwatch/src/experiments-v3/utils/__tests__/mappingInference.test.ts
@@ -573,6 +573,88 @@ describe("inferEvaluatorMappings", () => {
       expect(mappings.input.sourceId).toBe("ds-1");
     }
   });
+
+  // ==========================================================================
+  // Regression: side-locking — "output" never falls back to a dataset column,
+  // "expected_output"/"input" never fall back to a target output.
+  // Reported by customer; an evaluator's `output` was auto-mapped to a
+  // same-named dataset column (because the runner produced something else),
+  // grading the dataset against itself.
+  // ==========================================================================
+
+  describe("when the locked side has no matching column", () => {
+    it("leaves an `output` mapping empty rather than falling back to a same-named dataset column", () => {
+      const dataset = createTestDataset("ds-1", "Dataset 1", [
+        createTestColumn("output"), // dataset has output, target does not
+      ]);
+      const target = createTestTarget(
+        "target-1",
+        [{ identifier: "input", type: "str" }],
+        [{ identifier: "irrelevant", type: "str" }], // no output-like output
+      );
+      const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
+
+      const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+
+      expect(mappings.output).toBeUndefined();
+    });
+
+    it("leaves an `expected_output` mapping empty rather than falling back to a same-named target output", () => {
+      const dataset = createTestDataset("ds-1", "Dataset 1", [
+        createTestColumn("irrelevant"),
+      ]);
+      const target = createTestTarget(
+        "target-1",
+        [{ identifier: "input", type: "str" }],
+        [{ identifier: "expected_output", type: "str" }], // target has expected_output
+      );
+      const evaluatorInputs: Field[] = [
+        { identifier: "expected_output", type: "str" },
+      ];
+
+      const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+
+      expect(mappings.expected_output).toBeUndefined();
+    });
+
+    it("leaves an `input` mapping empty rather than falling back to a same-named target output", () => {
+      const dataset = createTestDataset("ds-1", "Dataset 1", [
+        createTestColumn("irrelevant"),
+      ]);
+      const target = createTestTarget(
+        "target-1",
+        [{ identifier: "input", type: "str" }],
+        [{ identifier: "input", type: "str" }], // target also emits an "input" output
+      );
+      const evaluatorInputs: Field[] = [{ identifier: "input", type: "str" }];
+
+      const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+
+      expect(mappings.input).toBeUndefined();
+    });
+
+    it("keeps the original dataset-first / target-fallback behavior for custom identifiers outside the locked families", () => {
+      // "score" is not in either locked set. When the dataset has nothing
+      // to offer, the heuristic should still pick a matching target output.
+      const dataset = createTestDataset("ds-1", "Dataset 1", [
+        createTestColumn("irrelevant"),
+      ]);
+      const target = createTestTarget(
+        "target-1",
+        [{ identifier: "input", type: "str" }],
+        [{ identifier: "score", type: "float" }],
+      );
+      const evaluatorInputs: Field[] = [{ identifier: "score", type: "float" }];
+
+      const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+
+      expect(mappings.score?.type).toBe("source");
+      if (mappings.score?.type === "source") {
+        expect(mappings.score.source).toBe("target");
+        expect(mappings.score.sourceField).toBe("score");
+      }
+    });
+  });
 });
 
 // ============================================================================

--- a/langwatch/src/experiments-v3/utils/__tests__/mappingInference.test.ts
+++ b/langwatch/src/experiments-v3/utils/__tests__/mappingInference.test.ts
@@ -457,6 +457,7 @@ describe("inferEvaluatorMappings", () => {
     });
   });
 
+  /** @scenario Target output wins over a same-named dataset column for "output" */
   it("prioritizes target output over dataset column for output field", () => {
     const dataset = createTestDataset("ds-1", "Dataset 1", [
       createTestColumn("output"), // Dataset also has "output"
@@ -583,6 +584,7 @@ describe("inferEvaluatorMappings", () => {
   // ==========================================================================
 
   describe("when the locked side has no matching column", () => {
+    /** @scenario "output" never falls back to a dataset column */
     it("leaves an `output` mapping empty rather than falling back to a same-named dataset column", () => {
       const dataset = createTestDataset("ds-1", "Dataset 1", [
         createTestColumn("output"), // dataset has output, target does not
@@ -599,6 +601,7 @@ describe("inferEvaluatorMappings", () => {
       expect(mappings.output).toBeUndefined();
     });
 
+    /** @scenario "expected_output" never picks the runner output */
     it("leaves an `expected_output` mapping empty rather than falling back to a same-named target output", () => {
       const dataset = createTestDataset("ds-1", "Dataset 1", [
         createTestColumn("irrelevant"),
@@ -617,6 +620,7 @@ describe("inferEvaluatorMappings", () => {
       expect(mappings.expected_output).toBeUndefined();
     });
 
+    /** @scenario "input" never picks the runner output */
     it("leaves an `input` mapping empty rather than falling back to a same-named target output", () => {
       const dataset = createTestDataset("ds-1", "Dataset 1", [
         createTestColumn("irrelevant"),

--- a/langwatch/src/experiments-v3/utils/mappingInference.ts
+++ b/langwatch/src/experiments-v3/utils/mappingInference.ts
@@ -271,8 +271,10 @@ export const propagateMappingsToNewDataset = (
 };
 
 /**
- * Fields that should primarily come from the target output.
- * "output" is the most common evaluator input that should connect to target.
+ * Identifiers whose only sensible source is the runner/target output. The
+ * heuristic never falls back to a same-named dataset column for these —
+ * letting an evaluator's `output` map back to a dataset column produces the
+ * very tautology the user did not want (grading the dataset against itself).
  */
 const TARGET_OUTPUT_FIELDS = new Set([
   "output",
@@ -280,6 +282,38 @@ const TARGET_OUTPUT_FIELDS = new Set([
   "answer",
   "result",
   "generated",
+]);
+
+/**
+ * Identifiers whose only sensible source is the dataset. The heuristic never
+ * falls back to a same-named runner output for these — the whole reason a
+ * dataset row carries an expected answer or an input is to grade against it,
+ * and reading those back from the runner would be a tautology too.
+ *
+ * Anything outside both sets (custom evaluator inputs like `score`,
+ * `threshold`, `label`) keeps the original dual-try behavior so the
+ * restriction stays narrow.
+ */
+const DATASET_INPUT_FIELDS = new Set([
+  // Input family (the prompt's input)
+  "input",
+  "question",
+  "user_input",
+  "user_query",
+  "query",
+  "prompt",
+  "message",
+  // Expected family (the golden answer)
+  "expected_output",
+  "expected_answer",
+  "ground_truth",
+  "expected",
+  "expected_result",
+  // Context family (retrieval / supporting facts)
+  "context",
+  "contexts",
+  "retrieved_contexts",
+  "relevant_context",
 ]);
 
 /**
@@ -314,11 +348,11 @@ export const inferEvaluatorMappings = (
     }
 
     const fieldLower = input.identifier.toLowerCase();
-    const shouldPrioritizeTarget = TARGET_OUTPUT_FIELDS.has(fieldLower);
+    const isTargetOnly = TARGET_OUTPUT_FIELDS.has(fieldLower);
+    const isDatasetOnly = DATASET_INPUT_FIELDS.has(fieldLower);
 
-    if (shouldPrioritizeTarget) {
-      // For "output" and similar: try target FIRST, then dataset
-      const targetOutputMatch = findMatchingColumn(
+    const targetMatch = (): string | undefined =>
+      findMatchingColumn(
         input.identifier,
         target.outputs.map((o) => ({
           id: o.identifier,
@@ -327,60 +361,54 @@ export const inferEvaluatorMappings = (
         })),
       );
 
-      if (targetOutputMatch) {
+    const datasetMatch = (): string | undefined =>
+      findMatchingColumn(input.identifier, dataset.columns);
+
+    if (isTargetOnly) {
+      const m = targetMatch();
+      if (m) {
         newMappings[input.identifier] = {
           type: "source",
           source: "target",
           sourceId: target.id,
-          sourceField: targetOutputMatch,
+          sourceField: m,
         };
-        continue;
       }
-
-      // Fallback to dataset if no target match
-      const datasetColumnMatch = findMatchingColumn(
-        input.identifier,
-        dataset.columns,
-      );
-      if (datasetColumnMatch) {
+      // No dataset fallback: empty beats a mapping that grades the dataset
+      // against itself.
+    } else if (isDatasetOnly) {
+      const m = datasetMatch();
+      if (m) {
         newMappings[input.identifier] = {
           type: "source",
           source: "dataset",
           sourceId: dataset.id,
-          sourceField: datasetColumnMatch,
+          sourceField: m,
         };
       }
+      // No target fallback: empty beats a mapping that reads an expected
+      // answer back from the runner.
     } else {
-      // For "input", "expected_output", etc: try dataset FIRST, then target
-      const datasetColumnMatch = findMatchingColumn(
-        input.identifier,
-        dataset.columns,
-      );
-      if (datasetColumnMatch) {
+      // Custom identifier (score, threshold, label, etc.): dataset first,
+      // then target. Preserves the original heuristic for everything
+      // outside the locked-side families above.
+      const fromDataset = datasetMatch();
+      if (fromDataset) {
         newMappings[input.identifier] = {
           type: "source",
           source: "dataset",
           sourceId: dataset.id,
-          sourceField: datasetColumnMatch,
+          sourceField: fromDataset,
         };
         continue;
       }
-
-      // Fallback to target if no dataset match
-      const targetOutputMatch = findMatchingColumn(
-        input.identifier,
-        target.outputs.map((o) => ({
-          id: o.identifier,
-          name: o.identifier,
-          type: "string" as const,
-        })),
-      );
-      if (targetOutputMatch) {
+      const fromTarget = targetMatch();
+      if (fromTarget) {
         newMappings[input.identifier] = {
           type: "source",
           source: "target",
           sourceId: target.id,
-          sourceField: targetOutputMatch,
+          sourceField: fromTarget,
         };
       }
     }

--- a/langwatch/src/server/routes/__tests__/evaluator-input-coercion.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/evaluator-input-coercion.unit.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression: workbench live-execute of an evaluator-as-target into a
+ * downstream string-input scorer used to reject boolean/number/object outputs
+ * with "Validation error: Expected string, received boolean at output".
+ *
+ * Covers the REST schema path (getEvaluatorDataForParams →
+ * defaultEvaluatorInputSchema.parse) for the source types listed in
+ * specs/experiments-v3/evaluator-as-target.feature.
+ */
+import { describe, expect, it } from "vitest";
+
+import { getEvaluatorDataForParams } from "../evaluations-legacy";
+
+const evaluate = (params: Record<string, unknown>) =>
+  getEvaluatorDataForParams("langevals/exact_match", params);
+
+describe("getEvaluatorDataForParams coercion", () => {
+  describe("when an upstream target output is a boolean", () => {
+    it("coerces true to the string 'true' on output", () => {
+      const result = evaluate({ output: true, expected_output: "1" });
+      expect(result.type).toBe("default");
+      if (result.type !== "default") throw new Error("unreachable");
+      expect(result.data.output).toBe("true");
+      expect(result.data.expected_output).toBe("1");
+    });
+
+    it("coerces false to the string 'false' on output", () => {
+      const result = evaluate({ output: false, expected_output: "0" });
+      if (result.type !== "default") throw new Error("unreachable");
+      expect(result.data.output).toBe("false");
+    });
+  });
+
+  describe("when an upstream target output is a number", () => {
+    it("coerces integers to their string form", () => {
+      const result = evaluate({ output: 42, expected_output: "42" });
+      if (result.type !== "default") throw new Error("unreachable");
+      expect(result.data.output).toBe("42");
+    });
+
+    it("coerces floats to their string form", () => {
+      const result = evaluate({ output: 0.5, expected_output: "0.5" });
+      if (result.type !== "default") throw new Error("unreachable");
+      expect(result.data.output).toBe("0.5");
+    });
+  });
+
+  describe("when an upstream target output is an object or array", () => {
+    it("JSON-stringifies objects on output", () => {
+      const result = evaluate({ output: { a: 1 }, expected_output: '{"a":1}' });
+      if (result.type !== "default") throw new Error("unreachable");
+      expect(result.data.output).toBe('{"a":1}');
+    });
+
+    it("JSON-stringifies arrays on output", () => {
+      const result = evaluate({ output: [1, 2, 3], expected_output: "[1,2,3]" });
+      if (result.type !== "default") throw new Error("unreachable");
+      expect(result.data.output).toBe("[1,2,3]");
+    });
+  });
+
+  describe("when the upstream target output is null", () => {
+    it("preserves null rather than coercing to the string 'null'", () => {
+      const result = evaluate({ output: null, expected_output: "anything" });
+      if (result.type !== "default") throw new Error("unreachable");
+      expect(result.data.output).toBeUndefined();
+    });
+  });
+
+  describe("when input + expected_output + conversation fields receive non-strings", () => {
+    it("coerces every scalar field the same way", () => {
+      const result = evaluate({
+        input: { user: "ok" },
+        output: true,
+        expected_output: 1,
+        conversation: [{ input: true, output: 0.5 }],
+      });
+      if (result.type !== "default") throw new Error("unreachable");
+      expect(result.data.input).toBe('{"user":"ok"}');
+      expect(result.data.output).toBe("true");
+      expect(result.data.expected_output).toBe("1");
+      expect(result.data.conversation).toBe(
+        JSON.stringify([{ input: "true", output: "0.5" }]),
+      );
+    });
+  });
+
+  describe("when checkType is a custom evaluator", () => {
+    it("passes params through without coercion (custom evaluators self-validate)", () => {
+      const result = getEvaluatorDataForParams("custom/wf_123", {
+        output: true,
+        expected_output: 1,
+      });
+      expect(result.type).toBe("custom");
+      if (result.type !== "custom") throw new Error("unreachable");
+      expect(result.data.output).toBe(true);
+      expect(result.data.expected_output).toBe(1);
+    });
+  });
+});

--- a/langwatch/src/server/routes/__tests__/evaluator-input-coercion.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/evaluator-input-coercion.unit.test.ts
@@ -16,6 +16,9 @@ const evaluate = (params: Record<string, unknown>) =>
 
 describe("getEvaluatorDataForParams coercion", () => {
   describe("when an upstream target output is a boolean", () => {
+    /** @scenario Downstream evaluator receives a boolean target output without rejection */
+    /** @scenario Non-string target outputs are coerced to the evaluator's declared input type */
+    /** @scenario Online evaluation request with a boolean trace metadata mapping runs without rejection */
     it("coerces true to the string 'true' on output", () => {
       const result = evaluate({ output: true, expected_output: "1" });
       expect(result.type).toBe("default");
@@ -60,6 +63,7 @@ describe("getEvaluatorDataForParams coercion", () => {
   });
 
   describe("when the upstream target output is null", () => {
+    /** @scenario Null target outputs are preserved, not coerced into a string */
     it("preserves null rather than coercing to the string 'null'", () => {
       const result = evaluate({ output: null, expected_output: "anything" });
       if (result.type !== "default") throw new Error("unreachable");

--- a/langwatch/src/server/routes/evaluations-legacy.ts
+++ b/langwatch/src/server/routes/evaluations-legacy.ts
@@ -67,6 +67,7 @@ import {
 } from "~/server/experiments/types.generated";
 import { getPayloadSizeHistogram } from "~/server/metrics";
 import { rAGChunkSchema } from "~/server/tracer/types.generated";
+import { coerceEvaluatorScalar } from "~/server/utils/coerceEvaluatorScalar";
 import { createLogger } from "~/utils/logger/server";
 import { findOrCreateExperiment } from "~/pages/api/experiment/init";
 import type { Permission } from "~/server/api/rbac";
@@ -488,14 +489,19 @@ const batchEvaluationInputSchema = z.object({
 
 type BatchEvaluationRESTParams = z.infer<typeof batchEvaluationInputSchema>;
 
+const coercedString = z.preprocess(
+  coerceEvaluatorScalar,
+  z.string().optional().nullable(),
+);
+
 const defaultEvaluatorInputSchema = z.object({
-  input: z.string().optional().nullable(),
-  output: z.string().optional().nullable(),
+  input: coercedString,
+  output: coercedString,
   contexts: z
     .union([z.array(rAGChunkSchema), z.array(z.string())])
     .optional()
     .nullable(),
-  expected_output: z.string().optional().nullable(),
+  expected_output: coercedString,
   expected_contexts: z
     .union([z.array(rAGChunkSchema), z.array(z.string())])
     .optional()
@@ -503,8 +509,8 @@ const defaultEvaluatorInputSchema = z.object({
   conversation: z
     .array(
       z.object({
-        input: z.string().optional().nullable(),
-        output: z.string().optional().nullable(),
+        input: coercedString,
+        output: coercedString,
       }),
     )
     .optional()

--- a/langwatch/src/server/utils/__tests__/coerceEvaluatorScalar.unit.test.ts
+++ b/langwatch/src/server/utils/__tests__/coerceEvaluatorScalar.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { coerceEvaluatorScalar } from "../coerceEvaluatorScalar";
+
+describe("coerceEvaluatorScalar", () => {
+  describe("when value is a string", () => {
+    it("passes the string through unchanged", () => {
+      expect(coerceEvaluatorScalar("hello")).toBe("hello");
+      expect(coerceEvaluatorScalar("")).toBe("");
+    });
+  });
+
+  describe("when value is null or undefined", () => {
+    it("preserves null", () => {
+      expect(coerceEvaluatorScalar(null)).toBeNull();
+    });
+
+    it("preserves undefined", () => {
+      expect(coerceEvaluatorScalar(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("when value is a boolean", () => {
+    it("coerces true to the string 'true'", () => {
+      expect(coerceEvaluatorScalar(true)).toBe("true");
+    });
+
+    it("coerces false to the string 'false'", () => {
+      expect(coerceEvaluatorScalar(false)).toBe("false");
+    });
+  });
+
+  describe("when value is a number", () => {
+    it("coerces integers to their string form", () => {
+      expect(coerceEvaluatorScalar(42)).toBe("42");
+      expect(coerceEvaluatorScalar(0)).toBe("0");
+      expect(coerceEvaluatorScalar(-1)).toBe("-1");
+    });
+
+    it("coerces floats to their string form", () => {
+      expect(coerceEvaluatorScalar(0.5)).toBe("0.5");
+    });
+
+    it("nulls out non-finite numbers so the schema rejects them rather than coerces 'NaN'/'Infinity'", () => {
+      expect(coerceEvaluatorScalar(NaN)).toBeNull();
+      expect(coerceEvaluatorScalar(Infinity)).toBeNull();
+      expect(coerceEvaluatorScalar(-Infinity)).toBeNull();
+    });
+  });
+
+  describe("when value is a bigint", () => {
+    it("coerces to its decimal string form", () => {
+      expect(coerceEvaluatorScalar(BigInt("9007199254740993"))).toBe(
+        "9007199254740993",
+      );
+    });
+  });
+
+  describe("when value is an object or array", () => {
+    it("JSON-stringifies plain objects", () => {
+      expect(coerceEvaluatorScalar({ a: 1 })).toBe('{"a":1}');
+    });
+
+    it("JSON-stringifies arrays", () => {
+      expect(coerceEvaluatorScalar([1, 2, 3])).toBe("[1,2,3]");
+    });
+
+    it("JSON-stringifies nested structures", () => {
+      expect(coerceEvaluatorScalar({ a: [1, { b: true }] })).toBe(
+        '{"a":[1,{"b":true}]}',
+      );
+    });
+  });
+});

--- a/langwatch/src/server/utils/coerceEvaluatorScalar.ts
+++ b/langwatch/src/server/utils/coerceEvaluatorScalar.ts
@@ -1,0 +1,23 @@
+/**
+ * Coerce a mapped evaluator input value to its string form before the request
+ * is validated against the langevals schema.
+ *
+ * Parity with langwatch_nlp/studio/field_parser.py `autoparse_field_value` for
+ * `FieldType.str`: strings pass through, null/undefined are preserved, every
+ * other shape is JSON-serialised. The batch and online paths already apply the
+ * same semantics via tracesMapping.ts `tryAndConvertTo`; this helper exists so
+ * the workbench REST live-execute path produces an identical string before the
+ * Zod schema rejects it.
+ */
+export const coerceEvaluatorScalar = (value: unknown): unknown => {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return value;
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return Number.isFinite(value) ? String(value) : null;
+  if (typeof value === "bigint") return value.toString();
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};

--- a/langwatch/src/server/utils/coerceEvaluatorScalar.ts
+++ b/langwatch/src/server/utils/coerceEvaluatorScalar.ts
@@ -4,7 +4,7 @@
  *
  * Parity with langwatch_nlp/studio/field_parser.py `autoparse_field_value` for
  * `FieldType.str`: strings pass through, null/undefined are preserved, every
- * other shape is JSON-serialised. The batch and online paths already apply the
+ * other shape is JSON-serialized. The batch and online paths already apply the
  * same semantics via tracesMapping.ts `tryAndConvertTo`; this helper exists so
  * the workbench REST live-execute path produces an identical string before the
  * Zod schema rejects it.

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/coerce.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/coerce.go
@@ -3,6 +3,7 @@ package evaluatorblock
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 )
 
@@ -30,11 +31,18 @@ func coerceScalar(v any) any {
 	case json.Number:
 		return x.String()
 	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return nil
+		}
 		// strconv with -1 prec emits the shortest round-trip form
 		// (e.g. 42, 0.5) without trailing ".000000".
 		return strconv.FormatFloat(x, 'f', -1, 64)
 	case float32:
-		return strconv.FormatFloat(float64(x), 'f', -1, 32)
+		f := float64(x)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return nil
+		}
+		return strconv.FormatFloat(f, 'f', -1, 32)
 	case int:
 		return strconv.Itoa(x)
 	case int8:

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/coerce.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/coerce.go
@@ -10,7 +10,7 @@ import (
 // the langevals string-input schema expects. Parity with
 // langwatch_nlp/studio/field_parser.py `autoparse_field_value` for
 // `FieldType.str`: strings pass through, nil is preserved, every other shape
-// is serialised to its JSON form.
+// is serialized to its JSON form.
 //
 // This restores at the Studio workflow boundary what the Python NLP era
 // hid behind autoparse; without it a workflow that pipes a bool-emitting

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/coerce.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/coerce.go
@@ -1,0 +1,107 @@
+package evaluatorblock
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// coerceScalar converts a single mapped evaluator input value into the form
+// the langevals string-input schema expects. Parity with
+// langwatch_nlp/studio/field_parser.py `autoparse_field_value` for
+// `FieldType.str`: strings pass through, nil is preserved, every other shape
+// is serialised to its JSON form.
+//
+// This restores at the Studio workflow boundary what the Python NLP era
+// hid behind autoparse; without it a workflow that pipes a bool-emitting
+// node into a string-input evaluator surfaces a Pydantic rejection.
+func coerceScalar(v any) any {
+	if v == nil {
+		return nil
+	}
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case json.Number:
+		return x.String()
+	case float64:
+		// strconv with -1 prec emits the shortest round-trip form
+		// (e.g. 42, 0.5) without trailing ".000000".
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(x), 'f', -1, 32)
+	case int:
+		return strconv.Itoa(x)
+	case int8:
+		return strconv.FormatInt(int64(x), 10)
+	case int16:
+		return strconv.FormatInt(int64(x), 10)
+	case int32:
+		return strconv.FormatInt(int64(x), 10)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case uint:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint64:
+		return strconv.FormatUint(x, 10)
+	}
+	if b, err := json.Marshal(v); err == nil {
+		return string(b)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// coerceData walks an evaluator input payload and coerces each scalar field.
+// Conversation arrays are recursed into so per-turn input/output are coerced
+// too. Contexts arrays are left as-is — the langevals schema accepts either
+// list[str] or list[RAGChunk], and per-element coercion happens at the
+// langwatch app boundary if needed.
+func coerceData(data map[string]any) map[string]any {
+	if data == nil {
+		return nil
+	}
+	out := make(map[string]any, len(data))
+	for k, v := range data {
+		switch k {
+		case "contexts", "expected_contexts":
+			out[k] = v
+		case "conversation":
+			out[k] = coerceConversation(v)
+		default:
+			out[k] = coerceScalar(v)
+		}
+	}
+	return out
+}
+
+func coerceConversation(v any) any {
+	arr, ok := v.([]any)
+	if !ok {
+		return v
+	}
+	out := make([]any, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			out = append(out, item)
+			continue
+		}
+		coerced := make(map[string]any, len(m))
+		for k, val := range m {
+			coerced[k] = coerceScalar(val)
+		}
+		out = append(out, coerced)
+	}
+	return out
+}

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/coerce_test.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/coerce_test.go
@@ -1,0 +1,76 @@
+package evaluatorblock
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCoerceScalar(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{"nil preserved", nil, nil},
+		{"string passthrough", "hello", "hello"},
+		{"empty string passthrough", "", ""},
+		{"true to 'true'", true, "true"},
+		{"false to 'false'", false, "false"},
+		{"int to decimal", 42, "42"},
+		{"int64 to decimal", int64(-7), "-7"},
+		{"float64 integer to '42'", float64(42), "42"},
+		{"float64 to '0.5'", 0.5, "0.5"},
+		{"json.Number passthrough as string", json.Number("12.5"), "12.5"},
+		{"map to JSON", map[string]any{"a": 1}, `{"a":1}`},
+		{"slice to JSON", []any{1, 2, 3}, `[1,2,3]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := coerceScalar(tc.in)
+			if got != tc.want {
+				t.Fatalf("coerceScalar(%v) = %v (%T), want %v (%T)", tc.in, got, got, tc.want, tc.want)
+			}
+		})
+	}
+}
+
+func TestCoerceDataPreservesContextsAndConversation(t *testing.T) {
+	in := map[string]any{
+		"input":           true,
+		"output":          float64(0.5),
+		"expected_output": 1,
+		"contexts":        []any{"a", "b"},
+		"conversation": []any{
+			map[string]any{"input": true, "output": 42},
+			map[string]any{"input": "still", "output": "string"},
+		},
+	}
+	out := coerceData(in)
+
+	if out["input"] != "true" {
+		t.Errorf("expected input='true', got %v", out["input"])
+	}
+	if out["output"] != "0.5" {
+		t.Errorf("expected output='0.5', got %v", out["output"])
+	}
+	if out["expected_output"] != "1" {
+		t.Errorf("expected expected_output='1', got %v", out["expected_output"])
+	}
+	if ctxs, ok := out["contexts"].([]any); !ok || len(ctxs) != 2 || ctxs[0] != "a" {
+		t.Errorf("contexts should pass through unchanged, got %v", out["contexts"])
+	}
+	conv, ok := out["conversation"].([]any)
+	if !ok || len(conv) != 2 {
+		t.Fatalf("conversation lost shape: %v", out["conversation"])
+	}
+	turn0, _ := conv[0].(map[string]any)
+	if turn0["input"] != "true" || turn0["output"] != "42" {
+		t.Errorf("turn 0 not coerced: %v", turn0)
+	}
+}
+
+func TestCoerceDataNil(t *testing.T) {
+	if got := coerceData(nil); got != nil {
+		t.Fatalf("coerceData(nil) = %v, want nil", got)
+	}
+}

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/coerce_test.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/coerce_test.go
@@ -2,6 +2,7 @@ package evaluatorblock
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 )
 
@@ -67,6 +68,28 @@ func TestCoerceDataPreservesContextsAndConversation(t *testing.T) {
 	turn0, _ := conv[0].(map[string]any)
 	if turn0["input"] != "true" || turn0["output"] != "42" {
 		t.Errorf("turn 0 not coerced: %v", turn0)
+	}
+}
+
+func TestCoerceScalarNonFiniteFloats(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+	}{
+		{"NaN float64", math.NaN()},
+		{"+Inf float64", math.Inf(1)},
+		{"-Inf float64", math.Inf(-1)},
+		{"NaN float32", float32(math.NaN())},
+		{"+Inf float32", float32(math.Inf(1))},
+		{"-Inf float32", float32(math.Inf(-1))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := coerceScalar(tc.in)
+			if got != nil {
+				t.Fatalf("coerceScalar(%v) = %v, want nil (parity with TS coerceEvaluatorScalar)", tc.in, got)
+			}
+		})
 	}
 }
 

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/coerce_test.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/coerce_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 )
 
+/** @scenario Non-string upstream outputs are coerced before dispatch */
 func TestCoerceScalar(t *testing.T) {
 	cases := []struct {
 		name string
@@ -69,6 +70,7 @@ func TestCoerceDataPreservesContextsAndConversation(t *testing.T) {
 	}
 }
 
+/** @scenario Null upstream values are preserved, not coerced into a string */
 func TestCoerceDataNil(t *testing.T) {
 	if got := coerceData(nil); got != nil {
 		t.Fatalf("coerceData(nil) = %v, want nil", got)

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/executor.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/executor.go
@@ -159,7 +159,7 @@ func (e *Executor) Execute(ctx context.Context, req Request) (*Result, error) {
 	}
 
 	body := map[string]any{
-		"data": req.Data,
+		"data": coerceData(req.Data),
 	}
 	if req.Name != "" {
 		body["name"] = req.Name

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/executor.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/executor.go
@@ -158,8 +158,21 @@ func (e *Executor) Execute(ctx context.Context, req Request) (*Result, error) {
 		return nil, err
 	}
 
+	// Coercion is scoped to the default langevals/* string-input path,
+	// where the receiving Pydantic schema declares every field as `str`
+	// and would reject a raw bool/number with "Expected string, received
+	// boolean". Saved (`evaluators/*`) and workflow (`custom/*`)
+	// evaluators carry their own typed field definitions
+	// (bool/float/int/dict/json_schema) and the app side resolves them
+	// against the evaluator's declared inputs, so the data payload must
+	// stay pass-through here — coercing would silently convert typed
+	// fields to strings before the receiving evaluator can validate them.
+	data := req.Data
+	if strings.HasPrefix(req.EvaluatorSlug, "langevals/") {
+		data = coerceData(req.Data)
+	}
 	body := map[string]any{
-		"data": coerceData(req.Data),
+		"data": data,
 	}
 	if req.Name != "" {
 		body["name"] = req.Name

--- a/services/nlpgo/app/engine/blocks/evaluatorblock/executor_test.go
+++ b/services/nlpgo/app/engine/blocks/evaluatorblock/executor_test.go
@@ -211,6 +211,94 @@ func TestExecute_NonJSONErrorBodyPropagatesAsHTTPError(t *testing.T) {
 	}
 }
 
+// Saved + workflow evaluators own their input typing (bool, float, int,
+// dict, json_schema) and the app resolves them against the evaluator's
+// declared inputs. The langevals/* coercion path stringifies non-strings
+// so the receiving Pydantic schema accepts them — applying the same
+// stringification to a workflow evaluator would silently destroy the
+// caller's declared types. This test pins the boundary.
+func TestExecute_CustomAndSavedSlugsPassDataThroughUnchanged(t *testing.T) {
+	cases := []struct {
+		name string
+		slug string
+	}{
+		{"saved evaluator slug", "evaluators/saved-eval-id"},
+		{"custom workflow evaluator slug", "custom/workflow-id-abc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := &captureCall{}
+			srv := newServer(t, 200, map[string]any{"status": "processed"}, capture)
+
+			exec := evaluatorblock.New(evaluatorblock.Options{})
+			_, err := exec.Execute(context.Background(), evaluatorblock.Request{
+				BaseURL:       srv.URL,
+				APIKey:        "k",
+				EvaluatorSlug: tc.slug,
+				Data: map[string]any{
+					"flag":      true,
+					"threshold": 0.5,
+					"limit":     42,
+					"shape":     map[string]any{"a": 1},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			data, ok := capture.requestBody["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("body.data missing or wrong shape: %v", capture.requestBody["data"])
+			}
+			// JSON round-trip turns the bool into true (not "true"), int
+			// into float64 42 (not "42"), and the map stays a map.
+			if got, ok := data["flag"].(bool); !ok || got != true {
+				t.Errorf("flag = %v (%T), want true (bool, unchanged)", data["flag"], data["flag"])
+			}
+			if got, ok := data["threshold"].(float64); !ok || got != 0.5 {
+				t.Errorf("threshold = %v (%T), want 0.5 (float64, unchanged)", data["threshold"], data["threshold"])
+			}
+			if got, ok := data["limit"].(float64); !ok || got != 42 {
+				t.Errorf("limit = %v (%T), want 42 (float64, unchanged)", data["limit"], data["limit"])
+			}
+			if shape, ok := data["shape"].(map[string]any); !ok || shape["a"] != float64(1) {
+				t.Errorf("shape = %v, want map preserved unchanged", data["shape"])
+			}
+		})
+	}
+}
+
+// Langevals/* slugs MUST still be coerced — the receiving Pydantic schema
+// types every field as `str`. This pairs with the pass-through test above
+// to pin the boundary from both sides.
+func TestExecute_LangevalsSlugStillCoercesData(t *testing.T) {
+	capture := &captureCall{}
+	srv := newServer(t, 200, map[string]any{"status": "processed"}, capture)
+
+	exec := evaluatorblock.New(evaluatorblock.Options{})
+	_, err := exec.Execute(context.Background(), evaluatorblock.Request{
+		BaseURL:       srv.URL,
+		APIKey:        "k",
+		EvaluatorSlug: "langevals/exact_match",
+		Data: map[string]any{
+			"output":          true,
+			"expected_output": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	data, ok := capture.requestBody["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("body.data missing or wrong shape: %v", capture.requestBody["data"])
+	}
+	if got, ok := data["output"].(string); !ok || got != "true" {
+		t.Errorf("output = %v (%T), want \"true\" (string, coerced)", data["output"], data["output"])
+	}
+	if got, ok := data["expected_output"].(string); !ok || got != "1" {
+		t.Errorf("expected_output = %v (%T), want \"1\" (string passthrough)", data["expected_output"], data["expected_output"])
+	}
+}
+
 func TestExecute_NestedSlugUrlEncodedCorrectly(t *testing.T) {
 	capture := &captureCall{}
 	srv := newServer(t, 200, map[string]any{"status": "processed"}, capture)

--- a/specs/evaluators/exact-match-loose-equality.feature
+++ b/specs/evaluators/exact-match-loose-equality.feature
@@ -1,0 +1,63 @@
+@regression
+Feature: Exact-match scorer with JavaScript-style loose equality
+  As an evaluation author
+  I want exact-match to treat numerically- or semantically-equivalent values
+    as a match even when one side is a boolean and the other a string
+  So that an evaluator-as-target's `passed: true` output can be graded
+    against a dataset golden label of "1" without false negatives
+
+  # The scorer has long used a float-equality short-circuit so "1.0" matches
+  # "1". The same intuition applies to booleans: an upstream evaluator that
+  # emits `passed: true` represents the same answer as a dataset row whose
+  # golden label is "1" (or "true"). Without the loose-equality layer the
+  # rows score as a mismatch even though the user clearly intends them to
+  # match. The semantic lives in the scorer (not in the upstream coercion)
+  # so that the value still arrives at the scorer with full fidelity — the
+  # match is a scorer decision, not a string-pipeline artifact.
+
+  Background:
+    Given the exact-match scorer with default settings
+
+  Scenario Outline: Boolean values match their numeric and string equivalents
+    Given the evaluator output is "<output>"
+    And the expected output is "<expected>"
+    When the row is scored
+    Then the row is reported as a match
+
+    Examples:
+      | output | expected |
+      | true   | 1        |
+      | 1      | true     |
+      | true   | true     |
+      | false  | 0        |
+      | 0      | false    |
+      | false  | false    |
+      | 1.0    | 1        |
+      | 1      | 1.0      |
+
+  Scenario Outline: Mismatched values do not falsely match
+    Given the evaluator output is "<output>"
+    And the expected output is "<expected>"
+    When the row is scored
+    Then the row is reported as a mismatch
+
+    Examples:
+      | output | expected |
+      | true   | 0        |
+      | false  | 1        |
+      | 2      | true     |
+      | hello  | true     |
+      | true   | hello    |
+
+  Scenario: Non-numeric, non-boolean strings still use the existing transform chain
+    Given the evaluator output is "  Hello!  "
+    And the expected output is "hello"
+    And the scorer is configured to trim whitespace, ignore punctuation, and ignore case
+    When the row is scored
+    Then the row is reported as a match
+
+  Scenario: The float-equality short-circuit still applies for numeric strings
+    Given the evaluator output is "1.50"
+    And the expected output is "1.5"
+    When the row is scored
+    Then the row is reported as a match

--- a/specs/experiments-v3/evaluator-as-target.feature
+++ b/specs/experiments-v3/evaluator-as-target.feature
@@ -194,3 +194,55 @@ Feature: Evaluator as evaluation target
     Then the evaluator target is restored
     And the target has the correct dbEvaluatorId
     And the mappings are preserved
+
+  # ============================================================================
+  # Type coercion when piping a target output into a downstream evaluator input
+  # ============================================================================
+  #
+  # An evaluator-as-target emits typed outputs: passed (bool), score (float),
+  # label (str). A downstream string-input evaluator (Exact Match, LLM Answer
+  # Match, etc.) accepts those outputs without surfacing the customer-visible
+  # "Validation error: Expected string, received boolean" rejection. The
+  # workbench live-execute path coerces the mapped value to the evaluator's
+  # declared input type before the request is validated, matching the
+  # coercion the batch worker already applied for years.
+
+  @regression
+  Scenario: Downstream evaluator receives a boolean target output without rejection
+    Given an evaluator target "Sentiment Check" emits "passed" as a boolean
+    And a downstream evaluator "Exact Match" expects "output" as a string
+    And "output" is mapped to "Sentiment Check.passed"
+    And "expected_output" is mapped to a dataset column containing "1"
+    When I run the downstream evaluator
+    Then the evaluator runs without a "Expected string, received boolean" error
+    And the row scores as a match
+
+  Scenario Outline: Non-string target outputs are coerced to the evaluator's declared input type
+    Given an evaluator target emits an output of type "<source_type>" with value "<source_value>"
+    And a downstream evaluator expects an "output" input typed as string
+    When the downstream evaluator runs with that mapping
+    Then the value reaches the scorer as the string "<as_string>"
+    And no validation error is surfaced to the user
+
+    Examples:
+      | source_type | source_value | as_string          |
+      | boolean     | true         | true               |
+      | boolean     | false        | false              |
+      | number      | 42           | 42                 |
+      | number      | 0.5          | 0.5                |
+      | object      | {"a":1}      | {"a":1}            |
+      | array       | [1,2,3]      | [1,2,3]            |
+
+  Scenario: Null target outputs are preserved, not coerced into a string
+    Given an evaluator target emits "output" as null
+    And a downstream evaluator's "output" mapping points at that field
+    When the downstream evaluator runs
+    Then the scorer receives a null/absent value
+    And the row is reported as inconclusive rather than rejected
+
+  @regression
+  Scenario: Online evaluation request with a boolean trace metadata mapping runs without rejection
+    Given an online evaluator pulls "output" from a trace metadata field that is a boolean
+    When the evaluation is dispatched
+    Then the live-execute path coerces the boolean to its string form
+    And no "Expected string, received boolean" error is surfaced

--- a/specs/experiments-v3/mapping-auto-inference.feature
+++ b/specs/experiments-v3/mapping-auto-inference.feature
@@ -81,6 +81,24 @@ Feature: Mapping Auto-Inference
   # ============================================================================
   # Evaluator Auto-Inference
   # ============================================================================
+  #
+  # The auto-inference is restricted by INPUT IDENTITY so a confused-looking
+  # mapping never lands ahead of an empty one:
+  #
+  #   - "output"-like fields (output, response, answer, result, generated)
+  #     are ALWAYS sourced from the runner/target output, never the dataset.
+  #     Mapping them to a dataset column would let the evaluator grade the
+  #     dataset against itself, which is never what the user wants.
+  #
+  #   - "expected_output"-like fields (expected_output, expected_answer,
+  #     ground_truth) and "input"-like fields (input, question, user_input,
+  #     user_query, context, contexts, retrieved_contexts) are ALWAYS sourced
+  #     from the dataset, never the runner/target output. The whole reason a
+  #     dataset row carries an expected answer is for the evaluator to grade
+  #     against it; reading it back from the runner would be a tautology.
+  #
+  # When no candidate column exists on the correct side, the mapping stays
+  # empty — empty is recoverable, a wrong default mapping is not.
 
   Scenario: Auto-infer evaluator mappings for standard fields
     Given I have a dataset with columns "input, expected_output"
@@ -98,6 +116,37 @@ Feature: Mapping Auto-Inference
     When I add an evaluator with input "output"
     Then evaluator "output" is mapped to "answer" for "Runner A"
     And evaluator "output" is mapped to "result" for "Runner B"
+
+  @regression
+  Scenario: "output" never falls back to a dataset column
+    Given I have a dataset with column "output"
+    And I have a runner with no output named like "output"
+    When I add an evaluator with input "output"
+    Then evaluator "output" has no auto-inferred mapping
+    And the dataset's "output" column is NOT chosen
+
+  @regression
+  Scenario: "expected_output" never picks the runner output
+    Given I have a runner producing output "expected_output"
+    And I have a dataset with no column named like an expected answer
+    When I add an evaluator with input "expected_output"
+    Then evaluator "expected_output" has no auto-inferred mapping
+    And the runner's "expected_output" output is NOT chosen
+
+  @regression
+  Scenario: "input" never picks the runner output
+    Given I have a runner producing output "input"
+    And I have a dataset with no column named like "input"
+    When I add an evaluator with input "input"
+    Then evaluator "input" has no auto-inferred mapping
+    And the runner's "input" output is NOT chosen
+
+  Scenario: Target output wins over a same-named dataset column for "output"
+    Given I have a dataset with column "output"
+    And I have a runner producing output "output"
+    When I add an evaluator with input "output"
+    Then evaluator "output" is mapped to the runner output "output"
+    And the dataset's "output" column is not chosen
 
   # ============================================================================
   # Semantic Mapping Dictionary

--- a/specs/studio/workflow-evaluator-input-coercion.feature
+++ b/specs/studio/workflow-evaluator-input-coercion.feature
@@ -1,0 +1,40 @@
+@regression
+Feature: Workflow evaluator input coercion at the executor boundary
+  As an experiment author wiring an evaluator block into a Studio workflow
+  I want non-string upstream node outputs to reach the evaluator as their string form
+  So that a langevals evaluator never rejects a request with
+    "Expected string, received boolean" simply because an upstream node emitted a bool
+
+  # The legacy Python Studio executor coerced every evaluator input to the
+  # evaluator's declared input type at the workflow boundary (see
+  # langwatch_nlp's autoparse_field_value). The Go nlpgo executor never wired
+  # that coercion onto its evaluator-block dispatch, so a workflow that
+  # composes a boolean-emitting node with a string-input evaluator now
+  # surfaces a Pydantic rejection that the Python era hid. This restores
+  # parity: the chain is deterministic — coerce at the boundary, scorer
+  # decides equality.
+
+  Background:
+    Given a Studio workflow that pipes an upstream node output into an evaluator block
+    And the evaluator block's input declares the field as a string
+
+  Scenario Outline: Non-string upstream outputs are coerced before dispatch
+    Given the upstream node emits "<source_value>" of type "<source_type>"
+    When the workflow executor invokes the evaluator block
+    Then the evaluator request carries the value as the string "<as_string>"
+    And the evaluator does not surface a type-validation rejection
+
+    Examples:
+      | source_type | source_value | as_string          |
+      | boolean     | true         | true               |
+      | boolean     | false        | false              |
+      | number      | 42           | 42                 |
+      | number      | 0.5          | 0.5                |
+      | object      | {"a":1}      | {"a":1}            |
+      | array       | [1,2,3]      | [1,2,3]            |
+
+  Scenario: Null upstream values are preserved, not coerced into a string
+    Given the upstream node emits null for the evaluator input
+    When the workflow executor invokes the evaluator block
+    Then the evaluator request omits the field or sends a null value
+    And the row is reported as inconclusive rather than rejected


### PR DESCRIPTION
## Summary

Two related evaluations-v3 bugs from a workbench customer report:

1. Live "Run on row" rejected non-string mapped values with `Validation error: Expected string, received boolean at "output"` whenever an upstream target output (bool/number/object) was piped into a downstream string-input evaluator. The batch + online paths had quietly coerced for years via `tracesMapping.tryAndConvertTo`; the REST route never did.
2. `inferEvaluatorMappings` happily mapped an evaluator's `output` identifier to `dataset.output`, producing a tautological default that was more confusing than useful.

The fix lands across two lanes on one branch.

### Lane A (89583bcbc) — non-string evaluator inputs no longer get rejected

Three layers, deterministic chain:

- **REST live-execute**: new `coerceEvaluatorScalar` (`langwatch/src/server/utils/coerceEvaluatorScalar.ts`) wired through `z.preprocess` on every scalar field of `defaultEvaluatorInputSchema`. Semantics match the python NLP era `autoparse_field_value` for `FieldType.str`: `true → "true"`, `42 → "42"`, `{a:1} → '{"a":1}'`, null/undefined preserved, strings pass through.
- **nlpgo evaluator-block executor** (`services/nlpgo/app/engine/blocks/evaluatorblock/`): new `coerceData` helper applied at the Studio workflow dispatch boundary. Defense-in-depth + parity with the legacy python autoparse the Go migration had dropped. Contexts arrays pass through unchanged; conversation turns are walked.
- **langevals exact_match scorer** (`langevals/evaluators/langevals/langevals_langevals/exact_match.py`): a JavaScript-style loose-equality layer inserted between the existing `is_float` short-circuit and the trim/punctuation/case-fold chain. `json.loads` recovers each side's underlying type, then ECMA 7.2.13 abstract equality compares bool/number/string across the trio (`True → 1`, `False → 0`, numeric strings cross-coerce). So an upstream `passed: true` matches a dataset golden of `"1"` without false negatives. Free-form text still falls through to the existing transform chain.

The "match boolean against 1" semantic intentionally lives in the scorer, not in the coercion layer. Coercion preserves fidelity; semantic match is a scorer decision.

### Lane B (74cb22b52) — auto-mapping is now identity-locked

`inferEvaluatorMappings` heuristic restricted so:
- `output` identifiers ALWAYS source from a runner/target output, never the dataset.
- `expected_output` / `input` identifiers ALWAYS source from the dataset, never a runner.
- Empty is better than wrong: if no match exists, leave the mapping blank.

### Specs

- `specs/experiments-v3/evaluator-as-target.feature` — REST coercion regression + Scenario Outline per source type + null preservation + online-eval boolean metadata
- `specs/experiments-v3/mapping-auto-inference.feature` — output-from-target-only, expected/input-from-dataset-only, no cross-fall
- `specs/evaluators/exact-match-loose-equality.feature` — bool/number/string matches + mismatches + existing transform-chain preservation
- `specs/studio/workflow-evaluator-input-coercion.feature` — nlpgo workflow executor parity restoration

### Coverage

- `langwatch/src/server/utils/__tests__/coerceEvaluatorScalar.unit.test.ts` — 12 cases
- `langwatch/src/server/routes/__tests__/evaluator-input-coercion.unit.test.ts` — 9 cases through `getEvaluatorDataForParams`
- `services/nlpgo/app/engine/blocks/evaluatorblock/coerce_test.go` — 12 scalar + contexts passthrough + conversation recursion + nil
- `langevals/evaluators/langevals/tests/test_exact_match.py` — 8 loose-equal matches + 5 mismatches + transform-chain preservation + float-short-circuit preservation
- Plus Lane B unit + integration suites in Sarah's commit (42 + 8 green locally)

## Live QA proof (lw-local stack on :5580 + langevals :5562)

### Lane A — REST grid against the customer's failing endpoint

Customer's exact failure mode was `POST /api/evaluations/evaluators/<slug>/evaluate` returning `400 "Validation error: Expected string, received boolean at output"`. After the fix:

| Mapped `output` | `expected_output` | Verdict | Details |
|---|---|---|---|
| `true` (bool) | `"1"` | **passed** | `"true == 1"` — customer's case, no more 400 |
| `false` (bool) | `"0"` | **passed** | `"false == 0"` |
| `true` (bool) | `"true"` | **passed** | string-form match (python NLP parity) |
| `42` (number) | `"42"` | **passed** | numeric coerce |
| `true` (bool) | `"0"` | **rejected** | correct mismatch, scorer not over-eager |
| `"hello"` (str) | `"hello"` | **passed** | strings pass through coercion untouched |

Full payloads + responses captured at https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4642/lane-a/rest-grid-results.txt.

### Lane B — workbench auto-mapping no longer cross-falls

Added `Exact Match Evaluator` as a target, then added `Downstream Exact Match` on top. The downstream evaluator drawer shows:

![lane-b output required](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4642/lane-b/01-output-required-no-fallback.png)

`output` is shown as **Required** (orange — no auto-mapping) because the target output names (`passed` / `score` / `label`) don't semantically match `output`, and the dataset's `output`-like columns are correctly suppressed. `expected_output` auto-mapped to `Test Data.expected_output` as expected.

After manual mapping `output → Exact Match Evaluator.passed`:

![lane-b mapped](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4642/lane-b/02-user-mapped-output-to-target-passed.png)

The Variables panel now shows `output = Exact Match Evaluator.passed` (boolean target output) and `expected_output = Test Data.expected_output` — exactly the customer's intended wiring, with no confusing dataset-to-itself default to undo first.

## Test plan

- [x] `pnpm test:unit` for Lane A TS surfaces
- [x] `go test` for nlpgo evaluatorblock package
- [x] `uv run pytest` for langevals exact_match
- [x] Workbench end-to-end: evaluator-as-target with bool output, downstream Exact Match expecting "1" — verified live on lw-local, REST returns `passed=true` with `details: "true == 1"`
- [x] Auto-mapping inference: confirmed `output` ignores `dataset.output`, leaves the mapping empty when the target outputs don't match
- [ ] Online evaluation with bool trace metadata — same REST entry point, covered transitively by Lane A1