### PR TITLE
fix(ci): unbreak clickhouse-serverless lint and dependabot update jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,42 @@
 version: 2
+
+# The npm workspaces enforce pnpm's minimumReleaseAge (7 days) and the uv
+# projects enforce exclude-newer = "7 days", so dependabot must not propose
+# versions younger than that: the package manager would refuse to resolve
+# them and the update run would fail. The cooldowns below keep candidate
+# selection behind the same gate, with one extra day of margin.
 updates:
   - package-ecosystem: "npm"
     directory: "/langwatch"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
+    cooldown:
+      default-days: 8
 
   - package-ecosystem: "npm"
     directory: "/typescript-sdk"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
+    cooldown:
+      default-days: 8
 
   - package-ecosystem: "npm"
     directory: "/mcp-server"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
+    cooldown:
+      default-days: 8
 
   - package-ecosystem: "uv"
     directory: "/python-sdk"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
-
-  - package-ecosystem: "uv"
-    directory: "/langwatch_nlp"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 50
+    cooldown:
+      default-days: 8
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/clickhouse-serverless.yml
+++ b/.github/workflows/clickhouse-serverless.yml
@@ -30,6 +30,7 @@ jobs:
           filters: |
             relevant:
               - 'clickhouse-serverless/**'
+              - 'charts/clickhouse-serverless/**'
               - '.github/workflows/clickhouse-serverless.yml'
 
   test:

--- a/.github/workflows/issue-link.yml
+++ b/.github/workflows/issue-link.yml
@@ -10,12 +10,43 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: tkt-actions/add-issue-links@841937371056b3af09cdbdf8c45d8bd48c58fcec # v1.9.1
+      # The repo's Actions policy only allows github-owned actions plus a
+      # curated allowlist, so the issue-link behaviour is implemented inline
+      # with github-script: a PR from a branch named issue<number>/<slug>
+      # gets a "Resolves #<number>" section in its body and its author
+      # assigned to the issue. Writes are best-effort because fork PRs run
+      # with a read-only token.
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          branch-prefix: 'issue'
-          link-style: 'body'
-          position: 'body'
-          header: '# Related Issue'
-          resolve: true
-          assign-pr-creator-to-issue: 'true'
+          script: |
+            const pr = context.payload.pull_request;
+            const match = pr.head.ref.match(/^issue(\d+)(?:[\/-]|$)/);
+            if (!match) {
+              core.info(`branch ${pr.head.ref} does not reference an issue, skipping`);
+              return;
+            }
+            const issueNumber = Number(match[1]);
+            const header = '# Related Issue';
+            if (!(pr.body ?? '').includes(header)) {
+              const body = `${header}\n\n- Resolves #${issueNumber}\n\n${pr.body ?? ''}`;
+              try {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  body,
+                });
+              } catch (e) {
+                core.warning(`could not update PR body: ${e.message}`);
+              }
+            }
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                assignees: [pr.user.login],
+              });
+            } catch (e) {
+              core.warning(`could not assign @${pr.user.login} to #${issueNumber}: ${e.message}`);
+            }

