### PR TITLE
chore(queue): orphaned-blob reclaim tool

### DIFF
--- a/langwatch/scripts/ops/reclaim-orphaned-blobs.sh
+++ b/langwatch/scripts/ops/reclaim-orphaned-blobs.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# Reclaim orphaned GroupQueue offload blobs (one-shot prod ops tool).
+#
+# ADR-026 offloads payloads >32KiB to standalone {prefix}blob:<id> keys. Before
+# PR #4758 a dedup squash (recordSpan/reactor re-fold) overwrote a staged value
+# in place without reclaiming the blob the displaced value pointed at, so the
+# blob leaked until its 7-day TTL. On 2026-06-11 (#4757) this reached ~280K
+# orphan blobs / ~7.4GB (~91% of the keyspace). #4758 stops NEW orphans; this
+# tool reclaims the EXISTING pool instead of waiting out the 7-day TTL.
+#
+# DRY-RUN BY DEFAULT: builds the referenced set, discovers orphans, writes them
+# to OUT, prints a summary, and stops. Re-run with APPLY=1 to UNLINK them.
+#
+# A blob is reclaimed only when it is BOTH:
+#   (a) UNREFERENCED — no live {prefix}group:*:data envelope carries its id in
+#       the "r" field. This protects every STAGED job (normal, paused, retry-
+#       backoff — all re-staged into the data hash), so their blobs are kept.
+#   (b) AGED > MIN_AGE_HOURS — derived from the remaining TTL (age =
+#       BLOB_TTL_SECONDS - ttl). This protects IN-FLIGHT jobs whose value left
+#       the data hash at dispatch (so they look unreferenced) but whose blob a
+#       worker is about to read. The processing window is bounded by the active
+#       key TTL (~300s), so a multi-hour floor cannot hit a live in-flight blob.
+# Canonical span data lives in ClickHouse and a missing blob is recoverable via
+# event replay (decode throws -> slot completed -> replay), so (b) is belt-and-
+# suspenders, not a correctness requirement.
+#
+# Usage (run co-located with redis, e.g. a redis:7-alpine pod like the drain pods):
+#   H=<host> REDISCLI_AUTH=<pw> sh reclaim-orphaned-blobs.sh             # discover
+#   H=<host> REDISCLI_AUTH=<pw> APPLY=1 sh reclaim-orphaned-blobs.sh     # reclaim
+#   H=127.0.0.1 PORT=6390 TLS= sh reclaim-orphaned-blobs.sh             # local (no TLS)
+
+set -eu
+
+# A literal "}" cannot live inside a ${VAR:-default} expansion in POSIX sh, so
+# set the default in two steps (mirrors reap-stranded-group-keys.sh).
+PREFIX="${PREFIX:-}"
+[ -n "$PREFIX" ] || PREFIX='{event-sourcing/jobs}:gq:'
+APPLY="${APPLY:-0}"
+MIN_AGE_HOURS="${MIN_AGE_HOURS:-2}"
+# Must match RedisJobBlobStore BLOB_TTL_SECONDS (7 days). age = this - ttl.
+BLOB_TTL_SECONDS="${BLOB_TTL_SECONDS:-604800}"
+BATCH="${BATCH:-500}"          # keys per UNLINK call (command efficiency)
+# Progressive reclaim: free FREE_CHUNK orphans, report memory, pause SLEEP, repeat
+# — so memory drains in visible steps instead of one large sweep. UNLINK frees
+# asynchronously, so the per-chunk "freed" figure lags slightly and catches up.
+FREE_CHUNK="${FREE_CHUNK:-5000}"
+SLEEP="${SLEEP:-2}"
+LIMIT="${LIMIT:-}"             # optional cap on orphans reclaimed this run (default: all)
+OUT="${OUT:-/tmp/orphan-blobs.txt}"
+REF="${REF:-/tmp/referenced-blobs.txt}"
+TLS="${TLS-1}"          # default on (prod); set TLS= to disable for a local redis
+INSECURE="${INSECURE:-}" # set INSECURE=1 to skip TLS cert verification (e.g. reaching
+                         # the public ElastiCache endpoint from outside the VPC)
+
+R="redis-cli -h ${H:?set H to the redis host} -p ${PORT:-6379} ${TLS:+--tls} ${INSECURE:+--insecure} --no-auth-warning"
+
+cutoff_ttl=$(( BLOB_TTL_SECONDS - MIN_AGE_HOURS * 3600 ))
+
+echo "mode=$([ "$APPLY" = 1 ] && echo APPLY || echo DISCOVER) prefix=${PREFIX} min_age_hours=${MIN_AGE_HOURS} cutoff_ttl=${cutoff_ttl} batch=${BATCH}"
+
+# ── 1. Referenced blob ids ──────────────────────────────────────────────────
+# Only a few hundred group hashes; HVALS each and pull the id out of every
+# e:"ref" envelope. Base64 inline bodies cannot forge a "r":"<uuid>" match
+# (no quotes/colons in base64), so this never over-counts.
+: > "$REF"
+$R --scan --pattern "${PREFIX}group:*:data" --count "${SCAN_COUNT:-1000}" | while IFS= read -r dk; do
+  $R HVALS "$dk"
+done | grep -oE '"r":"[0-9a-f-]{36}"' | sed 's/.*"r":"//; s/"$//' | sort -u > "$REF"
+ref_count=$(wc -l < "$REF" | tr -d ' ')
+
+# ── 2. Discover orphans (unreferenced AND aged) ─────────────────────────────
+# Bulk-fetch every blob key + TTL in two pipelined passes, then classify
+# locally against the referenced set — per-key round-trips would be 100K+.
+blobs_tmp=$(mktemp); ttls_tmp=$(mktemp); sum_tmp=$(mktemp)
+trap 'rm -f "$blobs_tmp" "$ttls_tmp" "$sum_tmp"' EXIT
+$R --scan --pattern "${PREFIX}blob:*" --count "${SCAN_COUNT:-1000}" > "$blobs_tmp"
+total=$(wc -l < "$blobs_tmp" | tr -d ' ')
+# Fetch every blob's TTL in chunks via EVAL — per-key TTL round-trips would be
+# 100K+ (≈hours over a WAN). Keys go in ARGV with numkeys=0: blob keys share the
+# queue hash tag so they live in one slot, and this is a single-shard replication
+# group, so there is no cross-slot concern. xargs preserves input order and EVAL
+# returns ARGV order, so ttls_tmp stays line-aligned with blobs_tmp for paste.
+: > "$ttls_tmp"
+if [ "$total" -gt 0 ]; then
+  TTL_LUA='local r={} for i=1,#ARGV do r[i]=redis.call("ttl",ARGV[i]) end return r'
+  xargs -n "${CHUNK:-2000}" $R EVAL "$TTL_LUA" 0 < "$blobs_tmp" > "$ttls_tmp"
+fi
+
+paste "$blobs_tmp" "$ttls_tmp" | awk -F'\t' \
+  -v cutoff="$cutoff_ttl" -v pfx="${PREFIX}blob:" -v reffile="$REF" -v sumf="$sum_tmp" '
+  BEGIN { while ((getline r < reffile) > 0) ref[r] = 1 }
+  {
+    key = $1; ttl = $2 + 0
+    id = substr(key, length(pfx) + 1)
+    if (id in ref)             { referenced++; next }   # live staged job — keep
+    if (ttl <= 0 || ttl >= cutoff) { young++;  next }   # in-flight / too young — keep
+    orphans++; print key                                # unreferenced + aged — reclaim
+  }
+  END { printf "referenced=%d young_skipped=%d orphans=%d\n", referenced, young, orphans > sumf }
+' > "$OUT"
+
+. "$sum_tmp" 2>/dev/null || true
+referenced="${referenced:-0}"; young_skipped="${young_skipped:-0}"; orphans="${orphans:-0}"
+
+# Estimate freed memory from a sample of up to 200 orphans.
+est_bytes=0
+if [ "$orphans" -gt 0 ]; then
+  avg=$(head -200 "$OUT" | while IFS= read -r k; do $R MEMORY USAGE "$k"; done \
+        | awk '{s+=$1; n++} END {if (n) printf "%d", s/n; else print 0}')
+  est_bytes=$(( avg * orphans ))
+fi
+
+est_mb=$(( est_bytes / 1024 / 1024 ))
+echo "total_blobs=${total} referenced_kept=${ref_count} (live=${referenced}) young_kept=${young_skipped} orphans_to_reclaim=${orphans} est_freed=${est_mb}MB"
+
+# Chunk plan (how the progressive reclaim would step through the orphans).
+chunks=0; per_chunk_mb=0
+if [ "$orphans" -gt 0 ]; then
+  chunks=$(( (orphans + FREE_CHUNK - 1) / FREE_CHUNK ))
+  per_chunk_mb=$(( est_mb * FREE_CHUNK / orphans ))
+fi
+
+if [ "$APPLY" != "1" ]; then
+  echo "DISCOVER only — nothing mutated."
+  echo "plan: reclaim ${orphans} orphan(s) in ${chunks} chunk(s) of ${FREE_CHUNK} (~${per_chunk_mb}MB/chunk, ${SLEEP}s pause between)"
+  echo "list: ${OUT} (first 3):"; head -3 "$OUT" || true
+  echo "to free: APPLY=1 [FREE_CHUNK=N] [SLEEP=N] [LIMIT=N] ... (LIMIT caps this run for incremental freeing)"
+  exit 0
+fi
+
+# ── 3. Apply: progressive chunked reclaim with memory reporting ──────────────
+[ "$orphans" -eq 0 ] && { echo "nothing to reclaim"; exit 0; }
+to_reclaim="$orphans"
+if [ -n "$LIMIT" ] && [ "$LIMIT" -lt "$to_reclaim" ]; then to_reclaim="$LIMIT"; fi
+mem0=$($R INFO memory | awk -F: '/^used_memory:/{print $2+0}')
+echo "reclaiming ${to_reclaim}/${orphans} in chunks of ${FREE_CHUNK} (UNLINK batch ${BATCH}); used_memory=$(( mem0/1024/1024 ))MB"
+
+done_n=0
+while [ "$done_n" -lt "$to_reclaim" ]; do
+  start=$(( done_n + 1 )); end=$(( done_n + FREE_CHUNK ))
+  [ "$end" -gt "$to_reclaim" ] && end="$to_reclaim"
+  # UNLINK this slice (non-blocking; async free). Tolerate a transient blip.
+  set +e
+  sed -n "${start},${end}p" "$OUT" | xargs -n "$BATCH" $R UNLINK >/dev/null 2>&1
+  set -e
+  done_n="$end"
+  memn=$($R INFO memory | awk -F: '/^used_memory:/{print $2+0}')
+  echo "  reclaimed=${done_n}/${to_reclaim} used_memory=$(( memn/1024/1024 ))MB freed_so_far=$(( (mem0-memn)/1024/1024 ))MB"
+  [ "$done_n" -lt "$to_reclaim" ] && [ "$SLEEP" -gt 0 ] && sleep "$SLEEP"
+done
+
+remaining=$($R --scan --pattern "${PREFIX}blob:*" --count "${SCAN_COUNT:-1000}" | wc -l | tr -d ' ')
+echo "DONE reclaimed=${done_n} remaining_blobs=${remaining} used_memory=$(( $($R INFO memory | awk -F: '/^used_memory:/{print $2+0}')/1024/1024 ))MB"

