### PR TITLE
fix(aigateway): 14-minute provider timeout + fault-attributed error logging

### DIFF
--- a/services/aigateway/adapters/httpapi/faults.go
+++ b/services/aigateway/adapters/httpapi/faults.go
@@ -1,0 +1,118 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/langwatch/langwatch/pkg/herr"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+// Fault attributes a failed request to who it is on, so operators can alert
+// on error increases and tell customer-caused failures apart from platform
+// problems. Customer faults are still logged (at info) because a spike in
+// them can be a false flag for a platform problem.
+type Fault string
+
+const (
+	// FaultCustomer is caused by the caller: out of credits, invalid key,
+	// bad request, model not allowed, payload too large.
+	FaultCustomer Fault = "customer"
+	// FaultProvider is an upstream LLM provider failure or timeout. A spike
+	// here can also mean a gateway misconfiguration (e.g. a too-low timeout),
+	// so it warrants a look even though the proximate failure is upstream.
+	FaultProvider Fault = "provider"
+	// FaultPlatform is our bug or infrastructure problem.
+	FaultPlatform Fault = "platform"
+)
+
+// level maps fault attribution to log severity: customer→info,
+// provider→warn, platform→error.
+func (f Fault) level() zapcore.Level {
+	switch f {
+	case FaultCustomer:
+		return zapcore.InfoLevel
+	case FaultProvider:
+		return zapcore.WarnLevel
+	default:
+		return zapcore.ErrorLevel
+	}
+}
+
+// faultForUpstreamStatus attributes a provider's HTTP response status:
+// 4xx means the provider rejected this caller (their key, their credits,
+// their request), 5xx or no status (transport failure / timeout) means the
+// provider side failed.
+func faultForUpstreamStatus(status int) Fault {
+	if status >= 400 && status < 500 {
+		return FaultCustomer
+	}
+	return FaultProvider
+}
+
+// faultForCode attributes the gateway's own error codes.
+func faultForCode(code herr.Code) Fault {
+	switch code {
+	case domain.ErrInvalidAPIKey, domain.ErrBudgetExceeded, domain.ErrRateLimited,
+		domain.ErrGuardrailBlocked, domain.ErrPolicyViolation, domain.ErrModelNotAllowed,
+		domain.ErrPayloadTooLarge, domain.ErrBadRequest, domain.ErrNotFound,
+		domain.ErrKeyRevoked:
+		return FaultCustomer
+	case domain.ErrProviderError, domain.ErrProviderTimeout,
+		domain.ErrChainExhausted, domain.ErrCircuitOpen:
+		return FaultProvider
+	default:
+		// internal_error, auth_upstream_unavailable, anything unrecognized.
+		return FaultPlatform
+	}
+}
+
+// logRequestError emits the single stable failure log line CloudWatch metric
+// filters key on: msg="gateway_request_failed" with fault/code/status fields,
+// plus the calling identity when the request was authenticated.
+func logRequestError(logger *zap.Logger, ctx context.Context, fault Fault, code string, status int, message string) {
+	fields := []zap.Field{
+		zap.String("fault", string(fault)),
+		zap.String("code", code),
+		zap.String("message", message),
+	}
+	if status > 0 {
+		fields = append(fields, zap.Int("status", status))
+	}
+	if bundle := BundleFromContext(ctx); bundle != nil {
+		fields = append(fields,
+			zap.String("project_id", bundle.ProjectID),
+			zap.String("organization_id", bundle.OrganizationID),
+			zap.String("virtual_key_id", bundle.VirtualKeyID),
+		)
+	}
+	logger.Log(fault.level(), "gateway_request_failed", fields...)
+}
+
+// logWriteError classifies err and logs it; the single logging choke point
+// for every error response the gateway writes (writeError).
+func logWriteError(logger *zap.Logger, ctx context.Context, err error) {
+	var ue *domain.UpstreamError
+	if errors.As(err, &ue) {
+		status := ue.StatusCode
+		if status <= 0 {
+			status = http.StatusBadGateway
+		}
+		logRequestError(logger, ctx, faultForUpstreamStatus(ue.StatusCode), "upstream_error", status, ue.Message)
+		return
+	}
+	var e herr.E
+	if errors.As(err, &e) {
+		msg := ""
+		if m, ok := e.Meta["message"].(string); ok {
+			msg = m
+		}
+		logRequestError(logger, ctx, faultForCode(e.Code), e.Code.String(), 0, msg)
+		return
+	}
+	logRequestError(logger, ctx, FaultPlatform, "unhandled", 0, err.Error())
+}

--- a/services/aigateway/adapters/httpapi/faults_test.go
+++ b/services/aigateway/adapters/httpapi/faults_test.go
@@ -1,0 +1,102 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/langwatch/langwatch/pkg/herr"
+	"github.com/langwatch/langwatch/services/aigateway/domain"
+)
+
+func observedWriteError(t *testing.T, ctx context.Context, err error) *observer.ObservedLogs {
+	t.Helper()
+	core, logs := observer.New(zapcore.DebugLevel)
+	w := httptest.NewRecorder()
+	writeError(zap.New(core), w, ctx, err)
+	return logs
+}
+
+func requireSingleFailureLog(t *testing.T, logs *observer.ObservedLogs) observer.LoggedEntry {
+	t.Helper()
+	entries := logs.FilterMessage("gateway_request_failed").All()
+	require.Len(t, entries, 1)
+	return entries[0]
+}
+
+// @scenario "A provider error response is logged with provider fault"
+func TestWriteErrorLogsUpstreamServerErrorAsProviderFault(t *testing.T) {
+	logs := observedWriteError(t, context.Background(), &domain.UpstreamError{
+		StatusCode: 504,
+		Message:    "request timed out (default is 30 seconds)",
+	})
+	entry := requireSingleFailureLog(t, logs)
+	assert.Equal(t, zapcore.WarnLevel, entry.Level)
+	fields := entry.ContextMap()
+	assert.Equal(t, "provider", fields["fault"])
+	assert.Equal(t, "upstream_error", fields["code"])
+	assert.Equal(t, int64(504), fields["status"])
+	assert.Contains(t, fields["message"], "timed out")
+}
+
+// @scenario "A customer-caused provider rejection is logged with customer fault"
+func TestWriteErrorLogsUpstreamRejectionAsCustomerFault(t *testing.T) {
+	logs := observedWriteError(t, context.Background(), &domain.UpstreamError{
+		StatusCode: 402,
+		Message:    "credit balance too low",
+	})
+	entry := requireSingleFailureLog(t, logs)
+	assert.Equal(t, zapcore.InfoLevel, entry.Level)
+	assert.Equal(t, "customer", entry.ContextMap()["fault"])
+}
+
+// @scenario "A gateway-classified error is logged by its error code"
+func TestWriteErrorLogsHerrCodesWithTheirFault(t *testing.T) {
+	cases := []struct {
+		code  herr.Code
+		fault string
+		level zapcore.Level
+	}{
+		{domain.ErrBudgetExceeded, "customer", zapcore.InfoLevel},
+		{domain.ErrProviderTimeout, "provider", zapcore.WarnLevel},
+		{domain.ErrInternal, "platform", zapcore.ErrorLevel},
+	}
+	for _, tc := range cases {
+		logs := observedWriteError(t, context.Background(),
+			herr.New(context.Background(), tc.code, herr.M{"message": "boom"}))
+		entry := requireSingleFailureLog(t, logs)
+		assert.Equal(t, tc.level, entry.Level, "code %s", tc.code)
+		fields := entry.ContextMap()
+		assert.Equal(t, tc.fault, fields["fault"], "code %s", tc.code)
+		assert.Equal(t, tc.code.String(), fields["code"])
+	}
+}
+
+// @scenario "An unexpected error is logged with platform fault"
+func TestWriteErrorLogsUnhandledAsPlatformFault(t *testing.T) {
+	logs := observedWriteError(t, context.Background(), errors.New("nil pointer somewhere"))
+	entry := requireSingleFailureLog(t, logs)
+	assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+	assert.Equal(t, "platform", entry.ContextMap()["fault"])
+}
+
+// @scenario "Failure logs identify the calling project"
+func TestWriteErrorLogsCarryBundleIdentity(t *testing.T) {
+	ctx := context.WithValue(context.Background(), bundleCtxKey{}, &domain.Bundle{
+		ProjectID:      "project_x",
+		OrganizationID: "org_y",
+		VirtualKeyID:   "vk_z",
+	})
+	logs := observedWriteError(t, ctx, &domain.UpstreamError{StatusCode: 500, Message: "boom"})
+	fields := requireSingleFailureLog(t, logs).ContextMap()
+	assert.Equal(t, "project_x", fields["project_id"])
+	assert.Equal(t, "org_y", fields["organization_id"])
+	assert.Equal(t, "vk_z", fields["virtual_key_id"])
+}

