### PR TITLE
perf(clickhouse): add time predicate to span-tree drawer reads (stop stored_spans cold scan)

### DIFF
--- a/langwatch/src/components/traces/SpanTree.tsx
+++ b/langwatch/src/components/traces/SpanTree.tsx
@@ -289,6 +289,12 @@ const SpanCost = ({ span }: { span: Span }) => {
 
 type SpanTreeProps = {
   traceId: string;
+  /**
+   * Approximate trace timestamp (ms since epoch), forwarded to the span reads
+   * as a partition-pruning hint. Lets the drawer's span loads target the
+   * trace's weekly `stored_spans` partitions instead of cold-scanning S3.
+   */
+  occurredAtMs?: number;
 };
 
 export function SpanTree(props: SpanTreeProps) {
@@ -300,6 +306,7 @@ export function SpanTree(props: SpanTreeProps) {
   const loader = useSpanTreeLoader({
     projectId: project?.id ?? "",
     traceId: props.traceId,
+    occurredAtMs: props.occurredAtMs,
     enabled: !!project && !!props.traceId,
   });
 

--- a/langwatch/src/components/traces/TraceDetails.tsx
+++ b/langwatch/src/components/traces/TraceDetails.tsx
@@ -412,7 +412,10 @@ export function TraceDetails(props: {
           {selectedTab === "traceDetails" && (
             <VStack paddingBottom={6}>
               <TraceSummary traceId={props.traceId} />
-              <SpanTree traceId={props.traceId} />
+              <SpanTree
+                traceId={props.traceId}
+                occurredAtMs={trace.data?.timestamps.started_at}
+              />
             </VStack>
           )}
         </Tabs.Content>

--- a/langwatch/src/hooks/__tests__/useSpanTreeLoader.test.tsx
+++ b/langwatch/src/hooks/__tests__/useSpanTreeLoader.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { useSpanTreeLoader } from "../useSpanTreeLoader";
+
+// Mock the tRPC api. We only care about the inputs the hook passes to the
+// span-read endpoints, so the query stubs return an empty/loading result.
+const mockUseQuery = vi.fn();
+const mockPaginatedFetch = vi.fn();
+const mockDeltaFetch = vi.fn();
+
+vi.mock("../../utils/api", () => ({
+  api: {
+    tracesV2: {
+      spansPaginated: {
+        useQuery: (...args: unknown[]) => mockUseQuery(...args),
+      },
+    },
+    useUtils: () => ({
+      tracesV2: {
+        spansPaginated: { fetch: mockPaginatedFetch },
+        spansDelta: { fetch: mockDeltaFetch },
+      },
+    }),
+  },
+}));
+
+describe("useSpanTreeLoader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseQuery.mockReturnValue({ data: undefined, error: null });
+    mockPaginatedFetch.mockResolvedValue({ spans: [], total: 0 });
+    mockDeltaFetch.mockResolvedValue([]);
+  });
+
+  describe("when an occurredAtMs hint is provided", () => {
+    it("threads it into the initial paginated span read as a partition hint", () => {
+      renderHook(() =>
+        useSpanTreeLoader({
+          projectId: "project-123",
+          traceId: "trace-abc",
+          occurredAtMs: 1_700_000_000_000,
+        }),
+      );
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project-123",
+          traceId: "trace-abc",
+          occurredAtMs: 1_700_000_000_000,
+        }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
+  });
+
+  describe("when no occurredAtMs hint is provided", () => {
+    it("still issues the read (hint is optional, full scan fallback)", () => {
+      renderHook(() =>
+        useSpanTreeLoader({
+          projectId: "project-123",
+          traceId: "trace-abc",
+        }),
+      );
+
+      const [input] = mockUseQuery.mock.calls[0]!;
+      expect(input).toMatchObject({
+        projectId: "project-123",
+        traceId: "trace-abc",
+      });
+      expect((input as { occurredAtMs?: number }).occurredAtMs).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/hooks/useSpanTreeLoader.ts
+++ b/langwatch/src/hooks/useSpanTreeLoader.ts
@@ -93,10 +93,19 @@ const INITIAL_STATE: SpanTreeState = {
 export function useSpanTreeLoader({
   projectId,
   traceId,
+  occurredAtMs,
   enabled = true,
 }: {
   projectId: string;
   traceId: string;
+  /**
+   * Approximate trace timestamp (ms since epoch). Threaded into the span reads
+   * as a partition-pruning hint so they scan the trace's weekly `stored_spans`
+   * partitions instead of cold-scanning every partition (incl. cold S3) on each
+   * drawer open. Optional: when absent the reads fall back to the full scan, so
+   * correctness is unchanged either way.
+   */
+  occurredAtMs?: number;
   enabled?: boolean;
 }) {
   const [state, dispatch] = useReducer(spanTreeReducer, INITIAL_STATE);
@@ -105,7 +114,7 @@ export function useSpanTreeLoader({
 
   // Initial paginated load
   const initialQuery = api.tracesV2.spansPaginated.useQuery(
-    { projectId, traceId, limit: PAGE_SIZE, offset: 0 },
+    { projectId, traceId, limit: PAGE_SIZE, offset: 0, occurredAtMs },
     { enabled: enabled && !!projectId && !!traceId },
   );
 
@@ -133,6 +142,7 @@ export function useSpanTreeLoader({
           traceId,
           limit: PAGE_SIZE,
           offset: state.nextOffset,
+          occurredAtMs,
         });
         dispatch({ type: "BATCH_LOADED", spans: result.spans });
 
@@ -155,7 +165,7 @@ export function useSpanTreeLoader({
         backfillTimerRef.current = null;
       }
     };
-  }, [state.phase, state.nextOffset, state.total, enabled, projectId, traceId, utils]);
+  }, [state.phase, state.nextOffset, state.total, enabled, projectId, traceId, occurredAtMs, utils]);
 
   // Delta fetch callback for SSE events
   const onSpanStored = useCallback(async () => {
@@ -165,6 +175,7 @@ export function useSpanTreeLoader({
         projectId,
         traceId,
         sinceStartTimeMs: state.highWaterMark,
+        occurredAtMs,
       });
       if (deltaSpans.length > 0) {
         dispatch({ type: "DELTA_RECEIVED", spans: deltaSpans });
@@ -172,7 +183,7 @@ export function useSpanTreeLoader({
     } catch {
       // Silently fail — next SSE event will retry
     }
-  }, [enabled, projectId, traceId, state.highWaterMark, utils]);
+  }, [enabled, projectId, traceId, occurredAtMs, state.highWaterMark, utils]);
 
   // Clear new flags after animation
   useEffect(() => {


### PR DESCRIPTION
## Evidence

Triaging the last 24h of prod ClickHouse logs (cold-scan signal), `stored_spans` is the top uncovered cold-scan table at ~1.1k `coldScan:true` warns/day. The largest single shape, by per-call read bytes, is the trace drawer's span-tree load: `paramKeys: [tenantId, traceId, limit, offset]` (and its delta sibling), p50 read ~11.8 MB, reading the full span payload (`SpanAttributes`, `Events.*`, `Links.*`) with no time predicate.

`stored_spans` is `PARTITION BY toYearWeek(StartTime)` and tiered to S3 after the hot window. A span read with no `StartTime` predicate can't prune partitions, so it walks every weekly partition including cold ones on S3. Latency is usually acceptable (the rows are few), but each cold partition is a burst of S3 GETs, and this shape fires on every drawer open.

## Suspected cause

The repository (`span-storage.clickhouse.repository.ts`) already supports a partition hint via `withPartitionHint(occurredAtMs, ...)`, and the `spansPaginated` / `spansDelta` tRPC endpoints already accept an optional `occurredAtMs`. But the only caller, `useSpanTreeLoader`, never passes it, so the reads fall through to the unbounded (cold-scan) path. The drawer already has the trace loaded, so the trace's `started_at` is available for free, with no extra query.

## Proposed fix

Thread `occurredAtMs` from the loaded trace down through the span tree:

- `TraceDetails` passes `trace.data.timestamps.started_at` to `SpanTree`.
- `SpanTree` forwards it to `useSpanTreeLoader`.
- `useSpanTreeLoader` includes it in the initial `spansPaginated.useQuery`, the backfill `spansPaginated.fetch`, and the `spansDelta.fetch`.

The hint stays optional end to end: when absent (e.g. the trace summary hasn't loaded yet), the reads fall back to the full scan, so correctness is unchanged either way. The repository already applies the `StartTime` window and retries unconstrained on an empty hinted result.

## Expected impact

Partition pruning on the span reads; user-visible latency may not move much (the read was already returning few rows), but the per-open S3 GET burst on cold partitions is eliminated for any trace whose timestamp is known (the common case). No change to which spans are returned.

## EXPLAIN check

`EXPLAIN INDEXES` on the single-trace `stored_spans` read against a large prod tenant (literals redacted):

Old (no `StartTime` predicate):
```
Parts:    268/268
Granules: 133717/133717
```

New (`StartTime` window from the hint):
```
Parts:    22/268
Granules: 1726/133717
```

A ~12x reduction in parts opened (each cold part avoided is a saved S3 GET burst). The reviewer should re-run before merge.

## Test plan

- `src/hooks/__tests__/useSpanTreeLoader.test.tsx` (new): asserts the hook threads `occurredAtMs` into the paginated read as a partition hint, and that the read still issues (full-scan fallback) when the hint is absent.
- `pnpm typecheck` clean.
- Repository-level partition pruning is already covered by `span-storage.clickhouse.repository.integration.test.ts`.

Advisory PR from the ClickHouse slow-query optimizer. Open for review, not for self-merge.