### PR TITLE
fix(event-sourcing): reclaim blobs displaced by GroupQueue dedup squash

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -322,9 +322,16 @@ describe.skipIf(!hasTestcontainers)(
             // Squash-replace: a fresh blob is staged and the first is displaced.
             await queue.send(bigPayload("b"));
 
-            const blobs = await redis.keys(`${queueName}:gq:blob:*`);
-            expect(blobs).toHaveLength(1);
-            expect(blobs).not.toContain(firstBlob);
+            // The displaced blob is reclaimed fire-and-forget; only the new
+            // one survives.
+            await vi.waitFor(
+              async () => {
+                const blobs = await redis.keys(`${queueName}:gq:blob:*`);
+                expect(blobs).toHaveLength(1);
+                expect(blobs).not.toContain(firstBlob);
+              },
+              { timeout: 5000, interval: 50 },
+            );
             // Staging holds exactly the one squashed job, referencing the new blob.
             expect(
               await redis.hlen(`${queueName}:gq:group:group-a:data`),
@@ -355,12 +362,17 @@ describe.skipIf(!hasTestcontainers)(
             expect(keptBlob).toBeDefined();
 
             // Dedup hit without replace: the new value never lands, its blob is
-            // discarded and must be reclaimed; the original blob stays.
+            // discarded and reclaimed fire-and-forget; the original blob stays.
             await queue.send(bigPayload("b"));
 
-            expect(await redis.keys(`${queueName}:gq:blob:*`)).toEqual([
-              keptBlob,
-            ]);
+            await vi.waitFor(
+              async () => {
+                expect(await redis.keys(`${queueName}:gq:blob:*`)).toEqual([
+                  keptBlob,
+                ]);
+              },
+              { timeout: 5000, interval: 50 },
+            );
             expect(
               await redis.hlen(`${queueName}:gq:group:group-a:data`),
             ).toBe(1);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -291,6 +291,84 @@ describe.skipIf(!hasTestcontainers)(
           }
         });
       });
+
+      // Regression for the 2026-06-11 Redis capacity incident: a dedup squash
+      // displaced a blob-backed payload but nothing reclaimed the displaced
+      // blob, so ~280K orphans (~7.4 GB) accumulated until their 7-day TTL. The
+      // `delay` keeps both sends in staging so the second squash-replaces the
+      // first in place (the production path: a reactor re-folding a turn).
+      describe("when a dedup squash displaces a large payload", () => {
+        const bigPayload = (filler: string): TestPayload => ({
+          id: "dup",
+          groupId: "group-a",
+          value: filler.repeat(64 * 1024),
+        });
+
+        it("reclaims the displaced old blob on replace so it cannot leak", async () => {
+          vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
+          try {
+            const queueName = `{test/gq/blob-dedup-${crypto.randomUUID().slice(0, 8)}}`;
+            const queue = createQueue(vi.fn().mockResolvedValue(undefined), {
+              name: queueName,
+              delay: 60_000,
+              deduplication: { makeId: (p) => p.id, ttlMs: 120_000 },
+            });
+            await queue.waitUntilReady();
+
+            await queue.send(bigPayload("a"));
+            const [firstBlob] = await redis.keys(`${queueName}:gq:blob:*`);
+            expect(firstBlob).toBeDefined();
+
+            // Squash-replace: a fresh blob is staged and the first is displaced.
+            await queue.send(bigPayload("b"));
+
+            const blobs = await redis.keys(`${queueName}:gq:blob:*`);
+            expect(blobs).toHaveLength(1);
+            expect(blobs).not.toContain(firstBlob);
+            // Staging holds exactly the one squashed job, referencing the new blob.
+            expect(
+              await redis.hlen(`${queueName}:gq:group:group-a:data`),
+            ).toBe(1);
+          } finally {
+            vi.unstubAllEnvs();
+          }
+        });
+
+        it("reclaims the discarded new blob when the existing payload is kept (replace:false)", async () => {
+          vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
+          try {
+            const queueName = `{test/gq/blob-keep-${crypto.randomUUID().slice(0, 8)}}`;
+            const queue = createQueue(vi.fn().mockResolvedValue(undefined), {
+              name: queueName,
+              delay: 60_000,
+              deduplication: {
+                makeId: (p) => p.id,
+                ttlMs: 120_000,
+                extend: false,
+                replace: false,
+              },
+            });
+            await queue.waitUntilReady();
+
+            await queue.send(bigPayload("a"));
+            const [keptBlob] = await redis.keys(`${queueName}:gq:blob:*`);
+            expect(keptBlob).toBeDefined();
+
+            // Dedup hit without replace: the new value never lands, its blob is
+            // discarded and must be reclaimed; the original blob stays.
+            await queue.send(bigPayload("b"));
+
+            expect(await redis.keys(`${queueName}:gq:blob:*`)).toEqual([
+              keptBlob,
+            ]);
+            expect(
+              await redis.hlen(`${queueName}:gq:group:group-a:data`),
+            ).toBe(1);
+          } finally {
+            vi.unstubAllEnvs();
+          }
+        });
+      });
     });
 
     describe("per-group sequential processing", () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -117,7 +117,7 @@ describe("GroupStagingScripts", () => {
       });
 
       it("returns true for new job", async () => {
-        const result = await scripts.stage(makeJob());
+        const { isNew: result } = await scripts.stage(makeJob());
         expect(result).toBe(true);
       });
     });
