### PR TITLE
fix(traces): deserialize stored span attributes on trace read paths

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -544,8 +544,11 @@ function validateStatusCode(value: number | null): NormalizedStatusCode | null {
 /**
  * Ensures a ClickHouse Map(String, String) value is actually Record<string, string>.
  * Non-string values are dropped with a warning.
+ *
+ * Exported so every stored_spans read path shares the same row decoding —
+ * pair with {@link deserializeAttributes}.
  */
-function ensureStringRecord(
+export function ensureStringRecord(
   raw: Record<string, unknown>,
 ): Record<string, string> {
   const result: Record<string, string> = {};

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -545,8 +545,8 @@ function validateStatusCode(value: number | null): NormalizedStatusCode | null {
  * Ensures a ClickHouse Map(String, String) value is actually Record<string, string>.
  * Non-string values are dropped with a warning.
  *
- * Exported so every stored_spans read path shares the same row decoding —
- * pair with {@link deserializeAttributes}.
+ * Exported so every stored_spans read path shares the same row decoding.
+ * Pair with {@link deserializeAttributes}.
  */
 export function ensureStringRecord(
   raw: Record<string, unknown>,

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Integration tests for RAG contexts surviving the stored_spans read path.
+ *
+ * ClickHouse stores SpanAttributes as Map(String, String), so the canonical
+ * `langwatch.rag.contexts` array is a JSON string on disk. The trace-details
+ * read path (`getTracesWithSpans`, used by GET /api/trace/{id}) and the
+ * trace-scoped span listing (`SpanStorageClickHouseRepository`) used to cast
+ * the raw map straight into NormalizedSpan, so `extractContexts` saw a string,
+ * failed its Array.isArray check, and every RAG span came back with
+ * `contexts: []`. See specs/traces/rag-contexts-read-deserialization.feature.
+ *
+ * Uses testcontainers ClickHouse to exercise real SQL against the production
+ * schema — rows are inserted exactly as serializeAttributes writes them.
+ */
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseTraceService } from "../clickhouse-trace.service";
+import { SpanStorageClickHouseRepository } from "../repositories/span-storage.clickhouse.repository";
+import type { Protections } from "../../elasticsearch/protections";
+import type { RAGSpan } from "~/server/tracer/types";
+
+const tenantId = `test-rag-contexts-${nanoid()}`;
+const now = Date.now();
+
+const ragChunks = [
+  { document_id: "kb-billing.md", chunk_id: null, content: "Billing article body" },
+  { document_id: "kb-coverage.md", chunk_id: "c-2", content: "Coverage article body" },
+];
+
+function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: `trace-${nanoid()}`,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(now),
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ComputedIOSchemaVersion: "v1",
+    ComputedInput: null,
+    ComputedOutput: null,
+    TimeToFirstTokenMs: null,
+    TimeToLastTokenMs: null,
+    TotalDurationMs: 100,
+    TokensPerSecond: null,
+    SpanCount: 1,
+    ContainsErrorStatus: false,
+    ContainsOKStatus: true,
+    ErrorMessage: null,
+    Models: [],
+    TotalCost: null,
+    TokensEstimated: false,
+    TotalPromptTokenCount: null,
+    TotalCompletionTokenCount: null,
+    OutputFromRootSpan: false,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: false,
+    SatisfactionScore: null,
+    TopicId: null,
+    SubTopicId: null,
+    HasAnnotation: null,
+    ...overrides,
+  };
+}
+
+/**
+ * stored_spans row shaped exactly like the write path produces it:
+ * every SpanAttributes value is a string (Map(String, String)), with
+ * objects/arrays JSON-stringified by serializeAttributes.
+ */
+function makeRagSpanRow(traceId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    TraceId: traceId,
+    SpanId: `span-${nanoid()}`,
+    ParentSpanId: null,
+    ParentTraceId: null,
+    ParentIsRemote: null,
+    Sampled: 1,
+    StartTime: new Date(now),
+    EndTime: new Date(now + 100),
+    DurationMs: 100,
+    SpanName: "retrieve_kb",
+    SpanKind: 1,
+    ServiceName: "test-service",
+    ResourceAttributes: {},
+    SpanAttributes: {
+      "langwatch.span.type": "rag",
+      "langwatch.rag.contexts": JSON.stringify(ragChunks),
+      "langwatch.timestamps": JSON.stringify({ started_at: now }),
+      "langwatch.input": JSON.stringify({ type: "text", value: "user question" }),
+    },
+    StatusCode: 1,
+    StatusMessage: null,
+    ScopeName: "test",
+    ScopeVersion: null,
+    "Events.Timestamp": [],
+    "Events.Name": [],
+    "Events.Attributes": [],
+    "Links.TraceId": [],
+    "Links.SpanId": [],
+    "Links.Attributes": [],
+    DroppedAttributesCount: 0,
+    DroppedEventsCount: 0,
+    DroppedLinksCount: 0,
+    CreatedAt: new Date(now),
+    UpdatedAt: new Date(now),
+    ...overrides,
+  };
+}
+
+const openProtections: Protections = {
+  canSeeCosts: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+};
+
+let ch: ClickHouseClient;
+let service: ClickHouseTraceService;
+
+vi.mock("~/server/clickhouse/clickhouseClient", () => ({
+  getClickHouseClientForProject: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {
+    project: {
+      findUnique: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+
+  const chModule = await import("~/server/clickhouse/clickhouseClient");
+  vi.mocked(chModule.getClickHouseClientForProject).mockResolvedValue(ch);
+
+  const { prisma } = await import("~/server/db");
+  service = new ClickHouseTraceService(
+    prisma as ConstructorParameters<typeof ClickHouseTraceService>[0],
+  );
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+    await ch.exec({
+      query: `ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("RAG contexts read path (integration)", () => {
+  describe("getTracesWithSpans()", () => {
+    const traceId = `trace-rag-${nanoid()}`;
+
+    it("returns the stored contexts on the RAG span", async () => {
+      await ch.insert({
+        table: "trace_summaries",
+        values: [makeTraceSummaryRow({ TraceId: traceId })],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+      await ch.insert({
+        table: "stored_spans",
+        values: [makeRagSpanRow(traceId)],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+
+      const traces = await service.getTracesWithSpans(
+        tenantId,
+        [traceId],
+        openProtections,
+      );
+
+      expect(traces).not.toBeNull();
+      const ragSpan = traces![0]!.spans!.find((s) => s.type === "rag") as
+        | RAGSpan
+        | undefined;
+      expect(ragSpan).toBeDefined();
+      expect(ragSpan!.contexts).toEqual(ragChunks);
+    });
+
+    it("returns JSON-typed attributes as structured params, not strings", async () => {
+      const traces = await service.getTracesWithSpans(
+        tenantId,
+        [traceId],
+        openProtections,
+      );
+
+      const ragSpan = traces![0]!.spans!.find((s) => s.type === "rag")!;
+      const params = ragSpan.params as Record<string, any>;
+      // Was previously the raw string '{"started_at":...}'
+      expect(params.langwatch.timestamps).toEqual({ started_at: now });
+    });
+  });
+
+  describe("SpanStorageClickHouseRepository.getSpansByTraceId()", () => {
+    const traceId = `trace-rag-repo-${nanoid()}`;
+
+    it("returns the stored contexts on the RAG span", async () => {
+      await ch.insert({
+        table: "stored_spans",
+        values: [makeRagSpanRow(traceId)],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+
+      const repo = new SpanStorageClickHouseRepository(ch);
+      const spans = await repo.getSpansByTraceId(tenantId, traceId);
+
+      const ragSpan = spans.find((s) => s.type === "rag") as
+        | RAGSpan
+        | undefined;
+      expect(ragSpan).toBeDefined();
+      expect(ragSpan!.contexts).toEqual(ragChunks);
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
@@ -22,7 +22,7 @@ import {
 import { ClickHouseTraceService } from "../clickhouse-trace.service";
 import { SpanStorageClickHouseRepository } from "../repositories/span-storage.clickhouse.repository";
 import type { Protections } from "../../elasticsearch/protections";
-import type { RAGSpan } from "~/server/tracer/types";
+import type { RAGSpan, Span } from "~/server/tracer/types";
 
 const tenantId = `test-rag-contexts-${nanoid()}`;
 const now = Date.now();
@@ -164,11 +164,17 @@ afterAll(async () => {
   await stopTestContainers();
 });
 
+function findRagSpan(spans: readonly Span[] | undefined): RAGSpan {
+  const ragSpan = spans?.find((s) => s.type === "rag");
+  expect(ragSpan).toBeDefined();
+  return ragSpan as RAGSpan;
+}
+
 describe("RAG contexts read path (integration)", () => {
   describe("getTracesWithSpans()", () => {
     const traceId = `trace-rag-${nanoid()}`;
 
-    it("returns the stored contexts on the RAG span", async () => {
+    beforeAll(async () => {
       await ch.insert({
         table: "trace_summaries",
         values: [makeTraceSummaryRow({ TraceId: traceId })],
@@ -181,19 +187,18 @@ describe("RAG contexts read path (integration)", () => {
         format: "JSONEachRow",
         clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
       });
+    });
 
+    it("returns the stored contexts on the RAG span", async () => {
       const traces = await service.getTracesWithSpans(
         tenantId,
         [traceId],
         openProtections,
       );
 
-      expect(traces).not.toBeNull();
-      const ragSpan = traces![0]!.spans!.find((s) => s.type === "rag") as
-        | RAGSpan
-        | undefined;
-      expect(ragSpan).toBeDefined();
-      expect(ragSpan!.contexts).toEqual(ragChunks);
+      expect(traces).toHaveLength(1);
+      const ragSpan = findRagSpan(traces?.[0]?.spans);
+      expect(ragSpan.contexts).toEqual(ragChunks);
     });
 
     it("returns JSON-typed attributes as structured params, not strings", async () => {
@@ -203,10 +208,13 @@ describe("RAG contexts read path (integration)", () => {
         openProtections,
       );
 
-      const ragSpan = traces![0]!.spans!.find((s) => s.type === "rag")!;
-      const params = ragSpan.params as Record<string, any>;
+      expect(traces).toHaveLength(1);
+      const ragSpan = findRagSpan(traces?.[0]?.spans);
+      const params = ragSpan.params as {
+        langwatch?: { timestamps?: unknown };
+      };
       // Was previously the raw string '{"started_at":...}'
-      expect(params.langwatch.timestamps).toEqual({ started_at: now });
+      expect(params.langwatch?.timestamps).toEqual({ started_at: now });
     });
   });
 
@@ -224,11 +232,8 @@ describe("RAG contexts read path (integration)", () => {
       const repo = new SpanStorageClickHouseRepository(ch);
       const spans = await repo.getSpansByTraceId(tenantId, traceId);
 
-      const ragSpan = spans.find((s) => s.type === "rag") as
-        | RAGSpan
-        | undefined;
-      expect(ragSpan).toBeDefined();
-      expect(ragSpan!.contexts).toEqual(ragChunks);
+      const ragSpan = findRagSpan(spans);
+      expect(ragSpan.contexts).toEqual(ragChunks);
     });
   });
 });

--- a/langwatch/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts
@@ -10,26 +10,35 @@
  * `contexts: []`. See specs/traces/rag-contexts-read-deserialization.feature.
  *
  * Uses testcontainers ClickHouse to exercise real SQL against the production
- * schema — rows are inserted exactly as serializeAttributes writes them.
+ * schema. Rows are inserted exactly as serializeAttributes writes them.
  */
+
+import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import type { ClickHouseClient } from "@clickhouse/client";
+import type { RAGSpan, Span } from "~/server/tracer/types";
+import type { Protections } from "~/server/traces/protections";
 import {
   startTestContainers,
   stopTestContainers,
 } from "../../event-sourcing/__tests__/integration/testContainers";
 import { ClickHouseTraceService } from "../clickhouse-trace.service";
 import { SpanStorageClickHouseRepository } from "../repositories/span-storage.clickhouse.repository";
-import type { Protections } from "../../elasticsearch/protections";
-import type { RAGSpan, Span } from "~/server/tracer/types";
 
 const tenantId = `test-rag-contexts-${nanoid()}`;
 const now = Date.now();
 
 const ragChunks = [
-  { document_id: "kb-billing.md", chunk_id: null, content: "Billing article body" },
-  { document_id: "kb-coverage.md", chunk_id: "c-2", content: "Coverage article body" },
+  {
+    document_id: "kb-billing.md",
+    chunk_id: null,
+    content: "Billing article body",
+  },
+  {
+    document_id: "kb-coverage.md",
+    chunk_id: "c-2",
+    content: "Coverage article body",
+  },
 ];
 
 function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
@@ -74,7 +83,10 @@ function makeTraceSummaryRow(overrides: Record<string, unknown> = {}) {
  * every SpanAttributes value is a string (Map(String, String)), with
  * objects/arrays JSON-stringified by serializeAttributes.
  */
-function makeRagSpanRow(traceId: string, overrides: Record<string, unknown> = {}) {
+function makeRagSpanRow(
+  traceId: string,
+  overrides: Record<string, unknown> = {},
+) {
   return {
     ProjectionId: `proj-${nanoid()}`,
     TenantId: tenantId,
@@ -95,7 +107,10 @@ function makeRagSpanRow(traceId: string, overrides: Record<string, unknown> = {}
       "langwatch.span.type": "rag",
       "langwatch.rag.contexts": JSON.stringify(ragChunks),
       "langwatch.timestamps": JSON.stringify({ started_at: now }),
-      "langwatch.input": JSON.stringify({ type: "text", value: "user question" }),
+      "langwatch.input": JSON.stringify({
+        type: "text",
+        value: "user question",
+      }),
     },
     StatusCode: 1,
     StatusMessage: null,

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -7,6 +7,10 @@ import { LLM_PARAMETER_MAP } from "~/prompts/prompt-playground/llmParameterMap";
 import { HandledError } from "@langwatch/handled-error";
 import type { ExtractedIO } from "~/server/app-layer/traces/trace-io-extraction.service";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import {
+  deserializeAttributes,
+  ensureStringRecord,
+} from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
 import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
 import {
   DEFAULT_PARTITION_WINDOW_MS,
@@ -3086,97 +3090,6 @@ export class ClickHouseTraceService {
   }
 
   /**
-   * Extract NormalizedSpan from a joined row.
-   * @internal
-   */
-  private extractSpanFromRow(
-    row: JoinedTraceSpanRow,
-    tenantId: string,
-  ): NormalizedSpan {
-    // Reconstruct events array with proper typing
-    const events = (row.ss_Events_Timestamp ?? []).map((timestamp, index) => ({
-      name: row.ss_Events_Name?.[index] ?? "",
-      timeUnixMs: timestamp,
-      attributes: (row.ss_Events_Attributes?.[index] ?? {}) as Record<
-        string,
-        | string
-        | number
-        | bigint
-        | boolean
-        | (string | number | bigint | boolean)[]
-      >,
-    }));
-
-    // Reconstruct links array with proper typing
-    const links = (row.ss_Links_TraceId ?? []).map((linkTraceId, index) => ({
-      traceId: linkTraceId,
-      spanId: row.ss_Links_SpanId?.[index] ?? "",
-      attributes: (row.ss_Links_Attributes?.[index] ?? {}) as Record<
-        string,
-        | string
-        | number
-        | bigint
-        | boolean
-        | (string | number | bigint | boolean)[]
-      >,
-    }));
-
-    // Map numeric status code to enum
-    const statusCode =
-      row.ss_StatusCode !== null
-        ? (row.ss_StatusCode as NormalizedStatusCode)
-        : null;
-
-    // Map numeric span kind to enum
-    const kind = (row.ss_SpanKind ?? 0) as NormalizedSpanKind;
-
-    return {
-      id: row.ss_Id ?? "",
-      traceId: row.ss_TraceId ?? "",
-      spanId: row.ss_SpanId ?? "",
-      tenantId,
-      parentSpanId: row.ss_ParentSpanId,
-      parentTraceId: row.ss_ParentTraceId,
-      parentIsRemote: row.ss_ParentIsRemote,
-      sampled: row.ss_Sampled ?? true,
-      startTimeUnixMs: row.ss_StartTime ?? 0,
-      endTimeUnixMs: row.ss_EndTime ?? 0,
-      durationMs: row.ss_DurationMs ?? 0,
-      name: row.ss_SpanName ?? "",
-      kind,
-      resourceAttributes: (row.ss_ResourceAttributes ?? {}) as Record<
-        string,
-        | string
-        | number
-        | bigint
-        | boolean
-        | (string | number | bigint | boolean)[]
-      >,
-      spanAttributes: (row.ss_SpanAttributes ?? {}) as Record<
-        string,
-        | string
-        | number
-        | bigint
-        | boolean
-        | (string | number | bigint | boolean)[]
-      >,
-      events,
-      links,
-      statusMessage: row.ss_StatusMessage,
-      statusCode,
-      instrumentationScope: {
-        name: row.ss_ScopeName ?? "",
-        version: row.ss_ScopeVersion,
-      },
-      droppedAttributesCount: 0,
-      droppedEventsCount: 0,
-      droppedLinksCount: 0,
-      cost: null,
-      nonBilledCost: null,
-    };
-  }
-
-  /**
    * Map a span row from a standalone spans query (no JOIN prefix) to NormalizedSpan.
    * @internal
    */
@@ -3212,27 +3125,17 @@ export class ClickHouseTraceService {
     const events = (row.Events_Timestamp ?? []).map((timestamp, index) => ({
       name: row.Events_Name?.[index] ?? "",
       timeUnixMs: timestamp,
-      attributes: (row.Events_Attributes?.[index] ?? {}) as Record<
-        string,
-        | string
-        | number
-        | bigint
-        | boolean
-        | (string | number | bigint | boolean)[]
-      >,
+      attributes: deserializeAttributes(
+        ensureStringRecord(row.Events_Attributes?.[index] ?? {}),
+      ) as NormalizedSpan["events"][number]["attributes"],
     }));
 
     const links = (row.Links_TraceId ?? []).map((linkTraceId, index) => ({
       traceId: linkTraceId,
       spanId: row.Links_SpanId?.[index] ?? "",
-      attributes: (row.Links_Attributes?.[index] ?? {}) as Record<
-        string,
-        | string
-        | number
-        | bigint
-        | boolean
-        | (string | number | bigint | boolean)[]
-      >,
+      attributes: deserializeAttributes(
+        ensureStringRecord(row.Links_Attributes?.[index] ?? {}),
+      ) as NormalizedSpan["links"][number]["attributes"],
     }));
 
     return {
@@ -3249,9 +3152,12 @@ export class ClickHouseTraceService {
       durationMs: row.DurationMs,
       name: row.SpanName,
       kind: row.SpanKind as NormalizedSpanKind,
-      resourceAttributes:
-        row.ResourceAttributes as NormalizedSpan["resourceAttributes"],
-      spanAttributes: row.SpanAttributes as NormalizedSpan["spanAttributes"],
+      resourceAttributes: deserializeAttributes(
+        ensureStringRecord(row.ResourceAttributes),
+      ) as NormalizedSpan["resourceAttributes"],
+      spanAttributes: deserializeAttributes(
+        ensureStringRecord(row.SpanAttributes),
+      ) as NormalizedSpan["spanAttributes"],
       statusCode: row.StatusCode as NormalizedStatusCode | null,
       statusMessage: row.StatusMessage,
       instrumentationScope: {

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -1,21 +1,21 @@
 import type { ClickHouseClient } from "@clickhouse/client";
+import { HandledError } from "@langwatch/handled-error";
 import { createLogger } from "@langwatch/observability";
 import type { PrismaClient } from "@prisma/client";
 import { getLangWatchTracer } from "langwatch";
 import type { TraceWithGuardrail } from "~/components/messages/MessageCard";
 import { LLM_PARAMETER_MAP } from "~/prompts/prompt-playground/llmParameterMap";
-import { HandledError } from "@langwatch/handled-error";
-import type { ExtractedIO } from "~/server/app-layer/traces/trace-io-extraction.service";
-import type { TraceSummaryData } from "~/server/app-layer/traces/types";
-import {
-  deserializeAttributes,
-  ensureStringRecord,
-} from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
-import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
 import {
   DEFAULT_PARTITION_WINDOW_MS,
   queryWindowed,
 } from "~/server/app-layer/clients/clickhouse/windowed-read";
+import {
+  deserializeAttributes,
+  ensureStringRecord,
+} from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
+import type { ExtractedIO } from "~/server/app-layer/traces/trace-io-extraction.service";
+import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import { getClickHouseClientForProject } from "~/server/clickhouse/clickhouseClient";
 import { prisma as defaultPrisma } from "~/server/db";
 import {
   type ClickHouseEvaluationRunRow,

--- a/langwatch/src/server/traces/mappers/__tests__/span.mapper.test.ts
+++ b/langwatch/src/server/traces/mappers/__tests__/span.mapper.test.ts
@@ -432,6 +432,89 @@ describe("mapNormalizedSpanToSpan", () => {
     });
   });
 
+  describe("when extracting RAG contexts", () => {
+    const chunks = [
+      { document_id: "doc-1", chunk_id: "c-1", content: "first chunk" },
+      { document_id: "doc-2", content: "second chunk" },
+    ];
+
+    it("maps contexts when the attribute is a parsed array", () => {
+      const span = makeSpan({
+        spanAttributes: {
+          "langwatch.span.type": "rag",
+          "langwatch.rag.contexts": chunks,
+        },
+      });
+
+      const result = mapNormalizedSpanToSpan(span);
+
+      expect(result.type).toBe("rag");
+      expect((result as { contexts: unknown }).contexts).toEqual([
+        { document_id: "doc-1", chunk_id: "c-1", content: "first chunk" },
+        { document_id: "doc-2", chunk_id: null, content: "second chunk" },
+      ]);
+    });
+
+    it("maps contexts when the attribute is a JSON string (ClickHouse Map round-trip)", () => {
+      const span = makeSpan({
+        spanAttributes: {
+          "langwatch.span.type": "rag",
+          "langwatch.rag.contexts": JSON.stringify(chunks),
+        },
+      });
+
+      const result = mapNormalizedSpanToSpan(span);
+
+      expect(result.type).toBe("rag");
+      expect((result as { contexts: unknown }).contexts).toEqual([
+        { document_id: "doc-1", chunk_id: "c-1", content: "first chunk" },
+        { document_id: "doc-2", chunk_id: null, content: "second chunk" },
+      ]);
+    });
+
+    it("maps string-only contexts arrays", () => {
+      const span = makeSpan({
+        spanAttributes: {
+          "langwatch.span.type": "rag",
+          "langwatch.rag.contexts": JSON.stringify(["plain chunk"]),
+        },
+      });
+
+      const result = mapNormalizedSpanToSpan(span);
+
+      expect((result as { contexts: unknown }).contexts).toEqual([
+        { content: "plain chunk" },
+      ]);
+    });
+
+    it("returns empty contexts for malformed JSON strings without throwing", () => {
+      const span = makeSpan({
+        spanAttributes: {
+          "langwatch.span.type": "rag",
+          "langwatch.rag.contexts": "[not valid json",
+        },
+      });
+
+      const result = mapNormalizedSpanToSpan(span);
+
+      expect(result.type).toBe("rag");
+      expect((result as { contexts: unknown }).contexts).toEqual([]);
+    });
+
+    it("returns empty contexts for JSON strings that are not arrays", () => {
+      const span = makeSpan({
+        spanAttributes: {
+          "langwatch.span.type": "rag",
+          "langwatch.rag.contexts": JSON.stringify({ not: "an array" }),
+        },
+      });
+
+      const result = mapNormalizedSpanToSpan(span);
+
+      expect((result as { contexts: unknown }).contexts).toEqual([]);
+    });
+  });
+
   describe("when extracting error information", () => {
     it("returns null when statusCode is not ERROR", () => {
       const span = makeSpan({

--- a/langwatch/src/server/traces/mappers/span.mapper.ts
+++ b/langwatch/src/server/traces/mappers/span.mapper.ts
@@ -390,7 +390,16 @@ function extractVendor(spanAttributes: NormalizedAttributes): string | null {
 function extractContexts(
   spanAttributes: NormalizedAttributes,
 ): RAGChunk[] | undefined {
-  const contexts = spanAttributes["langwatch.rag.contexts"];
+  let contexts = spanAttributes["langwatch.rag.contexts"];
+
+  // ClickHouse Map(String, String) stores arrays as JSON strings
+  if (typeof contexts === "string") {
+    try {
+      contexts = JSON.parse(contexts);
+    } catch {
+      return undefined;
+    }
+  }
 
   if (!contexts || !Array.isArray(contexts)) {
     return undefined;

--- a/langwatch/src/server/traces/offloaded-eventref-parsing.ts
+++ b/langwatch/src/server/traces/offloaded-eventref-parsing.ts
@@ -6,6 +6,7 @@
  * in exactly one place.
  */
 import { EVENTREF_ATTR_PREFIX } from "~/server/app-layer/traces/lean-for-projection";
+import type { NormalizedAttributes } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 
 /** One decoded eventref pointer ready to fetch from event_log. */
 export interface EventRefEntry {
@@ -20,7 +21,7 @@ export interface EventRefEntry {
 /** Result of splitting a span's attributes into preview attrs + eventref pointers. */
 export interface ParsedSpanEventRefs {
   /** Non-reserved attributes (previews and regular attrs), reserved keys removed. */
-  cleanedAttrs: Record<string, string>;
+  cleanedAttrs: NormalizedAttributes;
   /** Well-formed eventref pointers to resolve. */
   eventrefEntries: EventRefEntry[];
   /** attrKeys whose eventref carried no usable eventId — caller warns + keeps preview. */
@@ -28,7 +29,7 @@ export interface ParsedSpanEventRefs {
 }
 
 /** True when the attribute map carries at least one eventref pointer. */
-export function hasEventRefs(attributes: Record<string, string>): boolean {
+export function hasEventRefs(attributes: NormalizedAttributes): boolean {
   return Object.keys(attributes).some((key) =>
     key.startsWith(EVENTREF_ATTR_PREFIX),
   );
@@ -44,9 +45,9 @@ export function hasEventRefs(attributes: Record<string, string>): boolean {
  *   sits in `cleanedAttrs` under the non-reserved IO key).
  */
 export function parseSpanEventRefs(
-  attrs: Record<string, string>,
+  attrs: NormalizedAttributes,
 ): ParsedSpanEventRefs {
-  const cleanedAttrs: Record<string, string> = {};
+  const cleanedAttrs: NormalizedAttributes = {};
   const eventrefEntries: EventRefEntry[] = [];
   const missingEventIdKeys: string[] = [];
 
@@ -54,14 +55,25 @@ export function parseSpanEventRefs(
     if (key.startsWith(EVENTREF_ATTR_PREFIX)) {
       const attrKey = key.slice(EVENTREF_ATTR_PREFIX.length);
       try {
-        const ref = JSON.parse(value) as { field?: string; eventId?: string };
+        const decoded = typeof value === "string" ? JSON.parse(value) : value;
+        if (
+          typeof decoded !== "object" ||
+          decoded === null ||
+          Array.isArray(decoded)
+        ) {
+          continue;
+        }
+        const ref = decoded as { field?: unknown; eventId?: unknown };
         if (typeof ref.eventId !== "string" || ref.eventId.length === 0) {
           missingEventIdKeys.push(attrKey);
           continue;
         }
         eventrefEntries.push({
           attrKey,
-          field: ref.field ?? attrKey,
+          field:
+            typeof ref.field === "string" && ref.field.length > 0
+              ? ref.field
+              : attrKey,
           eventId: ref.eventId,
         });
       } catch {

--- a/langwatch/src/server/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/traces/repositories/span-storage.clickhouse.repository.ts
@@ -1,4 +1,8 @@
 import type { ClickHouseClient } from "@clickhouse/client";
+import {
+  deserializeAttributes,
+  ensureStringRecord,
+} from "~/server/app-layer/traces/repositories/span-storage.clickhouse.repository";
 import type {
   NormalizedSpan,
   NormalizedSpanKind,
@@ -42,17 +46,17 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
           \`Links.TraceId\` AS Links_TraceId,
           \`Links.SpanId\` AS Links_SpanId,
           \`Links.Attributes\` AS Links_Attributes
-        FROM stored_spans
-        WHERE TenantId = {tenantId:String}
-          AND TraceId = {traceId:String}
-          AND (TenantId, TraceId, SpanId, StartTime) IN (
+        FROM stored_spans AS t
+        WHERE t.TenantId = {tenantId:String}
+          AND t.TraceId = {traceId:String}
+          AND (t.TenantId, t.TraceId, t.SpanId, t.StartTime) IN (
             SELECT TenantId, TraceId, SpanId, max(StartTime)
             FROM stored_spans
             WHERE TenantId = {tenantId:String}
               AND TraceId = {traceId:String}
             GROUP BY TenantId, TraceId, SpanId
           )
-        ORDER BY StartTime ASC
+        ORDER BY t.StartTime ASC
       `,
       query_params: { tenantId, traceId },
       format: "JSONEachRow",
@@ -99,9 +103,12 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       durationMs: row.DurationMs,
       name: row.SpanName,
       kind: row.SpanKind as NormalizedSpanKind,
-      resourceAttributes:
-        row.ResourceAttributes as NormalizedSpan["resourceAttributes"],
-      spanAttributes: row.SpanAttributes as NormalizedSpan["spanAttributes"],
+      resourceAttributes: deserializeAttributes(
+        ensureStringRecord(row.ResourceAttributes),
+      ) as NormalizedSpan["resourceAttributes"],
+      spanAttributes: deserializeAttributes(
+        ensureStringRecord(row.SpanAttributes),
+      ) as NormalizedSpan["spanAttributes"],
       statusCode: row.StatusCode as NormalizedStatusCode | null,
       statusMessage: row.StatusMessage,
       instrumentationScope: {
@@ -111,14 +118,16 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
       events: (row.Events_Timestamp ?? []).map((ts, i) => ({
         name: row.Events_Name?.[i] ?? "",
         timeUnixMs: ts,
-        attributes: (row.Events_Attributes?.[i] ??
-          {}) as NormalizedSpan["events"][number]["attributes"],
+        attributes: deserializeAttributes(
+          ensureStringRecord(row.Events_Attributes?.[i] ?? {}),
+        ) as NormalizedSpan["events"][number]["attributes"],
       })),
       links: (row.Links_TraceId ?? []).map((lt, i) => ({
         traceId: lt,
         spanId: row.Links_SpanId?.[i] ?? "",
-        attributes: (row.Links_Attributes?.[i] ??
-          {}) as NormalizedSpan["links"][number]["attributes"],
+        attributes: deserializeAttributes(
+          ensureStringRecord(row.Links_Attributes?.[i] ?? {}),
+        ) as NormalizedSpan["links"][number]["attributes"],
       })),
       droppedAttributesCount: 0,
       droppedEventsCount: 0,

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
@@ -177,7 +177,7 @@ export async function resolveOffloadedTracesBatch({
   const fetchTasks = new Map<string, FetchTask>();
   const tracePlans: SpanPlan[][] = spansPerTrace.map((spans) =>
     spans.map((span) => {
-      const attrs = span.spanAttributes as NormalizedAttributes;
+      const attrs = span.spanAttributes;
       if (!hasEventRefs(attrs)) {
         return { cleanedAttrs: attrs, refs: [], hadRefs: false };
       }

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.ts
@@ -26,7 +26,10 @@ import {
   BlobNotFoundError,
 } from "~/server/app-layer/traces/blob-store.service";
 import type { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
-import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import type {
+  NormalizedAttributes,
+  NormalizedSpan,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { hasEventRefs, parseSpanEventRefs } from "./offloaded-eventref-parsing";
 import type {
   ResolvedTraceSpans,
@@ -52,7 +55,7 @@ interface FetchTask {
 /** Internal: per-span plan built in the parse phase. */
 interface SpanPlan {
   /** Preview/regular attributes with reserved keys removed. */
-  cleanedAttrs: Record<string, string>;
+  cleanedAttrs: NormalizedAttributes;
   /** Which fetch key fills which attribute key. */
   refs: Array<{ attrKey: string; fetchKey: string }>;
   /** False when the span had no eventrefs (returned untouched). */
@@ -174,7 +177,7 @@ export async function resolveOffloadedTracesBatch({
   const fetchTasks = new Map<string, FetchTask>();
   const tracePlans: SpanPlan[][] = spansPerTrace.map((spans) =>
     spans.map((span) => {
-      const attrs = span.spanAttributes as Record<string, string>;
+      const attrs = span.spanAttributes as NormalizedAttributes;
       if (!hasEventRefs(attrs)) {
         return { cleanedAttrs: attrs, refs: [], hadRefs: false };
       }

--- a/langwatch/src/server/traces/resolve-offloaded-traces-batch.unit.test.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces-batch.unit.test.ts
@@ -256,6 +256,41 @@ describe("resolveOffloadedTracesBatch() — AC6 bounded resolution", () => {
     });
   });
 
+  describe("given an eventref already decoded by attribute deserialization", () => {
+    describe("when resolved as a batch", () => {
+      it("restores the full value and removes the reserved attribute", async () => {
+        const { blobStore } =
+          makeConcurrencyTrackingBlobStore("full batch output");
+        const span = makeSpan({
+          spanAttributes: {
+            "langwatch.output": "preview",
+            [`${EVENTREF_ATTR_PREFIX}langwatch.output`]: {
+              field: "langwatch.output",
+              eventId: "evt-decoded",
+            },
+          },
+        });
+
+        const results = await resolveOffloadedTracesBatch({
+          projectId: "proj-1",
+          spansPerTrace: [[span]],
+          blobStore,
+          ioExtractionService: realIOService,
+          logger: createMockLogger(),
+        });
+
+        expect(results[0]!.resolvedSpans[0]!.spanAttributes).toMatchObject({
+          "langwatch.output": "full batch output",
+        });
+        expect(
+          results[0]!.resolvedSpans[0]!.spanAttributes[
+            `${EVENTREF_ATTR_PREFIX}langwatch.output`
+          ],
+        ).toBeUndefined();
+      });
+    });
+  });
+
   describe("given a trace with no offloaded spans", () => {
     describe("when resolved as a batch", () => {
       it("issues zero event_log reads and returns the spans untouched", async () => {

--- a/langwatch/src/server/traces/resolve-offloaded-traces.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces.ts
@@ -31,7 +31,10 @@ import type {
   ExtractedIO,
   TraceIOExtractionService,
 } from "~/server/app-layer/traces/trace-io-extraction.service";
-import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import type {
+  NormalizedAttributes,
+  NormalizedSpan,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { hasEventRefs, parseSpanEventRefs } from "./offloaded-eventref-parsing";
 
 /** Minimal logger interface required by this module (subset of PinoLogger). */
@@ -101,7 +104,7 @@ export async function resolveOffloadedTraces({
 }): Promise<ResolvedTraceSpans> {
   // Fast path: no span in this trace has any event ref — skip entirely.
   const anyHasRefs = normalizedSpans.some((span) =>
-    hasEventRefs(span.spanAttributes as Record<string, string>),
+    hasEventRefs(span.spanAttributes),
   );
 
   if (!anyHasRefs) {
@@ -118,7 +121,7 @@ export async function resolveOffloadedTraces({
   // returned even when a span's resolver throws an unexpected uncaught error.
   const spanSettlements = await Promise.allSettled(
     normalizedSpans.map(async (span) => {
-      const attrs = span.spanAttributes as Record<string, string>;
+      const attrs = span.spanAttributes as NormalizedAttributes;
       if (!hasEventRefs(attrs)) {
         return { span, resolvedCount: 0 };
       }
@@ -127,7 +130,7 @@ export async function resolveOffloadedTraces({
       const { cleanedAttrs, eventrefEntries, missingEventIdKeys } =
         parseSpanEventRefs(attrs);
 
-      // Eventref missing the embedded eventId — can't resolve. The reserved
+      // Eventref missing the embedded eventId can't resolve. The reserved
       // key is already stripped (kept out of cleanedAttrs) so the UI never
       // sees the namespace; the preview under the plain IO key stays in place.
       for (const attrKey of missingEventIdKeys) {

--- a/langwatch/src/server/traces/resolve-offloaded-traces.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces.ts
@@ -31,10 +31,7 @@ import type {
   ExtractedIO,
   TraceIOExtractionService,
 } from "~/server/app-layer/traces/trace-io-extraction.service";
-import type {
-  NormalizedAttributes,
-  NormalizedSpan,
-} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
+import type { NormalizedSpan } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { hasEventRefs, parseSpanEventRefs } from "./offloaded-eventref-parsing";
 
 /** Minimal logger interface required by this module (subset of PinoLogger). */
@@ -121,7 +118,7 @@ export async function resolveOffloadedTraces({
   // returned even when a span's resolver throws an unexpected uncaught error.
   const spanSettlements = await Promise.allSettled(
     normalizedSpans.map(async (span) => {
-      const attrs = span.spanAttributes as NormalizedAttributes;
+      const attrs = span.spanAttributes;
       if (!hasEventRefs(attrs)) {
         return { span, resolvedCount: 0 };
       }

--- a/langwatch/src/server/traces/resolve-offloaded-traces.unit.test.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces.unit.test.ts
@@ -15,7 +15,7 @@ vi.mock("langwatch", () => ({
       _name: string,
       _opts: unknown,
       fn: (span: { setAttributes: () => void }) => unknown,
-    ) => fn({ setAttributes: () => {} }),
+    ) => fn({ setAttributes: () => undefined }),
   }),
 }));
 

--- a/langwatch/src/server/traces/resolve-offloaded-traces.unit.test.ts
+++ b/langwatch/src/server/traces/resolve-offloaded-traces.unit.test.ts
@@ -198,6 +198,38 @@ describe("resolveOffloadedTraces()", () => {
     });
   });
 
+  describe("given an eventref already decoded by attribute deserialization", () => {
+    describe("when resolved", () => {
+      it("restores the full value and removes the reserved attribute", async () => {
+        const span = makeSpan({
+          spanAttributes: {
+            "langwatch.output": "preview",
+            [`${EVENTREF_ATTR_PREFIX}langwatch.output`]: {
+              field: "langwatch.output",
+              eventId: "evt-decoded",
+            },
+          },
+        });
+        const result = await resolveOffloadedTraces({
+          projectId: "proj-1",
+          normalizedSpans: [span],
+          blobStore: fakeBlobStore({ "langwatch.output": "full output" }),
+          ioExtractionService: realIOService,
+          logger: createMockLogger(),
+        });
+
+        expect(result.resolvedSpans[0]!.spanAttributes).toMatchObject({
+          "langwatch.output": "full output",
+        });
+        expect(
+          result.resolvedSpans[0]!.spanAttributes[
+            `${EVENTREF_ATTR_PREFIX}langwatch.output`
+          ],
+        ).toBeUndefined();
+      });
+    });
+  });
+
   describe("given a trace with no eventref pointers in any span", () => {
     const spanClean = makeSpan({
       spanAttributes: {

--- a/specs/traces/rag-contexts-read-deserialization.feature
+++ b/specs/traces/rag-contexts-read-deserialization.feature
@@ -1,0 +1,91 @@
+Feature: RAG contexts survive the ClickHouse read path
+  As an SDK user attaching RAG contexts to a span
+  I want the trace read APIs to return those contexts
+  So that RAG debugging and faithfulness evaluation work from stored traces
+
+  # =========================================================================
+  # Why this exists
+  # =========================================================================
+  #
+  # The Python/TS SDKs attach retrieval results to a span as the
+  # `langwatch.rag_contexts` attribute: a JSON-encoded array of
+  # `{document_id, chunk_id, content}` chunks. Ingestion canonicalises it to
+  # `langwatch.rag.contexts` (parsed array), and ClickHouse stores it in
+  # `stored_spans.SpanAttributes`, a Map(String, String) column, so on disk
+  # the value is a JSON string again.
+  #
+  # Reading spans back happens at three sites:
+  #
+  #   1. `app-layer/traces/repositories/span-storage.clickhouse.repository.ts`
+  #      → runs `deserializeAttributes` (JSON strings parsed back). Correct.
+  #   2. `server/traces/clickhouse-trace.service.ts` (`mapSpanRow`)
+  #      → cast the raw Map values straight into NormalizedSpan. Broken.
+  #   3. `server/traces/repositories/span-storage.clickhouse.repository.ts`
+  #      → same raw cast. Broken.
+  #
+  # Sites 2 and 3 feed `mapNormalizedSpansToSpans`, whose `extractContexts`
+  # required an actual array (`Array.isArray`) and returned nothing for the
+  # stored JSON string, so the public REST trace API returned
+  # `contexts: []` for every RAG span, while the same span rendered fine on
+  # read paths that go through site 1. Sibling extractors (`extractInput`,
+  # `extractOutput`, `getAnnotatedType`) already JSON-parse string values
+  # defensively; `extractContexts` was the odd one out.
+  #
+  # =========================================================================
+
+  Background:
+    Given a project with traces stored in ClickHouse `stored_spans`
+    And a span of type "rag" whose `langwatch.rag.contexts` attribute was
+      serialized to a JSON string by the Map(String, String) write boundary
+
+  Scenario: Span mapper recovers contexts from a stored JSON string
+    When `mapNormalizedSpansToSpans` maps span attributes containing
+      `langwatch.rag.contexts` as the string "[{\"document_id\":\"doc-1\",\"content\":\"chunk text\"}]"
+    Then the mapped span has contexts with document_id "doc-1" and content "chunk text"
+
+  Scenario: Span mapper still accepts contexts as a real array
+    When `mapNormalizedSpansToSpans` maps span attributes containing
+      `langwatch.rag.contexts` as a parsed array of chunk objects
+    Then the mapped span has the same contexts as before this fix
+
+  Scenario: Malformed contexts strings degrade to no contexts, not an error
+    When `mapNormalizedSpansToSpans` maps span attributes containing
+      `langwatch.rag.contexts` as the string "[not json"
+    Then the mapped span has empty contexts
+    And mapping does not throw
+
+  Scenario: REST trace API returns contexts for a RAG span
+    Given a RAG span ingested through the OTLP collector with two contexts
+    When the client calls GET /api/trace/{traceId}
+    Then the RAG span in the response carries both contexts
+    And string-typed JSON attributes (timestamps, params) are returned as
+      structured values, not JSON-encoded strings
+
+  Scenario: Trace-scoped span listing returns contexts
+    Given the same RAG span
+    When spans are read through `SpanStorageService.getSpansByTraceId`
+    Then the RAG span carries both contexts
+
+  Scenario: Deserialized event references remain resolvable
+    Given an offloaded span value whose reserved event reference was decoded
+      from a JSON string into an object by the shared attribute deserializer
+    When either the single-trace or batch offloaded-value resolver reads it
+    Then the full value is restored from the event log
+    And the reserved event reference attribute is removed
+
+  # ==========================================================================
+  # Found while writing the integration test for the scenario above:
+  # the repository's dedup tuple `(TenantId, TraceId, SpanId, StartTime)`
+  # resolved `StartTime` to the SELECT alias
+  # `toUnixTimestamp64Milli(StartTime) AS StartTime` (ClickHouse lets SELECT
+  # aliases shadow columns in WHERE), comparing milliseconds against
+  # `max(StartTime)` as DateTime64(9), which never equals it, so the repository
+  # returned ZERO spans for every trace. The trace-details service avoids
+  # this by table-qualifying the tuple (`t.StartTime`); the repository now
+  # does the same.
+  # ==========================================================================
+  Scenario: Span listing dedup tuple compares the raw StartTime column
+    Given a single stored span version for a trace
+    When spans are read through `SpanStorageService.getSpansByTraceId`
+    Then the span is returned (the dedup tuple must not match against the
+      millisecond SELECT alias)


### PR DESCRIPTION
## What

RAG spans could return `contexts: []` from `GET /api/trace/{id}` even though the SDK sent them correctly. ClickHouse stores `SpanAttributes` as `Map(String, String)`, and active `stored_spans` readers were casting the raw map directly into normalized span types. As a result, the mapper received `langwatch.rag.contexts` as a JSON string and discarded it.

The trace-scoped span listing query also compared a millisecond `StartTime` alias against the raw `DateTime64` maximum, causing valid rows to be excluded.

## Changes

- Deserialize span, resource, event, and link attributes in all full-span ClickHouse read paths.
- Parse string-valued RAG contexts defensively in the span mapper.
- Keep offloaded event references resolvable whether their value arrives as JSON text or an already decoded object.
- Qualify the raw `t.StartTime` column in the trace-scoped deduplication tuple.
- Remove a dead joined-row span mapper.
- Add BDD coverage, focused unit coverage, and real ClickHouse integration coverage.

## Why this is still needed

The current main branch still contains two active full-span readers that treat ClickHouse attribute maps as normalized data without deserialization. Existing stored traces can therefore lose RAG contexts or expose structured fields as JSON strings on those read paths.

## Verification

- `pnpm test:unit run src/server/traces/mappers/__tests__/span.mapper.test.ts src/server/traces/resolve-offloaded-traces.unit.test.ts src/server/traces/resolve-offloaded-traces-batch.unit.test.ts`
  - 67 tests passed.
- `pnpm test:integration run src/server/traces/__tests__/clickhouse-trace-rag-contexts.integration.test.ts --watch=false`
  - 3 tests passed against the real local ClickHouse schema and queries.
- `pnpm typecheck:all`
  - Production and test-file typechecks passed.
- `pnpm dlx @biomejs/biome@2.4.14 check <changed TypeScript files>`
  - Passed with the version matching the repository configuration.
- `git diff --check origin/main...HEAD`
  - Passed.

## Proof

| Behavior | Evidence |
| --- | --- |
| Parsed context arrays remain intact | Span mapper unit test |
| JSON-string contexts are decoded | Span mapper unit test |
| Malformed or non-array values safely produce no contexts | Span mapper unit tests |
| Trace details returns contexts and structured params | Real ClickHouse integration test |
| Trace-scoped span listing returns decoded contexts | Real ClickHouse integration test |
| Decoded event references resolve in single and batch paths | Resolver unit tests |
| Span deduplication compares raw timestamps | Qualified query plus integration coverage |

The codebase sweep checked all three production `stored_spans` readers. No additional raw attribute-cast sites remain in full-span readers. The lightweight resource-info projection intentionally remains string-only.

## Dogfood proof

The existing full pipeline dogfood run sent a RAG span through the SDK, OTLP collector, event sourcing, ClickHouse, and REST API. The trace details UI returned both stored contexts and structured params:

![RAG span with contexts](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4735/rag-contexts/rag-span.png)

![Decoded contexts](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4735/rag-contexts/rag-contexts.png)

Both screenshots were rechecked after the rebase and show the expected decoded contexts.

## Deployment Impact

No environment variables, Helm values, migrations, or backfills are required. The change only affects application read paths. Existing stored traces begin returning decoded contexts and structured attributes after rollout.
