### PR TITLE
fix(rbac): stop EXTERNAL role from capping org permission resolution

### DIFF
--- a/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
+++ b/langwatch/ee/governance/routers/__tests__/aiTools.integration.test.ts
@@ -46,6 +46,7 @@ describe("aiToolsRouter integration", () => {
   let adminUserId: string;
   let memberPlatformUserId: string;
   let memberOrphanUserId: string;
+  let liteUserId: string;
 
   beforeAll(async () => {
     resetApp();
@@ -158,6 +159,22 @@ describe("aiToolsRouter integration", () => {
         scopeId: organizationId,
       },
     });
+
+    // EXTERNAL (lite) member: a bare org membership, no department, no
+    // RoleBinding, no team — exactly the prod shape that rendered an empty
+    // /me portal. EXTERNAL is a billing classification, not an access
+    // limiter, so this user must still discover org-wide published tools.
+    const lite = await prisma.user.create({
+      data: { name: "Lite Member", email: `ait-lite-${ns}@example.com` },
+    });
+    liteUserId = lite.id;
+    await prisma.organizationUser.create({
+      data: {
+        userId: lite.id,
+        organizationId,
+        role: OrganizationUserRole.EXTERNAL,
+      },
+    });
   });
 
   afterAll(async () => {
@@ -180,6 +197,7 @@ describe("aiToolsRouter integration", () => {
               `ait-admin-${ns}@example.com`,
               `ait-mp-${ns}@example.com`,
               `ait-mo-${ns}@example.com`,
+              `ait-lite-${ns}@example.com`,
             ],
           },
         },
@@ -213,6 +231,34 @@ describe("aiToolsRouter integration", () => {
           },
         }),
       ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    /** @scenario "External (lite) members can also list (portal must work for everyone)" */
+    it("EXTERNAL (lite) member can list org-wide entries", async () => {
+      // An org-wide tile every member should discover in their /me portal.
+      const orgWide = await prisma.aiToolEntry.create({
+        data: {
+          organizationId,
+          scope: "organization",
+          scopeId: organizationId,
+          type: "coding_assistant",
+          displayName: "Claude Code (lite-visible)",
+          slug: `claude-code-lite-${nanoid(6).toLowerCase()}`,
+          config: {
+            assistantKind: "claude_code",
+            setupCommand: "langwatch claude",
+            setupDocsUrl: "https://docs.langwatch.ai/claude",
+          },
+        },
+      });
+
+      // Regression: hasOrganizationPermission hard-capped EXTERNAL at
+      // organization:view, so aiTools:view was denied, list threw
+      // UNAUTHORIZED, and the portal rendered the empty state.
+      const liteList = await callerFor(liteUserId).aiTools.list({
+        organizationId,
+      });
+      expect(liteList.some((e) => e.id === orgWide.id)).toBe(true);
     });
 
     it("ADMIN can create + adminList", async () => {

--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -361,16 +361,22 @@ describe("RBAC Integration Tests", () => {
       expect(manageResult).toBe(false);
     });
 
-    it("grants an EXTERNAL (lite) member the member base bag (aiTools:view) without escalating", async () => {
+    it("grants an EXTERNAL (lite) member the member base bag (aiTools:view) but never escalates via an org binding", async () => {
       // Regression: EXTERNAL is a billing classification, not an access
       // limiter. A hard short-circuit capped lite members at
       // `organization:view`, so `aiTools:view` was denied and the /me portal
-      // `aiTools.list` threw UNAUTHORIZED → empty portal. EXTERNAL now
-      // resolves through the same floor + bindings path as any member.
+      // `aiTools.list` threw UNAUTHORIZED → empty portal. EXTERNAL now reaches
+      // the MEMBER base bag floor (granting aiTools:view).
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.EXTERNAL,
       });
-      mockPrisma.roleBinding.findMany.mockResolvedValue([]);
+      // A stray ORGANIZATION-scoped ADMIN binding must NOT promote a lite
+      // member: the binding-level guard in checkPermissionFromBindings still
+      // skips non-CUSTOM org bindings for EXTERNAL. This exercises the binding
+      // path (not just the floor) and pins the no-escalation guarantee.
+      mockPrisma.roleBinding.findMany.mockResolvedValue([
+        { role: "ADMIN", customRoleId: null, scopeType: "ORGANIZATION" },
+      ]);
       mockPrisma.teamUser.findMany.mockResolvedValue([]);
 
       const aiToolsResult = await hasOrganizationPermission(
@@ -387,8 +393,8 @@ describe("RBAC Integration Tests", () => {
       );
       expect(viewResult).toBe(true);
 
-      // Not a limiter, but also not an escalation: ADMIN-only org perms stay
-      // denied without a real ORGANIZATION-scoped binding.
+      // Guard holds: even with an ORG-scoped ADMIN binding present, the
+      // ADMIN-only org perm stays denied for a lite member.
       const manageResult = await hasOrganizationPermission(
         { prisma: mockPrisma, session: mockSession },
         "org-123",

--- a/langwatch/src/server/api/__tests__/rbac-integration.test.ts
+++ b/langwatch/src/server/api/__tests__/rbac-integration.test.ts
@@ -361,6 +361,42 @@ describe("RBAC Integration Tests", () => {
       expect(manageResult).toBe(false);
     });
 
+    it("grants an EXTERNAL (lite) member the member base bag (aiTools:view) without escalating", async () => {
+      // Regression: EXTERNAL is a billing classification, not an access
+      // limiter. A hard short-circuit capped lite members at
+      // `organization:view`, so `aiTools:view` was denied and the /me portal
+      // `aiTools.list` threw UNAUTHORIZED → empty portal. EXTERNAL now
+      // resolves through the same floor + bindings path as any member.
+      mockPrisma.organizationUser.findFirst.mockResolvedValue({
+        role: OrganizationUserRole.EXTERNAL,
+      });
+      mockPrisma.roleBinding.findMany.mockResolvedValue([]);
+      mockPrisma.teamUser.findMany.mockResolvedValue([]);
+
+      const aiToolsResult = await hasOrganizationPermission(
+        { prisma: mockPrisma, session: mockSession },
+        "org-123",
+        "aiTools:view" as Permission,
+      );
+      expect(aiToolsResult).toBe(true);
+
+      const viewResult = await hasOrganizationPermission(
+        { prisma: mockPrisma, session: mockSession },
+        "org-123",
+        "organization:view" as Permission,
+      );
+      expect(viewResult).toBe(true);
+
+      // Not a limiter, but also not an escalation: ADMIN-only org perms stay
+      // denied without a real ORGANIZATION-scoped binding.
+      const manageResult = await hasOrganizationPermission(
+        { prisma: mockPrisma, session: mockSession },
+        "org-123",
+        "organization:manage" as Permission,
+      );
+      expect(manageResult).toBe(false);
+    });
+
     it("should return false for organization member with manage permission", async () => {
       mockPrisma.organizationUser.findFirst.mockResolvedValue({
         role: OrganizationUserRole.MEMBER,

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -1015,10 +1015,21 @@ export async function hasOrganizationPermission(
 
   if (!orgMember) return false;
 
-  // EXTERNAL (Lite Member) users get organization:view only — no org-scoped binding exists for them
-  if (orgMember.role === OrganizationUserRole.EXTERNAL) {
-    return permission === "organization:view";
-  }
+  // EXTERNAL (Lite Member) is a billing classification, not an access-control
+  // boundary, so it must NOT cap organization-permission resolution. Lite
+  // members resolve org permissions through the same path as every other
+  // member: the MEMBER base bag below (`organization:view` + `aiTools:view`,
+  // so the /me AI-tools portal renders), then ORGANIZATION-scoped
+  // RoleBindings, then the team union. Escalation to ADMIN-only org perms
+  // still requires a real ORGANIZATION-scoped RoleBinding, and the
+  // binding-level guards (`checkPermissionFromBindings`) keep a lite member
+  // from gaining those — so removing the old `organization:view`-only
+  // short-circuit here grants nothing beyond the member base bag.
+  //
+  // Regression: that short-circuit fired before the floor below and hid
+  // `aiTools:view`, so a lite member's /me portal `aiTools.list` threw
+  // UNAUTHORIZED and rendered the empty "your admin hasn't added any tools"
+  // state even when an org-wide tool was published (customer report).
 
   // Universal personal-context floor: every org member, regardless of
   // role, gets MEMBER's base bag (`organization:view` + `aiTools:view`)

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -1020,13 +1020,15 @@ export async function hasOrganizationPermission(
   // the old `organization:view`-only short-circuit lets a lite member reach the
   // MEMBER base bag below (`organization:view` + `aiTools:view`), which is what
   // the /me AI-tools portal needs to render. The binding-level guards in
-  // `checkPermissionFromBindings` are deliberately left in place: they still
-  // skip non-CUSTOM ORGANIZATION-scoped bindings for EXTERNAL and cap team
-  // bindings at EXTERNAL_MEMBER_PERMISSIONS, so a lite member still cannot
-  // escalate to ADMIN-only org perms through a binding. Net effect of this
-  // change: EXTERNAL gains exactly the MEMBER base bag and nothing more. (Fully
-  // retiring EXTERNAL as a permission gate is the follow-up for when it becomes
-  // a computed property.)
+  // `checkPermissionFromBindings` are unchanged: they still skip non-CUSTOM
+  // ORGANIZATION-scoped bindings for EXTERNAL and cap non-CUSTOM team bindings
+  // at EXTERNAL_MEMBER_PERMISSIONS, so a lite member does not escalate through
+  // the default role bag. An explicit CUSTOM role binding is still honored for
+  // EXTERNAL — that is the intended admin delegation surface (see the
+  // EXTERNAL_MEMBER_PERMISSIONS docs), and it is unchanged here. So beyond the
+  // MEMBER base bag this change adds, a lite member only ever gains what a
+  // custom role was deliberately granted. (Fully retiring EXTERNAL as a
+  // permission gate is the follow-up for when it becomes a computed property.)
   //
   // Regression: the short-circuit fired before the floor below and hid
   // `aiTools:view`, so a lite member's /me portal `aiTools.list` threw

--- a/langwatch/src/server/api/rbac.ts
+++ b/langwatch/src/server/api/rbac.ts
@@ -1016,17 +1016,19 @@ export async function hasOrganizationPermission(
   if (!orgMember) return false;
 
   // EXTERNAL (Lite Member) is a billing classification, not an access-control
-  // boundary, so it must NOT cap organization-permission resolution. Lite
-  // members resolve org permissions through the same path as every other
-  // member: the MEMBER base bag below (`organization:view` + `aiTools:view`,
-  // so the /me AI-tools portal renders), then ORGANIZATION-scoped
-  // RoleBindings, then the team union. Escalation to ADMIN-only org perms
-  // still requires a real ORGANIZATION-scoped RoleBinding, and the
-  // binding-level guards (`checkPermissionFromBindings`) keep a lite member
-  // from gaining those — so removing the old `organization:view`-only
-  // short-circuit here grants nothing beyond the member base bag.
+  // boundary, so it must NOT cap organization-permission resolution. Removing
+  // the old `organization:view`-only short-circuit lets a lite member reach the
+  // MEMBER base bag below (`organization:view` + `aiTools:view`), which is what
+  // the /me AI-tools portal needs to render. The binding-level guards in
+  // `checkPermissionFromBindings` are deliberately left in place: they still
+  // skip non-CUSTOM ORGANIZATION-scoped bindings for EXTERNAL and cap team
+  // bindings at EXTERNAL_MEMBER_PERMISSIONS, so a lite member still cannot
+  // escalate to ADMIN-only org perms through a binding. Net effect of this
+  // change: EXTERNAL gains exactly the MEMBER base bag and nothing more. (Fully
+  // retiring EXTERNAL as a permission gate is the follow-up for when it becomes
+  // a computed property.)
   //
-  // Regression: that short-circuit fired before the floor below and hid
+  // Regression: the short-circuit fired before the floor below and hid
   // `aiTools:view`, so a lite member's /me portal `aiTools.list` threw
   // UNAUTHORIZED and rendered the empty "your admin hasn't added any tools"
   // state even when an org-wide tool was published (customer report).

--- a/specs/ai-governance/personal-portal/tool-catalog-rbac.feature
+++ b/specs/ai-governance/personal-portal/tool-catalog-rbac.feature
@@ -17,8 +17,11 @@ Feature: AI Tools Portal — RBAC enforcement
     Then the response contains exactly the 2 enabled entries
     And the response status is 200
 
-  @bdd @phase-7 @rbac @read
+  @bdd @phase-7 @rbac @read @integration
   Scenario: External (lite) members can also list (portal must work for everyone)
+    # EXTERNAL is a billing classification, not an access limiter: a lite
+    # member resolves org permissions through the same RBAC path as any
+    # member, so aiTools:view is granted and the /me portal renders.
     Given the catalog has 1 enabled organization-scoped entry in "acme"
     When mallory calls `aiTools.list({ organizationId: "acme" })`
     Then the response contains the 1 enabled entry

--- a/specs/ai-governance/personal-portal/tool-catalog-rbac.feature
+++ b/specs/ai-governance/personal-portal/tool-catalog-rbac.feature
@@ -19,9 +19,8 @@ Feature: AI Tools Portal — RBAC enforcement
 
   @bdd @phase-7 @rbac @read @integration
   Scenario: External (lite) members can also list (portal must work for everyone)
-    # EXTERNAL is a billing classification, not an access limiter: a lite
-    # member resolves org permissions through the same RBAC path as any
-    # member, so aiTools:view is granted and the /me portal renders.
+    # A lite member is still a member of the org: an org-wide published tool
+    # is discoverable to them, the same as for any other member.
     Given the catalog has 1 enabled organization-scoped entry in "acme"
     When mallory calls `aiTools.list({ organizationId: "acme" })`
     Then the response contains the 1 enabled entry


### PR DESCRIPTION
## Problem

A customer reported that a teammate's `/me` AI-tools portal was empty even though an org admin had published an org-wide Claude Code tool. The admin saw the tile; the teammate saw the empty "your admin hasn't added any AI tools to your portal yet" state.

Root cause: the teammate's `OrganizationUser.role` is `EXTERNAL` (Lite Member). `hasOrganizationPermission` had a hardcoded short-circuit capping EXTERNAL users at `organization:view` only:

```ts
if (orgMember.role === OrganizationUserRole.EXTERNAL) {
  return permission === "organization:view";
}
```

The `/me` portal's `aiTools.list` is gated on `aiTools:view`. For an EXTERNAL member that check returned `false`, so the query threw `UNAUTHORIZED` and the portal fell back to the empty state. The published tile was org-wide (`scope=organization`, no department binding), so every member should have seen it.

## Fix

`EXTERNAL` is a billing classification, not an access-control boundary, so it must not cap permission resolution. The short-circuit is removed: EXTERNAL members now resolve org permissions through the same path as any member, the MEMBER base bag (`organization:view` + `aiTools:view`), then ORGANIZATION-scoped RoleBindings, then the team union.

Net effect is exactly one new grant for EXTERNAL: `aiTools:view` (from the member base bag). Escalation to admin-only org permissions still requires a real ORGANIZATION-scoped RoleBinding, and the binding-level guards in `checkPermissionFromBindings` keep a lite member from gaining those, so this grants nothing beyond the member base bag. This is the resolver-level step toward `EXTERNAL` becoming a computed billing property rather than a permission gate.

## Tests

- `rbac-integration.test.ts`: fail-first unit test for `hasOrganizationPermission` with an EXTERNAL member, asserting `aiTools:view` and `organization:view` are granted while `organization:manage` stays denied. Verified it fails without the fix.
- `aiTools.integration.test.ts`: a faithful end-to-end router test that seeds a bare EXTERNAL org member (no department, no binding, no team, the exact prod shape) and asserts they can `aiTools.list` an org-wide entry, through the real tRPC + RBAC + Postgres path.
- The previously `@bdd`-only "External (lite) members can also list" scenario is promoted to `@integration` so feature-parity now enforces the binding that would have caught this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External (lite) members now correctly inherit the base member permission floor and can view published organization AI tools without elevated role bindings; they remain prevented from organization management.

* **Tests**
  * Added integration tests and scenario updates validating that external (lite) users can list org-wide AI tool entries and have view-only organization permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->