### PR TITLE
feat(dark-mode): add color mode toggle to navigation header

### DIFF
--- a/langwatch/src/components/DashboardLayout.tsx
+++ b/langwatch/src/components/DashboardLayout.tsx
@@ -66,6 +66,7 @@ import { SavedViewsBar } from "./messages/SavedViewsBar";
 import { PresenceMenuItem } from "./sidebar/PresenceMenuItem";
 import { SdkRadarBanner } from "./SdkRadarBanner";
 import { UpgradeModal } from "./UpgradeModal";
+import { ColorModeButton } from "./ui/color-mode";
 import { Link } from "./ui/link";
 import { Menu } from "./ui/menu";
 import { PageErrorFallback } from "./ui/PageErrorFallback";
@@ -707,6 +708,8 @@ export const DashboardLayout = ({
 
           {/* Command bar trigger */}
           {project && <CommandBarTrigger />}
+
+          <ColorModeButton />
 
           <Menu.Root>
             <Menu.Trigger asChild>

--- a/langwatch/src/components/datasets/MultilineJSONCellEditor.tsx
+++ b/langwatch/src/components/datasets/MultilineJSONCellEditor.tsx
@@ -74,7 +74,7 @@ export function MultilineJSONCellEditor({
         width="100%"
         height="100%"
         minHeight="64px"
-        backgroundColor="white"
+        backgroundColor="bg.surface"
         fontSize="13px"
         lineHeight="1.5em"
         value={localValue || ""}

--- a/langwatch/src/components/suites/ScenarioGridCard.tsx
+++ b/langwatch/src/components/suites/ScenarioGridCard.tsx
@@ -60,13 +60,13 @@ export function ScenarioGridCard({
           paddingY={0.5}
           borderRadius="md"
           border="1px solid"
-          borderColor="gray.300"
+          borderColor="border.muted"
           fontSize="xs"
           color="fg.default"
-          bg="white"
+          bg="bg.panel"
           cursor={isCancelling ? "default" : "pointer"}
           opacity={isCancelling ? 0.6 : 1}
-          _hover={isCancelling ? undefined : { bg: "gray.100", borderColor: "gray.400" }}
+          _hover={isCancelling ? undefined : { bg: "bg.muted", borderColor: "border.emphasized" }}
           position="absolute"
           top={2}
           right={2}

--- a/langwatch/src/pages/me/configure.tsx
+++ b/langwatch/src/pages/me/configure.tsx
@@ -587,7 +587,7 @@ function RevealedSecretBanner({
           gap={2}
           paddingX={2}
           paddingY={2}
-          backgroundColor="white"
+          backgroundColor="bg.panel"
           borderRadius="sm"
           borderWidth="1px"
           borderColor="border.muted"

--- a/specs/components/dark-mode.feature
+++ b/specs/components/dark-mode.feature
@@ -1,0 +1,24 @@
+Feature: Dark Mode Toggle
+
+  Background:
+    Given the user is logged into LangWatch
+
+  Scenario: Toggle dark mode from the header
+    When the user clicks the color mode button in the top navigation
+    Then the UI switches to dark mode
+    And the background becomes dark
+    And text remains readable
+
+  Scenario: Toggle back to light mode
+    Given the user is in dark mode
+    When the user clicks the color mode button in the top navigation
+    Then the UI switches to light mode
+
+  Scenario: Dark mode preference persists across page navigation
+    Given the user has enabled dark mode
+    When the user navigates to a different page
+    Then the UI remains in dark mode
+
+  Scenario: System preference is respected by default
+    Given the user has not set a preference
+    Then the UI follows the operating system color scheme preference


### PR DESCRIPTION
## Summary

- Adds the existing `ColorModeButton` to the `DashboardLayout` top-right header, making dark/light mode toggle accessible from every page using the dashboard shell (traces, analytics, settings, etc.)
- Replaces hardcoded `bg="white"` / `backgroundColor="white"` with semantic tokens in three components that were breaking dark mode visually
- Creates a BDD feature spec for dark mode toggle behavior

## Details

The dark mode infrastructure was already fully in place (Chakra v3 + `next-themes` + `ColorModeProvider` + comprehensive `_dark` semantic tokens in `_app.tsx`), but `ColorModeButton` was never rendered in any navigation surface. This PR closes that gap.

**Changed files:**
- `src/components/DashboardLayout.tsx` -- adds `ColorModeButton` between the command bar trigger and the user avatar
- `src/components/suites/ScenarioGridCard.tsx` -- `white` -> `bg.panel`, hover `gray.100` -> `bg.muted`
- `src/components/datasets/MultilineJSONCellEditor.tsx` -- `white` -> `bg.surface`
- `src/pages/me/configure.tsx` -- secret key display `white` -> `bg.panel`
- `specs/components/dark-mode.feature` -- BDD scenarios for the toggle

**Intentionally skipped:** CTA buttons on colored gradient banners (VoiceAgents, TracesV2, GovernanceGettingStarted, NewTracesPromo), toggle thumb in LLMConfigPopover, radio dot in IconRadioCardGroup -- all are deliberate design choices where white is part of the visual identity on colored backgrounds.

## Test plan

- [ ] Click the sun/moon icon in the top-right header -- UI switches between light and dark
- [ ] Navigate across pages (traces, settings, analytics) -- preference persists
- [ ] Reload the page -- preference persists (next-themes stores in localStorage)
- [ ] Scenario cards, JSON cell editor, and configure page secret display render correctly in dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added color mode toggle button in the dashboard header for seamless theme switching between light and dark modes.

* **Styling**
  * Updated component styling to use theme tokens for improved visual consistency and dark mode support across multiple components.

* **Tests**
  * Added comprehensive dark mode feature specifications including toggle functionality, persistence across navigation, and system preference detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->