### PR TITLE
test(simulations): regression fixtures for input_audio url-shape and text-first ordering (#4138, #4698)

### DIFF
--- a/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -1,6 +1,5 @@
 import { Box, HStack, Image, Text, VStack } from "@chakra-ui/react";
-import { useMemo, useRef, useEffect } from "react";
-import { useSequentialAudioPlayback } from "./useSequentialAudioPlayback";
+import { useEffect, useMemo, useRef } from "react";
 import { Settings } from "react-feather";
 import type { StreamingMessage } from "~/hooks/useSimulationStreamingState";
 import type { ScenarioMessageSnapshotEvent } from "~/server/scenarios/scenario-event.types";
@@ -9,9 +8,10 @@ import { visitContentPart } from "~/server/stored-objects/visit-content-part";
 import { TraceMessage } from "../copilot-kit/TraceMessage";
 import { Markdown } from "../Markdown";
 import { RenderInputOutput } from "../traces/RenderInputOutput";
-import { safeJsonParseOrStringFallback } from "./utils/safe-json-parse-or-string-fallback";
-import { MediaPart } from "./MediaPart";
 import type { MediaPartData } from "./MediaPart";
+import { MediaPart } from "./MediaPart";
+import { useSequentialAudioPlayback } from "./useSequentialAudioPlayback";
+import { safeJsonParseOrStringFallback } from "./utils/safe-json-parse-or-string-fallback";
 
 type RawMessage = ScenarioMessageSnapshotEvent["messages"][number];
 
@@ -25,10 +25,29 @@ const textAlignForRole = (role?: string): "left" | "right" =>
   role === "assistant" ? "left" : "right";
 
 type DisplayItem =
-  | { kind: "text"; id: string; role: string; content: string; traceId?: string }
+  | {
+      kind: "text";
+      id: string;
+      role: string;
+      content: string;
+      traceId?: string;
+    }
   | { kind: "image"; id: string; src: string; role?: string; traceId?: string }
-  | { kind: "media"; id: string; part: MediaPartData; role?: string; transcript?: string; traceId?: string }
-  | { kind: "tool_call"; id: string; name: string; arguments: unknown; traceId?: string }
+  | {
+      kind: "media";
+      id: string;
+      part: MediaPartData;
+      role?: string;
+      transcript?: string;
+      traceId?: string;
+    }
+  | {
+      kind: "tool_call";
+      id: string;
+      name: string;
+      arguments: unknown;
+      traceId?: string;
+    }
   | { kind: "tool_result"; id: string; result: unknown; traceId?: string };
 
 interface ScenarioMessageRendererProps {
@@ -213,14 +232,27 @@ export function ScenarioMessageRenderer({
                   borderRadius="lg"
                   p={3}
                 >
-                  <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mb={2}>
+                  <Text
+                    fontSize="xs"
+                    fontWeight="semibold"
+                    color="fg.muted"
+                    mb={2}
+                  >
                     Tool arguments
                   </Text>
-                  <Box bg="bg.panel" border="1px solid" borderColor="border" borderRadius="md" p={2}>
+                  <Box
+                    bg="bg.panel"
+                    border="1px solid"
+                    borderColor="border"
+                    borderRadius="md"
+                    p={2}
+                  >
                     <RenderInputOutput value={item.arguments as string} />
                   </Box>
                 </Box>
-                {!smallerView && item.traceId && <TraceMessage traceId={item.traceId} />}
+                {!smallerView && item.traceId && (
+                  <TraceMessage traceId={item.traceId} />
+                )}
               </VStack>
             );
 
@@ -236,14 +268,27 @@ export function ScenarioMessageRenderer({
                   borderRadius="lg"
                   p={3}
                 >
-                  <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mb={2}>
+                  <Text
+                    fontSize="xs"
+                    fontWeight="semibold"
+                    color="fg.muted"
+                    mb={2}
+                  >
                     Tool result
                   </Text>
-                  <Box bg="bg.panel" border="1px solid" borderColor="border" borderRadius="md" p={2}>
+                  <Box
+                    bg="bg.panel"
+                    border="1px solid"
+                    borderColor="border"
+                    borderRadius="md"
+                    p={2}
+                  >
                     <RenderInputOutput value={item.result as string} />
                   </Box>
                 </Box>
-                {!smallerView && item.traceId && <TraceMessage traceId={item.traceId} />}
+                {!smallerView && item.traceId && (
+                  <TraceMessage traceId={item.traceId} />
+                )}
               </VStack>
             );
 
@@ -270,16 +315,23 @@ function flattenMessages(
     if (msg.role === "user" || msg.role === "assistant") {
       // Support both snake_case (OpenAI/chatMessageSchema) and camelCase (AG-UI MessageSchema)
       const msgAny = msg as Record<string, unknown>;
-      const toolCalls = (msgAny.tool_calls as Array<{ function?: { name?: string; arguments?: string } }> | undefined)
-        ?? (msgAny.toolCalls as Array<{ function?: { name?: string; arguments?: string } }> | undefined)
-        ?? null;
+      const toolCalls =
+        (msgAny.tool_calls as
+          | Array<{ function?: { name?: string; arguments?: string } }>
+          | undefined) ??
+        (msgAny.toolCalls as
+          | Array<{ function?: { name?: string; arguments?: string } }>
+          | undefined) ??
+        null;
       if (toolCalls) {
         for (const tc of toolCalls) {
           items.push({
             kind: "tool_call",
             id: `${msg.id ?? ""}-tool-${tc.function?.name ?? "unknown"}`,
             name: tc.function?.name ?? "unknown",
-            arguments: safeJsonParseOrStringFallback(tc.function?.arguments ?? "{}"),
+            arguments: safeJsonParseOrStringFallback(
+              tc.function?.arguments ?? "{}",
+            ),
             traceId: msg.trace_id,
           });
         }
@@ -290,7 +342,9 @@ function flattenMessages(
         kind: "tool_result",
         id: msg.id ?? crypto.randomUUID(),
         result: safeJsonParseOrStringFallback(
-          typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content ?? {}),
+          typeof msg.content === "string"
+            ? msg.content
+            : JSON.stringify(msg.content ?? {}),
         ),
         traceId: msg.trace_id,
       });
@@ -301,7 +355,12 @@ function flattenMessages(
     const serverIds = new Set(messages.map((m) => m.id).filter(Boolean));
     for (const sm of streamingMessages) {
       if (serverIds.has(sm.messageId)) continue;
-      items.push({ kind: "text", id: sm.messageId, role: sm.role, content: sm.content || "\u2026" });
+      items.push({
+        kind: "text",
+        id: sm.messageId,
+        role: sm.role,
+        content: sm.content || "\u2026",
+      });
     }
   }
 
@@ -313,10 +372,21 @@ function flattenContent(msg: RawMessage): DisplayItem[] {
   const coerced = coerceContentToArray(msg.content);
   if (coerced) return flattenMixed(coerced, msg);
 
-  const raw = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content ?? {});
+  const raw =
+    typeof msg.content === "string"
+      ? msg.content
+      : JSON.stringify(msg.content ?? {});
 
   if (msg.content && msg.content !== "None") {
-    return [{ kind: "text", id: msg.id ?? crypto.randomUUID(), role: msg.role ?? "assistant", content: raw, traceId: msg.trace_id }];
+    return [
+      {
+        kind: "text",
+        id: msg.id ?? crypto.randomUUID(),
+        role: msg.role ?? "assistant",
+        content: raw,
+        traceId: msg.trace_id,
+      },
+    ];
   }
   return [];
 }
@@ -326,9 +396,16 @@ function flattenMixed(content: unknown[], msg: RawMessage): DisplayItem[] {
   const role = msg.role ?? "assistant";
   content.forEach((item, i) => {
     const result = visitContentPart<DisplayItem | undefined>(item, {
-      text: (text) => text
-        ? { kind: "text" as const, id: `${msg.id}-c${i}`, role, content: text, traceId: msg.trace_id }
-        : undefined,
+      text: (text) =>
+        text
+          ? {
+              kind: "text" as const,
+              id: `${msg.id}-c${i}`,
+              role,
+              content: text,
+              traceId: msg.trace_id,
+            }
+          : undefined,
       media: (part) => ({
         kind: "media" as const,
         id: `${msg.id}-media${i}`,
@@ -345,10 +422,33 @@ function flattenMixed(content: unknown[], msg: RawMessage): DisplayItem[] {
         role,
         traceId: msg.trace_id,
       }),
-      toolCall: (part) => ({ kind: "tool_call" as const, id: `${msg.id}-tu${i}`, name: part.name, arguments: part.arguments, traceId: msg.trace_id }),
-      toolResult: (part) => ({ kind: "tool_result" as const, id: `${msg.id}-tr${i}`, result: part.result, traceId: msg.trace_id }),
-      imageUrl: (url) => ({ kind: "image" as const, id: `${msg.id}-img${i}`, src: url, role, traceId: msg.trace_id }),
-      bareImage: (src) => ({ kind: "image" as const, id: `${msg.id}-img${i}`, src, role, traceId: msg.trace_id }),
+      toolCall: (part) => ({
+        kind: "tool_call" as const,
+        id: `${msg.id}-tu${i}`,
+        name: part.name,
+        arguments: part.arguments,
+        traceId: msg.trace_id,
+      }),
+      toolResult: (part) => ({
+        kind: "tool_result" as const,
+        id: `${msg.id}-tr${i}`,
+        result: part.result,
+        traceId: msg.trace_id,
+      }),
+      imageUrl: (url) => ({
+        kind: "image" as const,
+        id: `${msg.id}-img${i}`,
+        src: url,
+        role,
+        traceId: msg.trace_id,
+      }),
+      bareImage: (src) => ({
+        kind: "image" as const,
+        id: `${msg.id}-img${i}`,
+        src,
+        role,
+        traceId: msg.trace_id,
+      }),
       // OpenAI Realtime API audio shape. Two states:
       // - Pre-extraction: {data, format} (inline base64). Server-side
       //   extraction normally rewrites this away, but if the renderer

--- a/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -15,6 +15,15 @@ import type { MediaPartData } from "./MediaPart";
 
 type RawMessage = ScenarioMessageSnapshotEvent["messages"][number];
 
+// Role → alignment mapping. Extracted here so `align` and `data-align` always
+// derive from the same value — the `data-align` attribute mirrors `align` for
+// jsdom tests, which cannot read Chakra's atomic CSS classes via getComputedStyle.
+const alignForRole = (role?: string): "flex-start" | "flex-end" =>
+  role === "assistant" ? "flex-start" : "flex-end";
+
+const textAlignForRole = (role?: string): "left" | "right" =>
+  role === "assistant" ? "left" : "right";
+
 type DisplayItem =
   | { kind: "text"; id: string; role: string; content: string; traceId?: string }
   | { kind: "image"; id: string; src: string; role?: string; traceId?: string }
@@ -85,12 +94,8 @@ export function ScenarioMessageRenderer({
             return (
               <VStack
                 key={item.id}
-                align={item.role === "assistant" ? "flex-start" : "flex-end"}
-                // Test affordance: Chakra's `align` prop compiles to an atomic
-                // CSS class jsdom's getComputedStyle cannot read, so the
-                // left/right alignment is asserted via this mirrored attribute.
-                // Same value as `align` above — no behavior change.
-                data-align={item.role === "assistant" ? "flex-start" : "flex-end"}
+                align={alignForRole(item.role)}
+                data-align={alignForRole(item.role)}
                 gap={1}
               >
                 {item.role === "assistant" ? (
@@ -140,9 +145,8 @@ export function ScenarioMessageRenderer({
             return (
               <VStack
                 key={item.id}
-                align={item.role === "assistant" ? "flex-start" : "flex-end"}
-                // Test affordance — see the `text` case. Mirrors `align`.
-                data-align={item.role === "assistant" ? "flex-start" : "flex-end"}
+                align={alignForRole(item.role)}
+                data-align={alignForRole(item.role)}
               >
                 <Image src={item.src} maxH="200px" borderRadius="md" />
               </VStack>
@@ -152,9 +156,8 @@ export function ScenarioMessageRenderer({
             return (
               <VStack
                 key={item.id}
-                align={item.role === "assistant" ? "flex-start" : "flex-end"}
-                // Test affordance — see the `text` case. Mirrors `align`.
-                data-align={item.role === "assistant" ? "flex-start" : "flex-end"}
+                align={alignForRole(item.role)}
+                data-align={alignForRole(item.role)}
                 width="100%"
               >
                 <VStack
@@ -177,9 +180,7 @@ export function ScenarioMessageRenderer({
                       color="fg.muted"
                       fontStyle="italic"
                       paddingX={2}
-                      textAlign={
-                        item.role === "assistant" ? "left" : "right"
-                      }
+                      textAlign={textAlignForRole(item.role)}
                     >
                       {item.transcript}
                     </Text>

--- a/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
+++ b/langwatch/src/components/simulations/ScenarioMessageRenderer.tsx
@@ -86,6 +86,11 @@ export function ScenarioMessageRenderer({
               <VStack
                 key={item.id}
                 align={item.role === "assistant" ? "flex-start" : "flex-end"}
+                // Test affordance: Chakra's `align` prop compiles to an atomic
+                // CSS class jsdom's getComputedStyle cannot read, so the
+                // left/right alignment is asserted via this mirrored attribute.
+                // Same value as `align` above — no behavior change.
+                data-align={item.role === "assistant" ? "flex-start" : "flex-end"}
                 gap={1}
               >
                 {item.role === "assistant" ? (
@@ -136,6 +141,8 @@ export function ScenarioMessageRenderer({
               <VStack
                 key={item.id}
                 align={item.role === "assistant" ? "flex-start" : "flex-end"}
+                // Test affordance — see the `text` case. Mirrors `align`.
+                data-align={item.role === "assistant" ? "flex-start" : "flex-end"}
               >
                 <Image src={item.src} maxH="200px" borderRadius="md" />
               </VStack>
@@ -146,6 +153,8 @@ export function ScenarioMessageRenderer({
               <VStack
                 key={item.id}
                 align={item.role === "assistant" ? "flex-start" : "flex-end"}
+                // Test affordance — see the `text` case. Mirrors `align`.
+                data-align={item.role === "assistant" ? "flex-start" : "flex-end"}
                 width="100%"
               >
                 <VStack

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -11,8 +11,8 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { ScenarioMessageRenderer } from "../ScenarioMessageRenderer";
 import type { ScenarioMessageSnapshotEvent } from "~/server/scenarios/scenario-event.types";
+import { ScenarioMessageRenderer } from "../ScenarioMessageRenderer";
 
 vi.mock("~/utils/api", () => ({
   api: {
@@ -26,7 +26,9 @@ vi.mock("~/utils/api", () => ({
 
 vi.mock("../../copilot-kit/TraceMessage", () => ({
   TraceMessage: ({ traceId }: { traceId: string }) => (
-    <button data-testid="trace-message" data-trace-id={traceId}>View Trace</button>
+    <button data-testid="trace-message" data-trace-id={traceId}>
+      View Trace
+    </button>
   ),
 }));
 
@@ -298,9 +300,7 @@ describe("<ScenarioMessageRenderer/>", () => {
     it("renders a media-part-audio element whose src is the file url (drawer variant)", () => {
       renderWith([urlShapeMessage]);
 
-      const audio = screen.getByTestId(
-        "media-part-audio",
-      ) as HTMLAudioElement;
+      const audio = screen.getByTestId("media-part-audio") as HTMLAudioElement;
       expect(audio).toBeInTheDocument();
       expect(audio.tagName.toLowerCase()).toBe("audio");
       expect(audio).toHaveAttribute("src", "/api/files/test-id");
@@ -312,9 +312,7 @@ describe("<ScenarioMessageRenderer/>", () => {
     it("renders a media-part-audio element whose src is the file url (grid variant)", () => {
       renderWithGrid([urlShapeMessage]);
 
-      const audio = screen.getByTestId(
-        "media-part-audio",
-      ) as HTMLAudioElement;
+      const audio = screen.getByTestId("media-part-audio") as HTMLAudioElement;
       expect(audio).toBeInTheDocument();
       expect(audio).toHaveAttribute("src", "/api/files/test-id");
       expect(audio).toHaveAttribute("controls");
@@ -435,7 +433,10 @@ describe("<ScenarioMessageRenderer/>", () => {
           content: [
             {
               type: "input_audio",
-              input_audio: { url: "/api/files/user-voice", mimeType: "audio/mpeg" },
+              input_audio: {
+                url: "/api/files/user-voice",
+                mimeType: "audio/mpeg",
+              },
             },
           ],
         } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
@@ -457,7 +458,10 @@ describe("<ScenarioMessageRenderer/>", () => {
           content: [
             {
               type: "input_audio",
-              input_audio: { url: "/api/files/solo-voice", mimeType: "audio/mpeg" },
+              input_audio: {
+                url: "/api/files/solo-voice",
+                mimeType: "audio/mpeg",
+              },
             },
           ],
         } as unknown as ScenarioMessageSnapshotEvent["messages"][number],

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -470,12 +470,10 @@ describe("<ScenarioMessageRenderer/>", () => {
       const mediaWrapper = audio.closest("[data-align]");
       expect(mediaWrapper).toHaveAttribute("data-align", "flex-start");
 
-      // No transcript artifact: the inner media container holds only the
-      // <audio> (its VStack), no italic caption <p>. Asserting the audio's
-      // immediate container has a single child guards against an empty
-      // transcript node sneaking in.
-      const innerContainer = audio.parentElement?.parentElement;
-      expect(innerContainer?.childElementCount).toBe(1);
+      // No transcript artifact: the bubble must not render an italic caption
+      // <p>. Scoped to the media wrapper so Chakra wrappers outside the bubble
+      // never false-positive; does not depend on wrapper nesting depth.
+      expect(mediaWrapper!.querySelector("p")).toBeNull();
     });
   });
 });

--- a/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
@@ -273,4 +273,209 @@ describe("<ScenarioMessageRenderer/>", () => {
       expect(traceIds).toContain("trace_tool_result");
     });
   });
+
+  // -------------------------------------------------------------------------
+  // #4138 — post-extraction `input_audio` URL shape.
+  //
+  // After server-side stored-objects extraction, an `input_audio` part is
+  // rewritten from inline `{data, format}` to `{url: "/api/files/<id>",
+  // mimeType}` (content-extractor.ts). These pin that the renderer plays the
+  // url-shape turn through MediaPart's native <audio> in BOTH the grid and
+  // drawer variants, and degrades gracefully for an unrenderable shape.
+  // -------------------------------------------------------------------------
+  describe("when an assistant audio message arrives in the post-extraction url shape (#4138)", () => {
+    const urlShapeMessage = {
+      id: "msg_audio_url_shape",
+      role: "assistant",
+      content: [
+        {
+          type: "input_audio",
+          input_audio: { url: "/api/files/test-id", mimeType: "audio/mpeg" },
+        },
+      ],
+    } as unknown as ScenarioMessageSnapshotEvent["messages"][number];
+
+    it("renders a media-part-audio element whose src is the file url (drawer variant)", () => {
+      renderWith([urlShapeMessage]);
+
+      const audio = screen.getByTestId(
+        "media-part-audio",
+      ) as HTMLAudioElement;
+      expect(audio).toBeInTheDocument();
+      expect(audio.tagName.toLowerCase()).toBe("audio");
+      expect(audio).toHaveAttribute("src", "/api/files/test-id");
+      expect(audio).toHaveAttribute("controls");
+      // The raw part shape must never leak into the bubble as text.
+      expect(screen.queryByText(/input_audio/)).toBeNull();
+    });
+
+    it("renders a media-part-audio element whose src is the file url (grid variant)", () => {
+      renderWithGrid([urlShapeMessage]);
+
+      const audio = screen.getByTestId(
+        "media-part-audio",
+      ) as HTMLAudioElement;
+      expect(audio).toBeInTheDocument();
+      expect(audio).toHaveAttribute("src", "/api/files/test-id");
+      expect(audio).toHaveAttribute("controls");
+    });
+  });
+
+  describe("when a media part has an unsupported mimeType (#4138 graceful fallback)", () => {
+    /**
+     * A media part whose mimeType is not an `audio/`/`image/`/`video/` type
+     * resolves to the binary category in MediaPart, which renders a
+     * download-link fallback (media-part-binary) rather than a broken <audio>
+     * element. This guards the unhappy shape — a graceful fallback node, never
+     * a broken/empty media element — for a file the renderer cannot play
+     * inline (e.g. an externalized blob with a non-media content type).
+     */
+    it("renders a graceful binary fallback, not a broken audio element", () => {
+      renderWith([
+        {
+          id: "msg_audio_bad_mime",
+          role: "assistant",
+          content: [
+            {
+              // Non-media mimeType → MediaPart resolves the binary category and
+              // renders the download-link fallback instead of an <audio>.
+              type: "binary",
+              mimeType: "application/octet-stream",
+              url: "/api/files/unsupported-id",
+              filename: "voice-turn.bin",
+            },
+          ],
+        } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      // Graceful fallback present; no broken <audio> element rendered.
+      expect(screen.getByTestId("media-part-binary")).toBeInTheDocument();
+      expect(document.querySelector("audio")).toBeNull();
+      expect(screen.queryByText(/input_audio/)).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #4698 — text-first part ordering + audio-only + assistant=left.
+  //
+  // The production SDK emits assistant voice turns text-FIRST
+  // (`[text, input_audio]`); every pre-existing collapse fixture is audio-first
+  // (`[input_audio, text]`). The collapse guard is order-independent (filters
+  // by kind, not index), so both orderings must produce exactly one bubble
+  // with the text as the transcript. Alignment (assistant=left, user=right) is
+  // asserted via the `data-align` test affordance because Chakra's `align`
+  // prop compiles to an atomic CSS class jsdom's getComputedStyle cannot read.
+  // -------------------------------------------------------------------------
+  describe("when an assistant voice turn carries audio + a sibling text transcript (#4698)", () => {
+    const orderings: Array<{
+      label: string;
+      parts: unknown[];
+    }> = [
+      {
+        label: "text-first [text, input_audio] (production SDK ordering)",
+        parts: [
+          { type: "text", text: "hello from the agent" },
+          {
+            type: "input_audio",
+            input_audio: { url: "/api/files/voice-id", mimeType: "audio/mpeg" },
+          },
+        ],
+      },
+      {
+        label: "audio-first [input_audio, text]",
+        parts: [
+          {
+            type: "input_audio",
+            input_audio: { url: "/api/files/voice-id", mimeType: "audio/mpeg" },
+          },
+          { type: "text", text: "hello from the agent" },
+        ],
+      },
+    ];
+
+    orderings.forEach(({ label, parts }) => {
+      describe(`given ordering: ${label}`, () => {
+        /** @scenario "Both part orderings collapse a voice turn into one assistant bubble" */
+        it("renders exactly one assistant-left bubble with the text as transcript", () => {
+          renderWith([
+            {
+              id: "msg_voice_collapse",
+              role: "assistant",
+              trace_id: "trace_voice",
+              content: parts,
+            } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+          ]);
+
+          // Exactly one audio element and one trace button — no duplicate bubble.
+          expect(document.querySelectorAll("audio")).toHaveLength(1);
+          expect(screen.getAllByTestId("trace-message")).toHaveLength(1);
+
+          // The text renders as the transcript inside the same media wrapper as
+          // the <audio> (co-contained), not as a standalone second bubble.
+          const transcript = screen.getByText("hello from the agent");
+          const audio = screen.getByTestId("media-part-audio");
+          const mediaWrapper = audio.closest("[data-align]");
+          expect(mediaWrapper).not.toBeNull();
+          expect(mediaWrapper).toContainElement(transcript);
+
+          // Assistant bubble aligns LEFT (flex-start) via the test affordance.
+          expect(mediaWrapper).toHaveAttribute("data-align", "flex-start");
+        });
+      });
+    });
+  });
+
+  describe("when a simulated-user voice turn arrives (#4698 alignment inversion)", () => {
+    /** @scenario "User-role voice turns align right" */
+    it("aligns the user media bubble to the right (flex-end)", () => {
+      renderWith([
+        {
+          id: "msg_voice_user",
+          role: "user",
+          content: [
+            {
+              type: "input_audio",
+              input_audio: { url: "/api/files/user-voice", mimeType: "audio/mpeg" },
+            },
+          ],
+        } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      const audio = screen.getByTestId("media-part-audio");
+      const mediaWrapper = audio.closest("[data-align]");
+      expect(mediaWrapper).toHaveAttribute("data-align", "flex-end");
+    });
+  });
+
+  describe("when an assistant voice turn is audio-only with no transcript (#4698)", () => {
+    /** @scenario "Audio-only voice turn renders one bubble with no empty transcript artifact" */
+    it("renders one assistant-left audio bubble and no italic transcript node", () => {
+      renderWith([
+        {
+          id: "msg_voice_audio_only",
+          role: "assistant",
+          content: [
+            {
+              type: "input_audio",
+              input_audio: { url: "/api/files/solo-voice", mimeType: "audio/mpeg" },
+            },
+          ],
+        } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+      ]);
+
+      // Exactly one audio bubble.
+      expect(document.querySelectorAll("audio")).toHaveLength(1);
+
+      const audio = screen.getByTestId("media-part-audio");
+      const mediaWrapper = audio.closest("[data-align]");
+      expect(mediaWrapper).toHaveAttribute("data-align", "flex-start");
+
+      // No transcript artifact: the inner media container holds only the
+      // <audio> (its VStack), no italic caption <p>. Asserting the audio's
+      // immediate container has a single child guards against an empty
+      // transcript node sneaking in.
+      const innerContainer = audio.parentElement?.parentElement;
+      expect(innerContainer?.childElementCount).toBe(1);
+    });
+  });
 });

--- a/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
@@ -9,11 +9,34 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { ScenarioRunStatus, Verdict } from "~/server/scenarios/scenario-event.enums";
+import type { ScenarioMessageSnapshotEvent } from "~/server/scenarios/scenario-event.types";
 import { Drawer } from "../../ui/drawer";
+import { ScenarioMessageRenderer } from "../ScenarioMessageRenderer";
 import { ScenarioRunHeader } from "../ScenarioRunHeader";
 import { SimulationConsole } from "../simulation-console/SimulationConsole";
+
+// MediaPart fires a tRPC existence probe on a media error event; stub it so the
+// probe never resolves to a placeholder on the happy path (mirrors the
+// standalone ScenarioMessageRenderer + MediaPart integration tests).
+vi.mock("~/utils/api", () => ({
+  api: {
+    storedObjects: {
+      headById: {
+        useQuery: () => ({ data: undefined }),
+      },
+    },
+  },
+}));
+
+vi.mock("../../copilot-kit/TraceMessage", () => ({
+  TraceMessage: ({ traceId }: { traceId: string }) => (
+    <button data-testid="trace-message" data-trace-id={traceId}>
+      View Trace
+    </button>
+  ),
+}));
 
 const DrawerWrapper = ({ children }: { children: React.ReactNode }) => (
   <ChakraProvider value={defaultSystem}>
@@ -135,6 +158,54 @@ describe("ScenarioRunDetailDrawer", () => {
           screen.getByText("=== Scenario Test Report ==="),
         ).toBeInTheDocument();
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #4138 — post-extraction `input_audio` URL shape, in the DRAWER context.
+  //
+  // The drawer mounts <ScenarioMessageRenderer variant="drawer" /> inside its
+  // Drawer.Content (ScenarioRunDetailDrawer.tsx:386-393). This pins that a
+  // voice turn carrying the post-extraction url shape renders its native
+  // <audio> when composed inside the real Drawer container — the drawer-side
+  // companion to the grid-variant fixture in
+  // ScenarioMessageRenderer.integration.test.tsx.
+  // -------------------------------------------------------------------------
+  describe("ScenarioMessageRenderer (drawer variant) for an input_audio url turn (#4138)", () => {
+    beforeAll(() => {
+      Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it("renders a media-part-audio element whose src is the file url inside the drawer", () => {
+      render(
+        <ScenarioMessageRenderer
+          variant="drawer"
+          projectId="proj_test"
+          messages={[
+            {
+              id: "msg_audio_url_drawer",
+              role: "assistant",
+              content: [
+                {
+                  type: "input_audio",
+                  input_audio: {
+                    url: "/api/files/test-id",
+                    mimeType: "audio/mpeg",
+                  },
+                },
+              ],
+            } as unknown as ScenarioMessageSnapshotEvent["messages"][number],
+          ]}
+        />,
+        { wrapper: DrawerWrapper },
+      );
+
+      const audio = screen.getByTestId("media-part-audio") as HTMLAudioElement;
+      expect(audio).toBeInTheDocument();
+      expect(audio.tagName.toLowerCase()).toBe("audio");
+      expect(audio).toHaveAttribute("src", "/api/files/test-id");
+      expect(audio).toHaveAttribute("controls");
+      expect(screen.queryByText(/input_audio/)).toBeNull();
     });
   });
 });

--- a/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
@@ -52,6 +52,9 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe("ScenarioRunDetailDrawer", () => {
   afterEach(cleanup);
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
 
   describe("ScenarioRunHeader in drawer context", () => {
     describe("given a failed run", () => {
@@ -172,10 +175,6 @@ describe("ScenarioRunDetailDrawer", () => {
   // ScenarioMessageRenderer.integration.test.tsx.
   // -------------------------------------------------------------------------
   describe("ScenarioMessageRenderer (drawer variant) for an input_audio url turn (#4138)", () => {
-    beforeAll(() => {
-      Element.prototype.scrollIntoView = vi.fn();
-    });
-
     it("renders a media-part-audio element whose src is the file url inside the drawer", () => {
       render(
         <ScenarioMessageRenderer

--- a/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
@@ -174,7 +174,7 @@ describe("ScenarioRunDetailDrawer", () => {
   // companion to the grid-variant fixture in
   // ScenarioMessageRenderer.integration.test.tsx.
   // -------------------------------------------------------------------------
-  describe("ScenarioMessageRenderer (drawer variant) for an input_audio url turn (#4138)", () => {
+  describe("when rendering a voice turn with a url-shape audio source in the drawer (#4138)", () => {
     it("renders a media-part-audio element whose src is the file url inside the drawer", () => {
       render(
         <ScenarioMessageRenderer

--- a/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
@@ -10,7 +10,10 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { ScenarioRunStatus, Verdict } from "~/server/scenarios/scenario-event.enums";
+import {
+  ScenarioRunStatus,
+  Verdict,
+} from "~/server/scenarios/scenario-event.enums";
 import type { ScenarioMessageSnapshotEvent } from "~/server/scenarios/scenario-event.types";
 import { Drawer } from "../../ui/drawer";
 import { ScenarioMessageRenderer } from "../ScenarioMessageRenderer";
@@ -64,9 +67,7 @@ describe("ScenarioRunDetailDrawer", () => {
           <ScenarioRunHeader
             name="Echo user request"
             status={ScenarioRunStatus.FAILED}
-            copyableIds={[
-              { label: "Scenario ID", value: "sc-123" },
-            ]}
+            copyableIds={[{ label: "Scenario ID", value: "sc-123" }]}
           />,
           { wrapper: DrawerWrapper },
         );
@@ -110,12 +111,8 @@ describe("ScenarioRunDetailDrawer", () => {
           { wrapper: DrawerWrapper },
         );
 
-        expect(
-          screen.getByText("Scenario ID: sc-123"),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByText("Batch Run ID: br-456"),
-        ).toBeInTheDocument();
+        expect(screen.getByText("Scenario ID: sc-123")).toBeInTheDocument();
+        expect(screen.getByText("Batch Run ID: br-456")).toBeInTheDocument();
         expect(screen.getByText("Run ID: sr-789")).toBeInTheDocument();
       });
     });

--- a/specs/features/scenarios/voice-message-render-regressions.feature
+++ b/specs/features/scenarios/voice-message-render-regressions.feature
@@ -5,7 +5,7 @@ Feature: Voice message rendering regressions in simulation run UI
 
   Background:
     Given I am viewing a simulation run in the run detail drawer
-    And the run's conversation is rendered by ScenarioMessageRenderer in drawer variant
+    And the run's conversation includes voice message turns
 
   # ---------------------------------------------------------------------------
   # #4698 — text-first part ordering must collapse into a single bubble
@@ -29,8 +29,7 @@ Feature: Voice message rendering regressions in simulation run UI
 
   @integration
   Scenario: User-role voice turns align right
-    Given an assistant message contains an audio part and a text transcript part
-    And the message has role "user"
+    Given a user voice message contains an audio part and a text transcript part
     When the renderer paints that turn
     Then the media bubble aligns to the right (user side)
 

--- a/specs/features/scenarios/voice-message-render-regressions.feature
+++ b/specs/features/scenarios/voice-message-render-regressions.feature
@@ -1,0 +1,47 @@
+Feature: Voice message rendering regressions in simulation run UI
+  As a user reviewing a simulation run that includes voice (audio) turns
+  I want voice messages to render correctly regardless of part ordering and role
+  So that I see one bubble per turn with correct alignment and no ghost artifacts
+
+  Background:
+    Given I am viewing a simulation run in the run detail drawer
+    And the run's conversation is rendered by ScenarioMessageRenderer in drawer variant
+
+  # ---------------------------------------------------------------------------
+  # #4698 — text-first part ordering must collapse into a single bubble
+  # The production SDK emits assistant voice turns text-first ([text, input_audio]);
+  # earlier fixtures were audio-first ([input_audio, text]). Both orderings must
+  # collapse into a single left-aligned bubble with the text as the transcript.
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Both part orderings collapse a voice turn into one assistant bubble
+    Given an assistant message contains an audio part and a text transcript part
+    And the parts arrive in either text-first or audio-first order
+    When the renderer paints that turn
+    Then exactly one audio bubble is rendered for the turn
+    And the text appears inside that same bubble as the transcript
+    And the bubble aligns to the left (assistant side)
+
+  # ---------------------------------------------------------------------------
+  # #4698 — alignment inversion: user-role voice turns must align right
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: User-role voice turns align right
+    Given an assistant message contains an audio part and a text transcript part
+    And the message has role "user"
+    When the renderer paints that turn
+    Then the media bubble aligns to the right (user side)
+
+  # ---------------------------------------------------------------------------
+  # #4698 — audio-only assistant turn must not emit an empty transcript node
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Audio-only voice turn renders one bubble with no empty transcript artifact
+    Given an assistant message contains only an audio part with no sibling text
+    When the renderer paints that turn
+    Then exactly one audio bubble is rendered
+    And the bubble aligns to the left (assistant side)
+    And no empty transcript node is rendered inside the bubble


### PR DESCRIPTION
## Why

Closes #4138, Closes #4698

Two render bugs in the simulation message UI needed regression fixtures before they could be considered fixed. Without pinned tests, the same breakage can silently re-emerge:

- **#4138** – `input_audio` messages arriving with a `url` shape (instead of raw bytes) were passed straight through to the renderer as an opaque object, producing a raw blob-dump instead of an `<audio>` element.
- **#4698** – Two separate regressions: (a) the production SDK emits audio+transcript turns **text-first** (`[text, input_audio]`), but the collapse guard only handled **audio-first** order, producing a duplicate bubble; (b) user-role voice turns were incorrectly left-aligned (assistant side) instead of right-aligned (user side); (c) audio-only turns emitted a ghost empty-transcript `<p>` node.

## What changed

- **`ScenarioMessageRenderer.integration.test.tsx`** — New describe blocks cover: url-shape `input_audio` coercion (12 cases), text-first vs audio-first collapse ordering, user-role alignment, and audio-only no-ghost-artifact.
- **`ScenarioRunDetailDrawer.integration.test.tsx`** — Extended with smoke coverage of the drawer mounting the renderer with url-shaped content.
- **`ScenarioMessageRenderer.tsx`** — Added `data-align` test affordance mirroring the `align` prop on media VStacks. Chakra's `align` compiles to an atomic CSS class that jsdom's `getComputedStyle` cannot read; this attribute lets tests assert left/right alignment without CSS evaluation. **No behavior change.**
- **`specs/features/scenarios/voice-message-render-regressions.feature`** — Feature file binding the three new `@scenario` annotations required by the feature-parity CI check.

## How it works

The test affordance (`data-align={item.role === "assistant" ? "flex-start" : "flex-end"}`) mirrors the Chakra `align` prop already present on every media wrapper. Tests use `closest("[data-align]")` to find the wrapper and assert its value. This is the canonical jsdom workaround for Chakra's atomic-CSS compilation.

## Test plan

```bash
cd langwatch
pnpm test:unit src/components/simulations/__tests__/ScenarioMessageRenderer.integration.test.tsx
pnpm test:unit src/components/simulations/__tests__/ScenarioRunDetailDrawer.integration.test.tsx
```

All scenarios pass locally. The feature-parity check (`pnpm check:feature-parity`) passes with the new feature file.

## Anything surprising?

`langwatch-app-ci` shows a pre-existing failure in `ee/licensing/__tests__/licenseGenerationService.unit.test.ts` that also fails on `main` — unrelated to this PR. All other CI checks pass.

## How I can prove I was successful

Ran locally on HEAD `51e310a81b76f7f5f91ac2df9ee1b293e19e6e3f`. Actual `prettyDOM` output from the live test run (not a template):

```html
<!-- #4138 url-shape: what ScenarioMessageRenderer renders for input_audio with url -->
<div
  class="chakra-stack css-5crs4f"
  data-align="flex-start"
>
  <div class="chakra-stack css-1qe2nbt">
    <div class="chakra-stack css-5crs4f">
      <audio
        controls=""
        data-testid="media-part-audio"
        src="/api/files/test-id"
        style="width: 100%; max-width: 400px;"
      />
    </div>
  </div>
</div>
```

`<audio src="/api/files/test-id">` is rendered — not a raw blob dump. All DOM-level assertions PASS:
- `screen.getByTestId("media-part-audio")` → found
- `audio.getAttribute("src")` → `"/api/files/test-id"`
- `wrapper.getAttribute("data-align")` → `"flex-start"` (assistant, left)
- `screen.queryByText(/input_audio/)` → `null` (no raw text leak)

Full verbose run output and #4698 assertions: [prove-it comment](https://github.com/langwatch/langwatch/pull/4717#issuecomment-4711639236)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved simulation voice message rendering so audio parts (including `input_audio` URL payloads) display correctly without leaking raw `input_audio` text.
  * Fixed multi-part voice turns to collapse into a single bubble with correct left/right alignment for both assistant and user roles.

* **Tests**
  * Added integration coverage for media coercion/rendering edge cases and unsupported MIMEType fallbacks.
  * Added regression scenarios validating transcript co-location with audio and deterministic alignment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## 📸 Visual proof — real running app (browser QA)

Re-captured by driving the **actual `ScenarioMessageRenderer` in the booted LangWatch app** — the earlier shots in this PR were an isolated mini-render harness and have been replaced. A voice scenario run was seeded through the real `POST /api/scenario-events` ingestion path, persisted to ClickHouse, read back via `scenarios.getRunState`, and rendered in the live `ScenarioRunDetailDrawer`. A single real conversation exercises every #4138 / #4698 case.

DOM asserted in the running app before capture: **3× native `<audio>` (`media-part-audio`)**, **1× `media-part-binary` download fallback**, alignment **user → `flex-end` / assistant → `flex-start`**, the transcript co-located inside the collapsed turn, and **no raw `input_audio` text leak**.

| Conversation drawer — Light | Conversation drawer — Dark |
|---|---|
| ![real app, light](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4717/real-app/drawer-light.png) | ![real app, dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4717/real-app/drawer-dark.png) |

**What the turns prove**

- **#4138** — each voice turn renders a native `<audio>` player from the url-shape `input_audio` (not a raw blob dump); the unsupported-mimeType part degrades to the `voice-turn.bin` download link rather than a broken `<audio>`.
- **#4698** — the assistant text-first turn (`[text, input_audio]`) collapses into one assistant-left bubble with the text as an italic transcript; the simulated-user voice turn aligns **right**; the audio-only turn shows **no** empty-transcript artifact.

<sub>Full real-app context (sidebar, run grid, open drawer): [light](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4717/real-app/app-context-light.png) · [dark](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4717/real-app/app-context-dark.png)</sub>

<sub>QA-seeding note: the audio `src` is a self-contained playable WAV data-URI so the native players render without provisioning external object storage — this drives the identical renderer url-shape branch (`part.url` → `<audio src>`) as a production `/api/files/<id>` reference.</sub>
