### PR TITLE
feat(event-sourcing): store GroupQueue payloads as compressed envelopes with header-only routing reads

### DIFF
--- a/dev/docs/adr/026-groupqueue-payload-envelope.md
+++ b/dev/docs/adr/026-groupqueue-payload-envelope.md
@@ -50,7 +50,20 @@ GQ1|<headerLen>|<headerJson><body>
   fields `p`/`t`/`n` (pipelineName/jobType/jobName).
 - `<body>` is the full payload JSON (including `__context`, `__attempt`,
   and the routing fields, unchanged) — gzip-compressed and
-  base64-encoded when the JSON exceeds a 1 KiB threshold, raw otherwise.
+  base64-encoded when the JSON exceeds a 1 KiB threshold **and**
+  compression actually shrinks it; high-entropy payloads (inline
+  base64-ish data below the S3 spool threshold) grow under gzip+base64
+  and stay raw.
+
+**Rollout is two-phase.** Readers (TS decode, Lua routing helper, ops
+repository) are always envelope-aware, but writes stay legacy bare JSON
+until `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED=true` is set. A pod from the
+previous release drops any `GQ1|` value it dispatches — its
+`JSON.parse` failure path completes the group slot without invoking the
+handler — and app and worker Deployments roll independently, so a new
+producer can feed an old consumer mid-deploy. Phase 1 ships dual
+readers fleet-wide writing legacy JSON; the flag is flipped only once
+no pre-envelope pods remain.
 
 The dispatch/fail Lua scripts gain a shared helper that reads routing
 metadata from the header alone (a ~100-byte `cjson.decode`), with a
@@ -106,11 +119,14 @@ Redis's thread — which is the point).
   accordingly.
 - The ops dashboard's routing-field extraction gets cheaper (header
   parse) and must go through the shared envelope reader.
-- Rolling deploys are safe in the forward direction (new code reads
-  legacy values). **Rollback while envelope-encoded jobs are in flight
-  is not safe** — old code would fail to `JSON.parse` them and complete
-  the group slot without processing. Drain or accept replay if rolling
-  back.
+- Deploying the dual readers (phase 1) is safe in any direction and at
+  any rollout speed: nothing new is written. **Enabling
+  `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED` is only safe once every
+  consumer pod runs envelope-aware code**, and rolling back to a
+  pre-envelope release while envelope-encoded jobs are in flight is not
+  safe — old code fails to `JSON.parse` them and completes the group
+  slot without processing. Disable the flag and drain (or accept
+  replay) before such a rollback.
 - The S3 offload path for oversized media payloads is unaffected and
   remains the mechanism for keeping large blobs out of Redis.
 

--- a/dev/docs/adr/026-groupqueue-payload-envelope.md
+++ b/dev/docs/adr/026-groupqueue-payload-envelope.md
@@ -40,7 +40,7 @@ for the behavioural contract this decision supports.
 We will store each job's value in the data hash as a **versioned string
 envelope** instead of bare JSON:
 
-```
+```text
 GQ1|<headerLen>|<headerJson><body>
 ```
 

--- a/dev/docs/adr/026-groupqueue-payload-envelope.md
+++ b/dev/docs/adr/026-groupqueue-payload-envelope.md
@@ -1,0 +1,121 @@
+# ADR-026: GroupQueue payload envelope — opaque compressed payloads with a routing header
+
+**Date:** 2026-06-10
+
+**Status:** Accepted
+
+## Context
+
+GroupQueue stores every staged job's payload as a plain `JSON.stringify`
+string in the per-group data hash (`{queue}:gq:group:{groupId}:data`).
+Two costs follow from that:
+
+1. **Redis memory and network.** Span-processing payloads run 2–50 KB of
+   highly repetitive JSON (attribute keys, resource labels). At ingestion
+   volume this dominates Redis memory, bounding how many events the queue
+   can absorb during bursts or downstream slowdowns.
+2. **Redis-side CPU on every dispatch.** The dispatch Lua scripts
+   `cjson.decode` the *full* payload of every candidate job just to read
+   three routing fields (`__pipelineName`, `__jobType`, `__jobName`) for
+   the pause-check, and again on failure to bump a per-job-name counter.
+   With dispatch batches of up to 200 jobs this can decode megabytes of
+   JSON per pass — on Redis's single thread.
+
+The routing fields are injected by the queue-manager facades into the
+payload itself, which is why Lua has no cheaper way to see them. The ops
+dashboard repository does the same full-payload parse for the same three
+fields.
+
+Separately, a payload-offload system already moves very large payloads
+(base64-encoded audio/video/images inside LLM interactions) out of Redis
+into S3. That system stays: compression does not help much on base64
+media, and those payloads should not transit Redis at all. This decision
+targets the ordinary span-sized payloads that remain inline.
+
+See [specs/event-sourcing/payload-envelope.feature](../../../specs/event-sourcing/payload-envelope.feature)
+for the behavioural contract this decision supports.
+
+## Decision
+
+We will store each job's value in the data hash as a **versioned string
+envelope** instead of bare JSON:
+
+```
+GQ1|<headerLen>|<headerJson><body>
+```
+
+- `<headerJson>` is a tiny JSON object holding only what Redis-side and
+  ops-side readers need without touching the body: `v` (version), `e`
+  (body encoding: `"j"` raw JSON or `"gz"` gzip+base64), and the routing
+  fields `p`/`t`/`n` (pipelineName/jobType/jobName).
+- `<body>` is the full payload JSON (including `__context`, `__attempt`,
+  and the routing fields, unchanged) — gzip-compressed and
+  base64-encoded when the JSON exceeds a 1 KiB threshold, raw otherwise.
+
+The dispatch/fail Lua scripts gain a shared helper that reads routing
+metadata from the header alone (a ~100-byte `cjson.decode`), with a
+fallback to full-payload decode for **legacy bare-JSON values**, so jobs
+staged before a deploy still dispatch, pause, and fail-count correctly.
+The ops repository uses the same envelope-aware reader on the TypeScript
+side.
+
+Encoding happens once at stage time (and on retry/exhaust re-stage,
+where the payload is re-serialized anyway); decoding happens once at
+processing time. Handlers, queue-manager facades, dedup semantics, and
+all key shapes are untouched — the envelope is invisible outside the
+GroupQueue serialization boundary.
+
+## Rationale / Trade-offs
+
+**Why gzip+base64 inside a string, not raw binary?** Lua strings and
+Redis bulk strings are binary-safe, but ioredis decodes script replies
+as UTF-8 strings by default; carrying raw binary through the dispatch,
+drain, retry, and ops paths would require switching every reply path to
+`evalBuffer`/Buffer variants and would render the data hash unreadable
+to existing ops tooling. Base64 surrenders ~25% of the compression win
+but keeps the entire pipeline string-safe with zero changes to the
+eval plumbing. Net effect on span JSON is still roughly 4–6×. Raw-binary
+storage remains open as a follow-up if the residual size matters.
+
+**Why gzip, not zstd?** `node:zlib` gzip is available and stable on our
+Node 24 baseline with no new dependency; zstd's ratio/speed edge is not
+worth a format question right now. The envelope's `e` field is exactly
+the seam to introduce `"zs"` later without migration.
+
+**Why a header prefix, not a companion hash field?** A second field per
+job would have to be written, replaced, moved, and deleted in lockstep
+across every Lua path (stage, dedup-replace, dispatch, drain, retry,
+exhaust, DLQ move). A prefix on the existing value keeps every
+`HSET`/`HGET`/`HDEL` site untouched.
+
+**Why a compression threshold?** gzip+base64 of sub-kilobyte JSON is
+frequently *larger* than the input. Small routing events stay raw.
+
+**What is compromised:** payloads in the data hash are no longer
+human-readable via `redis-cli` for compressed jobs; debugging requires
+the decode helper. Stage/processing paths pay a small async
+gzip/gunzip CPU cost (microseconds to low milliseconds per job, off
+Redis's thread — which is the point).
+
+## Consequences
+
+- Redis memory per span-sized job drops ~4–6×; the queue absorbs
+  proportionally larger bursts before memory pressure.
+- Dispatch-time Lua decodes ~100-byte headers instead of full payloads;
+  the failed-counter path likewise. Redis CPU per dispatch batch falls
+  accordingly.
+- The ops dashboard's routing-field extraction gets cheaper (header
+  parse) and must go through the shared envelope reader.
+- Rolling deploys are safe in the forward direction (new code reads
+  legacy values). **Rollback while envelope-encoded jobs are in flight
+  is not safe** — old code would fail to `JSON.parse` them and complete
+  the group slot without processing. Drain or accept replay if rolling
+  back.
+- The S3 offload path for oversized media payloads is unaffected and
+  remains the mechanism for keeping large blobs out of Redis.
+
+## References
+
+- Related ADRs: ADR-014 (Skynet/BullMQ removal), ADR-023 (orphan sweep
+  reactor chain — GroupQueue dispatch mechanics)
+- Spec: `specs/event-sourcing/payload-envelope.feature`

--- a/dev/docs/adr/026-groupqueue-payload-envelope.md
+++ b/dev/docs/adr/026-groupqueue-payload-envelope.md
@@ -116,6 +116,8 @@ Redis's thread — which is the point).
 
 ## References
 
-- Related ADRs: ADR-014 (Skynet/BullMQ removal), ADR-023 (orphan sweep
-  reactor chain — GroupQueue dispatch mechanics)
+- Related ADRs: [ADR-014](./014-skynet-bullmq-removal.md)
+  (Skynet/BullMQ removal),
+  [ADR-023](./023-orphan-sweep-reactor-chain.md) (superseded by ADR-025;
+  cited only for its description of GroupQueue dispatch mechanics)
 - Spec: `specs/event-sourcing/payload-envelope.feature`

--- a/dev/docs/adr/026-groupqueue-payload-envelope.md
+++ b/dev/docs/adr/026-groupqueue-payload-envelope.md
@@ -49,11 +49,31 @@ GQ1|<headerLen>|<headerJson><body>
   (body encoding: `"j"` raw JSON or `"gz"` gzip+base64), and the routing
   fields `p`/`t`/`n` (pipelineName/jobType/jobName).
 - `<body>` is the full payload JSON (including `__context`, `__attempt`,
-  and the routing fields, unchanged) — gzip-compressed and
-  base64-encoded when the JSON exceeds a 1 KiB threshold **and**
-  compression actually shrinks it; high-entropy payloads (inline
-  base64-ish data below the S3 spool threshold) grow under gzip+base64
-  and stay raw.
+  and the routing fields, unchanged), encoded by size tier:
+  - **≤1 KiB:** raw JSON (`e:"j"`) — gzip+base64 of small JSON is
+    frequently larger than the input.
+  - **1–32 KiB:** gzip+base64 inline (`e:"gz"`), but only when
+    compression actually shrinks it; high-entropy payloads (inline
+    base64-ish data) grow under gzip+base64 and stay raw.
+  - **>32 KiB:** offloaded (`e:"ref"`). The body is empty; the header
+    carries a blob id pointing at a standalone key
+    `{queueName}:gq:blob:<id>` holding the gzipped JSON as **raw
+    binary** (no base64 — the key is read/written directly by the
+    client, never through a Lua script reply, so ioredis's UTF-8
+    decoding is not a constraint). The bulk of a large payload thus
+    transits Redis exactly twice (one `SET` at stage, one `GETBUFFER`
+    at processing) and never flows through the dispatch, drain, or
+    restage Lua scripts or sits in the group hash.
+
+Blob lifecycle: the worker deletes the blob best-effort after the job
+completes, exhausts, or is re-encoded for retry (a retry writes a fresh
+envelope and blob; drained siblings re-staged after a batch failure
+keep their original values and blobs). A 7-day TTL on every blob key is
+the correctness backstop for orphans — dedup-squashed jobs, crashes
+between stage and delete — so a missed delete only lingers, never
+leaks forever. A missing blob at decode time is treated like a corrupt
+value: the slot is completed and the job is recoverable via event
+replay.
 
 **Rollout is two-phase.** Readers (TS decode, Lua routing helper, ops
 repository) are always envelope-aware, but writes stay legacy bare JSON
@@ -80,15 +100,29 @@ GroupQueue serialization boundary.
 
 ## Rationale / Trade-offs
 
-**Why gzip+base64 inside a string, not raw binary?** Lua strings and
-Redis bulk strings are binary-safe, but ioredis decodes script replies
-as UTF-8 strings by default; carrying raw binary through the dispatch,
-drain, retry, and ops paths would require switching every reply path to
-`evalBuffer`/Buffer variants and would render the data hash unreadable
-to existing ops tooling. Base64 surrenders ~25% of the compression win
-but keeps the entire pipeline string-safe with zero changes to the
-eval plumbing. Net effect on span JSON is still roughly 4–6×. Raw-binary
-storage remains open as a follow-up if the residual size matters.
+**Why gzip+base64 for mid-size bodies, not raw binary?** Lua strings
+and Redis bulk strings are binary-safe, but ioredis decodes script
+replies as UTF-8 strings by default; carrying raw binary through the
+dispatch, drain, retry, and ops paths would require switching every
+reply path to `evalBuffer`/Buffer variants and would render the data
+hash unreadable to existing ops tooling. Base64 surrenders ~25% of the
+compression win but keeps the entire pipeline string-safe with zero
+changes to the eval plumbing. Net effect on span JSON is still roughly
+4–6×.
+
+**Why offload large bodies to a standalone key instead of a companion
+hash field?** Above ~32 KiB the dominant cost is no longer format
+overhead but the bytes themselves transiting Redis's single thread on
+every Lua touch (dispatch HGET+return, drain, restage). A standalone
+key read/written only by the client sidesteps that entirely — and
+because the *reference travels inside the envelope value*, every Lua
+path (stage, dedup-replace, dispatch, drain, retry, exhaust, DLQ move)
+keeps moving one small string exactly as before, with zero script
+changes. A companion hash field, by contrast, would need lockstep
+handling in all of those scripts. The TTL makes orphaned blobs
+self-cleaning, so no path is *required* to delete in lockstep either.
+Blob keys share the queue name's hash tag, so they stay in the queue's
+cluster slot.
 
 **Why gzip, not zstd?** `node:zlib` gzip is available and stable on our
 Node 24 baseline with no new dependency; zstd's ratio/speed edge is not
@@ -105,15 +139,19 @@ exhaust, DLQ move). A prefix on the existing value keeps every
 frequently *larger* than the input. Small routing events stay raw.
 
 **What is compromised:** payloads in the data hash are no longer
-human-readable via `redis-cli` for compressed jobs; debugging requires
-the decode helper. Stage/processing paths pay a small async
-gzip/gunzip CPU cost (microseconds to low milliseconds per job, off
-Redis's thread — which is the point).
+human-readable via `redis-cli` for compressed or offloaded jobs;
+debugging requires the decode helper. Stage/processing paths pay a
+small async gzip/gunzip CPU cost (microseconds to low milliseconds per
+job, off Redis's thread — which is the point). Offloaded jobs pay one
+extra Redis round trip at stage and at processing, and orphaned blobs
+can occupy memory for up to the 7-day TTL.
 
 ## Consequences
 
 - Redis memory per span-sized job drops ~4–6×; the queue absorbs
-  proportionally larger bursts before memory pressure.
+  proportionally larger bursts before memory pressure. Large payloads
+  additionally stop transiting the Lua scripts at all, and gain the
+  base64-free ~25% on top of compression.
 - Dispatch-time Lua decodes ~100-byte headers instead of full payloads;
   the failed-counter path likewise. Redis CPU per dispatch batch falls
   accordingly.

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -20,6 +20,7 @@ import {
   decodeJobEnvelope,
   readJobRoutingMeta,
 } from "~/server/event-sourcing/queues/groupQueue/jobEnvelope";
+import { RedisJobBlobStore } from "~/server/event-sourcing/queues/groupQueue/redisJobBlobStore";
 
 const logger = createLogger("langwatch:ops:queue-redis-repository");
 
@@ -546,12 +547,16 @@ export class QueueRedisRepository implements QueueRepository {
       }
       const dataResults = await dataPipeline.exec();
 
+      const blobs = new RedisJobBlobStore({
+        redis: this.redis,
+        queueName: params.queueName,
+      });
       await Promise.all(
         jobIds.map(async (_, i) => {
           const raw = dataResults?.[i]?.[1] as string | null;
           if (raw) {
             try {
-              jobs[i]!.data = await decodeJobEnvelope(raw);
+              jobs[i]!.data = await decodeJobEnvelope({ value: raw, blobs });
             } catch {
               // ignore undecodable values
             }

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -16,13 +16,19 @@ import {
   TTL_HELPER_LUA,
   PARK_HELPER_LUA,
 } from "~/server/event-sourcing/queues/groupQueue/scripts";
-import { readJobRoutingMeta } from "~/server/event-sourcing/queues/groupQueue/jobEnvelope";
+import {
+  decodeJobEnvelope,
+  readJobRoutingMeta,
+} from "~/server/event-sourcing/queues/groupQueue/jobEnvelope";
 
 const logger = createLogger("langwatch:ops:queue-redis-repository");
 
 // ── Lua Scripts ──────────────────────────────────────────────────────
 
-const UNBLOCK_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
+const UNBLOCK_LUA =
+  TTL_HELPER_LUA +
+  PARK_HELPER_LUA +
+  `
 local blockedKey = KEYS[1]
 local activeKey  = KEYS[2]
 local jobsKey    = KEYS[3]
