### PR TITLE
feat(prompts): expose runtime parameters in Python SDK facade + document the feature

### DIFF
--- a/docs/api-reference/openapiLangWatch.json
+++ b/docs/api-reference/openapiLangWatch.json
@@ -12795,6 +12795,11 @@
                           ]
                         },
                         "default": []
+                      },
+                      "parameters": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "default": {}
                       }
                     },
                     "required": [
@@ -12813,7 +12818,8 @@
                       "inputs",
                       "outputs",
                       "model",
-                      "tags"
+                      "tags",
+                      "parameters"
                     ]
                   }
                 }
@@ -13338,6 +13344,11 @@
                         ]
                       },
                       "default": []
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "additionalProperties": {},
+                      "default": {}
                     }
                   },
                   "required": [
@@ -13356,7 +13367,8 @@
                     "inputs",
                     "outputs",
                     "model",
-                    "tags"
+                    "tags",
+                    "parameters"
                   ]
                 }
               }
@@ -14563,6 +14575,11 @@
                         ]
                       },
                       "default": []
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "additionalProperties": {},
+                      "default": {}
                     }
                   },
                   "required": [
@@ -14581,7 +14598,8 @@
                     "inputs",
                     "outputs",
                     "model",
-                    "tags"
+                    "tags",
+                    "parameters"
                   ]
                 }
               }
@@ -15155,6 +15173,11 @@
                         ]
                       },
                       "default": []
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "additionalProperties": {},
+                      "default": {}
                     }
                   },
                   "required": [
@@ -15173,7 +15196,8 @@
                     "inputs",
                     "outputs",
                     "model",
-                    "tags"
+                    "tags",
+                    "parameters"
                   ]
                 }
               }
@@ -15449,6 +15473,10 @@
                       "minLength": 1
                     }
                   },
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
                   "scope": {
                     "type": "string",
                     "enum": [
@@ -15459,10 +15487,6 @@
                   "handle": {
                     "type": "string",
                     "pattern": "^[a-z0-9_-]+(?:\\/[a-z0-9_-]+)?$"
-                  },
-                  "parameters": {
-                    "type": "object",
-                    "additionalProperties": {}
                   }
                 },
                 "required": [
@@ -16056,6 +16080,11 @@
                             ]
                           },
                           "default": []
+                        },
+                        "parameters": {
+                          "type": "object",
+                          "additionalProperties": {},
+                          "default": {}
                         }
                       },
                       "required": [
@@ -16074,7 +16103,8 @@
                         "inputs",
                         "outputs",
                         "model",
-                        "tags"
+                        "tags",
+                        "parameters"
                       ]
                     },
                     "conflictInfo": {
@@ -16492,6 +16522,10 @@
                             "outputs",
                             "model"
                           ]
+                        },
+                        "remoteConfig": {
+                          "type": "object",
+                          "additionalProperties": {}
                         }
                       },
                       "required": [
@@ -17010,6 +17044,10 @@
                       "outputs",
                       "model"
                     ]
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
                   },
                   "localVersion": {
                     "type": "number",
@@ -17639,6 +17677,11 @@
                           ]
                         },
                         "default": []
+                      },
+                      "parameters": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "default": {}
                       }
                     },
                     "required": [
@@ -17657,7 +17700,8 @@
                       "inputs",
                       "outputs",
                       "model",
-                      "tags"
+                      "tags",
+                      "parameters"
                     ]
                   }
                 }
@@ -18214,6 +18258,11 @@
                         ]
                       },
                       "default": []
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "additionalProperties": {},
+                      "default": {}
                     }
                   },
                   "required": [
@@ -18232,7 +18281,8 @@
                     "inputs",
                     "outputs",
                     "model",
-                    "tags"
+                    "tags",
+                    "parameters"
                   ]
                 }
               }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -172,6 +172,7 @@
                   "prompt-management/features/essential/version-control",
                   "prompts/template-syntax",
                   "prompt-management/data-model",
+                  "prompt-management/features/essential/runtime-parameters",
                   "prompt-management/scope",
                   "prompt-management/features/essential/analytics",
                   "prompt-management/features/essential/github-integration",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -15436,6 +15436,128 @@ For complete documentation on all CLI commands, advanced workflows, conflict res
 
 ---
 
