### PR TITLE
perf(clickhouse): backfill drawer occurredAtMs hint from the resolved header

### DIFF
--- a/langwatch/src/features/traces-v2/hooks/__tests__/useTraceHeader.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useTraceHeader.unit.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDrawerStore } from "../../stores/drawerStore";
 import { useTraceHeader } from "../useTraceHeader";
 
-const headerData: { timestamp?: number } = {};
+const headerData: { traceId?: string; timestamp?: number } = {};
 
 vi.mock("~/utils/api", () => ({
   api: {
@@ -31,6 +31,7 @@ vi.mock("../../stores/sseStatusStore", () => ({
 
 describe("useTraceHeader", () => {
   beforeEach(() => {
+    headerData.traceId = undefined;
     headerData.timestamp = undefined;
     useDrawerStore.setState({ traceId: null, occurredAtMs: null });
   });
@@ -39,6 +40,7 @@ describe("useTraceHeader", () => {
     describe("when the header resolves with a trace timestamp", () => {
       it("backfills occurredAtMs from the resolved timestamp", () => {
         useDrawerStore.getState().openTrace("trace-1");
+        headerData.traceId = "trace-1";
         headerData.timestamp = 1_700_000_000_000;
 
         renderHook(() => useTraceHeader());
@@ -52,11 +54,28 @@ describe("useTraceHeader", () => {
     describe("when the header resolves with a different timestamp", () => {
       it("leaves the opener-supplied hint untouched", () => {
         useDrawerStore.getState().openTrace("trace-1", 1_700_000_000_000);
+        headerData.traceId = "trace-1";
         headerData.timestamp = 1_699_000_000_000;
 
         renderHook(() => useTraceHeader());
 
         expect(useDrawerStore.getState().occurredAtMs).toBe(1_700_000_000_000);
+      });
+    });
+  });
+
+  describe("given a trace switch leaves stale header data (keepPreviousData)", () => {
+    describe("when the lingering header belongs to the previous trace", () => {
+      it("does not backfill the new trace with the stale timestamp", () => {
+        // Drawer is now on trace-1 (no hint), but React Query still holds
+        // the previous trace's header until the new fetch lands.
+        useDrawerStore.getState().openTrace("trace-1");
+        headerData.traceId = "trace-OLD";
+        headerData.timestamp = 1_699_000_000_000;
+
+        renderHook(() => useTraceHeader());
+
+        expect(useDrawerStore.getState().occurredAtMs).toBeNull();
       });
     });
   });

--- a/langwatch/src/features/traces-v2/hooks/__tests__/useTraceHeader.unit.test.ts
+++ b/langwatch/src/features/traces-v2/hooks/__tests__/useTraceHeader.unit.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDrawerStore } from "../../stores/drawerStore";
+import { useTraceHeader } from "../useTraceHeader";
+
+const headerData: { timestamp?: number } = {};
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    tracesV2: {
+      header: {
+        useQuery: () => ({ data: headerData, isLoading: false }),
+      },
+    },
+  },
+}));
+
+vi.mock("../useTraceQueryArgs", () => ({
+  useTraceQueryArgs: () => ({
+    isLive: false,
+    isReady: true,
+    queryArgs: { projectId: "p1", traceId: "trace-1" },
+  }),
+}));
+
+vi.mock("../../stores/sseStatusStore", () => ({
+  useSseStatusStore: () => false,
+}));
+
+describe("useTraceHeader", () => {
+  beforeEach(() => {
+    headerData.timestamp = undefined;
+    useDrawerStore.setState({ traceId: null, occurredAtMs: null });
+  });
+
+  describe("given the drawer opened without a partition hint", () => {
+    describe("when the header resolves with a trace timestamp", () => {
+      it("backfills occurredAtMs from the resolved timestamp", () => {
+        useDrawerStore.getState().openTrace("trace-1");
+        headerData.timestamp = 1_700_000_000_000;
+
+        renderHook(() => useTraceHeader());
+
+        expect(useDrawerStore.getState().occurredAtMs).toBe(1_700_000_000_000);
+      });
+    });
+  });
+
+  describe("given the drawer already carries a partition hint", () => {
+    describe("when the header resolves with a different timestamp", () => {
+      it("leaves the opener-supplied hint untouched", () => {
+        useDrawerStore.getState().openTrace("trace-1", 1_700_000_000_000);
+        headerData.timestamp = 1_699_000_000_000;
+
+        renderHook(() => useTraceHeader());
+
+        expect(useDrawerStore.getState().occurredAtMs).toBe(1_700_000_000_000);
+      });
+    });
+  });
+
+  describe("given the header has not resolved yet", () => {
+    describe("when no timestamp is available", () => {
+      it("leaves occurredAtMs null", () => {
+        useDrawerStore.getState().openTrace("trace-1");
+
+        renderHook(() => useTraceHeader());
+
+        expect(useDrawerStore.getState().occurredAtMs).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/hooks/useTraceHeader.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceHeader.ts
@@ -55,7 +55,14 @@ export function useTraceHeader() {
   // (span tree, events, signals) and any header refetch prune partitions
   // instead of cold-scanning `stored_spans` on S3. No-op when a hint was
   // already present, so a correct opener-supplied value is never lost.
-  const resolvedTimestamp = query.data?.timestamp;
+  // Guard against `keepPreviousData`: on a trace switch the previous
+  // trace's header lingers in `query.data` until the new fetch lands, so
+  // only trust the timestamp when it belongs to the trace we're asking
+  // about — otherwise we'd backfill trace A's time onto trace B.
+  const resolvedTimestamp =
+    query.data?.traceId === queryArgs.traceId
+      ? query.data.timestamp
+      : undefined;
   useEffect(() => {
     if (occurredAtMs === null && typeof resolvedTimestamp === "number") {
       backfillOccurredAtMs(resolvedTimestamp);

--- a/langwatch/src/features/traces-v2/hooks/useTraceHeader.ts
+++ b/langwatch/src/features/traces-v2/hooks/useTraceHeader.ts
@@ -1,5 +1,7 @@
+import { useEffect } from "react";
 import { api } from "~/utils/api";
 import { LIVE_REFETCH_MS } from "../constants/freshness";
+import { useDrawerStore } from "../stores/drawerStore";
 import { useSseStatusStore } from "../stores/sseStatusStore";
 import { useTraceQueryArgs } from "./useTraceQueryArgs";
 
@@ -10,6 +12,8 @@ const PROMPTS_PENDING_REFETCH_MS = 8_000;
 
 export function useTraceHeader() {
   const { isLive, isReady, queryArgs } = useTraceQueryArgs();
+  const occurredAtMs = useDrawerStore((s) => s.occurredAtMs);
+  const backfillOccurredAtMs = useDrawerStore((s) => s.backfillOccurredAtMs);
   // SSE-aware polling: when `useTraceFreshness` has an active
   // subscription, `trace_summary_updated` events invalidate this query
   // push-style and any timer is redundant. The prompt-pending fallback
@@ -25,7 +29,7 @@ export function useTraceHeader() {
   // newly arrived spans show up without a manual refresh. Once the
   // trace is older than the window, the interval falls away and the
   // query goes back to its normal staleTime caching behaviour.
-  return api.tracesV2.header.useQuery(queryArgs, {
+  const query = api.tracesV2.header.useQuery(queryArgs, {
     enabled: isReady,
     staleTime: 300_000,
     cacheTime: 1_800_000,
@@ -43,4 +47,20 @@ export function useTraceHeader() {
       return false;
     },
   });
+
+  // When the drawer opened without a partition hint (deep link / refresh
+  // whose URL carried no `t`), the header itself runs an unconstrained
+  // by-id scan — but its result carries the trace's real timestamp. Feed
+  // that back into the store so the drawer's *other* per-trace reads
+  // (span tree, events, signals) and any header refetch prune partitions
+  // instead of cold-scanning `stored_spans` on S3. No-op when a hint was
+  // already present, so a correct opener-supplied value is never lost.
+  const resolvedTimestamp = query.data?.timestamp;
+  useEffect(() => {
+    if (occurredAtMs === null && typeof resolvedTimestamp === "number") {
+      backfillOccurredAtMs(resolvedTimestamp);
+    }
+  }, [occurredAtMs, resolvedTimestamp, backfillOccurredAtMs]);
+
+  return query;
 }

--- a/langwatch/src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts
+++ b/langwatch/src/features/traces-v2/stores/__tests__/drawerStore.unit.test.ts
@@ -229,3 +229,44 @@ describe("drawerStore persistence is idempotent", () => {
     expect(useDrawerStore.getState().widthPx).toBe(549);
   });
 });
+
+describe("drawerStore.backfillOccurredAtMs", () => {
+  /** @scenario Deep link / refresh opens the drawer without a `t` hint */
+  describe("given the drawer was opened without an occurredAtMs hint", () => {
+    describe("when the resolved header timestamp is backfilled", () => {
+      it("sets occurredAtMs so per-trace reads can prune", () => {
+        useDrawerStore.getState().openTrace("trace-1");
+        expect(useDrawerStore.getState().occurredAtMs).toBeNull();
+
+        useDrawerStore.getState().backfillOccurredAtMs(1_700_000_000_000);
+
+        expect(useDrawerStore.getState().occurredAtMs).toBe(1_700_000_000_000);
+      });
+    });
+  });
+
+  describe("given the drawer already has an occurredAtMs hint", () => {
+    describe("when a backfill is attempted", () => {
+      it("keeps the opener-supplied hint (no overwrite)", () => {
+        useDrawerStore.getState().openTrace("trace-1", 1_700_000_000_000);
+
+        useDrawerStore.getState().backfillOccurredAtMs(1_699_000_000_000);
+
+        expect(useDrawerStore.getState().occurredAtMs).toBe(1_700_000_000_000);
+      });
+    });
+  });
+
+  describe("given an invalid timestamp", () => {
+    describe("when a backfill is attempted", () => {
+      it("leaves occurredAtMs null", () => {
+        useDrawerStore.getState().openTrace("trace-1");
+
+        useDrawerStore.getState().backfillOccurredAtMs(0);
+        useDrawerStore.getState().backfillOccurredAtMs(Number.NaN);
+
+        expect(useDrawerStore.getState().occurredAtMs).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/features/traces-v2/stores/drawerStore.ts
+++ b/langwatch/src/features/traces-v2/stores/drawerStore.ts
@@ -127,6 +127,15 @@ interface DrawerState extends DrawerUrlState {
     occurredAtMs?: number | null,
     expectedSpanCount?: number | null,
   ) => void;
+  /**
+   * Fill in the partition-pruning hint after the fact, from a resolved
+   * trace timestamp, when the drawer was opened without one (deep link /
+   * refresh whose URL carries no `t`). Only sets when `occurredAtMs` is
+   * currently null, so it never overwrites a hint the opener already
+   * supplied. Once set, the drawer's per-trace `stored_spans` reads can
+   * prune to the trace's weekly partitions instead of cold-scanning S3.
+   */
+  backfillOccurredAtMs: (occurredAtMs: number) => void;
   closeDrawer: () => void;
   selectSpan: (spanId: string) => void;
   clearSpan: () => void;
@@ -500,6 +509,13 @@ export const useDrawerStore = create<DrawerState>((set, get) => ({
       expectedSpanCount: expectedSpanCount ?? null,
       selectedSpanId: null,
       pinnedSpanIds: [],
+    }),
+
+  backfillOccurredAtMs: (occurredAtMs) =>
+    set((s) => {
+      if (s.occurredAtMs !== null) return {};
+      if (!Number.isFinite(occurredAtMs) || occurredAtMs <= 0) return {};
+      return { occurredAtMs };
     }),
 
   closeDrawer: () =>


### PR DESCRIPTION
## Evidence

Two related shapes show up in the last 24h of prod logs, both from the trace drawer firing per-trace reads without a partition hint:

- A `trace_summaries` summary fetch keyed on `[tenantId, traceId]`: ~236 slow-query warns at p50 ~1065ms with very low read bytes (latency from partition count, not data volume).
- `stored_spans` cold-scan warnings keyed on `[tenantId, traceId]` (span tree / span events / signals reads): the drawer's heavy reads walking every weekly partition including the S3 tier.

Both originate when the drawer's `occurredAtMs` hint is null. The drawer normally gets the hint from the row it opened from (`openTrace(traceId, trace.timestamp)`) or from the `t` URL param. The null case is a deep link or refresh whose URL carries no `t` (shared links pasted without it, older links).

## Suspected cause

`trace_summaries` is `PARTITION BY toYearWeek(OccurredAt)` and `stored_spans` is `PARTITION BY toYearWeek(StartTime)`. A `traceId`-only filter prunes within a part via the primary key but cannot drop any partition, so the reads open every part. The per-trace hooks (`useTraceHeader`, the span-tree hook, etc.) already forward `occurredAtMs` when the store has it; they just have nothing to forward on the deep-link path.

## Proposed fix

The header query response already carries the trace's real `occurredAt` (`TraceHeader.timestamp`). Feed it back into the drawer store:

- New idempotent store action `backfillOccurredAtMs(ms)` — sets `occurredAtMs` only when it is currently null and the value is finite/positive, so a correct opener-supplied hint is never overwritten.
- `useTraceHeader` calls it once the header resolves and the store hint is null.

Once backfilled, the store value flows through `useTraceQueryArgs` into the drawer's other per-trace reads (span tree, events, signals) and any header refetch, so they prune. The very first header fetch on a cold deep-link still runs unconstrained (it is what produces the timestamp); everything after it for that open drawer is bounded.

This is caller/state-side only; no query text or server hint handling changes.

## Expected impact

Headline metric is partitions pruned and `stored_spans` cold-scan S3 GETs avoided, not first-paint latency. For a deep-linked/refreshed drawer the first summary fetch is unchanged (one unconstrained scan), but the span tree / events / signals reads and all header refetches over the drawer's open lifetime move from all-partitions to a ±2-day window. Drawers opened normally (row click) already carried the hint and are unaffected.

## Test plan

- `drawerStore.unit.test.ts`: `backfillOccurredAtMs` sets when null, no-ops when a hint already exists, and ignores invalid timestamps (0 / NaN).
- `useTraceHeader.unit.test.ts`: backfills from the resolved header timestamp when the hint is null, leaves an existing hint untouched, and leaves it null when the header has not resolved.
- 20 tests pass. `tsgo` typecheck clean on the changed files.

## EXPLAIN check

Same `trace_summaries` partition-prune delta as the by-id summary read (measured on a known-large tenant): the unconstrained read walks 303/303 parts (10,063 granules) at the MinMax/Partition stage; with a ±2-day `OccurredAt` window it prunes to 12/305 parts (144 granules). The `stored_spans` span reads prune analogously on `StartTime` once the hint reaches them via the existing per-trace hooks.

## Notes

- The hint is not yet written back to the URL, so a hard refresh re-pays one unconstrained header fetch before re-backfilling. Persisting it to the `t` param is a reasonable follow-up but adds history churn, so it is left out here.
- Advisory PR from the ClickHouse slow-query sweep. Please re-run the EXPLAIN before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering header-driven timestamp backfill, preservation of explicit timestamp hints, prevention of stale header data from affecting new traces, and validation of invalid timestamps.

* **Refactor**
  * Drawer initialization now automatically backfills a trace timestamp when missing, preserves existing hints, and guards against stale or invalid header data to avoid unnecessary scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->