--- a/.github/workflows/issue-link.yml
+++ b/.github/workflows/issue-link.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const match = pr.head.ref.match(/^issue(\d+)(?:[\/-]|$)/);
+            const match = pr.head.ref.match(/^issue(\d+)\//);
             if (!match) {
               core.info(`branch ${pr.head.ref} does not reference an issue, skipping`);
               return;

--- a/clickhouse-serverless/Makefile
+++ b/clickhouse-serverless/Makefile
@@ -14,9 +14,9 @@ test: ## Run Go unit tests
 lint: ## Run go vet + helm lint + helm template
 	go vet ./...
 	@command -v helm >/dev/null || { echo "helm not installed, skipping"; exit 0; }
-	helm lint $(HELM_DIR)
-	helm template test $(HELM_DIR) --set cpu=4,memory=8Gi > /dev/null
-	helm template test-ha $(HELM_DIR) --set cpu=4,memory=8Gi,replicas=3 > /dev/null
+	helm lint $(HELM_DIR) --set autogen.enabled=true
+	helm template test $(HELM_DIR) --set cpu=4,memory=8Gi,autogen.enabled=true > /dev/null
+	helm template test-ha $(HELM_DIR) --set cpu=4,memory=8Gi,replicas=3,autogen.enabled=true > /dev/null
 
 build: ## Build Docker image
 	docker build -t $(IMAGE):$(TAG) --platform=$(PLATFORM) .

--- a/typescript-sdk/pnpm-lock.yaml
+++ b/typescript-sdk/pnpm-lock.yaml
@@ -2590,8 +2590,8 @@ packages:
     resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
     engines: {node: '>= 8'}
 
-  protobufjs@8.6.1:
-    resolution: {integrity: sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==}
+  protobufjs@8.5.0:
+    resolution: {integrity: sha512-df1jWDPA5VIBNRtuAHjqr09f2qN5D4Vke1wYqOQg1XJ7ZDpA7BD6L7E4tyChgGRLB5hqk2m79Zsy0WHwV9a84A==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
@@ -3399,7 +3399,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 8.6.1
+      protobufjs: 8.5.0
       yargs: 17.7.2
 
   '@humanfs/core@0.19.1': {}
@@ -3748,7 +3748,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      protobufjs: 8.6.1
+      protobufjs: 8.5.0
 
   '@opentelemetry/otlp-transformer@0.216.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -3759,7 +3759,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      protobufjs: 8.6.1
+      protobufjs: 8.5.0
 
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -5178,7 +5178,7 @@ snapshots:
 
   propagate@2.0.1: {}
 
-  protobufjs@8.6.1:
+  protobufjs@8.5.0:
     dependencies:
       long: 5.3.2
 


### PR DESCRIPTION
## What was red on main

Three failure classes this morning:

1. The `clickhouse-serverless` workflow fails on every main push (e.g. run 27338502342): `make lint` renders the chart bare, and since #4447 the chart fails fast when no credentials Secret is configured.
2. Every `npm_and_yarn in /typescript-sdk` Dependabot job fails: the lockfile pins `protobufjs@8.6.1`, published Jun 07, which violates the workspace's `minimumReleaseAge: 10080` (7 days). Any pnpm re-resolution dies with `ERR_PNPM_NO_MATCHING_VERSION`, so no dependency in the workspace can be updated at all.
3. The `uv in /langwatch_nlp` Dependabot job fails at file fetching: the directory was removed in the NLP Go migration, but the config still scans it. The `uv in /python-sdk` job also fails because Dependabot proposes versions younger than the 7-day `exclude-newer` gate (anthropic, openai, litellm, langchain were all released within the last week), and uv then refuses to resolve them.

## Fixes

**clickhouse-serverless lint** (`clickhouse-serverless/Makefile`): the chart requires `autogen.enabled=true` or `auth.existingSecret` by design, and its own e2e asserts that bare rendering fails. The Go service's lint target now renders with `autogen.enabled=true`.

The chart path was also missing from the workflow's change filter (`clickhouse-serverless/**` does not match `charts/clickhouse-serverless/**`), which is why #4447 landed without this lint ever running on the PR: the breakage only surfaced on main pushes, where detect-changes forces all filters true. The filter now includes `charts/clickhouse-serverless/**`.

**typescript-sdk lockfile**: protobufjs re-locked from 8.6.1 to 8.5.0 (published May 29), the newest version that satisfies the `>=8.2.0` security override and clears the age gate. 8.6.1 entered the lock in #4650 in violation of the gate, which is what poisoned every later resolution. The override policy itself is unchanged, and the gate will let the lock advance to 8.6.x as those releases age in.

**dependabot config**: the dead `/langwatch_nlp` entry is gone, and the npm and uv ecosystems get `cooldown: default-days: 8`. Without a cooldown Dependabot always proposes the newest release, and whenever that release is younger than 7 days pnpm/uv reject it and the run goes red. The cooldown keeps candidate selection behind the same gate the package managers enforce, with one day of margin.

## Verified

- `make -C clickhouse-serverless lint` passes locally (helm lint plus both template renders).
- The exact command Dependabot failed on (`corepack pnpm update msw@2.14.6 --lockfile-only --no-save -r`) exits 0 on the fixed lockfile.
- The `protobufjs@8.5.0` integrity hash in the lock matches the npm registry.
- typescript-sdk: `pnpm install --frozen-lockfile` plus all 1313 unit tests pass.
- `dependabot.yml` and the workflow YAML parse clean. The docker and github-actions Dependabot runs were already green.

## Known remaining red, out of scope here

The `uv in /langevals` grouped security-update job cannot resolve under any CI config: `langevals-legacy` pins `langchain-openai <0.3.0` (pydantic v1 compat for the vendored `legacy_ragas` code), which caps langchain-core below 0.4, while `langevals-ragas` needs `ragas==0.4.3`, which requires langchain-core >=1.0. Security bumps for langchain-text-splitters, langchain-core, ragas and torch cannot land in langevals until the legacy evaluator is migrated off the vendored pydantic-v1-era code. That is a real migration, not a CI-config fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added cooldowns (default 8 days) to automated dependency update groups and removed one obsolete update entry.
  * Expanded CI path detection so chart-only changes trigger the appropriate test and aggregation jobs.
  * Enabled autogen during Helm lint and template validation runs.
  * Replaced an external workflow action with an inline script to auto-link issues from PR branch names and attempt assignee updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->