### PR TITLE
perf(clickhouse): add time predicate to analytics span-facet subqueries (stop stored_spans cold scan)

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -53,6 +53,23 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("'previous'");
     });
 
+    // A span/event facet filter resolves to a `... FROM stored_spans ...`
+    // subquery. stored_spans is partitioned by toYearWeek(StartTime) and tiered
+    // to S3, so the subquery must carry a StartTime predicate or it cold-scans
+    // every weekly partition. The envelope reuses the query's own date params.
+    it("bounds the stored_spans facet subquery to the date envelope by StartTime", () => {
+      const input = {
+        ...baseInput,
+        filters: { "spans.type": ["llm"] },
+      };
+      const result = buildTimeseriesQuery(input);
+
+      expect(result.sql).toContain("FROM stored_spans");
+      // The subquery prunes partitions instead of cold-scanning S3.
+      expect(result.sql).toContain("StartTime >= {previousStart:DateTime64(3)}");
+      expect(result.sql).toContain("StartTime < {currentEnd:DateTime64(3)}");
+    });
+
     it("includes date truncation for timescale", () => {
       const result = buildTimeseriesQuery(baseInput);
 

--- a/langwatch/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
@@ -177,6 +177,54 @@ describe("filter-translator", () => {
       });
     });
 
+    describe("stored_spans subquery partition pruning", () => {
+      // The stored_spans facet subqueries must accept a StartTime predicate so
+      // they prune to the dashboard's date range instead of cold-scanning every
+      // weekly partition on S3. The predicate is the caller's responsibility
+      // (aggregation-builder passes the date envelope); the translator just has
+      // to thread it into the subquery WHERE.
+      const SPAN_TIME = "AND StartTime >= {startDate:DateTime64(3)}";
+      const SPAN_SUBQUERY_FILTERS = [
+        { field: "spans.type", values: ["llm"], key: undefined },
+        { field: "spans.model", values: ["gpt-4"], key: undefined },
+        { field: "events.event_type", values: ["feedback"], key: undefined },
+        { field: "events.metrics.key", values: ["score"], key: "feedback" },
+        { field: "events.event_details.key", values: ["note"], key: "feedback" },
+      ] as const;
+
+      for (const { field, values, key } of SPAN_SUBQUERY_FILTERS) {
+        it(`injects the StartTime predicate into the ${field} subquery`, () => {
+          const result = translateFilter(
+            field,
+            [...values],
+            key,
+            undefined,
+            SPAN_TIME,
+          );
+          expect(result.whereClause).toContain("stored_spans");
+          expect(result.whereClause).toContain(SPAN_TIME);
+        });
+
+        it(`omits the StartTime predicate for ${field} when none is given (unchanged behavior)`, () => {
+          const result = translateFilter(field, [...values], key);
+          expect(result.whereClause).toContain("stored_spans");
+          expect(result.whereClause).not.toContain("StartTime");
+        });
+      }
+
+      it("leaves non-span filters untouched even when a predicate is supplied", () => {
+        const result = translateFilter(
+          "topics.topics",
+          ["topic-1"],
+          undefined,
+          undefined,
+          SPAN_TIME,
+        );
+        expect(result.whereClause).not.toContain("StartTime");
+        expect(result.whereClause).not.toContain("stored_spans");
+      });
+    });
+
     describe("evaluation filters", () => {
       it("translates evaluations.evaluator_id filter with parameterized IN subquery", () => {
         const result = translateFilter("evaluations.evaluator_id", [

--- a/langwatch/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/filter-translator.test.ts
@@ -177,7 +177,7 @@ describe("filter-translator", () => {
       });
     });
 
-    describe("stored_spans subquery partition pruning", () => {
+    describe("when a span or event facet filter targets stored_spans", () => {
       // The stored_spans facet subqueries must accept a StartTime predicate so
       // they prune to the dashboard's date range instead of cold-scanning every
       // weekly partition on S3. The predicate is the caller's responsibility

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -28,9 +28,6 @@ import {
   translateAllFilters,
   type FilterTranslation,
 } from "./filter-translator";
-import { createLogger } from "../../../utils/logger/server";
-
-const logger = createLogger("langwatch:analytics:aggregation-builder");
 
 /**
  * Resolve which columns a joined table needs based on the SQL expressions

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -66,6 +66,24 @@ const DATE_FILTER_PREVIOUS = `AND OccurredAt >= {previousStart:DateTime64(3)} AN
 const DATE_FILTER_START_END = `AND OccurredAt >= {startDate:DateTime64(3)} AND OccurredAt < {endDate:DateTime64(3)}`;
 
 /**
+ * StartTime partition-pruning predicates for the `stored_spans` subqueries that
+ * span/event facet filters generate (see translateAllFilters' spanTimePredicate
+ * argument). `stored_spans` is partitioned by `toYearWeek(StartTime)` and tiered
+ * to S3, so an unbounded facet subquery cold-scans every weekly partition. A
+ * span's StartTime falls within its trace's lifetime, so bounding it to the same
+ * date envelope the outer OccurredAt filter uses — plus a 2-day cushion for long
+ * traces / clock skew, matching the span-fetch partition hints elsewhere — prunes
+ * the scan without changing which traces match. One constant per caller date
+ * regime: the two-period aggregation vs. the single start/end-range builders.
+ */
+const SPAN_TIME_FILTER_BOTH_PERIODS =
+  "AND StartTime >= {previousStart:DateTime64(3)} - INTERVAL 2 DAY " +
+  "AND StartTime < {currentEnd:DateTime64(3)} + INTERVAL 2 DAY";
+const SPAN_TIME_FILTER_START_END =
+  "AND StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY " +
+  "AND StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY";
+
+/**
  * Returns a deduped FROM-clause expression for trace_summaries.
  *
  * trace_summaries uses ReplacingMergeTree(UpdatedAt) which can return
@@ -493,8 +511,13 @@ export function buildTimeseriesQuery(input: TimeseriesQueryInput): BuiltQuery {
     }
   }
 
-  // Translate filters
-  const filterTranslation = translateAllFilters(input.filters ?? {});
+  // Translate filters. Span/event facet filters resolve to stored_spans
+  // subqueries; pass the StartTime envelope so they prune partitions instead of
+  // cold-scanning S3 (see SPAN_TIME_FILTER_BOTH_PERIODS).
+  const filterTranslation = translateAllFilters(
+    input.filters ?? {},
+    SPAN_TIME_FILTER_BOTH_PERIODS,
+  );
   for (const join of filterTranslation.requiredJoins) {
     allJoins.add(join);
   }
@@ -1188,6 +1211,9 @@ function buildArrayJoinTimeseriesQuery(
   // TODO(#3115): port this path to extractTraceAggregationColumn for parity.
   cteSelectExprs.push(
     `${traceColumnWrapper(`${ts}.TotalCost`)} AS trace_total_cost`,
+  );
+  cteSelectExprs.push(
+    `${traceColumnWrapper(`${ts}.NonBilledCost`)} AS trace_non_billed_cost`,
   );
   cteSelectExprs.push(
     `${traceColumnWrapper(`${ts}.TotalDurationMs`)} AS trace_duration_ms`,
@@ -2033,6 +2059,7 @@ function buildPipelineMetricCTE(
 /** Maps source field names to their corresponding CTE column names */
 const DEDUP_FIELD_MAPPINGS: Record<string, string> = {
   TotalCost: "trace_total_cost",
+  NonBilledCost: "trace_non_billed_cost",
   TotalDurationMs: "trace_duration_ms",
   TotalPromptTokenCount: "trace_prompt_tokens",
   TotalCompletionTokenCount: "trace_completion_tokens",
@@ -2233,7 +2260,10 @@ export function buildDataForFilterQuery(
   const es = tableAliases.evaluation_runs;
 
   // Translate filters if provided
-  const filterTranslation = translateAllFilters(filters ?? {});
+  const filterTranslation = translateAllFilters(
+    filters ?? {},
+    SPAN_TIME_FILTER_START_END,
+  );
   const filterWhere =
     filterTranslation.whereClause !== "1=1"
       ? `AND ${filterTranslation.whereClause}`
@@ -2454,7 +2484,10 @@ export function buildTopDocumentsQuery(
   const ss = tableAliases.stored_spans;
 
   // Translate filters
-  const filterTranslation = translateAllFilters(filters ?? {});
+  const filterTranslation = translateAllFilters(
+    filters ?? {},
+    SPAN_TIME_FILTER_START_END,
+  );
   const filterWhere =
     filterTranslation.whereClause !== "1=1"
       ? `AND ${filterTranslation.whereClause}`
@@ -2545,7 +2578,10 @@ export function buildFeedbacksQuery(
   const ss = tableAliases.stored_spans;
 
   // Translate filters
-  const filterTranslation = translateAllFilters(filters ?? {});
+  const filterTranslation = translateAllFilters(
+    filters ?? {},
+    SPAN_TIME_FILTER_START_END,
+  );
   const filterWhere =
     filterTranslation.whereClause !== "1=1"
       ? `AND ${filterTranslation.whereClause}`

--- a/langwatch/src/server/analytics/clickhouse/field-mappings.ts
+++ b/langwatch/src/server/analytics/clickhouse/field-mappings.ts
@@ -27,6 +27,7 @@ export const TRACE_ANALYTICS_COLUMNS = [
   ...TRACE_IDENTITY_COLUMNS,
   "CreatedAt",
   "TotalCost",
+  "NonBilledCost",
   "TotalDurationMs",
   "TimeToFirstTokenMs",
   "TotalPromptTokenCount",

--- a/langwatch/src/server/analytics/clickhouse/filter-translator.ts
+++ b/langwatch/src/server/analytics/clickhouse/filter-translator.ts
@@ -32,12 +32,19 @@ export interface FilterTranslation {
 }
 
 /**
- * Handler function type for filter translation
+ * Handler function type for filter translation.
+ *
+ * `spanTimePredicate` is an optional SQL fragment (e.g. `AND StartTime >= ...`)
+ * that handlers whose subquery reads the time-partitioned `stored_spans` table
+ * inject into that subquery's WHERE, so the scan prunes to the dashboard's date
+ * range instead of cold-scanning every weekly partition (incl. cold S3).
+ * Handlers that don't touch `stored_spans` ignore it.
  */
 type FilterHandler = (
   values: string[],
   key?: string,
   subkey?: string,
+  spanTimePredicate?: string,
 ) => FilterTranslation;
 
 /**
@@ -89,8 +96,10 @@ const filterHandlers: Record<FilterField, FilterHandler | null> = {
   "traces.name": (values) => translateTraceNameFilter(values),
 
   // Span Filters
-  "spans.type": (values) => translateSpanTypeFilter(values),
-  "spans.model": (values) => translateSpanModelFilter(values),
+  "spans.type": (values, _key, _subkey, spanTime) =>
+    translateSpanTypeFilter(values, spanTime),
+  "spans.model": (values, _key, _subkey, spanTime) =>
+    translateSpanModelFilter(values, spanTime),
 
   // Evaluation Filters
   "evaluations.evaluator_id": (values) => translateEvaluatorIdFilter(values),
@@ -115,13 +124,14 @@ const filterHandlers: Record<FilterField, FilterHandler | null> = {
     translateEvaluationStateFilter(values, key),
 
   // Event Filters
-  "events.event_type": (values) => translateEventTypeFilter(values),
-  "events.metrics.key": (values, key) =>
-    translateEventMetricKeyFilter(values, key),
-  "events.metrics.value": (values, key, subkey) =>
-    translateEventMetricValueFilter(values, key, subkey),
-  "events.event_details.key": (values, key) =>
-    translateEventDetailKeyFilter(values, key),
+  "events.event_type": (values, _key, _subkey, spanTime) =>
+    translateEventTypeFilter(values, spanTime),
+  "events.metrics.key": (values, key, _subkey, spanTime) =>
+    translateEventMetricKeyFilter(values, key, spanTime),
+  "events.metrics.value": (values, key, subkey, spanTime) =>
+    translateEventMetricValueFilter(values, key, subkey, spanTime),
+  "events.event_details.key": (values, key, _subkey, spanTime) =>
+    translateEventDetailKeyFilter(values, key, spanTime),
 
   // Annotation Filters
   "annotations.hasAnnotation": (values) => translateAnnotationFilter(values),
@@ -146,13 +156,14 @@ export function translateFilter(
   values: string[],
   key?: string,
   subkey?: string,
+  spanTimePredicate?: string,
 ): FilterTranslation {
   if (values.length === 0) {
     return noOpFilter;
   }
 
   const handler = filterHandlers[field];
-  return handler ? handler(values, key, subkey) : noOpFilter;
+  return handler ? handler(values, key, subkey, spanTimePredicate) : noOpFilter;
 }
 
 /**
@@ -366,7 +377,10 @@ function translateTraceNameFilter(values: string[]): FilterTranslation {
  * subqueries (issue #2660). IN subqueries are semantically equivalent and avoid
  * this planner bug.
  */
-function translateSpanTypeFilter(values: string[]): FilterTranslation {
+function translateSpanTypeFilter(
+  values: string[],
+  spanTimePredicate = "",
+): FilterTranslation {
   const ts = tableAliases.trace_summaries;
   const paramName = genParamName("spanTypes");
 
@@ -374,6 +388,7 @@ function translateSpanTypeFilter(values: string[]): FilterTranslation {
     whereClause: `${ts}.TraceId IN (
       SELECT TraceId FROM stored_spans
       WHERE TenantId = {tenantId:String}
+        ${spanTimePredicate}
         AND SpanAttributes['langwatch.span.type'] IN ({${paramName}:Array(String)})
     )`,
     requiredJoins: [],
@@ -384,7 +399,10 @@ function translateSpanTypeFilter(values: string[]): FilterTranslation {
 /**
  * Translate span model filter (requires JOIN)
  */
-function translateSpanModelFilter(values: string[]): FilterTranslation {
+function translateSpanModelFilter(
+  values: string[],
+  spanTimePredicate = "",
+): FilterTranslation {
   const ts = tableAliases.trace_summaries;
   const paramName = genParamName("models");
 
@@ -392,6 +410,7 @@ function translateSpanModelFilter(values: string[]): FilterTranslation {
     whereClause: `${ts}.TraceId IN (
       SELECT TraceId FROM stored_spans
       WHERE TenantId = {tenantId:String}
+        ${spanTimePredicate}
         AND SpanAttributes['gen_ai.request.model'] IN ({${paramName}:Array(String)})
     )`,
     requiredJoins: [],
@@ -566,7 +585,10 @@ function translateEvaluationStateFilter(
 /**
  * Translate event type filter
  */
-function translateEventTypeFilter(values: string[]): FilterTranslation {
+function translateEventTypeFilter(
+  values: string[],
+  spanTimePredicate = "",
+): FilterTranslation {
   const ts = tableAliases.trace_summaries;
   const paramName = genParamName("eventTypes");
 
@@ -574,6 +596,7 @@ function translateEventTypeFilter(values: string[]): FilterTranslation {
     whereClause: `${ts}.TraceId IN (
       SELECT TraceId FROM stored_spans
       WHERE TenantId = {tenantId:String}
+        ${spanTimePredicate}
         AND hasAny("Events.Name", {${paramName}:Array(String)})
     )`,
     requiredJoins: [],
@@ -590,6 +613,7 @@ function translateEventTypeFilter(values: string[]): FilterTranslation {
 function translateEventMetricKeyFilter(
   values: string[],
   eventType?: string,
+  spanTimePredicate = "",
 ): FilterTranslation {
   const ts = tableAliases.trace_summaries;
   const keysParam = genParamName("metricKeys");
@@ -621,6 +645,7 @@ function translateEventMetricKeyFilter(
     whereClause: `${ts}.TraceId IN (
       SELECT TraceId FROM stored_spans
       WHERE TenantId = {tenantId:String}
+        ${spanTimePredicate}
         AND ${metricKeyCondition}
     )`,
     requiredJoins: [],
@@ -638,6 +663,7 @@ function translateEventMetricValueFilter(
   values: string[],
   eventType?: string,
   metricKey?: string,
+  spanTimePredicate = "",
 ): FilterTranslation {
   const ts = tableAliases.trace_summaries;
 
@@ -685,6 +711,7 @@ function translateEventMetricValueFilter(
     whereClause: `${ts}.TraceId IN (
       SELECT TraceId FROM stored_spans
       WHERE TenantId = {tenantId:String}
+        ${spanTimePredicate}
         AND ${valueCondition}
     )`,
     requiredJoins: [],
@@ -698,9 +725,10 @@ function translateEventMetricValueFilter(
 function translateEventDetailKeyFilter(
   values: string[],
   eventType?: string,
+  spanTimePredicate = "",
 ): FilterTranslation {
   // Same as metric key filter - event details are stored in Events.Attributes
-  return translateEventMetricKeyFilter(values, eventType);
+  return translateEventMetricKeyFilter(values, eventType, spanTimePredicate);
 }
 
 /**
@@ -777,6 +805,7 @@ export function translateAllFilters(
       | Record<string, Record<string, string[]>>
     >
   >,
+  spanTimePredicate?: string,
 ): FilterTranslation {
   const translations: FilterTranslation[] = [];
 
@@ -787,13 +816,27 @@ export function translateAllFilters(
 
     if (Array.isArray(value)) {
       // Simple array filter
-      translations.push(translateFilter(field as FilterField, value));
+      translations.push(
+        translateFilter(
+          field as FilterField,
+          value,
+          undefined,
+          undefined,
+          spanTimePredicate,
+        ),
+      );
     } else if (typeof value === "object") {
       // Nested filter with key
       for (const [key, subValue] of Object.entries(value)) {
         if (Array.isArray(subValue)) {
           translations.push(
-            translateFilter(field as FilterField, subValue, key),
+            translateFilter(
+              field as FilterField,
+              subValue,
+              key,
+              undefined,
+              spanTimePredicate,
+            ),
           );
         } else if (typeof subValue === "object") {
           // Double nested with key and subkey
@@ -805,6 +848,7 @@ export function translateAllFilters(
                   subSubValue,
                   key,
                   subkey,
+                  spanTimePredicate,
                 ),
               );
             }


### PR DESCRIPTION
## Evidence

Triaging the last 24h of prod ClickHouse logs (cold-scan signal), `stored_spans` is the top uncovered cold-scan table. After the per-trace drawer reads, the next concentration is analytics: dashboard queries that filter traces by a span or event facet. Their `coldScanTable` is `stored_spans` even though the request carries a date range (`paramKeys` like `[tenantId, startDate, endDate, f0_values, ...]` and `[tenantId, currentStart, currentEnd, previousStart, previousEnd, models, labels]`), p50 read ~130 MB.

`stored_spans` is `PARTITION BY toYearWeek(StartTime)` and tiered to S3. A facet subquery with no `StartTime` predicate walks every weekly partition including cold ones on S3 (a burst of GETs per cold partition), on every dashboard load that uses a span/event filter.

## Suspected cause

Span and event facet filters translate to `trace_summaries.TraceId IN (SELECT TraceId FROM stored_spans WHERE TenantId = ... AND <attr/event match>)` (`filter-translator.ts`). The outer `trace_summaries` query is correctly bounded on `OccurredAt` (its partition key), but that bound is never propagated into the inner `stored_spans` subquery, so the inner scan can't prune partitions. The SQL is otherwise correct; the missing piece is a `StartTime` predicate on the subquery.

## Proposed fix

Thread the dashboard date envelope into the `stored_spans` facet subqueries as a `StartTime` bound:

- `translateFilter` / `translateAllFilters` take an optional `spanTimePredicate` SQL fragment, passed only into the handlers whose subquery reads `stored_spans` (span type/model, event type, event metric key/value, event detail key). Non-span handlers ignore it.
- `aggregation-builder.ts` builds the fragment from the same date params the outer filter already binds (`SPAN_TIME_FILTER_BOTH_PERIODS` for the two-period aggregation; `SPAN_TIME_FILTER_START_END` for the single start/end-range builders) and passes it in.

A span's `StartTime` falls within its trace's lifetime, so the bound is the same `[period start, period end]` envelope the outer `OccurredAt` filter uses, plus a 2-day cushion for long traces / clock skew (matching the ±2-day span-fetch partition hints elsewhere in the codebase). This prunes the scan without changing which traces match.

This PR also completes the wiring of `NonBilledCost` (a `trace_summaries` column added in #4646). The non-billed-cost metric references `${ts}.NonBilledCost`, but the column was never added to `TRACE_ANALYTICS_COLUMNS`, so the deduped `trace_summaries` subquery never projected it and any query using that metric failed at runtime with `Identifier ts.NonBilledCost cannot be resolved`. This also left the guard test (every `${ts}.<Column>` reference must be handled) red on `main`. The fix mirrors `TotalCost`: add the column to `TRACE_ANALYTICS_COLUMNS` (inner projection), `DEDUP_FIELD_MAPPINGS`, and the period-comparison CTE select. Verified end to end against a real ClickHouse instance via the `trace-eval-mix-inflation` and `memory-safety` integration suites.

## Expected impact

For dashboard queries with a span/event facet filter, the `stored_spans` subquery prunes to the date range's weekly partitions instead of all of them. Headline metric is partitions pruned and the projected S3 GET reduction, not latency (the subquery returns few TraceIds). No change to results.

## EXPLAIN check

`EXPLAIN INDEXES` on the `spans.type` facet subquery against a large prod tenant over a 7-day range (literals redacted):

Old (no `StartTime` predicate):
```
Parts:    269/269
Granules: 133718/133718
```

New (`StartTime` envelope, ±2-day cushion):
```
Parts:    30/269
Granules: 4718/133718
```

A ~9x reduction in parts opened. The reviewer should re-run before merge.

## Test plan

- `filter-translator.test.ts`: new cases assert the `StartTime` predicate is injected into each `stored_spans` facet subquery when supplied, omitted when not (unchanged behavior), and never leaks into non-span filters.
- `aggregation-builder.test.ts`: new case asserts a built timeseries query with a `spans.type` filter carries the `StartTime` envelope on the subquery; the pre-existing `NonBilledCost` guard test now passes.
- `pnpm typecheck` clean; analytics unit suite green (150+ tests).

Note for the table in the skill docs: `project_FzsKx-0tpHezJlGxrG0sD` still EXPLAINs against ~268 `stored_spans` parts, a good large-tenant reference.

Advisory PR from the ClickHouse slow-query optimizer. Open for review, not for self-merge.