+# FILE: ./prompt-management/features/essential/runtime-parameters.mdx
+
+---
+title: "Runtime Parameters"
+description: "Version arbitrary application settings alongside your prompts and fetch them via the SDK or REST API."
+---
+
+# Runtime Parameters
+
+Every prompt version can carry a `parameters` object: arbitrary JSON that is versioned, tagged, and fetched together with the prompt itself. Use it for application settings that should change in lockstep with the prompt — search iteration limits, confidence thresholds, structured output schemas, metadata field lists, feature switches.
+
+<Note>
+Available since Python SDK `0.25.0` and TypeScript SDK `0.33.0`. Changing `parameters` creates a new prompt version, just like changing the prompt text.
+</Note>
+
+## Why
+
+Prompts rarely live alone. The code around them has knobs — how many retrieval rounds to run, what score counts as confident, which fields to extract. When those knobs are hardcoded, a prompt rollback doesn't roll them back. Storing them in `parameters` means one versioned unit: deploy, tag, and revert prompt + settings together.
+
+## Shape
+
+`parameters` is an object with arbitrary JSON values (nested objects and arrays included). It defaults to `{}`. LangWatch does not interpret its contents — your application owns the schema.
+
+```json
+{
+  "max_search_iterations": 3,
+  "confidence_threshold": 0.8,
+  "extraction": {
+    "metadata_fields": ["category", "priority"],
+    "response_schema": { "type": "object", "properties": { "answer": { "type": "string" } } }
+  }
+}
+```
+
+## Reading parameters
+
+### Python SDK
+
+```python
+import langwatch
+
+prompt = langwatch.prompts.get("qa-extractor", tag="production")
+
+prompt.parameters
+# {"max_search_iterations": 3, "confidence_threshold": 0.8, ...}
+
+iterations = prompt.parameters.get("max_search_iterations", 1)
+```
+
+### TypeScript SDK
+
+```typescript
+import { LangWatch } from "langwatch";
+
+const langwatch = new LangWatch();
+const prompt = await langwatch.prompts.get("qa-extractor", { tag: "production" });
+
+prompt.parameters;
+// { max_search_iterations: 3, confidence_threshold: 0.8, ... }
+```
+
+### REST API
+
+```bash
+curl -s "https://app.langwatch.ai/api/prompts/qa-extractor" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" | jq .parameters
+```
+
+## Writing parameters
+
+### Python SDK
+
+```python
+import langwatch
+
+# On create
+langwatch.prompts.create(
+    "qa-extractor",
+    prompt="Extract the answer from {{document}}",
+    parameters={"max_search_iterations": 3, "confidence_threshold": 0.8},
+)
+
+# On update — creates a new version
+langwatch.prompts.update(
+    "qa-extractor",
+    scope="PROJECT",
+    parameters={"max_search_iterations": 5, "confidence_threshold": 0.9},
+    commit_message="raise threshold for production",
+)
+```
+
+### TypeScript SDK
+
+```typescript
+await langwatch.prompts.update("qa-extractor", {
+  parameters: { max_search_iterations: 5, confidence_threshold: 0.9 },
+  commitMessage: "raise threshold for production",
+});
+```
+
+### REST API
+
+```bash
+curl -X PUT "https://app.langwatch.ai/api/prompts/qa-extractor" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"parameters": {"max_search_iterations": 5, "confidence_threshold": 0.9}}'
+```
+
+## Versioning behavior
+
+- Updating `parameters` (even with no other change) creates a new prompt version with its own `versionId`.
+- Restoring an older version restores that version's `parameters` too.
+- Tags (`production`, `staging`, custom) resolve to a version, so fetching by tag always returns the matching `parameters`.
+- Comparison is key-order independent — re-sending the same object with keys in a different order does not create a new version.
+
+## In the UI
+
+In the prompt editor, the collapsible **Config** section lets you edit the parameters JSON for a draft, and the version history shows a read-only **Config** tab per version.
+
+---
+
 # FILE: ./prompt-management/features/essential/tags.mdx
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -15550,7 +15550,8 @@ curl -X PUT "https://app.langwatch.ai/api/prompts/qa-extractor" \
 - Updating `parameters` (even with no other change) creates a new prompt version with its own `versionId`.
 - Restoring an older version restores that version's `parameters` too.
 - Tags (`production`, `staging`, custom) resolve to a version, so fetching by tag always returns the matching `parameters`.
