### PR TITLE
fix(ops): self-heal GroupQueue pending counter drift via ground-truth reconcile

### DIFF
--- a/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
@@ -1,0 +1,123 @@
+import type { Redis } from "ioredis";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { QueueRedisRepository } from "../../repositories/queue.redis.repository";
+
+let redis: Redis;
+beforeAll(async () => {
+  ({ redisConnection: redis } = await startTestContainers());
+});
+afterAll(async () => {
+  await stopTestContainers();
+});
+
+// Module-level incrementing counter for unique queue names — no Date.now() or random.
+let queueCounter = 0;
+
+describe("QueueRedisRepository.reconcileTotalPending", () => {
+  let repo: QueueRedisRepository;
+
+  beforeEach(() => {
+    repo = new QueueRedisRepository(redis);
+    queueCounter++;
+  });
+
+  describe("given the pending counter has drifted above ground truth", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario Reconcile heals an over-counted pending counter to the live ground truth */
+      it("heals the counter to ground truth and returns the drift", async () => {
+        const queueName = `test-recon-${queueCounter}`;
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+        const groupAJobsKey = `${queueName}:gq:group:groupA:jobs`;
+        const groupBJobsKey = `${queueName}:gq:group:groupB:jobs`;
+        const readyKey = `${queueName}:gq:ready`;
+        const markerKey = `${queueName}:gq:stats:pending-recon-ts`;
+
+        // Clear any leftover marker from a previous run
+        await redis.del(markerKey);
+
+        // Seed: group A has 3 jobs, group B has 2 jobs → ground truth = 5
+        await redis.zadd(groupAJobsKey, 1000, "job-a1", 1001, "job-a2", 1002, "job-a3");
+        await redis.zadd(groupBJobsKey, 2000, "job-b1", 2001, "job-b2");
+
+        // Also add both groups to the ready zset (production shape)
+        await redis.zadd(readyKey, 1, "groupA", 1, "groupB");
+
+        // SET counter = 100 (drifted well above ground truth 5)
+        await redis.set(counterKey, "100");
+
+        // Pre-assert: counter is 100 and is greater than ground truth 5
+        expect(await redis.get(counterKey)).toBe("100");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result).not.toBeNull();
+        expect(result!.counter).toBe(100);
+        expect(result!.groundTruth).toBe(5);
+        expect(result!.drift).toBe(95);
+
+        // Counter must be healed to ground truth
+        expect(await redis.get(counterKey)).toBe("5");
+      });
+    });
+  });
+
+  describe("given the counter already matches ground truth", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario Reconcile returns zero drift when the counter is already accurate */
+      it("returns zero drift and leaves the counter unchanged", async () => {
+        const queueName = `test-recon-${queueCounter}`;
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+        const groupJobsKey = `${queueName}:gq:group:groupX:jobs`;
+        const markerKey = `${queueName}:gq:stats:pending-recon-ts`;
+
+        // Clear any leftover marker
+        await redis.del(markerKey);
+
+        // Seed: 2 jobs in one group, counter = 2 (no drift)
+        await redis.zadd(groupJobsKey, 1000, "job-x1", 1001, "job-x2");
+        await redis.set(counterKey, "2");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result).not.toBeNull();
+        expect(result!.drift).toBe(0);
+        expect(await redis.get(counterKey)).toBe("2");
+      });
+    });
+  });
+
+  describe("given a reconcile already ran within the single-flight window", () => {
+    describe("when reconcile runs again immediately", () => {
+      /** @scenario Single-flight gate prevents a redundant reconcile within the same window */
+      it("returns null on the second call and leaves the counter unchanged from the first heal", async () => {
+        const queueName = `test-recon-${queueCounter}`;
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+        const groupJobsKey = `${queueName}:gq:group:groupY:jobs`;
+        const markerKey = `${queueName}:gq:stats:pending-recon-ts`;
+
+        // Clear any leftover marker
+        await redis.del(markerKey);
+
+        // Seed: 1 job, counter = 999 (drifted)
+        await redis.zadd(groupJobsKey, 1000, "job-y1");
+        await redis.set(counterKey, "999");
+
+        // First call — heals the counter
+        const firstResult = await repo.reconcileTotalPending(queueName);
+        expect(firstResult).not.toBeNull();
+        expect(await redis.get(counterKey)).toBe("1");
+
+        // Second call — marker key should still be set, so it is skipped
+        const secondResult = await repo.reconcileTotalPending(queueName);
+        expect(secondResult).toBeNull();
+
+        // Counter must be unchanged from the first heal
+        expect(await redis.get(counterKey)).toBe("1");
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/integration/pending-counter-reconcile.integration.test.ts
@@ -19,22 +19,24 @@ let queueCounter = 0;
 
 describe("QueueRedisRepository.reconcileTotalPending", () => {
   let repo: QueueRedisRepository;
+  let queueName: string;
+  let markerKey: string;
 
   beforeEach(() => {
     repo = new QueueRedisRepository(redis);
     queueCounter++;
+    queueName = `test-recon-${queueCounter}`;
+    markerKey = `${queueName}:gq:stats:pending-recon-ts`;
   });
 
   describe("given the pending counter has drifted above ground truth", () => {
     describe("when reconcile runs", () => {
       /** @scenario Reconcile heals an over-counted pending counter to the live ground truth */
       it("heals the counter to ground truth and returns the drift", async () => {
-        const queueName = `test-recon-${queueCounter}`;
         const counterKey = `${queueName}:gq:stats:total-pending`;
         const groupAJobsKey = `${queueName}:gq:group:groupA:jobs`;
         const groupBJobsKey = `${queueName}:gq:group:groupB:jobs`;
         const readyKey = `${queueName}:gq:ready`;
-        const markerKey = `${queueName}:gq:stats:pending-recon-ts`;
 
         // Clear any leftover marker from a previous run
         await redis.del(markerKey);
@@ -48,9 +50,6 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
 
         // SET counter = 100 (drifted well above ground truth 5)
         await redis.set(counterKey, "100");
-
-        // Pre-assert: counter is 100 and is greater than ground truth 5
-        expect(await redis.get(counterKey)).toBe("100");
 
         const result = await repo.reconcileTotalPending(queueName);
 
@@ -69,10 +68,8 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
     describe("when reconcile runs", () => {
       /** @scenario Reconcile returns zero drift when the counter is already accurate */
       it("returns zero drift and leaves the counter unchanged", async () => {
-        const queueName = `test-recon-${queueCounter}`;
         const counterKey = `${queueName}:gq:stats:total-pending`;
         const groupJobsKey = `${queueName}:gq:group:groupX:jobs`;
-        const markerKey = `${queueName}:gq:stats:pending-recon-ts`;
 
         // Clear any leftover marker
         await redis.del(markerKey);
@@ -84,6 +81,8 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
         const result = await repo.reconcileTotalPending(queueName);
 
         expect(result).not.toBeNull();
+        expect(result!.counter).toBe(2);
+        expect(result!.groundTruth).toBe(2);
         expect(result!.drift).toBe(0);
         expect(await redis.get(counterKey)).toBe("2");
       });
@@ -94,10 +93,8 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
     describe("when reconcile runs again immediately", () => {
       /** @scenario Single-flight gate prevents a redundant reconcile within the same window */
       it("returns null on the second call and leaves the counter unchanged from the first heal", async () => {
-        const queueName = `test-recon-${queueCounter}`;
         const counterKey = `${queueName}:gq:stats:total-pending`;
         const groupJobsKey = `${queueName}:gq:group:groupY:jobs`;
-        const markerKey = `${queueName}:gq:stats:pending-recon-ts`;
 
         // Clear any leftover marker
         await redis.del(markerKey);
@@ -117,6 +114,60 @@ describe("QueueRedisRepository.reconcileTotalPending", () => {
 
         // Counter must be unchanged from the first heal
         expect(await redis.get(counterKey)).toBe("1");
+      });
+    });
+  });
+
+  describe("given the pending counter is below the actual number of jobs", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario Reconcile corrects an under-counted pending counter upward to ground truth */
+      it("heals the counter upward and returns negative drift", async () => {
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+
+        // Clear any leftover marker
+        await redis.del(markerKey);
+
+        // Seed 7 jobs across groups
+        await redis.zadd(`${queueName}:gq:group:ga:jobs`, 1, "j1", 2, "j2", 3, "j3");
+        await redis.zadd(`${queueName}:gq:group:gb:jobs`, 4, "j4", 5, "j5");
+        await redis.zadd(`${queueName}:gq:group:gc:jobs`, 6, "j6", 7, "j7");
+
+        // SET counter = 3 (under-counted)
+        await redis.set(counterKey, "3");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result).not.toBeNull();
+        expect(result!.counter).toBe(3);
+        expect(result!.groundTruth).toBe(7);
+        expect(result!.drift).toBe(-4);
+
+        // Counter must be healed upward to ground truth
+        expect(await redis.get(counterKey)).toBe("7");
+      });
+    });
+  });
+
+  describe("given no group jobs remain in the queue", () => {
+    describe("when reconcile runs", () => {
+      /** @scenario Reconcile sets the counter to zero when no jobs remain */
+      it("sets the counter to zero and returns the full positive drift", async () => {
+        const counterKey = `${queueName}:gq:stats:total-pending`;
+
+        // Clear any leftover marker
+        await redis.del(markerKey);
+
+        // Seed NO group:*:jobs keys — queue is empty
+        await redis.set(counterKey, "50");
+
+        const result = await repo.reconcileTotalPending(queueName);
+
+        expect(result).not.toBeNull();
+        expect(result!.groundTruth).toBe(0);
+        expect(result!.drift).toBe(50);
+
+        // Counter must be healed to zero
+        expect(await redis.get(counterKey)).toBe("0");
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/queue.service.unit.test.ts
@@ -52,6 +52,7 @@ function createMockRepo(overrides: Partial<QueueRepository> = {}): QueueReposito
     unpauseTenant: vi.fn().mockResolvedValue(undefined),
     listPausedTenants: vi.fn().mockResolvedValue([]),
     drainTenant: vi.fn().mockResolvedValue({ groupsDrained: 0, jobsDrained: 0 }),
+    reconcileTotalPending: vi.fn().mockResolvedValue(null),
     ...overrides,
   };
 }

--- a/langwatch/src/server/app-layer/ops/__tests__/reconcile-pending.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/__tests__/reconcile-pending.unit.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { OpsMetricsCollector } from "../metrics-collector";
+import type { QueueRepository } from "../repositories/queue.repository";
+
+function createMockRedis() {
+  return {
+    pipeline: vi.fn().mockReturnValue({
+      exec: vi.fn().mockResolvedValue([]),
+      get: vi.fn(),
+      zadd: vi.fn(),
+      zremrangebyscore: vi.fn(),
+      smembers: vi.fn(),
+    }),
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue("OK"),
+    info: vi.fn().mockResolvedValue(""),
+    smembers: vi.fn().mockResolvedValue([]),
+    zrange: vi.fn().mockResolvedValue([]),
+  } as unknown as import("ioredis").default;
+}
+
+function createMockRepo(overrides: Partial<QueueRepository> = {}): QueueRepository {
+  return {
+    discoverQueueNames: vi.fn().mockResolvedValue([]),
+    scanQueues: vi.fn().mockResolvedValue([]),
+    getGroupJobs: vi.fn().mockResolvedValue({ jobs: [], total: 0 }),
+    getBlockedSummary: vi.fn().mockResolvedValue({ totalBlocked: 0, clusters: [] }),
+    unblockGroup: vi.fn().mockResolvedValue({ wasBlocked: false }),
+    unblockAll: vi.fn().mockResolvedValue({ unblockedCount: 0 }),
+    drainGroup: vi.fn().mockResolvedValue({ jobsRemoved: 0 }),
+    pausePipeline: vi.fn().mockResolvedValue(undefined),
+    unpausePipeline: vi.fn().mockResolvedValue(undefined),
+    retryBlocked: vi.fn().mockResolvedValue({ wasBlocked: false }),
+    listPausedKeys: vi.fn().mockResolvedValue([]),
+    moveToDlq: vi.fn().mockResolvedValue({ jobsMoved: 0 }),
+    moveAllBlockedToDlq: vi.fn().mockResolvedValue({ movedCount: 0, jobsMoved: 0 }),
+    replayFromDlq: vi.fn().mockResolvedValue({ jobsReplayed: 0 }),
+    replayAllFromDlq: vi.fn().mockResolvedValue({ replayedCount: 0, jobsReplayed: 0 }),
+    canaryRedrive: vi.fn().mockResolvedValue({ redrivenCount: 0, groupIds: [] }),
+    canaryUnblock: vi.fn().mockResolvedValue({ unblockedCount: 0, groupIds: [] }),
+    listDlqGroups: vi.fn().mockResolvedValue([]),
+    drainAllBlockedPreview: vi.fn().mockResolvedValue({ totalAffected: 0, byPipeline: [], byError: [] }),
+    pauseTenant: vi.fn().mockResolvedValue(undefined),
+    unpauseTenant: vi.fn().mockResolvedValue(undefined),
+    listPausedTenants: vi.fn().mockResolvedValue([]),
+    drainTenant: vi.fn().mockResolvedValue({ groupsDrained: 0, jobsDrained: 0 }),
+    reconcileTotalPending: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+describe("OpsMetricsCollector", () => {
+  describe("reconcilePending()", () => {
+    describe("given two queues with opposing drifts", () => {
+      describe("when reconcilePending runs", () => {
+        /**
+         * Opposing per-queue drifts (+30 and -10) must not cancel each other.
+         * The health signal accumulates absolute values so the dashboard tile
+         * always shows total magnitude of drift regardless of direction.
+         */
+        it("accumulates absolute drift values so opposing drifts do not cancel", async () => {
+          const queueRepo = createMockRepo({
+            discoverQueueNames: vi.fn().mockResolvedValue(["queue-alpha", "queue-beta"]),
+            reconcileTotalPending: vi.fn()
+              .mockResolvedValueOnce({ counter: 130, groundTruth: 100, drift: 30 })
+              .mockResolvedValueOnce({ counter: 40, groundTruth: 50, drift: -10 }),
+          });
+
+          const collector = new OpsMetricsCollector({
+            redis: createMockRedis(),
+            queueRepo,
+          });
+
+          // Populate groupQueueNames via the public discovery path
+          await collector.discoverQueues();
+
+          // Call the private method through the public reconcile path.
+          // Access via bracket notation to avoid exposing a test-only public API.
+          await (collector as unknown as { reconcilePending(): Promise<void> }).reconcilePending();
+
+          expect(collector.getDashboardData().pendingDrift).toBe(40);
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/metrics-collector.ts
+++ b/langwatch/src/server/app-layer/ops/metrics-collector.ts
@@ -23,6 +23,7 @@ const logger = createLogger("langwatch:ops:metrics-collector");
 
 const THROUGHPUT_BUFFER_SIZE = 900;
 const METRICS_COLLECT_INTERVAL_MS = 2_000;
+const PENDING_RECONCILE_INTERVAL_MS = 60_000;
 const DASHBOARD_BROADCAST_INTERVAL_MS = 2_000;
 const REDIS_STATE_TTL_SECONDS = 3600;
 const QUEUE_DISCOVERY_INTERVAL_MS = 10_000;
@@ -277,6 +278,7 @@ export class OpsMetricsCollector {
   private collectInterval: ReturnType<typeof setInterval> | null = null;
   private discoveryInterval: ReturnType<typeof setInterval> | null = null;
   private broadcastInterval: ReturnType<typeof setInterval> | null = null;
+  private reconcileInterval: ReturnType<typeof setInterval> | null = null;
   private lastCpuUsage = process.cpuUsage();
   private lastCpuTime = Date.now();
   private currentCpuPercent = 0;
@@ -291,6 +293,7 @@ export class OpsMetricsCollector {
   >();
   private currentJobNameMetrics: JobNameMetrics[] = [];
   private currentPausedKeys: string[] = [];
+  private latestPendingDrift = 0;
   private knownPipelinePaths: string[] = [];
   private isCollecting = false;
   private prevCompleted = new Map<string, number>();
@@ -330,6 +333,10 @@ export class OpsMetricsCollector {
       () => this.discoverQueues(),
       QUEUE_DISCOVERY_INTERVAL_MS,
     );
+    this.reconcileInterval = setInterval(
+      () => this.reconcilePending(),
+      PENDING_RECONCILE_INTERVAL_MS,
+    );
     this.broadcastInterval = setInterval(() => {
       if (this.emitter.listenerCount(DASHBOARD_EVENT) === 0) return;
       try {
@@ -352,6 +359,10 @@ export class OpsMetricsCollector {
     if (this.broadcastInterval) {
       clearInterval(this.broadcastInterval);
       this.broadcastInterval = null;
+    }
+    if (this.reconcileInterval) {
+      clearInterval(this.reconcileInterval);
+      this.reconcileInterval = null;
     }
     this.emitter.removeAllListeners();
   }
@@ -410,6 +421,25 @@ export class OpsMetricsCollector {
       computedAt: new Date(now),
     };
     return this.badgeCountsCache;
+  }
+
+  private async reconcilePending(): Promise<void> {
+    try {
+      let totalDrift = 0;
+      for (const queueName of this.groupQueueNames) {
+        const result = await this.queueRepo.reconcileTotalPending(queueName);
+        if (result) totalDrift += result.drift;
+      }
+      this.latestPendingDrift = totalDrift;
+      if (totalDrift !== 0) {
+        logger.info(
+          { pendingDrift: totalDrift },
+          "Reconciled GroupQueue pending counter to ground truth",
+        );
+      }
+    } catch (err) {
+      logger.warn({ error: err }, "Failed to reconcile pending counter");
+    }
   }
 
   getDashboardData(): DashboardData {
@@ -486,6 +516,7 @@ export class OpsMetricsCollector {
       blockedGroups,
       parkedGroups,
       totalPendingJobs,
+      pendingDrift: this.latestPendingDrift,
       throughputIngestedPerSec: this.currentIngestedPerSec,
       totalCompleted: this.latestTotalCompleted,
       totalFailed: this.latestTotalFailed,

--- a/langwatch/src/server/app-layer/ops/metrics-collector.ts
+++ b/langwatch/src/server/app-layer/ops/metrics-collector.ts
@@ -337,6 +337,7 @@ export class OpsMetricsCollector {
       () => this.reconcilePending(),
       PENDING_RECONCILE_INTERVAL_MS,
     );
+    void this.reconcilePending();
     this.broadcastInterval = setInterval(() => {
       if (this.emitter.listenerCount(DASHBOARD_EVENT) === 0) return;
       try {
@@ -428,7 +429,7 @@ export class OpsMetricsCollector {
       let totalDrift = 0;
       for (const queueName of this.groupQueueNames) {
         const result = await this.queueRepo.reconcileTotalPending(queueName);
-        if (result) totalDrift += result.drift;
+        if (result) totalDrift += Math.abs(result.drift);
       }
       this.latestPendingDrift = totalDrift;
       if (totalDrift !== 0) {

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1423,6 +1423,88 @@ export class QueueRedisRepository implements QueueRepository {
     };
   }
 
+  // ── Counter Reconciliation ──────────────────────────────────────
+
+  /**
+   * Reconcile the total-pending counter against the live ground truth.
+   *
+   * WHY: The `total-pending` counter is incremented at dispatch (INCR) and
+   * decremented at complete (DECR), but several paths leak without a DECR:
+   *   - worker death after dispatch but before complete
+   *   - the 6-hour `:jobs` TTL reaping a group without a DECR
+   *   - MOVE_TO_DLQ_LUA which deletes `:jobs` without decrementing the counter
+   * Over time the counter drifts upward. Since it is read-only ops metadata
+   * (drives the dashboard "pending" tile), overwriting it with the ZCARD-derived
+   * ground truth is safe and does not affect dispatch correctness.
+   *
+   * The reconcile is single-flighted per `singleFlightWindowMs` so only one
+   * pod recomputes per window. It is intentionally off the hot dispatch path.
+   *
+   * See issue #4683.
+   */
+  async reconcileTotalPending(
+    queueName: string,
+    singleFlightWindowMs = 55_000,
+  ): Promise<{ counter: number; groundTruth: number; drift: number } | null> {
+    const prefix = `${queueName}:gq:`;
+    const counterKey = `${prefix}stats:total-pending`;
+    const markerKey = `${prefix}stats:pending-recon-ts`;
+
+    // Single-flight gate: only one pod/cycle runs per window.
+    const acquired = await this.redis.set(
+      markerKey,
+      String(Date.now()),
+      "PX",
+      singleFlightWindowMs,
+      "NX",
+    );
+    if (acquired !== "OK") return null;
+
+    // Read the pre-reconcile counter.
+    const raw = await this.redis.get(counterKey);
+    const counter = Math.max(0, parseInt(raw ?? "0", 10) || 0);
+
+    // Enumerate all group-jobs zsets via SCAN.
+    const jobsKeys: string[] = [];
+    const matchPattern = `${prefix}group:*:jobs`;
+    let cursor = "0";
+    do {
+      const [nextCursor, keys] = await this.redis.scan(
+        cursor,
+        "MATCH",
+        matchPattern,
+        "COUNT",
+        1000,
+      );
+      cursor = nextCursor;
+      for (const key of keys) {
+        jobsKeys.push(key);
+      }
+    } while (cursor !== "0");
+
+    // Pipeline ZCARD for every collected key and sum the results.
+    let groundTruth = 0;
+    if (jobsKeys.length > 0) {
+      const pipeline = this.redis.pipeline();
+      for (const key of jobsKeys) {
+        pipeline.zcard(key);
+      }
+      const results = await pipeline.exec();
+      if (results) {
+        for (const [, val] of results) {
+          groundTruth += Number(val) || 0;
+        }
+      }
+    }
+
+    const drift = counter - groundTruth;
+
+    // Overwrite the counter with the ground truth.
+    await this.redis.set(counterKey, String(groundTruth));
+
+    return { counter, groundTruth, drift };
+  }
+
   // ── Private Filter Helpers ──────────────────────────────────────
 
   private async filterByPipelineName(params: {

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -7,13 +7,17 @@ import type {
   DlqGroupInfo,
   DrainPreview,
   JobEntry,
+  ReconcileResult,
 } from "./queue.repository";
 import { normalizeErrorMessage } from "../normalize-error-message";
+import { createLogger } from "~/utils/logger/server";
 import {
   GROUP_QUEUE_REGISTRY_KEY,
   TTL_HELPER_LUA,
   PARK_HELPER_LUA,
 } from "~/server/event-sourcing/queues/groupQueue/scripts";
+
+const logger = createLogger("langwatch:ops:queue-redis-repository");
 
 // ── Lua Scripts ──────────────────────────────────────────────────────
 
@@ -196,6 +200,7 @@ return count
 const SUMMARY_TOP_N = 200;
 const DLQ_TTL_SECONDS = 604800;
 const SSCAN_BATCH = 500;
+const PENDING_RECONCILE_SCAN_COUNT = 1000;
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -1437,6 +1442,17 @@ export class QueueRedisRepository implements QueueRepository {
    * (drives the dashboard "pending" tile), overwriting it with the ZCARD-derived
    * ground truth is safe and does not affect dispatch correctness.
    *
+   * The ground truth is the authoritative Σ ZCARD over ALL `group:*:jobs` keys
+   * for this queue — intentionally the complete count, distinct from the top-N
+   * sampled per-group dashboard tile.
+   *
+   * A small re-drift from concurrent dispatch/complete INCR/DECR during the SET
+   * window is acceptable and self-corrects on the next scheduled cycle.
+   *
+   * The single-flight window default is shorter than the collector's reconcile
+   * interval so each scheduled cycle can acquire the marker while still guarding
+   * against multi-pod overlap.
+   *
    * The reconcile is single-flighted per `singleFlightWindowMs` so only one
    * pod recomputes per window. It is intentionally off the hot dispatch path.
    *
@@ -1445,7 +1461,7 @@ export class QueueRedisRepository implements QueueRepository {
   async reconcileTotalPending(
     queueName: string,
     singleFlightWindowMs = 55_000,
-  ): Promise<{ counter: number; groundTruth: number; drift: number } | null> {
+  ): Promise<ReconcileResult | null> {
     const prefix = `${queueName}:gq:`;
     const counterKey = `${prefix}stats:total-pending`;
     const markerKey = `${prefix}stats:pending-recon-ts`;
@@ -1474,7 +1490,7 @@ export class QueueRedisRepository implements QueueRepository {
         "MATCH",
         matchPattern,
         "COUNT",
-        1000,
+        PENDING_RECONCILE_SCAN_COUNT,
       );
       cursor = nextCursor;
       for (const key of keys) {
@@ -1483,6 +1499,8 @@ export class QueueRedisRepository implements QueueRepository {
     } while (cursor !== "0");
 
     // Pipeline ZCARD for every collected key and sum the results.
+    // If ANY pipeline entry errors, abort — a flaky ZCARD must never write
+    // a partial under-count as ground truth; the next cycle retries.
     let groundTruth = 0;
     if (jobsKeys.length > 0) {
       const pipeline = this.redis.pipeline();
@@ -1491,7 +1509,11 @@ export class QueueRedisRepository implements QueueRepository {
       }
       const results = await pipeline.exec();
       if (results) {
-        for (const [, val] of results) {
+        for (const [err, val] of results) {
+          if (err) {
+            logger.warn({ error: err }, "ZCARD pipeline error during pending reconcile — aborting to avoid under-count");
+            return null;
+          }
           groundTruth += Number(val) || 0;
         }
       }

--- a/langwatch/src/server/app-layer/ops/repositories/queue.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.repository.ts
@@ -30,6 +30,19 @@ export interface JobEntry {
   data: Record<string, unknown> | null;
 }
 
+/** Result returned by {@link QueueRepository.reconcileTotalPending}. */
+export interface ReconcileResult {
+  /** The value of the counter before this reconcile cycle. */
+  counter: number;
+  /** The authoritative Σ ZCARD over ALL `group:*:jobs` keys for the queue. */
+  groundTruth: number;
+  /**
+   * How far the counter was above ground truth before healing.
+   * Positive = over-counted; negative = under-counted.
+   */
+  drift: number;
+}
+
 export interface QueueRepository {
   discoverQueueNames(): Promise<string[]>;
 
@@ -149,8 +162,7 @@ export interface QueueRepository {
 
   reconcileTotalPending(
     queueName: string,
-    singleFlightWindowMs?: number,
-  ): Promise<{ counter: number; groundTruth: number; drift: number } | null>;
+  ): Promise<ReconcileResult | null>;
 }
 
 export class NullQueueRepository implements QueueRepository {
@@ -250,11 +262,7 @@ export class NullQueueRepository implements QueueRepository {
     return { totalAffected: 0, byPipeline: [], byError: [] };
   }
 
-  async reconcileTotalPending(): Promise<{
-    counter: number;
-    groundTruth: number;
-    drift: number;
-  } | null> {
+  async reconcileTotalPending(): Promise<ReconcileResult | null> {
     return null;
   }
 }

--- a/langwatch/src/server/app-layer/ops/repositories/queue.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.repository.ts
@@ -146,6 +146,11 @@ export interface QueueRepository {
     pipelineFilter?: string;
     errorFilter?: string;
   }): Promise<DrainPreview>;
+
+  reconcileTotalPending(
+    queueName: string,
+    singleFlightWindowMs?: number,
+  ): Promise<{ counter: number; groundTruth: number; drift: number } | null>;
 }
 
 export class NullQueueRepository implements QueueRepository {
@@ -243,5 +248,13 @@ export class NullQueueRepository implements QueueRepository {
 
   async drainAllBlockedPreview(): Promise<DrainPreview> {
     return { totalAffected: 0, byPipeline: [], byError: [] };
+  }
+
+  async reconcileTotalPending(): Promise<{
+    counter: number;
+    groundTruth: number;
+    drift: number;
+  } | null> {
+    return null;
   }
 }

--- a/langwatch/src/server/app-layer/ops/types.ts
+++ b/langwatch/src/server/app-layer/ops/types.ts
@@ -121,6 +121,8 @@ export interface DashboardData {
   blockedGroups: number;
   parkedGroups: number;
   totalPendingJobs: number;
+  // counter − ground-truth drift from the last reconcile cycle (0 = healthy); see #4683
+  pendingDrift: number;
   throughputIngestedPerSec: number;
   totalCompleted: number;
   totalFailed: number;

--- a/specs/ops/pending-counter-reconcile.feature
+++ b/specs/ops/pending-counter-reconcile.feature
@@ -5,8 +5,7 @@ Feature: GroupQueue pending counter ground-truth reconcile
   TTL reaps, or DLQ moves that cannot decrement the counter atomically
 
   Background:
-    Given a GroupQueue with at least one group containing jobs
-    And the pending counter has drifted above the actual number of jobs
+    Given a GroupQueue whose pending counter is tracked separately from the jobs
 
   @integration @regression
   Scenario: Reconcile heals an over-counted pending counter to the live ground truth
@@ -22,6 +21,22 @@ Feature: GroupQueue pending counter ground-truth reconcile
     When the reconcile runs
     Then the pending counter is unchanged
     And the reconcile result reports a drift of 0
+
+  @integration
+  Scenario: Reconcile corrects an under-counted pending counter upward to ground truth
+    Given the pending counter reports 3
+    And the actual job zsets sum to 7 jobs
+    When the reconcile runs
+    Then the pending counter is corrected to 7
+    And the reconcile result reports a drift of -4
+
+  @integration
+  Scenario: Reconcile sets the counter to zero when no jobs remain
+    Given the pending counter reports 50
+    And no jobs remain in the queue
+    When the reconcile runs
+    Then the pending counter is corrected to 0
+    And the reconcile result reports a drift of 50
 
   @integration
   Scenario: Single-flight gate prevents a redundant reconcile within the same window

--- a/specs/ops/pending-counter-reconcile.feature
+++ b/specs/ops/pending-counter-reconcile.feature
@@ -1,0 +1,31 @@
+Feature: GroupQueue pending counter ground-truth reconcile
+  As an operator monitoring the GroupQueue dashboard
+  I want the pending counter to self-heal to the live ground truth
+  So that the "pending jobs" tile reflects reality even after worker deaths,
+  TTL reaps, or DLQ moves that cannot decrement the counter atomically
+
+  Background:
+    Given a GroupQueue with at least one group containing jobs
+    And the pending counter has drifted above the actual number of jobs
+
+  @integration @regression
+  Scenario: Reconcile heals an over-counted pending counter to the live ground truth
+    Given the pending counter reports 100
+    And the actual job zsets sum to 5 jobs
+    When the reconcile runs
+    Then the pending counter is corrected to 5
+    And the reconcile result reports a drift of 95
+
+  @integration
+  Scenario: Reconcile returns zero drift when the counter is already accurate
+    Given the pending counter matches the number of jobs in the queue
+    When the reconcile runs
+    Then the pending counter is unchanged
+    And the reconcile result reports a drift of 0
+
+  @integration
+  Scenario: Single-flight gate prevents a redundant reconcile within the same window
+    Given the reconcile ran once and healed the counter
+    When the reconcile is triggered again immediately within the same window
+    Then the second call is skipped
+    And the counter remains as healed by the first call


### PR DESCRIPTION
## What

Self-heals the GroupQueue `total-pending` counter drift from #4683. A low-cadence (60s), single-flighted reconcile recomputes `total-pending = Σ ZCARD` over the live group set and writes it back, off the hot dispatch path.

## Why

The global `gq:stats:total-pending` counter drifts upward: INCR at stage, DECR at dispatch/complete — but the DECR is permanently lost on ungraceful worker death, the 6h safety-net `:jobs` TTL reap, and `MOVE_TO_DLQ` (deletes `:jobs` without a DECR). The existing reconcile only repairs parked-group / dynamic-cap state and never touches the pending counter, so drift never heals. Production showed a ~12% over-count (a flat ~473k dashboard "Pending" while real Σ ZCARD ≈ 411k and memory was falling). It's read-only ops-dashboard metadata — nothing reads it for dispatch decisions — so recomputing it to ground truth is safe.

## How

- `QueueRedisRepository.reconcileTotalPending(queueName)`: single-flight NX marker (`stats:pending-recon-ts`), SCAN `group:*:jobs`, pipelined ZCARD, sum, `SET total-pending = sum`, return `ReconcileResult { counter, groundTruth, drift }`. **Aborts without writing** if any ZCARD errors, so a flaky read never persists a partial under-count.
- `OpsMetricsCollector`: a 60s interval (eager first run on start) calls it per queue, accumulates `abs(drift)` into `pendingDrift` on the dashboard model and logs when non-zero — the drift observability promised in prior incidents, never shipped.
- New `DashboardData.pendingDrift`.

## Scope

**In:** the self-healing reconcile + drift surfacing + tests + spec.
**Out (deliberate, deferred in #4683):** the DECR-at-dispatch structural Lua rewrite — higher risk (the naive 2-script version inverts drift via the retry paths) and unnecessary, since the reconcile heals every leak path regardless of cause. The hot dispatch/complete counter Lua is untouched. Production counter resync is an operator action, not part of this PR.

## Evidence

| Check | Result |
|---|---|
| Regression test: heal, zero-drift, under-count, empty-queue, single-flight | 5/5 pass (real testcontainer Redis) |
| Red phase confirmed before fix | `reconcileTotalPending is not a function` (3/3 fail) |
| Collector drift-gauge unit test (abs-sum +30/−10 → 40) | pass |
| ops + groupQueue unit suites | 63/63 pass |
| groupQueue counter-Lua integration (hot Lua unchanged) | 132/132 pass |
| `git diff` excludes `groupQueue/scripts.ts` | confirmed untouched |
| `pnpm typecheck` | clean |
| `pnpm check:feature-parity` | 1624 scenarios bound |

Reviewed by principles / hygiene / test / security agents; all must-fix items applied (error-abort, abs-drift, interface cleanup, added under-count + empty-queue coverage).

Refs #4683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays pending counter drift metrics, showing the difference between tracked and actual job counts.
  * System automatically reconciles and heals inaccurate pending counters against ground truth in the background.

* **Tests**
  * Added comprehensive test coverage for pending counter reconciliation logic and metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->