@@ -151,7 +157,10 @@ redis.call("LTRIM", signalKey, 0, 999)
 return count
 `;
 
-const REPLAY_FROM_DLQ_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
+const REPLAY_FROM_DLQ_LUA =
+  TTL_HELPER_LUA +
+  PARK_HELPER_LUA +
+  `
 local dlqJobsKey   = KEYS[1]
 local dlqDataKey   = KEYS[2]
 local dlqErrorKey  = KEYS[3]
@@ -342,7 +351,10 @@ export class QueueRedisRepository implements QueueRepository {
 
     const blockedMembers =
       blockedCount > 0
-        ? await this.redis.srandmember(blockedKey, Math.min(limit, blockedCount))
+        ? await this.redis.srandmember(
+            blockedKey,
+            Math.min(limit, blockedCount),
+          )
         : [];
     const readyGroupIdSet = new Set(groupIds);
     const blockedGroupIds = (blockedMembers ?? []).filter(
@@ -384,8 +396,7 @@ export class QueueRedisRepository implements QueueRepository {
         dataFetchCount++;
       }
     }
-    const dataResults =
-      dataFetchCount > 0 ? await dataPipeline.exec() : [];
+    const dataResults = dataFetchCount > 0 ? await dataPipeline.exec() : [];
 
     const errorPipeline = this.redis.pipeline();
     for (const groupId of allGroupIds) {
@@ -418,12 +429,9 @@ export class QueueRedisRepository implements QueueRepository {
       const base = i * CMDS_PER_GROUP;
 
       const pendingJobs = (pipelineResults?.[base]?.[1] as number) ?? 0;
-      const activeJobId =
-        (pipelineResults?.[base + 1]?.[1] as string) ?? null;
-      const oldestArr =
-        (pipelineResults?.[base + 2]?.[1] as string[]) ?? [];
-      const newestArr =
-        (pipelineResults?.[base + 3]?.[1] as string[]) ?? [];
+      const activeJobId = (pipelineResults?.[base + 1]?.[1] as string) ?? null;
+      const oldestArr = (pipelineResults?.[base + 2]?.[1] as string[]) ?? [];
+      const newestArr = (pipelineResults?.[base + 3]?.[1] as string[]) ?? [];
       const isBlocked = (pipelineResults?.[base + 4]?.[1] as number) === 1;
       const activeKeyTtlSec =
         (pipelineResults?.[base + 5]?.[1] as number) ?? -2;
@@ -534,10 +542,7 @@ export class QueueRedisRepository implements QueueRepository {
     if (jobIds.length > 0) {
       const dataPipeline = this.redis.pipeline();
       for (const jobId of jobIds) {
-        dataPipeline.hget(
-          `${prefix}group:${params.groupId}:data`,
-          jobId,
-        );
+        dataPipeline.hget(`${prefix}group:${params.groupId}:data`, jobId);
       }
       const dataResults = await dataPipeline.exec();
 
@@ -545,9 +550,9 @@ export class QueueRedisRepository implements QueueRepository {
         const raw = dataResults?.[i]?.[1] as string | null;
         if (raw) {
           try {
-            jobs[i]!.data = JSON.parse(raw);
+            jobs[i]!.data = await decodeJobEnvelope(raw);
           } catch {
-            // ignore invalid JSON
+            // ignore undecodable values
           }
         }
       }
@@ -607,16 +612,9 @@ export class QueueRedisRepository implements QueueRepository {
         for (let i = 0; i < jobDataRequests.length; i++) {
           const raw = jobDataResults?.[i]?.[1] as string | null;
           if (raw) {
-            try {
-              const parsed = JSON.parse(raw);
-              if (parsed.__pipelineName) {
-                pipelineNames.set(
-                  jobDataRequests[i]!.groupId,
-                  parsed.__pipelineName,
-                );
-              }
-            } catch {
-              // ignore parse errors
+            const pipelineName = readJobRoutingMeta(raw).pipelineName;
+            if (pipelineName) {
+              pipelineNames.set(jobDataRequests[i]!.groupId, pipelineName);
             }
           }
         }
@@ -776,9 +774,7 @@ export class QueueRedisRepository implements QueueRepository {
     });
   }
 
-  async listPausedKeys(params: {
-    queueName: string;
-  }): Promise<string[]> {
+  async listPausedKeys(params: { queueName: string }): Promise<string[]> {
     return this.redis.smembers(`${params.queueName}:gq:paused-jobs`);
   }
 
@@ -812,12 +808,8 @@ export class QueueRedisRepository implements QueueRepository {
     await this.redis.lpush(`${params.queueName}:gq:signal`, "1");
   }
 
-  async listPausedTenants(params: {
-    queueName: string;
-  }): Promise<string[]> {
-    const all = await this.redis.smembers(
-      `${params.queueName}:gq:paused-jobs`,
-    );
+  async listPausedTenants(params: { queueName: string }): Promise<string[]> {
+    const all = await this.redis.smembers(`${params.queueName}:gq:paused-jobs`);
     const prefix = QueueRedisRepository.TENANT_PAUSE_PREFIX;
     return all
       .filter((k) => k.startsWith(prefix))
@@ -1125,9 +1117,7 @@ export class QueueRedisRepository implements QueueRepository {
     if (!candidates || candidates.length === 0)
       return { redrivenCount: 0, groupIds: [] };
 
-    let groupsToRedrive = candidates.filter(
-      (id): id is string => id !== null,
-    );
+    let groupsToRedrive = candidates.filter((id): id is string => id !== null);
 
     if (params.pipelineFilter) {
       groupsToRedrive = await this.filterByPipelineName({
@@ -1139,8 +1129,7 @@ export class QueueRedisRepository implements QueueRepository {
     }
 
     groupsToRedrive = groupsToRedrive.slice(0, count);
-    if (groupsToRedrive.length === 0)
-      return { redrivenCount: 0, groupIds: [] };
+    if (groupsToRedrive.length === 0) return { redrivenCount: 0, groupIds: [] };
 
     const pipeline = this.redis.pipeline();
     for (const groupId of groupsToRedrive) {
@@ -1189,9 +1178,7 @@ export class QueueRedisRepository implements QueueRepository {
     if (!candidates || candidates.length === 0)
       return { unblockedCount: 0, groupIds: [] };
 
-    let groupsToUnblock = candidates.filter(
-      (id): id is string => id !== null,
-    );
+    let groupsToUnblock = candidates.filter((id): id is string => id !== null);
 
     if (params.pipelineFilter) {
       groupsToUnblock = await this.filterByPipelineName({
@@ -1240,9 +1227,7 @@ export class QueueRedisRepository implements QueueRepository {
 
   // ── DLQ Listing ─────────────────────────────────────────────────
 
-  async listDlqGroups(params: {
-    queueName: string;
-  }): Promise<DlqGroupInfo[]> {
+  async listDlqGroups(params: { queueName: string }): Promise<DlqGroupInfo[]> {
     const prefix = `${params.queueName}:gq:`;
     const dlqIndexKey = `${prefix}dlq`;
     const groups: DlqGroupInfo[] = [];
@@ -1283,16 +1268,9 @@ export class QueueRedisRepository implements QueueRepository {
       for (let j = 0; j < dataRequests.length; j++) {
         const raw = dataResults?.[j]?.[1] as string | null;
         if (raw) {
-          try {
-            const parsed = JSON.parse(raw);
-            if (parsed.__pipelineName) {
-              groupPipelines.set(
-                dataRequests[j]!.groupId,
-                parsed.__pipelineName,
-              );
-            }
-          } catch {
-            // ignore
+          const pipelineName = readJobRoutingMeta(raw).pipelineName;
+          if (pipelineName) {
+            groupPipelines.set(dataRequests[j]!.groupId, pipelineName);
           }
         }
       }
@@ -1359,10 +1337,7 @@ export class QueueRedisRepository implements QueueRepository {
       for (let i = 0; i < members.length; i++) {
         const jobArr = (results?.[i * 2 + 1]?.[1] as string[]) ?? [];
         if (jobArr[0]) {
-          jobDataPipeline.hget(
-            `${prefix}group:${members[i]!}:data`,
-            jobArr[0],
-          );
+          jobDataPipeline.hget(`${prefix}group:${members[i]!}:data`, jobArr[0]);
           jobDataRequests.push({ groupId: members[i]! });
         }
       }
@@ -1373,16 +1348,9 @@ export class QueueRedisRepository implements QueueRepository {
       for (let j = 0; j < jobDataRequests.length; j++) {
         const raw = jobDataResults?.[j]?.[1] as string | null;
         if (raw) {
-          try {
-            const parsed = JSON.parse(raw);
-            if (parsed.__pipelineName) {
-              groupPipelines.set(
-                jobDataRequests[j]!.groupId,
-                parsed.__pipelineName,
-              );
-            }
-          } catch {
-            // ignore
+          const pipelineName = readJobRoutingMeta(raw).pipelineName;
+          if (pipelineName) {
+            groupPipelines.set(jobDataRequests[j]!.groupId, pipelineName);
           }
         }
       }
@@ -1508,7 +1476,10 @@ export class QueueRedisRepository implements QueueRepository {
       if (results) {
         for (const [err, val] of results) {
           if (err) {
-            logger.warn({ error: err }, "ZCARD pipeline error during pending reconcile — aborting to avoid under-count");
+            logger.warn(
+              { error: err },
+              "ZCARD pipeline error during pending reconcile — aborting to avoid under-count",
+            );
             return null;
           }
           groundTruth += Number(val) || 0;
@@ -1561,13 +1532,8 @@ export class QueueRedisRepository implements QueueRepository {
     for (let i = 0; i < dataRequests.length; i++) {
       const raw = dataResults?.[i]?.[1] as string | null;
       if (raw) {
-        try {
-          const parsed = JSON.parse(raw);
-          if (parsed.__pipelineName === params.pipelineFilter) {
-            matchingGroups.add(dataRequests[i]!.groupId);
-          }
-        } catch {
-          // ignore
+        if (readJobRoutingMeta(raw).pipelineName === params.pipelineFilter) {
+          matchingGroups.add(dataRequests[i]!.groupId);
         }
       }
     }
@@ -1600,8 +1566,7 @@ export class QueueRedisRepository implements QueueRepository {
         jobDataMap.set(params.members[i]!, jobFetchIdx++);
       }
     }
-    const jobDataResults =
-      jobFetchIdx > 0 ? await jobDataPipeline.exec() : [];
+    const jobDataResults = jobFetchIdx > 0 ? await jobDataPipeline.exec() : [];
 
     return params.members.filter((groupId, i) => {
       if (params.errorFilter) {
@@ -1618,12 +1583,8 @@ export class QueueRedisRepository implements QueueRepository {
         if (fetchIdx !== undefined) {
           const raw = jobDataResults?.[fetchIdx]?.[1] as string | null;
           if (raw) {
-            try {
-              const parsed = JSON.parse(raw);
-              if (parsed.__pipelineName !== params.pipelineFilter) return false;
-            } catch {
+            if (readJobRoutingMeta(raw).pipelineName !== params.pipelineFilter)
               return false;
-            }
           } else return false;
         } else return false;
       }
@@ -1657,8 +1618,7 @@ export class QueueRedisRepository implements QueueRepository {
         jobDataMap.set(params.members[i]!, jobFetchIdx++);
       }
     }
-    const jobDataResults =
-      jobFetchIdx > 0 ? await jobDataPipeline.exec() : [];
+    const jobDataResults = jobFetchIdx > 0 ? await jobDataPipeline.exec() : [];
 
     return params.members.filter((groupId, i) => {
       if (params.errorFilter) {
@@ -1675,12 +1635,8 @@ export class QueueRedisRepository implements QueueRepository {
         if (fetchIdx !== undefined) {
           const raw = jobDataResults?.[fetchIdx]?.[1] as string | null;
           if (raw) {
-            try {
-              const parsed = JSON.parse(raw);
-              if (parsed.__pipelineName !== params.pipelineFilter) return false;
-            } catch {
+            if (readJobRoutingMeta(raw).pipelineName !== params.pipelineFilter)
               return false;
-            }
           } else return false;
         } else return false;
       }

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -16,6 +16,7 @@ import {
   TTL_HELPER_LUA,
   PARK_HELPER_LUA,
 } from "~/server/event-sourcing/queues/groupQueue/scripts";
+import { readJobRoutingMeta } from "~/server/event-sourcing/queues/groupQueue/jobEnvelope";
 
 const logger = createLogger("langwatch:ops:queue-redis-repository");
 
@@ -440,14 +441,10 @@ export class QueueRedisRepository implements QueueRepository {
         const rawData = (dataResults?.[dataIdx]?.[1] as string) ?? null;
         dataIdx++;
         if (rawData) {
-          try {
-            const parsed = JSON.parse(rawData);
-            pipelineName = parsed.__pipelineName ?? null;
-            jobType = parsed.__jobType ?? null;
-            jobName = parsed.__jobName ?? null;
-          } catch {
-            // ignore invalid JSON
-          }
+          const meta = readJobRoutingMeta(rawData);
+          pipelineName = meta.pipelineName;
+          jobType = meta.jobType;
+          jobName = meta.jobName;
         }
       }
 

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -546,16 +546,18 @@ export class QueueRedisRepository implements QueueRepository {
       }
       const dataResults = await dataPipeline.exec();
 
-      for (let i = 0; i < jobIds.length; i++) {
-        const raw = dataResults?.[i]?.[1] as string | null;
-        if (raw) {
-          try {
-            jobs[i]!.data = await decodeJobEnvelope(raw);
-          } catch {
-            // ignore undecodable values
+      await Promise.all(
+        jobIds.map(async (_, i) => {
+          const raw = dataResults?.[i]?.[1] as string | null;
+          if (raw) {
+            try {
+              jobs[i]!.data = await decodeJobEnvelope(raw);
+            } catch {
+              // ignore undecodable values
+            }
           }
-        }
-      }
+        }),
+      );
     }
 
     return { jobs, total };

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -209,6 +209,90 @@ describe.skipIf(!hasTestcontainers)(
       });
     });
 
+    describe("envelope blob offload", () => {
+      describe("when a payload exceeds the blob offload threshold", () => {
+        it("stores the body under a blob key, delivers it intact, and deletes the blob on completion", async () => {
+          process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED = "true";
+          try {
+            const queueName = `{test/gq/blob-${crypto.randomUUID().slice(0, 8)}}`;
+            const blobKeysDuringProcessing: string[] = [];
+            const processed = vi.fn(async (_payload: TestPayload) => {
+              blobKeysDuringProcessing.push(
+                ...(await redis.keys(`${queueName}:gq:blob:*`)),
+              );
+            });
+
+            const queue = createQueue(processed, { name: queueName });
+            await queue.waitUntilReady();
+
+            const bigValue = "z".repeat(64 * 1024);
+            await queue.send({
+              id: "big-1",
+              groupId: "group-a",
+              value: bigValue,
+            });
+
+            await vi.waitFor(
+              () => {
+                expect(processed).toHaveBeenCalledTimes(1);
+              },
+              { timeout: 5000, interval: 50 },
+            );
+
+            expect(processed.mock.calls[0]![0].value).toBe(bigValue);
+            expect(blobKeysDuringProcessing).toHaveLength(1);
+
+            await vi.waitFor(
+              async () => {
+                expect(await redis.keys(`${queueName}:gq:blob:*`)).toHaveLength(
+                  0,
+                );
+              },
+              { timeout: 5000, interval: 50 },
+            );
+          } finally {
+            delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+          }
+        });
+
+        it("sets a TTL safety net on the blob key", async () => {
+          process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED = "true";
+          try {
+            const queueName = `{test/gq/blob-${crypto.randomUUID().slice(0, 8)}}`;
+            let release: () => void;
+            const gate = new Promise<void>((resolve) => {
+              release = resolve;
+            });
+            const processed = vi.fn(async (_payload: TestPayload) => {
+              await gate;
+            });
+
+            const queue = createQueue(processed, { name: queueName });
+            await queue.waitUntilReady();
+            await queue.send({
+              id: "big-2",
+              groupId: "group-a",
+              value: "z".repeat(64 * 1024),
+            });
+
+            await vi.waitFor(
+              async () => {
+                expect(await redis.keys(`${queueName}:gq:blob:*`)).toHaveLength(
+                  1,
+                );
+              },
+              { timeout: 5000, interval: 50 },
+            );
+            const [blobKey] = await redis.keys(`${queueName}:gq:blob:*`);
+            expect(await redis.ttl(blobKey!)).toBeGreaterThan(0);
+            release!();
+          } finally {
+            delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+          }
+        });
+      });
+    });
+
     describe("per-group sequential processing", () => {
       describe("when multiple jobs share the same group key", () => {
         it("processes them one at a time, not in parallel", async () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -212,7 +212,7 @@ describe.skipIf(!hasTestcontainers)(
     describe("envelope blob offload", () => {
       describe("when a payload exceeds the blob offload threshold", () => {
         it("stores the body under a blob key, delivers it intact, and deletes the blob on completion", async () => {
-          process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED = "true";
+          vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
           try {
             const queueName = `{test/gq/blob-${crypto.randomUUID().slice(0, 8)}}`;
             const blobKeysDuringProcessing: string[] = [];
@@ -251,12 +251,12 @@ describe.skipIf(!hasTestcontainers)(
               { timeout: 5000, interval: 50 },
             );
           } finally {
-            delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+            vi.unstubAllEnvs();
           }
         });
 
         it("sets a TTL safety net on the blob key", async () => {
-          process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED = "true";
+          vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
           try {
             const queueName = `{test/gq/blob-${crypto.randomUUID().slice(0, 8)}}`;
             let release: () => void;
@@ -287,7 +287,7 @@ describe.skipIf(!hasTestcontainers)(
             expect(await redis.ttl(blobKey!)).toBeGreaterThan(0);
             release!();
           } finally {
-            delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+            vi.unstubAllEnvs();
           }
         });
       });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   decodeJobEnvelope,
@@ -7,6 +7,45 @@ import {
 } from "../jobEnvelope";
 
 describe("jobEnvelope", () => {
+  beforeEach(() => {
+    process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+  });
+
+  describe("given envelope writes are not enabled", () => {
+    const payload = {
+      __pipelineName: "traces",
+      __jobType: "command",
+      __jobName: "recordSpan",
+      bulk: "x".repeat(4096),
+    };
+
+    beforeEach(() => {
+      delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+    });
+
+    describe("when encoding", () => {
+      it("writes legacy bare JSON that a previous-release JSON.parse reader accepts", async () => {
+        const encoded = await encodeJobEnvelope(payload);
+        expect(encoded.startsWith("GQ1|")).toBe(false);
+        expect(JSON.parse(encoded)).toEqual(payload);
+      });
+
+      it("still decodes and exposes routing meta through the dual readers", async () => {
+        const encoded = await encodeJobEnvelope(payload);
+        expect(await decodeJobEnvelope(encoded)).toEqual(payload);
+        expect(readJobRoutingMeta(encoded)).toEqual({
+          pipelineName: "traces",
+          jobType: "command",
+          jobName: "recordSpan",
+        });
+      });
+    });
+  });
+
   describe("given a payload over the compression threshold", () => {
     const largePayload = {
       __pipelineName: "traces",
@@ -96,6 +135,28 @@ describe("jobEnvelope", () => {
       const payload = payloadOfJsonByteLength(1025);
       expect(Buffer.byteLength(JSON.stringify(payload))).toBe(1025);
       expect(await encodeJobEnvelope(payload)).toContain('"e":"gz"');
+    });
+  });
+
+  describe("given a large incompressible payload", () => {
+    it("keeps the body raw when gzip+base64 would grow it", async () => {
+      // Simulates inline base64-ish data below the S3 spool threshold:
+      // high-entropy strings gain ~37% through gzip+base64.
+      const bytes = Buffer.alloc(8192);
+      let state = 0x9e3779b9;
+      for (let i = 0; i < bytes.length; i++) {
+        state ^= state << 13;
+        state ^= state >>> 17;
+        state ^= state << 5;
+        bytes[i] = state & 0xff;
+      }
+      const payload = { __jobName: "media", blob: bytes.toString("base64") };
+      const json = JSON.stringify(payload);
+
+      const encoded = await encodeJobEnvelope(payload);
+      expect(encoded).toContain('"e":"j"');
+      expect(encoded.length).toBeLessThan(json.length + 64);
+      expect(await decodeJobEnvelope(encoded)).toEqual(payload);
     });
   });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -3,8 +3,26 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   decodeJobEnvelope,
   encodeJobEnvelope,
+  type JobBlobStore,
+  readEnvelopeBlobId,
   readJobRoutingMeta,
 } from "../jobEnvelope";
+
+class InMemoryBlobStore implements JobBlobStore {
+  readonly blobs = new Map<string, Buffer>();
+
+  async put({ id, data }: { id: string; data: Buffer }): Promise<void> {
+    this.blobs.set(id, data);
+  }
+
+  async get({ id }: { id: string }): Promise<Buffer | null> {
+    return this.blobs.get(id) ?? null;
+  }
+
+  async delete({ id }: { id: string }): Promise<void> {
+    this.blobs.delete(id);
+  }
+}
 
 describe("jobEnvelope", () => {
   beforeEach(() => {
@@ -29,14 +47,14 @@ describe("jobEnvelope", () => {
 
     describe("when encoding", () => {
       it("writes legacy bare JSON that a previous-release JSON.parse reader accepts", async () => {
-        const encoded = await encodeJobEnvelope(payload);
+        const encoded = await encodeJobEnvelope({ jobData: payload });
         expect(encoded.startsWith("GQ1|")).toBe(false);
         expect(JSON.parse(encoded)).toEqual(payload);
       });
 
       it("still decodes and exposes routing meta through the dual readers", async () => {
-        const encoded = await encodeJobEnvelope(payload);
-        expect(await decodeJobEnvelope(encoded)).toEqual(payload);
+        const encoded = await encodeJobEnvelope({ jobData: payload });
+        expect(await decodeJobEnvelope({ value: encoded })).toEqual(payload);
         expect(readJobRoutingMeta(encoded)).toEqual({
           pipelineName: "traces",
           jobType: "command",
@@ -57,12 +75,14 @@ describe("jobEnvelope", () => {
 
     describe("when encoded and decoded", () => {
       it("round-trips the payload deep-equal", async () => {
-        const encoded = await encodeJobEnvelope(largePayload);
-        expect(await decodeJobEnvelope(encoded)).toEqual(largePayload);
+        const encoded = await encodeJobEnvelope({ jobData: largePayload });
+        expect(await decodeJobEnvelope({ value: encoded })).toEqual(
+          largePayload,
+        );
       });
 
       it("stores the body gzip-compressed and smaller than the raw JSON", async () => {
-        const encoded = await encodeJobEnvelope(largePayload);
+        const encoded = await encodeJobEnvelope({ jobData: largePayload });
         expect(encoded.startsWith("GQ1|")).toBe(true);
         expect(encoded).toContain('"e":"gz"');
         expect(encoded.length).toBeLessThan(
@@ -71,7 +91,7 @@ describe("jobEnvelope", () => {
       });
 
       it("exposes routing fields from the header without decoding the body", async () => {
-        const encoded = await encodeJobEnvelope(largePayload);
+        const encoded = await encodeJobEnvelope({ jobData: largePayload });
         expect(readJobRoutingMeta(encoded)).toEqual({
           pipelineName: "traces",
           jobType: "command",
@@ -86,14 +106,16 @@ describe("jobEnvelope", () => {
 
     describe("when encoded", () => {
       it("keeps the body as raw JSON", async () => {
-        const encoded = await encodeJobEnvelope(smallPayload);
+        const encoded = await encodeJobEnvelope({ jobData: smallPayload });
         expect(encoded).toContain('"e":"j"');
         expect(encoded).toContain('"value":1');
       });
 
       it("round-trips the payload deep-equal", async () => {
-        const encoded = await encodeJobEnvelope(smallPayload);
-        expect(await decodeJobEnvelope(encoded)).toEqual(smallPayload);
+        const encoded = await encodeJobEnvelope({ jobData: smallPayload });
+        expect(await decodeJobEnvelope({ value: encoded })).toEqual(
+          smallPayload,
+        );
       });
     });
   });
@@ -107,7 +129,9 @@ describe("jobEnvelope", () => {
     });
 
     it("decodes as plain JSON", async () => {
-      expect(await decodeJobEnvelope(legacy)).toEqual(JSON.parse(legacy));
+      expect(await decodeJobEnvelope({ value: legacy })).toEqual(
+        JSON.parse(legacy),
+      );
     });
 
     it("reads routing fields via full parse", () => {
@@ -128,13 +152,102 @@ describe("jobEnvelope", () => {
     it("keeps a payload of exactly 1024 JSON bytes raw", async () => {
       const payload = payloadOfJsonByteLength(1024);
       expect(Buffer.byteLength(JSON.stringify(payload))).toBe(1024);
-      expect(await encodeJobEnvelope(payload)).toContain('"e":"j"');
+      expect(await encodeJobEnvelope({ jobData: payload })).toContain(
+        '"e":"j"',
+      );
     });
 
     it("compresses a payload of 1025 JSON bytes", async () => {
       const payload = payloadOfJsonByteLength(1025);
       expect(Buffer.byteLength(JSON.stringify(payload))).toBe(1025);
-      expect(await encodeJobEnvelope(payload)).toContain('"e":"gz"');
+      expect(await encodeJobEnvelope({ jobData: payload })).toContain(
+        '"e":"gz"',
+      );
+    });
+  });
+
+  describe("given a payload over the blob offload threshold", () => {
+    const hugePayload = {
+      __pipelineName: "traces",
+      __jobType: "command",
+      __jobName: "recordSpan",
+      bulk: "y".repeat(64 * 1024),
+    };
+
+    describe("when a blob store is provided", () => {
+      it("offloads the body to the store and leaves a tiny ref envelope", async () => {
+        const blobs = new InMemoryBlobStore();
+        const encoded = await encodeJobEnvelope({
+          jobData: hugePayload,
+          blobs,
+        });
+        expect(encoded).toContain('"e":"ref"');
+        expect(encoded.length).toBeLessThan(256);
+        expect(blobs.blobs.size).toBe(1);
+        expect(readJobRoutingMeta(encoded)).toEqual({
+          pipelineName: "traces",
+          jobType: "command",
+          jobName: "recordSpan",
+        });
+      });
+
+      it("round-trips the payload through the store", async () => {
+        const blobs = new InMemoryBlobStore();
+        const encoded = await encodeJobEnvelope({
+          jobData: hugePayload,
+          blobs,
+        });
+        expect(await decodeJobEnvelope({ value: encoded, blobs })).toEqual(
+          hugePayload,
+        );
+      });
+
+      it("exposes the blob id for completion-time deletion", async () => {
+        const blobs = new InMemoryBlobStore();
+        const encoded = await encodeJobEnvelope({
+          jobData: hugePayload,
+          blobs,
+        });
+        const blobId = readEnvelopeBlobId(encoded);
+        expect(blobId).not.toBeNull();
+        expect(blobs.blobs.has(blobId!)).toBe(true);
+      });
+
+      it("rejects decode when the blob is missing or no store is given", async () => {
+        const blobs = new InMemoryBlobStore();
+        const encoded = await encodeJobEnvelope({
+          jobData: hugePayload,
+          blobs,
+        });
+        await expect(decodeJobEnvelope({ value: encoded })).rejects.toThrow(
+          /blob store/,
+        );
+        blobs.blobs.clear();
+        await expect(
+          decodeJobEnvelope({ value: encoded, blobs }),
+        ).rejects.toThrow(/missing/);
+      });
+    });
+
+    describe("when no blob store is provided", () => {
+      it("falls back to inline gzip+base64", async () => {
+        const encoded = await encodeJobEnvelope({ jobData: hugePayload });
+        expect(encoded).toContain('"e":"gz"');
+        expect(await decodeJobEnvelope({ value: encoded })).toEqual(
+          hugePayload,
+        );
+      });
+    });
+  });
+
+  describe("given an inline-body envelope", () => {
+    it("readEnvelopeBlobId returns null", async () => {
+      const encoded = await encodeJobEnvelope({
+        jobData: { __jobName: "tiny", value: 1 },
+      });
+      expect(readEnvelopeBlobId(encoded)).toBeNull();
+      expect(readEnvelopeBlobId('{"legacy":true}')).toBeNull();
+      expect(readEnvelopeBlobId("GQ1|nonsense")).toBeNull();
     });
   });
 
@@ -153,10 +266,10 @@ describe("jobEnvelope", () => {
       const payload = { __jobName: "media", blob: bytes.toString("base64") };
       const json = JSON.stringify(payload);
 
-      const encoded = await encodeJobEnvelope(payload);
+      const encoded = await encodeJobEnvelope({ jobData: payload });
       expect(encoded).toContain('"e":"j"');
       expect(encoded.length).toBeLessThan(json.length + 64);
-      expect(await decodeJobEnvelope(encoded)).toEqual(payload);
+      expect(await decodeJobEnvelope({ value: encoded })).toEqual(payload);
     });
   });
 
@@ -168,13 +281,13 @@ describe("jobEnvelope", () => {
         __jobName: "spanReçu",
         bulk: "x".repeat(2048),
       };
-      const encoded = await encodeJobEnvelope(payload);
+      const encoded = await encodeJobEnvelope({ jobData: payload });
       expect(readJobRoutingMeta(encoded)).toEqual({
         pipelineName: "traçes-π",
         jobType: "événement",
         jobName: "spanReçu",
       });
-      expect(await decodeJobEnvelope(encoded)).toEqual(payload);
+      expect(await decodeJobEnvelope({ value: encoded })).toEqual(payload);
     });
   });
 
@@ -190,14 +303,16 @@ describe("jobEnvelope", () => {
         __attempt: 1,
         data: true,
       };
-      const decoded = await decodeJobEnvelope(
-        await encodeJobEnvelope(original),
-      );
+      const decoded = await decodeJobEnvelope({
+        value: await encodeJobEnvelope({ jobData: original }),
+      });
       const { __context: _c, __attempt: _a, ...stripped } = decoded;
       const reEncoded = await encodeJobEnvelope({
-        ...stripped,
-        __context: { traceId: "t1" },
-        __attempt: 2,
+        jobData: {
+          ...stripped,
+          __context: { traceId: "t1" },
+          __attempt: 2,
+        },
       });
       expect(readJobRoutingMeta(reEncoded)).toEqual({
         pipelineName: "traces",
@@ -209,11 +324,15 @@ describe("jobEnvelope", () => {
 
   describe("given a corrupt value", () => {
     it("decodeJobEnvelope rejects", async () => {
-      await expect(decodeJobEnvelope("GQ1|nonsense")).rejects.toThrow();
-      await expect(decodeJobEnvelope("not json")).rejects.toThrow();
-      await expect(decodeJobEnvelope("GQ1|5")).rejects.toThrow();
-      await expect(decodeJobEnvelope("GQ1|0|{}")).rejects.toThrow();
-      await expect(decodeJobEnvelope("GQ1|8|{not:js}body")).rejects.toThrow();
+      await expect(
+        decodeJobEnvelope({ value: "GQ1|nonsense" }),
+      ).rejects.toThrow();
+      await expect(decodeJobEnvelope({ value: "not json" })).rejects.toThrow();
+      await expect(decodeJobEnvelope({ value: "GQ1|5" })).rejects.toThrow();
+      await expect(decodeJobEnvelope({ value: "GQ1|0|{}" })).rejects.toThrow();
+      await expect(
+        decodeJobEnvelope({ value: "GQ1|8|{not:js}body" }),
+      ).rejects.toThrow();
     });
 
     it("readJobRoutingMeta returns nulls instead of throwing", () => {
@@ -233,8 +352,8 @@ describe("jobEnvelope", () => {
   describe("given a payload containing multibyte characters", () => {
     it("round-trips unicode through compression intact", async () => {
       const payload = { __jobName: "uni", text: "héllo 🌍 ".repeat(500) };
-      const encoded = await encodeJobEnvelope(payload);
-      expect(await decodeJobEnvelope(encoded)).toEqual(payload);
+      const encoded = await encodeJobEnvelope({ jobData: payload });
+      expect(await decodeJobEnvelope({ value: encoded })).toEqual(payload);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeJobEnvelope,
+  encodeJobEnvelope,
+  readJobRoutingMeta,
+} from "../jobEnvelope";
+
+describe("jobEnvelope", () => {
+  describe("given a payload over the compression threshold", () => {
+    const largePayload = {
+      __pipelineName: "traces",
+      __jobType: "command",
+      __jobName: "recordSpan",
+      __context: { traceId: "t1", projectId: "p1" },
+      span: { attributes: "x".repeat(4096) },
+    };
+
+    describe("when encoded and decoded", () => {
+      it("round-trips the payload deep-equal", async () => {
+        const encoded = await encodeJobEnvelope(largePayload);
+        expect(await decodeJobEnvelope(encoded)).toEqual(largePayload);
+      });
+
+      it("stores the body gzip-compressed and smaller than the raw JSON", async () => {
+        const encoded = await encodeJobEnvelope(largePayload);
+        expect(encoded.startsWith("GQ1|")).toBe(true);
+        expect(encoded).toContain('"e":"gz"');
+        expect(encoded.length).toBeLessThan(JSON.stringify(largePayload).length);
+      });
+
+      it("exposes routing fields from the header without decoding the body", async () => {
+        const encoded = await encodeJobEnvelope(largePayload);
+        expect(readJobRoutingMeta(encoded)).toEqual({
+          pipelineName: "traces",
+          jobType: "command",
+          jobName: "recordSpan",
+        });
+      });
+    });
+  });
+
+  describe("given a payload under the compression threshold", () => {
+    const smallPayload = { __jobName: "tiny", value: 1 };
+
+    describe("when encoded", () => {
+      it("keeps the body as raw JSON", async () => {
+        const encoded = await encodeJobEnvelope(smallPayload);
+        expect(encoded).toContain('"e":"j"');
+        expect(encoded).toContain('"value":1');
+      });
+
+      it("round-trips the payload deep-equal", async () => {
+        const encoded = await encodeJobEnvelope(smallPayload);
+        expect(await decodeJobEnvelope(encoded)).toEqual(smallPayload);
+      });
+    });
+  });
+
+  describe("given a legacy bare-JSON value", () => {
+    const legacy = JSON.stringify({
+      __pipelineName: "traces",
+      __jobType: "event",
+      __jobName: "spanReceived",
+      data: true,
+    });
+
+    it("decodes as plain JSON", async () => {
+      expect(await decodeJobEnvelope(legacy)).toEqual(JSON.parse(legacy));
+    });
+
+    it("reads routing fields via full parse", () => {
+      expect(readJobRoutingMeta(legacy)).toEqual({
+        pipelineName: "traces",
+        jobType: "event",
+        jobName: "spanReceived",
+      });
+    });
+  });
+
+  describe("given a corrupt value", () => {
+    it("decodeJobEnvelope rejects", async () => {
+      await expect(decodeJobEnvelope("GQ1|nonsense")).rejects.toThrow();
+      await expect(decodeJobEnvelope("not json")).rejects.toThrow();
+    });
+
+    it("readJobRoutingMeta returns nulls instead of throwing", () => {
+      expect(readJobRoutingMeta("GQ1|nonsense")).toEqual({
+        pipelineName: null,
+        jobType: null,
+        jobName: null,
+      });
+      expect(readJobRoutingMeta("not json")).toEqual({
+        pipelineName: null,
+        jobType: null,
+        jobName: null,
+      });
+    });
+  });
+
+  describe("given a payload containing multibyte characters", () => {
+    it("round-trips unicode through compression intact", async () => {
+      const payload = { __jobName: "uni", text: "héllo 🌍 ".repeat(500) };
+      const encoded = await encodeJobEnvelope(payload);
+      expect(await decodeJobEnvelope(encoded)).toEqual(payload);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   decodeJobEnvelope,
@@ -26,11 +26,11 @@ class InMemoryBlobStore implements JobBlobStore {
 
 describe("jobEnvelope", () => {
   beforeEach(() => {
-    process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED = "true";
+    vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
   });
 
   afterEach(() => {
-    delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+    vi.unstubAllEnvs();
   });
 
   describe("given envelope writes are not enabled", () => {
@@ -42,7 +42,7 @@ describe("jobEnvelope", () => {
     };
 
     beforeEach(() => {
-      delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+      vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", undefined);
     });
 
     describe("when encoding", () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -26,7 +26,9 @@ describe("jobEnvelope", () => {
         const encoded = await encodeJobEnvelope(largePayload);
         expect(encoded.startsWith("GQ1|")).toBe(true);
         expect(encoded).toContain('"e":"gz"');
-        expect(encoded.length).toBeLessThan(JSON.stringify(largePayload).length);
+        expect(encoded.length).toBeLessThan(
+          JSON.stringify(largePayload).length,
+        );
       });
 
       it("exposes routing fields from the header without decoding the body", async () => {
@@ -78,10 +80,79 @@ describe("jobEnvelope", () => {
     });
   });
 
+  describe("given a payload at the compression threshold boundary", () => {
+    function payloadOfJsonByteLength(target: number): Record<string, unknown> {
+      const skeleton = JSON.stringify({ pad: "" });
+      return { pad: "x".repeat(target - Buffer.byteLength(skeleton)) };
+    }
+
+    it("keeps a payload of exactly 1024 JSON bytes raw", async () => {
+      const payload = payloadOfJsonByteLength(1024);
+      expect(Buffer.byteLength(JSON.stringify(payload))).toBe(1024);
+      expect(await encodeJobEnvelope(payload)).toContain('"e":"j"');
+    });
+
+    it("compresses a payload of 1025 JSON bytes", async () => {
+      const payload = payloadOfJsonByteLength(1025);
+      expect(Buffer.byteLength(JSON.stringify(payload))).toBe(1025);
+      expect(await encodeJobEnvelope(payload)).toContain('"e":"gz"');
+    });
+  });
+
+  describe("given routing fields containing non-ASCII characters", () => {
+    it("round-trips and exposes routing meta with a byte-accurate header length", async () => {
+      const payload = {
+        __pipelineName: "traçes-π",
+        __jobType: "événement",
+        __jobName: "spanReçu",
+        bulk: "x".repeat(2048),
+      };
+      const encoded = await encodeJobEnvelope(payload);
+      expect(readJobRoutingMeta(encoded)).toEqual({
+        pipelineName: "traçes-π",
+        jobType: "événement",
+        jobName: "spanReçu",
+      });
+      expect(await decodeJobEnvelope(encoded)).toEqual(payload);
+    });
+  });
+
+  describe("given a payload that went through internal-field stripping", () => {
+    it("keeps routing fields in the header after a strip and re-encode cycle", async () => {
+      // Retry/exhaust re-staging spreads the stripped payload back into a new
+      // envelope; routing fields must survive or pause checks stop matching.
+      const original = {
+        __pipelineName: "traces",
+        __jobType: "command",
+        __jobName: "recordSpan",
+        __context: { traceId: "t1" },
+        __attempt: 1,
+        data: true,
+      };
+      const decoded = await decodeJobEnvelope(
+        await encodeJobEnvelope(original),
+      );
+      const { __context: _c, __attempt: _a, ...stripped } = decoded;
+      const reEncoded = await encodeJobEnvelope({
+        ...stripped,
+        __context: { traceId: "t1" },
+        __attempt: 2,
+      });
+      expect(readJobRoutingMeta(reEncoded)).toEqual({
+        pipelineName: "traces",
+        jobType: "command",
+        jobName: "recordSpan",
+      });
+    });
+  });
+
   describe("given a corrupt value", () => {
     it("decodeJobEnvelope rejects", async () => {
       await expect(decodeJobEnvelope("GQ1|nonsense")).rejects.toThrow();
       await expect(decodeJobEnvelope("not json")).rejects.toThrow();
+      await expect(decodeJobEnvelope("GQ1|5")).rejects.toThrow();
+      await expect(decodeJobEnvelope("GQ1|0|{}")).rejects.toThrow();
+      await expect(decodeJobEnvelope("GQ1|8|{not:js}body")).rejects.toThrow();
     });
 
     it("readJobRoutingMeta returns nulls instead of throwing", () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1436,11 +1436,13 @@ describe("GroupStagingScripts", () => {
     ): Promise<string> {
       // >1 KiB so the body is gzip+base64 — proves Lua reads the header only.
       return await encodeJobEnvelope({
-        __pipelineName: "ingestion",
-        __jobType: "projection",
-        __jobName: "traceProjection",
-        bulk: "x".repeat(4096),
-        ...overrides,
+        jobData: {
+          __pipelineName: "ingestion",
+          __jobType: "projection",
+          __jobName: "traceProjection",
+          bulk: "x".repeat(4096),
+          ...overrides,
+        },
       });
     }
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -13,6 +13,7 @@ import {
   type DispatchResult,
 } from "../scripts";
 import { QueueRedisRepository } from "../../../../app-layer/ops/repositories/queue.redis.repository";
+import { encodeJobEnvelope } from "../jobEnvelope";
 
 let redis: Redis;
 let scripts: GroupStagingScripts;
@@ -1416,6 +1417,102 @@ describe("GroupStagingScripts", () => {
       const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
       expect(result).not.toBeNull();
       expect(result!.stagedJobId).toBe("j1");
+    });
+  });
+
+  // ADR-026: staged values are GQ1 envelopes whose routing fields live in a
+  // tiny header so the Lua pause-check never decodes the (gzipped) body.
+  describe("when head-of-line job is envelope-encoded", () => {
+    async function makeEnvelopeJobData(
+      overrides: Record<string, unknown> = {},
+    ): Promise<string> {
+      // >1 KiB so the body is gzip+base64 — proves Lua reads the header only.
+      return await encodeJobEnvelope({
+        __pipelineName: "ingestion",
+        __jobType: "projection",
+        __jobName: "traceProjection",
+        bulk: "x".repeat(4096),
+        ...overrides,
+      });
+    }
+
+    it("skips group whose envelope header matches a paused pipeline", async () => {
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          dispatchAfterMs: 100,
+          jobDataJson: await makeEnvelopeJobData(),
+        }),
+      );
+      await scripts.addPauseKey("ingestion");
+
+      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+      expect(result).toBeNull();
+    });
+
+    it("skips group when paused at jobType level via the header", async () => {
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          dispatchAfterMs: 100,
+          jobDataJson: await makeEnvelopeJobData(),
+        }),
+      );
+      await scripts.addPauseKey("ingestion/projection");
+
+      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+      expect(result).toBeNull();
+    });
+
+    it("skips group when paused at jobType/jobName level via the header", async () => {
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          dispatchAfterMs: 100,
+          jobDataJson: await makeEnvelopeJobData(),
+        }),
+      );
+      await scripts.addPauseKey("ingestion/projection/traceProjection");
+
+      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+      expect(result).toBeNull();
+    });
+
+    it("dispatches the envelope intact when nothing is paused", async () => {
+      const jobDataJson = await makeEnvelopeJobData();
+      await scripts.stage(
+        makeJob({ stagedJobId: "j1", dispatchAfterMs: 100, jobDataJson }),
+      );
+
+      const result = await scripts.dispatch({ nowMs: 200, activeTtlSec: 60 });
+      expect(result).not.toBeNull();
+      expect(result!.jobDataJson).toBe(jobDataJson);
+    });
+
+    it("increments the per-job-name failed counter from the envelope header", async () => {
+      await scripts.stage(
+        makeJob({
+          stagedJobId: "j1",
+          dispatchAfterMs: 100,
+          jobDataJson: await makeEnvelopeJobData(),
+        }),
+      );
+      const dispatched = (await scripts.dispatch({
+        nowMs: 200,
+        activeTtlSec: 60,
+      }))!;
+
+      await scripts.restageAndBlock({
+        groupId: "group-a",
+        newStagedJobId: "j1/r/1",
+        score: 100,
+        jobDataJson: dispatched.jobDataJson,
+      });
+
+      const perJobName = await redis.get(
+        `${keyPrefix()}stats:failed:traceProjection`,
+      );
+      expect(perJobName).toBe("1");
     });
   });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1423,6 +1423,14 @@ describe("GroupStagingScripts", () => {
   // ADR-026: staged values are GQ1 envelopes whose routing fields live in a
   // tiny header so the Lua pause-check never decodes the (gzipped) body.
   describe("when head-of-line job is envelope-encoded", () => {
+    beforeEach(() => {
+      process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED = "true";
+    });
+
+    afterEach(() => {
+      delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+    });
+
     async function makeEnvelopeJobData(
       overrides: Record<string, unknown> = {},
     ): Promise<string> {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Redis } from "ioredis";
 import {
   startTestContainers,
@@ -1424,11 +1424,11 @@ describe("GroupStagingScripts", () => {
   // tiny header so the Lua pause-check never decodes the (gzipped) body.
   describe("when head-of-line job is envelope-encoded", () => {
     beforeEach(() => {
-      process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED = "true";
+      vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
     });
 
     afterEach(() => {
-      delete process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED;
+      vi.unstubAllEnvs();
     });
 
     async function makeEnvelopeJobData(

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -519,13 +519,14 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         drainedSiblings = [];
       }
       if (drainedSiblings.length > 0) {
-        const siblingPayloads = (
-          await Promise.all(
-            drainedSiblings.map((sibling) =>
-              this.parseDrainedPayload(sibling, groupId),
-            ),
-          )
-        ).filter((parsed): parsed is Payload => parsed !== null);
+        const parsedSiblings = await Promise.all(
+          drainedSiblings.map((sibling) =>
+            this.parseDrainedPayload(sibling, groupId),
+          ),
+        );
+        const siblingPayloads = parsedSiblings.filter(
+          (parsed) => parsed !== null,
+        ) as Payload[];
         if (siblingPayloads.length > 0) {
           batchPayloads = [payload, ...siblingPayloads];
         }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -18,7 +18,12 @@ import {
   runWithContext,
 } from "../../../context/asyncContext";
 import { connection } from "../../../redis";
-import { decodeJobEnvelope, encodeJobEnvelope } from "./jobEnvelope";
+import {
+  decodeJobEnvelope,
+  encodeJobEnvelope,
+  readEnvelopeBlobId,
+} from "./jobEnvelope";
+import { RedisJobBlobStore } from "./redisJobBlobStore";
 import type {
   DeduplicationConfig,
   EventSourcedQueueDefinition,
@@ -125,6 +130,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   private readonly redisConnection: IORedis | Cluster;
   private readonly blockingConnection: IORedis | Cluster;
   private readonly scripts: GroupStagingScripts;
+  private readonly blobs: RedisJobBlobStore;
   private readonly rateTracker!: TenantRateTracker;
   private readonly globalConcurrency: number;
   private readonly consumerEnabled: boolean;
@@ -197,6 +203,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       this.redisConnection,
       this.queueName,
     );
+
+    // Offloaded envelope bodies (ADR-026): large payloads live under
+    // standalone blob keys so their bulk never transits the Lua scripts.
+    this.blobs = new RedisJobBlobStore({
+      redis: this.redisConnection,
+      queueName: this.queueName,
+    });
 
     // Advertise this queue in the registry set so the ops dashboard enumerates
     // it via SMEMBERS instead of an O(keyspace) `SCAN MATCH *:gq:ready`.
@@ -319,7 +332,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       dispatchAfterMs,
       dedupId,
       dedupTtlMs,
-      jobDataJson: await encodeJobEnvelope(payloadWithContext),
+      jobDataJson: await encodeJobEnvelope({
+        jobData: payloadWithContext,
+        blobs: this.blobs,
+      }),
       shouldExtend,
       shouldReplace,
     });
@@ -403,7 +419,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           dispatchAfterMs,
           dedupId,
           dedupTtlMs,
-          jobDataJson: await encodeJobEnvelope(payloadWithContext),
+          jobDataJson: await encodeJobEnvelope({
+            jobData: payloadWithContext,
+            blobs: this.blobs,
+          }),
           shouldExtend,
           shouldReplace,
         };
@@ -465,7 +484,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // Parse the stored job data
     let jobData: Record<string, unknown>;
     try {
-      jobData = await decodeJobEnvelope(jobDataJson);
+      jobData = await decodeJobEnvelope({
+        value: jobDataJson,
+        blobs: this.blobs,
+      });
     } catch {
       this.logger.error(
         { queueName: this.queueName, stagedJobId, groupId },
@@ -473,6 +495,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       );
       // Complete the group slot so it's not stuck
       await this.scripts.complete({ groupId, stagedJobId });
+      this.deleteEnvelopeBlobs([jobDataJson]);
       return;
     }
 
@@ -619,6 +642,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               // removed from staging during the drain, so completing the
               // dispatched job is enough to free the group.
               await this.scripts.complete({ groupId, stagedJobId, jobName });
+              this.deleteEnvelopeBlobs([
+                jobDataJson,
+                ...drainedSiblings.map((sibling) => sibling.jobDataJson),
+              ]);
               gqJobsCompletedTotal.inc(routingLabels);
 
               this.logger.debug(
@@ -652,9 +679,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 gqRetryBackoffMilliseconds.observe(routingLabels, backoffMs);
                 const newStagedJobId = `${stagedJobId}/r/${attempt}`;
                 const retryJobData = await encodeJobEnvelope({
-                  ...(payload as Record<string, unknown>),
-                  __context: contextMetadata,
-                  __attempt: attempt + 1,
+                  jobData: {
+                    ...(payload as Record<string, unknown>),
+                    __context: contextMetadata,
+                    __attempt: attempt + 1,
+                  },
+                  blobs: this.blobs,
                 });
 
                 await this.scripts.retryRestage({
@@ -665,6 +695,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   jobDataJson: retryJobData,
                   backoffMs,
                 });
+                // The re-stage wrote a fresh envelope (and blob, if large);
+                // the dispatched value's blob is now unreferenced. Drained
+                // siblings were re-staged with their ORIGINAL values, so
+                // their blobs stay.
+                this.deleteEnvelopeBlobs([jobDataJson]);
 
                 this.logger.warn(
                   {
@@ -706,6 +741,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   contextMetadata,
                   routingLabels,
                 });
+                this.deleteEnvelopeBlobs([jobDataJson]);
               }
             }
           },
@@ -745,6 +781,20 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   }
 
   /**
+   * Best-effort deletion of offloaded bodies whose staged values are retired.
+   * Fire-and-forget: the blob TTL is the correctness backstop, so a failed
+   * delete only means the blob lingers until expiry.
+   */
+  private deleteEnvelopeBlobs(values: string[]): void {
+    for (const value of values) {
+      const blobId = readEnvelopeBlobId(value);
+      if (blobId) {
+        void this.blobs.delete({ id: blobId }).catch(() => {});
+      }
+    }
+  }
+
+  /**
    * Strips internal metadata fields from job data, returning the clean payload.
    */
   private stripInternalFields(jobData: Record<string, unknown>): Payload {
@@ -769,7 +819,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     groupId: string;
   }): Promise<Payload | null> {
     try {
-      const jobData = await decodeJobEnvelope(sibling.jobDataJson);
+      const jobData = await decodeJobEnvelope({
+        value: sibling.jobDataJson,
+        blobs: this.blobs,
+      });
       return this.stripInternalFields(jobData);
     } catch {
       this.logger.error(
@@ -881,8 +934,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // Re-stage with a new ID
     const newStagedJobId = `${stagedJobId}/r/${Date.now()}`;
     const jobDataJson = await encodeJobEnvelope({
-      ...(payload as Record<string, unknown>),
-      __context: contextMetadata,
+      jobData: {
+        ...(payload as Record<string, unknown>),
+        __context: contextMetadata,
+      },
+      blobs: this.blobs,
     });
 
     // Atomically: block the group, re-stage the job, update ready score, store error

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -521,7 +521,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       if (drainedSiblings.length > 0) {
         const parsedSiblings = await Promise.all(
           drainedSiblings.map((sibling) =>
-            this.parseDrainedPayload(sibling, groupId),
+            this.parseDrainedPayload({ sibling, groupId }),
           ),
         );
         const siblingPayloads = parsedSiblings.filter(
@@ -761,10 +761,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * here and recoverable via event replay, mirroring the dispatched job's own
    * parse-failure handling).
    */
-  private async parseDrainedPayload(
-    sibling: DrainedJob,
-    groupId: string,
-  ): Promise<Payload | null> {
+  private async parseDrainedPayload({
+    sibling,
+    groupId,
+  }: {
+    sibling: DrainedJob;
+    groupId: string;
+  }): Promise<Payload | null> {
     try {
       const jobData = await decodeJobEnvelope(sibling.jobDataJson);
       return this.stripInternalFields(jobData);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -13,6 +13,7 @@ import {
   runWithContext,
 } from "../../../context/asyncContext";
 import { connection } from "../../../redis";
+import { decodeJobEnvelope, encodeJobEnvelope } from "./jobEnvelope";
 import type {
   DeduplicationConfig,
   EventSourcedQueueDefinition,
@@ -299,7 +300,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       dispatchAfterMs,
       dedupId,
       dedupTtlMs,
-      jobDataJson: JSON.stringify(payloadWithContext),
+      jobDataJson: await encodeJobEnvelope(payloadWithContext),
       shouldExtend,
       shouldReplace,
     });
@@ -357,7 +358,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const shouldExtend = dedup ? dedup.extend !== false : true;
     const shouldReplace = dedup ? dedup.replace !== false : true;
 
-    const jobsToStage = payloads.map((payload, index) => {
+    const jobsToStage = await Promise.all(payloads.map(async (payload, index) => {
       const groupId = this.groupKey(payload);
       const stagedJobId = this.generateStagedJobId(payload);
       const score = this.score?.(payload) ?? now;
@@ -382,11 +383,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         dispatchAfterMs,
         dedupId,
         dedupTtlMs,
-        jobDataJson: JSON.stringify(payloadWithContext),
+        jobDataJson: await encodeJobEnvelope(payloadWithContext),
         shouldExtend,
         shouldReplace,
       };
-    });
+    }));
 
     const newStagedCount = await this.scripts.stageBatch(jobsToStage);
 
@@ -440,7 +441,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // Parse the stored job data
     let jobData: Record<string, unknown>;
     try {
-      jobData = JSON.parse(jobDataJson) as Record<string, unknown>;
+      jobData = await decodeJobEnvelope(jobDataJson);
     } catch {
       this.logger.error(
         { queueName: this.queueName, stagedJobId, groupId },
@@ -490,7 +491,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       if (drainedSiblings.length > 0) {
         const siblingPayloads: Payload[] = [];
         for (const sibling of drainedSiblings) {
-          const parsed = this.parseDrainedPayload(sibling, groupId);
+          const parsed = await this.parseDrainedPayload(sibling, groupId);
           if (parsed) siblingPayloads.push(parsed);
         }
         if (siblingPayloads.length > 0) {
@@ -606,7 +607,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 gqRetryAttempt.observe(routingLabels, attempt);
                 gqRetryBackoffMilliseconds.observe(routingLabels, backoffMs);
                 const newStagedJobId = `${stagedJobId}/r/${attempt}`;
-                const retryJobData = JSON.stringify({
+                const retryJobData = await encodeJobEnvelope({
                   ...(payload as Record<string, unknown>),
                   __context: contextMetadata,
                   __attempt: attempt + 1,
@@ -716,9 +717,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * here and recoverable via event replay, mirroring the dispatched job's own
    * parse-failure handling).
    */
-  private parseDrainedPayload(sibling: DrainedJob, groupId: string): Payload | null {
+  private async parseDrainedPayload(sibling: DrainedJob, groupId: string): Promise<Payload | null> {
     try {
-      const jobData = JSON.parse(sibling.jobDataJson) as Record<string, unknown>;
+      const jobData = await decodeJobEnvelope(sibling.jobDataJson);
       return this.stripInternalFields(jobData);
     } catch {
       this.logger.error(
@@ -825,7 +826,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     // Re-stage with a new ID
     const newStagedJobId = `${stagedJobId}/r/${Date.now()}`;
-    const jobDataJson = JSON.stringify({
+    const jobDataJson = await encodeJobEnvelope({
       ...(payload as Record<string, unknown>),
       __context: contextMetadata,
     });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1,5 +1,10 @@
 import { performance } from "node:perf_hooks";
-import { context as otelContext, SpanKind, trace, TraceFlags } from "@opentelemetry/api";
+import {
+  context as otelContext,
+  SpanKind,
+  trace,
+  TraceFlags,
+} from "@opentelemetry/api";
 import fastq from "fastq";
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
@@ -20,7 +25,12 @@ import type {
   EventSourcedQueueProcessor,
   QueueSendOptions,
 } from "../../queues";
-import { categorizeError, ConfigurationError, ErrorCategory, QueueError } from "../../services/errorHandling";
+import {
+  categorizeError,
+  ConfigurationError,
+  ErrorCategory,
+  QueueError,
+} from "../../services/errorHandling";
 import { JOB_RETRY_CONFIG, getBackoffMs } from "../shared";
 import { GroupQueueDispatcher } from "./dispatcher";
 import {
@@ -38,7 +48,11 @@ import {
   gqJobDurationMilliseconds,
 } from "./metrics";
 import { GroupQueueMetricsCollector } from "./metricsCollector";
-import { type DispatchResult, type DrainedJob, GroupStagingScripts } from "./scripts";
+import {
+  type DispatchResult,
+  type DrainedJob,
+  GroupStagingScripts,
+} from "./scripts";
 import {
   TenantRateTracker,
   tenantIdFromGroupId,
@@ -50,8 +64,7 @@ import { featureFlagService } from "../../../featureFlag";
  */
 const GROUP_QUEUE_CONFIG = {
   /** Default global concurrency (max parallel groups) */
-  defaultGlobalConcurrency:
-    Number(process.env.GLOBAL_QUEUE_CONCURRENCY) || 100,
+  defaultGlobalConcurrency: Number(process.env.GLOBAL_QUEUE_CONCURRENCY) || 100,
   /** TTL for the active key (safety net for crashes), in seconds */
   activeTtlSec: 300,
   /** BRPOP timeout in seconds (fallback polling interval) */
@@ -70,7 +83,13 @@ const GROUP_QUEUE_CONFIG = {
 const DEFAULT_DEDUPLICATION_TTL_MS = 200;
 
 /** Internal fields attached to job data that must be stripped before processing. */
-const INTERNAL_FIELDS = ["__context", "__groupId", "__stagedJobId", "__dispatchScore", "__attempt"] as const;
+const INTERNAL_FIELDS = [
+  "__context",
+  "__groupId",
+  "__stagedJobId",
+  "__dispatchScore",
+  "__attempt",
+] as const;
 
 /**
  * Group Queue Processor that provides per-group FIFO with cross-group parallelism.
@@ -358,36 +377,38 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const shouldExtend = dedup ? dedup.extend !== false : true;
     const shouldReplace = dedup ? dedup.replace !== false : true;
 
-    const jobsToStage = await Promise.all(payloads.map(async (payload, index) => {
-      const groupId = this.groupKey(payload);
-      const stagedJobId = this.generateStagedJobId(payload);
-      const score = this.score?.(payload) ?? now;
-      // Add index to ensure FIFO order within the batch even if timestamps are identical
-      const dispatchAfterMs = score + (delay ?? 0) + index;
+    const jobsToStage = await Promise.all(
+      payloads.map(async (payload, index) => {
+        const groupId = this.groupKey(payload);
+        const stagedJobId = this.generateStagedJobId(payload);
+        const score = this.score?.(payload) ?? now;
+        // Add index to ensure FIFO order within the batch even if timestamps are identical
+        const dispatchAfterMs = score + (delay ?? 0) + index;
 
-      let dedupId = "";
-      let dedupTtlMs = 0;
-      if (dedup) {
-        dedupId = dedup.makeId(payload).replaceAll(":", ".");
-        dedupTtlMs = dedup.ttlMs ?? DEFAULT_DEDUPLICATION_TTL_MS;
-      }
+        let dedupId = "";
+        let dedupTtlMs = 0;
+        if (dedup) {
+          dedupId = dedup.makeId(payload).replaceAll(":", ".");
+          dedupTtlMs = dedup.ttlMs ?? DEFAULT_DEDUPLICATION_TTL_MS;
+        }
 
-      const payloadWithContext = {
-        ...(payload as Record<string, unknown>),
-        __context: contextMetadata,
-      };
+        const payloadWithContext = {
+          ...(payload as Record<string, unknown>),
+          __context: contextMetadata,
+        };
 
-      return {
-        stagedJobId,
-        groupId,
-        dispatchAfterMs,
-        dedupId,
-        dedupTtlMs,
-        jobDataJson: await encodeJobEnvelope(payloadWithContext),
-        shouldExtend,
-        shouldReplace,
-      };
-    }));
+        return {
+          stagedJobId,
+          groupId,
+          dispatchAfterMs,
+          dedupId,
+          dedupTtlMs,
+          jobDataJson: await encodeJobEnvelope(payloadWithContext),
+          shouldExtend,
+          shouldReplace,
+        };
+      }),
+    );
 
     const newStagedCount = await this.scripts.stageBatch(jobsToStage);
 
@@ -398,7 +419,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       if (effectiveDelay && effectiveDelay > 0) {
         gqJobsDelayedTotal.inc({ queue_name: this.queueName }, newStagedCount);
         for (let i = 0; i < newStagedCount; i++) {
-          gqJobDelayMilliseconds.observe({ queue_name: this.queueName }, effectiveDelay);
+          gqJobDelayMilliseconds.observe(
+            { queue_name: this.queueName },
+            effectiveDelay,
+          );
         }
       }
       // Per-tenant rate tracking. The Lua script may have deduped some
@@ -453,11 +477,17 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     }
 
     const contextMetadata = jobData.__context as JobContextMetadata | undefined;
-    const attempt = typeof jobData.__attempt === "number" ? jobData.__attempt : 1;
+    const attempt =
+      typeof jobData.__attempt === "number" ? jobData.__attempt : 1;
     const pipelineName = (jobData.__pipelineName as string) ?? "unknown";
     const jobType = (jobData.__jobType as string) ?? "unknown";
     const jobName = (jobData.__jobName as string) ?? "unknown";
-    const routingLabels = { queue_name: this.queueName, pipeline_name: pipelineName, job_type: jobType, job_name: jobName };
+    const routingLabels = {
+      queue_name: this.queueName,
+      pipeline_name: pipelineName,
+      job_type: jobType,
+      job_name: jobName,
+    };
     const payload = this.stripInternalFields(jobData);
 
     // Opt-in batch coalescing: if this job type supports it, drain additional
@@ -489,11 +519,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         drainedSiblings = [];
       }
       if (drainedSiblings.length > 0) {
-        const siblingPayloads: Payload[] = [];
-        for (const sibling of drainedSiblings) {
-          const parsed = await this.parseDrainedPayload(sibling, groupId);
-          if (parsed) siblingPayloads.push(parsed);
-        }
+        const siblingPayloads = (
+          await Promise.all(
+            drainedSiblings.map((sibling) =>
+              this.parseDrainedPayload(sibling, groupId),
+            ),
+          )
+        ).filter((parsed): parsed is Payload => parsed !== null);
         if (siblingPayloads.length > 0) {
           batchPayloads = [payload, ...siblingPayloads];
         }
@@ -520,7 +552,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         try {
           const custom = this.spanAttributes(payload);
           for (const [key, value] of Object.entries(custom)) {
-            if (value !== undefined && (typeof value === "string" || typeof value === "number" || typeof value === "boolean")) {
+            if (
+              value !== undefined &&
+              (typeof value === "string" ||
+                typeof value === "number" ||
+                typeof value === "boolean")
+            ) {
               spanAttributes[key] = value;
             }
           }
@@ -550,7 +587,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
             // Add business context attributes
             if (contextMetadata?.organizationId) {
-              span.setAttribute("organization.id", contextMetadata.organizationId);
+              span.setAttribute(
+                "organization.id",
+                contextMetadata.organizationId,
+              );
             }
             if (contextMetadata?.projectId) {
               span.setAttribute("tenant.id", contextMetadata.projectId);
@@ -564,7 +604,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               const requestContext = createContextFromJobData(contextMetadata);
               await runWithContext(requestContext, async () => {
                 if (batchPayloads && this.processBatch) {
-                  span.setAttribute("queue.coalesced_batch_size", batchPayloads.length);
+                  span.setAttribute(
+                    "queue.coalesced_batch_size",
+                    batchPayloads.length,
+                  );
                   await this.processBatch(batchPayloads);
                 } else {
                   await this.process(payload);
@@ -717,13 +760,20 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
    * here and recoverable via event replay, mirroring the dispatched job's own
    * parse-failure handling).
    */
-  private async parseDrainedPayload(sibling: DrainedJob, groupId: string): Promise<Payload | null> {
+  private async parseDrainedPayload(
+    sibling: DrainedJob,
+    groupId: string,
+  ): Promise<Payload | null> {
     try {
       const jobData = await decodeJobEnvelope(sibling.jobDataJson);
       return this.stripInternalFields(jobData);
     } catch {
       this.logger.error(
-        { queueName: this.queueName, groupId, stagedJobId: sibling.stagedJobId },
+        {
+          queueName: this.queueName,
+          groupId,
+          stagedJobId: sibling.stagedJobId,
+        },
         "Failed to parse drained sibling job data — dropping (recoverable via replay)",
       );
       return null;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -1,5 +1,5 @@
 import { promisify } from "node:util";
-import { gzip, gunzip } from "node:zlib";
+import { gunzip, gzip } from "node:zlib";
 
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
@@ -37,7 +37,8 @@ export async function encodeJobEnvelope(
   const json = JSON.stringify(jobData);
 
   const header: EnvelopeHeader = { v: 1, e: "j" };
-  if (typeof jobData.__pipelineName === "string") header.p = jobData.__pipelineName;
+  if (typeof jobData.__pipelineName === "string")
+    header.p = jobData.__pipelineName;
   if (typeof jobData.__jobType === "string") header.t = jobData.__jobType;
   if (typeof jobData.__jobName === "string") header.n = jobData.__jobName;
 
@@ -48,7 +49,9 @@ export async function encodeJobEnvelope(
   }
 
   const headerJson = JSON.stringify(header);
-  return `${ENVELOPE_PREFIX}${headerJson.length}|${headerJson}${body}`;
+  // Header length is in BYTES: the Lua reader slices bytes, and UTF-16 code
+  // units diverge from bytes if a routing field ever carries non-ASCII.
+  return `${ENVELOPE_PREFIX}${Buffer.byteLength(headerJson)}|${headerJson}${body}`;
 }
 
 export async function decodeJobEnvelope(
@@ -82,7 +85,10 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
     }
     const parsed = JSON.parse(value) as Record<string, unknown>;
     return {
-      pipelineName: typeof parsed.__pipelineName === "string" ? parsed.__pipelineName : null,
+      pipelineName:
+        typeof parsed.__pipelineName === "string"
+          ? parsed.__pipelineName
+          : null,
       jobType: typeof parsed.__jobType === "string" ? parsed.__jobType : null,
       jobName: typeof parsed.__jobName === "string" ? parsed.__jobName : null,
     };
@@ -91,16 +97,31 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
   }
 }
 
-function splitEnvelope(value: string): { header: EnvelopeHeader; body: string } {
+function splitEnvelope(value: string): {
+  header: EnvelopeHeader;
+  body: string;
+} {
   const lenEnd = value.indexOf("|", ENVELOPE_PREFIX.length);
   if (lenEnd === -1) {
     throw new Error("Malformed job envelope: missing header length delimiter");
   }
-  const headerLen = Number(value.slice(ENVELOPE_PREFIX.length, lenEnd));
-  if (!Number.isInteger(headerLen) || headerLen <= 0) {
+  const lenDigits = value.slice(ENVELOPE_PREFIX.length, lenEnd);
+  if (!/^\d+$/.test(lenDigits)) {
     throw new Error("Malformed job envelope: invalid header length");
   }
-  const headerJson = value.slice(lenEnd + 1, lenEnd + 1 + headerLen);
+  const headerLen = Number(lenDigits);
+  if (headerLen <= 0) {
+    throw new Error("Malformed job envelope: invalid header length");
+  }
+  // Prefix and length digits are ASCII, so lenEnd is the same offset in bytes
+  // and code units; the header itself must be sliced as bytes to match Lua.
+  const buf = Buffer.from(value, "utf8");
+  const headerJson = buf
+    .subarray(lenEnd + 1, lenEnd + 1 + headerLen)
+    .toString("utf8");
   const header = JSON.parse(headerJson) as EnvelopeHeader;
-  return { header, body: value.slice(lenEnd + 1 + headerLen) };
+  return {
+    header,
+    body: buf.subarray(lenEnd + 1 + headerLen).toString("utf8"),
+  };
 }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -17,6 +17,18 @@ const ENVELOPE_PREFIX = "GQ1|";
 /** gzip+base64 of sub-kilobyte JSON is frequently larger than the input. */
 const COMPRESSION_THRESHOLD_BYTES = 1024;
 
+/**
+ * Phase gate for the two-phase format rollout (ADR-026). Readers are always
+ * envelope-aware, but writes stay legacy bare JSON until every consumer in
+ * the fleet is known to read envelopes — a pod from the previous release
+ * drops any `GQ1|` value it dispatches (its JSON.parse failure path completes
+ * the group slot without running the handler). Read at call time so tests can
+ * toggle it without module reloads.
+ */
+function envelopeWritesEnabled(): boolean {
+  return process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED === "true";
+}
+
 export interface JobRoutingMeta {
   pipelineName: string | null;
   jobType: string | null;
@@ -35,6 +47,9 @@ export async function encodeJobEnvelope(
   jobData: Record<string, unknown>,
 ): Promise<string> {
   const json = JSON.stringify(jobData);
+  if (!envelopeWritesEnabled()) {
+    return json;
+  }
 
   const header: EnvelopeHeader = { v: 1, e: "j" };
   if (typeof jobData.__pipelineName === "string")
@@ -44,8 +59,14 @@ export async function encodeJobEnvelope(
 
   let body = json;
   if (Buffer.byteLength(json) > COMPRESSION_THRESHOLD_BYTES) {
-    header.e = "gz";
-    body = (await gzipAsync(json)).toString("base64");
+    const compressed = (await gzipAsync(json)).toString("base64");
+    // High-entropy payloads (inline base64-ish data) can come out LARGER
+    // after gzip+base64; keep raw JSON unless compression actually wins.
+    // `"gz"` costs one more header byte than `"j"`.
+    if (Buffer.byteLength(compressed) + 1 < Buffer.byteLength(json)) {
+      header.e = "gz";
+      body = compressed;
+    }
   }
 
   const headerJson = JSON.stringify(header);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -78,9 +78,9 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
     if (value.startsWith(ENVELOPE_PREFIX)) {
       const { header } = splitEnvelope(value);
       return {
-        pipelineName: header.p ?? null,
-        jobType: header.t ?? null,
-        jobName: header.n ?? null,
+        pipelineName: typeof header.p === "string" ? header.p : null,
+        jobType: typeof header.t === "string" ? header.t : null,
+        jobName: typeof header.n === "string" ? header.n : null,
       };
     }
     const parsed = JSON.parse(value) as Record<string, unknown>;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
 
@@ -8,14 +9,24 @@ const gunzipAsync = promisify(gunzip);
  * Versioned envelope for staged job values: `GQ1|<headerLen>|<headerJson><body>`.
  *
  * The header carries only what dispatch-time Lua and the ops dashboard need
- * without touching the body (routing fields + body encoding); the body is the
- * full payload JSON, gzip+base64 when it exceeds the threshold. Values without
- * the prefix are legacy bare JSON and decode as-is. See ADR-026.
+ * without touching the body (routing fields + body encoding). The body is the
+ * full payload JSON: gzip+base64 inline when compression wins, or offloaded to
+ * a standalone blob key (raw gzip binary, fetched outside Lua) when the
+ * payload is large — then the body is empty and the header carries the blob
+ * id. Values without the prefix are legacy bare JSON and decode as-is.
+ * See ADR-026.
  */
 const ENVELOPE_PREFIX = "GQ1|";
 
 /** gzip+base64 of sub-kilobyte JSON is frequently larger than the input. */
 const COMPRESSION_THRESHOLD_BYTES = 1024;
+
+/**
+ * Above this, the body moves to a standalone blob key so the bulk never
+ * transits the dispatch/drain/restage Lua scripts or sits in the group hash.
+ * Payloads ≥256 KiB never reach the queue at all (S3 spool).
+ */
+const BLOB_OFFLOAD_THRESHOLD_BYTES = 32 * 1024;
 
 /**
  * Phase gate for the two-phase format rollout (ADR-026). Readers are always
@@ -29,6 +40,17 @@ function envelopeWritesEnabled(): boolean {
   return process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED === "true";
 }
 
+/**
+ * Storage for offloaded envelope bodies. Implementations must persist with a
+ * TTL safety net: deletion is best-effort at job completion, and a blob whose
+ * job was squashed by dedup or lost in a crash must eventually expire.
+ */
+export interface JobBlobStore {
+  put(params: { id: string; data: Buffer }): Promise<void>;
+  get(params: { id: string }): Promise<Buffer | null>;
+  delete(params: { id: string }): Promise<void>;
+}
+
 export interface JobRoutingMeta {
   pipelineName: string | null;
   jobType: string | null;
@@ -37,15 +59,20 @@ export interface JobRoutingMeta {
 
 interface EnvelopeHeader {
   v: number;
-  e: "j" | "gz";
+  e: "j" | "gz" | "ref";
+  r?: string;
   p?: string;
   t?: string;
   n?: string;
 }
 
-export async function encodeJobEnvelope(
-  jobData: Record<string, unknown>,
-): Promise<string> {
+export async function encodeJobEnvelope({
+  jobData,
+  blobs,
+}: {
+  jobData: Record<string, unknown>;
+  blobs?: JobBlobStore;
+}): Promise<string> {
   const json = JSON.stringify(jobData);
   if (!envelopeWritesEnabled()) {
     return json;
@@ -58,12 +85,19 @@ export async function encodeJobEnvelope(
   if (typeof jobData.__jobName === "string") header.n = jobData.__jobName;
 
   let body = json;
-  if (Buffer.byteLength(json) > COMPRESSION_THRESHOLD_BYTES) {
+  const jsonBytes = Buffer.byteLength(json);
+  if (blobs && jsonBytes > BLOB_OFFLOAD_THRESHOLD_BYTES) {
+    const id = randomUUID();
+    await blobs.put({ id, data: await gzipAsync(json) });
+    header.e = "ref";
+    header.r = id;
+    body = "";
+  } else if (jsonBytes > COMPRESSION_THRESHOLD_BYTES) {
     const compressed = (await gzipAsync(json)).toString("base64");
     // High-entropy payloads (inline base64-ish data) can come out LARGER
     // after gzip+base64; keep raw JSON unless compression actually wins.
     // `"gz"` costs one more header byte than `"j"`.
-    if (Buffer.byteLength(compressed) + 1 < Buffer.byteLength(json)) {
+    if (Buffer.byteLength(compressed) + 1 < jsonBytes) {
       header.e = "gz";
       body = compressed;
     }
@@ -75,14 +109,39 @@ export async function encodeJobEnvelope(
   return `${ENVELOPE_PREFIX}${Buffer.byteLength(headerJson)}|${headerJson}${body}`;
 }
 
-export async function decodeJobEnvelope(
-  value: string,
-): Promise<Record<string, unknown>> {
+export async function decodeJobEnvelope({
+  value,
+  blobs,
+}: {
+  value: string;
+  blobs?: JobBlobStore;
+}): Promise<Record<string, unknown>> {
   if (!value.startsWith(ENVELOPE_PREFIX)) {
     return JSON.parse(value) as Record<string, unknown>;
   }
 
   const { header, body } = splitEnvelope(value);
+  if (header.e === "ref") {
+    if (typeof header.r !== "string" || header.r.length === 0) {
+      throw new Error("Malformed job envelope: ref body without a blob id");
+    }
+    if (!blobs) {
+      throw new Error(
+        "Job envelope references an offloaded blob but no blob store was provided",
+      );
+    }
+    const data = await blobs.get({ id: header.r });
+    if (!data) {
+      throw new Error(
+        `Job envelope blob ${header.r} is missing (deleted or expired)`,
+      );
+    }
+    return JSON.parse((await gunzipAsync(data)).toString("utf8")) as Record<
+      string,
+      unknown
+    >;
+  }
+
   const json =
     header.e === "gz"
       ? (await gunzipAsync(Buffer.from(body, "base64"))).toString("utf8")
@@ -115,6 +174,21 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
     };
   } catch {
     return { pipelineName: null, jobType: null, jobName: null };
+  }
+}
+
+/**
+ * Returns the offloaded-blob id of an envelope value, or null for inline
+ * bodies, legacy JSON, and unreadable values. Used by the completion and
+ * restage paths to delete blobs whose staged value is being retired.
+ */
+export function readEnvelopeBlobId(value: string): string | null {
+  try {
+    if (!value.startsWith(ENVELOPE_PREFIX)) return null;
+    const { header } = splitEnvelope(value);
+    return header.e === "ref" && typeof header.r === "string" ? header.r : null;
+  } catch {
+    return null;
   }
 }
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -1,0 +1,106 @@
+import { promisify } from "node:util";
+import { gzip, gunzip } from "node:zlib";
+
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
+
+/**
+ * Versioned envelope for staged job values: `GQ1|<headerLen>|<headerJson><body>`.
+ *
+ * The header carries only what dispatch-time Lua and the ops dashboard need
+ * without touching the body (routing fields + body encoding); the body is the
+ * full payload JSON, gzip+base64 when it exceeds the threshold. Values without
+ * the prefix are legacy bare JSON and decode as-is. See ADR-026.
+ */
+const ENVELOPE_PREFIX = "GQ1|";
+
+/** gzip+base64 of sub-kilobyte JSON is frequently larger than the input. */
+const COMPRESSION_THRESHOLD_BYTES = 1024;
+
+export interface JobRoutingMeta {
+  pipelineName: string | null;
+  jobType: string | null;
+  jobName: string | null;
+}
+
+interface EnvelopeHeader {
+  v: number;
+  e: "j" | "gz";
+  p?: string;
+  t?: string;
+  n?: string;
+}
+
+export async function encodeJobEnvelope(
+  jobData: Record<string, unknown>,
+): Promise<string> {
+  const json = JSON.stringify(jobData);
+
+  const header: EnvelopeHeader = { v: 1, e: "j" };
+  if (typeof jobData.__pipelineName === "string") header.p = jobData.__pipelineName;
+  if (typeof jobData.__jobType === "string") header.t = jobData.__jobType;
+  if (typeof jobData.__jobName === "string") header.n = jobData.__jobName;
+
+  let body = json;
+  if (Buffer.byteLength(json) > COMPRESSION_THRESHOLD_BYTES) {
+    header.e = "gz";
+    body = (await gzipAsync(json)).toString("base64");
+  }
+
+  const headerJson = JSON.stringify(header);
+  return `${ENVELOPE_PREFIX}${headerJson.length}|${headerJson}${body}`;
+}
+
+export async function decodeJobEnvelope(
+  value: string,
+): Promise<Record<string, unknown>> {
+  if (!value.startsWith(ENVELOPE_PREFIX)) {
+    return JSON.parse(value) as Record<string, unknown>;
+  }
+
+  const { header, body } = splitEnvelope(value);
+  const json =
+    header.e === "gz"
+      ? (await gunzipAsync(Buffer.from(body, "base64"))).toString("utf8")
+      : body;
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+/**
+ * Reads routing fields from the header alone (envelope values) or via a full
+ * parse (legacy bare JSON). Never throws; unreadable values yield nulls.
+ */
+export function readJobRoutingMeta(value: string): JobRoutingMeta {
+  try {
+    if (value.startsWith(ENVELOPE_PREFIX)) {
+      const { header } = splitEnvelope(value);
+      return {
+        pipelineName: header.p ?? null,
+        jobType: header.t ?? null,
+        jobName: header.n ?? null,
+      };
+    }
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    return {
+      pipelineName: typeof parsed.__pipelineName === "string" ? parsed.__pipelineName : null,
+      jobType: typeof parsed.__jobType === "string" ? parsed.__jobType : null,
+      jobName: typeof parsed.__jobName === "string" ? parsed.__jobName : null,
+    };
+  } catch {
+    return { pipelineName: null, jobType: null, jobName: null };
+  }
+}
+
+function splitEnvelope(value: string): { header: EnvelopeHeader; body: string } {
+  const lenEnd = value.indexOf("|", ENVELOPE_PREFIX.length);
+  if (lenEnd === -1) {
+    throw new Error("Malformed job envelope: missing header length delimiter");
+  }
+  const headerLen = Number(value.slice(ENVELOPE_PREFIX.length, lenEnd));
+  if (!Number.isInteger(headerLen) || headerLen <= 0) {
+    throw new Error("Malformed job envelope: invalid header length");
+  }
+  const headerJson = value.slice(lenEnd + 1, lenEnd + 1 + headerLen);
+  const header = JSON.parse(headerJson) as EnvelopeHeader;
+  return { header, body: value.slice(lenEnd + 1 + headerLen) };
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/redisJobBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/redisJobBlobStore.ts
@@ -1,0 +1,46 @@
+import type { Cluster, Redis as IORedis } from "ioredis";
+
+import type { JobBlobStore } from "./jobEnvelope";
+
+/**
+ * Safety-net TTL for offloaded bodies. Deletion is best-effort at job
+ * completion/restage; this bounds how long an orphan (dedup-squashed job,
+ * crash between stage and delete) lingers. Must comfortably exceed the
+ * longest plausible staged residence — retry backoff chains and paused
+ * pipelines hold jobs for hours, not days.
+ */
+const BLOB_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Stores offloaded envelope bodies as raw gzip binary under standalone keys,
+ * read and written directly by the client (never through Lua, so ioredis's
+ * UTF-8 script-reply decoding is not a constraint). Keys share the queue
+ * name's hash tag so they land in the queue's cluster slot.
+ */
+export class RedisJobBlobStore implements JobBlobStore {
+  private readonly redis: IORedis | Cluster;
+  private readonly keyPrefix: string;
+
+  constructor({
+    redis,
+    queueName,
+  }: {
+    redis: IORedis | Cluster;
+    queueName: string;
+  }) {
+    this.redis = redis;
+    this.keyPrefix = `${queueName}:gq:blob:`;
+  }
+
+  async put({ id, data }: { id: string; data: Buffer }): Promise<void> {
+    await this.redis.set(this.keyPrefix + id, data, "EX", BLOB_TTL_SECONDS);
+  }
+
+  async get({ id }: { id: string }): Promise<Buffer | null> {
+    return await this.redis.getBuffer(this.keyPrefix + id);
+  }
+
+  async delete({ id }: { id: string }): Promise<void> {
+    await this.redis.unlink(this.keyPrefix + id);
+  }
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -370,6 +370,33 @@ local function unparkLeastServedParked(readyKey, keyPrefix, pausedJobKey, nowMs,
 end
 `;
 
+// Reads routing metadata (pipelineName, jobType, jobName) from a stored job
+// value. Envelope values (ADR-026, "GQ1|<headerLen>|<headerJson><body>") expose
+// it in the tiny header so the payload body is never decoded on Redis's
+// thread; legacy bare-JSON values fall back to a full decode.
+const ROUTING_META_HELPER_LUA = `
+local function gqRoutingMeta(jobDataJson)
+  if string.sub(jobDataJson, 1, 4) == "GQ1|" then
+    local barIdx = string.find(jobDataJson, "|", 5, true)
+    if barIdx then
+      local headerLen = tonumber(string.sub(jobDataJson, 5, barIdx - 1))
+      if headerLen and headerLen > 0 then
+        local ok, header = pcall(cjson.decode, string.sub(jobDataJson, barIdx + 1, barIdx + headerLen))
+        if ok and type(header) == "table" then
+          return header["p"], header["t"], header["n"]
+        end
+      end
+    end
+    return nil, nil, nil
+  end
+  local ok, data = pcall(cjson.decode, jobDataJson)
+  if ok and type(data) == "table" then
+    return data["__pipelineName"], data["__jobType"], data["__jobName"]
+  end
+  return nil, nil, nil
+end
+`;
+
 const STAGE_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
 local groupJobsKey    = KEYS[1]
 local readyKey        = KEYS[2]
@@ -557,7 +584,7 @@ end
 return newStagedCount
 `;
 
-const DISPATCH_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + `
+const DISPATCH_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + ROUTING_META_HELPER_LUA + `
 local readyKey         = KEYS[1]
 local blockedKey       = KEYS[2]
 local pausedJobKey     = KEYS[3]
@@ -698,19 +725,14 @@ local function scanAndDispatch(effCap, bypassPark)
                 local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
                 local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
                 if jobDataJson then
-                  local ok, data = pcall(cjson.decode, jobDataJson)
-                  if ok and type(data) == "table" then
-                    local p = data["__pipelineName"]
-                    local t = data["__jobType"]
-                    local n = data["__jobName"]
-                    local pIsStr = type(p) == "string"
-                    local tIsStr = type(t) == "string"
-                    local nIsStr = type(n) == "string"
-                    if pIsStr then
-                      if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
-                      elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
-                      elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
-                      end
+                  local p, t, n = gqRoutingMeta(jobDataJson)
+                  local pIsStr = type(p) == "string"
+                  local tIsStr = type(t) == "string"
+                  local nIsStr = type(n) == "string"
+                  if pIsStr then
+                    if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
+                    elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
+                    elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
                     end
                   end
                 end
@@ -779,7 +801,7 @@ end
 return nil
 `;
 
-const DISPATCH_BATCH_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + `
+const DISPATCH_BATCH_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + ROUTING_META_HELPER_LUA + `
 local readyKey         = KEYS[1]
 local blockedKey       = KEYS[2]
 local pausedJobKey     = KEYS[3]
@@ -910,19 +932,14 @@ local function scanBatch(effCap, bypassPark, dispatched)
                 local dataKey = keyPrefix .. "group:" .. groupId .. ":data"
                 local jobDataJson = redis.call("HGET", dataKey, stagedJobId)
                 if jobDataJson then
-                  local ok, data = pcall(cjson.decode, jobDataJson)
-                  if ok and type(data) == "table" then
-                    local p = data["__pipelineName"]
-                    local t = data["__jobType"]
-                    local n = data["__jobName"]
-                    local pIsStr = type(p) == "string"
-                    local tIsStr = type(t) == "string"
-                    local nIsStr = type(n) == "string"
-                    if pIsStr then
-                      if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
-                      elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
-                      elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
-                      end
+                  local p, t, n = gqRoutingMeta(jobDataJson)
+                  local pIsStr = type(p) == "string"
+                  local tIsStr = type(t) == "string"
+                  local nIsStr = type(n) == "string"
+                  if pIsStr then
+                    if redis.call("SISMEMBER", pausedJobKey, p) == 1 then paused = true
+                    elseif tIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t) == 1 then paused = true
+                    elseif tIsStr and nIsStr and redis.call("SISMEMBER", pausedJobKey, p .. "/" .. t .. "/" .. n) == 1 then paused = true
                     end
                   end
                 end
@@ -1173,7 +1190,7 @@ end
 return 0
 `;
 
-const RESTAGE_AND_BLOCK_LUA = `
+const RESTAGE_AND_BLOCK_LUA = ROUTING_META_HELPER_LUA + `
 local blockedKey      = KEYS[1]
 local readyKey        = KEYS[2]
 local statsKey        = KEYS[3]
@@ -1238,12 +1255,9 @@ end
 redis.call("INCR", statsKey)
 
 -- 7. Increment per-job-name failed counter
-local ok, data = pcall(cjson.decode, jobDataJson)
-if ok and data then
-  local jn = data["__jobName"]
-  if jn and jn ~= "" then
-    redis.call("INCR", statsKey .. ":" .. jn)
-  end
+local _, _, jn = gqRoutingMeta(jobDataJson)
+if jn and jn ~= "" then
+  redis.call("INCR", statsKey .. ":" .. jn)
 end
 
 return 1

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -125,7 +125,9 @@ end
 //
 // Prepends TENANT_ACTIVE_HELPER_LUA so reconcileParked can read the self-healing
 // in-flight count; every script that includes PARK_HELPER_LUA gets both.
-export const PARK_HELPER_LUA = TENANT_ACTIVE_HELPER_LUA + `
+export const PARK_HELPER_LUA =
+  TENANT_ACTIVE_HELPER_LUA +
+  `
 -- Tenant segment of a groupId (everything before the first '/'), else the id.
 local function parkTenantOf(groupId)
   local slashPos = string.find(groupId, "/", 1, true)
@@ -397,7 +399,10 @@ local function gqRoutingMeta(jobDataJson)
 end
 `;
 
-const STAGE_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
+const STAGE_LUA =
+  TTL_HELPER_LUA +
+  PARK_HELPER_LUA +
+  `
 local groupJobsKey    = KEYS[1]
 local readyKey        = KEYS[2]
 local signalKey       = KEYS[3]
@@ -486,7 +491,10 @@ redis.call("INCR", totalPendingKey)
 return 1
 `;
 
-const STAGE_BATCH_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
+const STAGE_BATCH_LUA =
+  TTL_HELPER_LUA +
+  PARK_HELPER_LUA +
+  `
 local readyKey        = KEYS[1]
 local signalKey       = KEYS[2]
 local totalPendingKey = KEYS[3]
@@ -584,7 +592,11 @@ end
 return newStagedCount
 `;
 
-const DISPATCH_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + ROUTING_META_HELPER_LUA + `
+const DISPATCH_LUA =
+  PARK_HELPER_LUA +
+  WATER_LEVEL_HELPER_LUA +
+  ROUTING_META_HELPER_LUA +
+  `
 local readyKey         = KEYS[1]
 local blockedKey       = KEYS[2]
 local pausedJobKey     = KEYS[3]
@@ -801,7 +813,11 @@ end
 return nil
 `;
 
-const DISPATCH_BATCH_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + ROUTING_META_HELPER_LUA + `
+const DISPATCH_BATCH_LUA =
+  PARK_HELPER_LUA +
+  WATER_LEVEL_HELPER_LUA +
+  ROUTING_META_HELPER_LUA +
+  `
 local readyKey         = KEYS[1]
 local blockedKey       = KEYS[2]
 local pausedJobKey     = KEYS[3]
@@ -1060,7 +1076,10 @@ end
 return results
 `;
 
-const COMPLETE_LUA = PARK_HELPER_LUA + WATER_LEVEL_HELPER_LUA + `
+const COMPLETE_LUA =
+  PARK_HELPER_LUA +
+  WATER_LEVEL_HELPER_LUA +
+  `
 local activeKey       = KEYS[1]
 local jobsKey         = KEYS[2]
 local readyKey        = KEYS[3]
@@ -1147,7 +1166,9 @@ redis.call("DEL", errorKey)
 return 1
 `;
 
-const REFRESH_LUA = TTL_HELPER_LUA + `
+const REFRESH_LUA =
+  TTL_HELPER_LUA +
+  `
 local activeKey    = KEYS[1]
 local readyKey     = KEYS[2]
 local stagedJobId           = ARGV[1]
@@ -1190,7 +1211,9 @@ end
 return 0
 `;
 
-const RESTAGE_AND_BLOCK_LUA = ROUTING_META_HELPER_LUA + `
+const RESTAGE_AND_BLOCK_LUA =
+  ROUTING_META_HELPER_LUA +
+  `
 local blockedKey      = KEYS[1]
 local readyKey        = KEYS[2]
 local statsKey        = KEYS[3]
@@ -1263,7 +1286,10 @@ end
 return 1
 `;
 
-const RETRY_RESTAGE_LUA = TTL_HELPER_LUA + PARK_HELPER_LUA + `
+const RETRY_RESTAGE_LUA =
+  TTL_HELPER_LUA +
+  PARK_HELPER_LUA +
+  `
 local activeKey       = KEYS[1]
 local totalPendingKey = KEYS[2]
 
@@ -1482,7 +1508,9 @@ export class GroupStagingScripts {
     const readyKey = `${this.keyPrefix}ready`;
     const signalKey = `${this.keyPrefix}signal`;
     const dedupKey =
-      dedupId !== "" ? `${this.keyPrefix}dedup:${dedupId}` : `${this.keyPrefix}dedup:__none__`;
+      dedupId !== ""
+        ? `${this.keyPrefix}dedup:${dedupId}`
+        : `${this.keyPrefix}dedup:__none__`;
 
     const dataKey = `${this.keyPrefix}group:${groupId}:data`;
     const totalPendingKey = `${this.keyPrefix}stats:total-pending`;
@@ -1557,7 +1585,14 @@ export class GroupStagingScripts {
     args.push(String(Date.now()));
     args.push(String(readGlobalBudget()));
 
-    const result = await this.redis.eval(STAGE_BATCH_LUA, 3, readyKey, signalKey, totalPendingKey, ...args);
+    const result = await this.redis.eval(
+      STAGE_BATCH_LUA,
+      3,
+      readyKey,
+      signalKey,
+      totalPendingKey,
+      ...args,
+    );
 
     return Number(result);
   }
@@ -1938,4 +1973,3 @@ export class GroupStagingScripts {
     return this.keyPrefix;
   }
 }
-

--- a/specs/event-sourcing/payload-envelope.feature
+++ b/specs/event-sourcing/payload-envelope.feature
@@ -27,6 +27,8 @@ Feature: GroupQueue payload envelope
 
   # Dispatch-time routing reads
 
+  # Pause hold-back behaviour is owned by specs/queue-pausing/queue-pausing.feature;
+  # this scenario specs only the mechanism (header-only read).
   Scenario: Pause checks read only the envelope header
     Given a pipeline is paused via the queue-pausing kill-switch
     When dispatch evaluates a staged job belonging to that pipeline

--- a/specs/event-sourcing/payload-envelope.feature
+++ b/specs/event-sourcing/payload-envelope.feature
@@ -21,6 +21,18 @@ Feature: GroupQueue payload envelope
     When a job whose payload JSON is under the compression threshold is staged
     Then the stored value is an envelope with a raw JSON body
 
+  Scenario: Incompressible payloads stay uncompressed
+    When a staged payload would grow under gzip plus base64
+    Then the stored value is an envelope with a raw JSON body
+
+  # Two-phase format rollout
+
+  Scenario: Envelope writes stay off until the whole fleet reads envelopes
+    Given envelope writes have not been enabled for the deployment
+    When a job is staged
+    Then the stored value is legacy bare JSON readable by the previous release
+    And dispatch and the ops dashboard read it through the dual readers
+
   Scenario: A staged payload round-trips through the envelope unchanged
     When a job is staged and later dispatched to its handler
     Then the handler receives a payload deep-equal to the one that was sent

--- a/specs/event-sourcing/payload-envelope.feature
+++ b/specs/event-sourcing/payload-envelope.feature
@@ -1,0 +1,68 @@
+# See dev/docs/adr/026-groupqueue-payload-envelope.md for the architectural rationale
+Feature: GroupQueue payload envelope
+
+  GroupQueue stores staged job payloads as a versioned envelope
+  (routing header + optionally compressed body) so that dispatch-time
+  pause checks and failure accounting read a tiny header instead of
+  decoding the full payload, and so large span payloads occupy a
+  fraction of the Redis memory of their raw JSON.
+
+  Background:
+    Given a GroupQueue with jobs routed through queue-manager facades
+
+  # Envelope encoding
+
+  Scenario: Large payloads are compressed at stage time
+    When a job whose payload JSON exceeds the compression threshold is staged
+    Then the stored value is an envelope with a gzip-encoded body
+    And the envelope header carries the pipeline name, job type, and job name
+
+  Scenario: Small payloads stay uncompressed
+    When a job whose payload JSON is under the compression threshold is staged
+    Then the stored value is an envelope with a raw JSON body
+
+  Scenario: A staged payload round-trips through the envelope unchanged
+    When a job is staged and later dispatched to its handler
+    Then the handler receives a payload deep-equal to the one that was sent
+
+  # Dispatch-time routing reads
+
+  Scenario: Pause checks read only the envelope header
+    Given a pipeline is paused via the queue-pausing kill-switch
+    When dispatch evaluates a staged job belonging to that pipeline
+    Then the job is held back without decoding the payload body
+
+  Scenario: Exhausted-retry accounting reads only the envelope header
+    When a job exhausts its retries
+    Then the per-job-name failed counter is incremented from the header
+
+  # Backward compatibility
+
+  Scenario: Legacy bare-JSON jobs staged before the deploy still process
+    Given a job staged as plain JSON by a previous deployment
+    When dispatch evaluates and delivers that job
+    Then pause checks fall back to decoding the legacy JSON
+    And the handler receives the original payload
+
+  # Retry and coalescing paths
+
+  Scenario: Retried jobs are re-staged as envelopes
+    When a job fails with a retryable error
+    Then the re-staged job is envelope-encoded with the attempt counter incremented
+
+  Scenario: Drained coalesced siblings decode from envelopes
+    Given a group with multiple due jobs and batch coalescing enabled
+    When the dispatched job drains its siblings into one handler invocation
+    Then every sibling payload is decoded from its envelope
+
+  Scenario: A corrupt stored value does not wedge the group
+    Given a staged value that is neither a valid envelope nor valid JSON
+    When dispatch delivers it to the worker
+    Then the job is completed without invoking the handler
+    And the group continues processing subsequent jobs
+
+  # Ops visibility
+
+  Scenario: The ops dashboard shows routing fields for envelope jobs
+    When the queue dashboard inspects a group's first pending job
+    Then pipeline name, job type, and job name come from the envelope header

--- a/specs/event-sourcing/payload-envelope.feature
+++ b/specs/event-sourcing/payload-envelope.feature
@@ -25,6 +25,25 @@ Feature: GroupQueue payload envelope
     When a staged payload would grow under gzip plus base64
     Then the stored value is an envelope with a raw JSON body
 
+  # Large-payload blob offload
+
+  Scenario: Very large payloads are offloaded out of the queue hash
+    When a job whose payload exceeds the blob offload threshold is staged
+    Then the body is stored under a standalone blob key as compressed binary
+    And the queued value is a tiny envelope referencing the blob
+    And the handler receives the payload intact
+
+  Scenario: Offloaded blobs are cleaned up when the job completes
+    Given an offloaded job has been processed successfully
+    Then its blob key is deleted
+    And any blob that escapes deletion expires via its TTL safety net
+
+  Scenario: A missing blob does not wedge the group
+    Given an offloaded job whose blob has expired or been deleted
+    When dispatch delivers it to the worker
+    Then the job is completed without invoking the handler
+    And the group continues processing subsequent jobs
+
   # Two-phase format rollout
 
   Scenario: Envelope writes stay off until the whole fleet reads envelopes


### PR DESCRIPTION
## Why

GroupQueue stores every staged job as plain JSON in Redis. Span payloads run 2-50 KB of highly repetitive JSON, which dominates Redis memory at ingestion volume, and the dispatch Lua scripts decode the full payload of every candidate job (up to 200 per batch, on Redis's single thread) only to read three routing fields for the pause check. Memory bounds how many events we can absorb during bursts; the decode cost is pure waste.

## What changed

Staged values are now a versioned envelope: `GQ1|<headerLen>|<headerJson><body>`. The header is a tiny JSON object carrying the routing fields (pipeline, job type, job name) and a body-encoding flag; the body is the full payload JSON, gzip+base64 once it exceeds 1 KiB. Dispatch-time Lua and the ops dashboard read the header only. Values without the `GQ1|` prefix are treated as legacy plain JSON, so jobs staged before the deploy keep processing - old and new formats coexist with no flag day.

Net effect: roughly 4-6x less Redis memory per span-sized job, and dispatch decodes ~100-byte headers instead of full payloads.

## How it works

See [ADR-026](dev/docs/adr/026-groupqueue-payload-envelope.md) for the trade-offs (why gzip+base64 in a string rather than raw binary, why a header prefix rather than a companion hash field) and [the spec](specs/event-sourcing/payload-envelope.feature) for the behavioural contract. The existing S3 offload for oversized media payloads is untouched - this targets the ordinary span-sized payloads that stay inline.

## Test plan

- [x] Envelope unit tests: round-trip, 1024/1025-byte threshold boundary, legacy fallback, corrupt headers, non-ASCII routing fields, strip-and-re-encode retry cycle
- [x] Lua integration tests: pause checks at pipeline/jobType/jobName level against envelope-staged (gzipped) jobs, per-job-name failed counter from the header, envelope dispatched intact
- [x] Full GroupQueue, ops dashboard, and event-sourcing integration suites (199 tests)

## Anything surprising?

Rolling **back** while envelope-encoded jobs are in flight is not safe - old code can't parse `GQ1|` values and will complete those slots without processing. Drain first or accept replay. Forward deploys are safe.

## Large-payload blob offload

Payloads over 32 KiB no longer carry their body inline at all. The body is gzipped and stored as **raw binary** (no base64) under a standalone `{queueName}:gq:blob:<id>` key written and read directly by the client; the queued value is a tiny `e:"ref"` envelope whose header carries the blob id. The bulk transits Redis exactly twice (one SET at stage, one GETBUFFER at processing) and never flows through the dispatch/drain/restage Lua scripts or sits in the group hash. Blobs are deleted best-effort on completion/retry/exhaust, with a 7-day TTL as the orphan backstop; a missing blob is handled like a corrupt value (slot completed, recoverable via replay). Zero Lua changes — the reference travels inside the envelope string.

## Deployment Impact

No migrations, no chart changes, no new dependencies. Rollout is two-phase: this PR ships envelope-aware **readers everywhere while writes stay legacy bare JSON** (`GROUP_QUEUE_ENVELOPE_WRITES_ENABLED` defaults off), so deploying it is safe in any order and at any rolling speed — nothing new is written. Phase 2 is flipping `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED=true` once no pre-envelope pods remain (app and workers roll independently, so this must wait for both Deployments).

Rollback caveat (phase 2 only): once envelope writes are enabled, rolling back to a build without the envelope decoder will fail to parse in-flight envelope jobs and complete their group slots without processing them (recoverable via event replay). Disable the flag and drain the GroupQueue first, or accept replaying the gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Versioned job payload envelope with header-only routing metadata, automatic compression for large payloads, and async envelope-based staging/decoding across producer/worker/dispatch paths; ops dashboard reads header routing.
* **Bug Fixes**
  * Graceful handling of corrupt or legacy bare-JSON payloads to avoid blocking groups; pause/retry logic uses header-only routing to be safe and efficient.
* **Tests**
  * Added unit, integration, and feature tests covering encode/decode, routing, pause behavior, compression thresholds, unicode, and rollback cases.
* **Documentation**
  * Added ADR and feature spec describing format, rollout, trade-offs, and rollback guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

