### PR TITLE
fix(cli): stale ingestion-key cache never invalidated after platform revoke

### DIFF
--- a/langwatch/ee/governance/services/ingestionKey.service.ts
+++ b/langwatch/ee/governance/services/ingestionKey.service.ts
@@ -163,6 +163,7 @@ export class IngestionKeyService {
     {
       apiKeyId: string;
       sourceType: string;
+      lookupId: string;
       ingestionTemplateId: string | null;
     }[]
   > {
@@ -183,6 +184,7 @@ export class IngestionKeyService {
       .map((k) => ({
         apiKeyId: k.id,
         sourceType: k.ingestSourceType,
+        lookupId: k.lookupId,
         ingestionTemplateId: k.ingestionTemplateId,
       }));
   }

--- a/langwatch/src/server/routes/__tests__/auth-cli-governance.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-governance.integration.test.ts
@@ -35,6 +35,7 @@ import { createTestApp } from "~/server/app-layer/presets";
 
 import { app } from "../auth-cli";
 import { IngestionKeyService } from "@ee/governance/services/ingestionKey.service";
+import { PersonalWorkspaceService } from "@ee/governance/services/personalWorkspace.service";
 
 // Phase 4b-6 added a 402 license gate on every /api/auth/cli/governance/*
 // route. This test pins read-and-tenancy behavior, not license behavior, so
@@ -472,6 +473,13 @@ describe("GET /api/auth/cli/governance/*", () => {
         60 * 60,
       );
 
+      // The mint path resolves the caller's personal workspace and refuses to
+      // allocate one — create it first, as a real login would.
+      await new PersonalWorkspaceService(prisma).ensure({
+        userId: INGEST_KEY_USER,
+        organizationId: INGEST_KEY_ORG,
+      });
+
       // Mint a live key via the service so we can verify it appears in the list
       const service = IngestionKeyService.create(prisma);
       const result = await service.ensureForPersonalProject({
@@ -504,13 +512,27 @@ describe("GET /api/auth/cli/governance/*", () => {
       if (redisConnection) {
         await redisConnection.del(`lwcli:access:${INGEST_KEY_TOKEN}`);
       }
+      // RoleBindings reference ApiKeys (required relation), so they go first.
+      await prisma.roleBinding.deleteMany({
+        where: { organizationId: INGEST_KEY_ORG },
+      });
       await prisma.apiKey.deleteMany({
         where: { organizationId: INGEST_KEY_ORG },
       });
       await prisma.organizationUser.deleteMany({
         where: { organizationId: INGEST_KEY_ORG },
       });
-      await prisma.roleBinding.deleteMany({
+      await prisma.project.deleteMany({
+        where: { team: { organizationId: INGEST_KEY_ORG } },
+      });
+      await prisma.teamUser.deleteMany({
+        where: { team: { organizationId: INGEST_KEY_ORG } },
+      });
+      await prisma.team.deleteMany({
+        where: { organizationId: INGEST_KEY_ORG },
+      });
+      // Ingest-key mints allocate a CUSTOM role per key.
+      await prisma.customRole.deleteMany({
         where: { organizationId: INGEST_KEY_ORG },
       });
       await prisma.user.deleteMany({ where: { id: INGEST_KEY_USER } });

--- a/langwatch/src/server/routes/__tests__/auth-cli-governance.integration.test.ts
+++ b/langwatch/src/server/routes/__tests__/auth-cli-governance.integration.test.ts
@@ -34,6 +34,7 @@ import { globalForApp, resetApp } from "~/server/app-layer/app";
 import { createTestApp } from "~/server/app-layer/presets";
 
 import { app } from "../auth-cli";
+import { IngestionKeyService } from "@ee/governance/services/ingestionKey.service";
 
 // Phase 4b-6 added a 402 license gate on every /api/auth/cli/governance/*
 // route. This test pins read-and-tenancy behavior, not license behavior, so
@@ -413,6 +414,159 @@ describe("GET /api/auth/cli/governance/*", () => {
         expect(typeof body.health.events7d).toBe("number");
         expect(typeof body.health.events30d).toBe("number");
         // lastSuccessIso is `string | null` — both acceptable.
+      });
+    });
+  });
+
+  // ── GET /governance/ingestion-keys ─────────────────────────────────────────
+  // Issue #4755: revoking an ingestion key on the platform must be reflected by
+  // the new list endpoint so the CLI can detect stale cache entries and re-mint.
+  // The endpoint returns snake_case { keys: [{ source_type, lookup_id,
+  // ingestion_template_id }] }. Revoked keys must NOT appear. lookupId must be
+  // included so the CLI can match against the cached token prefix.
+  describe("GET /governance/ingestion-keys", () => {
+    const INGEST_KEY_USER = `usr-cli-ik-${suffix}`;
+    const INGEST_KEY_ORG = `org-cli-ik-${suffix}`;
+    const INGEST_KEY_TOKEN = `lw_at_${"k".repeat(43)}-${suffix}`;
+    let ingestionKeyLookupId: string | undefined;
+    let revokedKeyLookupId: string | undefined;
+
+    beforeAll(async () => {
+      await prisma.organization.create({
+        data: {
+          id: INGEST_KEY_ORG,
+          name: `IK Org ${suffix}`,
+          slug: `ik-org-${suffix}`,
+        },
+      });
+      await prisma.user.create({
+        data: {
+          id: INGEST_KEY_USER,
+          email: `ik-user-${suffix}@example.com`,
+          name: "IK Tester",
+        },
+      });
+      await prisma.organizationUser.create({
+        data: { organizationId: INGEST_KEY_ORG, userId: INGEST_KEY_USER, role: "ADMIN" },
+      });
+      await prisma.roleBinding.create({
+        data: {
+          organizationId: INGEST_KEY_ORG,
+          userId: INGEST_KEY_USER,
+          role: "ADMIN",
+          scopeType: "ORGANIZATION",
+          scopeId: INGEST_KEY_ORG,
+        },
+      });
+
+      if (!redisConnection) throw new Error("Redis unavailable");
+      await redisConnection.set(
+        `lwcli:access:${INGEST_KEY_TOKEN}`,
+        JSON.stringify({
+          user_id: INGEST_KEY_USER,
+          organization_id: INGEST_KEY_ORG,
+          issued_at: Date.now(),
+          expires_at: Date.now() + 60 * 60 * 1000,
+        }),
+        "EX",
+        60 * 60,
+      );
+
+      // Mint a live key via the service so we can verify it appears in the list
+      const service = IngestionKeyService.create(prisma);
+      const result = await service.ensureForPersonalProject({
+        userId: INGEST_KEY_USER,
+        organizationId: INGEST_KEY_ORG,
+        sourceType: "codex",
+        createdByDeviceLabel: null,
+      });
+      ingestionKeyLookupId = result.token.split("_")[0]?.replace("ik-lw-", "");
+
+      // Mint a second key then revoke it immediately — it must not appear
+      const revokedResult = await service.ensureForPersonalProject({
+        userId: INGEST_KEY_USER,
+        organizationId: INGEST_KEY_ORG,
+        sourceType: "claude_code",
+        createdByDeviceLabel: null,
+      });
+      revokedKeyLookupId = revokedResult.token.split("_")[0]?.replace("ik-lw-", "");
+      // Revoke by setting revokedAt directly to avoid needing full admin context
+      await prisma.apiKey.updateMany({
+        where: {
+          id: revokedResult.apiKeyId,
+          organizationId: INGEST_KEY_ORG,
+        },
+        data: { revokedAt: new Date() },
+      });
+    });
+
+    afterAll(async () => {
+      if (redisConnection) {
+        await redisConnection.del(`lwcli:access:${INGEST_KEY_TOKEN}`);
+      }
+      await prisma.apiKey.deleteMany({
+        where: { organizationId: INGEST_KEY_ORG },
+      });
+      await prisma.organizationUser.deleteMany({
+        where: { organizationId: INGEST_KEY_ORG },
+      });
+      await prisma.roleBinding.deleteMany({
+        where: { organizationId: INGEST_KEY_ORG },
+      });
+      await prisma.user.deleteMany({ where: { id: INGEST_KEY_USER } });
+      await prisma.organization.deleteMany({ where: { id: INGEST_KEY_ORG } });
+    });
+
+    describe("when called with a valid Bearer token", () => {
+      it("returns 200 with keys array containing only live (non-revoked) entries", async () => {
+        const res = await app.request(
+          "/api/auth/cli/governance/ingestion-keys",
+          {
+            method: "GET",
+            headers: { Authorization: `Bearer ${INGEST_KEY_TOKEN}` },
+          },
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          keys: Array<{
+            source_type: string;
+            lookup_id: string;
+            ingestion_template_id: string | null;
+          }>;
+        };
+        expect(Array.isArray(body.keys)).toBe(true);
+        const sourceTypes = body.keys.map((k) => k.source_type);
+        expect(sourceTypes).toContain("codex");
+        // Revoked claude_code key must NOT appear
+        expect(sourceTypes).not.toContain("claude_code");
+      });
+
+      it("includes lookup_id so the CLI can detect stale cached tokens", async () => {
+        const res = await app.request(
+          "/api/auth/cli/governance/ingestion-keys",
+          {
+            method: "GET",
+            headers: { Authorization: `Bearer ${INGEST_KEY_TOKEN}` },
+          },
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          keys: Array<{ source_type: string; lookup_id: string }>;
+        };
+        const codexEntry = body.keys.find((k) => k.source_type === "codex");
+        expect(codexEntry).toBeDefined();
+        expect(typeof codexEntry!.lookup_id).toBe("string");
+        expect(codexEntry!.lookup_id.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe("when called without a Bearer token", () => {
+      it("returns 401", async () => {
+        const res = await app.request(
+          "/api/auth/cli/governance/ingestion-keys",
+          { method: "GET" },
+        );
+        expect(res.status).toBe(401);
       });
     });
   });

--- a/langwatch/src/server/routes/auth-cli.ts
+++ b/langwatch/src/server/routes/auth-cli.ts
@@ -1365,6 +1365,56 @@ secured.access(CLI_POLICY).post(
 );
 
 // ---------------------------------------------------------------------------
+// GET /api/auth/cli/governance/ingestion-keys
+// ---------------------------------------------------------------------------
+// Returns all live (non-revoked) personal-project ingestion keys for the
+// caller's org. The CLI uses this as a cache-liveness preflight (#4755) —
+// revoking a key on the platform silently bricks Path B telemetry because
+// the wrapper reuses a locally cached token forever. By calling this list
+// before reusing a cached key, the wrapper can detect the revocation and
+// re-mint rather than repeatedly sending unauthenticated spans.
+//
+// Response: { keys: [{ source_type, lookup_id, ingestion_template_id }] }
+//
+// lookup_id is the 16-char identifier embedded in the token prefix
+// (`ik-lw-{lookupId}_…`) so the CLI can match the cached token against a
+// live server entry without possessing the full secret.
+// ---------------------------------------------------------------------------
+secured.access(CLI_POLICY).get(
+  "/governance/ingestion-keys",
+  async (c: Context) => {
+    const tokenRecord = await validateAccessToken(
+      c.req.header("Authorization"),
+    );
+    if (!tokenRecord) {
+      return c.json(
+        {
+          error: "unauthorized",
+          error_description:
+            "Bearer access token is missing, malformed, or expired",
+        },
+        401,
+      );
+    }
+    const service = IngestionKeyService.create(prisma);
+    const keys = await service.listForPersonalProject({
+      userId: tokenRecord.user_id,
+      organizationId: tokenRecord.organization_id,
+    });
+    return c.json(
+      {
+        keys: keys.map((k) => ({
+          source_type: k.sourceType,
+          lookup_id: k.lookupId,
+          ingestion_template_id: k.ingestionTemplateId,
+        })),
+      },
+      200,
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
 // GET /api/auth/cli/lookup?user_code=XXXX-YYYY
 // ---------------------------------------------------------------------------
 // Used by the browser-side approval page to surface the device-code

--- a/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
@@ -16,7 +16,7 @@
  */
 import {
   afterEach,
-  beforeEach,
+
   describe,
   expect,
   it,
@@ -277,7 +277,7 @@ describe("runUnifiedLoginFlow", () => {
         (configMod.loadConfig as ReturnType<typeof vi.fn>).mockReturnValue(cfg);
 
         // Suppress console output during test
-        vi.spyOn(console, "log").mockImplementation(() => {});
+        vi.spyOn(console, "log").mockImplementation(() => undefined);
 
         await loginFlow.runUnifiedLoginFlow({ kind: "device_session", cfg });
 
@@ -296,10 +296,10 @@ describe("runUnifiedLoginFlow", () => {
 
         expect(reconcileSave).toBeDefined();
         expect(
-          reconcileSave!.default_personal_ingest_keys!["codex"],
+          reconcileSave!.default_personal_ingest_keys!.codex,
         ).toBeDefined();
         expect(
-          reconcileSave!.default_personal_ingest_keys!["claude_code"],
+          reconcileSave!.default_personal_ingest_keys!.claude_code,
         ).toBeUndefined();
       });
 
@@ -345,7 +345,7 @@ describe("runUnifiedLoginFlow", () => {
 
         (configMod.loadConfig as ReturnType<typeof vi.fn>).mockReturnValue(cfg);
 
-        vi.spyOn(console, "log").mockImplementation(() => {});
+        vi.spyOn(console, "log").mockImplementation(() => undefined);
 
         await loginFlow.runUnifiedLoginFlow({ kind: "device_session", cfg });
 
@@ -359,7 +359,7 @@ describe("runUnifiedLoginFlow", () => {
           (c) => c.default_personal_ingest_keys !== undefined,
         );
         for (const saved of keySaves) {
-          expect(saved.default_personal_ingest_keys!["codex"]).toBeDefined();
+          expect(saved.default_personal_ingest_keys!.codex).toBeDefined();
         }
       });
 
@@ -406,7 +406,7 @@ describe("runUnifiedLoginFlow", () => {
 
         (configMod.loadConfig as ReturnType<typeof vi.fn>).mockReturnValue(cfg);
 
-        vi.spyOn(console, "log").mockImplementation(() => {});
+        vi.spyOn(console, "log").mockImplementation(() => undefined);
 
         // Must not throw even when listIngestionKeys fails
         await expect(

--- a/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
@@ -55,7 +55,7 @@ function baseCfg(overrides: Partial<GovernanceConfig> = {}): GovernanceConfig {
     gateway_url: "http://gw.example.com",
     control_plane_url: "http://app.example.com",
     access_token: "tok",
-    user: { id: "u1", email: "u@example.com" },
+    user: { id: "u1", email: "u@example.com", name: "U" },
     organization: { id: "o1", slug: "acme" },
     ...overrides,
   };
@@ -258,10 +258,10 @@ describe("runUnifiedLoginFlow", () => {
           kind: "device_session",
           access_token: "tok-new",
           refresh_token: "rtok",
-          expires_at: 9999999999,
-          user: { id: "u1", email: "u@example.com" },
+          expires_in: 3600,
+          user: { id: "u1", email: "u@example.com", name: "U" },
           organization: { id: "o1", slug: "acme", name: "Acme" },
-          personal_vk: undefined,
+          default_personal_vk: undefined,
         });
 
         // listIngestionKeys returns only the live key
@@ -329,10 +329,10 @@ describe("runUnifiedLoginFlow", () => {
           kind: "device_session",
           access_token: "tok-new",
           refresh_token: "rtok",
-          expires_at: 9999999999,
-          user: { id: "u1", email: "u@example.com" },
+          expires_in: 3600,
+          user: { id: "u1", email: "u@example.com", name: "U" },
           organization: { id: "o1", slug: "acme", name: "Acme" },
-          personal_vk: undefined,
+          default_personal_vk: undefined,
         });
 
         (cliApi.listIngestionKeys as ReturnType<typeof vi.fn>).mockResolvedValue(
@@ -389,10 +389,10 @@ describe("runUnifiedLoginFlow", () => {
           kind: "device_session",
           access_token: "tok-new",
           refresh_token: "rtok",
-          expires_at: 9999999999,
-          user: { id: "u1", email: "u@example.com" },
+          expires_in: 3600,
+          user: { id: "u1", email: "u@example.com", name: "U" },
           organization: { id: "o1", slug: "acme", name: "Acme" },
-          personal_vk: undefined,
+          default_personal_vk: undefined,
         });
 
         // Network is down during reconcile

--- a/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
@@ -14,18 +14,14 @@
  *      default_personal_ingest_keys — drop entries whose lookupId is not
  *      in the live list, keep ones that are.
  */
-import {
-  afterEach,
-
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as cliApi from "../cli-api";
 import * as configMod from "../config";
 import type { GovernanceConfig } from "../config";
+import * as deviceFlow from "../device-flow";
+import { runUnifiedLoginFlow } from "../login-flow";
+import { resolveWrapperMode } from "../wrapper-mode";
 
 // ─── Module mocks ────────────────────────────────────────────────────────────
 
@@ -85,7 +81,6 @@ describe("resolveWrapperMode", () => {
   describe("given a cached ingest key", () => {
     describe("when the key is no longer live on the platform", () => {
       it("mints a fresh key, uses the new token, and persists it over the stale cache entry", async () => {
-        const { resolveWrapperMode } = await import("../wrapper-mode.js");
 
         const staleLookupId = "aabbccdd11223344";
         const staleToken = makeToken({ lookupId: staleLookupId });
@@ -135,7 +130,6 @@ describe("resolveWrapperMode", () => {
       });
 
       it("mints a fresh key when the server returns a different lookupId for that sourceType", async () => {
-        const { resolveWrapperMode } = await import("../wrapper-mode.js");
 
         const cachedLookupId = "aabbccdd11223344";
         const liveLookupId = "zzzzzzzz99999999"; // different — the old one was revoked
@@ -167,7 +161,6 @@ describe("resolveWrapperMode", () => {
 
     describe("when the key is still live on the platform (lookupId matches)", () => {
       it("reuses the cached token and does NOT call mintIngestionKey", async () => {
-        const { resolveWrapperMode } = await import("../wrapper-mode.js");
 
         const lookupId = "aabbccdd11223344";
         const cachedToken = makeToken({ lookupId });
@@ -194,7 +187,6 @@ describe("resolveWrapperMode", () => {
 
     describe("when listIngestionKeys rejects (network error / older server)", () => {
       it("falls back to the cached token without minting (offline fallback)", async () => {
-        const { resolveWrapperMode } = await import("../wrapper-mode.js");
 
         const lookupId = "aabbccdd11223344";
         const cachedToken = makeToken({ lookupId });
@@ -228,8 +220,6 @@ describe("runUnifiedLoginFlow", () => {
       it("removes stale entries whose lookupId is absent from the live list", async () => {
         // We exercise the real login-flow code path with all external
         // dependencies mocked at module boundaries.
-        const deviceFlow = await import("../device-flow.js");
-        const loginFlow = await import("../login-flow.js");
 
         const liveLookupId = "live0000live0000";
         const staleLookupId = "dead0000dead0000";
@@ -279,7 +269,7 @@ describe("runUnifiedLoginFlow", () => {
         // Suppress console output during test
         vi.spyOn(console, "log").mockImplementation(() => undefined);
 
-        await loginFlow.runUnifiedLoginFlow({ kind: "device_session", cfg });
+        await runUnifiedLoginFlow({ kind: "device_session", cfg });
 
         // saveConfig must have been called with claude_code removed (stale)
         // and codex retained (live)
@@ -304,8 +294,6 @@ describe("runUnifiedLoginFlow", () => {
       });
 
       it("keeps live entries that are still valid on the platform", async () => {
-        const deviceFlow = await import("../device-flow.js");
-        const loginFlow = await import("../login-flow.js");
 
         const liveLookupId = "live0000live0000";
         const liveToken = makeToken({ lookupId: liveLookupId });
@@ -347,7 +335,7 @@ describe("runUnifiedLoginFlow", () => {
 
         vi.spyOn(console, "log").mockImplementation(() => undefined);
 
-        await loginFlow.runUnifiedLoginFlow({ kind: "device_session", cfg });
+        await runUnifiedLoginFlow({ kind: "device_session", cfg });
 
         const savedCfgs: GovernanceConfig[] = (
           configMod.saveConfig as ReturnType<typeof vi.fn>
@@ -364,8 +352,6 @@ describe("runUnifiedLoginFlow", () => {
       });
 
       it("silently ignores errors from listIngestionKeys during reconcile", async () => {
-        const deviceFlow = await import("../device-flow.js");
-        const loginFlow = await import("../login-flow.js");
 
         const lookupId = "live0000live0000";
         const token = makeToken({ lookupId });
@@ -410,7 +396,7 @@ describe("runUnifiedLoginFlow", () => {
 
         // Must not throw even when listIngestionKeys fails
         await expect(
-          loginFlow.runUnifiedLoginFlow({ kind: "device_session", cfg }),
+          runUnifiedLoginFlow({ kind: "device_session", cfg }),
         ).resolves.toBeDefined();
       });
     });

--- a/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Regression tests for issue #4755: revoking an ingestion key on the
+ * platform silently bricks CLI Path B telemetry because the wrapper
+ * reuses a locally cached key forever.
+ *
+ * Contract under test:
+ *   1. wrapper-mode: before reusing a cached key, call listIngestionKeys;
+ *      derive the cached token's lookupId (format `ik-lw-{16-char lookupId}_{secret}`);
+ *      if the server list resolves and the lookupId is not found for that
+ *      sourceType → mint a fresh key and persist it.
+ *   2. wrapper-mode: if listIngestionKeys rejects → reuse the cache as-is
+ *      (offline fallback).
+ *   3. login-flow: after a successful device_session login, reconcile
+ *      default_personal_ingest_keys — drop entries whose lookupId is not
+ *      in the live list, keep ones that are.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import * as cliApi from "../cli-api";
+import * as configMod from "../config";
+import type { GovernanceConfig } from "../config";
+
+// ─── Module mocks ────────────────────────────────────────────────────────────
+
+vi.mock("../cli-api", async () => {
+  const actual = await vi.importActual<typeof cliApi>("../cli-api");
+  return {
+    ...actual,
+    mintIngestionKey: vi.fn(),
+    listIngestionKeys: vi.fn(),
+    getCliBootstrap: vi.fn(),
+  };
+});
+
+vi.mock("../config", async () => {
+  const actual = await vi.importActual<typeof configMod>("../config");
+  return {
+    ...actual,
+    saveConfig: vi.fn(),
+    loadConfig: vi.fn(),
+  };
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function baseCfg(overrides: Partial<GovernanceConfig> = {}): GovernanceConfig {
+  return {
+    gateway_url: "http://gw.example.com",
+    control_plane_url: "http://app.example.com",
+    access_token: "tok",
+    user: { id: "u1", email: "u@example.com" },
+    organization: { id: "o1", slug: "acme" },
+    ...overrides,
+  };
+}
+
+/**
+ * Construct a realistic cached ingestion token from a lookupId.
+ * Format: `ik-lw-{16-char lookupId}_{secret}`
+ */
+function makeToken({
+  lookupId,
+  secret = "realsecret0000000000000000000000",
+}: {
+  lookupId: string;
+  secret?: string;
+}): string {
+  return `ik-lw-${lookupId}_${secret}`;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── wrapper-mode: stale cache detection ─────────────────────────────────────
+
+describe("resolveWrapperMode", () => {
+  describe("given a cached ingest key", () => {
+    describe("when the key is no longer live on the platform", () => {
+      it("mints a fresh key, uses the new token, and persists it over the stale cache entry", async () => {
+        const { resolveWrapperMode } = await import("../wrapper-mode.js");
+
+        const staleLookupId = "aabbccdd11223344";
+        const staleToken = makeToken({ lookupId: staleLookupId });
+
+        const cfg = baseCfg({
+          default_personal_ingest_keys: {
+            codex: { secret: staleToken, prefix: "ik-lw-aabb" },
+          },
+        });
+
+        // Server returns an empty list — no live key for this sourceType
+        (cliApi.listIngestionKeys as ReturnType<typeof vi.fn>).mockResolvedValue(
+          [],
+        );
+
+        (cliApi.mintIngestionKey as ReturnType<typeof vi.fn>).mockResolvedValue({
+          token: "ik-lw-newlookupid0000_freshsecret000000000000000",
+          prefix: "ik-lw-newl",
+          endpoint: "http://app.example.com/api/otel",
+        });
+
+        const out = await resolveWrapperMode(cfg, "codex", {});
+
+        // Fresh key is used for OTEL transport
+        expect(out.mode).toBe("ingestion");
+        expect(out.vars.OTEL_EXPORTER_OTLP_HEADERS).toContain(
+          "ik-lw-newlookupid0000_freshsecret000000000000000",
+        );
+        expect(out.vars.OTEL_EXPORTER_OTLP_HEADERS).not.toContain(staleToken);
+
+        // A fresh mint was triggered
+        expect(cliApi.mintIngestionKey).toHaveBeenCalledWith(
+          expect.any(Object),
+          "codex",
+        );
+
+        // The new key was persisted, overwriting the stale cache entry
+        expect(configMod.saveConfig).toHaveBeenCalledWith(
+          expect.objectContaining({
+            default_personal_ingest_keys: expect.objectContaining({
+              codex: expect.objectContaining({
+                secret: "ik-lw-newlookupid0000_freshsecret000000000000000",
+              }),
+            }),
+          }),
+        );
+      });
+
+      it("mints a fresh key when the server returns a different lookupId for that sourceType", async () => {
+        const { resolveWrapperMode } = await import("../wrapper-mode.js");
+
+        const cachedLookupId = "aabbccdd11223344";
+        const liveLookupId = "zzzzzzzz99999999"; // different — the old one was revoked
+        const staleToken = makeToken({ lookupId: cachedLookupId });
+
+        const cfg = baseCfg({
+          default_personal_ingest_keys: {
+            codex: { secret: staleToken, prefix: "ik-lw-aabb" },
+          },
+        });
+
+        (cliApi.listIngestionKeys as ReturnType<typeof vi.fn>).mockResolvedValue(
+          [{ sourceType: "codex", lookupId: liveLookupId }],
+        );
+
+        (cliApi.mintIngestionKey as ReturnType<typeof vi.fn>).mockResolvedValue({
+          token: makeToken({ lookupId: liveLookupId, secret: "freshsecret000000000000000000000" }),
+          prefix: "ik-lw-zzzz",
+          endpoint: "http://app.example.com/api/otel",
+        });
+
+        const out = await resolveWrapperMode(cfg, "codex", {});
+
+        expect(out.mode).toBe("ingestion");
+        expect(cliApi.mintIngestionKey).toHaveBeenCalled();
+        expect(out.vars.OTEL_EXPORTER_OTLP_HEADERS).not.toContain(staleToken);
+      });
+    });
+
+    describe("when the key is still live on the platform (lookupId matches)", () => {
+      it("reuses the cached token and does NOT call mintIngestionKey", async () => {
+        const { resolveWrapperMode } = await import("../wrapper-mode.js");
+
+        const lookupId = "aabbccdd11223344";
+        const cachedToken = makeToken({ lookupId });
+
+        const cfg = baseCfg({
+          default_personal_ingest_keys: {
+            codex: { secret: cachedToken, prefix: "ik-lw-aabb" },
+          },
+        });
+
+        // Server confirms the same lookupId is still live
+        (cliApi.listIngestionKeys as ReturnType<typeof vi.fn>).mockResolvedValue(
+          [{ sourceType: "codex", lookupId }],
+        );
+
+        const out = await resolveWrapperMode(cfg, "codex", {});
+
+        expect(out.mode).toBe("ingestion");
+        expect(out.newKeyMinted).toBe(false);
+        expect(out.vars.OTEL_EXPORTER_OTLP_HEADERS).toContain(cachedToken);
+        expect(cliApi.mintIngestionKey).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when listIngestionKeys rejects (network error / older server)", () => {
+      it("falls back to the cached token without minting (offline fallback)", async () => {
+        const { resolveWrapperMode } = await import("../wrapper-mode.js");
+
+        const lookupId = "aabbccdd11223344";
+        const cachedToken = makeToken({ lookupId });
+
+        const cfg = baseCfg({
+          default_personal_ingest_keys: {
+            codex: { secret: cachedToken, prefix: "ik-lw-aabb" },
+          },
+        });
+
+        (cliApi.listIngestionKeys as ReturnType<typeof vi.fn>).mockRejectedValue(
+          new Error("fetch failed"),
+        );
+
+        const out = await resolveWrapperMode(cfg, "codex", {});
+
+        expect(out.mode).toBe("ingestion");
+        expect(out.newKeyMinted).toBe(false);
+        expect(out.vars.OTEL_EXPORTER_OTLP_HEADERS).toContain(cachedToken);
+        expect(cliApi.mintIngestionKey).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+// ─── login-flow: stale cache reconciliation ───────────────────────────────────
+
+describe("runUnifiedLoginFlow", () => {
+  describe("given default_personal_ingest_keys in the config after a successful device_session login", () => {
+    describe("when some cached keys are no longer live on the platform", () => {
+      it("removes stale entries whose lookupId is absent from the live list", async () => {
+        // We exercise the real login-flow code path with all external
+        // dependencies mocked at module boundaries.
+        const deviceFlow = await import("../device-flow.js");
+        const loginFlow = await import("../login-flow.js");
+
+        const liveLookupId = "live0000live0000";
+        const staleLookupId = "dead0000dead0000";
+
+        const liveToken = makeToken({ lookupId: liveLookupId });
+        const staleToken = makeToken({ lookupId: staleLookupId });
+
+        const cfg = baseCfg({
+          default_personal_ingest_keys: {
+            codex: { secret: liveToken, prefix: "ik-lw-live" },
+            claude_code: { secret: staleToken, prefix: "ik-lw-dead" },
+          },
+        });
+
+        // Mock device-flow layer
+        vi.spyOn(deviceFlow, "startDeviceCode").mockResolvedValue({
+          device_code: "dc",
+          user_code: "USER-CODE",
+          verification_uri: "http://app.example.com/device",
+          verification_uri_complete: "http://app.example.com/device?code=USER-CODE",
+          expires_in: 300,
+          interval: 5,
+        });
+
+        vi.spyOn(deviceFlow, "pollUntilDone").mockResolvedValue({
+          kind: "device_session",
+          access_token: "tok-new",
+          refresh_token: "rtok",
+          expires_at: 9999999999,
+          user: { id: "u1", email: "u@example.com" },
+          organization: { id: "o1", slug: "acme", name: "Acme" },
+          personal_vk: undefined,
+        });
+
+        // listIngestionKeys returns only the live key
+        (cliApi.listIngestionKeys as ReturnType<typeof vi.fn>).mockResolvedValue(
+          [{ sourceType: "codex", lookupId: liveLookupId }],
+        );
+
+        // getCliBootstrap returns minimal shape (no gatewayUrl / toolPolicies)
+        (cliApi.getCliBootstrap as ReturnType<typeof vi.fn>).mockResolvedValue(
+          null,
+        );
+
+        (configMod.loadConfig as ReturnType<typeof vi.fn>).mockReturnValue(cfg);
+
+        // Suppress console output during test
+        vi.spyOn(console, "log").mockImplementation(() => {});
+
+        await loginFlow.runUnifiedLoginFlow({ kind: "device_session", cfg });
+
+        // saveConfig must have been called with claude_code removed (stale)
+        // and codex retained (live)
+        const savedCfgs: GovernanceConfig[] = (
+          configMod.saveConfig as ReturnType<typeof vi.fn>
+        ).mock.calls.map((call: unknown[]) => call[0] as GovernanceConfig);
+
+        // Find the reconcile save — it's the one that drops claude_code
+        const reconcileSave = savedCfgs.find(
+          (c) =>
+            c.default_personal_ingest_keys !== undefined &&
+            !("claude_code" in (c.default_personal_ingest_keys ?? {})),
+        );
+
+        expect(reconcileSave).toBeDefined();
+        expect(
+          reconcileSave!.default_personal_ingest_keys!["codex"],
+        ).toBeDefined();
+        expect(
+          reconcileSave!.default_personal_ingest_keys!["claude_code"],
+        ).toBeUndefined();
+      });
+
+      it("keeps live entries that are still valid on the platform", async () => {
+        const deviceFlow = await import("../device-flow.js");
+        const loginFlow = await import("../login-flow.js");
+
+        const liveLookupId = "live0000live0000";
+        const liveToken = makeToken({ lookupId: liveLookupId });
+
+        const cfg = baseCfg({
+          default_personal_ingest_keys: {
+            codex: { secret: liveToken, prefix: "ik-lw-live" },
+          },
+        });
+
+        vi.spyOn(deviceFlow, "startDeviceCode").mockResolvedValue({
+          device_code: "dc",
+          user_code: "USER-CODE",
+          verification_uri: "http://app.example.com/device",
+          verification_uri_complete: "http://app.example.com/device?code=USER-CODE",
+          expires_in: 300,
+          interval: 5,
+        });
+
+        vi.spyOn(deviceFlow, "pollUntilDone").mockResolvedValue({
+          kind: "device_session",
+          access_token: "tok-new",
+          refresh_token: "rtok",
+          expires_at: 9999999999,
+          user: { id: "u1", email: "u@example.com" },
+          organization: { id: "o1", slug: "acme", name: "Acme" },
+          personal_vk: undefined,
+        });
+
+        (cliApi.listIngestionKeys as ReturnType<typeof vi.fn>).mockResolvedValue(
+          [{ sourceType: "codex", lookupId: liveLookupId }],
+        );
+
+        (cliApi.getCliBootstrap as ReturnType<typeof vi.fn>).mockResolvedValue(
+          null,
+        );
+
+        (configMod.loadConfig as ReturnType<typeof vi.fn>).mockReturnValue(cfg);
+
+        vi.spyOn(console, "log").mockImplementation(() => {});
+
+        await loginFlow.runUnifiedLoginFlow({ kind: "device_session", cfg });
+
+        const savedCfgs: GovernanceConfig[] = (
+          configMod.saveConfig as ReturnType<typeof vi.fn>
+        ).mock.calls.map((call: unknown[]) => call[0] as GovernanceConfig);
+
+        // The live codex entry must be present in every save that touches
+        // default_personal_ingest_keys
+        const keySaves = savedCfgs.filter(
+          (c) => c.default_personal_ingest_keys !== undefined,
+        );
+        for (const saved of keySaves) {
+          expect(saved.default_personal_ingest_keys!["codex"]).toBeDefined();
+        }
+      });
+
+      it("silently ignores errors from listIngestionKeys during reconcile", async () => {
+        const deviceFlow = await import("../device-flow.js");
+        const loginFlow = await import("../login-flow.js");
+
+        const lookupId = "live0000live0000";
+        const token = makeToken({ lookupId });
+
+        const cfg = baseCfg({
+          default_personal_ingest_keys: {
+            codex: { secret: token, prefix: "ik-lw-live" },
+          },
+        });
+
+        vi.spyOn(deviceFlow, "startDeviceCode").mockResolvedValue({
+          device_code: "dc",
+          user_code: "USER-CODE",
+          verification_uri: "http://app.example.com/device",
+          verification_uri_complete: "http://app.example.com/device?code=USER-CODE",
+          expires_in: 300,
+          interval: 5,
+        });
+
+        vi.spyOn(deviceFlow, "pollUntilDone").mockResolvedValue({
+          kind: "device_session",
+          access_token: "tok-new",
+          refresh_token: "rtok",
+          expires_at: 9999999999,
+          user: { id: "u1", email: "u@example.com" },
+          organization: { id: "o1", slug: "acme", name: "Acme" },
+          personal_vk: undefined,
+        });
+
+        // Network is down during reconcile
+        (cliApi.listIngestionKeys as ReturnType<typeof vi.fn>).mockRejectedValue(
+          new Error("fetch failed"),
+        );
+
+        (cliApi.getCliBootstrap as ReturnType<typeof vi.fn>).mockResolvedValue(
+          null,
+        );
+
+        (configMod.loadConfig as ReturnType<typeof vi.fn>).mockReturnValue(cfg);
+
+        vi.spyOn(console, "log").mockImplementation(() => {});
+
+        // Must not throw even when listIngestionKeys fails
+        await expect(
+          loginFlow.runUnifiedLoginFlow({ kind: "device_session", cfg }),
+        ).resolves.toBeDefined();
+      });
+    });
+  });
+});

--- a/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
+++ b/typescript-sdk/src/cli/utils/governance/__tests__/stale-ingest-key-cache.unit.test.ts
@@ -25,6 +25,11 @@ import { resolveWrapperMode } from "../wrapper-mode";
 
 // ─── Module mocks ────────────────────────────────────────────────────────────
 
+// runUnifiedLoginFlow opens the device-approval URL in a real browser via the
+// `open` package. Stub it so the login-flow tests don't hijack the developer's
+// browser on every run.
+vi.mock("open", () => ({ default: vi.fn() }));
+
 vi.mock("../cli-api", async () => {
   const actual = await vi.importActual<typeof cliApi>("../cli-api");
   return {

--- a/typescript-sdk/src/cli/utils/governance/cli-api.ts
+++ b/typescript-sdk/src/cli/utils/governance/cli-api.ts
@@ -416,6 +416,33 @@ export async function mintIngestionKey(
   );
 }
 
+// Ingestion key listing -------------------------------------------------------
+
+/**
+ * Lists all live (non-revoked) personal-project ingestion keys for the
+ * caller's org. Used as a cache-liveness preflight (#4755): before reusing a
+ * locally cached token, the wrapper calls this to confirm the key is still
+ * active. If the server resolves and the cached lookupId is absent → the key
+ * was revoked → mint fresh. If the call rejects (offline / older server) →
+ * reuse the cache as-is (offline-first fallback).
+ */
+export async function listIngestionKeys(
+  cfg: GovernanceConfig,
+  options: CliApiOptions = {},
+): Promise<{ sourceType: string; lookupId: string }[]> {
+  const body = await requestREST<{
+    keys: Array<{
+      source_type: string;
+      lookup_id: string;
+      ingestion_template_id: string | null;
+    }>;
+  }>(cfg, "GET", "/api/auth/cli/governance/ingestion-keys", options);
+  return body.keys.map((k) => ({
+    sourceType: k.source_type,
+    lookupId: k.lookup_id,
+  }));
+}
+
 // IngestionTemplate verbs ----------------------------------------------------
 
 export async function adminListIngestionTemplates(

--- a/typescript-sdk/src/cli/utils/governance/cli-api.ts
+++ b/typescript-sdk/src/cli/utils/governance/cli-api.ts
@@ -416,6 +416,18 @@ export async function mintIngestionKey(
   );
 }
 
+
+/**
+ * Extracts the 16-char lookupId from an ingestion token.
+ * Token format: `ik-lw-{16-char lookupId}_{secret}`.
+ * Returns the lookupId string, or undefined when the token doesn't match the
+ * expected format (older token shapes, malformed cache entries).
+ */
+export function extractLookupIdFromToken(token: string): string | undefined {
+  const match = /^ik-lw-([^_]+)_/.exec(token);
+  return match?.[1];
+}
+
 // Ingestion key listing -------------------------------------------------------
 
 /**

--- a/typescript-sdk/src/cli/utils/governance/login-flow.ts
+++ b/typescript-sdk/src/cli/utils/governance/login-flow.ts
@@ -32,7 +32,7 @@ import {
 } from "./device-flow";
 import { loadConfig, saveConfig, type GovernanceConfig } from "./config";
 import { formatLoginCeremony } from "./login-ceremony";
-import { getCliBootstrap, type CliBootstrapResponse } from "./cli-api";
+import { getCliBootstrap, listIngestionKeys, type CliBootstrapResponse } from "./cli-api";
 
 export interface RunUnifiedLoginOptions {
   /** Credential type to mint. Defaults to 'device_session' for back-compat. */
@@ -127,6 +127,36 @@ export async function runUnifiedLoginFlow(
       if (bootstrap?.toolPolicies) {
         cfg.tool_policies = bootstrap.toolPolicies;
         saveConfig(cfg);
+      }
+
+      // Reconcile cached ingestion keys (#4755): after a fresh login, drop
+      // any locally cached entries whose token was revoked on the platform.
+      // Errors are swallowed — a login must never fail on reconcile; the
+      // worst outcome is a stale cache entry that the per-invocation wrapper
+      // check will catch anyway.
+      if (cfg.default_personal_ingest_keys && Object.keys(cfg.default_personal_ingest_keys).length > 0) {
+        try {
+          const liveKeys = await listIngestionKeys(cfg);
+          const liveSet = new Set(liveKeys.map((k) => `${k.sourceType}:${k.lookupId}`));
+          const reconciled: GovernanceConfig["default_personal_ingest_keys"] = {};
+          let changed = false;
+          for (const [sourceType, entry] of Object.entries(cfg.default_personal_ingest_keys)) {
+            const tokenMatch = /^ik-lw-([^_]+)_/.exec(entry.secret ?? "");
+            const lookupId = tokenMatch?.[1];
+            if (lookupId && liveSet.has(`${sourceType}:${lookupId}`)) {
+              reconciled[sourceType] = entry;
+            } else {
+              // Entry is stale (revoked or lookupId missing) — omit from reconciled
+              changed = true;
+            }
+          }
+          if (changed) {
+            cfg.default_personal_ingest_keys = reconciled;
+            saveConfig(cfg);
+          }
+        } catch {
+          // Network error / older server: keep existing cache untouched
+        }
       }
 
       console.log();

--- a/typescript-sdk/src/cli/utils/governance/login-flow.ts
+++ b/typescript-sdk/src/cli/utils/governance/login-flow.ts
@@ -32,7 +32,12 @@ import {
 } from "./device-flow";
 import { loadConfig, saveConfig, type GovernanceConfig } from "./config";
 import { formatLoginCeremony } from "./login-ceremony";
-import { getCliBootstrap, listIngestionKeys, type CliBootstrapResponse } from "./cli-api";
+import {
+  extractLookupIdFromToken,
+  getCliBootstrap,
+  listIngestionKeys,
+  type CliBootstrapResponse,
+} from "./cli-api";
 
 export interface RunUnifiedLoginOptions {
   /** Credential type to mint. Defaults to 'device_session' for back-compat. */
@@ -141,8 +146,7 @@ export async function runUnifiedLoginFlow(
           const reconciled: GovernanceConfig["default_personal_ingest_keys"] = {};
           let changed = false;
           for (const [sourceType, entry] of Object.entries(cfg.default_personal_ingest_keys)) {
-            const tokenMatch = /^ik-lw-([^_]+)_/.exec(entry.secret ?? "");
-            const lookupId = tokenMatch?.[1];
+            const lookupId = extractLookupIdFromToken(entry.secret ?? "");
             if (lookupId && liveSet.has(`${sourceType}:${lookupId}`)) {
               reconciled[sourceType] = entry;
             } else {

--- a/typescript-sdk/src/cli/utils/governance/wrapper-mode.ts
+++ b/typescript-sdk/src/cli/utils/governance/wrapper-mode.ts
@@ -33,21 +33,14 @@ import { setOpencodeOpenTelemetryFlag } from "@/cli/utils/opencode-config-flag";
 import { lwTag } from "./brand";
 import type { GovernanceConfig } from "./config";
 import { saveConfig } from "./config";
-import { GovernanceCliError, listIngestionKeys, mintIngestionKey } from "./cli-api";
+import {
+  extractLookupIdFromToken,
+  GovernanceCliError,
+  listIngestionKeys,
+  mintIngestionKey,
+} from "./cli-api";
 import { warnIfGeminiOAuthSelected } from "./gemini-settings-preflight";
 import { resolvePlatformToolPolicy } from "./platform-tool-policy";
-
-/**
- * Extracts the 16-char lookupId from an ingestion token.
- * Token format: `ik-lw-{16-char lookupId}_{secret}`.
- * Returns the lookupId string, or undefined when the token doesn't match the
- * expected format (older token shapes, malformed cache entries).
- */
-function extractLookupIdFromToken(token: string): string | undefined {
-  // `ik-lw-` prefix + lookupId (up to first `_`)
-  const match = /^ik-lw-([^_]+)_/.exec(token);
-  return match?.[1];
-}
 
 export type WrapperMode = "gateway" | "ingestion";
 

--- a/typescript-sdk/src/cli/utils/governance/wrapper-mode.ts
+++ b/typescript-sdk/src/cli/utils/governance/wrapper-mode.ts
@@ -33,9 +33,21 @@ import { setOpencodeOpenTelemetryFlag } from "@/cli/utils/opencode-config-flag";
 import { lwTag } from "./brand";
 import type { GovernanceConfig } from "./config";
 import { saveConfig } from "./config";
-import { GovernanceCliError, mintIngestionKey } from "./cli-api";
+import { GovernanceCliError, listIngestionKeys, mintIngestionKey } from "./cli-api";
 import { warnIfGeminiOAuthSelected } from "./gemini-settings-preflight";
 import { resolvePlatformToolPolicy } from "./platform-tool-policy";
+
+/**
+ * Extracts the 16-char lookupId from an ingestion token.
+ * Token format: `ik-lw-{16-char lookupId}_{secret}`.
+ * Returns the lookupId string, or undefined when the token doesn't match the
+ * expected format (older token shapes, malformed cache entries).
+ */
+function extractLookupIdFromToken(token: string): string | undefined {
+  // `ik-lw-` prefix + lookupId (up to first `_`)
+  const match = /^ik-lw-([^_]+)_/.exec(token);
+  return match?.[1];
+}
 
 export type WrapperMode = "gateway" | "ingestion";
 
@@ -238,16 +250,50 @@ export async function resolveWrapperMode(
   // present; otherwise mint a fresh one. The mint route returns the
   // plaintext key once, so we persist it to the per-tool cache below
   // and read it back on subsequent invocations rather than re-minting.
+  //
+  // Stale-cache check (#4755): before reusing a cached key, confirm it is
+  // still live on the platform. Token format: `ik-lw-{16-char lookupId}_{secret}`.
+  // If the server resolves and the lookupId is absent → the key was revoked
+  // (hard-cut rotation also invalidates the cache) → mint fresh and overwrite.
+  // If the request rejects (offline / older server without this endpoint) →
+  // offline-first fallback: reuse the cache so air-gapped / degraded environments
+  // still work.
   const cached = cfg.default_personal_ingest_keys?.[sourceType];
   let token: string;
   let prefix: string | undefined;
   let endpoint: string;
   let minted: boolean;
   if (cached?.secret) {
-    token = cached.secret;
-    prefix = cached.prefix;
-    endpoint = `${cfg.control_plane_url.replace(/\/+$/, "")}/api/otel`;
-    minted = false;
+    const cachedLookupId = extractLookupIdFromToken(cached.secret);
+    let cacheIsLive = true; // assume live; falsified when server confirms otherwise
+    try {
+      const liveKeys = await listIngestionKeys(cfg);
+      // Server resolved — verify the cached lookupId is still present for this sourceType
+      const liveEntry = liveKeys.find(
+        (k) => k.sourceType === sourceType && k.lookupId === cachedLookupId,
+      );
+      if (!liveEntry) {
+        // Key was revoked or rotated on the platform — treat as no cache
+        cacheIsLive = false;
+      }
+    } catch {
+      // Network error / older server without the endpoint: reuse cache as-is
+      // (offline-first fallback — hard-cut rotation is a re-mint-kills-old
+      // invariant, so a genuinely revoked key will self-correct next time the
+      // device is online).
+    }
+    if (cacheIsLive) {
+      token = cached.secret;
+      prefix = cached.prefix;
+      endpoint = `${cfg.control_plane_url.replace(/\/+$/, "")}/api/otel`;
+      minted = false;
+    } else {
+      const r = await mintIngestionKey(cfg, sourceType);
+      token = r.token;
+      prefix = r.prefix;
+      endpoint = r.endpoint;
+      minted = true;
+    }
   } else {
     const r = await mintIngestionKey(cfg, sourceType);
     token = r.token;

--- a/typescript-sdk/src/internal/generated/openapi/api-client.ts
+++ b/typescript-sdk/src/internal/generated/openapi/api-client.ts
@@ -558,7 +558,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/evaluations/v3/runs/{runId}": {
+    "/api/experiments/runs/{runId}": {
         parameters: {
             query?: never;
             header?: never;
@@ -575,7 +575,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/evaluations/v3/{slug}/run": {
+    "/api/experiments/{slug}/run": {
         parameters: {
             query?: never;
             header?: never;
@@ -1207,7 +1207,7 @@ export interface paths {
         put?: never;
         /** @description Create a new scenario event */
         post: operations["postApiScenario-events"];
-        /** @description Delete all events */
+        /** @description Archive the simulation runs for a batch run and/or scenario set. Requires at least one of batchRunId or scenarioSetId — archiving every run in the project in one call is not supported. */
         delete: operations["deleteApiScenario-events"];
         options?: never;
         head?: never;
@@ -1877,6 +1877,167 @@ export interface paths {
         head?: never;
         /** @description Update a workflow's metadata (name, icon, description) */
         patch: operations["patchApiWorkflowsById"];
+        trace?: never;
+    };
+    "/api/model-defaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Snapshot of the default-model cascade for this project: effective resolution per role, plus the configs the caller can read. */
+        get: operations["getApiModel-defaults"];
+        put?: never;
+        /** @description Create a default-model config attached to one or more scopes. JSON keys may be roles (DEFAULT, FAST, EMBEDDINGS) or registered feature keys; missing keys inherit from a higher scope. */
+        post: operations["postApiModel-defaults"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/model-defaults/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** @description Update a config's JSON payload and/or its scope attachments. Sending `scopes: []` deletes the config. */
+        put: operations["putApiModel-defaultsById"];
+        post?: never;
+        /** @description Delete a default-model config. Scope attachments cascade. */
+        delete: operations["deleteApiModel-defaultsById"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/governance/ingestion-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List ingestion templates
+         * @description Returns the union of platform-published default templates and any org-authored templates visible to the caller's organization. Disabled / archived rows are filtered out. `ottl_rules` is empty in this end-user shape; admins use GET /ingestion-templates/admin to read the canonical OTTL.
+         */
+        get: operations["getApiGovernanceIngestion-templates"];
+        put?: never;
+        /**
+         * Create org-authored ingestion template
+         * @description Creates a brand-new template scoped to the caller's organization. Slug is auto-generated. Platform rows (organizationId IS NULL) are NEVER created via this endpoint — admins customize platform defaults via POST /ingestion-templates/clone instead.
+         */
+        post: operations["postApiGovernanceIngestion-templates"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/governance/ingestion-templates/admin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List ingestion templates (admin shape, includes OTTL)
+         * @description Same union as the user list but includes the canonical `ottl_rules` source for every row. Used by admin tooling to render the transparency block / authoring drawer.
+         */
+        get: operations["getApiGovernanceIngestion-templatesAdmin"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/governance/ingestion-templates/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get ingestion template
+         * @description Single-template lookup by id, scoped to the caller's organization. Cross-org probes collapse to 404 (no enumeration vector).
+         */
+        get: operations["getApiGovernanceIngestion-templatesById"];
+        put?: never;
+        post?: never;
+        /**
+         * Soft-archive an org-authored template
+         * @description Marks the row archived; existing ingestion keys continue to land traces but the row disappears from list views. Platform-published rows reject with 403.
+         */
+        delete: operations["deleteApiGovernanceIngestion-templatesById"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/governance/ingestion-templates/{id}/ottl-rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Replace ottl_rules on an org-authored template
+         * @description Audit-logged with line counts pre/post. Platform-published rows reject with 403. Admins must clone a platform row before editing it.
+         */
+        patch: operations["patchApiGovernanceIngestion-templatesByIdOttl-rules"];
+        trace?: never;
+    };
+    "/api/governance/ingestion-templates/clone": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Clone a platform-published template into the caller's org
+         * @description Forks the source row's source_type / display_name / OTTL into a fresh org-authored row that the admin can then edit via PATCH /ingestion-templates/:id/ottl-rules.
+         */
+        post: operations["postApiGovernanceIngestion-templatesClone"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/events/track": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Record a user event (e.g. thumbs up/down, selected text) attached to a trace. Predefined event types validate against their schemas; custom event types pass through `trackEventRESTParamsValidatorSchema`. */
+        post: operations["postApiEventsTrack"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
 }
@@ -3357,7 +3518,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The run ID returned from POST /api/evaluations/v3/{slug}/run */
+                /** @description The run ID returned from POST /api/experiments/{slug}/run */
                 runId: string;
             };
             cookie?: never;
@@ -5123,8 +5284,6 @@ export interface operations {
                             name: string;
                             description: string | null;
                             /** @enum {string} */
-                            environment: "live" | "test";
-                            /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
                             provider_credential_ids: string[];
@@ -5206,8 +5365,6 @@ export interface operations {
                             display_prefix: string;
                             name: string;
                             description: string | null;
-                            /** @enum {string} */
-                            environment: "live" | "test";
                             /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
@@ -5296,8 +5453,6 @@ export interface operations {
                             display_prefix: string;
                             name: string;
                             description: string | null;
-                            /** @enum {string} */
-                            environment: "live" | "test";
                             /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
@@ -5398,8 +5553,6 @@ export interface operations {
                             name: string;
                             description: string | null;
                             /** @enum {string} */
-                            environment: "live" | "test";
-                            /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
                             provider_credential_ids: string[];
@@ -5487,8 +5640,6 @@ export interface operations {
                             name: string;
                             description: string | null;
                             /** @enum {string} */
-                            environment: "live" | "test";
-                            /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
                             provider_credential_ids: string[];
@@ -5572,8 +5723,6 @@ export interface operations {
                             display_prefix: string;
                             name: string;
                             description: string | null;
-                            /** @enum {string} */
-                            environment: "live" | "test";
                             /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
@@ -7358,7 +7507,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        config: {
+                        parameters: {
                             [key: string]: unknown;
                         };
                     }[];
@@ -7459,7 +7608,7 @@ export interface operations {
                     /** @enum {string} */
                     schemaVersion?: "1.0";
                     tags?: string[];
-                    config?: {
+                    parameters?: {
                         [key: string]: unknown;
                     };
                 };
@@ -7560,7 +7709,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        config: {
+                        parameters: {
                             [key: string]: unknown;
                         };
                     };
@@ -8037,7 +8186,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        config: {
+                        parameters: {
                             [key: string]: unknown;
                         };
                     };
@@ -8146,7 +8295,7 @@ export interface operations {
                     /** @enum {string} */
                     schemaVersion?: "1.0";
                     tags?: string[];
-                    config?: {
+                    parameters?: {
                         [key: string]: unknown;
                     };
                     /** @enum {string} */
@@ -8250,7 +8399,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        config: {
+                        parameters: {
                             [key: string]: unknown;
                         };
                     };
@@ -8508,7 +8657,7 @@ export interface operations {
                             } | null;
                         };
                     };
-                    config?: {
+                    parameters?: {
                         [key: string]: unknown;
                     };
                     localVersion?: number;
@@ -8614,7 +8763,7 @@ export interface operations {
                                 versionId: string;
                             }[];
                             /** @default {} */
-                            config: {
+                            parameters: {
                                 [key: string]: unknown;
                             };
                         };
@@ -8961,7 +9110,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        config: {
+                        parameters: {
                             [key: string]: unknown;
                         };
                     }[];
@@ -9135,7 +9284,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        config: {
+                        parameters: {
                             [key: string]: unknown;
                         };
                     };
@@ -9422,6 +9571,14 @@ export interface operations {
                             toolName?: string;
                             toolCallId?: string;
                             result?: unknown;
+                        } | {
+                            /** @constant */
+                            type: "binary";
+                            mimeType: string;
+                            data?: string;
+                            url?: string;
+                            id?: string;
+                            filename?: string;
                         })[] | null;
                         parts?: ({
                             /** @constant */
@@ -9452,6 +9609,14 @@ export interface operations {
                             toolName?: string;
                             toolCallId?: string;
                             result?: unknown;
+                        } | {
+                            /** @constant */
+                            type: "binary";
+                            mimeType: string;
+                            data?: string;
+                            url?: string;
+                            id?: string;
+                            filename?: string;
                         })[];
                         function_call?: {
                             name?: string;
@@ -9623,14 +9788,17 @@ export interface operations {
     };
     "deleteApiScenario-events": {
         parameters: {
-            query?: never;
+            query?: {
+                batchRunId?: string;
+                scenarioSetId?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Events deleted successfully */
+            /** @description Matching runs archived successfully */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -9642,7 +9810,7 @@ export interface operations {
                     };
                 };
             };
-            /** @description Bad Request */
+            /** @description No scope provided — a batchRunId or scenarioSetId is required */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -9650,7 +9818,6 @@ export interface operations {
                 content: {
                     "application/json": {
                         error: string;
-                        message?: string;
                     };
                 };
             };
@@ -12765,6 +12932,1077 @@ export interface operations {
             };
             /** @description Workflow not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getApiModel-defaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        scope: {
+                            projectId: string;
+                            teamId: string | null;
+                            organizationId: string | null;
+                            organizationName: string | null;
+                        };
+                        effective: {
+                            DEFAULT: {
+                                model: string;
+                                source: string;
+                                scope: string | null;
+                            } | null;
+                            FAST: {
+                                model: string;
+                                source: string;
+                                scope: string | null;
+                            } | null;
+                            EMBEDDINGS: {
+                                model: string;
+                                source: string;
+                                scope: string | null;
+                            } | null;
+                        };
+                        configs: {
+                            id: string;
+                            config: {
+                                [key: string]: string;
+                            };
+                            scopes: {
+                                /** @enum {string} */
+                                type: "ORGANIZATION" | "TEAM" | "PROJECT";
+                                id: string;
+                                name: string;
+                            }[];
+                            createdAt: string;
+                            updatedAt: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postApiModel-defaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    config: {
+                        [key: string]: string;
+                    };
+                    scopes: {
+                        /** @enum {string} */
+                        scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+                        scopeId: string;
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "putApiModel-defaultsById": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    config?: {
+                        [key: string]: string;
+                    };
+                    scopes?: {
+                        /** @enum {string} */
+                        scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
+                        scopeId: string;
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description Updated */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "deleteApiModel-defaultsById": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getApiGovernanceIngestion-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Templates visible to the caller */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            id: string;
+                            slug: string;
+                            source_type: string;
+                            display_name: string;
+                            description: string | null;
+                            icon_asset: string | null;
+                            credential_schema: string | null;
+                            ottl_rules: string;
+                            platform_published: boolean;
+                            enabled: boolean;
+                            organization_id: string | null;
+                        }[];
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postApiGovernanceIngestion-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Template created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ingestion_template: {
+                            id: string;
+                            slug: string;
+                            source_type: string;
+                            display_name: string;
+                            description: string | null;
+                            icon_asset: string | null;
+                            credential_schema: string | null;
+                            ottl_rules: string;
+                            platform_published: boolean;
+                            enabled: boolean;
+                            organization_id: string | null;
+                        };
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getApiGovernanceIngestion-templatesAdmin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Admin templates */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            id: string;
+                            slug: string;
+                            source_type: string;
+                            display_name: string;
+                            description: string | null;
+                            icon_asset: string | null;
+                            credential_schema: string | null;
+                            ottl_rules: string;
+                            platform_published: boolean;
+                            enabled: boolean;
+                            organization_id: string | null;
+                        }[];
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "getApiGovernanceIngestion-templatesById": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Template detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ingestion_template: {
+                            id: string;
+                            slug: string;
+                            source_type: string;
+                            display_name: string;
+                            description: string | null;
+                            icon_asset: string | null;
+                            credential_schema: string | null;
+                            ottl_rules: string;
+                            platform_published: boolean;
+                            enabled: boolean;
+                            organization_id: string | null;
+                        };
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "deleteApiGovernanceIngestion-templatesById": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Archived */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        archived: true;
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Platform template immutable */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Template not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "patchApiGovernanceIngestion-templatesByIdOttl-rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ingestion_template: {
+                            id: string;
+                            slug: string;
+                            source_type: string;
+                            display_name: string;
+                            description: string | null;
+                            icon_asset: string | null;
+                            credential_schema: string | null;
+                            ottl_rules: string;
+                            platform_published: boolean;
+                            enabled: boolean;
+                            organization_id: string | null;
+                        };
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Platform template immutable */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Template not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    "postApiGovernanceIngestion-templatesClone": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Cloned */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ingestion_template: {
+                            id: string;
+                            slug: string;
+                            source_type: string;
+                            display_name: string;
+                            description: string | null;
+                            icon_asset: string | null;
+                            credential_schema: string | null;
+                            ottl_rules: string;
+                            platform_published: boolean;
+                            enabled: boolean;
+                            organization_id: string | null;
+                        };
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Source template not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: {
+                            type: string;
+                            code: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+        };
+    };
+    postApiEventsTrack: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Event tracked */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        message: "Event tracked";
+                    };
+                };
+            };
+            /** @description Invalid event payload */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/typescript-sdk/src/internal/generated/openapi/api-client.ts
+++ b/typescript-sdk/src/internal/generated/openapi/api-client.ts
@@ -558,7 +558,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/experiments/runs/{runId}": {
+    "/api/evaluations/v3/runs/{runId}": {
         parameters: {
             query?: never;
             header?: never;
@@ -575,7 +575,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/experiments/{slug}/run": {
+    "/api/evaluations/v3/{slug}/run": {
         parameters: {
             query?: never;
             header?: never;
@@ -1207,7 +1207,7 @@ export interface paths {
         put?: never;
         /** @description Create a new scenario event */
         post: operations["postApiScenario-events"];
-        /** @description Archive the simulation runs for a batch run and/or scenario set. Requires at least one of batchRunId or scenarioSetId — archiving every run in the project in one call is not supported. */
+        /** @description Delete all events */
         delete: operations["deleteApiScenario-events"];
         options?: never;
         head?: never;
@@ -1877,167 +1877,6 @@ export interface paths {
         head?: never;
         /** @description Update a workflow's metadata (name, icon, description) */
         patch: operations["patchApiWorkflowsById"];
-        trace?: never;
-    };
-    "/api/model-defaults": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Snapshot of the default-model cascade for this project: effective resolution per role, plus the configs the caller can read. */
-        get: operations["getApiModel-defaults"];
-        put?: never;
-        /** @description Create a default-model config attached to one or more scopes. JSON keys may be roles (DEFAULT, FAST, EMBEDDINGS) or registered feature keys; missing keys inherit from a higher scope. */
-        post: operations["postApiModel-defaults"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/model-defaults/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /** @description Update a config's JSON payload and/or its scope attachments. Sending `scopes: []` deletes the config. */
-        put: operations["putApiModel-defaultsById"];
-        post?: never;
-        /** @description Delete a default-model config. Scope attachments cascade. */
-        delete: operations["deleteApiModel-defaultsById"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/governance/ingestion-templates": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List ingestion templates
-         * @description Returns the union of platform-published default templates and any org-authored templates visible to the caller's organization. Disabled / archived rows are filtered out. `ottl_rules` is empty in this end-user shape; admins use GET /ingestion-templates/admin to read the canonical OTTL.
-         */
-        get: operations["getApiGovernanceIngestion-templates"];
-        put?: never;
-        /**
-         * Create org-authored ingestion template
-         * @description Creates a brand-new template scoped to the caller's organization. Slug is auto-generated. Platform rows (organizationId IS NULL) are NEVER created via this endpoint — admins customize platform defaults via POST /ingestion-templates/clone instead.
-         */
-        post: operations["postApiGovernanceIngestion-templates"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/governance/ingestion-templates/admin": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List ingestion templates (admin shape, includes OTTL)
-         * @description Same union as the user list but includes the canonical `ottl_rules` source for every row. Used by admin tooling to render the transparency block / authoring drawer.
-         */
-        get: operations["getApiGovernanceIngestion-templatesAdmin"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/governance/ingestion-templates/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get ingestion template
-         * @description Single-template lookup by id, scoped to the caller's organization. Cross-org probes collapse to 404 (no enumeration vector).
-         */
-        get: operations["getApiGovernanceIngestion-templatesById"];
-        put?: never;
-        post?: never;
-        /**
-         * Soft-archive an org-authored template
-         * @description Marks the row archived; existing ingestion keys continue to land traces but the row disappears from list views. Platform-published rows reject with 403.
-         */
-        delete: operations["deleteApiGovernanceIngestion-templatesById"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/governance/ingestion-templates/{id}/ottl-rules": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Replace ottl_rules on an org-authored template
-         * @description Audit-logged with line counts pre/post. Platform-published rows reject with 403. Admins must clone a platform row before editing it.
-         */
-        patch: operations["patchApiGovernanceIngestion-templatesByIdOttl-rules"];
-        trace?: never;
-    };
-    "/api/governance/ingestion-templates/clone": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Clone a platform-published template into the caller's org
-         * @description Forks the source row's source_type / display_name / OTTL into a fresh org-authored row that the admin can then edit via PATCH /ingestion-templates/:id/ottl-rules.
-         */
-        post: operations["postApiGovernanceIngestion-templatesClone"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/events/track": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Record a user event (e.g. thumbs up/down, selected text) attached to a trace. Predefined event types validate against their schemas; custom event types pass through `trackEventRESTParamsValidatorSchema`. */
-        post: operations["postApiEventsTrack"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
 }
@@ -3518,7 +3357,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The run ID returned from POST /api/experiments/{slug}/run */
+                /** @description The run ID returned from POST /api/evaluations/v3/{slug}/run */
                 runId: string;
             };
             cookie?: never;
@@ -5284,6 +5123,8 @@ export interface operations {
                             name: string;
                             description: string | null;
                             /** @enum {string} */
+                            environment: "live" | "test";
+                            /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
                             provider_credential_ids: string[];
@@ -5365,6 +5206,8 @@ export interface operations {
                             display_prefix: string;
                             name: string;
                             description: string | null;
+                            /** @enum {string} */
+                            environment: "live" | "test";
                             /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
@@ -5453,6 +5296,8 @@ export interface operations {
                             display_prefix: string;
                             name: string;
                             description: string | null;
+                            /** @enum {string} */
+                            environment: "live" | "test";
                             /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
@@ -5553,6 +5398,8 @@ export interface operations {
                             name: string;
                             description: string | null;
                             /** @enum {string} */
+                            environment: "live" | "test";
+                            /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
                             provider_credential_ids: string[];
@@ -5640,6 +5487,8 @@ export interface operations {
                             name: string;
                             description: string | null;
                             /** @enum {string} */
+                            environment: "live" | "test";
+                            /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
                             provider_credential_ids: string[];
@@ -5723,6 +5572,8 @@ export interface operations {
                             display_prefix: string;
                             name: string;
                             description: string | null;
+                            /** @enum {string} */
+                            environment: "live" | "test";
                             /** @enum {string} */
                             status: "active" | "revoked";
                             principal_user_id: string | null;
@@ -7507,7 +7358,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        parameters: {
+                        config: {
                             [key: string]: unknown;
                         };
                     }[];
@@ -7608,7 +7459,7 @@ export interface operations {
                     /** @enum {string} */
                     schemaVersion?: "1.0";
                     tags?: string[];
-                    parameters?: {
+                    config?: {
                         [key: string]: unknown;
                     };
                 };
@@ -7709,7 +7560,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        parameters: {
+                        config: {
                             [key: string]: unknown;
                         };
                     };
@@ -8186,7 +8037,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        parameters: {
+                        config: {
                             [key: string]: unknown;
                         };
                     };
@@ -8295,7 +8146,7 @@ export interface operations {
                     /** @enum {string} */
                     schemaVersion?: "1.0";
                     tags?: string[];
-                    parameters?: {
+                    config?: {
                         [key: string]: unknown;
                     };
                     /** @enum {string} */
@@ -8399,7 +8250,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        parameters: {
+                        config: {
                             [key: string]: unknown;
                         };
                     };
@@ -8657,7 +8508,7 @@ export interface operations {
                             } | null;
                         };
                     };
-                    parameters?: {
+                    config?: {
                         [key: string]: unknown;
                     };
                     localVersion?: number;
@@ -8763,7 +8614,7 @@ export interface operations {
                                 versionId: string;
                             }[];
                             /** @default {} */
-                            parameters: {
+                            config: {
                                 [key: string]: unknown;
                             };
                         };
@@ -9110,7 +8961,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        parameters: {
+                        config: {
                             [key: string]: unknown;
                         };
                     }[];
@@ -9284,7 +9135,7 @@ export interface operations {
                             versionId: string;
                         }[];
                         /** @default {} */
-                        parameters: {
+                        config: {
                             [key: string]: unknown;
                         };
                     };
@@ -9571,14 +9422,6 @@ export interface operations {
                             toolName?: string;
                             toolCallId?: string;
                             result?: unknown;
-                        } | {
-                            /** @constant */
-                            type: "binary";
-                            mimeType: string;
-                            data?: string;
-                            url?: string;
-                            id?: string;
-                            filename?: string;
                         })[] | null;
                         parts?: ({
                             /** @constant */
@@ -9609,14 +9452,6 @@ export interface operations {
                             toolName?: string;
                             toolCallId?: string;
                             result?: unknown;
-                        } | {
-                            /** @constant */
-                            type: "binary";
-                            mimeType: string;
-                            data?: string;
-                            url?: string;
-                            id?: string;
-                            filename?: string;
                         })[];
                         function_call?: {
                             name?: string;
@@ -9788,17 +9623,14 @@ export interface operations {
     };
     "deleteApiScenario-events": {
         parameters: {
-            query?: {
-                batchRunId?: string;
-                scenarioSetId?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Matching runs archived successfully */
+            /** @description Events deleted successfully */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -9810,7 +9642,7 @@ export interface operations {
                     };
                 };
             };
-            /** @description No scope provided — a batchRunId or scenarioSetId is required */
+            /** @description Bad Request */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -9818,6 +9650,7 @@ export interface operations {
                 content: {
                     "application/json": {
                         error: string;
+                        message?: string;
                     };
                 };
             };
@@ -12932,1077 +12765,6 @@ export interface operations {
             };
             /** @description Workflow not found */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "getApiModel-defaults": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Success */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        scope: {
-                            projectId: string;
-                            teamId: string | null;
-                            organizationId: string | null;
-                            organizationName: string | null;
-                        };
-                        effective: {
-                            DEFAULT: {
-                                model: string;
-                                source: string;
-                                scope: string | null;
-                            } | null;
-                            FAST: {
-                                model: string;
-                                source: string;
-                                scope: string | null;
-                            } | null;
-                            EMBEDDINGS: {
-                                model: string;
-                                source: string;
-                                scope: string | null;
-                            } | null;
-                        };
-                        configs: {
-                            id: string;
-                            config: {
-                                [key: string]: string;
-                            };
-                            scopes: {
-                                /** @enum {string} */
-                                type: "ORGANIZATION" | "TEAM" | "PROJECT";
-                                id: string;
-                                name: string;
-                            }[];
-                            createdAt: string;
-                            updatedAt: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "postApiModel-defaults": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    config: {
-                        [key: string]: string;
-                    };
-                    scopes: {
-                        /** @enum {string} */
-                        scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
-                        scopeId: string;
-                    }[];
-                };
-            };
-        };
-        responses: {
-            /** @description Success */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "putApiModel-defaultsById": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    config?: {
-                        [key: string]: string;
-                    };
-                    scopes?: {
-                        /** @enum {string} */
-                        scopeType: "ORGANIZATION" | "TEAM" | "PROJECT";
-                        scopeId: string;
-                    }[];
-                };
-            };
-        };
-        responses: {
-            /** @description Updated */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "deleteApiModel-defaultsById": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "getApiGovernanceIngestion-templates": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Templates visible to the caller */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data: {
-                            id: string;
-                            slug: string;
-                            source_type: string;
-                            display_name: string;
-                            description: string | null;
-                            icon_asset: string | null;
-                            credential_schema: string | null;
-                            ottl_rules: string;
-                            platform_published: boolean;
-                            enabled: boolean;
-                            organization_id: string | null;
-                        }[];
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "postApiGovernanceIngestion-templates": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Template created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        ingestion_template: {
-                            id: string;
-                            slug: string;
-                            source_type: string;
-                            display_name: string;
-                            description: string | null;
-                            icon_asset: string | null;
-                            credential_schema: string | null;
-                            ottl_rules: string;
-                            platform_published: boolean;
-                            enabled: boolean;
-                            organization_id: string | null;
-                        };
-                    };
-                };
-            };
-            /** @description Validation error */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: {
-                            type: string;
-                            code: string;
-                            message: string;
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "getApiGovernanceIngestion-templatesAdmin": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Admin templates */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data: {
-                            id: string;
-                            slug: string;
-                            source_type: string;
-                            display_name: string;
-                            description: string | null;
-                            icon_asset: string | null;
-                            credential_schema: string | null;
-                            ottl_rules: string;
-                            platform_published: boolean;
-                            enabled: boolean;
-                            organization_id: string | null;
-                        }[];
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "getApiGovernanceIngestion-templatesById": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Template detail */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        ingestion_template: {
-                            id: string;
-                            slug: string;
-                            source_type: string;
-                            display_name: string;
-                            description: string | null;
-                            icon_asset: string | null;
-                            credential_schema: string | null;
-                            ottl_rules: string;
-                            platform_published: boolean;
-                            enabled: boolean;
-                            organization_id: string | null;
-                        };
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: {
-                            type: string;
-                            code: string;
-                            message: string;
-                        };
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "deleteApiGovernanceIngestion-templatesById": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Archived */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        archived: true;
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Platform template immutable */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: {
-                            type: string;
-                            code: string;
-                            message: string;
-                        };
-                    };
-                };
-            };
-            /** @description Template not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: {
-                            type: string;
-                            code: string;
-                            message: string;
-                        };
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "patchApiGovernanceIngestion-templatesByIdOttl-rules": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        ingestion_template: {
-                            id: string;
-                            slug: string;
-                            source_type: string;
-                            display_name: string;
-                            description: string | null;
-                            icon_asset: string | null;
-                            credential_schema: string | null;
-                            ottl_rules: string;
-                            platform_published: boolean;
-                            enabled: boolean;
-                            organization_id: string | null;
-                        };
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Platform template immutable */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: {
-                            type: string;
-                            code: string;
-                            message: string;
-                        };
-                    };
-                };
-            };
-            /** @description Template not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: {
-                            type: string;
-                            code: string;
-                            message: string;
-                        };
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    "postApiGovernanceIngestion-templatesClone": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Cloned */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        ingestion_template: {
-                            id: string;
-                            slug: string;
-                            source_type: string;
-                            display_name: string;
-                            description: string | null;
-                            icon_asset: string | null;
-                            credential_schema: string | null;
-                            ottl_rules: string;
-                            platform_published: boolean;
-                            enabled: boolean;
-                            organization_id: string | null;
-                        };
-                    };
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Source template not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: {
-                            type: string;
-                            code: string;
-                            message: string;
-                        };
-                    };
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-        };
-    };
-    postApiEventsTrack: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Event tracked */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @constant */
-                        message: "Event tracked";
-                    };
-                };
-            };
-            /** @description Invalid event payload */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Fixes #4755

## Problem

Revoking an ingestion key on `/settings/api-keys` silently bricks `langwatch <tool>` Path B telemetry forever on the affected device. The wrapper reuses `default_personal_ingest_keys[sourceType]` from `~/.langwatch/config.json` whenever present, with no liveness validation — and nothing (including `langwatch login`) ever invalidates that cache. Every OTLP batch is then rejected with 401 server-side, invisibly: the tool's exporter eats the errors, and `markUsed` only fires on successful auth so even `lastUsedAt` stops moving.

Server-side behavior was verified correct (revoked keys 401 at `api-key.service.ts` → `otel.ts`); this is purely a client-side stale-cache bug, plus the missing server surface to check liveness.

## Fix

- **Server**: new `GET /api/auth/cli/governance/ingestion-keys` (auth-cli) returning the caller's live personal-project ingestion keys as `{ source_type, lookup_id, ingestion_template_id }`. `IngestionKeyService.listForPersonalProject` now exposes `lookupId` (already on the repo row). Only `revokedAt: null` keys are returned.
- **Wrapper preflight** (`wrapper-mode.ts`): before reusing a cached key, derive its lookupId from the token (`ik-lw-{lookupId}_{secret}`) and check it against the live list. Stale/missing → mint fresh (hard-cut rotation) and overwrite the cache. The liveness call failing (offline, older server) falls back to the cached key — offline-first, no behavior change for air-gapped runs.
- **Login reconcile** (`login-flow.ts`): after a successful device-session login, prune cached entries whose lookupId is no longer live. Best-effort; login never fails on reconcile errors.

## Tests

- `typescript-sdk .../stale-ingest-key-cache.unit.test.ts` (7): re-mint on revoked (empty list / lookupId mismatch), reuse on live match, offline fallback, login reconcile prune/keep/error-swallow — all executing the real wrapper/login code paths (TDD: committed red first).
- `langwatch .../auth-cli-governance.integration.test.ts` (+3): live keys returned with `lookup_id`, revoked keys excluded, 401 without bearer. Also fixed the new block's teardown FK ordering.

## Verification

- `typescript-sdk`: 221/221 governance CLI tests, `tsc --noEmit` clean
- `langwatch`: 29/29 auth-cli-governance integration tests, `pnpm typecheck` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST endpoint to list live personal ingestion keys; each key now includes a stable lookup identifier.
  * CLI adds helpers to extract lookup IDs and to fetch live ingestion keys.
  * CLI now validates cached ingestion keys against platform state and refreshes stale/revoked keys while tolerating failures.

* **Tests**
  * Added integration and unit tests covering listing, cache reconciliation, stale-key handling, and login-flow reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->