### PR TITLE
perf(clickhouse): scope model-cost matching-spans preview to candidate traces

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/model-cost-span-preview.integration.test.ts
@@ -90,12 +90,81 @@ function makeSpanRow({
   };
 }
 
+// The sample-span read narrows to candidate traces via `trace_summaries.Models`
+// before scanning spans, so each span's trace needs a summary row carrying the
+// model in `Models` (exactly what the fold projection writes in production).
+function makeTraceSummaryRow({
+  tenant,
+  traceId,
+  startMs,
+  model,
+}: {
+  tenant: string;
+  traceId: string;
+  startMs: number;
+  model: string;
+}) {
+  return {
+    ProjectionId: `tsproj-${nanoid()}`,
+    TenantId: tenant,
+    TraceId: traceId,
+    OccurredAt: new Date(startMs),
+    CreatedAt: new Date(startMs),
+    UpdatedAt: new Date(startMs),
+    Models: [model],
+  };
+}
+
 beforeAll(async () => {
   const containers = await startTestContainers();
   ch = containers.clickHouseClient;
   spans = new SpanStorageService(
     new SpanStorageClickHouseRepository(async () => ch),
   );
+
+  await ch.insert({
+    table: "trace_summaries",
+    values: [
+      makeTraceSummaryRow({
+        tenant: tenantId,
+        traceId: `trace-bedrock-${ns}`,
+        startMs: recentMs,
+        model: "bedrock/eu.anthropic.claude-sonnet-4-6",
+      }),
+      makeTraceSummaryRow({
+        tenant: tenantId,
+        traceId: `trace-raw-bedrock-${ns}`,
+        startMs: recentMs - 1000,
+        model: "eu.anthropic.claude-sonnet-4-6-v1:0",
+      }),
+      makeTraceSummaryRow({
+        tenant: tenantId,
+        traceId: `trace-mini-${ns}`,
+        startMs: recentMs - 2000,
+        model: "gpt-5-mini",
+      }),
+      makeTraceSummaryRow({
+        tenant: tenantId,
+        traceId: `trace-respmodel-${ns}`,
+        startMs: recentMs - 3000,
+        model: `response-model-${ns}`,
+      }),
+      makeTraceSummaryRow({
+        tenant: tenantId,
+        traceId: `trace-old-${ns}`,
+        startMs: beyondWindowMs,
+        model: `stale-model-${ns}`,
+      }),
+      makeTraceSummaryRow({
+        tenant: otherTenantId,
+        traceId: `trace-foreign-${ns}`,
+        startMs: recentMs,
+        model: "bedrock/eu.anthropic.claude-sonnet-4-6",
+      }),
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
 
   await ch.insert({
     table: "stored_spans",
@@ -179,6 +248,11 @@ afterAll(async () => {
     await ch.exec({
       query:
         "ALTER TABLE stored_spans DELETE WHERE TenantId IN ({a:String}, {b:String})",
+      query_params: { a: tenantId, b: otherTenantId },
+    });
+    await ch.exec({
+      query:
+        "ALTER TABLE trace_summaries DELETE WHERE TenantId IN ({a:String}, {b:String})",
       query_params: { a: tenantId, b: otherTenantId },
     });
   }

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -184,6 +184,14 @@ const MODEL_ATTR_SELECT = `coalesce(
     SpanAttributes['gen_ai.request.model']
   )`;
 
+/**
+ * How many recent candidate traces the model-cost sample read pulls from
+ * `trace_summaries` before scanning their spans. Large enough that per-model
+ * token-bearing samples reliably resolve, small enough that the `TraceId IN`
+ * set still prunes `stored_spans` granules hard.
+ */
+const SAMPLE_CANDIDATE_TRACE_POOL = 500;
+
 interface ModelSpanSampleQueryRow {
   TraceId: string;
   SpanId: string;
@@ -1617,13 +1625,34 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     if (models.length === 0) return [];
 
     const client = await this.resolveClient(tenantId);
-    // Light columns only (scalars + token Map subscripts), grouped by span
-    // with argMax so ReplacingMergeTree versions dedup to the latest row.
-    // Spans carrying token usage sort first, a token-less span makes a
-    // poor cost example, then recency. `LIMIT BY` keeps one chatty model
-    // from crowding out the rest of the sample.
+    // The `Model IN` filter is computed from the SpanAttributes map, so on its
+    // own this read decodes that heavy map for every span in the window just to
+    // evaluate the predicate. Instead, first narrow to the recent traces that
+    // use one of these models via `trace_summaries.Models` (a small, deduped,
+    // bloom-indexed Array(String) populated at fold time), then constrain the
+    // span scan to `TraceId IN (...)`. `stored_spans` is
+    // `ORDER BY (TenantId, TraceId, SpanId)`, so the TraceId set prunes granules
+    // to just those traces' spans rather than the whole partition window.
+    //
+    // The candidate pool is generous so per-model token-bearing samples still
+    // resolve. Models is complete per trace, so the candidate set cannot drop a
+    // model the rule matches (a just-folded trace may lag by seconds, which is
+    // acceptable for a best-effort preview). Within `stored_spans` the read is
+    // unchanged: light columns, argMax dedup over ReplacingMergeTree versions,
+    // token-bearing spans first, then recency, and `LIMIT BY` so one chatty
+    // model can't crowd out the rest of the sample.
     const result = await client.query({
       query: `
+        WITH candidate_traces AS (
+          SELECT TraceId
+          FROM trace_summaries
+          WHERE TenantId = {tenantId:String}
+            AND OccurredAt >= fromUnixTimestamp64Milli({fromMs:Int64})
+            AND hasAny(Models, {models:Array(String)})
+          GROUP BY TraceId
+          ORDER BY max(OccurredAt) DESC
+          LIMIT {candidatePool:UInt32}
+        )
         SELECT
           TraceId,
           SpanId,
@@ -1641,13 +1670,21 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         FROM ${TABLE_NAME}
         WHERE TenantId = {tenantId:String}
           AND StartTime >= fromUnixTimestamp64Milli({fromMs:Int64})
+          AND TraceId IN (SELECT TraceId FROM candidate_traces)
           AND Model IN {models:Array(String)}
         GROUP BY TraceId, SpanId, Model
         ORDER BY HasTokens DESC, StartTimeMs DESC
         LIMIT {perModelLimit:UInt32} BY Model
         LIMIT {limit:UInt32}
       `,
-      query_params: { tenantId, models, fromMs, perModelLimit, limit },
+      query_params: {
+        tenantId,
+        models,
+        fromMs,
+        perModelLimit,
+        limit,
+        candidatePool: SAMPLE_CANDIDATE_TRACE_POOL,
+      },
       format: "JSONEachRow",
     });
 


### PR DESCRIPTION
Addresses a report that the model-cost rule "matching spans" preview (added in #4727) is slow in production.

## What I found

- **Debounce already exists**: the drawer debounces the form (regex + rates) 400ms before the preview query fires (`useDebounce(liveValues, 400)`), so this is not a per-keystroke storm.
- **Regex is already safe**: `safe-regex2` static analysis (catastrophic-backtracking / ReDoS) gates the pattern on both client (`isSafeRegex`) and server (`compileSafeRegex`), and the regex is **never sent to ClickHouse** — matching runs in app code over the project's recently-seen models. So no SQL-injection / ReDoS surface in the query path.
- **The real cost is the ClickHouse reads.** The preview makes two reads. `findModelUsageStats` (model inventory) and `findRecentSpansByModels` (sample spans) both filter `stored_spans` on the model, which is a `SpanAttributes` map subscript. That predicate forces ClickHouse to decode the heavy `SpanAttributes` map for every span in the 7-day window.

## This PR: the sample-span read

`findRecentSpansByModels` runs whenever the regex matches, and its `Model IN (...)` filter is computed from the map. Fix: narrow first via `trace_summaries.Models` — a small, deduped, **bloom-indexed** `Array(String)` written at fold time — to the recent traces using one of the matched models, then constrain the span scan with `TraceId IN (candidate set)`. `stored_spans` is `ORDER BY (TenantId, TraceId, SpanId)`, so the TraceId set prunes via the primary index to just those traces' granules before any `SpanAttributes` map is decoded.

The in-`stored_spans` selection is unchanged (light columns, `argMax` dedup over ReplacingMergeTree versions, token-bearing spans first then recency, `LIMIT … BY Model`), so the sample list the user sees is the same.

## Expected impact

The sample read stops decoding the `SpanAttributes` map across the whole 7-day partition window and instead touches only the candidate traces' spans (capped at a 500-trace pool). On busy projects that turns a multi-second map scan into a small indexed read.

## Trade-off (please weigh in)

The sample now depends on `trace_summaries` being folded for a trace (seconds of lag) rather than reading `stored_spans` directly. `Models` is complete per trace, so a matched model can't be dropped from the candidate set; a just-ingested trace could lag by seconds, which is acceptable for a best-effort preview. If you'd rather keep strict stored_spans-only sourcing, say so and I'll revert to a bounded direct scan.

## Not changed (deliberately)

`findModelUsageStats` (the always-run inventory) stays on `stored_spans`: it must reliably surface **rare** models, so it can't be sampled or window-shortened, and sourcing it from `trace_summaries.Models` would change its per-model count from span-based to trace-based. That's a larger, semantics-changing call for the feature owner — happy to follow up if wanted.

## Test plan

- `model-cost-span-preview.integration.test.ts` (testcontainers, real ClickHouse): extended to insert the matching `trace_summaries` rows (as production folding does) alongside the spans. All 16 cases green — matched/unmatched models, sample ordering (token-bearing first), per-model limit, window exclusion, cross-tenant isolation.
- `pnpm typecheck` clean.

Advisory PR from the ClickHouse slow-query optimizer. Open for review, not for self-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model cost span preview accuracy by correctly filtering candidate traces based on model information.

* **Performance**
  * Optimized trace data scanning for model cost previews by limiting candidate trace selection, reducing query overhead.

* **Tests**
  * Enhanced integration test coverage for span preview functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->