### PR TITLE
perf(clickhouse): add time predicate to claude-code log re-fold (stop stored_log_records cold scan)

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.integration.test.ts
@@ -25,13 +25,19 @@ const tag = nanoid();
 // short retention floor (a fixed past date would be GC'd by the _retention_days
 // TTL). The +/-2-day hint window dwarfs any host-vs-container clock skew, so the
 // host-side Date.now() hint reliably covers the container-side insert time.
-async function insertMarkedLog(
-  tenantId: string,
-  traceId: string,
-  spanId: string,
-  agoSec: number,
-  marked: boolean,
-) {
+async function insertMarkedLog({
+  tenantId,
+  traceId,
+  spanId,
+  agoSec,
+  marked,
+}: {
+  tenantId: string;
+  traceId: string;
+  spanId: string;
+  agoSec: number;
+  marked: boolean;
+}) {
   await ch.command({
     query: `
       INSERT INTO stored_log_records
@@ -75,10 +81,28 @@ describe("getMarkedClaudeCodeLogsByTrace partition hint", () => {
   const traceId = `${tag}-trace`;
 
   beforeAll(async () => {
-    await insertMarkedLog(tenantId, traceId, `${tag}-a`, 10, true);
-    await insertMarkedLog(tenantId, traceId, `${tag}-b`, 5, true);
+    await insertMarkedLog({
+      tenantId,
+      traceId,
+      spanId: `${tag}-a`,
+      agoSec: 10,
+      marked: true,
+    });
+    await insertMarkedLog({
+      tenantId,
+      traceId,
+      spanId: `${tag}-b`,
+      agoSec: 5,
+      marked: true,
+    });
     // An unmarked log for the same trace must never be returned.
-    await insertMarkedLog(tenantId, traceId, `${tag}-c`, 5, false);
+    await insertMarkedLog({
+      tenantId,
+      traceId,
+      spanId: `${tag}-c`,
+      agoSec: 5,
+      marked: false,
+    });
   });
 
   describe("when a TimeUnixMs hint around the turn is supplied", () => {

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.integration.test.ts
@@ -10,27 +10,26 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLAUDE_CODE_KIND_ATTR } from "../../claude-code-log-to-span";
-import { LogRecordStorageClickHouseRepository } from "../log-record-storage.clickhouse.repository";
 import {
   startTestContainers,
   stopTestContainers,
 } from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { CLAUDE_CODE_KIND_ATTR } from "../../claude-code-log-to-span";
+import { LogRecordStorageClickHouseRepository } from "../log-record-storage.clickhouse.repository";
 
 let ch: ClickHouseClient;
 let repo: LogRecordStorageClickHouseRepository;
 const tag = nanoid();
 
-// A fixed turn time, so the assertions don't couple the container clock
-// (now64) to the host clock (Date.now): both the inserted TimeUnixMs and the
-// hint are derived from this constant.
-const TURN_MS = 1_700_000_000_000;
-
+// Insert at server `now64(3)` minus a few seconds so the rows stay inside the
+// short retention floor (a fixed past date would be GC'd by the _retention_days
+// TTL). The +/-2-day hint window dwarfs any host-vs-container clock skew, so the
+// host-side Date.now() hint reliably covers the container-side insert time.
 async function insertMarkedLog(
   tenantId: string,
   traceId: string,
   spanId: string,
-  timeMs: number,
+  agoSec: number,
   marked: boolean,
 ) {
   await ch.command({
@@ -41,7 +40,7 @@ async function insertMarkedLog(
          ScopeVersion, CreatedAt, UpdatedAt, _retention_days)
       VALUES
         ({pid:String}, {tenantId:String}, {traceId:String}, {spanId:String},
-         fromUnixTimestamp64Milli(toInt64({timeMs:String})), 9, 'INFO', '{}',
+         now64(3) - {agoSec:UInt32}, 9, 'INFO', '{}',
          ${marked ? `map('${CLAUDE_CODE_KIND_ATTR}', 'model')` : `map()`},
          map(), 'com.anthropic.claude_code.events', NULL, now64(3), now64(3), 30)
     `,
@@ -50,7 +49,7 @@ async function insertMarkedLog(
       tenantId,
       traceId,
       spanId,
-      timeMs: String(timeMs),
+      agoSec,
     },
   });
 }
@@ -64,8 +63,8 @@ beforeAll(async () => {
 afterAll(async () => {
   if (ch) {
     await ch.exec({
-      query: `ALTER TABLE stored_log_records DELETE WHERE startsWith(ProjectionId, {tag:String})`,
-      query_params: { tag },
+      query: `ALTER TABLE stored_log_records DELETE WHERE TenantId = {tenantId:String} AND startsWith(ProjectionId, {tag:String})`,
+      query_params: { tenantId: `${tag}-project`, tag },
     });
   }
   await stopTestContainers();
@@ -76,24 +75,19 @@ describe("getMarkedClaudeCodeLogsByTrace partition hint", () => {
   const traceId = `${tag}-trace`;
 
   beforeAll(async () => {
-    await insertMarkedLog(tenantId, traceId, `${tag}-a`, TURN_MS - 10_000, true);
-    await insertMarkedLog(tenantId, traceId, `${tag}-b`, TURN_MS - 5_000, true);
+    await insertMarkedLog(tenantId, traceId, `${tag}-a`, 10, true);
+    await insertMarkedLog(tenantId, traceId, `${tag}-b`, 5, true);
     // An unmarked log for the same trace must never be returned.
-    await insertMarkedLog(tenantId, traceId, `${tag}-c`, TURN_MS - 5_000, false);
+    await insertMarkedLog(tenantId, traceId, `${tag}-c`, 5, false);
   });
 
   describe("when a TimeUnixMs hint around the turn is supplied", () => {
     it("returns exactly the marked logs, ordered by time", async () => {
-      const unbounded = await repo.getMarkedClaudeCodeLogsByTrace(tenantId, traceId);
-      // eslint-disable-next-line no-console
-      console.error("DBG_UNBOUNDED_TIMES", JSON.stringify(unbounded.map(r => ({s: r.spanId, t: r.timeUnixMs}))));
       const rows = await repo.getMarkedClaudeCodeLogsByTrace(
         tenantId,
         traceId,
-        TURN_MS,
+        Date.now(),
       );
-      // eslint-disable-next-line no-console
-      console.error("DBG_HINTED", JSON.stringify(rows.map(r => r.spanId)), "TURN_MS", TURN_MS);
 
       expect(rows.map((r) => r.spanId)).toEqual([`${tag}-a`, `${tag}-b`]);
     });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * Verifies the TimeUnixMs partition hint on getMarkedClaudeCodeLogsByTrace:
+ * the hinted read (and the unbounded fallback) return the same marked logs, so
+ * adding the partition predicate is correctness-preserving while letting the
+ * scan prune `stored_log_records` weekly partitions instead of cold-scanning S3.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLAUDE_CODE_KIND_ATTR } from "../../claude-code-log-to-span";
+import { LogRecordStorageClickHouseRepository } from "../log-record-storage.clickhouse.repository";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../../event-sourcing/__tests__/integration/testContainers";
+
+let ch: ClickHouseClient;
+let repo: LogRecordStorageClickHouseRepository;
+const tag = nanoid();
+
+// A fixed turn time, so the assertions don't couple the container clock
+// (now64) to the host clock (Date.now): both the inserted TimeUnixMs and the
+// hint are derived from this constant.
+const TURN_MS = 1_700_000_000_000;
+
+async function insertMarkedLog(
+  tenantId: string,
+  traceId: string,
+  spanId: string,
+  timeMs: number,
+  marked: boolean,
+) {
+  await ch.command({
+    query: `
+      INSERT INTO stored_log_records
+        (ProjectionId, TenantId, TraceId, SpanId, TimeUnixMs, SeverityNumber,
+         SeverityText, Body, Attributes, ResourceAttributes, ScopeName,
+         ScopeVersion, CreatedAt, UpdatedAt, _retention_days)
+      VALUES
+        ({pid:String}, {tenantId:String}, {traceId:String}, {spanId:String},
+         fromUnixTimestamp64Milli(toInt64({timeMs:String})), 9, 'INFO', '{}',
+         ${marked ? `map('${CLAUDE_CODE_KIND_ATTR}', 'model')` : `map()`},
+         map(), 'com.anthropic.claude_code.events', NULL, now64(3), now64(3), 30)
+    `,
+    query_params: {
+      pid: `${tag}-${spanId}`,
+      tenantId,
+      traceId,
+      spanId,
+      timeMs: String(timeMs),
+    },
+  });
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  repo = new LogRecordStorageClickHouseRepository(async () => ch);
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE stored_log_records DELETE WHERE startsWith(ProjectionId, {tag:String})`,
+      query_params: { tag },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("getMarkedClaudeCodeLogsByTrace partition hint", () => {
+  const tenantId = `${tag}-project`;
+  const traceId = `${tag}-trace`;
+
+  beforeAll(async () => {
+    await insertMarkedLog(tenantId, traceId, `${tag}-a`, TURN_MS - 10_000, true);
+    await insertMarkedLog(tenantId, traceId, `${tag}-b`, TURN_MS - 5_000, true);
+    // An unmarked log for the same trace must never be returned.
+    await insertMarkedLog(tenantId, traceId, `${tag}-c`, TURN_MS - 5_000, false);
+  });
+
+  describe("when a TimeUnixMs hint around the turn is supplied", () => {
+    it("returns exactly the marked logs, ordered by time", async () => {
+      const unbounded = await repo.getMarkedClaudeCodeLogsByTrace(tenantId, traceId);
+      // eslint-disable-next-line no-console
+      console.error("DBG_UNBOUNDED_TIMES", JSON.stringify(unbounded.map(r => ({s: r.spanId, t: r.timeUnixMs}))));
+      const rows = await repo.getMarkedClaudeCodeLogsByTrace(
+        tenantId,
+        traceId,
+        TURN_MS,
+      );
+      // eslint-disable-next-line no-console
+      console.error("DBG_HINTED", JSON.stringify(rows.map(r => r.spanId)), "TURN_MS", TURN_MS);
+
+      expect(rows.map((r) => r.spanId)).toEqual([`${tag}-a`, `${tag}-b`]);
+    });
+  });
+
+  describe("when no hint is supplied (unbounded fallback)", () => {
+    it("returns the same marked logs", async () => {
+      const rows = await repo.getMarkedClaudeCodeLogsByTrace(tenantId, traceId);
+
+      expect(rows.map((r) => r.spanId)).toEqual([`${tag}-a`, `${tag}-b`]);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
@@ -37,6 +37,23 @@ const repoCapturingInsert = () => {
 const insertedRow = (insert: ReturnType<typeof vi.fn>) =>
   insert.mock.calls[0]![0].values[0] as { _retention_days: number };
 
+const repoCapturingQuery = () => {
+  const query = vi
+    .fn()
+    .mockResolvedValue({ json: async () => [] as unknown[] });
+  const resolveClient = (async () => ({ query })) as unknown as ConstructorParameters<
+    typeof LogRecordStorageClickHouseRepository
+  >[0];
+  const repo = new LogRecordStorageClickHouseRepository(resolveClient);
+  return { repo, query };
+};
+
+const capturedQuery = (query: ReturnType<typeof vi.fn>) =>
+  query.mock.calls[0]![0] as {
+    query: string;
+    query_params: Record<string, unknown>;
+  };
+
 describe("LogRecordStorageClickHouseRepository.insertLogRecord", () => {
   describe("when the log record is part of a Claude Code fold", () => {
     /** @scenario "A folded Claude Code log is retained only briefly" */
@@ -84,6 +101,46 @@ describe("LogRecordStorageClickHouseRepository.insertLogRecord", () => {
       await repo.insertLogRecord(makeRecord({ attributes: {} }), 308);
 
       expect(insertedRow(insert)._retention_days).toBe(308);
+    });
+  });
+});
+
+describe("LogRecordStorageClickHouseRepository.getMarkedClaudeCodeLogsByTrace", () => {
+  // stored_log_records is PARTITION BY toYearWeek(TimeUnixMs); the read must
+  // carry a TimeUnixMs predicate to prune partitions instead of cold-scanning
+  // every weekly partition (incl. cold S3).
+  describe("when the caller provides the turn's approximate time", () => {
+    it("bounds the scan to a TimeUnixMs window in both the outer and dedup scopes", async () => {
+      const { repo, query } = repoCapturingQuery();
+      const occurredAtMs = 1_700_000_000_000;
+
+      await repo.getMarkedClaudeCodeLogsByTrace(
+        "project_test",
+        "trace-1",
+        occurredAtMs,
+      );
+
+      const { query: sql, query_params } = capturedQuery(query);
+      // Predicate present in both the outer SELECT and the dedup subquery.
+      expect(sql.match(/TimeUnixMs >= fromUnixTimestamp64Milli/g)).toHaveLength(
+        2,
+      );
+      const windowMs = 2 * 24 * 60 * 60 * 1000;
+      expect(query_params.fromMs).toBe(occurredAtMs - windowMs);
+      expect(query_params.toMs).toBe(occurredAtMs + windowMs);
+    });
+  });
+
+  describe("when the caller does not provide a time", () => {
+    it("omits the TimeUnixMs predicate (unbounded fallback, unchanged behavior)", async () => {
+      const { repo, query } = repoCapturingQuery();
+
+      await repo.getMarkedClaudeCodeLogsByTrace("project_test", "trace-1");
+
+      const { query: sql, query_params } = capturedQuery(query);
+      expect(sql).not.toContain("TimeUnixMs >= fromUnixTimestamp64Milli");
+      expect(query_params.fromMs).toBeUndefined();
+      expect(query_params.toMs).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
@@ -83,6 +83,7 @@ export class LogRecordStorageClickHouseRepository
   async getMarkedClaudeCodeLogsByTrace(
     tenantId: string,
     traceId: string,
+    occurredAtMs?: number,
   ): Promise<StoredLogRecordRow[]> {
     EventUtils.validateTenantId(
       { tenantId },
@@ -90,11 +91,38 @@ export class LogRecordStorageClickHouseRepository
     );
 
     const client = await this.resolveClient(tenantId);
+
+    // `stored_log_records` is `PARTITION BY toYearWeek(TimeUnixMs)` and tiered to
+    // S3 after the hot window. Filtering only on TenantId + TraceId can't prune
+    // partitions, so the read walks every weekly partition (incl. cold S3) — a
+    // burst of S3 GETs on every claude-code log re-fold. When the caller knows
+    // the turn's approximate time we bound the scan to a ±2-day window around it.
+    // A turn's logs all land within its lifetime, so the window is generous
+    // headroom; without a hint we fall back to the unbounded scan (correctness
+    // is identical either way).
+    const partitionWindowMs = 2 * 24 * 60 * 60 * 1000;
+    const hasWindow = typeof occurredAtMs === "number" && occurredAtMs > 0;
+    // Qualify the bound with the table name: the outer SELECT aliases
+    // `toUnixTimestamp64Milli(TimeUnixMs) AS TimeUnixMs`, and ClickHouse would
+    // otherwise resolve a bare `TimeUnixMs` in WHERE to that ms-integer alias
+    // instead of the DateTime64 column, making the partition bound nonsensical.
+    const timeFilter = hasWindow
+      ? `AND ${TABLE_NAME}.TimeUnixMs >= fromUnixTimestamp64Milli({fromMs:Int64}) ` +
+        `AND ${TABLE_NAME}.TimeUnixMs <= fromUnixTimestamp64Milli({toMs:Int64})`
+      : "";
+    const timeParams = hasWindow
+      ? {
+          fromMs: occurredAtMs - partitionWindowMs,
+          toMs: occurredAtMs + partitionWindowMs,
+        }
+      : {};
+
     // Dedup to the latest version of each distinct stored log (the table is a
     // ReplacingMergeTree(UpdatedAt) keyed on TenantId,TraceId,SpanId,ProjectionId);
     // the IN-tuple over max(UpdatedAt) returns one row per record. TenantId is
-    // the first predicate (no other id is unique across tenants).
-    const result = await client.query({
+    // the first predicate (no other id is unique across tenants). The partition
+    // window is applied to both scopes so the dedup sees the same row set.
+            const result = await client.query({
       query: `
         SELECT
           TraceId,
@@ -107,18 +135,25 @@ export class LogRecordStorageClickHouseRepository
         FROM ${TABLE_NAME}
         WHERE TenantId = {tenantId:String}
           AND TraceId = {traceId:String}
+          ${timeFilter}
           AND Attributes[{kindKey:String}] != ''
           AND (TenantId, TraceId, SpanId, ProjectionId, UpdatedAt) IN (
             SELECT TenantId, TraceId, SpanId, ProjectionId, max(UpdatedAt)
             FROM ${TABLE_NAME}
             WHERE TenantId = {tenantId:String}
               AND TraceId = {traceId:String}
+              ${timeFilter}
               AND Attributes[{kindKey:String}] != ''
             GROUP BY TenantId, TraceId, SpanId, ProjectionId
           )
         ORDER BY TimeUnixMs ASC
       `,
-      query_params: { tenantId, traceId, kindKey: CLAUDE_CODE_KIND_ATTR },
+      query_params: {
+        tenantId,
+        traceId,
+        kindKey: CLAUDE_CODE_KIND_ATTR,
+        ...timeParams,
+      },
       format: "JSONEachRow",
     });
 

--- a/langwatch/src/server/app-layer/traces/repositories/log-record-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/log-record-storage.repository.ts
@@ -24,6 +24,7 @@ export interface LogRecordStorageRepository {
   getMarkedClaudeCodeLogsByTrace(
     tenantId: string,
     traceId: string,
+    occurredAtMs?: number,
   ): Promise<StoredLogRecordRow[]>;
 }
 
@@ -34,6 +35,7 @@ export class NullLogRecordStorageRepository
   async getMarkedClaudeCodeLogsByTrace(
     _tenantId: string,
     _traceId: string,
+    _occurredAtMs?: number,
   ): Promise<StoredLogRecordRow[]> {
     return [];
   }

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -368,10 +368,11 @@ export class PipelineRegistry {
     });
 
     const claudeCodeSpanSyncReactor = createClaudeCodeSpanSyncReactor({
-      getMarkedClaudeCodeLogs: (tenantId, traceId) =>
+      getMarkedClaudeCodeLogs: (tenantId, traceId, occurredAtMs) =>
         this.deps.repositories.logRecordStorage.getMarkedClaudeCodeLogsByTrace(
           tenantId,
           traceId,
+          occurredAtMs,
         ),
       recordSpan: recordSpanDispatch.fn,
     });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/claudeCodeSpanSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/claudeCodeSpanSync.reactor.ts
@@ -26,6 +26,7 @@ export interface ClaudeCodeSpanSyncReactorDeps {
   getMarkedClaudeCodeLogs: (
     tenantId: string,
     traceId: string,
+    occurredAtMs?: number,
   ) => Promise<StoredLogRecordRow[]>;
   recordSpan: CommandDispatcher<RecordSpanCommandData>;
 }
@@ -74,7 +75,13 @@ export function createClaudeCodeSpanSyncReactor(
       const traceId = String(event.aggregateId);
 
       try {
-        const rows = await deps.getMarkedClaudeCodeLogs(tenantId, traceId);
+        // The triggering log event's occurredAt bounds the stored_log_records
+        // scan to the turn's partitions instead of cold-scanning S3.
+        const rows = await deps.getMarkedClaudeCodeLogs(
+          tenantId,
+          traceId,
+          event.occurredAt,
+        );
         if (rows.length === 0) return;
 
         const records = rows.map(rowToRecord);


### PR DESCRIPTION
## Evidence

In the last 24h of prod ClickHouse logs, `stored_log_records` is a newly-prominent cold-scan table: ~7.8k `coldScan:true` warns/day, concentrated entirely in one shape (`paramKeys: [tenantId, traceId, kindKey]`). That shape is the claude-code log re-fold read.

`stored_log_records` is `PARTITION BY toYearWeek(TimeUnixMs)` and tiered to S3 after the hot window. The read filters only on `TenantId` + `TraceId`, so it can't prune partitions and walks every weekly partition (incl. cold S3) on each fold. Latency is fine (turns are small), but each cold partition is a burst of S3 GETs, and the `claudeCodeSpanSync` reactor re-reads the whole turn on every claude-code log batch.

## Suspected cause

`getMarkedClaudeCodeLogsByTrace` has no predicate on `TimeUnixMs` (the partition key). The reactor that calls it already holds the triggering log event's `occurredAt`, but never passed it down, so the read always took the unbounded path.

## Proposed fix

Thread `event.occurredAt` from the reactor into `getMarkedClaudeCodeLogsByTrace` as a +/-2-day `TimeUnixMs` window (a turn's logs all land within its lifetime, so the window is generous headroom). Applied symmetrically to the outer scan and the IN-tuple dedup subquery so the dedup sees the same row set. The hint is optional: without it the read falls back to the unbounded scan, so correctness is unchanged either way.

One subtlety the integration test caught: the outer SELECT aliases `toUnixTimestamp64Milli(TimeUnixMs) AS TimeUnixMs`, which shadows the column. A bare `TimeUnixMs` in the WHERE resolves to that ms-integer alias, so `TimeUnixMs <= fromUnixTimestamp64Milli(toMs)` compared a ms-integer against a `DateTime64` coerced to seconds and returned nothing. The bound is therefore qualified as `stored_log_records.TimeUnixMs` to force the column.

## Expected impact

The fold read prunes to the turn's weekly partitions instead of all of them. Headline metric is partitions pruned and the projected S3 GET reduction, not latency (the read returns few rows). No change to which logs are returned.

## EXPLAIN check

The `/ops` EXPLAIN endpoint reaches only the shared instance, where the claude-code-logging tenants have no `stored_log_records` data (0 parts), so a real granule delta isn't reproducible there (same limitation noted on earlier per-tenant-instance PRs). The structural plan confirms the predicate reaches the partition-pruning layer:

Old (no time predicate):
```
ReadFromMergeTree (langwatch.stored_log_records)   -- no partition condition
```

New (with the `TimeUnixMs` window):
```
MinMax
  Condition: and((TimeUnixMs in (-Inf, '1700172800']), (TimeUnixMs in ['1699827200', +Inf)))
Partition
  Keys: ...
```

## Test plan

- `log-record-storage.clickhouse.repository.integration.test.ts` (new, testcontainers + real ClickHouse): asserts the hinted read returns exactly the marked logs (and not the unmarked one), and that the unbounded fallback returns the same set. This test is what surfaced the alias-shadow bug above.
- `log-record-storage.clickhouse.repository.unit.test.ts`: asserts the `TimeUnixMs` predicate is injected into both query scopes with the right window params, and omitted (unbounded) when no hint is given.
- `pnpm typecheck` clean; repo + reactor unit suites green.

Advisory PR from the ClickHouse slow-query optimizer. Open for review, not for self-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit and integration tests verifying retrieval of marked log entries both with and without an approximate time hint.

* **Improvements**
  * Log retrieval can now be optionally bounded by an event timestamp, reducing scan scope and improving query performance.
  * Event processing now supplies event timestamps to log lookups so searches are limited to the relevant time range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->