### PR TITLE
docs(traces): remove stale comment in recordSpan dedup test

### DIFF
--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/recordSpanCommand.dedup.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/__tests__/recordSpanCommand.dedup.integration.test.ts
@@ -122,11 +122,6 @@ function buildTestSpan({
  * and real ClickHouse — mirroring `createTraceTestPipeline` from the sibling
  * integration test, except processRole is "web" so jobs are staged but never
  * dispatched. This lets us inspect the GQ :data hash before it is drained.
- *
- * IMPORTANT: `.withCommand("recordSpan", RecordSpanCommand as any)` is kept
- * with NO options, faithfully mirroring the production registration shape.
- * The test's purpose is to prove the current shape lacks dedup (Scenario 1
- * fails before the fix); the production fix at pipeline.ts adds dedup options.
  */
 function createDeduplicationTestPipeline(): PipelineWithCommandHandlers<
   any,


### PR DESCRIPTION
## Summary

CodeRabbit flagged a stale doc comment on the merged #4680. The block at lines 126-129 of `recordSpanCommand.dedup.integration.test.ts` described the test's pre-fix TDD state ("kept with NO options ... fails before the fix"), but the test was rebound to the shared `RECORD_SPAN_DEDUPLICATION` constant before merge — so the comment contradicted the code at lines 201-203.

The inline block at lines 190-200 already explains the production-faithful registration. Keeping only that.

## Test plan

- [x] `pnpm typecheck` clean (doc-only change)
- [ ] CI green

## Refs

- Follow-up to merged #4680
- CodeRabbit comment: https://github.com/langwatch/langwatch/pull/4680#discussion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cleaned up test documentation for span recording validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->