### PR TITLE
docs: add Cloud pricing page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -212,7 +212,8 @@
                   "platform/rbac",
                   "platform/audit-log",
                   "platform/scim",
-                  "platform/model-providers"
+                  "platform/model-providers",
+                  "platform/data-retention"
                 ]
               }
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -245,6 +245,7 @@
           {
             "group": "Help",
             "pages": [
+              "pricing",
               "support",
               "status"
             ]

--- a/docs/platform/data-retention.mdx
+++ b/docs/platform/data-retention.mdx
@@ -22,7 +22,7 @@ Retention is configured with **retention policies**. Each policy has two parts:
   - **Project** — overrides both the team and organization defaults for that project only.
 - **Retention period** — how long data is kept before deletion.
 
-Retention periods are chosen from week-aligned options — for example **7 weeks**, **3 months**, **6 months**, **1 year**, **2 years**, or **5 years** — and you can set a custom value in weeks, months, or years. Periods always round to whole weeks, because deletion is partition-aligned (see [How deletion works](#how-deletion-works)).
+Retention periods range from a few weeks up to several years, set in weeks, months, or years. Periods always round to whole weeks, because deletion is partition-aligned (see [How deletion works](#how-deletion-works)).
 
 <Note>
   When you retain data longer than your plan's included window, the additional storage is billed at **€3 per extra GB** — you only pay for what you actually store.

--- a/docs/platform/data-retention.mdx
+++ b/docs/platform/data-retention.mdx
@@ -1,0 +1,76 @@
+---
+title: Data Retention
+description: Control how long LangWatch keeps your event data before it's deleted.
+keywords: data retention, retention policy, delete data, ttl, retention period, enterprise, self-hosting
+---
+
+With LangWatch's Data Retention controls, you decide how long your event data is kept before it's automatically deleted. Retention applies to the events LangWatch ingests — the spans within your traces and your scenario runs — along with their associated data.
+
+You can tighten or extend retention per scope, giving teams that handle sensitive data full control over how long it lives in LangWatch.
+
+<Note>
+  Configuring data retention requires an **Enterprise plan**. On other plans, every project uses the platform default window. See the [pricing page](/pricing) for how extended retention is billed.
+</Note>
+
+## How it works
+
+Retention is configured with **retention policies**. Each policy has two parts:
+
+- **Scope** — the level the policy applies to. Policies cascade most-specific-first, so a more specific scope overrides a broader one:
+  - **Organization** — the default that applies to every project in the org.
+  - **Team** — overrides the organization default for projects in that team.
+  - **Project** — overrides both the team and organization defaults for that project only.
+- **Retention period** — how long data is kept before deletion.
+
+Retention periods are chosen from week-aligned options — for example **7 weeks**, **3 months**, **6 months**, **1 year**, **2 years**, or **5 years** — and you can set a custom value in weeks, months, or years. Periods always round to whole weeks, because deletion is partition-aligned (see [How deletion works](#how-deletion-works)).
+
+<Note>
+  When you retain data longer than your plan's included window, the additional storage is billed at **€3 per extra GB** — you only pay for what you actually store.
+</Note>
+
+## Configuration
+
+Organization owners and administrators manage policies under **Settings → Data Retention** at [app.langwatch.ai/settings/data-retention](https://app.langwatch.ai/settings/data-retention).
+
+To add a scoped policy:
+
+<Steps>
+  <Step title="Open the drawer">
+    Click **Add retention policy**.
+  </Step>
+  <Step title="Choose a scope">
+    Pick the organization, a team, or a single project. A more specific scope overrides the broader defaults.
+  </Step>
+  <Step title="Pick a retention period">
+    Choose one of the preset windows or enter a custom value in weeks, months, or years.
+  </Step>
+  <Step title="Create">
+    Click **Create** to save the policy.
+  </Step>
+</Steps>
+
+### Applying the change to existing data
+
+When you create or update a policy, you choose whether it applies only going forward or also to data you've already stored:
+
+- **Off** — the new retention applies to newly ingested data only.
+- **On** (*"Apply this change to existing data"*) — LangWatch rewrites the scope's existing rows so the new retention takes effect immediately, not just for new ingestion. Data that is already older than the new window is removed on the next cleanup.
+
+## How deletion works
+
+LangWatch periodically removes any events that fall outside the configured retention window. Because retention is partition-aligned, data is cleaned up in whole-week partitions rather than row-by-row at the exact second it expires.
+
+A few things to keep in mind:
+
+<Warning>
+  **Deletion is permanent.** Once data is removed it cannot be recovered. If you need to keep data beyond your retention window, export it before it expires.
+</Warning>
+
+- **Retention applies to the underlying data, regardless of references.** If another object — for example a dataset or an evaluation — references an event that has since been deleted, that reference will point to data that no longer exists.
+- **More specific scopes override broader ones.** A project with its own policy ignores the team and organization defaults; a team policy overrides the organization default.
+
+## Self-hosted and hybrid instances
+
+Data Retention works the same way on self-hosted deployments, with deletion running against your own storage. Make sure the LangWatch service has permission to delete objects from the storage bucket it manages.
+
+If you use versioned object storage, removing an object leaves earlier versions and delete markers in place — clean these up manually or with a storage lifecycle rule. See the [self-hosting docs](/self-hosting/overview) for setup details.

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -14,7 +14,7 @@ LangWatch Cloud pricing is built around two ideas: **seats scale with your team,
 
 LangWatch Cloud pricing is based on the number of **ingested events per billing period.**
 
-An event is a standard telemetry point — the building block of everything you observe in LangWatch. A single event captures a moment in your system: an LLM call, a span, a tool execution, a span timer firing, or the point at which a system error occurred.
+An event is a standard telemetry point — the building block of everything you observe in LangWatch. The most common event is a **span**: a single step in your system, such as an LLM call, a tool execution, a retrieval step, a span timer firing, or the point at which an error occurred.
 
 A **billable event** is either:
 
@@ -74,7 +74,7 @@ This keeps the model predictable: your base plan covers normal usage at its defa
   </Accordion>
 
   <Accordion title="Can I self-host or run a hybrid setup?">
-    Yes. LangWatch is available both [self-hosted](/self-hosting/overview) and [hybrid](/hybrid-setup/overview). With the hybrid option you get the convenience of running on our Cloud while your data stays on your side. See the self-hosting docs or reach out for more information. You can run the self-hosted version for free; if you'd require enterprise features such as SSO, RBAC, SCIM, or a support SLA, [reach out to us](mailto:enterprise@langwatch.ai).
+    Yes. LangWatch is available both [self-hosted](/self-hosting/overview) and [hybrid](/hybrid-setup/overview). With the hybrid option you get the convenience of running on our Cloud while your data stays on your side. See the self-hosting docs or reach out for more information. You can run the self-hosted version for free. If you require enterprise features such as SSO, RBAC, SCIM, or a support SLA, [reach out to us](mailto:enterprise@langwatch.ai).
   </Accordion>
 
   <Accordion title="Where is my data stored?">

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -25,7 +25,7 @@ Both contribute to your event count for the billing period. There are no separat
 
 ### What's included
 
-Each plan includes a base volume of events stored for a default window. For example, the **Growth** plan includes **200,000 events stored for 30 days.** If you need more — a longer retention window or higher volume — you can [extend storage](#extending-retention) rather than jumping to a different price tier.
+Each plan includes a base volume of events stored for a default window. For example, the **Growth** plan includes **200,000 events stored for 30 days.** If you need more — a longer retention window or higher volume — you can [extend retention](#extending-retention) with an Enterprise plan or a self-hosted license.
 
 ## Custom data retention
 
@@ -40,12 +40,14 @@ Retention controls how long your events are kept before they're automatically re
 
 ### Extending retention
 
-On the Growth plan, your 200,000 included events are stored for 30 days. If you want to keep more — whether that's a longer window or a higher volume of stored events — you can extend storage for **€3 per GB.** You set this directly in the platform, so you only pay for the additional storage you actually use.
+Going beyond your plan's default window — keeping events longer, or storing a higher volume — is a licensed capability. It's available on **Enterprise plans**, or when you **self-host with a license**; it isn't a self-serve toggle on the standard Cloud tiers.
 
-This keeps the model predictable: your base plan covers normal usage, and retention scales linearly with storage rather than forcing an upgrade.
+On Enterprise, extended storage is priced from **€3 per GB** and configured as part of your agreement, so you only pay for the additional storage you actually use. Self-hosted deployments with a license configure retention directly in the platform.
+
+This keeps the model predictable: your base plan covers normal usage at its default window, and longer or higher-volume retention is unlocked through an Enterprise agreement or a self-hosted license.
 
 <Note>
-  If you're on a custom or Enterprise plan, retention is configured as part of your agreement — reach out to your contact or [enterprise@langwatch.ai](mailto:enterprise@langwatch.ai).
+  To extend retention beyond your plan default, reach out to your contact or [enterprise@langwatch.ai](mailto:enterprise@langwatch.ai). Self-hosting? See the [self-hosting docs](/self-hosting/overview) to configure retention with a license.
 </Note>
 
 ## Frequently asked questions
@@ -65,6 +67,10 @@ This keeps the model predictable: your base plan covers normal usage, and retent
 
   <Accordion title="What counts as a billable event?">
     A billable event is either a span within a trace or a scenario run used to test your AI agents. Pricing is based on the total number of ingested events per billing period.
+  </Accordion>
+
+  <Accordion title="Can I customize how long my data is retained?">
+    Each plan includes a default retention window (see the table above). Extending it — a longer window or a higher volume of stored events — is available on **Enterprise plans** or when you **self-host with a license**. Reach out to [enterprise@langwatch.ai](mailto:enterprise@langwatch.ai) to set this up.
   </Accordion>
 
   <Accordion title="Can I self-host or run a hybrid setup?">

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -1,0 +1,95 @@
+---
+title: Pricing
+description: How LangWatch Cloud pricing works — events, data retention, and answers to common questions.
+keywords: pricing, events, billable event, data retention, plans, free plan, enterprise, self-hosting
+---
+
+LangWatch Cloud pricing is built around two ideas: **seats scale with your team, and usage stays cheap.** Building reliable AI systems is collaborative work — engineers iterate, product teams define success metrics, domain experts review outputs, and stakeholders track performance. We price around that collaboration and keep usage costs extremely low, so growing your tracking, evaluations, and production traffic never feels like a penalty.
+
+<Card title="Start for free — no credit card required" icon="rocket" href="https://app.langwatch.ai">
+  The free plan gives you immediate access to all core features, including evaluations, monitoring, and agent simulations.
+</Card>
+
+## Events
+
+LangWatch Cloud pricing is based on the number of **ingested events per billing period.**
+
+An event is a standard telemetry point — the building block of everything you observe in LangWatch. A single event captures a moment in your system: an LLM call, a span, a tool execution, a span timer firing, or the point at which a system error occurred.
+
+A **billable event** is either:
+
+- **A span within a trace** — the individual steps that make up a request to your agent or LLM application, or
+- **A scenario or evaluation run** — a single execution used to test your AI agents in simulation.
+
+Both contribute to your event count for the billing period. There are no separate charges per feature on top of this — evaluations, monitoring, and simulations all run against the same event stream.
+
+### What's included
+
+Each plan includes a base volume of events stored for a default window. For example, the **Growth** plan includes **200,000 events stored for 30 days.** If you need more — a longer retention window or higher volume — you can [extend storage](#extending-retention) rather than jumping to a different price tier.
+
+## Custom data retention
+
+Retention controls how long your events are kept before they're automatically removed. Default retention depends on your plan:
+
+| Plan | Default retention |
+| --- | --- |
+| Free | 14 days |
+| Accelerate (legacy) | 30 days |
+| Growth | 30 days |
+| Custom / Enterprise | Defined with you directly |
+
+### Extending retention
+
+On the Growth plan, your 200,000 included events are stored for 30 days. If you want to keep more — whether that's a longer window or a higher volume of stored events — you can extend storage for **€3 per GB.** You set this directly in the platform, so you only pay for the additional storage you actually use.
+
+This keeps the model predictable: your base plan covers normal usage, and retention scales linearly with storage rather than forcing an upgrade.
+
+<Note>
+  If you're on a custom or Enterprise plan, retention is configured as part of your agreement — reach out to your contact or [enterprise@langwatch.ai](mailto:enterprise@langwatch.ai).
+</Note>
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="How does pricing behave as I scale up?">
+    There are no sudden pricing jumps tied to volume. LangWatch is designed so teams can track all agent activity, run continuous evaluations, and scale to production workloads without their bill spiking. Seats scale with team size, and event pricing stays extremely low — because reliable AI is built collaboratively, we focus pricing on collaboration and keep usage costs minimal so growth is never discouraged.
+  </Accordion>
+
+  <Accordion title="Is there a free plan?">
+    Yes. You can start for free with LangWatch Cloud, no credit card required. The free plan gives you immediate access to all core features — evaluations, monitoring, and agent simulations. It's ideal for developers who want to experiment or run small-scale testing.
+  </Accordion>
+
+  <Accordion title="What if I'm working with sensitive data from the start?">
+    Run LangWatch locally on your own machine. All features are available from our [open-source repository](https://github.com/langwatch/langwatch), so you can build with sensitive data without it leaving your environment.
+  </Accordion>
+
+  <Accordion title="What counts as a billable event?">
+    A billable event is either a span within a trace or a scenario run used to test your AI agents. Pricing is based on the total number of ingested events per billing period.
+  </Accordion>
+
+  <Accordion title="Can I self-host or run a hybrid setup?">
+    Yes. LangWatch is available both [self-hosted](/self-hosting/overview) and [hybrid](/hybrid-setup/overview). With the hybrid option you get the convenience of running on our Cloud while your data stays on your side. See the self-hosting docs or reach out for more information. You can run the self-hosted version for free; if you'd require enterprise features such as SSO, RBAC, SCIM, or a support SLA, [reach out to us](mailto:enterprise@langwatch.ai).
+  </Accordion>
+
+  <Accordion title="Where is my data stored?">
+    For LangWatch Cloud, data is stored securely in the EU. For the US, Pacific, and other regions, contact us at [contact@langwatch.ai](mailto:contact@langwatch.ai) and we'll meet your requirements. For Enterprise users, we offer on-premise options so your data stays entirely within your own infrastructure — nothing leaves your environment.
+  </Accordion>
+
+  <Accordion title="Do you support custom contracts and procurement reviews?">
+    Yes. We know procurement and legal teams often have their own review processes. For Enterprise and regulated-industry plans, we support custom contracting and custom workflows.
+  </Accordion>
+
+  <Accordion title="Is LangWatch secure and compliant?">
+    LangWatch is ISO 27001 and GDPR compliant. Enterprise customers can request our security documentation, pentest results, and vendor assessments. For more, see [langwatch.ai/security](https://langwatch.ai/security).
+  </Accordion>
+
+  <Accordion title="Can my security team review your security documentation?">
+    Yes. Your security team can access the full set of LangWatch security documentation, including:
+
+    - **Pentest report** — performed by a CREST-certified third-party security firm, covering LangWatch Cloud and hybrid setups.
+    - **Data flow & architecture diagrams** — including deployment models, encryption protocols (in-transit and at-rest), and data boundaries.
+    - **Latest ISO 27001 reports** — covering more than SOC 2.
+
+    Reach out to our team at [enterprise@langwatch.ai](mailto:enterprise@langwatch.ai).
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
## Why

Customers and prospects need clear docs for how LangWatch Cloud pricing works and how data retention is configured — what a billable event is, plan retention defaults, how to extend retention, and how to set retention policies in-product. Neither page existed.

## What changed

Two new docs pages, both wired into `docs/docs.json` nav:

**1. `docs/pricing.mdx` (Platform → Help)**
- **Events** — what an event is and what counts as billable (span within a trace, or a scenario/evaluation run).
- **What's included** — base volume + default retention window per plan.
- **Custom data retention** — per-plan default retention table; extended/custom retention positioned as an **Enterprise-plan or self-hosted-license** capability (not a self-serve Growth toggle). Enterprise extended storage from €3/GB.
- **FAQ** — scaling, free plan, sensitive data, retention customization, self-host/hybrid, data residency, contracts, security & compliance.

**2. `docs/platform/data-retention.mdx` (Platform → Administration)**
- **How it works** — retention policies with an **Organization → Team → Project** scope cascade (most-specific wins), and week-aligned retention periods (7 weeks / 3 months / 6 months / 1 / 2 / 5 years + custom).
- **Configuration** — `Settings → Data Retention` flow (`/settings/data-retention`), `Add retention policy` steps.
- **Apply to existing data** — forward-only vs. retroactive rewrite toggle.
- **How deletion works** — partition-aligned whole-week cleanup, permanence, dangling references, scope precedence.
- **Self-hosted & hybrid** — deletion against your own storage, versioned-bucket cleanup caveat.

## How it works

Standard Mintlify MDX using existing components (`Card`, `Note`, `Warning`, `Steps`, `AccordionGroup`). Cross-links between the two pages and to `/self-hosting/overview`, `/hybrid-setup/overview`, security page, and mailto contacts. `docs.json` validated.

## Test plan

- `python3 -c "import json; json.load(open('docs/docs.json'))"` passes.
- Data-retention page verified against the actual implementation: route `pages/settings/data-retention.tsx`, scope triad in `ScopeChipPicker`/`dataRetentionPolicy.authz.ts`, week-aligned presets in `components/data-retention/constants.ts`, headings/buttons ("Retention Policies", "Add retention policy").
- Visual render to be confirmed on the Mintlify preview deploy.

## Anything surprising?

- **Corrected two errors from the source copy** for the retention page: scope is an org/team/**project** triad (source said org+project only), and periods are **week-aligned** presets (source's "7 days / 30 days" examples aren't valid — minimum is 7 weeks / 49 days, the platform default).
- **Docs/code gap on retention gating (intentional, docs-only):** both pages state retention config requires an **Enterprise plan**, but current code (`canConfigureRetention`) unlocks it for **any paid plan** (Growth included); *disabling* retention (keep-forever) is platform-admin/self-hosted only. Docs are deliberately stricter than enforcement — tightening the code gate was scoped out.
- Public-facing copy with **hard pricing claims** (€3/GB, 200k events, retention windows) — worth a content/marketing sign-off before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive pricing documentation covering billing models, billable events, plan inclusions, and cost factors.
  * Added data retention documentation detailing retention policies, configuration options, and deletion behavior across different deployment types.
  * Updated navigation to include pricing information in the Help section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->