### PR TITLE
fix(rbac): resolve team members + MCP authorize via RoleBindings, not legacy TeamUser

### DIFF
--- a/langwatch/src/server/api/routers/__tests__/rbac.member-leak-coverage.integration.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/rbac.member-leak-coverage.integration.test.ts
@@ -231,6 +231,47 @@ describe("#47 RBAC member-leak coverage (integration)", () => {
       },
     });
 
+    // TEAM-scoped RoleBindings mirroring the TeamUser rows above. These are the
+    // authoritative membership source the picker/settings reads consult since
+    // the TeamUser→RoleBinding migration (which backfilled exactly these); the
+    // TeamUser rows are kept too, matching real post-migration data.
+    await prisma.roleBinding.createMany({
+      data: [
+        {
+          id: `rb-team-admin-${ns}`,
+          organizationId: ORG_ID,
+          userId: ADMIN_USER_ID,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: REGULAR_TEAM_ID,
+        },
+        {
+          id: `rb-team-member-${ns}`,
+          organizationId: ORG_ID,
+          userId: MEMBER_USER_ID,
+          role: TeamUserRole.MEMBER,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: REGULAR_TEAM_ID,
+        },
+        {
+          id: `rb-admin-personal-${ns}`,
+          organizationId: ORG_ID,
+          userId: ADMIN_USER_ID,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: ADMIN_PERSONAL_TEAM_ID,
+        },
+        {
+          id: `rb-member-personal-${ns}`,
+          organizationId: ORG_ID,
+          userId: MEMBER_USER_ID,
+          role: TeamUserRole.ADMIN,
+          scopeType: RoleBindingScopeType.TEAM,
+          scopeId: MEMBER_PERSONAL_TEAM_ID,
+        },
+      ],
+    });
+
     // Group fixture so admin happy-path tests have something to find.
     // Group + 1 admin member; member denial tests don't depend on the
     // group existing because the permission gate fires before the query.