@@ -125,7 +125,7 @@ describe("GroupStagingScripts", () => {
     describe("when staging with deduplication", () => {
       describe("when dedup key exists", () => {
         it("squashes onto original job, returns false", async () => {
-          const first = await scripts.stage(
+          const { isNew: first } = await scripts.stage(
             makeJob({
               stagedJobId: "j1",
               dedupId: "dedup-1",
@@ -135,7 +135,7 @@ describe("GroupStagingScripts", () => {
           );
           expect(first).toBe(true);
 
-          const second = await scripts.stage(
+          const { isNew: second } = await scripts.stage(
             makeJob({
               stagedJobId: "j2",
               dedupId: "dedup-1",
@@ -169,7 +169,7 @@ describe("GroupStagingScripts", () => {
           // Wait for TTL to expire
           await new Promise((r) => setTimeout(r, 10));
 
-          const result = await scripts.stage(
+          const { isNew: result } = await scripts.stage(
             makeJob({
               stagedJobId: "j2",
               dedupId: "dedup-exp",
@@ -199,7 +199,7 @@ describe("GroupStagingScripts", () => {
           }),
         );
 
-        const result = await scripts.stage(
+        const { isNew: result } = await scripts.stage(
           makeJob({
             stagedJobId: "j2",
             dedupId: "squash-1",
@@ -280,7 +280,7 @@ describe("GroupStagingScripts", () => {
         const jobsAfterDispatch = await inspectGroupJobs("group-a");
         expect(jobsAfterDispatch).toEqual([]);
 
-        const result = await scripts.stage(
+        const { isNew: result } = await scripts.stage(
           makeJob({
             stagedJobId: "j2",
             dedupId: "race-1",
@@ -314,7 +314,7 @@ describe("GroupStagingScripts", () => {
         await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
 
         // j2 is new (j1 dispatched)
-        const r2 = await scripts.stage(
+        const { isNew: r2 } = await scripts.stage(
           makeJob({
             stagedJobId: "j2",
             dedupId: "multi-race",
@@ -329,7 +329,7 @@ describe("GroupStagingScripts", () => {
         await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
 
         // j3 is new (j2 dispatched)
-        const r3 = await scripts.stage(
+        const { isNew: r3 } = await scripts.stage(
           makeJob({
             stagedJobId: "j3",
             dedupId: "multi-race",
@@ -458,7 +458,7 @@ describe("GroupStagingScripts", () => {
           }),
         );
 
-        const result = await scripts.stage(
+        const { isNew: result } = await scripts.stage(
           makeJob({
             stagedJobId: "j2",
             dedupId: "both-false",
@@ -514,6 +514,114 @@ describe("GroupStagingScripts", () => {
       });
     });
 
+    // A dedup squash drops one payload on the floor. When that payload carried
+    // an offloaded blob (ADR-026) the blob would leak until its 7-day TTL (the
+    // 2026-06-11 Redis capacity incident). stage()/stageBatch() report the
+    // displaced value so GroupQueue can reclaim its blob; these lock the
+    // reporting contract at the script layer (which is itself blob-agnostic).
+    describe("displaced-value reporting (blob reclamation contract)", () => {
+      it("reports no orphan for a genuinely new stage", async () => {
+        const { isNew, orphanedValue } = await scripts.stage(
+          makeJob({ stagedJobId: "j1", jobDataJson: JSON.stringify({ v: 1 }) }),
+        );
+
+        expect(isNew).toBe(true);
+        expect(orphanedValue).toBe("");
+      });
+
+      it("reports the displaced OLD value when a squash replaces in place", async () => {
+        const oldValue = JSON.stringify({ v: 1 });
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dedupId: "orphan-replace",
+            dedupTtlMs: 60000,
+            jobDataJson: oldValue,
+            shouldReplace: true,
+          }),
+        );
+
+        const { isNew, orphanedValue } = await scripts.stage(
+          makeJob({
+            stagedJobId: "j2",
+            dedupId: "orphan-replace",
+            dedupTtlMs: 60000,
+            jobDataJson: JSON.stringify({ v: 2 }),
+            shouldReplace: true,
+          }),
+        );
+
+        // v2 now occupies the field; v1 is the value dropped → its blob reclaims.
+        expect(isNew).toBe(false);
+        expect(orphanedValue).toBe(oldValue);
+      });
+
+      it("reports the discarded NEW value when a squash keeps the existing payload", async () => {
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j1",
+            dedupId: "orphan-keep",
+            dedupTtlMs: 60000,
+            jobDataJson: JSON.stringify({ kept: true }),
+            shouldExtend: false,
+            shouldReplace: false,
+          }),
+        );
+
+        const discardedValue = JSON.stringify({ discarded: true });
+        const { isNew, orphanedValue } = await scripts.stage(
+          makeJob({
+            stagedJobId: "j2",
+            dedupId: "orphan-keep",
+            dedupTtlMs: 60000,
+            jobDataJson: discardedValue,
+            shouldExtend: false,
+            shouldReplace: false,
+          }),
+        );
+
+        // The existing payload stays; the new value never lands → ITS blob reclaims.
+        expect(isNew).toBe(false);
+        expect(orphanedValue).toBe(discardedValue);
+      });
+
+      it("reports per-job orphans index-aligned in a batch", async () => {
+        // Pre-stage j0 so the first batch entry squash-replaces it in place.
+        await scripts.stage(
+          makeJob({
+            stagedJobId: "j0",
+            groupId: "group-a",
+            dedupId: "batch-orphan",
+            dedupTtlMs: 60000,
+            jobDataJson: JSON.stringify({ v: 1 }),
+            shouldReplace: true,
+          }),
+        );
+
+        const { newStagedCount, orphanedValues } = await scripts.stageBatch([
+          makeJob({
+            stagedJobId: "j1",
+            groupId: "group-a",
+            dedupId: "batch-orphan",
+            dedupTtlMs: 60000,
+            jobDataJson: JSON.stringify({ v: 2 }),
+            shouldReplace: true,
+          }),
+          makeJob({
+            stagedJobId: "j2",
+            groupId: "group-b",
+            dedupId: "batch-fresh",
+            dedupTtlMs: 60000,
+            jobDataJson: JSON.stringify({ fresh: true }),
+          }),
+        ]);
+
+        // Entry 0 squashed j0 (orphan = old v1); entry 1 is fresh (no orphan).
+        expect(newStagedCount).toBe(1);
+        expect(orphanedValues).toEqual([JSON.stringify({ v: 1 }), ""]);
+      });
+    });
+
     describe("edge cases", () => {
       it("creates genuinely new job after dedup TTL expires", async () => {
         await scripts.stage(
@@ -527,7 +635,7 @@ describe("GroupStagingScripts", () => {
 
         await new Promise((r) => setTimeout(r, 10));
 
-        const result = await scripts.stage(
+        const { isNew: result } = await scripts.stage(
           makeJob({
             stagedJobId: "j2",
             dedupId: "exp-1",
@@ -544,7 +652,7 @@ describe("GroupStagingScripts", () => {
       });
 
       it("does not interfere across different dedup IDs in different groups", async () => {
-        const r1 = await scripts.stage(
+        const { isNew: r1 } = await scripts.stage(
           makeJob({
             stagedJobId: "j1",
             groupId: "group-a",
@@ -552,7 +660,7 @@ describe("GroupStagingScripts", () => {
             dedupTtlMs: 60000,
           }),
         );
-        const r2 = await scripts.stage(
+        const { isNew: r2 } = await scripts.stage(
           makeJob({
             stagedJobId: "j2",
             groupId: "group-b",
@@ -708,7 +816,7 @@ describe("GroupStagingScripts", () => {
         );
 
         // Batch includes a dedup replacement and a new job
-        const count = await scripts.stageBatch([
+        const { newStagedCount: count } = await scripts.stageBatch([
           makeJob({
             stagedJobId: "j1",
             groupId: "group-x",
@@ -738,7 +846,7 @@ describe("GroupStagingScripts", () => {
         await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
 
         // Batch: j1 has same dedup (race — j0 already dispatched), j2 is no dedup
-        const count = await scripts.stageBatch([
+        const { newStagedCount: count } = await scripts.stageBatch([
           makeJob({
             stagedJobId: "j1",
             groupId: "group-x",
@@ -792,7 +900,7 @@ describe("GroupStagingScripts", () => {
         await scripts.dispatch({ nowMs: Date.now(), activeTtlSec: 300 });
 
         // Batch: j2 squashes onto j0 (mix-a), j3 is new (mix-b race)
-        const count = await scripts.stageBatch([
+        const { newStagedCount: count } = await scripts.stageBatch([
           makeJob({
             stagedJobId: "j2",
             groupId: "group-a",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/scripts.integration.test.ts
@@ -519,106 +519,113 @@ describe("GroupStagingScripts", () => {
     // 2026-06-11 Redis capacity incident). stage()/stageBatch() report the
     // displaced value so GroupQueue can reclaim its blob; these lock the
     // reporting contract at the script layer (which is itself blob-agnostic).
-    describe("displaced-value reporting (blob reclamation contract)", () => {
-      it("reports no orphan for a genuinely new stage", async () => {
-        const { isNew, orphanedValue } = await scripts.stage(
-          makeJob({ stagedJobId: "j1", jobDataJson: JSON.stringify({ v: 1 }) }),
-        );
+    describe("given stage scripts report displaced values for blob reclamation", () => {
+      describe("when a genuinely new job is staged", () => {
+        it("reports no orphan", async () => {
+          const { isNew, orphanedValue } = await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              jobDataJson: JSON.stringify({ v: 1 }),
+            }),
+          );
 
-        expect(isNew).toBe(true);
-        expect(orphanedValue).toBe("");
+          expect(isNew).toBe(true);
+          expect(orphanedValue).toBe("");
+        });
       });
 
-      it("reports the displaced OLD value when a squash replaces in place", async () => {
-        const oldValue = JSON.stringify({ v: 1 });
-        await scripts.stage(
-          makeJob({
-            stagedJobId: "j1",
-            dedupId: "orphan-replace",
-            dedupTtlMs: 60000,
-            jobDataJson: oldValue,
-            shouldReplace: true,
-          }),
-        );
+      describe("when a dedup squash displaces a staged payload", () => {
+        it("reports the displaced OLD value on replace", async () => {
+          const oldValue = JSON.stringify({ v: 1 });
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              dedupId: "orphan-replace",
+              dedupTtlMs: 60000,
+              jobDataJson: oldValue,
+              shouldReplace: true,
+            }),
+          );
 
-        const { isNew, orphanedValue } = await scripts.stage(
-          makeJob({
-            stagedJobId: "j2",
-            dedupId: "orphan-replace",
-            dedupTtlMs: 60000,
-            jobDataJson: JSON.stringify({ v: 2 }),
-            shouldReplace: true,
-          }),
-        );
+          const { isNew, orphanedValue } = await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              dedupId: "orphan-replace",
+              dedupTtlMs: 60000,
+              jobDataJson: JSON.stringify({ v: 2 }),
+              shouldReplace: true,
+            }),
+          );
 
-        // v2 now occupies the field; v1 is the value dropped → its blob reclaims.
-        expect(isNew).toBe(false);
-        expect(orphanedValue).toBe(oldValue);
-      });
+          // v2 now occupies the field; v1 is dropped → its blob reclaims.
+          expect(isNew).toBe(false);
+          expect(orphanedValue).toBe(oldValue);
+        });
 
-      it("reports the discarded NEW value when a squash keeps the existing payload", async () => {
-        await scripts.stage(
-          makeJob({
-            stagedJobId: "j1",
-            dedupId: "orphan-keep",
-            dedupTtlMs: 60000,
-            jobDataJson: JSON.stringify({ kept: true }),
-            shouldExtend: false,
-            shouldReplace: false,
-          }),
-        );
+        it("reports the discarded NEW value when the existing payload is kept", async () => {
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j1",
+              dedupId: "orphan-keep",
+              dedupTtlMs: 60000,
+              jobDataJson: JSON.stringify({ kept: true }),
+              shouldExtend: false,
+              shouldReplace: false,
+            }),
+          );
 
-        const discardedValue = JSON.stringify({ discarded: true });
-        const { isNew, orphanedValue } = await scripts.stage(
-          makeJob({
-            stagedJobId: "j2",
-            dedupId: "orphan-keep",
-            dedupTtlMs: 60000,
-            jobDataJson: discardedValue,
-            shouldExtend: false,
-            shouldReplace: false,
-          }),
-        );
+          const discardedValue = JSON.stringify({ discarded: true });
+          const { isNew, orphanedValue } = await scripts.stage(
+            makeJob({
+              stagedJobId: "j2",
+              dedupId: "orphan-keep",
+              dedupTtlMs: 60000,
+              jobDataJson: discardedValue,
+              shouldExtend: false,
+              shouldReplace: false,
+            }),
+          );
 
-        // The existing payload stays; the new value never lands → ITS blob reclaims.
-        expect(isNew).toBe(false);
-        expect(orphanedValue).toBe(discardedValue);
-      });
+          // The existing payload stays; the new value never lands → ITS blob reclaims.
+          expect(isNew).toBe(false);
+          expect(orphanedValue).toBe(discardedValue);
+        });
 
-      it("reports per-job orphans index-aligned in a batch", async () => {
-        // Pre-stage j0 so the first batch entry squash-replaces it in place.
-        await scripts.stage(
-          makeJob({
-            stagedJobId: "j0",
-            groupId: "group-a",
-            dedupId: "batch-orphan",
-            dedupTtlMs: 60000,
-            jobDataJson: JSON.stringify({ v: 1 }),
-            shouldReplace: true,
-          }),
-        );
+        it("reports per-job orphans index-aligned in a batch", async () => {
+          // Pre-stage j0 so the first batch entry squash-replaces it in place.
+          await scripts.stage(
+            makeJob({
+              stagedJobId: "j0",
+              groupId: "group-a",
+              dedupId: "batch-orphan",
+              dedupTtlMs: 60000,
+              jobDataJson: JSON.stringify({ v: 1 }),
+              shouldReplace: true,
+            }),
+          );
 
-        const { newStagedCount, orphanedValues } = await scripts.stageBatch([
-          makeJob({
-            stagedJobId: "j1",
-            groupId: "group-a",
-            dedupId: "batch-orphan",
-            dedupTtlMs: 60000,
-            jobDataJson: JSON.stringify({ v: 2 }),
-            shouldReplace: true,
-          }),
-          makeJob({
-            stagedJobId: "j2",
-            groupId: "group-b",
-            dedupId: "batch-fresh",
-            dedupTtlMs: 60000,
-            jobDataJson: JSON.stringify({ fresh: true }),
-          }),
-        ]);
+          const { newStagedCount, orphanedValues } = await scripts.stageBatch([
+            makeJob({
+              stagedJobId: "j1",
+              groupId: "group-a",
+              dedupId: "batch-orphan",
+              dedupTtlMs: 60000,
+              jobDataJson: JSON.stringify({ v: 2 }),
+              shouldReplace: true,
+            }),
+            makeJob({
+              stagedJobId: "j2",
+              groupId: "group-b",
+              dedupId: "batch-fresh",
+              dedupTtlMs: 60000,
+              jobDataJson: JSON.stringify({ fresh: true }),
+            }),
+          ]);
 
-        // Entry 0 squashed j0 (orphan = old v1); entry 1 is fresh (no orphan).
-        expect(newStagedCount).toBe(1);
-        expect(orphanedValues).toEqual([JSON.stringify({ v: 1 }), ""]);
+          // Entry 0 squashed j0 (orphan = old v1); entry 1 is fresh (no orphan).
+          expect(newStagedCount).toBe(1);
+          expect(orphanedValues).toEqual([JSON.stringify({ v: 1 }), ""]);
+        });
       });
     });
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -342,10 +342,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     // A dedup squash displaced a staged payload; reclaim its offloaded blob so
     // it does not leak until the 7-day TTL (the 2026-06-11 capacity incident).
-    // No-op for inline payloads (readEnvelopeBlobId yields null) and new stages
-    // (orphanedValue is "").
+    // Fire-and-forget (matches the worker reclaim paths); a no-op for inline
+    // payloads (readEnvelopeBlobId yields null) and new stages (orphanedValue "").
     if (orphanedValue) {
-      await this.deleteEnvelopeBlobs([orphanedValue]);
+      this.deleteEnvelopeBlobs([orphanedValue]);
     }
 
     if (isNew) {
@@ -443,7 +443,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // Reclaim blobs displaced by any in-batch dedup squashes (see send()).
     const orphans = orphanedValues.filter((value) => value.length > 0);
     if (orphans.length > 0) {
-      await this.deleteEnvelopeBlobs(orphans);
+      this.deleteEnvelopeBlobs(orphans);
     }
 
     const dedupedCount = payloads.length - newStagedCount;
@@ -510,7 +510,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       );
       // Complete the group slot so it's not stuck
       await this.scripts.complete({ groupId, stagedJobId });
-      void this.deleteEnvelopeBlobs([jobDataJson]);
+      this.deleteEnvelopeBlobs([jobDataJson]);
       return;
     }
 
@@ -657,7 +657,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               // removed from staging during the drain, so completing the
               // dispatched job is enough to free the group.
               await this.scripts.complete({ groupId, stagedJobId, jobName });
-              void this.deleteEnvelopeBlobs([
+              this.deleteEnvelopeBlobs([
                 jobDataJson,
                 ...drainedSiblings.map((sibling) => sibling.jobDataJson),
               ]);
@@ -714,7 +714,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 // the dispatched value's blob is now unreferenced. Drained
                 // siblings were re-staged with their ORIGINAL values, so
                 // their blobs stay.
-                void this.deleteEnvelopeBlobs([jobDataJson]);
+                this.deleteEnvelopeBlobs([jobDataJson]);
 
                 this.logger.warn(
                   {
@@ -756,7 +756,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   contextMetadata,
                   routingLabels,
                 });
-                void this.deleteEnvelopeBlobs([jobDataJson]);
+                this.deleteEnvelopeBlobs([jobDataJson]);
               }
             }
           },
@@ -798,27 +798,18 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   /**
    * Best-effort reclamation of offloaded bodies whose staged values are retired
    * (drained, completed, retried, or displaced by a dedup squash). Inline and
-   * legacy values yield no blob id and are skipped. Errors are swallowed: the
-   * blob TTL is the correctness backstop.
-   *
-   * Awaitable so the producer paths (send/sendBatch) can reclaim a squash-
-   * displaced blob synchronously with the enqueue — that round-trip only happens
-   * when a blob actually exists, so inline traffic pays nothing. The worker
-   * drain/complete/retry paths call it fire-and-forget (`void`) to avoid adding
-   * latency to the processing loop.
+   * legacy values yield no blob id and are skipped. Fire-and-forget: the blob
+   * TTL is the correctness backstop, so a failed delete only means the blob
+   * lingers until expiry. Producer (send/sendBatch) and worker paths alike call
+   * this without awaiting, to keep the hot path off the extra round-trip.
    */
-  private async deleteEnvelopeBlobs(values: string[]): Promise<void> {
-    await Promise.all(
-      values.map(async (value) => {
-        const blobId = readEnvelopeBlobId(value);
-        if (!blobId) return;
-        try {
-          await this.blobs.delete({ id: blobId });
-        } catch {
-          // Best-effort: the blob TTL is the correctness backstop.
-        }
-      }),
-    );
+  private deleteEnvelopeBlobs(values: string[]): void {
+    for (const value of values) {
+      const blobId = readEnvelopeBlobId(value);
+      if (blobId) {
+        void this.blobs.delete({ id: blobId }).catch(() => {});
+      }
+    }
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -326,7 +326,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       span.setAttributes({ ...customAttributes });
     }
 
-    const isNew = await this.scripts.stage({
+    const { isNew, orphanedValue } = await this.scripts.stage({
       stagedJobId,
       groupId,
       dispatchAfterMs,
@@ -339,6 +339,14 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       shouldExtend,
       shouldReplace,
     });
+
+    // A dedup squash displaced a staged payload; reclaim its offloaded blob so
+    // it does not leak until the 7-day TTL (the 2026-06-11 capacity incident).
+    // No-op for inline payloads (readEnvelopeBlobId yields null) and new stages
+    // (orphanedValue is "").
+    if (orphanedValue) {
+      await this.deleteEnvelopeBlobs([orphanedValue]);
+    }
 
     if (isNew) {
       gqJobsStagedTotal.inc({ queue_name: this.queueName });
@@ -429,7 +437,14 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       }),
     );
 
-    const newStagedCount = await this.scripts.stageBatch(jobsToStage);
+    const { newStagedCount, orphanedValues } =
+      await this.scripts.stageBatch(jobsToStage);
+
+    // Reclaim blobs displaced by any in-batch dedup squashes (see send()).
+    const orphans = orphanedValues.filter((value) => value.length > 0);
+    if (orphans.length > 0) {
+      await this.deleteEnvelopeBlobs(orphans);
+    }
 
     const dedupedCount = payloads.length - newStagedCount;
     if (newStagedCount > 0) {
@@ -495,7 +510,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       );
       // Complete the group slot so it's not stuck
       await this.scripts.complete({ groupId, stagedJobId });
-      this.deleteEnvelopeBlobs([jobDataJson]);
+      void this.deleteEnvelopeBlobs([jobDataJson]);
       return;
     }
 
@@ -642,7 +657,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               // removed from staging during the drain, so completing the
               // dispatched job is enough to free the group.
               await this.scripts.complete({ groupId, stagedJobId, jobName });
-              this.deleteEnvelopeBlobs([
+              void this.deleteEnvelopeBlobs([
                 jobDataJson,
                 ...drainedSiblings.map((sibling) => sibling.jobDataJson),
               ]);
@@ -699,7 +714,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 // the dispatched value's blob is now unreferenced. Drained
                 // siblings were re-staged with their ORIGINAL values, so
                 // their blobs stay.
-                this.deleteEnvelopeBlobs([jobDataJson]);
+                void this.deleteEnvelopeBlobs([jobDataJson]);
 
                 this.logger.warn(
                   {
@@ -741,7 +756,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   contextMetadata,
                   routingLabels,
                 });
-                this.deleteEnvelopeBlobs([jobDataJson]);
+                void this.deleteEnvelopeBlobs([jobDataJson]);
               }
             }
           },
@@ -781,17 +796,29 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   }
 
   /**
-   * Best-effort deletion of offloaded bodies whose staged values are retired.
-   * Fire-and-forget: the blob TTL is the correctness backstop, so a failed
-   * delete only means the blob lingers until expiry.
+   * Best-effort reclamation of offloaded bodies whose staged values are retired
+   * (drained, completed, retried, or displaced by a dedup squash). Inline and
+   * legacy values yield no blob id and are skipped. Errors are swallowed: the
+   * blob TTL is the correctness backstop.
+   *
+   * Awaitable so the producer paths (send/sendBatch) can reclaim a squash-
+   * displaced blob synchronously with the enqueue — that round-trip only happens
+   * when a blob actually exists, so inline traffic pays nothing. The worker
+   * drain/complete/retry paths call it fire-and-forget (`void`) to avoid adding
+   * latency to the processing loop.
    */
-  private deleteEnvelopeBlobs(values: string[]): void {
-    for (const value of values) {
-      const blobId = readEnvelopeBlobId(value);
-      if (blobId) {
-        void this.blobs.delete({ id: blobId }).catch(() => {});
-      }
-    }
+  private async deleteEnvelopeBlobs(values: string[]): Promise<void> {
+    await Promise.all(
+      values.map(async (value) => {
+        const blobId = readEnvelopeBlobId(value);
+        if (!blobId) return;
+        try {
+          await this.blobs.delete({ id: blobId });
+        } catch {
+          // Best-effort: the blob TTL is the correctness backstop.
+        }
+      }),
+    );
   }
 
   /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/scripts.ts
@@ -447,11 +447,18 @@ if dedupId ~= "" and dedupTtlMs > 0 then
   if existingJobId then
     local rank = redis.call("ZRANK", groupJobsKey, existingJobId)
     if rank then
-      -- Still in staging: squash in place (net zero pending count change)
+      -- Still in staging: squash in place (net zero pending count change). The
+      -- squash drops one payload on the floor; if it carried an offloaded blob
+      -- (ADR-026) that blob is now unreferenced and would leak until its TTL
+      -- (the 2026-06-11 capacity incident). Report the displaced value so the
+      -- caller can reclaim its blob. On replace the OLD stored value is dropped;
+      -- otherwise the NEW value we were just handed is the one discarded.
+      local orphanedValue = jobDataJson
       if shouldExtend == 1 then
         redis.call("ZADD", groupJobsKey, dispatchAfter, existingJobId)
       end
       if shouldReplace == 1 then
+        orphanedValue = redis.call("HGET", dataKey, existingJobId) or ""
         redis.call("HSET", dataKey, existingJobId, jobDataJson)
       end
       redis.call("SET", dedupKey, existingJobId, "PX", dedupTtlMs)
@@ -462,7 +469,7 @@ if dedupId ~= "" and dedupTtlMs > 0 then
       refreshGroupKeyTtl(groupJobsKey, dataKey, nowMs)
       redis.call("LPUSH", signalKey, "1")
       redis.call("LTRIM", signalKey, 0, 999)
-      return 0
+      return {0, orphanedValue}
     end
     -- Already dispatched: dedup key is stale, clean it up
     redis.call("DEL", dedupKey)
@@ -488,7 +495,8 @@ redis.call("LTRIM", signalKey, 0, 999)
 -- New job staged: increment total pending counter
 redis.call("INCR", totalPendingKey)
 
-return 1
+-- A genuinely new stage displaces nothing, so there is no blob to reclaim.
+return {1, ""}
 `;
 
 const STAGE_BATCH_LUA =
@@ -510,6 +518,9 @@ local nowMs        = tonumber(ARGV[#ARGV - 1])
 
 local newStagedCount = 0
 local affectedGroups = {}
+-- Per-job (index-aligned) displaced values whose offloaded blob the caller must
+-- reclaim; "" for a genuine new stage. Mirrors STAGE_LUA's single-job report.
+local orphanedValues = {}
 
 for i = 1, count do
   local offset = 2 + (i - 1) * 8
@@ -527,16 +538,21 @@ for i = 1, count do
   local dedupKey     = (dedupId ~= "") and (keyPrefix .. "dedup:" .. dedupId) or (keyPrefix .. "dedup:__none__")
 
   local isDeduped = false
+  local orphanedValue = ""
   if dedupId ~= "" and dedupTtlMs > 0 then
     local existingJobId = redis.call("GET", dedupKey)
     if existingJobId then
       local rank = redis.call("ZRANK", groupJobsKey, existingJobId)
       if rank then
-        -- Still in staging: squash in place
+        -- Still in staging: squash in place. The displaced payload's blob would
+        -- leak (see STAGE_LUA) — on replace it is the OLD stored value, else the
+        -- NEW value we were handed is the one dropped.
+        orphanedValue = jobDataJson
         if shouldExtend == 1 then
           redis.call("ZADD", groupJobsKey, dispatchAfter, existingJobId)
         end
         if shouldReplace == 1 then
+          orphanedValue = redis.call("HGET", dataKey, existingJobId) or ""
           redis.call("HSET", dataKey, existingJobId, jobDataJson)
         end
         redis.call("SET", dedupKey, existingJobId, "PX", dedupTtlMs)
@@ -556,6 +572,7 @@ for i = 1, count do
     end
     newStagedCount = newStagedCount + 1
   end
+  orphanedValues[i] = orphanedValue
 
   refreshGroupKeyTtl(groupJobsKey, dataKey, nowMs)
 
@@ -589,7 +606,7 @@ if newStagedCount > 0 then
   redis.call("INCRBY", totalPendingKey, newStagedCount)
 end
 
-return newStagedCount
+return {newStagedCount, orphanedValues}
 `;
 
 const DISPATCH_LUA =
@@ -1483,7 +1500,13 @@ export class GroupStagingScripts {
    * shouldExtend/shouldReplace). When the old job was already dispatched, the
    * stale dedup key is cleaned up and the new job is staged as genuinely new.
    *
-   * @returns true if a new job was staged, false if squashed onto an existing job (dedup)
+   * A squash drops one payload (the replaced old value, or the discarded new
+   * value when `replace` is off); `orphanedValue` reports it so the caller can
+   * reclaim its offloaded blob (ADR-026) instead of leaking it. It is `""` for a
+   * genuine new stage, which displaces nothing.
+   *
+   * @returns `isNew` (true if staged fresh, false if deduped) plus the displaced
+   *   `orphanedValue` whose blob the caller must reclaim.
    */
   async stage({
     stagedJobId,
@@ -1503,7 +1526,7 @@ export class GroupStagingScripts {
     jobDataJson: string;
     shouldExtend?: boolean;
     shouldReplace?: boolean;
-  }): Promise<boolean> {
+  }): Promise<{ isNew: boolean; orphanedValue: string }> {
     const groupJobsKey = `${this.keyPrefix}group:${groupId}:jobs`;
     const readyKey = `${this.keyPrefix}ready`;
     const signalKey = `${this.keyPrefix}signal`;
@@ -1540,13 +1563,23 @@ export class GroupStagingScripts {
       String(readGlobalBudget()),
     );
 
-    return result === 1;
+    // STAGE_LUA returns [code, orphanedValue]. Tolerate a bare integer reply
+    // defensively (e.g. a stale cached script during a rolling deploy).
+    const [code, orphanedValue] = Array.isArray(result)
+      ? (result as [number, unknown])
+      : [result as number, ""];
+    return {
+      isNew: Number(code) === 1,
+      orphanedValue: orphanedValue == null ? "" : String(orphanedValue),
+    };
   }
 
   /**
    * Stage a batch of jobs into their respective group queues.
    *
-   * @returns number of new jobs staged (excluding replaced ones)
+   * @returns `newStagedCount` (new jobs, excluding deduped) plus the
+   *   index-aligned `orphanedValues` of squashed jobs whose offloaded blobs the
+   *   caller must reclaim (`""` where nothing was displaced). See {@link stage}.
    */
   async stageBatch(
     jobs: Array<{
@@ -1559,8 +1592,8 @@ export class GroupStagingScripts {
       shouldExtend?: boolean;
       shouldReplace?: boolean;
     }>,
-  ): Promise<number> {
-    if (jobs.length === 0) return 0;
+  ): Promise<{ newStagedCount: number; orphanedValues: string[] }> {
+    if (jobs.length === 0) return { newStagedCount: 0, orphanedValues: [] };
 
     const readyKey = `${this.keyPrefix}ready`;
     const signalKey = `${this.keyPrefix}signal`;
@@ -1594,7 +1627,18 @@ export class GroupStagingScripts {
       ...args,
     );
 
-    return Number(result);
+    // STAGE_BATCH_LUA returns [newStagedCount, orphanedValues[]]. Tolerate a
+    // bare integer reply defensively (stale cached script mid-deploy).
+    if (Array.isArray(result)) {
+      const [count, orphans] = result as [number, unknown];
+      return {
+        newStagedCount: Number(count),
+        orphanedValues: Array.isArray(orphans)
+          ? orphans.map((v) => (v == null ? "" : String(v)))
+          : [],
+      };
+    }
+    return { newStagedCount: Number(result), orphanedValues: [] };
   }
 
   /**

--- a/specs/event-sourcing/payload-envelope.feature
+++ b/specs/event-sourcing/payload-envelope.feature
@@ -38,6 +38,12 @@ Feature: GroupQueue payload envelope
     Then its blob key is deleted
     And any blob that escapes deletion expires via its TTL safety net
 
+  Scenario: Offloaded blobs displaced by a dedup squash are reclaimed
+    Given a staged offloaded job
+    When a later job with the same dedup id squashes it in place
+    Then the displaced payload's blob key is deleted
+    And only the surviving payload's blob remains
+
   Scenario: A missing blob does not wedge the group
     Given an offloaded job whose blob has expired or been deleted
     When dispatch delivers it to the worker


### PR DESCRIPTION
## Why

The payload-envelope blob offload (#4726) leaks orphaned `gq:blob:*` keys whenever a staged, blob-backed payload is **squashed by deduplication** before it is processed, driving Redis toward its `noeviction` ceiling under sustained large-span ingestion (the `redis-capacity-usage-high` alarm).

Validated read-only in production: ~280K blob keys = **91% of the keyspace**, of which **99.25% (~7.4 GB) are unreferenced** by any live staged job. A 1,000-blob sample had **100% `IDLETIME == age`** — written once, never read — the signature of a value displaced *before* it was ever dispatched (a dedup-squash orphan), not a completion-delete miss.

### Root cause

Two correct changes interact into an unmanaged resource leak:

- **#4680** made `recordSpan` dedup `extend+replace`. On a dedup hit the stage Lua squashes in place (`HSET dataKey existingJobId <new value>`), overwriting the stored value. Before #4726 that value was inline JSON — overwriting freed it. Bounded.
- **#4726** moved `> 32 KiB` bodies to standalone `gq:blob:<id>` keys (7-day TTL), with the staged value reduced to a tiny `ref` envelope. Blob deletion is wired only on the worker drain/complete/retry paths — **never on the stage-time squash path**, because the overwrite happens entirely inside Lua and the client never sees the value it displaced.

So every squash of a large payload orphans one blob: with `replace` the **old** value's blob, without `replace` the **discarded new** value's blob. The `claudeCodeSpanSync` reactor re-folds a turn every ~1.5 s with stable span ids, so the same large spans re-dispatch and orphan the prior fire's blob repeatedly. Only the 7-day TTL ever reclaims them — far slower than they arrive.

## What changed

The stage Lua now **reports the value it displaced**, and `GroupQueue` reclaims that value's blob via the existing `deleteEnvelopeBlobs` path. This mirrors the established dispatch pattern (Lua returns the value; `GroupQueue` owns all envelope/blob lifecycle) and keeps the Lua layer blob-agnostic.

- `STAGE_LUA` → `{code, orphanedValue}`; `STAGE_BATCH_LUA` → `{newStagedCount, orphanedValues[]}` (index-aligned).
- `orphanedValue` is the **old** stored value when `replace` is on, otherwise the **new** discarded value — covering every `extend`/`replace` combination — and `""` for a genuine new stage.
- `send()` / `sendBatch()` reclaim the displaced blob fire-and-forget — consistent with the existing worker drain/complete/retry reclaim paths, so the producer hot path takes no extra round-trip. Inline/legacy values yield no blob id (`readEnvelopeBlobId` → null) and are skipped.

## How it works

`deleteEnvelopeBlobs` (unchanged from `main`) is best-effort and fire-and-forget — the blob TTL remains the correctness backstop, so a failed delete only means the blob lingers until expiry. Both producer and worker paths call it without awaiting, keeping the hot path off the extra round-trip; the squash deletes the displaced blob within milliseconds, so orphans never accumulate.

## Test plan

- [x] **Script layer** (`scripts.integration.test.ts`): `stage`/`stageBatch` report the displaced value for replace, no-replace, and new-stage, plus per-job index alignment in a batch. **141 passed.**
- [x] **End-to-end** (`groupQueue.integration.test.ts`): stage a `> 32 KiB` payload, squash it with a second large payload, assert the **displaced blob key is gone** and only the survivor's blob remains — for `replace: true` (old blob reclaimed) and `replace: false` (new blob reclaimed). **17 passed.**
- [x] Behaviour contract added to `specs/event-sourcing/payload-envelope.feature` (completes the blob-lifecycle section).
- [x] `pnpm typecheck` clean on changed files.

## Anything surprising?

Forward-only: #4726 cannot be rolled back while `GQ1|` envelopes are in flight (old code can't parse them).

## Deployment Impact

No schema, migration, config, or chart changes. The stage scripts are sent inline on every `eval` (not `evalsha`-cached), so the new return shape changes atomically with the deploy; the wrappers also tolerate a bare-integer reply defensively. Clearing the **existing** ~7.4 GB of orphaned blobs is a separate operational task (safe `UNLINK` — canonical data is in ClickHouse, a missing blob is recoverable via replay); this PR only stops new orphans.

Fixes #4757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blob storage reclamation when deduplication replaces staged payloads in event sourcing queues, ensuring displaced offloaded payloads are properly cleaned up.

* **Tests**
  * Added integration test coverage for blob reclamation during deduplication operations and payload envelope handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->