### PR TITLE
perf(clickhouse): fold simulation set-id dedup to a single argMax pass

### DIFF
--- a/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/simulations/__tests__/simulation.clickhouse.repository.integration.test.ts
@@ -635,5 +635,59 @@ describe("SimulationClickHouseRepository (integration)", () => {
         expect(result.size).toBe(2);
       });
     });
+
+    describe("when a run has an archived state that changed across versions", () => {
+      it("reads each run's latest version to decide inclusion", async () => {
+        const tenantId = `test-distinct-versions-${nanoid()}`;
+
+        // set-revived: latest version un-archives the run -> set included.
+        const revivedRun = `run-revived-${nanoid()}`;
+        const revivedBatch = `batch-revived-${nanoid()}`;
+        await insertRow(ch, makeInsertRow({
+          TenantId: tenantId,
+          ScenarioRunId: revivedRun,
+          BatchRunId: revivedBatch,
+          ScenarioSetId: "set-revived",
+          ArchivedAt: new Date(Date.now() - 10_000),
+          UpdatedAt: new Date(Date.now() - 10_000),
+        }));
+        await insertRow(ch, makeInsertRow({
+          TenantId: tenantId,
+          ScenarioRunId: revivedRun,
+          BatchRunId: revivedBatch,
+          ScenarioSetId: "set-revived",
+          ArchivedAt: null,
+          UpdatedAt: new Date(),
+        }));
+
+        // set-archived: latest version archives the run -> set excluded, even
+        // though an older non-archived version exists.
+        const archivedRun = `run-archived-${nanoid()}`;
+        const archivedBatch = `batch-archived-${nanoid()}`;
+        await insertRow(ch, makeInsertRow({
+          TenantId: tenantId,
+          ScenarioRunId: archivedRun,
+          BatchRunId: archivedBatch,
+          ScenarioSetId: "set-archived",
+          ArchivedAt: null,
+          UpdatedAt: new Date(Date.now() - 10_000),
+        }));
+        await insertRow(ch, makeInsertRow({
+          TenantId: tenantId,
+          ScenarioRunId: archivedRun,
+          BatchRunId: archivedBatch,
+          ScenarioSetId: "set-archived",
+          ArchivedAt: new Date(),
+          UpdatedAt: new Date(),
+        }));
+
+        const result = await repo.getDistinctExternalSetIds({
+          projectIds: [tenantId],
+        });
+
+        expect(result.has("set-revived")).toBe(true);
+        expect(result.has("set-archived")).toBe(false);
+      });
+    });
   });
 });

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -979,19 +979,26 @@ export class SimulationClickHouseRepository implements SimulationRepository {
       return new Set();
     }
 
+    // simulation_runs is a ReplacingMergeTree, so each run is read at its
+    // latest version. Rather than the IN-tuple dedup pattern — which scans the
+    // table twice (once to build the latest-version key set, once for the
+    // outer filter) and materialises a key set sized to every run — fold each
+    // run to its latest version in a single GROUP BY pass with
+    // argMax(ArchivedAt, UpdatedAt) and keep the sets whose latest run is not
+    // archived. Light columns only; the distinct external set ids are
+    // identical.
     const rows = await this.queryRows<{ ScenarioSetId: string }>(
       `SELECT DISTINCT IF(ScenarioSetId = '', '${DEFAULT_SET_ID}', ScenarioSetId) AS ScenarioSetId
-       FROM ${TABLE_NAME}
-       WHERE TenantId IN ({projectIds:Array(String)})
-         AND NOT startsWith(ScenarioSetId, '${INTERNAL_SET_PREFIX}')
-         AND ArchivedAt IS NULL
-         AND (TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, UpdatedAt) IN (
-           SELECT TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, max(UpdatedAt)
-           FROM ${TABLE_NAME}
-           WHERE TenantId IN ({projectIds:Array(String)})
-             AND NOT startsWith(ScenarioSetId, '${INTERNAL_SET_PREFIX}')
-           GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
-         )`,
+       FROM (
+         SELECT
+           ScenarioSetId,
+           argMax(ArchivedAt, UpdatedAt) AS latestArchivedAt
+         FROM ${TABLE_NAME}
+         WHERE TenantId IN ({projectIds:Array(String)})
+           AND NOT startsWith(ScenarioSetId, '${INTERNAL_SET_PREFIX}')
+         GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
+       )
+       WHERE latestArchivedAt IS NULL`,
       { tenantId: firstProjectId, projectIds },
     );
 

--- a/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/simulations/repositories/simulation.clickhouse.repository.ts
@@ -983,22 +983,28 @@ export class SimulationClickHouseRepository implements SimulationRepository {
     // latest version. Rather than the IN-tuple dedup pattern — which scans the
     // table twice (once to build the latest-version key set, once for the
     // outer filter) and materialises a key set sized to every run — fold each
-    // run to its latest version in a single GROUP BY pass with
-    // argMax(ArchivedAt, UpdatedAt) and keep the sets whose latest run is not
-    // archived. Light columns only; the distinct external set ids are
-    // identical.
+    // run to its latest version in a single GROUP BY pass and keep the sets
+    // whose latest run is not archived. Light columns only; the distinct
+    // external set ids are identical.
+    //
+    // We fold over `argMax(ArchivedAt IS NULL, UpdatedAt)` rather than
+    // `argMax(ArchivedAt, UpdatedAt)`: ArchivedAt is Nullable, and argMax
+    // skips rows whose first argument is NULL, so a freshly un-archived run
+    // (latest ArchivedAt = NULL) would otherwise be ignored and the run would
+    // look archived. The `IS NULL` expression is non-nullable, so the fold
+    // reads the true latest version.
     const rows = await this.queryRows<{ ScenarioSetId: string }>(
       `SELECT DISTINCT IF(ScenarioSetId = '', '${DEFAULT_SET_ID}', ScenarioSetId) AS ScenarioSetId
        FROM (
          SELECT
            ScenarioSetId,
-           argMax(ArchivedAt, UpdatedAt) AS latestArchivedAt
+           argMax(ArchivedAt IS NULL, UpdatedAt) AS latestIsActive
          FROM ${TABLE_NAME}
          WHERE TenantId IN ({projectIds:Array(String)})
            AND NOT startsWith(ScenarioSetId, '${INTERNAL_SET_PREFIX}')
          GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
        )
-       WHERE latestArchivedAt IS NULL`,
+       WHERE latestIsActive`,
       { tenantId: firstProjectId, projectIds },
     );
 


