### PR TITLE
fix(costs): apply org/team-scoped custom model costs at ingestion and price bedrock/-prefixed model ids

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/span-cost-enrichment.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/span-cost-enrichment.service.unit.test.ts
@@ -1,3 +1,4 @@
+import type { PrismaClient } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   matchModelCostWithFallbacks,
@@ -7,6 +8,7 @@ import type { MaybeStoredLLMModelCost } from "~/server/modelProviders/llmModelCo
 import { getStaticModelCosts } from "~/server/modelProviders/llmModelCost";
 import type { OtlpSpan } from "../../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 import {
+  createCostEnrichmentDeps,
   OtlpSpanCostEnrichmentService,
   type OtlpSpanCostEnrichmentServiceDependencies,
 } from "../span-cost-enrichment.service";
@@ -284,6 +286,154 @@ describe("OtlpSpanCostEnrichmentService", () => {
           value: { doubleValue: 0.00000025 },
         });
       });
+    });
+  });
+});
+
+describe("createCostEnrichmentDeps", () => {
+  const project = {
+    id: "project-1",
+    teamId: "team-1",
+    team: { organizationId: "org-1" },
+  };
+
+  const costRow = ({
+    scopeType,
+    scopeId,
+    projectId,
+    inputCostPerToken,
+    outputCostPerToken,
+  }: {
+    scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+    scopeId: string;
+    projectId: string | null;
+    inputCostPerToken: number;
+    outputCostPerToken: number;
+  }) => ({
+    id: `llmcost_${scopeType}`,
+    organizationId: "org-1",
+    scopeType,
+    scopeId,
+    projectId,
+    model: "bedrock/eu.anthropic.claude-sonnet-4-6",
+    regex: "^bedrock\\/eu\\.anthropic\\.claude-sonnet-4-6$",
+    inputCostPerToken,
+    outputCostPerToken,
+    cacheReadCostPerToken: null,
+    cacheCreationCostPerToken: null,
+    createdAt: new Date("2026-06-04T21:36:54Z"),
+    updatedAt: new Date("2026-06-04T21:36:54Z"),
+  });
+
+  const createPrismaMock = (rows: unknown[]) => {
+    const findUnique = vi.fn().mockResolvedValue(project);
+    const findMany = vi.fn().mockResolvedValue(rows);
+    const prisma = {
+      project: { findUnique },
+      customLLMModelCost: { findMany },
+    } as unknown as PrismaClient;
+    return { prisma, findUnique, findMany };
+  };
+
+  describe("when the custom cost is organization-scoped (@regression)", () => {
+    /** @scenario An organization-level custom cost prices spans at ingestion */
+    it("enriches the span through the scope cascade, not the legacy projectId column", async () => {
+      const orgRow = costRow({
+        scopeType: "ORGANIZATION",
+        scopeId: "org-1",
+        projectId: null,
+        inputCostPerToken: 0.000003,
+        outputCostPerToken: 0.000015,
+      });
+      const { prisma, findMany } = createPrismaMock([orgRow]);
+      const service = new OtlpSpanCostEnrichmentService(
+        createCostEnrichmentDeps(prisma),
+      );
+      const span = createTestSpan([
+        {
+          key: "gen_ai.request.model",
+          value: { stringValue: "bedrock/eu.anthropic.claude-sonnet-4-6" },
+        },
+      ]);
+
+      await service.enrichSpan(span, "project-1");
+
+      expect(span.attributes).toContainEqual({
+        key: "langwatch.model.inputCostPerToken",
+        value: { doubleValue: 0.000003 },
+      });
+      expect(span.attributes).toContainEqual({
+        key: "langwatch.model.outputCostPerToken",
+        value: { doubleValue: 0.000015 },
+      });
+      // The lookup must target the org-anchored scope chain; an org- or
+      // team-scoped row carries a null legacy projectId and is invisible
+      // to a { where: { projectId } } query.
+      expect(findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ organizationId: "org-1" }),
+        }),
+      );
+    });
+  });
+
+  describe("when project- and organization-level rows both price the same model", () => {
+    /** @scenario A project-level custom cost beats the organization rate at ingestion */
+    it("applies the project-level rates", async () => {
+      const orgRow = costRow({
+        scopeType: "ORGANIZATION",
+        scopeId: "org-1",
+        projectId: null,
+        inputCostPerToken: 0.000003,
+        outputCostPerToken: 0.000015,
+      });
+      const projectRow = costRow({
+        scopeType: "PROJECT",
+        scopeId: "project-1",
+        projectId: "project-1",
+        inputCostPerToken: 0.000001,
+        outputCostPerToken: 0.000002,
+      });
+      // Org row first: tier sorting, not row order, must decide the winner.
+      const { prisma } = createPrismaMock([orgRow, projectRow]);
+      const service = new OtlpSpanCostEnrichmentService(
+        createCostEnrichmentDeps(prisma),
+      );
+      const span = createTestSpan([
+        {
+          key: "gen_ai.request.model",
+          value: { stringValue: "bedrock/eu.anthropic.claude-sonnet-4-6" },
+        },
+      ]);
+
+      await service.enrichSpan(span, "project-1");
+
+      expect(span.attributes).toContainEqual({
+        key: "langwatch.model.inputCostPerToken",
+        value: { doubleValue: 0.000001 },
+      });
+      expect(span.attributes).toContainEqual({
+        key: "langwatch.model.outputCostPerToken",
+        value: { doubleValue: 0.000002 },
+      });
+    });
+  });
+
+  describe("when the project does not exist", () => {
+    it("returns no custom costs and leaves the span untouched", async () => {
+      const { prisma, findUnique, findMany } = createPrismaMock([]);
+      findUnique.mockResolvedValue(null);
+      const service = new OtlpSpanCostEnrichmentService(
+        createCostEnrichmentDeps(prisma),
+      );
+      const span = createTestSpan([
+        { key: "gen_ai.request.model", value: { stringValue: "gpt-4o" } },
+      ]);
+
+      await service.enrichSpan(span, "project-unknown");
+
+      expect(findMany).not.toHaveBeenCalled();
+      expect(span.attributes).toHaveLength(1);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/span-cost-enrichment.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-cost-enrichment.service.ts
@@ -1,6 +1,9 @@
 import type { PrismaClient } from "@prisma/client";
 import { matchModelCostWithFallbacks } from "~/server/background/workers/collector/cost";
-import type { MaybeStoredLLMModelCost } from "~/server/modelProviders/llmModelCost";
+import {
+  getCustomLLMModelCosts,
+  type MaybeStoredLLMModelCost,
+} from "~/server/modelProviders/llmModelCost";
 import type { OtlpSpan } from "../../event-sourcing/pipelines/trace-processing/schemas/otlp";
 import { ATTR_KEYS } from "./canonicalisation/extractors/_constants";
 import { extractModelName } from "./utils/spanModel";
@@ -26,28 +29,18 @@ export interface OtlpSpanCostEnrichmentServiceDependencies {
 
 /**
  * Creates default dependencies from a Prisma client.
+ *
+ * Custom costs resolve through the PROJECT -> TEAM -> ORGANIZATION scope
+ * cascade, so a cost saved at any tier prices this project's spans. Org- and
+ * team-scoped rows carry a null legacy projectId column and are invisible to
+ * a plain { where: { projectId } } lookup.
  */
 export function createCostEnrichmentDeps(
   prisma: PrismaClient,
 ): OtlpSpanCostEnrichmentServiceDependencies {
   return {
-    getCustomModelCosts: async (projectId: string) => {
-      const records = await prisma.customLLMModelCost.findMany({
-        where: { projectId },
-      });
-      return records.map((r) => ({
-        id: r.id,
-        projectId,
-        model: r.model,
-        regex: r.regex,
-        inputCostPerToken: r.inputCostPerToken ?? undefined,
-        outputCostPerToken: r.outputCostPerToken ?? undefined,
-        cacheReadCostPerToken: r.cacheReadCostPerToken ?? undefined,
-        cacheCreationCostPerToken: r.cacheCreationCostPerToken ?? undefined,
-        updatedAt: r.updatedAt,
-        createdAt: r.createdAt,
-      }));
-    },
+    getCustomModelCosts: (projectId: string) =>
+      getCustomLLMModelCosts({ projectId, prismaClient: prisma }),
   };
 }
 

--- a/langwatch/src/server/background/workers/collector/__tests__/cost.unit.test.ts
+++ b/langwatch/src/server/background/workers/collector/__tests__/cost.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   estimateCost,
   matchModelCostWithFallbacks,
+  normalizeBedrockModelId,
   normalizeModelName,
 } from "../cost";
 import { getStaticModelCosts } from "../../../../modelProviders/llmModelCost";
@@ -195,6 +196,56 @@ describe("normalizeModelName", () => {
   });
 });
 
+describe("normalizeBedrockModelId", () => {
+  describe("when given a regional Bedrock model id", () => {
+    it("strips the region and converts vendor-dot to vendor-slash", () => {
+      expect(normalizeBedrockModelId("eu.anthropic.claude-sonnet-4-6")).toBe(
+        "anthropic/claude-sonnet-4-6",
+      );
+    });
+  });
+
+  describe("when given a versioned Bedrock model id", () => {
+    it("strips the revision marker and version suffix", () => {
+      expect(
+        normalizeBedrockModelId("us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+      ).toBe("anthropic/claude-haiku-4-5-20251001");
+    });
+  });
+
+  describe("when given a litellm-style bedrock/ prefixed id (@regression)", () => {
+    it("strips the bedrock/ envelope along with the region", () => {
+      expect(
+        normalizeBedrockModelId("bedrock/eu.anthropic.claude-sonnet-4-6"),
+      ).toBe("anthropic/claude-sonnet-4-6");
+    });
+
+    it("strips the bedrock/ envelope on versioned ids", () => {
+      expect(
+        normalizeBedrockModelId(
+          "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        ),
+      ).toBe("anthropic/claude-haiku-4-5-20251001");
+    });
+
+    it("strips the bedrock/ envelope when no region prefix is present", () => {
+      expect(
+        normalizeBedrockModelId("bedrock/anthropic.claude-sonnet-4-6"),
+      ).toBe("anthropic/claude-sonnet-4-6");
+    });
+  });
+
+  describe("when given a non-Bedrock model id", () => {
+    it("leaves a vendor-slash model untouched", () => {
+      expect(normalizeBedrockModelId("openai/gpt-4o")).toBe("openai/gpt-4o");
+    });
+
+    it("leaves a bare model name untouched", () => {
+      expect(normalizeBedrockModelId("gpt-4o")).toBe("gpt-4o");
+    });
+  });
+});
+
 describe("matchModelCostWithFallbacks", () => {
   describe("when model name matches exactly", () => {
     it("finds cost for model name without vendor prefix", () => {
@@ -357,6 +408,55 @@ describe("matchModelCostWithFallbacks", () => {
       expect(
         matchModelCostWithFallbacks("minimaxai/minimax-m2.1", realCosts)?.model
       ).toBe("minimax/minimax-m2.1");
+    });
+  });
+
+  describe("when model id comes from Bedrock (@regression)", () => {
+    const realCosts = getStaticModelCosts();
+
+    /** @scenario A bare regional Bedrock model id keeps resolving registry pricing */
+    it("matches eu.anthropic.claude-sonnet-4-6 to anthropic/claude-sonnet-4-6", () => {
+      expect(
+        matchModelCostWithFallbacks("eu.anthropic.claude-sonnet-4-6", realCosts)
+          ?.model
+      ).toBe("anthropic/claude-sonnet-4-6");
+    });
+
+    /** @scenario A bedrock/-prefixed regional model id resolves registry pricing */
+    it("matches bedrock/eu.anthropic.claude-sonnet-4-6 to anthropic/claude-sonnet-4-6", () => {
+      expect(
+        matchModelCostWithFallbacks(
+          "bedrock/eu.anthropic.claude-sonnet-4-6",
+          realCosts
+        )?.model
+      ).toBe("anthropic/claude-sonnet-4-6");
+    });
+
+    /** @scenario A bedrock/-prefixed versioned model id resolves registry pricing */
+    it("matches bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0 to anthropic/claude-haiku-4-5", () => {
+      expect(
+        matchModelCostWithFallbacks(
+          "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+          realCosts
+        )?.model
+      ).toBe("anthropic/claude-haiku-4-5");
+    });
+
+    /** @scenario A custom cost regex written against the bedrock/-prefixed spelling still wins */
+    it("prefers a custom cost regex anchored on the bedrock/ spelling over the registry", () => {
+      const customCost: MaybeStoredLLMModelCost = {
+        projectId: "proj1",
+        model: "bedrock/eu.anthropic.claude-sonnet-4-6",
+        regex: "^bedrock\\/eu\\.anthropic\\.claude-sonnet-4-6$",
+        inputCostPerToken: 0.000003,
+        outputCostPerToken: 0.000015,
+      };
+      expect(
+        matchModelCostWithFallbacks("bedrock/eu.anthropic.claude-sonnet-4-6", [
+          customCost,
+          ...realCosts,
+        ])?.model
+      ).toBe("bedrock/eu.anthropic.claude-sonnet-4-6");
     });
   });
 

--- a/langwatch/src/server/background/workers/collector/cost.ts
+++ b/langwatch/src/server/background/workers/collector/cost.ts
@@ -176,11 +176,15 @@ export function stripProviderSubtype(model: string): string {
  *   [<region>.]<vendor>.<model>[-v<N>][:<version>]
  * e.g. `eu.anthropic.claude-haiku-4-5-20251001-v1:0` →
  *      `anthropic/claude-haiku-4-5-20251001`
- * The registry regexes already match dated Claude/Nova slugs, so
- * stripping just the Bedrock envelope is enough.
+ * litellm-style clients report the same id behind a `bedrock/` provider
+ * prefix (`bedrock/eu.anthropic.claude-sonnet-4-6`); that prefix is part
+ * of the envelope and is stripped too. The registry regexes already match
+ * dated Claude/Nova slugs, so stripping just the Bedrock envelope is enough.
  */
 export function normalizeBedrockModelId(model: string): string {
   let normalized = model;
+  // 0. Strip the litellm-style `bedrock/` provider prefix.
+  normalized = normalized.replace(/^bedrock\//i, "");
   // 1. Strip `:<version>` suffix (`:0`, `:1`, `:latest`).
   normalized = normalized.replace(/:[0-9a-z.]+$/i, "");
   // 2. Strip `-v<N>` revision marker (`-v1`, `-v2`).

--- a/langwatch/src/server/modelProviders/llmModelCost.tsx
+++ b/langwatch/src/server/modelProviders/llmModelCost.tsx
@@ -1,3 +1,4 @@
+import type { PrismaClient } from "@prisma/client";
 import escapeStringRegexp from "escape-string-regexp";
 import { prisma } from "../db";
 import { resolveScopeChain } from "../scopes/resolveScopeChain";
@@ -163,12 +164,23 @@ const SCOPE_TIER_RANK: Record<ScopeTier, number> = {
   ORGANIZATION: 2,
 };
 
-export const getLLMModelCosts = async ({
+/**
+ * Resolves the custom cost overrides that apply to a project, most specific
+ * first (PROJECT, then TEAM, then ORGANIZATION; newest first within a tier).
+ * Static catalog entries are NOT included — callers that want the full
+ * cascade with platform defaults use getLLMModelCosts.
+ *
+ * Accepts an injectable Prisma client so ingestion-side services can pass
+ * their own instance.
+ */
+export const getCustomLLMModelCosts = async ({
   projectId,
+  prismaClient = prisma,
 }: {
   projectId: string;
+  prismaClient?: PrismaClient;
 }): Promise<MaybeStoredLLMModelCost[]> => {
-  const project = await prisma.project.findUnique({
+  const project = await prismaClient.project.findUnique({
     where: { id: projectId },
     select: {
       id: true,
@@ -177,9 +189,9 @@ export const getLLMModelCosts = async ({
     },
   });
 
-  // No project context means no custom overrides apply; fall back to the
-  // static catalog rather than leaking another tenant's costs.
-  if (!project) return getStaticModelCosts();
+  // No project context means no custom overrides apply; never fall back to
+  // an unscoped read that could leak another tenant's costs.
+  if (!project) return [];
 
   const organizationId = project.team.organizationId;
   const chain = resolveScopeChain({
@@ -188,17 +200,19 @@ export const getLLMModelCosts = async ({
     projectId,
   });
 
-  const llmModelCostsCustomData = await prisma.customLLMModelCost.findMany({
-    where: {
-      organizationId,
-      OR: chain.map((scope) => ({
-        scopeType: scope.scopeType,
-        scopeId: scope.scopeId,
-      })),
+  const llmModelCostsCustomData = await prismaClient.customLLMModelCost.findMany(
+    {
+      where: {
+        organizationId,
+        OR: chain.map((scope) => ({
+          scopeType: scope.scopeType,
+          scopeId: scope.scopeId,
+        })),
+      },
     },
-  });
+  );
 
-  const customCosts = llmModelCostsCustomData
+  return llmModelCostsCustomData
     .map(
       (record) =>
         ({
@@ -222,6 +236,13 @@ export const getLLMModelCosts = async ({
         SCOPE_TIER_RANK[a.scopeType!] - SCOPE_TIER_RANK[b.scopeType!] ||
         b.createdAt!.getTime() - a.createdAt!.getTime(),
     );
+};
 
+export const getLLMModelCosts = async ({
+  projectId,
+}: {
+  projectId: string;
+}): Promise<MaybeStoredLLMModelCost[]> => {
+  const customCosts = await getCustomLLMModelCosts({ projectId });
   return [...customCosts, ...getStaticModelCosts()];
 };

--- a/specs/model-providers/model-cost-scoping.feature
+++ b/specs/model-providers/model-cost-scoping.feature
@@ -116,6 +116,28 @@ Feature: Multi-scope model cost overrides
     Then the write succeeds
 
   # ────────────────────────────────────────────────────────────────────────────
+  # Ingestion cost enrichment
+  # ────────────────────────────────────────────────────────────────────────────
+  #
+  # Span ingestion resolves custom costs through the same
+  # PROJECT -> TEAM -> ORGANIZATION cascade as the settings page: a custom
+  # cost visible in settings is the cost applied to incoming traces, no
+  # matter which tier it was saved at.
+
+  @unit
+  Scenario: An organization-level custom cost prices spans at ingestion
+    Given "acme" has an organization-level custom cost for "bedrock/eu.anthropic.claude-sonnet-4-6"
+    When a span using that model is ingested for project "web-app"
+    Then the span is enriched with the organization-level cost rates
+
+  @unit
+  Scenario: A project-level custom cost beats the organization rate at ingestion
+    Given "acme" has an organization-level custom cost for "openai/gpt-5-mini"
+    And project "web-app" has a project-level custom cost for "openai/gpt-5-mini"
+    When a span using that model is ingested for project "web-app"
+    Then the span is enriched with the project-level cost rates
+
+  # ────────────────────────────────────────────────────────────────────────────
   # Migration
   # ────────────────────────────────────────────────────────────────────────────
 

--- a/specs/trace-processing/bedrock-model-cost-matching.feature
+++ b/specs/trace-processing/bedrock-model-cost-matching.feature
@@ -1,0 +1,42 @@
+Feature: Bedrock model id cost matching
+  As a LangWatch user tracing LLM calls made through AWS Bedrock
+  I want spans reporting any spelling of a Bedrock model id
+  To resolve the platform's registry pricing for the underlying model
+  So that Bedrock traffic is costed without needing a custom cost row per project
+
+  # Background
+  #
+  # Bedrock identifies models as [<region>.]<vendor>.<model>[-v<N>][:<version>],
+  # e.g. eu.anthropic.claude-sonnet-4-6 or anthropic.claude-haiku-4-5-20251001-v1:0.
+  # The pricing registry keys models as <vendor>/<model>. Matching strips the
+  # Bedrock envelope (region prefix, revision/version suffixes, vendor-dot
+  # notation) to land on the registry key.
+  #
+  # litellm-style clients report the model id WITH a "bedrock/" provider
+  # prefix (bedrock/eu.anthropic.claude-sonnet-4-6). That prefix is part of
+  # the same envelope and is stripped before normalization, so both spellings
+  # of the same model id resolve the same registry entry.
+
+  @unit
+  Scenario: A bedrock/-prefixed regional model id resolves registry pricing
+    Given the pricing registry has an entry for "anthropic/claude-sonnet-4-6"
+    When the cost for model "bedrock/eu.anthropic.claude-sonnet-4-6" is matched
+    Then the "anthropic/claude-sonnet-4-6" registry entry is returned
+
+  @unit
+  Scenario: A bedrock/-prefixed versioned model id resolves registry pricing
+    Given the pricing registry has an entry for "anthropic/claude-haiku-4.5"
+    When the cost for model "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0" is matched
+    Then the "anthropic/claude-haiku-4.5" registry entry is returned
+
+  @unit
+  Scenario: A bare regional Bedrock model id keeps resolving registry pricing
+    Given the pricing registry has an entry for "anthropic/claude-sonnet-4-6"
+    When the cost for model "eu.anthropic.claude-sonnet-4-6" is matched
+    Then the "anthropic/claude-sonnet-4-6" registry entry is returned
+
+  @unit
+  Scenario: A custom cost regex written against the bedrock/-prefixed spelling still wins
+    Given a custom cost whose regex matches "bedrock/eu.anthropic.claude-sonnet-4-6" exactly
+    When the cost for model "bedrock/eu.anthropic.claude-sonnet-4-6" is matched
+    Then the custom cost entry is returned, not the registry entry


### PR DESCRIPTION
Investigating a customer report of a trace with hundreds of thousands of tokens but no cost, even though the organization had a custom cost row whose regex matched the span model exactly (`^bedrock\/eu\.anthropic\.claude-sonnet-4-6$` against `bedrock/eu.anthropic.claude-sonnet-4-6`). Two separate bugs stacked up to produce the NULL.

## Bug 1: ingestion enrichment reads the legacy projectId column

`createCostEnrichmentDeps` (the trace-processing pipeline's custom cost lookup, applied in `RecordSpanCommand` before events are persisted) queried:

```ts
prisma.customLLMModelCost.findMany({ where: { projectId } })
```

Since the multi-scope migration (`20260529120000_custom_llm_model_cost_multi_scope`), `projectId` is a legacy compat column that is only populated for PROJECT-tier rows. ORGANIZATION- and TEAM-scoped rows carry `projectId = NULL`, so the query returned nothing, `enrichSpan` bailed, and no `langwatch.model.*CostPerToken` attributes were written to the span. The settings page resolves through the scope cascade and happily shows the cost, so the configuration looked correct while ingestion ignored it.

The cascade query is now extracted from `getLLMModelCosts` into `getCustomLLMModelCosts` (custom rows only, most specific tier first, injectable Prisma client) and the enrichment deps delegate to it. Project-tier rows keep working as before, and a project row still shadows a team or org row for the same model because the cascade sort order decides the first regex match.

## Bug 2: bedrock/-prefixed model ids never match the static registry

Without enrichment attributes, the fold falls back to the static registry. `normalizeBedrockModelId` handles bare Bedrock ids (`eu.anthropic.claude-sonnet-4-6` resolves to `anthropic/claude-sonnet-4-6`), but litellm-style clients report the id behind a `bedrock/` provider prefix, which defeated the region-strip regex and the vendor-dot conversion. The model fell through every fallback and the span priced at zero even though the registry has the model.

`normalizeBedrockModelId` now strips the `bedrock/` prefix as step 0 of the envelope normalization, so both spellings resolve the same registry entry. Custom cost regexes written against the raw `bedrock/...` spelling still win because raw matching runs before any normalization fallback.

## Verification

8 new unit tests, red before the fix, green after (93 tests in the two touched suites, 1609 across the affected areas, feature parity check passes with the new scenario bindings).

Also verified end to end on a local stack by sending OTLP spans with `gen_ai.request.model = bedrock/eu.anthropic.claude-sonnet-4-6` (1000 input, 100 output tokens) through the real ingestion pipeline:

| Setup | TotalCost in trace_summaries | Expected |
|---|---|---|
| Org-scoped custom cost (2e-6 in, 1e-5 out) | 0.003 | 1000 x 2e-6 + 100 x 1e-5 = 0.003 |
| No custom cost, registry fallback | 0.0045 | 1000 x 3e-6 + 100 x 1.5e-5 = 0.0045 |

Both were NULL before this change.

Note: already-ingested traces keep their NULL cost, span events are immutable and summaries only refold on new events. New traces price correctly once this deploys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom LLM model cost overrides now respect scope cascading (project-level costs override team-level, which override organization-level costs).

* **Bug Fixes**
  * Improved Bedrock model identifier normalization to correctly match cost pricing across different naming conventions and regional variants.

* **Tests**
  * Added comprehensive test coverage for custom cost scope resolution and Bedrock model ID normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->