--- a/services/aigateway/adapters/httpapi/router.go
+++ b/services/aigateway/adapters/httpapi/router.go
@@ -654,6 +654,10 @@ func writeSSE(ctx context.Context, w http.ResponseWriter, iter domain.StreamIter
 // writeError sends a herr directly to the client. For unexpected (non-herr)
 // errors it logs the details and returns a generic internal error.
 func writeError(logger *zap.Logger, w http.ResponseWriter, ctx context.Context, err error) {
+	// Every error response is logged with fault attribution before it is
+	// written, so failures are visible in CloudWatch even when the response
+	// correctly forwards the provider's error to the client.
+	logWriteError(logger, ctx, err)
 	var ue *domain.UpstreamError
 	if errors.As(err, &ue) {
 		writeUpstreamError(w, ue)
@@ -664,7 +668,6 @@ func writeError(logger *zap.Logger, w http.ResponseWriter, ctx context.Context, 
 		herr.WriteHTTP(w, e)
 		return
 	}
-	logger.Error("unhandled error", zap.Error(err))
 	herr.WriteHTTP(w, herr.New(ctx, domain.ErrInternal, nil))
 }
 

--- a/services/aigateway/adapters/providers/bifrost.go
+++ b/services/aigateway/adapters/providers/bifrost.go
@@ -62,8 +62,15 @@ func NewBifrostRouter(ctx context.Context, opts BifrostOptions) (*BifrostRouter,
 	return &BifrostRouter{
 		bf:           bf,
 		logger:       opts.Logger,
-		voyageClient: &http.Client{Timeout: 60 * time.Second},
+		voyageClient: newVoyageClient(),
 	}, nil
+}
+
+// newVoyageClient builds the direct Voyage HTTP client. Shares the
+// gateway-wide request-timeout ceiling so no dispatch path keeps a shorter
+// hidden limit.
+func newVoyageClient() *http.Client {
+	return &http.Client{Timeout: ProviderRequestTimeoutSeconds * time.Second}
 }
 
 // Close releases the underlying Bifrost connection pool. Safe to call
@@ -744,8 +751,24 @@ func (a *account) GetKeysForProvider(ctx context.Context, provider bfschemas.Mod
 	return []bfschemas.Key{key}, nil
 }
 
+// ProviderRequestTimeoutSeconds is the gateway-wide upstream request timeout,
+// applied to every provider. Bifrost's built-in default is 30s, which long
+// LLM completions (reasoning models, large generations) regularly exceed —
+// in prod that surfaced as `upstream error (status 504): request timed out
+// (default is 30 seconds)` on evaluator LLM calls. The gateway's
+// longest-running callers are AWS Lambdas hard-capped at 15 minutes, so 14
+// minutes is the useful ceiling: long enough for any realistic completion,
+// one minute of margin under the caller's cap.
+const ProviderRequestTimeoutSeconds = 14 * 60
+
 func (a *account) GetConfigForProvider(provider bfschemas.ModelProvider) (*bfschemas.ProviderConfig, error) {
 	cfg := &bfschemas.ProviderConfig{}
+	// Whole-gateway timeout ceiling. StreamIdleTimeoutInSeconds gets the
+	// same value: its 60s default is a per-chunk gap limit, and reasoning
+	// models can think for minutes before the first token without emitting
+	// anything.
+	cfg.NetworkConfig.DefaultRequestTimeoutInSeconds = ProviderRequestTimeoutSeconds
+	cfg.NetworkConfig.StreamIdleTimeoutInSeconds = ProviderRequestTimeoutSeconds
 	if proxyURL := os.Getenv("LW_GATEWAY_OUTBOUND_PROXY"); proxyURL != "" {
 		// Debug-only: route outbound provider traffic through an HTTP proxy
 		// (e.g. `http://localhost:8888` for mitmproxy). Lets operators

--- a/services/aigateway/adapters/providers/network_config_test.go
+++ b/services/aigateway/adapters/providers/network_config_test.go
@@ -1,0 +1,38 @@
+package providers
+
+import (
+	"testing"
+	"time"
+
+	bfschemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// @scenario "Upstream requests get a 14 minute timeout for every provider"
+func TestGetConfigForProviderSetsFourteenMinuteRequestTimeout(t *testing.T) {
+	a := &account{}
+	for _, provider := range []bfschemas.ModelProvider{bfschemas.OpenAI, bfschemas.Anthropic, bfschemas.Bedrock} {
+		cfg, err := a.GetConfigForProvider(provider)
+		require.NoError(t, err)
+		assert.Equal(t, 14*60, cfg.NetworkConfig.DefaultRequestTimeoutInSeconds,
+			"provider %s must get the gateway-wide 14m timeout, not bifrost's 30s default", provider)
+	}
+}
+
+// @scenario "Streaming responses tolerate long gaps between chunks"
+func TestGetConfigForProviderAlignsStreamIdleTimeout(t *testing.T) {
+	a := &account{}
+	cfg, err := a.GetConfigForProvider(bfschemas.OpenAI)
+	require.NoError(t, err)
+	assert.Equal(t, 14*60, cfg.NetworkConfig.StreamIdleTimeoutInSeconds,
+		"per-chunk idle timeout must match the request ceiling; the 60s default kills reasoning-model streams that think before the first token")
+	// CheckAndSetDefaults must still fill the knobs we don't pin.
+	assert.NotZero(t, cfg.ConcurrencyAndBufferSize.Concurrency)
+	assert.NotZero(t, cfg.NetworkConfig.RetryBackoffInitial)
+}
+
+// @scenario "Direct embedding requests share the same ceiling"
+func TestVoyageClientSharesTimeoutCeiling(t *testing.T) {
+	assert.Equal(t, 14*60*time.Second, newVoyageClient().Timeout)
+}

--- a/services/aigateway/adapters/providers/network_config_test.go
+++ b/services/aigateway/adapters/providers/network_config_test.go
@@ -12,6 +12,9 @@ import (
 // @scenario "Upstream requests get a 14 minute timeout for every provider"
 func TestGetConfigForProviderSetsFourteenMinuteRequestTimeout(t *testing.T) {
 	a := &account{}
+	// 14*60 is intentionally an independent literal, not the exported
+	// constant: this pins the BEHAVIOR (14 minutes) so a fat-fingered
+	// constant fails here instead of self-verifying.
 	for _, provider := range []bfschemas.ModelProvider{bfschemas.OpenAI, bfschemas.Anthropic, bfschemas.Bedrock} {
 		cfg, err := a.GetConfigForProvider(provider)
 		require.NoError(t, err)
@@ -34,5 +37,8 @@ func TestGetConfigForProviderAlignsStreamIdleTimeout(t *testing.T) {
 
 // @scenario "Direct embedding requests share the same ceiling"
 func TestVoyageClientSharesTimeoutCeiling(t *testing.T) {
-	assert.Equal(t, 14*60*time.Second, newVoyageClient().Timeout)
+	// The contract here is the relationship: the direct Voyage client uses
+	// the same ceiling as the routed providers. The absolute 14m value is
+	// pinned by the request-timeout tests above with independent literals.
+	assert.Equal(t, ProviderRequestTimeoutSeconds*time.Second, newVoyageClient().Timeout)
 }

--- a/services/nlpgo/adapters/httpapi/handler_errors.go
+++ b/services/nlpgo/adapters/httpapi/handler_errors.go
@@ -1,0 +1,53 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/langwatch/langwatch/pkg/clog"
+	"github.com/langwatch/langwatch/pkg/herr"
+	"github.com/langwatch/langwatch/services/nlpgo/domain"
+)
+
+// handlerFault attributes an HTTP-layer failure by its error code:
+// customer (their request/workflow/code) logs at info, platform (our bug or
+// our infrastructure, including the gateway being unreachable) logs at
+// error. Customer faults are still logged because a spike in them can be a
+// false flag for a platform problem. Node-level failures inside a run carry
+// the finer-grained attribution (see app/engine/faults.go); this covers the
+// request envelope.
+func handlerFault(code herr.Code) (string, zapcore.Level) {
+	switch code {
+	case domain.ErrBadRequest, domain.ErrInvalidWorkflow, domain.ErrInvalidDataset,
+		domain.ErrUnsupportedNodeKind, domain.ErrUnauthorized, domain.ErrNotFound,
+		domain.ErrCodeBlockTimeout, domain.ErrSSRFBlocked:
+		return "customer", zapcore.InfoLevel
+	default:
+		// internal_error, idle_timeout, gateway_unavailable, unknown.
+		return "platform", zapcore.ErrorLevel
+	}
+}
+
+// writeHandlerError logs the failure with fault attribution, then writes the
+// herr response. The single choke point for handler error responses so every
+// failed request leaves a log line (herr.WriteHTTP itself does not log). The
+// ctx logger carries project_id, trace_id and origin when the request got far
+// enough to be decoded.
+func writeHandlerError(ctx context.Context, w http.ResponseWriter, e herr.E) {
+	fault, level := handlerFault(e.Code)
+	fields := []zap.Field{
+		zap.String("fault", fault),
+		zap.String("code", e.Code.String()),
+	}
+	if reason, ok := e.Meta["reason"].(string); ok {
+		fields = append(fields, zap.String("reason", reason))
+	}
+	if msg, ok := e.Meta["message"].(string); ok {
+		fields = append(fields, zap.String("message", msg))
+	}
+	clog.Get(ctx).Log(level, "request_failed", fields...)
+	herr.WriteHTTP(w, e)
+}

--- a/services/nlpgo/adapters/httpapi/handler_errors_test.go
+++ b/services/nlpgo/adapters/httpapi/handler_errors_test.go
@@ -1,0 +1,47 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/langwatch/langwatch/pkg/clog"
+	"github.com/langwatch/langwatch/pkg/herr"
+	"github.com/langwatch/langwatch/services/nlpgo/domain"
+)
+
+// @scenario "A failed request is logged before the error response is written"
+func TestWriteHandlerErrorLogsWithFaultAttribution(t *testing.T) {
+	cases := []struct {
+		code  herr.Code
+		fault string
+		level zapcore.Level
+	}{
+		{domain.ErrBadRequest, "customer", zapcore.InfoLevel},
+		{domain.ErrInternal, "platform", zapcore.ErrorLevel},
+	}
+	for _, tc := range cases {
+		core, logs := observer.New(zapcore.DebugLevel)
+		ctx := clog.Set(context.Background(), zap.New(core))
+		w := httptest.NewRecorder()
+
+		writeHandlerError(ctx, w, herr.New(ctx, tc.code, herr.M{"reason": "engine_error"}))
+
+		entries := logs.FilterMessage("request_failed").All()
+		require.Len(t, entries, 1, "code %s", tc.code)
+		assert.Equal(t, tc.level, entries[0].Level)
+		fields := entries[0].ContextMap()
+		assert.Equal(t, tc.fault, fields["fault"])
+		assert.Equal(t, tc.code.String(), fields["code"])
+		assert.Equal(t, "engine_error", fields["reason"])
+		// The herr response still reaches the client.
+		assert.GreaterOrEqual(t, w.Code, http.StatusBadRequest)
+	}
+}

--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -82,7 +82,9 @@ func executeSyncHandler(application *app.App) http.HandlerFunc {
 		result, err := executor.Execute(ctx, *req)
 		if err != nil {
 			span.RecordError(err)
-			writeHandlerError(r.Context(), w, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+			// Use the enriched ctx so the request_failed line carries
+			// project_id / trace_id / origin for per-customer filtering.
+			writeHandlerError(ctx, w, herr.New(ctx, domain.ErrBadRequest, herr.M{
 				"reason": "engine_error",
 			}, err))
 			return
@@ -456,7 +458,7 @@ func executeStreamHandler(application *app.App) http.HandlerFunc {
 		if err != nil {
 			// The SSE error frame reaches the client; this line is the
 			// server-side trail for it (the engine stream failed to start).
-			clog.Get(r.Context()).Error("studio_stream_failed",
+			clog.Get(ctx).Error("studio_stream_failed",
 				zap.String("fault", "platform"), zap.String("message", err.Error()))
 			writeSSE(w, flusher, "error", map[string]any{"message": err.Error()})
 			return

--- a/services/nlpgo/adapters/httpapi/handlers.go
+++ b/services/nlpgo/adapters/httpapi/handlers.go
@@ -53,14 +53,14 @@ func executeSyncHandler(application *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		executor := application.Executor()
 		if executor == nil {
-			herr.WriteHTTP(w, herr.New(r.Context(), domain.ErrInternal, herr.M{
+			writeHandlerError(r.Context(), w, herr.New(r.Context(), domain.ErrInternal, herr.M{
 				"reason": "engine_not_wired",
 			}, errors.New("workflow executor missing from app")))
 			return
 		}
 		body, err := readStudioRequestBody(r, stagedPayloadClient)
 		if err != nil {
-			herr.WriteHTTP(w, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+			writeHandlerError(r.Context(), w, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
 				"reason": "read_body",
 			}, err))
 			return
@@ -68,7 +68,7 @@ func executeSyncHandler(application *app.App) http.HandlerFunc {
 
 		req, herrErr := decodeStudioClientEvent(r, body)
 		if herrErr != nil {
-			herr.WriteHTTP(w, *herrErr)
+			writeHandlerError(r.Context(), w, *herrErr)
 			return
 		}
 		ctx := enrichRequestLogContext(r.Context(), req)
@@ -82,7 +82,7 @@ func executeSyncHandler(application *app.App) http.HandlerFunc {
 		result, err := executor.Execute(ctx, *req)
 		if err != nil {
 			span.RecordError(err)
-			herr.WriteHTTP(w, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+			writeHandlerError(r.Context(), w, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
 				"reason": "engine_error",
 			}, err))
 			return
@@ -326,7 +326,7 @@ func emitStudioControlEvent(w http.ResponseWriter, eventType string) {
 	if !ok {
 		// Same flusher constraint as the main path; surface a
 		// structured error before any 200 OK lands on the wire.
-		herr.WriteHTTP(w, herr.New(context.Background(), domain.ErrInternal, herr.M{
+		writeHandlerError(context.Background(), w, herr.New(context.Background(), domain.ErrInternal, herr.M{
 			"reason": "no_flusher",
 		}, errors.New("response writer does not support flushing")))
 		return
@@ -378,14 +378,14 @@ func executeStreamHandler(application *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		executor := application.Executor()
 		if executor == nil {
-			herr.WriteHTTP(w, herr.New(r.Context(), domain.ErrInternal, herr.M{
+			writeHandlerError(r.Context(), w, herr.New(r.Context(), domain.ErrInternal, herr.M{
 				"reason": "engine_not_wired",
 			}, errors.New("workflow executor missing from app")))
 			return
 		}
 		body, err := readStudioRequestBody(r, stagedPayloadClient)
 		if err != nil {
-			herr.WriteHTTP(w, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
+			writeHandlerError(r.Context(), w, herr.New(r.Context(), domain.ErrBadRequest, herr.M{
 				"reason": "read_body",
 			}, err))
 			return
@@ -410,7 +410,7 @@ func executeStreamHandler(application *app.App) http.HandlerFunc {
 
 		req, herrErr := decodeStudioClientEvent(r, body)
 		if herrErr != nil {
-			herr.WriteHTTP(w, *herrErr)
+			writeHandlerError(r.Context(), w, *herrErr)
 			return
 		}
 		ctx := enrichRequestLogContext(r.Context(), req)
@@ -430,7 +430,7 @@ func executeStreamHandler(application *app.App) http.HandlerFunc {
 			// any Set/WriteHeader call — once 200 OK is on the wire,
 			// herr.WriteHTTP can no longer set a non-2xx status and
 			// the client sees mixed signals.
-			herr.WriteHTTP(w, herr.New(ctx, domain.ErrInternal, herr.M{
+			writeHandlerError(ctx, w, herr.New(ctx, domain.ErrInternal, herr.M{
 				"reason": "no_flusher",
 			}, errors.New("response writer does not support flushing")))
 			return
@@ -454,6 +454,10 @@ func executeStreamHandler(application *app.App) http.HandlerFunc {
 			Heartbeat: streamHeartbeat(r),
 		})
 		if err != nil {
+			// The SSE error frame reaches the client; this line is the
+			// server-side trail for it (the engine stream failed to start).
+			clog.Get(r.Context()).Error("studio_stream_failed",
+				zap.String("fault", "platform"), zap.String("message", err.Error()))
 			writeSSE(w, flusher, "error", map[string]any{"message": err.Error()})
 			return
 		}
@@ -538,7 +542,7 @@ func proxyPassthroughHandler(proxy PlaygroundProxy) http.HandlerFunc {
 		// Fall back to the original 501 stub when the dispatcher isn't
 		// wired (eg. in tests that don't exercise the playground path).
 		return func(w http.ResponseWriter, r *http.Request) {
-			herr.WriteHTTP(w, herr.New(r.Context(), domain.ErrInternal, herr.M{
+			writeHandlerError(r.Context(), w, herr.New(r.Context(), domain.ErrInternal, herr.M{
 				"reason": "gateway_proxy_not_wired",
 				"path":   r.URL.Path,
 			}, errors.New("playground proxy not wired")))

--- a/services/nlpgo/adapters/httpapi/handlers_logging_test.go
+++ b/services/nlpgo/adapters/httpapi/handlers_logging_test.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/langwatch/langwatch/pkg/clog"
 	"github.com/langwatch/langwatch/services/nlpgo/app"
@@ -85,4 +89,74 @@ func TestEnrichRequestLogContext_OmitsAbsentFields(t *testing.T) {
 			t.Errorf("expected %s absent for empty WorkflowRequest, got line %q", key, out)
 		}
 	}
+}
+
+// failingExecutor stubs app.WorkflowExecutor so handler tests can force
+// the sync-execute and stream-start failure paths.
+type failingExecutor struct {
+	execErr   error
+	streamErr error
+}
+
+func (f *failingExecutor) Execute(context.Context, app.WorkflowRequest) (*app.WorkflowResult, error) {
+	return nil, f.execErr
+}
+func (f *failingExecutor) ExecuteStream(context.Context, app.WorkflowRequest, app.WorkflowStreamOptions) (<-chan app.WorkflowStreamEvent, error) {
+	return nil, f.streamErr
+}
+
+const enrichedEventBody = `{"type":"execute_flow","payload":{"trace_id":"trace_abc123","project_id":"proj_acme","origin":"workflow","workflow":{"workflow_id":"wf","nodes":[],"edges":[]}}}`
+
+func observedHandlerRequest(t *testing.T, handler http.HandlerFunc) *observer.ObservedLogs {
+	t.Helper()
+	core, logs := observer.New(zapcore.DebugLevel)
+	req := httptest.NewRequest(http.MethodPost, "/go/studio/execute_sync", strings.NewReader(enrichedEventBody))
+	req = req.WithContext(clog.Set(req.Context(), zap.New(core)))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	return logs
+}
+
+func requireEnrichedFields(t *testing.T, fields map[string]any) {
+	t.Helper()
+	for key, want := range map[string]string{
+		"project_id": "proj_acme",
+		"trace_id":   "trace_abc123",
+		"origin":     "workflow",
+	} {
+		if got := fields[key]; got != want {
+			t.Errorf("%s = %v; want %s (the failure log must carry the enriched request context)", key, got, want)
+		}
+	}
+}
+
+// A sync executor failure must log request_failed on the ENRICHED context:
+// dropping project_id/trace_id/origin would make the line unfilterable to
+// the affected customer/run, defeating the per-customer attribution.
+func TestExecuteSyncHandlerLogsEngineErrorWithEnrichedContext(t *testing.T) {
+	application := app.New(app.WithWorkflowExecutor(&failingExecutor{execErr: errors.New("engine exploded")}))
+	logs := observedHandlerRequest(t, executeSyncHandler(application))
+
+	entries := logs.FilterMessage("request_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("want exactly 1 request_failed log, got %d", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if fields["reason"] != "engine_error" {
+		t.Errorf("reason = %v; want engine_error", fields["reason"])
+	}
+	requireEnrichedFields(t, fields)
+}
+
+// A stream-start failure must log studio_stream_failed on the ENRICHED
+// context for the same reason: it is the server-side trail for the SSE
+// error frame the client sees.
+func TestExecuteStreamHandlerLogsStartFailureWithEnrichedContext(t *testing.T) {
+	application := app.New(app.WithWorkflowExecutor(&failingExecutor{streamErr: errors.New("stream refused to start")}))
+	logs := observedHandlerRequest(t, executeStreamHandler(application))
+
+	entries := logs.FilterMessage("studio_stream_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("want exactly 1 studio_stream_failed log, got %d", len(entries))
+	}
+	requireEnrichedFields(t, entries[0].ContextMap())
 }

--- a/services/nlpgo/adapters/httpapi/playground_proxy.go
+++ b/services/nlpgo/adapters/httpapi/playground_proxy.go
@@ -15,6 +15,9 @@ import (
 	"net/http"
 	"strings"
 
+	"go.uber.org/zap"
+
+	"github.com/langwatch/langwatch/pkg/clog"
 	"github.com/langwatch/langwatch/pkg/herr"
 	"github.com/langwatch/langwatch/services/aigateway/domain"
 	"github.com/langwatch/langwatch/services/nlpgo/adapters/gatewayproxy"
@@ -71,7 +74,7 @@ func playgroundProxyDispatch(proxy PlaygroundProxy) http.HandlerFunc {
 
 		cred, err := gatewayproxy.ParseCredentialFromHeaders(r.Header)
 		if err != nil {
-			herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
+			writeHandlerError(ctx, w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
 				"reason": "missing_provider",
 			}, err))
 			return
@@ -79,7 +82,7 @@ func playgroundProxyDispatch(proxy PlaygroundProxy) http.HandlerFunc {
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
+			writeHandlerError(ctx, w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
 				"reason": "read_body",
 			}, err))
 			return
@@ -89,7 +92,7 @@ func playgroundProxyDispatch(proxy PlaygroundProxy) http.HandlerFunc {
 		// caller to duplicate that information in headers.
 		model, isStream, err := peekBodyMetadata(body)
 		if err != nil {
-			herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
+			writeHandlerError(ctx, w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
 				"reason": "invalid_json_body",
 			}, err))
 			return
@@ -111,7 +114,7 @@ func playgroundProxyDispatch(proxy PlaygroundProxy) http.HandlerFunc {
 		if model != "" && bareModel != model {
 			body, err = rewriteBodyModel(body, bareModel)
 			if err != nil {
-				herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
+				writeHandlerError(ctx, w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
 					"reason": "rewrite_body_model",
 				}, err))
 				return
@@ -131,7 +134,7 @@ func playgroundProxyDispatch(proxy PlaygroundProxy) http.HandlerFunc {
 		if litellm.IsReasoningModel(bareModel) {
 			body, err = applyReasoningOverridesToBody(body, bareModel)
 			if err != nil {
-				herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
+				writeHandlerError(ctx, w, herr.New(ctx, nlpgodomain.ErrBadRequest, herr.M{
 					"reason": "apply_reasoning_overrides",
 				}, err))
 				return
@@ -302,7 +305,7 @@ func classifyPath(urlPath string) (domain.RequestType, string) {
 func handleSync(ctx context.Context, w http.ResponseWriter, proxy PlaygroundProxy, req playgroundProxyRequest) {
 	resp, err := proxy.Dispatch(ctx, req)
 	if err != nil {
-		herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrGatewayUnavailable, herr.M{
+		writeHandlerError(ctx, w, herr.New(ctx, nlpgodomain.ErrGatewayUnavailable, herr.M{
 			"reason": "dispatcher_error",
 		}, err))
 		return
@@ -332,7 +335,7 @@ func handleSync(ctx context.Context, w http.ResponseWriter, proxy PlaygroundProx
 func handleStream(ctx context.Context, w http.ResponseWriter, proxy PlaygroundProxy, req playgroundProxyRequest) {
 	iter, err := proxy.DispatchStream(ctx, req)
 	if err != nil {
-		herr.WriteHTTP(w, herr.New(ctx, nlpgodomain.ErrGatewayUnavailable, herr.M{
+		writeHandlerError(ctx, w, herr.New(ctx, nlpgodomain.ErrGatewayUnavailable, herr.M{
 			"reason": "dispatcher_stream_error",
 		}, err))
 		return
@@ -366,6 +369,8 @@ func handleStream(ctx context.Context, w http.ResponseWriter, proxy PlaygroundPr
 		// Stream errored mid-flight — emit a final event the playground
 		// parser will surface as a banner. We don't set an HTTP status
 		// because headers are already on the wire.
+		clog.Get(ctx).Warn("playground_stream_failed",
+			zap.String("fault", "provider"), zap.String("message", err.Error()))
 		errFrame := fmt.Sprintf("event: error\ndata: %s\n\n", jsonEscape(err.Error()))
 		_, _ = w.Write([]byte(errFrame))
 		if flusher != nil {

--- a/services/nlpgo/adapters/llmexecutor/executor.go
+++ b/services/nlpgo/adapters/llmexecutor/executor.go
@@ -98,6 +98,11 @@ type GatewayHTTPError struct {
 	Headers    map[string]string
 }
 
+// HTTPStatusCode exposes the gateway/provider status for fault
+// classification in the engine without it importing this adapter package
+// (errors.As against a small interface target).
+func (e *GatewayHTTPError) HTTPStatusCode() int { return e.StatusCode }
+
 // Error implements error. Surfaces the upstream provider's message
 // verbatim (parsed out of the OpenAI-shape response body) so the trace
 // drawer and SSE error frame carry the real reason — "You exceeded your

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -250,6 +250,7 @@ func (e *Engine) runLayer(ctx context.Context, req ExecuteRequest, plan *planner
 				ns.Error = derr
 				ns.Error.NodeID = nodeID
 				state.recordError(derr)
+				logNodeFailure(nodeCtx, node, derr)
 			} else {
 				ns.Status = "success"
 				ns.Outputs = outputs
@@ -455,7 +456,15 @@ func (e *Engine) runSignature(ctx context.Context, execReq ExecuteRequest, node 
 	resp, err := e.llm.Execute(llmCtx, req)
 	endLLMSpan(llmSpan, resp, err)
 	if err != nil {
-		return nil, &NodeError{Type: "llm_error", Message: err.Error()}
+		ne := &NodeError{Type: "llm_error", Message: err.Error()}
+		// Thread the upstream HTTP status through for fault attribution
+		// (4xx = caller's key/credits/request, 5xx = provider failure).
+		// Duck-typed so the engine doesn't import the gateway adapter.
+		var hs interface{ HTTPStatusCode() int }
+		if errors.As(err, &hs) {
+			ne.Status = hs.HTTPStatusCode()
+		}
+		return nil, ne
 	}
 	if useStructured {
 		out, warnings := extractSignatureOutputs(resp.Content, node.Data.Outputs)

--- a/services/nlpgo/app/engine/faults.go
+++ b/services/nlpgo/app/engine/faults.go
@@ -1,0 +1,87 @@
+package engine
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/langwatch/langwatch/pkg/clog"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// fault attributes a node failure to who it is on, so operators can alert on
+// error increases and tell customer-caused failures apart from platform
+// problems. Customer faults are still logged (at info) because a spike in
+// them can be a false flag for a platform problem.
+type fault string
+
+const (
+	// faultCustomer: their workflow, dataset, code, endpoint, or provider
+	// account (out of credits, invalid key).
+	faultCustomer fault = "customer"
+	// faultProvider: the upstream LLM provider or evaluator backend failed
+	// or timed out. A spike here can also mean a misconfiguration on our
+	// side (e.g. a too-low gateway timeout), so it warrants a look.
+	faultProvider fault = "provider"
+	// faultPlatform: our bug (engine error, executor not wired).
+	faultPlatform fault = "platform"
+)
+
+// level maps fault attribution to log severity: customer→info,
+// provider→warn, platform→error.
+func (f fault) level() zapcore.Level {
+	switch f {
+	case faultCustomer:
+		return zapcore.InfoLevel
+	case faultProvider:
+		return zapcore.WarnLevel
+	default:
+		return zapcore.ErrorLevel
+	}
+}
+
+// classifyNodeFault attributes a node failure. An upstream HTTP status wins
+// when present (4xx = the upstream rejected this caller, 5xx = the upstream
+// failed); otherwise the NodeError type decides.
+func classifyNodeFault(ne *NodeError) fault {
+	if ne.Status >= 400 && ne.Status < 500 {
+		return faultCustomer
+	}
+	if ne.Status >= 500 {
+		return faultProvider
+	}
+	switch ne.Type {
+	case "invalid_dataset", "invalid_workflow", "unsupported_node_kind",
+		"code_runner_error", "code_block_timeout", "ssrf_blocked",
+		"http_error", "upstream_http_error", "context_canceled":
+		return faultCustomer
+	case "llm_error", "evaluator_error", "agent_workflow_error", "custom_workflow_error":
+		// LLM-dependent blocks without a status failed on the way to or at
+		// the provider (transport error, timeout, malformed response).
+		return faultProvider
+	default:
+		// engine_error, llm_executor_unavailable, anything unrecognized.
+		return faultPlatform
+	}
+}
+
+// logNodeFailure is the single log line every failed node passes through —
+// the stable message CloudWatch metric filters key on. The ctx logger
+// already carries project_id, trace_id and origin (workflow, evaluation,
+// playground, scenario) from the request boundary, so failures are
+// attributable per customer and per surface.
+func logNodeFailure(ctx context.Context, node *dsl.Node, ne *NodeError) {
+	f := classifyNodeFault(ne)
+	fields := []zap.Field{
+		zap.String("fault", string(f)),
+		zap.String("node_id", ne.NodeID),
+		zap.String("node_type", string(node.Type)),
+		zap.String("error_type", ne.Type),
+		zap.String("message", ne.Message),
+	}
+	if ne.Status > 0 {
+		fields = append(fields, zap.Int("upstream_status", ne.Status))
+	}
+	clog.Get(ctx).Log(f.level(), "workflow_node_failed", fields...)
+}

--- a/services/nlpgo/app/engine/faults_test.go
+++ b/services/nlpgo/app/engine/faults_test.go
@@ -1,0 +1,121 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/langwatch/langwatch/pkg/clog"
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
+)
+
+// statusFailingLLM fails every call with an error exposing an upstream HTTP
+// status, mirroring the llmexecutor.GatewayHTTPError duck type.
+type statusFailingLLM struct{ err error }
+
+func (f *statusFailingLLM) Execute(context.Context, app.LLMRequest) (*app.LLMResponse, error) {
+	return nil, f.err
+}
+func (f *statusFailingLLM) ExecuteStream(context.Context, app.LLMRequest) (app.StreamIterator, error) {
+	return nil, f.err
+}
+
+type statusErr struct {
+	msg    string
+	status int
+}
+
+func (e *statusErr) Error() string       { return e.msg }
+func (e *statusErr) HTTPStatusCode() int { return e.status }
+
+func signatureWorkflow() *dsl.Workflow {
+	model := "openai/gpt-5-mini"
+	return &dsl.Workflow{
+		WorkflowID: "wf_faults",
+		APIKey:     "k",
+		DefaultLLM: &dsl.LLMConfig{Model: &model},
+		Nodes: []dsl.Node{
+			{ID: "entry", Type: dsl.ComponentEntry},
+			{ID: "sig", Type: dsl.ComponentSignature, Data: dsl.Component{
+				Inputs:  []dsl.Field{{Identifier: "q", Type: "str"}},
+				Outputs: []dsl.Field{{Identifier: "answer", Type: "str"}},
+			}},
+		},
+		Edges: []dsl.Edge{
+			{Source: "entry", SourceHandle: "outputs.q", Target: "sig", TargetHandle: "inputs.q"},
+		},
+	}
+}
+
+func executeWithObservedLogs(t *testing.T, llmErr error) (*ExecuteResult, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.DebugLevel)
+	ctx := clog.Set(context.Background(), zap.New(core))
+	eng := New(Options{LLM: &statusFailingLLM{err: llmErr}})
+	res, err := eng.Execute(ctx, ExecuteRequest{
+		Workflow: signatureWorkflow(),
+		Inputs:   map[string]any{"q": "hi"},
+		TraceID:  "trace_faults",
+	})
+	require.NoError(t, err)
+	return res, logs
+}
+
+func singleNodeFailureLog(t *testing.T, logs *observer.ObservedLogs) observer.LoggedEntry {
+	t.Helper()
+	entries := logs.FilterMessage("workflow_node_failed").All()
+	require.Len(t, entries, 1)
+	return entries[0]
+}
+
+// @scenario "A failed node is logged with its node and error identity"
+func TestFailedNodeIsLoggedWithIdentity(t *testing.T) {
+	res, logs := executeWithObservedLogs(t, &statusErr{msg: "boom upstream", status: 503})
+	require.Equal(t, "error", res.Status)
+
+	entry := singleNodeFailureLog(t, logs)
+	fields := entry.ContextMap()
+	assert.Equal(t, "sig", fields["node_id"])
+	assert.Equal(t, string(dsl.ComponentSignature), fields["node_type"])
+	assert.Equal(t, "llm_error", fields["error_type"])
+	assert.Contains(t, fields["message"], "boom upstream")
+}
+
+// @scenario "An LLM call rejected by the provider carries the upstream status"
+func TestLLMRejectionCarriesUpstreamStatusAndFault(t *testing.T) {
+	res, logs := executeWithObservedLogs(t, &statusErr{msg: "credit balance too low", status: 402})
+	require.Equal(t, "error", res.Status)
+	require.NotNil(t, res.Error)
+	assert.Equal(t, 402, res.Error.Status, "upstream status must thread into the NodeError")
+
+	entry := singleNodeFailureLog(t, logs)
+	assert.Equal(t, zapcore.InfoLevel, entry.Level, "a 4xx rejection is on the customer")
+	fields := entry.ContextMap()
+	assert.Equal(t, "customer", fields["fault"])
+	assert.Equal(t, int64(402), fields["upstream_status"])
+
+	// And a 5xx is on the provider, at warn.
+	_, logs5 := executeWithObservedLogs(t, &statusErr{msg: "upstream exploded", status: 502})
+	entry5 := singleNodeFailureLog(t, logs5)
+	assert.Equal(t, zapcore.WarnLevel, entry5.Level)
+	assert.Equal(t, "provider", entry5.ContextMap()["fault"])
+}
+
+// @scenario "An engine bug is logged as a platform fault"
+func TestEngineBugClassifiesAsPlatformFault(t *testing.T) {
+	assert.Equal(t, faultPlatform, classifyNodeFault(&NodeError{Type: "engine_error", Message: "nil deref"}))
+	assert.Equal(t, faultPlatform, classifyNodeFault(&NodeError{Type: "llm_executor_unavailable"}))
+	assert.Equal(t, zapcore.ErrorLevel, faultPlatform.level())
+
+	// Customer-shaped inputs stay off the pager.
+	assert.Equal(t, faultCustomer, classifyNodeFault(&NodeError{Type: "invalid_dataset"}))
+	assert.Equal(t, faultCustomer, classifyNodeFault(&NodeError{Type: "code_runner_error"}))
+	// LLM-dependent failures without a status default to provider.
+	assert.Equal(t, faultProvider, classifyNodeFault(&NodeError{Type: "evaluator_error"}))
+}

--- a/services/nlpgo/tests/integration/workflow_llm_bedrock_customer_repro_test.go
+++ b/services/nlpgo/tests/integration/workflow_llm_bedrock_customer_repro_test.go
@@ -139,11 +139,11 @@ func TestSync_RealWorkflowEndToEnd_BedrockCustomerReproVerbatim(t *testing.T) {
 	// one of them somewhere upstream; for this e2e replay we drop top_p
 	// because temperature is the more authoritative knob.
 	llmValue := map[string]any{
-		"model":             "bedrock/" + model,
-		"max_tokens":        8192,
-		"temperature":       1,
-		"reasoning_effort":  "medium",
-		"litellm_params":    litellmParams,
+		"model":            "bedrock/" + model,
+		"max_tokens":       8192,
+		"temperature":      1,
+		"reasoning_effort": "medium",
+		"litellm_params":   litellmParams,
 	}
 
 	// Customer-exact inputs (screenshot 2026-05-31): the failing case is

--- a/specs/ai-gateway/error-observability.feature
+++ b/specs/ai-gateway/error-observability.feature
@@ -1,0 +1,50 @@
+Feature: Gateway errors are logged with fault attribution
+  As an operator of the gateway
+  I want every failed request logged with who the failure is on
+  So that I can alert on error increases before customers report them, and
+    tell customer-caused failures apart from platform problems
+
+  Background:
+    Failures must be visible in logs (picked up by CloudWatch) even when the
+    response correctly forwards the provider's error to the client. Every
+    failure carries a fault attribution:
+      - customer: caused by the caller (out of credits, invalid key, bad
+        request, model not allowed) — logged at info
+      - provider: the upstream LLM provider failed or timed out — logged at
+        warn
+      - platform: our bug or infrastructure problem — logged at error
+    Customer faults are still logged because a spike in them can be a false
+    flag for a platform problem.
+
+    # Bindings: services/aigateway/adapters/httpapi/faults_test.go
+    # Choke point: services/aigateway/adapters/httpapi/router.go (writeError)
+
+  @unit
+  Scenario: A provider error response is logged with provider fault
+    Given the upstream provider returns a server error or times out
+    When the gateway forwards the error to the client
+    Then a warn log records the failure with provider fault, status and message
+
+  @unit
+  Scenario: A customer-caused provider rejection is logged with customer fault
+    Given the upstream provider rejects the request as out of credits or unauthorized
+    When the gateway forwards the rejection to the client
+    Then an info log records the failure with customer fault, status and message
+
+  @unit
+  Scenario: A gateway-classified error is logged by its error code
+    Given the gateway rejects or fails a request with one of its own error codes
+    When the error response is written
+    Then the failure is logged with the fault attribution of that code
+
+  @unit
+  Scenario: An unexpected error is logged with platform fault
+    Given a request fails with an error the gateway does not recognize
+    When the generic internal error is returned
+    Then an error log records the failure with platform fault
+
+  @unit
+  Scenario: Failure logs identify the calling project
+    Given an authenticated request fails
+    When the failure is logged
+    Then the log carries the project, organization and virtual key identifiers

--- a/specs/ai-gateway/provider-request-timeout.feature
+++ b/specs/ai-gateway/provider-request-timeout.feature
@@ -1,0 +1,34 @@
+Feature: Provider request timeout fits slow LLM completions
+  As a user running long LLM completions through the gateway
+  I want the gateway's upstream request timeout to allow slow models to finish
+  So that long evaluations and workflows don't fail with a 504 after 30 seconds
+
+  Background:
+    Bifrost's built-in default request timeout is 30 seconds, which long
+    completions (reasoning models, large generations) regularly exceed. The
+    gateway's longest-running callers are AWS Lambdas hard-capped at 15
+    minutes, so the gateway-wide ceiling is 14 minutes: long enough for any
+    realistic completion, with a one-minute margin under the caller's cap.
+
+    # Bindings: services/aigateway/adapters/providers/network_config_test.go
+    # Sender: services/aigateway/adapters/providers/bifrost.go (account.GetConfigForProvider)
+
+  @unit
+  Scenario: Upstream requests get a 14 minute timeout for every provider
+    Given the gateway builds the connection configuration for any provider
+    When a request is dispatched upstream
+    Then the request timeout is 14 minutes instead of the 30 second default
+
+  @unit
+  Scenario: Streaming responses tolerate long gaps between chunks
+    Given a streaming completion where the model thinks for minutes before the first token
+    When the gateway waits for the next chunk
+    Then the per-chunk idle timeout matches the same 14 minute ceiling
+    # The default 60s idle timeout would kill reasoning-model streams that
+    # emit nothing while thinking.
+
+  @unit
+  Scenario: Direct embedding requests share the same ceiling
+    Given an embeddings request served by the direct (non-routed) client
+    When the request is dispatched
+    Then its client timeout is the same 14 minute ceiling

--- a/specs/nlp-go/error-observability.feature
+++ b/specs/nlp-go/error-observability.feature
@@ -1,0 +1,50 @@
+Feature: Workflow and evaluation failures are logged with fault attribution
+  As an operator of the NLP engine
+  I want every node failure and request failure logged with who it is on
+  So that I can see the errors users face on workflows and evaluations, and
+    alert on increases before customers report them
+
+  Background:
+    Node failures (LLM calls, evaluators, code blocks, HTTP blocks) currently
+    flow to the client as error events with no server-side log line. Every
+    failure gets logged with a fault attribution:
+      - customer: their workflow, dataset, code, endpoint, or provider
+        account (out of credits, invalid key) — logged at info
+      - provider: the upstream LLM provider or evaluator backend failed or
+        timed out — logged at warn
+      - platform: our bug (engine error, executor not wired) — logged at error
+    Customer faults are still logged because a spike in them can be a false
+    flag for a platform problem. Logs inherit the request's project, trace
+    and origin context so failures are attributable per customer and per
+    surface (workflow, evaluation, playground, scenario).
+
+    # Bindings: services/nlpgo/app/engine/faults_test.go,
+    #   services/nlpgo/adapters/httpapi/handler_errors_test.go
+    # Choke points: services/nlpgo/app/engine/engine.go (runLayer),
+    #   services/nlpgo/adapters/httpapi/handlers.go (error responses)
+
+  @unit
+  Scenario: A failed node is logged with its node and error identity
+    Given any workflow or evaluation node fails during a run
+    When the node result is recorded
+    Then a log records the node id, node type, error type and message with a
+      fault attribution
+
+  @unit
+  Scenario: An LLM call rejected by the provider carries the upstream status
+    Given a signature node's LLM call is rejected by the gateway or provider
+    When the node failure is recorded
+    Then the node error carries the upstream HTTP status
+    And the fault is customer for a rejection and provider for a server error
+
+  @unit
+  Scenario: An engine bug is logged as a platform fault
+    Given a node fails because of an engine-side problem
+    When the node failure is recorded
+    Then the failure is logged at error level with platform fault
+
+  @unit
+  Scenario: A failed request is logged before the error response is written
+    Given a workflow or evaluation request fails at the HTTP layer
+    When the error response is written
+    Then the failure is logged with its error code and fault attribution


### PR DESCRIPTION
## What

Two prod gaps around LLM request failures, reported from a customer eval erroring with:

```
gateway chat/completions: upstream error (status 504): request timed out (default is 30 seconds)
```

### 1. Gateway-wide provider request timeout: 30s → 14 minutes

Bifrost's built-in default request timeout is 30 seconds, and the gateway never set its own, so every provider inherited it. Long completions (reasoning models, large generations) regularly exceed 30s. The gateway's longest-running callers are AWS Lambdas hard-capped at 15 minutes, so 14 minutes is the useful ceiling: long enough for any realistic completion, one minute of margin under the caller's cap.

Applied to every provider via `GetConfigForProvider`, plus:
- the stream per-chunk idle timeout (its 60s default would kill reasoning-model streams that think for minutes before the first token), and
- the direct Voyage embeddings client, so no dispatch path keeps a shorter hidden limit.

### 2. Fault-attributed error logging across nlpgo and the gateway

That 504 (and every workflow/evaluation node failure, and every gateway error response) was forwarded to the client with **no server-side log line**, so error increases were invisible until customers reported them. Every failure now leaves a stable log line CloudWatch can alert on, attributed to who it is on:

| fault | meaning | level |
|---|---|---|
| `customer` | their key/credits/request/code/dataset (e.g. out of credits) | info |
| `provider` | upstream LLM provider failed or timed out | warn |
| `platform` | our bug or infrastructure | error |

Customer faults are still logged because a spike in them can be a false flag for a platform problem.

- **Gateway** (`writeError` choke point): `msg=gateway_request_failed` with `fault`, `code`, `status`, `message` plus the calling `project_id` / `organization_id` / `virtual_key_id`.
- **nlpgo node failures** (`runLayer` choke point, covers workflows + evaluations v3 + playground + scenarios): `msg=workflow_node_failed` with `node_id`, `node_type`, `error_type`, `upstream_status` and the request's `project_id` / `trace_id` / `origin`. LLM node errors now thread the upstream HTTP status into `NodeError` (duck-typed so the engine keeps not importing adapters).
- **nlpgo handler errors**: `msg=request_failed` with `fault`, `code`, `reason`; SSE stream-start and playground mid-flight stream errors get their own lines.

Real line from a local run (failing LLM call, quota error):

```json
{"level":"info","msg":"workflow_node_failed","project_id":"project_demo","trace_id":"trace_demo","origin":"evaluation","fault":"customer","node_id":"sig","node_type":"signature","error_type":"llm_error","message":"You exceeded your current quota, please check your plan and billing details","upstream_status":429}
```

## Testing

- `services/aigateway/adapters/providers/network_config_test.go` - 14m default on every provider, stream idle aligned, voyage client ceiling.
- `services/aigateway/adapters/httpapi/faults_test.go` - upstream 5xx → provider/warn, upstream 402 → customer/info, herr codes by their fault, unhandled → platform/error, bundle identity on the log.
- `services/nlpgo/app/engine/faults_test.go` - failed node logged with identity through a real `Execute`, upstream status threading (402 → customer, 502 → provider), engine bugs → platform.
- `services/nlpgo/adapters/httpapi/handler_errors_test.go` - handler errors logged before the response is written.
- Full `go test ./services/aigateway/... ./services/nlpgo/...` green, `go vet` clean, feature-parity 12/12 new scenarios bound (specs: `specs/ai-gateway/provider-request-timeout.feature`, `specs/ai-gateway/error-observability.feature`, `specs/nlp-go/error-observability.feature`).

Post-deploy: CloudWatch metric filters can key on `gateway_request_failed` / `workflow_node_failed` / `request_failed` and the `fault` field to alert on increases before customers report.

## Deployment Impact

- **aigateway**: needs an image rebuild + redeploy for the timeout and logging to take effect (both are compile-time changes; no env vars or config to set).
- **nlpgo**: per-project Lambdas pick the change up through the normal lazy image rollout once the next image is baked and applied; no manual action.
- No env var changes, no schema changes, no migrations, no infra changes.
- Follow-up op (not in this PR): add CloudWatch metric filters/alarms on `gateway_request_failed` / `workflow_node_failed` / `request_failed` keyed by the `fault` field to catch error increases before customer reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized fault attribution for request and node failures (customer/provider/platform) with consistent log levels and enriched request/context fields.
  * Unified error-response paths to ensure stable, structured failure logs and propagation of upstream status where available.

* **Tests**
  * Added comprehensive unit and engine tests validating fault classification, log contents, and context propagation.

* **Chores**
  * Standardized upstream/provider request timeout to a 14-minute ceiling.

* **Documentation**
  * Added BDD specs for error observability and provider-request-timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->