### PR TITLE
fix(langy): unblock chat round-trip in local + minikube dev

### DIFF
--- a/langwatch/src/server.mts
+++ b/langwatch/src/server.mts
@@ -3,7 +3,16 @@ import dotenv from "dotenv";
 import events from "events";
 import Module from "module";
 
-dotenv.config();
+// `override: true` lets `.env` win over values that scripts/start.sh exported
+// before this entry runs. start.sh defaults LW_GATEWAY_BASE_URL,
+// LW_GATEWAY_PUBLIC_URL, LANGWATCH_API_URL etc. based on $PORT when those vars
+// are unset in the shell — without override, dotenv.config() sees them as set
+// and silently skips the .env value, so an explicit
+// LW_GATEWAY_PUBLIC_URL=http://host.minikube.internal:5563 in .env never
+// reaches the running process (and Langy can't reach the gateway from inside
+// the OpenCode pod). NODE_ENV / PORT / similar process-level vars stay
+// shell-only because .env shouldn't carry them.
+dotenv.config({ override: true });
 setEnvironment(process.env.ENVIRONMENT ?? "local");
 
 if (process.env.NODE_ENV === "production") {

--- a/langwatch/src/server/services/langy/LangyCredentialService.ts
+++ b/langwatch/src/server/services/langy/LangyCredentialService.ts
@@ -90,7 +90,8 @@ export class LangyCredentialService {
     }
 
     const langwatchEndpoint = process.env.LANGWATCH_API_URL;
-    const gatewayBaseUrl = process.env.LW_GATEWAY_BASE_URL;
+    const gatewayBaseUrl =
+      process.env.LW_GATEWAY_PUBLIC_URL ?? process.env.LW_GATEWAY_BASE_URL;
     if (!langwatchEndpoint) {
       throw new LangyCredentialResolutionError(
         "LANGWATCH_API_URL is not configured on the control plane.",

--- a/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
+++ b/langwatch/src/server/services/langy/__tests__/LangyCredentialService.unit.test.ts
@@ -59,6 +59,12 @@ beforeEach(() => {
   });
   process.env.LANGWATCH_API_URL = "https://api.langwatch.test";
   process.env.LW_GATEWAY_BASE_URL = "http://gateway.test:5563/v1";
+  // Clear LW_GATEWAY_PUBLIC_URL so it doesn't leak in from the developer's
+  // shell (`pnpm dev` setups pre-source .env to dodge the start.sh defaulting
+  // bug, and that .env now carries LW_GATEWAY_PUBLIC_URL on the WSL+minikube
+  // layout). The credential service prefers PUBLIC over BASE, so an inherited
+  // value would shadow whatever the test pins via LW_GATEWAY_BASE_URL above.
+  delete process.env.LW_GATEWAY_PUBLIC_URL;
 });
 
 describe("LangyCredentialService", () => {

--- a/langwatch/src/server/services/langy/langyVirtualKey.ts
+++ b/langwatch/src/server/services/langy/langyVirtualKey.ts
@@ -3,20 +3,11 @@ import { Prisma } from "@prisma/client";
 
 import { encrypt, decrypt } from "~/utils/encryption";
 import { VirtualKeyService } from "~/server/gateway/virtualKey.service";
-import { getResolvedDefaultForFeature } from "~/server/modelProviders/modelDefaults.read";
 import { createLogger } from "~/utils/logger/server";
 import { resolveAttributionUserId } from "./langyAttribution";
 import { backfillLangyCredentialPerProject } from "./langyBackfill";
 
 const logger = createLogger("langwatch:langy:virtual-key");
-
-/**
- * Feature key whose cascade-resolved model we seed onto the Langy VK's
- * `modelsAllowed` at provision time. Same key the sidebar picker seeds
- * itself from (LangySidebar's LANGY_GATE_FEATURE_KEY) so the VK and the
- * composer agree on "the model Langy uses by default".
- */
-const LANGY_VK_MODEL_FEATURE_KEY = "prompt.create_default";
 
 /**
  * Name under which the auto-provisioned Langy VK secret is stored in
@@ -81,27 +72,15 @@ export async function provisionLangyVirtualKey(args: {
     return null;
   }
 
-  // Seed the VK's model allowlist with whatever the project currently
-  // resolves as its default chat model, so the VK "has a model in it" from
-  // day 1 and the sidebar picker starts narrowed to it. At a fresh
-  // project.create there's usually no provider yet → this resolves to null
-  // and we leave modelsAllowed null (= "all eligible models"). It fires when
-  // an org/team default is inherited, and on the self-heal / backfill paths.
-  // getResolvedDefaultForFeature returns null instead of throwing when
-  // nothing is configured, so a missing default never breaks provisioning.
-  const resolvedDefault = await getResolvedDefaultForFeature(
-    // ReadCtx wants a session, but this resolver only reads ctx.prisma;
-    // provisioning runs without a user session, so null is correct.
-    { prisma, session: null },
-    { projectId, featureKey: LANGY_VK_MODEL_FEATURE_KEY },
-  );
-  const modelsAllowed = resolvedDefault?.model
-    ? [resolvedDefault.model]
-    : null;
-
-  // GatewayProviderCredential was removed in iter 110 — VKs route through the
-  // project's ModelProviders. The /chat route's model gate handles "no model
-  // configured" with a 409 before we get here, so we don't validate here.
+  // Leave modelsAllowed at the schema default (null = all eligible models).
+  // We used to seed it from getResolvedDefaultForFeature("prompt.create_default")
+  // so the VK "had a model in it" on day 1 — but that resolver can return a
+  // model id the gateway has no provider for (the SaaS dev cluster currently
+  // resolves to `openai/gpt-5.5`, which the gateway rejects as
+  // `model_not_allowed` since it isn't a real OpenAI model). The resulting
+  // single-item allowlist then blocks every actual chat. The sidebar picker
+  // continues to surface a default via its own feature-key resolution; the
+  // VK no longer needs to encode the allowlist defensively at provision time.
   const virtualKeyService = VirtualKeyService.create(prisma);
   const created = await virtualKeyService.create({
     organizationId,
@@ -111,9 +90,6 @@ export async function provisionLangyVirtualKey(args: {
     principalUserId: null,
     scopes: [{ scopeType: "PROJECT", scopeId: projectId }],
     actorUserId,
-    // Omit config entirely when nothing resolved so the VK keeps the schema
-    // default (modelsAllowed: null = all). Only set it when we have a seed.
-    ...(modelsAllowed ? { config: { modelsAllowed } } : {}),
   });
 
   try {


### PR DESCRIPTION
## Summary

Three independent bugs each made Langy time out (or silently swallow replies) on a fresh worktree on the WSL2 + Docker Desktop + minikube layout. Each surfaced as the panel's status placeholder spinning for ~120s and then vanishing with no assistant bubble.

1. **`scripts/start.sh` defaults out-race `.env`.** start.sh exports defaults for `LW_GATEWAY_BASE_URL`, `LW_GATEWAY_PUBLIC_URL`, `LANGWATCH_API_URL` before `src/server.mts` runs. `dotenv.config()` doesn't override existing env, so any explicit `.env` value for those keys was silently discarded. Call `dotenv.config({ override: true })`.

2. **`LW_GATEWAY_BASE_URL` name collision.** `LangyCredentialService` read it directly as the URL the control plane hands to OpenCode (= "pod → gateway"). But the Go gateway ALSO reads the same env name as its own control-plane URL (= "gateway → API"). They can't both be the same value on a layout where the pod uses `host.minikube.internal:5563` and the gateway uses `localhost:6560`. Mirror the pattern in `personalVirtualKeys.ts` and prefer `LW_GATEWAY_PUBLIC_URL`, falling back to `LW_GATEWAY_BASE_URL` for back-compat.

3. **VK auto-provisioner seeded a phantom model allowlist.** `provisionLangyVirtualKey` set `modelsAllowed: [resolvedDefault.model]` from `getResolvedDefaultForFeature("prompt.create_default")`. On a fresh dev project that resolves to `"openai/gpt-5.5"` — not a real OpenAI model. The single-item allowlist then made the gateway reject every chat with `model_not_allowed`. Leave `modelsAllowed` at the schema default (null = all eligible) on auto-provision; the sidebar picker continues to surface its own default via the same feature-key resolver, no UX regression.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit src/server/services/langy` — 23 passed (had to clear `LW_GATEWAY_PUBLIC_URL` in `beforeEach` so the new precedence is hermetic against a developer's inherited shell env)
- [x] Manual round-trip: opened Langy panel on `http://localhost:5560/browser-test-org-Ewt1Er`, sent `"Just say PONG."`, received `"PONG"` from `gpt-5-mini` via the gateway in ~60s (pod cold-start)
- [ ] Re-test against the SaaS dev cluster (k8s) to confirm fix 2 doesn't regress the SaaS-layout path where `LW_GATEWAY_PUBLIC_URL` and `LW_GATEWAY_BASE_URL` legitimately are the same value — the `??` fallback covers it but worth a manual check before merging

## Why this PR exists separately from #4272

These bugs only surface when you actually run the chat round-trip end-to-end on a non-Helm dev layout, which the existing PR's review surface doesn't easily test. Splitting them out keeps the diff scoped to "things that make Langy work in `make quickstart`-style dev" without bloating #4272's already-large diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)