### PR TITLE
fix(traces): route REST collector + track_event through shared span dedup gate

### DIFF
--- a/langwatch/pnpm-lock.yaml
+++ b/langwatch/pnpm-lock.yaml
@@ -845,7 +845,7 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0
       vitest:
-        specifier: '>=4.1.0'
+        specifier: ^4.1.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.25.12)(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       yargs:
         specifier: ^17.7.2
@@ -7510,9 +7510,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -17661,7 +17658,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19867,8 +19864,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@2.0.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -25001,7 +24996,7 @@ snapshots:
       '@vitest/snapshot': 4.1.4
       '@vitest/spy': 4.1.4
       '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -25033,7 +25028,7 @@ snapshots:
       '@vitest/snapshot': 4.1.4
       '@vitest/spy': 4.1.4
       '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1

--- a/langwatch/src/server/app-layer/traces/__tests__/trace-request-collection.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-request-collection.service.unit.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  PIIRedactionLevel,
+  RecordSpanCommandData,
+} from "../../../event-sourcing/pipelines/trace-processing/schemas/commands";
+import type { OtlpSpan } from "../../../event-sourcing/pipelines/trace-processing/schemas/otlp";
+import type { SpanDedupService } from "../span-dedupe.service";
+import { TraceRequestCollectionService } from "../trace-request-collection.service";
+
+function makeOtlpSpan(overrides: Partial<OtlpSpan> = {}): OtlpSpan {
+  const now = Date.now();
+  return {
+    traceId: "trace_test",
+    spanId: "span_a",
+    parentSpanId: "",
+    name: "span",
+    kind: 1,
+    startTimeUnixNano: String(now * 1_000_000),
+    endTimeUnixNano: String(now * 1_000_000),
+    attributes: [],
+    droppedAttributesCount: 0,
+    events: [],
+    droppedEventsCount: 0,
+    links: [],
+    droppedLinksCount: 0,
+    status: { code: 0, message: "" },
+    traceState: "",
+    flags: 0,
+    ...overrides,
+  } as OtlpSpan;
+}
+
+function makeService(opts: { dedupAcquire?: boolean | null } = {}) {
+  const recordSpan =
+    vi.fn<(data: RecordSpanCommandData) => Promise<void>>(() => Promise.resolve());
+
+  const tryAcquireProcessingLock = vi.fn<
+    SpanDedupService["tryAcquireProcessingLock"]
+  >(() => Promise.resolve(opts.dedupAcquire ?? true));
+  const tryConfirmProcessed = vi.fn<SpanDedupService["tryConfirmProcessed"]>(
+    () => Promise.resolve(),
+  );
+  const tryReleaseOnFailure = vi.fn<SpanDedupService["tryReleaseOnFailure"]>(
+    () => Promise.resolve(),
+  );
+
+  const dedup: SpanDedupService = {
+    tryAcquireProcessingLock,
+    tryConfirmProcessed,
+    tryReleaseOnFailure,
+  };
+
+  const service = new TraceRequestCollectionService({ dedup, recordSpan });
+  return {
+    service,
+    recordSpan,
+    tryAcquireProcessingLock,
+    tryConfirmProcessed,
+    tryReleaseOnFailure,
+  };
+}
+
+const tenantId = "project_test";
+const piiRedactionLevel: PIIRedactionLevel = "ESSENTIAL";
+
+describe("TraceRequestCollectionService.ingestNormalizedSpan", () => {
+  describe("given the dedup gate releases the span", () => {
+    describe("when a single span is ingested", () => {
+      it("dispatches recordSpan exactly once and confirms the lock", async () => {
+        const { service, recordSpan, tryConfirmProcessed } = makeService({
+          dedupAcquire: true,
+        });
+        const span = makeOtlpSpan({ traceId: "trace_x", spanId: "span_1" });
+
+        const result = await service.ingestNormalizedSpan({
+          tenantId,
+          span,
+          resource: null,
+          instrumentationScope: null,
+          piiRedactionLevel,
+        });
+
+        expect(result.status).toBe("collected");
+        expect(recordSpan).toHaveBeenCalledTimes(1);
+        expect(tryConfirmProcessed).toHaveBeenCalledWith(
+          tenantId,
+          "trace_x",
+          "span_1",
+        );
+      });
+    });
+  });
+
+  describe("given the dedup gate has already claimed the span", () => {
+    describe("when the same span is ingested again within the dedup window", () => {
+      it("reports deduped and does not dispatch recordSpan", async () => {
+        const { service, recordSpan, tryConfirmProcessed } = makeService({
+          dedupAcquire: false,
+        });
+        const span = makeOtlpSpan({ traceId: "trace_x", spanId: "span_1" });
+
+        const result = await service.ingestNormalizedSpan({
+          tenantId,
+          span,
+          resource: null,
+          instrumentationScope: null,
+          piiRedactionLevel,
+        });
+
+        expect(result.status).toBe("deduped");
+        expect(recordSpan).not.toHaveBeenCalled();
+        expect(tryConfirmProcessed).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given recordSpan throws", () => {
+    describe("when the dedup lock was acquired by this attempt", () => {
+      it("releases the lock so a retry can proceed", async () => {
+        const { service, recordSpan, tryReleaseOnFailure } = makeService({
+          dedupAcquire: true,
+        });
+        recordSpan.mockRejectedValueOnce(new Error("dispatch failed"));
+        const span = makeOtlpSpan({ traceId: "trace_x", spanId: "span_1" });
+
+        const result = await service.ingestNormalizedSpan({
+          tenantId,
+          span,
+          resource: null,
+          instrumentationScope: null,
+          piiRedactionLevel,
+        });
+
+        expect(result.status).toBe("failed");
+        expect(tryReleaseOnFailure).toHaveBeenCalledWith(
+          tenantId,
+          "trace_x",
+          "span_1",
+        );
+      });
+    });
+  });
+
+  describe("given dedup is unavailable (returns null)", () => {
+    describe("when a span is ingested", () => {
+      it("still dispatches recordSpan", async () => {
+        const { service, recordSpan } = makeService({ dedupAcquire: null });
+        const span = makeOtlpSpan({ traceId: "trace_x", spanId: "span_1" });
+
+        const result = await service.ingestNormalizedSpan({
+          tenantId,
+          span,
+          resource: null,
+          instrumentationScope: null,
+          piiRedactionLevel,
+        });
+
+        expect(result.status).toBe("collected");
+        expect(recordSpan).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/trace-request-collection.service.ts
+++ b/langwatch/src/server/app-layer/traces/trace-request-collection.service.ts
@@ -8,6 +8,8 @@ import type {
 } from "../../event-sourcing/pipelines/trace-processing/schemas/commands";
 import {
   instrumentationScopeSchema,
+  type OtlpInstrumentationScope,
+  type OtlpResource,
   type OtlpSpan,
   resourceSchema,
   spanSchema,
@@ -17,6 +19,17 @@ import type { SpanDedupService } from "./span-dedupe.service";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const SPAN_MAX_PAST_MS = 31 * ONE_DAY_MS;
+
+export type SpanIngestionStatus =
+  | "collected"
+  | "dropped"
+  | "deduped"
+  | "failed";
+
+export interface SpanIngestionResult {
+  status: SpanIngestionStatus;
+  error?: string;
+}
 
 /** An OtlpSpan whose ID fields have been normalized to hex strings. */
 type NormalizedIdSpan = OtlpSpan & { traceId: string; spanId: string };
@@ -160,6 +173,92 @@ export class TraceRequestCollectionService {
     );
   }
 
+  /**
+   * Dedup-gated dispatch of a single span into the trace processing pipeline.
+   *
+   * Both the OTLP collector (via `handleOtlpTraceRequest`) and the REST
+   * `/api/collector` endpoint must route through this method so that a
+   * retry storm on either path cannot bypass the `(tenant, trace, span)`
+   * dedup gate and accumulate duplicate `recordSpan` jobs in the
+   * event-sourcing group queue.
+   *
+   * The caller is responsible for delivering an already-parsed `OtlpSpan`
+   * with hex-normalised id fields (use `normalizeSpanIds` for OTLP input,
+   * or `CollectorSpanUtils.convertSpanToOtlp` for the REST path).
+   */
+  async ingestNormalizedSpan({
+    tenantId,
+    span,
+    resource,
+    instrumentationScope,
+    piiRedactionLevel,
+    otelSpanRef,
+  }: {
+    tenantId: string;
+    span: OtlpSpan;
+    resource: OtlpResource | null;
+    instrumentationScope: OtlpInstrumentationScope | null;
+    piiRedactionLevel: PIIRedactionLevel;
+    otelSpanRef?: import("@opentelemetry/api").Span;
+  }): Promise<SpanIngestionResult> {
+    let lockAcquired = false;
+
+    try {
+      const lockResult = await this.deps.dedup.tryAcquireProcessingLock(
+        tenantId,
+        span.traceId,
+        span.spanId,
+      );
+      if (lockResult === false) {
+        return { status: "deduped" };
+      }
+      lockAcquired = lockResult === true;
+
+      await this.deps.recordSpan({
+        tenantId,
+        span,
+        resource,
+        instrumentationScope,
+        piiRedactionLevel,
+        occurredAt: Date.now(),
+      });
+
+      await this.deps.dedup.tryConfirmProcessed(
+        tenantId,
+        span.traceId,
+        span.spanId,
+      );
+
+      return { status: "collected" };
+    } catch (error) {
+      if (lockAcquired) {
+        await this.deps.dedup.tryReleaseOnFailure(
+          tenantId,
+          span.traceId,
+          span.spanId,
+        );
+      }
+
+      otelSpanRef?.addEvent("span_ingestion_error", {
+        "error.message": error instanceof Error ? error.message : String(error),
+        "tenant.id": tenantId,
+      });
+      this.logger.error(
+        {
+          error,
+          tenantId,
+          traceId: span.traceId,
+          spanId: span.spanId,
+        },
+        "Error dispatching span to the trace processing pipeline",
+      );
+      return {
+        status: "failed",
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
   private async processSpan({
     tenantId,
     otelSpan,
@@ -170,18 +269,11 @@ export class TraceRequestCollectionService {
   }: {
     tenantId: string;
     otelSpan: unknown;
-    resource:
-      | import("../../event-sourcing/pipelines/trace-processing/schemas/otlp").OtlpResource
-      | null;
-    scope:
-      | import("../../event-sourcing/pipelines/trace-processing/schemas/otlp").OtlpInstrumentationScope
-      | null;
+    resource: OtlpResource | null;
+    scope: OtlpInstrumentationScope | null;
     piiRedactionLevel: PIIRedactionLevel;
     otelSpanRef: import("@opentelemetry/api").Span;
-  }): Promise<{
-    status: "collected" | "dropped" | "deduped" | "failed";
-    error?: string;
-  }> {
+  }): Promise<SpanIngestionResult> {
     const spanParseResult = spanSchema.safeParse(otelSpan);
     if (!spanParseResult.success) {
       this.logger.warn(
@@ -210,62 +302,13 @@ export class TraceRequestCollectionService {
       };
     }
 
-    const normalizedSpan = normalizeSpanIds(spanParseResult.data);
-    let lockAcquired = false;
-
-    try {
-      const lockResult = await this.deps.dedup.tryAcquireProcessingLock(
-        tenantId,
-        normalizedSpan.traceId,
-        normalizedSpan.spanId,
-      );
-      if (lockResult === false) {
-        return { status: "deduped" };
-      }
-      lockAcquired = lockResult === true;
-
-      await this.deps.recordSpan({
-        tenantId,
-        span: normalizedSpan,
-        resource,
-        instrumentationScope: scope,
-        piiRedactionLevel,
-        occurredAt: Date.now(),
-      });
-
-      await this.deps.dedup.tryConfirmProcessed(
-        tenantId,
-        normalizedSpan.traceId,
-        normalizedSpan.spanId,
-      );
-
-      return { status: "collected" };
-    } catch (error) {
-      if (lockAcquired) {
-        await this.deps.dedup.tryReleaseOnFailure(
-          tenantId,
-          normalizedSpan.traceId,
-          normalizedSpan.spanId,
-        );
-      }
-
-      otelSpanRef.addEvent("span_ingestion_error", {
-        "error.message": error instanceof Error ? error.message : String(error),
-        "tenant.id": tenantId,
-      });
-      this.logger.error(
-        {
-          error,
-          tenantId,
-          traceId: normalizedSpan.traceId,
-          spanId: normalizedSpan.spanId,
-        },
-        "Error converting raw OTEL span",
-      );
-      return {
-        status: "failed",
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
+    return await this.ingestNormalizedSpan({
+      tenantId,
+      span: normalizeSpanIds(spanParseResult.data),
+      resource,
+      instrumentationScope: scope,
+      piiRedactionLevel,
+      otelSpanRef,
+    });
   }
 }

--- a/langwatch/src/server/routes/collector.ts
+++ b/langwatch/src/server/routes/collector.ts
@@ -494,7 +494,7 @@ secured.access(handlerManagedAuth("ingestion API key resolved in-handler")).post
 
       return c.json({
         message: "No changes",
-        partialSuccess: { rejectedSpans: 0, errorMessage: "" },
+        partialSuccess: { rejectedSpans: 0, dedupedSpans: 0, errorMessage: "" },
       });
     }
 
@@ -520,6 +520,7 @@ secured.access(handlerManagedAuth("ingestion API key resolved in-handler")).post
     }
 
     let rejectedSpans = 0;
+    let dedupedSpans = 0;
     let rejectionErrors: string[] = [];
     try {
       const resource = CollectorSpanUtils.buildResource({
@@ -528,35 +529,38 @@ secured.access(handlerManagedAuth("ingestion API key resolved in-handler")).post
         expectedOutput,
       });
 
-      const results = await Promise.allSettled(
+      const ingestion = getApp().traces.collection;
+      const results = await Promise.all(
         spans.map((span) =>
-          getApp().traces.recordSpan({
+          ingestion.ingestNormalizedSpan({
             tenantId: project.id,
             span: CollectorSpanUtils.convertSpanToOtlp(span),
             resource,
             instrumentationScope: { name: "langwatch.rest.collector" },
             piiRedactionLevel: project.piiRedactionLevel,
-            occurredAt: Date.now(),
           }),
         ),
       );
 
-      const failures = results.filter(
-        (r): r is PromiseRejectedResult => r.status === "rejected",
-      );
+      const failures = results.filter((r) => r.status === "failed");
+      dedupedSpans = results.filter((r) => r.status === "deduped").length;
       rejectedSpans = failures.length;
-      rejectionErrors = failures.map((f) =>
-        f.reason instanceof Error ? f.reason.message : String(f.reason),
-      );
+      rejectionErrors = failures.map((f) => f.error ?? "unknown error");
       if (failures.length > 0) {
         logger.error(
           {
             projectId: project.id,
             traceId,
             failureCount: failures.length,
-            errors: failures.map((f) => f.reason),
+            errors: rejectionErrors,
           },
           "Error dispatching collector spans to event sourcing",
+        );
+      }
+      if (dedupedSpans > 0) {
+        logger.info(
+          { projectId: project.id, traceId, dedupedSpans },
+          "REST collector deduped repeated spans",
         );
       }
     } catch (error) {
@@ -626,6 +630,7 @@ secured.access(handlerManagedAuth("ingestion API key resolved in-handler")).post
       message: "Trace received successfully.",
       partialSuccess: {
         rejectedSpans,
+        dedupedSpans,
         errorMessage: rejectionErrors.join("; "),
       },
     });

--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -797,7 +797,7 @@ secured.access(inRouteAuth).post("/track_event", authMiddleware, requireTracesCr
       }
     }
 
-    await getApp().traces.recordSpan({
+    await getApp().traces.collection.ingestNormalizedSpan({
       tenantId: project.id,
       span: {
         traceId: body.trace_id,
@@ -825,7 +825,6 @@ secured.access(inRouteAuth).post("/track_event", authMiddleware, requireTracesCr
       resource: { attributes: [] },
       instrumentationScope: { name: TRACK_EVENT_SPAN_NAME },
       piiRedactionLevel: project.piiRedactionLevel,
-      occurredAt: Date.now(),
     });
   } catch (error) {
     logger.error({ error }, "unable to dispatch tracked event span");

--- a/specs/traces/rest-collector-span-dedup.feature
+++ b/specs/traces/rest-collector-span-dedup.feature
@@ -1,0 +1,55 @@
+Feature: REST collector deduplicates repeated spans
+  As an operator running the LangWatch trace ingestion pipeline
+  I want the REST `/api/collector` endpoint to skip spans that were already
+  ingested for the same `(tenant, trace, span)` tuple
+  So that an SDK retry loop cannot fan out into the event-sourcing group
+  queue and exhaust Redis memory
+
+  # =========================================================================
+  # Why this exists
+  # =========================================================================
+  #
+  # The OTLP ingestion path (`TraceRequestCollectionService.handleOtlpTraceRequest`)
+  # short-circuits duplicate spans via `SpanDedupService.tryAcquireProcessingLock`
+  # — a Redis SET-NX with TTL keyed on `(tenantId, traceId, spanId)`. When the
+  # same span arrives twice, the second attempt resolves as `deduped` and never
+  # dispatches the `recordSpan` command.
+  #
+  # The legacy REST `/api/collector` endpoint did not call the same dedup gate.
+  # It dispatched `recordSpan` for every span on every request, relying only on
+  # a coarse per-trace MD5 check that misses any payload that changes a single
+  # byte (e.g. timestamps, attached evaluations, partial updates).
+  #
+  # A retry loop on a single trace can therefore enqueue the same span tens of
+  # thousands of times into the same event-sourcing group hash
+  # (`{event-sourcing/jobs}:gq:group:<tenant>/command/recordSpan/trace:<id>:data`).
+  # Each event lands under a fresh event UUID, so the GQ never collapses them.
+  #
+  # =========================================================================
+  # Behavior
+  # =========================================================================
+  #
+  # Both ingestion paths must go through the same dedup gate. A repeated span
+  # — same tenant, same trace_id, same span_id — must dispatch `recordSpan`
+  # exactly once until the dedup TTL expires.
+
+  Background:
+    Given the REST `/api/collector` endpoint accepts span payloads from a project's API key
+    And a span is identified by the tuple `(tenantId, traceId, spanId)`
+    And the dedup TTL window has not expired
+
+  Scenario: A repeated span is skipped on the REST path
+    When the same span is posted twice in the same dedup window
+    Then the trace processing pipeline receives the span exactly once
+    And the duplicate is counted toward the response's `dedupedSpans` summary
+
+  Scenario: Distinct spans on the same trace are not deduped
+    Given a trace containing two distinct spans
+    When both spans are posted in the same request
+    Then the pipeline receives both spans
+    And no span is reported as deduped
+
+  Scenario: Two ingestion paths share the same dedup gate
+    Given a span has already been ingested via the OTLP collector
+    When the same span is posted via the REST collector within the dedup window
+    Then the REST request does not dispatch the span to the pipeline


### PR DESCRIPTION
## Summary

- The OTLP collector path short-circuits duplicate spans via `SpanDedupService.tryAcquireProcessingLock` — a Redis `SET NX` keyed on `(tenantId, traceId, spanId)`. Both legacy REST paths (`/api/collector`, `/api/track_event`) dispatched `recordSpan` directly and bypassed it.
- An SDK retry loop on a single trace can therefore enqueue the same span thousands of times into the event-sourcing group hash (each event lands under a fresh UUID, so the GQ never collapses them). Memory grows unbounded under `noeviction`.
- This PR extracts `TraceRequestCollectionService.ingestNormalizedSpan` and routes both REST endpoints through it. OTLP's existing `processSpan` now delegates to the same method — single source of truth for the dedup gate, no path can drift again.

## Observed pre-fix behavior

Triggered by a Redis capacity alarm. One project's event-sourcing GQ group hash held 303k `recordSpan` events that resolved to only ~14 distinct `(traceId, spanId)` tuples — i.e. ~21k retries per span, ~2.91 GB in a single Redis key (`MEMORY USAGE … SAMPLES 0`). Every sampled payload was tagged `instrumentationScope.name = \"langwatch.rest.collector\"`. The corresponding `span_dedup:<tenant>:…` keys did not exist — confirming the REST path never visited the dedup gate.

## Changes

- `langwatch/src/server/app-layer/traces/trace-request-collection.service.ts` — new public `ingestNormalizedSpan({tenantId, span, resource, instrumentationScope, piiRedactionLevel})` that owns the dedup acquire → `recordSpan` → confirm/release dance. `processSpan` (OTLP path) now delegates to it after parsing and id-normalising.
- `langwatch/src/server/routes/collector.ts` — REST `/api/collector` calls `app.traces.collection.ingestNormalizedSpan(...)` instead of `traces.recordSpan(...)` directly. Adds a `dedupedSpans` counter to the `partialSuccess` response so operators can see when the gate fires.
- `langwatch/src/server/routes/misc.ts` — `/api/track_event` (synthesises one span per tracked event) goes through the same gate. `spanId` here is deterministic (`sha256(traceId:eventId).slice(0,16)`) so a repeated `event_id` on the same trace deduplicates cleanly.
- `specs/traces/rest-collector-span-dedup.feature` — captures the behaviour as a feature file.
- `langwatch/src/server/app-layer/traces/__tests__/trace-request-collection.service.unit.test.ts` — unit coverage for the new method: collected vs. deduped vs. failed paths, lock-release on dispatch error, fallback when dedup is unavailable.

## Test plan

- [x] `pnpm typecheck` (tsgo, clean)
- [x] `pnpm test:unit src/server/app-layer/traces/__tests__/` — 206 tests pass, including the 4 new dedup scenarios
- [x] `pnpm test:unit src/server/event-sourcing/pipelines/trace-processing/` — 487 tests pass
- [x] `pnpm test:unit src/server/background/workers/collectorWorker.unit.test.ts` — 8 tests pass
- [ ] Operational mitigation (separate, manual): `DEL` the runaway GQ group hash + jobs zset for the affected tenant to immediately free Redis. The fix prevents new accumulation but does not garbage-collect existing payloads.