--- a/langwatch/scripts/ops/reclaim-orphaned-blobs.sh
+++ b/langwatch/scripts/ops/reclaim-orphaned-blobs.sh
@@ -13,21 +13,32 @@
 #
 # A blob is reclaimed only when it is BOTH:
 #   (a) UNREFERENCED — no live {prefix}group:*:data envelope carries its id in
-#       the "r" field. This protects every STAGED job (normal, paused, retry-
-#       backoff — all re-staged into the data hash), so their blobs are kept.
-#   (b) AGED > MIN_AGE_HOURS — derived from the remaining TTL (age =
-#       BLOB_TTL_SECONDS - ttl). This protects IN-FLIGHT jobs whose value left
-#       the data hash at dispatch (so they look unreferenced) but whose blob a
-#       worker is about to read. The processing window is bounded by the active
-#       key TTL (~300s), so a multi-hour floor cannot hit a live in-flight blob.
-# Canonical span data lives in ClickHouse and a missing blob is recoverable via
-# event replay (decode throws -> slot completed -> replay), so (b) is belt-and-
-# suspenders, not a correctness requirement.
+#       the "r" field. Protects every STAGED job (normal, paused, retry-backoff —
+#       all re-staged into the data hash), so their blobs are kept. The reference
+#       set is built FAIL-CLOSED: any SCAN/HVALS error aborts before any delete,
+#       because a partial set would misclassify live blobs as orphans.
+#   (b) AGED > MIN_AGE_HOURS — derived from remaining TTL (age = BLOB_TTL - ttl).
+#       This skips RECENTLY-CREATED blobs, narrowing the window in which a just-
+#       staged value's blob could be touched.
+#
+# SAFETY / in-flight race: (b) keys on blob CREATION time, not dispatch time, so
+# it does NOT protect an OLD staged blob dispatched DURING the sweep — its value
+# leaves the data hash at dispatch (looks unreferenced) while a worker is about
+# to read it. The real backstop is recoverability: a missing blob makes the
+# worker's decode throw, the slot is completed, and the event replays from the
+# canonical ClickHouse data. In practice this tool's targets are dedup-SQUASHED
+# blobs whose staged value was overwritten in place — they have no jobs-zset or
+# dedup entry, so they are NON-DISPATCHABLE and the race cannot reach them; the
+# only exposed blobs are live delayed/retry/just-unpaused jobs dispatched mid-
+# sweep. For ZERO replays, quiesce first: pause the queues and wait for
+# {prefix}group:*:active to drain to 0. APPLY refuses to run while any group is
+# active unless FORCE=1 (accept the recoverable-replay risk).
 #
 # Usage (run co-located with redis, e.g. a redis:7-alpine pod like the drain pods):
