### PR TITLE
feat(traces): add from/select projection DSL + updated-axis to /api/traces/search

### DIFF
--- a/docs/api-reference/traces/overview.mdx
+++ b/docs/api-reference/traces/overview.mdx
@@ -11,6 +11,13 @@ Both search and get-trace endpoints support a `format` parameter:
 - **`digest`** (default), Returns an AI-readable formatted trace with hierarchical span tree, timing, inputs/outputs, and errors. Optimized for LLM consumption.
 - **`json`**, Returns the full raw trace data with all fields.
 
+For data-team ETL, `POST /api/traces/search` also accepts a **projection DSL**
+(`from` + `select`) that returns exactly the fields you ask for — including
+nested events, annotations, and evaluations joined server-side — so a daily pull
+becomes one paginated loop instead of a per-trace fan-out. It pairs with a
+`dateField` option to page by when traces were **last modified** rather than when
+they occurred. See [Projection DSL & field catalog](/api-reference/traces/projection-dsl).
+
 ## Authentication
 
 Pass your LangWatch API key in the `X-Auth-Token` header. Your API key can be found on the setup page under settings.

--- a/docs/api-reference/traces/projection-dsl.mdx
+++ b/docs/api-reference/traces/projection-dsl.mdx
@@ -1,0 +1,218 @@
+---
+title: 'Projection DSL & field catalog'
+description: 'Declare exactly which trace fields to return from POST /api/traces/search — including nested events, annotations, and evaluations — so a daily ETL becomes one paginated loop instead of a per-trace fan-out.'
+---
+
+## Why
+
+By default `POST /api/traces/search` returns the full trace shape. For an ETL
+pipeline that only needs a handful of fields across thousands of traces, that is
+both more data than required and forces a second call per trace to read
+event-level feedback. The projection DSL lets a caller declare the columns of
+interest up front; the server returns exactly that shape — with nested events,
+annotations, and evaluations joined server-side — in one paginated response.
+
+The feature is fully additive: a request without `from`/`select` behaves exactly
+as before.
+
+## The contract
+
+Two optional fields on the search request body:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `from` | `"traces"` | Entity root to read from. Only `traces` is supported today; defaults to `traces` when `select` is present. |
+| `select` | `string[]` | Flat list of dotted-path columns to project. Must be non-empty when present. |
+
+```bash
+curl -X POST https://app.langwatch.ai/api/traces/search \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": 1717200000000,
+    "endDate":   1717286400000,
+    "from": "traces",
+    "select": [
+      "trace_id",
+      "started_at",
+      "metadata.user_id",
+      "metrics.total_cost",
+      "evaluations.name", "evaluations.score",
+      "events.type", "events.metrics",
+      "annotations.is_thumbs_up", "annotations.scores"
+    ]
+  }'
+```
+
+## How paths map to the response
+
+Paths group by their root, so the response mirrors the selection:
+
+- **Scalar fields** (`trace_id`, `started_at`, `input`, …) stay at the top level
+  of each row.
+- **`metadata.*`** nests under a `metadata` object.
+- **`metrics.*`** nests under a `metrics` object.
+- **`events.*`**, **`annotations.*`**, **`evaluations.*`** return as **nested
+  arrays** — one row per trace, with each child record projected to the
+  requested sub-fields.
+
+A request for the `select` above yields rows shaped like:
+
+```jsonc
+{
+  "trace_id": "abc123…",
+  "started_at": 1717200001234,
+  "metadata": { "user_id": "u_42" },
+  "metrics": { "total_cost": 0.0031 },
+  "evaluations": [
+    { "name": "Faithfulness", "score": 0.91 }
+  ],
+  "events": [
+    { "type": "thumbs_up_down", "metrics": { "vote": 1 } }
+  ],
+  "annotations": [
+    { "is_thumbs_up": true, "scores": { "quality": { "value": "5" } } }
+  ]
+}
+```
+
+## The `schema` response field
+
+When `select` is present, the response envelope gains a top-level `schema`
+object listing the resolved columns — their dotted path, value type, and whether
+they belong to a nested collection. Use it to pre-allocate a typed reader
+(pandas, a Parquet writer, a warehouse table) without inferring types from the
+data:
+
+```jsonc
+{
+  "traces": [ /* projected rows */ ],
+  "pagination": { "totalHits": 3120, "scrollId": "…" },
+  "schema": {
+    "from": "traces",
+    "columns": [
+      { "path": "trace_id",         "type": "string",  "collection": false },
+      { "path": "metrics.total_cost","type": "number", "collection": false },
+      { "path": "evaluations.score","type": "number",  "collection": true  }
+    ]
+  }
+}
+```
+
+## Field catalog
+
+Every selectable path is listed below. A path outside this catalog is rejected
+at request time with **HTTP 400** and the offending path named in the error, so
+you can correct the whole `select` in one round-trip.
+
+### Trace scalars
+
+| Path | Type | Notes |
+|------|------|-------|
+| `trace_id` | string | |
+| `project_id` | string | |
+| `started_at` | number | Epoch ms — when the trace occurred. |
+| `inserted_at` | number | Epoch ms — when first stored. |
+| `updated_at` | number | Epoch ms — when last modified. |
+| `input` | string | Captured input. Requires input-visibility permission; redacted to `null` otherwise. |
+| `output` | string | Captured output. Requires output-visibility permission; redacted to `null` otherwise. |
+
+### `metadata.<key>`
+
+Any metadata key (e.g. `metadata.user_id`, `metadata.customer_id`,
+`metadata.thread_id`, or your own custom keys). Returned under a `metadata`
+object.
+
+### `metrics.<key>`
+
+| Path | Type |
+|------|------|
+| `metrics.first_token_ms` | number |
+| `metrics.total_time_ms` | number |
+| `metrics.prompt_tokens` | number |
+| `metrics.completion_tokens` | number |
+| `metrics.reasoning_tokens` | number |
+| `metrics.cache_read_input_tokens` | number |
+| `metrics.cache_creation_input_tokens` | number |
+| `metrics.total_cost` | number — requires cost-visibility permission; redacted to `null` otherwise |
+| `metrics.tokens_estimated` | boolean |
+
+### `evaluations.<field>` (nested array)
+
+| Path | Type |
+|------|------|
+| `evaluations.name` | string |
+| `evaluations.score` | number |
+| `evaluations.passed` | boolean |
+| `evaluations.label` | string |
+| `evaluations.details` | string |
+| `evaluations.status` | string |
+| `evaluations.evaluator_id` | string |
+| `evaluations.type` | string |
+| `evaluations.is_guardrail` | boolean |
+
+### `events.<field>` (nested array)
+
+| Path | Type | Notes |
+|------|------|-------|
+| `events.type` | string | The event name, e.g. `thumbs_up_down`, `star_rating`. |
+| `events.timestamp` | number | Epoch ms. |
+| `events.metrics` | json | All numeric metrics for the event. |
+| `events.metrics.<key>` | number | A single named metric. |
+| `events.details` | json | All string details for the event. |
+| `events.details.<key>` | string | A single named detail. |
+
+### `annotations.<field>` (nested array)
+
+| Path | Type | Notes |
+|------|------|-------|
+| `annotations.is_thumbs_up` | boolean | |
+| `annotations.comment` | string | |
+| `annotations.expected_output` | string | |
+| `annotations.created_at` | number | Epoch ms. |
+| `annotations.scores` | json | All named score values. |
+| `annotations.scores.<name>` | json | A single named score. |
+
+<Info>
+Annotations are manual reviews captured in the LangWatch UI (thumbs, scores,
+comments). They live alongside SDK-emitted `events` and are joined into the same
+response — no separate annotations call needed.
+</Info>
+
+## Choosing the date axis
+
+By default the `startDate`/`endDate` window filters traces by **when they
+occurred**. For incremental ETL you usually want **everything changed since your
+last pull** — a trace can occur weeks before it gains a later evaluation or
+annotation. Set `dateField` to switch the axis:
+
+| `dateField` | Window applies to | Use for |
+|-------------|-------------------|---------|
+| `occurred` (default) | When the trace happened | Time-bucketed reporting. |
+| `updated` | When the trace was last modified | Incremental / CDC pulls. |
+
+```jsonc
+{
+  "startDate": 1717200000000,   // last watermark
+  "endDate":   1717286400000,   // now
+  "dateField": "updated",
+  "select": ["trace_id", "updated_at", "annotations.is_thumbs_up"]
+}
+```
+
+On the `updated` axis, pagination is **at-least-once**: a trace modified again
+while you are paging may reappear on a later page, but nothing changed in the
+window is ever missed — exactly what a change-data-capture loop wants.
+
+## Performance
+
+The projection drives column selection, so asking for only lightweight fields
+keeps the query lightweight. In particular, the heavy captured `input`/`output`
+columns are only read when you `select` them — omit them and a wide window stays
+fast. Each page is capped at 1000 rows; keep following `pagination.scrollId`
+until it is absent to sweep a full window.
+
+## Backwards compatibility
+
+A request with neither `from` nor `select` returns the existing full-trace shape
+and **no** `schema` field. Existing integrations are unaffected.

--- a/docs/api-reference/traces/projection-dsl.mdx
+++ b/docs/api-reference/traces/projection-dsl.mdx
@@ -159,16 +159,16 @@ object.
 | `events.timestamp` | number | Epoch ms. |
 | `events.metrics` | json | All numeric metrics for the event. |
 | `events.metrics.<key>` | number | A single named metric. |
-| `events.details` | json | All string details for the event. |
-| `events.details.<key>` | string | A single named detail. |
+| `events.details` | json | All string details for the event. Redacted without input-visibility permission. |
+| `events.details.<key>` | string | A single named detail. Redacted without input-visibility permission. |
 
 ### `annotations.<field>` (nested array)
 
 | Path | Type | Notes |
 |------|------|-------|
 | `annotations.is_thumbs_up` | boolean | |
-| `annotations.comment` | string | |
-| `annotations.expected_output` | string | |
+| `annotations.comment` | string | Requires output-visibility permission; redacted to `null` otherwise (reviewers routinely quote model output here). |
+| `annotations.expected_output` | string | Requires output-visibility permission; redacted to `null` otherwise. |
 | `annotations.created_at` | number | Epoch ms. |
 | `annotations.scores` | json | All score values, keyed by your AnnotationScore **name**. |
 | `annotations.scores.<name>` | json | A single score, addressed by its AnnotationScore **name** (e.g. `annotations.scores.quality`). |
@@ -200,9 +200,12 @@ annotation. Set `dateField` to switch the axis:
 }
 ```
 
-On the `updated` axis, pagination is **at-least-once**: a trace modified again
-while you are paging may reappear on a later page, but no ClickHouse-side change
-in the window is missed — exactly what a change-data-capture loop wants.
+Delivery contract on the `updated` axis: **at-least-once across pulls,
+at-most-once within a single scroll**. A trace modified again *while you are
+paging* moves past the cursor and is not re-delivered in the current scroll —
+but its new `updated_at` lands in your **next** pull's window (which starts at
+your last watermark), so no change is ever lost across pulls. A CDC loop that
+advances its watermark to the previous pull's start time gets every change.
 
 <Note>
 The `updated` watermark advances on every ClickHouse-side change to a trace —

--- a/docs/api-reference/traces/projection-dsl.mdx
+++ b/docs/api-reference/traces/projection-dsl.mdx
@@ -170,8 +170,8 @@ object.
 | `annotations.comment` | string | |
 | `annotations.expected_output` | string | |
 | `annotations.created_at` | number | Epoch ms. |
-| `annotations.scores` | json | All named score values. |
-| `annotations.scores.<name>` | json | A single named score. |
+| `annotations.scores` | json | All score values, keyed by your AnnotationScore **name**. |
+| `annotations.scores.<name>` | json | A single score, addressed by its AnnotationScore **name** (e.g. `annotations.scores.quality`). |
 
 <Info>
 Annotations are manual reviews captured in the LangWatch UI (thumbs, scores,
@@ -201,8 +201,19 @@ annotation. Set `dateField` to switch the axis:
 ```
 
 On the `updated` axis, pagination is **at-least-once**: a trace modified again
-while you are paging may reappear on a later page, but nothing changed in the
-window is ever missed — exactly what a change-data-capture loop wants.
+while you are paging may reappear on a later page, but no ClickHouse-side change
+in the window is missed — exactly what a change-data-capture loop wants.
+
+<Note>
+The `updated` watermark advances on every ClickHouse-side change to a trace —
+evaluations, metadata updates, spans, and annotation **creates** and **deletes**.
+**One gap today:** an **in-place edit** to an existing annotation (e.g. changing a
+score from 3 to 5) writes Postgres only and does not advance the trace's
+ClickHouse `updated_at`, so `dateField: "updated"` does not pick it up until the
+trace changes again. New and removed annotations *are* caught. See
+[#4736](https://github.com/langwatch/langwatch/issues/4736) for the cross-store
+watermark follow-up.
+</Note>
 
 ## Performance
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -803,6 +803,7 @@
             "pages": [
               "api-reference/traces/overview",
               "api-reference/traces/search",
+              "api-reference/traces/projection-dsl",
               "api-reference/traces/get-trace",
               "api-reference/traces/update-metadata",
               "api-reference/traces/create-public-trace-path",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -31572,6 +31572,13 @@ Both search and get-trace endpoints support a `format` parameter:
 - **`digest`** (default), Returns an AI-readable formatted trace with hierarchical span tree, timing, inputs/outputs, and errors. Optimized for LLM consumption.
 - **`json`**, Returns the full raw trace data with all fields.
 
+For data-team ETL, `POST /api/traces/search` also accepts a **projection DSL**
+(`from` + `select`) that returns exactly the fields you ask for — including
+nested events, annotations, and evaluations joined server-side — so a daily pull
+becomes one paginated loop instead of a per-trace fan-out. It pairs with a
+`dateField` option to page by when traces were **last modified** rather than when
+they occurred. See [Projection DSL & field catalog](/api-reference/traces/projection-dsl).
+
 ## Authentication
 
 Pass your LangWatch API key in the `X-Auth-Token` header. Your API key can be found on the setup page under settings.
@@ -31590,6 +31597,229 @@ Pass your LangWatch API key in the `X-Auth-Token` header. Your API key can be fo
 <Info>
 The older `/api/trace/search` and `/api/trace/{id}` endpoints still work but are deprecated. Migrate to `/api/traces/search` and `/api/traces/{traceId}` for the improved `format` parameter and AI-readable digests.
 </Info>
+
+---
+
+# FILE: ./api-reference/traces/projection-dsl.mdx
+
+---
+title: 'Projection DSL & field catalog'
+description: 'Declare exactly which trace fields to return from POST /api/traces/search — including nested events, annotations, and evaluations — so a daily ETL becomes one paginated loop instead of a per-trace fan-out.'
+---
+
+## Why
+
+By default `POST /api/traces/search` returns the full trace shape. For an ETL
+pipeline that only needs a handful of fields across thousands of traces, that is
+both more data than required and forces a second call per trace to read
+event-level feedback. The projection DSL lets a caller declare the columns of
+interest up front; the server returns exactly that shape — with nested events,
+annotations, and evaluations joined server-side — in one paginated response.
+
+The feature is fully additive: a request without `from`/`select` behaves exactly
+as before.
+
+## The contract
+
+Two optional fields on the search request body:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `from` | `"traces"` | Entity root to read from. Only `traces` is supported today; defaults to `traces` when `select` is present. |
+| `select` | `string[]` | Flat list of dotted-path columns to project. Must be non-empty when present. |
+
+```bash
+curl -X POST https://app.langwatch.ai/api/traces/search \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": 1717200000000,
+    "endDate":   1717286400000,
+    "from": "traces",
+    "select": [
+      "trace_id",
+      "started_at",
+      "metadata.user_id",
+      "metrics.total_cost",
+      "evaluations.name", "evaluations.score",
+      "events.type", "events.metrics",
+      "annotations.is_thumbs_up", "annotations.scores"
+    ]
+  }'
+```
+
+## How paths map to the response
+
+Paths group by their root, so the response mirrors the selection:
+
+- **Scalar fields** (`trace_id`, `started_at`, `input`, …) stay at the top level
+  of each row.
+- **`metadata.*`** nests under a `metadata` object.
+- **`metrics.*`** nests under a `metrics` object.
+- **`events.*`**, **`annotations.*`**, **`evaluations.*`** return as **nested
+  arrays** — one row per trace, with each child record projected to the
+  requested sub-fields.
+
+A request for the `select` above yields rows shaped like:
+
+```jsonc
+{
+  "trace_id": "abc123…",
+  "started_at": 1717200001234,
+  "metadata": { "user_id": "u_42" },
+  "metrics": { "total_cost": 0.0031 },
+  "evaluations": [
+    { "name": "Faithfulness", "score": 0.91 }
+  ],
+  "events": [
+    { "type": "thumbs_up_down", "metrics": { "vote": 1 } }
+  ],
+  "annotations": [
+    { "is_thumbs_up": true, "scores": { "quality": { "value": "5" } } }
+  ]
+}
+```
+
+## The `schema` response field
+
+When `select` is present, the response envelope gains a top-level `schema`
+object listing the resolved columns — their dotted path, value type, and whether
+they belong to a nested collection. Use it to pre-allocate a typed reader
+(pandas, a Parquet writer, a warehouse table) without inferring types from the
+data:
+
+```jsonc
+{
+  "traces": [ /* projected rows */ ],
+  "pagination": { "totalHits": 3120, "scrollId": "…" },
+  "schema": {
+    "from": "traces",
+    "columns": [
+      { "path": "trace_id",         "type": "string",  "collection": false },
+      { "path": "metrics.total_cost","type": "number", "collection": false },
+      { "path": "evaluations.score","type": "number",  "collection": true  }
+    ]
+  }
+}
+```
+
+## Field catalog
+
+Every selectable path is listed below. A path outside this catalog is rejected
+at request time with **HTTP 400** and the offending path named in the error, so
+you can correct the whole `select` in one round-trip.
+
+### Trace scalars
+
+| Path | Type | Notes |
+|------|------|-------|
+| `trace_id` | string | |
+| `project_id` | string | |
+| `started_at` | number | Epoch ms — when the trace occurred. |
+| `inserted_at` | number | Epoch ms — when first stored. |
+| `updated_at` | number | Epoch ms — when last modified. |
+| `input` | string | Captured input. Requires input-visibility permission; redacted to `null` otherwise. |
+| `output` | string | Captured output. Requires output-visibility permission; redacted to `null` otherwise. |
+
+### `metadata.<key>`
+
+Any metadata key (e.g. `metadata.user_id`, `metadata.customer_id`,
+`metadata.thread_id`, or your own custom keys). Returned under a `metadata`
+object.
+
+### `metrics.<key>`
+
+| Path | Type |
+|------|------|
+| `metrics.first_token_ms` | number |
+| `metrics.total_time_ms` | number |
+| `metrics.prompt_tokens` | number |
+| `metrics.completion_tokens` | number |
+| `metrics.reasoning_tokens` | number |
+| `metrics.cache_read_input_tokens` | number |
+| `metrics.cache_creation_input_tokens` | number |
+| `metrics.total_cost` | number — requires cost-visibility permission; redacted to `null` otherwise |
+| `metrics.tokens_estimated` | boolean |
+
+### `evaluations.<field>` (nested array)
+
+| Path | Type |
+|------|------|
+| `evaluations.name` | string |
+| `evaluations.score` | number |
+| `evaluations.passed` | boolean |
+| `evaluations.label` | string |
+| `evaluations.details` | string |
+| `evaluations.status` | string |
+| `evaluations.evaluator_id` | string |
+| `evaluations.type` | string |
+| `evaluations.is_guardrail` | boolean |
+
+### `events.<field>` (nested array)
+
+| Path | Type | Notes |
+|------|------|-------|
+| `events.type` | string | The event name, e.g. `thumbs_up_down`, `star_rating`. |
+| `events.timestamp` | number | Epoch ms. |
+| `events.metrics` | json | All numeric metrics for the event. |
+| `events.metrics.<key>` | number | A single named metric. |
+| `events.details` | json | All string details for the event. |
+| `events.details.<key>` | string | A single named detail. |
+
+### `annotations.<field>` (nested array)
+
+| Path | Type | Notes |
+|------|------|-------|
+| `annotations.is_thumbs_up` | boolean | |
+| `annotations.comment` | string | |
+| `annotations.expected_output` | string | |
+| `annotations.created_at` | number | Epoch ms. |
+| `annotations.scores` | json | All named score values. |
+| `annotations.scores.<name>` | json | A single named score. |
+
+<Info>
+Annotations are manual reviews captured in the LangWatch UI (thumbs, scores,
+comments). They live alongside SDK-emitted `events` and are joined into the same
+response — no separate annotations call needed.
+</Info>
+
+## Choosing the date axis
+
+By default the `startDate`/`endDate` window filters traces by **when they
+occurred**. For incremental ETL you usually want **everything changed since your
+last pull** — a trace can occur weeks before it gains a later evaluation or
+annotation. Set `dateField` to switch the axis:
+
+| `dateField` | Window applies to | Use for |
+|-------------|-------------------|---------|
+| `occurred` (default) | When the trace happened | Time-bucketed reporting. |
+| `updated` | When the trace was last modified | Incremental / CDC pulls. |
+
+```jsonc
+{
+  "startDate": 1717200000000,   // last watermark
+  "endDate":   1717286400000,   // now
+  "dateField": "updated",
+  "select": ["trace_id", "updated_at", "annotations.is_thumbs_up"]
+}
+```
+
+On the `updated` axis, pagination is **at-least-once**: a trace modified again
+while you are paging may reappear on a later page, but nothing changed in the
+window is ever missed — exactly what a change-data-capture loop wants.
+
+## Performance
+
+The projection drives column selection, so asking for only lightweight fields
+keeps the query lightweight. In particular, the heavy captured `input`/`output`
+columns are only read when you `select` them — omit them and a wide window stays
+fast. Each page is capped at 1000 rows; keep following `pagination.scrollId`
+until it is absent to sweep a full window.
+
+## Backwards compatibility
+
+A request with neither `from` nor `select` returns the existing full-trace shape
+and **no** `schema` field. Existing integrations are unaffected.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -31774,8 +31774,8 @@ object.
 | `annotations.comment` | string | |
 | `annotations.expected_output` | string | |
 | `annotations.created_at` | number | Epoch ms. |
-| `annotations.scores` | json | All named score values. |
-| `annotations.scores.<name>` | json | A single named score. |
+| `annotations.scores` | json | All score values, keyed by your AnnotationScore **name**. |
+| `annotations.scores.<name>` | json | A single score, addressed by its AnnotationScore **name** (e.g. `annotations.scores.quality`). |
 
 <Info>
 Annotations are manual reviews captured in the LangWatch UI (thumbs, scores,
@@ -31805,8 +31805,19 @@ annotation. Set `dateField` to switch the axis:
 ```
 
 On the `updated` axis, pagination is **at-least-once**: a trace modified again
-while you are paging may reappear on a later page, but nothing changed in the
-window is ever missed — exactly what a change-data-capture loop wants.
+while you are paging may reappear on a later page, but no ClickHouse-side change
+in the window is missed — exactly what a change-data-capture loop wants.
+
+<Note>
+The `updated` watermark advances on every ClickHouse-side change to a trace —
+evaluations, metadata updates, spans, and annotation **creates** and **deletes**.
+**One gap today:** an **in-place edit** to an existing annotation (e.g. changing a
+score from 3 to 5) writes Postgres only and does not advance the trace's
+ClickHouse `updated_at`, so `dateField: "updated"` does not pick it up until the
+trace changes again. New and removed annotations *are* caught. See
+[#4736](https://github.com/langwatch/langwatch/issues/4736) for the cross-store
+watermark follow-up.
+</Note>
 
 ## Performance
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -31763,16 +31763,16 @@ object.
 | `events.timestamp` | number | Epoch ms. |
 | `events.metrics` | json | All numeric metrics for the event. |
 | `events.metrics.<key>` | number | A single named metric. |
-| `events.details` | json | All string details for the event. |
-| `events.details.<key>` | string | A single named detail. |
+| `events.details` | json | All string details for the event. Redacted without input-visibility permission. |
+| `events.details.<key>` | string | A single named detail. Redacted without input-visibility permission. |
 
 ### `annotations.<field>` (nested array)
 
 | Path | Type | Notes |
 |------|------|-------|
 | `annotations.is_thumbs_up` | boolean | |
-| `annotations.comment` | string | |
-| `annotations.expected_output` | string | |
+| `annotations.comment` | string | Requires output-visibility permission; redacted to `null` otherwise (reviewers routinely quote model output here). |
+| `annotations.expected_output` | string | Requires output-visibility permission; redacted to `null` otherwise. |
 | `annotations.created_at` | number | Epoch ms. |
 | `annotations.scores` | json | All score values, keyed by your AnnotationScore **name**. |
 | `annotations.scores.<name>` | json | A single score, addressed by its AnnotationScore **name** (e.g. `annotations.scores.quality`). |
@@ -31804,9 +31804,12 @@ annotation. Set `dateField` to switch the axis:
 }
 ```
 
-On the `updated` axis, pagination is **at-least-once**: a trace modified again
-while you are paging may reappear on a later page, but no ClickHouse-side change
-in the window is missed — exactly what a change-data-capture loop wants.
+Delivery contract on the `updated` axis: **at-least-once across pulls,
+at-most-once within a single scroll**. A trace modified again *while you are
+paging* moves past the cursor and is not re-delivered in the current scroll —
+but its new `updated_at` lands in your **next** pull's window (which starts at
+your last watermark), so no change is ever lost across pulls. A CDC loop that
+advances its watermark to the previous pull's start time gets every change.
 
 <Note>
 The `updated` watermark advances on every ClickHouse-side change to a trace —

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -56,6 +56,7 @@ Always navigate to docs links using the .md extension for better readability.
 
 - [Overview](https://langwatch.ai/docs/api-reference/traces/overview.md): Search, retrieve, and share LangWatch traces via the REST API. Traces capture the full execution of your LLM pipelines including all spans, evaluations, and metadata.
 - [Search traces](https://langwatch.ai/docs/api-reference/traces/search.md)
+- [Projection DSL & field catalog](https://langwatch.ai/docs/api-reference/traces/projection-dsl.md): Declare exactly which trace fields to return from POST /api/traces/search — including nested events, annotations, and evaluations — so a daily ETL becomes one paginated loop instead of a per-trace fan-out.
 - [Get trace details](https://langwatch.ai/docs/api-reference/traces/get-trace.md)
 - [Update trace metadata](https://langwatch.ai/docs/api-reference/traces/update-metadata.md): Update metadata on an existing trace by trace ID. Injects a synthetic span through the standard ingestion pipeline carrying the new attributes.
 - [Create public path for single trace](https://langwatch.ai/docs/api-reference/traces/create-public-trace-path.md)

--- a/langwatch/src/app/api/openapiLangWatch.json
+++ b/langwatch/src/app/api/openapiLangWatch.json
@@ -1723,6 +1723,8 @@
                             "performance.completion_time",
                             "performance.first_token",
                             "performance.total_cost",
+                            "performance.cost_billed",
+                            "performance.cost_non_billed",
                             "performance.prompt_tokens",
                             "performance.completion_tokens",
                             "performance.total_tokens",
@@ -19214,18 +19216,6 @@
                                                   },
                                                   "text": {
                                                     "type": "string"
-                                                  }
-                                                },
-                                                "required": [
-                                                  "type"
-                                                ]
-                                              },
-                                              {
-                                                "type": "object",
-                                                "properties": {
-                                                  "type": {
-                                                    "type": "string",
-                                                    "const": "text"
                                                   },
                                                   "content": {
                                                     "type": "string"
@@ -19374,18 +19364,6 @@
                                               },
                                               "text": {
                                                 "type": "string"
-                                              }
-                                            },
-                                            "required": [
-                                              "type"
-                                            ]
-                                          },
-                                          {
-                                            "type": "object",
-                                            "properties": {
-                                              "type": {
-                                                "type": "string",
-                                                "const": "text"
                                               },
                                               "content": {
                                                 "type": "string"
@@ -24370,6 +24348,41 @@
                       "required": [
                         "totalHits"
                       ]
+                    },
+                    "schema": {
+                      "type": "object",
+                      "properties": {
+                        "from": {
+                          "type": "string"
+                        },
+                        "columns": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "collection": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "path",
+                              "type",
+                              "collection"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "from",
+                        "columns"
+                      ],
+                      "description": "Present only when 'select' is provided. Describes the resolved columns — the dotted path, its value type, and whether it belongs to a nested child collection — so callers can pre-allocate a typed reader."
                     }
                   },
                   "required": [
@@ -25419,6 +25432,30 @@
                   },
                   "llmMode": {
                     "type": "boolean"
+                  },
+                  "dateField": {
+                    "type": "string",
+                    "enum": [
+                      "occurred",
+                      "updated"
+                    ],
+                    "description": "Which timestamp the startDate/endDate window filters on. 'occurred' (default) selects traces by when they happened. 'updated' selects traces by when they were last modified — use this for incremental ETL ('give me everything changed since my last pull'), since a trace can occur long before it gains a later evaluation or annotation."
+                  },
+                  "from": {
+                    "type": "string",
+                    "enum": [
+                      "traces"
+                    ],
+                    "description": "Entity root to read from. Only 'traces' is supported today. Defaults to 'traces' when 'select' is present."
+                  },
+                  "select": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "minItems": 1,
+                    "description": "Flat list of dotted-path columns to project, e.g. ['trace_id','metadata.user_id','events.type','evaluations.score']. Paths group by root in the response: scalar fields stay top-level, 'metadata.*' nests under a metadata object, and 'events.*'/'annotations.*'/'evaluations.*' return as nested arrays (one row per trace). When present, the response gains a top-level 'schema' field describing the resolved columns. When omitted, the response is unchanged from the legacy shape."
                   }
                 },
                 "required": [
@@ -29484,6 +29521,171 @@
         "operationId": "postApiEventsTrack",
         "parameters": [],
         "description": "Record a user event (e.g. thumbs up/down, selected text) attached to a trace. Predefined event types validate against their schemas; custom event types pass through `trackEventRESTParamsValidatorSchema`."
+      }
+    },
+    "/api/traces/{traceId}/metadata": {
+      "patch": {
+        "responses": {
+          "200": {
+            "description": "Metadata updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "traceId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "traceId"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patchApiTracesByTraceIdMetadata",
+        "tags": [
+          "Traces"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "traceId",
+            "required": true
+          }
+        ],
+        "summary": "Update trace metadata",
+        "description": "Update metadata on a trace after creation. Inserts a synthetic span carrying the new attributes through the standard ingestion pipeline. New keys are added, existing keys are updated, missing keys are preserved. Labels replace entirely.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "maxLength": 4096
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "metadata"
+                ]
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -397,7 +397,8 @@ describe("POST /search", () => {
     },
     plan: {
       from: "traces" as const,
-      needsIO: false,
+      needsInput: false,
+      needsOutput: false,
       needsEvents: false,
       eventPaths: [],
       needsAnnotations: false,

--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -559,6 +559,26 @@ describe("POST /search", () => {
       expect(res.status).toBe(400);
       expect(mockCompileProjection).not.toHaveBeenCalled();
     });
+
+    it("rejects a select with more than 200 paths with 400", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        select: Array.from({ length: 201 }, (_, i) => `metadata.key_${i}`),
+      });
+      expect(res.status).toBe(400);
+      expect(mockCompileProjection).not.toHaveBeenCalled();
+    });
+
+    it("rejects a select path longer than 256 characters with 400", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        select: [`metadata.${"x".repeat(300)}`],
+      });
+      expect(res.status).toBe(400);
+      expect(mockCompileProjection).not.toHaveBeenCalled();
+    });
   });
 
   describe("when a date axis is specified", () => {

--- a/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/__tests__/search-traces.unit.test.ts
@@ -40,6 +40,21 @@ vi.mock("~/utils/logger/server", () => ({
   }),
 }));
 