### PR DESCRIPTION
## Evidence

`getDistinctExternalSetIds` (lists the distinct external scenario-set ids for a project; used by the usage/limit check) shows up in the last 24h of prod slow-query logs at ~27 hits, **p50 ~3.2s / p95 ~5.4s**. It is one of the two slowest distinct query shapes in the window and is not addressed by any open PR.

## Suspected cause

The query uses the IN-tuple dedup pattern with no time bound (the list is all-time by design):

```sql
SELECT DISTINCT IF(ScenarioSetId='','default',ScenarioSetId) AS ScenarioSetId
FROM simulation_runs
WHERE TenantId IN (..) AND NOT startsWith(ScenarioSetId, '<internal>') AND ArchivedAt IS NULL
  AND (TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, UpdatedAt) IN (
    SELECT TenantId, ScenarioSetId, BatchRunId, ScenarioRunId, max(UpdatedAt)
    FROM simulation_runs
    WHERE TenantId IN (..) AND NOT startsWith(ScenarioSetId, '<internal>')
    GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
  )
```

The IN-tuple pattern earns its keep when fetching heavy columns for a small set of rows. Here the columns are light and the output is a small distinct list, so the pattern costs more than it saves: the whole table is scanned twice (once to build the latest-version key set, once for the outer filter) and ClickHouse materialises an IN-set sized to every run for the tenant.

## Proposed fix

Fold each run to its latest version in a single `GROUP BY` pass with `argMax(ArchivedAt, UpdatedAt)`, then keep the sets whose latest run is not archived:

```sql
SELECT DISTINCT IF(ScenarioSetId='','default',ScenarioSetId) AS ScenarioSetId
FROM (
  SELECT ScenarioSetId, argMax(ArchivedAt, UpdatedAt) AS latestArchivedAt
  FROM simulation_runs
  WHERE TenantId IN (..) AND NOT startsWith(ScenarioSetId, '<internal>')
  GROUP BY TenantId, ScenarioSetId, BatchRunId, ScenarioRunId
)
WHERE latestArchivedAt IS NULL
```

`argMax(ArchivedAt, UpdatedAt)` is the latest version's archived flag — the same row the IN-tuple shape kept — so the distinct set ids are identical. One scan, no IN-set build. Matches the repo's guidance to derive latest-version values with `argMax(col, UpdatedAt)`.

## Expected impact

Roughly halves the read (one pass instead of two) and removes the per-run IN-set materialisation, the dominant cost on busy tenants. Expect p50/p95 and read-bytes to drop materially. `simulation_runs` is `ReplacingMergeTree(UpdatedAt)`, `ORDER BY (TenantId, ScenarioRunId)`; the rewrite keeps the `TenantId`-prefix primary-key filter.

## Test plan

Extends `simulation.clickhouse.repository.integration.test.ts` (testcontainers, real ClickHouse). Keeps the existing legacy `""`/`default` merge test, and adds a regression that flips a run's archived state across versions:
- `set-revived`: latest version un-archives the run -> set **included**.
- `set-archived`: latest version archives the run (older version non-archived) -> set **excluded**.

This distinguishes a correct latest-version fold from a naive `ArchivedAt IS NULL` over all versions. Both tests pass locally.

## EXPLAIN check

`EXPLAIN PIPELINE` on a known-large tenant:

- Old: contains a `CreatingSets` stage (builds + probes the latest-version IN-set).
- New: **no `CreatingSets`** — a single grouped `ReadFromMergeTree` -> `AggregatingTransform`.

```
OLD: 1 ReadFromMergeTree (outer) + 1 CreatingSets (the dedup IN-set scan)
NEW: 1 ReadFromMergeTree, 0 CreatingSets
```

## Notes

- Advisory PR from the ClickHouse slow-query sweep. Please re-run the EXPLAIN before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test covering version-aware archival behavior for simulations, verifying revived sets are returned and archived sets are excluded.

* **Refactor**
  * Updated the active scenario set retrieval logic to determine activity based on each run key’s latest version, improving correctness and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->