### PR TITLE
fix(logger): complete server-logger migration for event-sourcing pipelines + add regression guard (#1587 follow-up)

### DIFF
--- a/langwatch/biome.json
+++ b/langwatch/biome.json
@@ -155,6 +155,25 @@
 					}
 				}
 			}
+		},
+		{
+			"includes": ["src/server/**/*.ts", "src/server/**/*.tsx"],
+			"linter": {
+				"rules": {
+					"style": {
+						"noRestrictedImports": {
+							"level": "error",
+							"options": {
+								"paths": {
+									"~/utils/logger": {
+										"message": "Server files must import from ~/utils/logger/server (uses AsyncLocalStorage). ~/utils/logger is browser-safe only."
+									}
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 	],
 	"assist": {

--- a/langwatch/biome.json
+++ b/langwatch/biome.json
@@ -183,10 +183,7 @@
 			}
 		},
 		{
-			"includes": [
-				"src/server/elasticsearch/transformers.ts",
-				"src/server/evaluations/preconditions.ts"
-			],
+			"includes": ["src/server/evaluations/preconditions.ts"],
 			"linter": {
 				"rules": {
 					"style": {

--- a/langwatch/biome.json
+++ b/langwatch/biome.json
@@ -157,7 +157,11 @@
 			}
 		},
 		{
-			"includes": ["src/server/**/*.ts", "src/server/**/*.tsx"],
+			"includes": [
+				"src/server/**/*.ts",
+				"src/server/**/*.tsx",
+				"!src/server/evaluations/preconditions.ts"
+			],
 			"linter": {
 				"rules": {
 					"style": {
@@ -178,16 +182,6 @@
 								]
 							}
 						}
-					}
-				}
-			}
-		},
-		{
-			"includes": ["src/server/evaluations/preconditions.ts"],
-			"linter": {
-				"rules": {
-					"style": {
-						"noRestrictedImports": "off"
 					}
 				}
 			}

--- a/langwatch/biome.json
+++ b/langwatch/biome.json
@@ -165,12 +165,32 @@
 							"level": "error",
 							"options": {
 								"paths": {
-									"~/utils/logger": {
-										"message": "Server files must import from ~/utils/logger/server (uses AsyncLocalStorage). ~/utils/logger is browser-safe only."
+									"@chakra-ui/react": {
+										"importNames": ["Dialog", "Drawer", "Modal"],
+										"message": "Import Dialog or Drawer from ~/components/ui/dialog and ~/components/ui/drawer instead. Modal-style flows also use the Dialog wrapper (see AICreateModal, RunScenarioModal, etc.) — there is no Modal wrapper. The wrappers force a transparent backdrop (no dark grey overlay), wire focus/scroll defaults, and add an inline error boundary. Raw Chakra primitives reintroduce the dark backdrop we explicitly do not want."
 									}
-								}
+								},
+								"patterns": [
+									{
+										"group": ["**/utils/logger"],
+										"message": "Server files must import from ~/utils/logger/server (uses AsyncLocalStorage). ~/utils/logger is browser-safe only. Relative spellings such as ../../utils/logger are also banned."
+									}
+								]
 							}
 						}
+					}
+				}
+			}
+		},
+		{
+			"includes": [
+				"src/server/elasticsearch/transformers.ts",
+				"src/server/evaluations/preconditions.ts"
+			],
+			"linter": {
+				"rules": {
+					"style": {
+						"noRestrictedImports": "off"
 					}
 				}
 			}

--- a/langwatch/src/server/__tests__/logger-import-boundary.unit.test.ts
+++ b/langwatch/src/server/__tests__/logger-import-boundary.unit.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join, relative, resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `~/utils/logger` is browser-safe. `~/utils/logger/server` uses AsyncLocalStorage
+ * and must never reach a client bundle. Files under `src/server/` therefore import
+ * the server logger — except the handful that are value-imported by client code.
+ *
+ * `biome.json` enforces this via `noRestrictedImports`, but that guard only runs
+ * when Biome's CLI version matches the config schema, and a stale exemption for a
+ * deleted file rots silently. This test enforces the same invariant from the
+ * filesystem, and treats `biome.json` as the single source of truth for exemptions
+ * so the two cannot drift.
+ */
+
+const LANGWATCH_ROOT = resolve(__dirname, "../../..");
+const SERVER_DIR = join(LANGWATCH_ROOT, "src/server");
+const SERVER_OVERRIDE_GLOB = "src/server/**/*.ts";
+
+/** Matches a specifier ending exactly at `utils/logger` — `utils/logger/server` does not match. */
+const BROWSER_LOGGER_IMPORT = /from\s+["'][^"']*utils\/logger["']/;
+
+function readBiomeOverrides(): { includes?: string[] }[] {
+  const biome = JSON.parse(
+    readFileSync(join(LANGWATCH_ROOT, "biome.json"), "utf-8"),
+  ) as { overrides?: { includes?: string[] }[] };
+  return biome.overrides ?? [];
+}
+
+/** The `!`-negated entries on the `src/server/**` override are the exempted files. */
+function exemptedPathsFromBiomeConfig(): string[] {
+  const serverOverride = readBiomeOverrides().find((override) =>
+    override.includes?.includes(SERVER_OVERRIDE_GLOB),
+  );
+  if (!serverOverride) {
+    throw new Error(
+      `no biome override found covering ${SERVER_OVERRIDE_GLOB} — the logger guard is gone`,
+    );
+  }
+  return (serverOverride.includes ?? [])
+    .filter((pattern) => pattern.startsWith("!"))
+    .map((pattern) => pattern.slice(1));
+}
+
+function serverSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return serverSourceFiles(full);
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+}
+
+function filesImportingBrowserLogger(): string[] {
+  return serverSourceFiles(SERVER_DIR)
+    .filter((file) => BROWSER_LOGGER_IMPORT.test(readFileSync(file, "utf-8")))
+    .map((file) => relative(LANGWATCH_ROOT, file))
+    .sort();
+}
+
+describe("given the server logger import boundary", () => {
+  const exempted = exemptedPathsFromBiomeConfig();
+
+  describe("when scanning every source file under src/server", () => {
+    it("finds the browser-safe logger imported only by exempted files", () => {
+      expect(filesImportingBrowserLogger()).toEqual([...exempted].sort());
+    });
+  });
+
+  describe("when checking the exemptions declared in biome.json", () => {
+    it("points every exemption at a file that still exists", () => {
+      const missing = exempted.filter(
+        (path) => !existsSync(join(LANGWATCH_ROOT, path)),
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it("keeps every exempted file on the browser-safe logger", () => {
+      const unnecessary = exempted.filter(
+        (path) =>
+          !BROWSER_LOGGER_IMPORT.test(
+            readFileSync(join(LANGWATCH_ROOT, path), "utf-8"),
+          ),
+      );
+      expect(unnecessary).toEqual([]);
+    });
+  });
+});

--- a/langwatch/src/server/__tests__/logger-import-boundary.unit.test.ts
+++ b/langwatch/src/server/__tests__/logger-import-boundary.unit.test.ts
@@ -1,44 +1,70 @@
-import { existsSync, readdirSync, readFileSync } from "fs";
+import { readdirSync, readFileSync } from "fs";
 import { join, relative, resolve } from "path";
 import { describe, expect, it } from "vitest";
 
 /**
- * `~/utils/logger` is browser-safe. `~/utils/logger/server` uses AsyncLocalStorage
- * and must never reach a client bundle. Files under `src/server/` therefore import
- * the server logger — except the handful that are value-imported by client code.
+ * `~/utils/logger` is browser-safe. `~/utils/logger/server` pulls in
+ * `node:async_hooks` (AsyncLocalStorage) and must never reach a client bundle.
+ * Files under `src/server/` therefore import the server logger — except those
+ * that client code value-imports.
  *
- * `biome.json` enforces this via `noRestrictedImports`, but that guard only runs
- * when Biome's CLI version matches the config schema, and a stale exemption for a
- * deleted file rots silently. This test enforces the same invariant from the
- * filesystem, and treats `biome.json` as the single source of truth for exemptions
- * so the two cannot drift.
+ * `biome.json` states this as a `noRestrictedImports` rule, but lint cannot
+ * check that an exemption still points at a file that exists, and the pinned
+ * Biome CLI currently rejects its own config (schema 2.4.14 vs CLI 2.5.1), so
+ * `pnpm lint` never evaluates the rule locally. This test enforces the boundary
+ * from the filesystem instead, independent of any Biome version.
+ *
+ * EXEMPTED is deliberately hardcoded rather than read out of `biome.json`.
+ * A guard that derives its expectations from the config it guards can never
+ * disagree with that config: adding a browser-logger import AND a matching
+ * exemption would satisfy both. Stating the list here forces widening the
+ * boundary to be an explicit, reviewable edit to this file.
  */
 
 const LANGWATCH_ROOT = resolve(__dirname, "../../..");
 const SERVER_DIR = join(LANGWATCH_ROOT, "src/server");
-const SERVER_OVERRIDE_GLOB = "src/server/**/*.ts";
+const LOGGER_PATTERN_GROUP = "**/utils/logger";
 
-/** Matches a specifier ending exactly at `utils/logger` — `utils/logger/server` does not match. */
-const BROWSER_LOGGER_IMPORT = /from\s+["'][^"']*utils\/logger["']/;
+/**
+ * Client-reachable files that must stay on the browser-safe logger.
+ * `src/server/evaluations/preconditions.ts` is value-imported by the client
+ * component `src/components/checks/TryItOut.tsx`.
+ */
+const EXEMPTED = ["src/server/evaluations/preconditions.ts"];
 
-function readBiomeOverrides(): { includes?: string[] }[] {
-  const biome = JSON.parse(
-    readFileSync(join(LANGWATCH_ROOT, "biome.json"), "utf-8"),
-  ) as { overrides?: { includes?: string[] }[] };
-  return biome.overrides ?? [];
+/**
+ * Matches a specifier ending exactly at `utils/logger`, in `import ... from`,
+ * `export ... from`, bare `import "..."`, and dynamic `import("...")` forms.
+ * `utils/logger/server` does not match, and neither does `some-utils/logger`.
+ */
+const BROWSER_LOGGER_IMPORT =
+  /(?:from|import)\s*\(?\s*["'](?:[^"']*\/)?utils\/logger["']/;
+
+interface BiomeOverride {
+  includes?: string[];
+  linter?: {
+    rules?: {
+      style?: {
+        noRestrictedImports?: {
+          options?: { patterns?: { group?: string[] }[] };
+        };
+      };
+    };
+  };
 }
 
-/** The `!`-negated entries on the `src/server/**` override are the exempted files. */
-function exemptedPathsFromBiomeConfig(): string[] {
-  const serverOverride = readBiomeOverrides().find((override) =>
-    override.includes?.includes(SERVER_OVERRIDE_GLOB),
+function readServerOverride(): BiomeOverride | undefined {
+  const biome = JSON.parse(
+    readFileSync(join(LANGWATCH_ROOT, "biome.json"), "utf-8"),
+  ) as { overrides?: BiomeOverride[] };
+  return biome.overrides?.find((override) =>
+    override.includes?.some((pattern) => pattern.startsWith("src/server/")),
   );
-  if (!serverOverride) {
-    throw new Error(
-      `no biome override found covering ${SERVER_OVERRIDE_GLOB} — the logger guard is gone`,
-    );
-  }
-  return (serverOverride.includes ?? [])
+}
+
+function exemptionsDeclaredInBiomeConfig(): string[] {
+  const includes = readServerOverride()?.includes ?? [];
+  return includes
     .filter((pattern) => pattern.startsWith("!"))
     .map((pattern) => pattern.slice(1));
 }
@@ -59,30 +85,25 @@ function filesImportingBrowserLogger(): string[] {
 }
 
 describe("given the server logger import boundary", () => {
-  const exempted = exemptedPathsFromBiomeConfig();
-
   describe("when scanning every source file under src/server", () => {
-    it("finds the browser-safe logger imported only by exempted files", () => {
-      expect(filesImportingBrowserLogger()).toEqual([...exempted].sort());
+    it("finds the browser-safe logger imported only by the exempted files", () => {
+      expect(filesImportingBrowserLogger()).toEqual([...EXEMPTED].sort());
     });
   });
 
-  describe("when checking the exemptions declared in biome.json", () => {
-    it("points every exemption at a file that still exists", () => {
-      const missing = exempted.filter(
-        (path) => !existsSync(join(LANGWATCH_ROOT, path)),
+  describe("when reading the guard declared in biome.json", () => {
+    it("exempts exactly the files this test exempts", () => {
+      expect(exemptionsDeclaredInBiomeConfig().sort()).toEqual(
+        [...EXEMPTED].sort(),
       );
-      expect(missing).toEqual([]);
     });
 
-    it("keeps every exempted file on the browser-safe logger", () => {
-      const unnecessary = exempted.filter(
-        (path) =>
-          !BROWSER_LOGGER_IMPORT.test(
-            readFileSync(join(LANGWATCH_ROOT, path), "utf-8"),
-          ),
-      );
-      expect(unnecessary).toEqual([]);
+    it("still bans the browser-safe logger under src/server", () => {
+      const patterns =
+        readServerOverride()?.linter?.rules?.style?.noRestrictedImports?.options
+          ?.patterns ?? [];
+      const groups = patterns.flatMap((pattern) => pattern.group ?? []);
+      expect(groups).toContain(LOGGER_PATTERN_GROUP);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/ai-query.ts
+++ b/langwatch/src/server/app-layer/traces/ai-query.ts
@@ -2,7 +2,7 @@ import { generateObject, generateText, type ModelMessage } from "ai";
 import { z } from "zod";
 import { getApp } from "~/server/app-layer/app";
 import { getVercelAIModel } from "~/server/modelProviders/utils";
-import { createLogger } from "~/utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import { QUERY_SYNTAX_DOC } from "./query-language/grammar";
 import { FIELD_VALUES, SEARCH_FIELDS } from "./query-language/metadata";
 import { isEmptyAST, parse } from "./query-language/parse";

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.store.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.store.ts
@@ -1,6 +1,6 @@
 import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { PLATFORM_DEFAULT_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
-import { createLogger } from "../../../../../utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import type { AppendStore } from "../../../projections/mapProjection.types";
 import type { ProjectionStoreContext } from "../../../projections/projectionStoreContext";
 import type { ClickHouseExperimentRunResultRecord } from "./experimentRunResultStorage.mapProjection";

--- a/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/experiment-run-processing/repositories/experimentRunState.clickhouse.repository.ts
@@ -7,7 +7,7 @@ import {
 	StoreError,
 	ValidationError,
 } from "~/server/event-sourcing/services/errorHandling";
-import { createLogger } from "../../../../../utils/logger/server";
+import { createLogger } from "~/utils/logger/server";
 import type {
 	Projection,
 	ProjectionStoreReadContext,

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/reactors/cancellationBroadcast.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/reactors/cancellationBroadcast.reactor.ts
@@ -1,4 +1,4 @@
-import { createLogger } from "../../../../../utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import type { CancellationPublisher } from "../../../../scenarios/cancellation-channel";
 import { publishCancellation } from "../../../../scenarios/cancellation-channel";
 import type {

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/reactors/scenarioExecution.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/reactors/scenarioExecution.reactor.ts
@@ -15,7 +15,7 @@
  * @see specs/scenarios/event-driven-execution-prep.feature
  */
 
-import { createLogger } from "../../../../../utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import type { ScenarioExecutionPool } from "../../../../scenarios/execution/execution-pool";
 import type {
   ReactorContext,

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts
@@ -7,7 +7,7 @@ import {
   StoreError,
   ValidationError,
 } from "~/server/event-sourcing/services/errorHandling";
-import { createLogger } from "../../../../../utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import type {
   Projection,
   ProjectionStoreReadContext,

--- a/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/repositories/suiteRunState.clickhouse.repository.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/suite-run-processing/repositories/suiteRunState.clickhouse.repository.ts
@@ -7,7 +7,7 @@ import {
   StoreError,
   ValidationError,
 } from "~/server/event-sourcing/services/errorHandling";
-import { createLogger } from "../../../../../utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import type {
   Projection,
   ProjectionStoreReadContext,

--- a/langwatch/src/server/invites/invite.service.ts
+++ b/langwatch/src/server/invites/invite.service.ts
@@ -43,7 +43,7 @@ import { TeamUserRole } from "@prisma/client";
 import type { Session } from "~/server/auth";
 import type { PlanProvider } from "../app-layer/subscription/plan-provider";
 import { getApp } from "../app-layer/app";
-import { createLogger } from "~/utils/logger";
+import { createLogger } from "~/utils/logger/server";
 
 const logger = createLogger("langwatch:invites");
 

--- a/langwatch/src/server/prompt-config/prompt.service.ts
+++ b/langwatch/src/server/prompt-config/prompt.service.ts
@@ -5,7 +5,7 @@ import type {
   PromptScope,
 } from "@prisma/client";
 import type { z } from "zod";
-import { createLogger } from "~/utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import {
   deriveResponseFormatFromOutputs,
   type inputsSchema,

--- a/langwatch/src/server/prompt-config/repositories/llm-config-tag.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/llm-config-tag.repository.ts
@@ -1,6 +1,6 @@
 import type { Prisma, PrismaClient, PromptTag, PromptTagAssignment } from "@prisma/client";
 import { nanoid } from "nanoid";
-import { createLogger } from "~/utils/logger";
+import { createLogger } from "~/utils/logger/server";
 
 const logger = createLogger("langwatch:prompt-version-tags");
 

--- a/langwatch/src/server/prompt-config/repositories/prompt-tag.repository.ts
+++ b/langwatch/src/server/prompt-config/repositories/prompt-tag.repository.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, PromptTag } from "@prisma/client";
 import { nanoid } from "nanoid";
-import { createLogger } from "~/utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import { SEEDED_TAGS } from "~/prompts/constants/tags";
 
 const logger = createLogger("langwatch:prompt-tags");

--- a/langwatch/src/server/workflows/runWorkflow.ts
+++ b/langwatch/src/server/workflows/runWorkflow.ts
@@ -12,7 +12,7 @@ import { getProjectModelProviders } from "../api/routers/modelProviders.utils";
 import { prisma } from "../db";
 import type { SingleEvaluationResult } from "../evaluations/evaluators";
 import type { MaybeStoredModelProvider } from "../modelProviders/registry";
-import { createLogger } from "../../utils/logger";
+import { createLogger } from "~/utils/logger/server";
 import { stripUnsupportedLLMParamsFromWorkflow } from "./stripUnsupportedLLMParams";
 
 const logger = createLogger("langwatch:workflows:runWorkflow");


### PR DESCRIPTION
**Low risk** — import-path-only change across 12 server files, plus a Biome lint guard and one unit test. No runtime logic touched, no UI surface, no dependency changes.

**Start here:** `langwatch/biome.json` — the `noRestrictedImports` override is the point of the PR; the 12 source edits are what it enforces. Then `src/server/__tests__/logger-import-boundary.unit.test.ts`, which enforces the same invariant without depending on Biome.

## Summary

Completes the server-logger migration started in #1587 (https://github.com/langwatch/langwatch/pull/1587).

PR #1587 migrated several event-sourcing files from `~/utils/logger` to `~/utils/logger/server` but had to revert two files that are reachable from client bundles. Five sibling files in the same event-sourcing directory were left un-migrated.

This PR:
1. Swaps the confirmed server-only files to `~/utils/logger/server`
2. Fixes the 5-level relative import `../../../../../utils/logger/server` → `~/utils/logger/server` in the file #1587 already changed
3. Adds a Biome `noRestrictedImports` guard banning any spelling of `utils/logger` under `src/server/**`, plus a unit test enforcing the same boundary from the filesystem

`~/utils/logger` is browser-safe; `~/utils/logger/server` uses `AsyncLocalStorage` and must never reach a client bundle. The guard makes that boundary enforceable instead of tribal.

## What changed

- **Guard by import *pattern*, not by exact path** → an exact-path `paths` entry → a `patterns` group of `["**/utils/logger"]` catches both the alias (`~/utils/logger`) and every relative spelling (`../../utils/logger`, `../../../../../utils/logger`). An exact-path entry would have silently missed all the relative offenders — which is precisely how the 5 stragglers survived #1587.
- **Re-declare the `@chakra-ui/react` restriction inside the `src/server/**` override** → inheriting it → Biome overrides *replace* a rule's config rather than merging it, so declaring `noRestrictedImports` in the override would otherwise clobber the repo-wide Chakra `importNames` restriction for every server file.
- **Exempt `preconditions.ts` with a negated glob, not with `noRestrictedImports: "off"`** → an `"off"` override → because overrides replace rather than merge, `"off"` would disable the Chakra restriction on that file too. A negated glob (`"!src/server/evaluations/preconditions.ts"`) drops the file out of the server override, so it falls back to the base rule: **Chakra restriction on, logger pattern off** — exactly the intent, with no duplicated config.
- **Enforce the boundary in a test, not only in lint** → lint-only → the lint rule cannot detect a *stale* exemption, and does not run at all when the pinned Biome CLI rejects the config (see below).
- **Hardcode the test's exemption list** → deriving it from `biome.json` → a guard that reads its expectations out of the config it guards can never disagree with that config. Adding a browser-logger import *and* a matching `!` exemption satisfied both. The list is now stated in the test, and `biome.json` must agree with **it** — so widening the boundary is an explicit, reviewable edit. (Caught in review; the derived version is proven to pass that input below.)
- **Drop the exemption for `elasticsearch/transformers.ts`** → keeping it → that file no longer exists: main deleted `src/server/elasticsearch/` wholesale in #4547 (remove Elasticsearch and the BullMQ legacy stack).

## How it works

```
langwatch/
├── biome.json
│     └── overrides[] — src/server/**/*.{ts,tsx}, minus !preconditions.ts
│           └── noRestrictedImports: chakra paths + patterns ["**/utils/logger"]
├── src/utils/logger/
│     ├── index.ts    — browser-safe (pino, level "info")
│     └── server.ts   — AsyncLocalStorage mixin, server-only
└── src/server/__tests__/logger-import-boundary.unit.test.ts
      ├── EXEMPTED = ["src/server/evaluations/preconditions.ts"]   <- the single source of truth
      ├── walks src/server/**/*.{ts,tsx} → asserts browser-logger importers == EXEMPTED
      ├── asserts biome.json's "!"-negated globs == EXEMPTED       (catches stale AND newly-added exemptions)
      └── asserts biome.json still declares the ["**/utils/logger"] ban
```

## Files swapped (confirmed server-only)

- `src/server/event-sourcing/pipelines/simulation-processing/repositories/simulationRunState.clickhouse.repository.ts`
- `src/server/event-sourcing/pipelines/suite-run-processing/repositories/suiteRunState.clickhouse.repository.ts`
- `src/server/event-sourcing/pipelines/experiment-run-processing/projections/experimentRunResultStorage.store.ts`
- `src/server/event-sourcing/pipelines/simulation-processing/reactors/cancellationBroadcast.reactor.ts`
- `src/server/event-sourcing/pipelines/simulation-processing/reactors/scenarioExecution.reactor.ts`

## Review-addressed files (inline threads on #1587)

Migrated 5 pre-existing `~/utils/logger` violations in `src/server/`:
- `src/server/prompt-config/prompt.service.ts`
- `src/server/prompt-config/repositories/prompt-tag.repository.ts`
- `src/server/prompt-config/repositories/llm-config-tag.repository.ts`
- `src/server/invites/invite.service.ts`
- `src/server/app-layer/traces/ai-query.ts`

Fixed `src/server/workflows/runWorkflow.ts` relative import (`../../utils/logger` → `~/utils/logger/server`).

## Files left as client-coupled (not swapped)

- `src/server/evaluations/preconditions.ts` — **value**-imported by `src/components/checks/TryItOut.tsx:35`, so it stays on the browser-safe logger and is excluded from the server override by negated glob.

No other file under `src/server/` is value-imported from client code; every other client-side reference to a migrated file is an `import type`, erased at compile time. So no client bundle gains an `AsyncLocalStorage` dependency.

## Rebase note

This branch was rebased onto `origin/main` (`47f168698`). The only conflicts were in `langwatch/pnpm-lock.yaml`, carried by two lockfile-only commits whose sole purpose was reconciling earlier rebases. Because this PR changes **no** `package.json`, both were dropped and main's lockfile is taken verbatim — `langwatch/pnpm-lock.yaml` is byte-identical to main, and `pnpm install --frozen-lockfile` exits 0.

No feature file was added. `specs/README.md` scopes `specs/` to "observable behavior, not implementation details" and "user stories, not technical architecture"; a module-import boundary is neither, so it is enforced by a unit test rather than a `.feature` scenario.

## Human verification

<!-- no-ui-surface -->

This change is backend-only: server-side logging imports, a Biome lint guard, and one unit test. There is no UI surface.

Note: `pnpm lint` cannot run on this repo right now — `package.json` pins `@biomejs/biome` 2.5.1 while `biome.json` declares `$schema` 2.4.14 and uses nursery keys 2.5.1 rejects, so Biome aborts on config parse for every file. This is pre-existing on `main` (reproduce by running 2.5.1 against main's own `biome.json`) and unrelated to this PR. CI is unaffected because its `lint` job uses `reviewdog-action-biome` with its own Biome version. Locally, use the 2.4.14 CLI:

1. `cd langwatch && pnpm exec vitest run src/server/__tests__/logger-import-boundary.unit.test.ts` — 3 tests green.
2. Revert any one migrated file to `~/utils/logger` and re-run that test — it fails.
3. Add `"!src/server/elasticsearch/transformers.ts"` (a deleted file) to the override's `includes` and re-run — it fails, proving a stale exemption cannot rot silently, and that a *new* exemption cannot be slipped in without editing the test.
4. `npx @biomejs/biome@2.4.14 check src/server` — zero `lint/style/noRestrictedImports` diagnostics.
5. Add `import { Dialog } from "@chakra-ui/react";` to `preconditions.ts` and re-run step 4 — exactly one Chakra violation, proving the exemption no longer disables that rule.
6. `pnpm typecheck` — zero errors.

## How I can prove I was successful

Every claim below was exercised this session; terminal output is quoted verbatim.

**1. The guard catches the bug it exists to prevent — `proven`.**
Falsifiability: keep this PR's `biome.json`, revert the 12 source files to `origin/main`, re-run.

```
### 12 source files reverted to origin/main, our biome.json kept
  11  lint/style/noRestrictedImports      <- guard fires on the pre-fix code
   8  format                              (pre-existing)
   4  assist/source/organizeImports       (pre-existing)

### with this PR's fix applied
   0  lint/style/noRestrictedImports      <- silent
   8  format                              (unchanged -> pre-existing, not introduced here)
   4  assist/source/organizeImports       (unchanged -> pre-existing, not introduced here)
```

11 rather than 12 because `experimentRunState.clickhouse.repository.ts` was already on the server logger via a 5-level relative path — that file is a path normalization, not a violation.

**2. The migration is complete, not partial — `proven`.**

```
$ npx @biomejs/biome@2.4.14 check src/server --max-diagnostics=5000
noRestrictedImports violations in src/server: 0
```

**3. The exemption no longer clobbers the Chakra guard — `proven`.**
This was a real defect in the earlier revision of this PR, caught in review. With a `Dialog` import injected into `preconditions.ts`:

```
### OLD config ("noRestrictedImports": "off" override)
   chakra violations: 0     <- Chakra guard silently disabled. The bug.
   logger violations: 0

### NEW config (negated glob, this PR)
   chakra violations: 1     <- guard enforced
   logger violations: 0     <- logger exemption still correct
```

**4. The regression test fails when the invariant breaks — `proven`.**
Four independent breakages, each restored afterwards:

```
$ vitest run src/server/__tests__/logger-import-boundary.unit.test.ts
  baseline ......................................... 3 passed   EXIT=0

A. one file regressed to "~/utils/logger" ......... 1 failed   EXIT=1
B. exemption added to biome.json alone ............ 1 failed   EXIT=1
C. browser-logger import PLUS its exemption ....... 2 failed   EXIT=1
D. the ["**/utils/logger"] ban deleted ............ 1 failed   EXIT=1
E. restored ....................................... 3 passed   EXIT=0
```

Case C is why the test hardcodes its exemption list. The earlier revision derived that list from `biome.json`, and I verified it exits **0** on Case C — a change could add a browser-logger import and an exemption for it, and pass both lint and test:

```
### Case C, old test (exemptions derived from biome.json)
  EXIT=0     Tests  3 passed (3)      <- the hole
### Case C, new test (exemptions hardcoded)
  EXIT=1     Tests  2 failed | 1 passed (3)
```

Case B is the one lint cannot catch, and is what happened on this branch: main deleted `src/server/elasticsearch/` in #4547, leaving the `transformers.ts` exemption pointing at nothing.

**5. Typecheck, tests, and the feature-parity gate — `proven`.**

```
$ pnpm typecheck
TYPECHECK_EXIT=0     (tsgo, 0 errors)

$ npx tsx scripts/check-feature-parity.ts
OK: 2403 enforced scenario(s) bound across 719 file(s).    PARITY_EXIT=0

$ pnpm exec vitest run src/server/invites src/server/prompt-config src/server/event-sourcing/pipelines
 Test Files  95 passed | 2 skipped (97)
      Tests  6146 passed | 45 todo (6191)
```

Three suites fail on this branch (`triggerEmail.unit`, `apiKey.restricted-permissions.unit`, `emailSuppression.service.unit` — 18 failed | 20 passed). They fail **identically on `origin/main` with this branch's commits absent**, so they are pre-existing:

```
### origin/main (47f16869), same three files
 Test Files  3 failed (3)
      Tests  18 failed | 20 passed (38)
### this branch, same three files
 Test Files  3 failed (3)
      Tests  18 failed | 20 passed (38)
```

## Anything surprising?

Two things a reviewer should know:

- **A full `vitest run` exits 0 even when suites fail.** `globalSetup` force-calls `process.exit(0)` at a 4-minute hard floor (`[unit globalSetup] hard floor reached at 4 min — forcing process.exit(0)`). Whole-suite exit codes are not a trustworthy signal on this repo; the per-directory runs above are. Unrelated to this PR, but it will mislead anyone verifying it.
- **The Biome rule may be inert.** The pinned CLI (2.5.1) rejects this repo's `biome.json` outright, and CI's `reviewdog-action-biome` pins no version, so I could not verify the rule is evaluated in CI. The unit test is therefore the enforcement that is *known* to run — it is Biome-version independent and wired into `test-unit`. The lint rule is belt to its braces, not the other way round.
- **`~/utils/logger/server` defaults to level `debug`, the browser logger to `info`.** Two `logger.debug` call sites in the migrated reactors (`cancellationBroadcast.reactor.ts`, `scenarioExecution.reactor.ts`) will emit where they previously did not, unless `PINO_LOG_LEVEL` is set in the deployed environment. Payloads are opaque IDs (`scenarioRunId`, `batchRunId`) — no PII — and the other ~283 server files already use this logger, so the default already applies broadly. Flagging it rather than assuming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized server-side logging usage across backend workflows to consistently use the server-safe logger configuration.
  * Tightened linting for server code to prevent restricted or browser-incompatible imports, improving build-time safety and reducing environment-related issues.
  * Restored/adjusted existing import restriction rules for UI components under server linting to keep guidance consistent and avoid accidental misuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
