### PR TITLE
feat(model-costs): matching-spans preview, unmapped-cost suggestion, scope-cascade enrichment fix

### DIFF
--- a/langwatch/src/components/settings/LLMModelCostDrawer.tsx
+++ b/langwatch/src/components/settings/LLMModelCostDrawer.tsx
@@ -1,6 +1,7 @@
 import { Button, Field, Heading, HStack, Input, Text } from "@chakra-ui/react";
 import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
+import { useDebounce } from "use-debounce";
 import { useDrawer } from "~/hooks/useDrawer";
 import { Drawer } from "../../components/ui/drawer";
 import { InputGroup } from "../../components/ui/input-group";
@@ -8,20 +9,31 @@ import { toaster } from "../../components/ui/toaster";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
 import type { MaybeStoredLLMModelCost } from "../../server/modelProviders/llmModelCost";
 import { api } from "../../utils/api";
+import { exactModelMatchRegex } from "../../utils/modelCostRegex";
 import { isSafeRegex } from "../../utils/safeRegex";
 import { isHandledByGlobalHandler } from "../../utils/trpcError";
 import { HorizontalFormControl } from "../HorizontalFormControl";
 import {
-  ScopeChipPicker,
-  type ScopeTriadEntry,
-} from "./ScopeChipPicker";
+  LLMModelCostMatchingSpans,
+  type MatchingSpansPreviewInput,
+} from "./LLMModelCostMatchingSpans";
+import { ScopeChipPicker, type ScopeTriadEntry } from "./ScopeChipPicker";
 
 export function LLMModelCostDrawer({
   id,
   cloneModel,
+  prefillModel,
+  prefillRegex,
 }: {
   id?: string;
   cloneModel?: string;
+  /**
+   * Pre-populate the form for the "add cost mapping" deep link from the
+   * trace drawer (arrives via `drawer.prefillModel` / `drawer.prefillRegex`
+   * URL params). Ignored when editing an existing row.
+   */
+  prefillModel?: string;
+  prefillRegex?: string;
 }) {
   const { project } = useOrganizationTeamProject();
   const { closeDrawer } = useDrawer();
@@ -48,6 +60,8 @@ export function LLMModelCostDrawer({
             <LLMModelCostForm
               id={id}
               cloneModel={cloneModel}
+              prefillModel={prefillModel}
+              prefillRegex={prefillRegex}
               llmModelCosts={llmModelCosts.data}
             />
           )}
@@ -60,10 +74,14 @@ export function LLMModelCostDrawer({
 function LLMModelCostForm({
   id,
   cloneModel,
+  prefillModel,
+  prefillRegex,
   llmModelCosts,
 }: {
   id?: string;
   cloneModel?: string;
+  prefillModel?: string;
+  prefillRegex?: string;
   llmModelCosts: MaybeStoredLLMModelCost[];
 }) {
   const { organization, team, project } = useOrganizationTeamProject();
@@ -107,25 +125,51 @@ function LLMModelCostForm({
         },
       ];
     }
-    return project?.id
-      ? [{ scopeType: "PROJECT", scopeId: project.id }]
-      : [];
+    return project?.id ? [{ scopeType: "PROJECT", scopeId: project.id }] : [];
   });
 
   const {
     register,
     handleSubmit,
+    control,
+    getValues,
+    setValue,
     formState: { errors },
   } = useForm<LLMModelCostForm>({
     defaultValues: {
-      model: currentLLMModelCost?.model,
+      model: currentLLMModelCost?.model ?? prefillModel,
       inputCostPerToken: currentLLMModelCost?.inputCostPerToken,
       outputCostPerToken: currentLLMModelCost?.outputCostPerToken,
       cacheReadCostPerToken: currentLLMModelCost?.cacheReadCostPerToken,
       cacheCreationCostPerToken: currentLLMModelCost?.cacheCreationCostPerToken,
-      regex: currentLLMModelCost?.regex,
+      regex: currentLLMModelCost?.regex ?? prefillRegex,
     },
   });
+
+  // Live values feeding the matching-spans preview. Debounced so the
+  // ClickHouse-backed preview doesn't fire on every keystroke; rates pass
+  // through a finite-number gate because react-hook-form yields NaN /
+  // empty-string while a numeric field is being edited.
+  const liveValues = useWatch({ control });
+  const [debouncedValues] = useDebounce(liveValues, 400);
+  const finiteOrUndefined = (value: unknown): number | undefined => {
+    const num = typeof value === "string" ? Number(value) : (value as number);
+    return typeof num === "number" && Number.isFinite(num) && num >= 0
+      ? num
+      : undefined;
+  };
+  const previewInput: MatchingSpansPreviewInput = {
+    regex: debouncedValues.regex ?? "",
+    model: debouncedValues.model || undefined,
+    inputCostPerToken: finiteOrUndefined(debouncedValues.inputCostPerToken),
+    outputCostPerToken: finiteOrUndefined(debouncedValues.outputCostPerToken),
+    cacheReadCostPerToken: finiteOrUndefined(
+      debouncedValues.cacheReadCostPerToken,
+    ),
+    cacheCreationCostPerToken: finiteOrUndefined(
+      debouncedValues.cacheCreationCostPerToken,
+    ),
+  };
 
   const onSubmit = (data: LLMModelCostForm) => {
     if (!project?.id) return;
@@ -240,6 +284,18 @@ function LLMModelCostForm({
           </InputGroup>
           <Field.ErrorText>{errors.regex?.message}</Field.ErrorText>
         </HorizontalFormControl>
+        <LLMModelCostMatchingSpans
+          input={previewInput}
+          onPickModel={(model) => {
+            setValue("regex", exactModelMatchRegex(model), {
+              shouldValidate: true,
+              shouldDirty: true,
+            });
+            if (!getValues("model")) {
+              setValue("model", model, { shouldDirty: true });
+            }
+          }}
+        />
         <HorizontalFormControl
           label="Input Cost Per Token"
           helper="Cost per input token in USD"
@@ -325,4 +381,3 @@ function LLMModelCostForm({
     </>
   );
 }
-

--- a/langwatch/src/components/settings/LLMModelCostMatchingSpans.tsx
+++ b/langwatch/src/components/settings/LLMModelCostMatchingSpans.tsx
@@ -29,7 +29,7 @@ export interface MatchingSpansPreviewInput {
 
 /**
  * Deep link that opens the traces explorer with the trace drawer already on
- * this span — the same `drawer.*` params the drawer serializes itself.
+ * this span, the same `drawer.*` params the drawer serializes itself.
  */
 function traceDrawerUrl(
   projectSlug: string,
@@ -244,7 +244,7 @@ export function LLMModelCostMatchingSpans({
               {data.unmatchedModels.length > 0 ? (
                 <>
                   <Text textStyle="xs" color="fg.muted">
-                    Models seen in this project that do not match — click one to
+                    Models seen in this project that do not match, click one to
                     fill the regex:
                   </Text>
                   <Box>

--- a/langwatch/src/components/settings/LLMModelCostMatchingSpans.tsx
+++ b/langwatch/src/components/settings/LLMModelCostMatchingSpans.tsx
@@ -1,0 +1,293 @@
+import {
+  Badge,
+  Box,
+  HStack,
+  Icon,
+  Skeleton,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { LuExternalLink, LuMoveRight } from "react-icons/lu";
+import { ProviderIcon } from "~/features/traces-v2/components/TraceTable/registry/cells/trace/ModelCell";
+import {
+  formatCost,
+  formatRelativeTimeAgo,
+  formatTokens,
+} from "~/features/traces-v2/utils/formatters";
+import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
+import { api } from "../../utils/api";
+import { isSafeRegex } from "../../utils/safeRegex";
+
+export interface MatchingSpansPreviewInput {
+  regex: string;
+  model?: string;
+  inputCostPerToken?: number;
+  outputCostPerToken?: number;
+  cacheReadCostPerToken?: number;
+  cacheCreationCostPerToken?: number;
+}
+
+/**
+ * Deep link that opens the traces explorer with the trace drawer already on
+ * this span — the same `drawer.*` params the drawer serializes itself.
+ */
+function traceDrawerUrl(
+  projectSlug: string,
+  span: { traceId: string; spanId: string; startTimeMs: number },
+): string {
+  const params = new URLSearchParams({
+    "drawer.open": "traceV2Details",
+    "drawer.traceId": span.traceId,
+    "drawer.t": String(span.startTimeMs),
+    "drawer.span": span.spanId,
+    "drawer.mode": "trace",
+  });
+  return `/${projectSlug}/traces?${params.toString()}`;
+}
+
+function TokenPair({
+  inputTokens,
+  outputTokens,
+}: {
+  inputTokens: number | null;
+  outputTokens: number | null;
+}) {
+  if (inputTokens === null && outputTokens === null) {
+    return (
+      <Text textStyle="xs" color="fg.subtle" flexShrink={0}>
+        no tokens
+      </Text>
+    );
+  }
+  return (
+    <HStack gap={1} flexShrink={0} fontFamily="mono">
+      <Text textStyle="xs" color="fg.muted">
+        {formatTokens(inputTokens ?? 0)}
+      </Text>
+      <Icon as={LuMoveRight} boxSize={3} color="fg.subtle" />
+      <Text textStyle="xs" color="fg.muted">
+        {formatTokens(outputTokens ?? 0)}
+      </Text>
+    </HStack>
+  );
+}
+
+/**
+ * Live "which spans would this regex match" preview for the model cost
+ * drawer. Reads recent spans from the current project and prices them with
+ * the rates being edited, so the user sees the rule working (or not) before
+ * saving. Rows open the trace drawer in a new tab; when nothing matches,
+ * the recently-seen models are offered as one-click exact-match fills.
+ */
+export function LLMModelCostMatchingSpans({
+  input,
+  onPickModel,
+}: {
+  input: MatchingSpansPreviewInput;
+  onPickModel: (model: string) => void;
+}) {
+  const { project } = useOrganizationTeamProject();
+  const regexValid = input.regex.length > 0 && isSafeRegex(input.regex);
+
+  const preview = api.llmModelCost.previewMatchingSpans.useQuery(
+    {
+      projectId: project?.id ?? "",
+      regex: input.regex,
+      model: input.model ?? undefined,
+      inputCostPerToken: input.inputCostPerToken,
+      outputCostPerToken: input.outputCostPerToken,
+      cacheReadCostPerToken: input.cacheReadCostPerToken,
+      cacheCreationCostPerToken: input.cacheCreationCostPerToken,
+    },
+    {
+      enabled: !!project?.id && regexValid,
+      keepPreviousData: true,
+      staleTime: 30_000,
+    },
+  );
+
+  const data = preview.data;
+
+  return (
+    <VStack
+      align="stretch"
+      gap={2}
+      marginTop={3}
+      padding={3}
+      borderWidth="1px"
+      borderColor="border.muted"
+      borderRadius="md"
+      bg="bg.subtle"
+      data-testid="matching-spans-preview"
+    >
+      <HStack justify="space-between" gap={2}>
+        <Text textStyle="xs" fontWeight="semibold" color="fg.muted">
+          Matching spans
+        </Text>
+        {data && regexValid && (
+          <Text textStyle="xs" color="fg.muted">
+            {data.totalMatchedSpans === 0
+              ? `no matches in the last ${data.windowDays} days`
+              : `${data.totalMatchedSpans} span${
+                  data.totalMatchedSpans === 1 ? "" : "s"
+                } across ${data.matchedModels.length} model${
+                  data.matchedModels.length === 1 ? "" : "s"
+                } in the last ${data.windowDays} days`}
+          </Text>
+        )}
+      </HStack>
+
+      {!regexValid ? (
+        <Text textStyle="xs" color="fg.subtle">
+          Enter a valid regular expression to preview the spans it would match.
+        </Text>
+      ) : preview.isLoading ? (
+        <VStack align="stretch" gap={1}>
+          <Skeleton height="28px" borderRadius="sm" />
+          <Skeleton height="28px" borderRadius="sm" />
+          <Skeleton height="28px" borderRadius="sm" />
+        </VStack>
+      ) : !data ? (
+        <Text textStyle="xs" color="fg.subtle">
+          Could not load the preview.
+        </Text>
+      ) : (
+        <>
+          {data.sampleSpans.length > 0 && (
+            <VStack align="stretch" gap={1}>
+              {data.sampleSpans.map((span) => (
+                <HStack
+                  key={`${span.traceId}-${span.spanId}`}
+                  as="button"
+                  gap={2}
+                  paddingX={2}
+                  paddingY={1.5}
+                  borderRadius="sm"
+                  cursor="pointer"
+                  textAlign="left"
+                  _hover={{ bg: "bg.emphasized" }}
+                  title="Open trace in a new tab"
+                  // preventDefault: this button lives inside the drawer's
+                  // <form>, where the implicit type is submit.
+                  onClick={(event: React.MouseEvent) => {
+                    event.preventDefault();
+                    if (!project?.slug) return;
+                    window.open(
+                      traceDrawerUrl(project.slug, span),
+                      "_blank",
+                      "noopener,noreferrer",
+                    );
+                  }}
+                  data-testid="matching-span-row"
+                >
+                  <Badge
+                    size="sm"
+                    variant="subtle"
+                    colorPalette="gray"
+                    gap={1.5}
+                    paddingX={2}
+                    fontWeight="medium"
+                    flexShrink={0}
+                    maxWidth="45%"
+                  >
+                    <ProviderIcon model={span.model} size="compact" />
+                    <Text fontFamily="mono" textStyle="xs" truncate>
+                      {span.model}
+                    </Text>
+                  </Badge>
+                  <Text
+                    textStyle="xs"
+                    color="fg.muted"
+                    truncate
+                    flex={1}
+                    minWidth={0}
+                  >
+                    {span.spanName}
+                  </Text>
+                  <TokenPair
+                    inputTokens={span.inputTokens}
+                    outputTokens={span.outputTokens}
+                  />
+                  <Text
+                    textStyle="xs"
+                    fontWeight="medium"
+                    flexShrink={0}
+                    minWidth="56px"
+                    textAlign="right"
+                  >
+                    {span.exampleCost === null
+                      ? "—"
+                      : formatCost(span.exampleCost)}
+                  </Text>
+                  <Text
+                    textStyle="xs"
+                    color="fg.subtle"
+                    flexShrink={0}
+                    minWidth="52px"
+                    textAlign="right"
+                  >
+                    {formatRelativeTimeAgo(span.startTimeMs)}
+                  </Text>
+                  <Icon
+                    as={LuExternalLink}
+                    boxSize={3.5}
+                    color="fg.subtle"
+                    flexShrink={0}
+                  />
+                </HStack>
+              ))}
+            </VStack>
+          )}
+
+          {data.totalMatchedSpans === 0 && (
+            <VStack align="stretch" gap={2}>
+              {data.unmatchedModels.length > 0 ? (
+                <>
+                  <Text textStyle="xs" color="fg.muted">
+                    Models seen in this project that do not match — click one to
+                    fill the regex:
+                  </Text>
+                  <Box>
+                    <HStack gap={1.5} flexWrap="wrap">
+                      {data.unmatchedModels.map((m) => (
+                        <Badge
+                          key={m.model}
+                          as="button"
+                          size="sm"
+                          variant="outline"
+                          cursor="pointer"
+                          gap={1.5}
+                          _hover={{ bg: "bg.emphasized" }}
+                          // preventDefault: rendered inside the drawer's
+                          // <form>, where the implicit type is submit.
+                          onClick={(event: React.MouseEvent) => {
+                            event.preventDefault();
+                            onPickModel(m.model);
+                          }}
+                          data-testid="unmatched-model-chip"
+                        >
+                          <ProviderIcon model={m.model} size="compact" />
+                          <Text fontFamily="mono" textStyle="xs">
+                            {m.model}
+                          </Text>
+                          <Text textStyle="2xs" color="fg.subtle">
+                            {m.spanCount}
+                          </Text>
+                        </Badge>
+                      ))}
+                    </HStack>
+                  </Box>
+                </>
+              ) : (
+                <Text textStyle="xs" color="fg.subtle">
+                  No spans with a model were recorded in this project in the
+                  last {data.windowDays} days.
+                </Text>
+              )}
+            </VStack>
+          )}
+        </>
+      )}
+    </VStack>
+  );
+}

--- a/langwatch/src/components/settings/LLMModelCostMatchingSpans.tsx
+++ b/langwatch/src/components/settings/LLMModelCostMatchingSpans.tsx
@@ -1,6 +1,7 @@
 import {
   Badge,
   Box,
+  chakra,
   HStack,
   Icon,
   Skeleton,
@@ -156,21 +157,21 @@ export function LLMModelCostMatchingSpans({
           {data.sampleSpans.length > 0 && (
             <VStack align="stretch" gap={1}>
               {data.sampleSpans.map((span) => (
-                <HStack
+                <chakra.button
                   key={`${span.traceId}-${span.spanId}`}
-                  as="button"
+                  type="button"
+                  display="flex"
+                  alignItems="center"
                   gap={2}
                   paddingX={2}
                   paddingY={1.5}
                   borderRadius="sm"
+                  bg="transparent"
                   cursor="pointer"
                   textAlign="left"
                   _hover={{ bg: "bg.emphasized" }}
                   title="Open trace in a new tab"
-                  // preventDefault: this button lives inside the drawer's
-                  // <form>, where the implicit type is submit.
-                  onClick={(event: React.MouseEvent) => {
-                    event.preventDefault();
+                  onClick={() => {
                     if (!project?.slug) return;
                     window.open(
                       traceDrawerUrl(project.slug, span),
@@ -234,7 +235,7 @@ export function LLMModelCostMatchingSpans({
                     color="fg.subtle"
                     flexShrink={0}
                   />
-                </HStack>
+                </chakra.button>
               ))}
             </VStack>
           )}
@@ -252,27 +253,26 @@ export function LLMModelCostMatchingSpans({
                       {data.unmatchedModels.map((m) => (
                         <Badge
                           key={m.model}
-                          as="button"
+                          asChild
                           size="sm"
                           variant="outline"
                           cursor="pointer"
                           gap={1.5}
                           _hover={{ bg: "bg.emphasized" }}
-                          // preventDefault: rendered inside the drawer's
-                          // <form>, where the implicit type is submit.
-                          onClick={(event: React.MouseEvent) => {
-                            event.preventDefault();
-                            onPickModel(m.model);
-                          }}
-                          data-testid="unmatched-model-chip"
                         >
-                          <ProviderIcon model={m.model} size="compact" />
-                          <Text fontFamily="mono" textStyle="xs">
-                            {m.model}
-                          </Text>
-                          <Text textStyle="2xs" color="fg.subtle">
-                            {m.spanCount}
-                          </Text>
+                          <button
+                            type="button"
+                            onClick={() => onPickModel(m.model)}
+                            data-testid="unmatched-model-chip"
+                          >
+                            <ProviderIcon model={m.model} size="compact" />
+                            <Text fontFamily="mono" textStyle="xs">
+                              {m.model}
+                            </Text>
+                            <Text textStyle="2xs" color="fg.subtle">
+                              {m.spanCount}
+                            </Text>
+                          </button>
                         </Badge>
                       ))}
                     </HStack>

--- a/langwatch/src/components/settings/__tests__/LLMModelCostDrawer.lite-member.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/LLMModelCostDrawer.lite-member.integration.test.tsx
@@ -96,6 +96,18 @@ vi.mock("~/utils/api", () => ({
           isLoading: false,
         }),
       },
+      previewMatchingSpans: {
+        useQuery: () => ({
+          data: {
+            windowDays: 7,
+            totalMatchedSpans: 0,
+            matchedModels: [],
+            sampleSpans: [],
+            unmatchedModels: [],
+          },
+          isLoading: false,
+        }),
+      },
     },
   },
 }));

--- a/langwatch/src/components/settings/__tests__/LLMModelCostDrawer.lite-member.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/LLMModelCostDrawer.lite-member.integration.test.tsx
@@ -80,7 +80,10 @@ vi.mock("~/utils/api", () => ({
       },
       createOrUpdate: {
         useMutation: () => ({
-          mutate: (data: unknown, options: { onError?: (error: unknown) => void }) => {
+          mutate: (
+            data: unknown,
+            options: { onError?: (error: unknown) => void },
+          ) => {
             mockCreateOrUpdateMutate(data, options);
 
             if (mockMutationError.current) {
@@ -127,10 +130,7 @@ const Wrapper = ({ children }: { children?: ReactNode }) => (
 );
 
 function renderDrawer(props: { id?: string; cloneModel?: string } = {}) {
-  return render(
-    <LLMModelCostDrawer {...props} />,
-    { wrapper: Wrapper },
-  );
+  return render(<LLMModelCostDrawer {...props} />, { wrapper: Wrapper });
 }
 
 async function submitStoredModelCost() {

--- a/langwatch/src/components/settings/__tests__/LLMModelCostMatchingSpans.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/LLMModelCostMatchingSpans.integration.test.tsx
@@ -11,6 +11,7 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LLMModelCostDrawer } from "~/components/settings/LLMModelCostDrawer";
 
 const { mockPreviewState, mockPreviewQueryInputs } = vi.hoisted(() => ({
   mockPreviewState: {
@@ -82,10 +83,6 @@ vi.mock("~/utils/api", () => ({
   },
 }));
 
-const { LLMModelCostDrawer } = await import(
-  "~/components/settings/LLMModelCostDrawer"
-);
-
 const Wrapper = ({ children }: { children?: ReactNode }) => (
   <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
 );
@@ -134,6 +131,7 @@ describe("Feature: Model cost regex matching spans preview", () => {
   });
 
   describe("when recent spans match the regex", () => {
+    /** @scenario Recent spans matching the regex are listed with tokens and an example cost */
     it("lists the spans with model, tokens, and example cost", () => {
       renderDrawer({ prefillRegex: "bedrock/eu\\." });
 
@@ -148,6 +146,7 @@ describe("Feature: Model cost regex matching spans preview", () => {
       ).toBeInTheDocument();
     });
 
+    /** @scenario A span row opens the trace details drawer in a new tab */
     it("opens the trace drawer deep link in a new tab on row click", () => {
       renderDrawer({ prefillRegex: "bedrock/eu\\." });
 
@@ -191,6 +190,7 @@ describe("Feature: Model cost regex matching spans preview", () => {
       };
     });
 
+    /** @scenario No matches shows the models that were seen instead */
     it("shows the recently seen models that did not match", () => {
       renderDrawer({ prefillRegex: "nothing-matches-this" });
 
@@ -237,6 +237,7 @@ describe("Feature: Model cost regex matching spans preview", () => {
   });
 
   describe("when a slash appears unescaped in the regex", () => {
+    /** @scenario Slashes in the regex are valid */
     it("treats the regex as valid and previews matches", () => {
       renderDrawer({
         prefillRegex: "^bedrock/eu\\.anthropic\\.claude-sonnet-4-6$",

--- a/langwatch/src/components/settings/__tests__/LLMModelCostMatchingSpans.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/LLMModelCostMatchingSpans.integration.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Matching-spans preview inside the LLM model cost drawer: real component
+ * tree (drawer + form + preview), with the tRPC client as the mocked
+ * boundary.
+ *
+ * Spec: specs/model-providers/model-cost-matching-spans-preview.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPreviewState, mockPreviewQueryInputs } = vi.hoisted(() => ({
+  mockPreviewState: {
+    current: null as null | {
+      windowDays: number;
+      totalMatchedSpans: number;
+      matchedModels: Array<{
+        model: string;
+        spanCount: number;
+        lastSeenMs: number;
+      }>;
+      sampleSpans: Array<{
+        traceId: string;
+        spanId: string;
+        spanName: string;
+        model: string;
+        inputTokens: number | null;
+        outputTokens: number | null;
+        cacheReadTokens: number | null;
+        cacheCreationTokens: number | null;
+        startTimeMs: number;
+        exampleCost: number | null;
+      }>;
+      unmatchedModels: Array<{ model: string; spanCount: number }>;
+    },
+  },
+  mockPreviewQueryInputs: [] as Array<{
+    input: Record<string, unknown>;
+    enabled: boolean | undefined;
+  }>,
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    organization: { id: "org-1", name: "Org One" },
+    team: { id: "team-1", name: "Team One" },
+    project: { id: "proj-1", slug: "test-project", name: "Test Project" },
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({ closeDrawer: vi.fn() }),
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    llmModelCost: {
+      getAllForProject: {
+        useQuery: () => ({ data: [], isLoading: false, refetch: vi.fn() }),
+      },
+      createOrUpdate: {
+        useMutation: () => ({ mutate: vi.fn(), isLoading: false }),
+      },
+      previewMatchingSpans: {
+        useQuery: (
+          input: Record<string, unknown>,
+          opts?: { enabled?: boolean },
+        ) => {
+          mockPreviewQueryInputs.push({ input, enabled: opts?.enabled });
+          return {
+            data:
+              opts?.enabled === false ? undefined : mockPreviewState.current,
+            isLoading: false,
+          };
+        },
+      },
+    },
+  },
+}));
+
+const { LLMModelCostDrawer } = await import(
+  "~/components/settings/LLMModelCostDrawer"
+);
+
+const Wrapper = ({ children }: { children?: ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderDrawer(
+  props: { id?: string; prefillModel?: string; prefillRegex?: string } = {},
+) {
+  return render(<LLMModelCostDrawer {...props} />, { wrapper: Wrapper });
+}
+
+const T_START = 1_750_000_000_000;
+
+describe("Feature: Model cost regex matching spans preview", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPreviewQueryInputs.length = 0;
+    vi.spyOn(window, "open").mockReturnValue(null);
+    mockPreviewState.current = {
+      windowDays: 7,
+      totalMatchedSpans: 12,
+      matchedModels: [
+        {
+          model: "bedrock/eu.anthropic.claude-sonnet-4-6",
+          spanCount: 12,
+          lastSeenMs: T_START,
+        },
+      ],
+      sampleSpans: [
+        {
+          traceId: "trace-1",
+          spanId: "span-1",
+          spanName: "chat completion",
+          model: "bedrock/eu.anthropic.claude-sonnet-4-6",
+          inputTokens: 1000,
+          outputTokens: 200,
+          cacheReadTokens: null,
+          cacheCreationTokens: null,
+          startTimeMs: T_START,
+          exampleCost: 0.006,
+        },
+      ],
+      unmatchedModels: [],
+    };
+  });
+
+  describe("when recent spans match the regex", () => {
+    it("lists the spans with model, tokens, and example cost", () => {
+      renderDrawer({ prefillRegex: "bedrock/eu\\." });
+
+      const row = screen.getByTestId("matching-span-row");
+      expect(row).toHaveTextContent("bedrock/eu.anthropic.claude-sonnet-4-6");
+      expect(row).toHaveTextContent("chat completion");
+      expect(row).toHaveTextContent("1.0K");
+      expect(row).toHaveTextContent("200");
+      expect(row).toHaveTextContent("$0.0060");
+      expect(
+        screen.getByText("12 spans across 1 model in the last 7 days"),
+      ).toBeInTheDocument();
+    });
+
+    it("opens the trace drawer deep link in a new tab on row click", () => {
+      renderDrawer({ prefillRegex: "bedrock/eu\\." });
+
+      fireEvent.click(screen.getByTestId("matching-span-row"));
+
+      expect(window.open).toHaveBeenCalledTimes(1);
+      const [url, target] = vi.mocked(window.open).mock.calls[0]!;
+      const parsed = new URL(`http://localhost${url as string}`);
+      expect(parsed.pathname).toBe("/test-project/traces");
+      expect(parsed.searchParams.get("drawer.open")).toBe("traceV2Details");
+      expect(parsed.searchParams.get("drawer.traceId")).toBe("trace-1");
+      expect(parsed.searchParams.get("drawer.span")).toBe("span-1");
+      expect(parsed.searchParams.get("drawer.t")).toBe(String(T_START));
+      expect(parsed.searchParams.get("drawer.mode")).toBe("trace");
+      expect(target).toBe("_blank");
+    });
+
+    it("does not submit the form when a span row is clicked", () => {
+      renderDrawer({ prefillRegex: "bedrock/eu\\." });
+
+      fireEvent.click(screen.getByTestId("matching-span-row"));
+
+      // Save submission would render the regex input invalid or fire the
+      // mutation; cheapest observable: the drawer is still rendered and no
+      // navigation/mutation happened.
+      expect(screen.getByTestId("matching-spans-preview")).toBeInTheDocument();
+    });
+  });
+
+  describe("when no spans match the regex", () => {
+    beforeEach(() => {
+      mockPreviewState.current = {
+        windowDays: 7,
+        totalMatchedSpans: 0,
+        matchedModels: [],
+        sampleSpans: [],
+        unmatchedModels: [
+          { model: "bedrock/eu.anthropic.claude-sonnet-4-6", spanCount: 42 },
+          { model: "gpt-5-mini", spanCount: 7 },
+        ],
+      };
+    });
+
+    it("shows the recently seen models that did not match", () => {
+      renderDrawer({ prefillRegex: "nothing-matches-this" });
+
+      expect(
+        screen.getByText("no matches in the last 7 days"),
+      ).toBeInTheDocument();
+      const chips = screen.getAllByTestId("unmatched-model-chip");
+      expect(chips).toHaveLength(2);
+      expect(chips[0]).toHaveTextContent(
+        "bedrock/eu.anthropic.claude-sonnet-4-6",
+      );
+      expect(chips[0]).toHaveTextContent("42");
+    });
+
+    it("fills an exact-match regex and the model name when a model chip is clicked", () => {
+      renderDrawer({ prefillRegex: "nothing-matches-this" });
+
+      fireEvent.click(screen.getAllByTestId("unmatched-model-chip")[0]!);
+
+      expect(
+        screen.getByDisplayValue(
+          "^bedrock\\/eu\\.anthropic\\.claude-sonnet-4-6$",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue("bedrock/eu.anthropic.claude-sonnet-4-6"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when the regex is invalid", () => {
+    it("disables the preview query and asks for a valid regex", () => {
+      renderDrawer({ prefillRegex: "(a+)+$" });
+
+      expect(
+        screen.getByText(
+          "Enter a valid regular expression to preview the spans it would match.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        mockPreviewQueryInputs.every((call) => call.enabled === false),
+      ).toBe(true);
+    });
+  });
+
+  describe("when a slash appears unescaped in the regex", () => {
+    it("treats the regex as valid and previews matches", () => {
+      renderDrawer({
+        prefillRegex: "^bedrock/eu\\.anthropic\\.claude-sonnet-4-6$",
+      });
+
+      expect(screen.getByTestId("matching-span-row")).toBeInTheDocument();
+      expect(
+        mockPreviewQueryInputs.some((call) => call.enabled !== false),
+      ).toBe(true);
+    });
+  });
+
+  describe("when opened from the add cost mapping deep link", () => {
+    it("prefills the model name and regex fields", () => {
+      renderDrawer({
+        prefillModel: "vertex_ai/gemini-3-pro-preview",
+        prefillRegex: "^vertex_ai\\/gemini-3-pro-preview$",
+      });
+
+      expect(
+        screen.getByDisplayValue("vertex_ai/gemini-3-pro-preview"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue("^vertex_ai\\/gemini-3-pro-preview$"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/RangeSection.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/RangeSection.tsx
@@ -25,6 +25,25 @@ export function sliderStepForSpan(span: number): number {
   return span >= 100 ? 1 : span / 100;
 }
 
+/**
+ * Clamp both thumb values into the facet's current bounds. The slider value
+ * lives in local state while min/max stream in from the facet snapshot, so
+ * for a frame the two can disagree (stale committed filter, snapshot
+ * refresh moving the bounds). zag-js throws synchronously when a thumb sits
+ * fully outside [min, max], which used to take the whole filter section
+ * down with a "Couldn't render the cost filter" error card until a retry.
+ * Exported for unit testing.
+ */
+export function clampRangeToBounds(
+  value: [number, number],
+  min: number,
+  max: number,
+): [number, number] {
+  const clamp = (v: number) =>
+    Math.min(Math.max(Number.isFinite(v) ? v : min, min), max);
+  return [clamp(value[0]), clamp(value[1])];
+}
+
 /** Strip currency / unit suffixes so users can paste back the formatted
  * label and still get a parseable number. "1.5s" → 1.5, "$0.05" → 0.05,
  * "12,300" → 12300. Returns null for anything that doesn't yield a
@@ -239,7 +258,7 @@ const RangeSectionInner: React.FC<RangeSectionProps> = ({
                   min={min}
                   max={max}
                   step={sliderStepForSpan(max - min)}
-                  value={localValue}
+                  value={clampRangeToBounds(localValue, min, max)}
                   onValueChange={(d) => {
                     // Drop frames that would inject NaN into local state —
                     // zag-js can momentarily emit `undefined` on degenerate

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/RangeSection.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/RangeSection.tsx
@@ -10,6 +10,19 @@ const COMMIT_DEBOUNCE_MS = 150;
 /** Snap to "cleared" when both endpoints are within this fraction of the full range. */
 const CLEAR_EPSILON = 0.01;
 
+/**
+ * Slider step sized to the range span. The default step of 1 makes a
+ * sub-unit range unusable, a cost facet spanning $0…$0.0139 only lets the
+ * thumbs snap to the two endpoints, so no intermediate filter can be set by
+ * dragging. Integer-scale spans keep step 1 so token/duration sliders snap
+ * to whole units; smaller spans get a fine fraction of the range. Exported
+ * for unit testing.
+ */
+export function sliderStepForSpan(span: number): number {
+  if (!Number.isFinite(span) || span <= 0) return 1;
+  return span >= 100 ? 1 : span / 100;
+}
+
 /** Strip currency / unit suffixes so users can paste back the formatted
  * label and still get a parseable number. "1.5s" → 1.5, "$0.05" → 0.05,
  * "12,300" → 12300. Returns null for anything that doesn't yield a
@@ -178,11 +191,7 @@ const RangeSectionInner: React.FC<RangeSectionProps> = ({
       hasActive={isActive}
       activeIndicator={
         summary ? (
-          <Text
-            textStyle="2xs"
-            color="blue.fg"
-            fontWeight="500"
-          >
+          <Text textStyle="2xs" color="blue.fg" fontWeight="500">
             {summary}
           </Text>
         ) : undefined
@@ -206,68 +215,69 @@ const RangeSectionInner: React.FC<RangeSectionProps> = ({
           </Box>
         ) : null}
         {!synthetic || max > 0 ? (
-        <>
-        {/*
-         * A SimpleSlider with `min === max` (or any non-positive span)
-         * trips zag-js's invariants and throws synchronously, which has
-         * been masking real errors during empty-state mounts. Skip the
-         * slider in that degenerate case.
-         *
-         * When every visible trace shares the same value (e.g. all
-         * traces have `totalTokens = 512`) the range can't narrow
-         * anything. Render a disabled-looking slider with both thumbs
-         * collapsed at the value plus a hover tooltip explaining why
-         * — visually consistent with the interactive case, just
-         * inert. Rare in practice (mostly sample-data territory) so
-         * it doesn't deserve its own special-case empty-state copy.
-         */}
-        {max > min ? (
           <>
-            <SimpleSlider
-              size="sm"
-              min={min}
-              max={max}
-              value={localValue}
-              onValueChange={(d) => {
-                // Drop frames that would inject NaN into local state —
-                // zag-js can momentarily emit `undefined` on degenerate
-                // ranges (rapid resize, value === min === max). Falling
-                // back to the previous local value keeps the slider
-                // visually stable instead of glitching to "0".
-                const lo = d.value[0];
-                const hi = d.value[1];
-                if (lo === undefined || hi === undefined) return;
-                setLocalValue([lo, hi]);
-              }}
-              onValueChangeEnd={handleChangeEnd}
-              colorPalette={isActive ? "blue" : "gray"}
-            />
+            {/*
+             * A SimpleSlider with `min === max` (or any non-positive span)
+             * trips zag-js's invariants and throws synchronously, which has
+             * been masking real errors during empty-state mounts. Skip the
+             * slider in that degenerate case.
+             *
+             * When every visible trace shares the same value (e.g. all
+             * traces have `totalTokens = 512`) the range can't narrow
+             * anything. Render a disabled-looking slider with both thumbs
+             * collapsed at the value plus a hover tooltip explaining why
+             * — visually consistent with the interactive case, just
+             * inert. Rare in practice (mostly sample-data territory) so
+             * it doesn't deserve its own special-case empty-state copy.
+             */}
+            {max > min ? (
+              <>
+                <SimpleSlider
+                  size="sm"
+                  min={min}
+                  max={max}
+                  step={sliderStepForSpan(max - min)}
+                  value={localValue}
+                  onValueChange={(d) => {
+                    // Drop frames that would inject NaN into local state —
+                    // zag-js can momentarily emit `undefined` on degenerate
+                    // ranges (rapid resize, value === min === max). Falling
+                    // back to the previous local value keeps the slider
+                    // visually stable instead of glitching to "0".
+                    const lo = d.value[0];
+                    const hi = d.value[1];
+                    if (lo === undefined || hi === undefined) return;
+                    setLocalValue([lo, hi]);
+                  }}
+                  onValueChangeEnd={handleChangeEnd}
+                  colorPalette={isActive ? "blue" : "gray"}
+                />
 
-            <HStack justify="space-between" gap={2}>
-              <RangeEndpointInput
-                value={localValue[0]}
+                <HStack justify="space-between" gap={2}>
+                  <RangeEndpointInput
+                    value={localValue[0]}
+                    format={formatValue}
+                    ariaLabel={`${title} minimum`}
+                    onCommit={(n) => commitImmediate(n, localValue[1])}
+                  />
+                  <RangeEndpointInput
+                    value={localValue[1]}
+                    format={formatValue}
+                    ariaLabel={`${title} maximum`}
+                    align="right"
+                    onCommit={(n) => commitImmediate(localValue[0], n)}
+                  />
+                </HStack>
+              </>
+            ) : (
+              <DisabledRangeVisual
+                value={min}
                 format={formatValue}
-                ariaLabel={`${title} minimum`}
-                onCommit={(n) => commitImmediate(n, localValue[1])}
+                isActive={isActive}
+                onClear={onClear}
               />
-              <RangeEndpointInput
-                value={localValue[1]}
-                format={formatValue}
-                ariaLabel={`${title} maximum`}
-                align="right"
-                onCommit={(n) => commitImmediate(localValue[0], n)}
-              />
-            </HStack>
+            )}
           </>
-        ) : (
-          <DisabledRangeVisual
-            value={min}
-            format={formatValue}
-            isActive={isActive}
-            onClear={onClear}
-          />
-        )}
-        </>
         ) : null}
       </VStack>
     </SidebarSection>

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/RangeSection.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/RangeSection.tsx
@@ -12,11 +12,13 @@ const CLEAR_EPSILON = 0.01;
 
 /**
  * Slider step sized to the range span. The default step of 1 makes a
- * sub-unit range unusable, a cost facet spanning $0…$0.0139 only lets the
- * thumbs snap to the two endpoints, so no intermediate filter can be set by
- * dragging. Integer-scale spans keep step 1 so token/duration sliders snap
- * to whole units; smaller spans get a fine fraction of the range. Exported
- * for unit testing.
+ * narrow range unusable, a cost facet spanning $0…$0.0139 only lets the
+ * thumbs snap to the two endpoints, so no intermediate filter can be set
+ * by dragging. Spans of 100+ units keep step 1 so wide token and duration
+ * sliders snap to whole units; narrower spans get 1/100 of the span so the
+ * thumbs always have about a hundred usable positions (a $0…$5 cost facet
+ * needs sub-dollar steps just as much as a sub-unit one). Exported for
+ * unit testing.
  */
 export function sliderStepForSpan(span: number): number {
   if (!Number.isFinite(span) || span <= 0) return 1;

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/RangeSection.subUnitSpan.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/RangeSection.subUnitSpan.integration.test.tsx
@@ -7,7 +7,13 @@
  * set by dragging. The slider must get a step sized to the span.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RangeSection, sliderStepForSpan } from "../RangeSection";
 
@@ -15,7 +21,7 @@ describe("RangeSection", () => {
   afterEach(cleanup);
 
   describe("when the facet span is sub-unit", () => {
-    it("mounts the slider with a step smaller than the span", async () => {
+    it("moves the thumb by the span-sized step on a keyboard increment", async () => {
       render(
         <ChakraProvider value={defaultSystem}>
           <RangeSection
@@ -34,10 +40,21 @@ describe("RangeSection", () => {
       fireEvent.click(screen.getByText("Cost"));
 
       const sliders = await screen.findAllByRole("slider");
-      expect(sliders.length).toBeGreaterThan(0);
-      // The step contract itself is asserted on the helper below; this
-      // render proves the component path feeds it to the slider without
-      // breaking the mount.
+      const lowerThumb = sliders[0]!;
+      expect(Number(lowerThumb.getAttribute("aria-valuenow"))).toBe(0);
+
+      // One ArrowRight from the min endpoint must advance by the computed
+      // step. With the default step of 1 the thumb would jump straight to
+      // the max endpoint of this $0…$0.0139 range instead.
+      lowerThumb.focus();
+      fireEvent.keyDown(lowerThumb, { key: "ArrowRight" });
+
+      await waitFor(() => {
+        expect(Number(lowerThumb.getAttribute("aria-valuenow"))).toBeCloseTo(
+          sliderStepForSpan(0.0139),
+          6,
+        );
+      });
     });
   });
 });
@@ -50,7 +67,13 @@ describe("sliderStepForSpan", () => {
     });
   });
 
-  describe("when the span covers whole units", () => {
+  describe("when the span covers a few units", () => {
+    it("still subdivides so narrow cost ranges stay draggable", () => {
+      expect(sliderStepForSpan(5)).toBe(0.05);
+    });
+  });
+
+  describe("when the span covers 100 units or more", () => {
     it("keeps the default step of 1", () => {
       expect(sliderStepForSpan(2100)).toBe(1);
       expect(sliderStepForSpan(100)).toBe(1);

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/RangeSection.subUnitSpan.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/RangeSection.subUnitSpan.integration.test.tsx
@@ -15,7 +15,11 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { RangeSection, sliderStepForSpan } from "../RangeSection";
+import {
+  clampRangeToBounds,
+  RangeSection,
+  sliderStepForSpan,
+} from "../RangeSection";
 
 describe("RangeSection", () => {
   afterEach(cleanup);
@@ -85,6 +89,47 @@ describe("sliderStepForSpan", () => {
       expect(sliderStepForSpan(0)).toBe(1);
       expect(sliderStepForSpan(-5)).toBe(1);
       expect(sliderStepForSpan(Number.NaN)).toBe(1);
+    });
+  });
+});
+
+describe("clampRangeToBounds", () => {
+  // The three thumb/bounds disagreement shapes that make zag-js throw
+  // synchronously at mount (verified against @zag-js/slider's normalize):
+  // a stale value entirely below the new min, entirely above the new max,
+  // or out of order. Clamping each thumb into [min, max] makes all of
+  // them representable.
+  describe("when a stale value disagrees with freshly-arrived bounds", () => {
+    it("clamps a range entirely below the bounds up to min", () => {
+      expect(clampRangeToBounds([0, 0.00001], 0.000032, 0.019895)).toEqual([
+        0.000032, 0.000032,
+      ]);
+    });
+
+    it("clamps a range entirely above the bounds down to max", () => {
+      expect(clampRangeToBounds([0.5, 0.9], 0.000032, 0.019895)).toEqual([
+        0.019895, 0.019895,
+      ]);
+    });
+
+    it("clamps out-of-order thumbs into the bounds", () => {
+      expect(clampRangeToBounds([0.9, 0.1], 0.000032, 0.019895)).toEqual([
+        0.019895, 0.019895,
+      ]);
+    });
+  });
+
+  describe("when the value already fits the bounds", () => {
+    it("passes it through unchanged", () => {
+      expect(clampRangeToBounds([0.001, 0.01], 0.000032, 0.019895)).toEqual([
+        0.001, 0.01,
+      ]);
+    });
+  });
+
+  describe("when a thumb is not a finite number", () => {
+    it("falls back to min instead of poisoning the slider", () => {
+      expect(clampRangeToBounds([Number.NaN, 0.01], 0, 1)).toEqual([0, 0.01]);
     });
   });
 });

--- a/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/RangeSection.subUnitSpan.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/FilterSidebar/__tests__/RangeSection.subUnitSpan.integration.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Sub-unit range facets (cost facets are USD values like 0…0.0139) used to
+ * mount the slider with the default step of 1, which left the thumbs
+ * snapping only to the two endpoints, no intermediate cost filter could be
+ * set by dragging. The slider must get a step sized to the span.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RangeSection, sliderStepForSpan } from "../RangeSection";
+
+describe("RangeSection", () => {
+  afterEach(cleanup);
+
+  describe("when the facet span is sub-unit", () => {
+    it("mounts the slider with a step smaller than the span", async () => {
+      render(
+        <ChakraProvider value={defaultSystem}>
+          <RangeSection
+            title="Cost"
+            field="cost"
+            min={0}
+            max={0.0139}
+            formatValue={(v) => `$${v.toFixed(4)}`}
+            onChange={vi.fn()}
+            onClear={vi.fn()}
+          />
+        </ChakraProvider>,
+      );
+
+      // Sections mount collapsed; the slider only mounts on expand.
+      fireEvent.click(screen.getByText("Cost"));
+
+      const sliders = await screen.findAllByRole("slider");
+      expect(sliders.length).toBeGreaterThan(0);
+      // The step contract itself is asserted on the helper below; this
+      // render proves the component path feeds it to the slider without
+      // breaking the mount.
+    });
+  });
+});
+
+describe("sliderStepForSpan", () => {
+  describe("when the span is sub-unit", () => {
+    it("returns a fraction of the span so the slider can express in-between values", () => {
+      expect(sliderStepForSpan(0.0139)).toBeLessThan(0.0139);
+      expect(sliderStepForSpan(0.0139)).toBeGreaterThan(0);
+    });
+  });
+
+  describe("when the span covers whole units", () => {
+    it("keeps the default step of 1", () => {
+      expect(sliderStepForSpan(2100)).toBe(1);
+      expect(sliderStepForSpan(100)).toBe(1);
+    });
+  });
+
+  describe("when the span is degenerate", () => {
+    it("falls back to 1 for zero, negative, and non-finite spans", () => {
+      expect(sliderStepForSpan(0)).toBe(1);
+      expect(sliderStepForSpan(-5)).toBe(1);
+      expect(sliderStepForSpan(Number.NaN)).toBe(1);
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -73,13 +73,14 @@ export function SpanAccordions({
   }, [hasError, hasIO, hasPrompt, hasScope]);
 
   // Same rule as the trace summary view: only auto-expand Attributes when
-  // the span itself has attributes — resource-only is rarely interesting
-  // and clutters the default view.
+  // the span itself has attributes (resource-only is rarely interesting
+  // and clutters the default view) or when an unmapped-cost suggestion
+  // needs surfacing there.
   const [openSections, setOpenSections] = useAutoOpenSections(span.spanId, {
     exceptions: hasError,
     io: hasIO,
     prompt: hasPrompt,
-    attributes: hasSpanAttrs,
+    attributes: hasSpanAttrs || !!detail?.costSuggestion,
     scope: hasScope,
     events: hasEvents,
   });
@@ -125,9 +126,6 @@ export function SpanAccordions({
           onDone={handleGlowDone}
         />
       ) : null}
-      {!detailQuery.isLoading && detail?.costSuggestion && (
-        <UnmappedCostSuggestion model={detail.costSuggestion.model} />
-      )}
       {detailQuery.isLoading ? (
         <VStack align="stretch" gap={2} padding={4}>
           <Skeleton height="32px" borderRadius="md" />
@@ -210,6 +208,11 @@ export function SpanAccordions({
                   isFirst={isFirst}
                   open={isOpen}
                 >
+                  {!detailQuery.isLoading && detail?.costSuggestion && (
+                    <UnmappedCostSuggestion
+                      model={detail.costSuggestion.model}
+                    />
+                  )}
                   {hasAttributes ? (
                     <AttributeTable
                       attributes={

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/SpanAccordions.tsx
@@ -21,6 +21,7 @@ import { EmptyEventsState, EmptyHint } from "./EmptyStates";
 import { EventCard } from "./EventCard";
 import { SectionFocusGlow } from "./SectionFocusGlow";
 import { useAutoOpenSections } from "./sectionPresence";
+import { UnmappedCostSuggestion } from "./UnmappedCostSuggestion";
 import { useSectionFocusGlow } from "./useSectionFocusGlow";
 import { countFlatLeaves } from "./utils";
 
@@ -124,6 +125,9 @@ export function SpanAccordions({
           onDone={handleGlowDone}
         />
       ) : null}
+      {!detailQuery.isLoading && detail?.costSuggestion && (
+        <UnmappedCostSuggestion model={detail.costSuggestion.model} />
+      )}
       {detailQuery.isLoading ? (
         <VStack align="stretch" gap={2} padding={4}>
           <Skeleton height="32px" borderRadius="md" />

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/UnmappedCostSuggestion.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/UnmappedCostSuggestion.tsx
@@ -1,0 +1,65 @@
+import { Button, HStack, Icon, Text } from "@chakra-ui/react";
+import { LuExternalLink, LuLightbulb } from "react-icons/lu";
+import { exactModelMatchRegex } from "~/utils/modelCostRegex";
+
+/**
+ * Deep link to the model costs settings page (project context comes from
+ * the session, not the path) with the cost drawer already open and
+ * prefilled — `drawer.*` params are how `CurrentDrawer` hydrates drawer
+ * props from the URL.
+ */
+export function modelCostMappingUrl(model: string): string {
+  const params = new URLSearchParams({
+    "drawer.open": "llmModelCost",
+    "drawer.prefillModel": model,
+    "drawer.prefillRegex": exactModelMatchRegex(model),
+  });
+  return `/settings/model-costs?${params.toString()}`;
+}
+
+/**
+ * Shown in the span detail pane when the span carries a model and token
+ * usage but nothing priced it (`spanDetail.costSuggestion`). One click opens
+ * the model costs page in a new window with the drawer prefilled for this
+ * exact model, regex auto-generated.
+ */
+export function UnmappedCostSuggestion({ model }: { model: string }) {
+  return (
+    <HStack
+      gap={2}
+      marginX={4}
+      marginTop={3}
+      paddingX={3}
+      paddingY={2}
+      borderRadius="sm"
+      bg="blue.subtle"
+      align="center"
+      data-testid="unmapped-cost-suggestion"
+    >
+      <Icon as={LuLightbulb} boxSize={4} color="blue.fg" flexShrink={0} />
+      <Text textStyle="xs" color="blue.fg" flex={1} minWidth={0}>
+        This span has token counts but no cost mapped for{" "}
+        <Text as="span" fontFamily="mono" fontWeight="semibold">
+          {model}
+        </Text>
+        .
+      </Text>
+      <Button
+        size="2xs"
+        variant="outline"
+        colorPalette="blue"
+        flexShrink={0}
+        onClick={() =>
+          window.open(
+            modelCostMappingUrl(model),
+            "_blank",
+            "noopener,noreferrer",
+          )
+        }
+      >
+        Add cost mapping
+        <Icon as={LuExternalLink} boxSize={3} />
+      </Button>
+    </HStack>
+  );
+}

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/UnmappedCostSuggestion.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/UnmappedCostSuggestion.tsx
@@ -5,7 +5,7 @@ import { exactModelMatchRegex } from "~/utils/modelCostRegex";
 /**
  * Deep link to the model costs settings page (project context comes from
  * the session, not the path) with the cost drawer already open and
- * prefilled — `drawer.*` params are how `CurrentDrawer` hydrates drawer
+ * prefilled, `drawer.*` params are how `CurrentDrawer` hydrates drawer
  * props from the URL.
  */
 export function modelCostMappingUrl(model: string): string {

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/UnmappedCostSuggestion.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/UnmappedCostSuggestion.tsx
@@ -18,17 +18,17 @@ export function modelCostMappingUrl(model: string): string {
 }
 
 /**
- * Shown in the span detail pane when the span carries a model and token
- * usage but nothing priced it (`spanDetail.costSuggestion`). One click opens
- * the model costs page in a new window with the drawer prefilled for this
- * exact model, regex auto-generated.
+ * Shown at the top of the Attributes section of the span detail pane when
+ * the span carries a model and token usage but nothing priced it
+ * (`spanDetail.costSuggestion`). One click opens the model costs page in a
+ * new window with the drawer prefilled for this exact model, regex
+ * auto-generated.
  */
 export function UnmappedCostSuggestion({ model }: { model: string }) {
   return (
     <HStack
       gap={2}
-      marginX={4}
-      marginTop={3}
+      marginBottom={2}
       paddingX={3}
       paddingY={2}
       borderRadius="sm"

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/UnmappedCostSuggestion.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/UnmappedCostSuggestion.integration.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Unmapped-cost suggestion in the span detail pane: shows when the span
+ * detail carries `costSuggestion`, opens the model costs page prefilled in
+ * a new window. Renders the real SpanAccordions tree with the span-detail
+ * data hook as the mocked boundary.
+ *
+ * Spec: specs/traces-v2/span-unmapped-cost-suggestion.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  SpanDetail,
+  SpanTreeNode,
+} from "~/server/api/routers/tracesV2.schemas";
+
+const { mockDetailState } = vi.hoisted(() => ({
+  mockDetailState: { current: null as SpanDetail | null },
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", slug: "test-project" },
+  }),
+}));
+
+vi.mock("../../../../hooks/useSpanDetail", () => ({
+  useSpanDetail: () => ({
+    data: mockDetailState.current,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("../../../../hooks/useTraceResources", () => ({
+  useTraceResources: () => ({ bySpanId: {}, isLoading: false }),
+}));
+
+const { SpanAccordions } = await import("../SpanAccordions");
+
+const span: SpanTreeNode = {
+  spanId: "span-1",
+  parentSpanId: null,
+  name: "chat completion",
+  type: "llm",
+  startTimeMs: 1_750_000_000_000,
+  endTimeMs: 1_750_000_000_500,
+  durationMs: 500,
+  status: "ok",
+  model: "vertex_ai/gemini-3-pro-preview",
+  cost: null,
+};
+
+function makeDetail(overrides: Partial<SpanDetail> = {}): SpanDetail {
+  return {
+    spanId: "span-1",
+    parentSpanId: null,
+    name: "chat completion",
+    type: "llm",
+    startTimeMs: 1_750_000_000_000,
+    endTimeMs: 1_750_000_000_500,
+    durationMs: 500,
+    status: "ok",
+    model: "vertex_ai/gemini-3-pro-preview",
+    metrics: {
+      promptTokens: 1200,
+      completionTokens: 80,
+      cost: null,
+    },
+    events: [],
+    costSuggestion: { model: "vertex_ai/gemini-3-pro-preview" },
+    ...overrides,
+  };
+}
+
+const Wrapper = ({ children }: { children?: ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+function renderSpanDetail() {
+  return render(<SpanAccordions traceId="trace-1" span={span} />, {
+    wrapper: Wrapper,
+  });
+}
+
+describe("Feature: Unmapped model cost suggestion in span details", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, "open").mockReturnValue(null);
+    mockDetailState.current = makeDetail();
+  });
+
+  describe("when the span has a model and tokens but no cost mapped", () => {
+    it("shows the suggestion with the model name and an add button", () => {
+      renderSpanDetail();
+
+      const suggestion = screen.getByTestId("unmapped-cost-suggestion");
+      expect(suggestion).toHaveTextContent("no cost mapped");
+      expect(suggestion).toHaveTextContent("vertex_ai/gemini-3-pro-preview");
+      expect(
+        screen.getByRole("button", { name: /add cost mapping/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("opens the model costs page prefilled in a new window", () => {
+      renderSpanDetail();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /add cost mapping/i }),
+      );
+
+      expect(window.open).toHaveBeenCalledTimes(1);
+      const [url, target] = vi.mocked(window.open).mock.calls[0]!;
+      const parsed = new URL(`http://localhost${url as string}`);
+      expect(parsed.pathname).toBe("/settings/model-costs");
+      expect(parsed.searchParams.get("drawer.open")).toBe("llmModelCost");
+      expect(parsed.searchParams.get("drawer.prefillModel")).toBe(
+        "vertex_ai/gemini-3-pro-preview",
+      );
+      expect(parsed.searchParams.get("drawer.prefillRegex")).toBe(
+        "^vertex_ai\\/gemini-3-pro-preview$",
+      );
+      expect(target).toBe("_blank");
+    });
+  });
+
+  describe("when no suggestion applies to the span", () => {
+    it("renders nothing when the span detail carries no costSuggestion", () => {
+      mockDetailState.current = makeDetail({ costSuggestion: null });
+
+      renderSpanDetail();
+
+      expect(
+        screen.queryByTestId("unmapped-cost-suggestion"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/UnmappedCostSuggestion.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/UnmappedCostSuggestion.integration.test.tsx
@@ -16,6 +16,7 @@ import type {
   SpanDetail,
   SpanTreeNode,
 } from "~/server/api/routers/tracesV2.schemas";
+import { SpanAccordions } from "../SpanAccordions";
 
 const { mockDetailState } = vi.hoisted(() => ({
   mockDetailState: { current: null as SpanDetail | null },
@@ -37,8 +38,6 @@ vi.mock("../../../../hooks/useSpanDetail", () => ({
 vi.mock("../../../../hooks/useTraceResources", () => ({
   useTraceResources: () => ({ bySpanId: {}, isLoading: false }),
 }));
-
-const { SpanAccordions } = await import("../SpanAccordions");
 
 const span: SpanTreeNode = {
   spanId: "span-1",
@@ -95,6 +94,7 @@ describe("Feature: Unmapped model cost suggestion in span details", () => {
   });
 
   describe("when the span has a model and tokens but no cost mapped", () => {
+    /** @scenario Span with model and tokens but no cost shows a cost mapping suggestion */
     it("shows the suggestion with the model name and an add button", () => {
       renderSpanDetail();
 
@@ -106,6 +106,8 @@ describe("Feature: Unmapped model cost suggestion in span details", () => {
       ).toBeInTheDocument();
     });
 
+    /** @scenario Suggestion opens the model costs page prefilled in a new window */
+    /** @scenario Generated regex escapes special characters */
     it("opens the model costs page prefilled in a new window", () => {
       renderSpanDetail();
 

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/UnmappedCostSuggestion.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/traceAccordions/__tests__/UnmappedCostSuggestion.integration.test.tsx
@@ -95,12 +95,16 @@ describe("Feature: Unmapped model cost suggestion in span details", () => {
 
   describe("when the span has a model and tokens but no cost mapped", () => {
     /** @scenario Span with model and tokens but no cost shows a cost mapping suggestion */
-    it("shows the suggestion with the model name and an add button", () => {
+    it("shows the suggestion inside the Attributes section with the model name and an add button", () => {
       renderSpanDetail();
 
       const suggestion = screen.getByTestId("unmapped-cost-suggestion");
       expect(suggestion).toHaveTextContent("no cost mapped");
       expect(suggestion).toHaveTextContent("vertex_ai/gemini-3-pro-preview");
+      // The banner lives inside the span's Attributes accordion section,
+      // above the attribute table and its filter input.
+      expect(suggestion.closest('[data-section="attributes"]')).not.toBeNull();
+      expect(suggestion.closest('[data-section="io"]')).toBeNull();
       expect(
         screen.getByRole("button", { name: /add cost mapping/i }),
       ).toBeInTheDocument();

--- a/langwatch/src/features/traces-v2/components/TraceTable/registry/cells/trace/ModelCell.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceTable/registry/cells/trace/ModelCell.tsx
@@ -1,4 +1,12 @@
-import { Badge, Box, HoverCard, HStack, Portal, Text, VStack } from "@chakra-ui/react";
+import {
+  Badge,
+  Box,
+  HoverCard,
+  HStack,
+  Portal,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import type React from "react";
 import { modelProviderIcons } from "~/server/modelProviders/iconsMap";
 import type { TraceListItem } from "../../../../../types/trace";
@@ -93,7 +101,7 @@ const MONOCHROME_PROVIDER_ICONS = new Set<ProviderKey>([
  * icon stays at 12px / 14px so it complements the mono label without
  * dominating it.
  */
-function ProviderIcon({
+export function ProviderIcon({
   model,
   size,
 }: {
@@ -127,9 +135,7 @@ function ProviderIcon({
         // away from neutral. We want neutral white-ish, so just
         // invert. brightness(0.92) tones the result to off-white so
         // it doesn't hard-burn against the dark surface.
-        isMonochrome
-          ? { filter: "invert(1) brightness(0.92)" }
-          : undefined
+        isMonochrome ? { filter: "invert(1) brightness(0.92)" } : undefined
       }
       aria-hidden="true"
     >

--- a/langwatch/src/server/api/routers/llmModelCosts.ts
+++ b/langwatch/src/server/api/routers/llmModelCosts.ts
@@ -1,12 +1,14 @@
 import type { PrismaClient } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
-import safe from "safe-regex2";
 import { z } from "zod";
+import { getApp } from "~/server/app-layer/app";
+import { previewCostRuleMatchingSpans } from "~/server/app-layer/traces/model-cost-span-preview.service";
 import { prisma } from "~/server/db";
 import { assertCanManageScope } from "~/server/modelProviders/modelProvider.authz";
 import { resolveOrganizationForScope as resolveOrganizationForScopeOrNull } from "~/server/scopes/resolveOrganizationForScope";
 import { SCOPE_TIERS, type ScopeTier } from "~/server/scopes/scope.types";
+import { isSafeRegex } from "~/utils/safeRegex";
 import { getModelLimits } from "../../../utils/modelLimits";
 import { getLLMModelCosts } from "../../modelProviders/llmModelCost";
 import { authorizeInResolver, checkProjectPermission } from "../rbac";
@@ -185,13 +187,34 @@ export const llmModelCostsRouter = createTRPCRouter({
     .input(z.object({ projectId: z.string(), model: z.string() }))
     .use(checkProjectPermission("project:view"))
     .query(async ({ input }) => getModelLimits(input.model)),
-});
 
-const isSafeRegex = (pattern: string): boolean => {
-  try {
-    const re = new RegExp(pattern);
-    return safe(re);
-  } catch {
-    return false;
-  }
-};
+  /**
+   * Live preview for the cost rule drawer: which recently-seen models (and
+   * sample spans) would this regex match, and what would those spans cost at
+   * the rates being edited. Gated on traces:view — the response exposes span
+   * metadata (model names, token counts, trace ids), not cost-rule config.
+   */
+  previewMatchingSpans: protectedProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        model: z.string().max(512).optional(),
+        regex: z
+          .string()
+          .min(1)
+          .max(512)
+          .refine((value) => isSafeRegex(value), {
+            message:
+              "Invalid or unsafe regular expression (avoid nested quantifiers like (a+)+)",
+          }),
+        inputCostPerToken: z.number().nonnegative().optional(),
+        outputCostPerToken: z.number().nonnegative().optional(),
+        cacheReadCostPerToken: z.number().nonnegative().optional(),
+        cacheCreationCostPerToken: z.number().nonnegative().optional(),
+      }),
+    )
+    .use(checkProjectPermission("traces:view"))
+    .query(async ({ input }) =>
+      previewCostRuleMatchingSpans(getApp().traces.spans, input),
+    ),
+});

--- a/langwatch/src/server/api/routers/llmModelCosts.ts
+++ b/langwatch/src/server/api/routers/llmModelCosts.ts
@@ -191,7 +191,7 @@ export const llmModelCostsRouter = createTRPCRouter({
   /**
    * Live preview for the cost rule drawer: which recently-seen models (and
    * sample spans) would this regex match, and what would those spans cost at
-   * the rates being edited. Gated on traces:view — the response exposes span
+   * the rates being edited. Gated on traces:view, the response exposes span
    * metadata (model names, token counts, trace ids), not cost-rule config.
    */
   previewMatchingSpans: protectedProcedure

--- a/langwatch/src/server/api/routers/llmModelCosts.ts
+++ b/langwatch/src/server/api/routers/llmModelCosts.ts
@@ -215,6 +215,6 @@ export const llmModelCostsRouter = createTRPCRouter({
     )
     .use(checkProjectPermission("traces:view"))
     .query(async ({ input }) =>
-      previewCostRuleMatchingSpans(getApp().traces.spans, input),
+      previewCostRuleMatchingSpans({ spans: getApp().traces.spans, input }),
     ),
 });

--- a/langwatch/src/server/api/routers/tracesV2.schemas.ts
+++ b/langwatch/src/server/api/routers/tracesV2.schemas.ts
@@ -196,7 +196,7 @@ export const spanDetailSchema = z.object({
   ),
   /**
    * Present when the span names a model and carries token usage but nothing
-   * (custom rule or static registry) prices it — the UI offers to create a
+   * (custom rule or static registry) prices it, the UI offers to create a
    * model cost mapping for `model`. Only computed by `spanDetail`.
    */
   costSuggestion: z.object({ model: z.string() }).nullish(),

--- a/langwatch/src/server/api/routers/tracesV2.schemas.ts
+++ b/langwatch/src/server/api/routers/tracesV2.schemas.ts
@@ -194,6 +194,12 @@ export const spanDetailSchema = z.object({
       attributes: z.record(z.unknown()),
     }),
   ),
+  /**
+   * Present when the span names a model and carries token usage but nothing
+   * (custom rule or static registry) prices it — the UI offers to create a
+   * model cost mapping for `model`. Only computed by `spanDetail`.
+   */
+  costSuggestion: z.object({ model: z.string() }).nullish(),
 });
 
 export type SpanDetail = z.infer<typeof spanDetailSchema>;

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -1014,7 +1014,7 @@ export const tracesV2Router = createTRPCRouter({
         }
       }
 
-      // Token usage with no price on it — offer the user a cost mapping.
+      // Token usage with no price on it, offer the user a cost mapping.
       // The cheap guards run first; the rule lookup only fires for spans
       // that actually present the unmapped-cost symptom.
       detail.costSuggestion = await deriveUnmappedCostSuggestion({

--- a/langwatch/src/server/api/routers/tracesV2.ts
+++ b/langwatch/src/server/api/routers/tracesV2.ts
@@ -3,33 +3,38 @@ import { z } from "zod";
 import { resolveNonBilledCost } from "~/features/traces-v2/utils/costAttribution";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
-import { CollectorSpanUtils } from "~/server/traces/collectorSpan.utils";
-import type { ReservedTraceMetadata, CustomMetadata } from "~/server/tracer/types";
-import { prisma } from "~/server/db";
+import { ValidationError } from "~/server/app-layer/domain-error";
 import {
   generateTraceAction,
   generateTraceQueryFromPrompt,
 } from "~/server/app-layer/traces/ai-query";
-import { ValidationError } from "~/server/app-layer/domain-error";
 import { deriveTraceStatus } from "~/server/app-layer/traces/derive-trace-status";
 import { TraceNotFoundError } from "~/server/app-layer/traces/errors";
 import { translateFilterToClickHouse } from "~/server/app-layer/traces/filter-to-clickhouse";
+import { deriveUnmappedCostSuggestion } from "~/server/app-layer/traces/model-cost-span-preview.service";
 import type { SpanSummaryRow } from "~/server/app-layer/traces/repositories/span-storage.repository";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
-import { changeTraceNameInputSchema } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
+import { prisma } from "~/server/db";
 import type { DerivedTraceEvent } from "~/server/event-sourcing/pipelines/trace-processing/projections/services/trace-events.derivation";
-import { withoutHiddenResourceAttrs } from "./tracesV2.resourceAttrs";
+import { changeTraceNameInputSchema } from "~/server/event-sourcing/pipelines/trace-processing/schemas/commands";
 import {
   TRACE_NAME_MAX_LENGTH,
   TRACE_NAME_MIN_LENGTH,
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import type {
+  CustomMetadata,
+  ReservedTraceMetadata,
+  Span,
+  SpanInputOutput,
+} from "~/server/tracer/types";
+import { CollectorSpanUtils } from "~/server/traces/collectorSpan.utils";
 import {
   findPromptReferenceInAncestors,
   flattenParamsToPromptAttributes,
   type PromptLookupSpan,
 } from "~/server/traces/findPromptReferenceInAncestors";
-import type { Span, SpanInputOutput } from "~/server/tracer/types";
 import { checkProjectPermission } from "../rbac";
+import { withoutHiddenResourceAttrs } from "./tracesV2.resourceAttrs";
 import type {
   SpanDetail,
   SpanLangwatchSignals,
@@ -194,7 +199,9 @@ function readSystemInstructions(
  * the stored attribute split semconv-correct while every view mode (pretty /
  * text / json / copy) stays consistent. All other shapes fall through.
  */
-export function buildDisplayInput(span: Pick<Span, "input" | "params">): string | null {
+export function buildDisplayInput(
+  span: Pick<Span, "input" | "params">,
+): string | null {
   const io = span.input;
   if (io && io.type === "chat_messages" && Array.isArray(io.value)) {
     const system = readSystemInstructions(span.params ?? null);
@@ -283,9 +290,7 @@ const PROMPT_ATTR_KEYS = [
   "langwatch.prompt.variables",
 ] as const;
 
-function hasOwnPromptAttrs(
-  params: Record<string, unknown> | null,
-): boolean {
+function hasOwnPromptAttrs(params: Record<string, unknown> | null): boolean {
   if (!params) return false;
   const flat = flattenParamsToPromptAttributes(params);
   return PROMPT_ATTR_KEYS.some((k) => flat[k] !== undefined);
@@ -695,26 +700,31 @@ export const tracesV2Router = createTRPCRouter({
       z.object({
         projectId: z.string(),
         traceId: z.string(),
-        metadata: z.record(
-          z.union([
-            z.string().max(4096),
-            z.number(),
-            z.boolean(),
-            z.array(z.string()),
-            z.record(z.unknown()),
-          ]),
-        ).refine((obj) => Object.keys(obj).length > 0, {
-          message: "metadata must contain at least one key",
-        }).refine(
-          (obj) => JSON.stringify(obj).length <= 32768,
-          { message: "total metadata payload must not exceed 32KB" },
-        ),
+        metadata: z
+          .record(
+            z.union([
+              z.string().max(4096),
+              z.number(),
+              z.boolean(),
+              z.array(z.string()),
+              z.record(z.unknown()),
+            ]),
+          )
+          .refine((obj) => Object.keys(obj).length > 0, {
+            message: "metadata must contain at least one key",
+          })
+          .refine((obj) => JSON.stringify(obj).length <= 32768, {
+            message: "total metadata payload must not exceed 32KB",
+          }),
       }),
     )
     .use(checkProjectPermission("traces:update"))
     .mutation(async ({ input }) => {
       const RESERVED_METADATA_KEYS = new Set([
-        "user_id", "customer_id", "thread_id", "labels",
+        "user_id",
+        "customer_id",
+        "thread_id",
+        "labels",
       ]);
 
       const reserved: ReservedTraceMetadata = {};
@@ -1003,6 +1013,17 @@ export const tracesV2Router = createTRPCRouter({
           detail.params = enriched;
         }
       }
+
+      // Token usage with no price on it — offer the user a cost mapping.
+      // The cheap guards run first; the rule lookup only fires for spans
+      // that actually present the unmapped-cost symptom.
+      detail.costSuggestion = await deriveUnmappedCostSuggestion({
+        projectId: input.projectId,
+        model: detail.model ?? null,
+        cost: detail.metrics?.cost,
+        promptTokens: detail.metrics?.promptTokens,
+        completionTokens: detail.metrics?.completionTokens,
+      });
 
       return detail;
     }),

--- a/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
@@ -188,11 +188,14 @@ afterAll(async () => {
 describe("previewCostRuleMatchingSpans", () => {
   describe("when the regex matches a recorded model exactly", () => {
     it("lists the matching model with sample spans, tokens, and an example cost", async () => {
-      const preview = await previewCostRuleMatchingSpans(spans, {
-        projectId: tenantId,
-        regex: "^bedrock/eu\\.anthropic\\.claude-sonnet-4-6$",
-        inputCostPerToken: 0.000003,
-        outputCostPerToken: 0.000015,
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: "^bedrock/eu\\.anthropic\\.claude-sonnet-4-6$",
+          inputCostPerToken: 0.000003,
+          outputCostPerToken: 0.000015,
+        },
       });
 
       expect(preview.matchedModels).toHaveLength(1);
@@ -219,11 +222,14 @@ describe("previewCostRuleMatchingSpans", () => {
     });
 
     it("reads token counts from the legacy prompt/completion attribute aliases", async () => {
-      const preview = await previewCostRuleMatchingSpans(spans, {
-        projectId: tenantId,
-        regex: "^eu\\.anthropic\\.claude-sonnet-4-6-v1:0$",
-        inputCostPerToken: 0.000002,
-        outputCostPerToken: 0.00001,
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: "^eu\\.anthropic\\.claude-sonnet-4-6-v1:0$",
+          inputCostPerToken: 0.000002,
+          outputCostPerToken: 0.00001,
+        },
       });
 
       expect(preview.sampleSpans).toHaveLength(1);
@@ -233,22 +239,48 @@ describe("previewCostRuleMatchingSpans", () => {
     });
 
     it("returns no example cost when no rates were entered yet", async () => {
-      const preview = await previewCostRuleMatchingSpans(spans, {
-        projectId: tenantId,
-        regex: "^bedrock/eu\\.anthropic\\.claude-sonnet-4-6$",
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: "^bedrock/eu\\.anthropic\\.claude-sonnet-4-6$",
+        },
       });
 
+      expect(preview.sampleSpans[0]!.exampleCost).toBeNull();
+    });
+
+    it("returns no example cost for a span without token usage even when rates are entered", async () => {
+      // A token-less span priced at the entered rates would read as a
+      // misleading $0.00; the preview shows a dash instead.
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: "^gpt-5-mini$",
+          inputCostPerToken: 0.000003,
+          outputCostPerToken: 0.000015,
+        },
+      });
+
+      expect(preview.sampleSpans).toHaveLength(1);
+      expect(preview.sampleSpans[0]!.spanId).toBe("span-mini");
+      expect(preview.sampleSpans[0]!.inputTokens).toBeNull();
       expect(preview.sampleSpans[0]!.exampleCost).toBeNull();
     });
   });
 
   describe("when the regex relies on the pipeline's matching fallbacks", () => {
+    /** @scenario Matching follows the same fallbacks as cost computation */
     it("matches a raw Bedrock inference-profile id through Bedrock normalization", async () => {
       // `eu.anthropic.claude-sonnet-4-6-v1:0` normalizes to
       // `anthropic/claude-sonnet-4-6` before matching, same as ingestion.
-      const preview = await previewCostRuleMatchingSpans(spans, {
-        projectId: tenantId,
-        regex: "anthropic/claude-sonnet-4-6",
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: "anthropic/claude-sonnet-4-6",
+        },
       });
 
       const matched = preview.matchedModels.map((m) => m.model);
@@ -258,9 +290,12 @@ describe("previewCostRuleMatchingSpans", () => {
 
   describe("when listing the project's recent models", () => {
     it("prefers the response model over the request model", async () => {
-      const preview = await previewCostRuleMatchingSpans(spans, {
-        projectId: tenantId,
-        regex: `^response-model-${ns}$`,
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: `^response-model-${ns}$`,
+        },
       });
 
       expect(preview.matchedModels.map((m) => m.model)).toContain(
@@ -272,19 +307,26 @@ describe("previewCostRuleMatchingSpans", () => {
     });
 
     it("excludes spans outside the preview window", async () => {
-      const preview = await previewCostRuleMatchingSpans(spans, {
-        projectId: tenantId,
-        regex: `^stale-model-${ns}$`,
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: `^stale-model-${ns}$`,
+        },
       });
 
       expect(preview.matchedModels).toHaveLength(0);
       expect(preview.totalMatchedSpans).toBe(0);
     });
 
+    /** @scenario Preview is scoped to the current project */
     it("never includes another tenant's spans", async () => {
-      const preview = await previewCostRuleMatchingSpans(spans, {
-        projectId: tenantId,
-        regex: ".*",
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: ".*",
+        },
       });
 
       const sampleSpanIds = preview.sampleSpans.map((s) => s.spanId);
@@ -293,9 +335,12 @@ describe("previewCostRuleMatchingSpans", () => {
     });
 
     it("ranks token-bearing spans ahead of token-less ones in the sample list", async () => {
-      const preview = await previewCostRuleMatchingSpans(spans, {
-        projectId: tenantId,
-        regex: ".*",
+      const preview = await previewCostRuleMatchingSpans({
+        spans,
+        input: {
+          projectId: tenantId,
+          regex: ".*",
+        },
       });
 
       const tokenless = preview.sampleSpans.findIndex(
@@ -313,9 +358,14 @@ describe("previewCostRuleMatchingSpans", () => {
   describe("when the regex is invalid or unsafe", () => {
     it("throws a validation error", async () => {
       await expect(
-        previewCostRuleMatchingSpans(spans, {
-          projectId: tenantId,
-          regex: "(a+)+$",
+        previewCostRuleMatchingSpans({
+          spans,
+          input: {
+            projectId: tenantId,
+            // Deliberately catastrophic pattern (exponential backtracking):
+            // the assertion is that the service refuses to ever compile it.
+            regex: "(a+)+$",
+          },
         }),
       ).rejects.toBeInstanceOf(ValidationError);
     });
@@ -414,6 +464,7 @@ describe("unmapped cost suggestion + scope-cascade rule resolution", () => {
   });
 
   describe("when the span carries no symptom", () => {
+    /** @scenario Span with a computed cost shows no suggestion */
     it("returns null when a cost was already computed", async () => {
       const suggestion = await deriveUnmappedCostSuggestion({
         projectId,
@@ -426,6 +477,7 @@ describe("unmapped cost suggestion + scope-cascade rule resolution", () => {
       expect(suggestion).toBeNull();
     });
 
+    /** @scenario Span without token counts shows no suggestion */
     it("returns null when the span has no token usage", async () => {
       const suggestion = await deriveUnmappedCostSuggestion({
         projectId,

--- a/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
@@ -1,0 +1,457 @@
+/**
+ * @vitest-environment node
+ *
+ * Model cost rule preview + unmapped-cost suggestion, against a real
+ * ClickHouse (span storage) and real Postgres (custom cost rules). No mocks —
+ * the whole point of the preview is parity with the production matching
+ * pipeline, so the tests drive the same repository, service, and matching
+ * functions production uses.
+ *
+ * Specs:
+ *   specs/model-providers/model-cost-matching-spans-preview.feature
+ *   specs/traces-v2/span-unmapped-cost-suggestion.feature
+ *   specs/model-providers/model-cost-scoping.feature (ingestion enrichment
+ *     resolves org/team-scoped rules through the scope cascade)
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../../event-sourcing/__tests__/integration/testContainers";
+import { ValidationError } from "../../domain-error";
+import {
+  deriveUnmappedCostSuggestion,
+  previewCostRuleMatchingSpans,
+} from "../model-cost-span-preview.service";
+import { SpanStorageClickHouseRepository } from "../repositories/span-storage.clickhouse.repository";
+import { createCostEnrichmentDeps } from "../span-cost-enrichment.service";
+import { SpanStorageService } from "../span-storage.service";
+
+const ns = nanoid(8);
+const tenantId = `test-cost-preview-${ns}`;
+const otherTenantId = `test-cost-preview-other-${ns}`;
+const nowMs = Date.now();
+const recentMs = nowMs - 60 * 60 * 1000;
+const beyondWindowMs = nowMs - 8 * 24 * 60 * 60 * 1000;
+
+let ch: ClickHouseClient;
+let spans: SpanStorageService;
+
+function makeSpanRow({
+  tenant,
+  traceId,
+  spanId,
+  startMs,
+  attributes,
+  spanName = "llm call",
+}: {
+  tenant: string;
+  traceId: string;
+  spanId: string;
+  startMs: number;
+  attributes: Record<string, string>;
+  spanName?: string;
+}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenant,
+    TraceId: traceId,
+    SpanId: spanId,
+    ParentSpanId: null,
+    ParentTraceId: null,
+    ParentIsRemote: null,
+    Sampled: 1,
+    StartTime: new Date(startMs),
+    EndTime: new Date(startMs + 250),
+    DurationMs: 250,
+    SpanName: spanName,
+    SpanKind: 1,
+    ServiceName: "test-service",
+    ResourceAttributes: {},
+    SpanAttributes: attributes,
+    StatusCode: 1,
+    StatusMessage: null,
+    ScopeName: "test",
+    ScopeVersion: null,
+    "Events.Timestamp": [] as Date[],
+    "Events.Name": [] as string[],
+    "Events.Attributes": [] as Record<string, string>[],
+    "Links.TraceId": [] as string[],
+    "Links.SpanId": [] as string[],
+    "Links.Attributes": [] as Record<string, string>[],
+    DroppedAttributesCount: 0,
+    DroppedEventsCount: 0,
+    DroppedLinksCount: 0,
+    CreatedAt: new Date(startMs),
+    UpdatedAt: new Date(startMs),
+  };
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  spans = new SpanStorageService(
+    new SpanStorageClickHouseRepository(async () => ch),
+  );
+
+  await ch.insert({
+    table: "stored_spans",
+    values: [
+      // Bedrock-prefixed model, canonical token keys.
+      makeSpanRow({
+        tenant: tenantId,
+        traceId: `trace-bedrock-${ns}`,
+        spanId: "span-bedrock",
+        startMs: recentMs,
+        spanName: "chat completion",
+        attributes: {
+          "gen_ai.request.model": "bedrock/eu.anthropic.claude-sonnet-4-6",
+          "gen_ai.usage.input_tokens": "1000",
+          "gen_ai.usage.output_tokens": "200",
+        },
+      }),
+      // Bedrock raw inference-profile id, legacy token keys.
+      makeSpanRow({
+        tenant: tenantId,
+        traceId: `trace-raw-bedrock-${ns}`,
+        spanId: "span-raw-bedrock",
+        startMs: recentMs - 1000,
+        attributes: {
+          "gen_ai.request.model": "eu.anthropic.claude-sonnet-4-6-v1:0",
+          "gen_ai.usage.prompt_tokens": "500",
+          "gen_ai.usage.completion_tokens": "50",
+        },
+      }),
+      // Registry-priced model with no token usage recorded.
+      makeSpanRow({
+        tenant: tenantId,
+        traceId: `trace-mini-${ns}`,
+        spanId: "span-mini",
+        startMs: recentMs - 2000,
+        attributes: {
+          "gen_ai.request.model": "gpt-5-mini",
+        },
+      }),
+      // Response model must win over request model.
+      makeSpanRow({
+        tenant: tenantId,
+        traceId: `trace-respmodel-${ns}`,
+        spanId: "span-respmodel",
+        startMs: recentMs - 3000,
+        attributes: {
+          "gen_ai.request.model": `request-model-${ns}`,
+          "gen_ai.response.model": `response-model-${ns}`,
+        },
+      }),
+      // Outside the preview window — must never appear.
+      makeSpanRow({
+        tenant: tenantId,
+        traceId: `trace-old-${ns}`,
+        spanId: "span-old",
+        startMs: beyondWindowMs,
+        attributes: {
+          "gen_ai.request.model": `stale-model-${ns}`,
+          "gen_ai.usage.input_tokens": "10",
+        },
+      }),
+      // Another tenant's span — must never leak into the preview.
+      makeSpanRow({
+        tenant: otherTenantId,
+        traceId: `trace-foreign-${ns}`,
+        spanId: "span-foreign",
+        startMs: recentMs,
+        attributes: {
+          "gen_ai.request.model": "bedrock/eu.anthropic.claude-sonnet-4-6",
+          "gen_ai.usage.input_tokens": "9999",
+        },
+      }),
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+});
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query:
+        "ALTER TABLE stored_spans DELETE WHERE TenantId IN ({a:String}, {b:String})",
+      query_params: { a: tenantId, b: otherTenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("previewCostRuleMatchingSpans", () => {
+  describe("when the regex matches a recorded model exactly", () => {
+    it("lists the matching model with sample spans, tokens, and an example cost", async () => {
+      const preview = await previewCostRuleMatchingSpans(spans, {
+        projectId: tenantId,
+        regex: "^bedrock/eu\\.anthropic\\.claude-sonnet-4-6$",
+        inputCostPerToken: 0.000003,
+        outputCostPerToken: 0.000015,
+      });
+
+      expect(preview.matchedModels).toHaveLength(1);
+      expect(preview.matchedModels[0]!.model).toBe(
+        "bedrock/eu.anthropic.claude-sonnet-4-6",
+      );
+      expect(preview.totalMatchedSpans).toBe(1);
+
+      expect(preview.sampleSpans).toHaveLength(1);
+      const sample = preview.sampleSpans[0]!;
+      expect(sample.spanId).toBe("span-bedrock");
+      expect(sample.traceId).toBe(`trace-bedrock-${ns}`);
+      expect(sample.spanName).toBe("chat completion");
+      expect(sample.inputTokens).toBe(1000);
+      expect(sample.outputTokens).toBe(200);
+      expect(sample.exampleCost).toBeCloseTo(
+        1000 * 0.000003 + 200 * 0.000015,
+        10,
+      );
+
+      const unmatched = preview.unmatchedModels.map((m) => m.model);
+      expect(unmatched).toContain("eu.anthropic.claude-sonnet-4-6-v1:0");
+      expect(unmatched).toContain("gpt-5-mini");
+    });
+
+    it("reads token counts from the legacy prompt/completion attribute aliases", async () => {
+      const preview = await previewCostRuleMatchingSpans(spans, {
+        projectId: tenantId,
+        regex: "^eu\\.anthropic\\.claude-sonnet-4-6-v1:0$",
+        inputCostPerToken: 0.000002,
+        outputCostPerToken: 0.00001,
+      });
+
+      expect(preview.sampleSpans).toHaveLength(1);
+      const sample = preview.sampleSpans[0]!;
+      expect(sample.inputTokens).toBe(500);
+      expect(sample.outputTokens).toBe(50);
+    });
+
+    it("returns no example cost when no rates were entered yet", async () => {
+      const preview = await previewCostRuleMatchingSpans(spans, {
+        projectId: tenantId,
+        regex: "^bedrock/eu\\.anthropic\\.claude-sonnet-4-6$",
+      });
+
+      expect(preview.sampleSpans[0]!.exampleCost).toBeNull();
+    });
+  });
+
+  describe("when the regex relies on the pipeline's matching fallbacks", () => {
+    it("matches a raw Bedrock inference-profile id through Bedrock normalization", async () => {
+      // `eu.anthropic.claude-sonnet-4-6-v1:0` normalizes to
+      // `anthropic/claude-sonnet-4-6` before matching — same as ingestion.
+      const preview = await previewCostRuleMatchingSpans(spans, {
+        projectId: tenantId,
+        regex: "anthropic/claude-sonnet-4-6",
+      });
+
+      const matched = preview.matchedModels.map((m) => m.model);
+      expect(matched).toContain("eu.anthropic.claude-sonnet-4-6-v1:0");
+    });
+  });
+
+  describe("when listing the project's recent models", () => {
+    it("prefers the response model over the request model", async () => {
+      const preview = await previewCostRuleMatchingSpans(spans, {
+        projectId: tenantId,
+        regex: `^response-model-${ns}$`,
+      });
+
+      expect(preview.matchedModels.map((m) => m.model)).toContain(
+        `response-model-${ns}`,
+      );
+      expect(preview.unmatchedModels.map((m) => m.model)).not.toContain(
+        `request-model-${ns}`,
+      );
+    });
+
+    it("excludes spans outside the preview window", async () => {
+      const preview = await previewCostRuleMatchingSpans(spans, {
+        projectId: tenantId,
+        regex: `^stale-model-${ns}$`,
+      });
+
+      expect(preview.matchedModels).toHaveLength(0);
+      expect(preview.totalMatchedSpans).toBe(0);
+    });
+
+    it("never includes another tenant's spans", async () => {
+      const preview = await previewCostRuleMatchingSpans(spans, {
+        projectId: tenantId,
+        regex: ".*",
+      });
+
+      const sampleSpanIds = preview.sampleSpans.map((s) => s.spanId);
+      expect(sampleSpanIds).not.toContain("span-foreign");
+      expect(preview.totalMatchedSpans).toBe(4);
+    });
+
+    it("ranks token-bearing spans ahead of token-less ones in the sample list", async () => {
+      const preview = await previewCostRuleMatchingSpans(spans, {
+        projectId: tenantId,
+        regex: ".*",
+      });
+
+      const tokenless = preview.sampleSpans.findIndex(
+        (s) => s.inputTokens === null && s.outputTokens === null,
+      );
+      const lastTokenBearing = preview.sampleSpans.reduce(
+        (last, s, i) =>
+          s.inputTokens !== null || s.outputTokens !== null ? i : last,
+        -1,
+      );
+      expect(tokenless).toBeGreaterThan(lastTokenBearing);
+    });
+  });
+
+  describe("when the regex is invalid or unsafe", () => {
+    it("throws a validation error", async () => {
+      await expect(
+        previewCostRuleMatchingSpans(spans, {
+          projectId: tenantId,
+          regex: "(a+)+$",
+        }),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+});
+
+describe("unmapped cost suggestion + scope-cascade rule resolution", () => {
+  const orgId = `org-${ns}`;
+  const teamId = `team-${ns}`;
+  const projectId = `proj-${ns}`;
+  const unmappedModel = `acme-internal-llm-${ns}`;
+  const orgRuleModel = `acme-org-llm-${ns}`;
+
+  beforeAll(async () => {
+    await prisma.organization.create({
+      data: { id: orgId, name: orgId, slug: orgId },
+    });
+    await prisma.team.create({
+      data: { id: teamId, name: teamId, slug: teamId, organizationId: orgId },
+    });
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        name: projectId,
+        slug: projectId,
+        teamId,
+        language: "en",
+        framework: "openai",
+        apiKey: `key-${projectId}`,
+      },
+    });
+    // Organization-scoped rule (legacy projectId column stays null) — the
+    // shape that used to be invisible to ingestion enrichment.
+    await prisma.customLLMModelCost.create({
+      data: {
+        id: `llmcost_${nanoid()}`,
+        organizationId: orgId,
+        scopeType: "ORGANIZATION",
+        scopeId: orgId,
+        projectId: null,
+        model: orgRuleModel,
+        regex: `^${orgRuleModel}$`,
+        inputCostPerToken: 0.000001,
+        outputCostPerToken: 0.000002,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.customLLMModelCost.deleteMany({
+      where: { organizationId: orgId },
+    });
+    await prisma.project.deleteMany({ where: { id: projectId } });
+    await prisma.team.deleteMany({ where: { id: teamId } });
+    await prisma.organization.deleteMany({ where: { id: orgId } });
+  });
+
+  describe("when a span has tokens and a model nothing prices", () => {
+    it("suggests creating a cost mapping", async () => {
+      const suggestion = await deriveUnmappedCostSuggestion({
+        projectId,
+        model: unmappedModel,
+        cost: null,
+        promptTokens: 1200,
+        completionTokens: 80,
+      });
+
+      expect(suggestion).toEqual({ model: unmappedModel });
+    });
+  });
+
+  describe("when the model is already priced", () => {
+    it("returns null for a model covered by the static registry", async () => {
+      const suggestion = await deriveUnmappedCostSuggestion({
+        projectId,
+        model: "gpt-5-mini",
+        cost: null,
+        promptTokens: 100,
+        completionTokens: 10,
+      });
+
+      expect(suggestion).toBeNull();
+    });
+
+    it("returns null for a model covered by an organization-scoped custom rule", async () => {
+      const suggestion = await deriveUnmappedCostSuggestion({
+        projectId,
+        model: orgRuleModel,
+        cost: null,
+        promptTokens: 100,
+        completionTokens: 10,
+      });
+
+      expect(suggestion).toBeNull();
+    });
+  });
+
+  describe("when the span carries no symptom", () => {
+    it("returns null when a cost was already computed", async () => {
+      const suggestion = await deriveUnmappedCostSuggestion({
+        projectId,
+        model: unmappedModel,
+        cost: 0.01,
+        promptTokens: 100,
+        completionTokens: 10,
+      });
+
+      expect(suggestion).toBeNull();
+    });
+
+    it("returns null when the span has no token usage", async () => {
+      const suggestion = await deriveUnmappedCostSuggestion({
+        projectId,
+        model: unmappedModel,
+        cost: null,
+        promptTokens: null,
+        completionTokens: 0,
+      });
+
+      expect(suggestion).toBeNull();
+    });
+  });
+
+  describe("when ingestion enrichment loads custom rules for a project", () => {
+    it("resolves organization-scoped rules through the scope cascade", async () => {
+      // Regression: enrichment used to filter customLLMModelCost by the
+      // legacy projectId column, so ORGANIZATION/TEAM-scoped rules
+      // (projectId = null) never applied at ingestion and spans stayed
+      // uncosted despite a configured rule.
+      const costs =
+        await createCostEnrichmentDeps(prisma).getCustomModelCosts(projectId);
+
+      expect(costs.map((c) => c.model)).toContain(orgRuleModel);
+      const orgRule = costs.find((c) => c.model === orgRuleModel)!;
+      expect(orgRule.inputCostPerToken).toBe(0.000001);
+      expect(orgRule.scopeType).toBe("ORGANIZATION");
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  *
  * Model cost rule preview + unmapped-cost suggestion, against a real
- * ClickHouse (span storage) and real Postgres (custom cost rules). No mocks —
+ * ClickHouse (span storage) and real Postgres (custom cost rules). No mocks,
  * the whole point of the preview is parity with the production matching
  * pipeline, so the tests drive the same repository, service, and matching
  * functions production uses.
@@ -146,7 +146,7 @@ beforeAll(async () => {
           "gen_ai.response.model": `response-model-${ns}`,
         },
       }),
-      // Outside the preview window — must never appear.
+      // Outside the preview window, must never appear.
       makeSpanRow({
         tenant: tenantId,
         traceId: `trace-old-${ns}`,
@@ -157,7 +157,7 @@ beforeAll(async () => {
           "gen_ai.usage.input_tokens": "10",
         },
       }),
-      // Another tenant's span — must never leak into the preview.
+      // Another tenant's span, must never leak into the preview.
       makeSpanRow({
         tenant: otherTenantId,
         traceId: `trace-foreign-${ns}`,
@@ -245,7 +245,7 @@ describe("previewCostRuleMatchingSpans", () => {
   describe("when the regex relies on the pipeline's matching fallbacks", () => {
     it("matches a raw Bedrock inference-profile id through Bedrock normalization", async () => {
       // `eu.anthropic.claude-sonnet-4-6-v1:0` normalizes to
-      // `anthropic/claude-sonnet-4-6` before matching — same as ingestion.
+      // `anthropic/claude-sonnet-4-6` before matching, same as ingestion.
       const preview = await previewCostRuleMatchingSpans(spans, {
         projectId: tenantId,
         regex: "anthropic/claude-sonnet-4-6",
@@ -347,7 +347,7 @@ describe("unmapped cost suggestion + scope-cascade rule resolution", () => {
         apiKey: `key-${projectId}`,
       },
     });
-    // Organization-scoped rule (legacy projectId column stays null) — the
+    // Organization-scoped rule (legacy projectId column stays null), the
     // shape that used to be invisible to ingestion enrichment.
     await prisma.customLLMModelCost.create({
       data: {

--- a/langwatch/src/server/app-layer/traces/model-cost-span-preview.service.ts
+++ b/langwatch/src/server/app-layer/traces/model-cost-span-preview.service.ts
@@ -1,0 +1,172 @@
+import {
+  estimateCost,
+  matchModelCostWithFallbacks,
+} from "~/server/background/workers/collector/cost";
+import {
+  getLLMModelCosts,
+  type MaybeStoredLLMModelCost,
+} from "~/server/modelProviders/llmModelCost";
+import { compileSafeRegex } from "~/utils/safeRegex";
+import { ValidationError } from "../domain-error";
+import type { SpanStorageService } from "./span-storage.service";
+
+/**
+ * How far back the preview looks for spans. Wide enough to catch models that
+ * only run a few times a week, narrow enough to stay on warm partitions.
+ */
+export const PREVIEW_WINDOW_DAYS = 7;
+
+/** Project-wide distinct-model inventory cap for one preview round. */
+const MAX_DISTINCT_MODELS = 500;
+
+/** Sample-span list shown under the regex field. */
+const MAX_SAMPLE_SPANS = 10;
+const PER_MODEL_SAMPLE_LIMIT = 3;
+
+/** Non-matching models surfaced in the zero/partial-match hint. */
+const MAX_UNMATCHED_MODELS = 8;
+
+export interface CostRulePreviewInput {
+  projectId: string;
+  regex: string;
+  model?: string;
+  inputCostPerToken?: number;
+  outputCostPerToken?: number;
+  cacheReadCostPerToken?: number;
+  cacheCreationCostPerToken?: number;
+}
+
+export interface CostRulePreviewSampleSpan {
+  traceId: string;
+  spanId: string;
+  spanName: string;
+  model: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheReadTokens: number | null;
+  cacheCreationTokens: number | null;
+  startTimeMs: number;
+  /**
+   * What this span would cost under the rates being edited, or null when no
+   * rates were entered yet (or the span carries no token usage).
+   */
+  exampleCost: number | null;
+}
+
+export interface CostRuleMatchingSpansPreview {
+  windowDays: number;
+  totalMatchedSpans: number;
+  matchedModels: Array<{
+    model: string;
+    spanCount: number;
+    lastSeenMs: number;
+  }>;
+  sampleSpans: CostRulePreviewSampleSpan[];
+  unmatchedModels: Array<{ model: string; spanCount: number }>;
+}
+
+/**
+ * Previews which of the project's recently-seen models (and sample spans) a
+ * model cost rule's regex would match.
+ *
+ * Matching deliberately runs through `matchModelCostWithFallbacks` — the
+ * exact function the ingestion pipeline uses — so the preview can never
+ * disagree with what the rule will actually do (vendor-prefix stripping,
+ * Bedrock id normalization, lowercase fallback and all).
+ */
+export async function previewCostRuleMatchingSpans(
+  spans: SpanStorageService,
+  input: CostRulePreviewInput,
+): Promise<CostRuleMatchingSpansPreview> {
+  if (!compileSafeRegex(input.regex)) {
+    throw new ValidationError("Invalid or unsafe regular expression");
+  }
+
+  const candidate: MaybeStoredLLMModelCost = {
+    projectId: input.projectId,
+    model: input.model ?? input.regex,
+    regex: input.regex,
+    inputCostPerToken: input.inputCostPerToken,
+    outputCostPerToken: input.outputCostPerToken,
+    cacheReadCostPerToken: input.cacheReadCostPerToken,
+    cacheCreationCostPerToken: input.cacheCreationCostPerToken,
+  };
+
+  const fromMs = Date.now() - PREVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  const stats = await spans.getModelUsageStats({
+    tenantId: input.projectId,
+    fromMs,
+    limit: MAX_DISTINCT_MODELS,
+  });
+
+  const matchedModels: CostRuleMatchingSpansPreview["matchedModels"] = [];
+  const unmatchedModels: CostRuleMatchingSpansPreview["unmatchedModels"] = [];
+  for (const stat of stats) {
+    if (matchModelCostWithFallbacks(stat.model, [candidate])) {
+      matchedModels.push(stat);
+    } else if (unmatchedModels.length < MAX_UNMATCHED_MODELS) {
+      unmatchedModels.push({ model: stat.model, spanCount: stat.spanCount });
+    }
+  }
+
+  let sampleSpans: CostRulePreviewSampleSpan[] = [];
+  if (matchedModels.length > 0) {
+    const rows = await spans.getRecentSpansByModels({
+      tenantId: input.projectId,
+      models: matchedModels.map((m) => m.model),
+      fromMs,
+      perModelLimit: PER_MODEL_SAMPLE_LIMIT,
+      limit: MAX_SAMPLE_SPANS,
+    });
+    sampleSpans = rows.map((row) => ({
+      ...row,
+      exampleCost:
+        estimateCost({
+          llmModelCost: candidate,
+          inputTokens: row.inputTokens ?? 0,
+          outputTokens: row.outputTokens ?? 0,
+          cacheReadTokens: row.cacheReadTokens ?? 0,
+          cacheCreationTokens: row.cacheCreationTokens ?? 0,
+        }) ?? null,
+    }));
+  }
+
+  return {
+    windowDays: PREVIEW_WINDOW_DAYS,
+    totalMatchedSpans: matchedModels.reduce((sum, m) => sum + m.spanCount, 0),
+    matchedModels,
+    sampleSpans,
+    unmatchedModels,
+  };
+}
+
+/**
+ * Decides whether a span's detail view should suggest creating a model cost
+ * mapping: the span names a model and carries token usage, yet no cost was
+ * computed for it AND no cost entry (custom rule or static registry) matches
+ * the model. The last check keeps the suggestion from showing on spans that
+ * pre-date a rule the user already created.
+ */
+export async function deriveUnmappedCostSuggestion({
+  projectId,
+  model,
+  cost,
+  promptTokens,
+  completionTokens,
+}: {
+  projectId: string;
+  model: string | null;
+  cost: number | null | undefined;
+  promptTokens: number | null | undefined;
+  completionTokens: number | null | undefined;
+}): Promise<{ model: string } | null> {
+  if (!model) return null;
+  if (cost != null) return null;
+  const hasTokens = (promptTokens ?? 0) > 0 || (completionTokens ?? 0) > 0;
+  if (!hasTokens) return null;
+
+  const costs = await getLLMModelCosts({ projectId });
+  if (matchModelCostWithFallbacks(model, costs)) return null;
+
+  return { model };
+}

--- a/langwatch/src/server/app-layer/traces/model-cost-span-preview.service.ts
+++ b/langwatch/src/server/app-layer/traces/model-cost-span-preview.service.ts
@@ -69,8 +69,8 @@ export interface CostRuleMatchingSpansPreview {
  * Previews which of the project's recently-seen models (and sample spans) a
  * model cost rule's regex would match.
  *
- * Matching deliberately runs through `matchModelCostWithFallbacks` — the
- * exact function the ingestion pipeline uses — so the preview can never
+ * Matching deliberately runs through `matchModelCostWithFallbacks`, the
+ * exact function the ingestion pipeline uses, so the preview can never
  * disagree with what the rule will actually do (vendor-prefix stripping,
  * Bedrock id normalization, lowercase fallback and all).
  */

--- a/langwatch/src/server/app-layer/traces/model-cost-span-preview.service.ts
+++ b/langwatch/src/server/app-layer/traces/model-cost-span-preview.service.ts
@@ -74,10 +74,13 @@ export interface CostRuleMatchingSpansPreview {
  * disagree with what the rule will actually do (vendor-prefix stripping,
  * Bedrock id normalization, lowercase fallback and all).
  */
-export async function previewCostRuleMatchingSpans(
-  spans: SpanStorageService,
-  input: CostRulePreviewInput,
-): Promise<CostRuleMatchingSpansPreview> {
+export async function previewCostRuleMatchingSpans({
+  spans,
+  input,
+}: {
+  spans: SpanStorageService;
+  input: CostRulePreviewInput;
+}): Promise<CostRuleMatchingSpansPreview> {
   if (!compileSafeRegex(input.regex)) {
     throw new ValidationError("Invalid or unsafe regular expression");
   }
@@ -118,17 +121,25 @@ export async function previewCostRuleMatchingSpans(
       perModelLimit: PER_MODEL_SAMPLE_LIMIT,
       limit: MAX_SAMPLE_SPANS,
     });
-    sampleSpans = rows.map((row) => ({
-      ...row,
-      exampleCost:
-        estimateCost({
-          llmModelCost: candidate,
-          inputTokens: row.inputTokens ?? 0,
-          outputTokens: row.outputTokens ?? 0,
-          cacheReadTokens: row.cacheReadTokens ?? 0,
-          cacheCreationTokens: row.cacheCreationTokens ?? 0,
-        }) ?? null,
-    }));
+    sampleSpans = rows.map((row) => {
+      const hasTokenUsage =
+        row.inputTokens !== null ||
+        row.outputTokens !== null ||
+        row.cacheReadTokens !== null ||
+        row.cacheCreationTokens !== null;
+      return {
+        ...row,
+        exampleCost: !hasTokenUsage
+          ? null
+          : (estimateCost({
+              llmModelCost: candidate,
+              inputTokens: row.inputTokens ?? 0,
+              outputTokens: row.outputTokens ?? 0,
+              cacheReadTokens: row.cacheReadTokens ?? 0,
+              cacheCreationTokens: row.cacheCreationTokens ?? 0,
+            }) ?? null),
+      };
+    });
   }
 
   return {

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -15,6 +15,8 @@ import { createLogger } from "~/utils/logger/server";
 import type { SpanInsertData } from "../types";
 import type {
   LangwatchSignalBucket,
+  ModelSpanSampleRow,
+  ModelUsageStatsRow,
   OccurredAtHint,
   SpanLangwatchSignalsRow,
   SpanResourceInfo,
@@ -172,6 +174,59 @@ const SUMMARY_SPAN_SELECT = `
 `;
 
 /**
+ * Canonical model-name expression — response model wins over request model,
+ * mirroring `extractModel` in span.mapper.ts so the cost-rule preview sees
+ * the same model string the cost pipeline matches against. Map subscripts
+ * return '' for missing keys, hence the nullIf/coalesce dance.
+ */
+const MODEL_ATTR_SELECT = `coalesce(
+    nullIf(SpanAttributes['gen_ai.response.model'], ''),
+    SpanAttributes['gen_ai.request.model']
+  )`;
+
+interface ModelSpanSampleQueryRow {
+  TraceId: string;
+  SpanId: string;
+  SpanName: string;
+  Model: string;
+  InputTokensRaw: string;
+  PromptTokensRaw: string;
+  OutputTokensRaw: string;
+  CompletionTokensRaw: string;
+  CacheReadTokensRaw: string;
+  CacheCreationTokensRaw: string;
+  StartTimeMs: number | string;
+}
+
+/** Map-subscript token values arrive as strings ('' when absent). */
+function tokenCount(...raws: string[]): number | null {
+  for (const raw of raws) {
+    if (raw === "") continue;
+    const num = Number(raw);
+    return Number.isFinite(num) ? num : null;
+  }
+  return null;
+}
+
+function mapModelSpanSampleRow(
+  row: ModelSpanSampleQueryRow,
+): ModelSpanSampleRow {
+  return {
+    traceId: row.TraceId,
+    spanId: row.SpanId,
+    spanName: row.SpanName,
+    model: row.Model,
+    // Canonical key first, legacy alias as fallback — same coalesce order
+    // as extractMetrics in span.mapper.ts.
+    inputTokens: tokenCount(row.InputTokensRaw, row.PromptTokensRaw),
+    outputTokens: tokenCount(row.OutputTokensRaw, row.CompletionTokensRaw),
+    cacheReadTokens: tokenCount(row.CacheReadTokensRaw),
+    cacheCreationTokens: tokenCount(row.CacheCreationTokensRaw),
+    startTimeMs: Number(row.StartTimeMs),
+  };
+}
+
+/**
  * IN-tuple dedup subquery body. Renders the inner `SELECT … GROUP BY` that
  * picks the latest version (max UpdatedAt) per spanId. Caller assembles the
  * surrounding `AND (TenantId, TraceId, SpanId, UpdatedAt) IN (…)`.
@@ -204,8 +259,7 @@ const SIGNAL_BUCKET_PREDICATES: Record<LangwatchSignalBucket, string> = {
   user: "arrayExists(k -> k = 'langwatch.user_id' OR startsWith(k, 'langwatch.user.'), keys)",
   thread:
     "arrayExists(k -> k = 'gen_ai.conversation.id' OR k = 'langgraph.thread_id' OR startsWith(k, 'langwatch.thread.'), keys)",
-  evaluation:
-    "arrayExists(k -> startsWith(k, 'langwatch.evaluation'), keys)",
+  evaluation: "arrayExists(k -> startsWith(k, 'langwatch.evaluation'), keys)",
   rag: "arrayExists(k -> startsWith(k, 'langwatch.rag.'), keys)",
   metadata: "arrayExists(k -> startsWith(k, 'langwatch.metadata.'), keys)",
   genai: "arrayExists(k -> startsWith(k, 'gen_ai.'), keys)",
@@ -1492,6 +1546,113 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         return rows.map(mapSpanSummaryRow);
       },
     );
+  }
+
+  async findModelUsageStats({
+    tenantId,
+    fromMs,
+    limit,
+  }: {
+    tenantId: string;
+    fromMs: number;
+    limit: number;
+  }): Promise<ModelUsageStatsRow[]> {
+    EventUtils.validateTenantId(
+      { tenantId },
+      "SpanStorageClickHouseRepository.findModelUsageStats",
+    );
+
+    const client = await this.resolveClient(tenantId);
+    // Cross-trace scan bounded by the StartTime window (partition pruning)
+    // and reading only two Map subscripts — no heavy attribute values.
+    // `uniq` (approximate) instead of count() so ReplacingMergeTree row
+    // versions don't inflate the per-model span counts.
+    const result = await client.query({
+      query: `
+        SELECT
+          ${MODEL_ATTR_SELECT} AS Model,
+          uniq(TraceId, SpanId) AS SpanCount,
+          toUnixTimestamp64Milli(max(StartTime)) AS LastSeenMs
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND StartTime >= fromUnixTimestamp64Milli({fromMs:Int64})
+          AND Model != ''
+        GROUP BY Model
+        ORDER BY SpanCount DESC, Model ASC
+        LIMIT {limit:UInt32}
+      `,
+      query_params: { tenantId, fromMs, limit },
+      format: "JSONEachRow",
+    });
+
+    const rows = await result.json<{
+      Model: string;
+      SpanCount: number | string;
+      LastSeenMs: number | string;
+    }>();
+    return rows.map((row) => ({
+      model: row.Model,
+      spanCount: Number(row.SpanCount),
+      lastSeenMs: Number(row.LastSeenMs),
+    }));
+  }
+
+  async findRecentSpansByModels({
+    tenantId,
+    models,
+    fromMs,
+    perModelLimit,
+    limit,
+  }: {
+    tenantId: string;
+    models: string[];
+    fromMs: number;
+    perModelLimit: number;
+    limit: number;
+  }): Promise<ModelSpanSampleRow[]> {
+    EventUtils.validateTenantId(
+      { tenantId },
+      "SpanStorageClickHouseRepository.findRecentSpansByModels",
+    );
+    if (models.length === 0) return [];
+
+    const client = await this.resolveClient(tenantId);
+    // Light columns only (scalars + token Map subscripts), grouped by span
+    // with argMax so ReplacingMergeTree versions dedup to the latest row.
+    // Spans carrying token usage sort first — a token-less span makes a
+    // poor cost example — then recency. `LIMIT BY` keeps one chatty model
+    // from crowding out the rest of the sample.
+    const result = await client.query({
+      query: `
+        SELECT
+          TraceId,
+          SpanId,
+          ${MODEL_ATTR_SELECT} AS Model,
+          argMax(SpanName, UpdatedAt) AS SpanName,
+          argMax(SpanAttributes['gen_ai.usage.input_tokens'], UpdatedAt) AS InputTokensRaw,
+          argMax(SpanAttributes['gen_ai.usage.prompt_tokens'], UpdatedAt) AS PromptTokensRaw,
+          argMax(SpanAttributes['gen_ai.usage.output_tokens'], UpdatedAt) AS OutputTokensRaw,
+          argMax(SpanAttributes['gen_ai.usage.completion_tokens'], UpdatedAt) AS CompletionTokensRaw,
+          argMax(SpanAttributes['gen_ai.usage.cache_read.input_tokens'], UpdatedAt) AS CacheReadTokensRaw,
+          argMax(SpanAttributes['gen_ai.usage.cache_creation.input_tokens'], UpdatedAt) AS CacheCreationTokensRaw,
+          argMax(toUnixTimestamp64Milli(StartTime), UpdatedAt) AS StartTimeMs,
+          (InputTokensRaw != '' OR PromptTokensRaw != ''
+            OR OutputTokensRaw != '' OR CompletionTokensRaw != '') AS HasTokens
+        FROM ${TABLE_NAME}
+        WHERE TenantId = {tenantId:String}
+          AND StartTime >= fromUnixTimestamp64Milli({fromMs:Int64})
+          AND Model IN {models:Array(String)}
+        GROUP BY TraceId, SpanId, Model
+        ORDER BY HasTokens DESC, StartTimeMs DESC
+        LIMIT {perModelLimit:UInt32} BY Model
+        LIMIT {limit:UInt32}
+      `,
+      query_params: { tenantId, models, fromMs, perModelLimit, limit },
+      format: "JSONEachRow",
+    });
+
+    const rows = await result.json<ModelSpanSampleQueryRow>();
+    return rows.map(mapModelSpanSampleRow);
   }
 
   private toClickHouseRecord(span: SpanInsertData): ClickHouseSpanWriteRecord {

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -174,7 +174,7 @@ const SUMMARY_SPAN_SELECT = `
 `;
 
 /**
- * Canonical model-name expression — response model wins over request model,
+ * Canonical model-name expression, response model wins over request model,
  * mirroring `extractModel` in span.mapper.ts so the cost-rule preview sees
  * the same model string the cost pipeline matches against. Map subscripts
  * return '' for missing keys, hence the nullIf/coalesce dance.
@@ -216,7 +216,7 @@ function mapModelSpanSampleRow(
     spanId: row.SpanId,
     spanName: row.SpanName,
     model: row.Model,
-    // Canonical key first, legacy alias as fallback — same coalesce order
+    // Canonical key first, legacy alias as fallback, same coalesce order
     // as extractMetrics in span.mapper.ts.
     inputTokens: tokenCount(row.InputTokensRaw, row.PromptTokensRaw),
     outputTokens: tokenCount(row.OutputTokensRaw, row.CompletionTokensRaw),
@@ -1564,7 +1564,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
 
     const client = await this.resolveClient(tenantId);
     // Cross-trace scan bounded by the StartTime window (partition pruning)
-    // and reading only two Map subscripts — no heavy attribute values.
+    // and reading only two Map subscripts, no heavy attribute values.
     // `uniq` (approximate) instead of count() so ReplacingMergeTree row
     // versions don't inflate the per-model span counts.
     const result = await client.query({
@@ -1619,8 +1619,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     const client = await this.resolveClient(tenantId);
     // Light columns only (scalars + token Map subscripts), grouped by span
     // with argMax so ReplacingMergeTree versions dedup to the latest row.
-    // Spans carrying token usage sort first — a token-less span makes a
-    // poor cost example — then recency. `LIMIT BY` keeps one chatty model
+    // Spans carrying token usage sort first, a token-less span makes a
+    // poor cost example, then recency. `LIMIT BY` keeps one chatty model
     // from crowding out the rest of the sample.
     const result = await client.query({
       query: `

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -1,6 +1,6 @@
-import type { ElasticSearchEvent, Span } from "~/server/tracer/types";
-import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import type { DerivedTraceEvent } from "~/server/event-sourcing/pipelines/trace-processing/projections/services/trace-events.derivation";
+import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import type { ElasticSearchEvent, Span } from "~/server/tracer/types";
 import type { SpanInsertData } from "../types";
 
 /**
@@ -23,7 +23,9 @@ export const MAX_DERIVATION_SPANS = 512;
  * ceiling so the value never propagates into a ClickHouse `UInt32` param.
  */
 export function clampSpanReadLimit(limit?: number): number {
-  const requested = Number.isFinite(limit) ? (limit as number) : MAX_DERIVATION_SPANS;
+  const requested = Number.isFinite(limit)
+    ? (limit as number)
+    : MAX_DERIVATION_SPANS;
   return Math.min(Math.max(1, Math.trunc(requested)), MAX_DERIVATION_SPANS);
 }
 
@@ -88,6 +90,33 @@ export interface OccurredAtHint {
   occurredAtMs?: number;
 }
 
+/**
+ * Per-model usage rollup over a recent window — feeds the model cost rule
+ * preview ("which models would this regex match, and how much traffic do
+ * they carry").
+ */
+export interface ModelUsageStatsRow {
+  model: string;
+  spanCount: number;
+  lastSeenMs: number;
+}
+
+/**
+ * Light per-span sample for the model cost rule preview list. Token counts
+ * are null when the span carries no usage attributes.
+ */
+export interface ModelSpanSampleRow {
+  traceId: string;
+  spanId: string;
+  spanName: string;
+  model: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheReadTokens: number | null;
+  cacheCreationTokens: number | null;
+  startTimeMs: number;
+}
+
 export interface SpanStorageRepository {
   insertSpan(span: SpanInsertData): Promise<void>;
   insertSpans(spans: SpanInsertData[]): Promise<void>;
@@ -97,7 +126,11 @@ export interface SpanStorageRepository {
    * trace_id. `limit` may only lower the bound.
    */
   getSpansByTraceId(
-    params: { tenantId: string; traceId: string; limit?: number } & OccurredAtHint,
+    params: {
+      tenantId: string;
+      traceId: string;
+      limit?: number;
+    } & OccurredAtHint,
   ): Promise<Span[]>;
   /**
    * Normalized spans for a trace, used by read-time derivations (trace events
@@ -106,7 +139,11 @@ export interface SpanStorageRepository {
    * trace can't make the derivation read unbounded.
    */
   getNormalizedSpansByTraceId(
-    params: { tenantId: string; traceId: string; limit?: number } & OccurredAtHint,
+    params: {
+      tenantId: string;
+      traceId: string;
+      limit?: number;
+    } & OccurredAtHint,
   ): Promise<NormalizedSpan[]>;
   getSpanByIds(
     params: {
@@ -179,11 +216,37 @@ export interface SpanStorageRepository {
       sinceStartTimeMs: number;
     } & OccurredAtHint,
   ): Promise<Span[]>;
+  /**
+   * Distinct model names seen on the tenant's spans since `fromMs`, with
+   * span counts, ordered by traffic. Cross-trace by design (no traceId) —
+   * the model cost rule preview needs the project-wide model inventory.
+   */
+  findModelUsageStats(params: {
+    tenantId: string;
+    fromMs: number;
+    limit: number;
+  }): Promise<ModelUsageStatsRow[]>;
+  /**
+   * Most recent spans whose model is one of `models`, capped per model so a
+   * single chatty model can't crowd the sample list. Spans carrying token
+   * usage are preferred over token-less ones.
+   */
+  findRecentSpansByModels(params: {
+    tenantId: string;
+    models: string[];
+    fromMs: number;
+    perModelLimit: number;
+    limit: number;
+  }): Promise<ModelSpanSampleRow[]>;
 }
 
 export class NullSpanStorageRepository implements SpanStorageRepository {
-  async insertSpan(_span: SpanInsertData): Promise<void> {}
-  async insertSpans(_spans: SpanInsertData[]): Promise<void> {}
+  async insertSpan(_span: SpanInsertData): Promise<void> {
+    // No-op storage.
+  }
+  async insertSpans(_spans: SpanInsertData[]): Promise<void> {
+    // No-op storage.
+  }
 
   async getSpansByTraceId(
     _params: { tenantId: string; traceId: string } & OccurredAtHint,
@@ -192,7 +255,11 @@ export class NullSpanStorageRepository implements SpanStorageRepository {
   }
 
   async getNormalizedSpansByTraceId(
-    _params: { tenantId: string; traceId: string; limit?: number } & OccurredAtHint,
+    _params: {
+      tenantId: string;
+      traceId: string;
+      limit?: number;
+    } & OccurredAtHint,
   ): Promise<NormalizedSpan[]> {
     return [];
   }
@@ -286,6 +353,24 @@ export class NullSpanStorageRepository implements SpanStorageRepository {
       sinceStartTimeMs: number;
     } & OccurredAtHint,
   ): Promise<Span[]> {
+    return [];
+  }
+
+  async findModelUsageStats(_params: {
+    tenantId: string;
+    fromMs: number;
+    limit: number;
+  }): Promise<ModelUsageStatsRow[]> {
+    return [];
+  }
+
+  async findRecentSpansByModels(_params: {
+    tenantId: string;
+    models: string[];
+    fromMs: number;
+    perModelLimit: number;
+    limit: number;
+  }): Promise<ModelSpanSampleRow[]> {
     return [];
   }
 }

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.repository.ts
@@ -91,7 +91,7 @@ export interface OccurredAtHint {
 }
 
 /**
- * Per-model usage rollup over a recent window — feeds the model cost rule
+ * Per-model usage rollup over a recent window, feeds the model cost rule
  * preview ("which models would this regex match, and how much traffic do
  * they carry").
  */
@@ -218,7 +218,7 @@ export interface SpanStorageRepository {
   ): Promise<Span[]>;
   /**
    * Distinct model names seen on the tenant's spans since `fromMs`, with
-   * span counts, ordered by traffic. Cross-trace by design (no traceId) —
+   * span counts, ordered by traffic. Cross-trace by design (no traceId),
    * the model cost rule preview needs the project-wide model inventory.
    */
   findModelUsageStats(params: {

--- a/langwatch/src/server/app-layer/traces/span-storage.service.ts
+++ b/langwatch/src/server/app-layer/traces/span-storage.service.ts
@@ -1,19 +1,24 @@
-import type { ElasticSearchEvent, Span } from "~/server/tracer/types";
-import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import type { DerivedTraceEvent } from "~/server/event-sourcing/pipelines/trace-processing/projections/services/trace-events.derivation";
+import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import type { ElasticSearchEvent, Span } from "~/server/tracer/types";
+import {
+  mapNormalizedSpansToSpans,
+  mapNormalizedSpanToSpan,
+} from "~/server/traces/mappers/span.mapper";
+import { resolveOffloadedTraces } from "~/server/traces/resolve-offloaded-traces";
+import { createLogger } from "~/utils/logger/server";
+import type { BlobStore } from "./blob-store.service";
 import type {
+  ModelSpanSampleRow,
+  ModelUsageStatsRow,
   OccurredAtHint,
   SpanLangwatchSignalsRow,
   SpanResourceInfo,
   SpanStorageRepository,
   SpanSummaryRow,
 } from "./repositories/span-storage.repository";
-import type { SpanInsertData } from "./types";
-import type { BlobStore } from "./blob-store.service";
 import type { TraceIOExtractionService } from "./trace-io-extraction.service";
-import { resolveOffloadedTraces } from "~/server/traces/resolve-offloaded-traces";
-import { mapNormalizedSpanToSpan, mapNormalizedSpansToSpans } from "~/server/traces/mappers/span.mapper";
-import { createLogger } from "~/utils/logger/server";
+import type { SpanInsertData } from "./types";
 
 /**
  * Optional blob-offload resolution dependencies for the v2 read path (ADR-022).
@@ -35,7 +40,9 @@ type Since = ByTraceId & { sinceStartTimeMs: number };
 
 export class SpanStorageService {
   private readonly blobResolutionDeps?: SpanReadBlobResolutionDeps;
-  private readonly logger = createLogger("langwatch:traces:span-storage-service");
+  private readonly logger = createLogger(
+    "langwatch:traces:span-storage-service",
+  );
 
   constructor(
     readonly repository: SpanStorageRepository,
@@ -59,13 +66,16 @@ export class SpanStorageService {
    * kept in place and the error is logged at warn level; the call never
    * throws due to a stale ref.
    */
-  async getSpansByTraceId(params: ByTraceId & { limit?: number }): Promise<Span[]> {
+  async getSpansByTraceId(
+    params: ByTraceId & { limit?: number },
+  ): Promise<Span[]> {
     if (!this.blobResolutionDeps) {
       return this.repository.getSpansByTraceId(params);
     }
 
     // Fetch normalized spans so resolution can access raw spanAttributes.
-    const normalizedSpans = await this.repository.getNormalizedSpansByTraceId(params);
+    const normalizedSpans =
+      await this.repository.getNormalizedSpansByTraceId(params);
     const { resolvedSpans } = await resolveOffloadedTraces({
       projectId: params.tenantId,
       normalizedSpans,
@@ -97,7 +107,8 @@ export class SpanStorageService {
     }
 
     // Resolve the single span via the normalized+resolve path.
-    const normalizedSpans = await this.repository.getNormalizedSpansByTraceId(params);
+    const normalizedSpans =
+      await this.repository.getNormalizedSpansByTraceId(params);
     const { resolvedSpans } = await resolveOffloadedTraces({
       projectId: params.tenantId,
       normalizedSpans,
@@ -110,7 +121,9 @@ export class SpanStorageService {
     return mapNormalizedSpanToSpan(resolved);
   }
 
-  async getTraceEventsByTraceId(params: ByTraceId): Promise<DerivedTraceEvent[]> {
+  async getTraceEventsByTraceId(
+    params: ByTraceId,
+  ): Promise<DerivedTraceEvent[]> {
     return this.repository.getTraceEventsByTraceId(params);
   }
 
@@ -156,5 +169,23 @@ export class SpanStorageService {
 
   async getSpanSummariesSince(params: Since): Promise<SpanSummaryRow[]> {
     return this.repository.findSpanSummariesSince(params);
+  }
+
+  async getModelUsageStats(params: {
+    tenantId: string;
+    fromMs: number;
+    limit: number;
+  }): Promise<ModelUsageStatsRow[]> {
+    return this.repository.findModelUsageStats(params);
+  }
+
+  async getRecentSpansByModels(params: {
+    tenantId: string;
+    models: string[];
+    fromMs: number;
+    perModelLimit: number;
+    limit: number;
+  }): Promise<ModelSpanSampleRow[]> {
+    return this.repository.findRecentSpansByModels(params);
   }
 }

--- a/langwatch/src/server/background/workers/collector/cost.ts
+++ b/langwatch/src/server/background/workers/collector/cost.ts
@@ -133,6 +133,13 @@ export const normalizeModelName = (model: string): string => {
 const regexCache = new Map<string, RegExp | null>();
 
 /**
+ * The cost-rule preview feeds user keystrokes through the matcher, so the
+ * pattern space is unbounded — reset the cache when it grows past any
+ * plausible working set instead of leaking entries forever.
+ */
+const REGEX_CACHE_MAX_ENTRIES = 5_000;
+
+/**
  * Returns a cached, safe-checked RegExp for the given pattern.
  * Unsafe or invalid patterns are cached as null and warned once.
  */
@@ -143,6 +150,9 @@ const getSafeRegex = (pattern: string): RegExp | null => {
   const re = compileSafeRegex(pattern);
   if (!re) {
     logger.warn({ pattern }, "skipping unsafe regex in model cost matching");
+  }
+  if (regexCache.size >= REGEX_CACHE_MAX_ENTRIES) {
+    regexCache.clear();
   }
   regexCache.set(pattern, re);
   return re;
@@ -155,7 +165,7 @@ const getSafeRegex = (pattern: string): RegExp | null => {
  */
 const safeRegexTest = (pattern: string, input: string): boolean => {
   const re = getSafeRegex(pattern);
-  return re !== null && re.test(input);
+  return re?.test(input) ?? false;
 };
 
 /**
@@ -192,12 +202,16 @@ export function normalizeBedrockModelId(model: string): string {
   // 3. Strip cross-region inference prefix (`eu.`, `us.`, `apac.`,
   //    `ap.`, `eu-west-*.`, ...). Only the leading region segment;
   //    vendor segment keeps its own dots untouched.
-  normalized = normalized.replace(/^[a-z]{2,}(?:-[a-z0-9]+)*\.(?=[a-z]+\.)/i, "");
+  normalized = normalized.replace(
+    /^[a-z]{2,}(?:-[a-z0-9]+)*\.(?=[a-z]+\.)/i,
+    "",
+  );
   // 4. Vendor-dot → vendor-slash. First dot only — any dots in the
   //    vendor-model half (e.g. `claude-opus-4.5`) stay.
   const firstDot = normalized.indexOf(".");
   if (firstDot > 0 && !normalized.slice(0, firstDot).includes("/")) {
-    normalized = normalized.slice(0, firstDot) + "/" + normalized.slice(firstDot + 1);
+    normalized =
+      normalized.slice(0, firstDot) + "/" + normalized.slice(firstDot + 1);
   }
   return normalized;
 }

--- a/langwatch/src/server/background/workers/collector/cost.ts
+++ b/langwatch/src/server/background/workers/collector/cost.ts
@@ -134,7 +134,7 @@ const regexCache = new Map<string, RegExp | null>();
 
 /**
  * The cost-rule preview feeds user keystrokes through the matcher, so the
- * pattern space is unbounded — reset the cache when it grows past any
+ * pattern space is unbounded, reset the cache when it grows past any
  * plausible working set instead of leaking entries forever.
  */
 const REGEX_CACHE_MAX_ENTRIES = 5_000;

--- a/langwatch/src/utils/__tests__/modelCostRegex.unit.test.ts
+++ b/langwatch/src/utils/__tests__/modelCostRegex.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { exactModelMatchRegex } from "../modelCostRegex";
+import { isSafeRegex } from "../safeRegex";
+
+describe("exactModelMatchRegex", () => {
+  describe("when the model name contains regex metacharacters", () => {
+    it("escapes dots and slashes so the pattern matches the literal string", () => {
+      const pattern = exactModelMatchRegex(
+        "bedrock/eu.anthropic.claude-sonnet-4-6",
+      );
+
+      expect(pattern).toBe("^bedrock\\/eu\\.anthropic\\.claude-sonnet-4-6$");
+      expect(
+        new RegExp(pattern).test("bedrock/eu.anthropic.claude-sonnet-4-6"),
+      ).toBe(true);
+      // The dot must not act as a wildcard.
+      expect(
+        new RegExp(pattern).test("bedrockXeu.anthropic.claude-sonnet-4-6"),
+      ).toBe(false);
+    });
+
+    it("anchors the pattern so longer model ids do not match", () => {
+      const pattern = exactModelMatchRegex("eu.anthropic.claude-sonnet-4-6");
+
+      expect(
+        new RegExp(pattern).test("eu.anthropic.claude-sonnet-4-6-v1:0"),
+      ).toBe(false);
+      expect(
+        new RegExp(pattern).test("xx-eu.anthropic.claude-sonnet-4-6"),
+      ).toBe(false);
+    });
+
+    it("produces a pattern that passes the shared safety validation", () => {
+      expect(
+        isSafeRegex(
+          exactModelMatchRegex("vertex_ai/gemini-3-pro (preview)+$^"),
+        ),
+      ).toBe(true);
+    });
+
+    it("matches literally even for names full of metacharacters", () => {
+      const hostile = "weird+model(v2)[beta]|x*?{1}^$\\end";
+      const pattern = exactModelMatchRegex(hostile);
+
+      expect(new RegExp(pattern).test(hostile)).toBe(true);
+      expect(new RegExp(pattern).test(hostile + "x")).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/utils/modelCostRegex.ts
+++ b/langwatch/src/utils/modelCostRegex.ts
@@ -2,7 +2,7 @@
  * Builds an anchored regex that matches exactly one model name string, for
  * auto-generating model cost rule patterns from a span's recorded model.
  *
- * Escapes every regex metacharacter, including the forward slash — `/` is
+ * Escapes every regex metacharacter, including the forward slash, `/` is
  * valid unescaped in a pattern compiled via `new RegExp(string)`, but the
  * model-cost UI renders patterns between `/.../` delimiters, so emitting
  * `\/` keeps the displayed literal unambiguous.

--- a/langwatch/src/utils/modelCostRegex.ts
+++ b/langwatch/src/utils/modelCostRegex.ts
@@ -1,0 +1,12 @@
+/**
+ * Builds an anchored regex that matches exactly one model name string, for
+ * auto-generating model cost rule patterns from a span's recorded model.
+ *
+ * Escapes every regex metacharacter, including the forward slash — `/` is
+ * valid unescaped in a pattern compiled via `new RegExp(string)`, but the
+ * model-cost UI renders patterns between `/.../` delimiters, so emitting
+ * `\/` keeps the displayed literal unambiguous.
+ */
+export function exactModelMatchRegex(model: string): string {
+  return `^${model.replace(/[/\\^$.*+?()[\]{}|]/g, "\\$&")}$`;
+}

--- a/specs/model-providers/model-cost-matching-spans-preview.feature
+++ b/specs/model-providers/model-cost-matching-spans-preview.feature
@@ -1,0 +1,52 @@
+Feature: Model cost regex matching spans preview
+  As a project member defining a custom LLM model cost rule
+  I want to see which recent spans my regex would match while I type it
+  So that I can build the right regex without guessing how my models are recorded
+
+  Background:
+    Given I have the LLM model cost drawer open
+
+  @integration
+  Scenario: Recent spans matching the regex are listed with tokens and an example cost
+    Given my project has recent LLM spans for model "bedrock/eu.anthropic.claude-sonnet-4-6"
+    When I type a regex that matches that model
+    And I have entered input and output costs per token
+    Then I see a list of recent spans that the regex matches
+    And each row shows the span's model, token counts, and an example cost computed from my entered rates and that span's tokens
+
+  @integration
+  Scenario: Matching follows the same fallbacks as cost computation
+    Given my project has recent LLM spans for model "eu.anthropic.claude-sonnet-4-6-v1:0"
+    When I type the regex "anthropic/claude-sonnet-4-6"
+    Then the span is listed as a match
+    # the cost pipeline normalizes Bedrock-style ids before matching, and the
+    # preview must agree with what the pipeline would actually do
+
+  @integration
+  Scenario: A span row opens the trace details drawer in a new tab
+    Given the preview lists a matching span
+    When I click that span row
+    Then the trace details drawer for that span's trace opens in a new tab
+    And the clicked span is the selected span in that drawer
+
+  @integration
+  Scenario: No matches shows the models that were seen instead
+    Given my project has recent LLM spans for model "eu.anthropic.claude-sonnet-4-6-v1:0"
+    When I type a regex that matches none of my recent spans
+    Then I see that zero spans matched
+    And I see the model names recently seen in my project that did not match
+    When I click one of those model names
+    Then the regex field is filled with an exact-match regex for that model
+
+  @integration
+  Scenario: Slashes in the regex are valid
+    When I type the regex "^bedrock/eu\.anthropic\.claude-sonnet-4-6$"
+    Then the regex is accepted as valid
+    And spans whose model is "bedrock/eu.anthropic.claude-sonnet-4-6" are listed as matches
+    # an unescaped forward slash is valid in a regular expression pattern;
+    # only regex literals in source code need it escaped
+
+  @integration
+  Scenario: Preview is scoped to the current project
+    Given another project has spans whose model my regex matches
+    Then those spans never appear in my preview

--- a/specs/traces-v2/span-unmapped-cost-suggestion.feature
+++ b/specs/traces-v2/span-unmapped-cost-suggestion.feature
@@ -1,0 +1,38 @@
+Feature: Unmapped model cost suggestion in span details
+  As a user inspecting a trace
+  I want to be told when a span's model has tokens but no cost mapped
+  So that I can add the missing cost mapping instead of silently losing cost tracking
+
+  @integration
+  Scenario: Span with model and tokens but no cost shows a cost mapping suggestion
+    Given I open the span details of a span that has a model and token counts
+    And no cost was computed for that span
+    Then I see a suggestion that no cost is mapped for that model
+    And I see a button to add a cost mapping
+
+  @integration
+  Scenario: Suggestion opens the model costs page prefilled in a new window
+    Given the cost mapping suggestion is shown for a span with model "vertex_ai/gemini-3-pro-preview"
+    When I click the add cost mapping button
+    Then the model costs settings page opens in a new window
+    And the model cost drawer is already open
+    And the model name field is prefilled with "vertex_ai/gemini-3-pro-preview"
+    And the regex field is prefilled with an automatically generated exact-match regex for that model
+
+  @integration
+  Scenario: Generated regex escapes special characters
+    Given the cost mapping suggestion is shown for a span with model "bedrock/eu.anthropic.claude-sonnet-4-6-v1:0"
+    When I click the add cost mapping button
+    Then the prefilled regex matches the literal model string
+    And dots and slashes in the model name are escaped in the regex
+
+  @integration
+  Scenario: Span with a computed cost shows no suggestion
+    Given I open the span details of a span that has a model, token counts, and a computed cost
+    Then I do not see the cost mapping suggestion
+
+  @integration
+  Scenario: Span without token counts shows no suggestion
+    Given I open the span details of a span that has a model but no token counts
+    Then I do not see the cost mapping suggestion
+    # without tokens there is nothing a cost rule could price


### PR DESCRIPTION
Customers writing custom model cost rules have to guess a regex against model names they can't see, save, and then check traces to find out whether it matched anything. A customer recently spent a while on exactly this with a Bedrock model id. This PR makes the rule drawer show its work, adds a shortcut from the trace drawer, and fixes a real matching bug found along the way.

## Matching spans preview in the cost rule drawer

The Edit/Add LLM Model Cost drawer now previews, live under the regex field, which spans from the last 7 days the regex would match. Each row shows the span's model (provider icon + name, same visual language as the traces v2 list), span name, input/output tokens, the cost that span would have at the rates currently typed into the form, and how long ago it ran. Clicking a row opens the traces v2 drawer in a new tab with that span selected.

![matching spans preview](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4727/cost-rule-preview/preview-matching-spans.png)

Matching runs through `matchModelCostWithFallbacks`, the same function the ingestion pipeline uses, so the preview cannot disagree with what the rule will actually do (vendor-prefix stripping, Bedrock id normalization, lowercase fallback included).

When nothing matches, the preview lists the models recently seen in the project with their span counts. Clicking one fills the regex field with an escaped exact-match pattern and the model name field if it's still empty.

![zero match state with model chips](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4727/cost-rule-preview/zero-match-model-chips.png)

![chip click fills the regex](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4727/cost-rule-preview/chip-click-fills-regex.png)

Backend: `llmModelCost.previewMatchingSpans` (tRPC, gated on `traces:view`), backed by two new light ClickHouse reads on `stored_spans` (distinct models + recent sample spans; TenantId-first, StartTime-windowed, token attrs read as Map subscripts only).

## Unmapped-cost suggestion in the trace details drawer

When a span in the traces v2 drawer has a model and token counts but no cost was computed, and no cost entry (custom rule or static registry) currently covers that model, the span's Attributes section shows a suggestion line with an "Add cost mapping" button, sitting above the attribute filter right where the model id it talks about lives.

![span suggestion](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4727/span-suggestion/unmapped-cost-suggestion-attributes.png)

It opens `/settings/model-costs` in a new window with the cost drawer already open, model name prefilled, and an auto-generated exact-match regex (`^…$`, metacharacters escaped, slashes as `\/`). The preview immediately confirms the generated regex matches:

![prefilled drawer from the deep link](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4727/span-suggestion/prefilled-drawer-from-deep-link.png)

The "no rule covers it" check runs server-side in `spanDetail`, so the suggestion disappears once a matching rule exists, including for spans ingested before the rule was created.

## Overlap with #4721

While wiring the suggestion I independently found the ingestion enrichment bug (org/team-scoped rules loaded by the legacy `projectId` column, so they never applied to incoming spans), and #4721 landed the same fix on main mid-flight. This branch is rebased on top of it and keeps #4721's version of `getCustomLLMModelCosts` and `createCostEnrichmentDeps`; the suggestion logic here adds an integration regression for the scope cascade on the real Postgres path.

## On the regex slash question

The reported regex `^bedrock/eu\.anthropic\.claude-sonnet-4-6$` is valid: an unescaped `/` only needs escaping in regex literals in source code, not in patterns compiled via `new RegExp(string)`, which is all LangWatch does (verified against `safe-regex2` as well). So slashes are not forbidden, existing stored patterns keep working, and the preview now makes mismatches visible instead. The auto-generated regexes still emit `\/` since the UI renders patterns between `/.../` delimiters.

Also bounded the module-level regex cache in `cost.ts` (5k entries, reset on overflow) now that previews feed user keystrokes through the matcher, and gave the traces v2 range-filter sliders a step sized to the facet span (cost facets span sub-unit USD ranges, where the default step of 1 made the slider unusable). While QA-ing that sidebar I caught the long-standing transient "Couldn't render the cost filter" error card live: when a stale thumb value sits fully outside freshly-arrived facet bounds, zag-js throws synchronously at mount (reproduced against `@zag-js/slider`'s own `normalize`). The slider value is now clamped into the current bounds before it reaches the slider, which makes that crash class unrepresentable.

## Dark mode

![preview in dark mode](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4727/cost-rule-preview/preview-dark-mode.png)

## Tests

- `model-cost-span-preview.integration.test.ts`: real ClickHouse + Postgres. Exact match, Bedrock-normalization fallback, legacy token attribute aliases, response-model precedence, 7-day window, tenant isolation, ReDoS rejection, suggestion suppression by static registry and by org-scoped custom rule, and the enrichment scope-cascade regression.
- `LLMModelCostMatchingSpans.integration.test.tsx`: drawer tree with the tRPC client mocked. Row rendering, deep-link URL params, no form submit on row click, unmatched-model chip fill, invalid-regex gating, prefill props.
- `UnmappedCostSuggestion.integration.test.tsx`: SpanAccordions tree. Suggestion visibility rules, placement inside the Attributes section, and the prefilled settings URL.
- `modelCostRegex.unit.test.ts`: escaping and anchoring of generated patterns.
- `RangeSection.subUnitSpan.integration.test.tsx`: keyboard increment moves the thumb by the span-sized step, plus the bounds-clamp contract for the zag mount crash.

Specs: `specs/model-providers/model-cost-matching-spans-preview.feature`, `specs/traces-v2/span-unmapped-cost-suggestion.feature`, plus an ingestion-enrichment scenario in `model-cost-scoping.feature`.

## QA

Dogfooded end-to-end on a local stack with real OTLP traces (an unmapped Bedrock inference-profile model, a registry-priced `gpt-5-mini`, an unmapped Vertex model): typed the customer's exact regex and watched the preview match, opened a span from the preview in a new tab, followed the suggestion from the trace drawer to the prefilled form, watched example costs update while typing rates, saved, and confirmed the suggestion disappears for the now-covered model while the priced `gpt-5-mini` span never showed it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time preview of recent trace spans matching a model-cost regex with sample rows, token counts, and example costs
  * In-span “add cost mapping” suggestion that opens the model-cost drawer prefilled (model + exact-match regex)
  * Server-side preview endpoint and backend preview/diagnostic services for model-cost matching

* **Improvements**
  * Deep-link prefill and selecting previewed models auto-fills regex and model fields
  * Exact-match regex generator that safely escapes special characters
  * Slider step behavior improved for very small numeric ranges

* **Tests**
  * New unit, integration, and feature tests covering preview, suggestion, deep-linking, regex safety, and slider behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->