### PR TITLE
perf(clickhouse): fold topic-clustering counts to a single argMax pass

### DIFF
--- a/langwatch/src/server/topicClustering/__tests__/fetchCountsFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchCountsFromClickHouse.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration coverage for the topic-clustering trace-counts query against a
+ * real ClickHouse.
+ *
+ * `fetchCountsFromClickHouse` returns total / recent (last 30d) / assigned
+ * (has a topic) counts over the last 12 months. trace_summaries is a
+ * ReplacingMergeTree, so each trace must be counted once at its *latest*
+ * version. These tests lock in that the single-pass argMax fold reads the
+ * latest version's OccurredAt / TopicId — including the case where a stale
+ * older version would otherwise change the count.
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { fetchCountsFromClickHouse } from "../topicClustering";
+
+const TENANT_ID = `topic-counts-test-${nanoid(6)}`;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+type TraceRow = Record<string, unknown>;
+
+function traceRow(opts: {
+  traceId: string;
+  occurredAtMs: number;
+  updatedAtMs: number;
+  topicId: string | null;
+}): TraceRow {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: TENANT_ID,
+    TraceId: opts.traceId,
+    Version: "v1",
+    Attributes: {},
+    OccurredAt: new Date(opts.occurredAtMs),
+    CreatedAt: new Date(opts.occurredAtMs),
+    UpdatedAt: new Date(opts.updatedAtMs),
+    ComputedIOSchemaVersion: "",
+    ComputedInput: "in",
+    ComputedOutput: "out",
+    TimeToFirstTokenMs: 1,
+    TimeToLastTokenMs: 1,
+    TotalDurationMs: 1,
+    TokensPerSecond: 1,
+    SpanCount: 1,
+    ContainsErrorStatus: 0,
+    ContainsOKStatus: 1,
+    ErrorMessage: null,
+    Models: ["gpt-5-mini"],
+    TotalCost: 0.01,
+    TokensEstimated: false,
+    TotalPromptTokenCount: 1,
+    TotalCompletionTokenCount: 1,
+    OutputFromRootSpan: 0,
+    OutputSpanEndTimeMs: 0,
+    BlockedByGuardrail: 0,
+    TopicId: opts.topicId,
+    SubTopicId: null,
+    HasAnnotation: null,
+  };
+}
+
+describe("fetchCountsFromClickHouse integration", () => {
+  let ch: ClickHouseClient;
+
+  beforeAll(async () => {
+    const raw = getTestClickHouseClient();
+    if (!raw) throw new Error("ClickHouse client not available");
+    ch = wrapWithDefaultSettings(raw);
+
+    const now = Date.now();
+    const rows: TraceRow[] = [
+      // A: latest version is recent (5d) AND assigned. A stale older version
+      // (200d, no topic) must NOT win the dedup.
+      traceRow({
+        traceId: `${TENANT_ID}-A`,
+        occurredAtMs: now - 200 * DAY,
+        updatedAtMs: now - 200 * DAY,
+        topicId: null,
+      }),
+      traceRow({
+        traceId: `${TENANT_ID}-A`,
+        occurredAtMs: now - 5 * DAY,
+        updatedAtMs: now - 5 * DAY,
+        topicId: "topic-1",
+      }),
+      // B: single version, old (90d, within 12mo) and unassigned.
+      traceRow({
+        traceId: `${TENANT_ID}-B`,
+        occurredAtMs: now - 90 * DAY,
+        updatedAtMs: now - 90 * DAY,
+        topicId: null,
+      }),
+      // C: single version, recent (10d) and unassigned.
+      traceRow({
+        traceId: `${TENANT_ID}-C`,
+        occurredAtMs: now - 10 * DAY,
+        updatedAtMs: now - 10 * DAY,
+        topicId: "",
+      }),
+      // D: outside the 12-month window — excluded entirely.
+      traceRow({
+        traceId: `${TENANT_ID}-D`,
+        occurredAtMs: now - 400 * DAY,
+        updatedAtMs: now - 400 * DAY,
+        topicId: "topic-2",
+      }),
+    ];
+
+    await ch.insert({
+      table: "trace_summaries",
+      values: rows,
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await cleanupTestData(TENANT_ID);
+  });
+
+  describe("when traces span the recency / assignment / version dimensions", () => {
+    it("counts each trace once at its latest version", async () => {
+      const counts = await fetchCountsFromClickHouse(ch, TENANT_ID);
+
+      // A, B, C are within 12 months; D is excluded.
+      expect(counts.totalTracesCount).toBe(3);
+      // A (5d) and C (10d) are within 30 days; B (90d) is not.
+      expect(counts.recentTracesCount).toBe(2);
+      // Only A's latest version carries a non-empty TopicId. C's "" and the
+      // stale A version's null must not count.
+      expect(counts.assignedTracesCount).toBe(1);
+    });
+  });
+});

--- a/langwatch/src/server/topicClustering/__tests__/fetchCountsFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchCountsFromClickHouse.integration.test.ts
@@ -125,17 +125,22 @@ describe("fetchCountsFromClickHouse integration", () => {
     await cleanupTestData(TENANT_ID);
   });
 
-  describe("when traces span the recency / assignment / version dimensions", () => {
-    it("counts each trace once at its latest version", async () => {
-      const counts = await fetchCountsFromClickHouse(ch, TENANT_ID);
+  describe("given traces across recency, assignment, and version dimensions", () => {
+    describe("when counting total / recent / assigned", () => {
+      it("counts each trace once at its latest version", async () => {
+        const counts = await fetchCountsFromClickHouse({
+          clickhouse: ch,
+          projectId: TENANT_ID,
+        });
 
-      // A, B, C are within 12 months; D is excluded.
-      expect(counts.totalTracesCount).toBe(3);
-      // A (5d) and C (10d) are within 30 days; B (90d) is not.
-      expect(counts.recentTracesCount).toBe(2);
-      // Only A's latest version carries a non-empty TopicId. C's "" and the
-      // stale A version's null must not count.
-      expect(counts.assignedTracesCount).toBe(1);
+        // A, B, C are within 12 months; D is excluded.
+        expect(counts.totalTracesCount).toBe(3);
+        // A (5d) and C (10d) are within 30 days; B (90d) is not.
+        expect(counts.recentTracesCount).toBe(2);
+        // Only A's latest version carries a non-empty TopicId. C's "" and the
+        // stale A version's null must not count.
+        expect(counts.assignedTracesCount).toBe(1);
+      });
     });
   });
 });

--- a/langwatch/src/server/topicClustering/__tests__/fetchCountsFromClickHouse.integration.test.ts
+++ b/langwatch/src/server/topicClustering/__tests__/fetchCountsFromClickHouse.integration.test.ts
@@ -111,6 +111,22 @@ describe("fetchCountsFromClickHouse integration", () => {
         updatedAtMs: now - 400 * DAY,
         topicId: "topic-2",
       }),
+      // E: latest version CLEARS the topic (recent). A stale older version
+      // (also recent) had a topic. The latest wins, so E is recent but NOT
+      // assigned — guards against argMax skipping the NULL latest TopicId and
+      // folding to the stale non-null one.
+      traceRow({
+        traceId: `${TENANT_ID}-E`,
+        occurredAtMs: now - 5 * DAY,
+        updatedAtMs: now - 5 * DAY,
+        topicId: "topic-3",
+      }),
+      traceRow({
+        traceId: `${TENANT_ID}-E`,
+        occurredAtMs: now - 1 * DAY,
+        updatedAtMs: now - 1 * DAY,
+        topicId: null,
+      }),
     ];
 
     await ch.insert({
@@ -133,12 +149,12 @@ describe("fetchCountsFromClickHouse integration", () => {
           projectId: TENANT_ID,
         });
 
-        // A, B, C are within 12 months; D is excluded.
-        expect(counts.totalTracesCount).toBe(3);
-        // A (5d) and C (10d) are within 30 days; B (90d) is not.
-        expect(counts.recentTracesCount).toBe(2);
-        // Only A's latest version carries a non-empty TopicId. C's "" and the
-        // stale A version's null must not count.
+        // A, B, C, E are within 12 months; D is excluded.
+        expect(counts.totalTracesCount).toBe(4);
+        // A (5d), C (10d), E (1d) are within 30 days; B (90d) is not.
+        expect(counts.recentTracesCount).toBe(3);
+        // Only A's latest version carries a non-empty TopicId. C's "", the
+        // stale A version's null, and E's latest-cleared null must not count.
         expect(counts.assignedTracesCount).toBe(1);
       });
     });

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -47,7 +47,7 @@ export const clusterTopicsForProject = async (
   }
 
   const { totalTracesCount, recentTracesCount, assignedTracesCount } =
-    await fetchCountsFromClickHouse(clickhouse, projectId);
+    await fetchCountsFromClickHouse({ clickhouse, projectId });
 
   logger.info(
     {
@@ -186,10 +186,13 @@ type TraceSearchResult = {
   returnedCount: number;
 };
 
-export async function fetchCountsFromClickHouse(
-  clickhouse: ClickHouseClient,
-  projectId: string,
-): Promise<TraceCounts> {
+export async function fetchCountsFromClickHouse({
+  clickhouse,
+  projectId,
+}: {
+  clickhouse: ClickHouseClient;
+  projectId: string;
+}): Promise<TraceCounts> {
   const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
   const twelveMonthsAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
 

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -186,29 +186,36 @@ type TraceSearchResult = {
   returnedCount: number;
 };
 
-async function fetchCountsFromClickHouse(
+export async function fetchCountsFromClickHouse(
   clickhouse: ClickHouseClient,
   projectId: string,
 ): Promise<TraceCounts> {
   const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
   const twelveMonthsAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
 
+  // trace_summaries is a ReplacingMergeTree, so we count one row per trace
+  // (its latest version). Rather than the IN-tuple dedup pattern — which
+  // scans the 12-month window twice (once to build the latest-version key
+  // set, once for the outer aggregate) and materialises a key set sized to
+  // every trace — fold to the latest version in a single GROUP BY pass with
+  // argMax(col, UpdatedAt). The conditional counts read the latest version's
+  // OccurredAt / TopicId, identical to the previous shape, but with one scan
+  // and no IN-set build. Light columns only (no heavy payloads).
   const result = await clickhouse.query({
     query: `
       SELECT
         toString(count(*)) AS total,
-        toString(countIf(OccurredAt >= fromUnixTimestamp64Milli({thirtyDaysAgo:UInt64}))) AS recent,
-        toString(countIf(TopicId IS NOT NULL AND TopicId != '')) AS assigned
-      FROM trace_summaries t
-      WHERE TenantId = {tenantId:String}
-        AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
-        AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
-          SELECT TenantId, TraceId, max(UpdatedAt)
-          FROM trace_summaries
-          WHERE TenantId = {tenantId:String}
-            AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
-          GROUP BY TenantId, TraceId
-        )
+        toString(countIf(latestOccurredAt >= fromUnixTimestamp64Milli({thirtyDaysAgo:UInt64}))) AS recent,
+        toString(countIf(latestTopicId IS NOT NULL AND latestTopicId != '')) AS assigned
+      FROM (
+        SELECT
+          argMax(OccurredAt, UpdatedAt) AS latestOccurredAt,
+          argMax(TopicId, UpdatedAt) AS latestTopicId
+        FROM trace_summaries
+        WHERE TenantId = {tenantId:String}
+          AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})
+        GROUP BY TenantId, TraceId
+      )
     `,
     query_params: { tenantId: projectId, thirtyDaysAgo, twelveMonthsAgo },
     format: "JSONEachRow",

--- a/langwatch/src/server/topicClustering/topicClustering.ts
+++ b/langwatch/src/server/topicClustering/topicClustering.ts
@@ -201,19 +201,26 @@ export async function fetchCountsFromClickHouse({
   // scans the 12-month window twice (once to build the latest-version key
   // set, once for the outer aggregate) and materialises a key set sized to
   // every trace — fold to the latest version in a single GROUP BY pass with
-  // argMax(col, UpdatedAt). The conditional counts read the latest version's
-  // OccurredAt / TopicId, identical to the previous shape, but with one scan
-  // and no IN-set build. Light columns only (no heavy payloads).
+  // argMax(expr, UpdatedAt). The conditional counts read the latest version's
+  // OccurredAt / assigned-state, identical to the previous shape, but with one
+  // scan and no IN-set build. Light columns only (no heavy payloads).
+  //
+  // The assigned check folds over `argMax(TopicId IS NOT NULL AND TopicId !=
+  // '', UpdatedAt)`, not `argMax(TopicId, UpdatedAt)`: TopicId is Nullable and
+  // argMax skips rows whose first argument is NULL, so a trace whose latest
+  // version cleared its topic (latest TopicId = NULL) would otherwise fold to
+  // an older non-null TopicId and be over-counted. The boolean expression is
+  // non-nullable, so the fold reads the true latest version.
   const result = await clickhouse.query({
     query: `
       SELECT
         toString(count(*)) AS total,
         toString(countIf(latestOccurredAt >= fromUnixTimestamp64Milli({thirtyDaysAgo:UInt64}))) AS recent,
-        toString(countIf(latestTopicId IS NOT NULL AND latestTopicId != '')) AS assigned
+        toString(countIf(latestAssigned)) AS assigned
       FROM (
         SELECT
           argMax(OccurredAt, UpdatedAt) AS latestOccurredAt,
-          argMax(TopicId, UpdatedAt) AS latestTopicId
+          argMax(TopicId IS NOT NULL AND TopicId != '', UpdatedAt) AS latestAssigned
         FROM trace_summaries
         WHERE TenantId = {tenantId:String}
           AND OccurredAt >= fromUnixTimestamp64Milli({twelveMonthsAgo:UInt64})


### PR DESCRIPTION
## Evidence

`fetchCountsFromClickHouse` (topic-clustering stats: total / recent-30d / assigned trace counts over the last 12 months) shows up in the last 24h of prod slow-query logs at ~52 hits, **p50 ~3.9s / p95 ~6.6s**, ~307MB read per call. It is one of the two slowest distinct query shapes in the window and is not addressed by any open PR (#4571 only caps the sibling page-fetch's `max_threads`).

## Suspected cause

The query uses the IN-tuple dedup pattern over a 12-month trace population:

```sql
... FROM trace_summaries t
WHERE TenantId = {..} AND OccurredAt >= {twelveMonthsAgo}
  AND (t.TenantId, t.TraceId, t.UpdatedAt) IN (
    SELECT TenantId, TraceId, max(UpdatedAt) FROM trace_summaries
    WHERE TenantId = {..} AND OccurredAt >= {twelveMonthsAgo}
    GROUP BY TenantId, TraceId
  )
```

That dedup pattern is the right call when you need to pull **heavy** columns for a small set of rows (it avoids materialising big payloads for stale versions). But here every selected column is light (`OccurredAt`, `TopicId`) and the result is an aggregate, so the pattern costs more than it saves: the 12-month window is scanned twice (once to build the latest-version key set, once for the outer aggregate) and ClickHouse materialises an IN-set sized to every trace in the window.

## Proposed fix

Fold each trace to its latest version in a single `GROUP BY` pass with `argMax(col, UpdatedAt)`, then aggregate:

```sql
SELECT
  count(*) AS total,
  countIf(latestOccurredAt >= {thirtyDaysAgo}) AS recent,
  countIf(latestTopicId IS NOT NULL AND latestTopicId != '') AS assigned
FROM (
  SELECT argMax(OccurredAt, UpdatedAt) AS latestOccurredAt,
         argMax(TopicId, UpdatedAt) AS latestTopicId
  FROM trace_summaries
  WHERE TenantId = {..} AND OccurredAt >= {twelveMonthsAgo}
  GROUP BY TenantId, TraceId
)
```

`argMax(col, UpdatedAt)` reads the latest version's value for each trace — the same value the IN-tuple shape selected — so total/recent/assigned are identical. One scan, no IN-set build. This matches the repo's own guidance to derive latest-version values with `argMax(col, UpdatedAt)`.

## Expected impact

Roughly halves the read (one pass instead of two) and removes the per-trace IN-set materialisation, which is the dominant cost on busy tenants. Expect p50/p95 and read-bytes to drop materially; the 12-month partition pruning is unchanged (already present on both shapes).

## Test plan

New `fetchCountsFromClickHouse.integration.test.ts` (testcontainers, real ClickHouse): inserts traces spanning the recency / assignment / 12-month-window dimensions, **including a stale older version of one trace** (old + no topic) whose latest version is recent + assigned, and asserts total=3 / recent=2 / assigned=1 — i.e. the fold reads the latest version, not a stale one. `fetchCountsFromClickHouse` is exported for this. Passes locally.

## EXPLAIN check

`EXPLAIN PIPELINE` on a known-large tenant:

- Old: contains a `CreatingSets` stage (builds + probes the latest-version IN-set).
- New: **no `CreatingSets`** — a single grouped `ReadFromMergeTree` → `AggregatingTransform`.

```
OLD: 1 ReadFromMergeTree (outer) + 1 CreatingSets (the dedup IN-set, its own scan)
NEW: 1 ReadFromMergeTree, 0 CreatingSets
```

## Notes

- Advisory PR from the ClickHouse slow-query sweep. Please re-run the EXPLAIN before merge.
- Sibling shape `fetchTracesFromClickHouse` (the page-fetch) is handled separately in #4571; this PR deliberately touches only the counts function to keep the diffs independent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a ClickHouse integration test for topic-clustering trace counting, covering multi-version deduplication, recency filtering (last 30 days), and assignment detection (including excluding traces older than 12 months).
* **Refactor**
  * Improved trace counting logic by deriving the latest per-trace values in the ClickHouse query, resulting in more accurate “recent” and “assigned” counts.
* **Chores**
  * Updated the ClickHouse counting helper and its call sites to use a single argument object for clearer invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->