### PR TITLE
feat(event-sourcing): gate reactor enqueue behind pure shouldReact predicates

### DIFF
--- a/dev/docs/adr/026-reactor-should-react-predicate.md
+++ b/dev/docs/adr/026-reactor-should-react-predicate.md
@@ -127,5 +127,12 @@ that condition belongs in `handle()`.
 ## References
 
 - Related ADRs: [ADR-023](./023-orphan-sweep-reactor-chain.md) (reactor
-  infrastructure background)
+  infrastructure background; its orphan-sweep reactor was since removed,
+  see [ADR-025](./025-remove-orphan-sweep.md)),
+  [ADR-021](./021-lean-fold-cache.md) and
+  [ADR-022](./022-event-log-source-of-truth.md) (fold-state caching —
+  the `toCacheable` lean-cache hook must preserve every field the fold's
+  `apply` reads, and reactors receive the post-apply state, so predicates
+  reading `foldState.attributes` see the same values the handler does
+  even on cache-rehydrated paths)
 - Spec: [specs/event-sourcing/reactors.feature](../../../specs/event-sourcing/reactors.feature)

--- a/dev/docs/adr/026-reactor-should-react-predicate.md
+++ b/dev/docs/adr/026-reactor-should-react-predicate.md
@@ -67,13 +67,19 @@ Constraints on the predicate, enforced by convention and review:
   A reactor whose relevance can only be decided with dependencies simply
   omits `shouldReact` and filters in the handler as before.
 
-The event-intrinsic guards migrate out of these trace-pipeline handlers
-into `shouldReact`: `customEvaluationSync` (span-event type + stale-trace
-cutoff + "span actually contains custom-evaluation events"),
+The event-intrinsic guards of these trace-pipeline reactors become
+`shouldReact` predicates: `customEvaluationSync` (span-event type +
+stale-trace cutoff + "span actually contains custom-evaluation events"),
 `simulationMetricsSync` (`scenario.run_id` presence + has data to
 aggregate), `experimentMetricsSync` (`evaluation.run_id` presence + has
 cost), `originGate` (stale cutoff + origin already resolved),
 `projectMetadata` (sample-origin seed traces).
+
+Because the predicate fails open, a handler can still occasionally
+receive an event its predicate would have rejected. Handlers therefore
+keep their guards — the guard logic lives in a shared pure helper per
+reactor, referenced by both `shouldReact` and `handle()`, so the two can
+never drift.
 
 ## Rationale / Trade-offs
 

--- a/dev/docs/adr/026-reactor-should-react-predicate.md
+++ b/dev/docs/adr/026-reactor-should-react-predicate.md
@@ -1,0 +1,125 @@
+# ADR-026: Pure `shouldReact` predicate gates reactor enqueue
+
+**Date:** 2026-06-10
+
+**Status:** Accepted
+
+## Context
+
+Reactors are post-projection side-effect handlers. After a fold (or map)
+projection applies and stores, `ProjectionRouter.dispatchToReactors`
+enqueues **one GroupQueue job per reactor per event**. The trace-processing
+pipeline registers ~9–13 reactors, so every span event becomes ~10 queue
+jobs once its projection lands.
+
+Most of those jobs do nothing. The relevance check lives at the top of
+each reactor's `handle()` — `if (!scenarioRunId) return`,
+`if (!isSpanReceivedEvent(event)) return`, `if (origin === "sample") return`
+— so for a typical production span the simulation, experiment, origin-gate
+and project-metadata reactors all pay the full enqueue → Redis write →
+dequeue → deserialize → no-op cycle.
+
+Under normal load this is waste; under recovery it is a hazard. When an
+outage backs up the event log, draining the backlog multiplies every
+deferred event by the reactor count, and the amplified job storm can
+re-saturate the queue that just recovered.
+
+The framework already has precedent for declarative pre-dispatch
+filtering: map projections register with an `eventTypes` array. Reactors
+never got an equivalent — `reactor.types.ts` explicitly documented
+"Reactors fire on every fold completion (no eventTypes filter)".
+
+A key enabler: the queue payload is `{ event, foldState }`, captured at
+dispatch. The exact value a predicate sees at enqueue time is the value
+`handle()` would later receive — there is no window in which the payload
+can change between the two, so a decision made at dispatch cannot be
+invalidated by execution-time drift.
+
+See [specs/event-sourcing/reactors.feature](../../../specs/event-sourcing/reactors.feature)
+for the behavioural contract this decision supports.
+
+## Decision
+
+We will add an optional **pure, stateless predicate** to
+`ReactorDefinition`:
+
+```ts
+shouldReact?(event: E, context: ReactorContext<FoldState>): boolean;
+```
+
+`ProjectionRouter.dispatchToReactors` evaluates it once per reactor per
+event, before enqueue (and before inline execution, so both modes behave
+identically). `false` skips the reactor entirely — no job is created —
+and increments `es_reactor_total{status="skipped"}` so the saved fan-out
+is observable.
+
+Constraints on the predicate, enforced by convention and review:
+
+- **Pure and synchronous.** No IO, no injected dependencies, no promise.
+  It may only inspect the event and fold state it is given (plus the
+  clock for stale-trace cutoffs). This runs on the projection hot path;
+  it must be cheap and must not introduce new failure modes there.
+- **Fail open.** A thrown predicate is caught, logged, and treated as
+  `true` — the job enqueues anyway. Worst case degrades to today's
+  behaviour; a predicate bug can never silently drop a side effect.
+- **Stateful guards stay in `handle()`.** Anything needing a DB lookup
+  (project already integrated, experiment-ID resolution) is not eligible.
+  A reactor whose relevance can only be decided with dependencies simply
+  omits `shouldReact` and filters in the handler as before.
+
+The event-intrinsic guards migrate out of these trace-pipeline handlers
+into `shouldReact`: `customEvaluationSync` (span-event type + stale-trace
+cutoff + "span actually contains custom-evaluation events"),
+`simulationMetricsSync` (`scenario.run_id` presence + has data to
+aggregate), `experimentMetricsSync` (`evaluation.run_id` presence + has
+cost), `originGate` (stale cutoff + origin already resolved),
+`projectMetadata` (sample-origin seed traces).
+
+## Rationale / Trade-offs
+
+The alternative shapes considered:
+
+- **Declarative `eventTypes` filter (mirror map projections).** Too
+  coarse: most reactor guards are attribute- or fold-state-based
+  (`scenario.run_id`, origin, cost presence), not event-type-based. A
+  predicate subsumes the event-type case.
+- **Batch/collapse jobs at the queue layer.** The existing
+  `makeJobId` + `ttl` dedup already collapses redundant work *within* a
+  reactor; it does nothing about the *cross-reactor* fan-out of jobs
+  that will no-op. The two mechanisms are orthogonal and compose.
+- **Run all reactors in one job.** Would couple unrelated side effects'
+  retry/failure semantics and break per-reactor dedup, delay and
+  kill-switch options.
+
+The accepted trade-off is that predicate logic now executes inside
+projection processing. We bound the risk by requiring purity (no new
+dependencies on the hot path) and failing open (a predicate error costs
+one log line and one redundant job, never a lost side effect or a failed
+projection).
+
+One subtlety: predicates that check `foldState` decide on the fold state
+*as of dispatch*. Because the payload is immutable and `handle()`
+receives that same snapshot, predicate and handler can never disagree.
+A reactor must not use `shouldReact` to approximate a condition it
+expects to be re-evaluated against *fresher* state at execution time —
+that condition belongs in `handle()`.
+
+## Consequences
+
+- Typical production spans stop enqueuing jobs for the simulation,
+  experiment, origin and project-metadata reactors — the bulk of the
+  per-event reactor fan-out disappears for events that don't match.
+- Backlog drains after an outage amplify by the number of *relevant*
+  reactors, not the number of registered ones.
+- `es_reactor_total{status="skipped"}` quantifies the savings and makes
+  an over-aggressive predicate visible as an anomalous skip rate.
+- Reactor unit tests gain a cheap, IO-free surface: predicate logic is
+  testable without mocking dependencies.
+- New reactors should default to providing `shouldReact` whenever their
+  relevance is decidable from `(event, foldState)` alone.
+
+## References
+
+- Related ADRs: [ADR-023](./023-orphan-sweep-reactor-chain.md) (reactor
+  infrastructure background)
+- Spec: [specs/event-sourcing/reactors.feature](../../../specs/event-sourcing/reactors.feature)

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.unit.test.ts
@@ -475,4 +475,61 @@ describe("customEvaluationSync reactor", () => {
       expect(call.isGuardrail).toBe(true);
     });
   });
