### PR TITLE
perf(clickhouse): add conversation-id skip-index for thread->traces lookups

### DIFF
--- a/langwatch/src/server/clickhouse/migrations/00035_add_trace_summary_conversation_id_index.sql
+++ b/langwatch/src/server/clickhouse/migrations/00035_add_trace_summary_conversation_id_index.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- trace_summaries is ORDER BY (TenantId, TraceId) and PARTITION BY a weekly
+-- bucket of OccurredAt. Resolving a conversation thread to its traces
+-- (getTracesByThreadId / getTracesWithSpansByThreadIds in
+-- clickhouse-trace.service.ts) filters by the conversation id held inside the
+-- Attributes map:
+--   SELECT DISTINCT TraceId FROM trace_summaries
+--   WHERE TenantId = {tenantId}
+--     AND Attributes['gen_ai.conversation.id'] = {threadId}   -- or IN (...)
+-- The thread view carries no time range (a conversation can span any period),
+-- so there is no OccurredAt predicate to prune partitions, and the
+-- conversation id lives in the Attributes map rather than a sort-key column.
+-- The read therefore decodes the Attributes map for every granule of every
+-- partition the tenant occupies — in production this shape read ~0.5-0.7 GB
+-- per call and ran 1-2.5s.
+--
+-- Add a bloom_filter skip-index on the conversation-id map element (matching
+-- the existing idx_models / idx_topic_id granularity) so a thread lookup skips
+-- the granule-blocks that cannot contain the id. The equality and IN forms
+-- both use a bloom_filter index.
+--
+-- This ADD INDEX only attaches the index to NEW parts. To backfill existing
+-- parts, the reviewer should run (out of band, it is a heavy mutation that
+-- reads the Attributes column across all parts — plan it for a low-traffic
+-- window):
+--   ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries MATERIALIZE INDEX idx_conversation_id;
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  ADD INDEX IF NOT EXISTS idx_conversation_id `Attributes`['gen_ai.conversation.id']
+    TYPE bloom_filter(0.01) GRANULARITY 4;
+-- +goose StatementEnd
+
+-- +goose Down
+-- To roll back, uncomment and run manually:
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries DROP INDEX IF EXISTS idx_conversation_id;

