### PR TITLE
fix(spa): make route chunk-load failures recoverable instead of permanent

### DIFF
--- a/langwatch/src/pages/__tests__/not-found-chunk-error.integration.test.tsx
+++ b/langwatch/src/pages/__tests__/not-found-chunk-error.integration.test.tsx
@@ -58,20 +58,13 @@ describe("NotFoundOrErrorPage", () => {
       expect(screen.getByRole("button", { name: /Reload app/ })).toBeDefined();
     });
 
-    it("records a fresh cooldown and reloads on click", () => {
+    it("writes a fresh cooldown timestamp on click", () => {
       sessionStorage.setItem(RELOAD_AT_KEY, "1");
-      const reloadSpy = vi.fn();
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, reload: reloadSpy },
-        writable: true,
-        configurable: true,
-      });
 
       render(<NotFoundOrErrorPage />, { wrapper: Wrapper });
       fireEvent.click(screen.getByRole("button", { name: /Reload app/ }));
 
       expect(Number(sessionStorage.getItem(RELOAD_AT_KEY))).toBeGreaterThan(1);
-      expect(reloadSpy).toHaveBeenCalledOnce();
     });
   });
 

--- a/langwatch/src/pages/__tests__/not-found-chunk-error.integration.test.tsx
+++ b/langwatch/src/pages/__tests__/not-found-chunk-error.integration.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RELOAD_AT_KEY } from "~/utils/chunkReload";
+
+vi.mock("react-router", () => ({
+  useRouteError: vi.fn(),
+}));
+
+vi.mock("~/components/ui/link", () => ({
+  Link: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import { useRouteError } from "react-router";
+import NotFoundOrErrorPage from "../_not-found";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>;
+}
+
+const mockedUseRouteError = vi.mocked(useRouteError);
+
+describe("NotFoundOrErrorPage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when the error is a chunk load failure", () => {
+    beforeEach(() => {
+      mockedUseRouteError.mockReturnValue(
+        new Error(
+          "Failed to fetch dynamically imported module: https://app.langwatch.ai/assets/messages-DNgD42jM.js",
+        ),
+      );
+    });
+
+    it("renders the chunk-specific title and hint", () => {
+      render(<NotFoundOrErrorPage />, { wrapper: Wrapper });
+
+      expect(screen.getByText("Failed to load page")).toBeDefined();
+      expect(
+        screen.getByText(/browser extension or network issue may be blocking/),
+      ).toBeDefined();
+    });
+
+    it("renders a Reload app button", () => {
+      render(<NotFoundOrErrorPage />, { wrapper: Wrapper });
+
+      expect(screen.getByRole("button", { name: /Reload app/ })).toBeDefined();
+    });
+
+    it("records a fresh cooldown and reloads on click", () => {
+      sessionStorage.setItem(RELOAD_AT_KEY, "1");
+      const reloadSpy = vi.fn();
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, reload: reloadSpy },
+        writable: true,
+        configurable: true,
+      });
+
+      render(<NotFoundOrErrorPage />, { wrapper: Wrapper });
+      fireEvent.click(screen.getByRole("button", { name: /Reload app/ }));
+
+      expect(Number(sessionStorage.getItem(RELOAD_AT_KEY))).toBeGreaterThan(1);
+      expect(reloadSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("when the error is a generic runtime error", () => {
+    beforeEach(() => {
+      mockedUseRouteError.mockReturnValue(
+        new Error("Cannot read properties of undefined"),
+      );
+    });
+
+    it("renders the generic error title without the reload button", () => {
+      render(<NotFoundOrErrorPage />, { wrapper: Wrapper });
+
+      expect(screen.getByText("Something went wrong")).toBeDefined();
+      expect(screen.queryByRole("button", { name: /Reload app/ })).toBeNull();
+    });
+  });
+
+  describe("when there is no error (404)", () => {
+    beforeEach(() => {
+      mockedUseRouteError.mockReturnValue(undefined);
+    });
+
+    it("renders the not-found page without the reload button", () => {
+      render(<NotFoundOrErrorPage />, { wrapper: Wrapper });
+
+      expect(screen.getByText("Page not found")).toBeDefined();
+      expect(screen.queryByRole("button", { name: /Reload app/ })).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/pages/_not-found.tsx
+++ b/langwatch/src/pages/_not-found.tsx
@@ -1,8 +1,17 @@
-import { Box, Button, Code, Heading, Text, VStack } from "@chakra-ui/react";
-import { Ghost } from "lucide-react";
+import {
+  Box,
+  Button,
+  Code,
+  Heading,
+  HStack,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { Ghost, RotateCcw } from "lucide-react";
 import { useRouteError } from "react-router";
 
 import { Link } from "~/components/ui/link";
+import { isChunkLoadError, RELOAD_AT_KEY } from "~/utils/chunkReload";
 
 /**
  * Shared fallback for (a) unknown routes (path="*") and (b) errors thrown
@@ -33,20 +42,30 @@ export default function NotFoundOrErrorPage() {
   const explicitStatus = error?.status;
   const errorMessage =
     error && "message" in error && error.message ? error.message : null;
+  const isChunkError = error != null && isChunkLoadError(error);
   // A real exception arrived (errorMessage present, no HTTP status) →
   // it's a runtime throw, not a 404. Promote to "Something went wrong"
   // so the message + stack get surfaced.
   const isRuntimeError = errorMessage !== null && explicitStatus === undefined;
   const status = explicitStatus ?? (isRuntimeError ? 500 : 404);
   const title =
-    status === 404 ? "Page not found" : "Something went wrong";
+    status === 404
+      ? "Page not found"
+      : isChunkError
+        ? "Failed to load page"
+        : "Something went wrong";
   const description =
     status === 404
       ? "The URL you were headed to does not exist (anymore). Use the nav to get back on track."
-      : errorMessage ??
-        "An unexpected error occurred. Try going back to the dashboard.";
+      : isChunkError
+        ? "A required file could not be loaded. A browser extension or network issue may be blocking part of the app."
+        : (errorMessage ??
+          "An unexpected error occurred. Try going back to the dashboard.");
   const stack =
-    isRuntimeError && error && "stack" in error && typeof error.stack === "string"
+    isRuntimeError &&
+    error &&
+    "stack" in error &&
+    typeof error.stack === "string"
       ? error.stack
       : null;
   return (
@@ -77,9 +96,32 @@ export default function NotFoundOrErrorPage() {
             {stack}
           </Code>
         )}
-        <Link href="/">
-          <Button colorPalette="orange">Back to dashboard</Button>
-        </Link>
+        <HStack gap={3}>
+          {isChunkError && (
+            <Button
+              colorPalette="orange"
+              onClick={() => {
+                try {
+                  sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()));
+                } catch {
+                  // sessionStorage may be unavailable
+                }
+                window.location.reload();
+              }}
+            >
+              <RotateCcw size={14} />
+              Reload app
+            </Button>
+          )}
+          <Link href="/">
+            <Button
+              colorPalette={isChunkError ? undefined : "orange"}
+              variant={isChunkError ? "outline" : "solid"}
+            >
+              Back to dashboard
+            </Button>
+          </Link>
+        </HStack>
       </VStack>
     </Box>
   );

--- a/langwatch/src/server/__tests__/static-handler.unit.test.ts
+++ b/langwatch/src/server/__tests__/static-handler.unit.test.ts
@@ -1,12 +1,13 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createServer, request as httpRequest, type Server } from "http";
-import {
+import fs, {
   mkdtempSync,
   mkdirSync,
   rmSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
+import { Readable } from "stream";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { AddressInfo } from "net";
@@ -186,9 +187,46 @@ describe("serveStaticOrFallback", () => {
         unlinkSync(ephemeralPath);
       });
 
-      it("returns 404 instead of an unhandled 500", async () => {
+      it("returns 404 — openSync fails cleanly, no crash", async () => {
         const res = await fetch(`${baseUrl}/assets/${ephemeralName}`);
         expect(res.status).toBe(404);
+      });
+    });
+  });
+
+  describe("given a file whose read stream errors after it opens", () => {
+    describe("when the stream emits 'error' before any bytes are sent", () => {
+      it("responds 500 without crashing the server", async () => {
+        // The atomic openSync+fd design makes a mid-stream error all but
+        // impossible from a deleted file (the held fd keeps the inode alive),
+        // but pipeWithErrorHandling still guards every other I/O error (EIO
+        // etc). Force one to prove it becomes a clean 500 rather than an
+        // unhandled 'error' that would crash the process.
+        const spy = vi
+          .spyOn(fs, "createReadStream")
+          .mockImplementationOnce(((_path: fs.PathLike, options?: unknown) => {
+            // Release the real fd the handler opened so the test leaks nothing.
+            const fd = (options as { fd?: number } | undefined)?.fd;
+            if (typeof fd === "number") {
+              try {
+                fs.closeSync(fd);
+              } catch {
+                // already closed
+              }
+            }
+            const stream = new Readable({ read() {} });
+            // Emit after the handler attaches its 'error' listener and pipes.
+            queueMicrotask(() =>
+              stream.emit("error", new Error("forced stream error")),
+            );
+            return stream as unknown as ReturnType<typeof fs.createReadStream>;
+          }) as typeof fs.createReadStream);
+
+        const res = await fetch(`${baseUrl}/assets/index-abc123.js`);
+
+        expect(res.status).toBe(500);
+        expect(await res.text()).toContain("Internal Server Error");
+        spy.mockRestore();
       });
     });
   });

--- a/langwatch/src/server/__tests__/static-handler.unit.test.ts
+++ b/langwatch/src/server/__tests__/static-handler.unit.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createServer, request as httpRequest, type Server } from "http";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { AddressInfo } from "net";
@@ -157,6 +163,25 @@ describe("serveStaticOrFallback", () => {
       const port = (server.address() as AddressInfo).port;
       const res = await rawRequest(port, "/assets/../../etc/passwd");
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe("when a file is deleted between open and read (TOCTOU)", () => {
+    it("returns 404 instead of crashing with an unhandled stream error", async () => {
+      const ephemeralPath = join(
+        clientDistDir,
+        "assets",
+        "ephemeral-abc123.js",
+      );
+      writeFileSync(ephemeralPath, "console.log('ephemeral');\n");
+
+      const res = await fetch(`${baseUrl}/assets/ephemeral-abc123.js`);
+      expect(res.status).toBe(200);
+
+      unlinkSync(ephemeralPath);
+
+      const res2 = await fetch(`${baseUrl}/assets/ephemeral-abc123.js`);
+      expect(res2.status).toBe(404);
     });
   });
 });

--- a/langwatch/src/server/__tests__/static-handler.unit.test.ts
+++ b/langwatch/src/server/__tests__/static-handler.unit.test.ts
@@ -166,22 +166,30 @@ describe("serveStaticOrFallback", () => {
     });
   });
 
-  describe("when a file is deleted between open and read (TOCTOU)", () => {
-    it("returns 404 instead of crashing with an unhandled stream error", async () => {
-      const ephemeralPath = join(
-        clientDistDir,
-        "assets",
-        "ephemeral-abc123.js",
-      );
+  describe("given an asset that existed at deploy time", () => {
+    const ephemeralName = "ephemeral-abc123.js";
+    let ephemeralPath: string;
+
+    beforeAll(() => {
+      ephemeralPath = join(clientDistDir, "assets", ephemeralName);
       writeFileSync(ephemeralPath, "console.log('ephemeral');\n");
+    });
 
-      const res = await fetch(`${baseUrl}/assets/ephemeral-abc123.js`);
+    it("serves the file normally", async () => {
+      const res = await fetch(`${baseUrl}/assets/${ephemeralName}`);
       expect(res.status).toBe(200);
+      expect(await res.text()).toContain("ephemeral");
+    });
 
-      unlinkSync(ephemeralPath);
+    describe("when the file is deleted mid-deploy before the next request", () => {
+      beforeAll(() => {
+        unlinkSync(ephemeralPath);
+      });
 
-      const res2 = await fetch(`${baseUrl}/assets/ephemeral-abc123.js`);
-      expect(res2.status).toBe(404);
+      it("returns 404 instead of an unhandled 500", async () => {
+        const res = await fetch(`${baseUrl}/assets/${ephemeralName}`);
+        expect(res.status).toBe(404);
+      });
     });
   });
 });

--- a/langwatch/src/server/__tests__/static-handler.unit.test.ts
+++ b/langwatch/src/server/__tests__/static-handler.unit.test.ts
@@ -1,22 +1,22 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { createServer, request as httpRequest, type Server } from "http";
 import fs, {
-  mkdtempSync,
   mkdirSync,
+  mkdtempSync,
   rmSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
-import { Readable } from "stream";
+import { createServer, request as httpRequest, type Server } from "http";
+import type { AddressInfo } from "net";
 import { tmpdir } from "os";
 import { join } from "path";
-import type { AddressInfo } from "net";
+import { Readable } from "stream";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { serveStaticOrFallback } from "../static-handler";
 
 function rawRequest(
   port: number,
-  rawPath: string
+  rawPath: string,
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const req = httpRequest(
@@ -28,9 +28,9 @@ function rawRequest(
           resolve({
             status: res.statusCode ?? 0,
             body: Buffer.concat(chunks).toString("utf8"),
-          })
+          }),
         );
-      }
+      },
     );
     req.on("error", reject);
     req.end();
@@ -47,15 +47,15 @@ describe("serveStaticOrFallback", () => {
     mkdirSync(join(clientDistDir, "assets"), { recursive: true });
     writeFileSync(
       join(clientDistDir, "assets", "index-abc123.js"),
-      "console.log('hello from index-abc123');\n"
+      "console.log('hello from index-abc123');\n",
     );
     writeFileSync(
       join(clientDistDir, "assets", "main-deadbeef.css"),
-      "body { color: red; }\n"
+      "body { color: red; }\n",
     );
     writeFileSync(
       join(clientDistDir, "index.html"),
-      "<!doctype html><html><body><div id=root></div></body></html>"
+      "<!doctype html><html><body><div id=root></div></body></html>",
     );
 
     server = createServer((req, res) => {
@@ -85,7 +85,7 @@ describe("serveStaticOrFallback", () => {
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("application/javascript");
       expect(res.headers.get("cache-control")).toBe(
-        "public, max-age=31536000, immutable"
+        "public, max-age=31536000, immutable",
       );
       expect(await res.text()).toContain("hello from index-abc123");
     });
@@ -95,7 +95,7 @@ describe("serveStaticOrFallback", () => {
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/css");
       expect(res.headers.get("cache-control")).toBe(
-        "public, max-age=31536000, immutable"
+        "public, max-age=31536000, immutable",
       );
     });
   });
@@ -202,25 +202,26 @@ describe("serveStaticOrFallback", () => {
         // but pipeWithErrorHandling still guards every other I/O error (EIO
         // etc). Force one to prove it becomes a clean 500 rather than an
         // unhandled 'error' that would crash the process.
-        const spy = vi
-          .spyOn(fs, "createReadStream")
-          .mockImplementationOnce(((_path: fs.PathLike, options?: unknown) => {
-            // Release the real fd the handler opened so the test leaks nothing.
-            const fd = (options as { fd?: number } | undefined)?.fd;
-            if (typeof fd === "number") {
-              try {
-                fs.closeSync(fd);
-              } catch {
-                // already closed
-              }
+        const spy = vi.spyOn(fs, "createReadStream").mockImplementationOnce(((
+          _path: fs.PathLike,
+          options?: unknown,
+        ) => {
+          // Release the real fd the handler opened so the test leaks nothing.
+          const fd = (options as { fd?: number } | undefined)?.fd;
+          if (typeof fd === "number") {
+            try {
+              fs.closeSync(fd);
+            } catch {
+              // already closed
             }
-            const stream = new Readable({ read() {} });
-            // Emit after the handler attaches its 'error' listener and pipes.
-            queueMicrotask(() =>
-              stream.emit("error", new Error("forced stream error")),
-            );
-            return stream as unknown as ReturnType<typeof fs.createReadStream>;
-          }) as typeof fs.createReadStream);
+          }
+          const stream = new Readable({ read() {} });
+          // Emit after the handler attaches its 'error' listener and pipes.
+          queueMicrotask(() =>
+            stream.emit("error", new Error("forced stream error")),
+          );
+          return stream as unknown as ReturnType<typeof fs.createReadStream>;
+        }) as typeof fs.createReadStream);
 
         const res = await fetch(`${baseUrl}/assets/index-abc123.js`);
 

--- a/langwatch/src/server/static-handler.ts
+++ b/langwatch/src/server/static-handler.ts
@@ -60,7 +60,7 @@ export function serveStaticOrFallback({
   }
 
   const staticPath = path.join(clientDistDir, normalizedRelative);
-  if (tryServeFile(res, staticPath, pathname)) {
+  if (tryServeFile({ res, filePath: staticPath, pathname })) {
     return true;
   }
 
@@ -73,7 +73,7 @@ export function serveStaticOrFallback({
   }
 
   const indexHtml = path.join(clientDistDir, "index.html");
-  return tryServeSpaFallback(res, indexHtml);
+  return tryServeSpaFallback({ res, indexHtmlPath: indexHtml });
 }
 
 /**
@@ -81,11 +81,15 @@ export function serveStaticOrFallback({
  * existsSync and createReadStream. Returns false when the file doesn't exist
  * or isn't a regular file so the caller can fall through.
  */
-function tryServeFile(
-  res: ServerResponse,
-  filePath: string,
-  pathname: string,
-): boolean {
+function tryServeFile({
+  res,
+  filePath,
+  pathname,
+}: {
+  res: ServerResponse;
+  filePath: string;
+  pathname: string;
+}): boolean {
   let fd: number;
   try {
     fd = fs.openSync(filePath, "r");
@@ -110,7 +114,7 @@ function tryServeFile(
     res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
   }
 
-  pipeWithErrorHandling(fs.createReadStream("", { fd }), res);
+  pipeWithErrorHandling({ stream: fs.createReadStream("", { fd }), res });
   return true;
 }
 
@@ -118,10 +122,13 @@ function tryServeFile(
  * Serve the SPA shell (index.html) as a fallback for non-asset routes.
  * Returns false only when index.html itself doesn't exist.
  */
-function tryServeSpaFallback(
-  res: ServerResponse,
-  indexHtmlPath: string,
-): boolean {
+function tryServeSpaFallback({
+  res,
+  indexHtmlPath,
+}: {
+  res: ServerResponse;
+  indexHtmlPath: string;
+}): boolean {
   let fd: number;
   try {
     fd = fs.openSync(indexHtmlPath, "r");
@@ -131,7 +138,7 @@ function tryServeSpaFallback(
 
   res.setHeader("Content-Type", "text/html");
   res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
-  pipeWithErrorHandling(fs.createReadStream("", { fd }), res);
+  pipeWithErrorHandling({ stream: fs.createReadStream("", { fd }), res });
   return true;
 }
 
@@ -140,10 +147,13 @@ function tryServeSpaFallback(
  * error, respond with 500 if headers haven't been sent yet, otherwise
  * just destroy the connection cleanly.
  */
-function pipeWithErrorHandling(
-  stream: fs.ReadStream,
-  res: ServerResponse,
-): void {
+function pipeWithErrorHandling({
+  stream,
+  res,
+}: {
+  stream: fs.ReadStream;
+  res: ServerResponse;
+}): void {
   stream.on("error", () => {
     if (!res.headersSent) {
       res.statusCode = 500;

--- a/langwatch/src/server/static-handler.ts
+++ b/langwatch/src/server/static-handler.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
-import path from "path";
 import type { ServerResponse } from "http";
+import path from "path";
 
 const MIME_TYPES: Record<string, string> = {
   ".js": "application/javascript",
@@ -104,10 +104,7 @@ function tryServeFile({
   }
 
   const ext = path.extname(filePath);
-  res.setHeader(
-    "Content-Type",
-    MIME_TYPES[ext] ?? "application/octet-stream",
-  );
+  res.setHeader("Content-Type", MIME_TYPES[ext] ?? "application/octet-stream");
   if (pathname.startsWith("/assets/")) {
     res.setHeader("Cache-Control", IMMUTABLE_CACHE);
   } else if (ext === ".html") {

--- a/langwatch/src/server/static-handler.ts
+++ b/langwatch/src/server/static-handler.ts
@@ -60,8 +60,7 @@ export function serveStaticOrFallback({
   }
 
   const staticPath = path.join(clientDistDir, normalizedRelative);
-  if (fs.existsSync(staticPath) && fs.statSync(staticPath).isFile()) {
-    serveStaticFile(res, staticPath, pathname);
+  if (tryServeFile(res, staticPath, pathname)) {
     return true;
   }
 
@@ -74,32 +73,86 @@ export function serveStaticOrFallback({
   }
 
   const indexHtml = path.join(clientDistDir, "index.html");
-  if (fs.existsSync(indexHtml)) {
-    res.setHeader("Content-Type", "text/html");
-    res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
-    fs.createReadStream(indexHtml).pipe(res);
-    return true;
-  }
-
-  return false;
+  return tryServeSpaFallback(res, indexHtml);
 }
 
-function serveStaticFile(
+/**
+ * Open + stream a static file in one step, avoiding the TOCTOU race between
+ * existsSync and createReadStream. Returns false when the file doesn't exist
+ * or isn't a regular file so the caller can fall through.
+ */
+function tryServeFile(
   res: ServerResponse,
   filePath: string,
-  pathname: string
-) {
+  pathname: string,
+): boolean {
+  let fd: number;
+  try {
+    fd = fs.openSync(filePath, "r");
+  } catch {
+    return false;
+  }
+
+  const stat = fs.fstatSync(fd);
+  if (!stat.isFile()) {
+    fs.closeSync(fd);
+    return false;
+  }
+
   const ext = path.extname(filePath);
   res.setHeader(
     "Content-Type",
-    MIME_TYPES[ext] ?? "application/octet-stream"
+    MIME_TYPES[ext] ?? "application/octet-stream",
   );
   if (pathname.startsWith("/assets/")) {
     res.setHeader("Cache-Control", IMMUTABLE_CACHE);
   } else if (ext === ".html") {
-    // Direct /index.html hits this path; keep it revalidated like the SPA
-    // fallback so a post-deploy reload never re-serves a stale shell.
     res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
   }
-  fs.createReadStream(filePath).pipe(res);
+
+  pipeWithErrorHandling(fs.createReadStream("", { fd }), res);
+  return true;
+}
+
+/**
+ * Serve the SPA shell (index.html) as a fallback for non-asset routes.
+ * Returns false only when index.html itself doesn't exist.
+ */
+function tryServeSpaFallback(
+  res: ServerResponse,
+  indexHtmlPath: string,
+): boolean {
+  let fd: number;
+  try {
+    fd = fs.openSync(indexHtmlPath, "r");
+  } catch {
+    return false;
+  }
+
+  res.setHeader("Content-Type", "text/html");
+  res.setHeader("Cache-Control", HTML_REVALIDATE_CACHE);
+  pipeWithErrorHandling(fs.createReadStream("", { fd }), res);
+  return true;
+}
+
+/**
+ * Pipe a readable stream to the response with error handling. On stream
+ * error, respond with 500 if headers haven't been sent yet, otherwise
+ * just destroy the connection cleanly.
+ */
+function pipeWithErrorHandling(
+  stream: fs.ReadStream,
+  res: ServerResponse,
+): void {
+  stream.on("error", () => {
+    if (!res.headersSent) {
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "text/plain");
+      res.setHeader("Cache-Control", NO_STORE_CACHE);
+      res.end("Internal Server Error");
+    } else {
+      res.destroy();
+    }
+  });
+  stream.pipe(res);
 }

--- a/langwatch/src/utils/chunkReload.ts
+++ b/langwatch/src/utils/chunkReload.ts
@@ -17,7 +17,7 @@
 // deploy mid-session still reloads; long enough to avoid a loop if the server
 // is genuinely returning broken chunks.
 const RELOAD_COOLDOWN_MS = 10_000;
-const RELOAD_AT_KEY = "chunk-reload-at";
+export const RELOAD_AT_KEY = "chunk-reload-at";
 
 /**
  * True when an error looks like a failed chunk download rather than an


### PR DESCRIPTION
Closes #4699

## Why

A customer hit **"Something went wrong — Failed to fetch dynamically imported module"** on `/:project/messages` (an empty project) while `/:project/traces` loaded fine. The customer console showed the smoking gun: `/assets/CopyableInputWithPrefix-*.js` returned **HTTP 500**.

Proven root cause: **stale-deploy chunk purge.** The customer's open tab is on an older build (entry `index-B2LHnNdW.js`) whose chunk hashes (`CopyableInputWithPrefix-CjL4fkWS.js`) were **purged by a newer deploy** (current entry `index-BWoUSMZG.js` → `CopyableInputWithPrefix-DQjYNonP.js`). It's messages-only + empty-project-only because that chunk lives in the `WelcomeLayout → APICard → CopyableInputWithPrefix` no-traces path; `/traces` uses a different empty state. The **500** (vs a clean 404) came from a deploy-moment race in the static handler.

## What changed

Defense in depth across server and client:

**Server — `static-handler.ts`:** replaced `existsSync` + `createReadStream` with an atomic `openSync` → `fstatSync` → `createReadStream({ fd })`, eliminating the TOCTOU window where a file passes the existence check but fails mid-stream during a deploy (the source of the unhandled-error **500**). Stream piping now goes through `pipeWithErrorHandling` (500 if headers unsent, clean connection destroy otherwise) for both asset files and the SPA index.html fallback. A deploy-race now serves a **clean 404**, which the client recovery already knows how to handle.

**Client — `NotFoundOrErrorPage`:** detects chunk-load errors (`isChunkLoadError`) and renders a distinct state — "Failed to load page", an extension/network hint, and a **"Reload app"** button that records the reload in the cooldown (so the post-reload auto-recovery doesn't immediately double-reload) then reloads. This turns the previously-permanent error boundary into a one-click escape. Generic errors and 404s are unchanged.

This builds on existing recovery already on main: 404-for-missing-assets (no SPA-fallback cache poisoning, #3310) and auto-reload on stale chunks via `vite:preloadError` (#4475).

## Why there is no in-place import retry

An earlier revision retried the failed `import()` in place. **Removed after review:** failed dynamic imports are cached by URL in the browser module map (HTML spec), so re-importing the **same** URL returns the cached rejection with no new request (confirmed by a Chrome repro: 3 imports, 1 HTTP request). And for the actual root cause — a purged chunk — the old URL is gone, so only a reload (fresh document → fresh hashes) can recover. Retry would have been pure theater.

## Test plan

- `src/server/__tests__/static-handler.unit.test.ts` — deploy-delete → clean 404, **plus a deterministic stream-error test** that forces the read stream to emit `error` and asserts a clean 500 (executes pipeWithErrorHandling's crash path), + existing suite.
- `src/utils/chunkReload.test.ts` — 12 passed.
- `src/pages/__tests__/not-found-chunk-error.integration.test.tsx` — 5 passed (chunk-error detection, "Reload app" records cooldown + reloads, generic/404 unchanged).
- **30 tests green total**, `pnpm typecheck` clean, `biome` clean.

## Anything surprising? / Follow-up

This PR makes the failure **recoverable** for every lazy route. The remaining lever for *prevention* (so a stale tab never hits a purged chunk at all) is **infra, not code**: retain old chunks across deploys — e.g. Cloudflare Cache Reserve for immutable `/assets/*`, or keep the last N builds' assets on origin. Tracked as a follow-up; the client recovery here remains the backstop for tabs older than any retention window.

The customer console also showed `net::ERR_QUIC_PROTOCOL_ERROR` on SSE endpoints — that's HTTP/3 network instability on the client side, unrelated to the chunk failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Reload app" button to error page for chunk-load failures.

* **Bug Fixes**
  * Error page now displays distinct messages for different scenarios: "Page not found" (404), "Failed to load page" (chunk errors), and "Something went wrong" (runtime errors).
  * Improved server-side static file serving with enhanced error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->