-#   H=<host> REDISCLI_AUTH=<pw> sh reclaim-orphaned-blobs.sh             # discover
-#   H=<host> REDISCLI_AUTH=<pw> APPLY=1 sh reclaim-orphaned-blobs.sh     # reclaim
-#   H=127.0.0.1 PORT=6390 TLS= sh reclaim-orphaned-blobs.sh             # local (no TLS)
+#   H=<host> REDISCLI_AUTH=<pw> sh reclaim-orphaned-blobs.sh                    # discover
+#   H=<host> REDISCLI_AUTH=<pw> APPLY=1 sh reclaim-orphaned-blobs.sh            # reclaim (quiesced)
+#   H=<host> REDISCLI_AUTH=<pw> APPLY=1 FORCE=1 sh reclaim-orphaned-blobs.sh    # reclaim on a live system
+#   H=127.0.0.1 PORT=6390 TLS= sh reclaim-orphaned-blobs.sh                     # local (no TLS)
 
 set -eu
 
@@ -58,22 +69,32 @@ cutoff_ttl=$(( BLOB_TTL_SECONDS - MIN_AGE_HOURS * 3600 ))
 
 echo "mode=$([ "$APPLY" = 1 ] && echo APPLY || echo DISCOVER) prefix=${PREFIX} min_age_hours=${MIN_AGE_HOURS} cutoff_ttl=${cutoff_ttl} batch=${BATCH}"
 
