### PR TITLE
fix(groupqueue): dispatch delayed jobs at their due time, not signalTimeout late

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -143,7 +143,10 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     env:
-      VITEST_MAX_WORKERS: "4" # physical core count on GitHub-hosted ubuntu runners
+      # Some legacy integration suites still call FLUSHALL on the shared Redis.
+      # Keep files in one worker, matching vitest.integration.config.ts, so one
+      # suite cannot erase another suite's in-flight queue state.
+      VITEST_MAX_WORKERS: "1"
       # Required environment variables for integration tests
       DATABASE_URL: "postgresql://langwatch_ci:ci_password@localhost:5432/langwatch_test"
       BASE_HOST: "localhost:3000"


### PR DESCRIPTION
## Root cause (#4742)

`groupQueue.integration.test.ts > ... > processes only once with squashed data` fails deterministically since #4726, taking ~5s. The dispatcher has **one wake source — stage-time signals — for work that becomes actionable at other times**: a future-scored job (the `delay` option, a retry backoff, a debounced reactor re-fold) signals before it is due; that signal is consumed and drained on an early poll, and nothing re-signals at due time, so the dispatcher sleeps the full `signalTimeoutSec` (5s) BRPOP. #4726 added the first test that waits on a delayed job, exposing the latency. (The companion CI failure mode — other tests observing partial state — was parallel test files `FLUSHALL`ing the shared Redis; fixed here by `VITEST_MAX_WORKERS=1`, matching the integration config's single-worker intent.)

## Fix

**1. Exact wake for future-due work** — `peekEarliestReadyScore()` (`ZRANGE ready 0 0 WITHSCORES`, read-only) caps the BRPOP wait at the time until the earliest future-due score. Delayed jobs now dispatch at their due time (~300ms in the regression test) instead of up to 5s late.

**2. Bounded backstop for due-but-undispatchable heads** — review iterations surfaced a class of ready heads that are *due but cannot dispatch*, which a tight floor would busy-poll:
- **fastq saturation** → guard: skip the peek, wait the heartbeat (a completion signals when a slot frees).
- **retry lock window** → retry backoff frees the fastq slot but holds the group's active lock for `ceil(backoff)+2s`; `RETRY_RESTAGE_LUA` now scores ready at the **lock expiry** (derived from caller inputs, `dispatchAfterMs − backoffMs + retryTtlSec·1000`, so fake-clock tests share the time base), making the wake land exactly when dispatch can first succeed.
- **job-level pause** (pipeline/jobType/jobName) → skips the job *in place* (unlike tenant pause, which parks the group), leaving the head past-due for the whole pause window — not fixable by scoring.
- **anything not yet enumerated** → the general bound: `waitForSignal` only runs after `dispatchBatch` returned 0, so a past-due head there is by construction either undispatchable or a tiny race (e.g. a completion signal destroyed by the post-dispatch signal `DEL`). It polls at `PAST_DUE_POLL_SEC = 1s`: every undispatchable case costs ~1 cycle/sec, and the race case recovers 5× faster than the heartbeat.

## Deploy safety

The change is purely dispatcher wake-timing plus one read-only `ZRANGE`; no key semantics, no new writes, no Lua dispatch/complete changes. Mixed-version rollout is safe: old and new pods share the unchanged atomic `dispatchBatch` claim, differing only in *when* they poll. The retry ready-score change is a per-`eval` script (no cached-script skew); old pods simply scan the retry group a few seconds later than new ones, exactly once either way.

## Proof (each guard has a failing counter-test)

| Behavior | With fix | Reverted |
|---|---|---|
| Delayed job dispatches at due time | ~300ms | fails: 0 calls in 4s |
| Saturated: no busy-poll | ~0 peeks | fails: 10 peeks/s |
| Retry lock: no busy-poll, retry at lock expiry | ~1 peek | fails: 9 peeks/s |
| Job-paused: bounded backstop, dispatch ≤1s after unpause | ~2 peeks/1.5s | fails: 14 peeks/1.5s |
| Counter conservation (fake clocks) | green | broken by clock-mixing |
| Full `scripts` + `groupQueue` integration suites | **162/162** | — |

Supersedes the 20s timeout de-flake (symptom mask, dropped from #4798).

Fixes #4742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate dispatch timing for delayed and retried jobs, bounded poll cadence for past-due work, and reduced unnecessary wake/poll activity when workers are saturated.

* **Tests**
  * New integration tests validating delayed dispatch timing, suppressed busy-polling under saturation, retry-backoff behavior with active locks, and bounded polling while a job is paused.

* **Chores**
  * CI adjusted to run integration tests serially to avoid shared Redis interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->