### PR TITLE
fix(cli): default login to project, guard against personal-project confusion

### DIFF
--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -43,19 +43,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 Then fetch the integration guide for this project's framework:
 
@@ -190,19 +190,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 Then read the evaluations overview:
 
@@ -450,19 +450,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 Then read the Scenario-specific pages:
 
@@ -1070,19 +1070,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 Then specifically read the Prompts CLI guide:
 
@@ -1231,19 +1231,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 ## Step 2: Get a Project Overview
 
@@ -1789,19 +1789,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 Then fetch the integration guide for this project's framework:
 
@@ -3528,19 +3528,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 ## Step 2: Get a Project Overview
 
@@ -3693,19 +3693,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 Then read the Scenario-specific pages:
 
@@ -4335,19 +4335,19 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.
 
 Then read the evaluations overview:
 

--- a/docs/snippets/prompts-data.jsx
+++ b/docs/snippets/prompts-data.jsx
@@ -43,6 +43,20 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+
 Then fetch the integration guide for this project's framework:
 
 \`\`\`bash
@@ -175,6 +189,20 @@ langwatch scenario-docs                           # Scenario docs index
 Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\`. List and get commands accept \`--format json\` for machine-readable output. Read the docs first instead of guessing SDK APIs or CLI flags.
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
+
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
 
 Then read the evaluations overview:
 
@@ -421,6 +449,20 @@ langwatch scenario-docs                           # Scenario docs index
 Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\`. List and get commands accept \`--format json\` for machine-readable output. Read the docs first instead of guessing SDK APIs or CLI flags.
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
+
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
 
 Then read the Scenario-specific pages:
 
@@ -1028,6 +1070,20 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+
 Then specifically read the Prompts CLI guide:
 
 \`\`\`bash
@@ -1174,6 +1230,20 @@ langwatch scenario-docs                           # Scenario docs index
 Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\`. List and get commands accept \`--format json\` for machine-readable output. Read the docs first instead of guessing SDK APIs or CLI flags.
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
+
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
 
 ## Step 2: Get a Project Overview
 
@@ -1719,6 +1789,20 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+
 Then fetch the integration guide for this project's framework:
 
 \`\`\`bash
@@ -1812,6 +1896,8 @@ If \`LANGWATCH_ENDPOINT\` is set in \`.env\`, the user is self-hosted — direct
 ## Step 1: Read the Prompts CLI Docs
 
 (see "CliSetup" above)
+
+(see "ProjectsAndApiKeys" above)
 
 Then specifically read the Prompts CLI guide:
 
@@ -1981,6 +2067,8 @@ Some features are code-only (experiments, guardrails) and some are platform-only
 ## Prerequisites
 
 (see "CliSetup" above)
+
+(see "ProjectsAndApiKeys" above)
 
 Then read the evaluations overview:
 
@@ -2201,6 +2289,8 @@ Best practices:
 ### Step 1: Read the Scenario Docs
 
 (see "CliSetup" above)
+
+(see "ProjectsAndApiKeys" above)
 
 Then read the Scenario-specific pages:
 
@@ -3438,6 +3528,20 @@ Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
 
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+
 ## Step 2: Get a Project Overview
 
 \`\`\`bash
@@ -3588,6 +3692,20 @@ langwatch scenario-docs                           # Scenario docs index
 Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\`. List and get commands accept \`--format json\` for machine-readable output. Read the docs first instead of guessing SDK APIs or CLI flags.
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
+
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
 
 Then read the Scenario-specific pages:
 
@@ -4216,6 +4334,20 @@ langwatch scenario-docs                           # Scenario docs index
 Discover commands with \`langwatch --help\` and \`langwatch <subcommand> --help\`. List and get commands accept \`--format json\` for machine-readable output. Read the docs first instead of guessing SDK APIs or CLI flags.
 
 If no shell is available, fetch the same Markdown over plain HTTP — append \`.md\` to any docs path (e.g. https://langwatch.ai/docs/integration/python/guide.md). Index: https://langwatch.ai/docs/llms.txt. Scenario index: https://langwatch.ai/scenario/llms.txt
+
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in \`.env\`** (\`LANGWATCH_API_KEY\`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **\`langwatch login --device\` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (\`langwatch claude\`, \`langwatch codex\`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure \`LANGWATCH_API_KEY\` for a real, shared project is in the project's \`.env\`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run \`langwatch login\` to pick a project, and never default to a personal project. If \`LANGWATCH_ENDPOINT\` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
 
 Then read the evaluations overview:
 

--- a/langwatch/src/components/me/PersonalTracesEmptyState.tsx
+++ b/langwatch/src/components/me/PersonalTracesEmptyState.tsx
@@ -123,7 +123,7 @@ export function PersonalTracesEmptyState({
   ];
 
   return (
-    <IntegratePaneShell compact ariaLabel="Start sending your AI usage">
+    <IntegratePaneShell isCompact ariaLabel="Start sending your AI usage">
       <VStack align="stretch" gap={6}>
         <VStack align="start" gap={1.5}>
           <Text

--- a/langwatch/src/components/settings/ScopeChipPicker.tsx
+++ b/langwatch/src/components/settings/ScopeChipPicker.tsx
@@ -260,6 +260,8 @@ export function ScopeChipPicker<
   showSummary = true,
   showQuickPicks = false,
   singleSelect = false,
+  variant = "chips",
+  placeholder,
   currentOrganizationId,
   currentTeamId,
   currentProjectId,
@@ -300,6 +302,21 @@ export function ScopeChipPicker<
    *  more than one, so the single-scope contract holds even if a caller passes
    *  a longer array. */
   singleSelect?: boolean;
+  /** Rendering variant.
+   *  - "chips" (default): the chip + multi-select / quick-pick UI, governed by
+   *    `singleSelect` / `showQuickPicks`.
+   *  - "single-select": a single-value dropdown over the full option list. The
+   *    component guarantees exactly one selection (or none), so callers never
+   *    constrain `onChange` themselves. PROJECT options nest under their team
+   *    (using `availableProjects[].teamId` + `availableTeams`) so the list
+   *    stays organised, and the trigger collapses to the picked option. Use
+   *    this to pick one concrete scope (e.g. the project an SDK key is minted
+   *    for) rather than choose a scope level for a config. */
+  variant?: "chips" | "single-select";
+  /** Placeholder for the single-select trigger when nothing is picked yet.
+   *  Defaults to "Select an option". Only consulted by the single-select
+   *  variant. */
+  placeholder?: string;
   /** When true, render the Organization/Team/Project quick-pick chip
    *  row above the field and collapse the multi-select dropdown by
    *  default. Clicking the 4th "Multiple" chip (CheckCheck icon)
@@ -475,6 +492,154 @@ export function ScopeChipPicker<
   }, [derivedMultiple]);
 
   const dropdownVisible = singleSelect ? false : !showQuickPicks || multipleMode;
+
+  if (variant === "single-select") {
+    const selected = scopes[0] ?? null;
+    const selectedOption = selected
+      ? options.find(
+          (o) =>
+            o.scopeType === selected.scopeType && o.scopeId === selected.scopeId,
+        )
+      : null;
+
+    // Group PROJECT options under their parent team so the list stays organised
+    // even with many projects across teams. Non-project options (org / team /
+    // department) keep their own flat groups.
+    const teamNameById = new Map(
+      (availableTeams ?? []).map((t) => [t.id, t.name] as const),
+    );
+    const teamIdByProjectId = new Map(
+      (availableProjects ?? []).map((p) => [p.id, p.teamId] as const),
+    );
+    const projectsByTeam = new Map<string, ScopeOption[]>();
+    const orphanProjects: ScopeOption[] = [];
+    for (const option of options.filter((o) => o.scopeType === "PROJECT")) {
+      const teamId = teamIdByProjectId.get(option.scopeId);
+      if (teamId && teamNameById.has(teamId)) {
+        const bucket = projectsByTeam.get(teamId) ?? [];
+        bucket.push(option);
+        projectsByTeam.set(teamId, bucket);
+      } else {
+        orphanProjects.push(option);
+      }
+    }
+    const teamGroups = Array.from(projectsByTeam.entries())
+      .map(([teamId, projects]) => ({
+        teamId,
+        teamName: teamNameById.get(teamId) ?? "Team",
+        projects,
+      }))
+      .sort((a, b) => a.teamName.localeCompare(b.teamName));
+    const orgOptions = options.filter((o) => o.scopeType === "ORGANIZATION");
+    const deptOptions = options.filter((o) => o.scopeType === "DEPARTMENT");
+    const teamScopeOptions = options.filter((o) => o.scopeType === "TEAM");
+    const fallbackPlaceholder = placeholder ?? "Select an option";
+
+    return (
+      <VStack align="start" width="full" gap={1.5}>
+        {label && <SmallLabel>{label}</SmallLabel>}
+        <Select.Root
+          collection={collection}
+          value={selected ? [`${selected.scopeType}:${selected.scopeId}`] : []}
+          onValueChange={(details) => {
+            const pickedValue = details.value[0];
+            const option = pickedValue
+              ? options.find((o) => o.value === pickedValue)
+              : undefined;
+            onChange(
+              option
+                ? [{ scopeType: option.scopeType, scopeId: option.scopeId }]
+                : [],
+            );
+          }}
+        >
+          <Select.Trigger>
+            <Select.ValueText placeholder={fallbackPlaceholder}>
+              {() =>
+                selectedOption ? (
+                  <HStack gap={2}>
+                    <ScopeIcon scopeType={selectedOption.scopeType} />
+                    <Text>{selectedOption.label}</Text>
+                  </HStack>
+                ) : (
+                  fallbackPlaceholder
+                )
+              }
+            </Select.ValueText>
+          </Select.Trigger>
+          <Select.Content>
+            {orgOptions.length > 0 && (
+              <Select.ItemGroup label="Organization">
+                {orgOptions.map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2}>
+                      <ScopeIcon scopeType="ORGANIZATION" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+              </Select.ItemGroup>
+            )}
+            {deptOptions.length > 0 && (
+              <Select.ItemGroup label="Departments">
+                {deptOptions.map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2}>
+                      <ScopeIcon scopeType="DEPARTMENT" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+              </Select.ItemGroup>
+            )}
+            {teamScopeOptions.length > 0 && (
+              <Select.ItemGroup label="Teams">
+                {teamScopeOptions.map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2}>
+                      <ScopeIcon scopeType="TEAM" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+              </Select.ItemGroup>
+            )}
+            {teamGroups.map((group) => (
+              <Select.ItemGroup key={group.teamId} label={group.teamName}>
+                {group.projects.map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2} paddingLeft={2}>
+                      <ScopeIcon scopeType="PROJECT" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+              </Select.ItemGroup>
+            ))}
+            {orphanProjects.length > 0 && (
+              <Select.ItemGroup label="Projects">
+                {orphanProjects.map((option) => (
+                  <Select.Item key={option.value} item={option}>
+                    <HStack gap={2}>
+                      <ScopeIcon scopeType="PROJECT" />
+                      <Text>{option.label}</Text>
+                    </HStack>
+                  </Select.Item>
+                ))}
+              </Select.ItemGroup>
+            )}
+          </Select.Content>
+        </Select.Root>
+        {showSummary && (
+          <Box>
+            <Text fontSize="xs" color="gray.600">
+              {summariseSelection(scopes)}
+            </Text>
+          </Box>
+        )}
+      </VStack>
+    );
+  }
 
   return (
     <VStack align="start" width="full" gap={1.5}>

--- a/langwatch/src/components/settings/__tests__/ScopeChipPicker.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ScopeChipPicker.integration.test.tsx
@@ -62,3 +62,63 @@ describe("ScopeChipPicker quick-picks", () => {
     });
   });
 });
+
+describe("ScopeChipPicker single-select variant", () => {
+  afterEach(cleanup);
+
+  const projects = [
+    { id: "p-prod", name: "ACME Prod", teamId: "t-acme" },
+    { id: "p-web", name: "web-app", teamId: "t-acme" },
+    { id: "p-bill", name: "billing-svc", teamId: "t-platform" },
+  ];
+  const teams = [
+    { id: "t-acme", name: "QA Shared Team" },
+    { id: "t-platform", name: "Platform Team" },
+  ];
+
+  describe("given a project is already selected", () => {
+    it("shows the picked project in the trigger and hides the scope summary", () => {
+      renderPicker(
+        <ScopeChipPicker
+          variant="single-select"
+          allowedScopeTypes={["PROJECT"]}
+          organizationId="org-1"
+          availableProjects={projects}
+          availableTeams={teams}
+          value={[{ scopeType: "PROJECT", scopeId: "p-web" }]}
+          onChange={vi.fn()}
+          showSummary={false}
+          placeholder="Select a project"
+        />,
+      );
+
+      // The collapsed trigger reflects the current selection by name.
+      expect(screen.getAllByText("web-app").length).toBeGreaterThan(0);
+      // showSummary={false} keeps the config-oriented helper line out.
+      expect(screen.queryByText(/can use this configuration/)).toBeNull();
+    });
+  });
+
+  describe("given nothing is selected yet", () => {
+    it("shows the placeholder and offers no chips or quick-picks", () => {
+      renderPicker(
+        <ScopeChipPicker
+          variant="single-select"
+          allowedScopeTypes={["PROJECT"]}
+          organizationId="org-1"
+          availableProjects={projects}
+          availableTeams={teams}
+          value={[]}
+          onChange={vi.fn()}
+          placeholder="Select a project"
+        />,
+      );
+
+      expect(screen.getAllByText("Select a project").length).toBeGreaterThan(0);
+      // A plain single-select dropdown: no multi-select chips and none of the
+      // org/team/project quick-pick buttons.
+      expect(screen.queryByTestId("quick-scope-project")).toBeNull();
+      expect(screen.queryByTestId("quick-scope-multiple")).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/ModeSwitch.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/ModeSwitch.tsx
@@ -23,7 +23,7 @@ interface ModeSwitchProps {
    * "no turns found" pane the moment the user opens the drawer reads
    * as broken even though the data is en route.
    */
-  conversationLoading?: boolean;
+  isConversationLoading?: boolean;
   /** Trace id used to scope the per-mode peer presence dots. */
   traceId?: string;
   /**
@@ -143,17 +143,17 @@ export function ModeSwitch({
   onViewModeChange,
   turnLabel,
   hasConversation = true,
-  conversationLoading = false,
+  isConversationLoading = false,
   traceId,
   endSlot,
 }: ModeSwitchProps) {
   // Tristate gate: no conversationId → permanently disabled; has id
   // but turns still in flight → disabled with loading copy; has id +
   // turns → enabled.
-  const conversationDisabled = !hasConversation || conversationLoading;
+  const conversationDisabled = !hasConversation || isConversationLoading;
   const conversationDisabledReason = !hasConversation
     ? "This trace is not part of a conversation"
-    : conversationLoading
+    : isConversationLoading
       ? "Loading conversation…"
       : undefined;
   const presenceFor = (mode: DrawerViewMode) =>

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/__tests__/AttributeTable.integration.test.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/__tests__/AttributeTable.integration.test.tsx
@@ -26,22 +26,24 @@ describe("AttributeTable", () => {
   afterEach(cleanup);
 
   describe("given a synthetic span_id row", () => {
-    it("shows a disabled, non-button pin instead of a blank gap", () => {
-      const { getByLabelText } = renderTable();
+    describe("when the attribute table is rendered", () => {
+      it("shows a disabled, non-button pin instead of a blank gap", () => {
+        const { getByLabelText } = renderTable();
 
-      const disabledPin = getByLabelText("span_id can't be pinned");
-      expect(disabledPin).toBeInTheDocument();
-      expect(disabledPin).toHaveAttribute("aria-disabled", "true");
-      // It must NOT be an actionable pin toggle.
-      expect(disabledPin.tagName).not.toBe("BUTTON");
-    });
+        const disabledPin = getByLabelText("span_id can't be pinned");
+        expect(disabledPin).toBeInTheDocument();
+        expect(disabledPin).toHaveAttribute("aria-disabled", "true");
+        // It must NOT be an actionable pin toggle.
+        expect(disabledPin.tagName).not.toBe("BUTTON");
+      });
 
-    it("still renders a real pin toggle for an actual attribute", () => {
-      const { getByRole } = renderTable();
+      it("still renders a real pin toggle for an actual attribute", () => {
+        const { getByRole } = renderTable();
 
-      expect(
-        getByRole("button", { name: /pin gen_ai\.operation\.name/i }),
-      ).toBeInTheDocument();
+        expect(
+          getByRole("button", { name: /pin gen_ai\.operation\.name/i }),
+        ).toBeInTheDocument();
+      });
     });
   });
 });

--- a/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
+++ b/langwatch/src/features/traces-v2/components/TraceDrawer/drawerHeader/DrawerHeader.tsx
@@ -1234,7 +1234,7 @@ export const DrawerHeader = memo(function DrawerHeader({
           // means the conversation hasn't resolved yet. We only want the
           // "loading" gate when a conversationId is declared — otherwise
           // the tab is permanently disabled with a different reason.
-          conversationLoading={
+          isConversationLoading={
             !!trace.conversationId &&
             conversationContext.isLoading &&
             conversationContext.turns.length === 0

--- a/langwatch/src/features/traces-v2/components/TracesPage/IntegratePaneShell.tsx
+++ b/langwatch/src/features/traces-v2/components/TracesPage/IntegratePaneShell.tsx
@@ -11,7 +11,7 @@
  *     faded SearchBar + Toolbar chrome passed via `chrome`, and the
  *     agent / MCP / SDK integration guide as the body.
  *   - the /me recent-activity card (`PersonalTracesEmptyState`):
- *     `compact`, no chrome, with a tiles pitch as the body.
+ *     `isCompact`, no chrome, with a tiles pitch as the body.
  */
 import { Box, Flex } from "@chakra-ui/react";
 import type React from "react";
@@ -29,20 +29,20 @@ export const IntegratePaneShell: React.FC<{
    * into a dashboard card rather than owning the whole viewport. Skips
    * the full-height `<main>` so the card sizes the frame instead.
    */
-  compact?: boolean;
+  isCompact?: boolean;
   ariaLabel?: string;
-}> = ({ children, chrome, compact = false, ariaLabel }) => {
+}> = ({ children, chrome, isCompact = false, ariaLabel }) => {
   return (
     <Flex
-      {...(compact ? {} : { as: "main", role: "main" })}
+      {...(isCompact ? {} : { as: "main", role: "main" })}
       aria-label={ariaLabel}
       direction="column"
       flex={1}
       minWidth={0}
-      height={compact ? undefined : "full"}
-      overflow={compact ? "hidden" : "auto"}
+      height={isCompact ? undefined : "full"}
+      overflow={isCompact ? "hidden" : "auto"}
       position="relative"
-      bg={compact ? "transparent" : "bg.surface"}
+      bg={isCompact ? "transparent" : "bg.surface"}
     >
       {/* Single soft orange glow centred on the frame that breathes and
           slow-rotates. Three slightly offset radial blobs share the
@@ -63,13 +63,13 @@ export const IntegratePaneShell: React.FC<{
         justifyContent="center"
       >
         <Box
-          width={compact ? "720px" : "140vmin"}
-          height={compact ? "720px" : "140vmin"}
+          width={isCompact ? "720px" : "140vmin"}
+          height={isCompact ? "720px" : "140vmin"}
           maxWidth="140vmin"
           maxHeight="140vmin"
           borderRadius="full"
           opacity={0.1}
-          filter={compact ? "blur(60px)" : "blur(80px)"}
+          filter={isCompact ? "blur(60px)" : "blur(80px)"}
           backgroundImage={`
             radial-gradient(circle at 46% 50%, var(--chakra-colors-orange-300) 0%, transparent 36%),
             radial-gradient(circle at 54% 48%, var(--chakra-colors-orange-400) 0%, transparent 30%),
