### PR TITLE
feat(billing): provision org retention policy on paid customers

### DIFF
--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -19,7 +19,10 @@ vi.mock("../../../src/server/app-layer/app", () => ({
 }));
 
 import { SubscriptionStatus } from "../planTypes";
-import { PLATFORM_DEFAULT_RETENTION_DAYS } from "../../../src/server/data-retention/retentionPolicy.schema";
+import {
+  PLATFORM_DEFAULT_RETENTION_DAYS,
+  RETENTION_CATEGORIES,
+} from "../../../src/server/data-retention/retentionPolicy.schema";
 import { EEWebhookService } from "../services/webhookService";
 import type { SubscriptionRepository, SubscriptionWithOrg } from "../../../src/server/app-layer/subscription/subscription.repository";
 import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
@@ -442,8 +445,8 @@ describe("webhookService", () => {
         expect(mockSendSlackSubscriptionEvent).toHaveBeenCalled();
       });
 
-      /** @scenario A first paid Growth Seat activation provisions the organization policy */
-      it("provisions an organization-scoped traces retention policy at the platform default", async () => {
+      /** @scenario A first paid Growth Seat activation provisions the organization policies */
+      it("provisions an organization-scoped retention policy for every category at the platform default", async () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
         );
@@ -459,11 +462,14 @@ describe("webhookService", () => {
         await vi.advanceTimersByTimeAsync(2000);
         await promise;
 
-        expect(mockSetForScope).toHaveBeenCalledWith({
-          scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
-          category: "traces",
-          retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
-        });
+        for (const category of RETENTION_CATEGORIES) {
+          expect(mockSetForScope).toHaveBeenCalledWith({
+            scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
+            category,
+            retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
+          });
+        }
+        expect(mockSetForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
       });
 
       /** @scenario A retention failure never fails the billing webhook */
@@ -901,10 +907,13 @@ describe("webhookService", () => {
         await vi.advanceTimersByTimeAsync(2000);
         await promise;
 
-        expect(mockRemoveForScope).toHaveBeenCalledWith({
-          scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
-          category: "traces",
-        });
+        for (const category of RETENTION_CATEGORIES) {
+          expect(mockRemoveForScope).toHaveBeenCalledWith({
+            scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
+            category,
+          });
+        }
+        expect(mockRemoveForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
       });
 
       /** @scenario A retention failure never fails the billing webhook */
@@ -1160,10 +1169,13 @@ describe("webhookService", () => {
         await promise;
 
         expect(subRepo.cancel).toHaveBeenCalledWith({ id: "sub_db_1" });
-        expect(mockRemoveForScope).toHaveBeenCalledWith({
-          scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
-          category: "traces",
-        });
+        for (const category of RETENTION_CATEGORIES) {
+          expect(mockRemoveForScope).toHaveBeenCalledWith({
+            scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
+            category,
+          });
+        }
+        expect(mockRemoveForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
       });
     });
   });

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -892,9 +892,11 @@ describe("webhookService", () => {
       });
     });
 
+    // Removal-on-cancellation is deactivated until the
+    // paid-retention feature is released.
     describe("when no active subscription remains", () => {
-      /** @scenario Cancelling the last active subscription removes the organization policies */
-      it("removes the organization-scoped traces retention policy", async () => {
+      /** @scenario Cancelling a subscription leaves the retention policies in place */
+      it("does not remove the organization retention policies (removal deactivated)", async () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
         );
@@ -905,54 +907,9 @@ describe("webhookService", () => {
         });
 
         await vi.advanceTimersByTimeAsync(2000);
-        await promise;
-
-        for (const category of RETENTION_CATEGORIES) {
-          expect(mockRemoveForScope).toHaveBeenCalledWith({
-            scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
-            category,
-          });
-        }
-        expect(mockRemoveForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
-      });
-
-      /** @scenario A retention failure never fails the billing webhook */
-      it("still cancels when retention removal throws", async () => {
-        subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
-        );
-        subRepo.findLastNonCancelled.mockResolvedValue(null);
-        mockRemoveForScope.mockRejectedValueOnce(new Error("retention store down"));
-
-        const promise = service.handleSubscriptionDeleted({
-          stripeSubscriptionId: "sub_stripe_1",
-        });
-
-        await vi.advanceTimersByTimeAsync(2000);
-        // Should not throw — retention failure is swallowed
         await promise;
 
         expect(subRepo.cancel).toHaveBeenCalledWith({ id: "sub_db_1" });
-      });
-    });
-
-    describe("when another active subscription remains", () => {
-      /** @scenario Cancelling one of several subscriptions keeps the policies */
-      it("leaves the organization retention policy in place", async () => {
-        subRepo.findByStripeId.mockResolvedValue(
-          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
-        );
-        subRepo.findLastNonCancelled.mockResolvedValue(
-          makeSubscription({ id: "sub_db_2", status: SubscriptionStatus.ACTIVE }),
-        );
-
-        const promise = service.handleSubscriptionDeleted({
-          stripeSubscriptionId: "sub_stripe_1",
-        });
-
-        await vi.advanceTimersByTimeAsync(2000);
-        await promise;
-
         expect(mockRemoveForScope).not.toHaveBeenCalled();
       });
     });
@@ -1148,9 +1105,11 @@ describe("webhookService", () => {
       });
     });
 
