### PR TITLE
fix(api-key): stop misclassifying legacy project keys that contain underscores

### DIFF
--- a/langwatch/src/server/api-key/__tests__/api-key-token.utils.unit.test.ts
+++ b/langwatch/src/server/api-key/__tests__/api-key-token.utils.unit.test.ts
@@ -128,21 +128,41 @@ describe("getTokenType", () => {
     });
   });
 
-  describe("when given a new sk-lw- token with underscore", () => {
+  describe("when given a new-format sk-lw- token", () => {
     it("returns apiKey", () => {
-      expect(getTokenType("sk-lw-abcdef1234567890_secretsecret")).toBe("apiKey");
+      const { token } = generateApiKeyToken();
+      expect(getTokenType(token)).toBe("apiKey");
     });
   });
 
   describe("when given an ingest ik-lw- token", () => {
     it("returns apiKey", () => {
-      expect(getTokenType("ik-lw-abcdef1234567890_secretsecret")).toBe("apiKey");
+      const { token } = generateApiKeyToken({ prefix: INGEST_KEY_PREFIX });
+      expect(getTokenType(token)).toBe("apiKey");
     });
   });
 
   describe("when given a legacy project key (sk-lw- without underscore)", () => {
     it("returns legacyProjectKey", () => {
       expect(getTokenType("sk-lw-abc123def456")).toBe("legacyProjectKey");
+    });
+  });
+
+  describe("when given a legacy project key whose body contains an underscore", () => {
+    it("returns legacyProjectKey", () => {
+      // Legacy keys are random strings from alphabets that include `_` and
+      // `-` — an underscore must not flip them to the API key lookup path
+      expect(
+        getTokenType("sk-lw-AbCdEfGhIjKlMnOpQrStUvWxYz012345_floM"),
+      ).toBe("legacyProjectKey");
+    });
+  });
+
+  describe("when given an sk-lw- token with underscore but wrong segment lengths", () => {
+    it("returns legacyProjectKey", () => {
+      expect(getTokenType("sk-lw-abcdef1234567890_secretsecret")).toBe(
+        "legacyProjectKey",
+      );
     });
   });
 

--- a/langwatch/src/server/api-key/__tests__/token-resolver.unit.test.ts
+++ b/langwatch/src/server/api-key/__tests__/token-resolver.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+
+import { TokenResolver } from "../token-resolver";
+import { generateApiKeyToken } from "../api-key-token.utils";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// A legacy project key whose random body happens to contain an underscore —
+// the regression shape: it must resolve via the project lookup, not 401
+const LEGACY_KEY_WITH_UNDERSCORE = "sk-lw-AbCdEfGhIjKlMnOpQrStUvWxYz012345_floM";
+
+const project = {
+  id: "project_1",
+  apiKey: LEGACY_KEY_WITH_UNDERSCORE,
+  archivedAt: null,
+  team: { id: "team_1", organizationId: "org_1" },
+};
+
+function createMockPrisma(opts?: { projectFound?: boolean }) {
+  return {
+    project: {
+      findUnique: vi
+        .fn()
+        .mockResolvedValue(opts?.projectFound === false ? null : project),
+    },
+    apiKey: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      findFirst: vi.fn().mockResolvedValue(null),
+      update: vi.fn(),
+    },
+  } as unknown as PrismaClient;
+}
+
+describe("TokenResolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("resolve", () => {
+    describe("when given a legacy project key containing an underscore", () => {
+      it("resolves to the project via the legacy lookup", async () => {
+        const prisma = createMockPrisma();
+        const resolver = TokenResolver.create(prisma);
+
+        const resolved = await resolver.resolve({
+          token: LEGACY_KEY_WITH_UNDERSCORE,
+        });
+
+        expect(resolved).not.toBeNull();
+        expect(resolved!.type).toBe("legacyProjectKey");
+        expect(resolved!.project.id).toBe("project_1");
+        expect(prisma.project.findUnique).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { apiKey: LEGACY_KEY_WITH_UNDERSCORE, archivedAt: null },
+          }),
+        );
+      });
+    });
+
+    describe("when a new-format sk-lw- token misses the ApiKey lookup", () => {
+      it("falls back to the legacy project key lookup", async () => {
+        const prisma = createMockPrisma();
+        const resolver = TokenResolver.create(prisma);
+        const { token } = generateApiKeyToken();
+
+        const resolved = await resolver.resolve({ token });
+
+        expect(resolved).not.toBeNull();
+        expect(resolved!.type).toBe("legacyProjectKey");
+        expect(prisma.project.findUnique).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { apiKey: token, archivedAt: null },
+          }),
+        );
+      });
+
+      it("returns null when the legacy fallback also misses", async () => {
+        const prisma = createMockPrisma({ projectFound: false });
+        const resolver = TokenResolver.create(prisma);
+        const { token } = generateApiKeyToken();
+
+        const resolved = await resolver.resolve({ token });
+
+        expect(resolved).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/api-key/api-key-token.utils.ts
+++ b/langwatch/src/server/api-key/api-key-token.utils.ts
@@ -162,12 +162,24 @@ export function verifySecret(
 }
 
 /**
+ * Matches the exact body structure of generated API keys:
+ * {16-char lookupId}_{48-char secret}, both from the alphanumeric ALPHABET.
+ * Legacy project keys were minted from alphabets that include `_` and `-`,
+ * so the mere presence of an underscore does not identify a new-format key.
+ */
+const API_KEY_BODY_REGEX = new RegExp(
+  `^[0-9A-Za-z]{${LOOKUP_ID_LENGTH}}_[0-9A-Za-z]{${SECRET_LENGTH}}$`,
+);
+
+/**
  * Determines the token type from its prefix and structure.
  *
  * - `pat-lw-*` → always an API key (old PAT format, backward compat)
- * - `ik-lw-{16chars}_{48chars}` → API key (ingestion-only key, always split format)
- * - `sk-lw-{16chars}_{48chars}` → API key (new format, has underscore separator)
- * - `sk-lw-*` (no underscore) → legacy project key
+ * - `ik-lw-*` → always an API key (ingestion-only prefix never existed for
+ *   legacy keys)
+ * - `sk-lw-{16chars}_{48chars}` → API key (new format, strict shape)
+ * - any other `sk-lw-*` → legacy project key, whose random body may itself
+ *   contain underscores and dashes
  * - anything else → unknown
  */
 export function getTokenType(
@@ -176,10 +188,8 @@ export function getTokenType(
   if (token.startsWith(LEGACY_PAT_PREFIX)) return "apiKey";
   if (token.startsWith(INGEST_KEY_PREFIX)) return "apiKey";
   if (token.startsWith(API_KEY_PREFIX)) {
-    // Distinguish new-format API keys from legacy project keys by structure:
-    // API keys have an underscore separating lookupId and secret
     const body = token.slice(API_KEY_PREFIX.length);
-    return body.includes("_") ? "apiKey" : "legacyProjectKey";
+    return API_KEY_BODY_REGEX.test(body) ? "apiKey" : "legacyProjectKey";
   }
   return "unknown";
 }

--- a/langwatch/src/server/api-key/token-resolver.ts
+++ b/langwatch/src/server/api-key/token-resolver.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient, Project } from "@prisma/client";
 import { RoleBindingScopeType } from "@prisma/client";
 
-import { getTokenType } from "./api-key-token.utils";
+import { API_KEY_PREFIX, getTokenType } from "./api-key-token.utils";
 import { ApiKeyService } from "./api-key.service";
 
 /**
@@ -45,8 +45,9 @@ export type OrgResolvedToken = {
  * path based on prefix and structure:
  *   - pat-lw-* → API key lookup (old PAT format, backward compat)
  *   - sk-lw-{id}_{secret} → API key lookup (new format; ingestion keys
- *     are ordinary API keys carrying ingestSourceType)
- *   - sk-lw-* (no underscore) → legacy project key lookup
+ *     are ordinary API keys carrying ingestSourceType), with a legacy
+ *     project key fallback for look-alike legacy keys
+ *   - any other sk-lw-* → legacy project key lookup
  */
 export class TokenResolver {
   private readonly apiKeyService: ApiKeyService;
@@ -80,8 +81,18 @@ export class TokenResolver {
     switch (tokenType) {
       case "legacyProjectKey":
         return this.resolveLegacyProjectKey(token);
-      case "apiKey":
-        return this.resolveApiKey(token, projectId ?? null);
+      case "apiKey": {
+        const resolved = await this.resolveApiKey(token, projectId ?? null);
+        // A legacy project key can be shaped exactly like a new API key
+        // (its random body may contain an underscore), so when API key
+        // resolution misses for an sk-lw- token, fall back to the legacy
+        // lookup. The fallback only grants access when the full token
+        // matches a stored project key, so misses stay a 401.
+        if (!resolved && token.startsWith(API_KEY_PREFIX)) {
+          return this.resolveLegacyProjectKey(token);
+        }
+        return resolved;
+      }
       default:
         // Unknown prefix — try legacy lookup as fallback
         return this.resolveLegacyProjectKey(token);


### PR DESCRIPTION
## Problem

Legacy project keys (`Project.apiKey`) are random strings minted from alphabets that include `_` and `-`. `getTokenType` classified any `sk-lw-` token containing an underscore as a new-format `{lookupId}_{secret}` API key. A legacy key with a random underscore in its body therefore went down the `ApiKey` table lookup path, missed, and the request got a 401 "Invalid credentials" with no fallback. The key itself was perfectly valid.

Found while dogfooding the evaluations skill against a local QA instance: the seeded project key happened to contain an underscore at body position 33 and every SDK and CLI call failed with 401 even though the key matched the database exactly.

## Fix

Two layers:

1. `getTokenType` now only classifies an `sk-lw-` token as a new-format API key when the body matches the exact generated shape (`{16 alphanumeric}_{48 alphanumeric}`, per `LOOKUP_ID_LENGTH`/`SECRET_LENGTH` and `ALPHABET`). Legacy bodies (different lengths, may contain `-`/`_`) can no longer match.
2. Defense in depth in `TokenResolver.resolve`: when an `sk-lw-` token is classified as an API key but misses the `ApiKey` lookup, fall back to the legacy project key lookup. The fallback only grants access when the full token matches a stored `Project.apiKey`, so invalid keys still 401. `pat-lw-`/`ik-lw-` prefixes never existed as legacy keys and don't fall back.

## Tests

- `getTokenType`: legacy key with underscore in body → `legacyProjectKey`; wrong-segment-length underscore tokens → `legacyProjectKey`; generated tokens (sk-lw and ik-lw) → `apiKey`.
- New `token-resolver.unit.test.ts`: legacy underscore key resolves via project lookup; new-format token missing the ApiKey lookup falls back to legacy lookup; returns null when both miss.
- All 84 unit tests in `src/server/api-key/__tests__/` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key validation with stricter format detection for new token types.
  * Added fallback authentication support for legacy project keys that resemble new token formats, ensuring backward compatibility.
  * Enhanced token resolution logic to properly handle edge cases and prevent authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->