### PR TITLE
docs: add Railway one-click deploy option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Run LangWatch on your own infrastructure:
 - [Docker Compose](https://docs.langwatch.ai/self-hosting/open-source#docker-compose) - Run LangWatch on your own machine.
 - [Kubernetes (Helm)](https://docs.langwatch.ai/self-hosting/open-source#helm-chart-for-langwatch) - Run LangWatch on a Kubernetes cluster using Helm.
 - [OnPrem](https://docs.langwatch.ai/self-hosting/onprem) - Cloud-specific setups for AWS, Google Cloud, and Azure.
+- [Railway](https://railway.com/deploy/langwatch-ai-observability) - One-click deploy of the full stack (app, workers, ClickHouse, Postgres, Redis) on Railway.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/langwatch-ai-observability)
 
 <details>
 <summary>Hybrid (OnPrem data) 🔀</summary>


### PR DESCRIPTION
Adds a Railway deployment option to the self-hosting section, alongside the existing Docker Compose, Kubernetes, and OnPrem options.

Came across a Railway template that deploys the full LangWatch stack (app, workers, ClickHouse, Postgres, Redis) and figured it'd be useful to surface for others who want a quick managed setup. Includes the standard "Deploy on Railway" button plus a list entry consistent with the other deployment methods.

## Why

<!-- What problem does this solve? Link the issue. A reviewer who hasn't seen the issue should understand the motivation after reading this section. -->

Closes #

## What changed

<!-- Plain-English summary of what you did. Focus on the approach and key decisions, not a line-by-line diff. A non-technical teammate should be able to follow this. -->

## How it works

<!-- Only if the "what" isn't obvious. Explain the mechanism, trade-offs, or why you chose this approach over alternatives. Skip this section for straightforward changes. -->

## Test plan

<!-- How did you verify this works? List the key test scenarios. For bug fixes: what regression test did you add, and does it fail without the fix? -->

## Anything surprising?

<!-- Optional. Call out: known limitations, follow-up work needed, things a reviewer should pay extra attention to, or edge cases you deliberately chose not to handle. Delete this section if there's nothing to flag. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Railway” as a new deployment option in the deployment options section, including a link for one-click full-stack deployment.
  * Included a “Deploy on Railway” button/link immediately after the Railway entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->