### PR TITLE
fix(nlpgo): preserve evaluator result envelope so reasoning survives

### DIFF
--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -734,14 +734,30 @@ func (e *Engine) runEvaluator(ctx context.Context, req ExecuteRequest, node *dsl
 		ns.Cost = res.Cost.Amount
 	}
 
-	// The evaluator node may declare a subset of outputs (e.g. a
-	// workflow that only cares about `passed`). Filter to declared
-	// names if present; otherwise hand back everything.
+	// The evaluator node may declare a subset of its VALUE outputs (e.g. a
+	// workflow that only wires `passed`). Restrict those to the declared
+	// set, but ALWAYS surface the EvaluationResultWithMetadata envelope
+	// (status / details / cost) regardless of what the node declares.
+	//
+	// The envelope is evaluation metadata, not workflow data: the Studio
+	// result panel, the experiments-v3 SSE consumer (resultMapper reads
+	// outputs.details for the reasoning) and the batch reporter
+	// (evaluation.go reads outputs.details) all expect it unconditionally.
+	// Python's end_component_event surfaced the full result dict and never
+	// filtered, so dropping `details` here was a silent NLP→Go migration
+	// regression that erased the evaluator reasoning everywhere the node
+	// declared only [passed, score, label].
 	declared := outputNames(node.Data.Outputs)
 	if len(declared) == 0 {
 		return out, nil
 	}
