### PR TITLE
perf(clickhouse): add time predicate to analytics RAG-document + feedback span joins

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -1221,6 +1221,24 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain("JOIN stored_spans");
     });
 
+    it("prunes the stored_spans join to the StartTime partition window", () => {
+      const result = buildTopDocumentsQuery(projectId, startDate, endDate);
+
+      // stored_spans is partitioned by toYearWeek(StartTime); without a
+      // StartTime bound the join scans every weekly partition (incl. cold S3).
+      // Both the top-10 and the total-count parts must carry the predicate.
+      expect(
+        result.sql.match(
+          /ss\.StartTime >= \{startDate:DateTime64\(3\)\} - INTERVAL 2 DAY/g,
+        ) ?? [],
+      ).toHaveLength(2);
+      expect(
+        result.sql.match(
+          /ss\.StartTime < \{endDate:DateTime64\(3\)\} \+ INTERVAL 2 DAY/g,
+        ) ?? [],
+      ).toHaveLength(2);
+    });
+
     it("includes query for total unique documents", () => {
       const result = buildTopDocumentsQuery(projectId, startDate, endDate);
 
@@ -1310,6 +1328,19 @@ describe("aggregation-builder", () => {
       expect(result.sql).toContain('Events.Timestamp"');
       expect(result.sql).toContain('Events.Name"');
       expect(result.sql).toContain('Events.Attributes"');
+    });
+
+    it("prunes the stored_spans join to the StartTime partition window", () => {
+      const result = buildFeedbacksQuery(projectId, startDate, endDate);
+
+      // Same partition-pruning rationale as the documents query: bound the
+      // stored_spans scan to the date window instead of every weekly partition.
+      expect(result.sql).toContain(
+        "ss.StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY",
+      );
+      expect(result.sql).toContain(
+        "ss.StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY",
+      );
     });
 
     it("includes filters when provided with parameterized values", () => {

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -2517,6 +2517,8 @@ export function buildTopDocumentsQuery(
       WHERE ${ts}.TenantId = {tenantId:String}
         AND ${ts}.OccurredAt >= {startDate:DateTime64(3)}
         AND ${ts}.OccurredAt < {endDate:DateTime64(3)}
+        AND ${ss}.StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY
+        AND ${ss}.StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY
         AND ${ss}.SpanAttributes['langwatch.rag.contexts'] != ''
         ${filterWhere}
     )
@@ -2540,6 +2542,8 @@ export function buildTopDocumentsQuery(
     WHERE ${ts}.TenantId = {tenantId:String}
       AND ${ts}.OccurredAt >= {startDate:DateTime64(3)}
       AND ${ts}.OccurredAt < {endDate:DateTime64(3)}
+      AND ${ss}.StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY
+      AND ${ss}.StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY
       AND ${ss}.SpanAttributes['langwatch.rag.contexts'] != ''
       ${filterWhere}
   `;
@@ -2613,6 +2617,8 @@ export function buildFeedbacksQuery(
     WHERE ${ts}.TenantId = {tenantId:String}
       AND ${ts}.OccurredAt >= {startDate:DateTime64(3)}
       AND ${ts}.OccurredAt < {endDate:DateTime64(3)}
+      AND ${ss}.StartTime >= {startDate:DateTime64(3)} - INTERVAL 2 DAY
+      AND ${ss}.StartTime < {endDate:DateTime64(3)} + INTERVAL 2 DAY
       AND event_name = 'thumbs_up_down'
       AND mapContains(event_attrs, 'event.metrics.vote')
       ${filterWhere}


### PR DESCRIPTION
## Evidence

In the last 24h cold-scan log (Signal C), the analytics dashboard's RAG-documents and feedback widgets are a recurring `stored_spans` cold-scan source (paramKeys `[tenantId, startDate, endDate]`, plus `topicIds` filter variants). The queries carry a date range, but it only bounds the `trace_summaries` side.

## Suspected cause

`buildTopDocumentsQuery` (top documents + total count) and `buildFeedbacksQuery` JOIN `stored_spans` to read RAG contexts (`SpanAttributes['langwatch.rag.contexts']`) and feedback events (`Events.*`). Their WHERE bounds only `ts.OccurredAt` (trace_summaries). `stored_spans` is `PARTITION BY toYearWeek(StartTime)`, so with no `StartTime` predicate the join walks every weekly partition, including cold S3 tiers, for the matched traces. The builder already defines `SPAN_TIME_FILTER_START_END` for exactly this, but these three joins (two in the documents query, one in feedbacks) never applied it.

## Proposed fix

Add the `ss.StartTime >= {startDate} - INTERVAL 2 DAY AND ss.StartTime < {endDate} + INTERVAL 2 DAY` predicate to all three `stored_spans` joins, reusing the params already bound. The +/-2-day cushion matches the span-fetch partition hints used elsewhere and is correctness-preserving: a span's `StartTime` always falls within its trace's lifetime, so the same date envelope (widened) cannot drop a matching span.

## Expected impact

Headline is **S3 GET reduction / cost**, not latency: the stored_spans scan prunes to the dashboard's date window instead of all partitions. User-visible response time may not move much (results are small), but the cold-partition GET burst is eliminated for these widgets.

## EXPLAIN check

`EXPLAIN INDEXES` on `stored_spans` for a real large tenant (ids redacted), isolating the partition-prune effect of the added `StartTime` predicate:

```
OLD  WHERE TenantId = {…}                                  -> Parts: 259/259
NEW  WHERE TenantId = {…} AND StartTime >= now()-2d AND <  -> Parts:  12/258
```

~21x fewer parts read at the partition-index stage. (The endpoint runs `EXPLAIN` only, never executes.)

## Test plan

- `aggregation-builder.test.ts`: new cases assert the `StartTime` window appears in both parts of `buildTopDocumentsQuery` (top-10 + total) and in `buildFeedbacksQuery`. Full builder suite green (90 tests).
- `pnpm typecheck` clean.

Advisory PR from the ClickHouse slow-query optimizer. Open for review, not for self-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized database query execution for RAG analytics endpoints, improving performance of top documents and feedback report generation through enhanced query construction and date range optimization.

* **Tests**
  * Added regression tests to verify analytics query behavior and optimization implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->