### PR TITLE
perf(clickhouse): add time predicate to trace-peek span tree read

### DIFF
--- a/langwatch/src/features/traces-v2/components/TraceTable/registry/addons/trace/ExpandedPeekAddon.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/registry/addons/trace/ExpandedPeekAddon.tsx
@@ -83,7 +83,10 @@ function flattenPeekTree(nodes: PeekTreeNode[]): PeekTreeNode[] {
 }
 
 const InlinePeekContent: React.FC<{ trace: TraceListItem }> = ({ trace }) => {
-  const { data: spans, isLoading } = useTraceSpanTree(trace.traceId);
+  const { data: spans, isLoading } = useTraceSpanTree(
+    trace.traceId,
+    trace.timestamp,
+  );
 
   const flatSpans = useMemo(() => {
     if (!spans || spans.length === 0) return [];

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useTraceSpanTree.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useTraceSpanTree.unit.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTraceSpanTree } from "../useTraceSpanTree";
+
+type SpanTreeInput = {
+  projectId: string;
+  traceId: string;
+  occurredAtMs?: number;
+};
+
+const capturedInputs: SpanTreeInput[] = [];
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    tracesV2: {
+      spanTree: {
+        useQuery: (input: SpanTreeInput) => {
+          capturedInputs.push(input);
+          return { data: [], isLoading: false };
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "p1" } }),
+}));
+
+vi.mock("../../onboarding/data/samplePreviewTraces", () => ({
+  isPreviewTraceId: () => false,
+}));
+
+const lastInput = (): SpanTreeInput => {
+  const input = capturedInputs[capturedInputs.length - 1];
+  if (!input) {
+    throw new Error("no query input was captured");
+  }
+  return input;
+};
+
+describe("useTraceSpanTree", () => {
+  beforeEach(() => {
+    capturedInputs.length = 0;
+  });
+
+  describe("when the row's trace timestamp is supplied", () => {
+    it("forwards it as the occurredAtMs partition hint", () => {
+      renderHook(() => useTraceSpanTree("trace-123", 1_700_000_000_000));
+
+      expect(lastInput()).toMatchObject({
+        traceId: "trace-123",
+        occurredAtMs: 1_700_000_000_000,
+      });
+    });
+  });
+
+  describe("when no trace timestamp is supplied", () => {
+    it("leaves occurredAtMs undefined (unconstrained scan fallback)", () => {
+      renderHook(() => useTraceSpanTree("trace-123"));
+
+      expect(lastInput().occurredAtMs).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/hooks/useTraceSpanTree.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceSpanTree.ts
@@ -9,11 +9,16 @@ import { isPreviewTraceId } from "../onboarding/data/samplePreviewTraces";
  * Distinct from `useSpansFull` (which pulls full attributes for the active
  * drawer trace via the drawer store) because peek consumers know the
  * traceId from a row prop, not from the open drawer.
+ *
+ * `occurredAtMs` (the row's trace timestamp) is forwarded as a partition hint
+ * so the `stored_spans` read prunes to the trace's weekly partitions instead
+ * of cold-scanning every partition (incl. S3). It is optional; callers that
+ * don't have it fall back to the unconstrained scan.
  */
-export function useTraceSpanTree(traceId: string) {
+export function useTraceSpanTree(traceId: string, occurredAtMs?: number) {
   const { project } = useOrganizationTeamProject();
   return api.tracesV2.spanTree.useQuery(
-    { projectId: project?.id ?? "", traceId },
+    { projectId: project?.id ?? "", traceId, occurredAtMs },
     {
       enabled: !!project?.id && !!traceId && !isPreviewTraceId(traceId),
       staleTime: 300_000,

--- a/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
+++ b/langwatch/src/server/experiments-v3/execution/__tests__/workflowBuilder.test.ts
@@ -751,6 +751,7 @@ describe("buildEvaluatorTargetNode", () => {
 // drawer's "Open in Prompts" resume is hidden.
 describe("buildSignatureNodeFromPrompt", () => {
   const createVersionedPrompt = (): VersionedPrompt => ({
+    parameters: {},
     id: "prompt_supportrouter_xyz",
     name: "support-router",
     handle: "support-router",
@@ -831,6 +832,7 @@ describe("buildSignatureNodeFromPrompt", () => {
 
 describe("buildSignatureNodeFromLocalConfig", () => {
   const createBasePrompt = (): VersionedPrompt => ({
+    parameters: {},
     id: "prompt_supportrouter_xyz",
     name: "support-router",
     handle: "support-router",


### PR DESCRIPTION
## Evidence

In the last 24h of prod ClickHouse logs (Signal C, cold scans), one of the top `stored_spans` cold-scan shapes is the trace-peek span read, paramKeys `[tenantId, traceId]` (~435 cold scans/day):

```
SELECT SpanId, ParentSpanId, SpanName, DurationMs, StatusCode,
       SpanAttributes['langwatch.span.type'] AS SpanType, ... FROM stored_spans
WHERE TenantId = {…} AND TraceId = {…} AND (dedup) ORDER BY StartTimeMs
```

`stored_spans` is partitioned on `StartTime` (weekly) and tiered to S3 after the hot window. A read with no `StartTime` predicate cannot prune partitions and walks every weekly part, including cold ones on S3, bursting S3 GET requests. Latency is usually acceptable here (small result), so this is a **cost** signal, not a latency one.

## Suspected cause

The server side is already fixed: the `spanTree` tRPC procedure accepts an optional `occurredAtMs` (`spanReadHintShape`) and `getSpanSummaryByTraceId` threads it through `withPartitionHint` (a ±2-day `StartTime` window). The cold scan comes from a **caller that omits the hint**: `useTraceSpanTree` (the table-row peek expansion, `ExpandedPeekAddon`) calls the query with only `{ projectId, traceId }`, so `occurredAtFromInput` returns empty and the server takes the unconstrained fallback path.

This peek path was missed when the span-tree hint was wired (#4661).

## Proposed fix

The trace-list row (`TraceListItem`) already carries its `timestamp`, so forward it:

- `useTraceSpanTree(traceId, occurredAtMs?)` passes `occurredAtMs` into the `spanTree` query input.
- `ExpandedPeekAddon` supplies `trace.timestamp`.

No server change: the existing `spanReadHintShape` + `withPartitionHint` widen the point timestamp to a ±2-day `StartTime` window. Omitted hints keep the current unconstrained fallback, so the change is backward-compatible.

## Expected impact

The peek span read prunes from every weekly `stored_spans` partition down to the trace's ±2-day window, eliminating the cold-partition S3 GET burst for this shape. Headline metric is **S3 GET reduction / cost**, not user-visible latency (the peek already returns quickly). No change for callers that don't pass a timestamp.

## EXPLAIN check

The query shape and the server-side `StartTime` window are unchanged from the already-merged span-tree hint (#4661); this PR only ensures the hint reaches that path from the peek caller. The partition-prune effect of a `StartTime` predicate on `stored_spans` (parts read dropping to a small fraction) is the same one validated in #4661's EXPLAIN. No new query shape is introduced, so there is no additional plan delta to show.

## Test plan

- `useTraceSpanTree.unit.test.ts` (new, jsdom): mocks the `spanTree` tRPC query and asserts (a) a supplied trace timestamp is forwarded as `occurredAtMs`, and (b) when omitted, `occurredAtMs` is `undefined` (the unconstrained fallback is preserved). Both green.
- `pnpm typecheck` clean for the changed files.

Advisory PR from the ClickHouse slow-query optimizer. Open for review, not for self-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating trace span tree behavior with and without a trace timestamp; updated test fixtures for prompt-related builders.

* **Refactor**
  * Trace span retrieval now optionally uses a trace timestamp to better constrain queries, improving loading efficiency and accuracy when timestamps are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->