### PR TITLE
silence(presidio): drop analyzer recognizer warnings to ERROR

### DIFF
--- a/langevals/evaluators/presidio/langevals_presidio/pii_detection.py
+++ b/langevals/evaluators/presidio/langevals_presidio/pii_detection.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from typing import Any, Literal, Optional
 from langevals_core.base_evaluator import (
@@ -15,6 +16,15 @@ import spacy.cli
 from presidio_analyzer import AnalyzerEngine
 from presidio_anonymizer import AnonymizerEngine
 from presidio_analyzer.nlp_engine import SpacyNlpEngine
+
+# Presidio's analyzer emits a WARNING for every requested entity that has
+# no recognizer in the active language. Our entity list intentionally
+# includes language-region specific types (SG_NRIC_FIN, AU_ABN, IN_PAN,
+# ...) that are absent from en, so each English call produced ~30 warning
+# lines. At lambda invocation volumes this was producing 13+ GB/day of
+# CloudWatch noise with no signal value: the "missing recognizer" facts
+# are static, not per-request, and known at configuration time.
+logging.getLogger("presidio-analyzer").setLevel(logging.ERROR)
 
 
 class PresidioPIIDetectionEntry(EvaluatorEntry):


### PR DESCRIPTION
## Summary

- `presidio-analyzer` logs a `WARNING` for every requested entity that has no recognizer in the active language. Our entity list intentionally includes language-region specific types (`SG_NRIC_FIN`, `AU_ABN`, `AU_ACN`, `AU_TFN`, `AU_MEDICARE`, `IN_PAN`, `IN_AADHAAR`, `IN_VEHICLE_REGISTRATION`, `IN_VOTER`, `IN_PASSPORT`) that are absent from the `en` model.
- Every English-language call emits ~30 WARNING lines. The recognizer set is fixed at configuration time, not per-request, so re-logging the same warnings on every invocation provides zero operational signal.
- At lambda invocation volumes (1-minute warmer x 80 concurrent + real evaluations) the `presidio-evaluator-lambda` CloudWatch log group was ingesting **13-15 GB/day**, costing roughly **\$200/month** of CloudWatch ingest, almost entirely from this static-fact chatter.

## Fix

One-line: set `logging.getLogger("presidio-analyzer").setLevel(logging.ERROR)` at the top of `pii_detection.py`. Real failures and any genuine ERROR-level signal still get through. Application logs from our own code (staged-payload INFO timings, etc.) are unaffected.

## Sample of what gets dropped (from prod logs)

```
[WARNING] Entity SG_NRIC_FIN doesn't have the corresponding recognizer in language : en
[WARNING] Entity AU_ABN doesn't have the corresponding recognizer in language : en
[WARNING] Entity AU_ACN doesn't have the corresponding recognizer in language : en
[WARNING] Entity AU_TFN doesn't have the corresponding recognizer in language : en
[WARNING] Entity AU_MEDICARE doesn't have the corresponding recognizer in language : en
... (~25 more, repeated for every single invocation)
```

## Test plan

- [ ] CI green
- [ ] Local: `cd langevals && uv run python -c "from langevals_presidio.pii_detection import PresidioPIIDetectionEvaluator; PresidioPIIDetectionEvaluator.preload(); e = PresidioPIIDetectionEvaluator(settings={}); from langevals_presidio.pii_detection import PresidioPIIDetectionEntry; print(e.evaluate(PresidioPIIDetectionEntry(input='Call me at 555-1234')))"` produces no `[WARNING]` lines about missing recognizers
- [ ] After deploy: `/aws/lambda/presidio-evaluator-lambda` daily ingest drops from 13-15 GB to <0.5 GB (measure 24h after rollout)