### PR TITLE
fix: do not require a project default model when the created prompt ships its own

### DIFF
--- a/langwatch/src/app/api/prompts/__tests__/prompts-api.integration.test.ts
+++ b/langwatch/src/app/api/prompts/__tests__/prompts-api.integration.test.ts
@@ -378,6 +378,41 @@ describe("Prompts API", () => {
       expect(body).toHaveProperty("handle", "test-handle/chunky-bacon");
     });
 
+    describe("when the project has no default model configured", () => {
+      it("creates a prompt that ships its own model", async () => {
+        // Remove the seeded default: a prompt that specifies its model,
+        // like every prompt pushed by `langwatch prompt sync`, must not
+        // depend on the project having a default model.
+        await prisma.modelDefaultConfig.deleteMany({
+          where: { id: testDefaultConfigId },
+        });
+
+        const res = await helpers.api.post(`/api/prompts`, {
+          handle: "synced-from-cli",
+          prompt: "You are a helpful assistant.",
+          model: "openai/gpt-4o-mini",
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toHaveProperty("id");
+        expect(body).toHaveProperty("model", "openai/gpt-4o-mini");
+      });
+
+      it("still reports the missing model when none is provided", async () => {
+        await prisma.modelDefaultConfig.deleteMany({
+          where: { id: testDefaultConfigId },
+        });
+
+        const res = await helpers.api.post(`/api/prompts`, {
+          handle: "needs-a-default",
+          prompt: "test",
+        });
+
+        expect(res.status).toBeGreaterThanOrEqual(400);
+      });
+    });
+
     it("validates input when creating a prompt", async () => {
       const invalidData = {
         // Missing required name field

--- a/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config.repository.ts
@@ -489,21 +489,26 @@ export class LlmConfigRepository {
           scope: configData.scope,
         },
       });
-      // Resolve the project's DEFAULT model via the cascade. We let
+      // Resolve the project's DEFAULT model via the cascade, but only on
+      // the paths that actually need one: no version data at all, or a
+      // version without a model. A prompt that ships its own model, like
+      // every prompt pushed by the CLI's sync, must not require the
+      // project to have a default model configured. We let
       // ModelNotConfiguredError propagate so the missing-model toast
       // fires; only swallow resolver-internal crashes and fall back to
       // DEFAULT_MODEL as a last-resort placeholder.
-      let defaultModel: string;
-      try {
-        const resolved = await resolveModelForFeature(
-          "prompt.create_default",
-          { prisma: this.prisma, projectId: configData.projectId },
-        );
-        defaultModel = resolved.model;
-      } catch (err) {
-        if (err instanceof ModelNotConfiguredError) throw err;
-        defaultModel = DEFAULT_MODEL;
-      }
+      const resolveDefaultModel = async (): Promise<string> => {
+        try {
+          const resolved = await resolveModelForFeature(
+            "prompt.create_default",
+            { prisma: this.prisma, projectId: configData.projectId },
+          );
+          return resolved.model;
+        } catch (err) {
+          if (err instanceof ModelNotConfiguredError) throw err;
+          return DEFAULT_MODEL;
+        }
+      };
 
       // Set the version data to the provided version data, or undefined if no version data is provided.
       let newVersionData: Partial<CreateLlmConfigVersionParams> | undefined =
@@ -512,7 +517,7 @@ export class LlmConfigRepository {
       // If no version data is provided, we'll create a default (draft) version.
       if (!newVersionData) {
         const configData = this.buildDefaultVersionConfigData({
-          model: defaultModel,
+          model: await resolveDefaultModel(),
         });
 
         newVersionData = {
@@ -524,7 +529,7 @@ export class LlmConfigRepository {
 
       // Ensure a model is set if configData is provided
       if (newVersionData.configData && !newVersionData.configData.model) {
-        newVersionData.configData.model = defaultModel;
+        newVersionData.configData.model = await resolveDefaultModel();
       }
 
       const newVersion = await tx.llmPromptConfigVersion.create({


### PR DESCRIPTION
## Problem

`langwatch prompt sync` against a fresh project fails on every prompt:

```
✗ Failed call_center_assistant: Failed to sync prompt: No model configured for "prompt.create_default" (role: DEFAULT, project: project_...). [ModelNotConfiguredError]
```

The sync only succeeded after manually configuring a default model in Settings, which from the user's perspective is an unrelated requirement: the prompt they are syncing already specifies its own model.

## Why a model is involved at all

A prompt *version* must name a model: the version schema requires `model` to be a non-empty string (`llm-config-version-schema.ts`, `z.string().min(1)`), because running a prompt needs to know which model to call. At creation the model is resolved in priority order: (1) the model the caller passes, (2) the project/team/org default, (3) a hardcoded `DEFAULT_MODEL` fallback.

When nothing is resolvable, the server throws `ModelNotConfiguredError` (cause `MODEL_NOT_CONFIGURED`) on purpose: a global client interceptor turns it into the "configure a model" popup (`MissingModelToast`). That behavior is intended and is kept.

## The bug

`createConfigWithInitialVersion` resolved the project default and rethrew `ModelNotConfiguredError` **unconditionally**, before checking whether the caller had already supplied a model. Prompts pushed by the CLI always carry their own model (priority 1), so they never needed a default, but the code asked for one anyway and threw. A fresh project with no default model could not sync any prompt.

The UI create flow never hit this: its empty model picker comes from a separate `resolvedDefault` query used only to prefill the form, and by the time you click Save the form always carries a picked model. So the create call always includes a model and the server never throws. The unconditional resolve only ever broke headless/CLI callers.

## The fix

Resolve the default lazily, only on the two paths that actually need one: no version data at all (the UI's draft create), or a version with no model. When the caller supplies a model, the default is never consulted and nothing throws. The genuinely-no-model-anywhere case still throws `ModelNotConfiguredError` and still surfaces the popup, unchanged.

Not changed on purpose: the no-model case is not silently defaulted to `DEFAULT_MODEL`. Doing so would create a prompt pointing at a flagship model the project may have no provider key for, with no signal; the explicit error is the same contract the UI honors.

## Tests

- New integration test: creating a prompt that specifies its model succeeds on a project with no default model configured (fails on `main`, passes here).
- New integration test: creating a prompt without a model on such a project still returns the missing-model error.
- Full `prompts-api.integration.test.ts` suite: 34/34 passing.
