### PR TITLE
perf(clickhouse): bound and harden storage-metering _size_bytes reads

### DIFF
--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { RETENTION_MANAGED_TABLES } from "../../retentionPolicy.schema";
 import { StorageMeterService } from "../storageMeter.service";
 
 /**
@@ -21,6 +22,9 @@ describe("StorageMeterService memory guard", () => {
   function assertGuarded(call: { clickhouse_settings?: Record<string, unknown> }) {
     expect(call.clickhouse_settings).toBeDefined();
     expect(call.clickhouse_settings!.max_threads).toBe(2);
+    // A coarse guardrail so a runaway byteSize recompute can't grind for a
+    // minute; a materialized read finishes in seconds, well under this.
+    expect(call.clickhouse_settings!.max_execution_time).toBe(45);
   }
 
   describe("when computing the per-category storage breakdown", () => {
@@ -44,6 +48,28 @@ describe("StorageMeterService memory guard", () => {
 
       expect(query).toHaveBeenCalledTimes(1);
       assertGuarded(query.mock.calls[0]![0]);
+    });
+  });
+
+  describe("when the single aggregate total query fails for a heavy table", () => {
+    it("falls back to the per-table breakdown instead of throwing", async () => {
+      // The combined UNION ALL aggregate trips the per-query limit, but each
+      // table's own query still succeeds — the total should degrade to the
+      // sum of the per-table subtotals rather than failing the whole metric.
+      const query = vi.fn().mockImplementation(async (arg: { query: string }) => {
+        if (arg.query.includes("UNION ALL")) {
+          throw new Error("Code: 241. DB::Exception: memory limit exceeded");
+        }
+        return { json: async () => [{ total: "10" }] };
+      });
+      const client = { query } as const;
+      const service = new StorageMeterService(async () => client as any);
+
+      const total = await service.getTotalStorageBytes({ tenantId: "p-heavy" });
+
+      expect(total).toBe(10 * RETENTION_MANAGED_TABLES.length);
+      // one failed aggregate attempt + one query per table for the fallback
+      expect(query).toHaveBeenCalledTimes(1 + RETENTION_MANAGED_TABLES.length);
     });
   });
 });

--- a/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
+++ b/langwatch/src/server/data-retention/metering/__tests__/storageMeter.service.unit.test.ts
@@ -51,25 +51,27 @@ describe("StorageMeterService memory guard", () => {
     });
   });
 
-  describe("when the single aggregate total query fails for a heavy table", () => {
-    it("falls back to the per-table breakdown instead of throwing", async () => {
-      // The combined UNION ALL aggregate trips the per-query limit, but each
-      // table's own query still succeeds — the total should degrade to the
-      // sum of the per-table subtotals rather than failing the whole metric.
-      const query = vi.fn().mockImplementation(async (arg: { query: string }) => {
-        if (arg.query.includes("UNION ALL")) {
-          throw new Error("Code: 241. DB::Exception: memory limit exceeded");
-        }
-        return { json: async () => [{ total: "10" }] };
+  describe("given a heavy tenant where the aggregate query can exceed limits", () => {
+    describe("when the single aggregate total query fails", () => {
+      it("falls back to the per-table breakdown instead of throwing", async () => {
+        // The combined UNION ALL aggregate trips the per-query limit, but each
+        // table's own query still succeeds — the total should degrade to the
+        // sum of the per-table subtotals rather than failing the whole metric.
+        const query = vi.fn().mockImplementation(async (arg: { query: string }) => {
+          if (arg.query.includes("UNION ALL")) {
+            throw new Error("Code: 241. DB::Exception: memory limit exceeded");
+          }
+          return { json: async () => [{ total: "10" }] };
+        });
+        const client = { query } as const;
+        const service = new StorageMeterService(async () => client as any);
+
+        const total = await service.getTotalStorageBytes({ tenantId: "p-heavy" });
+
+        expect(total).toBe(10 * RETENTION_MANAGED_TABLES.length);
+        // one failed aggregate attempt + one query per table for the fallback
+        expect(query).toHaveBeenCalledTimes(1 + RETENTION_MANAGED_TABLES.length);
       });
-      const client = { query } as const;
-      const service = new StorageMeterService(async () => client as any);
-
-      const total = await service.getTotalStorageBytes({ tenantId: "p-heavy" });
-
-      expect(total).toBe(10 * RETENTION_MANAGED_TABLES.length);
-      // one failed aggregate attempt + one query per table for the fallback
-      expect(query).toHaveBeenCalledTimes(1 + RETENTION_MANAGED_TABLES.length);
     });
   });
 });

--- a/langwatch/src/server/data-retention/metering/storageMeter.service.ts
+++ b/langwatch/src/server/data-retention/metering/storageMeter.service.ts
@@ -27,8 +27,19 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 // total server memory so it can't help tip the box into a server-wide OOM. The
 // common case (parts where `_size_bytes` is already materialized) reads a tiny
 // UInt32 column and is unaffected.
+//
+// `max_execution_time` is a coarse guardrail on top of that: a materialized
+// read finishes in a few seconds even for the largest tenants, so this only
+// trips on the pathological recompute path (observed at 24-60s reading tens of
+// GB). Tripping it fails that one read — which is then degraded gracefully (see
+// getStorageBreakdown's per-table catch and queryTotalBytes's fallback) instead
+// of letting one tenant's metering grind for a minute and burn tens of GB of
+// reads every cache cycle. The durable fix is to backfill the column so the
+// recompute never happens (see queryTotalBytes).
+const METERING_MAX_EXECUTION_SECONDS = 45;
 const METERING_CLICKHOUSE_SETTINGS = {
   max_threads: 2,
+  max_execution_time: METERING_MAX_EXECUTION_SECONDS,
 } as const;
 
 interface StorageBreakdown {
@@ -112,6 +123,18 @@ export class StorageMeterService {
    * Sums per-table `_size_bytes` totals for a tenant in a single query. Each
    * table is pre-aggregated inside a UNION ALL so only the 11 scalar subtotals
    * (not every row's `_size_bytes`) reach the outer sum.
+   *
+   * On parts where `_size_bytes` was never materialized this still recomputes
+   * `byteSize(...)` over the heavy payload columns, which for the largest
+   * tenants reads tens of GB and can exceed the per-query memory/time limit.
+   * If the single aggregate fails for any reason, fall back to the per-table
+   * {@link getStorageBreakdown}, whose per-table catch degrades only the
+   * failing table to zero — so one heavy table can't fail the whole total.
+   *
+   * The durable fix is to stop the recompute entirely by backfilling the
+   * column on existing parts (out of band, during a low-traffic window):
+   *   ALTER TABLE <table> MATERIALIZE COLUMN _size_bytes;
+   * after which every read hits the stored UInt32 and this path is cheap.
    */
   private async queryTotalBytes(tenantId: string): Promise<number> {
     if (!this.resolveClickHouseClient) return 0;
@@ -126,13 +149,22 @@ export class StorageMeterService {
         `SELECT sum(_size_bytes) AS t FROM ${table} WHERE TenantId = {tenantId:String}`,
     ).join("\n  UNION ALL\n  ");
 
-    const result = await client.query({
-      query: `SELECT sum(t) AS total FROM (\n  ${unions}\n)`,
-      query_params: { tenantId },
-      format: "JSONEachRow",
-      clickhouse_settings: METERING_CLICKHOUSE_SETTINGS,
-    });
-    const rows = (await result.json()) as Array<{ total: string }>;
-    return Number(rows[0]?.total ?? 0);
+    try {
+      const result = await client.query({
+        query: `SELECT sum(t) AS total FROM (\n  ${unions}\n)`,
+        query_params: { tenantId },
+        format: "JSONEachRow",
+        clickhouse_settings: METERING_CLICKHOUSE_SETTINGS,
+      });
+      const rows = (await result.json()) as Array<{ total: string }>;
+      return Number(rows[0]?.total ?? 0);
+    } catch (error) {
+      logger.warn(
+        { tenantId, error },
+        "Total _size_bytes query failed; falling back to per-table breakdown",
+      );
+      const { totalBytes } = await this.getStorageBreakdown({ tenantId });
+      return totalBytes;
+    }
   }
 }