-# ── 1. Referenced blob ids ──────────────────────────────────────────────────
-# Only a few hundred group hashes; HVALS each and pull the id out of every
-# e:"ref" envelope. Base64 inline bodies cannot forge a "r":"<uuid>" match
-# (no quotes/colons in base64), so this never over-counts.
-: > "$REF"
-$R --scan --pattern "${PREFIX}group:*:data" --count "${SCAN_COUNT:-1000}" | while IFS= read -r dk; do
-  $R HVALS "$dk"
-done | grep -oE '"r":"[0-9a-f-]{36}"' | sed 's/.*"r":"//; s/"$//' | sort -u > "$REF"
+hashes_tmp=$(mktemp); hvals_tmp=$(mktemp); blobs_tmp=$(mktemp)
+ttls_tmp=$(mktemp); sum_tmp=$(mktemp); slice_tmp=$(mktemp); unlink_tmp=$(mktemp)
+trap 'rm -f "$hashes_tmp" "$hvals_tmp" "$blobs_tmp" "$ttls_tmp" "$sum_tmp" "$slice_tmp" "$unlink_tmp"' EXIT
+
+# ── 1. Referenced blob ids (FAIL CLOSED) ────────────────────────────────────
+# A partial reference set would misclassify live blobs as orphans, so any
+# SCAN/HVALS failure aborts before anything is deleted. Collected via files (not
+# a pipe) so a mid-stream failure exits the whole script, not just a subshell.
+if ! $R --scan --pattern "${PREFIX}group:*:data" --count "${SCAN_COUNT:-1000}" > "$hashes_tmp"; then
+  echo "FATAL: SCAN of data hashes failed — aborting (fail closed)" >&2; exit 1
+fi
+: > "$hvals_tmp"
+while IFS= read -r dk; do
+  if ! $R HVALS "$dk" >> "$hvals_tmp"; then
+    echo "FATAL: HVALS failed for ${dk} — reference set incomplete, aborting (fail closed)" >&2; exit 1
+  fi
+done < "$hashes_tmp"
+# Base64 inline bodies cannot forge a "r":"<uuid>" match (no quotes/colons in
+# base64), so this never over-counts.
+grep -oE '"r":"[0-9a-f-]{36}"' "$hvals_tmp" | sed 's/.*"r":"//; s/"$//' | sort -u > "$REF"
 ref_count=$(wc -l < "$REF" | tr -d ' ')
 
 # ── 2. Discover orphans (unreferenced AND aged) ─────────────────────────────
