### PR TITLE
fix(groupQueue): prevent blockingConnection from inheriting maxRetriesPerRequest=0

### DIFF
--- a/langwatch/specs/ops/group-queue-dispatcher-resilience.feature
+++ b/langwatch/specs/ops/group-queue-dispatcher-resilience.feature
@@ -27,3 +27,9 @@ Feature: GroupQueue dispatcher connection resilience
     Given startTestContainers has been called once for a given ClickHouse URL
     When startTestContainers is called again with the same ClickHouse URL
     Then initializeClickHouseSchema is not called a second time for that URL
+
+  @unit
+  Scenario: Cluster connections also get a dedicated blocking connection
+    Given a Redis Cluster connection as the consumer connection
+    When a GroupQueueProcessor is created in consumer mode
+    Then the blocking connection is a dedicated duplicate, not the shared cluster connection

--- a/langwatch/specs/ops/group-queue-dispatcher-resilience.feature
+++ b/langwatch/specs/ops/group-queue-dispatcher-resilience.feature
@@ -10,10 +10,10 @@ Feature: GroupQueue dispatcher connection resilience
   # up to exceed the 10-second vi.waitFor timeout in the squash test.
 
   @integration
-  Scenario: Blocking connection overrides maxRetriesPerRequest from source connection
-    Given a Redis connection created with maxRetriesPerRequest set to 0
+  Scenario: GroupQueueProcessor retries blocked operations regardless of source connection retry settings
+    Given a Redis connection configured to fail immediately on transient errors
     When a GroupQueueProcessor is created with this connection as the consumer connection
-    Then the internal blockingConnection has maxRetriesPerRequest set to null
+    Then the dispatcher retries BRPOP operations automatically after transient connection failures
 
   @integration
   Scenario: Delayed squashed job processes exactly once within timeout

--- a/langwatch/specs/ops/group-queue-dispatcher-resilience.feature
+++ b/langwatch/specs/ops/group-queue-dispatcher-resilience.feature
@@ -1,0 +1,29 @@
+Feature: GroupQueue dispatcher connection resilience
+  As CI infrastructure running integration tests across 6 shards
+  I want the GroupQueueProcessor's blocking connection to retry after transient Redis errors
+  So that flaky BRPOP failures do not stall the dispatcher and cause test timeouts
+
+  # Issue: https://github.com/langwatch/langwatch/issues/4824
+  # Root cause: blockingConnection inherited maxRetriesPerRequest=0 from the test
+  # Redis connection via duplicate(), causing BRPOP to throw immediately on transient
+  # connection drops instead of retrying. The dispatcher's 1-second error-sleep stacked
+  # up to exceed the 10-second vi.waitFor timeout in the squash test.
+
+  @integration
+  Scenario: Blocking connection overrides maxRetriesPerRequest from source connection
+    Given a Redis connection created with maxRetriesPerRequest set to 0
+    When a GroupQueueProcessor is created with this connection as the consumer connection
+    Then the internal blockingConnection has maxRetriesPerRequest set to null
+
+  @integration
+  Scenario: Delayed squashed job processes exactly once within timeout
+    Given a GroupQueueProcessor with delay 200ms and deduplication enabled
+    When two jobs with the same dedup key are sent in rapid succession
+    Then the processor callback receives the second job's payload exactly once
+    And this completes within 10 seconds
+
+  @unit
+  Scenario: ClickHouse migration guard prevents duplicate migrations per URL
+    Given startTestContainers has been called once for a given ClickHouse URL
+    When startTestContainers is called again with the same ClickHouse URL
+    Then initializeClickHouseSchema is not called a second time for that URL

--- a/langwatch/src/server/event-sourcing/__tests__/integration/testContainers.ts
+++ b/langwatch/src/server/event-sourcing/__tests__/integration/testContainers.ts
@@ -8,6 +8,7 @@ const logger = createLogger("langwatch:event-sourcing:test-containers");
 
 let clickHouseClient: ClickHouseClient | null = null;
 let redisConnection: Redis | null = null;
