### PR TITLE
fix(langy): thread conversationId through chat sends so multi-turn actually works

### DIFF
--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -213,8 +213,27 @@ function LangyPanel({
   );
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  // Filled in below once useLangyConversations runs; the transport's fetch
+  // closes over the ref so the transport itself never needs recreating.
+  const adoptConversationRef = useRef<(id: string) => void>(() => undefined);
+
   const transport = useMemo(
-    () => new DefaultChatTransport({ api: "/api/langy/chat" }),
+    () =>
+      new DefaultChatTransport({
+        api: "/api/langy/chat",
+        // The chat route returns the conversation it created (or reused) in
+        // this header. Adopt it so the NEXT send carries `conversationId` —
+        // without this every message forks a fresh conversation (and a fresh
+        // OpenCode worker, which is keyed by conversation id).
+        fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+          const response = await fetch(input, init);
+          const conversationId = response.headers.get(
+            "x-langy-conversation-id",
+          );
+          if (conversationId) adoptConversationRef.current(conversationId);
+          return response;
+        }) as typeof fetch,
+      }),
     [],
   );
 
@@ -323,16 +342,19 @@ function LangyPanel({
 
   const {
     conversations,
+    currentConversationId,
     isLoading: isLoadingConversations,
     hasListError,
     select: selectConversation,
     startNew: startNewConversation,
     remove: removeConversation,
+    adopt: adoptConversation,
   } = useLangyConversations({
     projectId,
     setMessages: applyMessagesFromHistory,
     onError: surfaceConversationError,
   });
+  adoptConversationRef.current = adoptConversation;
 
   useEffect(() => {
     if (!scrollRef.current) return;
@@ -353,6 +375,11 @@ function LangyPanel({
       {
         body: {
           projectId,
+          // Stay in the active conversation; null/absent means "start a new
+          // one" and the transport adopts the id the server returns.
+          ...(currentConversationId
+            ? { conversationId: currentConversationId }
+            : {}),
           ...(modelOverride ? { modelOverride } : {}),
         },
       },

--- a/langwatch/src/components/langy/__tests__/LangyConversationThreading.integration.test.tsx
+++ b/langwatch/src/components/langy/__tests__/LangyConversationThreading.integration.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression for #4748: the sidebar must thread the active conversation id
+ * into every /api/langy/chat send, and adopt the id the server returns in
+ * `x-langy-conversation-id` — otherwise each message forks a brand-new
+ * conversation (and a brand-new OpenCode worker, which is keyed by
+ * conversation id), silently breaking multi-turn memory.
+ *
+ * Boundary mocks mirror LangyConversationHistory.integration.test.tsx:
+ * useOrganizationTeamProject, @ai-sdk/react useChat (sendMessage spy),
+ * the `ai` DefaultChatTransport (captures the transport options so the
+ * header-adoption fetch wrapper is testable), and global.fetch.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks (hoisted by vi.mock — must precede the LangyDrawer import)
+// ---------------------------------------------------------------------------
+
+const projectRef = {
+  current: { id: "project-demo", slug: "demo" } as {
+    id: string;
+    slug: string;
+  } | null,
+};
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: projectRef.current }),
+}));
+
+vi.mock("~/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+}));
+
+vi.mock("~/utils/trpcError", () => ({
+  isHandledByGlobalHandler: () => false,
+}));
+
+vi.mock("~/components/Markdown", () => ({
+  Markdown: ({ children }: { children: string }) => <span>{children}</span>,
+}));
+
+const chatRef = {
+  messages: [] as Array<{
+    id: string;
+    role: string;
+    parts: Array<{ type: string; text: string }>;
+  }>,
+  sendMessage: vi.fn(),
+  stop: vi.fn(),
+  status: "ready" as "ready" | "submitted" | "streaming" | "error",
+  setMessages: vi.fn(),
+};
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: () => ({
+    messages: chatRef.messages,
+    sendMessage: chatRef.sendMessage,
+    stop: chatRef.stop,
+    status: chatRef.status,
+    setMessages: chatRef.setMessages,
+  }),
+}));
+
+// Capture the options LangySidebar passes to the transport so the test can
+// drive its custom `fetch` (the header-adoption wrapper) directly.
+const transportOptionsRef = {
+  current: null as null | { api: string; fetch?: typeof fetch },
+};
+
+vi.mock("ai", () => ({
+  DefaultChatTransport: class {
+    constructor(opts: { api: string; fetch?: typeof fetch }) {
+      transportOptionsRef.current = opts;
+    }
+  },
+}));
+
+vi.mock("@paper-design/shaders-react", () => ({
+  MeshGradient: () => null,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    modelProvider: {
+      getResolvedDefault: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+      listAllForProjectForFrontend: {
+        useQuery: () => ({
+          data: { providers: [] },
+          isLoading: false,
+        }),
+      },
+    },
+    virtualKeys: {
+      list: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+  },
+}));
+
+import { LangyDrawer } from "../LangySidebar";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+interface ApiConversation {
+  id: string;
+  title: string | null;
+  lastActivityAt: string;
+}
+
+function installFetchMock(conversations: ApiConversation[]): Mock {
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.startsWith("/api/langy/chat") && method === "POST") {
+        return new Response("{}", {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "x-langy-conversation-id": "conv-created-by-server",
+          },
+        });
+      }
+
+      if (url.startsWith("/api/langy/conversations") && method === "GET") {
+        const isList = !/\/conversations\/[^/?]+/.test(url);
+        if (isList) {
+          return new Response(JSON.stringify({ conversations }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        const id = url.split("?")[0]!.split("/").pop()!;
+        const conv = conversations.find((c) => c.id === id);
+        if (!conv) {
+          return new Response(JSON.stringify({ error: "Not found" }), {
+            status: 404,
+          });
+        }
+        return new Response(
+          JSON.stringify({ conversation: conv, messages: [] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("not stubbed", { status: 501 });
+    },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function renderPanel() {
+  return render(<LangyDrawer isOpen={true} onOpenChange={() => undefined} />, {
+    wrapper: Wrapper,
+  });
+}
+
+async function sendFromComposer(text: string) {
+  const textbox = screen.getByRole("textbox");
+  await userEvent.type(textbox, text);
+  await userEvent.keyboard("{Enter}");
+}
+
+function lastSendBody(): Record<string, unknown> {
+  const calls = chatRef.sendMessage.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const options = calls[calls.length - 1]![1] as {
+    body: Record<string, unknown>;
+  };
+  return options.body;
+}
+
+beforeEach(() => {
+  projectRef.current = { id: "project-demo", slug: "demo" };
+  chatRef.messages = [];
+  chatRef.status = "ready";
+  chatRef.sendMessage.mockReset();
+  chatRef.setMessages.mockReset();
+  transportOptionsRef.current = null;
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("Langy conversation threading", () => {
+  describe("given an active restored conversation", () => {
+    const conversations = [
+      {
+        id: "conv-active",
+        title: "Active chat",
+        lastActivityAt: "2026-06-01T10:00:00.000Z",
+      },
+    ];
+
+    describe("when the user sends a message", () => {
+      it("includes the active conversationId in the chat body so the send stays in the same conversation", async () => {
+        installFetchMock(conversations);
+        renderPanel();
+        // Wait for the restore (conv-active becomes current).
+        await waitFor(() => expect(chatRef.setMessages).toHaveBeenCalled());
+
+        await sendFromComposer("second turn");
+
+        expect(lastSendBody()).toMatchObject({
+          projectId: "project-demo",
+          conversationId: "conv-active",
+        });
+      });
+    });
+  });
+
+  describe("given a fresh project with no conversations", () => {
+    describe("when the first send completes and the server returns x-langy-conversation-id", () => {
+      it("adopts the server's conversation id and threads it into the next send", async () => {
+        installFetchMock([]);
+        renderPanel();
+        await waitFor(() =>
+          expect(transportOptionsRef.current?.fetch).toBeTypeOf("function"),
+        );
+
+        // First send: no active conversation yet → no conversationId.
+        await sendFromComposer("first turn");
+        expect(lastSendBody().conversationId).toBeUndefined();
+
+        // Drive the transport's fetch wrapper the way useChat would: it hits
+        // /api/langy/chat, whose mocked response carries the header.
+        await act(async () => {
+          await transportOptionsRef.current!.fetch!("/api/langy/chat", {
+            method: "POST",
+            body: "{}",
+          });
+        });
+
+        await sendFromComposer("second turn");
+        await waitFor(() => {
+          expect(lastSendBody()).toMatchObject({
+            conversationId: "conv-created-by-server",
+          });
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/components/langy/useLangyConversations.ts
+++ b/langwatch/src/components/langy/useLangyConversations.ts
@@ -58,6 +58,14 @@ export interface UseLangyConversationsResult {
   select: (id: string) => Promise<void>;
   startNew: () => void;
   remove: (id: string) => Promise<void>;
+  /**
+   * Mark a conversation the server just created (or confirmed) as the
+   * active one — without reloading its messages, which the chat stream
+   * already holds. Used by the chat transport when /langy/chat returns
+   * `x-langy-conversation-id`, so follow-up sends stay in the same
+   * conversation instead of forking a new one per message.
+   */
+  adopt: (id: string) => void;
 }
 
 export function useLangyConversations({
@@ -175,6 +183,36 @@ export function useLangyConversations({
     setMessages([]);
   }, [projectId, setMessages]);
 
+  const adopt = useCallback(
+    (id: string) => {
+      const currentProjectId = projectIdRef.current;
+      if (!currentProjectId) return;
+      setCurrentConversationId(id);
+      writeLastConversationId(currentProjectId, id);
+      // Refresh the list in the background so the adopted conversation (and
+      // its server-derived title) appears in the recents list. Best-effort:
+      // a failure here only leaves the list slightly stale.
+      void (async () => {
+        try {
+          const res = await fetch(
+            `/api/langy/conversations?projectId=${encodeURIComponent(currentProjectId)}`,
+          );
+          if (!res.ok) return;
+          const data = (await res.json()) as ConversationsListResponse;
+          if (projectIdRef.current !== currentProjectId) return;
+          setConversations(
+            [...data.conversations].sort((a, b) =>
+              b.lastActivityAt.localeCompare(a.lastActivityAt),
+            ),
+          );
+        } catch {
+          // ignore — recents list refresh is cosmetic
+        }
+      })();
+    },
+    [],
+  );
+
   const remove = useCallback(
     async (id: string) => {
       if (!projectId) return;
@@ -206,5 +244,6 @@ export function useLangyConversations({
     select,
     startNew,
     remove,
+    adopt,
   };
 }


### PR DESCRIPTION
## Problem

Every Langy message forked a brand-new conversation — and a brand-new OpenCode worker, since the agent manager keys its worker pool by conversation id. `send()` never included `conversationId` and nothing read the `x-langy-conversation-id` header the chat route sets. Multi-turn memory was silently broken in the product; the scenario suite never caught it because it calls the agent directly with a stable id, bypassing the route.

Fixes #4748

## Fix

- `useLangyConversations` gains `adopt(id)` — marks the server-created conversation active (state + localStorage) and refreshes the recents list in the background
- the chat transport's `fetch` wrapper captures `x-langy-conversation-id` and adopts it, so the first send's conversation sticks
- `send()` threads the active `conversationId` into the body; "New chat" still clears it so the next send starts fresh

## Verification

- New regression test `LangyConversationThreading.integration.test.tsx` (2 cases: restored conversation stays active across sends; first-send header adoption feeds the second send). **Verified red on the unfixed code, green with the fix.**
- `pnpm typecheck` clean; full langy integration suite 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)