-# Bulk-fetch every blob key + TTL in two pipelined passes, then classify
-# locally against the referenced set — per-key round-trips would be 100K+.
-blobs_tmp=$(mktemp); ttls_tmp=$(mktemp); sum_tmp=$(mktemp)
-trap 'rm -f "$blobs_tmp" "$ttls_tmp" "$sum_tmp"' EXIT
-$R --scan --pattern "${PREFIX}blob:*" --count "${SCAN_COUNT:-1000}" > "$blobs_tmp"
+if ! $R --scan --pattern "${PREFIX}blob:*" --count "${SCAN_COUNT:-1000}" > "$blobs_tmp"; then
+  echo "FATAL: SCAN of blob keys failed — aborting" >&2; exit 1
+fi
 total=$(wc -l < "$blobs_tmp" | tr -d ' ')
 # Fetch every blob's TTL in chunks via EVAL — per-key TTL round-trips would be
 # 100K+ (≈hours over a WAN). Keys go in ARGV with numkeys=0: blob keys share the
@@ -83,7 +104,13 @@ total=$(wc -l < "$blobs_tmp" | tr -d ' ')
 : > "$ttls_tmp"
 if [ "$total" -gt 0 ]; then
   TTL_LUA='local r={} for i=1,#ARGV do r[i]=redis.call("ttl",ARGV[i]) end return r'
-  xargs -n "${CHUNK:-2000}" $R EVAL "$TTL_LUA" 0 < "$blobs_tmp" > "$ttls_tmp"
+  if ! xargs -n "${CHUNK:-2000}" $R EVAL "$TTL_LUA" 0 < "$blobs_tmp" > "$ttls_tmp"; then
+    echo "FATAL: TTL fetch failed — aborting" >&2; exit 1
+  fi
+  ttl_lines=$(wc -l < "$ttls_tmp" | tr -d ' ')
+  if [ "$ttl_lines" -ne "$total" ]; then
+    echo "FATAL: TTL count ${ttl_lines} != blob count ${total} (alignment broken) — aborting" >&2; exit 1
+  fi
 fi
 
 paste "$blobs_tmp" "$ttls_tmp" | awk -F'\t' \
@@ -93,7 +120,7 @@ paste "$blobs_tmp" "$ttls_tmp" | awk -F'\t' \
     key = $1; ttl = $2 + 0
     id = substr(key, length(pfx) + 1)
     if (id in ref)             { referenced++; next }   # live staged job — keep
-    if (ttl <= 0 || ttl >= cutoff) { young++;  next }   # in-flight / too young — keep
+    if (ttl <= 0 || ttl >= cutoff) { young++;  next }   # recent / in-flight — keep
     orphans++; print key                                # unreferenced + aged — reclaim
   }
   END { printf "referenced=%d young_skipped=%d orphans=%d\n", referenced, young, orphans > sumf }
@@ -102,14 +129,13 @@ paste "$blobs_tmp" "$ttls_tmp" | awk -F'\t' \
 . "$sum_tmp" 2>/dev/null || true
 referenced="${referenced:-0}"; young_skipped="${young_skipped:-0}"; orphans="${orphans:-0}"
 
-# Estimate freed memory from a sample of up to 200 orphans.
+# Estimate freed memory from a sample of up to 200 orphans (best-effort).
 est_bytes=0
 if [ "$orphans" -gt 0 ]; then
   avg=$(head -200 "$OUT" | while IFS= read -r k; do $R MEMORY USAGE "$k"; done \
         | awk '{s+=$1; n++} END {if (n) printf "%d", s/n; else print 0}')
   est_bytes=$(( avg * orphans ))
 fi
-
 est_mb=$(( est_bytes / 1024 / 1024 ))
 echo "total_blobs=${total} referenced_kept=${ref_count} (live=${referenced}) young_kept=${young_skipped} orphans_to_reclaim=${orphans} est_freed=${est_mb}MB"
 