+    // Removal-on-cancellation is deactivated until the
+    // paid-retention feature is released.
     describe("when a cancel-by-update leaves no active subscription", () => {
-      /** @scenario Cancelling the last active subscription removes the organization policies */
-      it("removes the organization-scoped traces retention policy", async () => {
+      /** @scenario Cancelling a subscription leaves the retention policies in place */
+      it("does not remove the organization retention policies (removal deactivated)", async () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
         );
@@ -1169,13 +1128,7 @@ describe("webhookService", () => {
         await promise;
 
         expect(subRepo.cancel).toHaveBeenCalledWith({ id: "sub_db_1" });
-        for (const category of RETENTION_CATEGORIES) {
-          expect(mockRemoveForScope).toHaveBeenCalledWith({
-            scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
-            category,
-          });
-        }
-        expect(mockRemoveForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
+        expect(mockRemoveForScope).not.toHaveBeenCalled();
       });
     });
   });

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -1,16 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSendSlackSubscriptionEvent = vi.fn().mockResolvedValue(undefined);
+const mockSetForScope = vi.fn().mockResolvedValue(undefined);
+const mockRemoveForScope = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("../../../src/server/app-layer/app", () => ({
   getApp: () => ({
     notifications: {
       sendSlackSubscriptionEvent: mockSendSlackSubscriptionEvent,
     },
+    dataRetention: {
+      policy: {
+        setForScope: mockSetForScope,
+        removeForScope: mockRemoveForScope,
+      },
+    },
   }),
 }));
 
 import { SubscriptionStatus } from "../planTypes";
+import { PLATFORM_DEFAULT_RETENTION_DAYS } from "../../../src/server/data-retention/retentionPolicy.schema";
 import { EEWebhookService } from "../services/webhookService";
 import type { SubscriptionRepository, SubscriptionWithOrg } from "../../../src/server/app-layer/subscription/subscription.repository";
 import type { OrganizationRepository } from "../../../src/server/app-layer/organizations/repositories/organization.repository";
@@ -432,6 +441,96 @@ describe("webhookService", () => {
 
         expect(mockSendSlackSubscriptionEvent).toHaveBeenCalled();
       });
+
+      /** @scenario A first paid Growth Seat activation provisions the organization policy */
+      it("provisions an organization-scoped traces retention policy at the platform default", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.migrateToSeatEvent.mockResolvedValue([]);
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSetForScope).toHaveBeenCalledWith({
+          scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
+          category: "traces",
+          retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
+        });
+      });
+
+      /** @scenario A retention failure never fails the billing webhook */
+      it("still activates and notifies when retention provisioning throws", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.migrateToSeatEvent.mockResolvedValue([]);
+        mockSetForScope.mockRejectedValueOnce(new Error("retention store down"));
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        // Should not throw — retention failure is swallowed
+        await promise;
+
+        expect(mockSendSlackSubscriptionEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "confirmed", organizationId: "org_123" }),
+        );
+      });
+    });
+
+    describe("when subscription is a non-seat plan", () => {
+      /** @scenario A non-seat plan does not provision a policy */
+      it("does not provision a retention policy on first activation", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.PENDING, plan: "LAUNCH" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "LAUNCH" }),
+        );
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSetForScope).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when an active seat subscription renews", () => {
+      /** @scenario A renewal does not re-provision the policy */
+      it("does not re-provision the retention policy", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.activate.mockResolvedValue(
+          makeSubscriptionWithOrg({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+
+        const promise = service.handleInvoicePaymentSucceeded({
+          subscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockSetForScope).not.toHaveBeenCalled();
+      });
     });
 
     describe("when subscription is already CANCELLED in DB and Stripe subscription is canceled", () => {
@@ -786,6 +885,68 @@ describe("webhookService", () => {
         expect(subRepo.cancel).toHaveBeenCalledWith({ id: "sub_db_1" });
       });
     });
+
+    describe("when no active subscription remains", () => {
+      /** @scenario Cancelling the last active subscription removes the organization policy */
+      it("removes the organization-scoped traces retention policy", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.findLastNonCancelled.mockResolvedValue(null);
+
+        const promise = service.handleSubscriptionDeleted({
+          stripeSubscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockRemoveForScope).toHaveBeenCalledWith({
+          scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
+          category: "traces",
+        });
+      });
+
+      /** @scenario A retention failure never fails the billing webhook */
+      it("still cancels when retention removal throws", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.findLastNonCancelled.mockResolvedValue(null);
+        mockRemoveForScope.mockRejectedValueOnce(new Error("retention store down"));
+
+        const promise = service.handleSubscriptionDeleted({
+          stripeSubscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        // Should not throw — retention failure is swallowed
+        await promise;
+
+        expect(subRepo.cancel).toHaveBeenCalledWith({ id: "sub_db_1" });
+      });
+    });
+
+    describe("when another active subscription remains", () => {
+      /** @scenario Cancelling one of several subscriptions keeps the policy */
+      it("leaves the organization retention policy in place", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.findLastNonCancelled.mockResolvedValue(
+          makeSubscription({ id: "sub_db_2", status: SubscriptionStatus.ACTIVE }),
+        );
+
+        const promise = service.handleSubscriptionDeleted({
+          stripeSubscriptionId: "sub_stripe_1",
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(mockRemoveForScope).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("handleSubscriptionUpdated()", () => {
@@ -975,6 +1136,34 @@ describe("webhookService", () => {
         await promise;
 
         expect(mockSendSlackSubscriptionEvent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when a cancel-by-update leaves no active subscription", () => {
+      /** @scenario Cancelling the last active subscription removes the organization policy */
+      it("removes the organization-scoped traces retention policy", async () => {
+        subRepo.findByStripeId.mockResolvedValue(
+          makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
+        );
+        subRepo.findLastNonCancelled.mockResolvedValue(null);
+
+        const promise = service.handleSubscriptionUpdated({
+          subscription: {
+            id: "sub_stripe_1",
+            status: "canceled",
+            ended_at: 1234567890,
+            items: { data: [] },
+          } as any,
+        });
+
+        await vi.advanceTimersByTimeAsync(2000);
+        await promise;
+
+        expect(subRepo.cancel).toHaveBeenCalledWith({ id: "sub_db_1" });
+        expect(mockRemoveForScope).toHaveBeenCalledWith({
+          scope: { scopeType: "ORGANIZATION", scopeId: "org_123" },
+          category: "traces",
+        });
       });
     });
   });

--- a/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
+++ b/langwatch/ee/billing/__tests__/webhookService.unit.test.ts
@@ -893,7 +893,7 @@ describe("webhookService", () => {
     });
 
     describe("when no active subscription remains", () => {
-      /** @scenario Cancelling the last active subscription removes the organization policy */
+      /** @scenario Cancelling the last active subscription removes the organization policies */
       it("removes the organization-scoped traces retention policy", async () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
@@ -937,7 +937,7 @@ describe("webhookService", () => {
     });
 
     describe("when another active subscription remains", () => {
-      /** @scenario Cancelling one of several subscriptions keeps the policy */
+      /** @scenario Cancelling one of several subscriptions keeps the policies */
       it("leaves the organization retention policy in place", async () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),
@@ -1149,7 +1149,7 @@ describe("webhookService", () => {
     });
 
     describe("when a cancel-by-update leaves no active subscription", () => {
-      /** @scenario Cancelling the last active subscription removes the organization policy */
+      /** @scenario Cancelling the last active subscription removes the organization policies */
       it("removes the organization-scoped traces retention policy", async () => {
         subRepo.findByStripeId.mockResolvedValue(
           makeSubscription({ status: SubscriptionStatus.ACTIVE, plan: "GROWTH_SEAT_EUR_MONTHLY" }),

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -16,7 +16,10 @@ import { isGrowthEventsPrice, isGrowthSeatEventPlan, isGrowthSeatPrice } from ".
 import { SubscriptionRecordNotFoundError } from "../errors";
 import { traced } from "../../../src/server/app-layer/tracing";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
-import { PLATFORM_DEFAULT_RETENTION_DAYS } from "../../../src/server/data-retention/retentionPolicy.schema";
+import {
+  PLATFORM_DEFAULT_RETENTION_DAYS,
+  RETENTION_CATEGORIES,
+} from "../../../src/server/data-retention/retentionPolicy.schema";
 
 const logger = createLogger("langwatch:billing:webhookService");
 
@@ -847,54 +850,61 @@ export class EEWebhookService implements WebhookService {
   }
 
   /**
-   * A paid Growth-Seat subscription entitles the organization to an explicit
-   * organization-scoped traces retention policy at the platform default window
-   * (49 days / 7 weeks). We stamp it on first activation so the entitlement is
-   * recorded rather than implied: an org with no override silently follows the
-   * platform default and would drift down if that default were ever lowered,
-   * whereas an explicit override holds the window. Today the value equals the
-   * platform default, so this has no observable effect yet — it is the
-   * mechanism the paid retention tier hangs off once the default diverges.
+   * A paid Growth-Seat subscription entitles the organization to explicit
+   * organization-scoped retention policies — one per category (traces,
+   * scenarios, experiments; evaluation runs live under traces, simulation runs
+   * under scenarios) — at the platform default window (49 days / 7 weeks). We
+   * stamp them on first activation so the entitlement is recorded rather than
+   * implied: an org with no override silently follows the platform default and
+   * would drift down if that default were ever lowered, whereas explicit
+   * overrides hold the window. Today the value equals the platform default, so
+   * this has no observable effect yet — it is the mechanism the paid retention
+   * tier hangs off once the default diverges.
    *
-   * Idempotent (upsert on scope + category) and best-effort: a retention
-   * failure must never fail the Stripe webhook — that would leave the
-   * subscription stuck PENDING and trigger Stripe retries — so we log and
-   * swallow, mirroring the surrounding notification side effects.
+   * Each category is upserted independently (idempotent on scope + category)
+   * and best-effort: a retention failure must never fail the Stripe webhook —
+   * that would leave the subscription stuck PENDING and trigger Stripe retries —
+   * so we log and continue to the next category, mirroring the surrounding
+   * notification side effects.
    */
   private async applySeatRetentionPolicy(organizationId: string): Promise<void> {
-    try {
-      await getApp().dataRetention.policy.setForScope({
-        scope: { scopeType: "ORGANIZATION", scopeId: organizationId },
-        category: "traces",
-        retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
-      });
-    } catch (err) {
-      logger.error(
-        { organizationId, err },
-        "[stripeWebhook] Failed to apply seat retention policy",
-      );
+    for (const category of RETENTION_CATEGORIES) {
+      try {
+        await getApp().dataRetention.policy.setForScope({
+          scope: { scopeType: "ORGANIZATION", scopeId: organizationId },
+          category,
+          retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
+        });
+      } catch (err) {
+        logger.error(
+          { organizationId, category, err },
+          "[stripeWebhook] Failed to apply seat retention policy",
+        );
+      }
     }
   }
 
   /**
    * Mirror of {@link applySeatRetentionPolicy}: once an organization has no
-   * active subscription left, drop the organization-scoped traces override so
-   * retention reverts to the platform default. Callers must only invoke this
-   * after confirming no active subscription remains (a still-paying org keeps
-   * its window). Idempotent (no-op when no override exists) and best-effort for
-   * the same reason as provisioning.
+   * active subscription left, drop every organization-scoped override (one per
+   * category) so retention reverts to the platform default. Callers must only
+   * invoke this after confirming no active subscription remains (a still-paying
+   * org keeps its window). Idempotent (no-op when no override exists) and
+   * best-effort, per category, for the same reason as provisioning.
    */
   private async removeSeatRetentionPolicy(organizationId: string): Promise<void> {
-    try {
-      await getApp().dataRetention.policy.removeForScope({
-        scope: { scopeType: "ORGANIZATION", scopeId: organizationId },
-        category: "traces",
-      });
-    } catch (err) {
-      logger.error(
-        { organizationId, err },
-        "[stripeWebhook] Failed to remove seat retention policy",
-      );
+    for (const category of RETENTION_CATEGORIES) {
+      try {
+        await getApp().dataRetention.policy.removeForScope({
+          scope: { scopeType: "ORGANIZATION", scopeId: organizationId },
+          category,
+        });
+      } catch (err) {
+        logger.error(
+          { organizationId, category, err },
+          "[stripeWebhook] Failed to remove seat retention policy",
+        );
+      }
     }
   }
 

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -857,7 +857,8 @@ export class EEWebhookService implements WebhookService {
    * would drift down if that default were ever lowered, whereas explicit
    * overrides hold the window. Today the value equals the platform default, so
    * this has no observable effect yet — it is the mechanism the paid retention
-   * tier hangs off once the default diverges.
+   * tier hangs off once the default diverges. TODO(#4745): per-plan windows
+   * below the 49-day floor (the pricing page's 14d/30d tiers).
    *
    * Each category is upserted independently (idempotent on scope + category)
    * and best-effort: a retention failure must never fail the Stripe webhook —

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -857,8 +857,10 @@ export class EEWebhookService implements WebhookService {
    * would drift down if that default were ever lowered, whereas explicit
    * overrides hold the window. Today the value equals the platform default, so
    * this has no observable effect yet — it is the mechanism the paid retention
-   * tier hangs off once the default diverges. TODO(#4745): per-plan windows
-   * below the 49-day floor (the pricing page's 14d/30d tiers).
+   * tier hangs off once the default diverges. The 49-day window is deliberate:
+   * pricing tiers are visibility (blur) thresholds on top of it, not shorter
+   * deletion windows — free-tier content blurs after 14d but stays recoverable
+   * until the 49d policy deletes it. TODO(#4745): the blur layer.
    *
    * Each category is upserted independently (idempotent on scope + category)
    * and best-effort: a retention failure must never fail the Stripe webhook —

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -16,6 +16,7 @@ import { isGrowthEventsPrice, isGrowthSeatEventPlan, isGrowthSeatPrice } from ".
 import { SubscriptionRecordNotFoundError } from "../errors";
 import { traced } from "../../../src/server/app-layer/tracing";
 import { fireSubscriptionSyncNurturing } from "../nurturing/hooks/subscriptionSync";
+import { PLATFORM_DEFAULT_RETENTION_DAYS } from "../../../src/server/data-retention/retentionPolicy.schema";
 
 const logger = createLogger("langwatch:billing:webhookService");
 
@@ -617,6 +618,10 @@ export class EEWebhookService implements WebhookService {
       organizationId: existingSubscription.organizationId,
       hasSubscription: !!remainingActive,
     });
+
+    if (!remainingActive) {
+      await this.removeSeatRetentionPolicy(existingSubscription.organizationId);
+    }
   }
 
   async handleSubscriptionUpdated({
@@ -655,6 +660,10 @@ export class EEWebhookService implements WebhookService {
         organizationId: existingSubForUpdate.organizationId,
         hasSubscription: !!remainingActive,
       });
+
+      if (!remainingActive) {
+        await this.removeSeatRetentionPolicy(existingSubForUpdate.organizationId);
+      }
     } else if (subscription.status === "active") {
       const shouldNotify =
         existingSubForUpdate.status !== SubscriptionStatus.ACTIVE;
@@ -815,6 +824,8 @@ export class EEWebhookService implements WebhookService {
             }
           }
         }
+
+        await this.applySeatRetentionPolicy(updatedSubscription.organizationId);
       }
 
       await getApp().notifications.sendSlackSubscriptionEvent({
@@ -832,6 +843,58 @@ export class EEWebhookService implements WebhookService {
         organizationId: updatedSubscription.organizationId,
         hasSubscription: true,
       });
+    }
+  }
+
+  /**
+   * A paid Growth-Seat subscription entitles the organization to an explicit
+   * organization-scoped traces retention policy at the platform default window
+   * (49 days / 7 weeks). We stamp it on first activation so the entitlement is
+   * recorded rather than implied: an org with no override silently follows the
+   * platform default and would drift down if that default were ever lowered,
+   * whereas an explicit override holds the window. Today the value equals the
+   * platform default, so this has no observable effect yet — it is the
+   * mechanism the paid retention tier hangs off once the default diverges.
+   *
+   * Idempotent (upsert on scope + category) and best-effort: a retention
+   * failure must never fail the Stripe webhook — that would leave the
+   * subscription stuck PENDING and trigger Stripe retries — so we log and
+   * swallow, mirroring the surrounding notification side effects.
+   */
+  private async applySeatRetentionPolicy(organizationId: string): Promise<void> {
+    try {
+      await getApp().dataRetention.policy.setForScope({
+        scope: { scopeType: "ORGANIZATION", scopeId: organizationId },
+        category: "traces",
+        retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
+      });
+    } catch (err) {
+      logger.error(
+        { organizationId, err },
+        "[stripeWebhook] Failed to apply seat retention policy",
+      );
+    }
+  }
+
+  /**
+   * Mirror of {@link applySeatRetentionPolicy}: once an organization has no
+   * active subscription left, drop the organization-scoped traces override so
+   * retention reverts to the platform default. Callers must only invoke this
+   * after confirming no active subscription remains (a still-paying org keeps
+   * its window). Idempotent (no-op when no override exists) and best-effort for
+   * the same reason as provisioning.
+   */
+  private async removeSeatRetentionPolicy(organizationId: string): Promise<void> {
+    try {
+      await getApp().dataRetention.policy.removeForScope({
+        scope: { scopeType: "ORGANIZATION", scopeId: organizationId },
+        category: "traces",
+      });
+    } catch (err) {
+      logger.error(
+        { organizationId, err },
+        "[stripeWebhook] Failed to remove seat retention policy",
+      );
     }
   }
 

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -622,9 +622,11 @@ export class EEWebhookService implements WebhookService {
       hasSubscription: !!remainingActive,
     });
 
-    if (!remainingActive) {
-      await this.removeSeatRetentionPolicy(existingSubscription.organizationId);
-    }
+    // Retention-policy removal on cancellation is deactivated until
+    // the paid-retention feature is released. Re-enable by restoring this call.
+    // if (!remainingActive) {
+    //   await this.removeSeatRetentionPolicy(existingSubscription.organizationId);
+    // }
   }
 
   async handleSubscriptionUpdated({
@@ -664,9 +666,11 @@ export class EEWebhookService implements WebhookService {
         hasSubscription: !!remainingActive,
       });
 
-      if (!remainingActive) {
-        await this.removeSeatRetentionPolicy(existingSubForUpdate.organizationId);
-      }
+      // Retention-policy removal on cancellation is deactivated until
+      // the paid-retention feature is released. Re-enable by restoring this call.
+      // if (!remainingActive) {
+      //   await this.removeSeatRetentionPolicy(existingSubForUpdate.organizationId);
+      // }
     } else if (subscription.status === "active") {
       const shouldNotify =
         existingSubForUpdate.status !== SubscriptionStatus.ACTIVE;

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -622,11 +622,8 @@ export class EEWebhookService implements WebhookService {
       hasSubscription: !!remainingActive,
     });
 
-    // Retention-policy removal on cancellation is deactivated until
-    // the paid-retention feature is released. Re-enable by restoring this call.
-    // if (!remainingActive) {
-    //   await this.removeSeatRetentionPolicy(existingSubscription.organizationId);
-    // }
+    // Cancellation deliberately leaves the org's retention policies in place
+    // until the paid-retention feature is released.
   }
 
   async handleSubscriptionUpdated({
@@ -666,11 +663,8 @@ export class EEWebhookService implements WebhookService {
         hasSubscription: !!remainingActive,
       });
 
-      // Retention-policy removal on cancellation is deactivated until
-      // the paid-retention feature is released. Re-enable by restoring this call.
-      // if (!remainingActive) {
-      //   await this.removeSeatRetentionPolicy(existingSubForUpdate.organizationId);
-      // }
+      // Cancellation deliberately leaves the org's retention policies in place
+      // until the paid-retention feature is released.
     } else if (subscription.status === "active") {
       const shouldNotify =
         existingSubForUpdate.status !== SubscriptionStatus.ACTIVE;
@@ -883,30 +877,6 @@ export class EEWebhookService implements WebhookService {
         logger.error(
           { organizationId, category, err },
           "[stripeWebhook] Failed to apply seat retention policy",
-        );
-      }
-    }
-  }
-
-  /**
-   * Mirror of {@link applySeatRetentionPolicy}: once an organization has no
-   * active subscription left, drop every organization-scoped override (one per
-   * category) so retention reverts to the platform default. Callers must only
-   * invoke this after confirming no active subscription remains (a still-paying
-   * org keeps its window). Idempotent (no-op when no override exists) and
-   * best-effort, per category, for the same reason as provisioning.
-   */
-  private async removeSeatRetentionPolicy(organizationId: string): Promise<void> {
-    for (const category of RETENTION_CATEGORIES) {
-      try {
-        await getApp().dataRetention.policy.removeForScope({
-          scope: { scopeType: "ORGANIZATION", scopeId: organizationId },
-          category,
-        });
-      } catch (err) {
-        logger.error(
-          { organizationId, category, err },
-          "[stripeWebhook] Failed to remove seat retention policy",
         );
       }
     }

--- a/langwatch/ee/licensing/__tests__/licenseHandler.retention.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/licenseHandler.retention.unit.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSetForScope = vi.fn().mockResolvedValue(undefined);
+const mockListOrganizationRules = vi.fn().mockResolvedValue([]);
+
+vi.mock("../../../src/server/app-layer/app", () => ({
+  getApp: () => ({
+    dataRetention: {
+      policy: {
+        setForScope: mockSetForScope,
+        listOrganizationRules: mockListOrganizationRules,
+      },
+    },
+  }),
+}));
+
+import type { PrismaClient } from "@prisma/client";
+import {
+  PLATFORM_DEFAULT_RETENTION_DAYS,
+  RETENTION_CATEGORIES,
+} from "../../../src/server/data-retention/retentionPolicy.schema";
+import { LicenseHandler } from "../licenseHandler";
+import type { ILicenseEnforcementRepository } from "~/server/license-enforcement/license-enforcement.repository";
+import {
+  VALID_LICENSE_KEY,
+  EXPIRED_LICENSE_KEY,
+} from "./fixtures/testLicenses";
+import { TEST_PUBLIC_KEY } from "./fixtures/testKeys";
+
+const ORG_ID = "org_123";
+
+const createMockPrisma = () =>
+  ({
+    organization: {
+      findUnique: vi.fn().mockResolvedValue({ id: ORG_ID }),
+      update: vi.fn().mockResolvedValue({ id: ORG_ID }),
+    },
+  }) as unknown as PrismaClient;
+
+describe("licenseHandler retention provisioning", () => {
+  let handler: LicenseHandler;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListOrganizationRules.mockResolvedValue([]);
+    prisma = createMockPrisma();
+    handler = new LicenseHandler({
+      prisma,
+      publicKey: TEST_PUBLIC_KEY,
+      repository: {} as ILicenseEnforcementRepository,
+    });
+  });
+
+  describe("when a valid license is activated", () => {
+    /** @scenario Activating a valid license provisions the missing organization policies */
+    it("creates an organization-scoped policy for every category that has none", async () => {
+      const result = await handler.validateAndStoreLicense(
+        ORG_ID,
+        VALID_LICENSE_KEY,
+      );
+
+      expect(result.success).toBe(true);
+      for (const category of RETENTION_CATEGORIES) {
+        expect(mockSetForScope).toHaveBeenCalledWith({
+          scope: { scopeType: "ORGANIZATION", scopeId: ORG_ID },
+          category,
+          retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
+        });
+      }
+      expect(mockSetForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
+    });
+  });
+
+  describe("when the organization already has an organization-level policy", () => {
+    /** @scenario License activation never overrides an existing organization policy */
+    it("leaves the existing policy untouched and creates only the missing categories", async () => {
+      mockListOrganizationRules.mockResolvedValue([
+        {
+          scopeType: "ORGANIZATION",
+          scopeId: ORG_ID,
+          category: "traces",
+          retentionDays: 91,
+        },
+        // PROJECT-scoped row must not count as organization coverage
+        {
+          scopeType: "PROJECT",
+          scopeId: "proj_1",
+          category: "scenarios",
+          retentionDays: 63,
+        },
+      ]);
+
+      const result = await handler.validateAndStoreLicense(
+        ORG_ID,
+        VALID_LICENSE_KEY,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockSetForScope).not.toHaveBeenCalledWith(
+        expect.objectContaining({ category: "traces" }),
+      );
+      for (const category of ["scenarios", "experiments"]) {
+        expect(mockSetForScope).toHaveBeenCalledWith({
+          scope: { scopeType: "ORGANIZATION", scopeId: ORG_ID },
+          category,
+          retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
+        });
+      }
+      expect(mockSetForScope).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("when the license is invalid", () => {
+    /** @scenario An invalid license provisions no retention policies */
+    it("creates no policies for an expired license", async () => {
+      const result = await handler.validateAndStoreLicense(
+        ORG_ID,
+        EXPIRED_LICENSE_KEY,
+      );
+
+      expect(result.success).toBe(false);
+      expect(mockSetForScope).not.toHaveBeenCalled();
+      expect(mockListOrganizationRules).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when retention provisioning fails", () => {
+    /** @scenario A retention failure never fails license activation */
+    it("still stores the license when listing rules throws", async () => {
+      mockListOrganizationRules.mockRejectedValue(
+        new Error("retention store down"),
+      );
+
+      const result = await handler.validateAndStoreLicense(
+        ORG_ID,
+        VALID_LICENSE_KEY,
+      );
+
+      expect(result.success).toBe(true);
+      expect(prisma.organization.update).toHaveBeenCalled();
+    });
+
+    it("continues to the next category when one upsert throws", async () => {
+      mockSetForScope.mockRejectedValueOnce(new Error("retention store down"));
+
+      const result = await handler.validateAndStoreLicense(
+        ORG_ID,
+        VALID_LICENSE_KEY,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockSetForScope).toHaveBeenCalledTimes(RETENTION_CATEGORIES.length);
+    });
+  });
+});

--- a/langwatch/ee/licensing/licenseHandler.ts
+++ b/langwatch/ee/licensing/licenseHandler.ts
@@ -1,11 +1,19 @@
 import type { PrismaClient } from "@prisma/client";
 import type { PlanInfo } from "./planInfo";
 import { FREE_PLAN, PUBLIC_KEY } from "./constants";
+import { createLogger } from "../../src/utils/logger";
+import { getApp } from "../../src/server/app-layer/app";
+import {
+  PLATFORM_DEFAULT_RETENTION_DAYS,
+  RETENTION_CATEGORIES,
+} from "../../src/server/data-retention/retentionPolicy.schema";
 import { resolvePlanDefaults } from "./defaults";
 import { OrganizationNotFoundError } from "./errors";
 import type { LicenseStatus, RemoveLicenseResult, StoreLicenseResult, LicensePlanLimits } from "./types";
 import { validateLicense, parseLicenseKey } from "./validation";
 import type { ILicenseEnforcementRepository } from "~/server/license-enforcement/license-enforcement.repository";
+
+const logger = createLogger("langwatch:licensing:licenseHandler");
 
 /**
  * Interface for trace usage counting.
@@ -128,10 +136,61 @@ export class LicenseHandler {
       },
     });
 
+    await this.provisionMissingRetentionPolicies(organizationId);
+
     return {
       success: true,
       planInfo,
     };
+  }
+
+  /**
+   * A successfully activated license is a paid entry point, so it provisions
+   * the same organization-scoped retention policies the Growth-Seat webhook
+   * does — but create-if-absent only: a category that already has an
+   * organization-level override is never overridden, so a manually-tuned
+   * window survives license activation.
+   *
+   * Best-effort: a retention failure must never fail license activation, so
+   * errors are logged and swallowed.
+   */
+  private async provisionMissingRetentionPolicies(
+    organizationId: string,
+  ): Promise<void> {
+    try {
+      const policy = getApp().dataRetention.policy;
+      const existing = await policy.listOrganizationRules(organizationId);
+      const covered = new Set(
+        existing
+          .filter(
+            (row) =>
+              row.scopeType === "ORGANIZATION" &&
+              row.scopeId === organizationId,
+          )
+          .map((row) => row.category),
+      );
+
+      for (const category of RETENTION_CATEGORIES) {
+        if (covered.has(category)) continue;
+        try {
+          await policy.setForScope({
+            scope: { scopeType: "ORGANIZATION", scopeId: organizationId },
+            category,
+            retentionDays: PLATFORM_DEFAULT_RETENTION_DAYS,
+          });
+        } catch (err) {
+          logger.error(
+            { organizationId, category, err },
+            "[license] Failed to provision retention policy on license activation",
+          );
+        }
+      }
+    } catch (err) {
+      logger.error(
+        { organizationId, err },
+        "[license] Failed to provision retention policies on license activation",
+      );
+    }
   }
 
   /**

--- a/specs/billing/seat-subscription-retention-policy.feature
+++ b/specs/billing/seat-subscription-retention-policy.feature
@@ -45,15 +45,10 @@ Feature: Seat subscription provisions an organization retention policy
     When the subscription is activated by a successful payment
     Then the activation still completes and the confirmation notification is sent
 
+  # Removal-on-cancellation is deactivated until the paid-retention
+  # feature is released. Cancelling currently leaves the policies in place.
   @unit
-  Scenario: Cancelling the last active subscription removes the organization policies
+  Scenario: Cancelling a subscription leaves the retention policies in place
     Given an organization whose only active subscription is cancelled
     When the cancellation is finalized
-    Then every organization-scoped retention policy is removed
-    And retention reverts to the platform default
-
-  @unit
-  Scenario: Cancelling one of several subscriptions keeps the policies
-    Given an organization that still has another active subscription
-    When one subscription is cancelled
     Then the organization-scoped retention policies are left in place

--- a/specs/billing/seat-subscription-retention-policy.feature
+++ b/specs/billing/seat-subscription-retention-policy.feature
@@ -45,6 +45,36 @@ Feature: Seat subscription provisions an organization retention policy
     When the subscription is activated by a successful payment
     Then the activation still completes and the confirmation notification is sent
 
+  # Activating a self-hosted license is the second paid entry point and
+  # provisions the same organization-scoped policies — but create-if-absent
+  # only: a category that already has an organization-level override is never
+  # overridden, so a manually-tuned window survives license activation.
+
+  @unit
+  Scenario: Activating a valid license provisions the missing organization policies
+    Given a valid license is activated for the organization
+    When the license is successfully stored
+    Then an organization-scoped retention policy is created for every category that has none
+
+  @unit
+  Scenario: License activation never overrides an existing organization policy
+    Given the organization already has an organization-level traces retention policy
+    When a valid license is successfully activated
+    Then the existing traces policy is left untouched
+    And policies are created only for the categories that have none
+
+  @unit
+  Scenario: An invalid license provisions no retention policies
+    Given an invalid or expired license is submitted
+    When activation is rejected
+    Then no retention policy is created
+
+  @unit
+  Scenario: A retention failure never fails license activation
+    Given provisioning the retention policy will fail
+    When a valid license is activated
+    Then the license is still stored and activation succeeds
+
   # Removal-on-cancellation is deactivated until the paid-retention
   # feature is released. Cancelling currently leaves the policies in place.
   @unit

--- a/specs/billing/seat-subscription-retention-policy.feature
+++ b/specs/billing/seat-subscription-retention-policy.feature
@@ -1,9 +1,9 @@
 Feature: Seat subscription provisions an organization retention policy
 
-  When an organization starts paying for a Growth Seat subscription, the
-  platform records its data-retention entitlement as an explicit
-  organization-scoped policy, and removes that policy once the organization
-  no longer has any active subscription.
+  When an organization starts paying — via a Growth Seat subscription or by
+  activating a self-hosted license — the platform records its data-retention
+  entitlement as explicit organization-scoped policies. Cancellation leaves
+  the policies in place until the paid-retention feature is released.
 
   # Retention is default-on (ADR-021): with no override anywhere in a project's
   # scope cascade, every category resolves to the platform default window

--- a/specs/billing/seat-subscription-retention-policy.feature
+++ b/specs/billing/seat-subscription-retention-policy.feature
@@ -1,0 +1,51 @@
+Feature: Seat subscription provisions an organization retention policy
+
+  When an organization starts paying for a Growth Seat subscription, the
+  platform records its data-retention entitlement as an explicit
+  organization-scoped policy, and removes that policy once the organization
+  no longer has any active subscription.
+
+  # Retention is default-on (ADR-021): with no override anywhere in a project's
+  # scope cascade, every category resolves to the platform default window
+  # (49 days / 7 weeks). A paid Growth Seat subscription stamps that same window
+  # as an explicit organization-scoped traces override, so the entitlement is
+  # recorded rather than implied — it survives any future lowering of the
+  # platform default that an org without an override would otherwise drift down
+  # to. Provisioning is idempotent (one override per scope + category) and is a
+  # best-effort side effect: a retention failure is logged, never raised, so it
+  # can never fail the Stripe webhook and leave the subscription stuck PENDING.
+
+  Background:
+    Given an organization with no retention override
+
+  Scenario: A first paid Growth Seat activation provisions the organization policy
+    Given a pending Growth Seat subscription for the organization
+    When the subscription is activated by a successful payment
+    Then an organization-scoped traces retention policy is set to the platform default
+
+  Scenario: A renewal does not re-provision the policy
+    Given an already-active Growth Seat subscription for the organization
+    When a renewal payment succeeds
+    Then no retention policy is provisioned
+
+  Scenario: A non-seat plan does not provision a policy
+    Given a pending non-seat paid subscription for the organization
+    When the subscription is activated by a successful payment
+    Then no retention policy is provisioned
+
+  Scenario: A retention failure never fails the billing webhook
+    Given a pending Growth Seat subscription for the organization
+    And provisioning the retention policy will fail
+    When the subscription is activated by a successful payment
+    Then the activation still completes and the confirmation notification is sent
+
+  Scenario: Cancelling the last active subscription removes the organization policy
+    Given an organization whose only active subscription is cancelled
+    When the cancellation is finalized
+    Then the organization-scoped traces retention policy is removed
+    And retention reverts to the platform default
+
+  Scenario: Cancelling one of several subscriptions keeps the policy
+    Given an organization that still has another active subscription
+    When one subscription is cancelled
+    Then the organization-scoped traces retention policy is left in place

--- a/specs/billing/seat-subscription-retention-policy.feature
+++ b/specs/billing/seat-subscription-retention-policy.feature
@@ -20,33 +20,39 @@ Feature: Seat subscription provisions an organization retention policy
   Background:
     Given an organization with no retention override
 
+  @unit
   Scenario: A first paid Growth Seat activation provisions the organization policies
     Given a pending Growth Seat subscription for the organization
     When the subscription is activated by a successful payment
     Then an organization-scoped retention policy is set to the platform default for every category
 
+  @unit
   Scenario: A renewal does not re-provision the policy
     Given an already-active Growth Seat subscription for the organization
     When a renewal payment succeeds
     Then no retention policy is provisioned
 
+  @unit
   Scenario: A non-seat plan does not provision a policy
     Given a pending non-seat paid subscription for the organization
     When the subscription is activated by a successful payment
     Then no retention policy is provisioned
 
+  @unit
   Scenario: A retention failure never fails the billing webhook
     Given a pending Growth Seat subscription for the organization
     And provisioning the retention policy will fail
     When the subscription is activated by a successful payment
     Then the activation still completes and the confirmation notification is sent
 
+  @unit
   Scenario: Cancelling the last active subscription removes the organization policies
     Given an organization whose only active subscription is cancelled
     When the cancellation is finalized
     Then every organization-scoped retention policy is removed
     And retention reverts to the platform default
 
+  @unit
   Scenario: Cancelling one of several subscriptions keeps the policies
     Given an organization that still has another active subscription
     When one subscription is cancelled

--- a/specs/billing/seat-subscription-retention-policy.feature
+++ b/specs/billing/seat-subscription-retention-policy.feature
@@ -8,20 +8,22 @@ Feature: Seat subscription provisions an organization retention policy
   # Retention is default-on (ADR-021): with no override anywhere in a project's
   # scope cascade, every category resolves to the platform default window
   # (49 days / 7 weeks). A paid Growth Seat subscription stamps that same window
-  # as an explicit organization-scoped traces override, so the entitlement is
-  # recorded rather than implied — it survives any future lowering of the
-  # platform default that an org without an override would otherwise drift down
-  # to. Provisioning is idempotent (one override per scope + category) and is a
-  # best-effort side effect: a retention failure is logged, never raised, so it
-  # can never fail the Stripe webhook and leave the subscription stuck PENDING.
+  # as an explicit organization-scoped override for every category (traces,
+  # scenarios, experiments — evaluation runs live under traces, simulation runs
+  # under scenarios), so the entitlement is recorded rather than implied — it
+  # survives any future lowering of the platform default that an org without an
+  # override would otherwise drift down to. Provisioning is idempotent (one
+  # override per scope + category) and is a best-effort side effect: a retention
+  # failure is logged, never raised, so it can never fail the Stripe webhook and
+  # leave the subscription stuck PENDING.
 
   Background:
     Given an organization with no retention override
 
-  Scenario: A first paid Growth Seat activation provisions the organization policy
+  Scenario: A first paid Growth Seat activation provisions the organization policies
     Given a pending Growth Seat subscription for the organization
     When the subscription is activated by a successful payment
-    Then an organization-scoped traces retention policy is set to the platform default
+    Then an organization-scoped retention policy is set to the platform default for every category
 
   Scenario: A renewal does not re-provision the policy
     Given an already-active Growth Seat subscription for the organization
@@ -39,13 +41,13 @@ Feature: Seat subscription provisions an organization retention policy
     When the subscription is activated by a successful payment
     Then the activation still completes and the confirmation notification is sent
 
-  Scenario: Cancelling the last active subscription removes the organization policy
+  Scenario: Cancelling the last active subscription removes the organization policies
     Given an organization whose only active subscription is cancelled
     When the cancellation is finalized
-    Then the organization-scoped traces retention policy is removed
+    Then every organization-scoped retention policy is removed
     And retention reverts to the platform default
 
-  Scenario: Cancelling one of several subscriptions keeps the policy
+  Scenario: Cancelling one of several subscriptions keeps the policies
     Given an organization that still has another active subscription
     When one subscription is cancelled
-    Then the organization-scoped traces retention policy is left in place
+    Then the organization-scoped retention policies are left in place


### PR DESCRIPTION
## What

Wire the data-retention system into both paid entry points:

1. **Growth Seat subscription** (Stripe webhook): on first activation, provision explicit **organization-scoped retention policies — one per category** (`traces`, `scenarios`, `experiments`) — at the platform default window (**49 days / 7 weeks**).
2. **License activation** (self-hosted/Enterprise): on successful `validateAndStoreLicense`, provision the same policies — but **create-if-absent only**: a category that already has an organization-level override is never overridden, so a manually-tuned window survives license activation.

> Evaluation runs fall under the `traces` category and simulation runs under `scenarios`, so iterating the three canonical `RETENTION_CATEGORIES` covers evaluations/simulations too.

> **⏸ Removal-on-cancellation is deactivated** (feature not yet released). The two cancel-path call sites are commented out; the `removeSeatRetentionPolicy` helper stays so re-enabling is a one-line uncomment per site. Tests pin the deactivated behavior (cancel leaves policies in place).

## Why / decisions

- **Why 49 days (= platform default)?** Today every org resolves to the 49d platform default when it has no override. An explicit org policy *records* the paid entitlement so it **survives any future lowering of the platform/free default**. Behaviorally inert today (49d == default) — this PR ships the mechanism; the number is tuned later.
- The literal ask was "30 days", which the retention schema **rejects** (floor `MIN_RETENTION_DAYS = 49`, multiple of 7). 49d is the nearest legal value — confirmed against `retentionPolicy.schema.ts`.
- **Seat path = upsert on first activation only; license path = create-if-absent.** The seat path's first-activation guard already prevents clobbering; the license path can fire repeatedly (license renewals/replacements), so it checks `listOrganizationRules` and skips covered categories.

## How

A retention policy is a Prisma row (`RetentionPolicy`, unique on `scopeType+scopeId+category`) via `getApp().dataRetention.policy`; enforcement is ClickHouse TTL. Both hooks call the service directly (trusted system actions) — not via the tRPC plan/RBAC authz path.

- **Seat create** — chokepoint in `syncInvoicePaymentSuccess` (checkout + invoice both funnel through), first-activation + `isGrowthSeatEventPlan` guarded. Loops `RETENTION_CATEGORIES`, upserts each.
- **License create** — `LicenseHandler.validateAndStoreLicense` after the license is persisted (the single success point for UI/tRPC `license.upload`). Lists org rules, skips categories with an existing ORGANIZATION-scoped row, creates the missing ones. Invalid/expired licenses provision nothing.
- **Remove (deactivated)** — both cancel entrypoints have the `!remainingActive`-guarded removal commented out until release.
- **Best-effort, per category** — every retention call is try/caught and **logs, never throws**. A retention hiccup must not fail the Stripe webhook or license activation.

## Anything surprising

- **The 49d floor is deliberate — it is the action window.** Pricing tiers are visibility (blur) thresholds on top of it: free-tier content blurs after 14d but stays recoverable until the 49d policy deletes it, giving users a window to upgrade and recover. The blur layer is tracked in #4745.
- Once removal is re-enabled: it is unconditional on downgrade-to-free (clears a manually-set org policy too). Accepted under the "delete the policy on cancel" decision.

## Tests

- BDD spec: `specs/billing/seat-subscription-retention-policy.feature` (seat + license + deactivated-cancel scenarios, all `@unit`-bound).
- `webhookService.unit.test.ts` — provisions all categories on seat activation; not for non-seat plans; not on renewal; survives retention failure; cancel paths do NOT remove (deactivated).
- `licenseHandler.retention.unit.test.ts` — provisions missing categories on valid activation; **never overrides an existing org-level policy** (creates only missing ones); nothing on invalid/expired license; survives list/upsert failures.
- ✅ 41/41 webhook + 5/5 license tests · `pnpm typecheck` clean · `check:feature-parity` green (1736 scenarios).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic data retention policy provisioning for Growth Seat plan activations using platform defaults.
  * Automatic data retention policy provisioning for self-hosted license activations, only filling in missing categories.
  * Best-effort retention policy setup that gracefully handles failures without disrupting subscription or license activation.

* **Tests**
  * Added comprehensive test coverage for retention policy provisioning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