+const migratedUrls = new Set<string>();
 
 /**
  * Checks if we're running in CI with service containers (GitHub Actions).
@@ -64,8 +65,12 @@ export async function startTestContainers(): Promise<{
       });
     }
 
-    // Run goose migrations to create database and tables
-    await initializeClickHouseSchema(clickHouseUrl, TEST_DATABASE);
+    // Run goose migrations once per URL per process — subsequent test files in the
+    // same shard skip this (migrations are already applied and goose spawnSync is blocking).
+    if (!migratedUrls.has(clickHouseUrl)) {
+      await initializeClickHouseSchema(clickHouseUrl, TEST_DATABASE);
+      migratedUrls.add(clickHouseUrl);
+    }
 
     // Create client with the database in the URL path
     const urlWithDatabase = new URL(clickHouseUrl);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.blockingConnection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.blockingConnection.unit.test.ts
@@ -15,17 +15,30 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EventSourcedQueueDefinition } from "../../queue.types";
 import { GroupQueueProcessor } from "../groupQueue";
 
-// Prevent the real BRPOP dispatcher loop from starting — it would attempt
-// network I/O and open timer handles that outlive the test.
-vi.mock("../dispatcher", () => {
-  return {
-    GroupQueueDispatcher: vi.fn().mockImplementation(() => ({
-      start: vi.fn(),
-      requestShutdown: vi.fn(),
-      waitUntilStopped: vi.fn().mockResolvedValue(undefined),
-    })),
-  };
-});
+// The processor instantiates these collaborators with `new` in consumer mode.
+// The mock implementations MUST therefore be constructible — a
+// `vi.fn(() => ({ ... }))` arrow-returning factory is NOT a constructor under
+// Vitest 4.x and throws `TypeError: ... is not a constructor`, which previously
+// made both consumer-mode cases fail before reaching their assertions. Using a
+// class keeps the mock constructible.
+//
+// Mocking them also prevents the real BRPOP dispatcher loop and the metrics
+// `setInterval` from starting — both would attempt network I/O and open handles
+// that outlive the test.
+vi.mock("../dispatcher", () => ({
+  GroupQueueDispatcher: class {
+    start(): void {}
+    requestShutdown(): void {}
+    async waitUntilStopped(): Promise<void> {}
+  },
+}));
+
+vi.mock("../metricsCollector", () => ({
+  GroupQueueMetricsCollector: class {
+    start(): void {}
+    stop(): void {}
+  },
+}));
 
 type TestPayload = { id: string; groupId: string };
 
@@ -38,17 +51,29 @@ function makeDefinition(): EventSourcedQueueDefinition<TestPayload> {
 }
 
 describe("GroupQueueProcessor blockingConnection selection", () => {
+  const connections: Array<IORedis | Cluster> = [];
+
+  function track<T extends IORedis | Cluster>(conn: T): T {
+    connections.push(conn);
+    return conn;
+  }
+
   afterEach(() => {
+    // Force-close every connection created during the test — even if an
+    // assertion threw before the assertions completed — so no socket or
+    // reconnect timer outlives the file and wedges the runner.
+    for (const conn of connections.splice(0)) {
+      conn.disconnect();
+    }
     vi.restoreAllMocks();
   });
 
   describe("given consumer mode is enabled", () => {
     describe("when the source connection is a standalone IORedis", () => {
-      it("duplicates the connection with maxRetriesPerRequest: null for the blocking connection", async () => {
-        const conn = new IORedis({
-          lazyConnect: true,
-          maxRetriesPerRequest: 0,
-        });
+      it("duplicates the connection with maxRetriesPerRequest: null for the blocking connection", () => {
+        const conn = track(
+          new IORedis({ lazyConnect: true, maxRetriesPerRequest: 0 }),
+        );
         const dupSentinel = {} as IORedis;
         vi.spyOn(conn, "duplicate").mockReturnValue(dupSentinel as any);
 
@@ -62,16 +87,16 @@ describe("GroupQueueProcessor blockingConnection selection", () => {
           maxRetriesPerRequest: null,
         });
         expect((processor as any).blockingConnection).toBe(dupSentinel);
-
-        conn.disconnect();
       });
     });
 
     describe("when the source connection is a Redis Cluster", () => {
-      it("duplicates the connection for a dedicated blocking connection", async () => {
-        const conn = new Cluster([{ host: "127.0.0.1", port: 6379 }], {
-          lazyConnect: true,
-        });
+      it("duplicates the connection for a dedicated blocking connection", () => {
+        const conn = track(
+          new Cluster([{ host: "127.0.0.1", port: 6379 }], {
+            lazyConnect: true,
+          }),
+        );
         const dupSentinel = {} as Cluster;
         vi.spyOn(conn, "duplicate").mockReturnValue(dupSentinel as any);
 
@@ -83,19 +108,16 @@ describe("GroupQueueProcessor blockingConnection selection", () => {
 
         expect(conn.duplicate).toHaveBeenCalled();
         expect((processor as any).blockingConnection).toBe(dupSentinel);
-
-        conn.disconnect();
       });
     });
   });
 
   describe("given consumer mode is disabled", () => {
     describe("when the source connection is a standalone IORedis", () => {
-      it("uses the shared connection directly without duplicating", async () => {
-        const conn = new IORedis({
-          lazyConnect: true,
-          maxRetriesPerRequest: 0,
-        });
+      it("uses the shared connection directly without duplicating", () => {
+        const conn = track(
+          new IORedis({ lazyConnect: true, maxRetriesPerRequest: 0 }),
+        );
         const dupSpy = vi.spyOn(conn, "duplicate");
 
         const processor = new GroupQueueProcessor<TestPayload>(
@@ -106,16 +128,16 @@ describe("GroupQueueProcessor blockingConnection selection", () => {
 
         expect(dupSpy).not.toHaveBeenCalled();
         expect((processor as any).blockingConnection).toBe(conn);
-
-        conn.disconnect();
       });
     });
 
     describe("when the source connection is a Redis Cluster", () => {
-      it("uses the shared cluster connection directly without duplicating", async () => {
-        const conn = new Cluster([{ host: "127.0.0.1", port: 6379 }], {
-          lazyConnect: true,
-        });
+      it("uses the shared cluster connection directly without duplicating", () => {
+        const conn = track(
+          new Cluster([{ host: "127.0.0.1", port: 6379 }], {
+            lazyConnect: true,
+          }),
+        );
         const dupSpy = vi.spyOn(conn, "duplicate");
 
         const processor = new GroupQueueProcessor<TestPayload>(
@@ -126,8 +148,6 @@ describe("GroupQueueProcessor blockingConnection selection", () => {
 
         expect(dupSpy).not.toHaveBeenCalled();
         expect((processor as any).blockingConnection).toBe(conn);
-
-        conn.disconnect();
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.blockingConnection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.blockingConnection.unit.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression test: GroupQueueProcessor must duplicate the source connection
+ * for its BRPOP loop in BOTH standalone (IORedis) and cluster (Cluster) topologies.
+ *
+ * Bug: after the PR changed the topology check from duck-type
+ * ("duplicate" in effectiveConnection) to instanceof IORedis, a Cluster
+ * connection would fall through to the else branch and share the single
+ * connection — re-introducing the "BRPOP blocks the shared connection" problem.
+ *
+ * Fix: add an `instanceof Cluster` branch that calls `.duplicate()` with no args.
+ */
+
+import { Cluster, Redis as IORedis } from "ioredis";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EventSourcedQueueDefinition } from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+
+// Prevent the real BRPOP dispatcher loop from starting — it would attempt
+// network I/O and open timer handles that outlive the test.
+vi.mock("../dispatcher", () => {
+  return {
+    GroupQueueDispatcher: vi.fn().mockImplementation(() => ({
+      start: vi.fn(),
+      requestShutdown: vi.fn(),
+      waitUntilStopped: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
+
+type TestPayload = { id: string; groupId: string };
+
+function makeDefinition(): EventSourcedQueueDefinition<TestPayload> {
+  return {
+    name: `{test/gq/bc/${crypto.randomUUID().slice(0, 8)}}`,
+    process: async () => {},
+    groupKey: (p) => p.groupId,
+  };
+}
+
+describe("GroupQueueProcessor blockingConnection selection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("given consumer mode is enabled", () => {
+    describe("when the source connection is a standalone IORedis", () => {
+      it("duplicates the connection with maxRetriesPerRequest: null for the blocking connection", async () => {
+        const conn = new IORedis({
+          lazyConnect: true,
+          maxRetriesPerRequest: 0,
+        });
+        const dupSentinel = {} as IORedis;
+        vi.spyOn(conn, "duplicate").mockReturnValue(dupSentinel as any);
+
+        const processor = new GroupQueueProcessor<TestPayload>(
+          makeDefinition(),
+          conn,
+          { consumerEnabled: true },
+        );
+
+        expect(conn.duplicate).toHaveBeenCalledWith({
+          maxRetriesPerRequest: null,
+        });
+        expect((processor as any).blockingConnection).toBe(dupSentinel);
+
+        conn.disconnect();
+      });
+    });
+
+    describe("when the source connection is a Redis Cluster", () => {
+      it("duplicates the connection for a dedicated blocking connection", async () => {
+        const conn = new Cluster([{ host: "127.0.0.1", port: 6379 }], {
+          lazyConnect: true,
+        });
+        const dupSentinel = {} as Cluster;
+        vi.spyOn(conn, "duplicate").mockReturnValue(dupSentinel as any);
+
+        const processor = new GroupQueueProcessor<TestPayload>(
+          makeDefinition(),
+          conn,
+          { consumerEnabled: true },
+        );
+
+        expect(conn.duplicate).toHaveBeenCalled();
+        expect((processor as any).blockingConnection).toBe(dupSentinel);
+
+        conn.disconnect();
+      });
+    });
+  });
+
+  describe("given consumer mode is disabled", () => {
+    describe("when the source connection is a standalone IORedis", () => {
+      it("uses the shared connection directly without duplicating", async () => {
+        const conn = new IORedis({
+          lazyConnect: true,
+          maxRetriesPerRequest: 0,
+        });
+        const dupSpy = vi.spyOn(conn, "duplicate");
+
+        const processor = new GroupQueueProcessor<TestPayload>(
+          makeDefinition(),
+          conn,
+          { consumerEnabled: false },
+        );
+
+        expect(dupSpy).not.toHaveBeenCalled();
+        expect((processor as any).blockingConnection).toBe(conn);
+
+        conn.disconnect();
+      });
+    });
+
+    describe("when the source connection is a Redis Cluster", () => {
+      it("uses the shared cluster connection directly without duplicating", async () => {
+        const conn = new Cluster([{ host: "127.0.0.1", port: 6379 }], {
+          lazyConnect: true,
+        });
+        const dupSpy = vi.spyOn(conn, "duplicate");
+
+        const processor = new GroupQueueProcessor<TestPayload>(
+          makeDefinition(),
+          conn,
+          { consumerEnabled: false },
+        );
+
+        expect(dupSpy).not.toHaveBeenCalled();
+        expect((processor as any).blockingConnection).toBe(conn);
+
+        conn.disconnect();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.waitUntilReady.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.waitUntilReady.unit.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression test: GroupQueueProcessor.waitUntilReady() must survive a normal
+ * ioredis reconnect cycle.
+ *
+ * Bug: rejecting readiness on the first `error` (or `close`) event turned an
+ * ordinary transient ioredis reconnect into a startup failure. On an
+ * unavailable endpoint with maxRetriesPerRequest: null, ioredis emits
+ * `error` → `close` → `reconnecting` and can later emit `ready`; the old code
+ * rejected at the first event instead of waiting for recovery.
+ *
+ * Fix: keep waiting across transient `error`/`close` events and resolve on
+ * `ready`; reject only on the terminal `end` event.
+ */
+
+import { EventEmitter } from "node:events";
+import { Redis as IORedis } from "ioredis";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EventSourcedQueueDefinition } from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+
+// Constructible class mocks — the processor instantiates these with `new` in
+// consumer mode, and their real implementations open timers / Redis I/O that
+// would outlive the test.
+vi.mock("../dispatcher", () => ({
+  GroupQueueDispatcher: class {
+    start(): void {}
+    requestShutdown(): void {}
+    async waitUntilStopped(): Promise<void> {}
+  },
+}));
+
+vi.mock("../metricsCollector", () => ({
+  GroupQueueMetricsCollector: class {
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+/**
+ * Minimal stand-in for an ioredis connection that lets a test drive the
+ * lifecycle events (`error`, `close`, `reconnecting`, `ready`, `end`) by hand.
+ */
+class FakeConnection extends EventEmitter {
+  status = "connecting";
+}
+
+type TestPayload = { id: string; groupId: string };
+
+function makeDefinition(): EventSourcedQueueDefinition<TestPayload> {
+  return {
+    name: `{test/gq/wur/${crypto.randomUUID().slice(0, 8)}}`,
+    process: async () => {},
+    groupKey: (p) => p.groupId,
+  };
+}
+
+describe("GroupQueueProcessor waitUntilReady", () => {
+  const connections: IORedis[] = [];
+
+  function makeProcessor(blocking: FakeConnection): GroupQueueProcessor<TestPayload> {
+    const conn = new IORedis({ lazyConnect: true, maxRetriesPerRequest: 0 });
+    connections.push(conn);
+    // In consumer mode the processor builds its blocking connection via
+    // `.duplicate()`; hand it our controllable fake so the test drives its
+    // lifecycle directly.
+    vi.spyOn(conn, "duplicate").mockReturnValue(blocking as any);
+    return new GroupQueueProcessor<TestPayload>(makeDefinition(), conn, {
+      consumerEnabled: true,
+    });
+  }
+
+  afterEach(() => {
+    for (const conn of connections.splice(0)) {
+      conn.disconnect();
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe("given the blocking connection is reconnecting", () => {
+    describe("when it emits error -> close -> reconnecting -> ready", () => {
+      it("resolves readiness instead of rejecting on the transient error/close", async () => {
+        const blocking = new FakeConnection();
+        const processor = makeProcessor(blocking);
+
+        const ready = processor.waitUntilReady();
+        // Capture the outcome as a settled value so a premature rejection can't
+        // escape as an unhandled rejection while we drive the lifecycle.
+        const outcome = ready.then(
+          () => "resolved" as const,
+          (err) => ({ rejected: err }),
+        );
+
+        // A normal ioredis reconnect cycle against an unavailable endpoint with
+        // maxRetriesPerRequest: null.
+        blocking.emit("error", new Error("connect ECONNREFUSED 127.0.0.1:6379"));
+        blocking.emit("close");
+        blocking.emit("reconnecting", 50);
+        blocking.status = "ready";
+        blocking.emit("ready");
+
+        await expect(outcome).resolves.toBe("resolved");
+      });
+    });
+  });
+
+  describe("given the blocking connection terminates", () => {
+    describe("when it emits end without ever becoming ready", () => {
+      it("rejects readiness on the terminal end event", async () => {
+        const blocking = new FakeConnection();
+        const processor = makeProcessor(blocking);
+
+        const ready = processor.waitUntilReady();
+        const outcome = ready.then(
+          () => "resolved" as const,
+          (err: Error) => err.message,
+        );
+
+        blocking.emit("error", new Error("connect ECONNREFUSED 127.0.0.1:6379"));
+        blocking.emit("close");
+        blocking.emit("end");
+
+        await expect(outcome).resolves.toMatch(/ended before ready/i);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.waitUntilReady.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.waitUntilReady.unit.test.ts
@@ -57,7 +57,9 @@ function makeDefinition(): EventSourcedQueueDefinition<TestPayload> {
 describe("GroupQueueProcessor waitUntilReady", () => {
   const connections: IORedis[] = [];
 
-  function makeProcessor(blocking: FakeConnection): GroupQueueProcessor<TestPayload> {
+  function makeProcessor(
+    blocking: FakeConnection,
+  ): GroupQueueProcessor<TestPayload> {
     const conn = new IORedis({ lazyConnect: true, maxRetriesPerRequest: 0 });
     connections.push(conn);
     // In consumer mode the processor builds its blocking connection via
@@ -92,7 +94,10 @@ describe("GroupQueueProcessor waitUntilReady", () => {
 
         // A normal ioredis reconnect cycle against an unavailable endpoint with
         // maxRetriesPerRequest: null.
-        blocking.emit("error", new Error("connect ECONNREFUSED 127.0.0.1:6379"));
+        blocking.emit(
+          "error",
+          new Error("connect ECONNREFUSED 127.0.0.1:6379"),
+        );
         blocking.emit("close");
         blocking.emit("reconnecting", 50);
         blocking.status = "ready";
@@ -115,7 +120,10 @@ describe("GroupQueueProcessor waitUntilReady", () => {
           (err: Error) => err.message,
         );
 
-        blocking.emit("error", new Error("connect ECONNREFUSED 127.0.0.1:6379"));
+        blocking.emit(
+          "error",
+          new Error("connect ECONNREFUSED 127.0.0.1:6379"),
+        );
         blocking.emit("close");
         blocking.emit("end");
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -7,8 +7,7 @@ import {
 } from "@opentelemetry/api";
 import fastq from "fastq";
 // biome-ignore lint/style/useImportType: instanceof requires runtime class value
-import { Redis as IORedis } from "ioredis";
-import type { Cluster } from "ioredis";
+import { Redis as IORedis, type Cluster } from "ioredis";
 import { getLangWatchTracer } from "langwatch";
 import type { SemConvAttributes } from "langwatch/observability";
 import { createLogger } from "../../../../utils/logger/server";

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -6,7 +6,7 @@ import {
   TraceFlags,
 } from "@opentelemetry/api";
 import fastq from "fastq";
-import type IORedis from "ioredis";
+import IORedis from "ioredis";
 import type { Cluster } from "ioredis";
 import { getLangWatchTracer } from "langwatch";
 import type { SemConvAttributes } from "langwatch/observability";
@@ -178,12 +178,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     this.consumerEnabled = options?.consumerEnabled ?? true;
     // Dedicated connection for BRPOP to avoid blocking the shared connection.
     // Only needed when the dispatcher loop runs (consumer mode).
-    this.blockingConnection = this.consumerEnabled
-      ? "duplicate" in effectiveConnection &&
-        typeof effectiveConnection.duplicate === "function"
+    this.blockingConnection =
+      this.consumerEnabled && effectiveConnection instanceof IORedis
         ? effectiveConnection.duplicate({ maxRetriesPerRequest: null })
-        : effectiveConnection
-      : effectiveConnection;
+        : effectiveConnection;
     this.spanAttributes = spanAttributes;
     this.delay = delay;
     this.deduplication = deduplication;
@@ -1010,7 +1008,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   }
 
   async waitUntilReady(): Promise<void> {
-    // No-op — Redis connection is already established, fastq needs no setup.
+    const bc = this.blockingConnection;
+    if (bc === this.redisConnection) return;
+    if (bc.status === "ready") return;
+    await new Promise<void>((resolve) => bc.once("ready", resolve));
   }
 
   async close(): Promise<void> {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -7,7 +7,7 @@ import {
 } from "@opentelemetry/api";
 import fastq from "fastq";
 // biome-ignore lint/style/useImportType: instanceof requires runtime class value
-import { Redis as IORedis, type Cluster } from "ioredis";
+import { type Cluster, Redis as IORedis } from "ioredis";
 import { getLangWatchTracer } from "langwatch";
 import type { SemConvAttributes } from "langwatch/observability";
 import { createLogger } from "../../../../utils/logger/server";

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -6,6 +6,7 @@ import {
   TraceFlags,
 } from "@opentelemetry/api";
 import fastq from "fastq";
+// biome-ignore lint/style/useImportType: instanceof requires runtime class value
 import { Redis as IORedis } from "ioredis";
 import type { Cluster } from "ioredis";
 import { getLangWatchTracer } from "langwatch";

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -6,7 +6,7 @@ import {
   TraceFlags,
 } from "@opentelemetry/api";
 import fastq from "fastq";
-import IORedis from "ioredis";
+import { Redis as IORedis } from "ioredis";
 import type { Cluster } from "ioredis";
 import { getLangWatchTracer } from "langwatch";
 import type { SemConvAttributes } from "langwatch/observability";

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1011,7 +1011,31 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const bc = this.blockingConnection;
     if (bc === this.redisConnection) return;
     if (bc.status === "ready") return;
-    await new Promise<void>((resolve) => bc.once("ready", resolve));
+    await new Promise<void>((resolve, reject) => {
+      const onReady = () => {
+        bc.off("error", onError);
+        bc.off("end", onEnd);
+        bc.off("close", onEnd);
+        resolve();
+      };
+      const onError = (err: unknown) => {
+        bc.off("ready", onReady);
+        bc.off("end", onEnd);
+        bc.off("close", onEnd);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      };
+      const onEnd = () => {
+        bc.off("ready", onReady);
+        bc.off("error", onError);
+        bc.off("end", onEnd);
+        bc.off("close", onEnd);
+        reject(new Error("Blocking Redis connection closed before ready"));
+      };
+      bc.once("ready", onReady);
+      bc.once("error", onError);
+      bc.once("end", onEnd);
+      bc.once("close", onEnd);
+    });
   }
 
   async close(): Promise<void> {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -6,8 +6,7 @@ import {
   TraceFlags,
 } from "@opentelemetry/api";
 import fastq from "fastq";
-// biome-ignore lint/style/useImportType: instanceof requires runtime class value
-import { type Cluster, Redis as IORedis } from "ioredis";
+import { Cluster, Redis as IORedis } from "ioredis";
 import { getLangWatchTracer } from "langwatch";
 import type { SemConvAttributes } from "langwatch/observability";
 import { createLogger } from "../../../../utils/logger/server";
@@ -178,10 +177,15 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     this.consumerEnabled = options?.consumerEnabled ?? true;
     // Dedicated connection for BRPOP to avoid blocking the shared connection.
     // Only needed when the dispatcher loop runs (consumer mode).
-    this.blockingConnection =
-      this.consumerEnabled && effectiveConnection instanceof IORedis
+    // IORedis.duplicate() takes an options override; Cluster.duplicate() takes no
+    // args (maxRetriesPerRequest: null is already set inside Cluster's redisOptions).
+    this.blockingConnection = !this.consumerEnabled
+      ? effectiveConnection
+      : effectiveConnection instanceof IORedis
         ? effectiveConnection.duplicate({ maxRetriesPerRequest: null })
-        : effectiveConnection;
+        : effectiveConnection instanceof Cluster
+          ? effectiveConnection.duplicate()
+          : effectiveConnection;
     this.spanAttributes = spanAttributes;
     this.delay = delay;
     this.deduplication = deduplication;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -181,7 +181,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     this.blockingConnection = this.consumerEnabled
       ? "duplicate" in effectiveConnection &&
         typeof effectiveConnection.duplicate === "function"
-        ? effectiveConnection.duplicate()
+        ? effectiveConnection.duplicate({ maxRetriesPerRequest: null })
         : effectiveConnection
       : effectiveConnection;
     this.spanAttributes = spanAttributes;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -1013,32 +1013,49 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
   async waitUntilReady(): Promise<void> {
     const bc = this.blockingConnection;
+    // The shared connection's readiness is owned by whoever created it.
     if (bc === this.redisConnection) return;
     if (bc.status === "ready") return;
+    // `end` is ioredis's terminal state — it fires only when no further
+    // reconnection will be attempted. If we already missed the window, fail
+    // fast rather than wait for an event that will never come.
+    if (bc.status === "end") {
+      throw new Error("Blocking Redis connection ended before ready");
+    }
     await new Promise<void>((resolve, reject) => {
-      const onReady = () => {
-        bc.off("error", onError);
+      const cleanup = () => {
+        bc.off("ready", onReady);
         bc.off("end", onEnd);
-        bc.off("close", onEnd);
+        bc.off("error", onError);
+      };
+      const onReady = () => {
+        cleanup();
         resolve();
       };
-      const onError = (err: unknown) => {
-        bc.off("ready", onReady);
-        bc.off("end", onEnd);
-        bc.off("close", onEnd);
-        reject(err instanceof Error ? err : new Error(String(err)));
-      };
       const onEnd = () => {
-        bc.off("ready", onReady);
-        bc.off("error", onError);
-        bc.off("end", onEnd);
-        bc.off("close", onEnd);
-        reject(new Error("Blocking Redis connection closed before ready"));
+        cleanup();
+        reject(new Error("Blocking Redis connection ended before ready"));
+      };
+      // Transient reconnect events are EXPECTED while ioredis retries with
+      // maxRetriesPerRequest: null — on an unavailable endpoint it emits
+      // `error` → `close` → `reconnecting` and can later recover with `ready`.
+      // Rejecting on `error`/`close` would turn a recoverable Redis blip into a
+      // pipeline-startup failure (the regression this guards). So we do NOT
+      // listen for `close` at all, and the `error` listener only absorbs the
+      // error (keeping a listener attached so ioredis' emit is never unhandled)
+      // and keeps waiting. Only the terminal `end` event fails readiness.
+      const onError = (err: unknown) => {
+        this.logger.debug(
+          {
+            queueName: this.queueName,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "Blocking connection error while awaiting readiness; awaiting reconnect",
+        );
       };
       bc.once("ready", onReady);
-      bc.once("error", onError);
       bc.once("end", onEnd);
-      bc.once("close", onEnd);
+      bc.on("error", onError);
     });
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `GroupQueueProcessor.blockingConnection` was created via `effectiveConnection.duplicate()` with no option overrides. The test Redis connection uses `maxRetriesPerRequest: 0` (fast-fail for isolation), so the blocking connection inherited this — causing BRPOP to throw immediately on any transient error instead of retrying.
- **Effect**: Under CI load (6 shards), transient connection drops on `blockingConnection` sent the dispatcher into a 1-second error-sleep loop for 10+ seconds, causing the "processes only once with squashed data" test to hit its `vi.waitFor` timeout.
- **Fix 1 (primary)**: `duplicate({ maxRetriesPerRequest: null })` for standalone IORedis and a dedicated `duplicate()` for Cluster — restores ioredis default unlimited-retry behaviour for the blocking connection regardless of source connection settings, in both topologies.
- **Fix 2 (readiness)**: `waitUntilReady()` now waits across transient `error`/`close` reconnect events and resolves on `ready`, rejecting only on the terminal `end` event — so a recoverable Redis blip no longer fails pipeline startup.
- **Fix 3 (secondary)**: Guard `initializeClickHouseSchema()` to run once per ClickHouse URL per process, eliminating redundant synchronous `spawnSync("goose", ...)` calls (previously called twice per test file).

Closes #4824 — unblocks PRs #4468, #3877, #3541, #2155.

## Test plan

- [x] `groupQueue.blockingConnection.unit.test.ts` — 4/4 pass, exit 0 (constructs + asserts under Vitest 4.1.4)
- [x] `groupQueue.waitUntilReady.unit.test.ts` — 2/2 pass, exit 0 (transient reconnect resolves; terminal `end` rejects)
- [x] `pnpm typecheck` — exit 0
- [ ] CI shard passes `groupQueue.integration.test.ts` (all tests green, including "processes only once with squashed data")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GroupQueue Redis blocking behavior to ensure transient failures correctly retry BRPOP even when per-request retries are effectively disabled.
  * Updated readiness handling to wait for the blocking connection to become ready, or fail fast on error/close/end.
  * Ensured deduplicated delayed jobs trigger the processor callback exactly once for rapid submissions with the same dedup key.

* **Tests**
  * Added resilience/correctness coverage for GroupQueue dispatcher/processor scenarios.
  * Prevented redundant ClickHouse schema/migration initialization by running migrations at most once per ClickHouse URL per process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## ✅ Falsifiability verification (Claude, 2026-06-19) — both review blockers closed

The two P1 blockers from the `langwatch-agent` review are now fixed, each proven with a **revert → FAIL / fix → PASS** capture run locally on the PR's pinned **Vitest 4.1.4** (no Redis/ClickHouse needed — `BUILD_TIME=1`, focused files exit 0 on their own).

### AC1 — the regression test now executes and is falsifiable

The committed test's dispatcher mock used an **arrow** `vi.fn(() => ({…}))`, which Vitest 4.x cannot invoke with `new`: both consumer-mode cases threw `TypeError: … is not a constructor` at `new GroupQueueProcessor` (`groupQueue.ts:252`) **before reaching their assertions**, and CI's `process.exit(0)` hard-floor (`src/test-unit-global-setup.ts`) swallowed the non-zero exit → false green. Fixed by using constructible `class` mocks for `GroupQueueDispatcher` **and** `GroupQueueMetricsCollector` (the latter's real `start()` opens a metrics `setInterval` + Redis I/O), and force-disconnecting created connections in `afterEach`.

| Code under test | Result |
|---|---|
| broken arrow mock (as previously committed) | `2 failed \| 2 passed`, **exit 1** — `TypeError: () => ({…}) is not a constructor` @ `groupQueue.ts:252` |
| mock fixed, `instanceof Cluster` branch **reverted** | `1 failed \| 3 passed`, **exit 1** — Cluster case: `AssertionError: expected "duplicate" to be called at least once` |
| mock fixed, full fix applied (HEAD) | **`4 passed`, exit 0** — clean exit, no open handles |

The middle row is the falsifiability proof: the test genuinely catches the Cluster regression it guards.

### AC2 — readiness survives a transient reconnect

`waitUntilReady()` rejected on the first `error` (and `close`), turning a normal ioredis reconnect (`error → close → reconnecting → ready`) into a startup failure. It now waits across transient events and rejects only on the terminal `end`. New test `groupQueue.waitUntilReady.unit.test.ts` drives the exact sequence with a controllable fake blocking connection.

| Code under test | Result |
|---|---|
| over-eager reject (pre-fix `waitUntilReady`) | `2 failed`, **exit 1** — reconnect case rejected with `connect ECONNREFUSED …` instead of resolving |
| fix applied (HEAD) | **`2 passed`, exit 0** — `error → close → reconnecting → ready` resolves; terminal `end` rejects with "ended before ready" |

### Combined

`vitest run` on both files together: **`Test Files 2 passed (2)`, `Tests 6 passed (6)`, exit 0**. `pnpm typecheck`: **exit 0**.

<!-- claude-falsifiability-verification: 2026-06-19 -->



### Browser/UI surface check (per `browser-qa` procedure)

Checked whether this fix has a user-observable surface to screenshot — **it does not**; this is a backend queue-config/infra fix:

- Diff touches **only `.ts` + `.feature`** — no `.tsx`, no pages, no components.
- `GroupQueueProcessor` is backend event-sourcing plumbing (instantiated only in `eventSourcing.ts`; feeds experiment-run-processing + event ingestion). No page renders queue / dispatcher / `blockingConnection` state (grep over `src/pages` + `src/components`: none).
- The fix changes BRPOP **resilience under transient Redis errors**, not any rendered output. Under normal operation the app behaves identically with or without it; showing the difference requires Redis fault-injection, not a browser interaction.

Per the browser-qa procedure ("When the PR has no UI surface — bail out immediately, do not browser-QA it"; "queue config" is a named trigger; canonical incident PR #4903), the **falsifiability tests above are the correct and primary proof**. No screenshots apply.

<!-- claude-ui-surface-check: 2026-06-18 -->