@@ -124,30 +150,61 @@ if [ "$APPLY" != "1" ]; then
   echo "DISCOVER only — nothing mutated."
   echo "plan: reclaim ${orphans} orphan(s) in ${chunks} chunk(s) of ${FREE_CHUNK} (~${per_chunk_mb}MB/chunk, ${SLEEP}s pause between)"
   echo "list: ${OUT} (first 3):"; head -3 "$OUT" || true
-  echo "to free: APPLY=1 [FREE_CHUNK=N] [SLEEP=N] [LIMIT=N] ... (LIMIT caps this run for incremental freeing)"
+  echo "to free: APPLY=1 [FORCE=1] [FREE_CHUNK=N] [SLEEP=N] [LIMIT=N] ... (FORCE=1 to run on a live system; LIMIT caps this run)"
   exit 0
 fi
 
 # ── 3. Apply: progressive chunked reclaim with memory reporting ──────────────
 [ "$orphans" -eq 0 ] && { echo "nothing to reclaim"; exit 0; }
+
+# Fail closed on a suspiciously empty reference set — a silent ref-build miss
+# would otherwise classify every live blob as an orphan.
+if [ "$ref_count" -eq 0 ] && [ "${ALLOW_EMPTY_REF:-0}" != "1" ]; then
+  echo "FATAL: reference set is empty — refusing to APPLY (set ALLOW_EMPTY_REF=1 only if the queue truly has no blob-backed staged jobs)" >&2; exit 1
+fi
+
+# Quiescence guard: a blob dispatched DURING the sweep is unreferenced but a
+# worker is about to read it (see header). Refuse while groups are processing
+# unless FORCE=1 (a hit is recoverable via event replay, but make it explicit).
+active=$($R --scan --pattern "${PREFIX}group:*:active" --count "${SCAN_COUNT:-1000}" | wc -l | tr -d ' ')
+if [ "$active" -gt 0 ] && [ "${FORCE:-0}" != "1" ]; then
+  echo "FATAL: ${active} group(s) currently processing — an in-flight blob could be hit." >&2
+  echo "  Quiesce first: pause the queues and wait for ${PREFIX}group:*:active to reach 0, then APPLY." >&2
+  echo "  Or set FORCE=1 to proceed now (a hit is recoverable via event replay)." >&2
+  exit 1
+fi
+[ "$active" -gt 0 ] && echo "WARNING: FORCE=1 with ${active} active group(s) — any in-flight blob hit will replay from ClickHouse"
+
 to_reclaim="$orphans"
 if [ -n "$LIMIT" ] && [ "$LIMIT" -lt "$to_reclaim" ]; then to_reclaim="$LIMIT"; fi
 mem0=$($R INFO memory | awk -F: '/^used_memory:/{print $2+0}')
 echo "reclaiming ${to_reclaim}/${orphans} in chunks of ${FREE_CHUNK} (UNLINK batch ${BATCH}); used_memory=$(( mem0/1024/1024 ))MB"
 
-done_n=0
+done_n=0; reclaimed=0; unlink_fail=0
 while [ "$done_n" -lt "$to_reclaim" ]; do
   start=$(( done_n + 1 )); end=$(( done_n + FREE_CHUNK ))
   [ "$end" -gt "$to_reclaim" ] && end="$to_reclaim"
-  # UNLINK this slice (non-blocking; async free). Tolerate a transient blip.
+  sed -n "${start},${end}p" "$OUT" > "$slice_tmp"
+  # UNLINK (non-blocking; async free). Capture xargs status separately from the
+  # reply sum so a real command error is tracked, not masked.
   set +e
-  sed -n "${start},${end}p" "$OUT" | xargs -n "$BATCH" $R UNLINK >/dev/null 2>&1
+  xargs -n "$BATCH" $R UNLINK < "$slice_tmp" > "$unlink_tmp" 2>/dev/null
+  xs=$?
   set -e
+  [ "$xs" -ne 0 ] && unlink_fail=$(( unlink_fail + 1 ))
+  chunk_removed=$(awk '{s+=$1} END {print s+0}' "$unlink_tmp")
+  reclaimed=$(( reclaimed + chunk_removed ))
   done_n="$end"
   memn=$($R INFO memory | awk -F: '/^used_memory:/{print $2+0}')