@@ -101,10 +101,10 @@ export const IntegratePaneShell: React.FC<{
       >
         <Box
           width="full"
-          maxWidth={compact ? "760px" : "980px"}
+          maxWidth={isCompact ? "760px" : "980px"}
           marginX="auto"
-          paddingX={compact ? 6 : 8}
-          paddingY={compact ? 8 : 10}
+          paddingX={isCompact ? 6 : 8}
+          paddingY={isCompact ? 8 : 10}
         >
           {children}
         </Box>

--- a/langwatch/src/pages/cli/__tests__/cliAuthProjects.unit.test.ts
+++ b/langwatch/src/pages/cli/__tests__/cliAuthProjects.unit.test.ts
@@ -4,6 +4,7 @@ import { resolveCliAuthProjects } from "../cliAuthProjects";
 describe("resolveCliAuthProjects", () => {
   const teams = [
     {
+      id: "t-acme",
       name: "ACME",
       projects: [
         { id: "p-shared", name: "ACME Prod", slug: "acme-prod", isPersonal: false, kind: "application" },
@@ -11,17 +12,28 @@ describe("resolveCliAuthProjects", () => {
         { id: "p-gov", name: "Governance", slug: "internal_governance", isPersonal: false, kind: "internal_governance" },
       ],
     },
+    {
+      id: "t-personal-only",
+      name: "Solo",
+      projects: [
+        { id: "p-solo", name: "My Workspace 2", slug: "bob-personal", isPersonal: true, kind: "application" },
+      ],
+    },
   ];
 
   describe("given a team with a personal, an internal-governance, and a shared project", () => {
     describe("when the CLI-auth project list is resolved", () => {
       /** @scenario the project picker omits personal and internal-governance projects */
-      it("offers only the shared project", () => {
-        const { projects } = resolveCliAuthProjects({ teams });
+      it("offers only the shared project, carries its team, and drops teams without an offered project", () => {
+        const { projects, teams: offeredTeams } = resolveCliAuthProjects({ teams });
 
         expect(projects.map((p) => p.id)).toEqual(["p-shared"]);
+        expect(projects[0]!.teamId).toBe("t-acme");
         expect(projects.map((p) => p.slug)).not.toContain("jane-personal");
         expect(projects.map((p) => p.slug)).not.toContain("internal_governance");
+        // Only teams that actually have an offered project are returned, so the
+        // grouped picker never renders an empty or personal-only team header.
+        expect(offeredTeams).toEqual([{ id: "t-acme", name: "ACME" }]);
       });
     });
   });
@@ -29,6 +41,7 @@ describe("resolveCliAuthProjects", () => {
   describe("given several offered projects and a known last project", () => {
     const multi = [
       {
+        id: "t-acme",
         name: "ACME",
         projects: [
           { id: "p-a", name: "A", slug: "acme-a", isPersonal: false, kind: "application" },

--- a/langwatch/src/pages/cli/__tests__/cliAuthProjects.unit.test.ts
+++ b/langwatch/src/pages/cli/__tests__/cliAuthProjects.unit.test.ts
@@ -14,13 +14,15 @@ describe("resolveCliAuthProjects", () => {
   ];
 
   describe("given a team with a personal, an internal-governance, and a shared project", () => {
-    /** @scenario the project picker omits personal and internal-governance projects */
-    it("offers only the shared project", () => {
-      const { projects } = resolveCliAuthProjects({ teams });
+    describe("when the CLI-auth project list is resolved", () => {
+      /** @scenario the project picker omits personal and internal-governance projects */
+      it("offers only the shared project", () => {
+        const { projects } = resolveCliAuthProjects({ teams });
 
-      expect(projects.map((p) => p.id)).toEqual(["p-shared"]);
-      expect(projects.map((p) => p.slug)).not.toContain("jane-personal");
-      expect(projects.map((p) => p.slug)).not.toContain("internal_governance");
+        expect(projects.map((p) => p.id)).toEqual(["p-shared"]);
+        expect(projects.map((p) => p.slug)).not.toContain("jane-personal");
+        expect(projects.map((p) => p.slug)).not.toContain("internal_governance");
+      });
     });
   });
 
@@ -36,30 +38,36 @@ describe("resolveCliAuthProjects", () => {
       },
     ];
 
-    /** @scenario the project picker pre-selects the user's last project when it is offered */
-    it("pre-selects the last project the user worked in", () => {
-      const { defaultProjectId } = resolveCliAuthProjects({
-        teams: multi,
-        lastProjectSlug: "acme-prod",
-      });
+    describe("when the last project slug matches an offered project", () => {
+      /** @scenario the project picker pre-selects the user's last project when it is offered */
+      it("pre-selects the last project the user worked in", () => {
+        const { defaultProjectId } = resolveCliAuthProjects({
+          teams: multi,
+          lastProjectSlug: "acme-prod",
+        });
 
-      expect(defaultProjectId).toBe("p-prod");
+        expect(defaultProjectId).toBe("p-prod");
+      });
     });
 
-    it("falls back to no default when the last project is not offered", () => {
-      const { defaultProjectId } = resolveCliAuthProjects({
-        teams: multi,
-        lastProjectSlug: "jane-personal",
-      });
+    describe("when the last project slug is not among the offered projects", () => {
+      it("falls back to no default", () => {
+        const { defaultProjectId } = resolveCliAuthProjects({
+          teams: multi,
+          lastProjectSlug: "jane-personal",
+        });
 
-      expect(defaultProjectId).toBeNull();
+        expect(defaultProjectId).toBeNull();
+      });
     });
   });
 
   describe("given a single offered project", () => {
-    it("auto-selects it", () => {
-      const { defaultProjectId } = resolveCliAuthProjects({ teams });
-      expect(defaultProjectId).toBe("p-shared");
+    describe("when the default project is computed", () => {
+      it("auto-selects it", () => {
+        const { defaultProjectId } = resolveCliAuthProjects({ teams });
+        expect(defaultProjectId).toBe("p-shared");
+      });
     });
   });
 });

--- a/langwatch/src/pages/cli/__tests__/cliAuthProjects.unit.test.ts
+++ b/langwatch/src/pages/cli/__tests__/cliAuthProjects.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { resolveCliAuthProjects } from "../cliAuthProjects";
+
+describe("resolveCliAuthProjects", () => {
+  const teams = [
+    {
+      name: "ACME",
+      projects: [
+        { id: "p-shared", name: "ACME Prod", slug: "acme-prod", isPersonal: false, kind: "application" },
+        { id: "p-personal", name: "My Workspace", slug: "jane-personal", isPersonal: true, kind: "application" },
+        { id: "p-gov", name: "Governance", slug: "internal_governance", isPersonal: false, kind: "internal_governance" },
+      ],
+    },
+  ];
+
+  describe("given a team with a personal, an internal-governance, and a shared project", () => {
+    /** @scenario the project picker omits personal and internal-governance projects */
+    it("offers only the shared project", () => {
+      const { projects } = resolveCliAuthProjects({ teams });
+
+      expect(projects.map((p) => p.id)).toEqual(["p-shared"]);
+      expect(projects.map((p) => p.slug)).not.toContain("jane-personal");
+      expect(projects.map((p) => p.slug)).not.toContain("internal_governance");
+    });
+  });
+
+  describe("given several offered projects and a known last project", () => {
+    const multi = [
+      {
+        name: "ACME",
+        projects: [
+          { id: "p-a", name: "A", slug: "acme-a", isPersonal: false, kind: "application" },
+          { id: "p-prod", name: "Prod", slug: "acme-prod", isPersonal: false, kind: "application" },
+          { id: "p-c", name: "C", slug: "acme-c", isPersonal: false, kind: "application" },
+        ],
+      },
+    ];
+
+    /** @scenario the project picker pre-selects the user's last project when it is offered */
+    it("pre-selects the last project the user worked in", () => {
+      const { defaultProjectId } = resolveCliAuthProjects({
+        teams: multi,
+        lastProjectSlug: "acme-prod",
+      });
+
+      expect(defaultProjectId).toBe("p-prod");
+    });
+
+    it("falls back to no default when the last project is not offered", () => {
+      const { defaultProjectId } = resolveCliAuthProjects({
+        teams: multi,
+        lastProjectSlug: "jane-personal",
+      });
+
+      expect(defaultProjectId).toBeNull();
+    });
+  });
+
+  describe("given a single offered project", () => {
+    it("auto-selects it", () => {
+      const { defaultProjectId } = resolveCliAuthProjects({ teams });
+      expect(defaultProjectId).toBe("p-shared");
+    });
+  });
+});

--- a/langwatch/src/pages/cli/auth.tsx
+++ b/langwatch/src/pages/cli/auth.tsx
@@ -107,9 +107,9 @@ export default function CliAuthPage() {
   }, [organizations, selectedOrgId]);
 
   // Projects offered in the project-login picker (project_api_key mode).
-  // resolveCliAuthProjects hides personal workspace projects — project login
+  // resolveCliAuthProjects hides personal workspace projects. Project login
   // must target a real, shared project, never a personal one (a coding agent
-  // that picked one silently routed evaluations there) — and the hidden
+  // that picked one silently routed evaluations there), and the hidden
   // internal_governance tenancy project. It also picks the default: the last
   // project the user worked in when it's offered, else the sole project.
   const lastProjectSlug = currentProject?.slug ?? null;

--- a/langwatch/src/pages/cli/auth.tsx
+++ b/langwatch/src/pages/cli/auth.tsx
@@ -11,7 +11,7 @@
  *        a. Mints (or returns existing) personal VK
  *        b. Flips the device-code record to `approved` with the VK secret
  *   7. CLI's polling /exchange returns 200 with the secret on its next poll.
- *   8. Done — user closes the browser tab.
+ *   8. Done, user closes the browser tab.
  *
  * Mirrors the screens-1-thru-4 storyboard in gateway.md.
  */
@@ -35,6 +35,7 @@ import { useRouter } from "~/utils/compat/next-router";
 import { useSession } from "~/utils/auth-client";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { resolveCliAuthProjects } from "./cliAuthProjects";
+import { ScopeChipPicker } from "~/components/settings/ScopeChipPicker";
 
 /**
  * Credential the CLI is requesting.
@@ -113,7 +114,11 @@ export default function CliAuthPage() {
   // internal_governance tenancy project. It also picks the default: the last
   // project the user worked in when it's offered, else the sole project.
   const lastProjectSlug = currentProject?.slug ?? null;
-  const { projects: projectsForOrg, defaultProjectId } = useMemo(() => {
+  const {
+    projects: projectsForOrg,
+    teams: teamsForOrg,
+    defaultProjectId,
+  } = useMemo(() => {
     const org = organizations?.find((o) => o.id === selectedOrgId);
     return resolveCliAuthProjects({ teams: org?.teams, lastProjectSlug });
   }, [organizations, selectedOrgId, lastProjectSlug]);
@@ -290,7 +295,7 @@ export default function CliAuthPage() {
   return (
     <>
       <Head>
-        <title>Authorize CLI — LangWatch</title>
+        <title>Authorize CLI · LangWatch</title>
       </Head>
       <Container maxWidth="540px" paddingTop="80px" paddingBottom="80px">
         <Card.Root>
@@ -352,7 +357,7 @@ export default function CliAuthPage() {
                 <>
                   <Text fontSize="sm" color="gray.600">
                     {requiresProject
-                      ? "The CLI is requesting a project SDK API key. Pick the project to mint a key for; the key will flow back to your terminal automatically — no copy-paste."
+                      ? "The CLI is requesting a project SDK API key. Pick the project to mint a key for; the key will flow back to your terminal automatically, with no copy-paste."
                       : "The CLI is requesting a device session. Approving signs in this device for AI-tool wrappers (Claude, Codex, etc.) and governance commands."}
                   </Text>
                   <Box
@@ -416,27 +421,29 @@ export default function CliAuthPage() {
                           </Alert.Content>
                         </Alert.Root>
                       ) : (
-                        <VStack align="stretch" gap={2}>
-                          {projectsForOrg.map((p) => (
-                            <Button
-                              key={p.id}
-                              variant={
-                                selectedProjectId === p.id ? "solid" : "outline"
-                              }
-                              onClick={() => setSelectedProjectId(p.id)}
-                              justifyContent="flex-start"
-                              height="auto"
-                              paddingY={3}
-                            >
-                              <VStack align="start" gap={0} width="full">
-                                <Text fontWeight="semibold">{p.name}</Text>
-                                <Text fontSize="xs" opacity={0.7}>
-                                  {p.teamName}
-                                </Text>
-                              </VStack>
-                            </Button>
-                          ))}
-                        </VStack>
+                        <ScopeChipPicker
+                          variant="single-select"
+                          label=""
+                          placeholder="Select a project"
+                          allowedScopeTypes={["PROJECT"]}
+                          organizationId={selectedOrgId ?? undefined}
+                          availableProjects={projectsForOrg}
+                          availableTeams={teamsForOrg}
+                          value={
+                            selectedProjectId
+                              ? [
+                                  {
+                                    scopeType: "PROJECT",
+                                    scopeId: selectedProjectId,
+                                  },
+                                ]
+                              : []
+                          }
+                          onChange={(next) =>
+                            setSelectedProjectId(next[0]?.scopeId ?? null)
+                          }
+                          showSummary={false}
+                        />
                       )}
                     </Box>
                   )}
@@ -488,7 +495,7 @@ export default function CliAuthPage() {
                             {action.projectName ?? "your project"}
                           </strong>{" "}
                           ({action.organizationName}). The key flowed back to
-                          your terminal automatically — your{" "}
+                          your terminal automatically, and your{" "}
                           <code>.env</code> is updated. You can close this tab.
                         </Alert.Description>
                       </>

--- a/langwatch/src/pages/cli/auth.tsx
+++ b/langwatch/src/pages/cli/auth.tsx
@@ -34,6 +34,7 @@ import { useRouter } from "~/utils/compat/next-router";
 
 import { useSession } from "~/utils/auth-client";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { resolveCliAuthProjects } from "./cliAuthProjects";
 
 /**
  * Credential the CLI is requesting.
@@ -75,7 +76,7 @@ type ActionState =
 export default function CliAuthPage() {
   const router = useRouter();
   const { data: session, status: sessionStatus } = useSession();
-  const { organizations } = useOrganizationTeamProject({
+  const { organizations, project: currentProject } = useOrganizationTeamProject({
     redirectToOnboarding: false,
   });
 
@@ -105,41 +106,28 @@ export default function CliAuthPage() {
     }
   }, [organizations, selectedOrgId]);
 
-  // Projects scoped to the selected org, flattened across teams. Drives
-  // the project picker that only renders for `project_api_key` mode.
-  // Excludes the hidden `internal_governance` project — it's a system
-  // tenancy boundary, never a target for SDK keys.
-  const projectsForOrg = useMemo(() => {
-    if (!selectedOrgId || !organizations) return [] as Array<{
-      id: string;
-      name: string;
-      slug: string;
-      teamName: string;
-    }>;
-    const org = organizations.find((o) => o.id === selectedOrgId);
-    if (!org) return [];
-    return (org.teams ?? []).flatMap((team) =>
-      (team.projects ?? [])
-        .filter((p) => p.slug !== "internal_governance")
-        .map((p) => ({
-          id: p.id,
-          name: p.name,
-          slug: p.slug,
-          teamName: team.name,
-        })),
-    );
-  }, [organizations, selectedOrgId]);
+  // Projects offered in the project-login picker (project_api_key mode).
+  // resolveCliAuthProjects hides personal workspace projects — project login
+  // must target a real, shared project, never a personal one (a coding agent
+  // that picked one silently routed evaluations there) — and the hidden
+  // internal_governance tenancy project. It also picks the default: the last
+  // project the user worked in when it's offered, else the sole project.
+  const lastProjectSlug = currentProject?.slug ?? null;
+  const { projects: projectsForOrg, defaultProjectId } = useMemo(() => {
+    const org = organizations?.find((o) => o.id === selectedOrgId);
+    return resolveCliAuthProjects({ teams: org?.teams, lastProjectSlug });
+  }, [organizations, selectedOrgId, lastProjectSlug]);
 
-  // Auto-pick the only project, if there is exactly one. Reset when org
-  // changes so the picker is fresh per-org.
+  // Reset when org changes so the picker is fresh per-org, then apply the
+  // computed default selection.
   useEffect(() => {
     setSelectedProjectId(null);
   }, [selectedOrgId]);
   useEffect(() => {
-    if (projectsForOrg.length === 1 && !selectedProjectId) {
-      setSelectedProjectId(projectsForOrg[0]!.id);
+    if (defaultProjectId && !selectedProjectId) {
+      setSelectedProjectId(defaultProjectId);
     }
-  }, [projectsForOrg, selectedProjectId]);
+  }, [defaultProjectId, selectedProjectId]);
 
   // Redirect to sign-in if unauthenticated, preserving the user_code in
   // the callback URL so the user lands back here after SSO.
@@ -418,10 +406,11 @@ export default function CliAuthPage() {
                         <Alert.Root status="warning">
                           <Alert.Indicator />
                           <Alert.Content>
-                            <Alert.Title>No projects yet</Alert.Title>
+                            <Alert.Title>No shared projects yet</Alert.Title>
                             <Alert.Description>
-                              Create a project in this organization first, then
-                              re-run <code>langwatch login</code> in your
+                              Create a team project in this organization first
+                              (personal projects can&apos;t back an SDK key),
+                              then re-run <code>langwatch login</code> in your
                               terminal.
                             </Alert.Description>
                           </Alert.Content>

--- a/langwatch/src/pages/cli/cliAuthProjects.ts
+++ b/langwatch/src/pages/cli/cliAuthProjects.ts
@@ -15,7 +15,13 @@ export interface CliAuthProjectOption {
   id: string;
   name: string;
   slug: string;
+  teamId: string;
   teamName: string;
+}
+
+export interface CliAuthTeamOption {
+  id: string;
+  name: string;
 }
 
 interface ProjectLike {
@@ -27,6 +33,7 @@ interface ProjectLike {
 }
 
 interface TeamLike {
+  id: string;
   name: string;
   projects?: ProjectLike[] | null;
 }
@@ -34,7 +41,11 @@ interface TeamLike {
 export function resolveCliAuthProjects(args: {
   teams: TeamLike[] | null | undefined;
   lastProjectSlug?: string | null;
-}): { projects: CliAuthProjectOption[]; defaultProjectId: string | null } {
+}): {
+  projects: CliAuthProjectOption[];
+  teams: CliAuthTeamOption[];
+  defaultProjectId: string | null;
+} {
   const projects = (args.teams ?? []).flatMap((team) =>
     (team.projects ?? [])
       .filter((p) => !p.isPersonal && p.kind !== "internal_governance")
@@ -42,9 +53,17 @@ export function resolveCliAuthProjects(args: {
         id: p.id,
         name: p.name,
         slug: p.slug,
+        teamId: team.id,
         teamName: team.name,
       })),
   );
+
+  // Only teams that actually have an offered project, so the grouped picker
+  // never renders an empty team header.
+  const offeredTeamIds = new Set(projects.map((p) => p.teamId));
+  const teams = (args.teams ?? [])
+    .filter((team) => offeredTeamIds.has(team.id))
+    .map((team) => ({ id: team.id, name: team.name }));
 
   const lastProject = args.lastProjectSlug
     ? projects.find((p) => p.slug === args.lastProjectSlug)
@@ -53,5 +72,5 @@ export function resolveCliAuthProjects(args: {
   const defaultProjectId =
     lastProject?.id ?? (projects.length === 1 ? projects[0]!.id : null);
 
-  return { projects, defaultProjectId };
+  return { projects, teams, defaultProjectId };
 }

--- a/langwatch/src/pages/cli/cliAuthProjects.ts
+++ b/langwatch/src/pages/cli/cliAuthProjects.ts
@@ -1,0 +1,57 @@
+/**
+ * Project list + default selection for the CLI device-flow project-login
+ * picker (`/cli/auth`, credential_type project_api_key).
+ *
+ * Project login mints a shared SDK API key, so the picker must never offer a
+ * personal workspace project: a coding agent that picked (or had auto-picked)
+ * one silently routed the user's evaluations to a personal project (customer
+ * report). It also hides the internal_governance tenancy project, which is
+ * never user-visible. The default selection prefers the last project the user
+ * worked in (when it is one of the offered projects), then the sole project,
+ * then nothing.
+ */
+
+export interface CliAuthProjectOption {
+  id: string;
+  name: string;
+  slug: string;
+  teamName: string;
+}
+
+interface ProjectLike {
+  id: string;
+  name: string;
+  slug: string;
+  isPersonal?: boolean | null;
+  kind?: string | null;
+}
+
+interface TeamLike {
+  name: string;
+  projects?: ProjectLike[] | null;
+}
+
+export function resolveCliAuthProjects(args: {
+  teams: TeamLike[] | null | undefined;
+  lastProjectSlug?: string | null;
+}): { projects: CliAuthProjectOption[]; defaultProjectId: string | null } {
+  const projects = (args.teams ?? []).flatMap((team) =>
+    (team.projects ?? [])
+      .filter((p) => !p.isPersonal && p.kind !== "internal_governance")
+      .map((p) => ({
+        id: p.id,
+        name: p.name,
+        slug: p.slug,
+        teamName: team.name,
+      })),
+  );
+
+  const lastProject = args.lastProjectSlug
+    ? projects.find((p) => p.slug === args.lastProjectSlug)
+    : undefined;
+
+  const defaultProjectId =
+    lastProject?.id ?? (projects.length === 1 ? projects[0]!.id : null);
+
+  return { projects, defaultProjectId };
+}

--- a/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -16,23 +16,25 @@
  *
  * Spec: specs/ai-gateway/governance/cli-login-personal-guard.feature
  */
-import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-const suffix = nanoid(8);
-const ORG_ID = `org-guard-${suffix}`;
-const TEAM_ID = `team-guard-${suffix}`;
-const PTEAM_ID = `pteam-guard-${suffix}`;
-const USER_ID = `usr-guard-${suffix}`;
-const SHARED_PROJECT_ID = `proj-shared-${suffix}`;
-const PERSONAL_PROJECT_ID = `proj-personal-${suffix}`;
-const SHARED_API_KEY = `sk-lw-shared-${suffix}-${"a".repeat(36)}`;
-const PERSONAL_API_KEY = `sk-lw-personal-${suffix}-${"b".repeat(36)}`;
+// vi.mock is hoisted above every top-level const, so the values the session
+// mock needs must come from vi.hoisted (hoisted alongside it). Math.random,
+// not nanoid — imports aren't available inside the hoisted block.
+const ids = vi.hoisted(() => {
+  const s = Math.random().toString(36).slice(2, 10);
+  return {
+    suffix: s,
+    USER_ID: `usr-guard-${s}`,
+    EMAIL: `guard-${s}@example.com`,
+    NAME: `Guard ${s}`,
+  };
+});
 
 // Only the auth identity is stubbed; the DB/governance calls are real.
 vi.mock("~/server/auth", () => ({
   getServerAuthSession: vi.fn().mockResolvedValue({
-    user: { id: USER_ID, email: `guard-${suffix}@example.com`, name: `Guard ${suffix}` },
+    user: { id: ids.USER_ID, email: ids.EMAIL, name: ids.NAME },
   }),
 }));
 // The picked shared project's key requires project:update; that RBAC decision
@@ -48,6 +50,16 @@ import {
   stopTestContainers,
 } from "~/server/event-sourcing/__tests__/integration/testContainers";
 import { app } from "../auth-cli";
+
+const suffix = ids.suffix;
+const ORG_ID = `org-guard-${suffix}`;
+const TEAM_ID = `team-guard-${suffix}`;
+const PTEAM_ID = `pteam-guard-${suffix}`;
+const USER_ID = ids.USER_ID;
+const SHARED_PROJECT_ID = `proj-shared-${suffix}`;
+const PERSONAL_PROJECT_ID = `proj-personal-${suffix}`;
+const SHARED_API_KEY = `sk-lw-shared-${suffix}-${"a".repeat(36)}`;
+const PERSONAL_API_KEY = `sk-lw-personal-${suffix}-${"b".repeat(36)}`;
 
 const GOV_FLAG = "release_ui_ai_governance_enabled";
 

--- a/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment node
+ *
+ * Integration coverage for the CLI login personal-project guards on
+ * `POST /api/auth/cli/approve` (real Redis + real Prisma):
+ *
+ *   1. device-session (AI-tools) login is refused when governance is not
+ *      enabled for the org — it would otherwise provision a personal
+ *      workspace + VK and capture the user's evaluations (customer report).
+ *   2. project-login (project_api_key) refuses a personal project id and only
+ *      hands back a shared project's key.
+ *
+ * The browser normally drives /approve behind a NextAuth session; we stub only
+ * that identity (the auth boundary) and let every governance / project / DB
+ * call run for real.
+ *
+ * Spec: specs/ai-gateway/governance/cli-login-personal-guard.feature
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const suffix = nanoid(8);
+const ORG_ID = `org-guard-${suffix}`;
+const TEAM_ID = `team-guard-${suffix}`;
+const PTEAM_ID = `pteam-guard-${suffix}`;
+const USER_ID = `usr-guard-${suffix}`;
+const SHARED_PROJECT_ID = `proj-shared-${suffix}`;
+const PERSONAL_PROJECT_ID = `proj-personal-${suffix}`;
+const SHARED_API_KEY = `sk-lw-shared-${suffix}-${"a".repeat(36)}`;
+const PERSONAL_API_KEY = `sk-lw-personal-${suffix}-${"b".repeat(36)}`;
+
+// Only the auth identity is stubbed; the DB/governance calls are real.
+vi.mock("~/server/auth", () => ({
+  getServerAuthSession: vi.fn().mockResolvedValue({
+    user: { id: USER_ID, email: `guard-${suffix}@example.com`, name: `Guard ${suffix}` },
+  }),
+}));
+// The picked shared project's key requires project:update; that RBAC decision
+// is covered elsewhere. Grant it so the gate logic is what's under test.
+vi.mock("~/server/api/rbac", async (importActual) => {
+  const actual = await importActual<typeof import("~/server/api/rbac")>();
+  return { ...actual, hasProjectPermission: vi.fn().mockResolvedValue(true) };
+});
+
+import { prisma } from "~/server/db";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { app } from "../auth-cli";
+
+const GOV_FLAG = "release_ui_ai_governance_enabled";
+
+async function mintDeviceCode(credentialType: string): Promise<string> {
+  const res = await app.request("/api/auth/cli/device-code", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ credential_type: credentialType }),
+  });
+  const dc = (await res.json()) as { user_code: string };
+  return dc.user_code;
+}
+
+async function approve(body: Record<string, unknown>) {
+  const res = await app.request("/api/auth/cli/approve", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ organization_id: ORG_ID, ...body }),
+  });
+  return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("CLI login personal-project guards", () => {
+  beforeAll(async () => {
+    await startTestContainers();
+    await prisma.organization.create({
+      data: { id: ORG_ID, name: `Guard Org ${suffix}`, slug: `guard-${suffix}` },
+    });
+    await prisma.user.create({
+      data: { id: USER_ID, email: `guard-${suffix}@example.com`, name: `Guard ${suffix}` },
+    });
+    await prisma.organizationUser.create({
+      data: { userId: USER_ID, organizationId: ORG_ID, role: "ADMIN" },
+    });
+    // Shared (team) project + a personal-workspace project for the same user.
+    await prisma.team.create({
+      data: { id: TEAM_ID, name: `Team ${suffix}`, slug: `team-${suffix}`, organizationId: ORG_ID },
+    });
+    await prisma.teamUser.create({ data: { userId: USER_ID, teamId: TEAM_ID, role: "ADMIN" } });
+    await prisma.project.create({
+      data: {
+        id: SHARED_PROJECT_ID, name: `Shared ${suffix}`, slug: `shared-${suffix}`,
+        apiKey: SHARED_API_KEY, teamId: TEAM_ID, language: "typescript", framework: "openai",
+        isPersonal: false,
+      },
+    });
+    await prisma.team.create({
+      data: {
+        id: PTEAM_ID, name: `Personal ${suffix}`, slug: `pteam-${suffix}`,
+        organizationId: ORG_ID, isPersonal: true, ownerUserId: USER_ID,
+      },
+    });
+    await prisma.teamUser.create({ data: { userId: USER_ID, teamId: PTEAM_ID, role: "ADMIN" } });
+    await prisma.project.create({
+      data: {
+        id: PERSONAL_PROJECT_ID, name: `My Workspace ${suffix}`, slug: `personal-${suffix}`,
+        apiKey: PERSONAL_API_KEY, teamId: PTEAM_ID, language: "typescript", framework: "openai",
+        isPersonal: true, ownerUserId: USER_ID,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    delete process.env.FEATURE_FLAG_FORCE_ENABLE;
+    await prisma.virtualKey.deleteMany({ where: { principalUserId: USER_ID } }).catch(() => {});
+    await prisma.project.deleteMany({ where: { teamId: { in: [TEAM_ID, PTEAM_ID] } } }).catch(() => {});
+    await prisma.teamUser.deleteMany({ where: { userId: USER_ID } }).catch(() => {});
+    await prisma.team.deleteMany({ where: { id: { in: [TEAM_ID, PTEAM_ID] } } }).catch(() => {});
+    await prisma.organizationUser.deleteMany({ where: { userId: USER_ID } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: USER_ID } }).catch(() => {});
+    await prisma.organization.deleteMany({ where: { id: ORG_ID } }).catch(() => {});
+    await stopTestContainers().catch(() => {});
+  });
+
+  describe("given an organization without governance enabled", () => {
+    /** @scenario device-session approval is refused when governance is disabled */
+    it("refuses a device-session approval with governance_required and mints no personal VK", async () => {
+      delete process.env.FEATURE_FLAG_FORCE_ENABLE;
+      const userCode = await mintDeviceCode("device_session");
+
+      const { status, json } = await approve({ user_code: userCode });
+
+      expect(status).toBe(403);
+      expect(json.error).toBe("governance_required");
+      const vks = await prisma.virtualKey.findMany({ where: { principalUserId: USER_ID } });
+      expect(vks).toHaveLength(0);
+    });
+  });
+
+  describe("given an organization with governance enabled", () => {
+    /** @scenario device-session approval succeeds when governance is enabled */
+    it("does not refuse the device-session approval", async () => {
+      process.env.FEATURE_FLAG_FORCE_ENABLE = GOV_FLAG;
+      const userCode = await mintDeviceCode("device_session");
+
+      const { status } = await approve({ user_code: userCode });
+
+      // Either a VK is issued (200) or the no-provider graceful fallback (200);
+      // the gate must NOT block it.
+      expect(status).not.toBe(403);
+      delete process.env.FEATURE_FLAG_FORCE_ENABLE;
+    });
+  });
+
+  describe("given a project-login (project_api_key) approval", () => {
+    /** @scenario project-login approval rejects a personal project id */
+    it("rejects a personal project id and does not return its API key", async () => {
+      const userCode = await mintDeviceCode("project_api_key");
+
+      const { status, json } = await approve({
+        user_code: userCode,
+        project_id: PERSONAL_PROJECT_ID,
+      });
+
+      expect(status).toBe(400);
+      expect(json.error).toBe("personal_project_not_allowed");
+      expect(JSON.stringify(json)).not.toContain(PERSONAL_API_KEY);
+    });
+
+    /** @scenario project-login approval returns the shared project's key */
+    it("approves a shared team project", async () => {
+      const userCode = await mintDeviceCode("project_api_key");
+
+      const { status, json } = await approve({
+        user_code: userCode,
+        project_id: SHARED_PROJECT_ID,
+      });
+
+      expect(status).toBe(200);
+      expect((json.project as { id: string }).id).toBe(SHARED_PROJECT_ID);
+    });
+  });
+});

--- a/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -45,6 +45,7 @@ vi.mock("~/server/api/rbac", async (importActual) => {
 });
 
 import { prisma } from "~/server/db";
+import { hasProjectPermission } from "~/server/api/rbac";
 import {
   startTestContainers,
   stopTestContainers,
@@ -55,11 +56,15 @@ const suffix = ids.suffix;
 const ORG_ID = `org-guard-${suffix}`;
 const TEAM_ID = `team-guard-${suffix}`;
 const PTEAM_ID = `pteam-guard-${suffix}`;
+// A second team the user is an org admin over but holds NO TeamUser row on.
+const OTHER_TEAM_ID = `oteam-guard-${suffix}`;
 const USER_ID = ids.USER_ID;
 const SHARED_PROJECT_ID = `proj-shared-${suffix}`;
 const PERSONAL_PROJECT_ID = `proj-personal-${suffix}`;
+const OTHER_TEAM_PROJECT_ID = `proj-other-${suffix}`;
 const SHARED_API_KEY = `sk-lw-shared-${suffix}-${"a".repeat(36)}`;
 const PERSONAL_API_KEY = `sk-lw-personal-${suffix}-${"b".repeat(36)}`;
+const OTHER_TEAM_API_KEY = `sk-lw-other-${suffix}-${"c".repeat(36)}`;
 
 const GOV_FLAG = "release_ui_ai_governance_enabled";
 
@@ -120,6 +125,23 @@ describe("CLI login personal-project guards", () => {
         isPersonal: true, ownerUserId: USER_ID,
       },
     });
+    // A shared project on a team the user is NOT a direct member of. The user
+    // is an org ADMIN (organizationUser above), so they see it in the picker
+    // via organization.getAll and hold project:update through the org scope,
+    // but there is deliberately no TeamUser row for them on this team.
+    await prisma.team.create({
+      data: {
+        id: OTHER_TEAM_ID, name: `Other ${suffix}`, slug: `oteam-${suffix}`,
+        organizationId: ORG_ID,
+      },
+    });
+    await prisma.project.create({
+      data: {
+        id: OTHER_TEAM_PROJECT_ID, name: `Other ${suffix}`, slug: `other-${suffix}`,
+        apiKey: OTHER_TEAM_API_KEY, teamId: OTHER_TEAM_ID, language: "typescript",
+        framework: "openai", isPersonal: false,
+      },
+    });
   });
 
   // Reset the governance baseline (off) before every test: the dev .env
@@ -133,9 +155,9 @@ describe("CLI login personal-project guards", () => {
   afterAll(async () => {
     delete process.env.FEATURE_FLAG_FORCE_ENABLE;
     await prisma.virtualKey.deleteMany({ where: { principalUserId: USER_ID } }).catch(() => {});
-    await prisma.project.deleteMany({ where: { teamId: { in: [TEAM_ID, PTEAM_ID] } } }).catch(() => {});
+    await prisma.project.deleteMany({ where: { teamId: { in: [TEAM_ID, PTEAM_ID, OTHER_TEAM_ID] } } }).catch(() => {});
     await prisma.teamUser.deleteMany({ where: { userId: USER_ID } }).catch(() => {});
-    await prisma.team.deleteMany({ where: { id: { in: [TEAM_ID, PTEAM_ID] } } }).catch(() => {});
+    await prisma.team.deleteMany({ where: { id: { in: [TEAM_ID, PTEAM_ID, OTHER_TEAM_ID] } } }).catch(() => {});
     await prisma.organizationUser.deleteMany({ where: { userId: USER_ID } }).catch(() => {});
     await prisma.user.deleteMany({ where: { id: USER_ID } }).catch(() => {});
     await prisma.organization.deleteMany({ where: { id: ORG_ID } }).catch(() => {});
@@ -203,6 +225,44 @@ describe("CLI login personal-project guards", () => {
 
         expect(status).toBe(200);
         expect((json.project as { id: string }).id).toBe(SHARED_PROJECT_ID);
+      });
+    });
+
+    describe("when an org admin approves a project on a team they do not belong to", () => {
+      /** @scenario project-login approval allows an org admin who is not a direct team member */
+      it("does not pre-filter on team membership and defers to the write-permission check", async () => {
+        // Org admins see every team's projects in the picker but may hold
+        // project:update only through an org-scoped binding, not a TeamUser
+        // row. The approval lookup must not reject them before the real RBAC
+        // check (mocked true here) runs.
+        const userCode = await mintDeviceCode("project_api_key");
+
+        const { status, json } = await approve({
+          user_code: userCode,
+          project_id: OTHER_TEAM_PROJECT_ID,
+        });
+
+        expect(status).toBe(200);
+        expect((json.project as { id: string }).id).toBe(OTHER_TEAM_PROJECT_ID);
+      });
+    });
+
+    describe("when the caller lacks write access to the picked project", () => {
+      /** @scenario project-login approval denies a project the caller cannot write */
+      it("returns forbidden and never the project's API key", async () => {
+        // hasProjectPermission is the source of truth: a caller without
+        // project:update is denied even though the project is in their org.
+        vi.mocked(hasProjectPermission).mockResolvedValueOnce(false);
+        const userCode = await mintDeviceCode("project_api_key");
+
+        const { status, json } = await approve({
+          user_code: userCode,
+          project_id: OTHER_TEAM_PROJECT_ID,
+        });
+
+        expect(status).toBe(403);
+        expect(json.error).toBe("forbidden");
+        expect(JSON.stringify(json)).not.toContain(OTHER_TEAM_API_KEY);
       });
     });
   });

--- a/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -16,7 +16,7 @@
  *
  * Spec: specs/ai-gateway/governance/cli-login-personal-guard.feature
  */
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // vi.mock is hoisted above every top-level const, so the values the session
 // mock needs must come from vi.hoisted (hoisted alongside it). Math.random,
@@ -122,6 +122,14 @@ describe("CLI login personal-project guards", () => {
     });
   });
 
+  // Reset the governance baseline (off) before every test: the dev .env
+  // force-enables the flag, so clearing it BEFORE each case is what guarantees
+  // isolation — and a failed assertion can never leak the forced flag forward.
+  // The one governance-on case opts in explicitly in its own body.
+  beforeEach(() => {
+    delete process.env.FEATURE_FLAG_FORCE_ENABLE;
+  });
+
   afterAll(async () => {
     delete process.env.FEATURE_FLAG_FORCE_ENABLE;
     await prisma.virtualKey.deleteMany({ where: { principalUserId: USER_ID } }).catch(() => {});
@@ -135,61 +143,67 @@ describe("CLI login personal-project guards", () => {
   });
 
   describe("given an organization without governance enabled", () => {
-    /** @scenario device-session approval is refused when governance is disabled */
-    it("refuses a device-session approval with governance_required and mints no personal VK", async () => {
-      delete process.env.FEATURE_FLAG_FORCE_ENABLE;
-      const userCode = await mintDeviceCode("device_session");
+    describe("when a device-session approval is requested", () => {
+      /** @scenario device-session approval is refused when governance is disabled */
+      it("refuses it with governance_required and mints no personal VK", async () => {
+        const userCode = await mintDeviceCode("device_session");
 
-      const { status, json } = await approve({ user_code: userCode });
+        const { status, json } = await approve({ user_code: userCode });
 
-      expect(status).toBe(403);
-      expect(json.error).toBe("governance_required");
-      const vks = await prisma.virtualKey.findMany({ where: { principalUserId: USER_ID } });
-      expect(vks).toHaveLength(0);
+        expect(status).toBe(403);
+        expect(json.error).toBe("governance_required");
+        const vks = await prisma.virtualKey.findMany({ where: { principalUserId: USER_ID } });
+        expect(vks).toHaveLength(0);
+      });
     });
   });
 
   describe("given an organization with governance enabled", () => {
-    /** @scenario device-session approval succeeds when governance is enabled */
-    it("does not refuse the device-session approval", async () => {
-      process.env.FEATURE_FLAG_FORCE_ENABLE = GOV_FLAG;
-      const userCode = await mintDeviceCode("device_session");
+    describe("when a device-session approval is requested", () => {
+      /** @scenario device-session approval succeeds when governance is enabled */
+      it("does not refuse the device-session approval", async () => {
+        process.env.FEATURE_FLAG_FORCE_ENABLE = GOV_FLAG;
+        const userCode = await mintDeviceCode("device_session");
 
-      const { status } = await approve({ user_code: userCode });
+        const { status } = await approve({ user_code: userCode });
 
-      // Either a VK is issued (200) or the no-provider graceful fallback (200);
-      // the gate must NOT block it.
-      expect(status).not.toBe(403);
-      delete process.env.FEATURE_FLAG_FORCE_ENABLE;
+        // Either a VK is issued (200) or the no-provider graceful fallback (200);
+        // the gate must NOT block it.
+        expect(status).not.toBe(403);
+      });
     });
   });
 
   describe("given a project-login (project_api_key) approval", () => {
-    /** @scenario project-login approval rejects a personal project id */
-    it("rejects a personal project id and does not return its API key", async () => {
-      const userCode = await mintDeviceCode("project_api_key");
+    describe("when the approval targets a personal project id", () => {
+      /** @scenario project-login approval rejects a personal project id */
+      it("rejects it and does not return its API key", async () => {
+        const userCode = await mintDeviceCode("project_api_key");
 
-      const { status, json } = await approve({
-        user_code: userCode,
-        project_id: PERSONAL_PROJECT_ID,
+        const { status, json } = await approve({
+          user_code: userCode,
+          project_id: PERSONAL_PROJECT_ID,
+        });
+
+        expect(status).toBe(400);
+        expect(json.error).toBe("personal_project_not_allowed");
+        expect(JSON.stringify(json)).not.toContain(PERSONAL_API_KEY);
       });
-
-      expect(status).toBe(400);
-      expect(json.error).toBe("personal_project_not_allowed");
-      expect(JSON.stringify(json)).not.toContain(PERSONAL_API_KEY);
     });
 
-    /** @scenario project-login approval returns the shared project's key */
-    it("approves a shared team project", async () => {
-      const userCode = await mintDeviceCode("project_api_key");
+    describe("when the approval targets a shared team project id", () => {
+      /** @scenario project-login approval returns the shared project's key */
+      it("approves it and returns that project", async () => {
+        const userCode = await mintDeviceCode("project_api_key");
 
-      const { status, json } = await approve({
-        user_code: userCode,
-        project_id: SHARED_PROJECT_ID,
+        const { status, json } = await approve({
+          user_code: userCode,
+          project_id: SHARED_PROJECT_ID,
+        });
+
+        expect(status).toBe(200);
+        expect((json.project as { id: string }).id).toBe(SHARED_PROJECT_ID);
       });
-
-      expect(status).toBe(200);
-      expect((json.project as { id: string }).id).toBe(SHARED_PROJECT_ID);
     });
   });
 });

--- a/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-personal-guard.integration.test.ts
@@ -5,7 +5,7 @@
  * `POST /api/auth/cli/approve` (real Redis + real Prisma):
  *
  *   1. device-session (AI-tools) login is refused when governance is not
- *      enabled for the org — it would otherwise provision a personal
+ *      enabled for the org, since it would otherwise provision a personal
  *      workspace + VK and capture the user's evaluations (customer report).
  *   2. project-login (project_api_key) refuses a personal project id and only
  *      hands back a shared project's key.
@@ -20,7 +20,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 
 // vi.mock is hoisted above every top-level const, so the values the session
 // mock needs must come from vi.hoisted (hoisted alongside it). Math.random,
-// not nanoid — imports aren't available inside the hoisted block.
+// not nanoid, since imports aren't available inside the hoisted block.
 const ids = vi.hoisted(() => {
   const s = Math.random().toString(36).slice(2, 10);
   return {
@@ -124,7 +124,7 @@ describe("CLI login personal-project guards", () => {
 
   // Reset the governance baseline (off) before every test: the dev .env
   // force-enables the flag, so clearing it BEFORE each case is what guarantees
-  // isolation — and a failed assertion can never leak the forced flag forward.
+  // isolation, and a failed assertion can never leak the forced flag forward.
   // The one governance-on case opts in explicitly in its own body.
   beforeEach(() => {
     delete process.env.FEATURE_FLAG_FORCE_ENABLE;

--- a/langwatch/src/server/routes/auth-cli.ts
+++ b/langwatch/src/server/routes/auth-cli.ts
@@ -1516,18 +1516,23 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
         400,
       );
     }
-    // Verify the user actually has access to the project: the project must
-    // belong to a team in the chosen org, and the user must be a member of
-    // that team (PG schema enforces this via TeamUser; we re-check here so
-    // a hostile browser request can't be tricked into leaking another org's
-    // key by spoofing project_id).
+    // Resolve the picked project: it must live in the chosen org and not be
+    // archived. Authorization is NOT decided by this lookup. The
+    // `hasProjectPermission(..., "project:update")` check below is the source
+    // of truth, and it re-derives the org from the project id and inspects
+    // project-, team- and org-scoped role bindings plus the org role. So an
+    // org-level admin (or an org/team-scoped role-binding admin) who sees the
+    // project in the picker via `organization.getAll`, but is not a direct
+    // TeamUser member, is authorized by their real permission instead of
+    // being pre-filtered out. The org-scoping predicate here plus that RBAC
+    // check together stop a spoofed `project_id` from leaking another org's
+    // key.
     const project = await prisma.project.findFirst({
       where: {
         id: project_id,
         archivedAt: null,
         team: {
           organizationId: organization_id,
-          members: { some: { userId: session.user.id } },
         },
       },
       select: { id: true, slug: true, name: true, apiKey: true, isPersonal: true },
@@ -1537,7 +1542,7 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
         {
           error: "forbidden",
           error_description:
-            "Project not found in this organization, or you do not have access to it",
+            "Project not found or unavailable in this organization",
         },
         403,
       );

--- a/langwatch/src/server/routes/auth-cli.ts
+++ b/langwatch/src/server/routes/auth-cli.ts
@@ -1543,7 +1543,7 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
       );
     }
 
-    // Project login must target a real, shared project — never a personal
+    // Project login must target a real, shared project, never a personal
     // workspace project. A coding agent that picked (or had auto-selected)
     // the personal project silently sent the user's evaluations there
     // (customer report). The browser picker hides personal projects; this
@@ -1620,7 +1620,7 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
       {
         error: "governance_required",
         error_description:
-          "AI-tools (device) login needs governance enabled for your organization. Re-run `langwatch login` and choose project login — it writes a project API key to your .env.",
+          "AI-tools (device) login needs governance enabled for your organization. Re-run `langwatch login` and choose project login. It writes a project API key to your .env.",
       },
       403,
     );

--- a/langwatch/src/server/routes/auth-cli.ts
+++ b/langwatch/src/server/routes/auth-cli.ts
@@ -49,6 +49,7 @@ import { IngestionSourceService } from "@ee/governance/services/activity-monitor
 import { ActivityMonitorService } from "@ee/governance/services/activity-monitor/activityMonitor.service";
 import { GovernanceSetupStateService } from "@ee/governance/services/setupState.service";
 import { CliBootstrapService } from "@ee/governance/services/cliBootstrap.service";
+import { featureFlagService } from "~/server/featureFlag";
 import { IngestionTemplateService } from "@ee/governance/services/ingestionTemplate.service";
 import { IngestionKeyService } from "@ee/governance/services/ingestionKey.service";
 import {
@@ -1529,7 +1530,7 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
           members: { some: { userId: session.user.id } },
         },
       },
-      select: { id: true, slug: true, name: true, apiKey: true },
+      select: { id: true, slug: true, name: true, apiKey: true, isPersonal: true },
     });
     if (!project) {
       return c.json(
@@ -1539,6 +1540,22 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
             "Project not found in this organization, or you do not have access to it",
         },
         403,
+      );
+    }
+
+    // Project login must target a real, shared project — never a personal
+    // workspace project. A coding agent that picked (or had auto-selected)
+    // the personal project silently sent the user's evaluations there
+    // (customer report). The browser picker hides personal projects; this
+    // is the server-side guarantee.
+    if (project.isPersonal) {
+      return c.json(
+        {
+          error: "personal_project_not_allowed",
+          error_description:
+            "Personal projects can't back a project API key. Pick a shared team project so your evaluations, prompts and traces land on a real project.",
+        },
+        400,
       );
     }
 
@@ -1582,6 +1599,30 @@ secured.access(CLI_POLICY).post("/approve", async (c: Context) => {
         organization_id,
       },
       200,
+    );
+  }
+
+  // Governance gate: the device-session flow provisions a personal
+  // workspace (Team + Project) and a personal virtual key for the user.
+  // That is a governance-plane capability; for an org without governance
+  // enabled it silently created a personal project that then captured the
+  // user's evaluations (customer report). Refuse it and point at project
+  // login, which writes a real project's API key to `.env`.
+  const governanceEnabled = await featureFlagService
+    .isEnabled("release_ui_ai_governance_enabled", {
+      distinctId: session.user.id,
+      organizationId: organization_id,
+      defaultValue: false,
+    })
+    .catch(() => false);
+  if (!governanceEnabled) {
+    return c.json(
+      {
+        error: "governance_required",
+        error_description:
+          "AI-tools (device) login needs governance enabled for your organization. Re-run `langwatch login` and choose project login — it writes a project API key to your .env.",
+      },
+      403,
     );
   }
 

--- a/skills/_shared/projects-and-api-keys.mdx
+++ b/skills/_shared/projects-and-api-keys.mdx
@@ -1,13 +1,13 @@
-**Projects and API keys — target a real project, not a personal one.**
+**Projects and API keys: target a real project, not a personal one.**
 
 LangWatch has two kinds of project:
 
-- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
-- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+- **Team / shared projects**: real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects**: a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
 
 And two ways to authenticate:
 
-- **A project API key in `.env`** (`LANGWATCH_API_KEY`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
-- **`langwatch login --device` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (`langwatch claude`, `langwatch codex`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+- **A project API key in `.env`** (`LANGWATCH_API_KEY`): the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **`langwatch login --device` (AI-tools / SSO)**: a personal device session for wrapping coding assistants (`langwatch claude`, `langwatch codex`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
 
-So for anything in these skills: make sure `LANGWATCH_API_KEY` for a real, shared project is in the project's `.env`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run `langwatch login` to pick a project, and never default to a personal project. If `LANGWATCH_ENDPOINT` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.
+So for anything in these skills: make sure `LANGWATCH_API_KEY` for a real, shared project is in the project's `.env`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run `langwatch login` to pick a project, and never default to a personal project. If `LANGWATCH_ENDPOINT` is set, they are self-hosted, use that endpoint instead of app.langwatch.ai.

--- a/skills/_shared/projects-and-api-keys.mdx
+++ b/skills/_shared/projects-and-api-keys.mdx
@@ -1,0 +1,13 @@
+**Projects and API keys — target a real project, not a personal one.**
+
+LangWatch has two kinds of project:
+
+- **Team / shared projects** — real projects inside an organization. Evaluations, experiments, prompts, datasets, simulations and instrumentation must always target one of these.
+- **Personal projects** — a private "My Workspace" scratch space tied to a single user. Never send a user's evaluations, experiments or production traces here: it is for personal exploration only and is easily confused with a real project.
+
+And two ways to authenticate:
+
+- **A project API key in `.env`** (`LANGWATCH_API_KEY`) — the credential everything in these skills uses. It is scoped to one real project. This is the default; prefer it unless the user explicitly asks for something else.
+- **`langwatch login --device` (AI-tools / SSO)** — a personal device session for wrapping coding assistants (`langwatch claude`, `langwatch codex`, …). It is NOT for evaluations, prompts, datasets, scenarios or SDK instrumentation, and it points at a personal workspace. Do not run it to set up the work in these skills.
+
+So for anything in these skills: make sure `LANGWATCH_API_KEY` for a real, shared project is in the project's `.env`. If it is missing, ask the user for it (they can mint a key for a specific project at https://app.langwatch.ai/authorize). Do NOT run `langwatch login` to pick a project, and never default to a personal project. If `LANGWATCH_ENDPOINT` is set, they are self-hosted — use that endpoint instead of app.langwatch.ai.

--- a/skills/_tests/cli-auth.scenario.test.ts
+++ b/skills/_tests/cli-auth.scenario.test.ts
@@ -82,7 +82,7 @@ describe("LangWatch CLI Auth Discovery — bare CLI, no skill", () => {
  * snippet), the agent must use the project API key already in `.env` and must
  * never run the AI-tools / device login or target a personal project.
  */
-describe("LangWatch CLI Auth — skill setup stays on a real project", () => {
+describe("LangWatch CLI Auth: skill setup stays on a real project", () => {
   it.skipIf(isCI)(
     "uses the .env project key and never device / personal login",
     async () => {
@@ -144,7 +144,7 @@ describe("LangWatch CLI Auth — skill setup stays on a real project", () => {
               .join("\n")
               .toLowerCase();
             // Hard guardrail: the AI-tools / device login must never be invoked
-            // for evaluation setup — that is what routes to a personal project.
+            // for evaluation setup, that is what routes to a personal project.
             expect(
               transcript.includes("login --device"),
               "agent must not run `langwatch login --device` for evaluation setup",

--- a/skills/_tests/cli-auth.scenario.test.ts
+++ b/skills/_tests/cli-auth.scenario.test.ts
@@ -82,80 +82,82 @@ describe("LangWatch CLI Auth Discovery — bare CLI, no skill", () => {
  * snippet), the agent must use the project API key already in `.env` and must
  * never run the AI-tools / device login or target a personal project.
  */
-describe("LangWatch CLI Auth: skill setup stays on a real project", () => {
-  it.skipIf(isCI)(
-    "uses the .env project key and never device / personal login",
-    async () => {
-      const tempFolder = fs.mkdtempSync(
-        path.join(os.tmpdir(), "langwatch-cli-auth-project-"),
-      );
-      // A real minimal agent with a project API key already present in .env.
-      fs.cpSync(
-        path.resolve(__dirname, "fixtures/python-openai"),
-        tempFolder,
-        { recursive: true },
-      );
-      const apiKey = process.env.LANGWATCH_API_KEY;
-      if (!apiKey) {
-        throw new Error(
-          "LANGWATCH_API_KEY is required for this scenario test",
+describe("given the evaluations skill installed with a project key in .env", () => {
+  describe("when the agent is asked to set up an evaluation", () => {
+    it.skipIf(isCI)(
+      "uses the .env project key and never device / personal login",
+      async () => {
+        const tempFolder = fs.mkdtempSync(
+          path.join(os.tmpdir(), "langwatch-cli-auth-project-"),
         );
-      }
-      fs.writeFileSync(
-        path.join(tempFolder, ".env"),
-        `LANGWATCH_API_KEY=${apiKey}\n`,
-      );
-      installSkillToWorkDir({
-        workingDirectory: tempFolder,
-        skillSubpath: "evaluations",
-      });
+        // A real minimal agent with a project API key already present in .env.
+        fs.cpSync(
+          path.resolve(__dirname, "fixtures/python-openai"),
+          tempFolder,
+          { recursive: true },
+        );
+        const apiKey = process.env.LANGWATCH_API_KEY;
+        if (!apiKey) {
+          throw new Error(
+            "LANGWATCH_API_KEY is required for this scenario test",
+          );
+        }
+        fs.writeFileSync(
+          path.join(tempFolder, ".env"),
+          `LANGWATCH_API_KEY=${apiKey}\n`,
+        );
+        installSkillToWorkDir({
+          workingDirectory: tempFolder,
+          skillSubpath: "evaluations",
+        });
 
-      const result = await scenario.run({
-        setId: SKILL_TESTS_SET_ID,
-        name: "Evaluation setup stays on a real project",
-        description:
-          "User asks the agent (with the evaluations skill installed) to set up a batch evaluation. A project API key is already in .env. The agent must use that real project key and must NOT run an AI-tools/device login or create/target a personal project.",
-        agents: [
-          createClaudeCodeAgent({ workingDirectory: tempFolder }),
-          scenario.userSimulatorAgent({ model: judgeModel }),
-          scenario.judgeAgent({
-            model: judgeModel,
-            criteria: [
-              "Agent used the LANGWATCH_API_KEY already present in .env (a real project key) for the setup",
-              "Agent did NOT run `langwatch login --device` or any device / SSO / AI-tools login",
-              "Agent did NOT create, select, or target a personal project / 'My Workspace' / personal workspace",
-            ],
-          }),
-        ],
-        script: [
-          scenario.user(
-            "set up a batch evaluation experiment for my agent using langwatch",
-          ),
-          scenario.agent(),
-          (state) => {
-            toolCallFix(state);
-            assertSkillWasRead(state, "evaluations");
-            const transcript = state.messages
-              .map((m) =>
-                typeof m.content === "string"
-                  ? m.content
-                  : JSON.stringify(m.content),
-              )
-              .join("\n")
-              .toLowerCase();
-            // Hard guardrail: the AI-tools / device login must never be invoked
-            // for evaluation setup, that is what routes to a personal project.
-            expect(
-              transcript.includes("login --device"),
-              "agent must not run `langwatch login --device` for evaluation setup",
-            ).toBe(false);
-          },
-          scenario.judge(),
-        ],
-      });
+        const result = await scenario.run({
+          setId: SKILL_TESTS_SET_ID,
+          name: "Evaluation setup stays on a real project",
+          description:
+            "User asks the agent (with the evaluations skill installed) to set up a batch evaluation. A project API key is already in .env. The agent must use that real project key and must NOT run an AI-tools/device login or create/target a personal project.",
+          agents: [
+            createClaudeCodeAgent({ workingDirectory: tempFolder }),
+            scenario.userSimulatorAgent({ model: judgeModel }),
+            scenario.judgeAgent({
+              model: judgeModel,
+              criteria: [
+                "Agent used the LANGWATCH_API_KEY already present in .env (a real project key) for the setup",
+                "Agent did NOT run `langwatch login --device` or any device / SSO / AI-tools login",
+                "Agent did NOT create, select, or target a personal project / 'My Workspace' / personal workspace",
+              ],
+            }),
+          ],
+          script: [
+            scenario.user(
+              "set up a batch evaluation experiment for my agent using langwatch",
+            ),
+            scenario.agent(),
+            (state) => {
+              toolCallFix(state);
+              assertSkillWasRead(state, "evaluations");
+              const transcript = state.messages
+                .map((m) =>
+                  typeof m.content === "string"
+                    ? m.content
+                    : JSON.stringify(m.content),
+                )
+                .join("\n")
+                .toLowerCase();
+              // Hard guardrail: the AI-tools / device login must never be invoked
+              // for evaluation setup, that is what routes to a personal project.
+              expect(
+                transcript.includes("login --device"),
+                "agent must not run `langwatch login --device` for evaluation setup",
+              ).toBe(false);
+            },
+            scenario.judge(),
+          ],
+        });
 
-      expect(result.success).toBe(true);
-    },
-    900_000,
-  );
+        expect(result.success).toBe(true);
+      },
+      900_000,
+    );
+  });
 });

--- a/skills/_tests/cli-auth.scenario.test.ts
+++ b/skills/_tests/cli-auth.scenario.test.ts
@@ -1,5 +1,6 @@
 import scenario from "@langwatch/scenario";
 import fs from "fs";
+import { execSync } from "child_process";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
 import os from "os";
@@ -9,6 +10,8 @@ import { openai } from "@ai-sdk/openai";
 import {
   createClaudeCodeAgent,
   toolCallFix,
+  assertSkillWasRead,
+  installSkillToWorkDir,
   SKILL_TESTS_SET_ID,
 } from "./helpers/claude-code-adapter";
 
@@ -62,6 +65,84 @@ describe("LangWatch CLI Auth Discovery — bare CLI, no skill", () => {
           scenario.agent(),
           (state) => {
             toolCallFix(state);
+          },
+          scenario.judge(),
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    },
+    900_000,
+  );
+});
+
+/**
+ * Regression for the customer report: a coding agent setting up experiments
+ * ran `langwatch login`, signed in to a personal project, and the evaluations
+ * went there. With the evaluations skill (and the projects-and-api-keys shared
+ * snippet), the agent must use the project API key already in `.env` and must
+ * never run the AI-tools / device login or target a personal project.
+ */
+describe("LangWatch CLI Auth — skill setup stays on a real project", () => {
+  it.skipIf(isCI)(
+    "uses the .env project key and never device / personal login",
+    async () => {
+      const tempFolder = fs.mkdtempSync(
+        path.join(os.tmpdir(), "langwatch-cli-auth-project-"),
+      );
+      // A real minimal agent with a project API key already present in .env.
+      execSync(
+        `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`,
+      );
+      const apiKey = process.env.LANGWATCH_API_KEY ?? "";
+      fs.writeFileSync(
+        path.join(tempFolder, ".env"),
+        `LANGWATCH_API_KEY=${apiKey}\n`,
+      );
+      installSkillToWorkDir({
+        workingDirectory: tempFolder,
+        skillSubpath: "evaluations",
+      });
+
+      const result = await scenario.run({
+        setId: SKILL_TESTS_SET_ID,
+        name: "Evaluation setup stays on a real project",
+        description:
+          "User asks the agent (with the evaluations skill installed) to set up a batch evaluation. A project API key is already in .env. The agent must use that real project key and must NOT run an AI-tools/device login or create/target a personal project.",
+        agents: [
+          createClaudeCodeAgent({ workingDirectory: tempFolder }),
+          scenario.userSimulatorAgent({ model: judgeModel }),
+          scenario.judgeAgent({
+            model: judgeModel,
+            criteria: [
+              "Agent used the LANGWATCH_API_KEY already present in .env (a real project key) for the setup",
+              "Agent did NOT run `langwatch login --device` or any device / SSO / AI-tools login",
+              "Agent did NOT create, select, or target a personal project / 'My Workspace' / personal workspace",
+            ],
+          }),
+        ],
+        script: [
+          scenario.user(
+            "set up a batch evaluation experiment for my agent using langwatch",
+          ),
+          scenario.agent(),
+          (state) => {
+            toolCallFix(state);
+            assertSkillWasRead(state, "evaluations");
+            const transcript = state.messages
+              .map((m) =>
+                typeof m.content === "string"
+                  ? m.content
+                  : JSON.stringify(m.content),
+              )
+              .join("\n")
+              .toLowerCase();
+            // Hard guardrail: the AI-tools / device login must never be invoked
+            // for evaluation setup — that is what routes to a personal project.
+            expect(
+              transcript.includes("login --device"),
+              "agent must not run `langwatch login --device` for evaluation setup",
+            ).toBe(false);
           },
           scenario.judge(),
         ],

--- a/skills/_tests/cli-auth.scenario.test.ts
+++ b/skills/_tests/cli-auth.scenario.test.ts
@@ -1,6 +1,5 @@
 import scenario from "@langwatch/scenario";
 import fs from "fs";
-import { execSync } from "child_process";
 import { describe, it, expect } from "vitest";
 import dotenv from "dotenv";
 import os from "os";
@@ -91,10 +90,17 @@ describe("LangWatch CLI Auth — skill setup stays on a real project", () => {
         path.join(os.tmpdir(), "langwatch-cli-auth-project-"),
       );
       // A real minimal agent with a project API key already present in .env.
-      execSync(
-        `cp -r ${path.resolve(__dirname, "fixtures/python-openai")}/* ${tempFolder}/`,
+      fs.cpSync(
+        path.resolve(__dirname, "fixtures/python-openai"),
+        tempFolder,
+        { recursive: true },
       );
-      const apiKey = process.env.LANGWATCH_API_KEY ?? "";
+      const apiKey = process.env.LANGWATCH_API_KEY;
+      if (!apiKey) {
+        throw new Error(
+          "LANGWATCH_API_KEY is required for this scenario test",
+        );
+      }
       fs.writeFileSync(
         path.join(tempFolder, ".env"),
         `LANGWATCH_API_KEY=${apiKey}\n`,

--- a/skills/_tests/cli-auth.scenario.test.ts
+++ b/skills/_tests/cli-auth.scenario.test.ts
@@ -130,25 +130,30 @@ describe("given the evaluations skill installed with a project key in .env", () 
           ],
           script: [
             scenario.user(
-              "set up a batch evaluation experiment for my agent using langwatch",
+              "Set up a batch evaluation experiment for my agent using langwatch: create the experiment script and wire up auth from the project's existing .env. Do NOT run it, install dependencies, or start any containers yet.",
             ),
             scenario.agent(),
             (state) => {
               toolCallFix(state);
               assertSkillWasRead(state, "evaluations");
-              const transcript = state.messages
-                .map((m) =>
+              // Hard guardrail: the agent must never EXECUTE the AI-tools / device
+              // login (that is what routes evaluations to a personal project). We
+              // scan the executed tool-call command fields, not the whole
+              // transcript: the skill prose itself names `langwatch login --device`
+              // to warn against it, so a plain substring check would always trip.
+              const ranDeviceLogin = state.messages.some((m) => {
+                const raw =
                   typeof m.content === "string"
                     ? m.content
-                    : JSON.stringify(m.content),
-                )
-                .join("\n")
-                .toLowerCase();
-              // Hard guardrail: the AI-tools / device login must never be invoked
-              // for evaluation setup, that is what routes to a personal project.
+                    : JSON.stringify(m.content ?? "");
+                const flattened = raw.replace(/\\/g, "");
+                return /"command":"[^"]*langwatch login[^"]*--device/.test(
+                  flattened,
+                );
+              });
               expect(
-                transcript.includes("login --device"),
-                "agent must not run `langwatch login --device` for evaluation setup",
+                ranDeviceLogin,
+                "agent must not execute `langwatch login --device` for evaluation setup",
               ).toBe(false);
             },
             scenario.judge(),

--- a/skills/analytics/SKILL.mdx
+++ b/skills/analytics/SKILL.mdx
@@ -7,6 +7,7 @@ compatibility: Works with Claude Code and similar AI assistants. The `langwatch`
 ---
 
 import CliSetup from '../_shared/cli-setup.mdx'
+import ProjectsAndApiKeys from '../_shared/projects-and-api-keys.mdx'
 
 # Analyze Agent Performance with LangWatch
 
@@ -15,6 +16,8 @@ This skill queries and presents analytics. It does NOT write code.
 ## Step 1: Set up the LangWatch CLI
 
 <CliSetup />
+
+<ProjectsAndApiKeys />
 
 ## Step 2: Get a Project Overview
 

--- a/skills/evaluations/SKILL.mdx
+++ b/skills/evaluations/SKILL.mdx
@@ -7,6 +7,7 @@ compatibility: Works with Claude Code and similar AI assistants. The `langwatch`
 ---
 
 import CliSetup from '../_shared/cli-setup.mdx'
+import ProjectsAndApiKeys from '../_shared/projects-and-api-keys.mdx'
 import PlanLimits from '../_shared/plan-limits.mdx'
 import ConsultantMode from '../_shared/consultant-mode.mdx'
 
@@ -54,6 +55,8 @@ Some features are code-only (experiments, guardrails) and some are platform-only
 ## Prerequisites
 
 <CliSetup />
+
+<ProjectsAndApiKeys />
 
 Then read the evaluations overview:
 

--- a/skills/level-up/SKILL.mdx
+++ b/skills/level-up/SKILL.mdx
@@ -7,6 +7,7 @@ compatibility: Works with Claude Code and similar coding agents. The `langwatch`
 ---
 
 import CliSetup from '../_shared/cli-setup.mdx'
+import ProjectsAndApiKeys from '../_shared/projects-and-api-keys.mdx'
 import PlanLimits from '../_shared/plan-limits.mdx'
 import ConsultantMode from '../_shared/consultant-mode.mdx'
 
@@ -21,6 +22,8 @@ This skill sets up your agent with the full LangWatch stack: tracing, prompt ver
 ## Prerequisites
 
 <CliSetup />
+
+<ProjectsAndApiKeys />
 
 ## Consultant Mode
 

--- a/skills/prompts/SKILL.mdx
+++ b/skills/prompts/SKILL.mdx
@@ -7,6 +7,7 @@ compatibility: Works with Claude Code and similar coding agents. The `langwatch`
 ---
 
 import CliSetup from '../_shared/cli-setup.mdx'
+import ProjectsAndApiKeys from '../_shared/projects-and-api-keys.mdx'
 import PlanLimits from '../_shared/plan-limits.mdx'
 
 # Version Your Prompts with LangWatch Prompts CLI
@@ -31,6 +32,8 @@ If the user's request is **specific** ("version this prompt", "create a new prom
 ## Step 1: Read the Prompts CLI Docs
 
 <CliSetup />
+
+<ProjectsAndApiKeys />
 
 Then specifically read the Prompts CLI guide:
 

--- a/skills/scenarios/SKILL.mdx
+++ b/skills/scenarios/SKILL.mdx
@@ -7,6 +7,7 @@ compatibility: Works with Claude Code and similar AI assistants. The `langwatch`
 ---
 
 import CliSetup from '../_shared/cli-setup.mdx'
+import ProjectsAndApiKeys from '../_shared/projects-and-api-keys.mdx'
 import PlanLimits from '../_shared/plan-limits.mdx'
 import ConsultantMode from '../_shared/consultant-mode.mdx'
 
@@ -57,6 +58,8 @@ Best practices:
 ### Step 1: Read the Scenario Docs
 
 <CliSetup />
+
+<ProjectsAndApiKeys />
 
 Then read the Scenario-specific pages:
 

--- a/skills/tracing/SKILL.mdx
+++ b/skills/tracing/SKILL.mdx
@@ -7,6 +7,7 @@ compatibility: Works with Claude Code and similar coding agents. The `langwatch`
 ---
 
 import CliSetup from '../_shared/cli-setup.mdx'
+import ProjectsAndApiKeys from '../_shared/projects-and-api-keys.mdx'
 
 # Add LangWatch Tracing to Your Code
 
@@ -27,6 +28,8 @@ This skill is code-only — there is no platform path for tracing. If the user h
 ## Step 1: Read the Integration Docs
 
 <CliSetup />
+
+<ProjectsAndApiKeys />
 
 Then fetch the integration guide for this project's framework:
 

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -2,7 +2,7 @@ Feature: CLI login never lands a user on a personal project
 
   A customer used the LangWatch coding-assistant skills to set up experiments. Their
   agent ran `langwatch login`, which signed them into a personal project, and the
-  evaluations they then created were sent to that personal project — confusing, and
+  evaluations they then created were sent to that personal project, confusing, and
   wrong for shared / team work. Two backend guards make this impossible, paired with
   the CLI-side default-to-project behavior:
 

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -54,6 +54,21 @@ Feature: CLI login never lands a user on a personal project
       When the user approves with the shared team project's id
       Then the response is 200 and returns that project's API key
 
+    @integration @project-picker @rbac
+    Scenario: project-login approval allows an org admin who is not a direct team member
+      Given a pending device code with credential_type "project_api_key"
+      And a shared project on a team the org admin does not directly belong to
+      When the org admin who can write the project approves with its id
+      Then the response is 200 and returns that project's API key
+
+    @integration @project-picker @rbac
+    Scenario: project-login approval denies a project the caller cannot write
+      Given a pending device code with credential_type "project_api_key"
+      And the caller lacks write access to the picked shared project
+      When the user approves with that project's id
+      Then the response is 403 with error "forbidden"
+      And the project's API key is NOT returned
+
     @unit @project-picker
     Scenario: the project picker omits personal and internal-governance projects
       Given an org team with a personal project, an internal-governance project, and a shared project

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -19,12 +19,13 @@ Feature: CLI login never lands a user on a personal project
   Background:
     Given a user who is a member of an organization
     And the CLI device-code approval endpoint `POST /api/auth/cli/approve`
+    And governance for an organization is gated by the `release_ui_ai_governance_enabled` feature flag
 
   Rule: device-session (AI-tools) login requires governance enabled
 
     @integration @governance-gate
     Scenario: device-session approval is refused when governance is disabled
-      Given the organization does NOT have `release_ui_ai_governance_enabled`
+      Given governance is disabled for the organization
       And a pending device code with credential_type "device_session"
       When the user approves it
       Then the response is 403 with error "governance_required"
@@ -32,7 +33,7 @@ Feature: CLI login never lands a user on a personal project
 
     @integration @governance-gate
     Scenario: device-session approval succeeds when governance is enabled
-      Given the organization HAS `release_ui_ai_governance_enabled`
+      Given governance is enabled for the organization
       And a pending device code with credential_type "device_session"
       When the user approves it
       Then the response is 200 and a personal virtual key is issued

--- a/specs/ai-gateway/governance/cli-login-personal-guard.feature
+++ b/specs/ai-gateway/governance/cli-login-personal-guard.feature
@@ -1,0 +1,66 @@
+Feature: CLI login never lands a user on a personal project
+
+  A customer used the LangWatch coding-assistant skills to set up experiments. Their
+  agent ran `langwatch login`, which signed them into a personal project, and the
+  evaluations they then created were sent to that personal project — confusing, and
+  wrong for shared / team work. Two backend guards make this impossible, paired with
+  the CLI-side default-to-project behavior:
+
+    1. The device-session (AI-tools) login provisions a personal workspace + personal
+       virtual key. That is a governance-plane feature; for an organization without
+       governance enabled it must be refused, with a message pointing at project login.
+    2. The project-login (project_api_key) flow must target a real, shared project. The
+       browser picker hides personal projects, the approval endpoint rejects a personal
+       project id, and the picker defaults to the last project the user worked in.
+
+  Pairs with:
+    - specs/ai-governance/cli-onboarding/login-unified.feature  (CLI-side default-to-project)
+
+  Background:
+    Given a user who is a member of an organization
+    And the CLI device-code approval endpoint `POST /api/auth/cli/approve`
+
+  Rule: device-session (AI-tools) login requires governance enabled
+
+    @integration @governance-gate
+    Scenario: device-session approval is refused when governance is disabled
+      Given the organization does NOT have `release_ui_ai_governance_enabled`
+      And a pending device code with credential_type "device_session"
+      When the user approves it
+      Then the response is 403 with error "governance_required"
+      And no personal virtual key is minted for the user
+
+    @integration @governance-gate
+    Scenario: device-session approval succeeds when governance is enabled
+      Given the organization HAS `release_ui_ai_governance_enabled`
+      And a pending device code with credential_type "device_session"
+      When the user approves it
+      Then the response is 200 and a personal virtual key is issued
+
+  Rule: project login targets a real project, never a personal one
+
+    @integration @project-picker
+    Scenario: project-login approval rejects a personal project id
+      Given a pending device code with credential_type "project_api_key"
+      And the user has a personal project and a shared team project
+      When the user approves with the personal project's id
+      Then the response is 400 with error "personal_project_not_allowed"
+      And the personal project's API key is NOT returned
+
+    @integration @project-picker
+    Scenario: project-login approval returns the shared project's key
+      Given a pending device code with credential_type "project_api_key"
+      When the user approves with the shared team project's id
+      Then the response is 200 and returns that project's API key
+
+    @unit @project-picker
+    Scenario: the project picker omits personal and internal-governance projects
+      Given an org team with a personal project, an internal-governance project, and a shared project
+      When the CLI-auth project list is resolved
+      Then only the shared project is offered
+
+    @unit @project-picker @last-project
+    Scenario: the project picker pre-selects the user's last project when it is offered
+      Given the resolved project list contains the user's last project "acme-prod"
+      When the CLI-auth project default is computed
+      Then "acme-prod" is the pre-selected project

--- a/specs/ai-governance/cli-onboarding/login-unified.feature
+++ b/specs/ai-governance/cli-onboarding/login-unified.feature
@@ -119,7 +119,7 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
     Then the CLI renders a top banner BEFORE the first prompt — always visible,
       not optional:
       "Running interactively. For agents/CI, skip the prompts by passing:
-         --api-key <K>    project SDK key into .env (default — SDK, evals, prompts)
+         --api-key <K>    project SDK key into .env (default: SDK, evals, prompts)
          --device         AI tools / SSO (claude, codex, gemini, opencode)
          --token <T>      pre-minted device session
          --endpoint <U>   self-hosted instance URL"
@@ -130,8 +130,8 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
     And on selecting (2) the CLI prompts for the URL and validates http(s) scheme
     And the CLI then prompts, with project login as the default (option 1):
       "How do you want to use it?
-        1) Project / SDK API key     (langwatch eval, sync, prompts, SDK)        — API key into .env
-        2) AI tools / agentic flows  (claude, codex, cursor, gemini, opencode)   — device-flow SSO
+        1) Project / SDK API key     (langwatch eval, sync, prompts, SDK)        - API key into .env
+        2) AI tools / agentic flows  (claude, codex, cursor, gemini, opencode)   - device-flow SSO
         3) Both"
     And on selecting (1) it runs the project API-key device-code flow → `$CWD/.env`
     And on selecting (2) it runs the device-flow → `~/.langwatch/config.json`

--- a/specs/ai-governance/cli-onboarding/login-unified.feature
+++ b/specs/ai-governance/cli-onboarding/login-unified.feature
@@ -119,8 +119,8 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
     Then the CLI renders a top banner BEFORE the first prompt — always visible,
       not optional:
       "Running interactively. For agents/CI, skip the prompts by passing:
-         --device         AI tools / SSO (recommended)
-         --api-key <K>    project SDK key (writes .env)
+         --api-key <K>    project SDK key into .env (default — SDK, evals, prompts)
+         --device         AI tools / SSO (claude, codex, gemini, opencode)
          --token <T>      pre-minted device session
          --endpoint <U>   self-hosted instance URL"
     And the CLI prompts:
@@ -128,13 +128,13 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
         1) LangWatch Cloud (app.langwatch.ai)
         2) Self-hosted instance (custom URL)"
     And on selecting (2) the CLI prompts for the URL and validates http(s) scheme
-    And the CLI then prompts:
+    And the CLI then prompts, with project login as the default (option 1):
       "How do you want to use it?
-        1) AI tools / agentic flows  (claude, codex, cursor, gemini, opencode) — device-flow SSO
-        2) Project / SDK API key     (langwatch sync, langwatch eval, …)        — API key into .env
+        1) Project / SDK API key     (langwatch eval, sync, prompts, SDK)        — API key into .env
+        2) AI tools / agentic flows  (claude, codex, cursor, gemini, opencode)   — device-flow SSO
         3) Both"
-    And on selecting (1) it runs the device-flow → `~/.langwatch/config.json`
-    And on selecting (2) it runs the legacy API-key paste flow → `$CWD/.env`
+    And on selecting (1) it runs the project API-key device-code flow → `$CWD/.env`
+    And on selecting (2) it runs the device-flow → `~/.langwatch/config.json`
     And on selecting (3) it runs both flows in sequence
 
   @bdd @cli @login @agent-aware @fake-tty
@@ -149,16 +149,19 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
       sees it correctly
 
   @bdd @cli @login @non-tty
-  Scenario: `langwatch login` (no flags, NON-TTY) errors with an actionable hint
+  Scenario: `langwatch login` (no flags, NON-TTY) defaults to project login, never AI-tools
     Given the user is in a non-interactive context (CI, agent stdin, piped)
     When the user runs `langwatch login` with no flags
-    Then the CLI exits 1 with stderr:
-      "Cannot run interactive login in a non-TTY context.
-       Run one of:
-         langwatch login --device                    # device-flow (recommended for AI tools)
-         langwatch login --api-key <KEY>             # project SDK key (writes .env)
-         langwatch login --token <TOKEN>             # pre-minted device session (CI)
-         LANGWATCH_AUTO_LOGIN=1 langwatch <wrapper>  # let the wrapper trigger it"
+    Then the CLI does NOT start the AI-tools / device-session flow
+    And the CLI defaults to PROJECT login: it requests `credential_type: "project_api_key"`
+      and writes the resulting key to `$CWD/.env`
+    And it first prints that project login is the default — so evaluations, prompts and
+      the SDK target a real project, not a personal one
+    And it prints that `--device` is required to log in to AI tools (claude, codex, …)
+    # Rationale: a customer's coding agent ran `langwatch login` non-interactively while
+    # setting up experiments; the old behavior funnelled it into a personal device-session
+    # and evaluations silently landed on a personal project. Defaulting to project login
+    # closes that at the source.
 
   @bdd @cli @login @endpoint
   Scenario: `langwatch login --endpoint <url>` skips the cloud-vs-self-hosted prompt

--- a/specs/ai-governance/cli-onboarding/login-unified.feature
+++ b/specs/ai-governance/cli-onboarding/login-unified.feature
@@ -116,11 +116,11 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
   Scenario: `langwatch login` (no flags, TTY) prompts for endpoint + auth mode with always-on agent-hint banner
     Given the user is in an interactive terminal (`process.stdin.isTTY === true`)
     When the user runs `langwatch login` with no flags
-    Then the CLI renders a top banner BEFORE the first prompt — always visible,
+    Then the CLI renders a top banner BEFORE the first prompt, always visible,
       not optional:
-      "Running interactively. For agents/CI, skip the prompts by passing:
-         --api-key <K>    project SDK key into .env (default: SDK, evals, prompts)
+      "Running interactively. To skip these prompts (CI / agents that already have a credential):
          --device         AI tools / SSO (claude, codex, gemini, opencode)
+         --api-key <K>    project SDK key into .env (SDK, evals, prompts)
          --token <T>      pre-minted device session
          --endpoint <U>   self-hosted instance URL"
     And the CLI prompts:
@@ -128,13 +128,15 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
         1) LangWatch Cloud (app.langwatch.ai)
         2) Self-hosted instance (custom URL)"
     And on selecting (2) the CLI prompts for the URL and validates http(s) scheme
-    And the CLI then prompts, with project login as the default (option 1):
+    And the CLI then prompts, with AI tools as the default (option 1) since a
+      human running this interactively most likely wants to track their own
+      coding-assistant usage:
       "How do you want to use it?
-        1) Project / SDK API key     (langwatch eval, sync, prompts, SDK)        - API key into .env
-        2) AI tools / agentic flows  (claude, codex, cursor, gemini, opencode)   - device-flow SSO
+        1) AI tools / agentic flows  (claude, codex, cursor, gemini, opencode)   - device-flow SSO
+        2) Project / SDK API key     (langwatch eval, sync, prompts, SDK)        - API key into .env
         3) Both"
-    And on selecting (1) it runs the project API-key device-code flow → `$CWD/.env`
-    And on selecting (2) it runs the device-flow → `~/.langwatch/config.json`
+    And on selecting (1) it runs the device-flow → `~/.langwatch/config.json`
+    And on selecting (2) it runs the project API-key device-code flow → `$CWD/.env`
     And on selecting (3) it runs both flows in sequence
 
   @bdd @cli @login @agent-aware @fake-tty

--- a/specs/ai-governance/cli-onboarding/login-unified.feature
+++ b/specs/ai-governance/cli-onboarding/login-unified.feature
@@ -153,9 +153,8 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
     Given the user is in a non-interactive context (CI, agent stdin, piped)
     When the user runs `langwatch login` with no flags
     Then the CLI does NOT start the AI-tools / device-session flow
-    And the CLI defaults to PROJECT login: it requests `credential_type: "project_api_key"`
-      and writes the resulting key to `$CWD/.env`
-    And it first prints that project login is the default — so evaluations, prompts and
+    And the CLI defaults to PROJECT login, writing the resulting project key to `$CWD/.env`
+    And it first prints that project login is the default, so evaluations, prompts and
       the SDK target a real project, not a personal one
     And it prints that `--device` is required to log in to AI tools (claude, codex, …)
     # Rationale: a customer's coding agent ran `langwatch login` non-interactively while

--- a/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // The two login-flow entry points are the seam: project login goes through
 // runUnifiedLoginFlow({ kind: "project_api_key" }); AI-tools login goes
 // through runDeviceFlowLogin (a device_session). We assert which one the
-// command picks per context — no network, no browser.
+// command picks per context, no network, no browser.
 const runUnifiedLoginFlow = vi.fn().mockResolvedValue({});
 const runDeviceFlowLogin = vi.fn().mockResolvedValue({});
 vi.mock("@/cli/utils/governance/login-flow", () => ({

--- a/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
@@ -52,34 +52,38 @@ describe("loginCommand", () => {
   describe("given no flags in a non-TTY context", () => {
     beforeEach(() => setTTY(false));
 
-    it("defaults to project login, never the AI-tools device session", async () => {
-      await loginCommand({});
+    describe("when the command is invoked with no flags", () => {
+      it("defaults to project login, never the AI-tools device session", async () => {
+        await loginCommand({});
 
-      expect(runUnifiedLoginFlow).toHaveBeenCalledTimes(1);
-      expect(runUnifiedLoginFlow).toHaveBeenCalledWith(
-        expect.objectContaining({ kind: "project_api_key" }),
-      );
-      expect(runDeviceFlowLogin).not.toHaveBeenCalled();
-    });
+        expect(runUnifiedLoginFlow).toHaveBeenCalledTimes(1);
+        expect(runUnifiedLoginFlow).toHaveBeenCalledWith(
+          expect.objectContaining({ kind: "project_api_key" }),
+        );
+        expect(runDeviceFlowLogin).not.toHaveBeenCalled();
+      });
 
-    it("prints the project-login default and the --device escape hatch", async () => {
-      const logSpy = console.log as unknown as ReturnType<typeof vi.fn>;
-      await loginCommand({});
+      it("prints the project-login default and the --device escape hatch", async () => {
+        const logSpy = console.log as unknown as ReturnType<typeof vi.fn>;
+        await loginCommand({});
 
-      const printed = logSpy.mock.calls.flat().join("\n");
-      expect(printed).toContain("project login");
-      expect(printed).toContain("--device");
+        const printed = logSpy.mock.calls.flat().join("\n");
+        expect(printed).toContain("project login");
+        expect(printed).toContain("--device");
+      });
     });
   });
 
   describe("given the --device flag", () => {
     beforeEach(() => setTTY(false));
 
-    it("runs the AI-tools device session, not project login", async () => {
-      await loginCommand({ device: true });
+    describe("when the command is invoked with --device", () => {
+      it("runs the AI-tools device session, not project login", async () => {
+        await loginCommand({ device: true });
 
-      expect(runDeviceFlowLogin).toHaveBeenCalledTimes(1);
-      expect(runUnifiedLoginFlow).not.toHaveBeenCalled();
+        expect(runDeviceFlowLogin).toHaveBeenCalledTimes(1);
+        expect(runUnifiedLoginFlow).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The two login-flow entry points are the seam: project login goes through
+// runUnifiedLoginFlow({ kind: "project_api_key" }); AI-tools login goes
+// through runDeviceFlowLogin (a device_session). We assert which one the
+// command picks per context — no network, no browser.
+const runUnifiedLoginFlow = vi.fn().mockResolvedValue({});
+const runDeviceFlowLogin = vi.fn().mockResolvedValue({});
+vi.mock("@/cli/utils/governance/login-flow", () => ({
+  runUnifiedLoginFlow: (...args: unknown[]) => runUnifiedLoginFlow(...args),
+  runDeviceFlowLogin: (...args: unknown[]) => runDeviceFlowLogin(...args),
+}));
+
+const loadConfig = vi.fn(() => ({
+  control_plane_url: "https://app.langwatch.ai",
+}));
+const saveConfig = vi.fn();
+vi.mock("@/cli/utils/governance/config", () => ({
+  loadConfig: () => loadConfig(),
+  saveConfig: (...args: unknown[]) => saveConfig(...args),
+}));
+
+import { loginCommand } from "../login";
+
+describe("loginCommand", () => {
+  const originalIsTTY = process.stdin.isTTY;
+  const originalEndpoint = process.env.LANGWATCH_ENDPOINT;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    delete process.env.LANGWATCH_ENDPOINT;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    if (originalEndpoint === undefined) delete process.env.LANGWATCH_ENDPOINT;
+    else process.env.LANGWATCH_ENDPOINT = originalEndpoint;
+    vi.restoreAllMocks();
+  });
+
+  const setTTY = (value: boolean) =>
+    Object.defineProperty(process.stdin, "isTTY", {
+      value,
+      configurable: true,
+    });
+
+  describe("given no flags in a non-TTY context", () => {
+    beforeEach(() => setTTY(false));
+
+    it("defaults to project login, never the AI-tools device session", async () => {
+      await loginCommand({});
+
+      expect(runUnifiedLoginFlow).toHaveBeenCalledTimes(1);
+      expect(runUnifiedLoginFlow).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "project_api_key" }),
+      );
+      expect(runDeviceFlowLogin).not.toHaveBeenCalled();
+    });
+
+    it("prints the project-login default and the --device escape hatch", async () => {
+      const logSpy = console.log as unknown as ReturnType<typeof vi.fn>;
+      await loginCommand({});
+
+      const printed = logSpy.mock.calls.flat().join("\n");
+      expect(printed).toContain("project login");
+      expect(printed).toContain("--device");
+    });
+  });
+
+  describe("given the --device flag", () => {
+    beforeEach(() => setTTY(false));
+
+    it("runs the AI-tools device session, not project login", async () => {
+      await loginCommand({ device: true });
+
+      expect(runDeviceFlowLogin).toHaveBeenCalledTimes(1);
+      expect(runUnifiedLoginFlow).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/typescript-sdk/src/cli/commands/login.ts
+++ b/typescript-sdk/src/cli/commands/login.ts
@@ -29,12 +29,12 @@ function printAgentHintBanner(): void {
   );
   console.log(
     chalk.gray(
-      "  --device                   AI tools / SSO (browser approval, no paste)",
+      "  --api-key <KEY>            project SDK key into .env (default — SDK, evals, prompts)",
     ),
   );
   console.log(
     chalk.gray(
-      "  --api-key <KEY>            project SDK key (writes .env)",
+      "  --device                   AI tools / SSO (claude, codex, gemini, opencode)",
     ),
   );
   console.log(
@@ -168,22 +168,30 @@ export const loginCommand = async (
       return;
     }
 
-    // Interactive mode (no flags). Refuse on non-TTY contexts with an
-    // actionable hint pointing at the escape-hatch flags — agents and CI
-    // pipelines should pass the right flag rather than getting stuck on a
-    // hidden interactive prompt.
+    // Interactive mode (no flags). On a non-TTY context (CI, an agent's
+    // piped stdin) we cannot prompt. Erroring here used to nudge agents
+    // toward `--device`, which signs them into a personal device-session and
+    // silently routed their evaluations to a personal project. Default to
+    // PROJECT login instead: it writes a real project's key to `.env`, which
+    // is what the SDK, `langwatch eval`, and the skills expect. AI-tools
+    // login stays explicit behind `--device`.
     if (!process.stdin.isTTY) {
-      console.error(
-        chalk.red(
-          "Error: cannot run interactive `langwatch login` in a non-TTY context.",
+      console.log(
+        chalk.gray(
+          "No login mode given — defaulting to project login (writes LANGWATCH_API_KEY to .env).",
         ),
       );
-      console.error(chalk.gray("Run one of:"));
-      console.error(chalk.gray("  langwatch login --device                # AI tools / SSO (recommended)"));
-      console.error(chalk.gray("  langwatch login --api-key <KEY>         # project SDK key (writes .env)"));
-      console.error(chalk.gray("  langwatch login --token <TOKEN>         # pre-minted device session"));
-      console.error(chalk.gray("  LANGWATCH_AUTO_LOGIN=1 langwatch <cmd>  # let the wrapper trigger device flow"));
-      process.exit(1);
+      console.log(
+        chalk.gray(
+          "For AI-tools login (claude, codex, gemini, opencode), re-run: langwatch login --device",
+        ),
+      );
+      console.log();
+      await runUnifiedLoginFlow({
+        kind: "project_api_key",
+        browser: options?.browser,
+      });
+      return;
     }
 
     // Always-on agent-hint banner — fake-TTY agents see this BEFORE the
@@ -252,14 +260,14 @@ export const loginCommand = async (
       message: "How do you want to use LangWatch?",
       choices: [
         {
+          title: "Project / SDK API key",
+          description: "langwatch eval, sync, prompts, SDK auto-instrumentation — writes .env",
+          value: "api-key",
+        },
+        {
           title: "AI tools / agentic flows",
           description: "claude, codex, cursor, gemini, opencode — device-flow SSO",
           value: "device",
-        },
-        {
-          title: "Project / SDK API key",
-          description: "langwatch sync, langwatch eval, SDK auto-instrumentation",
-          value: "api-key",
         },
         {
           title: "Both",

--- a/typescript-sdk/src/cli/commands/login.ts
+++ b/typescript-sdk/src/cli/commands/login.ts
@@ -29,12 +29,12 @@ function printAgentHintBanner(): void {
   );
   console.log(
     chalk.gray(
-      "  --api-key <KEY>            project SDK key into .env (default: SDK, evals, prompts)",
+      "  --device                   AI tools / SSO (claude, codex, gemini, opencode)",
     ),
   );
   console.log(
     chalk.gray(
-      "  --device                   AI tools / SSO (claude, codex, gemini, opencode)",
+      "  --api-key <KEY>            project SDK key into .env (SDK, evals, prompts)",
     ),
   );
   console.log(
@@ -260,14 +260,14 @@ export const loginCommand = async (
       message: "How do you want to use LangWatch?",
       choices: [
         {
-          title: "Project / SDK API key",
-          description: "langwatch eval, sync, prompts, SDK auto-instrumentation - writes .env",
-          value: "api-key",
-        },
-        {
           title: "AI tools / agentic flows",
           description: "claude, codex, cursor, gemini, opencode - device-flow SSO",
           value: "device",
+        },
+        {
+          title: "Project / SDK API key",
+          description: "langwatch eval, sync, prompts, SDK auto-instrumentation - writes .env",
+          value: "api-key",
         },
         {
           title: "Both",

--- a/typescript-sdk/src/cli/commands/login.ts
+++ b/typescript-sdk/src/cli/commands/login.ts
@@ -29,7 +29,7 @@ function printAgentHintBanner(): void {
   );
   console.log(
     chalk.gray(
-      "  --api-key <KEY>            project SDK key into .env (default — SDK, evals, prompts)",
+      "  --api-key <KEY>            project SDK key into .env (default: SDK, evals, prompts)",
     ),
   );
   console.log(
@@ -178,7 +178,7 @@ export const loginCommand = async (
     if (!process.stdin.isTTY) {
       console.log(
         chalk.gray(
-          "No login mode given — defaulting to project login (writes LANGWATCH_API_KEY to .env).",
+          "No login mode given. Defaulting to project login (writes LANGWATCH_API_KEY to .env).",
         ),
       );
       console.log(
@@ -261,12 +261,12 @@ export const loginCommand = async (
       choices: [
         {
           title: "Project / SDK API key",
-          description: "langwatch eval, sync, prompts, SDK auto-instrumentation — writes .env",
+          description: "langwatch eval, sync, prompts, SDK auto-instrumentation - writes .env",
           value: "api-key",
         },
         {
           title: "AI tools / agentic flows",
-          description: "claude, codex, cursor, gemini, opencode — device-flow SSO",
+          description: "claude, codex, cursor, gemini, opencode - device-flow SSO",
           value: "device",
         },
         {


### PR DESCRIPTION
## Problem

A customer used the LangWatch coding-assistant **skills** to set up experiments. Their agent ran `langwatch login`, got signed into a **personal project**, and the evaluations they created were silently sent there. Confusing, and wrong for shared/team work.

Root causes:
- `langwatch login` with no flags **errored on non-TTY** (agents) and **defaulted to the AI-tools device session** interactively. The device session provisions a personal workspace + personal VK.
- The project-login picker could **auto-pick a personal project**, so the `.env` key written was a personal project's key.
- Nothing told the skill agents to prefer a real project + `.env` key.

## The fix (every layer)

**CLI (`langwatch login`)**
- No flags + **non-TTY** now **defaults to project login** (writes `LANGWATCH_API_KEY` to `.env`) instead of erroring. It prints that project login is the default and that `--device` is needed for AI-tools login.
- The **interactive** prompt is unchanged: a human at the keyboard keeps **AI tools / SSO** as the default first option, since they most likely want to track their own coding-assistant usage. Only the **non-TTY** (agent / CI) path defaults to project login, which is where the mix-up actually came from.

**Backend (`POST /api/auth/cli/approve`)**
- The **device-session** path now requires governance to be **enabled** for the org (it provisions a personal workspace + VK). Otherwise it returns `403 governance_required` pointing the user at project login, and no personal workspace/VK is created.
- The **project_api_key** path **rejects a personal project id** (`400 personal_project_not_allowed`) and never returns its key.

**Browser approval (`/cli/auth`)**
- The project picker **hides personal projects** and defaults to the user's **last real project**. It now reuses the API-key drawer's `ScopeChipPicker` through a new `variant="single-select"`: a collapsed dropdown that groups projects under their team, replacing a flat card list that grew unbounded with many projects.

**Skills**
- New shared snippet `_shared/projects-and-api-keys.mdx` (wired into evaluations, scenarios, prompts, tracing, analytics, level-up): explains project + key types and that skills must always use a **real project + `.env` API key**, never a personal one or device login.
- New scenario test asserting the evaluations skill **never runs `langwatch login --device`**.

## Tests

- `login.unit.test.ts`: non-TTY defaults to `project_api_key`, never the device session; `--device` still routes to the device session.
- `cliAuthProjects.unit.test.ts`: picker omits personal + internal-governance projects; pre-selects the last project.
- `auth-cli-personal-guard.integration.test.ts`: real DB: device-session refused (governance off) with no VK minted; succeeds when on; project login rejects a personal project id; returns a shared project's key.
- `skills/_tests/cli-auth.scenario.test.ts`: evaluation setup stays on a real project, never device-logs-in.
- BDD specs: `login-unified.feature` (updated) + `cli-login-personal-guard.feature` (new). Typecheck + feature-parity green.

## QA (dogfooded)

**1. `langwatch login` in a non-TTY shell defaults to project login** (exactly how an agent's shell runs). Rebuilt the CLI and ran it for real:

```
No login mode given. Defaulting to project login (writes LANGWATCH_API_KEY to .env).
For AI-tools login (claude, codex, gemini, opencode), re-run: langwatch login --device

Mode: project SDK API key (will write .env)
Opening: http://localhost:5560/cli/auth?user_code=FSZD-PDV7
```

**2. A subordinate Claude agent told to run `langwatch login`** reported back: *"it defaulted to project API key into .env; first line: 'No login mode given - defaulting to project login...'"*. The customer's confusion is fixed at the source.

**3. The `/cli/auth` project picker is a team-grouped single-select** (the `ScopeChipPicker` `single-select` variant), hiding personal + internal-governance projects. Projects nest under their team, the dropdown collapses to the chosen project, and exactly one project can be selected:

![cli-auth project picker grouped by team](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4728/cli-auth/picker-team-grouped.png)

![cli-auth project picker with a project selected](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4728/cli-auth/picker-selected.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added governance guard for device-session (AI-tools) CLI login and explicit rejection of personal projects for project-key approvals

* **Bug Fixes**
  * Non-TTY CLI login now falls back to project API-key mode instead of failing
  * CLI project picker now omits personal and internal-governance projects

* **Documentation**
  * Added a shared “Projects and API keys” guidance and propagated it across skills/docs

* **Tests**
  * New unit and integration tests covering CLI auth, governance guards, and related flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

