### PR TITLE
test(groupqueue): stabilize jobEnvelope writes-disabled case under vmThreads

### DIFF
--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -42,7 +42,14 @@ describe("jobEnvelope", () => {
     };
 
     beforeEach(() => {
-      vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", undefined);
+      // Set "false" rather than unset: under the vmThreads pool process.env is
+      // shared and aggressively recycled, and vi.stubEnv(key, undefined) clears
+      // it via the metaEnv proxy's *delete* path (no deleteProperty trap — it
+      // only works by defaulting through to process.env), which races the
+      // outer "true" stub. Writing a value goes through the proxy set trap,
+      // which reliably forwards. Any non-"true" value exercises the same
+      // envelopeWritesEnabled() === false branch.
+      vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "false");
     });
 
     describe("when encoding", () => {


### PR DESCRIPTION
Reliably simulate the envelope-writes-disabled flag in `jobEnvelope.unit.test.ts` so the case doesn't race module state under vmThreads. Test-only.

(The 20s dispatch-latency de-flake that was originally bundled here has been dropped — it masked the #4742 latency instead of fixing it. The root-cause fix is #4800.)