### PR TITLE
fix: scope public-share authorization to projectId

### DIFF
--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -848,6 +848,112 @@ describe("RBAC Integration Tests", () => {
         expect(mockCtx.publiclyShared).toBe(true);
       });
 
+      describe("when scoping the public-share fallback to the project", () => {
+        // A share row that only exists in project-a. The findFirst mock honors
+        // the where clause's projectId so the query scoping is actually
+        // exercised (a `mockResolvedValue` would pass regardless of the fix).
+        function seedShareForProject(projectId: string) {
+          mockPrisma.project.findUnique.mockResolvedValue({
+            team: {
+              id: "team-123",
+              members: [],
+              organization: { members: [] },
+            },
+          });
+          mockPrisma.publicShare.findFirst.mockImplementation(
+            async ({ where }: { where: any }) =>
+              where.projectId === projectId &&
+              where.resourceType === "TRACE" &&
+              where.resourceId === "trace-123"
+                ? {
+                    id: "share-123",
+                    projectId,
+                    resourceType: "TRACE",
+                    resourceId: "trace-123",
+                  }
+                : null,
+          );
+        }
+
+        it("scopes the public-share lookup by the calling project", async () => {
+          seedShareForProject("project-a");
+
+          const middleware = checkPermissionOrPubliclyShared(
+            checkProjectPermission("workflows:view" as Permission),
+            { resourceType: "TRACE", resourceParam: "traceId" },
+          );
+
+          await middleware({
+            ctx: mockCtx,
+            input: { projectId: "project-a", traceId: "trace-123" },
+            next: mockNext,
+          });
+
+          expect(mockPrisma.publicShare.findFirst).toHaveBeenCalledWith(
+            expect.objectContaining({
+              where: expect.objectContaining({ projectId: "project-a" }),
+            }),
+          );
+        });
+
+        it("authorizes a same-project share (regression-safe)", async () => {
+          seedShareForProject("project-a");
+
+          const middleware = checkPermissionOrPubliclyShared(
+            checkProjectPermission("workflows:view" as Permission),
+            { resourceType: "TRACE", resourceParam: "traceId" },
+          );
+
+          const result = await middleware({
+            ctx: mockCtx,
+            input: { projectId: "project-a", traceId: "trace-123" },
+            next: mockNext,
+          });
+
+          expect(result).toBe("success");
+          expect(mockCtx.publiclyShared).toBe(true);
+        });
+
+        it("denies a cross-project read of a share that belongs to another project", async () => {
+          // Share lives in project-a; caller reads the same trace id under project-b.
+          seedShareForProject("project-a");
+
+          const middleware = checkPermissionOrPubliclyShared(
+            checkProjectPermission("workflows:view" as Permission),
+            { resourceType: "TRACE", resourceParam: "traceId" },
+          );
+
+          await expect(
+            middleware({
+              ctx: mockCtx,
+              input: { projectId: "project-b", traceId: "trace-123" },
+              next: mockNext,
+            }),
+          ).rejects.toThrow(TRPCError);
+        });
+
+        it("denies a stale share row from another project for a re-created same-id trace", async () => {
+          // A lingering share for trace-123 in project-a must not authorize a
+          // newly created trace-123 living under project-b.
+          seedShareForProject("project-a");
+
+          const middleware = checkPermissionOrPubliclyShared(
+            checkProjectPermission("workflows:view" as Permission),
+            { resourceType: "TRACE", resourceParam: "traceId" },
+          );
+
+          await expect(
+            middleware({
+              ctx: mockCtx,
+              input: { projectId: "project-b", traceId: "trace-123" },
+              next: mockNext,
+            }),
+          ).rejects.toThrow(
+            "You do not have permission and this resource is not publicly shared",
+          );
+        });
+      });
+
       it("should throw UNAUTHORIZED when no permission and not shared", async () => {
         mockPrisma.project.findUnique.mockResolvedValue({
           team: {

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -1504,6 +1504,7 @@ export const checkPermissionOrPubliclyShared =
     if (!allowed) {
       const sharedResource = await ctx.prisma.publicShare.findFirst({
         where: {
+          projectId: input.projectId,
           resourceType:
             typeof resourceType === "function"
               ? resourceType(input)


### PR DESCRIPTION
## Why

Issue #4531 (P1) reports a cross-tenant authorization hole. When a user lacks direct permission, `checkPermissionOrPubliclyShared` in `langwatch/src/server/api/rbac.ts` falls back to looking up a `PublicShare` row, but the `where` clause matched only on `(resourceType, resourceId)` and was not scoped to `input.projectId` even though the downstream read uses the caller-supplied project id.

With the orphan cleanup removed in #4526, a stale `PublicShare` row for a resource id in project A could authorize a read of the same resource id under project B, and same-project trace-id reuse could inherit an old public URL. This is a live-share authorization issue independent of the orphan sweep.

## What changed

- `langwatch/src/server/api/rbac.ts`: add `projectId: input.projectId` to the `publicShare.findFirst` `where` clause in `checkPermissionOrPubliclyShared`.
- `langwatch/src/server/api/__tests__/rbac-integration.test.ts`: extend the existing `checkPermissionOrPubliclyShared` suite with project-scoping coverage.

## How it works

The public-share fallback now only authorizes a resource when the matching `PublicShare` row belongs to the same `projectId` the caller is reading under. Cross-project and stale-reuse shares fail with the existing `UNAUTHORIZED` error, while legitimate same-project shares are unaffected (no behavior change). The generic constraint `InputType extends { projectId: string }` already guarantees `input.projectId` is present and type-safe, and this aligns with the repo convention of always scoping project-level Prisma queries by `projectId`.

## Test plan

- `pnpm typecheck` (tsgo, `tsconfig.tsgo.json`): clean, 0 errors.
- `npx vitest run src/server/api/__tests__/rbac-integration.test.ts`: 135 passed, 1 pre-existing skip.
- Scenarios added:
  - Lookup is scoped by `projectId` (asserts the `where` clause carries the calling project).
  - Same-project share still authorizes the read (regression-safe).
  - Cross-project share for the same resource id is now `UNAUTHORIZED`.
  - Stale share row from another project does not authorize a re-created same-id trace (`UNAUTHORIZED` with the existing message).

## Anything surprising?

The new tests mock `publicShare.findFirst` with an implementation that honors `where.projectId`, rather than a flat `mockResolvedValue`. A `mockResolvedValue` would pass regardless of the fix; the implementation-aware mock genuinely exercises the query scoping. As a check, temporarily reverting the one-line fix makes the scoping and same-project tests fail, confirming the tests are load-bearing.

Fixes #4531

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed a critical security issue in the permission system where publicly shared resources could be accessed across different projects. Public shares are now properly scoped and isolated to their respective projects, preventing unauthorized cross-project access attempts and ensuring proper access control boundaries are maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->