### PR TITLE
fix(deps): sync langwatch lockfile with mcp-server vitest bump

### DIFF
--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -845,7 +845,7 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       vitest:
-        specifier: '>=4.1.0'
+        specifier: ^4.1.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       yargs:
         specifier: ^17.7.2
@@ -7510,9 +7510,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -17661,7 +17658,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19867,8 +19864,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@2.0.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -25001,7 +24996,7 @@ snapshots:
       '@vitest/snapshot': 4.1.4
       '@vitest/spy': 4.1.4
       '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -25033,7 +25028,7 @@ snapshots:
       '@vitest/snapshot': 4.1.4
       '@vitest/spy': 4.1.4
       '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1


### PR DESCRIPTION
## Why

CI on `main` is failing `pnpm install --frozen-lockfile`:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with mcp-server/package.json
  - vitest (lockfile: >=4.1.0, manifest: ^4.1.0)
```

## Root cause

The langwatch workspace (`langwatch/pnpm-workspace.yaml`) includes `../mcp-server` as a member, and `langwatch/package.json` carries a security override `"vitest@<4.1.0": ">=4.1.0"`.

When `langwatch/pnpm-lock.yaml` was last generated, mcp-server's vitest was `< 4.1.0`, so that override matched and rewrote the lock's `../mcp-server` importer specifier to `>=4.1.0`.

#4479 then bumped mcp-server to `vitest ^4.1.0` and regenerated `mcp-server/pnpm-lock.yaml`, but it did not touch `langwatch/pnpm-lock.yaml`. `^4.1.0` no longer matches the `<4.1.0` override, so the expected importer specifier is `^4.1.0`, but the stale langwatch lock still recorded `>=4.1.0`. Hence the frozen-install mismatch.

## Fix

Regenerated `langwatch/pnpm-lock.yaml`. The diff is small:

- `../mcp-server` importer vitest specifier `>=4.1.0` -> `^4.1.0` (the actual fix).
- vitest still resolves to `4.1.4`, above the `4.1.0` first patched version, so the CRITICAL alerts (#1239 / #1240) stay closed.
- the re-resolution also deduped `es-module-lexer` to 2.1.0 and nudged `tinyglobby` to 0.2.16; nothing else changes.

The `vitest@<4.1.0` override is kept (it is harmless now and still guards against any future sub-4.1.0 vitest entering the tree).

## Verification

`pnpm install --frozen-lockfile` in `langwatch/` now succeeds ("Lockfile is up to date, resolution step is skipped").
