### PR TITLE
feat(billing): storage-billing schema — additive StorageUsageHourly + StorageBillingCheckpoint [ADR-027 PR1/7]

### DIFF
--- a/langwatch/prisma/migrations/20260619120000_add_storage_billing_tables/migration.sql
+++ b/langwatch/prisma/migrations/20260619120000_add_storage_billing_tables/migration.sql
@@ -1,0 +1,46 @@
+-- ADR-027 storage billing, schema phase. Purely additive: two new tables on top
+-- of the current implementation. The billable-events checkpoint
+-- (BillingMeterCheckpoint) and its unique index are left untouched — storage
+-- billing owns its own persistence rather than discriminating the shared one.
+--
+-- StorageUsageHourly       — durable per-sealed-UTC-hour stored-bytes
+--                            measurement + reporter cursor (reportedAt).
+-- StorageBillingCheckpoint — dedicated two-phase reporting checkpoint for the
+--                            STORAGE_GB meter (sibling of BillingMeterCheckpoint).
+--
+-- No ClickHouse migration — _size_bytes already exists (migration 00032).
+
+-- CreateTable
+CREATE TABLE "StorageUsageHourly" (
+    "organizationId" TEXT NOT NULL,
+    "sealedHour" TIMESTAMP(3) NOT NULL,
+    "megabytes" INTEGER NOT NULL,
+    "reportedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StorageUsageHourly_pkey" PRIMARY KEY ("organizationId","sealedHour")
+);
+
+-- CreateTable
+CREATE TABLE "StorageBillingCheckpoint" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "billingMonth" TEXT NOT NULL,
+    "lastReportedTotal" INTEGER NOT NULL DEFAULT 0,
+    "pendingReportedTotal" INTEGER,
+    "consecutiveFailures" INTEGER NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StorageBillingCheckpoint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "StorageUsageHourly_reportedAt_idx" ON "StorageUsageHourly"("reportedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StorageBillingCheckpoint_organizationId_billingMonth_key" ON "StorageBillingCheckpoint"("organizationId", "billingMonth");
+
+-- Down (reversible — purely additive). Commented out to avoid accidental data
+-- loss; to roll back, uncomment and run manually:
+-- DROP TABLE "StorageBillingCheckpoint";
+-- DROP TABLE "StorageUsageHourly";

--- a/langwatch/prisma/migrations/20260619120000_add_storage_billing_tables/migration.sql
+++ b/langwatch/prisma/migrations/20260619120000_add_storage_billing_tables/migration.sql
@@ -26,8 +26,8 @@ CREATE TABLE "StorageBillingCheckpoint" (
     "id" TEXT NOT NULL,
     "organizationId" TEXT NOT NULL,
     "billingMonth" TEXT NOT NULL,
-    "lastReportedTotal" INTEGER NOT NULL DEFAULT 0,
-    "pendingReportedTotal" INTEGER,
+    "lastReportedTotal" BIGINT NOT NULL DEFAULT 0,
+    "pendingReportedTotal" BIGINT,
     "consecutiveFailures" INTEGER NOT NULL DEFAULT 0,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -1793,6 +1793,43 @@ model BillingMeterCheckpoint {
   @@unique([organizationId, billingMonth])
 }
 
+// ADR-027 storage billing — own its persistence, additively, alongside (not
+// inside) the billable-events checkpoint above. Keeping a separate table means
+// the storage meter never touches BillingMeterCheckpoint's live unique index.
+
+// Durable per-hour stored-bytes measurement. The dispatcher writes one row per
+// sealed UTC hour (megabytes = stored bytes aged > 30d, measured once); the
+// reporter drains reportedAt IS NULL across orgs and stamps it on Stripe
+// success. This decouples measurement from Stripe availability — the reporter
+// can stall and resume without re-measuring or re-billing — and is the per-org
+// audit trail an invoice line traces back to.
+model StorageUsageHourly {
+  organizationId String
+  sealedHour     DateTime // UTC, truncated to hour
+  megabytes      Int // ceil(bytes / 1_048_576), measured at sample time
+  reportedAt     DateTime?
+  createdAt      DateTime  @default(now())
+
+  @@id([organizationId, sealedHour])
+  @@index([reportedAt])
+}
+
+// Two-phase reporting checkpoint dedicated to the STORAGE_GB meter — a parallel
+// of BillingMeterCheckpoint owned by StorageBillingCheckpointService. Separate
+// table (not a meterName discriminator on the shared one) so storage billing is
+// purely additive and the billable-events checkpoint is never altered.
+model StorageBillingCheckpoint {
+  id                   String   @id @default(cuid())
+  organizationId       String
+  billingMonth         String // "2026-02"
+  lastReportedTotal    Int      @default(0)
+  pendingReportedTotal Int? // non-null = in-flight Stripe call
+  consecutiveFailures  Int      @default(0)
+  updatedAt            DateTime @updatedAt
+
+  @@unique([organizationId, billingMonth])
+}
+
 // ============================================================================
 // AI Gateway
 //

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -1822,8 +1822,11 @@ model StorageBillingCheckpoint {
   id                   String   @id @default(cuid())
   organizationId       String
   billingMonth         String // "2026-02"
-  lastReportedTotal    Int      @default(0)
-  pendingReportedTotal Int? // non-null = in-flight Stripe call
+  // Cumulative MiB-hours reported for the period (ADR-027: Σ megabytes over the
+  // billing month). BigInt, not Int: Int32 caps at ~2.8 TiB held for a full
+  // month before overflow, which a large enterprise org can exceed.
+  lastReportedTotal    BigInt   @default(0)
+  pendingReportedTotal BigInt? // non-null = in-flight Stripe call
   consecutiveFailures  Int      @default(0)
   updatedAt            DateTime @updatedAt
 

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -1798,7 +1798,8 @@ model BillingMeterCheckpoint {
 // the storage meter never touches BillingMeterCheckpoint's live unique index.
 
 // Durable per-hour stored-bytes measurement. The dispatcher writes one row per
-// sealed UTC hour (megabytes = stored bytes aged > 30d, measured once); the
+// sealed UTC hour (megabytes = stored bytes aged beyond BILLABLE_AFTER_DAYS,
+// 35d — the paid included window, measured once); the
 // reporter drains reportedAt IS NULL across orgs and stamps it on Stripe
 // success. This decouples measurement from Stripe availability — the reporter
 // can stall and resume without re-measuring or re-billing — and is the per-org

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingCheckpoint.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingCheckpoint.service.unit.test.ts
@@ -1,0 +1,116 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaStorageBillingCheckpointService } from "../storageBillingCheckpoint.service";
+
+/**
+ * The storage checkpoint lives in its own table (StorageBillingCheckpoint),
+ * keyed by (organizationId, billingMonth). These tests pin that the service
+ * reads/writes ONLY that table — never BillingMeterCheckpoint — so storage
+ * billing stays fully decoupled from the billable-events checkpoint.
+ */
+const makePrisma = () => {
+  const storageBillingCheckpoint = {
+    findUnique: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+  };
+  const billingMeterCheckpoint = {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn(),
+  };
+  return {
+    prisma: {
+      storageBillingCheckpoint,
+      billingMeterCheckpoint,
+    } as unknown as PrismaClient,
+    storageBillingCheckpoint,
+    billingMeterCheckpoint,
+  };
+};
+
+describe("PrismaStorageBillingCheckpointService", () => {
+  describe("given a checkpoint lookup", () => {
+    it("reads the dedicated storage table scoped by organizationId and billingMonth", async () => {
+      const { prisma, storageBillingCheckpoint, billingMeterCheckpoint } =
+        makePrisma();
+      const service = new PrismaStorageBillingCheckpointService(prisma);
+
+      await service.getCheckpoint({
+        organizationId: "org-1",
+        billingMonth: "2026-02",
+      });
+
+      expect(storageBillingCheckpoint.findUnique).toHaveBeenCalledWith({
+        where: {
+          organizationId_billingMonth: {
+            organizationId: "org-1",
+            billingMonth: "2026-02",
+          },
+        },
+      });
+      // Never touches the billable-events checkpoint.
+      expect(billingMeterCheckpoint.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when writing intent then confirming", () => {
+    it("upserts the storage table only, clearing pending and resetting failures on confirm", async () => {
+      const { prisma, storageBillingCheckpoint, billingMeterCheckpoint } =
+        makePrisma();
+      const service = new PrismaStorageBillingCheckpointService(prisma);
+
+      await service.writeIntent({
+        organizationId: "org-1",
+        billingMonth: "2026-02",
+        lastReportedTotal: 0,
+        pendingReportedTotal: 5,
+      });
+      await service.confirm({
+        organizationId: "org-1",
+        billingMonth: "2026-02",
+        lastReportedTotal: 5,
+      });
+
+      expect(storageBillingCheckpoint.upsert).toHaveBeenCalledTimes(2);
+      expect(storageBillingCheckpoint.upsert).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          where: {
+            organizationId_billingMonth: {
+              organizationId: "org-1",
+              billingMonth: "2026-02",
+            },
+          },
+          update: {
+            lastReportedTotal: 5,
+            pendingReportedTotal: null,
+            consecutiveFailures: 0,
+          },
+        }),
+      );
+      expect(billingMeterCheckpoint.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a transient failure occurs", () => {
+    it("increments failures on the storage table without clearing pending", async () => {
+      const { prisma, storageBillingCheckpoint } = makePrisma();
+      const service = new PrismaStorageBillingCheckpointService(prisma);
+
+      await service.incrementFailures({
+        organizationId: "org-1",
+        billingMonth: "2026-02",
+        lastReportedTotal: 0,
+        pendingReportedTotal: 5,
+        consecutiveFailures: 3,
+      });
+
+      expect(storageBillingCheckpoint.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: { consecutiveFailures: 3 },
+        }),
+      );
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/billing/__tests__/storageBillingCheckpoint.service.unit.test.ts
+++ b/langwatch/src/server/app-layer/billing/__tests__/storageBillingCheckpoint.service.unit.test.ts
@@ -64,13 +64,13 @@ describe("PrismaStorageBillingCheckpointService", () => {
       await service.writeIntent({
         organizationId: "org-1",
         billingMonth: "2026-02",
-        lastReportedTotal: 0,
-        pendingReportedTotal: 5,
+        lastReportedTotal: 0n,
+        pendingReportedTotal: 5n,
       });
       await service.confirm({
         organizationId: "org-1",
         billingMonth: "2026-02",
-        lastReportedTotal: 5,
+        lastReportedTotal: 5n,
       });
 
       expect(storageBillingCheckpoint.upsert).toHaveBeenCalledTimes(2);
@@ -83,7 +83,7 @@ describe("PrismaStorageBillingCheckpointService", () => {
             },
           },
           update: {
-            lastReportedTotal: 5,
+            lastReportedTotal: 5n,
             pendingReportedTotal: null,
             consecutiveFailures: 0,
           },
@@ -101,8 +101,8 @@ describe("PrismaStorageBillingCheckpointService", () => {
       await service.incrementFailures({
         organizationId: "org-1",
         billingMonth: "2026-02",
-        lastReportedTotal: 0,
-        pendingReportedTotal: 5,
+        lastReportedTotal: 0n,
+        pendingReportedTotal: 5n,
         consecutiveFailures: 3,
       });
 

--- a/langwatch/src/server/app-layer/billing/storageBillingCheckpoint.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingCheckpoint.service.ts
@@ -1,0 +1,187 @@
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Checkpoint data for the storage-meter two-phase reporting protocol.
+ *
+ * Deliberately a sibling of BillingCheckpoint (billable-events) rather than a
+ * shared type: ADR-027 storage billing owns its own persistence so the
+ * billable-events checkpoint is never altered to make room for it.
+ */
+export interface StorageBillingCheckpoint {
+  lastReportedTotal: number;
+  pendingReportedTotal: number | null;
+  consecutiveFailures: number;
+}
+
+/**
+ * Service for managing the STORAGE_GB meter's reporting checkpoint, backed by
+ * the dedicated StorageBillingCheckpoint table.
+ *
+ * Mirrors the two-phase protocol of BillingCheckpointService:
+ * 1. writeIntent — sets pendingReportedTotal before calling Stripe
+ * 2. confirm — promotes pending to lastReportedTotal, clears pending, resets failures
+ *
+ * Also tracks consecutiveFailures for circuit-breaker logic. Keeping a separate
+ * service + table (not a meterName discriminator on the shared one) means the
+ * storage meter never touches BillingMeterCheckpoint's live unique index.
+ */
+export interface StorageBillingCheckpointService {
+  getCheckpoint(params: {
+    organizationId: string;
+    billingMonth: string;
+  }): Promise<StorageBillingCheckpoint | null>;
+
+  writeIntent(params: {
+    organizationId: string;
+    billingMonth: string;
+    lastReportedTotal: number;
+    pendingReportedTotal: number;
+  }): Promise<void>;
+
+  confirm(params: {
+    organizationId: string;
+    billingMonth: string;
+    lastReportedTotal: number;
+  }): Promise<void>;
+
+  clearPendingAndIncrementFailures(params: {
+    organizationId: string;
+    billingMonth: string;
+    consecutiveFailures: number;
+  }): Promise<void>;
+
+  incrementFailures(params: {
+    organizationId: string;
+    billingMonth: string;
+    lastReportedTotal: number;
+    pendingReportedTotal: number;
+    consecutiveFailures: number;
+  }): Promise<void>;
+}
+
+/**
+ * Prisma-backed storage billing checkpoint service.
+ */
+export class PrismaStorageBillingCheckpointService
+  implements StorageBillingCheckpointService
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getCheckpoint(params: {
+    organizationId: string;
+    billingMonth: string;
+  }): Promise<StorageBillingCheckpoint | null> {
+    const row = await this.prisma.storageBillingCheckpoint.findUnique({
+      where: {
+        organizationId_billingMonth: {
+          organizationId: params.organizationId,
+          billingMonth: params.billingMonth,
+        },
+      },
+    });
+    if (!row) return null;
+    return {
+      lastReportedTotal: row.lastReportedTotal,
+      pendingReportedTotal: row.pendingReportedTotal,
+      consecutiveFailures: row.consecutiveFailures,
+    };
+  }
+
+  async writeIntent(params: {
+    organizationId: string;
+    billingMonth: string;
+    lastReportedTotal: number;
+    pendingReportedTotal: number;
+  }): Promise<void> {
+    await this.prisma.storageBillingCheckpoint.upsert({
+      where: {
+        organizationId_billingMonth: {
+          organizationId: params.organizationId,
+          billingMonth: params.billingMonth,
+        },
+      },
+      create: {
+        organizationId: params.organizationId,
+        billingMonth: params.billingMonth,
+        lastReportedTotal: params.lastReportedTotal,
+        pendingReportedTotal: params.pendingReportedTotal,
+      },
+      update: {
+        pendingReportedTotal: params.pendingReportedTotal,
+      },
+    });
+  }
+
+  async confirm(params: {
+    organizationId: string;
+    billingMonth: string;
+    lastReportedTotal: number;
+  }): Promise<void> {
+    await this.prisma.storageBillingCheckpoint.upsert({
+      where: {
+        organizationId_billingMonth: {
+          organizationId: params.organizationId,
+          billingMonth: params.billingMonth,
+        },
+      },
+      create: {
+        organizationId: params.organizationId,
+        billingMonth: params.billingMonth,
+        lastReportedTotal: params.lastReportedTotal,
+        pendingReportedTotal: null,
+        consecutiveFailures: 0,
+      },
+      update: {
+        lastReportedTotal: params.lastReportedTotal,
+        pendingReportedTotal: null,
+        consecutiveFailures: 0,
+      },
+    });
+  }
+
+  async clearPendingAndIncrementFailures(params: {
+    organizationId: string;
+    billingMonth: string;
+    consecutiveFailures: number;
+  }): Promise<void> {
+    await this.prisma.storageBillingCheckpoint.update({
+      where: {
+        organizationId_billingMonth: {
+          organizationId: params.organizationId,
+          billingMonth: params.billingMonth,
+        },
+      },
+      data: {
+        pendingReportedTotal: null,
+        consecutiveFailures: params.consecutiveFailures,
+      },
+    });
+  }
+
+  async incrementFailures(params: {
+    organizationId: string;
+    billingMonth: string;
+    lastReportedTotal: number;
+    pendingReportedTotal: number;
+    consecutiveFailures: number;
+  }): Promise<void> {
+    await this.prisma.storageBillingCheckpoint.upsert({
+      where: {
+        organizationId_billingMonth: {
+          organizationId: params.organizationId,
+          billingMonth: params.billingMonth,
+        },
+      },
+      create: {
+        organizationId: params.organizationId,
+        billingMonth: params.billingMonth,
+        lastReportedTotal: params.lastReportedTotal,
+        pendingReportedTotal: params.pendingReportedTotal,
+        consecutiveFailures: params.consecutiveFailures,
+      },
+      update: {
+        consecutiveFailures: params.consecutiveFailures,
+      },
+    });
+  }
+}

--- a/langwatch/src/server/app-layer/billing/storageBillingCheckpoint.service.ts
+++ b/langwatch/src/server/app-layer/billing/storageBillingCheckpoint.service.ts
@@ -8,8 +8,8 @@ import type { PrismaClient } from "@prisma/client";
  * billable-events checkpoint is never altered to make room for it.
  */
 export interface StorageBillingCheckpoint {
-  lastReportedTotal: number;
-  pendingReportedTotal: number | null;
+  lastReportedTotal: bigint;
+  pendingReportedTotal: bigint | null;
   consecutiveFailures: number;
 }
 
@@ -34,14 +34,14 @@ export interface StorageBillingCheckpointService {
   writeIntent(params: {
     organizationId: string;
     billingMonth: string;
-    lastReportedTotal: number;
-    pendingReportedTotal: number;
+    lastReportedTotal: bigint;
+    pendingReportedTotal: bigint;
   }): Promise<void>;
 
   confirm(params: {
     organizationId: string;
     billingMonth: string;
-    lastReportedTotal: number;
+    lastReportedTotal: bigint;
   }): Promise<void>;
 
   clearPendingAndIncrementFailures(params: {
@@ -53,8 +53,8 @@ export interface StorageBillingCheckpointService {
   incrementFailures(params: {
     organizationId: string;
     billingMonth: string;
-    lastReportedTotal: number;
-    pendingReportedTotal: number;
+    lastReportedTotal: bigint;
+    pendingReportedTotal: bigint;
     consecutiveFailures: number;
   }): Promise<void>;
 }
@@ -90,8 +90,8 @@ export class PrismaStorageBillingCheckpointService
   async writeIntent(params: {
     organizationId: string;
     billingMonth: string;
-    lastReportedTotal: number;
-    pendingReportedTotal: number;
+    lastReportedTotal: bigint;
+    pendingReportedTotal: bigint;
   }): Promise<void> {
     await this.prisma.storageBillingCheckpoint.upsert({
       where: {
@@ -115,7 +115,7 @@ export class PrismaStorageBillingCheckpointService
   async confirm(params: {
     organizationId: string;
     billingMonth: string;
-    lastReportedTotal: number;
+    lastReportedTotal: bigint;
   }): Promise<void> {
     await this.prisma.storageBillingCheckpoint.upsert({
       where: {
@@ -161,8 +161,8 @@ export class PrismaStorageBillingCheckpointService
   async incrementFailures(params: {
     organizationId: string;
     billingMonth: string;
-    lastReportedTotal: number;
-    pendingReportedTotal: number;
+    lastReportedTotal: bigint;
+    pendingReportedTotal: bigint;
     consecutiveFailures: number;
   }): Promise<void> {
     await this.prisma.storageBillingCheckpoint.upsert({

--- a/langwatch/src/utils/dbOrganizationIdProtection.ts
+++ b/langwatch/src/utils/dbOrganizationIdProtection.ts
@@ -65,7 +65,8 @@ const hasCompositeOrgKey = (clause: any): boolean => {
 // id (a team or project id), so it resolves to exactly one organization.
 const hasInlineScope = (clause: any): boolean =>
   typeof clause?.scopeType === "string" &&
-  (typeof clause?.scopeId === "string" || isNonEmptyStringList(clause?.scopeId));
+  (typeof clause?.scopeId === "string" ||
+    isNonEmptyStringList(clause?.scopeId));
 
 const boundsToSingleOrg = (clause: any): boolean =>
   hasOrganizationId(clause) || hasRowId(clause) || hasCompositeOrgKey(clause);
@@ -148,6 +149,16 @@ export const ORG_TENANCY_EXEMPT: readonly string[] = [
   // organizationId; the evaluator's sweep is the constraint.
   "AnomalyRule",
   "AnomalyAlert",
+  // Billing reporter (ADR-027) drains `reportedAt IS NULL` across every org as a
+  // background sweep, so a mandatory-organizationId guard cannot apply. Per-org
+  // access (the dispatcher write, the invoice-audit read) carries the composite
+  // (organizationId, sealedHour) key, which the guard already accepts.
+  "StorageUsageHourly",
+  // Storage-meter checkpoint; sibling of BillingMeterCheckpoint above and
+  // deferred for the same reason — org-scoped but not yet audited for every
+  // query shape (ADR-021). Access is via the (organizationId, billingMonth)
+  // composite key.
+  "StorageBillingCheckpoint",
   // Org-scoped but not yet audited for every query shape. Listed explicitly so
   // the partition test stays green while the per-model call-site audit that
   // precedes enforcement (ADR-021) is completed.


### PR DESCRIPTION
**Stack:** PR1 of 7 — implements [ADR-027](https://github.com/langwatch/langwatch/pull/4752) storage-GiB-hours billing. Stacked on the ADR PR (#4752) as base.

## What

Phase 1 (persistence). **Purely additive — two new tables on top of the current implementation.** The billable-events checkpoint (`BillingMeterCheckpoint`) and its unique index are left completely untouched.

- **`StorageUsageHourly`** (new) — durable per-sealed-UTC-hour measurement of stored bytes aged > 30 days. PK `(organizationId, sealedHour)`, index on `reportedAt`. The dispatcher (PR5) writes one row/hour; the reporter (PR4) drains `reportedAt IS NULL` and stamps on Stripe success. Decouples *measurement* from *Stripe availability* — the reporter can stall and resume without re-measuring or re-billing — and is the per-org audit trail an invoice line traces back to.
- **`StorageBillingCheckpoint`** (new) — dedicated two-phase reporting checkpoint for the `STORAGE_GB` meter, a sibling of `BillingMeterCheckpoint`.
- **`StorageBillingCheckpointService`** (new) — its own service over the new table, mirroring the proven two-phase + circuit-breaker protocol.
- Both new org-bearing tables registered in the org-tenancy exempt list (`dbOrganizationIdProtection`).

No ClickHouse migration — `_size_bytes` already exists (migration `00032`).

## Design note — separate table, not a discriminator

The ADR's first draft proposed adding a `meterName` discriminator to `BillingMeterCheckpoint` and swapping its unique index. **This PR deliberately does not do that.** A separate `StorageBillingCheckpoint` table + service keeps the migration purely additive (no `DROP INDEX`, no `ALTER` on a live billing table) and the billable-events path 100% unchanged — each meter owns its own persistence. ADR-027 Schema section updated to match.

## Why dormant is safe

Nothing in this PR dispatches a storage report. The whole pipeline lands in later PRs; even after wire-up, no org bills until rollout attaches the `STORAGE_GB` SubscriptionItem.

## Verification

- Migration generated via `prisma@5.7.1 migrate diff`, then **applied cleanly over the full 182-migration history on a throwaway Postgres**. Confirmed both new tables + indexes exist and `BillingMeterCheckpoint`'s original unique index is **intact** (never dropped).
- `pnpm typecheck` clean.
- Unit tests green (75): new `storageBillingCheckpoint.service.unit.test.ts` (3 — proves the service touches only the storage table, never `BillingMeterCheckpoint`); billable-events `reportUsageForMonth.command.unit.test.ts` passes with its **original** assertions (path untouched); org-tenancy partition tests (58 — confirm both new tables classified org-bearing).

## Runbook

None — additive `CREATE TABLE`s only, no locks on existing tables.
