### PR TITLE
fix(ci): pin integration shards to one vitest worker to stop shared-Redis FLUSHALL races (#4742)

### DIFF
--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -143,7 +143,10 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     env:
-      VITEST_MAX_WORKERS: "4" # physical core count on GitHub-hosted ubuntu runners
+      # Some legacy integration suites still call FLUSHALL on the shared Redis.
+      # Keep files in one worker, matching vitest.integration.config.ts, so one
+      # suite cannot erase another suite's in-flight queue state.
+      VITEST_MAX_WORKERS: "1"
       # Required environment variables for integration tests
       DATABASE_URL: "postgresql://langwatch_ci:ci_password@localhost:5432/langwatch_test"
       BASE_HOST: "localhost:3000"

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -143,11 +143,13 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     env:
-      # Integration suites share one Redis and call FLUSHALL in afterEach.
-      # vitest.integration.config.ts sets fileParallelism: false (no concurrent
-      # files) but does NOT cap the worker pool, so on CI multiple workers still
-      # raced on FLUSHALL and wiped each other's in-flight queue state. Force a
-      # single worker so suites are fully serialized.
+      # Several integration suites (groupQueue, scripts, loopPrevention,
+      # traceparent) call redis.flushall() directly in afterEach against the
+      # shared Redis — the shared cleanup helper is tenant-scoped to avoid this
+      # race, but these suites aren't. vitest.integration.config.ts sets
+      # fileParallelism: false but does NOT cap the worker pool, so on CI
+      # multiple workers raced on those FLUSHALLs and wiped each other's
+      # in-flight queue state. Force a single worker to serialize them.
       VITEST_MAX_WORKERS: "1"
       # Required environment variables for integration tests
       DATABASE_URL: "postgresql://langwatch_ci:ci_password@localhost:5432/langwatch_test"

--- a/.github/workflows/langwatch-app-ci.yml
+++ b/.github/workflows/langwatch-app-ci.yml
@@ -143,9 +143,11 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     env:
-      # Some legacy integration suites still call FLUSHALL on the shared Redis.
-      # Keep files in one worker, matching vitest.integration.config.ts, so one
-      # suite cannot erase another suite's in-flight queue state.
+      # Integration suites share one Redis and call FLUSHALL in afterEach.
+      # vitest.integration.config.ts sets fileParallelism: false (no concurrent
+      # files) but does NOT cap the worker pool, so on CI multiple workers still
+      # raced on FLUSHALL and wiped each other's in-flight queue state. Force a
+      # single worker so suites are fully serialized.
       VITEST_MAX_WORKERS: "1"
       # Required environment variables for integration tests
       DATABASE_URL: "postgresql://langwatch_ci:ci_password@localhost:5432/langwatch_test"


### PR DESCRIPTION
# Related Issue

- Resolves #4742

## Problem

`groupQueue.integration.test.ts` failed deterministically on the integration shard (#4742), reliably taking down `test-integration (4)` and gating `app-complete`.

## Root cause

It wasn't a queue bug — it was CI test-worker contention. `VITEST_MAX_WORKERS: "4"` let vitest spin up multiple workers that raced on the **shared Redis** `FLUSHALL` in `afterEach`, wiping each other's in-flight queue state mid-test. `fileParallelism: false` serializes *files* but does not cap the worker pool, so the race still happened.

## Fix

Pin the integration shards to a single vitest worker, matching `vitest.integration.config.ts`'s intent:

```yaml
VITEST_MAX_WORKERS: "1"
```

One worker → no cross-suite `FLUSHALL` race → no state-wipe flake.

## Validation

Full `langwatch-app-ci` green, all 6 integration shards including the chronically-flaky shard 4, with this as the **only** change vs main.

## Note

The investigation into #4742 surfaced several real (but unrelated) GroupQueue dispatcher behaviors — delayed/future-scored jobs dispatching up to ~5s late in a quiet queue, and supporting correctness gaps. Those were **not** the cause of this flake and are tracked separately in #4814, with a working implementation preserved on `wip/groupqueue-dispatch-latency-findings`.

Closes #4742.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by serializing suites to prevent interference from shared test resources.
  * Added CI comments/documentation clarifying that integration suites share a single external instance and that file-level parallelism is disabled to avoid wiping in‑flight state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->