-- Comparison is key-order independent — re-sending the same object with keys in a different order does not create a new version.
+- Explicit updates (`PUT`, SDK `update`) always create a new version, even if the content is unchanged.
+- The sync endpoint (`POST /api/prompts/{id}/sync`, used by the CLI) compares content key-order independently — re-syncing the same parameters with keys in a different order reports `up_to_date` and does not create a new version.
 
 ## In the UI
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -15448,7 +15448,7 @@ description: "Version arbitrary application settings alongside your prompts and 
 Every prompt version can carry a `parameters` object: arbitrary JSON that is versioned, tagged, and fetched together with the prompt itself. Use it for application settings that should change in lockstep with the prompt — search iteration limits, confidence thresholds, structured output schemas, metadata field lists, feature switches.
 
 <Note>
-Available since Python SDK `0.25.0` and TypeScript SDK `0.33.0`. Changing `parameters` creates a new prompt version, just like changing the prompt text.
+Available since Python SDK `0.26.0` and TypeScript SDK `0.33.0` (reading `prompt.parameters` works from Python SDK `0.25.0`; writing via `create`/`update` requires `0.26.0`). Changing `parameters` creates a new prompt version, just like changing the prompt text.
 </Note>
 
 ## Why

--- a/docs/prompt-management/data-model.mdx
+++ b/docs/prompt-management/data-model.mdx
@@ -54,7 +54,12 @@ When you retrieve a prompt, you get all the configuration in a single response:
       { "id": "example_1", "input": "I need help with my account", "output": "I'd be happy to help you with your account. What specific issue are you experiencing?" }
     ]
   },
