### PR TITLE
fix(eval-v3): prompt-span parity + traces-v2 drawer opt-in routing

### DIFF
--- a/langwatch/src/components/executable-panel/__tests__/ExecutionOutputPanel.traceV2Routing.integration.test.tsx
+++ b/langwatch/src/components/executable-panel/__tests__/ExecutionOutputPanel.traceV2Routing.integration.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration test for the workflow execution panel's "Full Trace" button.
+ * Renders the real component and clicks the real button so the test guards
+ * against the button ever re-bypassing the central traces-v2 opt-in routing.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { push, replace } = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("~/utils/compat/next-router", () => {
+  const router = {
+    query: {},
+    asPath: "/test-project/workflows/wf-1",
+    push,
+    replace,
+  };
+  return { default: router, useRouter: () => router };
+});
+
+import type { ExecutionState } from "~/optimization_studio/types/dsl";
+import { setTracesV2Preferred } from "../../../features/traces-v2/hooks/useTracesV2Preference";
+import { ExecutionOutputPanel } from "../ExecutionOutputPanel";
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const completedExecution = {
+  status: "success",
+  trace_id: "trace-wf-7",
+  cost: 0.0012,
+  timestamps: { started_at: 1000, finished_at: 4500 },
+  outputs: {},
+} as unknown as ExecutionState;
+
+describe("ExecutionOutputPanel Full Trace button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when the device has opted into traces v2", () => {
+    /** @scenario "Viewing the full trace from a workflow run honors the opt-in" */
+    it("opens the new explorer drawer for the run's trace", async () => {
+      setTracesV2Preferred(true);
+      const user = userEvent.setup();
+
+      render(
+        <ExecutionOutputPanel
+          executionState={completedExecution}
+          isTracingEnabled
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await user.click(screen.getByRole("button", { name: /full trace/i }));
+
+      expect(push).toHaveBeenCalled();
+      const url = String(push.mock.calls[0]?.[0]);
+      expect(url).toMatch(/drawer\.open=traceV2Details/);
+      expect(url).toContain("trace-wf-7");
+    });
+  });
+
+  describe("when the device has not opted into traces v2", () => {
+    it("opens the legacy drawer for the run's trace", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <ExecutionOutputPanel
+          executionState={completedExecution}
+          isTracingEnabled
+        />,
+        { wrapper: Wrapper },
+      );
+
+      await user.click(screen.getByRole("button", { name: /full trace/i }));
+
+      expect(push).toHaveBeenCalled();
+      const url = String(push.mock.calls[0]?.[0]);
+      expect(url).toMatch(/drawer\.open=traceDetails/);
+      expect(url).toContain("trace-wf-7");
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/traceDrawerV2Routing.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/traceDrawerV2Routing.unit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { routeTraceDrawerForV2 } from "../traceDrawerV2Routing";
+
+describe("routeTraceDrawerForV2()", () => {
+  describe("when the device has opted into traces v2", () => {
+    /** @scenario "The opt-in applies to every trace entry point, not only the traces table" */
+    it("routes a traceDetails open with a trace id to the v2 drawer, keeping only the id", () => {
+      const routed = routeTraceDrawerForV2(
+        "traceDetails",
+        { traceId: "trace-1", selectedTab: "traceDetails" },
+        true,
+      );
+
+      expect(routed.drawer).toBe("traceV2Details");
+      expect(routed.props).toEqual({ traceId: "trace-1" });
+    });
+
+    it("forwards the partition-pruning timestamp hint when a caller has it", () => {
+      const routed = routeTraceDrawerForV2(
+        "traceDetails",
+        { traceId: "trace-1", t: "1733600000000" },
+        true,
+      );
+
+      expect(routed.drawer).toBe("traceV2Details");
+      expect(routed.props).toEqual({ traceId: "trace-1", t: "1733600000000" });
+    });
+
+    /** @scenario "Opening a non-trace drawer is unaffected by the opt-in" */
+    it("leaves a non-trace drawer untouched", () => {
+      const props = { promptId: "p-1" };
+
+      const routed = routeTraceDrawerForV2("promptEditor", props, true);
+
+      expect(routed.drawer).toBe("promptEditor");
+      expect(routed.props).toBe(props);
+    });
+
+    /** @scenario "A trace request without a trace id is left on the legacy drawer" */
+    it("leaves a traceDetails open without a trace id on the legacy drawer", () => {
+      const props = { selectedTab: "traceDetails" };
+
+      const routed = routeTraceDrawerForV2("traceDetails", props, true);
+
+      expect(routed.drawer).toBe("traceDetails");
+      expect(routed.props).toBe(props);
+    });
+
+    it("ignores a blank trace id", () => {
+      const props = { traceId: "" };
+
+      const routed = routeTraceDrawerForV2("traceDetails", props, true);
+
+      expect(routed.drawer).toBe("traceDetails");
+      expect(routed.props).toBe(props);
+    });
+  });
+
+  describe("when the device has not opted into traces v2", () => {
+    it("leaves a traceDetails open on the legacy drawer", () => {
+      const props = { traceId: "trace-1" };
+
+      const routed = routeTraceDrawerForV2("traceDetails", props, false);
+
+      expect(routed.drawer).toBe("traceDetails");
+      expect(routed.props).toBe(props);
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/traceDrawerV2Routing.unit.test.ts
+++ b/langwatch/src/hooks/__tests__/traceDrawerV2Routing.unit.test.ts
@@ -2,68 +2,79 @@ import { describe, expect, it } from "vitest";
 import { routeTraceDrawerForV2 } from "../traceDrawerV2Routing";
 
 describe("routeTraceDrawerForV2()", () => {
-  describe("when the device has opted into traces v2", () => {
-    /** @scenario "The opt-in applies to every trace entry point, not only the traces table" */
-    it("routes a traceDetails open with a trace id to the v2 drawer, keeping only the id", () => {
-      const routed = routeTraceDrawerForV2(
-        "traceDetails",
-        { traceId: "trace-1", selectedTab: "traceDetails" },
-        true,
-      );
+  describe("given the device has opted into traces v2", () => {
+    describe("when opening a trace's details with a trace id", () => {
+      /** @scenario "The opt-in applies to every trace entry point, not only the traces table" */
+      it("routes to the v2 drawer, keeping only the trace id", () => {
+        const routed = routeTraceDrawerForV2(
+          "traceDetails",
+          { traceId: "trace-1", selectedTab: "traceDetails" },
+          true,
+        );
 
-      expect(routed.drawer).toBe("traceV2Details");
-      expect(routed.props).toEqual({ traceId: "trace-1" });
+        expect(routed.drawer).toBe("traceV2Details");
+        expect(routed.props).toEqual({ traceId: "trace-1" });
+      });
+
+      it("forwards the partition-pruning timestamp hint when a caller has it", () => {
+        const routed = routeTraceDrawerForV2(
+          "traceDetails",
+          { traceId: "trace-1", t: "1733600000000" },
+          true,
+        );
+
+        expect(routed.drawer).toBe("traceV2Details");
+        expect(routed.props).toEqual({
+          traceId: "trace-1",
+          t: "1733600000000",
+        });
+      });
     });
 
-    it("forwards the partition-pruning timestamp hint when a caller has it", () => {
-      const routed = routeTraceDrawerForV2(
-        "traceDetails",
-        { traceId: "trace-1", t: "1733600000000" },
-        true,
-      );
+    describe("when opening a drawer that is not a trace", () => {
+      /** @scenario "Opening a non-trace drawer is unaffected by the opt-in" */
+      it("leaves it untouched", () => {
+        const props = { promptId: "p-1" };
 
-      expect(routed.drawer).toBe("traceV2Details");
-      expect(routed.props).toEqual({ traceId: "trace-1", t: "1733600000000" });
+        const routed = routeTraceDrawerForV2("promptEditor", props, true);
+
+        expect(routed.drawer).toBe("promptEditor");
+        expect(routed.props).toBe(props);
+      });
     });
 
-    /** @scenario "Opening a non-trace drawer is unaffected by the opt-in" */
-    it("leaves a non-trace drawer untouched", () => {
-      const props = { promptId: "p-1" };
+    describe("when opening a trace's details without a trace id", () => {
+      /** @scenario "A trace request without a trace id is left on the legacy drawer" */
+      it("leaves it on the legacy drawer", () => {
+        const props = { selectedTab: "traceDetails" };
 
-      const routed = routeTraceDrawerForV2("promptEditor", props, true);
+        const routed = routeTraceDrawerForV2("traceDetails", props, true);
 
-      expect(routed.drawer).toBe("promptEditor");
-      expect(routed.props).toBe(props);
-    });
+        expect(routed.drawer).toBe("traceDetails");
+        expect(routed.props).toBe(props);
+      });
 
-    /** @scenario "A trace request without a trace id is left on the legacy drawer" */
-    it("leaves a traceDetails open without a trace id on the legacy drawer", () => {
-      const props = { selectedTab: "traceDetails" };
+      it("ignores a blank trace id", () => {
+        const props = { traceId: "" };
 
-      const routed = routeTraceDrawerForV2("traceDetails", props, true);
+        const routed = routeTraceDrawerForV2("traceDetails", props, true);
 
-      expect(routed.drawer).toBe("traceDetails");
-      expect(routed.props).toBe(props);
-    });
-
-    it("ignores a blank trace id", () => {
-      const props = { traceId: "" };
-
-      const routed = routeTraceDrawerForV2("traceDetails", props, true);
-
-      expect(routed.drawer).toBe("traceDetails");
-      expect(routed.props).toBe(props);
+        expect(routed.drawer).toBe("traceDetails");
+        expect(routed.props).toBe(props);
+      });
     });
   });
 
-  describe("when the device has not opted into traces v2", () => {
-    it("leaves a traceDetails open on the legacy drawer", () => {
-      const props = { traceId: "trace-1" };
+  describe("given the device has not opted into traces v2", () => {
+    describe("when opening a trace's details", () => {
+      it("leaves it on the legacy drawer", () => {
+        const props = { traceId: "trace-1" };
 
-      const routed = routeTraceDrawerForV2("traceDetails", props, false);
+        const routed = routeTraceDrawerForV2("traceDetails", props, false);
 
-      expect(routed.drawer).toBe("traceDetails");
-      expect(routed.props).toBe(props);
+        expect(routed.drawer).toBe("traceDetails");
+        expect(routed.props).toBe(props);
+      });
     });
   });
 });

--- a/langwatch/src/hooks/__tests__/useDrawer.traceV2Routing.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useDrawer.traceV2Routing.integration.test.ts
@@ -39,55 +39,63 @@ describe("openDrawer traces-v2 opt-in routing", () => {
     window.localStorage.clear();
   });
 
-  describe("when the device has opted into traces v2", () => {
-    /** @scenario "A trace opened from a results view uses the new explorer when the device opted in" */
-    it("rewrites a traceDetails open to the v2 drawer in the URL", () => {
+  describe("given the device has opted into traces v2", () => {
+    beforeEach(() => {
       setTracesV2Preferred(true);
-      const { result } = renderHook(() => useDrawer());
-
-      act(() => {
-        result.current.openDrawer("traceDetails", { traceId: "trace-abc" });
-      });
-
-      const url = lastOpenedUrl();
-      expect(url).toMatch(/drawer\.open=traceV2Details/);
-      expect(url).toContain("trace-abc");
-      expect(url).not.toMatch(/drawer\.open=traceDetails(?![a-zA-Z])/);
     });
 
-    /** @scenario "Viewing a trace from evaluation results honors the opt-in" */
-    it("routes the evaluation-results View action and drops the legacy-only tab param", () => {
-      setTracesV2Preferred(true);
-      const { result } = renderHook(() => useDrawer());
+    describe("when opening a trace's details from a results view", () => {
+      /** @scenario "A trace opened from a results view uses the new explorer when the device opted in" */
+      it("rewrites the open to the v2 drawer in the URL", () => {
+        const { result } = renderHook(() => useDrawer());
 
-      // Mirrors the exact payload the eval results "View" button sends.
-      act(() => {
-        result.current.openDrawer("traceDetails", {
-          traceId: "trace-eval",
-          selectedTab: "traceDetails",
+        act(() => {
+          result.current.openDrawer("traceDetails", { traceId: "trace-abc" });
         });
-      });
 
-      const url = lastOpenedUrl();
-      expect(url).toMatch(/drawer\.open=traceV2Details/);
-      expect(url).toContain("trace-eval");
-      expect(url).not.toContain("selectedTab");
+        const url = lastOpenedUrl();
+        expect(url).toMatch(/drawer\.open=traceV2Details/);
+        expect(url).toContain("trace-abc");
+        expect(url).not.toMatch(/drawer\.open=traceDetails(?![a-zA-Z])/);
+      });
+    });
+
+    describe("when opening a trace from the evaluation results View action", () => {
+      /** @scenario "Viewing a trace from evaluation results honors the opt-in" */
+      it("routes to v2 and drops the legacy-only tab param", () => {
+        const { result } = renderHook(() => useDrawer());
+
+        // Mirrors the exact payload the eval results "View" button sends.
+        act(() => {
+          result.current.openDrawer("traceDetails", {
+            traceId: "trace-eval",
+            selectedTab: "traceDetails",
+          });
+        });
+
+        const url = lastOpenedUrl();
+        expect(url).toMatch(/drawer\.open=traceV2Details/);
+        expect(url).toContain("trace-eval");
+        expect(url).not.toContain("selectedTab");
+      });
     });
   });
 
-  describe("when the device has not opted into traces v2", () => {
-    /** @scenario "A trace opened from a results view uses the legacy drawer when the device has not opted in" */
-    it("keeps a traceDetails open on the legacy drawer in the URL", () => {
-      const { result } = renderHook(() => useDrawer());
+  describe("given the device has not opted into traces v2", () => {
+    describe("when opening a trace's details from a results view", () => {
+      /** @scenario "A trace opened from a results view uses the legacy drawer when the device has not opted in" */
+      it("keeps the open on the legacy drawer in the URL", () => {
+        const { result } = renderHook(() => useDrawer());
 
-      act(() => {
-        result.current.openDrawer("traceDetails", { traceId: "trace-abc" });
+        act(() => {
+          result.current.openDrawer("traceDetails", { traceId: "trace-abc" });
+        });
+
+        const url = lastOpenedUrl();
+        expect(url).toMatch(/drawer\.open=traceDetails/);
+        expect(url).toContain("trace-abc");
+        expect(url).not.toContain("traceV2Details");
       });
-
-      const url = lastOpenedUrl();
-      expect(url).toMatch(/drawer\.open=traceDetails/);
-      expect(url).toContain("trace-abc");
-      expect(url).not.toContain("traceV2Details");
     });
   });
 });

--- a/langwatch/src/hooks/__tests__/useDrawer.traceV2Routing.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useDrawer.traceV2Routing.integration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration test for the central traces-v2 opt-in routing inside
+ * `openDrawer`. Exercises the real hook, the real `getTracesV2Preferred`
+ * localStorage read, and the real `qs` URL serialization — only the router is
+ * harnessed (to capture the navigation it would perform).
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { push, replace } = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("~/utils/compat/next-router", () => {
+  const router = {
+    query: {},
+    asPath: "/test-project/experiments/exp-1",
+    push,
+    replace,
+  };
+  return { default: router, useRouter: () => router };
+});
+
+import { setTracesV2Preferred } from "../../features/traces-v2/hooks/useTracesV2Preference";
+import { useDrawer } from "../useDrawer";
+
+function lastOpenedUrl(): string {
+  expect(push).toHaveBeenCalled();
+  return String(push.mock.calls[push.mock.calls.length - 1]?.[0]);
+}
+
+describe("openDrawer traces-v2 opt-in routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  describe("when the device has opted into traces v2", () => {
+    /** @scenario "A trace opened from a results view uses the new explorer when the device opted in" */
+    it("rewrites a traceDetails open to the v2 drawer in the URL", () => {
+      setTracesV2Preferred(true);
+      const { result } = renderHook(() => useDrawer());
+
+      act(() => {
+        result.current.openDrawer("traceDetails", { traceId: "trace-abc" });
+      });
+
+      const url = lastOpenedUrl();
+      expect(url).toMatch(/drawer\.open=traceV2Details/);
+      expect(url).toContain("trace-abc");
+      expect(url).not.toMatch(/drawer\.open=traceDetails(?![a-zA-Z])/);
+    });
+
+    /** @scenario "Viewing a trace from evaluation results honors the opt-in" */
+    it("routes the evaluation-results View action and drops the legacy-only tab param", () => {
+      setTracesV2Preferred(true);
+      const { result } = renderHook(() => useDrawer());
+
+      // Mirrors the exact payload the eval results "View" button sends.
+      act(() => {
+        result.current.openDrawer("traceDetails", {
+          traceId: "trace-eval",
+          selectedTab: "traceDetails",
+        });
+      });
+
+      const url = lastOpenedUrl();
+      expect(url).toMatch(/drawer\.open=traceV2Details/);
+      expect(url).toContain("trace-eval");
+      expect(url).not.toContain("selectedTab");
+    });
+  });
+
+  describe("when the device has not opted into traces v2", () => {
+    /** @scenario "A trace opened from a results view uses the legacy drawer when the device has not opted in" */
+    it("keeps a traceDetails open on the legacy drawer in the URL", () => {
+      const { result } = renderHook(() => useDrawer());
+
+      act(() => {
+        result.current.openDrawer("traceDetails", { traceId: "trace-abc" });
+      });
+
+      const url = lastOpenedUrl();
+      expect(url).toMatch(/drawer\.open=traceDetails/);
+      expect(url).toContain("trace-abc");
+      expect(url).not.toContain("traceV2Details");
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useTraceDetailsDrawer.integration.test.ts
+++ b/langwatch/src/hooks/__tests__/useTraceDetailsDrawer.integration.test.ts
@@ -1,27 +1,19 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
-import { useTraceDetailsDrawer } from "../useTraceDetailsDrawer";
-import type { DrawerProps } from "../../components/drawerRegistry";
 
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DrawerProps } from "../../components/drawerRegistry";
+import { useTraceDetailsDrawer } from "../useTraceDetailsDrawer";
+
+// The hook is a thin convenience wrapper: it always delegates to
+// `openDrawer("traceDetails", …)`. The cross-cutting concerns (EXTERNAL-user
+// restriction, traces-v2 opt-in routing) live centrally in `CurrentDrawer`
+// and `openDrawer` and are covered by their own tests — here we only pin the
+// delegation contract.
 vi.mock("../useDrawer", () => ({
   useDrawer: vi.fn(),
-}));
-
-// `useTraceDetailsDrawer` now reads project / feature-flag / device
-// preference to decide v1-vs-v2 routing. Stub them so the hook always
-// stays on the legacy (v1) path — that's the behaviour these tests
-// were written against and the test name still asserts.
-vi.mock("../useOrganizationTeamProject", () => ({
-  useOrganizationTeamProject: () => ({ project: { id: "proj-1" } }),
-}));
-vi.mock("../useFeatureFlag", () => ({
-  useFeatureFlag: () => ({ enabled: false, isLoading: false }),
-}));
-vi.mock("../../features/traces-v2/hooks/useTracesV2Preference", () => ({
-  useTracesV2Preference: () => ({ preferred: false, setPreferred: vi.fn() }),
 }));
 
 import { useDrawer } from "../useDrawer";

--- a/langwatch/src/hooks/traceDrawerV2Routing.ts
+++ b/langwatch/src/hooks/traceDrawerV2Routing.ts
@@ -1,0 +1,42 @@
+import type { DrawerType } from "../components/drawerRegistry";
+
+/**
+ * Route a drawer-open request to the new Trace Explorer when this device has
+ * opted into traces v2.
+ *
+ * The new drawer ships as a per-device opt-in: once the operator chooses it,
+ * every trace they open should use it, regardless of which screen triggered
+ * the open. Instead of each "view trace" call site re-checking the preference
+ * (several historically forgot to, so evaluation results and workflow panels
+ * stayed on the legacy drawer), all opens funnel through `openDrawer`, which
+ * routes here. A `traceDetails` open carrying a trace id becomes a
+ * `traceV2Details` open; every other drawer — and a trace open with no id —
+ * passes through untouched.
+ *
+ * Kept pure (the preference is read by the caller and passed in, and the only
+ * import is a type) so the branch logic is testable without touching
+ * localStorage, a router, or the drawer component registry.
+ */
+export function routeTraceDrawerForV2(
+  drawer: DrawerType,
+  props: Record<string, unknown> | undefined,
+  prefersV2: boolean,
+): { drawer: DrawerType; props: Record<string, unknown> | undefined } {
+  if (
+    prefersV2 &&
+    drawer === "traceDetails" &&
+    typeof props?.traceId === "string" &&
+    props.traceId
+  ) {
+    return {
+      drawer: "traceV2Details",
+      props: {
+        traceId: props.traceId,
+        // `t` is the v2 drawer's partition-pruning timestamp hint; forward it
+        // when a caller happens to have it, otherwise the drawer fetches by id.
+        ...(typeof props.t === "string" && props.t ? { t: props.t } : {}),
+      },
+    };
+  }
+  return { drawer, props };
+}

--- a/langwatch/src/hooks/useDrawer.ts
+++ b/langwatch/src/hooks/useDrawer.ts
@@ -1,12 +1,14 @@
-import Router, { useRouter } from "~/utils/compat/next-router";
 import qs from "qs";
 import { useCallback, useMemo } from "react";
-import {
-  type DrawerCallbacks,
-  type DrawerProps,
-  type DrawerType,
+import Router, { useRouter } from "~/utils/compat/next-router";
+import type {
+  DrawerCallbacks,
+  DrawerProps,
+  DrawerType,
 } from "../components/drawerRegistry";
+import { getTracesV2Preferred } from "../features/traces-v2/hooks/useTracesV2Preference";
 import { createLogger } from "../utils/logger";
+import { routeTraceDrawerForV2 } from "./traceDrawerV2Routing";
 
 const logger = createLogger("useDrawer");
 
@@ -164,10 +166,8 @@ export const useUpdateDrawerParams = () => {
         comma: true,
         allowEmptyArrays: true,
       }) as Record<string, unknown>;
-      const drawer = ((parsed.drawer as Record<string, unknown>) ?? {}) as Record<
-        string,
-        unknown
-      >;
+      const drawer = ((parsed.drawer as Record<string, unknown>) ??
+        {}) as Record<string, unknown>;
       for (const [key, value] of Object.entries(updates)) {
         if (value === undefined) delete drawer[key];
         else drawer[key] = value;
@@ -386,12 +386,23 @@ export const useDrawer = () => {
         replaceCurrentInStack?: boolean;
       } = {},
     ) => {
+      // Traces V2 opt-in (transitional during rollout): route any trace open
+      // to the new explorer when this device opted in, so every entry point
+      // honors the choice — not only the call sites that go through
+      // useTraceDetailsDrawer. See routeTraceDrawerForV2.
+      const { drawer: effectiveDrawer, props: effectiveProps } =
+        routeTraceDrawerForV2(
+          drawer,
+          props as Record<string, unknown> | undefined,
+          getTracesV2Preferred(),
+        );
+
       // Extract urlParams and merge with props
-      const { urlParams, ...drawerProps } = props ?? {};
-      const allParams = { ...drawerProps, ...urlParams } as Record<
-        string,
-        unknown
-      >;
+      const { urlParams, ...drawerProps } = effectiveProps ?? {};
+      const allParams = {
+        ...drawerProps,
+        ...(urlParams as Record<string, string> | undefined),
+      } as Record<string, unknown>;
 
       // Read currentDrawer from router.query directly to get latest value
       const currentDrawerNow = router.query["drawer.open"] as
@@ -399,20 +410,20 @@ export const useDrawer = () => {
         | undefined;
 
       // If the same drawer is already open, just update the URL params without modifying the stack
-      if (currentDrawerNow === drawer) {
-        updateDrawerUrl(drawer, allParams, { replace: true });
+      if (currentDrawerNow === effectiveDrawer) {
+        updateDrawerUrl(effectiveDrawer, allParams, { replace: true });
         return;
       }
 
       // Manage drawer stack for navigation history
       if (resetStack || !currentDrawerNow) {
         // Reset stack - fresh start with no back navigation
-        drawerStack = [{ drawer, params: allParams }];
+        drawerStack = [{ drawer: effectiveDrawer, params: allParams }];
       } else if (replaceCurrentInStack && drawerStack.length > 0) {
         // Replace the current entry in the stack (useful for flow callbacks)
         // This makes "back" skip the replaced drawer
         drawerStack.pop();
-        drawerStack.push({ drawer, params: allParams });
+        drawerStack.push({ drawer: effectiveDrawer, params: allParams });
       } else {
         // A drawer is already open - navigating forward, push to stack
         // If stack is empty but currentDrawer exists (e.g., opened via direct URL),
@@ -434,7 +445,7 @@ export const useDrawer = () => {
           topEntry.params = currentUrlParams;
         }
 
-        drawerStack.push({ drawer, params: allParams });
+        drawerStack.push({ drawer: effectiveDrawer, params: allParams });
       }
 
       const badKeys = Object.entries(allParams)
@@ -442,14 +453,14 @@ export const useDrawer = () => {
         .map(([k]) => k);
       if (badKeys.length > 0) {
         logger.warn(
-          `Non-serializable props passed to drawer "${drawer}": ${badKeys.join(
+          `Non-serializable props passed to drawer "${effectiveDrawer}": ${badKeys.join(
             ", ",
           )}. ` +
             `Consider using setFlowCallbacks() for callbacks that need to persist across navigation.`,
         );
       }
 
-      updateDrawerUrl(drawer, allParams, { replace });
+      updateDrawerUrl(effectiveDrawer, allParams, { replace });
     },
     [router.query, updateDrawerUrl],
   );

--- a/langwatch/src/hooks/useDrawer.ts
+++ b/langwatch/src/hooks/useDrawer.ts
@@ -166,8 +166,15 @@ export const useUpdateDrawerParams = () => {
         comma: true,
         allowEmptyArrays: true,
       }) as Record<string, unknown>;
-      const drawer = ((parsed.drawer as Record<string, unknown>) ??
-        {}) as Record<string, unknown>;
+      // `parsed.drawer` is whatever qs parsed out of the URL — for a malformed
+      // query like `?drawer=foo` it's a string, not the object we mutate below.
+      // Guard the shape so the mutation loop can't throw at runtime.
+      const drawer =
+        parsed.drawer &&
+        typeof parsed.drawer === "object" &&
+        !Array.isArray(parsed.drawer)
+          ? (parsed.drawer as Record<string, unknown>)
+          : {};
       for (const [key, value] of Object.entries(updates)) {
         if (value === undefined) delete drawer[key];
         else drawer[key] = value;

--- a/langwatch/src/hooks/useTraceDetailsDrawer.ts
+++ b/langwatch/src/hooks/useTraceDetailsDrawer.ts
@@ -1,33 +1,25 @@
 import { useCallback } from "react";
 import type { DrawerProps } from "../components/drawerRegistry";
-import { useTracesV2Preference } from "../features/traces-v2/hooks/useTracesV2Preference";
 import { useDrawer } from "./useDrawer";
 
 /**
  * Convenience hook for opening the trace details drawer.
  *
- * EXTERNAL user restriction is enforced centrally in `CurrentDrawer` —
- * any `openDrawer("traceDetails", ...)` call (whether through this hook
- * or directly) is automatically intercepted for EXTERNAL users.
- *
- * Routes to the v2 drawer when the operator has clicked "Try the new
- * one" at least once on this device (the preference lives in
- * localStorage; see `useTracesV2Preference`); otherwise the legacy v1
- * drawer.
+ * It is a thin wrapper around `openDrawer("traceDetails", …)`. Both
+ * cross-cutting concerns are enforced centrally, so every trace open — through
+ * this hook or a direct `openDrawer` call — behaves identically:
+ * - EXTERNAL-user restriction, in `CurrentDrawer`.
+ * - Traces v2 opt-in routing, in `openDrawer` (a trace open is sent to the new
+ *   explorer when this device opted in; see `routeTraceDrawerForV2`).
  */
 export function useTraceDetailsDrawer() {
   const { openDrawer } = useDrawer();
-  const { preferred: prefersV2 } = useTracesV2Preference();
 
   const openTraceDetailsDrawer = useCallback(
     (props?: Partial<DrawerProps<"traceDetails">>) => {
-      if (prefersV2 && props?.traceId) {
-        openDrawer("traceV2Details", { traceId: props.traceId });
-        return;
-      }
       openDrawer("traceDetails", props);
     },
-    [openDrawer, prefersV2],
+    [openDrawer],
   );
 
   return { openTraceDetailsDrawer };

--- a/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.integration.test.ts
+++ b/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.integration.test.ts
@@ -174,13 +174,13 @@ describe("WorkflowBuilder", () => {
       const targetConfig = createBasicTargetConfig();
       const cell = createBasicCell();
 
-      const node = buildSignatureNodeFromLocalConfig(
-        "test-node",
-        "Test Prompt",
-        config,
+      const node = buildSignatureNodeFromLocalConfig({
+        nodeId: "test-node",
+        name: "Test Prompt",
+        localConfig: config,
         targetConfig,
         cell,
-      );
+      });
 
       expect(node.id).toBe("test-node");
       expect(node.type).toBe("signature");
@@ -192,13 +192,13 @@ describe("WorkflowBuilder", () => {
       const targetConfig = createBasicTargetConfig();
       const cell = createBasicCell();
 
-      const node = buildSignatureNodeFromLocalConfig(
-        "test-node",
-        "Test Prompt",
-        config,
+      const node = buildSignatureNodeFromLocalConfig({
+        nodeId: "test-node",
+        name: "Test Prompt",
+        localConfig: config,
         targetConfig,
         cell,
-      );
+      });
 
       const llmParam = (node.data as LlmPromptConfigComponent).parameters.find(
         (p) => p.identifier === "llm",
@@ -216,13 +216,13 @@ describe("WorkflowBuilder", () => {
       const targetConfig = createBasicTargetConfig();
       const cell = createBasicCell();
 
-      const node = buildSignatureNodeFromLocalConfig(
-        "test-node",
-        "Test Prompt",
-        config,
+      const node = buildSignatureNodeFromLocalConfig({
+        nodeId: "test-node",
+        name: "Test Prompt",
+        localConfig: config,
         targetConfig,
         cell,
-      );
+      });
 
       const instructionsParam = (
         node.data as LlmPromptConfigComponent
@@ -235,13 +235,13 @@ describe("WorkflowBuilder", () => {
       const targetConfig = createBasicTargetConfig();
       const cell = createBasicCell();
 
-      const node = buildSignatureNodeFromLocalConfig(
-        "test-node",
-        "Test Prompt",
-        config,
+      const node = buildSignatureNodeFromLocalConfig({
+        nodeId: "test-node",
+        name: "Test Prompt",
+        localConfig: config,
         targetConfig,
         cell,
-      );
+      });
 
       const messagesParam = (
         node.data as LlmPromptConfigComponent
@@ -256,13 +256,13 @@ describe("WorkflowBuilder", () => {
       const targetConfig = createBasicTargetConfig();
       const cell = createBasicCell();
 
-      const node = buildSignatureNodeFromLocalConfig(
-        "test-node",
-        "Test Prompt",
-        config,
+      const node = buildSignatureNodeFromLocalConfig({
+        nodeId: "test-node",
+        name: "Test Prompt",
+        localConfig: config,
         targetConfig,
         cell,
-      );
+      });
 
       expect(node.data.inputs).toHaveLength(1);
       expect(node.data.inputs?.[0]?.identifier).toBe("input");
@@ -300,12 +300,12 @@ describe("WorkflowBuilder", () => {
       const targetConfig = createBasicTargetConfig();
       const cell = createBasicCell();
 
-      const node = buildSignatureNodeFromPrompt(
-        "test-node",
+      const node = buildSignatureNodeFromPrompt({
+        nodeId: "test-node",
         prompt,
         targetConfig,
         cell,
-      );
+      });
 
       expect(node.id).toBe("test-node");
       expect(node.type).toBe("signature");
@@ -317,12 +317,12 @@ describe("WorkflowBuilder", () => {
       const targetConfig = createBasicTargetConfig();
       const cell = createBasicCell();
 
-      const node = buildSignatureNodeFromPrompt(
-        "test-node",
+      const node = buildSignatureNodeFromPrompt({
+        nodeId: "test-node",
         prompt,
         targetConfig,
         cell,
-      );
+      });
 
       const llmParam = (node.data as LlmPromptConfigComponent).parameters.find(
         (p) => p.identifier === "llm",

--- a/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.integration.test.ts
+++ b/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.integration.test.ts
@@ -19,7 +19,7 @@ import {
 describe("WorkflowBuilder", () => {
   const createBasicLocalPromptConfig = (): LocalPromptConfig => ({
     llm: {
-      model: "openai/gpt-4o-mini",
+      model: "openai/gpt-5-mini",
       temperature: 0,
       maxTokens: 1024,
     },
@@ -204,7 +204,7 @@ describe("WorkflowBuilder", () => {
         (p) => p.identifier === "llm",
       );
       expect(llmParam?.value).toEqual({
-        model: "openai/gpt-4o-mini",
+        model: "openai/gpt-5-mini",
         temperature: 0,
         max_tokens: 1024,
         litellm_params: undefined,
@@ -280,7 +280,7 @@ describe("WorkflowBuilder", () => {
       version: 1,
       versionId: "version-1",
       versionCreatedAt: new Date(),
-      model: "openai/gpt-4o",
+      model: "openai/gpt-5-mini",
       temperature: 0.7,
       maxTokens: 2048,
       prompt: "You are a helpful assistant.",
@@ -328,7 +328,7 @@ describe("WorkflowBuilder", () => {
         (p) => p.identifier === "llm",
       );
       expect(llmParam?.value).toEqual({
-        model: "openai/gpt-4o",
+        model: "openai/gpt-5-mini",
         temperature: 0.7,
         max_tokens: 2048,
       });

--- a/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
+++ b/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
@@ -758,7 +758,7 @@ describe("buildSignatureNodeFromPrompt", () => {
     version: 6,
     versionId: "prompt_version_supportrouter_v6",
     versionCreatedAt: new Date("2026-01-15T10:00:00.000Z"),
-    model: "openai/gpt-4o-mini",
+    model: "openai/gpt-5-mini",
     prompt: "You are a support router.",
     projectId: "project-1",
     organizationId: "org-1",
@@ -838,7 +838,7 @@ describe("buildSignatureNodeFromLocalConfig", () => {
     version: 6,
     versionId: "prompt_version_supportrouter_v6",
     versionCreatedAt: new Date("2026-01-15T10:00:00.000Z"),
-    model: "openai/gpt-4o-mini",
+    model: "openai/gpt-5-mini",
     prompt: "You are a support router.",
     projectId: "project-1",
     organizationId: "org-1",
@@ -852,7 +852,7 @@ describe("buildSignatureNodeFromLocalConfig", () => {
   });
 
   const createLocalPromptConfig = (): LocalPromptConfig => ({
-    llm: { model: "openai/gpt-4o-mini", temperature: 0 },
+    llm: { model: "openai/gpt-5-mini", temperature: 0 },
     messages: [
       { role: "system", content: "You are terse." },
       { role: "user", content: "{{input}}" },

--- a/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
+++ b/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
-import type { EvaluatorConfig, TargetConfig } from "~/experiments-v3/types";
+import type {
+  EvaluatorConfig,
+  LocalPromptConfig,
+  TargetConfig,
+} from "~/experiments-v3/types";
 import type {
   HttpComponentConfig,
+  LlmPromptConfigComponent,
   SignatureComponentConfig,
 } from "~/optimization_studio/types/dsl";
 import type { TypedAgent } from "~/server/agents/agent.repository";
+import type { VersionedPrompt } from "~/server/prompt-config/prompt.service";
 import type { ExecutionCell } from "../types";
 import {
   buildCodeNodeFromAgent,
@@ -12,6 +18,8 @@ import {
   buildEvaluatorTargetNode,
   buildHttpNodeFromAgent,
   buildSignatureNodeFromAgent,
+  buildSignatureNodeFromLocalConfig,
+  buildSignatureNodeFromPrompt,
 } from "../workflowBuilder";
 
 describe("buildEvaluatorNode", () => {
@@ -732,4 +740,175 @@ describe("buildEvaluatorTargetNode", () => {
     expect(node.data.name).toBe("target-eval-1");
   });
 
+});
+
+// Prompt-identity forwarding is what lets nlpgo emit the
+// PromptApiService.get + Prompt.compile spans (the engine emits them only
+// when the signature node carries data.configId — see
+// services/nlpgo/app/engine/prompt_spans_emit_test.go and
+// specs/nlp-go/prompt-spans-eval-v3.feature). Without these fields the
+// eval-v3 target prompt has no prompt ancestry in the trace and the
+// drawer's "Open in Prompts" resume is hidden.
+describe("buildSignatureNodeFromPrompt", () => {
+  const createVersionedPrompt = (): VersionedPrompt => ({
+    id: "prompt_supportrouter_xyz",
+    name: "support-router",
+    handle: "support-router",
+    scope: "PROJECT",
+    version: 6,
+    versionId: "prompt_version_supportrouter_v6",
+    versionCreatedAt: new Date("2026-01-15T10:00:00.000Z"),
+    model: "openai/gpt-4o-mini",
+    prompt: "You are a support router.",
+    projectId: "project-1",
+    organizationId: "org-1",
+    messages: [{ role: "user", content: "{{input}}" }],
+    authorId: null,
+    createdAt: new Date("2026-01-15T10:00:00.000Z"),
+    updatedAt: new Date("2026-01-15T10:00:00.000Z"),
+    tags: [],
+    inputs: [{ identifier: "input", type: "str" }],
+    outputs: [{ identifier: "output", type: "str" }],
+  });
+
+  const createPromptTargetConfig = (): TargetConfig => ({
+    id: "target-1",
+    type: "prompt",
+    promptId: "prompt_supportrouter_xyz",
+    promptVersionNumber: 6,
+    inputs: [{ identifier: "input", type: "str" }],
+    outputs: [{ identifier: "output", type: "str" }],
+    mappings: {
+      "dataset-1": {
+        input: {
+          type: "source",
+          source: "dataset",
+          sourceId: "dataset-1",
+          sourceField: "question",
+        },
+      },
+    },
+  });
+
+  const createCell = (): ExecutionCell => ({
+    rowIndex: 0,
+    targetId: "target-1",
+    targetConfig: createPromptTargetConfig(),
+    evaluatorConfigs: [],
+    datasetEntry: { _datasetId: "dataset-1", question: "I want a refund" },
+  });
+
+  it("forwards configId, handle and versionMetadata from the saved prompt", () => {
+    const node = buildSignatureNodeFromPrompt(
+      "target-1",
+      createVersionedPrompt(),
+      createPromptTargetConfig(),
+      createCell(),
+    );
+    const data = node.data as LlmPromptConfigComponent;
+
+    expect(data.configId).toBe("prompt_supportrouter_xyz");
+    expect(data.handle).toBe("support-router");
+    expect(data.versionMetadata).toEqual({
+      versionId: "prompt_version_supportrouter_v6",
+      versionNumber: 6,
+      versionCreatedAt: "2026-01-15T10:00:00.000Z",
+    });
+  });
+
+  it("does not flag a saved prompt as a draft", () => {
+    const node = buildSignatureNodeFromPrompt(
+      "target-1",
+      createVersionedPrompt(),
+      createPromptTargetConfig(),
+      createCell(),
+    );
+    const data = node.data as LlmPromptConfigComponent;
+
+    expect(data.promptDraft).toBeUndefined();
+  });
+});
+
+describe("buildSignatureNodeFromLocalConfig", () => {
+  const createBasePrompt = (): VersionedPrompt => ({
+    id: "prompt_supportrouter_xyz",
+    name: "support-router",
+    handle: "support-router",
+    scope: "PROJECT",
+    version: 6,
+    versionId: "prompt_version_supportrouter_v6",
+    versionCreatedAt: new Date("2026-01-15T10:00:00.000Z"),
+    model: "openai/gpt-4o-mini",
+    prompt: "You are a support router.",
+    projectId: "project-1",
+    organizationId: "org-1",
+    messages: [{ role: "user", content: "{{input}}" }],
+    authorId: null,
+    createdAt: new Date("2026-01-15T10:00:00.000Z"),
+    updatedAt: new Date("2026-01-15T10:00:00.000Z"),
+    tags: [],
+    inputs: [{ identifier: "input", type: "str" }],
+    outputs: [{ identifier: "output", type: "str" }],
+  });
+
+  const createLocalPromptConfig = (): LocalPromptConfig => ({
+    llm: { model: "openai/gpt-4o-mini", temperature: 0 },
+    messages: [
+      { role: "system", content: "You are terse." },
+      { role: "user", content: "{{input}}" },
+    ],
+    inputs: [{ identifier: "input", type: "str" }],
+    outputs: [{ identifier: "output", type: "str" }],
+  });
+
+  const createTargetConfig = (): TargetConfig => ({
+    id: "target-1",
+    type: "prompt",
+    promptId: "prompt_supportrouter_xyz",
+    promptVersionNumber: 6,
+    localPromptConfig: createLocalPromptConfig(),
+    inputs: [{ identifier: "input", type: "str" }],
+    outputs: [{ identifier: "output", type: "str" }],
+    mappings: {},
+  });
+
+  const createCell = (): ExecutionCell => ({
+    rowIndex: 0,
+    targetId: "target-1",
+    targetConfig: createTargetConfig(),
+    evaluatorConfigs: [],
+    datasetEntry: { _datasetId: "dataset-1", question: "I want a refund" },
+  });
+
+  it("keeps the base prompt identity and flags promptDraft when edited from a saved base", () => {
+    const node = buildSignatureNodeFromLocalConfig(
+      "target-1",
+      "support-router",
+      createLocalPromptConfig(),
+      createTargetConfig(),
+      createCell(),
+      createBasePrompt(),
+    );
+    const data = node.data as LlmPromptConfigComponent;
+
+    expect(data.configId).toBe("prompt_supportrouter_xyz");
+    expect(data.handle).toBe("support-router");
+    expect(data.versionMetadata?.versionNumber).toBe(6);
+    expect(data.promptDraft).toBe(true);
+  });
+
+  it("forwards no prompt identity for a brand-new local prompt with no saved base", () => {
+    const node = buildSignatureNodeFromLocalConfig(
+      "target-1",
+      "draft",
+      createLocalPromptConfig(),
+      createTargetConfig(),
+      createCell(),
+      undefined,
+    );
+    const data = node.data as LlmPromptConfigComponent;
+
+    expect(data.configId).toBeUndefined();
+    expect(data.promptDraft).toBeUndefined();
+  });
 });

--- a/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
+++ b/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
@@ -798,34 +798,34 @@ describe("buildSignatureNodeFromPrompt", () => {
     datasetEntry: { _datasetId: "dataset-1", question: "I want a refund" },
   });
 
-  it("forwards configId, handle and versionMetadata from the saved prompt", () => {
-    const node = buildSignatureNodeFromPrompt(
-      "target-1",
-      createVersionedPrompt(),
-      createPromptTargetConfig(),
-      createCell(),
-    );
-    const data = node.data as LlmPromptConfigComponent;
+  describe("given a target backed by a saved prompt", () => {
+    describe("when building the signature node", () => {
+      const buildNode = () =>
+        buildSignatureNodeFromPrompt({
+          nodeId: "target-1",
+          prompt: createVersionedPrompt(),
+          targetConfig: createPromptTargetConfig(),
+          cell: createCell(),
+        });
 
-    expect(data.configId).toBe("prompt_supportrouter_xyz");
-    expect(data.handle).toBe("support-router");
-    expect(data.versionMetadata).toEqual({
-      versionId: "prompt_version_supportrouter_v6",
-      versionNumber: 6,
-      versionCreatedAt: "2026-01-15T10:00:00.000Z",
+      it("forwards configId, handle and versionMetadata from the saved prompt", () => {
+        const data = buildNode().data as LlmPromptConfigComponent;
+
+        expect(data.configId).toBe("prompt_supportrouter_xyz");
+        expect(data.handle).toBe("support-router");
+        expect(data.versionMetadata).toEqual({
+          versionId: "prompt_version_supportrouter_v6",
+          versionNumber: 6,
+          versionCreatedAt: "2026-01-15T10:00:00.000Z",
+        });
+      });
+
+      it("does not flag a saved prompt as a draft", () => {
+        const data = buildNode().data as LlmPromptConfigComponent;
+
+        expect(data.promptDraft).toBeUndefined();
+      });
     });
-  });
-
-  it("does not flag a saved prompt as a draft", () => {
-    const node = buildSignatureNodeFromPrompt(
-      "target-1",
-      createVersionedPrompt(),
-      createPromptTargetConfig(),
-      createCell(),
-    );
-    const data = node.data as LlmPromptConfigComponent;
-
-    expect(data.promptDraft).toBeUndefined();
   });
 });
 
@@ -880,35 +880,43 @@ describe("buildSignatureNodeFromLocalConfig", () => {
     datasetEntry: { _datasetId: "dataset-1", question: "I want a refund" },
   });
 
-  it("keeps the base prompt identity and flags promptDraft when edited from a saved base", () => {
-    const node = buildSignatureNodeFromLocalConfig(
-      "target-1",
-      "support-router",
-      createLocalPromptConfig(),
-      createTargetConfig(),
-      createCell(),
-      createBasePrompt(),
-    );
-    const data = node.data as LlmPromptConfigComponent;
+  describe("given a local prompt edited from a saved base", () => {
+    describe("when building the signature node", () => {
+      it("keeps the base prompt identity and flags promptDraft", () => {
+        const node = buildSignatureNodeFromLocalConfig({
+          nodeId: "target-1",
+          name: "support-router",
+          localConfig: createLocalPromptConfig(),
+          targetConfig: createTargetConfig(),
+          cell: createCell(),
+          basePrompt: createBasePrompt(),
+        });
+        const data = node.data as LlmPromptConfigComponent;
 
-    expect(data.configId).toBe("prompt_supportrouter_xyz");
-    expect(data.handle).toBe("support-router");
-    expect(data.versionMetadata?.versionNumber).toBe(6);
-    expect(data.promptDraft).toBe(true);
+        expect(data.configId).toBe("prompt_supportrouter_xyz");
+        expect(data.handle).toBe("support-router");
+        expect(data.versionMetadata?.versionNumber).toBe(6);
+        expect(data.promptDraft).toBe(true);
+      });
+    });
   });
 
-  it("forwards no prompt identity for a brand-new local prompt with no saved base", () => {
-    const node = buildSignatureNodeFromLocalConfig(
-      "target-1",
-      "draft",
-      createLocalPromptConfig(),
-      createTargetConfig(),
-      createCell(),
-      undefined,
-    );
-    const data = node.data as LlmPromptConfigComponent;
+  describe("given a brand-new local prompt with no saved base", () => {
+    describe("when building the signature node", () => {
+      it("forwards no prompt identity", () => {
+        const node = buildSignatureNodeFromLocalConfig({
+          nodeId: "target-1",
+          name: "draft",
+          localConfig: createLocalPromptConfig(),
+          targetConfig: createTargetConfig(),
+          cell: createCell(),
+          basePrompt: undefined,
+        });
+        const data = node.data as LlmPromptConfigComponent;
 
-    expect(data.configId).toBeUndefined();
-    expect(data.promptDraft).toBeUndefined();
+        expect(data.configId).toBeUndefined();
+        expect(data.promptDraft).toBeUndefined();
+      });
+    });
   });
 });

--- a/langwatch/src/server/experiments-v3/execution/workflowBuilder.ts
+++ b/langwatch/src/server/experiments-v3/execution/workflowBuilder.ts
@@ -211,26 +211,26 @@ const buildTargetNode = (
         loadedData.prompt?.name ??
         targetConfig.id;
       return {
-        targetNode: buildSignatureNodeFromLocalConfig(
-          targetNodeId,
+        targetNode: buildSignatureNodeFromLocalConfig({
+          nodeId: targetNodeId,
           name,
-          targetConfig.localPromptConfig,
+          localConfig: targetConfig.localPromptConfig,
           targetConfig,
           cell,
           // The base prompt this draft started from (may be undefined for a
           // brand-new local prompt with no saved base).
-          loadedData.prompt,
-        ),
+          basePrompt: loadedData.prompt,
+        }),
         targetNodeId,
       };
     } else if (loadedData.prompt) {
       return {
-        targetNode: buildSignatureNodeFromPrompt(
-          targetNodeId,
-          loadedData.prompt,
+        targetNode: buildSignatureNodeFromPrompt({
+          nodeId: targetNodeId,
+          prompt: loadedData.prompt,
           targetConfig,
           cell,
-        ),
+        }),
         targetNodeId,
       };
     } else {
@@ -363,12 +363,17 @@ export const buildEvaluatorTargetNode = (
 /**
  * Builds a signature node from a VersionedPrompt (database prompt).
  */
-export const buildSignatureNodeFromPrompt = (
-  nodeId: string,
-  prompt: VersionedPrompt,
-  targetConfig: TargetConfig,
-  cell: ExecutionCell,
-): Node<Signature> => {
+export const buildSignatureNodeFromPrompt = ({
+  nodeId,
+  prompt,
+  targetConfig,
+  cell,
+}: {
+  nodeId: string;
+  prompt: VersionedPrompt;
+  targetConfig: TargetConfig;
+  cell: ExecutionCell;
+}): Node<Signature> => {
   const inputs = (prompt.inputs ?? []).map((input) => ({
     identifier: input.identifier,
     type: input.type as Field["type"],
@@ -500,15 +505,22 @@ const buildPromptIdentity = (identity: {
 /**
  * Builds a signature node from LocalPromptConfig (unsaved local changes).
  */
-export const buildSignatureNodeFromLocalConfig = (
-  nodeId: string,
-  name: string,
-  localConfig: LocalPromptConfig,
-  targetConfig: TargetConfig,
-  cell: ExecutionCell,
+export const buildSignatureNodeFromLocalConfig = ({
+  nodeId,
+  name,
+  localConfig,
+  targetConfig,
+  cell,
+  basePrompt,
+}: {
+  nodeId: string;
+  name: string;
+  localConfig: LocalPromptConfig;
+  targetConfig: TargetConfig;
+  cell: ExecutionCell;
   /** The saved prompt this draft started from, if any. */
-  basePrompt?: VersionedPrompt,
-): Node<Signature> => {
+  basePrompt?: VersionedPrompt;
+}): Node<Signature> => {
   const inputs = localConfig.inputs.map((input) => ({
     identifier: input.identifier,
     type: input.type as Field["type"],

--- a/langwatch/src/server/experiments-v3/execution/workflowBuilder.ts
+++ b/langwatch/src/server/experiments-v3/execution/workflowBuilder.ts
@@ -217,6 +217,9 @@ const buildTargetNode = (
           targetConfig.localPromptConfig,
           targetConfig,
           cell,
+          // The base prompt this draft started from (may be undefined for a
+          // brand-new local prompt with no saved base).
+          loadedData.prompt,
         ),
         targetNodeId,
       };
@@ -404,6 +407,20 @@ export const buildSignatureNodeFromPrompt = (
     position: { x: 200, y: 0 },
     data: {
       name: prompt.handle ?? prompt.name ?? "Prompt",
+      // Forward the prompt's identity so nlpgo emits the
+      // PromptApiService.get + Prompt.compile spans that let the trace
+      // drawer's "Open in Prompts" resume this exact (handle, version,
+      // variables) in the playground. Without configId, nlpgo treats the
+      // node as an inline prompt and emits no prompt ancestry.
+      // (services/nlpgo/app/engine/dsl/types.go reads configId / handle /
+      // versionMetadata; signatureComponentSchema mirrors the shape.)
+      ...buildPromptIdentity({
+        configId: prompt.id,
+        handle: prompt.handle,
+        versionId: prompt.versionId,
+        versionNumber: prompt.version,
+        versionCreatedAt: prompt.versionCreatedAt,
+      }),
       inputs,
       outputs,
       parameters: [
@@ -428,6 +445,59 @@ export const buildSignatureNodeFromPrompt = (
 };
 
 /**
+ * Builds the prompt-identity fields (configId / handle / versionMetadata)
+ * that nlpgo reads to emit PromptApiService.get + Prompt.compile spans.
+ * Mirrors signatureComponentSchema in optimization_studio/types/dsl.ts and
+ * the Go-side dsl.Component (PromptConfigID / PromptHandle / VersionMetadata).
+ *
+ * Returns an empty object when there is no configId, so non-prompt targets
+ * (agents, inline edits with no saved base) stay free of prompt ancestry.
+ */
+const buildPromptIdentity = (identity: {
+  configId?: string | null;
+  handle?: string | null;
+  versionId?: string | null;
+  versionNumber?: number | null;
+  versionCreatedAt?: Date | string | null;
+}): Partial<{
+  configId: string;
+  handle: string | null;
+  versionMetadata: {
+    versionId: string;
+    versionNumber: number;
+    versionCreatedAt: string;
+  };
+}> => {
+  if (!identity.configId) return {};
+
+  const base: { configId: string; handle: string | null } = {
+    configId: identity.configId,
+    handle: identity.handle ?? null,
+  };
+
+  // versionMetadata requires all three fields; only emit it when complete.
+  if (
+    identity.versionId &&
+    identity.versionNumber != null &&
+    identity.versionCreatedAt != null
+  ) {
+    return {
+      ...base,
+      versionMetadata: {
+        versionId: identity.versionId,
+        versionNumber: identity.versionNumber,
+        versionCreatedAt:
+          identity.versionCreatedAt instanceof Date
+            ? identity.versionCreatedAt.toISOString()
+            : identity.versionCreatedAt,
+      },
+    };
+  }
+
+  return base;
+};
+
+/**
  * Builds a signature node from LocalPromptConfig (unsaved local changes).
  */
 export const buildSignatureNodeFromLocalConfig = (
@@ -436,6 +506,8 @@ export const buildSignatureNodeFromLocalConfig = (
   localConfig: LocalPromptConfig,
   targetConfig: TargetConfig,
   cell: ExecutionCell,
+  /** The saved prompt this draft started from, if any. */
+  basePrompt?: VersionedPrompt,
 ): Node<Signature> => {
   const inputs = localConfig.inputs.map((input) => ({
     identifier: input.identifier,
@@ -477,6 +549,25 @@ export const buildSignatureNodeFromLocalConfig = (
     position: { x: 200, y: 0 },
     data: {
       name,
+      // Inline-edited draft: keep the BASE prompt's identity so the trace
+      // drawer can still resume "Open <handle>:<version>", and flag
+      // promptDraft so nlpgo stamps langwatch.prompt.draft=true (the
+      // "(unsaved edits)" label). When there's no saved base (a brand-new
+      // local prompt) we forward nothing, so no prompt ancestry is emitted.
+      // (specs/nlp-go/prompt-spans-unsaved-version.feature — wire format
+      // locked on the channel.)
+      ...(basePrompt
+        ? {
+            ...buildPromptIdentity({
+              configId: basePrompt.id,
+              handle: basePrompt.handle,
+              versionId: basePrompt.versionId,
+              versionNumber: basePrompt.version,
+              versionCreatedAt: basePrompt.versionCreatedAt,
+            }),
+            promptDraft: true,
+          }
+        : {}),
       inputs,
       outputs,
       parameters: [

--- a/services/nlpgo/tests/integration/prompt_spans_eval_v3_test.go
+++ b/services/nlpgo/tests/integration/prompt_spans_eval_v3_test.go
@@ -7,14 +7,48 @@
 // the trace-UI ancestor walk (findPromptReferenceInAncestors.ts) can
 // resolve a single prompt reference per result cell without
 // cross-row leakage.
+//
+// The orchestrator dispatches one execute_component (origin="evaluation")
+// per row; these tests pin the per-dispatch engine contract. The
+// app-side forwarding that makes the eval-v3 target node actually carry
+// configId / handle / versionMetadata is covered by
+// langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts.
 
 package integration_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 /** @scenario "each evaluated row emits its own PromptApiService.get + Prompt.compile pair" */
 func TestPromptSpansEvalV3_EachRowEmitsItsOwnGetCompilePair(t *testing.T) {
-	t.Skip(promptSpansPendingMsg)
+	body := signatureWorkflowBody(t, signatureNodeOpts{
+		ConfigID:      "prompt_supportrouter_xyz",
+		Handle:        "support-router",
+		VersionID:     "prompt_version_supportrouter_v6",
+		VersionNumber: 6,
+		Instructions:  "You are a support router.",
+		Origin:        "evaluation",
+	}, map[string]any{"input": "I want a refund"})
+
+	fx, _ := runPromptSpansDispatch(t, body)
+
+	get := promptSpanAttrs(fx.FindPromptSpan(t, "PromptApiService.get"))
+	assert.Equal(t, "support-router:6", get["langwatch.prompt.id"],
+		"get carries the combined handle:version stamp the drawer resumes")
+
+	compile := promptSpanAttrs(fx.FindPromptSpan(t, "Prompt.compile"))
+	assert.Equal(t, "prompt_supportrouter_xyz", compile["langwatch.prompt.id"],
+		"compile carries the raw configId (the base reference)")
+	assert.Equal(t, "support-router", compile["langwatch.prompt.handle"])
+	assert.Equal(t, int64(6), compile["langwatch.prompt.version.number"])
+
+	// The eval-v3 origin must reach the trace so the UI can group per-row
+	// prompt spans under the experiment surface (the root span carries it).
+	assert.Equal(t, "evaluation", evalV3Origin(fx),
+		"the dispatch stamps langwatch.origin=evaluation")
 }
 
 /** @scenario "per-row spans are scoped under their per-row execution root, not the experiment root" */
@@ -24,10 +58,35 @@ func TestPromptSpansEvalV3_PerRowScopingNoLeakage(t *testing.T) {
 
 /** @scenario "a target that is not a saved prompt emits no PromptApiService.get" */
 func TestPromptSpansEvalV3_CodeTargetEmitsNoGet(t *testing.T) {
-	t.Skip(promptSpansPendingMsg)
+	body := signatureWorkflowBody(t, signatureNodeOpts{
+		// No ConfigID → ad-hoc target (e.g. a code/agent target or an
+		// inline prompt) → no resolvable saved prompt → no prompt ancestry.
+		Instructions: "inline prompt, no saved config",
+		Origin:       "evaluation",
+	}, map[string]any{"input": "ping"})
+
+	fx, _ := runPromptSpansDispatch(t, body)
+
+	assert.Nil(t, findPromptSpan(fx.rec, "PromptApiService.get"),
+		"a non-saved-prompt target must not emit PromptApiService.get")
+	assert.Nil(t, findPromptSpan(fx.rec, "Prompt.compile"),
+		"a non-saved-prompt target must not emit Prompt.compile")
 }
 
 /** @scenario "a row whose prompt fetch fails records the exception on its own get span" */
 func TestPromptSpansEvalV3_RowFetchFailureRecordedAndOthersUnaffected(t *testing.T) {
 	t.Skip(promptSpansPendingMsg)
+}
+
+// evalV3Origin returns the langwatch.origin stamped on the dispatch's
+// root span (studioRequestAttrs sets it from payload.origin), or "".
+func evalV3Origin(fx *promptSpansFixture) string {
+	for _, s := range fx.Spans() {
+		for _, a := range s.Attributes() {
+			if a.Key == "langwatch.origin" {
+				return a.Value.AsString()
+			}
+		}
+	}
+	return ""
 }

--- a/services/nlpgo/tests/integration/prompt_spans_harness_test.go
+++ b/services/nlpgo/tests/integration/prompt_spans_harness_test.go
@@ -54,6 +54,11 @@ type signatureNodeOpts struct {
 	Draft         bool
 	Instructions  string
 	TemplateMsgs  []map[string]any
+	// Origin sets the dispatch envelope's payload.origin. Defaults to
+	// "workflow" (Studio Run-Component). Eval-v3 dispatches use
+	// "evaluation"; the engine stamps it on langwatch.origin so the
+	// trace-UI groups per-row prompt spans under the experiment surface.
+	Origin string
 }
 
 // signatureWorkflowBody builds an execute_component envelope shaped
@@ -68,6 +73,10 @@ func signatureWorkflowBody(t *testing.T, node signatureNodeOpts, inputs map[stri
 	}
 	if node.NodeName == "" {
 		node.NodeName = "LLM Node"
+	}
+	origin := node.Origin
+	if origin == "" {
+		origin = "workflow"
 	}
 
 	parameters := []map[string]any{
@@ -120,7 +129,7 @@ func signatureWorkflowBody(t *testing.T, node signatureNodeOpts, inputs map[stri
 		"payload": map[string]any{
 			"trace_id": "prompt-spans-" + node.NodeID,
 			"node_id":  node.NodeID,
-			"origin":   "workflow",
+			"origin":   origin,
 			"workflow": map[string]any{
 				"workflow_id":      "wf_prompt_spans",
 				"api_key":          "sk-prompt-spans",

--- a/specs/nlp-go/prompt-spans-eval-v3.feature
+++ b/specs/nlp-go/prompt-spans-eval-v3.feature
@@ -6,15 +6,19 @@ Feature: Prompt spans on Evaluations v3 — per-row prompt context for resumable
     in the playground for debugging or follow-up
 
   # Wire-format reference: identical to playground (see prompt-spans-playground.feature).
-  # Eval-v3 surfaces that exercise this path:
-  #   langwatch/src/evaluations-v3/components/TargetSection/TargetCell.tsx
-  #   langwatch/src/evaluations-v3/utils/promptEditorCallbacks.ts
-  # Per-row execution dispatcher:
-  #   useEvaluationExecution.ts:124 (origin = "evaluation")
+  # The prompt identity (configId / handle / versionMetadata) is forwarded onto
+  # the per-cell signature node by the server-side workflow builder:
+  #   langwatch/src/server/experiments-v3/execution/workflowBuilder.ts
+  #     (buildSignatureNodeFromPrompt — saved target; buildSignatureNodeFromLocalConfig
+  #      — inline-edited draft, which also forwards promptDraft=true)
+  # Per-row execution dispatcher (one execute_component per row, origin = "evaluation"):
+  #   langwatch/src/server/experiments-v3/execution/orchestrator.ts (executeCell)
   #
   # Bindings:
+  #   - App-side forwarding (the gap this feature fixes):
+  #       langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
   #   - Emission scenarios (1, 2, 4, 5): services/nlpgo/tests/integration/prompt_spans_eval_v3_test.go
-  #   - Drill-down resume (3): langwatch/src/evaluations-v3/components/.../TargetCell.integration.test.ts
+  #   - Drill-down resume (3): trace details drawer "Open in Prompts" (traces-v2)
 
   Background:
     Given the nlpgo service is running and the project is on the Go-NLP execution path

--- a/specs/traces-v2/drawer-opt-in-routing.feature
+++ b/specs/traces-v2/drawer-opt-in-routing.feature
@@ -41,8 +41,8 @@ Feature: Trace drawer honors the new-explorer opt-in from every entry point
     @integration
     Scenario: The opt-in applies to every trace entry point, not only the traces table
       Given I have opted into the new Trace Explorer on this device
-      When any screen requests to open a trace's details
-      Then the request is routed to the new Trace Explorer
+      When I open a trace's details from any screen
+      Then the new Trace Explorer drawer opens for that trace
 
   Rule: Non-trace drawers and incomplete requests are never rerouted
 

--- a/specs/traces-v2/drawer-opt-in-routing.feature
+++ b/specs/traces-v2/drawer-opt-in-routing.feature
@@ -1,0 +1,82 @@
+# Trace drawer opt-in routing — Gherkin Spec
+# Implementation: langwatch/src/hooks/useDrawer.ts (routeTraceDrawerForV2 +
+# the openDrawer interception) and
+# langwatch/src/features/traces-v2/hooks/useTracesV2Preference.ts
+#
+# The new Trace Explorer ("traces v2") ships behind a per-device opt-in: the
+# operator clicks "Try the new one" once and every trace they open from then
+# on should use the new drawer until they switch back. The opt-in is a
+# per-browser choice, independent of the rollout feature flag that decides
+# whether the opt-in affordance is even offered.
+#
+# The opt-in is honored at a single chokepoint: every request to open a
+# trace's details (no matter which screen triggered it — the traces table,
+# evaluation results, a workflow run panel, the command bar, a feedback row)
+# goes through the same open-drawer call, which routes to the new explorer
+# when the device opted in. This is why a single mechanism covers all
+# entry points rather than each screen re-implementing the choice.
+
+Feature: Trace drawer honors the new-explorer opt-in from every entry point
+  As an operator who opted into the new Trace Explorer
+  I want every "view trace" button across the product to open the new drawer
+  So that my choice is respected everywhere, not just on the traces table
+
+  Background:
+    Given I am logged into a project
+
+  Rule: The device opt-in routes all trace views to the new explorer
+
+    @integration
+    Scenario: A trace opened from a results view uses the new explorer when the device opted in
+      Given I have opted into the new Trace Explorer on this device
+      When I open a trace's details from a results view
+      Then the new Trace Explorer drawer opens for that trace
+
+    @integration
+    Scenario: A trace opened from a results view uses the legacy drawer when the device has not opted in
+      Given I have not opted into the new Trace Explorer on this device
+      When I open a trace's details from a results view
+      Then the legacy trace drawer opens for that trace
+
+    @integration
+    Scenario: The opt-in applies to every trace entry point, not only the traces table
+      Given I have opted into the new Trace Explorer on this device
+      When any screen requests to open a trace's details
+      Then the request is routed to the new Trace Explorer
+
+  Rule: Non-trace drawers and incomplete requests are never rerouted
+
+    @integration
+    Scenario: Opening a non-trace drawer is unaffected by the opt-in
+      Given I have opted into the new Trace Explorer on this device
+      When a screen opens a drawer that is not a trace drawer
+      Then that drawer opens unchanged
+
+    @integration
+    Scenario: A trace request without a trace id is left on the legacy drawer
+      Given I have opted into the new Trace Explorer on this device
+      When a screen requests the trace drawer without a trace id
+      Then the legacy trace drawer opens
+
+  Rule: Reported regressions are fixed at the shared chokepoint
+
+    @integration
+    Scenario: Viewing a trace from evaluation results honors the opt-in
+      Given I have opted into the new Trace Explorer on this device
+      When I click "View" on a row in the evaluation results table
+      Then the new Trace Explorer drawer opens for that trace
+
+    @integration
+    Scenario: Viewing the full trace from a workflow run honors the opt-in
+      Given I have opted into the new Trace Explorer on this device
+      When I click "Full Trace" on a workflow execution result
+      Then the new Trace Explorer drawer opens for that trace
+
+  Rule: Switching back returns to the legacy drawer
+
+    @planned
+    Scenario: Opting back out from the new explorer returns later trace views to the legacy drawer
+      Given I have opted into the new Trace Explorer on this device
+      And I switch back to the legacy drawer from the new explorer's menu
+      When I open a trace's details from a results view
+      Then the legacy trace drawer opens for that trace


### PR DESCRIPTION
## What

Two fixes to Evaluations v3 trace telemetry and trace viewing, both spotted while dogfooding the freshly-shipped Go-NLP migration, plus a confirmation that a third report is not a regression.

1. **Issue 2 - prompt identity now reaches eval-v3 traces** so each evaluated row emits the same `PromptApiService.get` + `Prompt.compile` span pair the langwatch SDKs emit for an ad-hoc `prompt.get` / `prompt.compile`. The trace drawer's "Open in Prompts" resume was hidden and you could not replay a row's prompt + version + variables in the playground.
2. **Issue 3 - traces-v2 drawer opt-in is honored from every trace entry point** so clicking "see traces" opens the v2 drawer once you have opted in, instead of always falling back to the old drawer.
3. **Issue 1 - "Evaluation V3 - Row N" repeated as a separate trace root per component is not a regression** (analysis below, follow-up proposed).

## Issue 2 - prompt spans missing from eval-v3 traces (fixed)

Evaluations v3 runs each row's target prompt through nlpgo via `execute_component`, but the per-cell workflow builder forwarded only the prompt's **content** (llm / instructions / messages) and dropped its **identity**. The nlpgo engine emits the `PromptApiService.get` + `Prompt.compile` spans only when the signature node carries `data.configId`, so eval-v3 LLM spans had no prompt ancestry.

The engine emission was already complete (`prompt_spans_emit_test` has zero skips); the gap was purely this app-side forwarding.

- `buildSignatureNodeFromPrompt`: forward `configId` / `handle` / `versionMetadata` from the saved `VersionedPrompt` (new `buildPromptIdentity` helper, shape mirrors `signatureComponentSchema` and the Go `dsl.Component` fields).
- `buildSignatureNodeFromLocalConfig`: forward the **base** prompt identity plus `promptDraft=true` for inline-edited targets (the "(unsaved edits)" case, wire format per `specs/nlp-go/prompt-spans-unsaved-version.feature`).
- nlpgo: un-skip the two core eval-v3 integration tests (per-row get+compile emission + the no-configId negative); add an `Origin` field to the shared prompt-spans test harness so eval-v3's `origin="evaluation"` dispatch is exercised.

## Issue 3 - traces-v2 drawer opt-in routing (fixed)

Problem: after opting into the new Trace Explorer, view-trace on eval-v3 results + workflow run panels still opened the OLD drawer. The opt-in routing lived inside `useTraceDetailsDrawer`, but ~10 call sites (eval-v3 `BatchEvaluationV2EvaluationResult`, workflow `ExecutionOutputPanel` "Full Trace", feedback, command bar, annotations, experiment target cells) called `openDrawer('traceDetails')` directly, bypassing it.

Fix: route at the single `openDrawer` chokepoint. `traceDetails` + `traceId` is rewritten to `traceV2Details` when the device opted in, so every entry point honors the choice at once (mirrors the central external-user restriction in `CurrentDrawer`). `useTraceDetailsDrawer` becomes a thin delegate; pure helper extracted to `traceDrawerV2Routing.ts`.

Tests: pure helper unit + `openDrawer` URL-rewrite integration + real `ExecutionOutputPanel` component (both opt-in states). Spec `specs/traces-v2/drawer-opt-in-routing.feature`, 7/7 bound.

## Issue 1 - "Evaluation V3 - Row N" repeated as a separate trace root per component (not a regression)

Confirmed this is pre-existing behavior preserved across the migration, not something the Go-NLP cutover broke. The orchestrator dispatches the target and each evaluator as separate `execute_component` calls (sharing one per-row `trace_id`, no shared parent), and nlpgo names each root after the workflow, mirroring Python's `optional_langwatch_trace(name=workflow.name)`. The spec only requires per-row `trace_id` isolation, which holds.

Nesting the per-row components under one shared parent span is a follow-up enhancement, not a fix. It would need either an `execute_flow` refactor, an app-side parent span threaded via traceparent (which risks double-naming the root), or an nlpgo studio-root-skip touching the causality-propagation code. Tracked as a follow-up rather than bundled here.

## Testing

- nlpgo: `go test ./tests/integration/ -run PromptSpans` green (eval-v3 per-row get+compile + no-configId negative un-skipped).
- `workflowBuilder.test.ts`: 29 pass (4 new - forwarding from saved prompt, from local config with a base, draft flag, and the no-base negative).
- traces-v2 drawer: 13 tests (helper unit + `openDrawer` integration + real `ExecutionOutputPanel` component render, both opt-in states).
- `pnpm typecheck` clean.
- Browser QA + screenshots below.

## Screenshots

### Issue 3: traces-v2 drawer opt-in routing

Same trace opened from the command bar (a bypass entry point), toggling only the per-device opt-in. Nothing else changed:

Opted in -> the new Trace Explorer (v2) drawer (URL `drawer.open=traceV2Details`):

![traces v2 drawer, opted in](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4657/drawer/traces-v2-drawer-opted-in.png)

Opted out -> the legacy Trace Details drawer (URL `drawer.open=traceDetails`):

![legacy trace drawer, opted out](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4657/drawer/traces-v2-drawer-opted-out.png)

### Issue 2: prompt spans in eval-v3 traces

A real eval-v3 run over a saved prompt ("support-router") across a 3-row dataset (gpt-5-mini classified each row into refund / technical / billing). Opening any result row's trace now shows the `PromptApiService.get` + `Prompt.compile` span pair that was missing before the fix, nested under the per-row `Evaluation V3 - Row N` root via the signature span:

![eval-v3 trace span tree with PromptApiService.get and Prompt.compile under the per-row root](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4657/eval-v3-prompt-spans/span-tree-get-compile.png)

The `Prompt.compile` span carries the full resume identity (configId, handle, version, and that row's variables) that the drawer's "Open in Prompts" uses to replay the exact prompt + version + inputs in the playground:

![Prompt.compile span identity attributes: handle support-router, version 1, and the row variables](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4657/eval-v3-prompt-spans/prompt-compile-identity-attrs.png)

## Specs

- `specs/nlp-go/prompt-spans-eval-v3.feature`
- `specs/traces-v2/drawer-opt-in-routing.feature`


