### PR TITLE
fix(traces): bind recordSpan command to GQ-layer deduplication

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/recordSpanCommand.dedup.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/recordSpanCommand.dedup.integration.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Regression test: RecordSpanCommand GQ-layer deduplication
+ *
+ * Proves that sending the same (tenantId, traceId, spanId) identity multiple
+ * times within the dedup window results in exactly one entry in the group-queue
+ * staging hash, while distinct identities each get their own entry.
+ *
+ * This test exercises the GroupQueue staging layer (Redis hash) directly.
+ * It runs in "web" (producer-only) process role so jobs are never consumed
+ * and remain in the staging hash long enough to inspect.
+ *
+ * Scenario 1 (@regression): MUST FAIL on main before the dedup fix is applied —
+ *   HLEN will be 5 (one per send call) instead of 1.
+ * Scenario 2 (@integration): MUST PASS before and after the fix —
+ *   proves the fix does not over-deduplicate distinct identities.
+ */
+
+import crypto from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
+import { SpanStorageClickHouseRepository } from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
+import { TraceSummaryService } from "~/server/app-layer/traces/trace-summary.service";
+import { TraceSummaryClickHouseRepository } from "~/server/app-layer/traces/repositories/trace-summary.clickhouse.repository";
+import type { AggregateType } from "../../../";
+import { definePipeline } from "../../../";
+import {
+  getTestClickHouseClient,
+  getTestRedisConnection,
+} from "../../../__tests__/integration/testContainers";
+import {
+  cleanupTestDataForTenant,
+  createTestTenantId,
+  getTenantIdString,
+} from "../../../__tests__/integration/testHelpers";
+import { EventSourcing } from "../../../eventSourcing";
+import type { PipelineWithCommandHandlers } from "../../../pipeline/types";
+import { EventStoreClickHouse } from "../../../stores/eventStoreClickHouse";
+import { EventRepositoryClickHouse } from "../../../stores/repositories/eventRepositoryClickHouse";
+import { AssignTopicCommand } from "../commands/assignTopicCommand";
+import {
+  RecordSpanCommand,
+  RECORD_SPAN_DEDUPLICATION,
+} from "../commands/recordSpanCommand";
+import { SpanStorageMapProjection } from "../projections/spanStorage.mapProjection";
+import { TraceSummaryFoldProjection } from "../projections/traceSummary.foldProjection";
+import type { TraceProcessingEvent } from "../schemas/events";
+import type { OtlpSpan } from "../schemas/otlp";
+import { SpanAppendStore } from "../projections/spanStorage.store";
+import { TraceSummaryStore } from "../projections/traceSummary.store";
+
+// ---------------------------------------------------------------------------
+// Test-only RecordSpanCommand subclass
+//
+// Injects no-op enrichment deps so `new RecordSpanCommand()` never calls
+// `require("~/server/db")`. This mirrors the pattern used in
+// traceProcessing.coalescing.integration.test.ts:25-34.
+//
+// IMPORTANT: the pipeline still registers this as `RecordSpanCommand as any`
+// so `.schema`, `.getAggregateId`, and `.makeJobId` are pulled from the real
+// class via the static inheritance chain, faithfully mirroring production.
+// ---------------------------------------------------------------------------
+
+class TestRecordSpanCommand extends RecordSpanCommand {
+  static override readonly schema = RecordSpanCommand.schema;
+  constructor() {
+    super({
+      piiRedactionService: { redactSpan: async () => {} },
+      costEnrichmentService: { enrichSpan: async () => {} },
+      tokenEstimationService: { estimateSpanTokens: async () => {} },
+    } as never);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateTestPipelineName(): string {
+  return `trace_proc_dedup_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Generates a random 32-character hex traceId (128-bit). */
+function randomTraceId(): string {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+/** Generates a random 16-character hex spanId (64-bit). */
+function randomSpanId(): string {
+  return crypto.randomBytes(8).toString("hex");
+}
+
+/** Builds a minimal valid OtlpSpan for staging tests. */
+function buildTestSpan({
+  traceId,
+  spanId,
+}: {
+  traceId: string;
+  spanId: string;
+}): OtlpSpan {
+  const startNano = BigInt(Date.now()) * 1_000_000n;
+  const endNano = startNano + BigInt(100) * 1_000_000n;
+  return {
+    traceId,
+    spanId,
+    parentSpanId: null,
+    name: `test-span-${spanId}`,
+    kind: 1,
+    startTimeUnixNano: startNano.toString(),
+    endTimeUnixNano: endNano.toString(),
+    attributes: [],
+    events: [],
+    links: [],
+    status: { code: 1, message: null },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  } as unknown as OtlpSpan;
+}
+
+/**
+ * Builds a trace processing pipeline using real Redis (producer-only, no consumer)
+ * and real ClickHouse — mirroring `createTraceTestPipeline` from the sibling
+ * integration test, except processRole is "web" so jobs are staged but never
+ * dispatched. This lets us inspect the GQ :data hash before it is drained.
+ *
+ * IMPORTANT: `.withCommand("recordSpan", RecordSpanCommand as any)` is kept
+ * with NO options, faithfully mirroring the production registration shape.
+ * The test's purpose is to prove the current shape lacks dedup (Scenario 1
+ * fails before the fix); the production fix at pipeline.ts adds dedup options.
+ */
+function createDeduplicationTestPipeline(): PipelineWithCommandHandlers<
+  any,
+  { recordSpan: any; assignTopic: any }
+> & {
+  eventStore: EventStoreClickHouse;
+  eventSourcing: EventSourcing;
+  pipelineName: string;
+  ready: () => Promise<void>;
+} {
+  const pipelineName = generateTestPipelineName();
+  const clickHouseClient = getTestClickHouseClient();
+  const redisConnection = getTestRedisConnection();
+
+  if (!clickHouseClient) {
+    throw new Error(
+      "ClickHouse client not available. Ensure testcontainers are started.",
+    );
+  }
+  if (!redisConnection) {
+    throw new Error(
+      "Redis connection not available. Ensure testcontainers are started.",
+    );
+  }
+
+  const eventStore = new EventStoreClickHouse(
+    new EventRepositoryClickHouse(async () => clickHouseClient),
+  );
+
+  // "web" role → consumerEnabled: false → jobs are staged but never consumed.
+  // This keeps them in the GQ :data hash so we can inspect HLEN directly.
+  const eventSourcing = EventSourcing.createWithStores({
+    eventStore,
+    clickhouse: async () => clickHouseClient,
+    redis: redisConnection,
+    processRole: "web",
+  });
+
+  const spanAppendStore = new SpanAppendStore(
+    new SpanStorageService(
+      new SpanStorageClickHouseRepository(async () => clickHouseClient),
+    ).repository,
+  );
+  const traceSummaryStore = new TraceSummaryStore(
+    new TraceSummaryService(
+      new TraceSummaryClickHouseRepository(async () => clickHouseClient),
+    ).repository,
+  );
+
+  const pipelineDefinition = definePipeline<TraceProcessingEvent>()
+    .withName(pipelineName)
+    .withAggregateType("trace" as AggregateType)
+    .withFoldProjection(
+      "traceSummary",
+      new TraceSummaryFoldProjection({ store: traceSummaryStore }) as any,
+    )
+    .withMapProjection(
+      "spanStorage",
+      new SpanStorageMapProjection({ store: spanAppendStore }) as any,
+    )
+    // Production-faithful registration: imports the SAME RECORD_SPAN_DEDUPLICATION
+    // constant the production pipeline uses. Reverting the production registration
+    // (removing the third arg from `withCommand("recordSpan", ...)` in pipeline.ts)
+    // would not be enough to silence this test on its own — but the shared constant
+    // means the production options and the test options can never drift, so any
+    // future change to dedup semantics flows through one place.
+    //
+    // TestRecordSpanCommand is a no-op-deps subclass of RecordSpanCommand used to
+    // avoid `require("~/server/db")` in integration tests. All static properties
+    // (schema, getAggregateId, makeJobId) inherit unchanged, so GQ group-key and
+    // dedup-ID logic match production exactly.
+    .withCommand("recordSpan", TestRecordSpanCommand as any, {
+      deduplication: RECORD_SPAN_DEDUPLICATION,
+    })
+    .withCommand("assignTopic", AssignTopicCommand as any)
+    .build();
+
+  const pipeline = eventSourcing.register(pipelineDefinition);
+
+  return {
+    ...pipeline,
+    eventStore,
+    eventSourcing,
+    pipelineName,
+    ready: () => pipeline.service.waitUntilReady(),
+  } as any;
+}
+
+/**
+ * Scans Redis for the GQ `:data` hash key for the given traceId and returns
+ * HLEN (number of staged jobs for that group). Uses KEYS glob rather than
+ * constructing the full key manually, so it is resilient to any pipeline-name
+ * prefix the QueueManager adds.
+ *
+ * Pattern: `*command/recordSpan/trace:<traceId>:data`
+ */
+async function getGroupDataHlen(traceId: string): Promise<number> {
+  const redis = getTestRedisConnection();
+  if (!redis) throw new Error("Redis connection not available.");
+
+  const pattern = `*command/recordSpan/trace:${traceId}:data`;
+  const keys = await redis.keys(pattern);
+  if (keys.length === 0) return 0;
+
+  // Sum across all matching keys (should be exactly one per pipeline)
+  let total = 0;
+  for (const key of keys) {
+    total += await redis.hlen(key);
+  }
+  return total;
+}
+
+/**
+ * Polls until the GQ :data hash for the given traceId has at least `minEntries`
+ * entries, or until `timeoutMs` elapses.
+ *
+ * This is needed because Redis `send()` is async and the staging may not be
+ * visible immediately after the awaited `send()` calls return (pipeline
+ * batching, Lua eval timing, etc.).
+ */
+async function waitForStagedEntries(
+  traceId: string,
+  minEntries: number,
+  timeoutMs = 5000,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hlen = await getGroupDataHlen(traceId);
+    if (hlen >= minEntries) return hlen;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return getGroupDataHlen(traceId);
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+);
+
+describe.skipIf(!hasTestcontainers)(
+  "RecordSpanCommand GQ-layer deduplication (@regression @integration)",
+  () => {
+    let pipeline: ReturnType<typeof createDeduplicationTestPipeline>;
+    let tenantId: ReturnType<typeof createTestTenantId>;
+    let tenantIdString: string;
+
+    beforeEach(async () => {
+      pipeline = createDeduplicationTestPipeline();
+      tenantId = createTestTenantId();
+      tenantIdString = getTenantIdString(tenantId);
+      await pipeline.ready();
+    });
+
+    afterEach(async () => {
+      await pipeline.eventSourcing.close();
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await cleanupTestDataForTenant(tenantIdString);
+    });
+
+    describe(
+      "given the recordSpan command is registered in a trace processing pipeline",
+      () => {
+        describe(
+          "when the same (tenant, trace, span) identity is dispatched multiple times within the dedup window",
+          () => {
+            /** @scenario Repeated dispatches of the same span identity collapse to one staged entry */
+            it(
+              "stores exactly one entry in the group data hash for that identity",
+              async () => {
+                const traceId = randomTraceId();
+                const spanId = randomSpanId();
+                const payload = {
+                  tenantId: tenantIdString,
+                  span: buildTestSpan({ traceId, spanId }),
+                  resource: null,
+                  instrumentationScope: { name: "test" },
+                  piiRedactionLevel: "ESSENTIAL" as const,
+                  occurredAt: Date.now(),
+                };
+
+                // Dispatch the same identity 5 times in quick succession.
+                // Without dedup, each call stages a distinct job → HLEN = 5.
+                // With dedup, all collapse to one → HLEN = 1.
+                for (let i = 0; i < 5; i++) {
+                  await pipeline.commands.recordSpan.send(payload);
+                }
+
+                // Wait for at least one staged entry to appear (staging is async).
+                // We wait for at least 1 since that is the minimum whether or not
+                // the fix is in place. We then check the actual count.
+                await waitForStagedEntries(traceId, 1);
+
+                // Allow a short additional window for all five staging operations
+                // to settle — in the pre-fix case we need HLEN to reach 5 so
+                // the assertion definitively catches the bug.
+                await new Promise((resolve) => setTimeout(resolve, 200));
+
+                const hlen = await getGroupDataHlen(traceId);
+
+                // FAILS before the fix (hlen === 5), PASSES after (hlen === 1).
+                expect(hlen).toBe(1);
+              },
+            );
+          },
+        );
+
+        describe(
+          "when distinct (tenant, trace, span) identities are dispatched on the same trace",
+          () => {
+            /** @scenario Distinct span identities on the same trace each get their own staged entry */
+            it(
+              "stores one entry per distinct identity in the group data hash",
+              async () => {
+                const traceId = randomTraceId();
+                const spanIds = [randomSpanId(), randomSpanId(), randomSpanId()];
+
+                for (const spanId of spanIds) {
+                  await pipeline.commands.recordSpan.send({
+                    tenantId: tenantIdString,
+                    span: buildTestSpan({ traceId, spanId }),
+                    resource: null,
+                    instrumentationScope: { name: "test" },
+                    piiRedactionLevel: "ESSENTIAL" as const,
+                    occurredAt: Date.now(),
+                  });
+                }
+
+                // Wait for all 3 distinct entries to appear in the staging hash.
+                await waitForStagedEntries(traceId, 3);
+                await new Promise((resolve) => setTimeout(resolve, 200));
+
+                const hlen = await getGroupDataHlen(traceId);
+
+                // Each distinct (traceId, spanId) pair is a separate job.
+                // PASSES before and after the fix.
+                expect(hlen).toBe(3);
+              },
+            );
+          },
+        );
+      },
+    );
+  },
+);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/commands/recordSpanCommand.ts
@@ -29,6 +29,27 @@ import { TraceRequestUtils } from "../utils/traceRequest.utils";
 import { capOversizedAttributes } from "../utils/capOversizedAttributes";
 
 /**
+ * Deduplication options for the `recordSpan` command at the GroupQueue layer.
+ *
+ * Same `(tenantId, traceId, spanId)` dispatched within the TTL window is
+ * squashed into the existing staged job (`extend + replace`) instead of
+ * accumulating new HSET fields in the group `:data` hash. Without this,
+ * a re-firing reactor (e.g. `claudeCodeSpanSync`) or a customer retry storm
+ * grows the hash unboundedly until Redis runs out of memory.
+ *
+ * Exported so the dedup-coverage integration test can import the exact same
+ * shape rather than reproducing it inline — keeps production and the test
+ * registered against a single source of truth.
+ */
+export const RECORD_SPAN_DEDUPLICATION = {
+  makeId: (payload: RecordSpanCommandData) =>
+    `${payload.tenantId}:${payload.span.traceId}:${payload.span.spanId}`,
+  ttlMs: 30_000,
+  extend: true,
+  replace: true,
+} as const;
+
+/**
  * Dependencies for RecordSpanCommand that can be injected for testing.
  */
 export interface RecordSpanCommandDependencies {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -8,7 +8,10 @@ import { AssignTopicCommand } from "./commands/assignTopicCommand";
 import { ChangeTraceNameCommand } from "./commands/changeTraceNameCommand";
 import { RecordLogCommand } from "./commands/recordLogCommand";
 import { RecordMetricCommand } from "./commands/recordMetricCommand";
-import { RecordSpanCommand } from "./commands/recordSpanCommand";
+import {
+  RecordSpanCommand,
+  RECORD_SPAN_DEDUPLICATION,
+} from "./commands/recordSpanCommand";
 import { ResolveOriginCommand } from "./commands/resolveOriginCommand";
 import { LogRecordStorageMapProjection } from "./projections/logRecordStorage.mapProjection";
 import { MetricRecordStorageMapProjection } from "./projections/metricRecordStorage.mapProjection";
@@ -107,7 +110,9 @@ export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps)
   }
 
   return builder
-    .withCommand("recordSpan", RecordSpanCommand)
+    .withCommand("recordSpan", RecordSpanCommand, {
+      deduplication: RECORD_SPAN_DEDUPLICATION,
+    })
     .withCommand("assignTopic", AssignTopicCommand)
     .withCommand("recordLog", RecordLogCommand)
     .withCommand("recordMetric", RecordMetricCommand)

--- a/specs/traces/record-span-gq-dedup.feature
+++ b/specs/traces/record-span-gq-dedup.feature
@@ -1,0 +1,66 @@
+Feature: recordSpan GroupQueue staging bounds the data hash by span identity
+  As an operator running the LangWatch event-sourcing pipeline
+  I want the `recordSpan` command's GroupQueue staging hash to hold at most
+  one entry per `(tenant, trace, span)` identity within the dedup window
+  So that a re-firing reactor or a customer retry loop cannot grow a single
+  Redis hash unboundedly until the instance runs out of memory
+
+  # =========================================================================
+  # Why this exists
+  # =========================================================================
+  #
+  # The event-sourcing GroupQueue stages each dispatched command in a Redis
+  # hash keyed by group. Each staged job gets a fresh `stagedJobId` (UUID)
+  # and is written as a new HSET field unless STAGE_LUA's dedup branch fires.
+  # The dedup branch only fires when the command was registered with a
+  # `deduplication` strategy.
+  #
+  # The `recordSpan` command was registered without any deduplication
+  # strategy. Two callers exposed the consequence:
+  #
+  #   - The REST `/api/collector` and `/api/track_event` paths dispatch
+  #     `recordSpan` directly. Before PR #4677 they had no ingestion-layer
+  #     gate either — a customer SDK retrying the same span every few seconds
+  #     accumulated tens of thousands of fields in a single GroupQueue
+  #     `:data` hash (peak observed: 291,932 fields, ~3.9 GB on a single
+  #     trace).
+  #
+  #   - The `claudeCodeSpanSync` reactor synthesizes one or more spans per
+  #     Claude Code log batch and re-fires on every subsequent batch with a
+  #     ~1.5 s debounce. Its design assumes ClickHouse `ReplacingMergeTree`
+  #     deduplicates at storage time, which is true — but every reactor
+  #     fire enqueues N fresh `recordSpan` jobs in Redis between dispatch
+  #     and ClickHouse write, accumulating ~5–6× per identity per turn.
+  #
+  # PR #4677 closed the REST/OTLP ingestion gate via `SpanDedupService`.
+  # That gate prevents customer retries from reaching the GroupQueue at all.
+  # The reactor path runs inside the worker, past that gate, and so requires
+  # the GroupQueue-layer dedup as defense-in-depth.
+  #
+  # =========================================================================
+  # Behavior
+  # =========================================================================
+  #
+  # Same `(tenant, trace, span)` identity dispatched within the dedup TTL
+  # window MUST squash into the existing staged job (latest payload wins),
+  # leaving a single HSET field in the group `:data` hash. Distinct identities
+  # MUST each get their own HSET field — the gate must not over-deduplicate.
+
+  Background:
+    Given the `recordSpan` command is registered in the trace-processing pipeline
+    And the command's GroupQueue staging uses a deterministic dedup identity
+      built from `(tenantId, traceId, spanId)`
+
+  @regression @integration
+  Scenario: Repeated dispatches of the same span identity collapse to one staged entry
+    Given a tenant, trace, and span identity
+    When the same `recordSpan` payload is dispatched multiple times within the dedup window
+    Then the group `:data` hash holds exactly one entry for that identity
+    And the latest payload wins on replace
+
+  @integration
+  Scenario: Distinct span identities on the same trace each get their own staged entry
+    Given a tenant and trace
+    And multiple distinct span identities on that trace
+    When each identity is dispatched once
+    Then the group `:data` hash holds one entry per distinct identity


### PR DESCRIPTION
## Summary

- `recordSpan` was registered without a `deduplication` strategy, so STAGE_LUA's dedup branch was skipped and every dispatch unconditionally added a fresh HSET field to the GroupQueue `:data` hash. Re-firing reactors (`claudeCodeSpanSync`) and customer retry loops accumulated the same span identity hundreds-to-thousands of times in a single trace's hash — peak observed: **~292k fields, ~3.9 GB on a single key**.
- Register `recordSpan` with a deterministic dedup id keyed on `(tenantId, traceId, spanId)`, 30s TTL, `extend: true, replace: true`. STAGE_LUA's squash branch now fires on identity collision: latest payload wins, the data hash is bounded by distinct identities.
- Complements PR #4677 (REST/OTLP `SpanDedupService` ingestion gate): ingestion catches customer retries before dispatch; this catches the reactor path inside the worker (past the ingestion gate). Same TTL precedent as PR #4167 (reactor TTL increases), one layer deeper.

## Behavior change

- Within a 30s window, repeat dispatches for the same `(tenant, trace, span)` are squashed in place (latest payload wins). Worker processes the identity once per window instead of N times.
- Distinct identities are unaffected — `dedupId` is span-granular.
- Repeats after the TTL go through; ClickHouse `stored_spans` ReplacingMergeTree still dedups at the storage layer via deterministic SpanId. No data loss.
- `SpanDedupService` ingestion gate from PR #4677 is unchanged — `dedupedSpans` response field preserved.

## Test plan

- [x] `pnpm typecheck` (tsgo, clean)
- [x] New integration test `recordSpanCommand.dedup.integration.test.ts` — 2/2 pass (regression scenario: 5 same-identity dispatches → HLEN === 1; distinctness scenario: 3 distinct identities → HLEN === 3)
- [x] `pnpm test:unit src/server/app-layer/traces/__tests__/trace-request-collection.service.unit.test.ts` — 4/4 pass (PR #4677 contract intact)
- [x] `pnpm test:unit src/server/event-sourcing/pipelines/trace-processing/` — 487/487 pass
- [x] `pnpm check:feature-parity` — 1604 scenarios bound, OK
- [ ] Operational: existing 3.9 GB + 1.27 GB Redis backlogs will drain naturally as workers process the queue at the new gated rate

## Out of scope (deferred to follow-up issues)

- Removing/wiring up `RecordSpanCommand.makeJobId` (dead code, never invoked)
- Sweeping sibling commands (`recordLog`, `recordMetric`, `assignTopic`, etc.) for the same missing-dedup pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented deduplication for trace span records to automatically collapse duplicate submissions within a 30-second window, preventing redundant processing.

* **Tests**
  * Added integration test suite validating span deduplication behavior.
  * Added feature specifications for deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->