-  "promptingTechnique": "chain_of_thought"
+  "promptingTechnique": "chain_of_thought",
+  "parameters": {
+    "max_search_iterations": 3,
+    "confidence_threshold": 0.8,
+    "metadata_fields": ["category", "priority"]
+  }
 }
 ```
 
@@ -132,6 +137,12 @@ The main prompt text (system message)
 
 <ResponseField name="messages" type="array">
 Array of chat messages with roles and content (alternative to prompt field)
+</ResponseField>
+
+### Runtime Parameters
+
+<ResponseField name="parameters" type="object" default="{}">
+Arbitrary JSON object versioned alongside the prompt. Use it to store application settings that should change together with the prompt (thresholds, iteration counts, structured output schemas, feature switches). Changing `parameters` creates a new prompt version. See [Runtime Parameters](/prompt-management/features/essential/runtime-parameters).
 </ResponseField>
 
 ## Variable System

--- a/docs/prompt-management/features/essential/runtime-parameters.mdx
+++ b/docs/prompt-management/features/essential/runtime-parameters.mdx
@@ -110,7 +110,8 @@ curl -X PUT "https://app.langwatch.ai/api/prompts/qa-extractor" \
 - Updating `parameters` (even with no other change) creates a new prompt version with its own `versionId`.
 - Restoring an older version restores that version's `parameters` too.
 - Tags (`production`, `staging`, custom) resolve to a version, so fetching by tag always returns the matching `parameters`.
-- Comparison is key-order independent — re-sending the same object with keys in a different order does not create a new version.
+- Explicit updates (`PUT`, SDK `update`) always create a new version, even if the content is unchanged.
+- The sync endpoint (`POST /api/prompts/{id}/sync`, used by the CLI) compares content key-order independently — re-syncing the same parameters with keys in a different order reports `up_to_date` and does not create a new version.
 
 ## In the UI
 

--- a/docs/prompt-management/features/essential/runtime-parameters.mdx
+++ b/docs/prompt-management/features/essential/runtime-parameters.mdx
@@ -1,0 +1,117 @@
+---
+title: "Runtime Parameters"
+description: "Version arbitrary application settings alongside your prompts and fetch them via the SDK or REST API."
+---
+
+# Runtime Parameters
+
+Every prompt version can carry a `parameters` object: arbitrary JSON that is versioned, tagged, and fetched together with the prompt itself. Use it for application settings that should change in lockstep with the prompt — search iteration limits, confidence thresholds, structured output schemas, metadata field lists, feature switches.
+
+<Note>
+Available since Python SDK `0.25.0` and TypeScript SDK `0.33.0`. Changing `parameters` creates a new prompt version, just like changing the prompt text.
+</Note>
+
+## Why
+
+Prompts rarely live alone. The code around them has knobs — how many retrieval rounds to run, what score counts as confident, which fields to extract. When those knobs are hardcoded, a prompt rollback doesn't roll them back. Storing them in `parameters` means one versioned unit: deploy, tag, and revert prompt + settings together.
+
+## Shape
+
+`parameters` is an object with arbitrary JSON values (nested objects and arrays included). It defaults to `{}`. LangWatch does not interpret its contents — your application owns the schema.
+
+```json
+{
+  "max_search_iterations": 3,
+  "confidence_threshold": 0.8,
+  "extraction": {
+    "metadata_fields": ["category", "priority"],
+    "response_schema": { "type": "object", "properties": { "answer": { "type": "string" } } }
+  }
+}
+```
+
+## Reading parameters
+
+### Python SDK
+
+```python
+import langwatch
+
+prompt = langwatch.prompts.get("qa-extractor", tag="production")
+
+prompt.parameters
+# {"max_search_iterations": 3, "confidence_threshold": 0.8, ...}
+
+iterations = prompt.parameters.get("max_search_iterations", 1)
+```
+
+### TypeScript SDK
+
+```typescript
+import { LangWatch } from "langwatch";
+
+const langwatch = new LangWatch();
+const prompt = await langwatch.prompts.get("qa-extractor", { tag: "production" });
+
+prompt.parameters;
+// { max_search_iterations: 3, confidence_threshold: 0.8, ... }
+```
+
+### REST API
+
+```bash
+curl -s "https://app.langwatch.ai/api/prompts/qa-extractor" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" | jq .parameters
+```
+
+## Writing parameters
+
+### Python SDK
+
+```python
+import langwatch
+
+# On create
+langwatch.prompts.create(
+    "qa-extractor",
+    prompt="Extract the answer from {{document}}",
+    parameters={"max_search_iterations": 3, "confidence_threshold": 0.8},
+)
+
+# On update — creates a new version
+langwatch.prompts.update(
+    "qa-extractor",
+    scope="PROJECT",
+    parameters={"max_search_iterations": 5, "confidence_threshold": 0.9},
+    commit_message="raise threshold for production",
+)
+```
+
+### TypeScript SDK
+
+```typescript
+await langwatch.prompts.update("qa-extractor", {
+  parameters: { max_search_iterations: 5, confidence_threshold: 0.9 },
+  commitMessage: "raise threshold for production",
+});
+```
+
+### REST API
+
+```bash
+curl -X PUT "https://app.langwatch.ai/api/prompts/qa-extractor" \
+  -H "X-Auth-Token: $LANGWATCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"parameters": {"max_search_iterations": 5, "confidence_threshold": 0.9}}'
+```
+
+## Versioning behavior
+
+- Updating `parameters` (even with no other change) creates a new prompt version with its own `versionId`.
+- Restoring an older version restores that version's `parameters` too.
+- Tags (`production`, `staging`, custom) resolve to a version, so fetching by tag always returns the matching `parameters`.
+- Comparison is key-order independent — re-sending the same object with keys in a different order does not create a new version.
+
+## In the UI
+
+In the prompt editor, the collapsible **Config** section lets you edit the parameters JSON for a draft, and the version history shows a read-only **Config** tab per version.

--- a/docs/prompt-management/features/essential/runtime-parameters.mdx
+++ b/docs/prompt-management/features/essential/runtime-parameters.mdx
@@ -8,7 +8,7 @@ description: "Version arbitrary application settings alongside your prompts and 
 Every prompt version can carry a `parameters` object: arbitrary JSON that is versioned, tagged, and fetched together with the prompt itself. Use it for application settings that should change in lockstep with the prompt — search iteration limits, confidence thresholds, structured output schemas, metadata field lists, feature switches.
 
 <Note>
-Available since Python SDK `0.25.0` and TypeScript SDK `0.33.0`. Changing `parameters` creates a new prompt version, just like changing the prompt text.
+Available since Python SDK `0.26.0` and TypeScript SDK `0.33.0` (reading `prompt.parameters` works from Python SDK `0.25.0`; writing via `create`/`update` requires `0.26.0`). Changing `parameters` creates a new prompt version, just like changing the prompt text.
 </Note>
 
 ## Why

--- a/python-sdk/src/langwatch/prompts/prompt_facade.py
+++ b/python-sdk/src/langwatch/prompts/prompt_facade.py
@@ -205,6 +205,7 @@ class PromptsFacade:
         inputs: Optional[List[InputDict]] = None,
         outputs: Optional[List[OutputDict]] = None,
         tags: Optional[List[str]] = None,
+        parameters: Optional[Dict[str, Any]] = None,
     ) -> Prompt:
         """
         Create a new prompt via API.
@@ -217,6 +218,7 @@ class PromptsFacade:
             messages: List of message dicts with 'role' and 'content' keys
             inputs: List of input dicts with 'identifier' and 'type' keys
             outputs: List of output dicts with 'identifier', 'type', and optional 'json_schema' keys
+            parameters: Arbitrary runtime parameters stored with the prompt version
 
         Returns:
             Prompt object containing the created prompt data
@@ -230,6 +232,7 @@ class PromptsFacade:
             inputs=inputs,
             outputs=outputs,
             tags=tags,
+            parameters=parameters,
         )
         return Prompt(data)
 
@@ -243,6 +246,7 @@ class PromptsFacade:
         inputs: Optional[List[InputDict]] = None,
         outputs: Optional[List[OutputDict]] = None,
         tags: Optional[List[str]] = None,
+        parameters: Optional[Dict[str, Any]] = None,
         *,
         commit_message: str = "",
     ) -> Prompt:
@@ -257,6 +261,7 @@ class PromptsFacade:
             messages: New list of message dicts
             inputs: New list of input dicts
             outputs: New list of output dicts
+            parameters: Arbitrary runtime parameters stored with the new prompt version
 
         Returns:
             Prompt object containing the updated prompt data
@@ -271,6 +276,7 @@ class PromptsFacade:
             inputs=inputs,
             outputs=outputs,
             tags=tags,
+            parameters=parameters,
         )
         return Prompt(data)
 

--- a/python-sdk/tests/prompts/test_prompt_tags.py
+++ b/python-sdk/tests/prompts/test_prompt_tags.py
@@ -18,7 +18,7 @@ import pytest
 import langwatch
 from langwatch.prompts.prompt_api_service import PromptApiService
 from langwatch.prompts.prompt_facade import PromptsFacade
-from langwatch.prompts.types import FetchPolicy
+from langwatch.prompts.types import FetchPolicy, Message, PromptData
 
 pytestmark = pytest.mark.unit
 
@@ -1385,9 +1385,7 @@ class TestPromptsFacadeParameters:
         mock_client = Mock()
         return PromptsFacade(mock_client)
 
-    def _mock_prompt_data(self, parameters) -> "PromptData":
-        from langwatch.prompts.types import PromptData, Message
-
+    def _mock_prompt_data(self, parameters) -> PromptData:
         return PromptData(
             id="pizza-prompt", handle="pizza-prompt", scope="PROJECT",
             version=1, version_id="v1_id", model="openai/gpt-4",

--- a/python-sdk/tests/prompts/test_prompt_tags.py
+++ b/python-sdk/tests/prompts/test_prompt_tags.py
@@ -1371,3 +1371,65 @@ class TestLangwatchPromptsGlobalInterface:
         """langwatch.prompts.tags exists and has an assign method."""
         assert hasattr(langwatch.prompts, "tags")
         assert callable(getattr(langwatch.prompts.tags, "assign", None))
+
+
+# ---------------------------------------------------------------------------
+# PromptsFacade.create() / update() -- parameters passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestPromptsFacadeParameters:
+    """Tests for PromptsFacade forwarding runtime parameters to the API service."""
+
+    def _make_facade_with_mock_api(self) -> PromptsFacade:
+        mock_client = Mock()
+        return PromptsFacade(mock_client)
+
+    def _mock_prompt_data(self, parameters):
+        from langwatch.prompts.types import PromptData, Message
+
+        return PromptData(
+            id="pizza-prompt", handle="pizza-prompt", scope="PROJECT",
+            version=1, version_id="v1_id", model="openai/gpt-4",
+            messages=[Message(role="system", content="v1")], prompt="v1",
+            parameters=parameters,
+        )
+
+    def test_create_forwards_parameters_to_api_service(self):
+        """
+        When create() is called with parameters
+        Then the API service receives the same parameters dict
+        """
+        facade = self._make_facade_with_mock_api()
+        facade._api_service.create = Mock(
+            return_value=self._mock_prompt_data({"max_iterations": 3})
+        )
+
+        result = facade.create("pizza-prompt", parameters={"max_iterations": 3})
+
+        assert facade._api_service.create.call_args[1]["parameters"] == {
+            "max_iterations": 3
+        }
+        assert result.parameters == {"max_iterations": 3}
+
+    def test_update_forwards_parameters_to_api_service(self):
+        """
+        When update() is called with parameters
+        Then the API service receives the same parameters dict
+        """
+        facade = self._make_facade_with_mock_api()
+        facade._api_service.update = Mock(
+            return_value=self._mock_prompt_data({"confidence_threshold": 0.8})
+        )
+
+        result = facade.update(
+            "pizza-prompt",
+            scope="PROJECT",
+            parameters={"confidence_threshold": 0.8},
+            commit_message="set threshold",
+        )
+
+        assert facade._api_service.update.call_args[1]["parameters"] == {
+            "confidence_threshold": 0.8
+        }
+        assert result.parameters == {"confidence_threshold": 0.8}

--- a/python-sdk/tests/prompts/test_prompt_tags.py
+++ b/python-sdk/tests/prompts/test_prompt_tags.py
@@ -1385,7 +1385,7 @@ class TestPromptsFacadeParameters:
         mock_client = Mock()
         return PromptsFacade(mock_client)
 
-    def _mock_prompt_data(self, parameters):
+    def _mock_prompt_data(self, parameters) -> "PromptData":
         from langwatch.prompts.types import PromptData, Message
 
         return PromptData(

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -20,7 +20,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-04T14:12:04.922681Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [[package]]

--- a/python-sdk/uv.lock
+++ b/python-sdk/uv.lock
@@ -20,7 +20,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-04T14:12:04.922681Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -3206,7 +3206,7 @@ wheels = [
 
 [[package]]
 name = "langwatch"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Why

Prompt versions carry a `parameters` object (arbitrary versioned JSON, shipped in #4043), but the feature was effectively invisible:

1. **Docs OpenAPI spec was stale**: `docs/api-reference/openapiLangWatch.json` only had `parameters` in the POST/PUT request bodies. Every prompt **response** schema (GET prompts, GET by id, versions, restore, sync) was missing it, so the docs site showed no such field anywhere you'd look for it. (Spec regen is broken on the prompts spec — #4283 zod-openapi circular ref — so the prompt path objects were synced directly from the app spec, verified identical.)
2. **No prose docs existed** for the feature at all.
3. **Python SDK public facade didn't expose it**: `PromptApiService.create/update` supported `parameters`, but `langwatch.prompts.create()/update()` (the API users actually call) silently dropped it. Reading worked (`prompt.parameters`, since 0.25.0), writing didn't.

## What

- **Docs spec sync**: all prompt path schemas in the docs spec now match the app spec (`parameters` in 12 places, was 4).
- **New docs page** `prompt-management/features/essential/runtime-parameters` — why/shape/read/write examples for Python SDK, TypeScript SDK, and REST, plus versioning behavior (new version on change, key-order independent comparison, tag resolution). Added to nav.
- **Data model page**: `parameters` added to the example payload + field reference, linking to the new page.
- **Python SDK**: `parameters` plumbed through `PromptsFacade.create/update` with passthrough tests (49 tests passing in `test_prompt_tags.py`).

## Notes

- TS SDK needed no change — `CreatePromptBody`/`UpdatePromptBody` derive from the OpenAPI types which already include `parameters`, and `prompt.parameters` is exposed.
- The Python SDK change is a minor feature; release-please will pick it up as 0.26.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime Parameters: per-prompt-version, versioned JSON config (create/update/read/restore) with SDKs accepting parameters and UI support.

* **Documentation**
  * Added Runtime Parameters docs, updated prompt examples and site navigation; standardized API schema to include parameters and a new remoteConfig property.

* **Tests**
  * Added unit tests ensuring SDK forwards and preserves parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->