### PR TITLE
feat(datasets): searchable span mapping dropdown + clearer expansion label

### DIFF
--- a/langwatch/src/components/traces/TracesMapping.tsx
+++ b/langwatch/src/components/traces/TracesMapping.tsx
@@ -5,7 +5,6 @@ import {
   GridItem,
   HStack,
   NativeSelect,
-  Spinner,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -614,6 +613,25 @@ export const TracesMapping = ({
               PROJECT_FIELD_NAME_SOURCES.includes(source)) ||
             (projectEventTypesLoading && source === "events");
 
+          // Options for the (searchable) key dropdown: the "match everything"
+          // entry plus every project-wide / trace name for this source. These
+          // lists can be large (hundreds of span names), which is why the key
+          // dropdown is a searchable select rather than a plain <select>.
+          const hasKeys =
+            !!traceMappingDefinition && "keys" in traceMappingDefinition;
+          const keyOptions: KeyOption[] =
+            isLoadingFieldNames || !hasKeys
+              ? []
+              : [
+                  { key: "", label: FIELD_NAME_ANY_LABEL[source] ?? "* (any)" },
+                  ...mergeProjectKeyOptions(
+                    source,
+                    traceMappingDefinition.keys(traces_),
+                  ),
+                ];
+          const selectedKeyOption =
+            keyOptions.find((option) => option.key === (key ?? "")) ?? null;
+
           const targetHandle = `inputs.${targetField}`;
           const currentSourceMapping = dsl?.targetEdges
             ?.filter((edge) => edge.targetHandle === `inputs.${targetField}`)
@@ -773,60 +791,55 @@ export const TracesMapping = ({
                               borderRight={0}
                               marginLeft="12px"
                             />
-                            <NativeSelect.Root
-                              width="full"
-                              disabled={isLoadingFieldNames}
-                            >
-                              <NativeSelect.Field
-                                onChange={(e) => {
-                                  setTraceMappingState((prev) => ({
-                                    ...prev,
-                                    mapping: {
-                                      ...prev.mapping,
-                                      [targetField]: {
-                                        ...(prev.mapping[targetField] as any),
-                                        key: e.target.value,
-                                      },
+                            {/* Searchable key dropdown: these lists can hold
+                                hundreds of names, so a plain <select> is hard to
+                                scan. While project-wide names load it shows a
+                                loading placeholder with a spinner. */}
+                            <MultiSelect
+                              isDisabled={isLoadingFieldNames}
+                              isLoading={isLoadingFieldNames}
+                              options={keyOptions.map((option) => ({
+                                value: option.key,
+                                label: option.label,
+                              }))}
+                              value={
+                                selectedKeyOption
+                                  ? {
+                                      value: selectedKeyOption.key,
+                                      label: selectedKeyOption.label,
+                                    }
+                                  : null
+                              }
+                              onChange={(newValue) => {
+                                const selected = newValue as {
+                                  value: string;
+                                } | null;
+                                setTraceMappingState((prev) => ({
+                                  ...prev,
+                                  mapping: {
+                                    ...prev.mapping,
+                                    [targetField]: {
+                                      ...(prev.mapping[targetField] as any),
+                                      key: selected?.value ?? "",
                                     },
-                                  }));
-                                }}
-                                value={key}
-                              >
-                                {/* While project-wide names load, show a single
-                                    placeholder so users don't pick from an
-                                    incomplete (trace-only) list. */}
-                                {isLoadingFieldNames ? (
-                                  <option value="">
-                                    {FIELD_NAME_LOADING_LABEL[source] ??
-                                      "Loading…"}
-                                  </option>
-                                ) : (
-                                  <>
-                                    {/* "match everything" option for the source */}
-                                    <option value="">
-                                      {FIELD_NAME_ANY_LABEL[source] ?? "* (any)"}
-                                    </option>
-                                    {mergeProjectKeyOptions(
-                                      source,
-                                      traceMappingDefinition.keys(traces_),
-                                    ).map(({ key, label }: KeyOption) => (
-                                      <option key={key} value={key}>
-                                        {label}
-                                      </option>
-                                    ))}
-                                  </>
-                                )}
-                              </NativeSelect.Field>
-                              <NativeSelect.Indicator />
-                            </NativeSelect.Root>
-                            {isLoadingFieldNames && (
-                              <Spinner
-                                size="sm"
-                                flexShrink={0}
-                                marginTop="8px"
-                                color="fg.muted"
-                              />
-                            )}
+                                  },
+                                }));
+                              }}
+                              placeholder={
+                                isLoadingFieldNames
+                                  ? FIELD_NAME_LOADING_LABEL[source] ??
+                                    "Loading…"
+                                  : FIELD_NAME_ANY_LABEL[source] ?? "* (any)"
+                              }
+                              chakraStyles={{
+                                container: (base) => ({
+                                  ...base,
+                                  width: "100%",
+                                  minWidth: "260px",
+                                }),
+                                menu: (base) => ({ ...base, zIndex: 2 }),
+                              }}
+                            />
                           </HStack>
                         )}
                       {subkeys && subkeys.length > 0 && (

--- a/langwatch/src/components/traces/__tests__/TracesMapping.evaluationNames.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/TracesMapping.evaluationNames.integration.test.tsx
@@ -103,7 +103,10 @@ describe("TracesMapping evaluations dropdown (integration)", () => {
   describe("when a project evaluator is absent from the loaded trace", () => {
     /** @scenario Evaluator names from the project are offered even when absent from the open trace */
     it("offers the project evaluator name for mapping", async () => {
+      const user = userEvent.setup();
       renderEvaluationsMapping();
+      // Open the searchable key dropdown (shows "* (any evaluation)" until opened).
+      await user.click(await screen.findByText("* (any evaluation)"));
 
       expect(
         await screen.findByRole("option", { name: "PII Check" }),
@@ -116,12 +119,11 @@ describe("TracesMapping evaluations dropdown (integration)", () => {
     it("offers the passed, score, label, details, status and error subfields", async () => {
       const user = userEvent.setup();
       renderEvaluationsMapping();
+      await user.click(await screen.findByText("* (any evaluation)"));
 
-      const piiOption = await screen.findByRole("option", { name: "PII Check" });
-      const keySelect = piiOption.closest("select");
-      expect(keySelect).not.toBeNull();
-
-      await user.selectOptions(keySelect!, piiOption as HTMLOptionElement);
+      await user.click(
+        await screen.findByRole("option", { name: "PII Check" }),
+      );
 
       // Scope the subfield assertions to the subkey <select> (identified by its
       // "* (full object)" option) so they don't collide with other dropdowns.

--- a/langwatch/src/components/traces/__tests__/TracesMapping.eventTypes.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/TracesMapping.eventTypes.integration.test.tsx
@@ -11,6 +11,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -107,7 +108,10 @@ describe("TracesMapping events dropdown (integration)", () => {
   describe("when a project event type is absent from the loaded trace", () => {
     /** @scenario Event types from the project are offered even when absent from the open trace */
     it("offers the project event type for mapping", async () => {
+      const user = userEvent.setup();
       renderEventsMapping();
+      // Open the searchable key dropdown (shows "* (any event)" until opened).
+      await user.click(await screen.findByText("* (any event)"));
 
       expect(
         await screen.findByRole("option", { name: "thumbs_up" }),

--- a/langwatch/src/components/traces/__tests__/TracesMapping.spanNames.integration.test.tsx
+++ b/langwatch/src/components/traces/__tests__/TracesMapping.spanNames.integration.test.tsx
@@ -97,13 +97,20 @@ function renderSpansMapping() {
   );
 }
 
+/** Open the searchable span/key dropdown (it shows "* (any span)" until opened). */
+async function openKeyDropdown(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByText("* (any span)"));
+}
+
 describe("TracesMapping spans dropdown (integration)", () => {
   afterEach(() => cleanup());
 
   describe("when a project span name is absent from the loaded trace", () => {
     /** @scenario Span names from the project are offered even when absent from the open trace */
     it("offers the project span name for mapping", async () => {
+      const user = userEvent.setup();
       renderSpansMapping();
+      await openKeyDropdown(user);
 
       expect(
         await screen.findByRole("option", {
@@ -116,7 +123,9 @@ describe("TracesMapping spans dropdown (integration)", () => {
   describe("when a span exists on the loaded trace", () => {
     /** @scenario Span names from the open trace are always offered */
     it("offers the loaded trace's span name for mapping", async () => {
+      const user = userEvent.setup();
       renderSpansMapping();
+      await openKeyDropdown(user);
 
       expect(
         await screen.findByRole("option", {
@@ -126,19 +135,37 @@ describe("TracesMapping spans dropdown (integration)", () => {
     });
   });
 
+  describe("when typing into the span dropdown", () => {
+    /** @scenario The span name dropdown is searchable for large projects */
+    it("filters the options down to the typed text", async () => {
+      const user = userEvent.setup();
+      renderSpansMapping();
+      await openKeyDropdown(user);
+
+      await user.keyboard("Classification");
+
+      expect(
+        await screen.findByRole("option", {
+          name: "Classification.aexecute_stream",
+        }),
+      ).toBeInTheDocument();
+      // A non-matching span name is filtered out of the menu.
+      expect(
+        screen.queryByRole("option", { name: "Research.aexecute_stream" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("when a project span name is selected", () => {
     /** @scenario Selecting a project span name lets me map its subfields */
     it("offers the span input, output, params and contexts subfields", async () => {
       const user = userEvent.setup();
       renderSpansMapping();
+      await openKeyDropdown(user);
 
-      const researchOption = await screen.findByRole("option", {
-        name: "Research.aexecute_stream",
-      });
-      const keySelect = researchOption.closest("select");
-      expect(keySelect).not.toBeNull();
-
-      await user.selectOptions(keySelect!, "Research.aexecute_stream");
+      await user.click(
+        await screen.findByRole("option", { name: "Research.aexecute_stream" }),
+      );
 
       // Scope the subfield assertions to the span subkey <select> (identified by
       // its "* (full span object)" option) so they don't collide with the

--- a/langwatch/src/server/tracer/__tests__/tracesMapping.test.ts
+++ b/langwatch/src/server/tracer/__tests__/tracesMapping.test.ts
@@ -260,6 +260,52 @@ describe("TRACE_MAPPINGS.spans.mapping", () => {
   });
 });
 
+describe("mapTraceToDatasetEntry span expansion", () => {
+  // Locks the "One row per span" behaviour: saved automations persist these
+  // expansion keys, so a flip here would silently corrupt customer datasets.
+  const threeSpanTrace = {
+    trace_id: "trace-1",
+    timestamps: { started_at: Date.now() },
+    spans: [
+      { span_id: "s1", name: "a", type: "span", input: { type: "text", value: "1" } },
+      { span_id: "s2", name: "b", type: "span", input: { type: "text", value: "2" } },
+      { span_id: "s3", name: "c", type: "span", input: { type: "text", value: "3" } },
+    ],
+  };
+  const spansMapping = {
+    spans: { source: "spans", key: "", subkey: "" },
+  };
+
+  describe("when the all-spans expansion is enabled", () => {
+    /** @scenario Expanding spans produces one dataset row per span */
+    it("produces one dataset row per span", () => {
+      const rows = mapTraceToDatasetEntry(
+        threeSpanTrace as any,
+        spansMapping,
+        new Set(["spans.all.span_id"]) as any,
+      );
+
+      expect(rows).toHaveLength(3);
+    });
+  });
+
+  describe("when no expansion is enabled", () => {
+    /** @scenario Without the span expansion the trace stays a single row */
+    it("produces a single row whose spans field holds all spans", () => {
+      const rows = mapTraceToDatasetEntry(
+        threeSpanTrace as any,
+        spansMapping,
+        new Set() as any,
+      );
+
+      expect(rows).toHaveLength(1);
+      // The spans column is serialized as JSON; it should contain all 3 spans.
+      const spansValue = JSON.parse(rows[0]!.spans as string);
+      expect(spansValue).toHaveLength(3);
+    });
+  });
+});
+
 describe("TRACE_MAPPINGS.metadata.mapping", () => {
   const mockTrace = {
     trace_id: "trace-1",

--- a/langwatch/src/server/tracer/tracesMapping.ts
+++ b/langwatch/src/server/tracer/tracesMapping.ts
@@ -540,7 +540,7 @@ export const TRACE_EXPANSIONS = {
     },
   },
   "spans.all.span_id": {
-    label: "all spans",
+    label: "span",
     expansion: (trace: TraceWithAnnotations) => {
       const spans = trace.spans ?? [];
       return spans.map((span) => ({

--- a/specs/datasets/add-to-dataset-span-mapping.feature
+++ b/specs/datasets/add-to-dataset-span-mapping.feature
@@ -44,6 +44,12 @@ Feature: Span field mapping when adding traces to a dataset
     When I select "spans" as the source and choose "Research.aexecute_stream"
     Then I can map its input, output, params and contexts subfields
 
+  Scenario: The span name dropdown is searchable for large projects
+    Given my project has so many span names that scanning the list is slow
+    When I select "spans" as the source for a column
+    And I type part of a span name into the dropdown
+    Then the dropdown filters down to the matching span names
+
   # ============================================================================
   # Server never silently truncates the available names or spans
   # ============================================================================
@@ -88,3 +94,21 @@ Feature: Span field mapping when adding traces to a dataset
     And the trace I opened the "Add to Dataset" drawer on has no such event
     When I select "events" as the source for a column
     Then "thumbs_up" is offered as an event type to map
+
+  # ============================================================================
+  # Span expansion behaviour (the "One row per span" toggle). Locked because
+  # saved automations persist these expansion keys; the toggle enabled means
+  # "normalize / expand", producing one row per span, not one row for all spans.
+  # ============================================================================
+
+  Scenario: Expanding spans produces one dataset row per span
+    Given a trace with three spans mapped with the spans source
+    And the "One row per span" expansion is enabled
+    When the trace is converted to dataset rows
+    Then it produces three rows, one per span
+
+  Scenario: Without the span expansion the trace stays a single row
+    Given a trace with three spans mapped with the spans source
+    And no expansion is enabled
+    When the trace is converted to dataset rows
+    Then it produces a single row whose spans field is the array of all spans


### PR DESCRIPTION
## What

Two follow-ups now that the "Add to Dataset" mapping dropdowns offer every project name from the last 30 days (#4644, #4645):

### 1. Searchable span / name dropdown

The key dropdown (span names, metadata keys, evaluator names, event types) was a plain native `<select>`. With project-wide names it can hold hundreds of entries, which is painful to scan. It is now a searchable `chakra-react-select`: click it and type to filter the list down to the matching names. It keeps the "* (any ...)" entry, the loading + disabled state, and the same `onChange` semantics; only the span/key dropdown changed (the short source and subkey selects stay native).

### 2. Clearer expansion toggle label (no behaviour change)

The "Expansions" toggle splits a trace into **one dataset row per span** (normalize / expand). Its per-item label read **"One row per all spans"**, which sounds like the opposite (all spans collapsed into one row), so it looked reverted. It is not: the apply logic has produced one-row-per-span when enabled for years, and live automations depend on it. Only the label was misleading.

Fix: relabel the all-spans expansion from "all spans" to "span", so it reads **"One row per span"** (matching "One row per LLM span", "One row per annotation", "One row per event"). This is display-only.

**Why this is safe for saved automations:** `ADD_TO_DATASET` triggers persist the expansion *keys* (e.g. `spans.all.span_id`) in `Trigger.actionParams.datasetMapping.expansions`, and the apply logic is untouched, so no saved trigger changes behaviour. I confirmed against prod (read-only): of 48 `ADD_TO_DATASET` triggers (45 active), 9 use expansions (`spans.llm.span_id` x6, `spans.all.span_id` x2, `annotations.id` x2). Flipping the logic would have corrupted those datasets, which is exactly why this PR only touches the label and adds a regression test locking the behaviour.

## Tests

- **Unit (`tracesMapping`):** `mapTraceToDatasetEntry` with the all-spans expansion turns a 3-span trace into 3 rows; without it, 1 row whose spans field is the array of all 3. Locks the behaviour against an accidental flip.
- **Frontend integration (real component render):** the span dropdown is opened, asserted to offer project + trace names, **filters as you type** (typing "Classification" hides "Research..."), and a selected span still exposes its subfields. Evaluation and event dropdowns updated for the new searchable control.

## Spec

`specs/datasets/add-to-dataset-span-mapping.feature` (searchable-dropdown scenario + two expansion-behaviour scenarios).

## QA

Verified locally in a browser against real ClickHouse (seeded a project with ~60 distinct span names). Opened "Add to Dataset", mapped the **spans** source, and typed into the key dropdown: it filters the list as you type (typed "owner" -> only `create_owner`, `fetch_owner`, `get_owner`, `update_owner`). The expansion toggle reads **"One row per span"**.

![Span mapping dropdown filters as you type, expansion reads One row per span](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4649/datasets/span-dropdown-search-filter.png)

![Expansion toggle now reads One row per span](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4649/datasets/one-row-per-span-label.png)