### PR DESCRIPTION
## Evidence

Storage metering's `SELECT sum(_size_bytes) ... WHERE TenantId = {..}` is the single most expensive query shape in the last 24h of prod logs:

- Signal A (slow-but-completed): one stored_spans read at **~60s / ~42 GB**, one event_log read at **~24s / ~43 GB**.
- Signal B (failed): several `sum(_size_bytes)` reads over event_log / stored_spans hit the per-query memory limit (Code 241 MEMORY_LIMIT_EXCEEDED).

Low volume (these are 5-min-cached background reads), but extreme per-call cost, and it recurs every cache cycle for the affected tenants.

## Suspected cause

`_size_bytes` is a `UInt32 MATERIALIZED byteSize(<heavy payload columns>)` (migration 00032). On parts written before the column existed there is no stored value, so ClickHouse recomputes it lazily on read by scanning the heavy source columns (`SpanAttributes`, `EventPayload`, ...). Summing across a large tenant with un-materialized parts therefore reads those payload columns for every row — tens of GB — and either grinds for ~a minute or trips the 3.5 GB per-query limit. The existing `max_threads: 2` cap bounds peak memory but not the volume read or the wall time.

## Proposed fix

This PR does not try to make the recompute cheap (that needs a backfill, see below); it bounds its blast radius and degrades gracefully:

