### PR TITLE
feat(spa): auto-recover stale tabs on a confirmed new deploy

### DIFF
--- a/langwatch/src/main.tsx
+++ b/langwatch/src/main.tsx
@@ -1,21 +1,26 @@
 import { Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
-import { router } from "./routes";
 import { OuterProviders } from "./AppProviders";
+import { router } from "./routes";
+import {
+  registerChunkReloadListener,
+  registerDeployWatcher,
+} from "./utils/chunkReload";
 import { setRouterInstance } from "./utils/compat/next-router";
-import { registerChunkReloadListener } from "./utils/chunkReload";
 import "nprogress/nprogress.css";
 import "./styles/globals.scss";
 
 // Enable imperative navigation from outside React (e.g. navigateToDrawer)
 setRouterInstance(router);
 
-// Recover from stale content-hashed chunks after a deploy: when a lazy import()
-// 404s (e.g. the trace-drawer JSON viewer), reload once to fetch the new hashes
-// instead of dead-ending on the "Failed to fetch dynamically imported module"
-// error boundary.
+// Recover from stale content-hashed chunks after a deploy. Reactively: when a
+// lazy import() 404s, reload for the newer build instead of dead-ending on the
+// "Failed to fetch dynamically imported module" error boundary. Proactively:
+// reload a tab left open across a deploy when it next becomes visible, before
+// the user can navigate into a purged chunk.
 registerChunkReloadListener();
+registerDeployWatcher();
 
 const container = document.getElementById("root");
 if (!container) throw new Error("Root element not found");
@@ -25,5 +30,5 @@ createRoot(container).render(
     <Suspense fallback={null}>
       <RouterProvider router={router} />
     </Suspense>
-  </OuterProviders>
+  </OuterProviders>,
 );

--- a/langwatch/src/pages/__tests__/not-found-chunk-error.integration.test.tsx
+++ b/langwatch/src/pages/__tests__/not-found-chunk-error.integration.test.tsx
@@ -3,7 +3,6 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { RELOAD_AT_KEY } from "~/utils/chunkReload";
 
 vi.mock("react-router", () => ({
   useRouteError: vi.fn(),
@@ -58,13 +57,12 @@ describe("NotFoundOrErrorPage", () => {
       expect(screen.getByRole("button", { name: /Reload app/ })).toBeDefined();
     });
 
-    it("writes a fresh cooldown timestamp on click", () => {
-      sessionStorage.setItem(RELOAD_AT_KEY, "1");
-
+    it("reloads on click without error", () => {
       render(<NotFoundOrErrorPage />, { wrapper: Wrapper });
-      fireEvent.click(screen.getByRole("button", { name: /Reload app/ }));
 
-      expect(Number(sessionStorage.getItem(RELOAD_AT_KEY))).toBeGreaterThan(1);
+      expect(() =>
+        fireEvent.click(screen.getByRole("button", { name: /Reload app/ })),
+      ).not.toThrow();
     });
   });
 

--- a/langwatch/src/pages/_not-found.tsx
+++ b/langwatch/src/pages/_not-found.tsx
@@ -11,7 +11,7 @@ import { Ghost, RotateCcw } from "lucide-react";
 import { useRouteError } from "react-router";
 
 import { Link } from "~/components/ui/link";
-import { isChunkLoadError, RELOAD_AT_KEY } from "~/utils/chunkReload";
+import { isChunkLoadError } from "~/utils/chunkReload";
 
 /**
  * Shared fallback for (a) unknown routes (path="*") and (b) errors thrown
@@ -100,14 +100,7 @@ export default function NotFoundOrErrorPage() {
           {isChunkError && (
             <Button
               colorPalette="orange"
-              onClick={() => {
-                try {
-                  sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()));
-                } catch {
-                  // sessionStorage may be unavailable
-                }
-                window.location.reload();
-              }}
+              onClick={() => window.location.reload()}
             >
               <RotateCcw size={14} />
               Reload app

--- a/langwatch/src/routes.tsx
+++ b/langwatch/src/routes.tsx
@@ -1,18 +1,18 @@
+import NProgress from "nprogress";
 import { Suspense, useEffect } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import {
   createBrowserRouter,
   Outlet,
+  type RouteObject,
   redirect,
   useLocation,
   useNavigation,
-  type RouteObject,
 } from "react-router";
-import { ErrorBoundary } from "react-error-boundary";
-import NProgress from "nprogress";
+import { PageErrorFallback } from "~/components/ui/PageErrorFallback";
 import { InnerProviders } from "./AppProviders";
 import NotFoundOrErrorPage from "./pages/_not-found";
-import { PageErrorFallback } from "~/components/ui/PageErrorFallback";
-import { reloadOnChunkError } from "./utils/chunkReload";
+import { handleChunkError } from "./utils/chunkReload";
 
 /**
  * Root layout - wraps all routes.
@@ -59,9 +59,9 @@ const page = (importFn: () => Promise<{ default: React.ComponentType }>) => ({
     importFn()
       .then((m) => ({ Component: m.default }))
       .catch((err: unknown) => {
-        // Stale route chunk after a deploy → reload once to pick up the new
-        // hashes. Non-chunk errors fall through to the error boundary.
-        reloadOnChunkError(err);
+        // Stale-deploy chunk → reload for the newer build (version-confirmed);
+        // persistent failures and non-chunk errors fall through to the boundary.
+        handleChunkError(err);
         throw err;
       }),
 });
@@ -199,8 +199,8 @@ const routes: RouteObject[] = [
   },
   {
     path: "/settings/governance/ingestion-sources/:id",
-    ...page(() =>
-      import("@ee/governance/dashboard/pages/ingestion-source-detail"),
+    ...page(
+      () => import("@ee/governance/dashboard/pages/ingestion-source-detail"),
     ),
   },
   {
@@ -380,14 +380,12 @@ const routes: RouteObject[] = [
   },
   {
     path: "/:project/messages/:trace/:openTab",
-    ...page(
-      () => import("./pages/[project]/messages/[trace]/[openTab]/index")
-    ),
+    ...page(() => import("./pages/[project]/messages/[trace]/[openTab]/index")),
   },
   {
     path: "/:project/messages/:trace/:openTab/:span",
     ...page(
-      () => import("./pages/[project]/messages/[trace]/[openTab]/[span]")
+      () => import("./pages/[project]/messages/[trace]/[openTab]/[span]"),
     ),
   },
   {

--- a/langwatch/src/utils/chunkReload.test.ts
+++ b/langwatch/src/utils/chunkReload.test.ts
@@ -1,18 +1,51 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  forceReloadOnce,
+  fetchNewerDeployEntry,
+  handleChunkError,
   isChunkLoadError,
   registerChunkReloadListener,
-  reloadOnChunkError,
+  registerDeployWatcher,
+  reloadForDeploy,
 } from "./chunkReload";
 
-// jsdom locks down window.location (non-configurable, can't be deleted, redefined
-// or spied), and location.reload() is a harmless no-op there. So rather than
-// asserting reload() was called, we assert the observable cooldown sentinel it
-// writes to sessionStorage — which is where the branching logic actually lives.
-const RELOAD_AT = "chunk-reload-at";
-const reloaded = () => sessionStorage.getItem(RELOAD_AT) !== null;
+// reloadForDeploy records the deployed entry it reloaded toward in
+// sessionStorage. jsdom's window.location.reload() is a harmless no-op (and is
+// non-spyable), so — like the rest of this module's recovery — we assert the
+// observable sentinel it writes rather than the reload itself.
+const RELOAD_TARGET = "chunk-reload-target";
+const reloadTarget = () => sessionStorage.getItem(RELOAD_TARGET);
+
+// Install a content-hashed entry <script> so loadedEntry() resolves, mimicking a
+// built index.html. The dev server's entry is /src/main.tsx, which has no hash
+// and disables version detection.
+function setLoadedEntry(path: string | null) {
+  document.head.innerHTML = path
+    ? `<script type="module" src="${path}"></script>`
+    : "";
+}
+
+// Stub the index.html the server serves, advertising the given entry path.
+function mockServedEntry(path: string, ok = true) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok,
+      text: async () => `<script type="module" src="${path}"></script>`,
+    }),
+  );
+}
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    configurable: true,
+  });
+}
+
+// Let a fetch().then() recovery chain settle (mock resolves immediately, so one
+// macrotask drains every queued microtask).
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe("isChunkLoadError", () => {
   describe("when the message is a Vite dynamic-import failure", () => {
@@ -54,62 +87,161 @@ describe("isChunkLoadError", () => {
   });
 });
 
-describe("forceReloadOnce", () => {
+describe("fetchNewerDeployEntry", () => {
   beforeEach(() => {
     sessionStorage.clear();
-    vi.useFakeTimers();
+    setLoadedEntry("/assets/index-OLD123.js");
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    setLoadedEntry(null);
   });
 
-  describe("when no reload has happened recently", () => {
-    it("reloads once and records the reload time", () => {
-      expect(forceReloadOnce()).toBe(true);
-      expect(reloaded()).toBe(true);
+  describe("when the server serves a different entry", () => {
+    it("returns the newer deployed entry", async () => {
+      mockServedEntry("/assets/index-NEW456.js");
+      await expect(fetchNewerDeployEntry()).resolves.toBe(
+        "/assets/index-NEW456.js",
+      );
     });
   });
 
-  describe("when a reload happened within the cooldown window", () => {
-    it("does not reload again", () => {
-      forceReloadOnce();
-      vi.advanceTimersByTime(5_000); // inside the 10s cooldown
-
-      expect(forceReloadOnce()).toBe(false);
+  describe("when the server serves the same entry this tab booted with", () => {
+    it("returns null", async () => {
+      mockServedEntry("/assets/index-OLD123.js");
+      await expect(fetchNewerDeployEntry()).resolves.toBeNull();
     });
   });
 
-  describe("when the cooldown window has elapsed", () => {
-    it("reloads again", () => {
-      forceReloadOnce();
-      vi.advanceTimersByTime(11_000); // past the 10s cooldown
+  describe("when there is no content-hashed entry (dev server)", () => {
+    it("returns null without fetching", async () => {
+      setLoadedEntry("/src/main.tsx");
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
 
-      expect(forceReloadOnce()).toBe(true);
+      await expect(fetchNewerDeployEntry()).resolves.toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the fetch fails", () => {
+    it("returns null", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      await expect(fetchNewerDeployEntry()).resolves.toBeNull();
     });
   });
 });
 
-describe("reloadOnChunkError", () => {
-  beforeEach(() => {
-    sessionStorage.clear();
-  });
+describe("reloadForDeploy", () => {
+  beforeEach(() => sessionStorage.clear());
 
-  describe("when the error is a chunk error", () => {
-    it("reloads and reports it handled the error", () => {
-      expect(
-        reloadOnChunkError(
-          new Error("Failed to fetch dynamically imported module"),
-        ),
-      ).toBe(true);
-      expect(reloaded()).toBe(true);
+  describe("when reloading toward a newly deployed entry", () => {
+    it("records the target and reports the reload", () => {
+      expect(reloadForDeploy("/assets/index-NEW456.js")).toBe(true);
+      expect(reloadTarget()).toBe("/assets/index-NEW456.js");
     });
   });
 
+  describe("when the same target was already reloaded toward", () => {
+    it("does not reload again (no loop on a build that won't land)", () => {
+      reloadForDeploy("/assets/index-NEW456.js");
+      expect(reloadForDeploy("/assets/index-NEW456.js")).toBe(false);
+    });
+  });
+
+  describe("when a different deploy ships next", () => {
+    it("reloads again", () => {
+      reloadForDeploy("/assets/index-NEW456.js");
+      expect(reloadForDeploy("/assets/index-NEWER789.js")).toBe(true);
+    });
+  });
+});
+
+describe("handleChunkError", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    setLoadedEntry("/assets/index-OLD123.js");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setLoadedEntry(null);
+  });
+
   describe("when the error is not a chunk error", () => {
-    it("does not reload and reports it did not handle the error", () => {
-      expect(reloadOnChunkError(new Error("boom"))).toBe(false);
-      expect(reloaded()).toBe(false);
+    it("returns false and does not check for a deploy", () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+
+      expect(handleChunkError(new Error("boom"))).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a chunk error coincides with a newer deploy", () => {
+    it("reloads for the newer deploy", async () => {
+      mockServedEntry("/assets/index-NEW456.js");
+
+      expect(
+        handleChunkError(
+          new Error("Failed to fetch dynamically imported module"),
+        ),
+      ).toBe(true);
+      await settle();
+
+      expect(reloadTarget()).toBe("/assets/index-NEW456.js");
+    });
+  });
+
+  describe("when a chunk error has no newer deploy (persistent failure)", () => {
+    it("does not reload, leaving the boundary to surface", async () => {
+      mockServedEntry("/assets/index-OLD123.js");
+
+      handleChunkError(
+        new Error("Failed to fetch dynamically imported module"),
+      );
+      await settle();
+
+      expect(reloadTarget()).toBeNull();
+    });
+  });
+});
+
+describe("registerDeployWatcher", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    setLoadedEntry("/assets/index-OLD123.js");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setLoadedEntry(null);
+  });
+
+  describe("when the tab becomes visible and a newer deploy is live", () => {
+    it("reloads for the newer deploy", async () => {
+      mockServedEntry("/assets/index-NEW456.js");
+      registerDeployWatcher();
+
+      setVisibility("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+      await settle();
+
+      expect(reloadTarget()).toBe("/assets/index-NEW456.js");
+    });
+  });
+
+  describe("when the tab is hidden", () => {
+    it("does not check for a deploy", () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+      registerDeployWatcher();
+
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 });
@@ -117,31 +249,23 @@ describe("reloadOnChunkError", () => {
 describe("registerChunkReloadListener", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    setLoadedEntry("/assets/index-OLD123.js");
   });
 
-  describe("when Vite dispatches vite:preloadError for a stale chunk", () => {
-    it("reloads the page once to fetch the new chunk hashes", () => {
-      registerChunkReloadListener();
-
-      const event = new Event("vite:preloadError", { cancelable: true });
-      window.dispatchEvent(event);
-
-      expect(event.defaultPrevented).toBe(true);
-      expect(reloaded()).toBe(true);
-    });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setLoadedEntry(null);
   });
 
-  describe("when a second vite:preloadError fires within the cooldown", () => {
-    it("does not suppress the error so it can reach the error boundary", () => {
-      // Simulate a reload already having happened in this session.
-      sessionStorage.setItem(RELOAD_AT, "9999999999999");
+  describe("when Vite fires vite:preloadError and a newer deploy is live", () => {
+    it("reloads for the newer deploy", async () => {
+      mockServedEntry("/assets/index-NEW456.js");
       registerChunkReloadListener();
 
-      const event = new Event("vite:preloadError", { cancelable: true });
-      window.dispatchEvent(event);
+      window.dispatchEvent(new Event("vite:preloadError"));
+      await settle();
 
-      // No reload scheduled → Vite's error must NOT be preventDefault()'d.
-      expect(event.defaultPrevented).toBe(false);
+      expect(reloadTarget()).toBe("/assets/index-NEW456.js");
     });
   });
 });

--- a/langwatch/src/utils/chunkReload.ts
+++ b/langwatch/src/utils/chunkReload.ts
@@ -2,27 +2,35 @@
  * Recovery from stale content-hashed chunks after a deploy.
  *
  * Vite emits JS chunks with content-hash filenames (e.g.
- * `react-json-view-CugXrtI-.js`). When a new version is deployed the old
- * hashes are removed from the CDN, but a tab opened *before* the deploy still
- * references them. The next lazy `import()` of such a chunk 404s with
- * "Failed to fetch dynamically imported module".
+ * `react-json-view-CugXrtI-.js`). When a new version is deployed the old hashes
+ * are purged from the CDN, but a tab opened *before* the deploy still references
+ * them; its next lazy `import()` 404s with "Failed to fetch dynamically imported
+ * module".
  *
- * Route chunks are guarded by the `page()` helper in `routes.tsx`; the global
- * `vite:preloadError` listener (registered in `main.tsx`) covers every other
- * lazy import — the trace-drawer JSON viewer, Monaco, the Foundry drawer — by
- * reloading once so the browser fetches the fresh chunk hashes.
+ * Recovery is *version-aware*. We only reload once we've confirmed the server is
+ * serving a newer build than the one this tab booted with — the stale-deploy
+ * case a reload provably fixes. A failure with no newer build is persistent (a
+ * broken build, an ad-blocker, an offline network); reloading would loop, so
+ * those fall through to the error boundary's manual "Reload app" escape hatch
+ * instead.
+ *
+ *  - `handleChunkError` (used by `routes.tsx`'s `page()` helper) and the global
+ *    `vite:preloadError` listener provide *reactive* recovery once a chunk has
+ *    failed to load.
+ *  - `registerDeployWatcher` provides *proactive* recovery: when a backgrounded
+ *    tab becomes visible again it reloads for a newer deploy before the user can
+ *    navigate into a purged chunk.
  */
 
-// Minimum gap between self-triggered reloads. Short enough that a second
-// deploy mid-session still reloads; long enough to avoid a loop if the server
-// is genuinely returning broken chunks.
-const RELOAD_COOLDOWN_MS = 10_000;
-export const RELOAD_AT_KEY = "chunk-reload-at";
+// Records the deployed entry we last reloaded toward. A reload that fails to
+// land on the new build (e.g. a CDN still serving the old index.html) would
+// otherwise loop; the per-target guard caps it at one reload per deployed entry.
+const RELOAD_TARGET_KEY = "chunk-reload-target";
 
 /**
- * True when an error looks like a failed chunk download rather than an
- * ordinary runtime error. Browsers phrase this differently
- * (Chrome/Firefox/Safari), so we match all known variants.
+ * True when an error looks like a failed chunk download rather than an ordinary
+ * runtime error. Browsers phrase this differently (Chrome/Firefox/Safari), so
+ * we match all known variants.
  */
 export function isChunkLoadError(err: unknown): boolean {
   const msg = (
@@ -35,45 +43,112 @@ export function isChunkLoadError(err: unknown): boolean {
   );
 }
 
+function toPath(href: string): string | null {
+  try {
+    return new URL(href, window.location.href).pathname;
+  } catch {
+    return null;
+  }
+}
+
+/** Pull the `/assets/index-<hash>.js` entry path out of an index.html string. */
+function entryFromHtml(html: string): string | null {
+  const match = /<script[^>]*\bsrc="([^"]*\/assets\/index-[^"]+\.js)"/i.exec(
+    html,
+  );
+  return match?.[1] ? toPath(match[1]) : null;
+}
+
 /**
- * Reload the page at most once per cooldown window. Returns whether a reload
- * was triggered. Guarded by sessionStorage so a server that genuinely serves
- * broken chunks can't trap the user in a reload loop.
+ * The content-hashed entry chunk this tab is running, read from the live DOM.
+ * Null when there is none — e.g. the dev server, whose entry is `/src/main.tsx`
+ * — which disables version detection (dev has no purged-chunk problem).
  */
-export function forceReloadOnce(): boolean {
+function loadedEntry(): string | null {
+  if (typeof document === "undefined") return null;
+  const el = document.querySelector<HTMLScriptElement>(
+    'script[type="module"][src*="/assets/index-"]',
+  );
+  return el ? toPath(el.src) : null;
+}
+
+/**
+ * Fetch the live index.html (bypassing cache) and return the entry chunk the
+ * server is serving IF it differs from this tab's — i.e. a newer deploy is live
+ * and a reload will pick up the fresh chunk hashes. Returns null when there's no
+ * newer deploy, or when it can't tell (dev, fetch failure, unparseable HTML), so
+ * callers make no change.
+ */
+export async function fetchNewerDeployEntry(): Promise<string | null> {
+  const loaded = loadedEntry();
+  if (!loaded || typeof fetch === "undefined") return null;
+  try {
+    const res = await fetch(`${window.location.origin}/`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    const deployed = entryFromHtml(await res.text());
+    return deployed && deployed !== loaded ? deployed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reload to pick up a newer deploy, at most once per deployed entry. The
+ * per-target guard means a reload that fails to land on the new build can't
+ * loop, while every genuinely-new deploy triggers exactly one reload. Returns
+ * whether a reload was triggered.
+ */
+export function reloadForDeploy(deployedEntry: string): boolean {
   if (typeof window === "undefined") return false;
-
-  const lastReloadAt = Number(sessionStorage.getItem(RELOAD_AT_KEY) ?? "0");
-  if (Date.now() - lastReloadAt <= RELOAD_COOLDOWN_MS) return false;
-
-  sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()));
+  if (sessionStorage.getItem(RELOAD_TARGET_KEY) === deployedEntry) return false;
+  sessionStorage.setItem(RELOAD_TARGET_KEY, deployedEntry);
   window.location.reload();
   return true;
 }
 
 /**
- * If `err` is a stale-chunk error, reload once to pick up the new hashes.
- * Returns whether the error was a chunk error (the caller should rethrow
- * non-chunk errors so the normal error boundary handles them).
+ * Reactively recover from a chunk-load error: if a newer deploy is live, reload
+ * for it; otherwise do nothing so the error boundary surfaces its manual escape
+ * hatch (the failure is persistent, not a stale deploy). Returns true for any
+ * chunk-load error (handled), false otherwise so the caller rethrows non-chunk
+ * errors.
  */
-export function reloadOnChunkError(err: unknown): boolean {
+export function handleChunkError(err: unknown): boolean {
   if (!isChunkLoadError(err)) return false;
-  forceReloadOnce();
+  void fetchNewerDeployEntry().then((deployedEntry) => {
+    if (deployedEntry) reloadForDeploy(deployedEntry);
+  });
   return true;
 }
 
 /**
- * Register the global recovery for component-level lazy imports. Vite fires
- * `vite:preloadError` on `window` whenever a dynamically imported chunk fails
- * to load; the event itself is the chunk-error signal, so we reload directly.
+ * Register the global reactive recovery for component-level lazy imports (the
+ * trace-drawer JSON viewer, Monaco, the Foundry drawer). Vite fires
+ * `vite:preloadError` on `window` when a dynamically imported chunk fails.
  */
 export function registerChunkReloadListener(): void {
   if (typeof window === "undefined") return;
-  window.addEventListener("vite:preloadError", (event) => {
-    // Only suppress Vite's error when we actually scheduled a reload. If we're
-    // inside the cooldown (forceReloadOnce returns false), let the error
-    // propagate to the error boundary instead of swallowing it — otherwise the
-    // lazy import gets neither recovery nor the normal failure path.
-    if (forceReloadOnce()) event.preventDefault();
+  window.addEventListener("vite:preloadError", () => {
+    void fetchNewerDeployEntry().then((deployedEntry) => {
+      if (deployedEntry) reloadForDeploy(deployedEntry);
+    });
+  });
+}
+
+/**
+ * Proactively recover stale tabs: when a backgrounded tab becomes visible again
+ * — the moment a tab left open across a deploy is about to be used — reload for
+ * a newer deploy before the user navigates into a purged chunk. Registered in
+ * `main.tsx`.
+ */
+export function registerDeployWatcher(): void {
+  if (typeof document === "undefined") return;
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState !== "visible") return;
+    void fetchNewerDeployEntry().then((deployedEntry) => {
+      if (deployedEntry) reloadForDeploy(deployedEntry);
+    });
   });
 }

--- a/specs/ops/stale-deploy-auto-recovery.feature
+++ b/specs/ops/stale-deploy-auto-recovery.feature
@@ -1,0 +1,40 @@
+Feature: Stale-deploy auto-recovery
+  The SPA serves each route as a content-hashed chunk. When a new version is
+  deployed the old chunk hashes are purged, so a tab opened before the deploy
+  hits a "Failed to fetch dynamically imported module" error on its next lazy
+  import. The app should recover itself by reloading — but only when a reload
+  will actually help (a newer deploy is live), never blindly (which would loop
+  forever on a persistent failure like an ad-blocker or an offline network).
+
+  Background:
+    Given the tab booted with a content-hashed entry chunk
+
+  Scenario: A chunk fails and a newer deploy is live
+    Given a lazy chunk fails to load
+    And the server is serving a newer entry than this tab booted with
+    When the app handles the chunk error
+    Then the app reloads itself to pick up the fresh chunk hashes
+    And the user is not left on the error boundary
+
+  Scenario: A chunk fails but no newer deploy is available
+    Given a lazy chunk fails to load
+    And the server is serving the same entry this tab booted with
+    When the app handles the chunk error
+    Then the app does not keep reloading
+    And the user is shown the error boundary with a manual reload escape hatch
+
+  Scenario: The user returns to a tab left open across a deploy
+    Given the tab was hidden while a new deploy shipped
+    When the tab becomes visible again
+    Then the app detects the newer deploy and reloads before the user navigates into a purged chunk
+
+  Scenario: The server reports a newer deploy that a reload does not resolve
+    Given the app already reloaded targeting a given deployed entry
+    And the server still reports that same entry as newer afterwards
+    When the app would reload again for that entry
+    Then it does not reload (no infinite loop)
+
+  Scenario: Running in development without content-hashed chunks
+    Given the booted entry is not a content-hashed asset
+    When the app checks for a newer deploy
+    Then it reports no newer deploy and changes nothing


### PR DESCRIPTION
## Why

Follow-up to #4697. That PR made stale-deploy chunk failures *recoverable* (a "Reload app" button) — but the user still has to click it. A customer kept hitting "Failed to load page" after each deploy: their long-open tab references content-hashed chunks that the new deploy purged, so the next lazy `import()` 404s.

The old recovery already auto-reloaded once, but behind a blunt 10s cooldown that can't tell *"a reload will fix this"* (stale deploy) from *"a reload will loop forever"* (broken build / ad-blocker / offline). So after the cooldown was spent, the user was sent to the error screen.

## What changed

Recovery is now **version-aware**: we only reload once we've **confirmed the server is serving a newer build** than this tab booted with — then we do it ourselves, silently, instead of inviting the user to reload.

On a chunk-load failure (reactive) **and** when a backgrounded tab becomes visible again (proactive), the app fetches the live `index.html` (`cache: no-store`) and compares the served `/assets/index-<hash>.js` entry to the one in this tab's DOM:

- **Newer entry → a deploy shipped → reload silently.** The user never sees the error screen.
- **Same entry → persistent failure → do nothing**, so the error boundary surfaces its manual "Reload app" escape hatch (the honest fallback we can't fix by reloading).

`reloadForDeploy` is guarded per deployed-entry (`chunk-reload-target`), so a reload that fails to land on the new build can't loop, while every genuine deploy triggers exactly one reload. This **replaces the 10s cooldown** (`forceReloadOnce` / `RELOAD_AT_KEY` removed) — the version check is the precise signal the cooldown was approximating. The "Reload app" button becomes a plain reload.

The proactive check (`registerDeployWatcher`, on `visibilitychange`) catches the prime real-world case — a tab left open across a deploy — *before* the user navigates into a purged chunk, so often there's no error at all.

## How it works

- **Stale deploy** (the recurring bug) → version check confirms newer entry → silent reload → fresh chunks. No user action.
- **Persistent failure** (ad-blocker / offline / genuinely broken build) → entry unchanged → no reload (no loop) → boundary + manual button.
- **Dev server** → entry is `/src/main.tsx` (no hash) → version detection no-ops (dev has no purged-chunk problem, HMR handles it).

## Test plan

- `src/utils/chunkReload.test.ts` — **18 passed**: `fetchNewerDeployEntry` (newer / same / dev / fetch-failure), `reloadForDeploy` dedup guard, `handleChunkError` (newer → reloads, persistent → doesn't), `registerDeployWatcher` (visible+newer → reloads, hidden → no-op), `registerChunkReloadListener`, `isChunkLoadError`.
- `src/pages/__tests__/not-found-chunk-error.integration.test.tsx` — updated for the plain-reload button.
- `pnpm typecheck` clean (proves no broken imports from removing the old exports); `biome` clean.
- Spec: `specs/ops/stale-deploy-auto-recovery.feature`.

> Note: the integration test couldn't be run locally (Docker/testcontainers unavailable in this environment); it's a jsdom component test that CI will validate.

## Anything surprising? / Follow-up

This removes the error screen for the *stale-deploy* case entirely. It does **not** prevent the chunk from being purged in the first place — the infra-level prevention (Cloudflare Cache Reserve for immutable `/assets/*`, so old chunks survive at the edge across deploys) stays a parallel follow-up. This client-side recovery is the backstop regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery when the app detects stale content after a deployment and a newer version is available.
  * Improved detection of backgrounded tabs becoming active after a deploy, enabling proactive recovery.

* **Bug Fixes**
  * Enhanced chunk-load error handling to prevent infinite reload loops.
  * Refined error recovery logic to avoid unnecessary reloads in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->