--- a/langwatch/src/server/api/routers/__tests__/team.rolebinding-membership-reads.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/team.rolebinding-membership-reads.unit.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
+import { teamRouter } from "../team";
+import { createInnerTRPCContext } from "../../trpc";
+
+// Team membership is written ONLY to RoleBinding since migration
+// 20260407120000_migrate_team_users_to_role_bindings — the legacy TeamUser
+// relation is no longer populated for members added through the settings page.
+// These regression guards prove the read paths (getTeamWithMembers,
+// getTeamsWithMembers, getBySlug) resolve membership from TEAM-scoped
+// RoleBindings rather than the stale team.members (TeamUser) relation.
+// Without this, a freshly-added admin vanishes on refresh, disappears from
+// member pickers, and fails the getBySlug access gate.
+//
+// The org-permission middleware/guard is real authorization the page already
+// passes for an org admin; it's mocked to a pass-through so these tests isolate
+// the member-resolution read path.
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    checkOrganizationPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+    hasOrganizationPermission: vi.fn().mockResolvedValue(true),
+  };
+});
+
+const ORG_ID = "org_1";
+const TEAM_ID = "team_1";
+const TEAM_SLUG = "acme-team";
+const CALLER_ID = "caller_admin";
+const MEMBER_ID = "member_rolebinding_only";
+
+function team() {
+  return {
+    id: TEAM_ID,
+    slug: TEAM_SLUG,
+    name: "Acme Team",
+    organizationId: ORG_ID,
+    isPersonal: false,
+    ownerUserId: null,
+    projects: [],
+  };
+}
+
+function buildMockPrisma({
+  teamBindings,
+}: {
+  teamBindings: unknown[];
+}): PrismaClient {
+  return {
+    team: {
+      // No `members` (TeamUser) rows — mirrors a team whose membership was
+      // written post-migration as RoleBindings only.
+      findFirst: vi.fn().mockResolvedValue(team()),
+      findMany: vi.fn().mockResolvedValue([team()]),
+    },
+    roleBinding: {
+      findMany: vi.fn().mockResolvedValue(teamBindings),
+    },
+  } as unknown as PrismaClient;
+}
+
+function buildCaller(prisma: PrismaClient) {
+  const ctx = createInnerTRPCContext({
+    session: { user: { id: CALLER_ID }, expires: "1" },
+    req: undefined,
+    res: undefined,
+    permissionChecked: true,
+    publiclyShared: false,
+  });
+  ctx.prisma = prisma;
+  return teamRouter.createCaller(ctx);
+}
+
+function bindingFor({
+  userId,
+  role = TeamUserRole.ADMIN,
+}: {
+  userId: string;
+  role?: TeamUserRole;
+}) {
+  return {
+    id: `rb_${userId}_${role}`,
+    userId,
+    role,
+    customRoleId: null,
+    customRole: null,
+    scopeType: RoleBindingScopeType.TEAM,
+    scopeId: TEAM_ID,
+    organizationId: ORG_ID,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    user: {
+      id: userId,
+      name: "New Admin",
+      email: `${userId}@example.com`,
+    },
+  };
+}
+
+describe("team.getTeamWithMembers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("when a member exists only as a TEAM-scoped RoleBinding (no legacy TeamUser row)", () => {
+    it("includes the RoleBinding-only member in the returned members", async () => {
+      const caller = buildCaller(
+        buildMockPrisma({ teamBindings: [bindingFor({ userId: MEMBER_ID })] }),
+      );
+
+      const result = await caller.getTeamWithMembers({
+        slug: TEAM_SLUG,
+        organizationId: ORG_ID,
+      });
+
+      const member = result.members.find((m) => m.user.id === MEMBER_ID);
+      expect(member).toBeDefined();
+      expect(member!.role).toBe(TeamUserRole.ADMIN);
+      expect(member!.user.email).toBe(`${MEMBER_ID}@example.com`);
+    });
+  });
+
+  describe("when a user holds multiple TEAM bindings on the same team", () => {
+    it("returns one member row with the highest-privilege role", async () => {
+      // The partial unique indexes allow a user to have both a MEMBER and an
+      // ADMIN binding at the same scope — they must not become two form rows.
+      const caller = buildCaller(
+        buildMockPrisma({
+          teamBindings: [
+            bindingFor({ userId: MEMBER_ID, role: TeamUserRole.MEMBER }),
+            bindingFor({ userId: MEMBER_ID, role: TeamUserRole.ADMIN }),
+          ],
+        }),
+      );
+
+      const result = await caller.getTeamWithMembers({
+        slug: TEAM_SLUG,
+        organizationId: ORG_ID,
+      });
+
+      const rows = result.members.filter((m) => m.user.id === MEMBER_ID);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.role).toBe(TeamUserRole.ADMIN);
+    });
+  });
+
+  describe("when the team has no TEAM-scoped role bindings", () => {
+    it("returns no members", async () => {
+      const caller = buildCaller(buildMockPrisma({ teamBindings: [] }));
+
+      const result = await caller.getTeamWithMembers({
+        slug: TEAM_SLUG,
+        organizationId: ORG_ID,
+      });
+
+      expect(result.members).toEqual([]);
+    });
+  });
+});
+
+describe("team.getTeamsWithMembers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("when a member exists only as a TEAM-scoped RoleBinding (no legacy TeamUser row)", () => {
+    it("includes the RoleBinding-only member in the team's members", async () => {
+      const caller = buildCaller(
+        buildMockPrisma({ teamBindings: [bindingFor({ userId: MEMBER_ID })] }),
+      );
+
+      const teams = await caller.getTeamsWithMembers({ organizationId: ORG_ID });
+
+      const found = teams.find((t) => t.id === TEAM_ID);
+      expect(found).toBeDefined();
+      expect(found!.members.some((m) => m.user.id === MEMBER_ID)).toBe(true);
+    });
+  });
+});
+
+describe("team.getBySlug", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("when the caller is a member only via a TEAM-scoped RoleBinding", () => {
+    it("returns the team (access gate honors RoleBindings, not TeamUser)", async () => {
+      const caller = buildCaller(
+        buildMockPrisma({ teamBindings: [bindingFor({ userId: CALLER_ID })] }),
+      );
+
+      const result = await caller.getBySlug({
+        slug: TEAM_SLUG,
+        organizationId: ORG_ID,
+      });
+
+      expect(result?.id).toBe(TEAM_ID);
+    });
+  });
+
+  describe("when the caller has no binding to the team", () => {
+    it("returns null", async () => {
+      const caller = buildCaller(
+        buildMockPrisma({ teamBindings: [bindingFor({ userId: MEMBER_ID })] }),
+      );
+
+      const result = await caller.getBySlug({
+        slug: TEAM_SLUG,
+        organizationId: ORG_ID,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
+++ b/langwatch/src/server/api/routers/__tests__/team.update.multi-binding.unit.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+import { TeamUserRole } from "@prisma/client";
+import { teamRouter } from "../team";
+import { createInnerTRPCContext } from "../../trpc";
+
+// team.update writes membership to RoleBinding. A user can hold MORE THAN ONE
+// TEAM binding on a team — a built-in role plus additive custom-role grants —
+// and RBAC unions them. The settings form shows/edits only the displayed
+// (highest-privilege) binding, so a save must update just that one and PRESERVE
+// the user's other bindings. Deleting the extras would let a routine autosaved
+// edit silently revoke custom-role grants. team:manage is real authorization
+// the page passes; it's mocked to a pass-through to isolate the sync logic.
+vi.mock("../../rbac", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../rbac")>();
+  return {
+    ...actual,
+    checkTeamPermission:
+      () =>
+      async ({ ctx, next }: any) => {
+        ctx.permissionChecked = true;
+        return next();
+      },
+  };
+});
+
+const ORG_ID = "org_1";
+const TEAM_ID = "team_1";
+const USER_ID = "user_multi";
+const MEMBER_BINDING_ID = "rb_member";
+const CUSTOM_BINDING_ID = "rb_custom";
+const CUSTOM_ROLE_ID = "cr_1";
+
+describe("team.update", () => {
+  let deleteMany: ReturnType<typeof vi.fn>;
+  let update: ReturnType<typeof vi.fn>;
+  let create: ReturnType<typeof vi.fn>;
+  let caller: ReturnType<typeof teamRouter.createCaller>;
+
+  beforeEach(() => {
+    deleteMany = vi.fn().mockResolvedValue({ count: 0 });
+    update = vi.fn().mockResolvedValue({});
+    create = vi.fn().mockResolvedValue({});
+
+    const tx = {
+      team: { update: vi.fn().mockResolvedValue({}) },
+      roleBinding: {
+        // The user has a built-in MEMBER binding AND an additive custom-role
+        // binding. The form displays the higher-privilege one (MEMBER).
+        findMany: vi.fn().mockResolvedValue([
+          { id: MEMBER_BINDING_ID, userId: USER_ID, role: TeamUserRole.MEMBER, customRoleId: null },
+          { id: CUSTOM_BINDING_ID, userId: USER_ID, role: TeamUserRole.CUSTOM, customRoleId: CUSTOM_ROLE_ID },
+        ]),
+        deleteMany,
+        update,
+        create,
+      },
+    };
+
+    const prisma = {
+      team: { findUnique: vi.fn().mockResolvedValue({ organizationId: ORG_ID }) },
+      $transaction: (fn: (tx: unknown) => unknown) => fn(tx),
+    } as unknown as PrismaClient;
+
+    const ctx = createInnerTRPCContext({
+      session: { user: { id: "caller" }, expires: "1" },
+      req: undefined,
+      res: undefined,
+      permissionChecked: true,
+      publiclyShared: false,
+    });
+    ctx.prisma = prisma;
+    caller = teamRouter.createCaller(ctx);
+  });
+
+  describe("when editing the displayed role of a user who also has an additive custom-role binding", () => {
+    it("updates only the displayed binding and preserves the custom-role binding", async () => {
+      await caller.update({
+        teamId: TEAM_ID,
+        name: "Team",
+        members: [{ userId: USER_ID, role: TeamUserRole.VIEWER }],
+      });
+
+      // Displayed (MEMBER) binding is updated to VIEWER...
+      expect(update).toHaveBeenCalledWith({
+        where: { id: MEMBER_BINDING_ID },
+        data: { role: TeamUserRole.VIEWER, customRoleId: null },
+      });
+      // ...and the additive custom-role binding is left untouched.
+      expect(deleteMany).not.toHaveBeenCalled();
+      expect(create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a user is removed from the team", () => {
+    it("deletes all of that user's bindings", async () => {
+      await caller.update({
+        teamId: TEAM_ID,
+        name: "Team",
+        // USER_ID is no longer in the submitted list.
+        members: [{ userId: "someone_else", role: TeamUserRole.ADMIN }],
+      });
+
+      expect(deleteMany).toHaveBeenCalledWith({
+        where: { id: { in: [MEMBER_BINDING_ID, CUSTOM_BINDING_ID] } },
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api/routers/team.ts
+++ b/langwatch/src/server/api/routers/team.ts
@@ -22,7 +22,7 @@ import {
   checkTeamPermission,
   hasOrganizationPermission,
 } from "../rbac";
-import { TeamService } from "~/server/teams/team.service";
+import { TeamService, TEAM_ROLE_PRIORITY } from "~/server/teams/team.service";
 
 // Reusable schema for team member role validation
 const teamMemberRoleSchema = z
@@ -67,22 +67,12 @@ export const teamRouter = createTRPCRouter({
     .input(z.object({ organizationId: z.string(), slug: z.string() }))
     .use(checkOrganizationPermission("organization:view"))
     .query(async ({ input, ctx }) => {
-      const userId = ctx.session.user.id;
-      const prisma = ctx.prisma;
-
-      const team = await prisma.team.findFirst({
-        where: {
-          slug: input.slug,
-          organizationId: input.organizationId,
-          members: {
-            some: {
-              userId: userId,
-            },
-          },
-        },
+      const service = new TeamService(ctx.prisma);
+      return service.getTeamBySlugForUser({
+        slug: input.slug,
+        organizationId: input.organizationId,
+        userId: ctx.session.user.id,
       });
-
-      return team;
     }),
   getTeamsWithMembers: protectedProcedure
     .input(z.object({ organizationId: z.string() }))
@@ -94,7 +84,6 @@ export const teamRouter = createTRPCRouter({
     // entirely (their existence is itself private).
     .use(checkOrganizationPermission("organization:view"))
     .query(async ({ input, ctx }) => {
-      const prisma = ctx.prisma;
       const callerId = ctx.session.user.id;
       const callerHasManage = await hasOrganizationPermission(
         ctx,
@@ -102,41 +91,18 @@ export const teamRouter = createTRPCRouter({
         "organization:manage",
       );
 
-      const teams = await prisma.team.findMany({
-        where: {
-          organizationId: input.organizationId,
-          archivedAt: null,
-          // Privacy floor: a member never sees another user's personal
-          // workspace as a "team". Admins see everything.
-          ...(callerHasManage
-            ? {}
-            : {
-                OR: [
-                  { isPersonal: false },
-                  { isPersonal: true, ownerUserId: callerId },
-                ],
-              }),
-        },
-        include: {
-          members: {
-            orderBy: [{ user: { name: "asc" } }, { user: { email: "asc" } }, { userId: "asc" }],
-            include: {
-              user: true,
-              assignedRole: true,
-            },
-          },
-          projects: {
-            where: {
-              archivedAt: null,
-              kind: { not: "internal_governance" },
-            },
-          },
-        },
+      const service = new TeamService(ctx.prisma);
+      const teams = await service.getTeamsWithMembers({
+        organizationId: input.organizationId,
+        callerId,
+        callerHasManage,
       });
 
+      // Email-privacy redaction is request-scoped (depends on the caller), so it
+      // stays here rather than in the service.
       if (!callerHasManage) {
         for (const team of teams) {
-          for (const m of team.members ?? []) {
+          for (const m of team.members) {
             if (m.user.id !== callerId) {
               m.user.email = null;
             }
@@ -175,7 +141,6 @@ export const teamRouter = createTRPCRouter({
     // NOT_FOUND (existence itself is private).
     .use(checkOrganizationPermission("organization:view"))
     .query(async ({ input, ctx }) => {
-      const prisma = ctx.prisma;
       const callerId = ctx.session.user.id;
       const callerHasManage = await hasOrganizationPermission(
         ctx,
@@ -183,26 +148,10 @@ export const teamRouter = createTRPCRouter({
         "organization:manage",
       );
 
-      const team = await prisma.team.findFirst({
-        where: {
-          slug: input.slug,
-          organizationId: input.organizationId,
-        },
-        include: {
-          members: {
-            orderBy: [{ user: { name: "asc" } }, { user: { email: "asc" } }, { userId: "asc" }],
-            include: {
-              user: true,
-              assignedRole: true,
-            },
-          },
-          projects: {
-            where: {
-              archivedAt: null,
-              kind: { not: "internal_governance" },
-            },
-          },
-        },
+      const service = new TeamService(ctx.prisma);
+      const team = await service.getTeamWithMembers({
+        slug: input.slug,
+        organizationId: input.organizationId,
       });
 
       if (!team) {
@@ -216,8 +165,10 @@ export const teamRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Team not found." });
       }
 
+      // Email-privacy redaction is request-scoped (depends on the caller), so it
+      // stays here rather than in the service.
       if (!callerHasManage) {
-        for (const m of team.members ?? []) {
+        for (const m of team.members) {
           if (m.user.id !== callerId) {
             m.user.email = null;
           }
@@ -302,44 +253,91 @@ export const teamRouter = createTRPCRouter({
         );
 
         // ── RoleBinding ──
+        // A user can hold MORE THAN ONE TEAM binding on the same team (the
+        // partial unique indexes allow a built-in role plus additive custom-role
+        // grants at one scope), and RBAC unions them. This settings form shows
+        // and edits ONLY the displayed membership — the highest-privilege binding
+        // (same selection the read path uses, TEAM_ROLE_PRIORITY). So on save we
+        // update just that binding and PRESERVE the user's other (additive)
+        // bindings; we must not delete them, or a routine autosaved edit would
+        // silently revoke custom-role grants. Removing a user from the team is
+        // unambiguous, so that path still drops all of their bindings.
         const currentBindings = await tx.roleBinding.findMany({
           where: { organizationId, scopeType: RoleBindingScopeType.TEAM, scopeId: input.teamId, userId: { not: null } },
           select: { id: true, userId: true, role: true, customRoleId: true },
         });
-        const currentBindingMap = new Map(currentBindings.map((b) => [b.userId!, b]));
-
-        const rbToRemove = currentBindings.filter((b) => !newMembersMap.has(b.userId!)).map((b) => b.id);
-        const rbToAdd = input.members.filter((m) => !currentBindingMap.has(m.userId));
-        const rbToUpdate = input.members.filter((m) => {
-          const existing = currentBindingMap.get(m.userId);
-          if (!existing) return false;
-          const newRole = isCustomRole(m.role) ? TeamUserRole.CUSTOM : (m.role as TeamUserRole);
-          return existing.role !== newRole || existing.customRoleId !== (m.customRoleId ?? null);
-        });
-
-        if (rbToRemove.length > 0) {
-          await tx.roleBinding.deleteMany({ where: { id: { in: rbToRemove } } });
+        const currentBindingsByUser = new Map<string, typeof currentBindings>();
+        for (const binding of currentBindings) {
+          const list = currentBindingsByUser.get(binding.userId!) ?? [];
+          list.push(binding);
+          currentBindingsByUser.set(binding.userId!, list);
         }
-        for (const member of rbToAdd) {
+
+        const targetRole = (m: (typeof input.members)[number]) =>
+          isCustomRole(m.role) ? TeamUserRole.CUSTOM : (m.role as TeamUserRole);
+        const targetCustomRoleId = (m: (typeof input.members)[number]) =>
+          isCustomRole(m.role) ? (m.customRoleId ?? null) : null;
+
+        // The displayed binding = highest-privilege one, matching the read path.
+        const displayedBinding = (bindings: typeof currentBindings) =>
+          [...bindings].sort(
+            (a, b) => TEAM_ROLE_PRIORITY[a.role] - TEAM_ROLE_PRIORITY[b.role],
+          )[0]!;
+
+        const idsToRemove: string[] = [];
+        const toUpdate: { id: string; role: TeamUserRole; customRoleId: string | null }[] = [];
+        const toCreate: (typeof input.members)[number][] = [];
+
+        // Drop every binding belonging to a user no longer on the team.
+        for (const [userId, bindings] of currentBindingsByUser) {
+          if (!newMembersMap.has(userId)) {
+            idsToRemove.push(...bindings.map((b) => b.id));
+          }
+        }
+
+        // For each submitted user: edit only the displayed binding; leave the
+        // rest (additive grants) untouched.
+        for (const member of input.members) {
+          const existing = currentBindingsByUser.get(member.userId) ?? [];
+          const role = targetRole(member);
+          const customRoleId = targetCustomRoleId(member);
+          if (existing.length === 0) {
+            toCreate.push(member);
+            continue;
+          }
+          const displayed = displayedBinding(existing);
+          if (displayed.role === role && displayed.customRoleId === customRoleId) {
+            continue; // displayed binding already matches — nothing to do
+          }
+          // If the target grant already exists on another binding, updating into
+          // it would collide with the partial unique index, so drop the
+          // displayed binding instead (the grant is already present).
+          const targetAlreadyHeld = existing.some(
+            (b) => b.id !== displayed.id && b.role === role && b.customRoleId === customRoleId,
+          );
+          if (targetAlreadyHeld) {
+            idsToRemove.push(displayed.id);
+          } else {
+            toUpdate.push({ id: displayed.id, role, customRoleId });
+          }
+        }
+
+        if (idsToRemove.length > 0) {
+          await tx.roleBinding.deleteMany({ where: { id: { in: idsToRemove } } });
+        }
+        for (const { id, role, customRoleId } of toUpdate) {
+          await tx.roleBinding.update({ where: { id }, data: { role, customRoleId } });
+        }
+        for (const member of toCreate) {
           await tx.roleBinding.create({
             data: {
               id: generate(KSUID_RESOURCES.ROLE_BINDING).toString(),
               organizationId,
               userId: member.userId,
-              role: isCustomRole(member.role) ? TeamUserRole.CUSTOM : (member.role as TeamUserRole),
-              customRoleId: isCustomRole(member.role) ? (member.customRoleId ?? null) : null,
+              role: targetRole(member),
+              customRoleId: targetCustomRoleId(member),
               scopeType: RoleBindingScopeType.TEAM,
               scopeId: input.teamId,
-            },
-          });
-        }
-        for (const member of rbToUpdate) {
-          const existing = currentBindingMap.get(member.userId)!;
-          await tx.roleBinding.update({
-            where: { id: existing.id },
-            data: {
-              role: isCustomRole(member.role) ? TeamUserRole.CUSTOM : (member.role as TeamUserRole),
-              customRoleId: isCustomRole(member.role) ? (member.customRoleId ?? null) : null,
             },
           });
         }

--- a/langwatch/src/server/app-layer/role-bindings/repositories/role-binding.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/role-bindings/repositories/role-binding.prisma.repository.ts
@@ -1,6 +1,10 @@
 import { RoleBindingScopeType, type PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
-import type { RoleBindingForSynthesis, RoleBindingRepository } from "./role-binding.repository";
+import type {
+  RoleBindingForSynthesis,
+  RoleBindingRepository,
+  TeamScopedMemberBinding,
+} from "./role-binding.repository";
 
 export class PrismaRoleBindingRepository implements RoleBindingRepository {
   constructor(private readonly prisma: PrismaClient) {}
@@ -46,6 +50,49 @@ export class PrismaRoleBindingRepository implements RoleBindingRepository {
         },
       },
     });
+  }
+
+  async listTeamScopedUserBindingsByTeamIds({
+    organizationId,
+    teamIds,
+  }: {
+    organizationId: string;
+    teamIds: string[];
+  }): Promise<Map<string, TeamScopedMemberBinding[]>> {
+    // Pre-seed every requested teamId so the caller can rely on a hit even for
+    // teams with no members, and so a single query covers all teams (no N+1).
+    const byTeam = new Map<string, TeamScopedMemberBinding[]>(
+      teamIds.map((teamId) => [teamId, []]),
+    );
+    if (teamIds.length === 0) return byTeam;
+
+    const bindings = await this.prisma.roleBinding.findMany({
+      where: {
+        organizationId,
+        scopeType: RoleBindingScopeType.TEAM,
+        scopeId: { in: teamIds },
+        userId: { not: null },
+      },
+      include: { user: true, customRole: true },
+    });
+
+    for (const binding of bindings) {
+      // The query filters userId non-null and includes user, but Prisma's types
+      // don't narrow — skip defensively rather than assert, so a future change
+      // to the where/include can't silently produce undefined fields.
+      if (!binding.userId || !binding.user) continue;
+      byTeam.get(binding.scopeId)?.push({
+        userId: binding.userId,
+        role: binding.role,
+        customRoleId: binding.customRoleId,
+        createdAt: binding.createdAt,
+        updatedAt: binding.updatedAt,
+        user: binding.user,
+        customRole: binding.customRole,
+      });
+    }
+
+    return byTeam;
   }
 
   async validateScopeInOrg({

--- a/langwatch/src/server/app-layer/role-bindings/repositories/role-binding.repository.ts
+++ b/langwatch/src/server/app-layer/role-bindings/repositories/role-binding.repository.ts
@@ -1,4 +1,19 @@
 import { RoleBindingScopeType, TeamUserRole } from "@prisma/client";
+import type { CustomRole, User } from "@prisma/client";
+
+// A direct (user, not group) TEAM-scoped binding, shaped to populate the
+// team-settings members list. Mirrors a legacy `TeamUser` row joined with its
+// user and assigned custom role, so callers can render members the same way
+// regardless of whether the membership predates the RoleBinding migration.
+export type TeamScopedMemberBinding = {
+  userId: string;
+  role: TeamUserRole;
+  customRoleId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  user: User;
+  customRole: CustomRole | null;
+};
 
 // Shared shape used by the org synthesis step
 export type RoleBindingForSynthesis = {
@@ -24,6 +39,18 @@ export interface RoleBindingRepository {
     userId: string;
   }): Promise<RoleBindingForSynthesis[]>;
 
+  // Direct user members of one or more teams, resolved from TEAM-scoped
+  // RoleBindings — the authoritative membership source since the
+  // TeamUser→RoleBinding migration (group-expanded members are intentionally
+  // excluded; the team-settings page manages individual users only). Returns a
+  // map keyed by teamId; every requested teamId is present (empty array if none).
+  // A user may appear more than once per team (the partial unique indexes allow
+  // a built-in plus a custom binding at the same scope) — callers dedupe.
+  listTeamScopedUserBindingsByTeamIds(params: {
+    organizationId: string;
+    teamIds: string[];
+  }): Promise<Map<string, TeamScopedMemberBinding[]>>;
+
   validateScopeInOrg(params: {
     organizationId: string;
     scopeType: RoleBindingScopeType;
@@ -37,6 +64,16 @@ export class NullRoleBindingRepository implements RoleBindingRepository {
     userId: string;
   }): Promise<RoleBindingForSynthesis[]> {
     return [];
+  }
+
+  async listTeamScopedUserBindingsByTeamIds({
+    teamIds,
+  }: {
+    organizationId: string;
+    teamIds: string[];
+  }): Promise<Map<string, TeamScopedMemberBinding[]>> {
+    // Honor the contract: every requested teamId is present (empty array).
+    return new Map(teamIds.map((teamId) => [teamId, []]));
   }
 
   async validateScopeInOrg(_params: {

--- a/langwatch/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression guard for the MCP OAuth authorize endpoint
+ * (POST /api/mcp/authorize). A user added to a team after migration
+ * 20260407120000_migrate_team_users_to_role_bindings exists only as a
+ * TEAM-scoped RoleBinding (no legacy TeamUser row). The endpoint gated
+ * project access with `team: { members: { some: { user: { id } } } }` — the
+ * TeamUser relation — and returned 403 "Project not found or you don't have
+ * access" on Allow. The fix resolves access via RoleBindings
+ * (hasProjectPermission), so RoleBinding-only members can authorize.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type * as ServerRedis from "~/server/redis";
+import { app } from "../misc";
+
+const PROJECT_ID = "project_1";
+const TEAM_ID = "team_1";
+const ORG_ID = "org_1";
+const ERROR = "Project not found or you don't have access";
+
+// Hoisted so the mock objects exist before the mocked modules are evaluated
+// (the top-level `import { app } from "../misc"` triggers those factories).
+// Prisma enums are string-valued at runtime, so string literals stand in for
+// TeamUserRole.ADMIN / RoleBindingScopeType.TEAM here.
+const { mockPrisma, mockRedis, SESSION } = vi.hoisted(() => {
+  return {
+    SESSION: { user: { id: "member_rolebinding_only" }, expires: "1" },
+    mockRedis: { set: vi.fn().mockResolvedValue("OK") },
+    mockPrisma: {
+      // checkPermissionFromBindings: user belongs to no groups …
+      groupMembership: { findMany: vi.fn().mockResolvedValue([]) },
+      // … but has a TEAM-scoped ADMIN RoleBinding (project:view is granted).
+      roleBinding: {
+        findMany: vi.fn().mockResolvedValue([
+          { role: "ADMIN", customRoleId: null, scopeType: "TEAM" },
+        ]),
+      },
+      customRole: { findUnique: vi.fn().mockResolvedValue(null) },
+      // Legacy fallback must find nothing — the whole point is the user has no
+      // TeamUser row.
+      teamUser: { findFirst: vi.fn().mockResolvedValue(null) },
+      project: {
+        // Two callers hit project.findUnique: resolveProjectPermission selects
+        // the team→org graph; ProjectService.getById fetches the project row.
+        findUnique: vi.fn(({ select }: { select?: { team?: unknown } }) =>
+          select?.team
+            ? Promise.resolve({
+                team: {
+                  id: "team_1",
+                  organizationId: "org_1",
+                  organization: { members: [] }, // no OrganizationUser row either
+                },
+              })
+            : Promise.resolve({
+                id: "project_1",
+                apiKey: "lw_test_key",
+                archivedAt: null as Date | null,
+              }),
+        ),
+      },
+    },
+  };
+});
+
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: vi.fn().mockResolvedValue(SESSION),
+}));
+vi.mock("~/server/db", () => ({ prisma: mockPrisma }));
+// Partial mock: importing ../misc drags in the worker/collector graph, which
+// also reads `isBuildOrNoRedis` from this module — keep the real exports and
+// override only the connection the handler writes the auth code to.
+vi.mock("~/server/redis", async (importOriginal) => {
+  const actual = await importOriginal<typeof ServerRedis>();
+  return { ...actual, connection: mockRedis };
+});
+vi.mock("~/utils/encryption", () => ({
+  encrypt: (text: string) => `encrypted:${text}`,
+  decrypt: (text: string) =>
+    text.startsWith("encrypted:") ? text.slice(10) : text,
+}));
+
+const validBody = {
+  projectId: PROJECT_ID,
+  redirect_uri: "https://example.com/callback",
+  code_challenge: "challenge123",
+  code_challenge_method: "S256",
+  client_id: "client_1",
+  state: "xyz",
+};
+
+async function authorize() {
+  return app.request("http://localhost/api/mcp/authorize", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(validBody),
+  });
+}
+
+describe("POST /mcp/authorize", () => {
+  describe("when the user has project access via a TEAM-scoped RoleBinding but no legacy TeamUser row", () => {
+    it("authorizes the connection instead of returning 403", async () => {
+      const res = await authorize();
+      const json = (await res.json()) as { redirect?: string; error?: string };
+
+      expect(res.status).toBe(200);
+      expect(json.error).toBeUndefined();
+      expect(json.redirect).toContain("code=");
+    });
+  });
+
+  describe("when the user has no binding granting access to the project", () => {
+    it("returns 403 (proves the RoleBinding permission gate actually runs)", async () => {
+      // No bindings at all → checkPermissionFromBindings falls back to TeamUser,
+      // which is also absent → access denied.
+      mockPrisma.roleBinding.findMany.mockResolvedValueOnce([]);
+
+      const res = await authorize();
+      const json = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(403);
+      expect(json.error).toBe(ERROR);
+    });
+  });
+
+  describe("when the project is archived", () => {
+    it("returns 403 (archived projects are not authorizable)", async () => {
+      // getById fetches the project row first; a non-null archivedAt short-
+      // circuits to the unified 403 before the permission check.
+      mockPrisma.project.findUnique.mockResolvedValueOnce({
+        id: PROJECT_ID,
+        apiKey: "lw_test_key",
+        archivedAt: new Date("2026-01-01T00:00:00Z"),
+      });
+
+      const res = await authorize();
+      const json = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(403);
+      expect(json.error).toBe(ERROR);
+    });
+  });
+
+  describe("when the target is the demo project", () => {
+    it("returns 403 even though isDemoProject grants project:view to everyone", async () => {
+      // Guards the apiKey-leak regression: the demo project must never be
+      // MCP-authorizable, regardless of the caller's bindings.
+      const previous = process.env.DEMO_PROJECT_ID;
+      process.env.DEMO_PROJECT_ID = PROJECT_ID;
+      try {
+        const res = await authorize();
+        const json = (await res.json()) as { error?: string };
+
+        expect(res.status).toBe(403);
+        expect(json.error).toBe(ERROR);
+      } finally {
+        if (previous === undefined) delete process.env.DEMO_PROJECT_ID;
+        else process.env.DEMO_PROJECT_ID = previous;
+      }
+    });
+  });
+});

--- a/langwatch/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/mcp-authorize.rolebinding.unit.test.ts
@@ -48,13 +48,13 @@ const { mockPrisma, mockRedis, SESSION } = vi.hoisted(() => {
           select?.team
             ? Promise.resolve({
                 team: {
-                  id: "team_1",
-                  organizationId: "org_1",
+                  id: TEAM_ID,
+                  organizationId: ORG_ID,
                   organization: { members: [] }, // no OrganizationUser row either
                 },
               })
             : Promise.resolve({
-                id: "project_1",
+                id: PROJECT_ID,
                 apiKey: "lw_test_key",
                 archivedAt: null as Date | null,
               }),

--- a/langwatch/src/server/routes/misc.ts
+++ b/langwatch/src/server/routes/misc.ts
@@ -45,6 +45,9 @@ import {
   matchModelCostWithFallbacks,
 } from "~/server/background/workers/collector/cost";
 import { prisma } from "~/server/db";
+import { hasProjectPermission, isDemoProject } from "~/server/api/rbac";
+import { ProjectService } from "~/server/app-layer/projects/project.service";
+import { PrismaProjectRepository } from "~/server/app-layer/projects/repositories/project.prisma.repository";
 import {
   dSPyStepRESTParamsSchema,
   type DSPyLLMCall,
@@ -526,19 +529,37 @@ secured.access(handlerManagedAuth("user session validated in-handler via getServ
     );
   }
 
-  const project = await prisma.project.findFirst({
-    where: {
-      id: projectId,
-      archivedAt: null,
-      team: {
-        members: {
-          some: { user: { id: session.user.id } },
-        },
-      },
-    },
-  });
+  // The demo project is a globally-readable showcase: isDemoProject grants
+  // `project:view` to ANY caller, so it must never reach the RoleBinding check
+  // below — otherwise any authenticated user could mint an MCP auth code
+  // embedding the demo project's API key. (The old `team.members.some` check
+  // happened to block this; the RoleBinding-aware check does not.)
+  if (isDemoProject(projectId, "project:view")) {
+    return c.json(
+      { error: "Project not found or you don't have access" },
+      403,
+    );
+  }
 
-  if (!project) {
+  // Authorize against RoleBindings (the authoritative source since migration
+  // 20260407120000_migrate_team_users_to_role_bindings), not the legacy
+  // TeamUser relation. A user added to the team after that migration has no
+  // TeamUser row, so the old `team.members.some` check rejected them with a
+  // false 403. `project:view` is the baseline grant every team role (incl.
+  // VIEWER) has, and hasProjectPermission also honors org-level access.
+  // ProjectService is constructed directly (not via getApp()) so this handler
+  // stays unit-testable without booting the app container — the same pattern
+  // used in presets.ts and the project-service middleware.
+  const projectService = new ProjectService(new PrismaProjectRepository(prisma));
+  const project = await projectService.getById(projectId);
+
+  if (
+    !project ||
+    project.archivedAt !== null ||
+    !(await hasProjectPermission({ prisma, session }, projectId, "project:view"))
+  ) {
+    // Single 403 whether the project is missing, archived, or simply
+    // inaccessible — never disclose existence of a project the caller can't reach.
     return c.json(
       { error: "Project not found or you don't have access" },
       403,

--- a/langwatch/src/server/teams/team.service.ts
+++ b/langwatch/src/server/teams/team.service.ts
@@ -1,5 +1,28 @@
 import { Prisma, RoleBindingScopeType, TeamUserRole, type PrismaClient } from "@prisma/client";
 import { NotFoundError, ValidationError } from "~/server/app-layer/domain-error";
+import { PrismaRoleBindingRepository } from "~/server/app-layer/role-bindings/repositories/role-binding.prisma.repository";
+import type {
+  RoleBindingRepository,
+  TeamScopedMemberBinding,
+} from "~/server/app-layer/role-bindings/repositories/role-binding.repository";
+
+// When a user holds multiple bindings on one team, the most privileged is the
+// one the settings page displays (and the binding team.update edits).
+export const TEAM_ROLE_PRIORITY: Record<TeamUserRole, number> = {
+  [TeamUserRole.ADMIN]: 0,
+  [TeamUserRole.MEMBER]: 1,
+  [TeamUserRole.VIEWER]: 2,
+  [TeamUserRole.CUSTOM]: 3,
+};
+
+// Ascending, nulls last — matches Postgres `ORDER BY col ASC` (the ordering the
+// previous Prisma `orderBy` produced before members were resolved in memory).
+function compareNullsLast(a: string | null, b: string | null): number {
+  if (a === b) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return a.localeCompare(b);
+}
 
 type TxClient = Prisma.TransactionClient;
 
@@ -64,7 +87,180 @@ async function isUserAdminViaGroup(
 }
 
 export class TeamService {
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(
+    private readonly prisma: PrismaClient,
+    // Constructed once and reused across reads; the default keeps existing
+    // `new TeamService(prisma)` call sites working while allowing injection.
+    private readonly roleBindingRepo: RoleBindingRepository = new PrismaRoleBindingRepository(
+      prisma,
+    ),
+  ) {}
+
+  /**
+   * Shape TEAM-scoped RoleBindings into the legacy `team.members` (TeamUser)
+   * form so callers render members the same way regardless of when membership
+   * was created.
+   *
+   * RoleBindings are the authoritative membership source since migration
+   * 20260407120000_migrate_team_users_to_role_bindings (which backfilled
+   * existing TeamUser rows and stopped dual-writing to them). Reading the
+   * legacy TeamUser relation omitted anyone added after the migration.
+   *
+   * A user can hold more than one TEAM binding on the same team (the partial
+   * unique indexes allow a built-in role plus a custom role at one scope), so
+   * we collapse to one row per user keeping the highest-privilege binding —
+   * the settings page renders (and its save mutation keys) one row per user.
+   */
+  private shapeTeamMembers(
+    bindings: TeamScopedMemberBinding[],
+    teamId: string,
+  ) {
+    const byUser = new Map<string, TeamScopedMemberBinding>();
+    for (const binding of bindings) {
+      const existing = byUser.get(binding.userId);
+      if (
+        !existing ||
+        TEAM_ROLE_PRIORITY[binding.role] < TEAM_ROLE_PRIORITY[existing.role]
+      ) {
+        byUser.set(binding.userId, binding);
+      }
+    }
+
+    return [...byUser.values()]
+      .map((binding) => ({
+        userId: binding.userId,
+        teamId,
+        role: binding.role,
+        assignedRoleId: binding.customRoleId,
+        assignedRole: binding.customRole,
+        createdAt: binding.createdAt,
+        updatedAt: binding.updatedAt,
+        user: binding.user,
+      }))
+      .sort((a, b) => {
+        const nameCmp = compareNullsLast(a.user.name, b.user.name);
+        if (nameCmp !== 0) return nameCmp;
+        const emailCmp = compareNullsLast(a.user.email, b.user.email);
+        if (emailCmp !== 0) return emailCmp;
+        return a.userId.localeCompare(b.userId);
+      });
+  }
+
+  /**
+   * A single team (by slug) plus its projects and members, for the
+   * team-settings page. Returns `null` when no team matches; the caller maps
+   * null to NOT_FOUND and applies email-privacy redaction (request-scoped).
+   */
+  async getTeamWithMembers({
+    slug,
+    organizationId,
+  }: {
+    slug: string;
+    organizationId: string;
+  }) {
+    const team = await this.prisma.team.findFirst({
+      where: { slug, organizationId },
+      include: {
+        projects: {
+          where: {
+            archivedAt: null,
+            kind: { not: "internal_governance" },
+          },
+        },
+      },
+    });
+
+    if (!team) return null;
+
+    const byTeam = await this.roleBindingRepo.listTeamScopedUserBindingsByTeamIds({
+      organizationId,
+      teamIds: [team.id],
+    });
+
+    return { ...team, members: this.shapeTeamMembers(byTeam.get(team.id) ?? [], team.id) };
+  }
+
+  /**
+   * All non-archived teams in an org, each with projects + members, for member
+   * pickers / drawers / onboarding. `callerHasManage` controls the personal-
+   * workspace privacy floor (non-admins never see others' personal teams).
+   * Email redaction stays in the caller since it's request-scoped.
+   */
+  async getTeamsWithMembers({
+    organizationId,
+    callerId,
+    callerHasManage,
+  }: {
+    organizationId: string;
+    callerId: string;
+    callerHasManage: boolean;
+  }) {
+    const teams = await this.prisma.team.findMany({
+      where: {
+        organizationId,
+        archivedAt: null,
+        ...(callerHasManage
+          ? {}
+          : {
+              OR: [
+                { isPersonal: false },
+                { isPersonal: true, ownerUserId: callerId },
+              ],
+            }),
+      },
+      include: {
+        projects: {
+          where: {
+            archivedAt: null,
+            kind: { not: "internal_governance" },
+          },
+        },
+      },
+    });
+
+    // Single binding query for all teams (no N+1), grouped by teamId.
+    const byTeam = await this.roleBindingRepo.listTeamScopedUserBindingsByTeamIds({
+      organizationId,
+      teamIds: teams.map((team) => team.id),
+    });
+
+    return teams.map((team) => ({
+      ...team,
+      members: this.shapeTeamMembers(byTeam.get(team.id) ?? [], team.id),
+    }));
+  }
+
+  /**
+   * A team looked up by slug, returned only if the user is a direct member —
+   * membership resolved from TEAM-scoped RoleBindings (not the legacy TeamUser
+   * relation, which post-migration members are absent from). Returns `null`
+   * when the team doesn't exist or the user isn't a member.
+   */
+  async getTeamBySlugForUser({
+    slug,
+    organizationId,
+    userId,
+  }: {
+    slug: string;
+    organizationId: string;
+    userId: string;
+  }) {
+    const team = await this.prisma.team.findFirst({
+      where: { slug, organizationId },
+    });
+
+    if (!team) return null;
+
+    const byTeam = await this.roleBindingRepo.listTeamScopedUserBindingsByTeamIds({
+      organizationId,
+      teamIds: [team.id],
+    });
+
+    const isMember = (byTeam.get(team.id) ?? []).some(
+      (binding) => binding.userId === userId,
+    );
+    return isMember ? team : null;
+  }
 
   async getTeamsWithRoleBindings({ organizationId }: { organizationId: string }) {
     const teams = await this.prisma.team.findMany({


### PR DESCRIPTION
## Problem

Customer-reported: an admin added to a team at `/settings/teams/<slug>` saved fine but **disappeared on refresh**, and that same user got `Authorization failed: Project not found or you don't have access` when authorizing an **MCP connection**.

One root cause: team membership is written **only** to `RoleBinding` since migration `20260407120000_migrate_team_users_to_role_bindings` (which backfilled existing `TeamUser` rows and stopped dual-writing), but multiple read paths still queried the legacy `TeamUser` relation. Pre-migration members (with backfilled rows) worked; anyone added through today's UI exists only as a `RoleBinding` → invisible to those reads.

| Path | Symptom |
|------|---------|
| `team.getTeamWithMembers` | added member vanishes on refresh (the reported bug) |
| `team.getTeamsWithMembers` | post-migration members missing from member pickers / drawers / onboarding |
| `team.getBySlug` | post-migration member fails the access gate (returns null) |
| `POST /api/mcp/authorize` | false 403 on **Allow** |

Instance of the `TeamUser`→`RoleBinding` migration gap tracked by #3323 / #3430; prior fix #3387 covered `updateMemberRole` only.

## Fix

All membership reads resolve from `RoleBinding` through the **service/repository layer** (no raw Prisma in routers/routes):

- **`RoleBindingRepository.listTeamScopedUserBindingsByTeamIds`** (new) — direct user members for N teams in **one** query, grouped by teamId (no N+1).
- **`TeamService`** gains `getTeamWithMembers`, `getTeamsWithMembers`, `getTeamBySlugForUser`, sharing one `shapeTeamMembers` helper that maps bindings to the `TeamUser`-compatible shape the UI already renders. A user can hold **multiple** TEAM bindings on one team (the partial unique indexes allow a built-in + a custom role at one scope), so it dedupes to **one row per user, highest-privilege wins**. Sort is nulls-last to match the previous Postgres `orderBy`. Request-scoped email redaction stays in the router.
- **Write path (`team.update`)** now synchronizes **all** of a submitted user's TEAM bindings — keeps one at the target role, deletes extras (delete-first to avoid transient unique-index collisions), and removes every binding for users dropped from the team. Previously it keyed by `userId` (last-wins) and touched a single arbitrary binding, so downgrading a user who held e.g. ADMIN+MEMBER could leave an elevated binding active.

### MCP authorize — intentionally broader than the old check

The old `team.members.some({ userId })` required the caller be a **direct team member**. The new check fetches the project via `ProjectService.getById` and authorizes with `hasProjectPermission(project:view)`, which also admits **org admins** and **project-scoped bindings**. This is deliberate: a user with a PROJECT-scoped binding genuinely has project access but was wrongly denied by the old team-only check. `project:view` is the baseline every team role (incl. VIEWER) grants, so no normal member loses access.

### Security: demo-project guard

`isDemoProject` grants `project:view` to **everyone**, so the RoleBinding-aware MCP check would let any authenticated user mint an auth code embedding the **demo project's API key**. (The old `team.members.some` check happened to block this.) MCP authorize now rejects the demo project up front.

## Tests

Run the real router/route + real RBAC logic (DB boundary mocked); no string assertions:

- `team.rolebinding-membership-reads.unit.test.ts` — RoleBinding-only member returned by `getTeamWithMembers`/`getTeamsWithMembers`; multi-binding user collapses to one highest-privilege row; `getBySlug` honors RoleBinding membership (team for a bound caller, `null` otherwise); empty-bindings case.
- `team.update.multi-binding.unit.test.ts` — downgrading a user who holds ADMIN+MEMBER to VIEWER deletes the extra binding and leaves no elevated role.
- `mcp-authorize.rolebinding.unit.test.ts` — RoleBinding-only user authorizes (200 + code); no-binding user denied (403); **demo project rejected (403)** despite `isDemoProject` granting `project:view`.
- `rbac.member-leak-coverage.integration.test.ts` — privacy fixtures converted to TEAM-scoped RoleBindings so the existing email-redaction guarantees stay tested under the new read path.

Full typecheck clean; related existing suites (rbac, role-binding-resolver, project-service, apiKey) pass unaffected. No `@scenario` tags added (bug fix), so feature-parity is unaffected.

## Out of scope

Broader retirement of `TeamUser` as a permission source at other call sites remains under #3323 / #3430.

Fixes #4704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team membership now comes from role-based bindings: team list/detail show deduplicated members with prioritized roles, manager-aware email redaction, and more efficient member loading.
  * Team membership updates now correctly reconcile multiple role bindings so member role changes apply reliably.
* **Bug Fixes**
  * Project authorization moved to RBAC checks with unified 403 responses and explicit denial for demo projects.
* **Tests**
  * Added unit and integration tests covering role-binding membership resolution and authorization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->