--- a/langwatch/src/server/traces/__tests__/conversation-id-index.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/conversation-id-index.integration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment node
+ * @integration
+ *
+ * Verifies the bloom_filter skip-index on the trace_summaries conversation-id
+ * map element (migration 00035):
+ *  - the migration attaches idx_conversation_id to the table, and
+ *  - the thread-lookup shapes (`Attributes['gen_ai.conversation.id'] = {id}`
+ *    and `... IN (...)`, no time bound) still return the correct traces.
+ *
+ * The lookup carries no OccurredAt predicate and the id lives in the Attributes
+ * map, so without a skip index it falls back to decoding Attributes for every
+ * granule. The index lets ClickHouse skip granule blocks that cannot contain
+ * the id; correctness is identical either way, which is what this test pins.
+ */
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+
+let ch: ClickHouseClient;
+const tag = nanoid();
+
+async function insertTrace(
+  tenantId: string,
+  traceId: string,
+  conversationId: string | null,
+) {
+  await ch.insert({
+    table: "trace_summaries",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: traceId,
+        Version: "v1",
+        Attributes:
+          conversationId === null
+            ? {}
+            : { "gen_ai.conversation.id": conversationId },
+        OccurredAt: new Date(),
+        CreatedAt: new Date(),
+        UpdatedAt: new Date(),
+        ComputedIOSchemaVersion: "",
+        ComputedInput: "in",
+        ComputedOutput: "out",
+        TimeToFirstTokenMs: 1,
+        TimeToLastTokenMs: 1,
+        TotalDurationMs: 1,
+        TokensPerSecond: 1,
+        SpanCount: 1,
+        ContainsErrorStatus: 0,
+        ContainsOKStatus: 1,
+        ErrorMessage: null,
+        Models: ["gpt-5-mini"],
+        TotalCost: 0.01,
+        TokensEstimated: false,
+        TotalPromptTokenCount: 1,
+        TotalCompletionTokenCount: 1,
+        OutputFromRootSpan: 0,
+        OutputSpanEndTimeMs: 0,
+        BlockedByGuardrail: 0,
+        TopicId: null,
+        SubTopicId: null,
+        HasAnnotation: null,
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE trace_summaries DELETE WHERE startsWith(TraceId, {tag:String})`,
+      query_params: { tag },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("trace_summaries conversation-id skip-index (migration 00035)", () => {
+  it("attaches a bloom_filter index on the conversation-id map element", async () => {
+    const ddl = await (
+      await ch.query({
+        query: "SHOW CREATE TABLE trace_summaries",
+        format: "TabSeparatedRaw",
+      })
+    ).text();
+    expect(ddl).toMatch(/INDEX\s+idx_conversation_id\b/i);
+    expect(ddl).toMatch(/idx_conversation_id[\s\S]*TYPE\s+bloom_filter/i);
+  });
+
+  describe("when resolving a single thread id", () => {
+    it("returns only the traces in that conversation", async () => {
+      const tenantId = `${tag}-tenant-a`;
+      const thread = `${tag}-conv-1`;
+      await insertTrace(tenantId, `${tag}-t1`, thread);
+      await insertTrace(tenantId, `${tag}-t2`, thread);
+      await insertTrace(tenantId, `${tag}-t3`, `${tag}-conv-2`);
+      await insertTrace(tenantId, `${tag}-t4`, null);
+
+      const rows = await (
+        await ch.query({
+          query: `
+            SELECT DISTINCT TraceId
+            FROM trace_summaries
+            WHERE TenantId = {tenantId:String}
+              AND Attributes['gen_ai.conversation.id'] = {threadId:String}
+          `,
+          query_params: { tenantId, threadId: thread },
+          format: "JSONEachRow",
+        })
+      ).json<{ TraceId: string }>();
+
+      expect(rows.map((r) => r.TraceId).sort()).toEqual(
+        [`${tag}-t1`, `${tag}-t2`].sort(),
+      );
+    });
+  });
+
+  describe("when resolving multiple thread ids", () => {
+    it("returns the union of their conversations", async () => {
+      const tenantId = `${tag}-tenant-b`;
+      await insertTrace(tenantId, `${tag}-b1`, `${tag}-bc-1`);
+      await insertTrace(tenantId, `${tag}-b2`, `${tag}-bc-2`);
+      await insertTrace(tenantId, `${tag}-b3`, `${tag}-bc-3`);
+
+      const rows = await (
+        await ch.query({
+          query: `
+            SELECT DISTINCT TraceId
+            FROM trace_summaries
+            WHERE TenantId = {tenantId:String}
+              AND Attributes['gen_ai.conversation.id'] IN ({threadIds:Array(String)})
+          `,
+          query_params: {
+            tenantId,
+            threadIds: [`${tag}-bc-1`, `${tag}-bc-3`],
+          },
+          format: "JSONEachRow",
+        })
+      ).json<{ TraceId: string }>();
+
+      expect(rows.map((r) => r.TraceId).sort()).toEqual(
+        [`${tag}-b1`, `${tag}-b3`].sort(),
+      );
+    });
+  });
+
+  describe("when the conversation id does not exist", () => {
+    it("returns nothing", async () => {
+      const rows = await (
+        await ch.query({
+          query: `
+            SELECT DISTINCT TraceId
+            FROM trace_summaries
+            WHERE TenantId = {tenantId:String}
+              AND Attributes['gen_ai.conversation.id'] = {threadId:String}
+          `,
+          query_params: {
+            tenantId: `${tag}-tenant-a`,
+            threadId: `${tag}-missing`,
+          },
+          format: "JSONEachRow",
+        })
+      ).json<{ TraceId: string }>();
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+});

--- a/langwatch/src/server/traces/__tests__/conversation-id-index.integration.test.ts
+++ b/langwatch/src/server/traces/__tests__/conversation-id-index.integration.test.ts
@@ -24,11 +24,15 @@ import {
 let ch: ClickHouseClient;
 const tag = nanoid();
 
-async function insertTrace(
-  tenantId: string,
-  traceId: string,
-  conversationId: string | null,
-) {
+async function insertTrace({
+  tenantId,
+  traceId,
+  conversationId,
+}: {
+  tenantId: string;
+  traceId: string;
+  conversationId: string | null;
+}) {
   await ch.insert({
     table: "trace_summaries",
     values: [
@@ -81,7 +85,7 @@ beforeAll(async () => {
 afterAll(async () => {
   if (ch) {
     await ch.exec({
-      query: `ALTER TABLE trace_summaries DELETE WHERE startsWith(TraceId, {tag:String})`,
+      query: `ALTER TABLE trace_summaries DELETE WHERE startsWith(TenantId, {tag:String}) AND startsWith(TraceId, {tag:String})`,
       query_params: { tag },
     });
   }
@@ -104,10 +108,26 @@ describe("trace_summaries conversation-id skip-index (migration 00035)", () => {
     it("returns only the traces in that conversation", async () => {
       const tenantId = `${tag}-tenant-a`;
       const thread = `${tag}-conv-1`;
-      await insertTrace(tenantId, `${tag}-t1`, thread);
-      await insertTrace(tenantId, `${tag}-t2`, thread);
-      await insertTrace(tenantId, `${tag}-t3`, `${tag}-conv-2`);
-      await insertTrace(tenantId, `${tag}-t4`, null);
+      await insertTrace({
+        tenantId: tenantId,
+        traceId: `${tag}-t1`,
+        conversationId: thread,
+      });
+      await insertTrace({
+        tenantId: tenantId,
+        traceId: `${tag}-t2`,
+        conversationId: thread,
+      });
+      await insertTrace({
+        tenantId: tenantId,
+        traceId: `${tag}-t3`,
+        conversationId: `${tag}-conv-2`,
+      });
+      await insertTrace({
+        tenantId: tenantId,
+        traceId: `${tag}-t4`,
+        conversationId: null,
+      });
 
       const rows = await (
         await ch.query({
@@ -131,9 +151,21 @@ describe("trace_summaries conversation-id skip-index (migration 00035)", () => {
   describe("when resolving multiple thread ids", () => {
     it("returns the union of their conversations", async () => {
       const tenantId = `${tag}-tenant-b`;
-      await insertTrace(tenantId, `${tag}-b1`, `${tag}-bc-1`);
-      await insertTrace(tenantId, `${tag}-b2`, `${tag}-bc-2`);
-      await insertTrace(tenantId, `${tag}-b3`, `${tag}-bc-3`);
+      await insertTrace({
+        tenantId: tenantId,
+        traceId: `${tag}-b1`,
+        conversationId: `${tag}-bc-1`,
+      });
+      await insertTrace({
+        tenantId: tenantId,
+        traceId: `${tag}-b2`,
+        conversationId: `${tag}-bc-2`,
+      });
+      await insertTrace({
+        tenantId: tenantId,
+        traceId: `${tag}-b3`,
+        conversationId: `${tag}-bc-3`,
+      });
 
       const rows = await (
         await ch.query({


### PR DESCRIPTION
## Evidence

Two thread-resolution shapes over `trace_summaries`, keyed on `[tenantId, threadId]` and `[tenantId, threadIds]`, show up in the last 24h of prod slow-query logs: ~8 + ~5 hits, p50 ~1.2-1.8s / p95 up to ~2.5s, reading **~0.5-0.7 GB per call**. Low-ish volume but heavy per call, and not addressed by any open PR.

These come from `getTracesByThreadId` / `getTracesWithSpansByThreadIds` in `clickhouse-trace.service.ts`:

```sql
SELECT DISTINCT TraceId FROM trace_summaries
WHERE TenantId = {tenantId}
  AND Attributes['gen_ai.conversation.id'] = {threadId}   -- or IN (...)
ORDER BY CreatedAt ASC LIMIT 1000
```

## Suspected cause

`trace_summaries` is `ORDER BY (TenantId, TraceId)`. `TenantId` prunes via the primary key, but the conversation id lives inside the `Attributes Map(String, String)` column, which has no index. There is also no `OccurredAt` predicate (the thread view has no time range — a conversation can span any period), so no partition pruning either. The read therefore decodes the `Attributes` map for every granule of every partition the tenant occupies.

## Proposed fix

Add a `bloom_filter` data-skipping index on the conversation-id map element, matching the granularity of the table's existing `idx_models` / `idx_topic_id` bloom indexes:

```sql
ALTER TABLE trace_summaries
  ADD INDEX IF NOT EXISTS idx_conversation_id `Attributes`['gen_ai.conversation.id']
    TYPE bloom_filter(0.01) GRANULARITY 4;
```

Both the `=` and `IN (...)` forms use a bloom_filter index, so the lookup skips the granule-blocks that cannot contain the id. This is the same approach `idx_models` / `idx_topic_id` already use for their equality/array filters, and mirrors the stored_objects.id skip-index in #4640.

## Expected impact

The lookup goes from decoding `Attributes` across all of the tenant's granules to probing the bloom filter and decoding only the surviving granule-blocks. For a conversation that touches a handful of traces, that is a large reduction in granules read; the headline metric is read-bytes / granules pruned, not a constant-factor speedup. Tenants with few conversations see little change; large tenants with many conversations benefit most. Correctness is identical (a skip index never changes results).

## Test plan

`conversation-id-index.integration.test.ts` (testcontainers, real ClickHouse, migration applied via goose): asserts the index attaches (`SHOW CREATE TABLE`), and that the `=` and `IN` thread lookups return exactly the traces in the matching conversation(s), plus the empty case. Passes locally.

## Rollout note

`ADD INDEX` attaches the index to **new** parts only (metadata-only, instant). To backfill existing parts the reviewer should run, out of band during a low-traffic window (it reads the `Attributes` column across all parts):

```sql
ALTER TABLE trace_summaries MATERIALIZE INDEX idx_conversation_id;
```

## EXPLAIN check

The index cannot be EXPLAINed against prod until it exists there (same caveat as #4640). The integration test confirms the index attaches and the planner accepts the equality/IN predicates against it; pruning is the standard bloom_filter skip-index behaviour already relied on by `idx_models` / `idx_topic_id`.

## Notes

- Migration numbered 00035 (main is at 00033; #4640 is expected to take 00034). If merge order differs, renumber accordingly.
- Advisory PR from the ClickHouse slow-query sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database query performance for conversation-related lookups by adding a bloom filter skip-index on conversation IDs in trace summaries.
  * Added an integration test covering schema creation and correctness for equality and multi-value conversation ID queries, including missing/null attribute cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->