+
+  describe("shouldReact predicate", () => {
+    describe("when span carries evaluation events", () => {
+      it("returns true", () => {
+        const reactor = createCustomEvaluationSyncReactor(deps);
+        const span = makeOtlpSpan([{ name: "quality", score: 0.9 }]);
+
+        expect(
+          reactor.shouldReact!(
+            createSpanReceivedEvent(span),
+            createContext(createFoldState()),
+          ),
+        ).toBe(true);
+      });
+    });
+
+    describe("when span has no evaluation events", () => {
+      it("returns false", () => {
+        const reactor = createCustomEvaluationSyncReactor(deps);
+        const span = makeOtlpSpan([]);
+
+        expect(
+          reactor.shouldReact!(
+            createSpanReceivedEvent(span),
+            createContext(createFoldState()),
+          ),
+        ).toBe(false);
+      });
+    });
+
+    describe("when event is not a SpanReceivedEvent", () => {
+      it("returns false", () => {
+        const reactor = createCustomEvaluationSyncReactor(deps);
+
+        expect(
+          reactor.shouldReact!(
+            createNonSpanEvent(),
+            createContext(createFoldState()),
+          ),
+        ).toBe(false);
+      });
+    });
+
+    describe("when event is too old", () => {
+      it("returns false", () => {
+        const reactor = createCustomEvaluationSyncReactor(deps);
+        const span = makeOtlpSpan([{ name: "quality", score: 0.9 }]);
+        const staleEvent = createSpanReceivedEvent(span, {
+          occurredAt: Date.now() - 2 * 60 * 60 * 1000,
+        });
+
+        expect(
+          reactor.shouldReact!(staleEvent, createContext(createFoldState())),
+        ).toBe(false);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/customEvaluationSync.reactor.unit.test.ts
@@ -476,7 +476,7 @@ describe("customEvaluationSync reactor", () => {
     });
   });
 
-  describe("shouldReact predicate", () => {
+  describe("when deciding whether to react", () => {
     describe("when span carries evaluation events", () => {
       it("returns true", () => {
         const reactor = createCustomEvaluationSyncReactor(deps);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/experimentMetricsSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/experimentMetricsSync.reactor.unit.test.ts
@@ -288,5 +288,23 @@ describe("experimentMetricsSync reactor (trace-side ECST publisher)", () => {
         ).toBe(false);
       });
     });
+
+    describe("when trace has exactly zero cost", () => {
+      it("returns false", () => {
+        const reactor = createExperimentMetricsSyncReactor(createDeps());
+        const foldState = createTraceSummaryState({
+          attributes: { "evaluation.run_id": "run-1" },
+          totalCost: 0,
+        });
+
+        expect(
+          reactor.shouldReact!(createSpanReceivedEvent(), {
+            tenantId: TEST_TENANT_ID,
+            aggregateId: "trace-1",
+            foldState,
+          }),
+        ).toBe(false);
+      });
+    });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/experimentMetricsSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/experimentMetricsSync.reactor.unit.test.ts
@@ -236,4 +236,57 @@ describe("experimentMetricsSync reactor (trace-side ECST publisher)", () => {
       ).resolves.toBeUndefined();
     });
   });
+
+  describe("shouldReact predicate", () => {
+    describe("when trace has evaluation.run_id and cost data", () => {
+      it("returns true", () => {
+        const reactor = createExperimentMetricsSyncReactor(createDeps());
+        const foldState = createTraceSummaryState({
+          attributes: { "evaluation.run_id": "run-1" },
+          totalCost: 0.003,
+        });
+
+        expect(
+          reactor.shouldReact!(createSpanReceivedEvent(), {
+            tenantId: TEST_TENANT_ID,
+            aggregateId: "trace-1",
+            foldState,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when trace has no evaluation.run_id", () => {
+      it("returns false", () => {
+        const reactor = createExperimentMetricsSyncReactor(createDeps());
+        const foldState = createTraceSummaryState({ attributes: {} });
+
+        expect(
+          reactor.shouldReact!(createSpanReceivedEvent(), {
+            tenantId: TEST_TENANT_ID,
+            aggregateId: "trace-1",
+            foldState,
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe("when trace has no cost data", () => {
+      it("returns false", () => {
+        const reactor = createExperimentMetricsSyncReactor(createDeps());
+        const foldState = createTraceSummaryState({
+          attributes: { "evaluation.run_id": "run-1" },
+          totalCost: null,
+        });
+
+        expect(
+          reactor.shouldReact!(createSpanReceivedEvent(), {
+            tenantId: TEST_TENANT_ID,
+            aggregateId: "trace-1",
+            foldState,
+          }),
+        ).toBe(false);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/experimentMetricsSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/experimentMetricsSync.reactor.unit.test.ts
@@ -237,7 +237,7 @@ describe("experimentMetricsSync reactor (trace-side ECST publisher)", () => {
     });
   });
 
-  describe("shouldReact predicate", () => {
+  describe("when deciding whether to react", () => {
     describe("when trace has evaluation.run_id and cost data", () => {
       it("returns true", () => {
         const reactor = createExperimentMetricsSyncReactor(createDeps());

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
@@ -185,6 +185,46 @@ describe("originGate reactor", () => {
       expect(deps.scheduleDeferred).not.toHaveBeenCalled();
     });
   });
+
+  describe("shouldReact predicate", () => {
+    describe("when origin is absent on a recent trace", () => {
+      it("returns true", () => {
+        const reactor = createOriginGateReactor(createDeps());
+        const state = createFoldState({ attributes: {} });
+
+        expect(reactor.shouldReact!(createEvent(), createContext(state))).toBe(
+          true,
+        );
+      });
+    });
+
+    describe("when origin is already resolved", () => {
+      it("returns false", () => {
+        const reactor = createOriginGateReactor(createDeps());
+        const state = createFoldState({
+          attributes: { "langwatch.origin": "application" },
+        });
+
+        expect(reactor.shouldReact!(createEvent(), createContext(state))).toBe(
+          false,
+        );
+      });
+    });
+
+    describe("when the trace is old (resyncing)", () => {
+      it("returns false", () => {
+        const reactor = createOriginGateReactor(createDeps());
+        const state = createFoldState({ attributes: {} });
+        const oldEvent = createEvent({
+          occurredAt: Date.now() - 2 * 60 * 60 * 1000,
+        });
+
+        expect(reactor.shouldReact!(oldEvent, createContext(state))).toBe(
+          false,
+        );
+      });
+    });
+  });
 });
 
 describe("createDeferredOriginHandler()", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/originGate.reactor.unit.test.ts
@@ -186,7 +186,7 @@ describe("originGate reactor", () => {
     });
   });
 
-  describe("shouldReact predicate", () => {
+  describe("when deciding whether to react", () => {
     describe("when origin is absent on a recent trace", () => {
       it("returns true", () => {
         const reactor = createOriginGateReactor(createDeps());

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
@@ -354,4 +354,38 @@ describe("createProjectMetadataReactor()", () => {
 
     expect(reactor.options!.runIn).toEqual(["worker"]);
   });
+
+  describe("shouldReact predicate", () => {
+    describe("when the trace is a real ingest", () => {
+      it("returns true", () => {
+        const reactor = createProjectMetadataReactor(deps);
+        const foldState = createFoldState({
+          attributes: { "langwatch.origin": "application" },
+        });
+
+        expect(
+          reactor.shouldReact!(
+            createEvent("tenant-1"),
+            createContext("tenant-1", foldState),
+          ),
+        ).toBe(true);
+      });
+    });
+
+    describe("when the trace is a seeded sample", () => {
+      it("returns false", () => {
+        const reactor = createProjectMetadataReactor(deps);
+        const foldState = createFoldState({
+          attributes: { "langwatch.origin": "sample" },
+        });
+
+        expect(
+          reactor.shouldReact!(
+            createEvent("tenant-1"),
+            createContext("tenant-1", foldState),
+          ),
+        ).toBe(false);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/projectMetadata.reactor.unit.test.ts
@@ -355,7 +355,7 @@ describe("createProjectMetadataReactor()", () => {
     expect(reactor.options!.runIn).toEqual(["worker"]);
   });
 
-  describe("shouldReact predicate", () => {
+  describe("when deciding whether to react", () => {
     describe("when the trace is a real ingest", () => {
       it("returns true", () => {
         const reactor = createProjectMetadataReactor(deps);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/simulationMetricsSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/simulationMetricsSync.reactor.unit.test.ts
@@ -190,6 +190,61 @@ describe("simulationMetricsSync reactor (trace-side metrics publisher)", () => {
     });
   });
 
+  describe("shouldReact predicate", () => {
+    describe("when trace has scenario.run_id and data to aggregate", () => {
+      it("returns true", () => {
+        const reactor = createSimulationMetricsSyncReactor(createDeps());
+        const foldState = createTraceSummaryState({
+          attributes: { "scenario.run_id": "run-1" },
+        });
+
+        expect(
+          reactor.shouldReact!(createSpanReceivedEvent(), {
+            tenantId: TEST_TENANT_ID,
+            aggregateId: "trace-1",
+            foldState,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when trace has no scenario.run_id", () => {
+      it("returns false", () => {
+        const reactor = createSimulationMetricsSyncReactor(createDeps());
+        const foldState = createTraceSummaryState({
+          attributes: { "langwatch.origin": "sdk" },
+        });
+
+        expect(
+          reactor.shouldReact!(createSpanReceivedEvent(), {
+            tenantId: TEST_TENANT_ID,
+            aggregateId: "trace-1",
+            foldState,
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe("when trace has no spans and no cost", () => {
+      it("returns false", () => {
+        const reactor = createSimulationMetricsSyncReactor(createDeps());
+        const foldState = createTraceSummaryState({
+          attributes: { "scenario.run_id": "run-1" },
+          spanCount: 0,
+          totalCost: null,
+        });
+
+        expect(
+          reactor.shouldReact!(createSpanReceivedEvent(), {
+            tenantId: TEST_TENANT_ID,
+            aggregateId: "trace-1",
+            foldState,
+          }),
+        ).toBe(false);
+      });
+    });
+  });
+
   describe("when totalCost is zero but the trace has spans", () => {
     it("dispatches computeRunMetrics", async () => {
       const deps = createDeps();

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/simulationMetricsSync.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/__tests__/simulationMetricsSync.reactor.unit.test.ts
@@ -190,7 +190,7 @@ describe("simulationMetricsSync reactor (trace-side metrics publisher)", () => {
     });
   });
 
-  describe("shouldReact predicate", () => {
+  describe("when deciding whether to react", () => {
     describe("when trace has scenario.run_id and data to aggregate", () => {
       it("returns true", () => {
         const reactor = createSimulationMetricsSyncReactor(createDeps());

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/customEvaluationSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/customEvaluationSync.reactor.ts
@@ -98,6 +98,25 @@ export function extractEvaluationsFromSpan(span: OtlpSpan): SdkEvaluation[] {
 }
 
 /**
+ * Cheap presence check — no JSON.parse. The predicate runs on the projection
+ * hot path with attacker-supplied span payloads, so it only looks for an
+ * evaluation event carrying a string payload; full parsing and validation
+ * stay in handle() off the hot path.
+ */
+function spanHasEvaluationEvents(span: OtlpSpan): boolean {
+  return (span.events ?? []).some(
+    (event) =>
+      event.name === EVAL_EVENT_NAME &&
+      event.attributes.some(
+        (attr) =>
+          attr.key === "json_encoded_event" &&
+          attr.value !== undefined &&
+          "stringValue" in attr.value,
+      ),
+  );
+}
+
+/**
  * Pure relevance guard, shared by shouldReact (pre-enqueue) and handle
  * (fail-open path): only span events that are recent (not a resync) and
  * actually carry `langwatch.evaluation.custom` events need this reactor.
@@ -105,7 +124,7 @@ export function extractEvaluationsFromSpan(span: OtlpSpan): SdkEvaluation[] {
 function hasSyncableEvaluations(event: TraceProcessingEvent): boolean {
   if (!isSpanReceivedEvent(event)) return false;
   if (event.occurredAt < Date.now() - STALE_TRACE_THRESHOLD_MS) return false;
-  return extractEvaluationsFromSpan(event.data.span).length > 0;
+  return spanHasEvaluationEvents(event.data.span);
 }
 
 /**
@@ -139,6 +158,7 @@ export function createCustomEvaluationSyncReactor(
       const { tenantId, aggregateId: traceId } = context;
 
       const evaluations = extractEvaluationsFromSpan(event.data.span);
+      if (evaluations.length === 0) return;
 
       logger.debug(
         { tenantId, traceId, evaluationCount: evaluations.length },

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/customEvaluationSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/customEvaluationSync.reactor.ts
@@ -98,6 +98,17 @@ export function extractEvaluationsFromSpan(span: OtlpSpan): SdkEvaluation[] {
 }
 
 /**
+ * Pure relevance guard, shared by shouldReact (pre-enqueue) and handle
+ * (fail-open path): only span events that are recent (not a resync) and
+ * actually carry `langwatch.evaluation.custom` events need this reactor.
+ */
+function hasSyncableEvaluations(event: TraceProcessingEvent): boolean {
+  if (!isSpanReceivedEvent(event)) return false;
+  if (event.occurredAt < Date.now() - STALE_TRACE_THRESHOLD_MS) return false;
+  return extractEvaluationsFromSpan(event.data.span).length > 0;
+}
+
+/**
  * Reactor that syncs custom SDK evaluations to the evaluation-processing pipeline.
  *
  * Reads `langwatch.evaluation.custom` events directly from each SpanReceivedEvent's
@@ -110,6 +121,7 @@ export function createCustomEvaluationSyncReactor(
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
   return {
     name: "customEvaluationSync",
+    shouldReact: (event) => hasSyncableEvaluations(event),
     options: {
       makeJobId: (payload) =>
         `custom-eval-sync:${payload.event.tenantId}:${payload.event.aggregateId}:${payload.event.id}`,
@@ -122,14 +134,11 @@ export function createCustomEvaluationSyncReactor(
       context: ReactorContext<TraceSummaryData>,
     ): Promise<void> {
       if (!isSpanReceivedEvent(event)) return;
+      if (!hasSyncableEvaluations(event)) return;
 
       const { tenantId, aggregateId: traceId } = context;
 
-      // Guard: skip old traces (resyncing)
-      if (event.occurredAt < Date.now() - STALE_TRACE_THRESHOLD_MS) return;
-
       const evaluations = extractEvaluationsFromSpan(event.data.span);
-      if (evaluations.length === 0) return;
 
       logger.debug(
         { tenantId, traceId, evaluationCount: evaluations.length },

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/experimentMetricsSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/experimentMetricsSync.reactor.ts
@@ -28,11 +28,24 @@ export interface ExperimentMetricsSyncReactorDeps {
  * Filtering: only fires for traces with evaluation.run_id
  * in their hoisted span attributes.
  */
+/**
+ * Pure relevance guard, shared by shouldReact (pre-enqueue) and handle
+ * (fail-open path): only experiment traces (evaluation.run_id present)
+ * with actual cost data need this reactor. The experiment-ID lookup is
+ * stateful and stays in handle.
+ */
+function hasExperimentCostMetrics(foldState: TraceSummaryData): boolean {
+  if (!foldState.attributes["evaluation.run_id"]) return false;
+  return foldState.totalCost !== null && foldState.totalCost !== 0;
+}
+
 export function createExperimentMetricsSyncReactor(
   deps: ExperimentMetricsSyncReactorDeps,
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
   return {
     name: "experimentMetricsSync",
+    shouldReact: (_event, context) =>
+      hasExperimentCostMetrics(context.foldState),
     options: {
       makeJobId: (payload) =>
         `exp-metrics:${payload.event.tenantId}:${payload.event.aggregateId}`,
@@ -45,14 +58,9 @@ export function createExperimentMetricsSyncReactor(
       context: ReactorContext<TraceSummaryData>,
     ): Promise<void> {
       const { tenantId, foldState } = context;
-      const runId = foldState.attributes["evaluation.run_id"];
+      if (!hasExperimentCostMetrics(foldState)) return;
 
-      if (!runId) return;
-
-      // Only dispatch if there's actual cost data
-      if (foldState.totalCost === null || foldState.totalCost === 0) {
-        return;
-      }
+      const runId = foldState.attributes["evaluation.run_id"]!;
 
       const traceId = foldState.traceId;
 
@@ -77,7 +85,7 @@ export function createExperimentMetricsSyncReactor(
           experimentId,
           runId,
           traceId,
-          totalCost: foldState.totalCost,
+          totalCost: foldState.totalCost!,
           occurredAt: Date.now(),
         });
       } catch (error) {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/originGate.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/originGate.reactor.ts
@@ -2,6 +2,7 @@ import type { ResolveOriginCommandData } from "../schemas/commands";
 import { createLogger } from "../../../../../utils/logger/server";
 import type { ReactorContext, ReactorDefinition } from "../../../reactors/reactor.types";
 import type { TraceSummaryData } from "../projections/traceSummary.foldProjection";
+import { STALE_TRACE_THRESHOLD_MS } from "../schemas/constants";
 import type { TraceProcessingEvent } from "../schemas/events";
 
 const logger = createLogger(
@@ -32,11 +33,26 @@ export interface OriginGateReactorDeps {
  * Completely decoupled from evaluation dispatch — evaluationTrigger
  * handles that independently.
  */
+/**
+ * Pure relevance guard, shared by shouldReact (pre-enqueue) and handle
+ * (fail-open path): skip stale resync traces and traces whose origin is
+ * already resolved.
+ */
+function needsOriginResolution(
+  event: TraceProcessingEvent,
+  foldState: TraceSummaryData,
+): boolean {
+  if (event.occurredAt < Date.now() - STALE_TRACE_THRESHOLD_MS) return false;
+  return !(foldState.attributes ?? {})["langwatch.origin"];
+}
+
 export function createOriginGateReactor(
   deps: OriginGateReactorDeps,
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
   return {
     name: "originGate",
+    shouldReact: (event, context) =>
+      needsOriginResolution(event, context.foldState),
     options: {
       makeJobId: (payload) =>
         `origin-gate:${payload.event.tenantId}:${payload.event.aggregateId}`,
@@ -50,11 +66,7 @@ export function createOriginGateReactor(
     ): Promise<void> {
       const { tenantId, aggregateId: traceId, foldState } = context;
 
-      // Guard: skip old traces (resyncing)
-      if (event.occurredAt < Date.now() - 60 * 60 * 1000) return;
-
-      const attrs = foldState.attributes ?? {};
-      if (attrs["langwatch.origin"]) return; // origin already resolved
+      if (!needsOriginResolution(event, foldState)) return;
 
       // No origin — schedule deferred resolution (5-min delay)
       logger.debug(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/originGate.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/originGate.reactor.ts
@@ -43,7 +43,7 @@ function needsOriginResolution(
   foldState: TraceSummaryData,
 ): boolean {
   if (event.occurredAt < Date.now() - STALE_TRACE_THRESHOLD_MS) return false;
-  return !(foldState.attributes ?? {})["langwatch.origin"];
+  return !foldState.attributes?.["langwatch.origin"];
 }
 
 export function createOriginGateReactor(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
@@ -31,7 +31,7 @@ export interface ProjectMetadataReactorDeps {
  * a real trace will trigger this reactor again.
  */
 function isRealFirstIngest(foldState: TraceSummaryData): boolean {
-  return (foldState.attributes ?? {})["langwatch.origin"] !== "sample";
+  return foldState.attributes?.["langwatch.origin"] !== "sample";
 }
 
 export function createProjectMetadataReactor(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/projectMetadata.reactor.ts
@@ -21,11 +21,25 @@ export interface ProjectMetadataReactorDeps {
  *
  * Uses a long dedup TTL so we only hit the database once per project in a given window.
  */
+/**
+ * Pure relevance guard, shared by shouldReact (pre-enqueue) and handle
+ * (fail-open path). Sample traces (seeded from the empty-state "Seed
+ * sample traces" path; every span carries `langwatch.origin = "sample"`)
+ * are not a real first ingest. Flipping `firstMessage` / `integrated` on
+ * them would prematurely dismiss the empty-state onboarding card even
+ * though the user hasn't connected their own app yet. Skip entirely —
+ * a real trace will trigger this reactor again.
+ */
+function isRealFirstIngest(foldState: TraceSummaryData): boolean {
+  return (foldState.attributes ?? {})["langwatch.origin"] !== "sample";
+}
+
 export function createProjectMetadataReactor(
   deps: ProjectMetadataReactorDeps,
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
   return {
     name: "projectMetadata",
+    shouldReact: (_event, context) => isRealFirstIngest(context.foldState),
     options: {
       runIn: ["worker"],
       makeJobId: (payload) =>
@@ -40,15 +54,7 @@ export function createProjectMetadataReactor(
       const { tenantId, foldState } = context;
       const attrs = foldState.attributes ?? {};
 
-      // Sample traces (seeded from the empty-state "Seed sample traces"
-      // path; every span carries `langwatch.origin = "sample"`) are not
-      // a real first ingest. Flipping `firstMessage` / `integrated` on
-      // them would prematurely dismiss the empty-state onboarding card
-      // even though the user hasn't connected their own app yet. Skip
-      // entirely — a real trace will trigger this reactor again.
-      if (attrs["langwatch.origin"] === "sample") {
-        return;
-      }
+      if (!isRealFirstIngest(foldState)) return;
 
       try {
         const project = await deps.projects.getById(tenantId);

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/simulationMetricsSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/simulationMetricsSync.reactor.ts
@@ -27,11 +27,22 @@ export interface SimulationMetricsSyncReactorDeps {
  * Scenario filtering: only fires for traces with scenario.run_id
  * in their hoisted span attributes.
  */
+/**
+ * Pure relevance guard, shared by shouldReact (pre-enqueue) and handle
+ * (fail-open path): only simulation traces (scenario.run_id present)
+ * with something to aggregate need this reactor.
+ */
+function hasSimulationMetrics(foldState: TraceSummaryData): boolean {
+  if (!foldState.attributes["scenario.run_id"]) return false;
+  return !(foldState.spanCount === 0 && foldState.totalCost === null);
+}
+
 export function createSimulationMetricsSyncReactor(
   deps: SimulationMetricsSyncReactorDeps,
 ): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
   return {
     name: "simulationMetricsSync",
+    shouldReact: (_event, context) => hasSimulationMetrics(context.foldState),
     options: {
       makeJobId: (payload) =>
         `sim-metrics:${payload.event.tenantId}:${payload.event.aggregateId}`,
@@ -44,16 +55,12 @@ export function createSimulationMetricsSyncReactor(
       context: ReactorContext<TraceSummaryData>,
     ): Promise<void> {
       const { tenantId, foldState } = context;
-      const scenarioRunId = foldState.attributes["scenario.run_id"];
+      if (!hasSimulationMetrics(foldState)) return;
 
-      if (!scenarioRunId) return;
-
-      // Skip traces with nothing to aggregate. Role cost/latency are no longer
-      // accumulated on the fold; computeRunMetrics derives them per-trace from
-      // stored_spans, so we dispatch in pull mode rather than carrying metrics.
-      if (foldState.spanCount === 0 && foldState.totalCost === null) {
-        return;
-      }
+      // Role cost/latency are no longer accumulated on the fold;
+      // computeRunMetrics derives them per-trace from stored_spans, so we
+      // dispatch in pull mode rather than carrying metrics.
+      const scenarioRunId = foldState.attributes["scenario.run_id"]!;
 
       const traceId = foldState.traceId;
 

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/simulationMetricsSync.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/reactors/simulationMetricsSync.reactor.ts
@@ -30,7 +30,10 @@ export interface SimulationMetricsSyncReactorDeps {
 /**
  * Pure relevance guard, shared by shouldReact (pre-enqueue) and handle
  * (fail-open path): only simulation traces (scenario.run_id present)
- * with something to aggregate need this reactor.
+ * with something to aggregate need this reactor. Role cost/latency are
+ * no longer accumulated on the fold; computeRunMetrics derives them
+ * per-trace from stored_spans, so we dispatch in pull mode rather than
+ * carrying metrics.
  */
 function hasSimulationMetrics(foldState: TraceSummaryData): boolean {
   if (!foldState.attributes["scenario.run_id"]) return false;
@@ -57,9 +60,6 @@ export function createSimulationMetricsSyncReactor(
       const { tenantId, foldState } = context;
       if (!hasSimulationMetrics(foldState)) return;
 
-      // Role cost/latency are no longer accumulated on the fold;
-      // computeRunMetrics derives them per-trace from stored_spans, so we
-      // dispatch in pull mode rather than carrying metrics.
       const scenarioRunId = foldState.attributes["scenario.run_id"]!;
 
       const traceId = foldState.traceId;

--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
@@ -440,6 +440,151 @@ describe("ProjectionRouter", () => {
       });
     });
 
+    describe("when a reactor declares a shouldReact predicate", () => {
+      const setupRouterWithFold = (queueManager: ReturnType<typeof createMockQueueManager>) => {
+        const router = new ProjectionRouter(
+          TEST_CONSTANTS.AGGREGATE_TYPE,
+          TEST_CONSTANTS.PIPELINE_NAME,
+          queueManager,
+        );
+
+        const store = createMockFoldProjectionStore<{ count: number }>();
+        (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const fold = createMockFoldProjectionDefinition("my-fold", {
+          store,
+          init: () => ({ count: 0 }),
+          apply: (state: { count: number }) => ({ count: state.count + 1 }),
+        });
+
+        router.registerFoldProjection(fold);
+        return router;
+      };
+
+      describe("when the predicate returns false", () => {
+        it("does not enqueue a job for that reactor", async () => {
+          const mockSend = vi.fn().mockResolvedValue(undefined);
+          const queueManager = createMockQueueManager({
+            hasReactorQueues: true,
+            getReactorQueue: vi.fn().mockReturnValue({ send: mockSend }),
+          });
+          const router = setupRouterWithFold(queueManager);
+
+          const reactorHandle = vi.fn().mockResolvedValue(undefined);
+          const reactor: ReactorDefinition<Event> = {
+            name: "filtered-reactor",
+            shouldReact: () => false,
+            handle: reactorHandle,
+          };
+          router.registerReactor("my-fold", reactor);
+
+          const event = createTestEvent(
+            TEST_CONSTANTS.AGGREGATE_ID,
+            TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId,
+          );
+
+          await router.dispatch([event], { tenantId });
+
+          expect(mockSend).not.toHaveBeenCalled();
+          expect(reactorHandle).not.toHaveBeenCalled();
+        });
+
+        it("skips inline execution too", async () => {
+          const queueManager = createMockQueueManager();
+          const router = setupRouterWithFold(queueManager);
+
+          const reactorHandle = vi.fn().mockResolvedValue(undefined);
+          const reactor: ReactorDefinition<Event> = {
+            name: "filtered-inline-reactor",
+            shouldReact: () => false,
+            handle: reactorHandle,
+          };
+          router.registerReactor("my-fold", reactor);
+
+          const event = createTestEvent(
+            TEST_CONSTANTS.AGGREGATE_ID,
+            TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId,
+          );
+
+          await router.dispatch([event], { tenantId });
+
+          expect(reactorHandle).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("when the predicate returns true", () => {
+        it("enqueues the job with the event and fold state", async () => {
+          const mockSend = vi.fn().mockResolvedValue(undefined);
+          const queueManager = createMockQueueManager({
+            hasReactorQueues: true,
+            getReactorQueue: vi.fn().mockReturnValue({ send: mockSend }),
+          });
+          const router = setupRouterWithFold(queueManager);
+
+          const shouldReact = vi.fn().mockReturnValue(true);
+          const reactor: ReactorDefinition<Event> = {
+            name: "passing-reactor",
+            shouldReact,
+            handle: vi.fn(),
+          };
+          router.registerReactor("my-fold", reactor);
+
+          const event = createTestEvent(
+            TEST_CONSTANTS.AGGREGATE_ID,
+            TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId,
+          );
+
+          await router.dispatch([event], { tenantId });
+
+          expect(shouldReact).toHaveBeenCalledWith(
+            event,
+            expect.objectContaining({
+              tenantId,
+              aggregateId: String(event.aggregateId),
+              foldState: { count: 1 },
+            }),
+          );
+          expect(mockSend).toHaveBeenCalledWith({
+            event,
+            foldState: { count: 1 },
+          });
+        });
+      });
+
+      describe("when the predicate throws", () => {
+        it("fails open and enqueues the job anyway", async () => {
+          const mockSend = vi.fn().mockResolvedValue(undefined);
+          const queueManager = createMockQueueManager({
+            hasReactorQueues: true,
+            getReactorQueue: vi.fn().mockReturnValue({ send: mockSend }),
+          });
+          const router = setupRouterWithFold(queueManager);
+
+          const reactor: ReactorDefinition<Event> = {
+            name: "throwing-predicate-reactor",
+            shouldReact: () => {
+              throw new Error("predicate boom");
+            },
+            handle: vi.fn(),
+          };
+          router.registerReactor("my-fold", reactor);
+
+          const event = createTestEvent(
+            TEST_CONSTANTS.AGGREGATE_ID,
+            TEST_CONSTANTS.AGGREGATE_TYPE,
+            tenantId,
+          );
+
+          await router.dispatch([event], { tenantId });
+
+          expect(mockSend).toHaveBeenCalled();
+        });
+      });
+    });
+
     describe("when a reactor queue send fails", () => {
       it("throws AggregateError", async () => {
         const mockSend = vi.fn().mockRejectedValue(new Error("queue send failed"));

--- a/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
+++ b/langwatch/src/server/event-sourcing/projections/__tests__/projectionRouter.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { incrementEsReactorTotal } from "~/server/metrics";
 import { ProjectionRouter } from "../projectionRouter";
+
+vi.mock("~/server/metrics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/server/metrics")>();
+  return {
+    ...actual,
+    incrementEsReactorTotal: vi.fn(),
+  };
+});
 import type { QueueManager } from "../../services/queues/queueManager";
 import type { Event } from "../../domain/types";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
@@ -488,6 +497,11 @@ describe("ProjectionRouter", () => {
 
           expect(mockSend).not.toHaveBeenCalled();
           expect(reactorHandle).not.toHaveBeenCalled();
+          expect(incrementEsReactorTotal).toHaveBeenCalledWith(
+            TEST_CONSTANTS.PIPELINE_NAME,
+            "filtered-reactor",
+            "skipped",
+          );
         });
 
         it("skips inline execution too", async () => {
@@ -953,6 +967,38 @@ describe("ProjectionRouter", () => {
         // Per-span reactors (embedded-eval sync, evaluation triggers) must see
         // EVERY event, not just the last — otherwise N-1 spans are dropped.
         expect(seen).toEqual(["e1", "e2", "e3"]);
+      });
+
+      it("evaluates shouldReact per coalesced event, not once per batch", async () => {
+        const router = new ProjectionRouter(
+          TEST_CONSTANTS.AGGREGATE_TYPE,
+          TEST_CONSTANTS.PIPELINE_NAME,
+          createMockQueueManager(),
+        );
+        const store = createMockFoldProjectionStore();
+        (store.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        const fold = batchFold(store);
+        router.registerFoldProjection(fold);
+
+        const seen: string[] = [];
+        const reactor: ReactorDefinition<Event> = {
+          name: "selective-per-span-spy",
+          shouldReact: (event) => event.id !== "e2",
+          handle: async (event) => {
+            seen.push(event.id);
+          },
+        };
+        router.registerReactor("my-fold", reactor);
+
+        const events = [
+          makeBatchEvent("e1", 1000),
+          makeBatchEvent("e2", 2000),
+          makeBatchEvent("e3", 3000),
+        ];
+
+        await (router as any).processFoldProjectionBatch("my-fold", fold, events, { tenantId });
+
+        expect(seen).toEqual(["e1", "e3"]);
       });
 
       it("dispatches reactors in occurredAt order even when events arrive shuffled", async () => {

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -743,7 +743,13 @@ export class ProjectionRouter<
    * Builds the context a reactor receives. Used for both shouldReact and
    * handle so the predicate can never see a different shape than the handler.
    */
-  private buildReactorContext(event: EventType, foldState: unknown) {
+  private buildReactorContext({
+    event,
+    foldState,
+  }: {
+    event: EventType;
+    foldState: unknown;
+  }) {
     return {
       tenantId: event.tenantId,
       aggregateId: String(event.aggregateId),
@@ -764,7 +770,10 @@ export class ProjectionRouter<
     if (!reactor.shouldReact) return true;
 
     try {
-      return reactor.shouldReact(event, this.buildReactorContext(event, foldState));
+      return reactor.shouldReact(
+        event,
+        this.buildReactorContext({ event, foldState }),
+      );
     } catch (error) {
       this.logger.error(
         {
@@ -831,7 +840,10 @@ export class ProjectionRouter<
           try {
             await withMetrics({
               fn: () =>
-                reactor.handle(event, this.buildReactorContext(event, foldState)),
+                reactor.handle(
+                  event,
+                  this.buildReactorContext({ event, foldState }),
+                ),
               onComplete: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "completed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
               onFail: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "failed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
             });
@@ -856,7 +868,10 @@ export class ProjectionRouter<
         try {
           await withMetrics({
             fn: () =>
-              reactor.handle(event, this.buildReactorContext(event, foldState)),
+              reactor.handle(
+                event,
+                this.buildReactorContext({ event, foldState }),
+              ),
             onComplete: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "completed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
             onFail: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "failed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
           });

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -740,6 +740,39 @@ export class ProjectionRouter<
   }
 
   /**
+   * Evaluates a reactor's optional shouldReact predicate. Fails open: a
+   * thrown predicate is logged and treated as true so a predicate bug can
+   * never drop a side effect (worst case is one redundant job).
+   */
+  private reactorShouldReact(
+    reactor: ReactorDefinition<EventType>,
+    event: EventType,
+    foldState: unknown,
+  ): boolean {
+    if (!reactor.shouldReact) return true;
+
+    try {
+      return reactor.shouldReact(event, {
+        tenantId: event.tenantId,
+        aggregateId: String(event.aggregateId),
+        foldState,
+      });
+    } catch (error) {
+      this.logger.error(
+        {
+          reactorName: reactor.name,
+          eventId: event.id,
+          eventType: event.type,
+          tenantId: event.tenantId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Reactor shouldReact predicate threw — failing open and dispatching",
+      );
+      return true;
+    }
+  }
+
+  /**
    * Dispatches a single event to reactors registered on a fold projection.
    * In queued mode, sends to reactor queues. In inline mode, calls directly.
    */
@@ -755,6 +788,10 @@ export class ProjectionRouter<
     for (const reactor of reactors) {
       if (reactor.options?.disabled) continue;
       if (this.isReactorExcluded(reactor)) continue;
+      if (!this.reactorShouldReact(reactor, event, foldState)) {
+        incrementEsReactorTotal(this.pipelineName, reactor.name, "skipped");
+        continue;
+      }
 
       if (hasReactorQueues) {
         const queueProcessor = this.queueManager.getReactorQueue(reactor.name);

--- a/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
+++ b/langwatch/src/server/event-sourcing/projections/projectionRouter.ts
@@ -740,6 +740,18 @@ export class ProjectionRouter<
   }
 
   /**
+   * Builds the context a reactor receives. Used for both shouldReact and
+   * handle so the predicate can never see a different shape than the handler.
+   */
+  private buildReactorContext(event: EventType, foldState: unknown) {
+    return {
+      tenantId: event.tenantId,
+      aggregateId: String(event.aggregateId),
+      foldState,
+    };
+  }
+
+  /**
    * Evaluates a reactor's optional shouldReact predicate. Fails open: a
    * thrown predicate is logged and treated as true so a predicate bug can
    * never drop a side effect (worst case is one redundant job).
@@ -752,11 +764,7 @@ export class ProjectionRouter<
     if (!reactor.shouldReact) return true;
 
     try {
-      return reactor.shouldReact(event, {
-        tenantId: event.tenantId,
-        aggregateId: String(event.aggregateId),
-        foldState,
-      });
+      return reactor.shouldReact(event, this.buildReactorContext(event, foldState));
     } catch (error) {
       this.logger.error(
         {
@@ -822,11 +830,8 @@ export class ProjectionRouter<
           );
           try {
             await withMetrics({
-              fn: () => reactor.handle(event, {
-                tenantId: event.tenantId,
-                aggregateId: String(event.aggregateId),
-                foldState,
-              }),
+              fn: () =>
+                reactor.handle(event, this.buildReactorContext(event, foldState)),
               onComplete: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "completed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
               onFail: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "failed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
             });
@@ -850,11 +855,8 @@ export class ProjectionRouter<
         // Inline mode: call reactor directly
         try {
           await withMetrics({
-            fn: () => reactor.handle(event, {
-              tenantId: event.tenantId,
-              aggregateId: String(event.aggregateId),
-              foldState,
-            }),
+            fn: () =>
+              reactor.handle(event, this.buildReactorContext(event, foldState)),
             onComplete: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "completed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
             onFail: (ms) => { incrementEsReactorTotal(this.pipelineName, reactor.name, "failed"); observeEsReactorDuration(this.pipelineName, reactor.name, ms); },
           });

--- a/langwatch/src/server/event-sourcing/reactors/reactor.types.ts
+++ b/langwatch/src/server/event-sourcing/reactors/reactor.types.ts
@@ -36,12 +36,29 @@ export interface ReactorOptions {
  * after every fold apply + store succeeds. This guarantees correctness:
  * if the fold fails, the reactor never fires.
  *
- * Reactors fire on every fold completion (no eventTypes filter).
+ * Reactors fire on every fold completion unless a `shouldReact`
+ * predicate filters the event out before enqueue.
  * Downstream commands handle their own dedup via makeJobId + delay.
+ *
+ * See dev/docs/adr/026-reactor-should-react-predicate.md.
  */
 export interface ReactorDefinition<E extends Event = Event, FoldState = unknown> {
   /** Unique name for this reactor */
   name: string;
+  /**
+   * Optional pure predicate evaluated at dispatch time, before any job is
+   * enqueued. Return false to skip this reactor entirely for the event.
+   *
+   * Must be pure and synchronous — no IO, no injected dependencies; it runs
+   * on the projection hot path. Guards that need dependencies (DB lookups
+   * etc.) belong in handle(). A thrown predicate is caught, logged, and
+   * treated as true (fail open — never drops a side effect).
+   *
+   * The queue payload `{ event, foldState }` is captured at dispatch, so the
+   * predicate sees exactly what handle() would receive — do not use this for
+   * conditions that should be re-evaluated against fresher state later.
+   */
+  shouldReact?(event: E, context: ReactorContext<FoldState>): boolean;
   /** Side-effect handler called after fold succeeds */
   handle(event: E, context: ReactorContext<FoldState>): Promise<void>;
   /** Optional configuration */

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -289,7 +289,9 @@ export const eventSourcingStoreDurationHistogram = new Histogram({
 // Event Sourcing Pipeline Metrics (command, fold, map, reactor)
 // ============================================================================
 
-type ESStatus = "completed" | "failed" | "skipped";
+type ESStatus = "completed" | "failed";
+/** Reactors additionally skip pre-enqueue when shouldReact returns false. */
+type ReactorStatus = ESStatus | "skipped";
 
 // --- Command metrics ---
 register.removeSingleMetric("es_command_total");
@@ -392,7 +394,7 @@ const esReactorTotal = new Counter({
 export const incrementEsReactorTotal = (
   pipelineName: string,
   reactorName: string,
-  status: ESStatus,
+  status: ReactorStatus,
 ) => esReactorTotal.labels(pipelineName, reactorName, status).inc();
 
 register.removeSingleMetric("es_reactor_duration_milliseconds");

--- a/langwatch/src/server/metrics.ts
+++ b/langwatch/src/server/metrics.ts
@@ -289,7 +289,7 @@ export const eventSourcingStoreDurationHistogram = new Histogram({
 // Event Sourcing Pipeline Metrics (command, fold, map, reactor)
 // ============================================================================
 
-type ESStatus = "completed" | "failed";
+type ESStatus = "completed" | "failed" | "skipped";
 
 // --- Command metrics ---
 register.removeSingleMetric("es_command_total");

--- a/specs/event-sourcing/reactors.feature
+++ b/specs/event-sourcing/reactors.feature
@@ -28,26 +28,26 @@ Feature: Reactors
     Then the reactor is NOT initialized or executed in this process
 
   Scenario: Irrelevant events are filtered before enqueue
-    Given a reactor with a shouldReact predicate
-    And an event the predicate evaluates as not relevant
+    Given a reactor that declares which events are relevant to it
+    And an event the reactor considers not relevant
     When the fold projection successfully applies and stores the event
     Then no job is enqueued for that reactor
     And the reactor's handler never runs for that event
     And a skipped outcome is recorded for observability
 
   Scenario: Relevant events are dispatched as before
-    Given a reactor with a shouldReact predicate
-    And an event the predicate evaluates as relevant
+    Given a reactor that declares which events are relevant to it
+    And an event the reactor considers relevant
     When the fold projection successfully applies and stores the event
     Then the reactor is dispatched with the event and the fold state
 
-  Scenario: A failing predicate never drops a side effect
-    Given a reactor whose shouldReact predicate throws an error
+  Scenario: A failing relevance check never drops a side effect
+    Given a reactor whose relevance check throws an error
     When the fold projection successfully applies and stores the event
     Then the error is logged
     And the reactor is dispatched anyway
 
-  Scenario: Reactors without a predicate are unaffected
-    Given a reactor with no shouldReact predicate
+  Scenario: Reactors without a relevance check are unaffected
+    Given a reactor that does not declare a relevance check
     When the fold projection successfully applies and stores the event
     Then the reactor is dispatched for every event

--- a/specs/event-sourcing/reactors.feature
+++ b/specs/event-sourcing/reactors.feature
@@ -1,3 +1,5 @@
+# See dev/docs/adr/026-reactor-should-react-predicate.md for the
+# shouldReact predicate rationale.
 Feature: Reactors
 
   Reactors are post-fold side-effect handlers. they allow reacting to the
@@ -24,3 +26,28 @@ Feature: Reactors
     And the current process role is "web"
     When a fold projection succeeds
     Then the reactor is NOT initialized or executed in this process
+
+  Scenario: Irrelevant events are filtered before enqueue
+    Given a reactor with a shouldReact predicate
+    And an event the predicate evaluates as not relevant
+    When the fold projection successfully applies and stores the event
+    Then no job is enqueued for that reactor
+    And the reactor's handler never runs for that event
+    And a skipped outcome is recorded for observability
+
+  Scenario: Relevant events are dispatched as before
+    Given a reactor with a shouldReact predicate
+    And an event the predicate evaluates as relevant
+    When the fold projection successfully applies and stores the event
+    Then the reactor is dispatched with the event and the fold state
+
+  Scenario: A failing predicate never drops a side effect
+    Given a reactor whose shouldReact predicate throws an error
+    When the fold projection successfully applies and stores the event
+    Then the error is logged
+    And the reactor is dispatched anyway
+
+  Scenario: Reactors without a predicate are unaffected
+    Given a reactor with no shouldReact predicate
+    When the fold projection successfully applies and stores the event
+    Then the reactor is dispatched for every event


### PR DESCRIPTION
## Why

Every projection update fans out one GroupQueue job per registered reactor - the trace pipeline has ~10 of them, and for a typical production span most immediately no-op on a guard at the top of `handle()` (no `scenario.run_id`, no `evaluation.run_id`, origin already resolved, no embedded SDK evals). Under normal load that's wasted Redis writes and worker dequeues. Under recovery it's a hazard: draining an outage backlog multiplies every deferred event by the reactor count, and the amplified job storm can re-saturate the queue that just recovered.

## What changed

`ReactorDefinition` gains an optional `shouldReact(event, context)` predicate, evaluated in `ProjectionRouter.dispatchToReactors` before any job is created. Return `false` and the reactor is skipped entirely - no enqueue, no dequeue, no no-op. Skips emit `es_reactor_total{status="skipped"}` so the saved fan-out is visible in Prometheus.

Five trace-pipeline reactors get predicates: `customEvaluationSync` (span event, recent, actually carries custom-eval events), `simulationMetricsSync` (`scenario.run_id` present, data to aggregate), `experimentMetricsSync` (`evaluation.run_id` present, has cost), `originGate` (recent, origin unresolved), `projectMetadata` (not a seeded sample trace). For a typical production span all five now skip before enqueue.

Full rationale in [ADR-026](dev/docs/adr/026-reactor-should-react-predicate.md); behavioural contract in [specs/event-sourcing/reactors.feature](specs/event-sourcing/reactors.feature).

## How it works

The predicate must be pure and synchronous - no IO, no injected dependencies - because it runs on the projection hot path. `customEvaluationSync`'s check is deliberately a parse-free presence scan (does the span carry an evaluation event with a string payload?); full JSON parsing stays in `handle()` off the hot path. Stateful guards (DB lookups like experiment-ID resolution) also stay in `handle()`; a reactor that can't decide relevance from `(event, foldState)` alone simply omits the predicate.

It fails open: a thrown predicate is caught, logged, and treated as `true`, so a predicate bug costs one redundant job, never a dropped side effect. Because of that, handlers keep their guards - each lives in one shared pure helper referenced by both `shouldReact` and `handle()`, so the two can't drift.

The queue payload `{ event, foldState }` is captured at dispatch, so the predicate sees exactly what the handler would later receive - a decision made at enqueue time can't be invalidated by execution-time drift.

## Deployment Impact

None beyond a new metric label value. No schema changes, no migrations, no config or chart changes. Rollout is backwards-compatible: reactors without a predicate behave exactly as before, and in-flight queue jobs are unaffected (the gate runs at enqueue time only). Dashboards gain `es_reactor_total{status="skipped"}` - note the skipped counter is emitted by the projection process while completed/failed come from the worker, so skip-rate panels must aggregate across both under the same pipeline/reactor labels. Rollback is a plain revert; worst case is returning to today's enqueue-everything behaviour.

## Test plan

- [ ] `projectionRouter.test.ts`: predicate `false` skips enqueue and inline execution and emits the skipped metric; `true` dispatches with event + fold state; a throwing predicate fails open and enqueues anyway; batch coalescing evaluates the predicate per event
- [ ] Per-reactor unit tests cover each predicate's accept and reject paths, including the zero-cost experiment branch
- [ ] Full event-sourcing unit suite passes: 117 files, 6375 tests

## Anything surprising?

The skip decision for `originGate` and `customEvaluationSync` includes a stale-trace clock cutoff (`Date.now()` against `event.occurredAt`), evaluated at dispatch time - same semantics the handlers had before, just earlier. ADR-026 documents why clock reads are allowed in an otherwise-pure predicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reactors can include an optional pre-enqueue predicate to skip irrelevant events; skipped runs increment a measurable "skipped" reactor metric and enqueued jobs include the event + fold state.
* **Documentation**
  * Added ADR detailing predicate semantics, purity, fail-open behavior, and migration guidance.
* **Refactor**
  * Centralized eligibility guards so pre-enqueue and handler checks stay consistent.
* **Tests**
  * Expanded unit and router tests covering predicate decisions, per-event evaluation, fail-open behavior, and skip/dispatch outcomes.
* **Metrics**
  * Reactor metrics now report a distinct "skipped" status.
* **Specs**
  * Updated feature scenarios to cover predicate relevance and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->