### PR TITLE
fix: make CodeRabbit reviews comment-only so they cannot satisfy approval gate

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,10 +23,12 @@ tone_instructions: >
 
 reviews:
   profile: assertive
-  # Comment-only reviews: CodeRabbit posts its verdict as a COMMENTED event,
-  # never APPROVED/CHANGES_REQUESTED, so its review cannot satisfy the
-  # required_approving_review_count gate. A human must still approve.
-  # (PR #4672 merged on CR's approval alone before this was set.)
+  # request_changes_workflow: false disables CodeRabbit's approval verdicts —
+  # both the automatic post-resolution Approve and the manual @coderabbitai
+  # approve command require this to be true. CodeRabbit's reviews land as
+  # COMMENTED, so they cannot satisfy the required_approving_review_count gate;
+  # a human must still approve. (PR #4672 merged on CR's approval alone before
+  # this was set.)
   request_changes_workflow: false
   high_level_summary: true
   poem: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,9 +23,11 @@ tone_instructions: >
 
 reviews:
   profile: assertive
-  # YAML alone is advisory — branch protection must be configured separately
-  # to require CR's status check. Tracked as AC1b in #3754.
-  request_changes_workflow: true
+  # Comment-only reviews: CodeRabbit posts its verdict as a COMMENTED event,
+  # never APPROVED/CHANGES_REQUESTED, so its review cannot satisfy the
+  # required_approving_review_count gate. A human must still approve.
+  # (PR #4672 merged on CR's approval alone before this was set.)
+  request_changes_workflow: false
   high_level_summary: true
   poem: false
   review_status: true


### PR DESCRIPTION
## Problem

`main` requires 1 approving review (ruleset 5925606 + legacy branch protection, `required_approving_review_count: 1`). CodeRabbit's `.coderabbit.yaml` had `reviews.request_changes_workflow: true`, which makes CodeRabbit submit real GitHub review **events** — including `APPROVED`. GitHub counts an App-submitted `APPROVED` toward the 1-review gate, so CodeRabbit can single-handedly satisfy the human-approval requirement.

## Evidence

This already happened: https://github.com/langwatch/langwatch/pull/4672 merged with CodeRabbit's `APPROVED` as the **only** approving review — the human reviewer (rogeriochaves) only `COMMENTED`.

## The fix

One line in `.coderabbit.yaml`:

```diff
-  request_changes_workflow: true
+  request_changes_workflow: false
```

With `request_changes_workflow: false`, CodeRabbit posts its verdict as a `COMMENTED` event only — never `APPROVED`/`CHANGES_REQUESTED` — so its review cannot satisfy `required_approving_review_count`. A human must still approve before merge. The comment above the key was updated to explain this new intent.

## Backstop considered

A GitHub-side backstop (ruleset `require_last_push_approval`, or restricting approvals to human reviewers) was considered to enforce this independent of the CodeRabbit config. For now the config-only fix is chosen — it closes the immediate gap without a ruleset change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted automated review workflow configuration: updated how the automation reports review outcomes so it posts verdicts as comments rather than as formal approve/request-change statuses. Clarified configuration comments and preserved the requirement that a human must provide final approval on all pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->