### PR TITLE
fix(langy): reset panel to fresh state when active chat is deleted

### DIFF
--- a/langwatch/src/components/langy/LangySidebar.tsx
+++ b/langwatch/src/components/langy/LangySidebar.tsx
@@ -340,6 +340,17 @@ function LangyPanel({
     [setMessages],
   );
 
+  // Wipe everything tied to the previous conversation when the active one
+  // goes away (delete-active or "New chat"). Without this, proposal caches
+  // keyed by message id from the deleted chat survive into the fresh one,
+  // and an in-flight stream keeps writing into the empty messages array.
+  const resetActivePanelState = useCallback(() => {
+    setAppliedOutcomes({});
+    setDiscardedProposals(new Set());
+    setApplyingProposals(new Set());
+    void stop();
+  }, [stop]);
+
   const {
     conversations,
     currentConversationId,
@@ -353,6 +364,7 @@ function LangyPanel({
     projectId,
     setMessages: applyMessagesFromHistory,
     onError: surfaceConversationError,
+    onActiveCleared: resetActivePanelState,
   });
   adoptConversationRef.current = adoptConversation;
 

--- a/langwatch/src/components/langy/__tests__/LangyConversationHistory.integration.test.tsx
+++ b/langwatch/src/components/langy/__tests__/LangyConversationHistory.integration.test.tsx
@@ -401,6 +401,64 @@ describe("LangyPanel conversation history", () => {
           expect(lastCall?.[0]).toEqual([]);
         });
       });