-  echo "  reclaimed=${done_n}/${to_reclaim} used_memory=$(( memn/1024/1024 ))MB freed_so_far=$(( (mem0-memn)/1024/1024 ))MB"
+  echo "  attempted=${done_n}/${to_reclaim} keys_removed=${reclaimed} used_memory=$(( memn/1024/1024 ))MB freed_so_far=$(( (mem0-memn)/1024/1024 ))MB"
   [ "$done_n" -lt "$to_reclaim" ] && [ "$SLEEP" -gt 0 ] && sleep "$SLEEP"
 done
 
 remaining=$($R --scan --pattern "${PREFIX}blob:*" --count "${SCAN_COUNT:-1000}" | wc -l | tr -d ' ')
-echo "DONE reclaimed=${done_n} remaining_blobs=${remaining} used_memory=$(( $($R INFO memory | awk -F: '/^used_memory:/{print $2+0}')/1024/1024 ))MB"
+mem_final=$($R INFO memory | awk -F: '/^used_memory:/{print $2+0}')
+echo "DONE attempted=${done_n} keys_removed=${reclaimed} unlink_cmd_failures=${unlink_fail} remaining_blobs=${remaining} used_memory=$(( mem_final/1024/1024 ))MB"
+if [ "$unlink_fail" -gt 0 ]; then
+  echo "WARN: ${unlink_fail} UNLINK batch(es) errored — re-run to retry the remainder" >&2
+  exit 1
+fi
+exit 0

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.integration.test.ts
@@ -419,7 +419,13 @@ describe.skipIf(!hasTestcontainers)(
             () => {
               expect(processed).toHaveBeenCalledTimes(3);
             },
-            { timeout: 10000, interval: 50 },
+            // Dispatch-latency waits use 20s, not 10s. Each same-group / delayed
+            // job needs its own dispatch cycle, and a wake-signal missed under
+            // load falls back to the 5s BRPOP poll (signalTimeoutSec) — a couple
+            // of misses on a saturated CI shard blow a 10s budget. The job lands
+            // in well under a second locally; the ceiling only absorbs shard
+            // contention. Matches the 20s re-stage test below.
+            { timeout: 20000, interval: 50 },
           );
 
           // Max concurrency within the same group must be 1
@@ -481,7 +487,7 @@ describe.skipIf(!hasTestcontainers)(
             () => {
               expect(processed).toHaveBeenCalledTimes(2);
             },
-            { timeout: 10000, interval: 50 },
+            { timeout: 20000, interval: 50 },
           );
         });
       });
@@ -516,7 +522,7 @@ describe.skipIf(!hasTestcontainers)(
             () => {
               expect(processed).toHaveBeenCalledTimes(1);
             },
-            { timeout: 10000, interval: 50 },
+            { timeout: 20000, interval: 50 },
           );
 
           const receivedPayload = processed.mock.calls[0]![0];
@@ -566,7 +572,7 @@ describe.skipIf(!hasTestcontainers)(
             () => {
               expect(processed).toHaveBeenCalledTimes(2);
             },
-            { timeout: 10000, interval: 50 },
+            { timeout: 20000, interval: 50 },
           );
 
           // Different groups should have been processed concurrently
@@ -609,7 +615,7 @@ describe.skipIf(!hasTestcontainers)(
               const total = batches.reduce((n, b) => n + b.length, 0) + singles.length;
               expect(total).toBe(10);
             },
-            { timeout: 10000, interval: 50 },
+            { timeout: 20000, interval: 50 },
           );
 
           // Coalescing actually happened: at least one multi-event batch.
@@ -640,7 +646,7 @@ describe.skipIf(!hasTestcontainers)(
             () => {
               expect(largest.length).toBe(5);
             },
-            { timeout: 10000, interval: 50 },
+            { timeout: 20000, interval: 50 },
           );
           expect(largest.map((p) => Number(p.value))).toEqual([0, 1, 2, 3, 4]);
         });
@@ -672,7 +678,7 @@ describe.skipIf(!hasTestcontainers)(
               const total = batches.reduce((n, b) => n + b.length, 0) + singles.length;
               expect(total).toBe(9);
             },
