### PR TITLE
feat(datasets): offer all 30d project evaluator names and event types in dataset mapping

### DIFF
--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -74,6 +74,44 @@ const DATASET_INFERRED_MAPPINGS_BY_NAME_TRANSPOSED = Object.entries(
 
 type KeyOption = { key: string; label: string };
 
+/**
+ * Sources whose key dropdowns are expanded with the project's distinct field
+ * names from the last 30 days (not just the names on the loaded trace).
+ *
+ * Events are deliberately absent: their types live only inside the heavy
+ * stored_spans.SpanAttributes map, so a project-wide scan is not memory-safe
+ * (see DistinctFieldNamesResult). The events dropdown stays trace-derived.
+ */
+const PROJECT_FIELD_NAME_SOURCES: string[] = [
+  "spans",
+  "metadata",
+  "evaluations",
+];
+
+/** Result subfields an evaluation always exposes (see the evaluations mapping). */
+const DEFAULT_EVALUATION_SUBKEYS: KeyOption[] = [
+  "passed",
+  "score",
+  "label",
+  "details",
+  "status",
+  "error",
+].map((key) => ({ key, label: key }));
+
+/** Placeholder shown while a source's project-wide names are still loading. */
+const FIELD_NAME_LOADING_LABEL: Record<string, string> = {
+  spans: "Loading span names…",
+  metadata: "Loading metadata keys…",
+  evaluations: "Loading evaluations…",
+};
+
+/** Label for the "match everything" option at the top of a source's dropdown. */
+const FIELD_NAME_ANY_LABEL: Record<string, string> = {
+  spans: "* (any span)",
+  metadata: "* (all metadata)",
+  evaluations: "* (any evaluation)",
+};
+
 /** Dedupe {key,label} options by key, preserving first-seen order. */
 const dedupeKeyOptions = (options: KeyOption[]): KeyOption[] => {
   const seen = new Set<string>();
@@ -208,30 +246,32 @@ export const TracesMapping = ({
   );
   const mapping = traceMappingState.mapping;
 
-  // Only the spans and metadata sources draw from project-wide names. Fetch the
-  // 30-day distinct field-name list lazily — only when such a column is actually
-  // being mapped — so merely opening the drawer/wizard (or any other place that
-  // renders this component) doesn't trigger the heavier ClickHouse scan when no
-  // span/metadata column is in play.
+  // The spans, metadata, evaluations and events sources draw from project-wide
+  // names. Fetch the 30-day distinct field-name list lazily — only when such a
+  // column is actually being mapped — so merely opening the drawer/wizard (or
+  // any other place that renders this component) doesn't trigger the heavier
+  // ClickHouse scan when none of those sources is in play.
   const needsProjectFieldNames = useMemo(
     () =>
-      Object.values(mapping).some(
-        (m) => m.source === "spans" || m.source === "metadata",
+      Object.values(mapping).some((m) =>
+        PROJECT_FIELD_NAME_SOURCES.includes(m.source),
       ),
     [mapping],
   );
   const {
     spanNames: projectSpanNames,
     metadataKeys: projectMetadataKeys,
+    evaluationNames: projectEvaluationNames,
     isLoading: projectFieldNamesLoading,
   } = useProjectSpanNames({
     projectId: project?.id,
     enabled: needsProjectFieldNames,
   });
 
-  // Span / metadata dropdowns should offer every name the project produced in
-  // the last 30 days, not just the names on the loaded trace(s) — otherwise a
-  // span that exists elsewhere in the project cannot be selected for mapping.
+  // These dropdowns should offer every name the project produced in the last 30
+  // days, not just the names on the loaded trace(s) — otherwise a span (or
+  // evaluator) that exists elsewhere in the project cannot be selected for
+  // mapping.
   const mergeProjectKeyOptions = useCallback(
     (source: string, baseOptions: KeyOption[]): KeyOption[] => {
       const projectOptions =
@@ -239,7 +279,9 @@ export const TracesMapping = ({
           ? projectSpanNames
           : source === "metadata"
             ? projectMetadataKeys
-            : [];
+            : source === "evaluations"
+              ? projectEvaluationNames
+              : [];
       if (projectOptions.length === 0) {
         return baseOptions;
       }
@@ -247,7 +289,7 @@ export const TracesMapping = ({
         a.label.localeCompare(b.label),
       );
     },
-    [projectSpanNames, projectMetadataKeys],
+    [projectSpanNames, projectMetadataKeys, projectEvaluationNames],
   );
 
   // Check if any column uses a server-only source (e.g. formatted_trace)
@@ -505,6 +547,13 @@ export const TracesMapping = ({
             { key: "contexts", label: "contexts" },
           ];
 
+          const computeSubkeys = (k: string) =>
+            traceMappingDefinition && "subkeys" in traceMappingDefinition
+              ? traceMappingDefinition.subkeys(traces_, k, {
+                  annotationScoreOptions: getAnnotationScoreOptions.data,
+                })
+              : [];
+
           const subkeys =
             traceMappingDefinition &&
             "subkeys" in traceMappingDefinition &&
@@ -516,21 +565,25 @@ export const TracesMapping = ({
                   // loaded trace, where subkey discovery would otherwise be empty.
                   dedupeKeyOptions([
                     ...defaultSpanSubkeys,
-                    ...(key
-                      ? traceMappingDefinition.subkeys(traces_, key, {
-                          annotationScoreOptions: getAnnotationScoreOptions.data,
-                        })
-                      : []),
+                    ...(key ? computeSubkeys(key) : []),
                   ])
-                : traceMappingDefinition.subkeys(traces_, key!, {
-                    annotationScoreOptions: getAnnotationScoreOptions.data,
-                  })
+                : source === "evaluations" && key
+                  ? // Evaluations always expose the same result subfields. Offer
+                    // them for any selected evaluator — including project-wide
+                    // ones not on the loaded trace, where subkey discovery would
+                    // otherwise be empty.
+                    dedupeKeyOptions([
+                      ...DEFAULT_EVALUATION_SUBKEYS,
+                      ...computeSubkeys(key),
+                    ])
+                  : computeSubkeys(key!)
               : undefined;
 
-          // The spans/metadata key dropdown waits on the project-wide name list.
+          // The spans/metadata/evaluations key dropdown waits on the
+          // project-wide name list.
           const isLoadingFieldNames =
             projectFieldNamesLoading &&
-            (source === "spans" || source === "metadata");
+            PROJECT_FIELD_NAME_SOURCES.includes(source);
 
           const targetHandle = `inputs.${targetField}`;
           const currentSourceMapping = dsl?.targetEdges
@@ -715,19 +768,14 @@ export const TracesMapping = ({
                                     incomplete (trace-only) list. */}
                                 {isLoadingFieldNames ? (
                                   <option value="">
-                                    {source === "spans"
-                                      ? "Loading span names…"
-                                      : "Loading metadata keys…"}
+                                    {FIELD_NAME_LOADING_LABEL[source] ??
+                                      "Loading…"}
                                   </option>
                                 ) : (
                                   <>
-                                    {/* "* (any span)" option - matches all spans */}
+                                    {/* "match everything" option for the source */}
                                     <option value="">
-                                      {source === "spans"
-                                        ? "* (any span)"
-                                        : source === "metadata"
-                                          ? "* (all metadata)"
-                                          : "* (any)"}
+                                      {FIELD_NAME_ANY_LABEL[source] ?? "* (any)"}
                                     </option>
                                     {mergeProjectKeyOptions(
                                       source,

--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -16,6 +16,7 @@ import type { Trace } from "~/server/tracer/types";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import { useAnnotationsByTraceIds } from "../../hooks/useAnnotationsByTraceIds";
 import { useProjectSpanNames } from "../../hooks/useProjectSpanNames";
+import { useProjectEventTypes } from "../../hooks/useProjectEventTypes";
 import type { Workflow } from "../../optimization_studio/types/dsl";
 import type { DatasetRecordEntry } from "../../server/datasets/types";
 import {
@@ -76,11 +77,14 @@ type KeyOption = { key: string; label: string };
 
 /**
  * Sources whose key dropdowns are expanded with the project's distinct field
- * names from the last 30 days (not just the names on the loaded trace).
+ * names from the last 30 days (not just the names on the loaded trace), served
+ * by getDistinctFieldNames / useProjectSpanNames.
  *
- * Events are deliberately absent: their types live only inside the heavy
- * stored_spans.SpanAttributes map, so a project-wide scan is not memory-safe
- * (see DistinctFieldNamesResult). The events dropdown stays trace-derived.
+ * Events are not in this list because their types are not served from
+ * getDistinctFieldNames (they live only in the heavy stored_spans.SpanAttributes
+ * map, which that query must not scan). They get the same project-wide treatment
+ * through a separate, bounded source — useProjectEventTypes, which reuses the
+ * analytics event-type filter options query.
  */
 const PROJECT_FIELD_NAME_SOURCES: string[] = [
   "spans",
@@ -103,6 +107,7 @@ const FIELD_NAME_LOADING_LABEL: Record<string, string> = {
   spans: "Loading span names…",
   metadata: "Loading metadata keys…",
   evaluations: "Loading evaluations…",
+  events: "Loading event types…",
 };
 
 /** Label for the "match everything" option at the top of a source's dropdown. */
@@ -110,6 +115,7 @@ const FIELD_NAME_ANY_LABEL: Record<string, string> = {
   spans: "* (any span)",
   metadata: "* (all metadata)",
   evaluations: "* (any evaluation)",
+  events: "* (any event)",
 };
 
 /** Dedupe {key,label} options by key, preserving first-seen order. */
@@ -246,8 +252,8 @@ export const TracesMapping = ({
   );
   const mapping = traceMappingState.mapping;
 
-  // The spans, metadata, evaluations and events sources draw from project-wide
-  // names. Fetch the 30-day distinct field-name list lazily — only when such a
+  // The spans, metadata and evaluations sources draw their project-wide names
+  // from getDistinctFieldNames. Fetch that 30-day list lazily — only when such a
   // column is actually being mapped — so merely opening the drawer/wizard (or
   // any other place that renders this component) doesn't trigger the heavier
   // ClickHouse scan when none of those sources is in play.
@@ -268,10 +274,24 @@ export const TracesMapping = ({
     enabled: needsProjectFieldNames,
   });
 
+  // Events get the same project-wide treatment from a separate bounded source
+  // (the analytics event-type filter options), gated the same way.
+  const needsProjectEventTypes = useMemo(
+    () => Object.values(mapping).some((m) => m.source === "events"),
+    [mapping],
+  );
+  const {
+    eventTypes: projectEventTypes,
+    isLoading: projectEventTypesLoading,
+  } = useProjectEventTypes({
+    projectId: project?.id,
+    enabled: needsProjectEventTypes,
+  });
+
   // These dropdowns should offer every name the project produced in the last 30
   // days, not just the names on the loaded trace(s) — otherwise a span (or
-  // evaluator) that exists elsewhere in the project cannot be selected for
-  // mapping.
+  // evaluator, or event type) that exists elsewhere in the project cannot be
+  // selected for mapping.
   const mergeProjectKeyOptions = useCallback(
     (source: string, baseOptions: KeyOption[]): KeyOption[] => {
       const projectOptions =
@@ -281,7 +301,9 @@ export const TracesMapping = ({
             ? projectMetadataKeys
             : source === "evaluations"
               ? projectEvaluationNames
-              : [];
+              : source === "events"
+                ? projectEventTypes
+                : [];
       if (projectOptions.length === 0) {
         return baseOptions;
       }
@@ -289,7 +311,12 @@ export const TracesMapping = ({
         a.label.localeCompare(b.label),
       );
     },
-    [projectSpanNames, projectMetadataKeys, projectEvaluationNames],
+    [
+      projectSpanNames,
+      projectMetadataKeys,
+      projectEvaluationNames,
+      projectEventTypes,
+    ],
   );
 
   // Check if any column uses a server-only source (e.g. formatted_trace)
@@ -579,11 +606,13 @@ export const TracesMapping = ({
                   : computeSubkeys(key!)
               : undefined;
 
-          // The spans/metadata/evaluations key dropdown waits on the
-          // project-wide name list.
+          // The key dropdown waits on whichever project-wide list feeds it:
+          // getDistinctFieldNames for spans/metadata/evaluations, the event-type
+          // options for events.
           const isLoadingFieldNames =
-            projectFieldNamesLoading &&
-            PROJECT_FIELD_NAME_SOURCES.includes(source);
+            (projectFieldNamesLoading &&
+              PROJECT_FIELD_NAME_SOURCES.includes(source)) ||
+            (projectEventTypesLoading && source === "events");
 
           const targetHandle = `inputs.${targetField}`;
           const currentSourceMapping = dsl?.targetEdges

--- a/langwatch/src/components/traces/__tests__/TracesMapping.evaluationNames.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/TracesMapping.evaluationNames.integration.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the "evaluations" field mapping dropdown in
+ * TracesMapping.
+ *
+ * Like the spans dropdown, it must offer every evaluator name the project ran
+ * in the last 30 days, not just the evaluators present on the currently loaded
+ * trace(s). These tests render the real component tree and assert the merged
+ * behaviour.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type { MappingState } from "~/server/tracer/tracesMapping";
+import type { Trace } from "~/server/tracer/types";
+import { TracesMapping } from "../TracesMapping";
+
+// Project-wide evaluator names returned for the last 30 days — note that the
+// "PII Check" evaluator is NOT present on the loaded trace below.
+const PROJECT_EVALUATION_NAMES = [
+  { key: "evaluator-pii", label: "PII Check" },
+  { key: "evaluator-toxicity", label: "Toxicity" },
+];
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project", slug: "test-project" },
+  }),
+}));
+
+vi.mock("~/hooks/useProjectSpanNames", () => ({
+  useProjectSpanNames: () => ({
+    spanNames: [],
+    metadataKeys: [],
+    evaluationNames: PROJECT_EVALUATION_NAMES,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("~/hooks/useAnnotationsByTraceIds", () => ({
+  useAnnotationsByTraceIds: () => ({ data: [] }),
+}));
+
+vi.mock(
+  "~/components/evaluations/wizard/hooks/evaluation-wizard-store/useEvaluationWizardStore",
+  () => ({
+    useEvaluationWizardStore: (selector: (state: unknown) => unknown) =>
+      selector({ workbenchState: { task: undefined } }),
+  }),
+);
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    annotationScore: {
+      getAllActive: { useQuery: () => ({ data: [] }) },
+    },
+    traces: {
+      getTracesWithSpansByThreadIds: { useQuery: () => ({ data: undefined }) },
+      getFormattedSpansDigest: { useQuery: () => ({ data: undefined }) },
+    },
+  },
+}));
+
+/** A trace that was not scored by the project-wide evaluators above. */
+const traceWithoutEvaluations = {
+  trace_id: "trace-1",
+  project_id: "test-project",
+  metadata: {},
+  timestamps: { started_at: 1, inserted_at: 1, updated_at: 1 },
+  spans: [],
+  evaluations: [],
+} as unknown as Trace;
+
+/** Render with a single column already mapped to the "evaluations" source. */
+function renderEvaluationsMapping() {
+  const traceMapping: MappingState = {
+    mapping: { eval_col: { source: "evaluations" as never, key: "", subkey: "" } },
+    expansions: [],
+  };
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <TracesMapping
+        traces={[traceWithoutEvaluations]}
+        traceMapping={traceMapping}
+        targetFields={["eval_col"]}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("TracesMapping evaluations dropdown (integration)", () => {
+  afterEach(() => cleanup());
+
+  describe("when a project evaluator is absent from the loaded trace", () => {
+    /** @scenario Evaluator names from the project are offered even when absent from the open trace */
+    it("offers the project evaluator name for mapping", async () => {
+      renderEvaluationsMapping();
+
+      expect(
+        await screen.findByRole("option", { name: "PII Check" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when a project evaluator is selected", () => {
+    /** @scenario Selecting a project evaluator lets me map its result subfields */
+    it("offers the passed, score, label, details, status and error subfields", async () => {
+      const user = userEvent.setup();
+      renderEvaluationsMapping();
+
+      const piiOption = await screen.findByRole("option", { name: "PII Check" });
+      const keySelect = piiOption.closest("select");
+      expect(keySelect).not.toBeNull();
+
+      await user.selectOptions(keySelect!, piiOption as HTMLOptionElement);
+
+      // Scope the subfield assertions to the subkey <select> (identified by its
+      // "* (full object)" option) so they don't collide with other dropdowns.
+      const fullObjectOption = await screen.findByRole("option", {
+        name: "* (full object)",
+      });
+      const subkeySelect = fullObjectOption.closest("select");
+      expect(subkeySelect).not.toBeNull();
+
+      for (const subfield of [
+        "passed",
+        "score",
+        "label",
+        "details",
+        "status",
+        "error",
+      ]) {
+        expect(
+          within(subkeySelect!).getByRole("option", { name: subfield }),
+        ).toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/langwatch/src/components/traces/__tests__/TracesMapping.evaluationNames.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/TracesMapping.evaluationNames.integration.test.tsx
@@ -42,6 +42,10 @@ vi.mock("~/hooks/useProjectSpanNames", () => ({
   }),
 }));
 
+vi.mock("~/hooks/useProjectEventTypes", () => ({
+  useProjectEventTypes: () => ({ eventTypes: [], isLoading: false, error: null }),
+}));
+
 vi.mock("~/hooks/useAnnotationsByTraceIds", () => ({
   useAnnotationsByTraceIds: () => ({ data: [] }),
 }));

--- a/langwatch/src/components/traces/__tests__/TracesMapping.eventTypes.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/TracesMapping.eventTypes.integration.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the "events" field mapping dropdown in TracesMapping.
+ *
+ * Like spans and evaluations, it must offer every event type the project
+ * tracked in the last 30 days, not just the ones on the currently loaded
+ * trace(s). Event types come from a separate bounded source
+ * (useProjectEventTypes, backed by the analytics event-type filter options),
+ * which this test mocks. These tests render the real component tree.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type { MappingState } from "~/server/tracer/tracesMapping";
+import type { Trace } from "~/server/tracer/types";
+import { TracesMapping } from "../TracesMapping";
+
+// Project-wide event types returned for the last 30 days — note that
+// "thumbs_up" is NOT present on the loaded trace below.
+const PROJECT_EVENT_TYPES = [
+  { key: "thumbs_up", label: "thumbs_up" },
+  { key: "thumbs_down", label: "thumbs_down" },
+];
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "test-project", slug: "test-project" },
+  }),
+}));
+
+vi.mock("~/hooks/useProjectSpanNames", () => ({
+  useProjectSpanNames: () => ({
+    spanNames: [],
+    metadataKeys: [],
+    evaluationNames: [],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("~/hooks/useProjectEventTypes", () => ({
+  useProjectEventTypes: () => ({
+    eventTypes: PROJECT_EVENT_TYPES,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("~/hooks/useAnnotationsByTraceIds", () => ({
+  useAnnotationsByTraceIds: () => ({ data: [] }),
+}));
+
+vi.mock(
+  "~/components/evaluations/wizard/hooks/evaluation-wizard-store/useEvaluationWizardStore",
+  () => ({
+    useEvaluationWizardStore: (selector: (state: unknown) => unknown) =>
+      selector({ workbenchState: { task: undefined } }),
+  }),
+);
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    annotationScore: {
+      getAllActive: { useQuery: () => ({ data: [] }) },
+    },
+    traces: {
+      getTracesWithSpansByThreadIds: { useQuery: () => ({ data: undefined }) },
+      getFormattedSpansDigest: { useQuery: () => ({ data: undefined }) },
+    },
+  },
+}));
+
+/** A trace with no events of the project-wide types above. */
+const traceWithoutEvents = {
+  trace_id: "trace-1",
+  project_id: "test-project",
+  metadata: {},
+  timestamps: { started_at: 1, inserted_at: 1, updated_at: 1 },
+  spans: [],
+  events: [],
+} as unknown as Trace;
+
+function renderEventsMapping() {
+  const traceMapping: MappingState = {
+    mapping: {
+      event_col: { source: "events" as never, key: "", subkey: "" },
+    },
+    expansions: [],
+  };
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <TracesMapping
+        traces={[traceWithoutEvents]}
+        traceMapping={traceMapping}
+        targetFields={["event_col"]}
+      />
+    </ChakraProvider>,
+  );
+}
+
+describe("TracesMapping events dropdown (integration)", () => {
+  afterEach(() => cleanup());
+
+  describe("when a project event type is absent from the loaded trace", () => {
+    /** @scenario Event types from the project are offered even when absent from the open trace */
+    it("offers the project event type for mapping", async () => {
+      renderEventsMapping();
+
+      expect(
+        await screen.findByRole("option", { name: "thumbs_up" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/components/traces/__tests__/TracesMapping.spanNames.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/TracesMapping.spanNames.integration.test.tsx
@@ -40,6 +40,10 @@ vi.mock("~/hooks/useProjectSpanNames", () => ({
   }),
 }));
 
+vi.mock("~/hooks/useProjectEventTypes", () => ({
+  useProjectEventTypes: () => ({ eventTypes: [], isLoading: false, error: null }),
+}));
+
 vi.mock("~/hooks/useAnnotationsByTraceIds", () => ({
   useAnnotationsByTraceIds: () => ({ data: [] }),
 }));

--- a/langwatch/src/hooks/__tests__/useProjectEventTypes.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProjectEventTypes.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { useProjectEventTypes } from "../useProjectEventTypes";
+
+const mockUseQuery = vi.fn();
+
+vi.mock("../../utils/api", () => ({
+  api: {
+    analytics: {
+      dataForFilter: {
+        useQuery: (...args: unknown[]) => mockUseQuery(...args),
+      },
+    },
+  },
+}));
+
+describe("useProjectEventTypes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty eventTypes when projectId is undefined", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false, error: null });
+
+    const { result } = renderHook(() =>
+      useProjectEventTypes({ projectId: undefined }),
+    );
+
+    expect(result.current.eventTypes).toEqual([]);
+  });
+
+  it("maps filter options into key/label event types", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        options: [
+          { field: "thumbs_up", label: "thumbs_up", count: 12 },
+          { field: "feedback", label: "feedback", count: 3 },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useProjectEventTypes({ projectId: "project-123" }),
+    );
+
+    expect(result.current.eventTypes).toEqual([
+      { key: "thumbs_up", label: "thumbs_up" },
+      { key: "feedback", label: "feedback" },
+    ]);
+  });
+
+  it("drops options with an empty field", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        options: [
+          { field: "", label: "", count: 1 },
+          { field: "thumbs_up", label: "thumbs_up", count: 2 },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useProjectEventTypes({ projectId: "project-123" }),
+    );
+
+    expect(result.current.eventTypes).toEqual([
+      { key: "thumbs_up", label: "thumbs_up" },
+    ]);
+  });
+
+  it("queries the events.event_type filter field", () => {
+    mockUseQuery.mockReturnValue({
+      data: { options: [] },
+      isLoading: false,
+      error: null,
+    });
+
+    renderHook(() => useProjectEventTypes({ projectId: "project-123" }));
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project-123",
+        field: "events.event_type",
+        startDate: expect.any(Number),
+        endDate: expect.any(Number),
+        filters: {},
+      }),
+      expect.objectContaining({
+        enabled: true,
+        refetchOnWindowFocus: false,
+        staleTime: 5 * 60 * 1000,
+      }),
+    );
+  });
+
+  it("disables the query when projectId is undefined", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false, error: null });
+
+    renderHook(() => useProjectEventTypes({ projectId: undefined }));
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it("disables the query when enabled is false even with a projectId", () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false, error: null });
+
+    renderHook(() =>
+      useProjectEventTypes({ projectId: "project-123", enabled: false }),
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+});

--- a/langwatch/src/hooks/__tests__/useProjectSpanNames.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProjectSpanNames.test.tsx
@@ -213,6 +213,48 @@ describe("useProjectSpanNames", () => {
     expect(keys).toContain("labels");
   });
 
+  it("passes through evaluation names from the endpoint response", () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        spanNames: [],
+        metadataKeys: [],
+        evaluationNames: [
+          { key: "evaluator-pii", label: "PII Check" },
+          { key: "evaluator-toxicity", label: "Toxicity" },
+        ],
+        eventTypes: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useProjectSpanNames({ projectId: "project-123" }),
+    );
+
+    expect(result.current.evaluationNames).toHaveLength(2);
+    expect(result.current.evaluationNames.map((e) => e.key)).toContain(
+      "evaluator-pii",
+    );
+    expect(result.current.evaluationNames.map((e) => e.label)).toContain(
+      "PII Check",
+    );
+  });
+
+  it("returns empty evaluationNames when absent from the response", () => {
+    mockUseQuery.mockReturnValue({
+      data: { spanNames: [], metadataKeys: [] },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useProjectSpanNames({ projectId: "project-123" }),
+    );
+
+    expect(result.current.evaluationNames).toEqual([]);
+  });
+
   it("excludes 'custom' and 'all_keys' from metadata keys", () => {
     mockUseQuery.mockReturnValue({
       data: {

--- a/langwatch/src/hooks/__tests__/useProjectSpanNames.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProjectSpanNames.test.tsx
@@ -222,7 +222,6 @@ describe("useProjectSpanNames", () => {
           { key: "evaluator-pii", label: "PII Check" },
           { key: "evaluator-toxicity", label: "Toxicity" },
         ],
-        eventTypes: [],
       },
       isLoading: false,
       error: null,

--- a/langwatch/src/hooks/useProjectEventTypes.ts
+++ b/langwatch/src/hooks/useProjectEventTypes.ts
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+import { api } from "../utils/api";
+
+/**
+ * Hook to fetch the distinct event types a project produced, for the events
+ * field-mapping dropdown.
+ *
+ * Event types live only inside the heavy `stored_spans.SpanAttributes` map
+ * (the trace_summaries event columns were dropped in migration 00025), so they
+ * are NOT served from `getDistinctFieldNames` — a full scan there would trip
+ * the memory-safety guard. Instead this reuses the same bounded, prod-proven
+ * query that backs the analytics "event type" filter dropdown
+ * (`dataForFilter` -> filter options: GROUP BY + LIMIT 10000 over the date
+ * range), which returns the clean custom event types that match the dataset
+ * mapping's `event_type` keys.
+ *
+ * The query is bounded but not free, so callers should pass `enabled: false`
+ * until an events column is actually being mapped.
+ *
+ * @param projectId - The project ID to fetch event types for
+ * @param enabled - Gate the query (default true); combined with projectId presence
+ * @returns Object with eventTypes array, isLoading state, and error if any
+ */
+export function useProjectEventTypes({
+  projectId,
+  enabled = true,
+}: {
+  projectId: string | undefined;
+  enabled?: boolean;
+}) {
+  const endDate = useMemo(() => Date.now(), []);
+  const startDate = useMemo(() => endDate - 30 * 24 * 60 * 60 * 1000, [endDate]);
+
+  const query = api.analytics.dataForFilter.useQuery(
+    {
+      projectId: projectId ?? "",
+      startDate,
+      endDate,
+      filters: {},
+      field: "events.event_type",
+    },
+    {
+      enabled: !!projectId && enabled,
+      refetchOnWindowFocus: false,
+      staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+    }
+  );
+
+  const eventTypes = useMemo(
+    () =>
+      (query.data?.options ?? [])
+        .map((option) => ({
+          key: String(option.field),
+          label: option.label,
+        }))
+        .filter((option) => option.key !== ""),
+    [query.data]
+  );
+
+  return {
+    eventTypes,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/langwatch/src/hooks/useProjectSpanNames.ts
+++ b/langwatch/src/hooks/useProjectSpanNames.ts
@@ -3,16 +3,18 @@ import { reservedTraceMetadataSchema } from "../server/tracer/types.generated";
 import { api } from "../utils/api";
 
 /**
- * Hook to fetch distinct span names and metadata keys for a project.
- * Uses a dedicated ClickHouse aggregation endpoint instead of loading full traces.
+ * Hook to fetch distinct span names, metadata keys and evaluator names for a
+ * project. Uses a dedicated ClickHouse aggregation endpoint instead of loading
+ * full traces.
  *
- * The underlying query scans the last 30 days of spans/summaries, so callers
- * that only need it conditionally (e.g. only when a span/metadata column is
- * being mapped) should pass `enabled: false` until it is actually needed.
+ * The underlying query scans the last 30 days of spans/summaries/evaluations,
+ * so callers that only need it conditionally (e.g. only when a span / metadata /
+ * evaluation column is being mapped) should pass `enabled: false` until it is
+ * actually needed.
  *
  * @param projectId - The project ID to fetch field names from
  * @param enabled - Gate the query (default true); combined with projectId presence
- * @returns Object with spanNames, metadataKeys arrays, isLoading state, and error if any
+ * @returns Object with spanNames, metadataKeys, evaluationNames arrays, isLoading state, and error if any
  */
 export function useProjectSpanNames({
   projectId,
@@ -60,6 +62,7 @@ export function useProjectSpanNames({
   return {
     spanNames: fieldNames.data?.spanNames ?? [],
     metadataKeys,
+    evaluationNames: fieldNames.data?.evaluationNames ?? [],
     isLoading: fieldNames.isLoading,
     error: fieldNames.error,
   };

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-field-names.integration.test.ts
@@ -120,6 +120,38 @@ async function insertTraceSummaries(
   });
 }
 
+function makeEvaluationRunRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    EvaluationId: `eval-${nanoid()}`,
+    Version: "v1",
+    EvaluatorId: `evaluator-${nanoid()}`,
+    EvaluatorType: "custom/test",
+    EvaluatorName: "test-evaluator",
+    TraceId: `trace-${nanoid()}`,
+    Status: "processed",
+    LastProcessedEventId: `evt-${nanoid()}`,
+    ScheduledAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    LastEventOccurredAt: new Date(now),
+    ...overrides,
+  };
+}
+
+async function insertEvaluationRuns(
+  ch: ClickHouseClient,
+  rows: ReturnType<typeof makeEvaluationRunRow>[],
+) {
+  await ch.insert({
+    table: "evaluation_runs",
+    values: rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
 const openProtections: Protections = {
   canSeeCosts: true,
   canSeeCapturedInput: true,
@@ -167,6 +199,10 @@ afterAll(async () => {
     });
     await ch.exec({
       query: `ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+    await ch.exec({
+      query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String}`,
       query_params: { tenantId },
     });
   }
@@ -239,6 +275,43 @@ describe("ClickHouse field-name queries (integration)", () => {
 
         expect(keys.has(`meta-key-${pad(LARGE_NAME_COUNT - 1)}`)).toBe(true);
         expect(keys.has("meta-key-0000")).toBe(true);
+      });
+    });
+
+    describe("when the project has more than a thousand distinct evaluator names", () => {
+      beforeAll(async () => {
+        // Distinct evaluator id + name pairs spread across many traces, so the
+        // names live project-wide rather than on any single open trace.
+        await insertEvaluationRuns(
+          ch,
+          Array.from({ length: LARGE_NAME_COUNT }, (_, i) =>
+            makeEvaluationRunRow({
+              EvaluatorId: `evaluator-${pad(i)}`,
+              EvaluatorName: `evaluator-name-${pad(i)}`,
+            }),
+          ),
+        );
+      });
+
+      /** @scenario All distinct evaluator names are returned even for projects with thousands of them */
+      it("returns every distinct evaluator name, none dropped", async () => {
+        const result = await service.getDistinctFieldNames(
+          tenantId,
+          now - 60_000,
+          now + 60_000,
+        );
+
+        expect(result).not.toBeNull();
+        const ids = new Set(result!.evaluationNames.map((e) => e.key));
+        const labels = new Set(result!.evaluationNames.map((e) => e.label));
+
+        expect(ids.size).toBe(LARGE_NAME_COUNT);
+        expect(ids.has(`evaluator-${pad(LARGE_NAME_COUNT - 1)}`)).toBe(true);
+        expect(ids.has("evaluator-0000")).toBe(true);
+        // The key is the evaluator id, the label its human-readable name.
+        expect(labels.has(`evaluator-name-${pad(LARGE_NAME_COUNT - 1)}`)).toBe(
+          true,
+        );
       });
     });
   });

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1235,7 +1235,42 @@ export class ClickHouseTraceService {
             label: row.key,
           }));
 
-          return { spanNames, metadataKeys };
+          // Get distinct evaluator names from evaluation_runs. Dedupe by
+          // evaluator id (an evaluator can be renamed over time) and keep the
+          // most recent name. The dropdown maps the id and shows the name.
+          const evalResult = await clickHouseClient.query({
+            query: `
+              SELECT
+                EvaluatorId AS id,
+                argMax(EvaluatorName, ScheduledAt) AS name
+              FROM evaluation_runs
+              WHERE TenantId = {tenantId:String}
+                AND ScheduledAt >= fromUnixTimestamp64Milli({startDate:UInt64})
+                AND ScheduledAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+                AND EvaluatorId != ''
+              GROUP BY EvaluatorId
+              ORDER BY name ASC
+              LIMIT ${DISTINCT_FIELD_NAMES_LIMIT}
+            `,
+            query_params: {
+              tenantId: projectId,
+              startDate,
+              endDate,
+            },
+            format: "JSONEachRow",
+          });
+
+          const evalRows = (await evalResult.json()) as Array<{
+            id: string;
+            name: string | null;
+          }>;
+
+          const evaluationNames = evalRows.map((row) => ({
+            key: row.id,
+            label: row.name ?? row.id,
+          }));
+
+          return { spanNames, metadataKeys, evaluationNames };
         } catch (error) {
           this.logger.error(
             {

--- a/langwatch/src/server/traces/elasticsearch-trace.service.ts
+++ b/langwatch/src/server/traces/elasticsearch-trace.service.ts
@@ -830,10 +830,16 @@ export class ElasticsearchTraceService {
     startDate: number,
     endDate: number,
   ): Promise<DistinctFieldNamesResult> {
-    return esGetDistinctFieldNames({
+    const { spanNames, metadataKeys } = await esGetDistinctFieldNames({
       connConfig: { projectId },
       startDate,
       endDate,
     });
+    // Project-wide evaluator names are served from ClickHouse, the active
+    // backend (TraceService.getDistinctFieldNames always routes there). This
+    // Elasticsearch path predates that and is not reached for field-name
+    // mapping; the dropdowns still fall back to the trace-derived keys, so ES
+    // projects keep working without the project-wide expansion.
+    return { spanNames, metadataKeys, evaluationNames: [] };
   }
 }

--- a/langwatch/src/server/traces/types.ts
+++ b/langwatch/src/server/traces/types.ts
@@ -67,11 +67,12 @@ export interface CustomersAndLabelsResult {
  * Evaluation entries carry the evaluator id as `key` and its display name as
  * `label`; the other arrays use the name for both.
  *
- * Event types are intentionally not included: they live only inside the heavy
- * `stored_spans.SpanAttributes` map (the trace_summaries event columns were
- * dropped in migration 00025), so a project-wide scan would materialise that
- * column — exactly the OOM/IO vector the memory-safety guard protects against.
- * The events dropdown keeps deriving its options from the loaded trace.
+ * Event types are intentionally not included here: they live only inside the
+ * heavy `stored_spans.SpanAttributes` map (the trace_summaries event columns
+ * were dropped in migration 00025), so scanning them in this query would
+ * materialise that column — exactly the OOM/IO vector the memory-safety guard
+ * protects against. The events dropdown instead gets its project-wide options
+ * from the bounded analytics event-type filter query (see useProjectEventTypes).
  */
 export interface DistinctFieldNamesResult {
   spanNames: Array<{ key: string; label: string }>;

--- a/langwatch/src/server/traces/types.ts
+++ b/langwatch/src/server/traces/types.ts
@@ -60,11 +60,23 @@ export interface CustomersAndLabelsResult {
 
 /**
  * Result structure for getDistinctFieldNames.
- * Returns unique span names and metadata keys for a project.
+ * Returns unique span names, metadata keys and evaluator names for a project,
+ * so field-mapping dropdowns can offer every name the project produced (not
+ * just the ones on the currently loaded trace).
+ *
+ * Evaluation entries carry the evaluator id as `key` and its display name as
+ * `label`; the other arrays use the name for both.
+ *
+ * Event types are intentionally not included: they live only inside the heavy
+ * `stored_spans.SpanAttributes` map (the trace_summaries event columns were
+ * dropped in migration 00025), so a project-wide scan would materialise that
+ * column — exactly the OOM/IO vector the memory-safety guard protects against.
+ * The events dropdown keeps deriving its options from the loaded trace.
  */
 export interface DistinctFieldNamesResult {
   spanNames: Array<{ key: string; label: string }>;
   metadataKeys: Array<{ key: string; label: string }>;
+  evaluationNames: Array<{ key: string; label: string }>;
 }
 
 /**

--- a/specs/datasets/add-to-dataset-span-mapping.feature
+++ b/specs/datasets/add-to-dataset-span-mapping.feature
@@ -11,14 +11,15 @@ Feature: Span field mapping when adding traces to a dataset
   # span name that clearly exists on a recent trace not being offered for
   # mapping. These scenarios pin the expected behaviour so it cannot regress.
   #
-  # The same trace-only limitation applied to the "evaluations" source: its
-  # dropdown only listed evaluators present on the open trace, so an evaluator
-  # that ran elsewhere in the project could not be mapped. It now also draws
-  # from the project's last 30 days, mirroring spans and metadata.
+  # The same trace-only limitation applied to the "evaluations" and "events"
+  # sources: their dropdowns only listed evaluators / event types present on the
+  # open trace, so ones that occurred elsewhere in the project could not be
+  # mapped. They now also draw from the project's last 30 days.
   #
-  # The "events" source stays trace-derived on purpose: event types live only
-  # inside the heavy stored_spans span-attributes map, so a project-wide scan
-  # would not be memory-safe.
+  # Evaluator names come from the same getDistinctFieldNames query as spans and
+  # metadata. Event types come from a separate, bounded source (the analytics
+  # event-type filter options) because they live only inside the heavy
+  # stored_spans span-attributes map, which that query must not scan.
 
   Background:
     Given I am on a project that has produced traces over the last 30 days
@@ -63,7 +64,7 @@ Feature: Span field mapping when adding traces to a dataset
     Then all of its spans are returned, none are dropped
 
   # ============================================================================
-  # Evaluations also offer project-wide names, not just the open trace's
+  # Evaluations and events also offer project-wide names, not just the open trace's
   # ============================================================================
 
   Scenario: Evaluator names from the project are offered even when absent from the open trace
@@ -81,3 +82,9 @@ Feature: Span field mapping when adding traces to a dataset
     Given my project has more than one thousand distinct evaluator names in the last 30 days
     When the available evaluator names are fetched for mapping
     Then every distinct evaluator name is returned, none are dropped
+
+  Scenario: Event types from the project are offered even when absent from the open trace
+    Given an event of type "thumbs_up" was tracked somewhere in my project in the last 30 days
+    And the trace I opened the "Add to Dataset" drawer on has no such event
+    When I select "events" as the source for a column
+    Then "thumbs_up" is offered as an event type to map

--- a/specs/datasets/add-to-dataset-span-mapping.feature
+++ b/specs/datasets/add-to-dataset-span-mapping.feature
@@ -10,6 +10,15 @@ Feature: Span field mapping when adding traces to a dataset
   # project-wide name list silently capped their results. A customer reported a
   # span name that clearly exists on a recent trace not being offered for
   # mapping. These scenarios pin the expected behaviour so it cannot regress.
+  #
+  # The same trace-only limitation applied to the "evaluations" source: its
+  # dropdown only listed evaluators present on the open trace, so an evaluator
+  # that ran elsewhere in the project could not be mapped. It now also draws
+  # from the project's last 30 days, mirroring spans and metadata.
+  #
+  # The "events" source stays trace-derived on purpose: event types live only
+  # inside the heavy stored_spans span-attributes map, so a project-wide scan
+  # would not be memory-safe.
 
   Background:
     Given I am on a project that has produced traces over the last 30 days
@@ -52,3 +61,23 @@ Feature: Span field mapping when adding traces to a dataset
     Given a single trace contains more than two hundred spans
     When that trace is loaded with its spans for mapping
     Then all of its spans are returned, none are dropped
+
+  # ============================================================================
+  # Evaluations also offer project-wide names, not just the open trace's
+  # ============================================================================
+
+  Scenario: Evaluator names from the project are offered even when absent from the open trace
+    Given an evaluator named "PII Check" ran somewhere in my project in the last 30 days
+    And the trace I opened the "Add to Dataset" drawer on was not scored by that evaluator
+    When I select "evaluations" as the source for a column
+    Then "PII Check" is offered as an evaluation to map
+
+  Scenario: Selecting a project evaluator lets me map its result subfields
+    Given an evaluator ran in my project but not on the open trace
+    When I select "evaluations" as the source and choose that evaluator
+    Then I can map its passed, score, label, details, status and error subfields
+
+  Scenario: All distinct evaluator names are returned even for projects with thousands of them
+    Given my project has more than one thousand distinct evaluator names in the last 30 days
+    When the available evaluator names are fetched for mapping
+    Then every distinct evaluator name is returned, none are dropped


### PR DESCRIPTION
## What

Follow-up to #4644. That PR made the "Add to Dataset" drawer's **spans** and **metadata** dropdowns offer every name the project produced in the last 30 days, not just the ones on the currently loaded trace. The **evaluations** and **events** sources had the exact same trace-only limitation: their dropdowns only listed evaluators / event types that occurred on the open trace, so ones that occurred elsewhere in the project could not be selected for mapping (the dataset mapping is reused across future traces, so this matters).

Both dropdowns now also merge the project's distinct values from the last 30 days, deduped with the open trace's own and sorted alphabetically.

## Changes

- **Evaluations:** `getDistinctFieldNames` (ClickHouse) now also returns `evaluationNames`, sourced from the `evaluation_runs` table: `EvaluatorId` as the option key, `EvaluatorName` as the label, deduped by id (`GROUP BY EvaluatorId` + `argMax(EvaluatorName, ScheduledAt)` so a renamed evaluator keeps its latest name), partition-pruned on `ScheduledAt`, bounded by the same `10_000` safety limit as spans/metadata. A selected project-wide evaluator that is not on the open trace still exposes its result subfields (passed, score, label, details, status, error) via a default set, mirroring how spans expose input/output/params/contexts.
- **Events (lighter, bounded):** event types live only inside the heavy `stored_spans.SpanAttributes` map (the `trace_summaries` event columns were dropped in migration 00025), so they are deliberately NOT added to `getDistinctFieldNames` — a full scan there would trip the ClickHouse memory-safety guard. Instead the events dropdown reuses the exact same bounded, prod-proven query that already backs the analytics "event type" filter (`dataForFilter` → filter options: `SELECT SpanAttributes['event.type'] ... GROUP BY field LIMIT 10000` over the date range), via a small `useProjectEventTypes` hook. No new heavy query, and it returns the clean custom event types that match the mapping's `event_type` keys.
- `TracesMapping`: merge the project evaluator names and event types into their dropdowns (with the loading spinner and disabled state, same as spans/metadata).
- Both lookups stay lazy: the evaluator/spans/metadata list only fires when one of those columns is mapped; the event-type list only fires when an events column is mapped. Merely opening the drawer/wizard triggers neither.

## Tests

- **CH integration (real ClickHouse via testcontainers):** a project with 1500 distinct evaluators returns all 1500, keys are the evaluator ids and labels the evaluator names, none dropped.
- **Frontend integration (real component render):** the evaluations dropdown offers a project evaluator absent from the loaded trace (and its result subfields); the events dropdown offers a project event type absent from the loaded trace.
- **Hooks:** `useProjectSpanNames` passes evaluator names through; `useProjectEventTypes` maps filter options to event types, drops empties, and gates on projectId + enabled.
- Memory-safety guard stays green (no new `SpanAttributes` access in `getDistinctFieldNames`).

## Spec

`specs/datasets/add-to-dataset-span-mapping.feature` (evaluation and event scenarios added; a note records that event types come from the bounded analytics event-type query rather than `getDistinctFieldNames`).

## QA

Verified locally in a browser against real ClickHouse. Seeded a project with evaluators ("PII Check", "Toxicity", "Answer Relevancy") and event types ("thumbs_up", "thumbs_down", "add_to_cart") that occurred on other traces, then opened "Add to Dataset" on a trace (`qa-trace-draft`) that had none of them (confirmed 0 matching rows for that trace).

The evaluations dropdown offered all three project evaluators, and "PII Check" mapped with its result subfields:

![Add to Dataset evaluations dropdown maps PII Check, an evaluator not on this trace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4645/datasets/dropdown-offers-project-evaluator.png)

The events dropdown offered all three project event types, and "thumbs_up" mapped (shown alongside the evaluations mapping, both from project-wide sources absent from this trace):

![Add to Dataset events dropdown maps thumbs_up, an event type not on this trace](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4645/datasets/dropdown-offers-project-event-type.png)