+
+      it("aborts any in-flight stream when the active conversation is deleted", async () => {
+        installFetchMock({ conversations, messagesById });
+        chatRef.status = "streaming";
+        renderPanel();
+        await screen.findByRole("button", { name: /Newest chat/i });
+        const newestItem = screen.getByRole("button", {
+          name: /Newest chat/i,
+        });
+        await userEvent.hover(newestItem);
+        chatRef.stop.mockClear();
+        await userEvent.click(
+          within(newestItem.parentElement!).getByRole("button", {
+            name: /delete/i,
+          }),
+        );
+        await waitFor(() => {
+          expect(chatRef.stop).toHaveBeenCalled();
+        });
+      });
+
+      it("leaves the active conversation untouched when a different chat is deleted", async () => {
+        installFetchMock({ conversations, messagesById });
+        renderPanel();
+        // Wait for initial load to finish so we don't race the seed-load.
+        await screen.findByRole("button", { name: /Older chat/i });
+        await waitFor(() => {
+          const lastCall =
+            chatRef.setMessages.mock.calls[
+              chatRef.setMessages.mock.calls.length - 1
+            ];
+          // initial seed loaded Newest's messages
+          expect(
+            (lastCall?.[0] as UIMessageLike[] | undefined)?.[0]?.parts?.[0]
+              ?.text,
+          ).toBe("hello from newest");
+        });
+        // Delete the OLDER (non-active) chat.
+        const olderItem = screen.getByRole("button", { name: /Older chat/i });
+        await userEvent.hover(olderItem);
+        chatRef.setMessages.mockClear();
+        chatRef.stop.mockClear();
+        await userEvent.click(
+          within(olderItem.parentElement!).getByRole("button", {
+            name: /delete/i,
+          }),
+        );
+        // Wait until the older chat is removed from the list — proves the
+        // delete completed — before asserting we did NOT reset the active.
+        await waitFor(() => {
+          expect(
+            screen.queryByRole("button", { name: /Older chat/i }),
+          ).not.toBeInTheDocument();
+        });
+        // Active chat state must not be wiped.
+        expect(chatRef.setMessages).not.toHaveBeenCalledWith([]);
+        expect(chatRef.stop).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/langwatch/src/components/langy/useLangyConversations.ts
+++ b/langwatch/src/components/langy/useLangyConversations.ts
@@ -25,6 +25,14 @@ interface UseLangyConversationsArgs {
   projectId: string | undefined;
   setMessages: (messages: LangyMessageRecord[]) => void;
   onError: (message: string) => void;
+  /**
+   * Called whenever the active conversation transitions to "none" — i.e.
+   * the user explicitly started a new chat, or deleted the conversation
+   * they were viewing. The panel uses this to wipe per-conversation local
+   * state (proposal caches) and abort any in-flight stream, so a fresh
+   * conversation isn't haunted by ghosts of the previous one.
+   */
+  onActiveCleared?: () => void;
 }
 
 function localStorageKey(projectId: string) {
@@ -72,6 +80,7 @@ export function useLangyConversations({
   projectId,
   setMessages,
   onError,
+  onActiveCleared,
 }: UseLangyConversationsArgs): UseLangyConversationsResult {
   const [conversations, setConversations] = useState<LangyConversationSummary[]>(
     [],
@@ -181,7 +190,8 @@ export function useLangyConversations({
     setCurrentConversationId(null);
     writeLastConversationId(projectId, null);
     setMessages([]);
-  }, [projectId, setMessages]);
+    onActiveCleared?.();
+  }, [projectId, setMessages, onActiveCleared]);
 
   const adopt = useCallback(
     (id: string) => {
@@ -228,12 +238,13 @@ export function useLangyConversations({
           setCurrentConversationId(null);
           writeLastConversationId(projectId, null);
           setMessages([]);
+          onActiveCleared?.();
         }
       } catch {
         onError("Failed to delete conversation.");
       }
     },
-    [projectId, currentConversationId, setMessages, onError],
+    [projectId, currentConversationId, setMessages, onError, onActiveCleared],
   );
 
   return {

--- a/specs/assistant/langy-baseline.feature
+++ b/specs/assistant/langy-baseline.feature
@@ -129,6 +129,22 @@ Feature: Langy in-product AI assistant — baseline (v1)
     And the partial response is preserved
 
   # ============================================================================
+  # Conversation history
+  # ============================================================================
+
+  Scenario: Deleting the active conversation resets the panel
+    Given I am viewing a conversation in the recent chats list
+    When I delete that conversation from the list
+    Then the panel returns to a fresh empty state
+    And any in-flight stream is stopped
+    And proposal state from the deleted conversation is cleared
+
+  Scenario: Deleting a non-active conversation leaves the current chat alone
+    Given I am viewing one conversation and another exists in the recent list
+    When I delete the other conversation
+    Then the conversation I am viewing remains open with its messages intact
+
+  # ============================================================================
   # Read-only boundary (v1)
   # ============================================================================
 


### PR DESCRIPTION
## Summary

- Deleting the **active** Langy conversation from the recents list now resets the panel to a fresh empty state: messages cleared, conversation id cleared, proposal caches (`appliedOutcomes` / `discardedProposals` / `applyingProposals`) wiped, and any in-flight stream stopped.
- Deleting a **non-active** conversation still leaves your current chat alone — only the entry is removed from the recents list.
- Same reset path runs on the \"New chat\" button, so a fresh conversation is never haunted by proposal state from the previous one.

The reset is driven by a new `onActiveCleared` callback on `useLangyConversations`. The hook fires it from both `startNew()` and `remove()` (when `wasActive`). `LangySidebar` implements the callback to wipe its local per-conversation state plus `stop()` the chat stream.

Stacked on #4272 (`langy/per-session-manager`).

## Test plan

- [x] `pnpm typecheck` — clean (Prisma errors are pre-existing fresh-worktree gen-files, not introduced here)
- [x] `pnpm test:integration src/components/langy/__tests__/LangyConversationHistory.integration.test.tsx` — 18/18 passing, including two new cases:
  - aborts any in-flight stream when the active conversation is deleted
  - leaves the active conversation untouched when a different chat is deleted
- [ ] Manual: open Langy, send a message in chat A, switch to chat B, delete chat A from recents → chat B remains open with its messages intact
- [ ] Manual: open Langy, send a message, delete the chat you're viewing → panel returns to empty state, composer fresh, no ghost proposals
- [ ] BDD spec added to `specs/assistant/langy-baseline.feature` under \"Conversation history\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)