1. **`max_execution_time: 45s`** on the metering settings. A materialized read finishes in a few seconds even for the largest tenants, so this only trips the pathological recompute path — stopping a single tenant's metering from grinding for a minute and burning tens of GB of reads every cache cycle.
2. **Resilient total.** `queryTotalBytes` (the combined `UNION ALL`) now falls back to the per-table `getStorageBreakdown` on any failure. The breakdown already catches per-table, so one heavy table tripping the limit degrades only that table to zero instead of failing the whole storage-usage metric (which currently throws and surfaces an error in the data-retention UI).

These callers are a cached storage-usage **display** (`dataRetention.getTotalStorageBytes` / `getStorageBreakdown`), so a momentarily degraded subtotal is acceptable where a 42 GB read or a hard error is not.

## Durable fix (recommended, out of band)

The real fix is to stop the recompute by backfilling the column on existing parts, during a low-traffic window (heavy mutation — reads the payload columns once per part, then every future read hits the stored UInt32):

```sql
ALTER TABLE stored_spans     MATERIALIZE COLUMN _size_bytes;
ALTER TABLE event_log        MATERIALIZE COLUMN _size_bytes;
-- ... other retention-managed tables as needed
```

This is intentionally left as an ops runbook rather than an auto-applied migration, since it is a long-running mutation on multi-TB tables and migration 00032's notes already flag heavy ALTERs on these tables as environmentally risky.

## Expected impact

No change for the common (materialized) case — those reads are already a few seconds. For the pathological un-materialized tenants: a single metering read can no longer run ~a minute / tens of GB before failing, and a heavy table's failure no longer zeroes the entire total. The underlying read volume is only removed by the backfill above.

## Test plan

`storageMeter.service.unit.test.ts`: existing guards extended to assert `max_execution_time` is applied on every metering query; new case verifies that when the combined aggregate fails (simulated Code 241), the total falls back to the per-table breakdown and returns the summed subtotals instead of throwing. 3 tests pass; `tsgo` clean.

## Notes

- Advisory PR from the ClickHouse slow-query sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 45-second execution-time guard to storage metering queries to reduce the risk of runaway resource usage.
  * If the total storage aggregate query fails (e.g., memory-limit exceeded), storage metering now automatically falls back to per-table breakdowns and returns the summed result instead of failing.
* **Tests**
  * Strengthened metering unit coverage, including a heavy-tenant scenario verifying the fallback behavior and query count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->