-	filtered := make(map[string]any, len(declared))
+	envelopeKeys := []string{"status", "details", "cost"}
+	filtered := make(map[string]any, len(declared)+len(envelopeKeys))
+	for _, name := range envelopeKeys {
+		if v, ok := out[name]; ok {
+			filtered[name] = v
+		}
+	}
 	for _, name := range declared {
 		if v, ok := out[name]; ok {
 			filtered[name] = v

--- a/services/nlpgo/app/engine/evaluator_envelope_test.go
+++ b/services/nlpgo/app/engine/evaluator_envelope_test.go
@@ -1,0 +1,130 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/evaluatorblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// newEvaluatorEnvelopeStub answers the LangWatch evaluator API with a full
+// EvaluationResultWithMetadata envelope, including a non-empty `details`
+// reasoning string — the field the regression silently dropped.
+func newEvaluatorEnvelopeStub(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":  "processed",
+			"score":   1,
+			"passed":  true,
+			"label":   "exact",
+			"details": "true == 1",
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// runEvaluatorNodeOutputs executes a minimal entry -> evaluator workflow and
+// returns the evaluator node's surfaced outputs. The evaluator node declares
+// only the given value-output names — mirroring experiments-v3's
+// workflowBuilder, which declares [passed, score, label] and never lists the
+// metadata envelope.
+func runEvaluatorNodeOutputs(t *testing.T, declaredOutputs []string) map[string]any {
+	t.Helper()
+	srv := newEvaluatorEnvelopeStub(t)
+	eng := New(Options{
+		Evaluator:        evaluatorblock.New(evaluatorblock.Options{}),
+		LangWatchBaseURL: srv.URL,
+	})
+
+	evalSlug := "langevals/exact_match"
+	declared := make([]dsl.Field, 0, len(declaredOutputs))
+	for _, id := range declaredOutputs {
+		declared = append(declared, dsl.Field{Identifier: id})
+	}
+
+	wf := &dsl.Workflow{
+		WorkflowID: "evaluator_envelope",
+		APIKey:     "test-key",
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{
+				ID:   "evaluator-1",
+				Type: dsl.ComponentEvaluator,
+				Data: dsl.Component{
+					Evaluator: &evalSlug,
+					Outputs:   declared,
+				},
+			},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.output", Target: "evaluator-1", TargetHandle: "inputs.output"},
+			{Source: "entry", SourceHandle: "outputs.expected_output", Target: "evaluator-1", TargetHandle: "inputs.expected_output"},
+		},
+	}
+
+	res, err := eng.Execute(context.Background(), ExecuteRequest{
+		Workflow: wf,
+		Inputs:   map[string]any{"output": "true", "expected_output": "1"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, res.Nodes, "evaluator-1")
+	require.Equal(t, "success", res.Nodes["evaluator-1"].Status,
+		"evaluator node should succeed against the stub server")
+	return res.Nodes["evaluator-1"].Outputs
+}
+
+// TestRunEvaluator_EnvelopeSurvivesDeclaredOutputs pins the parity fix: the
+// EvaluationResultWithMetadata envelope (status/details/cost) is surfaced even
+// when the node declares only its value outputs. Before the fix, the declared-
+// names filter dropped `details`, erasing the reasoning from the workbench
+// result popover and the batch eval report.
+//
+// @scenario Reasoning survives when the evaluator node declares only value outputs
+func TestRunEvaluator_EnvelopeSurvivesDeclaredOutputs(t *testing.T) {
+	outputs := runEvaluatorNodeOutputs(t, []string{"passed", "score", "label"})
+
+	// The envelope reasoning — the regressed field — must be present.
+	require.Equal(t, "true == 1", outputs["details"],
+		"evaluator reasoning (details) must survive even though the node never declares it")
+	assert.Equal(t, "processed", outputs["status"],
+		"status envelope field must survive the declared-outputs filter")
+
+	// Declared value fields still flow through.
+	assert.Equal(t, true, outputs["passed"])
+	assert.EqualValues(t, 1, outputs["score"])
+	assert.Equal(t, "exact", outputs["label"])
+}
+
+// TestRunEvaluator_FiltersUndeclaredValueOutputsButKeepsEnvelope pins the other
+// half of the contract: value outputs the author did NOT declare are still
+// filtered (respecting "a workflow that only wires passed"), while the metadata
+// envelope is always surfaced.
+//
+// @scenario Undeclared value outputs are filtered while the envelope is kept
+func TestRunEvaluator_FiltersUndeclaredValueOutputsButKeepsEnvelope(t *testing.T) {
+	outputs := runEvaluatorNodeOutputs(t, []string{"passed"})
+
+	// Declared value field present.
+	assert.Equal(t, true, outputs["passed"])
+
+	// Undeclared value fields filtered out.
+	_, hasScore := outputs["score"]
+	_, hasLabel := outputs["label"]
+	assert.False(t, hasScore, "undeclared score must be filtered")
+	assert.False(t, hasLabel, "undeclared label must be filtered")
+
+	// Envelope metadata always surfaced regardless of declarations.
+	require.Equal(t, "true == 1", outputs["details"],
+		"reasoning must survive even when only [passed] is declared")
+	assert.Equal(t, "processed", outputs["status"])
+}

--- a/specs/studio/workflow-evaluator-output-envelope.feature
+++ b/specs/studio/workflow-evaluator-output-envelope.feature
@@ -1,0 +1,38 @@
+@regression
+Feature: Workflow evaluator output envelope preservation
+  As an experiment author running an evaluator in a Studio workflow
+  I want the evaluation reasoning (details) to reach the result panel
+  So that I can see WHY an evaluator passed or failed, not just the verdict
+
+  # An evaluator node returns the EvaluationResultWithMetadata envelope:
+  # status, score, passed, label, details (the reasoning) and cost. The
+  # node's declared `outputs` only enumerate the VALUE fields a downstream
+  # node might wire (typically passed / score / label) — they never list
+  # the metadata envelope. The legacy Python executor surfaced the full
+  # result dict regardless (end_component_event did outputs = dict(result)),
+  # so the reasoning always reached the result panel + batch reporter.
+  #
+  # The Go nlpgo executor filtered the evaluator output down to the
+  # declared names, which silently dropped `details` (and status/cost)
+  # whenever a node declared only [passed, score, label] — erasing the
+  # reasoning from the workbench result popover and the batch eval report.
+  # This restores parity: value outputs stay author-controlled, the
+  # metadata envelope is always surfaced.
+
+  Scenario: Reasoning survives when the evaluator node declares only value outputs
+    Given a Studio workflow with an evaluator node
+    And the evaluator node declares its outputs as only "passed", "score" and "label"
+    And the evaluator returns a non-empty "details" reasoning string
+    When the workflow executor runs the evaluator node
+    Then the evaluator node output still carries the "details" reasoning
+    And it still carries the "status" envelope field
+    And it carries the declared "passed", "score" and "label" value fields
+
+  Scenario: Undeclared value outputs are filtered while the envelope is kept
+    Given a Studio workflow with an evaluator node
+    And the evaluator node declares its outputs as only "passed"
+    And the evaluator returns score, label and a non-empty "details" reasoning string
+    When the workflow executor runs the evaluator node
+    Then the evaluator node output carries the declared "passed" value field
+    And the undeclared "score" and "label" value fields are filtered out
+    And the "details" reasoning and "status" envelope fields are still present


### PR DESCRIPTION
## Summary

Customer report: in the experiments-v3 workbench, the evaluator result popover showed only **Status** (Passed/Failed) with no reasoning/**Details** — for both langevals scorers (Exact Match) and LLM-as-judge evaluators (LLM Answer Match).

### Root cause

The nlpgo Studio executor (`runEvaluator`) filtered the evaluator's output map down to the node's **declared** output names. experiments-v3 (`workflowBuilder`) declares evaluator outputs as exactly `[passed, score, label]` and never lists the metadata envelope, so the filter silently dropped `details` (the reasoning) plus `status` and `cost`.

The legacy Python executor surfaced the full result dict (`end_component_event` did `outputs = dict(result)`) and never filtered. So this was a **NLP→Go migration regression**, only affecting projects flipped to nlpgo for Studio execution.

The same filtered map (`ns.Outputs`) feeds two consumers, both of which lost the reasoning:
- **experiments-v3 SSE path**: `resultMapper` reads `outputs.details` to build the `evaluator_result` event the workbench popover renders.
- **batch eval reporter**: `evaluation.go` reads `ns.Outputs["details"]`.

> Note on attribution: #4642 only *unblocked reaching* a rendered downstream meta-eval result (the boolean-output 400 previously made this path unreachable). #4642 did not write this bug. The display layer (`EvaluatorChip`, `parseEvaluationResult`) and the SSE mapper (`resultMapper`) were never touched by #4642.

### Fix

In `runEvaluator`, always surface the `EvaluationResultWithMetadata` envelope (`status` / `details` / `cost`) regardless of declarations, and apply the declared-names filter only to the **value** outputs (`passed` / `score` / `label`). Value outputs stay author-controlled (a workflow that wires only `passed` still gets only `passed`); the reasoning always reaches the result panel and batch report.

This restores Python parity for the metadata envelope while keeping the declared-output filter's legitimate intent for value fields.

## Tests

`services/nlpgo/app/engine/evaluator_envelope_test.go` runs an `entry -> evaluator` workflow end-to-end against a stub langevals server (mock only at the HTTP boundary) and asserts:
1. `details` survives a `[passed, score, label]` declaration (+ `status`, + the value fields).
2. Undeclared value fields (`score`, `label`) are still filtered when the node declares only `[passed]`, while `details` + `status` remain.

**Proof these are real regression tests:** reverting the fix fails both with `details=nil`; restoring passes. Full nlpgo engine suite green, `go vet` + build clean, feature-parity 1549 bound.

Bound to `specs/studio/workflow-evaluator-output-envelope.feature` (2 `@regression` scenarios).

## Test plan

- [x] `go test ./services/nlpgo/app/engine/...`
- [x] `go vet` + `go build ./services/nlpgo/...`
- [x] feature-parity check
- [ ] Live workbench: downstream LLM Answer Match + Exact Match popovers show the Details/reasoning section (before/after capture)


---

## QA: reasoning restored (before/after)

Dogfooded on a real evaluator-as-target meta-eval (Exact Match Evaluator target → Downstream Exact Match) via nlpgo on the live stack, verified end-to-end against the fixed binary (`28098a094`).

| Before (old engine.go filter) | After (envelope-preserve) |
|---|---|
| ![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4648/01-before-no-details.png) | ![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4648/02-after-with-details.png) |

**Before:** target output `{ passed: false, score: 0 }`, popover shows **Status only** — no Details line (reproduces the customer report).
**After:** target output `{ details, passed, score, status }`, popover shows the full **Details** section with the reasoning sentence rendered (confirmed the reasoning TEXT renders, not just the label).