### PR TITLE
test(traces): deflake span-storage dedup integration test (stale fixture loses RMT merge)

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -103,9 +103,20 @@ beforeAll(async () => {
 
   // A stale earlier version of the first span: the dedup must return the
   // latest version (no `stale` marker), never this one.
+  //
+  // Override StartTime as well as UpdatedAt: stored_spans is
+  // ReplacingMergeTree(StartTime), so a tied StartTime lets the engine
+  // collapse the two versions at merge time keeping whichever was inserted
+  // last among the tie (the stale row here, inserted after the live span 0)
+  // — leaving the read with only the stale row to dedup. A strictly older
+  // StartTime makes the stale row deterministically lose the merge
+  // regardless of merge timing or shard load. (Same fix the events fixture
+  // below already applies for `evt-span-1`.)
   await insertRows([
     makeSpanRow(0, {
       SpanAttributes: { idx: "0", stale: "yes" },
+      StartTime: new Date(base - 10_000),
+      EndTime: new Date(base - 10_000 + 50),
       UpdatedAt: new Date(base - 10_000),
       CreatedAt: new Date(base - 10_000),
     }),


### PR DESCRIPTION
## Summary

- `stored_spans` is `ReplacingMergeTree(StartTime)`, but the single-trace dedup query uses `max(UpdatedAt)`. The "returns latest version, not stale" fixture inserted a stale span-0 version that **shared** the live row's `StartTime` (a tied engine version) and inserted it last. A background merge can resolve the tie by keeping the last-inserted row (the stale one), leaving the read with only the stale row to dedup — `max(UpdatedAt)` then returns the stale value and the assertion fails.
- Give the stale fixture row a strictly older `StartTime` so it deterministically loses the `ReplacingMergeTree(StartTime)` version comparison regardless of merge timing. Same pattern the sibling `evt-span-1` fixture in this file already uses.
- **Test-only.** Production dedup query is untouched.

The underlying production hazard — `stored_spans` is the lone `ReplacingMergeTree` table in `00002_create_schema.sql` that uses `StartTime` instead of `UpdatedAt`, so real upsert collisions can silently return stale data post-merge — is tracked separately in #4678.

## Test plan

- [x] Ran `pnpm test:integration src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts` 5 times in a row locally — 5/5 green, 0 flakes, ~9s avg wall-clock per run.
- [x] All 6 tests in the file pass every run, including "returns the latest version of a duplicated span, not the stale one".
- [ ] CI integration shard passes.