-            { timeout: 10000, interval: 50 },
+            { timeout: 20000, interval: 50 },
           );
 
           for (const batch of batches) {
@@ -710,7 +716,7 @@ describe.skipIf(!hasTestcontainers)(
             () => {
               expect(singles.length).toBe(5);
             },
-            { timeout: 10000, interval: 50 },
+            { timeout: 20000, interval: 50 },
           );
           expect(batches.length).toBe(0);
         });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -42,7 +42,14 @@ describe("jobEnvelope", () => {
     };
 
     beforeEach(() => {
-      vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", undefined);
+      // Set "false" rather than unset: under the vmThreads pool process.env is
+      // shared and aggressively recycled, and vi.stubEnv(key, undefined) clears
+      // it via the metaEnv proxy's *delete* path (no deleteProperty trap — it
+      // only works by defaulting through to process.env), which races the
+      // outer "true" stub. Writing a value goes through the proxy set trap,
+      // which reliably forwards. Any non-"true" value exercises the same
+      // envelopeWritesEnabled() === false branch.
+      vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "false");
     });
 
     describe("when encoding", () => {


### PR DESCRIPTION
## Why

#4758 stops **new** GroupQueue offload-blob orphans (a dedup squash now reclaims the displaced value's blob). But the **existing** pool from the 2026-06-11 capacity incident (#4757) — **~231K orphaned `gq:blob:*` keys / ~5.7 GB** — still sits on its 7-day TTL. Waiting it out keeps Redis near the `noeviction` ceiling for days; this tool reclaims it on demand.

Sibling to `scripts/ops/reap-stranded-group-keys.sh`, same conventions (POSIX sh, DRY-RUN by default, age floor, runs co-located with Redis or over TLS).

## What it does

`DISCOVER` (default, read-only) builds the live reference set, classifies every blob, and prints the count + a chunk plan. `APPLY=1` frees **progressively in chunks**, reporting `used_memory` after each chunk so memory drains in visible steps rather than one large sweep.

A blob is reclaimed only when it is **both**:
- **Unreferenced** — no live `{prefix}group:*:data` envelope carries its id in `"r"`. Protects every staged job (normal, paused, retry-backoff — all re-staged into the data hash).
- **Aged > `MIN_AGE_HOURS`** (default 2h, derived from remaining TTL) — protects in-flight jobs whose value left the data hash at dispatch but whose blob a worker is about to read. The processing window is bounded by the active-key TTL (~300s), so a multi-hour floor cannot hit a live blob.

Canonical span data lives in ClickHouse and a missing blob is replay-recoverable (decode throws → slot completed → replay), so the age guard is belt-and-suspenders, not a correctness requirement.

```sh
# discover (read-only): how many, how much, chunk plan
H=<host> REDISCLI_AUTH=<pw> sh scripts/ops/reclaim-orphaned-blobs.sh
# reclaim progressively, watching used_memory drop per chunk
H=<host> REDISCLI_AUTH=<pw> APPLY=1 FREE_CHUNK=10000 sh scripts/ops/reclaim-orphaned-blobs.sh
# incremental: cap one run, re-run to continue
H=<host> REDISCLI_AUTH=<pw> APPLY=1 LIMIT=10000 sh scripts/ops/reclaim-orphaned-blobs.sh
```

Performance: TTLs are fetched via chunked `EVAL` (ARGV, single-slot replication group) and `SCAN ... COUNT 1000`, so a full 300K-key pass runs in well under a minute even over a WAN, not the hours a per-key loop would take.

## Test plan

- [x] **Local (throwaway redis)**: referenced / young / aged classification correct; DRY-RUN mutates nothing; APPLY reclaims only aged orphans and keeps referenced + young; multi-chunk EVAL line-alignment; progressive chunk stepping; `LIMIT` caps a run.
- [x] **Prod DRY-RUN (read-only)**: 303,707 blobs → 231,196 reclaimable (~5.7 GB), 70,204 young held back, 2,308 referenced kept. Nothing mutated.

## Out of scope

The young-held-back pool (last ~2h of pre-deploy leak) ages past the floor and is reclaimed by a second run a few hours later — which also doubles as confirmation that #4758 stopped new orphans (the total should shift young→old, not grow).

Refs #4757, #4759


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a production ops tool to discover and reclaim leaked/unreferenced blob objects. Includes a safe discovery (dry-run) mode that lists candidates and estimates recoverable memory, plus a guarded apply mode that reclaims in chunks with safety checks, optional throttling, progress reporting, and final summary.
* **Tests**
  * Made a unit-test change to reliably simulate disabled envelope writes to prevent intermittent failures.
  * Increased several integration-test timeouts to reduce flakiness around queue dispatch and coordination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->