### PR TITLE
fix(datasets): offer all 30d project span names in dataset mapping, lift CH read caps

### DIFF
--- a/langwatch/src/components/evaluators/EvaluatorMappingsSection.tsx
+++ b/langwatch/src/components/evaluators/EvaluatorMappingsSection.tsx
@@ -67,9 +67,9 @@ export function EvaluatorMappingsSection({
 
   // Fetch span names and metadata keys for level-based mode
   // Only used when providedSources is not given
-  const { spanNames, metadataKeys } = useProjectSpanNames(
-    providedSources ? undefined : project?.id
-  );
+  const { spanNames, metadataKeys } = useProjectSpanNames({
+    projectId: providedSources ? undefined : project?.id,
+  });
 
   // Build availableSources - use providedSources if given, otherwise fetch based on level
   const availableSources = useMemo(() => {

--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -224,7 +224,10 @@ export const TracesMapping = ({
     spanNames: projectSpanNames,
     metadataKeys: projectMetadataKeys,
     isLoading: projectFieldNamesLoading,
-  } = useProjectSpanNames(project?.id, { enabled: needsProjectFieldNames });
+  } = useProjectSpanNames({
+    projectId: project?.id,
+    enabled: needsProjectFieldNames,
+  });
 
   // Span / metadata dropdowns should offer every name the project produced in
   // the last 30 days, not just the names on the loaded trace(s) — otherwise a

--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -524,6 +524,11 @@ export const TracesMapping = ({
                   })
               : undefined;
 
+          // The spans/metadata key dropdown waits on the project-wide name list.
+          const isLoadingFieldNames =
+            projectFieldNamesLoading &&
+            (source === "spans" || source === "metadata");
+
           const targetHandle = `inputs.${targetField}`;
           const currentSourceMapping = dsl?.targetEdges
             ?.filter((edge) => edge.targetHandle === `inputs.${targetField}`)
@@ -683,7 +688,10 @@ export const TracesMapping = ({
                               borderRight={0}
                               marginLeft="12px"
                             />
-                            <NativeSelect.Root width="full">
+                            <NativeSelect.Root
+                              width="full"
+                              disabled={isLoadingFieldNames}
+                            >
                               <NativeSelect.Field
                                 onChange={(e) => {
                                   setTraceMappingState((prev) => ({
@@ -699,35 +707,46 @@ export const TracesMapping = ({
                                 }}
                                 value={key}
                               >
-                                {/* "* (any span)" option - matches all spans */}
-                                <option value="">
-                                  {source === "spans"
-                                    ? "* (any span)"
-                                    : source === "metadata"
-                                      ? "* (all metadata)"
-                                      : "* (any)"}
-                                </option>
-                                {mergeProjectKeyOptions(
-                                  source,
-                                  traceMappingDefinition.keys(traces_),
-                                ).map(({ key, label }: KeyOption) => (
-                                  <option key={key} value={key}>
-                                    {label}
+                                {/* While project-wide names load, show a single
+                                    placeholder so users don't pick from an
+                                    incomplete (trace-only) list. */}
+                                {isLoadingFieldNames ? (
+                                  <option value="">
+                                    {source === "spans"
+                                      ? "Loading span names…"
+                                      : "Loading metadata keys…"}
                                   </option>
-                                ))}
+                                ) : (
+                                  <>
+                                    {/* "* (any span)" option - matches all spans */}
+                                    <option value="">
+                                      {source === "spans"
+                                        ? "* (any span)"
+                                        : source === "metadata"
+                                          ? "* (all metadata)"
+                                          : "* (any)"}
+                                    </option>
+                                    {mergeProjectKeyOptions(
+                                      source,
+                                      traceMappingDefinition.keys(traces_),
+                                    ).map(({ key, label }: KeyOption) => (
+                                      <option key={key} value={key}>
+                                        {label}
+                                      </option>
+                                    ))}
+                                  </>
+                                )}
                               </NativeSelect.Field>
                               <NativeSelect.Indicator />
                             </NativeSelect.Root>
-                            {projectFieldNamesLoading &&
-                              (source === "spans" ||
-                                source === "metadata") && (
-                                <Spinner
-                                  size="sm"
-                                  flexShrink={0}
-                                  marginTop="8px"
-                                  color="fg.muted"
-                                />
-                              )}
+                            {isLoadingFieldNames && (
+                              <Spinner
+                                size="sm"
+                                flexShrink={0}
+                                marginTop="8px"
+                                color="fg.muted"
+                              />
+                            )}
                           </HStack>
                         )}
                       {subkeys && subkeys.length > 0 && (

--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -5,6 +5,7 @@ import {
   GridItem,
   HStack,
   NativeSelect,
+  Spinner,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -14,6 +15,7 @@ import { ArrowRight } from "react-feather";
 import type { Trace } from "~/server/tracer/types";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { useAnnotationsByTraceIds } from "../../hooks/useAnnotationsByTraceIds";
+import { useProjectSpanNames } from "../../hooks/useProjectSpanNames";
 import type { Workflow } from "../../optimization_studio/types/dsl";
 import type { DatasetRecordEntry } from "../../server/datasets/types";
 import {
@@ -70,6 +72,20 @@ const DATASET_INFERRED_MAPPINGS_BY_NAME_TRANSPOSED = Object.entries(
   {} as Record<string, string[]>,
 );
 
+type KeyOption = { key: string; label: string };
+
+/** Dedupe {key,label} options by key, preserving first-seen order. */
+const dedupeKeyOptions = (options: KeyOption[]): KeyOption[] => {
+  const seen = new Set<string>();
+  const result: KeyOption[] = [];
+  for (const option of options) {
+    if (!option || seen.has(option.key)) continue;
+    seen.add(option.key);
+    result.push(option);
+  }
+  return result;
+};
+
 export const TracesMapping = ({
   titles,
   traces,
@@ -112,6 +128,15 @@ export const TracesMapping = ({
     task: state.workbenchState.task,
   }));
 
+  // Project-wide span names and metadata keys from the last 30 days, so the
+  // mapping dropdowns can offer names that exist in the project even when the
+  // currently loaded trace(s) don't contain them.
+  const {
+    spanNames: projectSpanNames,
+    metadataKeys: projectMetadataKeys,
+    isLoading: projectFieldNamesLoading,
+  } = useProjectSpanNames(project?.id);
+
   const annotationScores = useAnnotationsByTraceIds({
     projectId: project?.id ?? "",
     traceIds: traces.map((trace) => trace.trace_id),
@@ -153,6 +178,27 @@ export const TracesMapping = ({
         ),
       })),
     [traces, annotationScores.data],
+  );
+
+  // Span / metadata dropdowns should offer every name the project produced in
+  // the last 30 days, not just the names on the loaded trace(s) — otherwise a
+  // span that exists elsewhere in the project cannot be selected for mapping.
+  const mergeProjectKeyOptions = useCallback(
+    (source: string, baseOptions: KeyOption[]): KeyOption[] => {
+      const projectOptions =
+        source === "spans"
+          ? projectSpanNames
+          : source === "metadata"
+            ? projectMetadataKeys
+            : [];
+      if (projectOptions.length === 0) {
+        return baseOptions;
+      }
+      return dedupeKeyOptions([...baseOptions, ...projectOptions]).sort((a, b) =>
+        a.label.localeCompare(b.label),
+      );
+    },
+    [projectSpanNames, projectMetadataKeys],
   );
 
   const currentMapping = traceMapping ?? { mapping: {}, expansions: [] };
@@ -452,8 +498,18 @@ export const TracesMapping = ({
             "subkeys" in traceMappingDefinition &&
             source !== "threads" &&
             source !== "threads_until_current"
-              ? key === "" && source === "spans"
-                ? defaultSpanSubkeys
+              ? source === "spans"
+                ? // Spans always expose the same subfields. Offer them for any
+                  // span name — including project-wide names that aren't on the
+                  // loaded trace, where subkey discovery would otherwise be empty.
+                  dedupeKeyOptions([
+                    ...defaultSpanSubkeys,
+                    ...(key
+                      ? traceMappingDefinition.subkeys(traces_, key, {
+                          annotationScoreOptions: getAnnotationScoreOptions.data,
+                        })
+                      : []),
+                  ])
                 : traceMappingDefinition.subkeys(traces_, key!, {
                     annotationScoreOptions: getAnnotationScoreOptions.data,
                   })
@@ -642,24 +698,27 @@ export const TracesMapping = ({
                                       ? "* (all metadata)"
                                       : "* (any)"}
                                 </option>
-                                {traceMappingDefinition
-                                  .keys(traces_)
-                                  .map(
-                                    ({
-                                      key,
-                                      label,
-                                    }: {
-                                      key: string;
-                                      label: string;
-                                    }) => (
-                                      <option key={key} value={key}>
-                                        {label}
-                                      </option>
-                                    ),
-                                  )}
+                                {mergeProjectKeyOptions(
+                                  source,
+                                  traceMappingDefinition.keys(traces_),
+                                ).map(({ key, label }: KeyOption) => (
+                                  <option key={key} value={key}>
+                                    {label}
+                                  </option>
+                                ))}
                               </NativeSelect.Field>
                               <NativeSelect.Indicator />
                             </NativeSelect.Root>
+                            {projectFieldNamesLoading &&
+                              (source === "spans" ||
+                                source === "metadata") && (
+                                <Spinner
+                                  size="sm"
+                                  flexShrink={0}
+                                  marginTop="8px"
+                                  color="fg.muted"
+                                />
+                              )}
                           </HStack>
                         )}
                       {subkeys && subkeys.length > 0 && (

--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -128,15 +128,6 @@ export const TracesMapping = ({
     task: state.workbenchState.task,
   }));
 
-  // Project-wide span names and metadata keys from the last 30 days, so the
-  // mapping dropdowns can offer names that exist in the project even when the
-  // currently loaded trace(s) don't contain them.
-  const {
-    spanNames: projectSpanNames,
-    metadataKeys: projectMetadataKeys,
-    isLoading: projectFieldNamesLoading,
-  } = useProjectSpanNames(project?.id);
-
   const annotationScores = useAnnotationsByTraceIds({
     projectId: project?.id ?? "",
     traceIds: traces.map((trace) => trace.trace_id),
@@ -180,27 +171,6 @@ export const TracesMapping = ({
     [traces, annotationScores.data],
   );
 
-  // Span / metadata dropdowns should offer every name the project produced in
-  // the last 30 days, not just the names on the loaded trace(s) — otherwise a
-  // span that exists elsewhere in the project cannot be selected for mapping.
-  const mergeProjectKeyOptions = useCallback(
-    (source: string, baseOptions: KeyOption[]): KeyOption[] => {
-      const projectOptions =
-        source === "spans"
-          ? projectSpanNames
-          : source === "metadata"
-            ? projectMetadataKeys
-            : [];
-      if (projectOptions.length === 0) {
-        return baseOptions;
-      }
-      return dedupeKeyOptions([...baseOptions, ...projectOptions]).sort((a, b) =>
-        a.label.localeCompare(b.label),
-      );
-    },
-    [projectSpanNames, projectMetadataKeys],
-  );
-
   const currentMapping = traceMapping ?? { mapping: {}, expansions: [] };
 
   type LocalTraceMappingState = Omit<MappingState, "expansions"> & {
@@ -237,6 +207,45 @@ export const TracesMapping = ({
     [traceMappingState, setTraceMapping],
   );
   const mapping = traceMappingState.mapping;
+
+  // Only the spans and metadata sources draw from project-wide names. Fetch the
+  // 30-day distinct field-name list lazily — only when such a column is actually
+  // being mapped — so merely opening the drawer/wizard (or any other place that
+  // renders this component) doesn't trigger the heavier ClickHouse scan when no
+  // span/metadata column is in play.
+  const needsProjectFieldNames = useMemo(
+    () =>
+      Object.values(mapping).some(
+        (m) => m.source === "spans" || m.source === "metadata",
+      ),
+    [mapping],
+  );
+  const {
+    spanNames: projectSpanNames,
+    metadataKeys: projectMetadataKeys,
+    isLoading: projectFieldNamesLoading,
+  } = useProjectSpanNames(project?.id, { enabled: needsProjectFieldNames });
+
+  // Span / metadata dropdowns should offer every name the project produced in
+  // the last 30 days, not just the names on the loaded trace(s) — otherwise a
+  // span that exists elsewhere in the project cannot be selected for mapping.
+  const mergeProjectKeyOptions = useCallback(
+    (source: string, baseOptions: KeyOption[]): KeyOption[] => {
+      const projectOptions =
+        source === "spans"
+          ? projectSpanNames
+          : source === "metadata"
+            ? projectMetadataKeys
+            : [];
+      if (projectOptions.length === 0) {
+        return baseOptions;
+      }
+      return dedupeKeyOptions([...baseOptions, ...projectOptions]).sort((a, b) =>
+        a.label.localeCompare(b.label),
+      );
+    },
+    [projectSpanNames, projectMetadataKeys],
+  );
 
   // Check if any column uses a server-only source (e.g. formatted_trace)
   const needsFormattedDigest = useMemo(

--- a/langwatch/src/components/traces/__tests__/TracesMapping.spanNames.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/TracesMapping.spanNames.integration.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the "spans" field mapping dropdown in TracesMapping.
+ *
+ * The dropdown must offer every span name the project produced in the last 30
+ * days, not just the span names present on the currently loaded trace(s).
+ * A customer reported a span that existed in their project not being offered
+ * for mapping because the drawer only listed the open trace's spans. These
+ * tests render the real component tree and assert the merged behaviour.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type { Trace } from "~/server/tracer/types";
+import { TracesMapping } from "../TracesMapping";
+
+// Project-wide span names returned for the last 30 days — note that
+// "Research.aexecute_stream" is NOT present on the loaded trace below.
+const PROJECT_SPAN_NAMES = [
+  { key: "Research.aexecute_stream", label: "Research.aexecute_stream" },
+  { key: "Classification.aexecute_stream", label: "Classification.aexecute_stream" },
+];
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project", slug: "test-project" },
+  }),
+}));
+
+vi.mock("~/hooks/useProjectSpanNames", () => ({
+  useProjectSpanNames: () => ({
+    spanNames: PROJECT_SPAN_NAMES,
+    metadataKeys: [],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("~/hooks/useAnnotationsByTraceIds", () => ({
+  useAnnotationsByTraceIds: () => ({ data: [] }),
+}));
+
+vi.mock(
+  "~/components/evaluations/wizard/hooks/evaluation-wizard-store/useEvaluationWizardStore",
+  () => ({
+    useEvaluationWizardStore: (selector: (state: unknown) => unknown) =>
+      selector({ workbenchState: { task: undefined } }),
+  }),
+);
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    annotationScore: {
+      getAllActive: { useQuery: () => ({ data: [] }) },
+    },
+    traces: {
+      getTracesWithSpansByThreadIds: { useQuery: () => ({ data: undefined }) },
+      getFormattedSpansDigest: { useQuery: () => ({ data: undefined }) },
+    },
+  },
+}));
+
+/** A trace that contains "step_2a_research_iter1" but NOT "Research.aexecute_stream". */
+const traceWithoutResearchSpan = {
+  trace_id: "trace-1",
+  project_id: "test-project",
+  metadata: {},
+  timestamps: { started_at: 1, inserted_at: 1, updated_at: 1 },
+  spans: [
+    {
+      span_id: "span-1",
+      trace_id: "trace-1",
+      type: "span",
+      name: "step_2a_research_iter1",
+      timestamps: { started_at: 1, finished_at: 2 },
+    },
+  ],
+} as unknown as Trace;
+
+function renderSpansMapping() {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <TracesMapping
+        traces={[traceWithoutResearchSpan]}
+        traceMapping={{ mapping: {}, expansions: [] }}
+        targetFields={["spans"]}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("TracesMapping spans dropdown (integration)", () => {
+  afterEach(() => cleanup());
+
+  describe("when a project span name is absent from the loaded trace", () => {
+    /** @scenario Span names from the project are offered even when absent from the open trace */
+    it("offers the project span name for mapping", async () => {
+      renderSpansMapping();
+
+      expect(
+        await screen.findByRole("option", {
+          name: "Research.aexecute_stream",
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when a span exists on the loaded trace", () => {
+    /** @scenario Span names from the open trace are always offered */
+    it("offers the loaded trace's span name for mapping", async () => {
+      renderSpansMapping();
+
+      expect(
+        await screen.findByRole("option", {
+          name: "step_2a_research_iter1",
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when a project span name is selected", () => {
+    /** @scenario Selecting a project span name lets me map its subfields */
+    it("offers the span input, output, params and contexts subfields", async () => {
+      const user = userEvent.setup();
+      renderSpansMapping();
+
+      const researchOption = await screen.findByRole("option", {
+        name: "Research.aexecute_stream",
+      });
+      const keySelect = researchOption.closest("select");
+      expect(keySelect).not.toBeNull();
+
+      await user.selectOptions(keySelect!, "Research.aexecute_stream");
+
+      // Scope the subfield assertions to the span subkey <select> (identified by
+      // its "* (full span object)" option) so they don't collide with the
+      // source dropdown, which also has options named "input" / "output".
+      const fullSpanOption = await screen.findByRole("option", {
+        name: "* (full span object)",
+      });
+      const subkeySelect = fullSpanOption.closest("select");
+      expect(subkeySelect).not.toBeNull();
+
+      for (const subfield of ["input", "output", "params", "contexts"]) {
+        expect(
+          within(subkeySelect!).getByRole("option", { name: subfield }),
+        ).toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useProjectSpanNames.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProjectSpanNames.test.tsx
@@ -137,6 +137,44 @@ describe("useProjectSpanNames", () => {
     );
   });
 
+  it("disables query when options.enabled is false, even with a projectId", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    renderHook(() =>
+      useProjectSpanNames("project-123", { enabled: false }),
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+  });
+
+  it("enables query when options.enabled is true and projectId is set", () => {
+    mockUseQuery.mockReturnValue({
+      data: { spanNames: [], metadataKeys: [] },
+      isLoading: false,
+      error: null,
+    });
+
+    renderHook(() =>
+      useProjectSpanNames("project-123", { enabled: true }),
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        enabled: true,
+      })
+    );
+  });
+
   it("handles API errors", () => {
     const mockError = new Error("API Error");
     mockUseQuery.mockReturnValue({

--- a/langwatch/src/hooks/__tests__/useProjectSpanNames.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProjectSpanNames.test.tsx
@@ -36,7 +36,7 @@ describe("useProjectSpanNames", () => {
       error: null,
     });
 
-    const { result } = renderHook(() => useProjectSpanNames(undefined));
+    const { result } = renderHook(() => useProjectSpanNames({ projectId: undefined }));
 
     expect(result.current.spanNames).toEqual([]);
     expect(result.current.metadataKeys).toEqual([]);
@@ -51,7 +51,7 @@ describe("useProjectSpanNames", () => {
       error: null,
     });
 
-    const { result } = renderHook(() => useProjectSpanNames("project-123"));
+    const { result } = renderHook(() => useProjectSpanNames({ projectId: "project-123" }));
 
     expect(result.current.isLoading).toBe(true);
     expect(result.current.spanNames).toEqual([]);
@@ -71,7 +71,7 @@ describe("useProjectSpanNames", () => {
       error: null,
     });
 
-    const { result } = renderHook(() => useProjectSpanNames("project-123"));
+    const { result } = renderHook(() => useProjectSpanNames({ projectId: "project-123" }));
 
     expect(result.current.spanNames).toHaveLength(3);
     expect(result.current.spanNames.map((s) => s.key)).toContain(
@@ -92,7 +92,7 @@ describe("useProjectSpanNames", () => {
       error: null,
     });
 
-    const { result } = renderHook(() => useProjectSpanNames("project-123"));
+    const { result } = renderHook(() => useProjectSpanNames({ projectId: "project-123" }));
 
     expect(result.current.spanNames).toEqual([]);
   });
@@ -104,7 +104,7 @@ describe("useProjectSpanNames", () => {
       error: null,
     });
 
-    renderHook(() => useProjectSpanNames("project-123"));
+    renderHook(() => useProjectSpanNames({ projectId: "project-123" }));
 
     expect(mockUseQuery).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -127,7 +127,7 @@ describe("useProjectSpanNames", () => {
       error: null,
     });
 
-    renderHook(() => useProjectSpanNames(undefined));
+    renderHook(() => useProjectSpanNames({ projectId: undefined }));
 
     expect(mockUseQuery).toHaveBeenCalledWith(
       expect.anything(),
@@ -145,7 +145,7 @@ describe("useProjectSpanNames", () => {
     });
 
     renderHook(() =>
-      useProjectSpanNames("project-123", { enabled: false }),
+      useProjectSpanNames({ projectId: "project-123", enabled: false }),
     );
 
     expect(mockUseQuery).toHaveBeenCalledWith(
@@ -164,7 +164,7 @@ describe("useProjectSpanNames", () => {
     });
 
     renderHook(() =>
-      useProjectSpanNames("project-123", { enabled: true }),
+      useProjectSpanNames({ projectId: "project-123", enabled: true }),
     );
 
     expect(mockUseQuery).toHaveBeenCalledWith(
@@ -183,7 +183,7 @@ describe("useProjectSpanNames", () => {
       error: mockError,
     });
 
-    const { result } = renderHook(() => useProjectSpanNames("project-123"));
+    const { result } = renderHook(() => useProjectSpanNames({ projectId: "project-123" }));
 
     expect(result.current.error).toBe(mockError);
     expect(result.current.spanNames).toEqual([]);
@@ -203,7 +203,7 @@ describe("useProjectSpanNames", () => {
       error: null,
     });
 
-    const { result } = renderHook(() => useProjectSpanNames("project-123"));
+    const { result } = renderHook(() => useProjectSpanNames({ projectId: "project-123" }));
 
     const keys = result.current.metadataKeys.map((k) => k.key);
     expect(keys).toContain("user_id");
@@ -227,7 +227,7 @@ describe("useProjectSpanNames", () => {
       error: null,
     });
 
-    const { result } = renderHook(() => useProjectSpanNames("project-123"));
+    const { result } = renderHook(() => useProjectSpanNames({ projectId: "project-123" }));
 
     const keys = result.current.metadataKeys.map((k) => k.key);
     expect(keys).not.toContain("custom");

--- a/langwatch/src/hooks/useProjectSpanNames.ts
+++ b/langwatch/src/hooks/useProjectSpanNames.ts
@@ -11,13 +11,16 @@ import { api } from "../utils/api";
  * being mapped) should pass `enabled: false` until it is actually needed.
  *
  * @param projectId - The project ID to fetch field names from
- * @param options.enabled - Gate the query (default true); combined with projectId presence
+ * @param enabled - Gate the query (default true); combined with projectId presence
  * @returns Object with spanNames, metadataKeys arrays, isLoading state, and error if any
  */
-export function useProjectSpanNames(
-  projectId: string | undefined,
-  options?: { enabled?: boolean }
-) {
+export function useProjectSpanNames({
+  projectId,
+  enabled = true,
+}: {
+  projectId: string | undefined;
+  enabled?: boolean;
+}) {
   // Use last 30 days as default date range
   const endDate = useMemo(() => Date.now(), []);
   const startDate = useMemo(
@@ -32,7 +35,7 @@ export function useProjectSpanNames(
       endDate,
     },
     {
-      enabled: !!projectId && (options?.enabled ?? true),
+      enabled: !!projectId && enabled,
       refetchOnWindowFocus: false,
       staleTime: 5 * 60 * 1000, // Cache for 5 minutes
     }

--- a/langwatch/src/hooks/useProjectSpanNames.ts
+++ b/langwatch/src/hooks/useProjectSpanNames.ts
@@ -4,12 +4,20 @@ import { api } from "../utils/api";
 
 /**
  * Hook to fetch distinct span names and metadata keys for a project.
- * Uses a dedicated ES aggregation endpoint instead of loading full traces.
+ * Uses a dedicated ClickHouse aggregation endpoint instead of loading full traces.
+ *
+ * The underlying query scans the last 30 days of spans/summaries, so callers
+ * that only need it conditionally (e.g. only when a span/metadata column is
+ * being mapped) should pass `enabled: false` until it is actually needed.
  *
  * @param projectId - The project ID to fetch field names from
+ * @param options.enabled - Gate the query (default true); combined with projectId presence
  * @returns Object with spanNames, metadataKeys arrays, isLoading state, and error if any
  */
-export function useProjectSpanNames(projectId: string | undefined) {
+export function useProjectSpanNames(
+  projectId: string | undefined,
+  options?: { enabled?: boolean }
+) {
   // Use last 30 days as default date range
   const endDate = useMemo(() => Date.now(), []);
   const startDate = useMemo(
@@ -24,7 +32,7 @@ export function useProjectSpanNames(projectId: string | undefined) {
       endDate,
     },
     {
-      enabled: !!projectId,
+      enabled: !!projectId && (options?.enabled ?? true),
       refetchOnWindowFocus: false,
       staleTime: 5 * 60 * 1000, // Cache for 5 minutes
     }

--- a/langwatch/src/server/analytics/clickhouse/__tests__/memory-safety.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/memory-safety.test.ts
@@ -231,14 +231,17 @@ describe("memory-safety", () => {
     );
 
     describe("when the field discovery query SQL is inspected", () => {
+      // A bounded LIMIT is either a literal number or a named numeric constant
+      // interpolated into the query (e.g. `LIMIT ${DISTINCT_FIELD_NAMES_LIMIT}`).
+      // Both keep the query bounded, which is what memory-safety requires.
+      const BOUNDED_LIMIT = /\bLIMIT\s+(?:\d+|\$\{[A-Z0-9_]+\})/g;
+
       /** @scenario Field discovery query includes a LIMIT clause */
       it("span names query includes a LIMIT clause followed by a number", () => {
         expect(getDistinctFieldNamesBody).not.toBeNull();
         // The body contains two queries (span names + metadata keys).
         // Verify at least two LIMIT occurrences so both are covered.
-        const limitMatches = getDistinctFieldNamesBody![0].match(
-          /\bLIMIT\s+\d+/g,
-        );
+        const limitMatches = getDistinctFieldNamesBody![0].match(BOUNDED_LIMIT);
         expect(limitMatches).not.toBeNull();
         expect(limitMatches!.length).toBeGreaterThanOrEqual(1);
       });
@@ -246,9 +249,7 @@ describe("memory-safety", () => {
       it("metadata keys query includes a LIMIT clause followed by a number", () => {
         expect(getDistinctFieldNamesBody).not.toBeNull();
         // Both the span-names and metadata-keys queries must have LIMIT.
-        const limitMatches = getDistinctFieldNamesBody![0].match(
-          /\bLIMIT\s+\d+/g,
-        );
+        const limitMatches = getDistinctFieldNamesBody![0].match(BOUNDED_LIMIT);
         expect(limitMatches).not.toBeNull();
         expect(limitMatches!.length).toBeGreaterThanOrEqual(2);
       });

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Integration tests for the queries that feed the "Add to Dataset" / evaluator
+ * field-mapping dropdowns.
+ *
+ * The dropdowns let users map a trace field (span name, metadata key) to a
+ * dataset column. The server queries that back them must not silently truncate
+ * their results: a customer reported a span that clearly existed on a recent
+ * trace not being offered for mapping, traced back to hard `LIMIT` caps in
+ * these queries. These tests run real SQL against a ClickHouse testcontainer
+ * to prove every distinct name / span is returned even on large lists.
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import type { Protections } from "../../elasticsearch/protections";
+
+const tenantId = `test-field-names-${nanoid()}`;
+const now = Date.now();
+
+function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: `trace-${nanoid()}`,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: null,
+    ComputedOutput: null,
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: null,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    SatisfactionScore: null,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+    ...overrides,
+  };
+}
+
+function makeSpanRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: `trace-${nanoid()}`,
+    SpanId: `span-${nanoid()}`,
+    ParentSpanId: null,
+    ParentTraceId: null,
+    ParentIsRemote: null,
+    Sampled: 1,
+    StartTime: new Date(now),
+    EndTime: new Date(now + 100),
+    DurationMs: 100,
+    SpanName: "test-span",
+    SpanKind: 1,
+    ServiceName: "test-service",
+    ResourceAttributes: {},
+    SpanAttributes: {},
+    StatusCode: 1,
+    StatusMessage: null,
+    ScopeName: "test",
+    ScopeVersion: null,
+    "Events.Timestamp": [],
+    "Events.Name": [],
+    "Events.Attributes": [],
+    "Links.TraceId": [],
+    "Links.SpanId": [],
+    "Links.Attributes": [],
+    DroppedAttributesCount: 0,
+    DroppedEventsCount: 0,
+    DroppedLinksCount: 0,
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ...overrides,
+  };
+}
+
+async function insertSpans(
+  ch: ClickHouseClient,
+  rows: ReturnType<typeof makeSpanRow>[],
+) {
+  await ch.insert({
+    table: "stored_spans",
+    values: rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+async function insertTraceSummaries(
+  ch: ClickHouseClient,
+  rows: ReturnType<typeof makeTraceSummaryRow>[],
+) {
+  await ch.insert({
+    table: "trace_summaries",
+    values: rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+const openProtections: Protections = {
+  canSeeCosts: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+};
+
+// A list large enough to blow past the historical 1000 / 200 caps.
+const LARGE_NAME_COUNT = 1500;
+const LARGE_SPAN_COUNT = 250;
+const pad = (n: number) => String(n).padStart(4, "0");
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    project: {
+      findUnique: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+
+  const chModule = await import("~/server/clickhouse/clickhouseClient");
+  vi.mocked(chModule.getClickHouseClientForProject).mockResolvedValue(ch);
+
+  const { prisma } = await import("~/server/db");
+  service = new ClickHouseTraceService(
+    prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+  );
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+    await ch.exec({
+      query: `ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("ClickHouse field-name queries (integration)", () => {
+  describe("getDistinctFieldNames()", () => {
+    describe("when the project has more than a thousand distinct span names", () => {
+      const traceId = `trace-many-names-${nanoid()}`;
+
+      beforeAll(async () => {
+        // Alphabetically-ordered, zero-padded names so the historical
+        // `ORDER BY SpanName ASC LIMIT 1000` would keep 0000..0999 and drop
+        // the rest — making the assertion on the last name a precise probe.
+        await insertSpans(
+          ch,
+          Array.from({ length: LARGE_NAME_COUNT }, (_, i) =>
+            makeSpanRow({
+              TraceId: traceId,
+              SpanId: `span-name-${pad(i)}-${nanoid()}`,
+              SpanName: `span-name-${pad(i)}`,
+            }),
+          ),
+        );
+      });
+
+      /** @scenario All distinct span names are returned even for projects with thousands of them */
+      it("returns every distinct span name, none dropped", async () => {
+        const result = await service.getDistinctFieldNames(
+          tenantId,
+          now - 60_000,
+          now + 60_000,
+        );
+
+        expect(result).not.toBeNull();
+        const names = new Set(result!.spanNames.map((s) => s.key));
+
+        expect(names.size).toBe(LARGE_NAME_COUNT);
+        // The alphabetically-last name is the one the old LIMIT 1000 dropped.
+        expect(names.has(`span-name-${pad(LARGE_NAME_COUNT - 1)}`)).toBe(true);
+        expect(names.has("span-name-0000")).toBe(true);
+      });
+    });
+
+    describe("when the project has more than a thousand distinct metadata keys", () => {
+      beforeAll(async () => {
+        const attributes: Record<string, string> = {};
+        for (let i = 0; i < LARGE_NAME_COUNT; i++) {
+          attributes[`meta-key-${pad(i)}`] = "v";
+        }
+        await insertTraceSummaries(ch, [
+          makeTraceSummaryRow({
+            TraceId: `trace-many-meta-${nanoid()}`,
+            Attributes: attributes,
+          }),
+        ]);
+      });
+
+      /** @scenario All metadata keys are returned even for projects with thousands of them */
+      it("returns every distinct metadata key, none dropped", async () => {
+        const result = await service.getDistinctFieldNames(
+          tenantId,
+          now - 60_000,
+          now + 60_000,
+        );
+
+        expect(result).not.toBeNull();
+        const keys = new Set(result!.metadataKeys.map((k) => k.key));
+
+        expect(keys.has(`meta-key-${pad(LARGE_NAME_COUNT - 1)}`)).toBe(true);
+        expect(keys.has("meta-key-0000")).toBe(true);
+      });
+    });
+  });
+
+  describe("getTracesWithSpans()", () => {
+    describe("when a single trace has more than two hundred spans", () => {
+      const traceId = `trace-big-${nanoid()}`;
+
+      beforeAll(async () => {
+        await insertTraceSummaries(ch, [
+          makeTraceSummaryRow({
+            TraceId: traceId,
+            SpanCount: LARGE_SPAN_COUNT,
+          }),
+        ]);
+        // Distinct, increasing StartTime so the historical
+        // `ORDER BY StartTime ASC LIMIT 200 BY TraceId` keeps the first 200
+        // and drops the tail — the last span is a precise probe for the cap.
+        await insertSpans(
+          ch,
+          Array.from({ length: LARGE_SPAN_COUNT }, (_, i) =>
+            makeSpanRow({
+              TraceId: traceId,
+              SpanId: `bigspan-${pad(i)}-${nanoid()}`,
+              SpanName: `bigspan-${pad(i)}`,
+              StartTime: new Date(now + i),
+              EndTime: new Date(now + i + 10),
+            }),
+          ),
+        );
+      });
+
+      /** @scenario A trace with many spans exposes all of its spans */
+      it("returns all spans of the trace, none dropped", async () => {
+        const traces = await service.getTracesWithSpans(
+          tenantId,
+          [traceId],
+          openProtections,
+        );
+
+        expect(traces).not.toBeNull();
+        expect(traces).toHaveLength(1);
+
+        const spans = traces![0]!.spans;
+        expect(spans).toHaveLength(LARGE_SPAN_COUNT);
+
+        const spanNames = new Set(spans.map((s) => s.name));
+        // The last span by StartTime is what the old LIMIT 200 BY dropped.
+        expect(spanNames.has(`bigspan-${pad(LARGE_SPAN_COUNT - 1)}`)).toBe(true);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -54,6 +54,25 @@ interface ClickHouseScrollCursor {
 }
 
 /**
+ * Upper bound on distinct field names (span names, metadata keys) returned for
+ * the dataset / evaluator mapping dropdowns. Distinct names are low-cardinality
+ * in healthy projects (hundreds), so this only guards against pathological
+ * cardinality (e.g. dynamic IDs baked into span names) flooding the response.
+ * Set well above any real project so every name is offered for mapping rather
+ * than alphabetically truncated.
+ */
+const DISTINCT_FIELD_NAMES_LIMIT = 10_000;
+
+/**
+ * Upper bound on spans returned per trace by the spans-join read path. The REST
+ * collector no longer caps spans per trace (#4629), so this read cap must be
+ * high enough not to truncate real agentic traces while still protecting the
+ * read path from a pathologically large trace's full span payload. A trace that
+ * actually reaches this many spans is logged as a potential truncation.
+ */
+const MAX_SPANS_PER_TRACE = 10_000;
+
+/**
  * Service for fetching traces from ClickHouse.
  *
  * Fetches trace summaries and, when needed, span rows via separate ClickHouse
@@ -1169,7 +1188,7 @@ export class ClickHouseTraceService {
                 AND StartTime <= fromUnixTimestamp64Milli({endDate:UInt64})
                 AND SpanName != ''
               ORDER BY SpanName ASC
-              LIMIT 1000
+              LIMIT ${DISTINCT_FIELD_NAMES_LIMIT}
             `,
             query_params: {
               tenantId: projectId,
@@ -1197,7 +1216,7 @@ export class ClickHouseTraceService {
                 AND CreatedAt >= fromUnixTimestamp64Milli({startDate:UInt64})
                 AND CreatedAt <= fromUnixTimestamp64Milli({endDate:UInt64})
               ORDER BY key ASC
-              LIMIT 1000
+              LIMIT ${DISTINCT_FIELD_NAMES_LIMIT}
             `,
             query_params: {
               tenantId: projectId,
@@ -1866,7 +1885,7 @@ export class ClickHouseTraceService {
             GROUP BY TenantId, TraceId, SpanId
           )
         ORDER BY t.TraceId, t.StartTime ASC
-        LIMIT 200 BY t.TraceId
+        LIMIT ${MAX_SPANS_PER_TRACE} BY t.TraceId
       `,
             query_params: { tenantId: projectId, traceIds, ...spanTimeParams },
             format: "JSONEachRow",
@@ -1907,6 +1926,17 @@ export class ClickHouseTraceService {
           const spans = spansByTrace.get(row.TraceId) ?? [];
           spans.push(this.mapSpanRow(row, projectId));
           spansByTrace.set(row.TraceId, spans);
+        }
+
+        // Surface (rather than silently swallow) traces large enough to hit the
+        // per-trace span cap — their span list may be truncated.
+        for (const [traceId, spans] of spansByTrace) {
+          if (spans.length >= MAX_SPANS_PER_TRACE) {
+            this.logger.warn(
+              { projectId, traceId, spanCount: spans.length, cap: MAX_SPANS_PER_TRACE },
+              "Trace reached the per-trace span cap; span list may be truncated",
+            );
+          }
         }
 
         // Build the tracesMap by combining summaries + spans

--- a/specs/datasets/add-to-dataset-span-mapping.feature
+++ b/specs/datasets/add-to-dataset-span-mapping.feature
@@ -1,0 +1,54 @@
+Feature: Span field mapping when adding traces to a dataset
+  As a user mapping trace data into a dataset
+  I want the "spans" field to offer every span name my project has produced
+  So that I can map any span, even one that is not in the trace currently open
+
+  # Context: the "Add to Dataset" drawer lets users map a trace field to a
+  # dataset column. For the "spans" source a nested dropdown lists the span
+  # names to choose from. Historically that list was built only from the spans
+  # of the currently loaded trace(s), and the server-side queries that feed the
+  # project-wide name list silently capped their results. A customer reported a
+  # span name that clearly exists on a recent trace not being offered for
+  # mapping. These scenarios pin the expected behaviour so it cannot regress.
+
+  Background:
+    Given I am on a project that has produced traces over the last 30 days
+
+  # ============================================================================
+  # The dropdown offers all project span names, not just the open trace's spans
+  # ============================================================================
+
+  Scenario: Span names from the project are offered even when absent from the open trace
+    Given a span named "Research.aexecute_stream" was produced somewhere in my project in the last 30 days
+    And the trace I opened the "Add to Dataset" drawer on does not contain that span
+    When I select "spans" as the source for a column
+    Then "Research.aexecute_stream" is offered as a span name to map
+
+  Scenario: Span names from the open trace are always offered
+    Given the trace I opened the "Add to Dataset" drawer on contains a span named "step_2a_research_iter1"
+    When I select "spans" as the source for a column
+    Then "step_2a_research_iter1" is offered as a span name to map
+
+  Scenario: Selecting a project span name lets me map its subfields
+    Given a span named "Research.aexecute_stream" exists in my project but not in the open trace
+    When I select "spans" as the source and choose "Research.aexecute_stream"
+    Then I can map its input, output, params and contexts subfields
+
+  # ============================================================================
+  # Server never silently truncates the available names or spans
+  # ============================================================================
+
+  Scenario: All distinct span names are returned even for projects with thousands of them
+    Given my project has more than one thousand distinct span names in the last 30 days
+    When the available span names are fetched for mapping
+    Then every distinct span name is returned, none are dropped
+
+  Scenario: All metadata keys are returned even for projects with thousands of them
+    Given my project has more than one thousand distinct metadata keys in the last 30 days
+    When the available metadata keys are fetched for mapping
+    Then every distinct metadata key is returned, none are dropped
+
+  Scenario: A trace with many spans exposes all of its spans
+    Given a single trace contains more than two hundred spans
+    When that trace is loaded with its spans for mapping
+    Then all of its spans are returned, none are dropped


### PR DESCRIPTION
## What

The "Add to Dataset" drawer lets users map trace fields into a dataset. For the **spans** field a nested dropdown lists span names to choose from. A customer reported that a span clearly present on a recent trace (`Research.aexecute_stream`) was not offered for mapping.

Two independent problems caused span names to go missing:

1. **The dropdown only listed the currently loaded trace's spans.** It was built purely from `keys(traces_)`, so any span name that lived in the project but not in the open trace could not be selected, even though the dataset mapping is reused across future traces. The dropdown now also offers every unique span name (and metadata key) the project produced in the **last 30 days**, merged with the open trace's own spans.

2. **Two ClickHouse read queries silently truncated their results.** `getDistinctFieldNames` capped span names and metadata keys at `LIMIT 1000` (alphabetical), and `fetchTracesWithSpansJoined` capped spans at `LIMIT 200 BY TraceId`. The 200-span read cap was the symmetric twin of the REST-ingestion cap removed in #4629, so now that traces can grow past 200 spans, the read path was dropping the tail. Both caps are raised to a high safety bound (`10_000`) so real projects and agentic traces are never truncated; a trace that actually reaches the per-trace cap is now logged instead of silently swallowed.

## Why it regressed

The `LIMIT 200 BY TraceId` read cap has existed since Feb 2026 and mirrored the old 200-span ingestion cap. #4629 removed the ingestion cap yesterday, so large agentic traces can now exceed 200 spans and the read path started truncating them. The `LIMIT 1000` field-name cap and the trace-only dropdown were pre-existing gaps that surface as soon as a project has many span names or the wanted span is not in the open trace.

## Changes

- `TracesMapping`: merge 30d project-wide span names / metadata keys into the spans and metadata dropdowns (deduped, alphabetically sorted), with a loading spinner while the names are fetched. Project span names also expose the standard input/output/params/contexts subfields even when the span is not on the loaded trace.
- `clickhouse-trace.service`: raise the two field-name `LIMIT 1000` caps and the `LIMIT 200 BY TraceId` span cap to a named `10_000` bound; warn when a trace hits the per-trace span cap.

## Tests

- **CH integration (real ClickHouse via testcontainers):** a project with 1500 distinct span names returns all 1500; 1500 metadata keys all returned; a single trace with 250 spans returns all 250. All three fail against the old caps.
- **Frontend integration (real component render):** the spans dropdown offers a project span name that is absent from the loaded trace, still offers the trace's own spans, and exposes the subfields of a selected project span.
- Updated the memory-safety guard to accept a named-constant `LIMIT` (still bounded) alongside literal numbers.

## Spec

`specs/datasets/add-to-dataset-span-mapping.feature`

## QA

Reproduced against prod ClickHouse (read-only) to confirm the data and characterise the caps, then verified the fix locally in a browser.

Opened "Add to Dataset" on a trace (`qa-trace-draft`) that contains only three spans, none named `Research.aexecute_stream`. The spans dropdown still offered every span name the project produced in the last 30 days, including `Research.aexecute_stream`, and it could be selected and mapped:

![Add to Dataset spans dropdown maps Research.aexecute_stream, a span not in this trace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4644/datasets/dropdown-offers-project-span.png)

For contrast, the same trace's actual spans (Response_Draft.aexecute_stream, step_3_response_draft, Tenant_Resolution_Drafter_Agent.arun) — note none is named `Research.aexecute_stream`:

![qa-trace-draft contains no Research span](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4644/datasets/trace-without-research-span.png)