+// Partially mock the projection module: keep the real request schema + error
+// class (so validation and the 400 path are exercised for real) and stub only
+// `compileProjection` so these surface tests stay independent of the compiler
+// implementation (owned separately). Each test drives the stub's behavior.
+const mockCompileProjection = vi.fn();
+
+vi.mock("~/server/traces/projection", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/server/traces/projection")>();
+  return {
+    ...actual,
+    compileProjection: (args: unknown) => mockCompileProjection(args),
+  };
+});
+
 vi.mock("~/server/api/routers/traces.schemas", () => {
   const { z } = require("zod");
   return {
@@ -56,19 +71,27 @@ vi.mock("~/server/api/routers/traces.schemas", () => {
 // strategy runs the real authMiddleware. Mock it to a passthrough so these
 // unit tests exercise the handler logic with an injected project, not real auth.
 vi.mock("~/app/api/middleware/auth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("~/app/api/middleware/auth")>();
+  const actual =
+    await importOriginal<typeof import("~/app/api/middleware/auth")>();
   return {
     ...actual,
-    authMiddleware: async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
+    authMiddleware: async (
+      c: { set: (k: string, v: unknown) => void },
+      next: () => Promise<void>,
+    ) => {
       c.set("project", { id: "project-123", apiKey: "key-123" });
       await next();
     },
-    requirePermission: () => async (_c: unknown, next: () => Promise<void>) => next(),
+    requirePermission: () => async (_c: unknown, next: () => Promise<void>) =>
+      next(),
   };
 });
 
 const { registerTracesRoutes } = await import("../app.v1");
 const { createProjectApp } = await import("~/server/api/security");
+const { ProjectionValidationError } = await import(
+  "~/server/traces/projection"
+);
 const securedTest = createProjectApp({ basePath: "/" });
 registerTracesRoutes(securedTest);
 const v1App = securedTest.hono;
@@ -120,7 +143,17 @@ describe("POST /search", () => {
       groups: [sampleTraces],
       totalHits: 2,
       traceChecks: {
-        "trace-1": [{ evaluation_id: "eval-1", evaluator_id: "evaluator-1", name: "sentiment", status: "processed", score: 0.95, label: "positive", timestamps: { started_at: 1000, finished_at: 2000 } }],
+        "trace-1": [
+          {
+            evaluation_id: "eval-1",
+            evaluator_id: "evaluator-1",
+            name: "sentiment",
+            status: "processed",
+            score: 0.95,
+            label: "positive",
+            timestamps: { started_at: 1000, finished_at: 2000 },
+          },
+        ],
         "trace-2": [],
       },
       scrollId: undefined,
@@ -149,7 +182,7 @@ describe("POST /search", () => {
       const body = await res.json();
       expect(body.traces).toHaveLength(2);
       expect(body.traces[0].formatted_trace).toBe(
-        "Input: hello\nOutput: world"
+        "Input: hello\nOutput: world",
       );
     });
 
@@ -260,7 +293,11 @@ describe("POST /search", () => {
         project_id: "project-123",
         input: { value: `input-${i}` },
         output: { value: `output-${i}` },
-        timestamps: { started_at: i * 100, inserted_at: i * 100, updated_at: i * 100 },
+        timestamps: {
+          started_at: i * 100,
+          inserted_at: i * 100,
+          updated_at: i * 100,
+        },
         metadata: {},
         spans: [],
       }));
@@ -268,7 +305,9 @@ describe("POST /search", () => {
       mockGetAllTracesForProject.mockResolvedValue({
         groups: [manyTraces],
         totalHits: 50,
-        traceChecks: Object.fromEntries(manyTraces.map((t) => [t.trace_id, []])),
+        traceChecks: Object.fromEntries(
+          manyTraces.map((t) => [t.trace_id, []]),
+        ),
         scrollId: "next-page-token",
       });
 
@@ -300,6 +339,253 @@ describe("POST /search", () => {
       const body = await res.json();
       expect(body.traces).toHaveLength(0);
       expect(body.pagination.totalHits).toBe(0);
+    });
+  });
+
+  describe("when a trace fails to serialize", () => {
+    it("drops it and surfaces a skipped count in pagination", async () => {
+      const circular: Record<string, unknown> = {
+        trace_id: "bad-trace",
+        project_id: "project-123",
+        timestamps: { started_at: 1, inserted_at: 1, updated_at: 1 },
+        metadata: {},
+        spans: [],
+      };
+      // A circular reference makes JSON.stringify throw in the serialize loop.
+      (circular.metadata as Record<string, unknown>).self = circular;
+
+      mockGetAllTracesForProject.mockResolvedValue({
+        groups: [[circular, sampleTraces[0]]],
+        totalHits: 2,
+        traceChecks: { "bad-trace": [], "trace-1": [] },
+        scrollId: undefined,
+      });
+
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        format: "json",
+      });
+
+      const body = await res.json();
+      expect(body.traces).toHaveLength(1);
+      expect(body.traces[0].trace_id).toBe("trace-1");
+      expect(body.pagination.skipped).toBe(1);
+    });
+
+    it("omits skipped from pagination when nothing is dropped", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        format: "json",
+      });
+
+      const body = await res.json();
+      expect(body.pagination).not.toHaveProperty("skipped");
+    });
+  });
+
+  // The projector and plan shape come from the compiler (mocked here). These
+  // tests cover the SURFACE contract: when to compile, what to forward, how the
+  // response envelope changes.
+  const fakeProjection = () => ({
+    schema: {
+      from: "traces" as const,
+      columns: [
+        { path: "trace_id", type: "string" as const, collection: false },
+      ],
+    },
+    plan: {
+      from: "traces" as const,
+      needsIO: false,
+      needsEvents: false,
+      eventPaths: [],
+      needsAnnotations: false,
+      annotationPaths: [],
+      needsEvaluations: false,
+      evaluationPaths: [],
+    },
+    project: (trace: { trace_id: string }) => ({ trace_id: trace.trace_id }),
+  });
+
+  describe("when no projection select is provided", () => {
+    it("does not compile a projection", async () => {
+      await searchRequest({ startDate: 1000, endDate: 5000, format: "json" });
+      expect(mockCompileProjection).not.toHaveBeenCalled();
+    });
+
+    /** @scenario "Request without from or select returns the current response shape" */
+    it("omits the schema field from the response", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        format: "json",
+      });
+      const body = await res.json();
+      expect(body).not.toHaveProperty("schema");
+    });
+  });
+
+  describe("when a projection select is provided", () => {
+    beforeEach(() => {
+      mockCompileProjection.mockReturnValue(fakeProjection());
+    });
+
+    it("compiles the projection with from, select, and protections", async () => {
+      await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        from: "traces",
+        select: ["trace_id"],
+      });
+      expect(mockCompileProjection).toHaveBeenCalledWith({
+        from: "traces",
+        select: ["trace_id"],
+        protections: {},
+      });
+    });
+
+    it("forwards the compiled plan to the trace service", async () => {
+      await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        from: "traces",
+        select: ["trace_id"],
+      });
+      const options = mockGetAllTracesForProject.mock.calls[0]![2];
+      expect(options.projection).toEqual(fakeProjection().plan);
+    });
+
+    it("projects each trace through the compiled projector", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        from: "traces",
+        select: ["trace_id"],
+      });
+      const body = await res.json();
+      expect(body.traces).toEqual([
+        { trace_id: "trace-1" },
+        { trace_id: "trace-2" },
+      ]);
+    });
+
+    /** @scenario "Response includes schema when select is present" */
+    it("includes the resolved schema in the response envelope", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        from: "traces",
+        select: ["trace_id"],
+      });
+      const body = await res.json();
+      expect(body.schema).toEqual(fakeProjection().schema);
+    });
+
+    /** @scenario "Select without from defaults to the traces entity root" */
+    it("defaults from to traces when only select is provided", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        select: ["trace_id"],
+      });
+      expect(mockCompileProjection).toHaveBeenCalledWith({
+        from: "traces",
+        select: ["trace_id"],
+        protections: {},
+      });
+      const body = await res.json();
+      expect(body).toHaveProperty("schema");
+    });
+  });
+
+  describe("when the projection select is invalid", () => {
+    beforeEach(() => {
+      mockCompileProjection.mockImplementation(() => {
+        throw new ProjectionValidationError(["nonexistent_field"]);
+      });
+    });
+
+    /** @scenario "Unknown select path returns 400" */
+    it("responds 400", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        select: ["nonexistent_field"],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("names the invalid path in the error message", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        select: ["nonexistent_field"],
+      });
+      const body = await res.json();
+      expect(body.message).toContain("nonexistent_field");
+    });
+
+    it("does not query the trace service", async () => {
+      await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        select: ["nonexistent_field"],
+      });
+      expect(mockGetAllTracesForProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the projection request fails schema validation", () => {
+    /** @scenario "Unknown from entity returns 400" */
+    it("rejects an unsupported from entity with 400", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        from: "sessions",
+        select: ["trace_id"],
+      });
+      expect(res.status).toBe(400);
+      expect(mockCompileProjection).not.toHaveBeenCalled();
+    });
+
+    /** @scenario "Empty select array returns 400" */
+    it("rejects an empty select array with 400", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        select: [],
+      });
+      expect(res.status).toBe(400);
+      expect(mockCompileProjection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a date axis is specified", () => {
+    it("forwards dateField 'updated' to the trace service", async () => {
+      await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        dateField: "updated",
+      });
+      const options = mockGetAllTracesForProject.mock.calls[0]![2];
+      expect(options.dateField).toBe("updated");
+    });
+
+    it("defaults dateField to occurred when not specified", async () => {
+      await searchRequest({ startDate: 1000, endDate: 5000 });
+      const options = mockGetAllTracesForProject.mock.calls[0]![2];
+      expect(options.dateField).toBe("occurred");
+    });
+
+    /** @scenario "Invalid dateField value returns 400" */
+    it("rejects an unsupported date axis with 400", async () => {
+      const res = await searchRequest({
+        startDate: 1000,
+        endDate: 5000,
+        dateField: "created",
+      });
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
+++ b/langwatch/src/app/api/traces/[[...route]]/app.v1.ts
@@ -2,32 +2,50 @@ import { HTTPException } from "hono/http-exception";
 import { describeRoute } from "hono-openapi";
 import { resolver, validator as zValidator } from "hono-openapi/zod";
 import { z } from "zod";
+import { getAllForProjectInput } from "~/server/api/routers/traces.schemas";
+import { requires, type SecuredApp } from "~/server/api/security";
 import { getProtectionsForProject } from "~/server/api/utils";
+import { getApp } from "~/server/app-layer/app";
 import { prisma } from "~/server/db";
-import type { Trace } from "~/server/tracer/types";
 import { formatSpansDigest } from "~/server/tracer/spanToReadableSpan";
-import { generateAsciiTree, formatTraceSummaryDigest } from "~/server/traces/trace-formatting";
+import type {
+  CustomMetadata,
+  ReservedTraceMetadata,
+  Trace,
+} from "~/server/tracer/types";
+import { CollectorSpanUtils } from "~/server/traces/collectorSpan.utils";
 import { enrichTracesWithEvaluations } from "~/server/traces/enrich-evaluations";
+import {
+  type CompiledProjection,
+  compileProjection,
+  type ProjectableTrace,
+  ProjectionValidationError,
+  projectionRequestSchema,
+} from "~/server/traces/projection";
 import {
   AmbiguousTraceIdPrefixError,
   TraceService,
 } from "~/server/traces/trace.service";
-import { getApp } from "~/server/app-layer/app";
-import { CollectorSpanUtils } from "~/server/traces/collectorSpan.utils";
-import type { ReservedTraceMetadata, CustomMetadata } from "~/server/tracer/types";
+import {
+  formatTraceSummaryDigest,
+  generateAsciiTree,
+} from "~/server/traces/trace-formatting";
 import { createLogger } from "~/utils/logger/server";
-import { type SecuredApp, requires } from "~/server/api/security";
 import type { AuthMiddlewareVariables } from "../../middleware";
 import { baseResponses } from "../../shared/base-responses";
 import { platformUrl } from "../../shared/platform-url";
 import { coerceToEpoch, flexibleDateSchema } from "../../shared/schemas";
-import { getAllForProjectInput } from "~/server/api/routers/traces.schemas";
 
 const logger = createLogger("langwatch:api:traces");
 
 // Body schema for the search endpoint: reuses getAllForProjectInput but adjusts
 // startDate/endDate to accept ISO strings alongside epoch numbers, and adds
 // scrollId and format fields. llmMode is kept for backward compatibility.
+//
+// The projection DSL (`from` + `select`) and the date axis (`dateField`) are
+// additive: absent → the endpoint behaves exactly as before. `from`/`select`
+// come from the shared projection contract so the compiler and this surface
+// agree on one schema.
 const traceSearchBodySchema = getAllForProjectInput
   .omit({
     projectId: true,
@@ -42,297 +60,370 @@ const traceSearchBodySchema = getAllForProjectInput
       .enum(["digest", "json"])
       .optional()
       .describe(
-        "Output format: 'digest' (AI-readable trace digest) or 'json' (full raw data)"
+        "Output format: 'digest' (AI-readable trace digest) or 'json' (full raw data)",
       ),
     includeSpans: z
       .boolean()
       .optional()
       .describe(
-        "When true, fetches full span data for each trace. Useful for bulk export. Default false."
+        "When true, fetches full span data for each trace. Useful for bulk export. Default false.",
       ),
     llmMode: z.boolean().optional(),
-  });
+    dateField: z
+      .enum(["occurred", "updated"])
+      .default("occurred")
+      .describe(
+        "Which timestamp the startDate/endDate window filters on. 'occurred' (default) " +
+          "selects traces by when they happened. 'updated' selects traces by when they were " +
+          "last modified — use this for incremental ETL ('give me everything changed since my " +
+          "last pull'), since a trace can occur long before it gains a later evaluation or " +
+          "annotation.",
+      ),
+  })
+  .merge(projectionRequestSchema);
 
 export function registerTracesRoutes(
   secured: SecuredApp<{ Variables: AuthMiddlewareVariables }>,
 ): void {
   // POST /search - Search traces for a project
   secured.access(requires("traces:view")).post(
-  "/search",
-  describeRoute({
-    description: "Search traces for a project",
-    responses: {
-      ...baseResponses,
-      200: {
-        description: "Matching traces with pagination",
-        content: {
-          "application/json": {
-            schema: resolver(
-              z.object({
-                traces: z.array(z.any()),
-                pagination: z.object({
-                  totalHits: z.number(),
-                  scrollId: z.string().optional(),
+    "/search",
+    describeRoute({
+      description: "Search traces for a project",
+      responses: {
+        ...baseResponses,
+        200: {
+          description: "Matching traces with pagination",
+          content: {
+            "application/json": {
+              schema: resolver(
+                z.object({
+                  traces: z.array(z.any()),
+                  pagination: z.object({
+                    totalHits: z.number(),
+                    scrollId: z.string().optional(),
+                    skipped: z
+                      .number()
+                      .optional()
+                      .describe(
+                        "Number of traces dropped from this page because they failed to serialize. Present only when non-zero, so a caller can tell that traces.length is below the page size for a reason other than reaching the end of the result set.",
+                      ),
+                  }),
+                  schema: z
+                    .object({
+                      from: z.string(),
+                      columns: z.array(
+                        z.object({
+                          path: z.string(),
+                          type: z.string(),
+                          collection: z.boolean(),
+                        }),
+                      ),
+                    })
+                    .optional()
+                    .describe(
+                      "Present only when 'select' is provided. Describes the resolved columns — " +
+                        "the dotted path, its value type, and whether it belongs to a nested child " +
+                        "collection — so callers can pre-allocate a typed reader.",
+                    ),
                 }),
-              }),
-            ),
+              ),
+            },
           },
         },
       },
-    },
-  }),
-  zValidator("json", traceSearchBodySchema),
-  async (c) => {
-    const project = c.get("project");
-    const params = c.req.valid("json");
-    const {
-      format: formatParam,
-      includeSpans,
-      llmMode,
-      scrollId,
-      ...searchFields
-    } = params;
-    const format = formatParam ?? (llmMode ? "digest" : "json");
+    }),
+    zValidator("json", traceSearchBodySchema),
+    async (c) => {
+      const project = c.get("project");
+      const params = c.req.valid("json");
+      const {
+        from,
+        select,
+        dateField,
+        format: formatParam,
+        includeSpans,
+        llmMode,
+        scrollId,
+        ...searchFields
+      } = params;
+      const format = formatParam ?? (llmMode ? "digest" : "json");
 
-    logger.info({ projectId: project.id }, "Searching traces for project");
+      logger.info({ projectId: project.id }, "Searching traces for project");
 
-    const pageSize = Math.min(searchFields.pageSize ?? 1000, 1000);
-    const protections = await getProtectionsForProject(prisma, {
-      projectId: project.id,
-    });
-    const traceService = TraceService.create(prisma);
-    const results = await traceService.getAllTracesForProject(
-      {
-        ...searchFields,
+      const pageSize = Math.min(searchFields.pageSize ?? 1000, 1000);
+      const protections = await getProtectionsForProject(prisma, {
         projectId: project.id,
-        startDate: coerceToEpoch(params.startDate),
-        endDate: coerceToEpoch(params.endDate),
-        pageSize,
-      },
-      protections,
-      {
-        downloadMode: true,
-        includeSpans: includeSpans ?? false,
-        scrollId: scrollId ?? undefined,
-      },
-    );
+      });
 
-    const rawTraces = results.groups.flat() as Trace[];
-    const enrichedTraces = enrichTracesWithEvaluations({
-      traces: rawTraces,
-      traceChecks: results.traceChecks,
-    });
+      // When `select` is present, compile the projection up front. The compiled
+      // plan drives column pruning + child-collection joins in the ENGINE; the
+      // resolved schema goes into the response envelope; the projector replaces
+      // formatTrace per row. Invalid paths surface as a 400 with every offender.
+      let projection: CompiledProjection | undefined;
+      if (select && select.length > 0) {
+        try {
+          projection = compileProjection({ from, select, protections });
+        } catch (err) {
+          if (err instanceof ProjectionValidationError) {
+            throw new HTTPException(400, { message: err.message });
+          }
+          throw err;
+        }
+      }
 
-    const formatTrace = (trace: Trace) => {
-      if (format === "digest") {
+      const traceService = TraceService.create(prisma);
+      const results = await traceService.getAllTracesForProject(
+        {
+          ...searchFields,
+          projectId: project.id,
+          startDate: coerceToEpoch(params.startDate),
+          endDate: coerceToEpoch(params.endDate),
+          pageSize,
+        },
+        protections,
+        {
+          downloadMode: true,
+          includeSpans: includeSpans ?? false,
+          scrollId: scrollId ?? undefined,
+          dateField,
+          projection: projection?.plan,
+        },
+      );
+
+      const rawTraces = results.groups.flat() as Trace[];
+      const enrichedTraces = enrichTracesWithEvaluations({
+        traces: rawTraces,
+        traceChecks: results.traceChecks,
+      });
+
+      const formatTrace = (trace: Trace) => {
+        if (format === "digest") {
+          return {
+            trace_id: trace.trace_id,
+            formatted_trace: formatTraceSummaryDigest(trace),
+            input: trace.input,
+            output: trace.output,
+            timestamps: trace.timestamps,
+            metadata: trace.metadata,
+            error: trace.error,
+            evaluations: trace.evaluations,
+            platformUrl: platformUrl({
+              projectSlug: project.slug,
+              path: `/messages/${trace.trace_id}`,
+            }),
+          };
+        }
         return {
-          trace_id: trace.trace_id,
-          formatted_trace: formatTraceSummaryDigest(trace),
-          input: trace.input,
-          output: trace.output,
-          timestamps: trace.timestamps,
-          metadata: trace.metadata,
-          error: trace.error,
-          evaluations: trace.evaluations,
+          ...trace,
           platformUrl: platformUrl({
             projectSlug: project.slug,
             path: `/messages/${trace.trace_id}`,
           }),
         };
-      }
-      return {
-        ...trace,
-        platformUrl: platformUrl({
-          projectSlug: project.slug,
-          path: `/messages/${trace.trace_id}`,
-        }),
       };
-    };
 
-    const pagination = JSON.stringify({
-      totalHits: results.totalHits,
-      scrollId: results.scrollId,
-    });
+      // A projection (when active) replaces the default formatTrace, shaping each
+      // row to mirror the caller's `select`. The ENGINE has already attached the
+      // Postgres-sourced annotations the projector reads.
+      const serializeTrace = projection
+        ? (trace: Trace) => projection.project(trace as ProjectableTrace)
+        : formatTrace;
 
-    const serializedTraces: string[] = [];
-    for (const trace of enrichedTraces) {
-      try {
-        serializedTraces.push(JSON.stringify(formatTrace(trace)));
-      } catch (err) {
-        logger.error(
-          { traceId: trace.trace_id, error: err instanceof Error ? err.message : err },
-          "Failed to serialize trace, skipping",
-        );
-      }
-    }
-
-    const encoder = new TextEncoder();
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(encoder.encode('{"traces":['));
-
-        for (let i = 0; i < serializedTraces.length; i++) {
-          const prefix = i > 0 ? "," : "";
-          controller.enqueue(encoder.encode(prefix + serializedTraces[i]!));
+      const serializedTraces: string[] = [];
+      let skippedCount = 0;
+      for (const trace of enrichedTraces) {
+        try {
+          serializedTraces.push(JSON.stringify(serializeTrace(trace)));
+        } catch (err) {
+          skippedCount++;
+          logger.error(
+            {
+              traceId: trace.trace_id,
+              error: err instanceof Error ? err.message : err,
+            },
+            "Failed to serialize trace, skipping",
+          );
         }
+      }
 
-        controller.enqueue(
-          encoder.encode(`],"pagination":${pagination}}`)
-        );
-        controller.close();
-      },
-    });
+      // Surface dropped traces so a caller never silently sees fewer rows than
+      // totalHits with no signal. Emitted only when non-zero, so the common-case
+      // envelope stays byte-identical to before.
+      const pagination = JSON.stringify({
+        totalHits: results.totalHits,
+        scrollId: results.scrollId,
+        ...(skippedCount > 0 ? { skipped: skippedCount } : {}),
+      });
 
-    return new Response(stream, {
-      headers: { "Content-Type": "application/json" },
-    });
-  },
-);
+      // When a projection is active the envelope gains a `schema` field describing
+      // the resolved columns so callers can pre-allocate a typed reader.
+      const schemaSuffix = projection
+        ? `,"schema":${JSON.stringify(projection.schema)}`
+        : "";
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('{"traces":['));
+
+          for (let i = 0; i < serializedTraces.length; i++) {
+            const prefix = i > 0 ? "," : "";
+            controller.enqueue(encoder.encode(prefix + serializedTraces[i]!));
+          }
+
+          controller.enqueue(
+            encoder.encode(`],"pagination":${pagination}${schemaSuffix}}`),
+          );
+          controller.close();
+        },
+      });
+
+      return new Response(stream, {
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  );
 
   // GET /:traceId - Get a single trace by ID
   secured.access(requires("traces:view")).get(
-  "/:traceId",
-  describeRoute({
-    description: "Get a single trace by ID.",
-    parameters: [
-      {
-        name: "traceId",
-        in: "path",
-        description:
-          "The trace ID — either the full 32-char ID or a unique prefix (≥ 8 chars). Prefix lookup is scoped to the authenticated project.",
-        required: true,
-        schema: { type: "string" },
-      },
-      {
-        name: "format",
-        in: "query",
-        description:
-          "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)",
-        required: false,
-        schema: { type: "string", enum: ["digest", "json"] },
-      },
-      {
-        name: "llmMode",
-        in: "query",
-        description: "Deprecated: use format=digest instead",
-        required: false,
-        schema: { type: "string", enum: ["true", "false", "1", "0"] },
-      },
-    ],
-    responses: {
-      ...baseResponses,
-      200: {
-        description: "Trace detail with spans, evaluations, and ASCII tree",
-        content: {
-          "application/json": {
-            schema: resolver(z.object({}).passthrough()),
+    "/:traceId",
+    describeRoute({
+      description: "Get a single trace by ID.",
+      parameters: [
+        {
+          name: "traceId",
+          in: "path",
+          description:
+            "The trace ID — either the full 32-char ID or a unique prefix (≥ 8 chars). Prefix lookup is scoped to the authenticated project.",
+          required: true,
+          schema: { type: "string" },
+        },
+        {
+          name: "format",
+          in: "query",
+          description:
+            "Output format: 'digest' (default, AI-readable) or 'json' (full raw data)",
+          required: false,
+          schema: { type: "string", enum: ["digest", "json"] },
+        },
+        {
+          name: "llmMode",
+          in: "query",
+          description: "Deprecated: use format=digest instead",
+          required: false,
+          schema: { type: "string", enum: ["true", "false", "1", "0"] },
+        },
+      ],
+      responses: {
+        ...baseResponses,
+        200: {
+          description: "Trace detail with spans, evaluations, and ASCII tree",
+          content: {
+            "application/json": {
+              schema: resolver(z.object({}).passthrough()),
+            },
+          },
+        },
+        404: {
+          description: "Trace not found",
+          content: {
+            "application/json": {
+              schema: resolver(z.object({ message: z.string() })),
+            },
+          },
+        },
+        409: {
+          description:
+            "Ambiguous trace ID prefix — the prefix matches more than one trace",
+          content: {
+            "application/json": {
+              schema: resolver(
+                z.object({
+                  message: z.string(),
+                  candidateTraceIds: z.array(z.string()),
+                }),
+              ),
+            },
           },
         },
       },
-      404: {
-        description: "Trace not found",
-        content: {
-          "application/json": {
-            schema: resolver(
-              z.object({ message: z.string() }),
-            ),
-          },
-        },
-      },
-      409: {
-        description:
-          "Ambiguous trace ID prefix — the prefix matches more than one trace",
-        content: {
-          "application/json": {
-            schema: resolver(
-              z.object({
-                message: z.string(),
-                candidateTraceIds: z.array(z.string()),
-              }),
-            ),
-          },
-        },
-      },
-    },
-  }),
-  async (c) => {
-    const project = c.get("project");
-    const { traceId } = c.req.param();
-    const formatParam = c.req.query("format");
-    const llmModeParam = c.req.query("llmMode");
-    const format =
-      formatParam ??
-      (llmModeParam === "true" || llmModeParam === "1" ? "digest" : "json");
+    }),
+    async (c) => {
+      const project = c.get("project");
+      const { traceId } = c.req.param();
+      const formatParam = c.req.query("format");
+      const llmModeParam = c.req.query("llmMode");
+      const format =
+        formatParam ??
+        (llmModeParam === "true" || llmModeParam === "1" ? "digest" : "json");
 
-    logger.info(
-      { projectId: project.id, traceId },
-      "Getting trace by ID",
-    );
+      logger.info({ projectId: project.id, traceId }, "Getting trace by ID");
 
-    const protections = await getProtectionsForProject(prisma, {
-      projectId: project.id,
-    });
-    const traceService = TraceService.create(prisma);
-
-    let trace;
-    try {
-      trace = await traceService.getById(project.id, traceId, protections);
-    } catch (err) {
-      if (err instanceof AmbiguousTraceIdPrefixError) {
-        return c.json(
-          {
-            message: err.message,
-            candidateTraceIds: err.candidateTraceIds,
-          },
-          409,
-        );
-      }
-      throw err;
-    }
-
-    if (!trace) {
-      throw new HTTPException(404, {
-        message: "Trace not found.",
+      const protections = await getProtectionsForProject(prisma, {
+        projectId: project.id,
       });
-    }
+      const traceService = TraceService.create(prisma);
 
-    // If the caller passed a prefix, the resolved trace has the full ID.
-    // Use that everywhere downstream so the response, links, and evaluation
-    // lookup all key off the real trace ID.
-    const resolvedTraceId = trace.trace_id;
+      let trace;
+      try {
+        trace = await traceService.getById(project.id, traceId, protections);
+      } catch (err) {
+        if (err instanceof AmbiguousTraceIdPrefixError) {
+          return c.json(
+            {
+              message: err.message,
+              candidateTraceIds: err.candidateTraceIds,
+            },
+            409,
+          );
+        }
+        throw err;
+      }
 
-    const evaluationsMap = await traceService.getEvaluationsMultiple(
-      project.id,
-      [resolvedTraceId],
-      protections,
-    );
-    const evaluations = evaluationsMap[resolvedTraceId] ?? [];
+      if (!trace) {
+        throw new HTTPException(404, {
+          message: "Trace not found.",
+        });
+      }
 
-    if (format === "digest") {
+      // If the caller passed a prefix, the resolved trace has the full ID.
+      // Use that everywhere downstream so the response, links, and evaluation
+      // lookup all key off the real trace ID.
+      const resolvedTraceId = trace.trace_id;
+
+      const evaluationsMap = await traceService.getEvaluationsMultiple(
+        project.id,
+        [resolvedTraceId],
+        protections,
+      );
+      const evaluations = evaluationsMap[resolvedTraceId] ?? [];
+
+      if (format === "digest") {
+        return c.json({
+          trace_id: resolvedTraceId,
+          formatted_trace: await formatSpansDigest(trace.spans ?? []),
+          timestamps: trace.timestamps,
+          metadata: trace.metadata,
+          evaluations,
+          platformUrl: platformUrl({
+            projectSlug: project.slug,
+            path: `/messages/${resolvedTraceId}`,
+          }),
+        });
+      }
+
+      const asciiTree = generateAsciiTree(trace.spans);
       return c.json({
-        trace_id: resolvedTraceId,
-        formatted_trace: await formatSpansDigest(trace.spans ?? []),
-        timestamps: trace.timestamps,
-        metadata: trace.metadata,
+        ...trace,
         evaluations,
+        ascii_tree: asciiTree,
         platformUrl: platformUrl({
           projectSlug: project.slug,
           path: `/messages/${resolvedTraceId}`,
         }),
       });
-    }
-
-    const asciiTree = generateAsciiTree(trace.spans);
-    return c.json({
-      ...trace,
-      evaluations,
-      ascii_tree: asciiTree,
-      platformUrl: platformUrl({
-        projectSlug: project.slug,
-        path: `/messages/${resolvedTraceId}`,
-      }),
-    });
-  },
+    },
   );
 
   // PATCH /:traceId/metadata - Update trace metadata via synthetic span

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-updated-axis.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-updated-axis.integration.test.ts
@@ -66,6 +66,12 @@ const traceC = `trace-c-${nanoid()}`;
 // it. Global-max dedup must EXCLUDE it (in-window-max dedup would wrongly keep
 // it, re-emitting it in a later CDC window).
 const traceLateBumped = `trace-late-${nanoid()}`;
+// Isolated tenant for the filter-drift regression: a trace whose STALE version
+// matches a search term the LATEST version no longer does. On the updated axis
+// the filter must evaluate on the latest version (dedup-first-then-filter), so
+// the trace is excluded. Separate tenant to not perturb the ordering assertions.
+const filterTenant = `test-filter-drift-${nanoid()}`;
+const traceFilterDrift = `trace-drift-${nanoid()}`;
 
 // Latest UpdatedAt per in-window trace → expected updated-axis order (desc).
 const latest: Record<string, number> = {
@@ -183,15 +189,39 @@ beforeAll(async () => {
     makeTraceSummaryRow(traceLateBumped, now - 25 * SECOND),
     makeTraceSummaryRow(traceLateBumped, now + ONE_DAY),
   ]);
+
+  // Filter-drift trace (isolated tenant): stale version contains "needle", the
+  // latest version does not. Both in-window. On the updated axis the search
+  // must run on the LATEST version → "needle" excludes it, "moved" includes it.
+  await insert([
+    {
+      ...makeTraceSummaryRow(traceFilterDrift, now - 30 * SECOND),
+      TenantId: filterTenant,
+      ComputedInput: JSON.stringify({
+        type: "text",
+        value: "needle in the older version",
+      }),
+    },
+    {
+      ...makeTraceSummaryRow(traceFilterDrift, now - 10 * SECOND),
+      TenantId: filterTenant,
+      ComputedInput: JSON.stringify({
+        type: "text",
+        value: "moved on in the latest version",
+      }),
+    },
+  ]);
 }, 60_000);
 
 afterAll(async () => {
   if (ch) {
-    await ch.exec({
-      query:
-        "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
-      query_params: { tenantId },
-    });
+    for (const t of [tenantId, filterTenant]) {
+      await ch.exec({
+        query:
+          "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+        query_params: { tenantId: t },
+      });
+    }
   }
   await stopTestContainers();
 });
@@ -239,6 +269,38 @@ describe("updated date-axis pagination (integration)", () => {
         expect(seen).toEqual(expectedOrder);
         expect(new Set(seen).size).toBe(seen.length);
         expect(seen).not.toContain(traceLateBumped);
+      });
+    });
+  });
+
+  // Regression for the dedup-then-filter fix: filters/search must evaluate on
+  // the trace's LATEST version, not any stale version. Before the fix, a stale
+  // version matching the search would wrongly include the trace.
+  describe("given a trace whose latest version no longer matches a search term", () => {
+    const fetchDrift = (query: string) =>
+      service.getAllTracesForProject(
+        makeQueryInput({ projectId: filterTenant, query }),
+        openProtections,
+        { downloadMode: true, dateField: "updated" },
+      );
+
+    describe("when the search term only matches the stale version", () => {
+      it("excludes the trace (search runs on the latest version)", async () => {
+        const res = await fetchDrift("needle");
+        expect(res).not.toBeNull();
+        expect(
+          (res as TracesForProjectResult).groups.flat().map((t) => t.trace_id),
+        ).not.toContain(traceFilterDrift);
+      });
+    });
+
+    describe("when the search term matches the latest version", () => {
+      it("includes the trace", async () => {
+        const res = await fetchDrift("moved");
+        expect(res).not.toBeNull();
+        expect(
+          (res as TracesForProjectResult).groups.flat().map((t) => t.trace_id),
+        ).toContain(traceFilterDrift);
       });
     });
   });

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-updated-axis.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-updated-axis.integration.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Mechanism-level integration coverage for the updated date-axis keyset
+ * pagination (Track 1, API Export Traces RFC). The seam with
+ * projection-search.integration.test.ts: that file proves the projected OUTPUT
+ * shape; this file proves the QUERY MECHANISM the updated axis relies on —
+ *
+ *   - the dedup collapses every version of a trace to its GLOBAL latest
+ *     (max UpdatedAt across all versions), then applies the window/cursor to
+ *     that aggregate — so a trace whose latest version moved past the window is
+ *     excluded even if an older version falls inside it (no double-emit across
+ *     adjacent CDC windows), and
+ *   - the HAVING-on-max(UpdatedAt) cursor seek paginates completely: each trace
+ *     surfaces exactly once across pages, ordered by its latest UpdatedAt.
+ *
+ * This is the subtle correctness the occurred axis gets "for free" (OccurredAt
+ * is immutable per trace) but the updated axis must enforce explicitly, because
+ * UpdatedAt is the mutable RMT version column.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { prisma } from "~/server/db";
+import type { Protections } from "../../elasticsearch/protections";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import type {
+  GetAllTracesForProjectInput,
+  TracesForProjectResult,
+} from "../types";
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    project: { findUnique: vi.fn().mockResolvedValue({}) },
+    annotation: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+const tenantId = `test-updated-axis-${nanoid()}`;
+const now = Date.now();
+const SECOND = 1000;
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+const openProtections: Protections = {
+  canSeeCosts: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+};
+
+// Distinct traces, each inserted as MULTIPLE versions (same TraceId, same
+// OccurredAt, increasing UpdatedAt) — exactly what re-ingestion / late
+// evaluations / metadata patches produce. The latest-UpdatedAt version is the
+// one the dedup must keep, and its UpdatedAt is the updated-axis sort key.
+const traceA = `trace-a-${nanoid()}`;
+const traceB = `trace-b-${nanoid()}`;
+const traceC = `trace-c-${nanoid()}`;
+// Its latest version moved AFTER the query window; an older version sits inside
+// it. Global-max dedup must EXCLUDE it (in-window-max dedup would wrongly keep
+// it, re-emitting it in a later CDC window).
+const traceLateBumped = `trace-late-${nanoid()}`;
+
+// Latest UpdatedAt per in-window trace → expected updated-axis order (desc).
+const latest: Record<string, number> = {
+  [traceA]: now - 20 * SECOND,
+  [traceB]: now - 10 * SECOND,
+  [traceC]: now - 15 * SECOND,
+};
+const expectedOrder = [traceB, traceC, traceA];
+
+function makeTraceSummaryRow(traceId: string, updatedAt: number) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    Version: "v1",
+    Attributes: {},
+    // OccurredAt is constant and irrelevant on the updated axis — what varies,
+    // and what we page by, is UpdatedAt.
+    OccurredAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(updatedAt),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: JSON.stringify({ type: "text", value: "in" }),
+    ComputedOutput: JSON.stringify({ type: "text", value: "out" }),
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: 0,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    SatisfactionScore: null,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+  };
+}
+
+function makeQueryInput(
+  overrides: Partial<GetAllTracesForProjectInput> = {},
+): GetAllTracesForProjectInput {
+  return {
+    projectId: tenantId,
+    // Window applies to UpdatedAt on the updated axis; the in-window traces all
+    // fall inside, the late-bumped trace's latest version is past endDate.
+    startDate: now - 60 * SECOND,
+    endDate: now + 60 * SECOND,
+    filters: {},
+    pageSize: 100,
+    sortDirection: "desc",
+    ...overrides,
+  };
+}
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+
+async function insert(values: Record<string, unknown>[]) {
+  await ch.insert({
+    table: "trace_summaries",
+    values,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+async function fetchUpdatedAxisPage(
+  pageSize: number,
+  scrollId?: string | null,
+): Promise<TracesForProjectResult> {
+  const results = await service.getAllTracesForProject(
+    makeQueryInput({ pageSize }),
+    openProtections,
+    { downloadMode: true, dateField: "updated", scrollId },
+  );
+  expect(results).not.toBeNull();
+  return results as TracesForProjectResult;
+}
+
+function traceIdsOf(result: TracesForProjectResult): string[] {
+  return result.groups.flat().map((t) => t.trace_id);
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+  service = new ClickHouseTraceService(
+    prisma as unknown as ConstructorParameters<
+      typeof ClickHouseTraceService
+    >[0],
+  );
+
+  // Each in-window trace has several versions with increasing UpdatedAt — the
+  // dedup must collapse them to the latest. An earlier version of B sits BETWEEN
+  // C's and A's latest, so a pre-dedup keyset seek (raw UpdatedAt) would
+  // mis-place it. The late-bumped trace has an in-window version plus a much
+  // later one that the global-max dedup must use to exclude it.
+  await insert([
+    makeTraceSummaryRow(traceA, now - 40 * SECOND),
+    makeTraceSummaryRow(traceA, latest[traceA] as number),
+    makeTraceSummaryRow(traceB, now - 18 * SECOND),
+    makeTraceSummaryRow(traceB, latest[traceB] as number),
+    makeTraceSummaryRow(traceC, now - 30 * SECOND),
+    makeTraceSummaryRow(traceC, latest[traceC] as number),
+    makeTraceSummaryRow(traceLateBumped, now - 25 * SECOND),
+    makeTraceSummaryRow(traceLateBumped, now + ONE_DAY),
+  ]);
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query:
+        "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("updated date-axis pagination (integration)", () => {
+  describe("given traces inserted as multiple versions", () => {
+    describe("when fetched in a single page on the updated axis", () => {
+      /** @scenario Updated axis returns everything modified within the window */
+      it("collapses each trace to its latest version, ordered by UpdatedAt desc", async () => {
+        const page = await fetchUpdatedAxisPage(100);
+
+        // Each in-window trace appears once — not once per version.
+        expect(traceIdsOf(page)).toEqual(expectedOrder);
+
+        // The surviving version is the global latest (max UpdatedAt).
+        for (const trace of page.groups.flat()) {
+          expect(trace.timestamps.updated_at).toBe(latest[trace.trace_id]);
+        }
+      });
+
+      it("excludes a trace whose latest version moved past the window", async () => {
+        const page = await fetchUpdatedAxisPage(100);
+        // traceLateBumped has an in-window version (now-25s) but its global max
+        // (now + 1 day) is outside the window — global-max dedup drops it.
+        expect(traceIdsOf(page)).not.toContain(traceLateBumped);
+      });
+    });
+  });
+
+  describe("given more in-window traces than fit on one page", () => {
+    describe("when paginating the updated axis via scrollId", () => {
+      /** @scenario Updated axis pagination is complete and at-least-once */
+      /** @scenario Projection works with keyset cursor pagination */
+      it("returns every trace exactly once across pages, with no duplicates or skips", async () => {
+        const seen: string[] = [];
+        let scrollId: string | undefined;
+        // pageSize 2 over 3 in-window traces → page 1 (B, C) + page 2 (A).
+        for (let guard = 0; guard < 5; guard++) {
+          const page = await fetchUpdatedAxisPage(2, scrollId);
+          seen.push(...traceIdsOf(page));
+          scrollId = page.scrollId;
+          if (!scrollId) break;
+        }
+
+        expect(seen).toEqual(expectedOrder);
+        expect(new Set(seen).size).toBe(seen.length);
+        expect(seen).not.toContain(traceLateBumped);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/projection-search.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/projection-search.integration.test.ts
@@ -188,6 +188,12 @@ function makeQueryInput(
 let ch: ClickHouseClient;
 let service: ClickHouseTraceService;
 let annotationFindMany: ReturnType<typeof vi.fn>;
+let annotationScoreFindMany: ReturnType<typeof vi.fn>;
+
+// The AnnotationScore id whose definition names it "quality". In production
+// scoreOptions is keyed by this id, NOT the name — the service joins
+// AnnotationScore to remap id -> name for the name-addressable public contract.
+const QUALITY_SCORE_ID = "annscore-quality-id";
 
 vi.mock("~/server/clickhouse/clickhouseClient", () => ({
   getClickHouseClientForProject: vi.fn(),
@@ -197,6 +203,7 @@ vi.mock("~/server/db", () => ({
   prisma: {
     project: { findUnique: vi.fn().mockResolvedValue({}) },
     annotation: { findMany: vi.fn().mockResolvedValue([]) },
+    annotationScore: { findMany: vi.fn().mockResolvedValue([]) },
   },
 }));
 
@@ -241,6 +248,7 @@ beforeAll(async () => {
   vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
 
   annotationFindMany = vi.mocked(prisma.annotation.findMany);
+  annotationScoreFindMany = vi.mocked(prisma.annotationScore.findMany);
   service = new ClickHouseTraceService(
     prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
   );
@@ -274,6 +282,8 @@ beforeAll(async () => {
 
   // The Postgres annotations JOIN is mocked (no PG testcontainer here); the
   // service still maps these rows into ProjectedAnnotation[] for the projector.
+  // scoreOptions is keyed by the AnnotationScore id (as in production) — the
+  // service joins annotationScore to remap that id to the "quality" name.
   annotationFindMany.mockResolvedValue([
     {
       id: `annotation-${nanoid()}`,
@@ -281,9 +291,14 @@ beforeAll(async () => {
       isThumbsUp: true,
       comment: "looks right",
       expectedOutput: null,
-      scoreOptions: { quality: { value: "5", reason: "accurate" } },
+      scoreOptions: {
+        [QUALITY_SCORE_ID]: { value: "5", reason: "accurate" },
+      },
       createdAt: new Date(now),
     },
+  ]);
+  annotationScoreFindMany.mockResolvedValue([
+    { id: QUALITY_SCORE_ID, name: "quality" },
   ]);
 }, 60_000);
 

--- a/langwatch/src/server/traces/__tests__/projection-search.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/projection-search.integration.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Integration coverage for the trace search projection DSL (Track 1, API Export
+ * Traces RFC) — the END-TO-END projected SHAPE.
+ *
+ * Proves the feature-spec scenarios (`specs/traces/trace-search-projection.feature`)
+ * against real infrastructure: the compiler plans, the ClickHouse read path runs
+ * the bounded events JOIN over real `stored_spans`, the Postgres annotations JOIN
+ * runs (Prisma mocked — there is no PG testcontainer here, but the service's
+ * mapping is exercised), and the per-trace projector renders the requested shape.
+ *
+ * The seam with the service's own tests: this file asserts the projected OUTPUT
+ * (the contract a caller sees), including the `dateField: "updated"` axis SHAPE
+ * (a late-modified trace is caught on the updated axis, missed on the occurred
+ * axis). The mechanism — IN-tuple dedup, the ±2-day partition window, `mapFilter`
+ * event-attr extraction, `LIMIT N BY`, and the updated-axis pagination-completeness
+ * proof — lives in the ClickHouseTraceService tests, not here.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
+import { prisma } from "~/server/db";
+import type { Protections } from "../../elasticsearch/protections";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import { enrichTracesWithEvaluations } from "../enrich-evaluations";
+import {
+  compileProjection,
+  type ProjectableTrace,
+  type ProjectionFrom,
+} from "../projection";
+import type { GetAllTracesForProjectInput } from "../types";
+
+const tenantId = `test-projection-${nanoid()}`;
+const traceId = `trace-projection-${nanoid()}`;
+// A trace that OCCURRED long before the query window but was MODIFIED inside it
+// — the case the updated date-axis must catch and the occurred axis must miss.
+const lateTraceId = `trace-late-${nanoid()}`;
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const now = Date.now();
+
+const openProtections: Protections = {
+  canSeeCosts: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+};
+
+function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    Version: "v1",
+    Attributes: { "langwatch.user_id": "u_42" },
+    OccurredAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: JSON.stringify({ type: "text", value: "captured input" }),
+    ComputedOutput: JSON.stringify({ type: "text", value: "captured output" }),
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: 0.0031,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    SatisfactionScore: null,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+    ...overrides,
+  };
+}
+
+/** A stored_spans row carrying `event.*` attributes — one feedback event. */
+function makeEventSpanRow({
+  spanAttributes,
+  overrides = {},
+}: {
+  spanAttributes: Record<string, string>;
+  overrides?: Record<string, unknown>;
+}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    SpanId: `event-span-${nanoid()}`,
+    ParentSpanId: null,
+    ParentTraceId: null,
+    ParentIsRemote: null,
+    Sampled: 1,
+    StartTime: new Date(now),
+    EndTime: new Date(now + 5),
+    DurationMs: 5,
+    SpanName: "event",
+    SpanKind: 1,
+    ServiceName: "test-service",
+    ResourceAttributes: {},
+    SpanAttributes: spanAttributes,
+    StatusCode: 1,
+    StatusMessage: null,
+    ScopeName: "test",
+    ScopeVersion: null,
+    "Events.Timestamp": [],
+    "Events.Name": [],
+    "Events.Attributes": [],
+    "Links.TraceId": [],
+    "Links.SpanId": [],
+    "Links.Attributes": [],
+    DroppedAttributesCount: 0,
+    DroppedEventsCount: 0,
+    DroppedLinksCount: 0,
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ...overrides,
+  };
+}
+
+function makeEvaluationRunRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    EvaluationId: `eval-${nanoid()}`,
+    Version: "v1",
+    EvaluatorId: `evaluator-${nanoid()}`,
+    EvaluatorType: "custom/test",
+    EvaluatorName: "Faithfulness",
+    TraceId: traceId,
+    IsGuardrail: 0,
+    Status: "processed",
+    Score: 0.91,
+    Passed: 1,
+    Label: null,
+    Details: null,
+    Error: null,
+    ErrorDetails: null,
+    LastProcessedEventId: `evt-${nanoid()}`,
+    ScheduledAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    LastEventOccurredAt: new Date(now),
+    ...overrides,
+  };
+}
+
+async function insert({
+  table,
+  values,
+}: {
+  table: string;
+  values: Record<string, unknown>[];
+}) {
+  await ch.insert({
+    table,
+    values,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+function makeQueryInput(
+  overrides: Partial<GetAllTracesForProjectInput> = {},
+): GetAllTracesForProjectInput {
+  return {
+    projectId: tenantId,
+    startDate: now - 60_000,
+    endDate: now + 60_000,
+    filters: {},
+    pageSize: 100,
+    ...overrides,
+  };
+}
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+let annotationFindMany: ReturnType<typeof vi.fn>;
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    project: { findUnique: vi.fn().mockResolvedValue({}) },
+    annotation: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+/**
+ * Run the full surface pipeline against the real service: compile the
+ * projection, fetch the page, enrich evaluations exactly as the route does,
+ * then project each trace. Returns the projected rows a caller would receive.
+ */
+async function projectedSearch({
+  select,
+  from,
+  protections = openProtections,
+  dateField,
+}: {
+  select: string[];
+  from?: ProjectionFrom;
+  protections?: Protections;
+  dateField?: "occurred" | "updated";
+}) {
+  const compiled = compileProjection({ from, select, protections });
+  const results = await service.getAllTracesForProject(
+    makeQueryInput(),
+    protections,
+    {
+      downloadMode: true,
+      projection: compiled.plan,
+      dateField,
+    },
+  );
+  expect(results).not.toBeNull();
+  const enriched = enrichTracesWithEvaluations({
+    traces: results!.groups.flat(),
+    traceChecks: results!.traceChecks,
+  });
+  return enriched.map((t) => compiled.project(t as ProjectableTrace));
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+
+  vi.mocked(getClickHouseClientForProject).mockResolvedValue(ch);
+
+  annotationFindMany = vi.mocked(prisma.annotation.findMany);
+  service = new ClickHouseTraceService(
+    prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+  );
+
+  await insert({
+    table: "trace_summaries",
+    values: [
+      makeTraceSummaryRow(),
+      // Occurred 30 days ago, last modified now.
+      makeTraceSummaryRow({
+        TraceId: lateTraceId,
+        OccurredAt: new Date(now - THIRTY_DAYS_MS),
+        CreatedAt: new Date(now - THIRTY_DAYS_MS),
+        UpdatedAt: new Date(now),
+      }),
+    ],
+  });
+  await insert({
+    table: "stored_spans",
+    values: [
+      makeEventSpanRow({
+        spanAttributes: {
+          "event.type": "thumbs_up_down",
+          "event.metrics.vote": "1",
+          "event.details.reason": "great answer",
+        },
+      }),
+    ],
+  });
+  await insert({ table: "evaluation_runs", values: [makeEvaluationRunRow()] });
+
+  // The Postgres annotations JOIN is mocked (no PG testcontainer here); the
+  // service still maps these rows into ProjectedAnnotation[] for the projector.
+  annotationFindMany.mockResolvedValue([
+    {
+      id: `annotation-${nanoid()}`,
+      traceId,
+      isThumbsUp: true,
+      comment: "looks right",
+      expectedOutput: null,
+      scoreOptions: { quality: { value: "5", reason: "accurate" } },
+      createdAt: new Date(now),
+    },
+  ]);
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    for (const table of [
+      "trace_summaries",
+      "stored_spans",
+      "evaluation_runs",
+    ]) {
+      await ch.exec({
+        query: `ALTER TABLE ${table} DELETE WHERE TenantId = {tenantId:String}`,
+        query_params: { tenantId },
+      });
+    }
+  }
+  await stopTestContainers();
+});
+
+describe("trace search projection (integration)", () => {
+  describe("given a select over event fields", () => {
+    describe("when the page is projected", () => {
+      /** @scenario "Select event fields returned as nested array" */
+      it("returns events as a nested array of only the requested fields", async () => {
+        const rows = await projectedSearch({
+          select: ["trace_id", "events.type", "events.metrics"],
+        });
+
+        const row = rows.find((r) => r.trace_id === traceId);
+        expect(row).toBeDefined();
+        expect(row).toEqual({
+          trace_id: traceId,
+          events: [{ type: "thumbs_up_down", metrics: { vote: 1 } }],
+        });
+      });
+    });
+  });
+
+  describe("given a select over annotation fields", () => {
+    describe("when the page is projected", () => {
+      /** @scenario "Select annotation fields returned as nested array" */
+      it("returns annotations joined from Postgres as a nested array", async () => {
+        const rows = await projectedSearch({
+          select: [
+            "trace_id",
+            "annotations.is_thumbs_up",
+            "annotations.scores",
+          ],
+        });
+
+        const row = rows.find((r) => r.trace_id === traceId);
+        expect(row).toEqual({
+          trace_id: traceId,
+          annotations: [
+            {
+              is_thumbs_up: true,
+              scores: { quality: { value: "5", reason: "accurate" } },
+            },
+          ],
+        });
+      });
+    });
+  });
+
+  describe("given a select over evaluation fields", () => {
+    describe("when the page is projected", () => {
+      /** @scenario "Select evaluation fields returned as nested array" */
+      it("returns evaluations as a nested array of only the requested fields", async () => {
+        const rows = await projectedSearch({
+          select: ["trace_id", "evaluations.name", "evaluations.score"],
+        });
+
+        const row = rows.find((r) => r.trace_id === traceId);
+        expect(row?.evaluations).toEqual([
+          { name: "Faithfulness", score: 0.91 },
+        ]);
+      });
+    });
+  });
+
+  describe("given a select that omits input and output", () => {
+    describe("when the page is projected", () => {
+      it("returns only the requested lightweight fields, with no io keys", async () => {
+        const rows = await projectedSearch({
+          select: ["trace_id", "metadata.user_id", "metrics.total_cost"],
+        });
+
+        const row = rows.find((r) => r.trace_id === traceId);
+        expect(row).toEqual({
+          trace_id: traceId,
+          metadata: { user_id: "u_42" },
+          metrics: { total_cost: 0.0031 },
+        });
+        expect(row).not.toHaveProperty("input");
+        expect(row).not.toHaveProperty("output");
+      });
+    });
+  });
+
+  describe("given a select spanning every source", () => {
+    describe("when the page is projected in a single call", () => {
+      /** @scenario "Select fields from all sources in a single request" */
+      it("returns scalar, grouped, and all nested collections together", async () => {
+        const rows = await projectedSearch({
+          select: [
+            "trace_id",
+            "started_at",
+            "metadata.user_id",
+            "metrics.total_cost",
+            "events.type",
+            "annotations.is_thumbs_up",
+            "evaluations.score",
+          ],
+        });
+
+        const row = rows.find((r) => r.trace_id === traceId);
+        expect(row).toMatchObject({
+          trace_id: traceId,
+          metadata: { user_id: "u_42" },
+          metrics: { total_cost: 0.0031 },
+          events: [{ type: "thumbs_up_down" }],
+          annotations: [{ is_thumbs_up: true }],
+          evaluations: [{ score: 0.91 }],
+        });
+        expect(typeof row?.started_at).toBe("number");
+      });
+    });
+  });
+
+  describe("given a trace that occurred long ago but was modified recently", () => {
+    describe("when searching on the updated axis", () => {
+      /** @scenario "Updated axis captures a late-mutated old trace" */
+      it("includes the late-modified trace", async () => {
+        const rows = await projectedSearch({
+          select: ["trace_id", "updated_at"],
+          dateField: "updated",
+        });
+        expect(rows.some((r) => r.trace_id === lateTraceId)).toBe(true);
+      });
+    });
+
+    describe("when searching on the default occurred axis", () => {
+      /** @scenario "Default date axis is occurrence" */
+      it("excludes the trace whose occurrence is outside the window", async () => {
+        const rows = await projectedSearch({
+          select: ["trace_id", "updated_at"],
+        });
+        expect(rows.some((r) => r.trace_id === lateTraceId)).toBe(false);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/projection-search.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/projection-search.integration.test.ts
@@ -335,6 +335,32 @@ describe("trace search projection (integration)", () => {
         });
       });
     });
+
+    describe("when captured input is not visible", () => {
+      /** @scenario "Projected event details are redacted when captured input is not visible" */
+      it("redacts event detail values but keeps types and metrics", async () => {
+        const rows = await projectedSearch({
+          select: ["trace_id", "events.type", "events.metrics", "events.details"],
+          protections: {
+            canSeeCosts: true,
+            canSeeCapturedInput: false,
+            canSeeCapturedOutput: true,
+          },
+        });
+
+        const row = rows.find((r) => r.trace_id === traceId);
+        expect(row).toEqual({
+          trace_id: traceId,
+          events: [
+            {
+              type: "thumbs_up_down",
+              metrics: { vote: 1 },
+              details: { reason: "[REDACTED]" },
+            },
+          ],
+        });
+      });
+    });
   });
 
   describe("given a select over annotation fields", () => {

--- a/langwatch/src/server/traces/__tests__/remap-score-options.unit.test.ts
+++ b/langwatch/src/server/traces/__tests__/remap-score-options.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { remapScoreOptionsToNames } from "../clickhouse-trace.service";
+
+describe("remapScoreOptionsToNames", () => {
+  describe("when score ids resolve to distinct names", () => {
+    it("keys each value by its AnnotationScore name", () => {
+      const remapped = remapScoreOptionsToNames(
+        { "id-a": { value: "5" }, "id-b": { value: "low" } },
+        new Map([
+          ["id-a", "quality"],
+          ["id-b", "toxicity"],
+        ]),
+      );
+      expect(remapped).toEqual({
+        quality: { value: "5" },
+        toxicity: { value: "low" },
+      });
+    });
+  });
+
+  describe("when two score ids share the same name", () => {
+    it("keeps the first under the plain name and id-suffixes the rest deterministically", () => {
+      const remapped = remapScoreOptionsToNames(
+        { "id-a": { value: "5" }, "id-b": { value: "3" } },
+        new Map([
+          ["id-a", "quality"],
+          ["id-b", "quality"],
+        ]),
+      );
+      expect(remapped).toEqual({
+        quality: { value: "5" },
+        "quality (id-b)": { value: "3" },
+      });
+    });
+  });
+
+  describe("when a score id has no definition", () => {
+    it("keeps the id as the key so no data is lost", () => {
+      const remapped = remapScoreOptionsToNames(
+        { "id-unknown": { value: "1" } },
+        new Map(),
+      );
+      expect(remapped).toEqual({ "id-unknown": { value: "1" } });
+    });
+  });
+});

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -613,9 +613,11 @@ export class ClickHouseTraceService {
           // legacy full-trace response. When present, it drives heavy-column
           // pruning and which child collections are JOINed (events, annotations).
           const projection = options.projection;
-          // Fetch the heavy ComputedInput/ComputedOutput columns only when the
-          // legacy path runs or the projection actually selects io fields.
-          const fetchIO = !projection || projection.needsIO;
+          // Fetch each heavy Computed* column only when the legacy path runs
+          // or the projection selects that io field — independently, so an
+          // output-only select never materializes ComputedInput.
+          const fetchInput = !projection || projection.needsInput;
+          const fetchOutput = !projection || projection.needsOutput;
 
           // Time axis the date window + keyset cursor page on. Default "occurred"
           // keeps the legacy OccurredAt behavior; "updated" pages by last
@@ -717,7 +719,8 @@ export class ClickHouseTraceService {
               filterParams,
               traceIds: input.traceIds,
               query: input.query,
-              fetchIO,
+              fetchInput,
+              fetchOutput,
               dateField,
             });
 
@@ -1485,7 +1488,8 @@ export class ClickHouseTraceService {
     filterParams,
     traceIds,
     query,
-    fetchIO = true,
+    fetchInput = true,
+    fetchOutput = true,
     dateField = "occurred",
   }: {
     projectId: string;
@@ -1499,8 +1503,10 @@ export class ClickHouseTraceService {
     filterParams?: Record<string, unknown>;
     traceIds?: string[];
     query?: string;
-    /** Fetch heavy ComputedInput/ComputedOutput columns. False prunes them. */
-    fetchIO?: boolean;
+    /** Fetch the heavy ComputedInput column. False prunes it. */
+    fetchInput?: boolean;
+    /** Fetch the heavy ComputedOutput column. False prunes it. */
+    fetchOutput?: boolean;
     /** Time axis for the date window + keyset cursor. Default "occurred". */
     dateField?: TraceDateField;
   }): Promise<{ traces: Trace[]; totalHits: number; lastTrace: Trace | null }> {
@@ -1701,7 +1707,8 @@ export class ClickHouseTraceService {
           endDate: endDate ?? Date.now(),
           traceIds: pageTraceIds,
           orderDirection,
-          fetchIO,
+          fetchInput,
+          fetchOutput,
           dateColumn,
         });
 
@@ -1734,7 +1741,8 @@ export class ClickHouseTraceService {
     endDate,
     traceIds,
     orderDirection,
-    fetchIO = true,
+    fetchInput = true,
+    fetchOutput = true,
     dateColumn = "OccurredAt",
   }: {
     clickHouseClient: ClickHouseClient;
@@ -1743,9 +1751,10 @@ export class ClickHouseTraceService {
     endDate: number;
     traceIds: string[];
     orderDirection: string;
-    /** Fetch heavy ComputedInput/ComputedOutput. False reads '' instead — the
-     * row shape is unchanged but ClickHouse never materializes the heavy column. */
-    fetchIO?: boolean;
+    /** Fetch the heavy Computed* columns independently. False reads '' instead —
+     * the row shape is unchanged but ClickHouse never materializes that column. */
+    fetchInput?: boolean;
+    fetchOutput?: boolean;
     /** Column the date window + ORDER BY run on (must match the page-ID query). */
     dateColumn?: "OccurredAt" | "UpdatedAt";
   }): Promise<TraceSummaryRow[]> {
@@ -1756,8 +1765,8 @@ export class ClickHouseTraceService {
     if (dateColumn !== "OccurredAt" && dateColumn !== "UpdatedAt") {
       throw new Error(`Invalid dateColumn: ${String(dateColumn)}`);
     }
-    const computedInputExpr = fetchIO ? "ts.ComputedInput" : "''";
-    const computedOutputExpr = fetchIO ? "ts.ComputedOutput" : "''";
+    const computedInputExpr = fetchInput ? "ts.ComputedInput" : "''";
+    const computedOutputExpr = fetchOutput ? "ts.ComputedOutput" : "''";
     const isUpdatedAxis = dateColumn === "UpdatedAt";
     const sortColumn = isUpdatedAxis ? "ts_UpdatedAt" : "ts_OccurredAt";
     // Updated axis dedups on the GLOBAL max(UpdatedAt) — the page IDs were

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -100,6 +100,32 @@ const MAX_EVENTS_PER_TRACE = 1_000;
 /** Bounds the bounded events stored_spans scan to the page's occurrence weeks. */
 const EVENT_PARTITION_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
 
+/** Object keys that would corrupt the prototype chain if assigned. */
+const FORBIDDEN_SCORE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Annotation `scoreOptions` is keyed by AnnotationScore id; the public contract
+ * exposes `annotations.scores.<name>`, so remap id -> name. Score names are not
+ * unique per project — on a collision the last definition wins. An id with no
+ * matching score (e.g. a deleted definition) keeps its id as the key so data is
+ * never silently dropped. Prototype-polluting keys are skipped.
+ */
+function remapScoreOptionsToNames(
+  scoreOptions: unknown,
+  scoreNameById: Map<string, string>,
+): Record<string, unknown> {
+  if (!scoreOptions || typeof scoreOptions !== "object") return {};
+  const remapped: Record<string, unknown> = {};
+  for (const [scoreId, value] of Object.entries(
+    scoreOptions as Record<string, unknown>,
+  )) {
+    const key = scoreNameById.get(scoreId) ?? scoreId;
+    if (FORBIDDEN_SCORE_KEYS.has(key)) continue;
+    remapped[key] = value;
+  }
+  return remapped;
+}
+
 /**
  * Service for fetching traces from ClickHouse.
  *
@@ -1466,51 +1492,37 @@ export class ClickHouseTraceService {
           ? ` AND (${searchableColumns.map((col) => `${col} LIKE {searchQuery:String}`).join(" OR ")})`
           : "";
 
-        // Date axis. occurred (default) is the partition key — windowed in WHERE
-        // so partitions prune. updated is the last-mutation time for CDC: the
-        // version selector (_oa) computes each trace's GLOBAL max(UpdatedAt)
-        // over ALL versions first, then the window + cursor are applied to that
-        // aggregate (in HAVING). So "updated in [start,end]" means the trace's
-        // TRUE last modification — adjacent CDC windows stay mutually exclusive
-        // and never re-emit a trace whose later version moved past the window.
+        // Date axis.
+        //  occurred (default): windows + seeks on the immutable OccurredAt in
+        //    WHERE (prunes partitions). Keeps the pre-existing filter-then-dedup
+        //    structure verbatim — changing it would alter results for every
+        //    current client, so it stays byte-identical for backwards-compat.
+        //  updated (CDC): restricts ts to each trace's LATEST version first
+        //    (global max UpdatedAt, no window), THEN applies the window +
+        //    filters + cursor to THAT row. So a stale version can never satisfy
+        //    a filter the latest version doesn't, and "updated in [start,end]"
+        //    means the trace's TRUE last modification (adjacent CDC windows stay
+        //    mutually exclusive).
         const isUpdatedAxis = dateField === "updated";
         const dateColumn = isUpdatedAxis ? "UpdatedAt" : "OccurredAt";
         const cmp = sortDirection === "desc" ? "<" : ">";
         const orderDirection = sortDirection === "desc" ? "DESC" : "ASC";
 
-        // Per-trace sort key: occurred -> OccurredAt of the latest version;
-        // updated -> the global max UpdatedAt over all versions.
-        const oaExpr = isUpdatedAxis
-          ? "max(ts.UpdatedAt)"
-          : "argMax(ts.OccurredAt, ts.UpdatedAt)";
+        const occurredWindow =
+          " AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64}) AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})";
+        const updatedWindow =
+          " AND ts.UpdatedAt >= fromUnixTimestamp64Milli({startDate:UInt64}) AND ts.UpdatedAt <= fromUnixTimestamp64Milli({endDate:UInt64})";
+        // Collapses ts to each trace's latest version (global max UpdatedAt) so
+        // the updated-axis window/filters/cursor evaluate on the latest row.
+        const latestVersionOnly =
+          " AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (SELECT TenantId, TraceId, max(UpdatedAt) FROM trace_summaries WHERE TenantId = {tenantId:String} GROUP BY TenantId, TraceId)";
 
-        // Date window placement: occurred -> WHERE (prunes partitions);
-        // updated -> HAVING on the aggregated _oa.
-        const windowWhere = isUpdatedAxis
-          ? ""
-          : " AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64}) AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})";
-        const windowHaving = isUpdatedAxis
-          ? "_oa >= fromUnixTimestamp64Milli({startDate:UInt64}) AND _oa <= fromUnixTimestamp64Milli({endDate:UInt64})"
-          : "";
-
-        // Keyset cursor: occurred -> WHERE on raw (immutable) OccurredAt (also
-        // prunes); updated -> HAVING on the aggregated _oa, so the seek matches
-        // the version the dedup keeps (a raw pre-aggregate seek would let a
-        // non-max version slip past the cursor and duplicate the trace).
-        let cursorWhere = "";
-        let cursorHavingExpr = "";
+        let occurredCursor = "";
+        let updatedCursor = "";
         if (cursor) {
-          if (isUpdatedAxis) {
-            cursorHavingExpr = `(toUnixTimestamp64Milli(_oa), TraceId) ${cmp} ({lastTimestamp:UInt64}, {lastTraceId:String})`;
-          } else {
-            cursorWhere = ` AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) ${cmp} ({lastTimestamp:UInt64}, {lastTraceId:String})`;
-          }
+          occurredCursor = ` AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) ${cmp} ({lastTimestamp:UInt64}, {lastTraceId:String})`;
+          updatedCursor = ` AND (toUnixTimestamp64Milli(ts.UpdatedAt), ts.TraceId) ${cmp} ({lastTimestamp:UInt64}, {lastTraceId:String})`;
         }
-
-        const havingClause = [windowHaving, cursorHavingExpr]
-          .filter(Boolean)
-          .join(" AND ");
-        const havingSql = havingClause ? ` HAVING ${havingClause}` : "";
 
         const sharedParams = {
           tenantId: projectId,
@@ -1538,24 +1550,57 @@ export class ClickHouseTraceService {
           ? `
               SELECT count() AS total
               FROM (
-                SELECT ts.TraceId AS TraceId, max(ts.UpdatedAt) AS _oa
+                SELECT ts.TraceId
                 FROM trace_summaries ts
                 WHERE ts.TenantId = {tenantId:String}
+                  ${latestVersionOnly}
+                  ${updatedWindow}
                   ${extraFilters}
                   ${traceIdFilter}
                   ${searchFilter}
                 GROUP BY ts.TraceId
-                HAVING ${windowHaving}
               )
             `
           : `
               SELECT uniq(ts.TraceId) as total
               FROM trace_summaries ts
               WHERE ts.TenantId = {tenantId:String}
-                ${windowWhere}
+                ${occurredWindow}
                 ${extraFilters}
                 ${traceIdFilter}
                 ${searchFilter}
+            `;
+        const idQuery = isUpdatedAxis
+          ? `
+              SELECT ts.TraceId
+              FROM trace_summaries ts
+              WHERE ts.TenantId = {tenantId:String}
+                ${latestVersionOnly}
+                ${updatedWindow}
+                ${extraFilters}
+                ${traceIdFilter}
+                ${searchFilter}
+                ${updatedCursor}
+              GROUP BY ts.TraceId
+              ORDER BY max(toUnixTimestamp64Milli(ts.UpdatedAt)) ${orderDirection}, ts.TraceId ${orderDirection}
+              LIMIT {pageSize:UInt32}
+            `
+          : `
+              SELECT s.TraceId
+              FROM (
+                SELECT ts.TraceId AS TraceId,
+                       argMax(ts.OccurredAt, ts.UpdatedAt) AS _oa
+                FROM trace_summaries ts
+                WHERE ts.TenantId = {tenantId:String}
+                  ${occurredWindow}
+                  ${extraFilters}
+                  ${traceIdFilter}
+                  ${searchFilter}
+                  ${occurredCursor}
+                GROUP BY ts.TraceId
+              ) s
+              ORDER BY s._oa ${orderDirection}, s.TraceId ${orderDirection}
+              LIMIT {pageSize:UInt32}
             `;
         const [countResult, idsResult] = await Promise.all([
           clickHouseClient.query({
@@ -1564,24 +1609,7 @@ export class ClickHouseTraceService {
             format: "JSONEachRow",
           }),
           clickHouseClient.query({
-            query: `
-              SELECT s.TraceId
-              FROM (
-                SELECT ts.TraceId AS TraceId,
-                       ${oaExpr} AS _oa
-                FROM trace_summaries ts
-                WHERE ts.TenantId = {tenantId:String}
-                  ${windowWhere}
-                  ${extraFilters}
-                  ${traceIdFilter}
-                  ${searchFilter}
-                  ${cursorWhere}
-                GROUP BY ts.TraceId
-                ${havingSql}
-              ) s
-              ORDER BY s._oa ${orderDirection}, s.TraceId ${orderDirection}
-              LIMIT {pageSize:UInt32}
-            `,
+            query: idQuery,
             query_params: {
               ...sharedParams,
               ...cursorParams,
@@ -1821,8 +1849,8 @@ export class ClickHouseTraceService {
           AND t.TraceId IN ({traceIds:Array(String)})
           ${spanTimeFilterOuter}
           AND mapContains(t.SpanAttributes, 'event.type')
-          AND (t.TenantId, t.TraceId, t.SpanId, t.StartTime) IN (
-            SELECT TenantId, TraceId, SpanId, max(StartTime)
+          AND (t.TenantId, t.TraceId, t.SpanId, t.UpdatedAt) IN (
+            SELECT TenantId, TraceId, SpanId, max(UpdatedAt)
             FROM stored_spans
             WHERE TenantId = {tenantId:String}
               AND TraceId IN ({traceIds:Array(String)})
@@ -1885,19 +1913,30 @@ export class ClickHouseTraceService {
     const traceIds = traces.map((t) => t.trace_id);
     if (traceIds.length === 0) return;
 
-    const rows = await this.prisma.annotation.findMany({
-      where: { projectId, traceId: { in: traceIds } },
-      select: {
-        id: true,
-        traceId: true,
-        isThumbsUp: true,
-        comment: true,
-        expectedOutput: true,
-        scoreOptions: true,
-        createdAt: true,
-      },
-      orderBy: { createdAt: "asc" },
-    });
+    // scoreOptions is keyed by AnnotationScore id, but the public contract is
+    // name-addressable (annotations.scores.<name>), so fetch the score
+    // definitions to remap id -> name. Deleted definitions are included so
+    // historical scoreOptions still resolve.
+    const [rows, scoreDefs] = await Promise.all([
+      this.prisma.annotation.findMany({
+        where: { projectId, traceId: { in: traceIds } },
+        select: {
+          id: true,
+          traceId: true,
+          isThumbsUp: true,
+          comment: true,
+          expectedOutput: true,
+          scoreOptions: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "asc" },
+      }),
+      this.prisma.annotationScore.findMany({
+        where: { projectId },
+        select: { id: true, name: true },
+      }),
+    ]);
+    const scoreNameById = new Map(scoreDefs.map((s) => [s.id, s.name]));
 
     const byTrace = new Map<string, ProjectedAnnotation[]>();
     for (const row of rows) {
@@ -1907,10 +1946,7 @@ export class ClickHouseTraceService {
         is_thumbs_up: row.isThumbsUp ?? null,
         comment: row.comment ?? null,
         expected_output: row.expectedOutput ?? null,
-        scores:
-          row.scoreOptions && typeof row.scoreOptions === "object"
-            ? (row.scoreOptions as Record<string, unknown>)
-            : {},
+        scores: remapScoreOptionsToNames(row.scoreOptions, scoreNameById),
         created_at: row.createdAt.getTime(),
       });
       byTrace.set(row.traceId, list);

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -127,6 +127,57 @@ function remapScoreOptionsToNames(
 }
 
 /**
+ * Bound the events stored_spans scan to the partitions the page's traces
+ * actually occurred in. Occurrence times are clustered (a new cluster starts on
+ * a gap larger than the merge window), and each cluster contributes one tight
+ * [min - window, max + window] range OR'd into the filter — so a page mixing old
+ * and recent traces (common on the updated axis) scans a few small ranges rather
+ * than one range spanning every weekly partition between them.
+ */
+function buildEventOccurrenceWindows(occurredAts: number[]): {
+  outer: string;
+  inner: string;
+  params: Record<string, number>;
+} {
+  if (occurredAts.length === 0) return { outer: "", inner: "", params: {} };
+
+  const sorted = [...occurredAts].sort((a, b) => a - b);
+  // Merge points whose ±window ranges would overlap; split when farther apart.
+  const clusterGap = 2 * EVENT_PARTITION_WINDOW_MS;
+  const clusters: Array<{ from: number; to: number }> = [];
+  for (const ts of sorted) {
+    const last = clusters[clusters.length - 1];
+    if (last && ts - last.to <= clusterGap) {
+      last.to = ts;
+    } else {
+      clusters.push({ from: ts, to: ts });
+    }
+  }
+
+  const params: Record<string, number> = {};
+  const outerParts: string[] = [];
+  const innerParts: string[] = [];
+  clusters.forEach((c, i) => {
+    const fromKey = `spanFrom${i}`;
+    const toKey = `spanTo${i}`;
+    params[fromKey] = c.from - EVENT_PARTITION_WINDOW_MS;
+    params[toKey] = c.to + EVENT_PARTITION_WINDOW_MS;
+    outerParts.push(
+      `(t.StartTime >= fromUnixTimestamp64Milli({${fromKey}:Int64}) AND t.StartTime <= fromUnixTimestamp64Milli({${toKey}:Int64}))`,
+    );
+    innerParts.push(
+      `(StartTime >= fromUnixTimestamp64Milli({${fromKey}:Int64}) AND StartTime <= fromUnixTimestamp64Milli({${toKey}:Int64}))`,
+    );
+  });
+
+  return {
+    outer: ` AND (${outerParts.join(" OR ")})`,
+    inner: ` AND (${innerParts.join(" OR ")})`,
+    params,
+  };
+}
+
+/**
  * Service for fetching traces from ClickHouse.
  *
  * Fetches trace summaries and, when needed, span rows via separate ClickHouse
@@ -1822,19 +1873,16 @@ export class ClickHouseTraceService {
     const occurredAts = traces
       .map((t) => t.timestamps?.started_at)
       .filter((t): t is number => typeof t === "number" && t > 0);
-    const hasWindow = occurredAts.length > 0;
-    const spanTimeFilterOuter = hasWindow
-      ? "AND t.StartTime >= fromUnixTimestamp64Milli({spanFromMs:Int64}) AND t.StartTime <= fromUnixTimestamp64Milli({spanToMs:Int64})"
-      : "";
-    const spanTimeFilterInner = hasWindow
-      ? "AND StartTime >= fromUnixTimestamp64Milli({spanFromMs:Int64}) AND StartTime <= fromUnixTimestamp64Milli({spanToMs:Int64})"
-      : "";
-    const spanTimeParams = hasWindow
-      ? {
-          spanFromMs: Math.min(...occurredAts) - EVENT_PARTITION_WINDOW_MS,
-          spanToMs: Math.max(...occurredAts) + EVENT_PARTITION_WINDOW_MS,
-        }
-      : {};
+    // Cluster the occurrence times so the stored_spans scan is bounded to the
+    // partitions the page's traces ACTUALLY occurred in. The updated axis can
+    // put traces months apart on one page; a single min/max window would span
+    // every weekly partition between them — so OR per-cluster windows instead,
+    // each tight, with no single range crossing unrelated history.
+    const {
+      outer: spanTimeFilterOuter,
+      inner: spanTimeFilterInner,
+      params: spanTimeParams,
+    } = buildEventOccurrenceWindows(occurredAts);
 
     const result = await clickHouseClient.query({
       query: `

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -23,7 +23,9 @@ import type { Event, Span, Trace } from "~/server/tracer/types";
 import { createLogger } from "~/utils/logger/server";
 import { findPromptReferenceInAncestors } from "./findPromptReferenceInAncestors";
 import {
+  applyEventProtections,
   applyTraceProtections,
+  extractRedactionsForObject,
   mapNormalizedSpansToSpans,
   mapTraceSummaryToTrace,
 } from "./mappers";
@@ -817,6 +819,7 @@ export class ClickHouseTraceService {
                 clickHouseClient,
                 projectId: input.projectId,
                 traces: pageTraces,
+                protections,
               });
             }
             if (projection.needsAnnotations) {
@@ -1862,10 +1865,12 @@ export class ClickHouseTraceService {
     clickHouseClient,
     projectId,
     traces,
+    protections,
   }: {
     clickHouseClient: ClickHouseClient;
     projectId: string;
     traces: ProjectableTrace[];
+    protections: Protections;
   }): Promise<void> {
     const traceIds = traces.map((t) => t.trace_id);
     if (traceIds.length === 0) return;
@@ -1939,8 +1944,23 @@ export class ClickHouseTraceService {
         `Projected events[] hit the per-trace cap (${MAX_EVENTS_PER_TRACE}); some events were not returned`,
       );
     }
+    // RBAC parity with the legacy read path: events attach AFTER
+    // applyTraceProtections ran, so they must get the same treatment —
+    // event_details are blanked when captured input is not visible, and
+    // otherwise scrubbed of any substring mirroring the trace's redacted io.
     for (const trace of traces) {
-      trace.events = byTrace.get(trace.trace_id) ?? [];
+      const rawEvents = byTrace.get(trace.trace_id) ?? [];
+      const redactions = new Set<string>([
+        ...(!protections.canSeeCapturedInput
+          ? extractRedactionsForObject(trace.input?.value)
+          : []),
+        ...(!protections.canSeeCapturedOutput
+          ? extractRedactionsForObject(trace.output?.value)
+          : []),
+      ]);
+      trace.events = rawEvents.map((event) =>
+        applyEventProtections(event, protections, redactions),
+      );
     }
   }
 

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -2,14 +2,16 @@ import type { ClickHouseClient } from "@clickhouse/client";
 import type { PrismaClient } from "@prisma/client";
 import { getLangWatchTracer } from "langwatch";
 import type { TraceWithGuardrail } from "~/components/messages/MessageCard";
+import { LLM_PARAMETER_MAP } from "~/prompts/prompt-playground/llmParameterMap";
+import type { ExtractedIO } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
 import { prisma as defaultPrisma } from "~/server/db";
 import type { Protections } from "~/server/elasticsearch/protections";
 import {
+  type ClickHouseEvaluationRunRow,
   mapClickHouseEvaluationToTraceEvaluation,
   mapTraceEvaluationsToLegacyEvaluations,
-  type ClickHouseEvaluationRunRow,
 } from "~/server/evaluations/evaluation-run.mappers";
 import type {
   NormalizedSpan,
@@ -17,26 +19,31 @@ import type {
   NormalizedStatusCode,
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { generateClickHouseFilterConditions } from "~/server/filters/clickhouse";
-import type { Span, Trace } from "~/server/tracer/types";
-import { LLM_PARAMETER_MAP } from "~/prompts/prompt-playground/llmParameterMap";
+import type { Event, Span, Trace } from "~/server/tracer/types";
 import { createLogger } from "~/utils/logger/server";
+import { findPromptReferenceInAncestors } from "./findPromptReferenceInAncestors";
 import {
   applyTraceProtections,
   mapNormalizedSpansToSpans,
   mapTraceSummaryToTrace,
 } from "./mappers";
-import { findPromptReferenceInAncestors } from "./findPromptReferenceInAncestors";
 import { parseLLMSpanMessages } from "./parseLLMSpanMessages";
 import { parsePromptReference } from "./parsePromptReference";
-import type { ExtractedIO } from "~/server/app-layer/traces/trace-io-extraction.service";
+import {
+  type EventSpanRow,
+  mapEventAttrsToEvent,
+} from "./projection/event-attrs.mapper";
+import type { ProjectableTrace, ProjectedAnnotation } from "./projection/types";
 import type { ResolvedTraceSpans } from "./resolve-offloaded-traces";
 import type {
   AggregationFiltersInput,
   CustomersAndLabelsResult,
   DistinctFieldNamesResult,
   GetAllTracesForProjectInput,
+  GetAllTracesForProjectOptions,
   PromptStudioSpanResult,
   TopicCountsResult,
+  TraceDateField,
   TracesForProjectResult,
 } from "./types";
 
@@ -55,7 +62,10 @@ export type ResolveTraceSpansFn = (
  * Encoded as base64 JSON in the scrollId.
  */
 interface ClickHouseScrollCursor {
-  /** Last seen timestamp (CreatedAt) */
+  /**
+   * Last seen sort timestamp (epoch ms). The occurred axis pages on OccurredAt,
+   * the updated axis on the latest-version UpdatedAt.
+   */
   lastTimestamp: number;
   /** Last seen trace ID for tie-breaking */
   lastTraceId: string;
@@ -63,6 +73,8 @@ interface ClickHouseScrollCursor {
   pageSize: number;
   /** Sort direction */
   sortDirection: "asc" | "desc";
+  /** Time axis the cursor pages on. Absent = legacy "occurred". */
+  dateField?: TraceDateField;
 }
 
 /**
@@ -83,6 +95,10 @@ const DISTINCT_FIELD_NAMES_LIMIT = 10_000;
  * actually reaches this many spans is logged as a potential truncation.
  */
 const MAX_SPANS_PER_TRACE = 10_000;
+/** Per-trace cap on projected events (events are a small subset of spans). */
+const MAX_EVENTS_PER_TRACE = 1_000;
+/** Bounds the bounded events stored_spans scan to the page's occurrence weeks. */
+const EVENT_PARTITION_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
 
 /**
  * Service for fetching traces from ClickHouse.
@@ -493,10 +509,7 @@ export class ClickHouseTraceService {
   async getAllTracesForProject(
     input: GetAllTracesForProjectInput,
     protections: Protections,
-    options: {
-      includeSpans?: boolean;
-      scrollId?: string | null;
-    } = {},
+    options: GetAllTracesForProjectOptions = {},
   ): Promise<TracesForProjectResult | null> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.getAllTracesForProject",
@@ -510,6 +523,19 @@ export class ClickHouseTraceService {
           const pageSize = input.pageSize ?? 25;
           const sortDirection =
             (input.sortDirection as "asc" | "desc") ?? "desc";
+
+          // Projection DSL plan (from/select). When absent, behavior is the
+          // legacy full-trace response. When present, it drives heavy-column
+          // pruning and which child collections are JOINed (events, annotations).
+          const projection = options.projection;
+          // Fetch the heavy ComputedInput/ComputedOutput columns only when the
+          // legacy path runs or the projection actually selects io fields.
+          const fetchIO = !projection || projection.needsIO;
+
+          // Time axis the date window + keyset cursor page on. Default "occurred"
+          // keeps the legacy OccurredAt behavior; "updated" pages by last
+          // mutation time for incremental ETL (CDC) pulls.
+          const dateField: TraceDateField = options.dateField ?? "occurred";
 
           // Parse cursor from scrollId if present (matches ES service contract)
           let cursor: ClickHouseScrollCursor | null = null;
@@ -540,6 +566,18 @@ export class ClickHouseTraceService {
                     requestPageSize: pageSize,
                   },
                   "Page size mismatch in cursor, ignoring cursor",
+                );
+                cursor = null;
+              } else if (
+                cursor &&
+                (cursor.dateField ?? "occurred") !== dateField
+              ) {
+                this.logger.warn(
+                  {
+                    cursorDateField: cursor.dateField ?? "occurred",
+                    requestDateField: dateField,
+                  },
+                  "Date axis mismatch in cursor, ignoring cursor",
                 );
                 cursor = null;
               }
@@ -594,6 +632,8 @@ export class ClickHouseTraceService {
               filterParams,
               traceIds: input.traceIds,
               query: input.query,
+              fetchIO,
+              dateField,
             });
 
           // When includeSpans is requested, fetch and attach actual spans
@@ -605,14 +645,22 @@ export class ClickHouseTraceService {
             );
           }
 
-          // Generate new scrollId from last trace
+          // Generate new scrollId from last trace. The cursor seeks on the
+          // axis we paged by: OccurredAt (started_at) or, for the updated axis,
+          // the latest-version UpdatedAt — and records the axis so the next
+          // page rejects a cursor from a different axis.
           let newScrollId: string | undefined;
           if (lastTrace && traces.length === pageSize) {
+            const lastSortTimestamp =
+              dateField === "updated"
+                ? lastTrace.timestamps.updated_at
+                : lastTrace.timestamps.started_at;
             const newCursor: ClickHouseScrollCursor = {
-              lastTimestamp: lastTrace.timestamps.started_at,
+              lastTimestamp: lastSortTimestamp,
               lastTraceId: lastTrace.trace_id,
               pageSize,
               sortDirection,
+              dateField,
             };
             newScrollId = Buffer.from(JSON.stringify(newCursor)).toString(
               "base64",
@@ -678,6 +726,28 @@ export class ClickHouseTraceService {
             }
 
             traceChecks = mapTraceEvaluationsToLegacyEvaluations(grouped);
+          }
+
+          // Projection JOINs — attach child collections the legacy read path
+          // does not carry, scoped to this page's traces (never table-wide).
+          // Evaluations already flow through traceChecks; events and annotations
+          // are fetched here on demand. The compiled projector reads
+          // trace.events / trace.annotations off these same objects.
+          if (projection?.needsEvents || projection?.needsAnnotations) {
+            const pageTraces = groups.flat() as unknown as ProjectableTrace[];
+            if (projection.needsEvents && clickHouseClient) {
+              await this.enrichTracesWithEventsForProjection({
+                clickHouseClient,
+                projectId: input.projectId,
+                traces: pageTraces,
+              });
+            }
+            if (projection.needsAnnotations) {
+              await this.enrichTracesWithAnnotationsForProjection({
+                projectId: input.projectId,
+                traces: pageTraces,
+              });
+            }
           }
 
           return {
@@ -1329,6 +1399,8 @@ export class ClickHouseTraceService {
     filterParams,
     traceIds,
     query,
+    fetchIO = true,
+    dateField = "occurred",
   }: {
     projectId: string;
     pageSize: number;
@@ -1341,6 +1413,10 @@ export class ClickHouseTraceService {
     filterParams?: Record<string, unknown>;
     traceIds?: string[];
     query?: string;
+    /** Fetch heavy ComputedInput/ComputedOutput columns. False prunes them. */
+    fetchIO?: boolean;
+    /** Time axis for the date window + keyset cursor. Default "occurred". */
+    dateField?: TraceDateField;
   }): Promise<{ traces: Trace[]; totalHits: number; lastTrace: Trace | null }> {
     return await this.tracer.withActiveSpan(
       "ClickHouseTraceService.fetchTracesWithPagination",
@@ -1390,16 +1466,51 @@ export class ClickHouseTraceService {
           ? ` AND (${searchableColumns.map((col) => `${col} LIKE {searchQuery:String}`).join(" OR ")})`
           : "";
 
-        // Keyset cursor condition — inside WHERE for partition pruning
-        let cursorCondition = "";
+        // Date axis. occurred (default) is the partition key — windowed in WHERE
+        // so partitions prune. updated is the last-mutation time for CDC: the
+        // version selector (_oa) computes each trace's GLOBAL max(UpdatedAt)
+        // over ALL versions first, then the window + cursor are applied to that
+        // aggregate (in HAVING). So "updated in [start,end]" means the trace's
+        // TRUE last modification — adjacent CDC windows stay mutually exclusive
+        // and never re-emit a trace whose later version moved past the window.
+        const isUpdatedAxis = dateField === "updated";
+        const dateColumn = isUpdatedAxis ? "UpdatedAt" : "OccurredAt";
+        const cmp = sortDirection === "desc" ? "<" : ">";
+        const orderDirection = sortDirection === "desc" ? "DESC" : "ASC";
+
+        // Per-trace sort key: occurred -> OccurredAt of the latest version;
+        // updated -> the global max UpdatedAt over all versions.
+        const oaExpr = isUpdatedAxis
+          ? "max(ts.UpdatedAt)"
+          : "argMax(ts.OccurredAt, ts.UpdatedAt)";
+
+        // Date window placement: occurred -> WHERE (prunes partitions);
+        // updated -> HAVING on the aggregated _oa.
+        const windowWhere = isUpdatedAxis
+          ? ""
+          : " AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64}) AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})";
+        const windowHaving = isUpdatedAxis
+          ? "_oa >= fromUnixTimestamp64Milli({startDate:UInt64}) AND _oa <= fromUnixTimestamp64Milli({endDate:UInt64})"
+          : "";
+
+        // Keyset cursor: occurred -> WHERE on raw (immutable) OccurredAt (also
+        // prunes); updated -> HAVING on the aggregated _oa, so the seek matches
+        // the version the dedup keeps (a raw pre-aggregate seek would let a
+        // non-max version slip past the cursor and duplicate the trace).
+        let cursorWhere = "";
+        let cursorHavingExpr = "";
         if (cursor) {
-          cursorCondition =
-            sortDirection === "desc"
-              ? " AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) < ({lastTimestamp:UInt64}, {lastTraceId:String})"
-              : " AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) > ({lastTimestamp:UInt64}, {lastTraceId:String})";
+          if (isUpdatedAxis) {
+            cursorHavingExpr = `(toUnixTimestamp64Milli(_oa), TraceId) ${cmp} ({lastTimestamp:UInt64}, {lastTraceId:String})`;
+          } else {
+            cursorWhere = ` AND (toUnixTimestamp64Milli(ts.OccurredAt), ts.TraceId) ${cmp} ({lastTimestamp:UInt64}, {lastTraceId:String})`;
+          }
         }
 
-        const orderDirection = sortDirection === "desc" ? "DESC" : "ASC";
+        const havingClause = [windowHaving, cursorHavingExpr]
+          .filter(Boolean)
+          .join(" AND ");
+        const havingSql = havingClause ? ` HAVING ${havingClause}` : "";
 
         const sharedParams = {
           tenantId: projectId,
@@ -1420,20 +1531,35 @@ export class ClickHouseTraceService {
         };
 
         // Step 1: Find page trace IDs + count in parallel.
-        // The ID query is lightweight (no heavy columns), and the count uses
-        // HyperLogLog (~2% error) which is fine for pagination display.
-        const [countResult, idsResult] = await Promise.all([
-          clickHouseClient.query({
-            query: `
+        // The ID query is lightweight (no heavy columns). occurred counts with
+        // HyperLogLog (~2% error, fine for display); updated counts traces whose
+        // global max(UpdatedAt) falls in the window (exact, via the aggregate).
+        const countQuery = isUpdatedAxis
+          ? `
+              SELECT count() AS total
+              FROM (
+                SELECT ts.TraceId AS TraceId, max(ts.UpdatedAt) AS _oa
+                FROM trace_summaries ts
+                WHERE ts.TenantId = {tenantId:String}
+                  ${extraFilters}
+                  ${traceIdFilter}
+                  ${searchFilter}
+                GROUP BY ts.TraceId
+                HAVING ${windowHaving}
+              )
+            `
+          : `
               SELECT uniq(ts.TraceId) as total
               FROM trace_summaries ts
               WHERE ts.TenantId = {tenantId:String}
-                AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-                AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+                ${windowWhere}
                 ${extraFilters}
                 ${traceIdFilter}
                 ${searchFilter}
-            `,
+            `;
+        const [countResult, idsResult] = await Promise.all([
+          clickHouseClient.query({
+            query: countQuery,
             query_params: sharedParams,
             format: "JSONEachRow",
           }),
@@ -1442,16 +1568,16 @@ export class ClickHouseTraceService {
               SELECT s.TraceId
               FROM (
                 SELECT ts.TraceId AS TraceId,
-                       argMax(ts.OccurredAt, ts.UpdatedAt) AS _oa
+                       ${oaExpr} AS _oa
                 FROM trace_summaries ts
                 WHERE ts.TenantId = {tenantId:String}
-                  AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-                  AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+                  ${windowWhere}
                   ${extraFilters}
                   ${traceIdFilter}
                   ${searchFilter}
-                  ${cursorCondition}
+                  ${cursorWhere}
                 GROUP BY ts.TraceId
+                ${havingSql}
               ) s
               ORDER BY s._oa ${orderDirection}, s.TraceId ${orderDirection}
               LIMIT {pageSize:UInt32}
@@ -1487,6 +1613,8 @@ export class ClickHouseTraceService {
           endDate: endDate ?? Date.now(),
           traceIds: pageTraceIds,
           orderDirection,
+          fetchIO,
+          dateColumn,
         });
 
         const traces: Trace[] = summaryRows.map((row) => {
@@ -1518,6 +1646,8 @@ export class ClickHouseTraceService {
     endDate,
     traceIds,
     orderDirection,
+    fetchIO = true,
+    dateColumn = "OccurredAt",
   }: {
     clickHouseClient: ClickHouseClient;
     projectId: string;
@@ -1525,7 +1655,28 @@ export class ClickHouseTraceService {
     endDate: number;
     traceIds: string[];
     orderDirection: string;
+    /** Fetch heavy ComputedInput/ComputedOutput. False reads '' instead — the
+     * row shape is unchanged but ClickHouse never materializes the heavy column. */
+    fetchIO?: boolean;
+    /** Column the date window + ORDER BY run on (must match the page-ID query). */
+    dateColumn?: "OccurredAt" | "UpdatedAt";
   }): Promise<TraceSummaryRow[]> {
+    const computedInputExpr = fetchIO ? "ts.ComputedInput" : "''";
+    const computedOutputExpr = fetchIO ? "ts.ComputedOutput" : "''";
+    const isUpdatedAxis = dateColumn === "UpdatedAt";
+    const sortColumn = isUpdatedAxis ? "ts_UpdatedAt" : "ts_OccurredAt";
+    // Updated axis dedups on the GLOBAL max(UpdatedAt) — the page IDs were
+    // already filtered by the id-query's HAVING, so no date window is applied
+    // here (windowing would re-introduce the in-window-max staleness). Occurred
+    // axis windows the partition column in both the outer scan and the dedup.
+    const outerWindow = isUpdatedAxis
+      ? ""
+      : `AND ts.${dateColumn} >= fromUnixTimestamp64Milli({startDate:UInt64})
+            AND ts.${dateColumn} <= fromUnixTimestamp64Milli({endDate:UInt64})`;
+    const dedupWindow = isUpdatedAxis
+      ? ""
+      : `AND ${dateColumn} >= fromUnixTimestamp64Milli({startDate:UInt64})
+                AND ${dateColumn} <= fromUnixTimestamp64Milli({endDate:UInt64})`;
     const runQuery = async (ids: string[]) => {
       const result = await clickHouseClient.query({
         query: `
@@ -1550,8 +1701,8 @@ export class ClickHouseTraceService {
             ts.SubTopicId AS ts_SubTopicId,
             ts.HasAnnotation AS ts_HasAnnotation,
             ts.AnnotationIds AS ts_AnnotationIds,
-            ts.ComputedInput AS ts_ComputedInput,
-            ts.ComputedOutput AS ts_ComputedOutput,
+            ${computedInputExpr} AS ts_ComputedInput,
+            ${computedOutputExpr} AS ts_ComputedOutput,
             ts.Attributes AS ts_Attributes,
             ts.TraceName AS ts_TraceName,
             toUnixTimestamp64Milli(ts.OccurredAt) AS ts_OccurredAt,
@@ -1559,19 +1710,17 @@ export class ClickHouseTraceService {
             toUnixTimestamp64Milli(ts.UpdatedAt) AS ts_UpdatedAt
           FROM trace_summaries ts
           WHERE ts.TenantId = {tenantId:String}
-            AND ts.OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-            AND ts.OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+            ${outerWindow}
             AND ts.TraceId IN ({pageTraceIds:Array(String)})
             AND (ts.TenantId, ts.TraceId, ts.UpdatedAt) IN (
               SELECT TenantId, TraceId, max(UpdatedAt)
               FROM trace_summaries
               WHERE TenantId = {tenantId:String}
-                AND OccurredAt >= fromUnixTimestamp64Milli({startDate:UInt64})
-                AND OccurredAt <= fromUnixTimestamp64Milli({endDate:UInt64})
+                ${dedupWindow}
                 AND TraceId IN ({pageTraceIds:Array(String)})
               GROUP BY TenantId, TraceId
             )
-          ORDER BY ts.OccurredAt ${orderDirection}, ts.TraceId ${orderDirection}
+          ORDER BY ts.${dateColumn} ${orderDirection}, ts.TraceId ${orderDirection}
         `,
         query_params: {
           tenantId: projectId,
@@ -1611,13 +1760,163 @@ export class ClickHouseTraceService {
 
       const dir = orderDirection === "DESC" ? -1 : 1;
       allRows.sort((a, b) => {
-        const timeDiff = a.ts_OccurredAt - b.ts_OccurredAt;
+        const timeDiff = a[sortColumn] - b[sortColumn];
         if (timeDiff !== 0) return timeDiff * dir;
         if (a.ts_TraceId === b.ts_TraceId) return 0;
         return a.ts_TraceId < b.ts_TraceId ? -dir : dir;
       });
 
       return allRows;
+    }
+  }
+
+  /**
+   * Projection JOIN: attach events to a page of traces.
+   *
+   * Events live inside stored_spans.SpanAttributes under `event.*` keys. This
+   * extracts ONLY the event.* entries (via mapFilter) for the spans that carry
+   * an event, scoped to the page's trace IDs and bounded to the weeks those
+   * traces occurred in — so it never materializes the full SpanAttributes map
+   * table-wide (the OOM vector). Mutates each trace's `events` in place.
+   */
+  private async enrichTracesWithEventsForProjection({
+    clickHouseClient,
+    projectId,
+    traces,
+  }: {
+    clickHouseClient: ClickHouseClient;
+    projectId: string;
+    traces: ProjectableTrace[];
+  }): Promise<void> {
+    const traceIds = traces.map((t) => t.trace_id);
+    if (traceIds.length === 0) return;
+
+    const occurredAts = traces
+      .map((t) => t.timestamps?.started_at)
+      .filter((t): t is number => typeof t === "number" && t > 0);
+    const hasWindow = occurredAts.length > 0;
+    const spanTimeFilterOuter = hasWindow
+      ? "AND t.StartTime >= fromUnixTimestamp64Milli({spanFromMs:Int64}) AND t.StartTime <= fromUnixTimestamp64Milli({spanToMs:Int64})"
+      : "";
+    const spanTimeFilterInner = hasWindow
+      ? "AND StartTime >= fromUnixTimestamp64Milli({spanFromMs:Int64}) AND StartTime <= fromUnixTimestamp64Milli({spanToMs:Int64})"
+      : "";
+    const spanTimeParams = hasWindow
+      ? {
+          spanFromMs: Math.min(...occurredAts) - EVENT_PARTITION_WINDOW_MS,
+          spanToMs: Math.max(...occurredAts) + EVENT_PARTITION_WINDOW_MS,
+        }
+      : {};
+
+    const result = await clickHouseClient.query({
+      query: `
+        SELECT
+          t.TraceId AS TraceId,
+          t.SpanId AS SpanId,
+          toUnixTimestamp64Milli(t.StartTime) AS StartTimeMs,
+          toUnixTimestamp64Milli(t.EndTime) AS EndTimeMs,
+          mapFilter((k, v) -> startsWith(k, 'event.'), t.SpanAttributes) AS EventAttrs
+        FROM stored_spans AS t
+        WHERE t.TenantId = {tenantId:String}
+          AND t.TraceId IN ({traceIds:Array(String)})
+          ${spanTimeFilterOuter}
+          AND mapContains(t.SpanAttributes, 'event.type')
+          AND (t.TenantId, t.TraceId, t.SpanId, t.StartTime) IN (
+            SELECT TenantId, TraceId, SpanId, max(StartTime)
+            FROM stored_spans
+            WHERE TenantId = {tenantId:String}
+              AND TraceId IN ({traceIds:Array(String)})
+              ${spanTimeFilterInner}
+              AND mapContains(SpanAttributes, 'event.type')
+            GROUP BY TenantId, TraceId, SpanId
+          )
+        ORDER BY t.TraceId, t.StartTime ASC
+        LIMIT {maxEvents:UInt32} BY t.TraceId
+      `,
+      query_params: {
+        tenantId: projectId,
+        traceIds,
+        maxEvents: MAX_EVENTS_PER_TRACE,
+        ...spanTimeParams,
+      },
+      format: "JSONEachRow",
+    });
+
+    const rows = (await result.json()) as EventSpanRow[];
+    const byTrace = new Map<string, Event[]>();
+    for (const row of rows) {
+      const event = mapEventAttrsToEvent({ row, projectId });
+      if (!event) continue;
+      const list = byTrace.get(row.TraceId) ?? [];
+      list.push(event);
+      byTrace.set(row.TraceId, list);
+    }
+    // The `LIMIT {maxEvents} BY t.TraceId` cap silently clips a trace's events.
+    // Surface it (same posture as the span-cap) so callers know the projected
+    // events[] is truncated rather than silently incomplete.
+    const truncated = [...byTrace.entries()]
+      .filter(([, events]) => events.length >= MAX_EVENTS_PER_TRACE)
+      .map(([traceId]) => traceId);
+    if (truncated.length > 0) {
+      this.logger.warn(
+        { projectId, maxEvents: MAX_EVENTS_PER_TRACE, traceIds: truncated },
+        `Projected events[] hit the per-trace cap (${MAX_EVENTS_PER_TRACE}); some events were not returned`,
+      );
+    }
+    for (const trace of traces) {
+      trace.events = byTrace.get(trace.trace_id) ?? [];
+    }
+  }
+
+  /**
+   * Projection JOIN: attach annotations to a page of traces.
+   *
+   * Annotations are Postgres-only (Prisma), never carried by the ClickHouse
+   * read path. Fetched scoped to the page's trace IDs (multitenancy: projectId
+   * is the first predicate). Mutates each trace's `annotations` in place.
+   */
+  private async enrichTracesWithAnnotationsForProjection({
+    projectId,
+    traces,
+  }: {
+    projectId: string;
+    traces: ProjectableTrace[];
+  }): Promise<void> {
+    const traceIds = traces.map((t) => t.trace_id);
+    if (traceIds.length === 0) return;
+
+    const rows = await this.prisma.annotation.findMany({
+      where: { projectId, traceId: { in: traceIds } },
+      select: {
+        id: true,
+        traceId: true,
+        isThumbsUp: true,
+        comment: true,
+        expectedOutput: true,
+        scoreOptions: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    const byTrace = new Map<string, ProjectedAnnotation[]>();
+    for (const row of rows) {
+      const list = byTrace.get(row.traceId) ?? [];
+      list.push({
+        id: row.id,
+        is_thumbs_up: row.isThumbsUp ?? null,
+        comment: row.comment ?? null,
+        expected_output: row.expectedOutput ?? null,
+        scores:
+          row.scoreOptions && typeof row.scoreOptions === "object"
+            ? (row.scoreOptions as Record<string, unknown>)
+            : {},
+        created_at: row.createdAt.getTime(),
+      });
+      byTrace.set(row.traceId, list);
+    }
+    for (const trace of traces) {
+      trace.annotations = byTrace.get(trace.trace_id) ?? [];
     }
   }
 
@@ -1895,7 +2194,7 @@ export class ClickHouseTraceService {
         // around the summaries' OccurredAt range is safe headroom; when no
         // summary row is found we fall back to an unbounded span scan.
         const summaryResult = await clickHouseClient.query({
-            query: `
+          query: `
         SELECT
           TraceId AS ts_TraceId,
           SpanCount AS ts_SpanCount,
@@ -1936,9 +2235,9 @@ export class ClickHouseTraceService {
           )
         ORDER BY t.TraceId
       `,
-            query_params: { tenantId: projectId, traceIds },
-            format: "JSONEachRow",
-          });
+          query_params: { tenantId: projectId, traceIds },
+          format: "JSONEachRow",
+        });
 
         const summaryRows = (await summaryResult.json()) as TraceSummaryRow[];
 
@@ -1971,7 +2270,7 @@ export class ClickHouseTraceService {
           : {};
 
         const spansResult = await clickHouseClient.query({
-            query: `
+          query: `
         SELECT
           SpanId,
           TraceId,
@@ -2012,9 +2311,9 @@ export class ClickHouseTraceService {
         ORDER BY t.TraceId, t.StartTime ASC
         LIMIT ${MAX_SPANS_PER_TRACE} BY t.TraceId
       `,
-            query_params: { tenantId: projectId, traceIds, ...spanTimeParams },
-            format: "JSONEachRow",
-          });
+          query_params: { tenantId: projectId, traceIds, ...spanTimeParams },
+          format: "JSONEachRow",
+        });
 
         // Parse spans
         type SpanRow = {
@@ -2058,7 +2357,12 @@ export class ClickHouseTraceService {
         for (const [traceId, spans] of spansByTrace) {
           if (spans.length >= MAX_SPANS_PER_TRACE) {
             this.logger.warn(
-              { projectId, traceId, spanCount: spans.length, cap: MAX_SPANS_PER_TRACE },
+              {
+                projectId,
+                traceId,
+                spanCount: spans.length,
+                cap: MAX_SPANS_PER_TRACE,
+              },
               "Trace reached the per-trace span cap; span list may be truncated",
             );
           }
@@ -2298,7 +2602,8 @@ export class ClickHouseTraceService {
       durationMs: row.DurationMs,
       name: row.SpanName,
       kind: row.SpanKind as NormalizedSpanKind,
-      resourceAttributes: row.ResourceAttributes as NormalizedSpan["resourceAttributes"],
+      resourceAttributes:
+        row.ResourceAttributes as NormalizedSpan["resourceAttributes"],
       spanAttributes: row.SpanAttributes as NormalizedSpan["spanAttributes"],
       statusCode: row.StatusCode as NormalizedStatusCode | null,
       statusMessage: row.StatusMessage,
@@ -2468,9 +2773,7 @@ function findNearestLlm<T extends PromptStudioCandidateRow>(
 /**
  * Transform traces to include guardrail information
  */
-function transformTracesWithGuardrails(
-  traces: Trace[],
-): TraceWithGuardrail[] {
+function transformTracesWithGuardrails(traces: Trace[]): TraceWithGuardrail[] {
   return traces.map((trace) => {
     return {
       ...trace,

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -112,7 +112,7 @@ const FORBIDDEN_SCORE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
  * matching score (e.g. a deleted definition) keeps its id as the key so data is
  * never silently dropped. Prototype-polluting keys are skipped.
  */
-function remapScoreOptionsToNames(
+export function remapScoreOptionsToNames(
   scoreOptions: unknown,
   scoreNameById: Map<string, string>,
 ): Record<string, unknown> {
@@ -121,7 +121,13 @@ function remapScoreOptionsToNames(
   for (const [scoreId, value] of Object.entries(
     scoreOptions as Record<string, unknown>,
   )) {
-    const key = scoreNameById.get(scoreId) ?? scoreId;
+    const name = scoreNameById.get(scoreId) ?? scoreId;
+    if (FORBIDDEN_SCORE_KEYS.has(name)) continue;
+    // AnnotationScore names are not unique. On a collision the first entry
+    // keeps the plain name and later ones get an id-suffixed key — deterministic
+    // (object iteration is insertion-ordered) and lossless, instead of the
+    // engine-defined last-write-wins this used to be.
+    const key = name in remapped ? `${name} (${scoreId})` : name;
     if (FORBIDDEN_SCORE_KEYS.has(key)) continue;
     remapped[key] = value;
   }
@@ -1743,6 +1749,13 @@ export class ClickHouseTraceService {
     /** Column the date window + ORDER BY run on (must match the page-ID query). */
     dateColumn?: "OccurredAt" | "UpdatedAt";
   }): Promise<TraceSummaryRow[]> {
+    // dateColumn is interpolated into SQL. The surface validates it via a zod
+    // enum, but this method is also reachable from tRPC/internal paths whose
+    // options are only TypeScript-narrowed — assert at the trust boundary so a
+    // non-enum value can never reach the query string (defense-in-depth).
+    if (dateColumn !== "OccurredAt" && dateColumn !== "UpdatedAt") {
+      throw new Error(`Invalid dateColumn: ${String(dateColumn)}`);
+    }
     const computedInputExpr = fetchIO ? "ts.ComputedInput" : "''";
     const computedOutputExpr = fetchIO ? "ts.ComputedOutput" : "''";
     const isUpdatedAxis = dateColumn === "UpdatedAt";
@@ -1875,9 +1888,21 @@ export class ClickHouseTraceService {
     const traceIds = traces.map((t) => t.trace_id);
     if (traceIds.length === 0) return;
 
+    // Occurrence anchor per trace: started_at, falling back to updated_at for
+    // legacy/corrupt rows missing it — the scan must NEVER run time-unbounded
+    // (that is the exact blowup the windowing prevents). Traces with no usable
+    // timestamp at all get an empty events[] rather than an unbounded scan.
     const occurredAts = traces
-      .map((t) => t.timestamps?.started_at)
+      .map((t) => t.timestamps?.started_at || t.timestamps?.updated_at)
       .filter((t): t is number => typeof t === "number" && t > 0);
+    if (occurredAts.length === 0) {
+      this.logger.warn(
+        { projectId, traceCount: traces.length },
+        "No usable timestamps on page traces; skipping events projection rather than scanning unbounded",
+      );
+      for (const trace of traces) trace.events = [];
+      return;
+    }
     // Cluster the occurrence times so the stored_spans scan is bounded to the
     // partitions the page's traces ACTUALLY occurred in. The updated axis can
     // put traces months apart on one page; a single min/max window would span

--- a/langwatch/src/server/traces/mappers/index.ts
+++ b/langwatch/src/server/traces/mappers/index.ts
@@ -1,4 +1,5 @@
 export {
+  applyEventProtections,
   applySpanProtections,
   applyTraceProtections,
   extractRedactionsForObject,

--- a/langwatch/src/server/traces/projection/__tests__/compile-projection.unit.test.ts
+++ b/langwatch/src/server/traces/projection/__tests__/compile-projection.unit.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { Protections } from "~/server/elasticsearch/protections";
 import type { Trace } from "~/server/tracer/types";
-import { compileProjection } from "../compile-projection";
+import type { ResolvedField } from "../catalog";
+import { buildProjector, compileProjection } from "../compile-projection";
 import type { ProjectableTrace } from "../types";
 import { ProjectionValidationError } from "../types";
 
@@ -338,6 +339,49 @@ describe("compileProjection", () => {
           evaluations: [{ score: 0.9 }],
           events: [{ type: "thumbs_up_down" }],
           annotations: [{ is_thumbs_up: true }],
+        });
+      });
+    });
+  });
+});
+
+describe("buildProjector", () => {
+  // The catalog has no protected collection field today, so exercise the
+  // collection-path RBAC redaction with a synthetic one.
+  const protectedAnnotationComment: ResolvedField = {
+    path: "annotations.comment",
+    type: "string",
+    collection: "annotations",
+    protection: "input",
+    outPath: ["comment"],
+    read: (a) => a.comment ?? null,
+  };
+
+  describe("given a protected collection field", () => {
+    describe("when the gating permission is denied", () => {
+      it("redacts the value on the collection path", () => {
+        const project = buildProjector({
+          fields: [protectedAnnotationComment],
+          protections: {
+            canSeeCosts: true,
+            canSeeCapturedInput: false,
+            canSeeCapturedOutput: true,
+          },
+        });
+        expect(project(sampleTrace())).toEqual({
+          annotations: [{ comment: null }],
+        });
+      });
+    });
+
+    describe("when the gating permission is granted", () => {
+      it("emits the value", () => {
+        const project = buildProjector({
+          fields: [protectedAnnotationComment],
+          protections: fullAccess,
+        });
+        expect(project(sampleTrace())).toEqual({
+          annotations: [{ comment: "nice" }],
         });
       });
     });

--- a/langwatch/src/server/traces/projection/__tests__/compile-projection.unit.test.ts
+++ b/langwatch/src/server/traces/projection/__tests__/compile-projection.unit.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Protections } from "~/server/elasticsearch/protections";
 import type { Trace } from "~/server/tracer/types";
-import type { ResolvedField } from "../catalog";
-import { buildProjector, compileProjection } from "../compile-projection";
+import { compileProjection } from "../compile-projection";
 import type { ProjectableTrace } from "../types";
 import { ProjectionValidationError } from "../types";
 
@@ -345,43 +344,47 @@ describe("compileProjection", () => {
   });
 });
 
-describe("buildProjector", () => {
-  // The catalog has no protected collection field today, so exercise the
-  // collection-path RBAC redaction with a synthetic one.
-  const protectedAnnotationComment: ResolvedField = {
-    path: "annotations.comment",
-    type: "string",
-    collection: "annotations",
-    protection: "input",
-    outPath: ["comment"],
-    read: (a) => a.comment ?? null,
-  };
+describe("collection-path RBAC redaction", () => {
+  // annotations.comment / annotations.expected_output are free text where
+  // reviewers quote the model's output, so the catalog gates them behind
+  // output visibility — the collection-path RBAC redaction must hold for
+  // real catalog fields, not just synthetic ones.
+  const annotationSelect = [
+    "annotations.is_thumbs_up",
+    "annotations.comment",
+    "annotations.expected_output",
+  ];
 
-  describe("given a protected collection field", () => {
-    describe("when the gating permission is denied", () => {
-      it("redacts the value on the collection path", () => {
-        const project = buildProjector({
-          fields: [protectedAnnotationComment],
+  describe("given a select over gated annotation fields", () => {
+    describe("when captured-output visibility is denied", () => {
+      /** @scenario "Annotation comments and expected output respect captured-output visibility" */
+      it("nulls comment and expected_output but keeps the annotation row", () => {
+        const { project } = compileProjection({
+          select: annotationSelect,
           protections: {
             canSeeCosts: true,
-            canSeeCapturedInput: false,
-            canSeeCapturedOutput: true,
+            canSeeCapturedInput: true,
+            canSeeCapturedOutput: false,
           },
         });
         expect(project(sampleTrace())).toEqual({
-          annotations: [{ comment: null }],
+          annotations: [
+            { is_thumbs_up: true, comment: null, expected_output: null },
+          ],
         });
       });
     });
 
-    describe("when the gating permission is granted", () => {
-      it("emits the value", () => {
-        const project = buildProjector({
-          fields: [protectedAnnotationComment],
+    describe("when captured-output visibility is granted", () => {
+      it("emits the comment and expected_output values", () => {
+        const { project } = compileProjection({
+          select: annotationSelect,
           protections: fullAccess,
         });
         expect(project(sampleTrace())).toEqual({
-          annotations: [{ comment: "nice" }],
+          annotations: [
+            { is_thumbs_up: true, comment: "nice", expected_output: null },
+          ],
         });
       });
     });

--- a/langwatch/src/server/traces/projection/__tests__/compile-projection.unit.test.ts
+++ b/langwatch/src/server/traces/projection/__tests__/compile-projection.unit.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from "vitest";
+import type { Protections } from "~/server/elasticsearch/protections";
+import type { Trace } from "~/server/tracer/types";
+import { compileProjection } from "../compile-projection";
+import type { ProjectableTrace } from "../types";
+import { ProjectionValidationError } from "../types";
+
+const fullAccess: Protections = {
+  canSeeCosts: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+};
+
+/** A trace carrying every source the projector can read, for projection assertions. */
+function sampleTrace(): ProjectableTrace {
+  const base: Trace = {
+    trace_id: "trace-1",
+    project_id: "project-1",
+    metadata: {
+      user_id: "user-42",
+      customer_id: "acme",
+      labels: ["production"],
+      custom_key: "custom-value",
+    },
+    timestamps: { started_at: 1000, inserted_at: 1100, updated_at: 1200 },
+    input: { value: "the input" },
+    output: { value: "the output" },
+    metrics: { total_cost: 0.5, prompt_tokens: 10, tokens_estimated: false },
+    events: [
+      {
+        event_id: "evt-1",
+        event_type: "thumbs_up_down",
+        project_id: "project-1",
+        metrics: { vote: 1 },
+        event_details: { reason: "great" },
+        trace_id: "trace-1",
+        timestamps: { started_at: 2000, inserted_at: 2000, updated_at: 2000 },
+      },
+    ],
+    evaluations: [
+      {
+        evaluation_id: "eval-1",
+        evaluator_id: "evaluator-x",
+        name: "Faithfulness",
+        type: "faithfulness",
+        is_guardrail: false,
+        status: "processed",
+        passed: true,
+        score: 0.9,
+        label: "pass",
+        details: "looks good",
+        timestamps: {},
+      },
+    ],
+    spans: [],
+  };
+  return {
+    ...base,
+    annotations: [
+      {
+        id: "ann-1",
+        is_thumbs_up: true,
+        comment: "nice",
+        expected_output: null,
+        scores: { quality: 5 },
+        created_at: 3000,
+      },
+    ],
+  };
+}
+
+describe("compileProjection", () => {
+  describe("given a select with no from", () => {
+    describe("when compiling", () => {
+      it("defaults from to 'traces'", () => {
+        const compiled = compileProjection({
+          select: ["trace_id"],
+          protections: fullAccess,
+        });
+        expect(compiled.schema.from).toBe("traces");
+      });
+    });
+  });
+
+  describe("given trace-level scalar paths", () => {
+    describe("when building the schema", () => {
+      it("lists the requested columns with their types", () => {
+        const compiled = compileProjection({
+          select: ["trace_id", "started_at"],
+          protections: fullAccess,
+        });
+        expect(compiled.schema.columns).toEqual([
+          { path: "trace_id", type: "string", collection: false },
+          { path: "started_at", type: "number", collection: false },
+        ]);
+      });
+    });
+
+    describe("when projecting a trace", () => {
+      /** @scenario Select trace-level scalar fields */
+      it("emits only the requested scalars, nothing else", () => {
+        const compiled = compileProjection({
+          select: ["trace_id", "started_at"],
+          protections: fullAccess,
+        });
+        expect(compiled.project(sampleTrace())).toEqual({
+          trace_id: "trace-1",
+          started_at: 1000,
+        });
+      });
+    });
+
+    describe("when no io path is selected", () => {
+      it("does not flag the heavy io columns", () => {
+        const compiled = compileProjection({
+          select: ["trace_id", "metrics.total_cost"],
+          protections: fullAccess,
+        });
+        expect(compiled.plan.needsIO).toBe(false);
+      });
+    });
+  });
+
+  describe("given metadata paths", () => {
+    describe("when projecting a trace", () => {
+      /** @scenario Select metadata fields grouped into a metadata object */
+      it("groups them under a metadata object", () => {
+        const compiled = compileProjection({
+          select: ["trace_id", "metadata.user_id", "metadata.custom_key"],
+          protections: fullAccess,
+        });
+        expect(compiled.project(sampleTrace())).toEqual({
+          trace_id: "trace-1",
+          metadata: { user_id: "user-42", custom_key: "custom-value" },
+        });
+      });
+    });
+
+    describe("when the metadata key is an arbitrary custom name", () => {
+      it("accepts it into the schema", () => {
+        const compiled = compileProjection({
+          select: ["metadata.anything_goes"],
+          protections: fullAccess,
+        });
+        expect(compiled.schema.columns).toContainEqual({
+          path: "metadata.anything_goes",
+          type: "json",
+          collection: false,
+        });
+      });
+    });
+  });
+
+  describe("given metrics paths", () => {
+    describe("when projecting a trace", () => {
+      /** @scenario Select metrics fields */
+      it("groups them under a metrics object", () => {
+        const compiled = compileProjection({
+          select: ["metrics.total_cost", "metrics.prompt_tokens"],
+          protections: fullAccess,
+        });
+        expect(compiled.project(sampleTrace())).toEqual({
+          metrics: { total_cost: 0.5, prompt_tokens: 10 },
+        });
+      });
+    });
+  });
+
+  describe("given evaluation paths", () => {
+    describe("when projecting a trace", () => {
+      it("returns evaluations as a nested array of only the selected fields", () => {
+        const compiled = compileProjection({
+          select: ["trace_id", "evaluations.name", "evaluations.score"],
+          protections: fullAccess,
+        });
+        expect(compiled.plan.needsEvaluations).toBe(true);
+        expect(compiled.plan.evaluationPaths).toEqual(["name", "score"]);
+        expect(compiled.project(sampleTrace())).toEqual({
+          trace_id: "trace-1",
+          evaluations: [{ name: "Faithfulness", score: 0.9 }],
+        });
+      });
+    });
+  });
+
+  describe("given event paths", () => {
+    describe("when projecting a trace", () => {
+      it("flags the bounded events fetch and projects the events array", () => {
+        const compiled = compileProjection({
+          select: ["events.type", "events.metrics.vote", "events.timestamp"],
+          protections: fullAccess,
+        });
+        expect(compiled.plan.needsEvents).toBe(true);
+        expect(compiled.project(sampleTrace())).toEqual({
+          events: [
+            { type: "thumbs_up_down", metrics: { vote: 1 }, timestamp: 2000 },
+          ],
+        });
+      });
+    });
+  });
+
+  describe("given annotation paths", () => {
+    describe("when projecting a trace", () => {
+      it("flags the cross-store annotations fetch and projects the array", () => {
+        const compiled = compileProjection({
+          select: ["annotations.is_thumbs_up", "annotations.scores.quality"],
+          protections: fullAccess,
+        });
+        expect(compiled.plan.needsAnnotations).toBe(true);
+        expect(compiled.project(sampleTrace())).toEqual({
+          annotations: [{ is_thumbs_up: true, scores: { quality: 5 } }],
+        });
+      });
+    });
+  });
+
+  describe("given io paths", () => {
+    describe("when capture visibility is denied", () => {
+      const noIO: Protections = {
+        canSeeCosts: true,
+        canSeeCapturedInput: false,
+        canSeeCapturedOutput: false,
+      };
+
+      /** @scenario Projected io fields are dropped when user lacks captured-input permission */
+      it("keeps the column but projects null and does not fetch heavy io", () => {
+        const compiled = compileProjection({
+          select: ["trace_id", "input", "output"],
+          protections: noIO,
+        });
+        expect(compiled.plan.needsIO).toBe(false);
+        expect(compiled.project(sampleTrace())).toEqual({
+          trace_id: "trace-1",
+          input: null,
+          output: null,
+        });
+      });
+    });
+
+    describe("when capture visibility is granted", () => {
+      /** @scenario Projected io fields are included when user has full permissions */
+      it("fetches io and projects the values", () => {
+        const compiled = compileProjection({
+          select: ["input", "output"],
+          protections: fullAccess,
+        });
+        expect(compiled.plan.needsIO).toBe(true);
+        expect(compiled.project(sampleTrace())).toEqual({
+          input: "the input",
+          output: "the output",
+        });
+      });
+    });
+  });
+
+  describe("given an unknown select path", () => {
+    describe("when compiling", () => {
+      it("throws ProjectionValidationError", () => {
+        expect(() =>
+          compileProjection({
+            select: ["trace_id", "nonexistent_field"],
+            protections: fullAccess,
+          }),
+        ).toThrowError(ProjectionValidationError);
+      });
+
+      it("names every offending path (and only those)", () => {
+        let error: unknown;
+        try {
+          compileProjection({
+            select: ["nonexistent_field", "trace_id", "evaluations.bogus"],
+            protections: fullAccess,
+          });
+        } catch (caught) {
+          error = caught;
+        }
+        // Fail-fast: if nothing threw, `error` is undefined and this fails.
+        expect(error).toBeInstanceOf(ProjectionValidationError);
+        expect((error as ProjectionValidationError).invalidPaths).toEqual([
+          "nonexistent_field",
+          "evaluations.bogus",
+        ]);
+      });
+    });
+  });
+
+  describe("given a prototype-polluting path", () => {
+    describe("when compiling", () => {
+      it("rejects __proto__ / constructor / prototype segments", () => {
+        for (const path of [
+          "metadata.__proto__",
+          "metadata.constructor",
+          "events.metrics.__proto__",
+          "annotations.scores.prototype",
+        ]) {
+          expect(() =>
+            compileProjection({ select: [path], protections: fullAccess }),
+          ).toThrowError(ProjectionValidationError);
+        }
+      });
+    });
+  });
+
+  describe("given duplicate select paths", () => {
+    describe("when compiling", () => {
+      it("dedupes while preserving first-seen order", () => {
+        const compiled = compileProjection({
+          select: ["trace_id", "started_at", "trace_id"],
+          protections: fullAccess,
+        });
+        expect(compiled.schema.columns.map((c) => c.path)).toEqual([
+          "trace_id",
+          "started_at",
+        ]);
+      });
+    });
+  });
+
+  describe("given a mix of all sources", () => {
+    describe("when projecting a trace", () => {
+      it("emits scalar groups as objects and child collections as arrays", () => {
+        const compiled = compileProjection({
+          select: [
+            "trace_id",
+            "metadata.user_id",
+            "metrics.total_cost",
+            "evaluations.score",
+            "events.type",
+            "annotations.is_thumbs_up",
+          ],
+          protections: fullAccess,
+        });
+        expect(compiled.project(sampleTrace())).toEqual({
+          trace_id: "trace-1",
+          metadata: { user_id: "user-42" },
+          metrics: { total_cost: 0.5 },
+          evaluations: [{ score: 0.9 }],
+          events: [{ type: "thumbs_up_down" }],
+          annotations: [{ is_thumbs_up: true }],
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/traces/projection/__tests__/compile-projection.unit.test.ts
+++ b/langwatch/src/server/traces/projection/__tests__/compile-projection.unit.test.ts
@@ -116,7 +116,30 @@ describe("compileProjection", () => {
           select: ["trace_id", "metrics.total_cost"],
           protections: fullAccess,
         });
-        expect(compiled.plan.needsIO).toBe(false);
+        expect(compiled.plan.needsInput).toBe(false);
+        expect(compiled.plan.needsOutput).toBe(false);
+      });
+    });
+
+    describe("when only output is selected", () => {
+      it("flags ComputedOutput but not ComputedInput", () => {
+        const compiled = compileProjection({
+          select: ["trace_id", "output"],
+          protections: fullAccess,
+        });
+        expect(compiled.plan.needsInput).toBe(false);
+        expect(compiled.plan.needsOutput).toBe(true);
+      });
+    });
+
+    describe("when gated annotation text is selected without io", () => {
+      it("does not flag the heavy io columns despite the shared protection", () => {
+        const compiled = compileProjection({
+          select: ["annotations.comment"],
+          protections: fullAccess,
+        });
+        expect(compiled.plan.needsInput).toBe(false);
+        expect(compiled.plan.needsOutput).toBe(false);
       });
     });
   });
@@ -229,7 +252,8 @@ describe("compileProjection", () => {
           select: ["trace_id", "input", "output"],
           protections: noIO,
         });
-        expect(compiled.plan.needsIO).toBe(false);
+        expect(compiled.plan.needsInput).toBe(false);
+        expect(compiled.plan.needsOutput).toBe(false);
         expect(compiled.project(sampleTrace())).toEqual({
           trace_id: "trace-1",
           input: null,
@@ -245,7 +269,8 @@ describe("compileProjection", () => {
           select: ["input", "output"],
           protections: fullAccess,
         });
-        expect(compiled.plan.needsIO).toBe(true);
+        expect(compiled.plan.needsInput).toBe(true);
+        expect(compiled.plan.needsOutput).toBe(true);
         expect(compiled.project(sampleTrace())).toEqual({
           input: "the input",
           output: "the output",

--- a/langwatch/src/server/traces/projection/__tests__/event-attrs.mapper.unit.test.ts
+++ b/langwatch/src/server/traces/projection/__tests__/event-attrs.mapper.unit.test.ts
@@ -49,6 +49,23 @@ describe("mapEventAttrsToEvent", () => {
     });
   });
 
+  describe("when a metric value is empty, whitespace, or hex", () => {
+    it("drops it instead of coercing to a bogus number", () => {
+      const event = mapEventAttrsToEvent({
+        row: row({
+          "event.type": "thumbs_up_down",
+          "event.metrics.empty": "",
+          "event.metrics.blank": "   ",
+          "event.metrics.hex": "0x1f",
+          "event.metrics.valid": "-2.5",
+        }),
+        projectId: "project-1",
+      });
+
+      expect(event?.metrics).toEqual({ valid: -2.5 });
+    });
+  });
+
   describe("when the span has no event.type", () => {
     it("returns null so it is not counted as an event", () => {
       expect(

--- a/langwatch/src/server/traces/projection/__tests__/event-attrs.mapper.unit.test.ts
+++ b/langwatch/src/server/traces/projection/__tests__/event-attrs.mapper.unit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { type EventSpanRow, mapEventAttrsToEvent } from "../event-attrs.mapper";
+
+function row(attrs: Record<string, string>): EventSpanRow {
+  return {
+    TraceId: "trace-1",
+    SpanId: "span-1",
+    StartTimeMs: 1000,
+    EndTimeMs: 1500,
+    EventAttrs: attrs,
+  };
+}
+
+describe("mapEventAttrsToEvent", () => {
+  describe("when the span carries an event.type with metrics and details", () => {
+    it("maps it into a typed Event, splitting metrics from details", () => {
+      const event = mapEventAttrsToEvent({
+        row: row({
+          "event.type": "thumbs_up_down",
+          "event.metrics.vote": "1",
+          "event.details.reason": "great answer",
+        }),
+        projectId: "project-1",
+      });
+
+      expect(event).toEqual({
+        event_id: "span-1",
+        event_type: "thumbs_up_down",
+        project_id: "project-1",
+        metrics: { vote: 1 },
+        event_details: { reason: "great answer" },
+        trace_id: "trace-1",
+        timestamps: { started_at: 1000, inserted_at: 1000, updated_at: 1500 },
+      });
+    });
+  });
+
+  describe("when a metric value is not numeric", () => {
+    it("drops the non-finite metric rather than emitting NaN", () => {
+      const event = mapEventAttrsToEvent({
+        row: row({
+          "event.type": "custom",
+          "event.metrics.bad": "not-a-number",
+        }),
+        projectId: "project-1",
+      });
+
+      expect(event?.metrics).toEqual({});
+    });
+  });
+
+  describe("when the span has no event.type", () => {
+    it("returns null so it is not counted as an event", () => {
+      expect(
+        mapEventAttrsToEvent({
+          row: row({ "event.metrics.vote": "1" }),
+          projectId: "project-1",
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/server/traces/projection/catalog.ts
+++ b/langwatch/src/server/traces/projection/catalog.ts
@@ -133,12 +133,21 @@ const EVALUATION_FIELDS: Record<string, ProjectionValueType> = {
   is_guardrail: "boolean",
 };
 
-/** Annotation element scalar fields (`annotations.<key>`), read off each annotation. */
-const ANNOTATION_FIELDS: Record<string, ProjectionValueType> = {
-  is_thumbs_up: "boolean",
-  comment: "string",
-  expected_output: "string",
-  created_at: "number",
+/**
+ * Annotation element scalar fields (`annotations.<key>`), read off each
+ * annotation. `comment` and `expected_output` are free-text fields where
+ * reviewers routinely quote the model's captured output, so they share the
+ * output-visibility gate — otherwise the projection would be a side-channel
+ * around the io redaction.
+ */
+const ANNOTATION_FIELDS: Record<
+  string,
+  { type: ProjectionValueType; protection: FieldProtection | null }
+> = {
+  is_thumbs_up: { type: "boolean", protection: null },
+  comment: { type: "string", protection: "output" },
+  expected_output: { type: "string", protection: "output" },
+  created_at: { type: "number", protection: null },
 };
 
 function field(
@@ -309,9 +318,9 @@ function resolveAnnotationField({
   if (scalar) {
     return field({
       path,
-      type: scalar,
+      type: scalar.type,
       collection: "annotations",
-      protection: null,
+      protection: scalar.protection,
       outPath: [rest],
       read: (a) => a[rest] ?? null,
     });

--- a/langwatch/src/server/traces/projection/catalog.ts
+++ b/langwatch/src/server/traces/projection/catalog.ts
@@ -1,0 +1,342 @@
+/**
+ * Field catalog — the allowlist of selectable dotted-paths for the projection
+ * DSL. This is the public contract: every path a caller may put in `select`
+ * resolves here, and anything not here is rejected at compile time (HTTP 400).
+ *
+ * Mirrors the filter compiler's allowlist discipline: identifiers reaching the
+ * query come from this fixed catalog, never from raw caller input.
+ *
+ * Each path resolves to a {@link ResolvedField} carrying:
+ *  - where the value lands in the projected output (`outPath`),
+ *  - how to read it off the source (`read`) — the source is the trace for
+ *    scalar/grouped fields, or a single child element for collection fields,
+ *  - its advertised `type` and, for io/cost, the `protection` that gates it.
+ */
+
+import type { ProjectionCollection, ProjectionValueType } from "./types";
+
+/** Visibility gate a field is subject to, mirroring {@link Protections}. */
+export type FieldProtection = "input" | "output" | "costs";
+
+export interface ResolvedField {
+  /** The dotted path exactly as requested. */
+  path: string;
+  type: ProjectionValueType;
+  /** Child collection this field belongs to, or null for trace-level fields. */
+  collection: ProjectionCollection | null;
+  /** Visibility gate, or null when the field is always visible. */
+  protection: FieldProtection | null;
+  /**
+   * Where the value is placed in the output. For collection fields the path is
+   * relative to the projected element; for trace-level fields it is absolute on
+   * the row. Length > 1 means the value nests under an object (e.g.
+   * ["metadata","user_id"]).
+   */
+  outPath: string[];
+  /** Reads the value from the source (trace, or child element for collections). */
+  read: (src: ProjectionSource) => unknown;
+}
+
+/** Loose source shape — a trace or a child element. Reads are defensive (optional chaining). */
+export type ProjectionSource = Record<string, unknown> & {
+  timestamps?: { started_at?: number | null } | null;
+  input?: { value?: string | null } | null;
+  output?: { value?: string | null } | null;
+  metadata?: Record<string, unknown> | null;
+  metrics?: Record<string, unknown> | null;
+  event_details?: Record<string, unknown> | null;
+  scores?: Record<string, unknown> | null;
+};
+
+const PREFIX = {
+  metadata: "metadata.",
+  metrics: "metrics.",
+  evaluations: "evaluations.",
+  events: "events.",
+  annotations: "annotations.",
+} as const;
+
+/** Trace-level scalar fields addressable by their bare name. */
+const TRACE_SCALARS: Record<
+  string,
+  Pick<ResolvedField, "type" | "protection" | "outPath" | "read">
+> = {
+  trace_id: {
+    type: "string",
+    protection: null,
+    outPath: ["trace_id"],
+    read: (t) => t.trace_id ?? null,
+  },
+  project_id: {
+    type: "string",
+    protection: null,
+    outPath: ["project_id"],
+    read: (t) => t.project_id ?? null,
+  },
+  started_at: {
+    type: "number",
+    protection: null,
+    outPath: ["started_at"],
+    read: (t) => t.timestamps?.started_at ?? null,
+  },
+  inserted_at: {
+    type: "number",
+    protection: null,
+    outPath: ["inserted_at"],
+    read: (t) =>
+      (t.timestamps as { inserted_at?: number } | null)?.inserted_at ?? null,
+  },
+  updated_at: {
+    type: "number",
+    protection: null,
+    outPath: ["updated_at"],
+    read: (t) =>
+      (t.timestamps as { updated_at?: number } | null)?.updated_at ?? null,
+  },
+  input: {
+    type: "string",
+    protection: "input",
+    outPath: ["input"],
+    read: (t) => t.input?.value ?? null,
+  },
+  output: {
+    type: "string",
+    protection: "output",
+    outPath: ["output"],
+    read: (t) => t.output?.value ?? null,
+  },
+};
+
+/** Trace-level metric keys (`metrics.<key>`). total_cost is cost-gated. */
+const TRACE_METRICS: Record<string, ProjectionValueType> = {
+  first_token_ms: "number",
+  total_time_ms: "number",
+  prompt_tokens: "number",
+  completion_tokens: "number",
+  reasoning_tokens: "number",
+  cache_read_input_tokens: "number",
+  cache_creation_input_tokens: "number",
+  total_cost: "number",
+  tokens_estimated: "boolean",
+};
+
+/** Evaluation element fields (`evaluations.<key>`), read off each Evaluation. */
+const EVALUATION_FIELDS: Record<string, ProjectionValueType> = {
+  name: "string",
+  score: "number",
+  passed: "boolean",
+  label: "string",
+  details: "string",
+  status: "string",
+  evaluator_id: "string",
+  type: "string",
+  is_guardrail: "boolean",
+};
+
+/** Annotation element scalar fields (`annotations.<key>`), read off each annotation. */
+const ANNOTATION_FIELDS: Record<string, ProjectionValueType> = {
+  is_thumbs_up: "boolean",
+  comment: "string",
+  expected_output: "string",
+  created_at: "number",
+};
+
+function field(
+  partial: Omit<ResolvedField, "path"> & { path: string },
+): ResolvedField {
+  return partial;
+}
+
+/**
+ * Path segments that, used as an output object key, would corrupt the prototype
+ * chain. metadata.* and the *.metrics / *.details / *.scores sub-paths accept
+ * arbitrary segments, so a path like "metadata.__proto__" must be rejected
+ * before it ever reaches the projector's setPath.
+ */
+const FORBIDDEN_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Resolve a single dotted-path to its {@link ResolvedField}, or null when the
+ * path is not in the allowlist (the caller collects nulls into a 400).
+ */
+export function resolveField(path: string): ResolvedField | null {
+  // Reject prototype-pollution segments anywhere in the path (defense in depth
+  // alongside the projector's setPath guard).
+  if (path.split(".").some((segment) => FORBIDDEN_SEGMENTS.has(segment))) {
+    return null;
+  }
+
+  const scalar = TRACE_SCALARS[path];
+  if (scalar) return field({ path, collection: null, ...scalar });
+
+  if (path.startsWith(PREFIX.metrics)) {
+    const key = path.slice(PREFIX.metrics.length);
+    const type = TRACE_METRICS[key];
+    if (!type) return null;
+    return field({
+      path,
+      type,
+      collection: null,
+      protection: key === "total_cost" ? "costs" : null,
+      outPath: ["metrics", key],
+      read: (t) => t.metrics?.[key] ?? null,
+    });
+  }
+
+  if (path.startsWith(PREFIX.metadata)) {
+    const key = path.slice(PREFIX.metadata.length);
+    if (!key) return null;
+    return field({
+      path,
+      type: "json",
+      collection: null,
+      protection: null,
+      outPath: ["metadata", key],
+      read: (t) => t.metadata?.[key] ?? null,
+    });
+  }
+
+  if (path.startsWith(PREFIX.evaluations)) {
+    const key = path.slice(PREFIX.evaluations.length);
+    const type = EVALUATION_FIELDS[key];
+    if (!type) return null;
+    return field({
+      path,
+      type,
+      collection: "evaluations",
+      protection: null,
+      outPath: [key],
+      read: (ev) => ev[key] ?? null,
+    });
+  }
+
+  if (path.startsWith(PREFIX.events)) {
+    return resolveEventField({ path, rest: path.slice(PREFIX.events.length) });
+  }
+
+  if (path.startsWith(PREFIX.annotations)) {
+    return resolveAnnotationField({
+      path,
+      rest: path.slice(PREFIX.annotations.length),
+    });
+  }
+
+  return null;
+}
+
+function resolveEventField({
+  path,
+  rest,
+}: {
+  path: string;
+  rest: string;
+}): ResolvedField | null {
+  if (rest === "type") {
+    return field({
+      path,
+      type: "string",
+      collection: "events",
+      protection: null,
+      outPath: ["type"],
+      read: (e) => e.event_type ?? null,
+    });
+  }
+  if (rest === "timestamp") {
+    return field({
+      path,
+      type: "number",
+      collection: "events",
+      protection: null,
+      outPath: ["timestamp"],
+      read: (e) => e.timestamps?.started_at ?? null,
+    });
+  }
+  if (rest === "metrics") {
+    return field({
+      path,
+      type: "json",
+      collection: "events",
+      protection: null,
+      outPath: ["metrics"],
+      read: (e) => e.metrics ?? {},
+    });
+  }
+  if (rest === "details") {
+    return field({
+      path,
+      type: "json",
+      collection: "events",
+      protection: null,
+      outPath: ["details"],
+      read: (e) => e.event_details ?? {},
+    });
+  }
+  if (rest.startsWith("metrics.")) {
+    const k = rest.slice("metrics.".length);
+    if (!k) return null;
+    return field({
+      path,
+      type: "number",
+      collection: "events",
+      protection: null,
+      outPath: ["metrics", k],
+      read: (e) => e.metrics?.[k] ?? null,
+    });
+  }
+  if (rest.startsWith("details.")) {
+    const k = rest.slice("details.".length);
+    if (!k) return null;
+    return field({
+      path,
+      type: "string",
+      collection: "events",
+      protection: null,
+      outPath: ["details", k],
+      read: (e) => e.event_details?.[k] ?? null,
+    });
+  }
+  return null;
+}
+
+function resolveAnnotationField({
+  path,
+  rest,
+}: {
+  path: string;
+  rest: string;
+}): ResolvedField | null {
+  const scalar = ANNOTATION_FIELDS[rest];
+  if (scalar) {
+    return field({
+      path,
+      type: scalar,
+      collection: "annotations",
+      protection: null,
+      outPath: [rest],
+      read: (a) => a[rest] ?? null,
+    });
+  }
+  if (rest === "scores") {
+    return field({
+      path,
+      type: "json",
+      collection: "annotations",
+      protection: null,
+      outPath: ["scores"],
+      read: (a) => a.scores ?? {},
+    });
+  }
+  if (rest.startsWith("scores.")) {
+    const name = rest.slice("scores.".length);
+    if (!name) return null;
+    return field({
+      path,
+      type: "json",
+      collection: "annotations",
+      protection: null,
+      outPath: ["scores", name],
+      read: (a) => a.scores?.[name] ?? null,
+    });
+  }
+  return null;
+}

--- a/langwatch/src/server/traces/projection/compile-projection.ts
+++ b/langwatch/src/server/traces/projection/compile-projection.ts
@@ -127,7 +127,7 @@ function buildPlan({
  * Exported for unit-testing the collection-path RBAC redaction with a synthetic
  * protected collection field (the catalog has none today).
  */
-export function buildProjector({
+function buildProjector({
   fields,
   protections,
 }: {

--- a/langwatch/src/server/traces/projection/compile-projection.ts
+++ b/langwatch/src/server/traces/projection/compile-projection.ts
@@ -111,7 +111,7 @@ function buildPlan({
     needsIO: fields.some(
       (f) =>
         (f.protection === "input" || f.protection === "output") &&
-        isPermitted(f, protections),
+        isPermitted({ field: f, protections }),
     ),
     needsEvents: fields.some((f) => f.collection === "events"),
     eventPaths: subPaths("events"),
@@ -143,31 +143,39 @@ function buildProjector({
       setPath({
         target: row,
         path: f.outPath,
-        value: isPermitted(f, protections) ? f.read(source) : null,
+        value: isPermitted({ field: f, protections }) ? f.read(source) : null,
       });
     }
 
     for (const collection of COLLECTIONS) {
       const collFields = collectionFields[collection];
       if (collFields.length === 0) continue;
-      row[collection] = collectionElements(trace, collection).map((element) => {
-        const projected: ProjectedRow = {};
-        for (const f of collFields) {
-          setPath({
-            target: projected,
-            path: f.outPath,
-            value: f.read(element),
-          });
-        }
-        return projected;
-      });
+      row[collection] = collectionElements({ trace, collection }).map(
+        (element) => {
+          const projected: ProjectedRow = {};
+          for (const f of collFields) {
+            setPath({
+              target: projected,
+              path: f.outPath,
+              value: f.read(element),
+            });
+          }
+          return projected;
+        },
+      );
     }
 
     return row;
   };
 }
 
-function isPermitted(field: ResolvedField, protections: Protections): boolean {
+function isPermitted({
+  field,
+  protections,
+}: {
+  field: ResolvedField;
+  protections: Protections;
+}): boolean {
   switch (field.protection) {
     case "input":
       return !!protections.canSeeCapturedInput;
@@ -180,10 +188,13 @@ function isPermitted(field: ResolvedField, protections: Protections): boolean {
   }
 }
 
-function collectionElements(
-  trace: ProjectableTrace,
-  collection: ProjectionCollection,
-): ProjectionSource[] {
+function collectionElements({
+  trace,
+  collection,
+}: {
+  trace: ProjectableTrace;
+  collection: ProjectionCollection;
+}): ProjectionSource[] {
   const raw =
     collection === "events"
       ? trace.events

--- a/langwatch/src/server/traces/projection/compile-projection.ts
+++ b/langwatch/src/server/traces/projection/compile-projection.ts
@@ -1,0 +1,226 @@
+/**
+ * The schema compiler. Turns a validated `from` + `select` request into:
+ *  - a resolved `schema` (response envelope contract),
+ *  - a `plan` the ENGINE executes (which child collections to JOIN, whether to
+ *    fetch heavy io columns),
+ *  - a per-trace `project` function that shapes each trace to the selection.
+ *
+ * Pure and synchronous — no DB access — so it is unit-tested in isolation. The
+ * ClickHouse/Postgres execution that consumes `plan` lives in the trace service.
+ */
+
+import type { Protections } from "~/server/elasticsearch/protections";
+import {
+  type ProjectionSource,
+  type ResolvedField,
+  resolveField,
+} from "./catalog";
+import {
+  type CompiledProjection,
+  type CompileProjectionArgs,
+  type ProjectableTrace,
+  type ProjectedRow,
+  type ProjectionCollection,
+  type ProjectionFrom,
+  type ProjectionPlan,
+  ProjectionValidationError,
+  type ResolvedSchema,
+} from "./types";
+
+const COLLECTIONS: ProjectionCollection[] = [
+  "events",
+  "annotations",
+  "evaluations",
+];
+
+const COLLECTION_PREFIX: Record<ProjectionCollection, string> = {
+  events: "events.",
+  annotations: "annotations.",
+  evaluations: "evaluations.",
+};
+
+export function compileProjection({
+  from = "traces",
+  select,
+  protections,
+}: CompileProjectionArgs): CompiledProjection {
+  const fields = resolveSelectedFields(select);
+  return {
+    schema: buildSchema({ from, fields }),
+    plan: buildPlan({ from, fields, protections }),
+    project: buildProjector({ fields, protections }),
+  };
+}
+
+/**
+ * Resolve every select path against the allowlist, deduped and order-preserving.
+ * Throws {@link ProjectionValidationError} listing all unknown paths at once.
+ */
+function resolveSelectedFields(select: string[]): ResolvedField[] {
+  const fields: ResolvedField[] = [];
+  const invalidPaths: string[] = [];
+  const seen = new Set<string>();
+  for (const path of select) {
+    if (seen.has(path)) continue;
+    seen.add(path);
+    const resolved = resolveField(path);
+    if (resolved) fields.push(resolved);
+    else invalidPaths.push(path);
+  }
+  if (invalidPaths.length > 0) {
+    throw new ProjectionValidationError(invalidPaths);
+  }
+  return fields;
+}
+
+/** The response-envelope schema: one column descriptor per resolved field. */
+function buildSchema({
+  from,
+  fields,
+}: {
+  from: ProjectionFrom;
+  fields: ResolvedField[];
+}): ResolvedSchema {
+  return {
+    from,
+    columns: fields.map((f) => ({
+      path: f.path,
+      type: f.type,
+      collection: f.collection !== null,
+    })),
+  };
+}
+
+/** The query plan: which child collections to JOIN and whether to fetch io. */
+function buildPlan({
+  from,
+  fields,
+  protections,
+}: {
+  from: ProjectionFrom;
+  fields: ResolvedField[];
+  protections: Protections;
+}): ProjectionPlan {
+  const subPaths = (collection: ProjectionCollection): string[] =>
+    fields
+      .filter((f) => f.collection === collection)
+      .map((f) => f.path.slice(COLLECTION_PREFIX[collection].length));
+
+  return {
+    from,
+    needsIO: fields.some(
+      (f) =>
+        (f.protection === "input" || f.protection === "output") &&
+        isPermitted(f, protections),
+    ),
+    needsEvents: fields.some((f) => f.collection === "events"),
+    eventPaths: subPaths("events"),
+    needsAnnotations: fields.some((f) => f.collection === "annotations"),
+    annotationPaths: subPaths("annotations"),
+    needsEvaluations: fields.some((f) => f.collection === "evaluations"),
+    evaluationPaths: subPaths("evaluations"),
+  };
+}
+
+/** The per-trace projector: shapes one trace into the requested nested row. */
+function buildProjector({
+  fields,
+  protections,
+}: {
+  fields: ResolvedField[];
+  protections: Protections;
+}): (trace: ProjectableTrace) => ProjectedRow {
+  const scalarFields = fields.filter((f) => f.collection === null);
+  const collectionFields = Object.fromEntries(
+    COLLECTIONS.map((c) => [c, fields.filter((f) => f.collection === c)]),
+  ) as Record<ProjectionCollection, ResolvedField[]>;
+
+  return (trace: ProjectableTrace): ProjectedRow => {
+    const row: ProjectedRow = {};
+    const source = trace as unknown as ProjectionSource;
+
+    for (const f of scalarFields) {
+      setPath({
+        target: row,
+        path: f.outPath,
+        value: isPermitted(f, protections) ? f.read(source) : null,
+      });
+    }
+
+    for (const collection of COLLECTIONS) {
+      const collFields = collectionFields[collection];
+      if (collFields.length === 0) continue;
+      row[collection] = collectionElements(trace, collection).map((element) => {
+        const projected: ProjectedRow = {};
+        for (const f of collFields) {
+          setPath({
+            target: projected,
+            path: f.outPath,
+            value: f.read(element),
+          });
+        }
+        return projected;
+      });
+    }
+
+    return row;
+  };
+}
+
+function isPermitted(field: ResolvedField, protections: Protections): boolean {
+  switch (field.protection) {
+    case "input":
+      return !!protections.canSeeCapturedInput;
+    case "output":
+      return !!protections.canSeeCapturedOutput;
+    case "costs":
+      return !!protections.canSeeCosts;
+    default:
+      return true;
+  }
+}
+
+function collectionElements(
+  trace: ProjectableTrace,
+  collection: ProjectionCollection,
+): ProjectionSource[] {
+  const raw =
+    collection === "events"
+      ? trace.events
+      : collection === "annotations"
+        ? trace.annotations
+        : trace.evaluations;
+  return (raw ?? []) as unknown as ProjectionSource[];
+}
+
+/** Keys that would corrupt the prototype chain if written. */
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Place `value` at `path`, creating intermediate objects (e.g. metadata{}).
+ * Skips prototype-polluting keys — defense in depth; the catalog already rejects
+ * such paths up front, so this never fires in practice.
+ */
+function setPath({
+  target,
+  path,
+  value,
+}: {
+  target: ProjectedRow;
+  path: string[];
+  value: unknown;
+}): void {
+  let cursor = target;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i] as string;
+    if (FORBIDDEN_KEYS.has(key)) return;
+    const existing = cursor[key];
+    if (typeof existing !== "object" || existing === null) {
+      cursor[key] = {};
+    }
+    cursor = cursor[key] as ProjectedRow;
+  }
+  const last = path[path.length - 1] as string;
+  if (FORBIDDEN_KEYS.has(last)) return;
+  cursor[last] = value;
+}

--- a/langwatch/src/server/traces/projection/compile-projection.ts
+++ b/langwatch/src/server/traces/projection/compile-projection.ts
@@ -108,10 +108,14 @@ function buildPlan({
 
   return {
     from,
-    needsIO: fields.some(
-      (f) =>
-        (f.protection === "input" || f.protection === "output") &&
-        isPermitted({ field: f, protections }),
+    // Keyed on the scalar io paths themselves (not on `protection`, which
+    // other fields — e.g. gated annotation text — now share), so each heavy
+    // column is fetched only when its own field is selected and permitted.
+    needsInput: fields.some(
+      (f) => f.path === "input" && isPermitted({ field: f, protections }),
+    ),
+    needsOutput: fields.some(
+      (f) => f.path === "output" && isPermitted({ field: f, protections }),
     ),
     needsEvents: fields.some((f) => f.collection === "events"),
     eventPaths: subPaths("events"),

--- a/langwatch/src/server/traces/projection/compile-projection.ts
+++ b/langwatch/src/server/traces/projection/compile-projection.ts
@@ -122,8 +122,12 @@ function buildPlan({
   };
 }
 
-/** The per-trace projector: shapes one trace into the requested nested row. */
-function buildProjector({
+/**
+ * The per-trace projector: shapes one trace into the requested nested row.
+ * Exported for unit-testing the collection-path RBAC redaction with a synthetic
+ * protected collection field (the catalog has none today).
+ */
+export function buildProjector({
   fields,
   protections,
 }: {
@@ -154,10 +158,15 @@ function buildProjector({
         (element) => {
           const projected: ProjectedRow = {};
           for (const f of collFields) {
+            // Redact gated values on the collection path too — the catalog has
+            // no protected collection field today, but this keeps RBAC symmetric
+            // with the scalar path so a future protected field can't leak here.
             setPath({
               target: projected,
               path: f.outPath,
-              value: f.read(element),
+              value: isPermitted({ field: f, protections })
+                ? f.read(element)
+                : null,
             });
           }
           return projected;

--- a/langwatch/src/server/traces/projection/event-attrs.mapper.ts
+++ b/langwatch/src/server/traces/projection/event-attrs.mapper.ts
@@ -1,0 +1,61 @@
+/**
+ * Maps the `event.*` attributes of a stored_spans row into a trace Event.
+ *
+ * The events projection JOIN extracts only the `event.*` map entries from
+ * stored_spans (mapFilter). This mapper turns one such row into the public
+ * Event shape — mirroring extractEventsFromSpans (trace-summary.mapper) but
+ * reading directly off the ClickHouse map rather than an unflattened span.
+ */
+
+import type { Event } from "~/server/tracer/types";
+
+/** A stored_spans row carrying only the `event.*` attributes for one event span. */
+export interface EventSpanRow {
+  TraceId: string;
+  SpanId: string;
+  StartTimeMs: number;
+  EndTimeMs: number;
+  EventAttrs: Record<string, string>;
+}
+
+const METRICS_PREFIX = "event.metrics.";
+const DETAILS_PREFIX = "event.details.";
+
+export function mapEventAttrsToEvent({
+  row,
+  projectId,
+}: {
+  row: EventSpanRow;
+  projectId: string;
+}): Event | null {
+  const attrs = row.EventAttrs ?? {};
+  const eventType = attrs["event.type"];
+  if (!eventType) return null;
+
+  const metrics: Record<string, number> = {};
+  const details: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key.startsWith(METRICS_PREFIX)) {
+      const num = Number(value);
+      if (Number.isFinite(num)) {
+        metrics[key.slice(METRICS_PREFIX.length)] = num;
+      }
+    } else if (key.startsWith(DETAILS_PREFIX)) {
+      details[key.slice(DETAILS_PREFIX.length)] = value;
+    }
+  }
+
+  return {
+    event_id: row.SpanId,
+    event_type: eventType,
+    project_id: projectId,
+    metrics,
+    event_details: details,
+    trace_id: row.TraceId,
+    timestamps: {
+      started_at: row.StartTimeMs,
+      inserted_at: row.StartTimeMs,
+      updated_at: row.EndTimeMs,
+    },
+  };
+}

--- a/langwatch/src/server/traces/projection/event-attrs.mapper.ts
+++ b/langwatch/src/server/traces/projection/event-attrs.mapper.ts
@@ -19,6 +19,8 @@ export interface EventSpanRow {
 }
 
 const METRICS_PREFIX = "event.metrics.";
+/** Plain decimal numbers only — rejects '', whitespace, hex, exponents-with-garbage. */
+const DECIMAL_RE = /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/;
 const DETAILS_PREFIX = "event.details.";
 
 export function mapEventAttrsToEvent({
@@ -36,9 +38,11 @@ export function mapEventAttrsToEvent({
   const details: Record<string, string> = {};
   for (const [key, value] of Object.entries(attrs)) {
     if (key.startsWith(METRICS_PREFIX)) {
-      const num = Number(value);
-      if (Number.isFinite(num)) {
-        metrics[key.slice(METRICS_PREFIX.length)] = num;
+      // Strict decimal gate: Number('') / Number('   ') coerce to 0 and
+      // Number('0x1f') parses hex — all of which would silently project a
+      // bogus metric. An absent/garbled metric must stay absent, not become 0.
+      if (DECIMAL_RE.test(value.trim())) {
+        metrics[key.slice(METRICS_PREFIX.length)] = Number(value);
       }
     } else if (key.startsWith(DETAILS_PREFIX)) {
       details[key.slice(DETAILS_PREFIX.length)] = value;

--- a/langwatch/src/server/traces/projection/index.ts
+++ b/langwatch/src/server/traces/projection/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Schema compiler for the trace projection DSL (Track 1, API Export Traces RFC).
+ *
+ * The single translator from the JSON `from` + `select` contract to a
+ * ClickHouse/Postgres query plan + a per-trace response projector. Mirrors the
+ * existing filter compiler (`generateClickHouseFilterConditions`): an allowlist
+ * of selectable paths, never raw identifiers from the caller.
+ *
+ * Public surface (stable contract — app.v1.ts depends only on this):
+ *   compileProjection({ from, select, protections }) -> CompiledProjection
+ *     .schema  -> response envelope `schema` field
+ *     .plan    -> getAllTracesForProject options.projection
+ *     .project -> per-trace serializer (replaces formatTrace when active)
+ *   ProjectionValidationError -> map to HTTP 400
+ */
+
+export { compileProjection } from "./compile-projection";
+export * from "./types";

--- a/langwatch/src/server/traces/projection/types.ts
+++ b/langwatch/src/server/traces/projection/types.ts
@@ -38,9 +38,14 @@ export const projectionRequestSchema = z.object({
     .describe(
       "Entity root to read from. Only 'traces' is supported today; defaults to 'traces' when omitted.",
     ),
+  // Bounded so a caller can't submit unbounded path counts/lengths: the
+  // projector loops paths × pageSize per request, so without a cap a single
+  // request could pin the event loop (metadata.* accepts arbitrary keys, so
+  // the catalog itself doesn't bound cardinality).
   select: z
-    .array(z.string().min(1))
+    .array(z.string().min(1).max(256))
     .min(1)
+    .max(200)
     .optional()
     .describe(
       "Flat list of dotted-path columns to project, e.g. ['trace_id','metadata.user_id','events.type','evaluations.score']. " +

--- a/langwatch/src/server/traces/projection/types.ts
+++ b/langwatch/src/server/traces/projection/types.ts
@@ -1,0 +1,183 @@
+/**
+ * Projection DSL — public contract for Track 1 of the API Export Traces RFC
+ * (EPIC/Q2/api-export). Extends `POST /api/traces/search` with two optional
+ * request fields, `from` + `select`, letting a caller declare exactly which
+ * columns (and nested child collections) to project — one paginated loop
+ * replaces per-trace fan-out.
+ *
+ * This module is the boundary between the SURFACE (app.v1.ts: request schema,
+ * response envelope) and the ENGINE (the schema compiler + the ClickHouse /
+ * Postgres plan execution). Both sides depend only on the types here.
+ *
+ * `from` and `select` are OPTIONAL. Absent → the endpoint behaves exactly as
+ * before (backwards compatible).
+ */
+
+import { z } from "zod";
+import type { Protections } from "~/server/elasticsearch/protections";
+import type { Trace } from "~/server/tracer/types";
+
+/**
+ * Entity roots the DSL can read `from`. Only "traces" ships in M1; the RFC
+ * pre-declares "sessions" / "spans" as future roots so the contract shape
+ * does not change when they land.
+ */
+export const PROJECTION_FROM_ROOTS = ["traces"] as const;
+export type ProjectionFrom = (typeof PROJECTION_FROM_ROOTS)[number];
+export const projectionFromSchema = z.enum(PROJECTION_FROM_ROOTS);
+
+/**
+ * Request-body extension merged into `traceSearchBodySchema` (app.v1.ts).
+ * `select` is a FLAT dotted-path list (RFC Technical Plan §1). The server
+ * groups paths by root server-side (`metadata.*` → `metadata{}`, `events.*`
+ * → `events[]`, …) — the caller never declares the grouping.
+ */
+export const projectionRequestSchema = z.object({
+  from: projectionFromSchema
+    .default("traces")
+    .describe(
+      "Entity root to read from. Only 'traces' is supported today; defaults to 'traces' when omitted.",
+    ),
+  select: z
+    .array(z.string().min(1))
+    .min(1)
+    .optional()
+    .describe(
+      "Flat list of dotted-path columns to project, e.g. ['trace_id','metadata.user_id','events.type','evaluations.score']. " +
+        "Paths group by root in the response: scalar fields stay top-level, 'metadata.*' nests under a metadata object, and " +
+        "'events.*'/'annotations.*'/'evaluations.*' return as nested arrays (one row per trace). " +
+        "When present, the response gains a top-level 'schema' field describing the resolved columns. " +
+        "When omitted, the response is unchanged from the legacy shape.",
+    ),
+});
+export type ProjectionRequest = z.infer<typeof projectionRequestSchema>;
+
+/** Scalar value type advertised for a resolved column in the response `schema`. */
+export type ProjectionValueType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "string[]"
+  | "json";
+
+/**
+ * One entry in the resolved `schema` envelope field. `collection: true` means
+ * the path belongs to a nested child array (events/annotations/evaluations) and
+ * `type` describes the element-level value at that sub-path.
+ */
+export interface ResolvedColumn {
+  /** The dotted path exactly as requested, e.g. "metadata.user_id". */
+  path: string;
+  type: ProjectionValueType;
+  /** True when the path resolves into a nested child collection. */
+  collection: boolean;
+}
+
+/** The `schema` field added to the response envelope when `select` is present. */
+export interface ResolvedSchema {
+  from: ProjectionFrom;
+  columns: ResolvedColumn[];
+}
+
+/**
+ * Child-collection roots that group into nested arrays in the response. Scalar
+ * trace fields (trace_id, timestamps, io, metrics) and `metadata` are not
+ * collections.
+ */
+export type ProjectionCollection = "events" | "annotations" | "evaluations";
+
+/**
+ * What the ENGINE must fetch to satisfy a projection. Produced by the compiler,
+ * consumed by `getAllTracesForProject` (passed verbatim as `options.projection`)
+ * and by the bounded events / Postgres-annotations readers. Opaque to the
+ * SURFACE — app.v1.ts just forwards it.
+ *
+ * The plan is the lever for the perf win: when no `io.*` path is selected,
+ * `needsIO` is false and the heavy ComputedInput/ComputedOutput columns are
+ * pruned from the trace_summaries read.
+ */
+export interface ProjectionPlan {
+  from: ProjectionFrom;
+  /** Heavy ComputedInput/ComputedOutput columns are needed (and permitted). */
+  needsIO: boolean;
+  /** Build the nested events[] via a bounded stored_spans sub-query. */
+  needsEvents: boolean;
+  /** Event sub-paths requested, relative to the `events.` root (e.g. "type", "metrics.vote"). */
+  eventPaths: string[];
+  /** Build the nested annotations[] via a Postgres (Prisma) read. */
+  needsAnnotations: boolean;
+  /** Annotation sub-paths requested, relative to the `annotations.` root. */
+  annotationPaths: string[];
+  /** Include the nested evaluations[] (already enriched on the search path). */
+  needsEvaluations: boolean;
+  /** Evaluation sub-paths requested, relative to the `evaluations.` root. */
+  evaluationPaths: string[];
+}
+
+/**
+ * An annotation row attached to a trace by the ENGINE before projection.
+ * Sourced from Postgres (Prisma `Annotation`) — never present on the legacy
+ * read path, so it is carried as an augmentation of `Trace` rather than on the
+ * core type.
+ */
+export interface ProjectedAnnotation {
+  id: string;
+  is_thumbs_up: boolean | null;
+  comment: string | null;
+  expected_output: string | null;
+  /** Named score values from `scoreOptions`, keyed by score name. */
+  scores: Record<string, unknown>;
+  created_at: number;
+}
+
+/**
+ * A trace as seen by the projector: the core `Trace` plus the Postgres-sourced
+ * annotations the ENGINE attaches when `needsAnnotations` is set.
+ */
+export type ProjectableTrace = Trace & {
+  annotations?: ProjectedAnnotation[];
+};
+
+/** One projected output row (one per trace), shaped to mirror the selection. */
+export type ProjectedRow = Record<string, unknown>;
+
+/**
+ * The compiler's output. Single object that carries:
+ *  - `schema`  → goes into the response envelope when `select` is present.
+ *  - `plan`    → forwarded into `getAllTracesForProject` options.projection.
+ *  - `project` → applied per-trace in the response serialize loop, replacing
+ *                `formatTrace` when a projection is active.
+ */
+export interface CompiledProjection {
+  schema: ResolvedSchema;
+  plan: ProjectionPlan;
+  project: (trace: ProjectableTrace) => ProjectedRow;
+}
+
+/** Arguments to {@link compileProjection}. */
+export interface CompileProjectionArgs {
+  /** Defaults to "traces" when omitted. */
+  from?: ProjectionFrom;
+  select: string[];
+  /**
+   * Caller's data-visibility protections. `input`/`output` paths are pruned
+   * (fetched as null, never queried) when the corresponding capture visibility
+   * is not granted, mirroring the existing trace read path.
+   */
+  protections: Protections;
+}
+
+/**
+ * Thrown by the compiler when `select` contains paths outside the allowlist.
+ * The SURFACE maps this to HTTP 400. `invalidPaths` lists every offending path
+ * so the caller can fix all of them in one round-trip.
+ */
+export class ProjectionValidationError extends Error {
+  readonly invalidPaths: string[];
+
+  constructor(invalidPaths: string[]) {
+    super(`Unknown or unsupported select path(s): ${invalidPaths.join(", ")}`);
+    this.name = "ProjectionValidationError";
+    this.invalidPaths = invalidPaths;
+  }
+}

--- a/langwatch/src/server/traces/projection/types.ts
+++ b/langwatch/src/server/traces/projection/types.ts
@@ -97,14 +97,17 @@ export type ProjectionCollection = "events" | "annotations" | "evaluations";
  * and by the bounded events / Postgres-annotations readers. Opaque to the
  * SURFACE — app.v1.ts just forwards it.
  *
- * The plan is the lever for the perf win: when no `io.*` path is selected,
- * `needsIO` is false and the heavy ComputedInput/ComputedOutput columns are
- * pruned from the trace_summaries read.
+ * The plan is the lever for the perf win: input and output are pruned
+ * independently, so an output-only select (the common "grab completions"
+ * ETL shape) never materializes the heavy ComputedInput column, and vice
+ * versa.
  */
 export interface ProjectionPlan {
   from: ProjectionFrom;
-  /** Heavy ComputedInput/ComputedOutput columns are needed (and permitted). */
-  needsIO: boolean;
+  /** Heavy ComputedInput column is needed (selected and permitted). */
+  needsInput: boolean;
+  /** Heavy ComputedOutput column is needed (selected and permitted). */
+  needsOutput: boolean;
   /** Build the nested events[] via a bounded stored_spans sub-query. */
   needsEvents: boolean;
   /** Event sub-paths requested, relative to the `events.` root (e.g. "type", "metrics.vote"). */

--- a/langwatch/src/server/traces/trace.service.ts
+++ b/langwatch/src/server/traces/trace.service.ts
@@ -1,14 +1,14 @@
 import type { PrismaClient } from "@prisma/client";
 import { getLangWatchTracer } from "langwatch";
-import { prisma as defaultPrisma } from "~/server/db";
-import type { Protections } from "~/server/elasticsearch/protections";
-import { mapTraceEvaluationsToLegacyEvaluations } from "~/server/evaluations/evaluation-run.mappers";
-import { EvaluationService } from "~/server/evaluations/evaluation.service";
-import type { Evaluation, Trace } from "~/server/tracer/types";
-import { createLogger } from "~/utils/logger/server";
 import type { BlobStore } from "~/server/app-layer/traces/blob-store.service";
 import type { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import { prisma as defaultPrisma } from "~/server/db";
+import type { Protections } from "~/server/elasticsearch/protections";
+import { EvaluationService } from "~/server/evaluations/evaluation.service";
+import { mapTraceEvaluationsToLegacyEvaluations } from "~/server/evaluations/evaluation-run.mappers";
 import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import type { Evaluation, Trace } from "~/server/tracer/types";
+import { createLogger } from "~/utils/logger/server";
 import { ClickHouseTraceService } from "./clickhouse-trace.service";
 import { ElasticsearchTraceService } from "./elasticsearch-trace.service";
 import { resolveOffloadedTraces } from "./resolve-offloaded-traces";
@@ -73,11 +73,13 @@ export class AmbiguousTraceIdPrefixError extends Error {
  * short-circuit to 404 without scanning.
  */
 const HEX_ONLY = /^[0-9a-f]+$/i;
+
 import type {
   AggregationFiltersInput,
   CustomersAndLabelsResult,
   DistinctFieldNamesResult,
   GetAllTracesForProjectInput,
+  GetAllTracesForProjectOptions,
   PromptStudioSpanResult,
   TopicCountsResult,
   TracesForProjectResult,
@@ -164,7 +166,10 @@ export class TraceService {
     // the only level where spanAttributes carry the eventref keys.
     const resolveTraceSpansFn =
       blobResolutionDeps !== undefined
-        ? new OffloadedSpanResolver(blobResolutionDeps, this.logger).toResolverFn()
+        ? new OffloadedSpanResolver(
+            blobResolutionDeps,
+            this.logger,
+          ).toResolverFn()
         : undefined;
 
     this.clickHouseService = ClickHouseTraceService.create(
@@ -232,17 +237,18 @@ export class TraceService {
           HEX_ONLY.test(traceId)
         ) {
           const now = Date.now();
-          const candidates = await this.clickHouseService.resolveTraceIdByPrefix(
-            {
+          const candidates =
+            await this.clickHouseService.resolveTraceIdByPrefix({
               projectId,
               prefix: traceId,
               occurredAt: {
-                from: now - TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+                from:
+                  now -
+                  TRACE_ID_PREFIX_LOOKUP_WINDOW_DAYS * 24 * 60 * 60 * 1000,
                 to: now,
               },
               limit: TRACE_ID_PREFIX_CANDIDATE_LIMIT,
-            },
-          );
+            });
           if (candidates === null) {
             throw new Error(
               "ClickHouse is enabled but returned null for resolveTraceIdByPrefix — check ClickHouse client configuration",
@@ -351,11 +357,7 @@ export class TraceService {
   async getAllTracesForProject(
     input: GetAllTracesForProjectInput,
     protections: Protections,
-    options: {
-      downloadMode?: boolean;
-      includeSpans?: boolean;
-      scrollId?: string | null;
-    } = {},
+    options: GetAllTracesForProjectOptions = {},
   ): Promise<TracesForProjectResult> {
     return this.tracer.withActiveSpan(
       "TraceService.getAllTracesForProject",
@@ -554,12 +556,11 @@ export class TraceService {
       async (span) => {
         span.setAttribute("backend", "clickhouse");
 
-        const result =
-          await this.clickHouseService.getDistinctFieldNames(
-            projectId,
-            startDate,
-            endDate,
-          );
+        const result = await this.clickHouseService.getDistinctFieldNames(
+          projectId,
+          startDate,
+          endDate,
+        );
         if (result === null) {
           throw new Error(
             "ClickHouse is enabled but returned null for getDistinctFieldNames — check ClickHouse client configuration",

--- a/langwatch/src/server/traces/types.ts
+++ b/langwatch/src/server/traces/types.ts
@@ -8,6 +8,32 @@ import type {
   Span,
   SpanTimestamps,
 } from "~/server/tracer/types";
+import type { ProjectionPlan } from "./projection/types";
+
+/** Time axis that `startDate`/`endDate` and the keyset cursor apply to. */
+export type TraceDateField = "occurred" | "updated";
+
+/**
+ * Options for getAllTracesForProject, shared by the TraceService facade and the
+ * ClickHouse implementation so the contract stays in one place.
+ */
+export interface GetAllTracesForProjectOptions {
+  downloadMode?: boolean;
+  includeSpans?: boolean;
+  scrollId?: string | null;
+  /**
+   * Which time axis the date window + keyset cursor filter on. "occurred"
+   * (default) keeps the legacy OccurredAt behavior; "updated" pages by last
+   * mutation time for incremental ETL (CDC) pulls.
+   */
+  dateField?: TraceDateField;
+  /**
+   * Compiled projection plan (from the projection DSL). Drives which child
+   * collections are JOINed and whether the heavy io columns are fetched.
+   * Opaque to callers — produced by `compileProjection`.
+   */
+  projection?: ProjectionPlan;
+}
 
 /**
  * Input parameters for getAllTracesForProject.

--- a/specs/traces/trace-search-projection.feature
+++ b/specs/traces/trace-search-projection.feature
@@ -70,9 +70,9 @@ Feature: Trace search projection DSL
   # ==========================================================================
 
   Scenario: Select annotation fields returned as nested array
-    When I POST /api/traces/search with from "traces" and select ["trace_id", "annotations.is_thumbs_up", "annotations.score", "annotations.comment"]
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "annotations.is_thumbs_up", "annotations.scores", "annotations.comment"]
     Then each trace contains "trace_id" and an "annotations" array
-    And each annotation object contains only "is_thumbs_up", "score", and "comment"
+    And each annotation object contains only "is_thumbs_up", "scores", and "comment"
 
   # ==========================================================================
   # Mixed projection — all sources in one request

--- a/specs/traces/trace-search-projection.feature
+++ b/specs/traces/trace-search-projection.feature
@@ -131,6 +131,18 @@ Feature: Trace search projection DSL
     When I POST /api/traces/search with from "traces" and select ["trace_id", "input", "output"]
     Then each trace contains "trace_id", "input", and "output" with actual values
 
+  Scenario: Projected event details are redacted when captured input is not visible
+    Given the API key's role does not permit seeing captured input
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "events.details"]
+    Then event detail values are replaced with a redaction marker
+    And event types and metrics remain visible
+
+  Scenario: Annotation comments and expected output respect captured-output visibility
+    Given the API key's role does not permit seeing captured output
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "annotations.comment", "annotations.expected_output"]
+    Then annotation comment and expected output values are null
+    And the annotation rows themselves are still returned
+
   # ==========================================================================
   # Performance and OOM safety
   # ==========================================================================

--- a/specs/traces/trace-search-projection.feature
+++ b/specs/traces/trace-search-projection.feature
@@ -1,0 +1,216 @@
+@integration
+Feature: Trace search projection DSL
+  As an API consumer building an ETL pipeline
+  I want to declare which fields to return from POST /api/traces/search
+  So that I get exactly the data I need in one paginated loop without per-trace fan-out
+
+  # Track 1 / M1 of the API Export Traces RFC.
+  # Extends POST /api/traces/search with two new optional attributes:
+  #   from: "traces"  (entity root — only "traces" at launch)
+  #   select: ["trace_id", "metadata.user_id", "events.type", ...]
+  # When both are absent, behavior is unchanged (backwards compatible).
+  # When select is present, response includes a "schema" field and
+  # only the projected columns are returned per trace.
+
+  Background:
+    Given I am authenticated with a project API key that has traces:view permission
+    And my project has traces with metadata, events, annotations, and evaluations
+
+  # ==========================================================================
+  # Backwards compatibility
+  # ==========================================================================
+
+  Scenario: Request without from or select returns the current response shape
+    When I POST /api/traces/search with only startDate, endDate, and pageSize
+    Then the response status is 200
+    And the response body has "traces" array and "pagination" object
+    And no "schema" field is present in the response
+    And each trace contains the full default fields
+
+  # ==========================================================================
+  # Basic projection — cheap same-store fields
+  # ==========================================================================
+
+  Scenario: Select trace-level scalar fields
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "started_at"]
+    Then the response status is 200
+    And each trace contains only "trace_id" and "started_at"
+    And the response includes a "schema" field listing the resolved columns
+
+  Scenario: Select metadata fields grouped into a metadata object
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "metadata.user_id", "metadata.customer_id"]
+    Then each trace contains "trace_id" and a "metadata" object
+    And the metadata object contains only "user_id" and "customer_id"
+
+  Scenario: Select metrics fields
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "metrics.total_cost", "metrics.prompt_tokens"]
+    Then each trace contains "trace_id" and a "metrics" object
+    And the metrics object contains only "total_cost" and "prompt_tokens"
+
+  # ==========================================================================
+  # Evaluations projection
+  # ==========================================================================
+
+  Scenario: Select evaluation fields returned as nested array
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "evaluations.name", "evaluations.score", "evaluations.passed"]
+    Then each trace contains "trace_id" and an "evaluations" array
+    And each evaluation object contains only "name", "score", and "passed"
+
+  # ==========================================================================
+  # Events projection — bounded stored_spans sub-query
+  # ==========================================================================
+
+  Scenario: Select event fields returned as nested array
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "events.type", "events.metrics", "events.timestamp"]
+    Then each trace contains "trace_id" and an "events" array
+    And each event object contains only "type", "metrics", and "timestamp"
+
+  # ==========================================================================
+  # Annotations projection — cross-store Postgres join
+  # ==========================================================================
+
+  Scenario: Select annotation fields returned as nested array
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "annotations.is_thumbs_up", "annotations.score", "annotations.comment"]
+    Then each trace contains "trace_id" and an "annotations" array
+    And each annotation object contains only "is_thumbs_up", "score", and "comment"
+
+  # ==========================================================================
+  # Mixed projection — all sources in one request
+  # ==========================================================================
+
+  Scenario: Select fields from all sources in a single request
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "started_at", "metadata.user_id", "metrics.total_cost", "evaluations.score", "events.type", "annotations.is_thumbs_up"]
+    Then each trace contains "trace_id", "started_at", "metadata", "metrics", "evaluations", "events", and "annotations"
+    And child collections are nested arrays, scalar groups are objects
+
+  # ==========================================================================
+  # Schema field in response
+  # ==========================================================================
+
+  Scenario: Response includes schema when select is present
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "metadata.user_id", "evaluations.score"]
+    Then the response includes a "schema" field
+    And the schema lists the resolved column names and their types
+
+  # ==========================================================================
+  # Validation — unknown and invalid paths
+  # ==========================================================================
+
+  Scenario: Unknown select path returns 400
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "nonexistent_field"]
+    Then the response status is 400
+    And the error message identifies "nonexistent_field" as an invalid path
+
+  Scenario: Unknown from entity returns 400
+    When I POST /api/traces/search with from "sessions" and select ["trace_id"]
+    Then the response status is 400
+    And the error message identifies "sessions" as an unsupported entity
+
+  Scenario: Empty select array returns 400
+    When I POST /api/traces/search with from "traces" and select []
+    Then the response status is 400
+
+  Scenario: Select without from defaults to the traces entity root
+    When I POST /api/traces/search with select ["trace_id"] and no from field
+    Then the response status is 200
+    And the traces are projected as if from "traces" had been specified
+
+  # ==========================================================================
+  # RBAC protections — io.* fields respect canSeeCapturedInput/Output
+  # ==========================================================================
+
+  Scenario: Projected io fields are dropped when user lacks captured-input permission
+    Given the API key's role does not permit seeing captured input
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "input", "output"]
+    Then each trace contains "trace_id"
+    And "input" is redacted or null
+    And the response does not expose raw captured input
+
+  Scenario: Projected io fields are included when user has full permissions
+    Given the API key's role permits seeing captured input and output
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "input", "output"]
+    Then each trace contains "trace_id", "input", and "output" with actual values
+
+  # ==========================================================================
+  # Performance and OOM safety
+  # ==========================================================================
+
+  # Tracking: #4716 — deterministic perf/load test not written yet.
+  @unimplemented
+  Scenario: A projection of only lightweight fields returns quickly on a wide window
+    Given my project has tens of thousands of traces in the requested window
+    When I POST /api/traces/search with from "traces" and select ["trace_id", "metadata.user_id", "metrics.total_cost"]
+    Then the response returns within the 30-second target for a page of up to 1000 rows
+    And only the requested lightweight fields appear on each trace
+
+  # Tracking: #4716 — wide-window OOM-safety test needs a large-dataset harness.
+  @unimplemented
+  Scenario: A wide window with heavy fields stays within memory limits instead of failing
+    Given my project has a very large number of traces in the requested window
+    When I POST /api/traces/search with from "traces", select ["trace_id", "input", "output"], and pageSize 1000
+    Then the request succeeds or returns a bounded error
+    And the server does not run out of memory
+
+  # ==========================================================================
+  # Pagination — unchanged keyset cursor
+  # ==========================================================================
+
+  Scenario: Projection works with keyset cursor pagination
+    Given my project has more than 10 matching traces
+    When I POST /api/traces/search with from "traces", select ["trace_id", "started_at"], and pageSize 5
+    Then the response contains 5 traces and a scrollId
+    When I POST again with the same select and the returned scrollId
+    Then the response contains the next page of traces with no duplicates
+
+  # ==========================================================================
+  # Date axis — query by when a trace was modified, not when it occurred
+  # ==========================================================================
+
+  # ETL pipelines need "everything CHANGED since my last pull", not just
+  # "everything that STARTED since then". Traces mutate after creation:
+  # evaluations arrive later, annotations are added, metadata is patched.
+  # A trace can occur 30 days ago and be modified today — an occurrence-based
+  # window misses that change entirely. So the date window must be able to
+  # apply to the last-modified time instead.
+  #
+  # The request gains an optional dateField: "occurred" (default) or "updated".
+  # It selects which timestamp the existing startDate/endDate window filters.
+  # Default "occurred" keeps current behavior; the two axes are mutually
+  # exclusive within a single request.
+
+  Scenario: Default date axis is occurrence
+    When I POST /api/traces/search with startDate, endDate, and no dateField
+    Then the window filters traces by when they occurred
+    And the behavior is identical to today's
+
+  Scenario: Updated axis captures a late-mutated old trace
+    Given a trace occurred 30 days ago and was last modified today
+    When I POST /api/traces/search with dateField "updated" and a window covering only today
+    Then the response includes that trace because it was modified today
+    And an occurrence-based window covering only today would have excluded it
+
+  Scenario: Updated axis returns everything modified within the window
+    When I POST /api/traces/search with dateField "updated", select ["trace_id", "started_at"], and a one-day window
+    Then every trace modified within that day is returned regardless of when it occurred
+
+  Scenario: Updated axis pagination is complete and at-least-once
+    Given my project has more than one page of traces modified within the window
+    When I page through the results using the returned scrollId on the updated axis
+    Then no modified trace is missed across pages
+    And a trace modified again mid-pagination may reappear on a later page rather than being dropped
+
+  Scenario: Invalid dateField value returns 400
+    When I POST /api/traces/search with dateField "created"
+    Then the response status is 400
+    And the error identifies "created" as an unsupported date axis
+
+  # ==========================================================================
+  # Existing filters — unchanged
+  # ==========================================================================
+
+  # Tracking: #4716 — projection + filter-compiler combined test not written yet.
+  @unimplemented
+  Scenario: Projection works alongside existing filters
+    When I POST /api/traces/search with from "traces", select ["trace_id", "events.type"], and a label filter for "production"
+    Then only traces matching the "production" label are returned
+    And each trace is projected to contain only "trace_id" and "events"


### PR DESCRIPTION
## What & why

**Track 1 / M1 of the API Export Traces RFC.** A customer's data team runs an ETL that pulls trace + feedback data into their warehouse on a schedule. The current API forces **one request per trace** to assemble events / annotations / evaluations — thousands of calls per day — which stalled their pipeline. This makes the existing **synchronous** `POST /api/traces/search` return complete, caller-shaped results in **one paginated request**.

> **Track 2 (async `/api/exports`, Parquet, S3 worker, polling) is explicitly OUT of scope for this PR.**

## What's added (all additive + backwards-compatible)

`POST /api/traces/search` gains three optional fields:

- **`from`** — entity root (`"traces"` only at launch; `sessions`/`spans` reserved for later).
- **`select`** — flat dotted-path projection, e.g.
  `["trace_id","metadata.user_id","events.type","events.metrics.vote","annotations.is_thumbs_up","annotations.scores","evaluations.score"]`.
  The server groups by root: scalars stay top-level, `metadata.*` nests under `metadata{}`, and `events.*` / `annotations.*` / `evaluations.*` return as **nested arrays** — one row per trace.
- **`dateField`** — `"occurred"` (default, unchanged) or `"updated"` for incremental ETL / CDC delta pulls (page by last-mutation time, not occurrence — catches a trace modified after it occurred, which the occurred axis misses).

When `select` is present, the response adds a `schema` field describing the resolved columns. When all three are absent, the response is **byte-identical to today**.

## How it works

- **Schema compiler** (`src/server/traces/projection/`) — allowlist-validated parse → query plan → per-trace projector. Unknown paths → `400`. Mirrors the existing filter-compiler discipline; no caller-supplied identifiers ever reach ClickHouse.
- **Server-side JOINs, page-scoped** (run only after the ≤1000-id keyset page resolves — never table-wide, so they can't OOM):
  - `events` ← bounded `stored_spans` query extracting only `event.*` attributes
  - `annotations` ← Postgres (the only cross-store source)
  - `evaluations` ← existing enrichment path
- **Heavy-column pruning** — `ComputedInput` / `ComputedOutput` are not fetched unless `input` / `output` is selected, so projected queries run lighter than the legacy full response.
- **Updated-axis** — dedup-correct keyset cursor (`HAVING max(UpdatedAt)`) so a non-latest version can't slip past the cursor and duplicate a trace; the occurred-axis path is unchanged.

## Tests

- **293 unit** — schema compiler (incl. prototype-pollution rejection), event-attribute mapper, route handler (incl. serialize-skip `pagination.skipped` signal), plus zero-regression on the existing trace read path.
- **11 integration** — projected-shape scenarios over real ClickHouse + updated-axis global-`max(UpdatedAt)` dedup-completeness scenarios.
- `pnpm typecheck` 0 errors · Biome clean · feature-parity green (CI 57 pass / 0 fail).

Spec: `specs/traces/trace-search-projection.feature` (24 scenarios). Customer-facing docs: `docs/api-reference/traces/projection-dsl.mdx`.

## Proof

See the comment below — one live request returning trace + metadata + events + annotations + evaluations against a real project, versus the per-trace fan-out it replaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projection DSL for trace search: request selective fields (including nested events/annotations/evaluations) and receive a conditional schema describing resolved columns.
  * dateField option: paginate by occurrence or last-modified (updated) — at-least-once across CDC pulls.

* **Bug Fixes / Validation**
  * Request-time validation returns 400 for invalid selects; IO/cost fields are redacted based on visibility.

* **Documentation**
  * Added API reference, field catalog, and usage/performance guidance for the Projection DSL.

* **Tests**
  * New unit, integration, and end-to-end tests for projection shaping, pagination, validation, and updated-axis behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
