### PR TITLE
fix(home): deterministic org resolution for /me & /governance, closing the deferred bare-nav gap (#5278)

### DIFF
--- a/langwatch/src/pages/index.tsx
+++ b/langwatch/src/pages/index.tsx
@@ -54,6 +54,10 @@ export default function Index() {
           governanceUiEnabled: resolved.data.governanceUiEnabled,
           lastVisitedHomeKind,
           lastProjectSlug: project?.slug ?? null,
+          // The org the resolver ran against; carried onto /me and /governance
+          // so the org-scoped page re-pins to it instead of 404ing behind its
+          // feature-flag guard when the selected project's org has drifted.
+          organizationSlug: organization?.slug ?? null,
         }),
       );
       return;

--- a/langwatch/src/server/app-layer/organizations/__tests__/organization.prisma.repository.membership-order.integration.test.ts
+++ b/langwatch/src/server/app-layer/organizations/__tests__/organization.prisma.repository.membership-order.integration.test.ts
@@ -1,4 +1,4 @@
-import { type Organization, type User } from "@prisma/client";
+import type { Organization, User } from "@prisma/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { prisma } from "~/server/db";
@@ -93,7 +93,10 @@ describe("PrismaOrganizationRepository — membership order determinism (#5278)"
 
   afterAll(async () => {
     await prisma.organizationUser.deleteMany({
-      where: { userId: testUser.id, organizationId: { in: [orgA.id, orgB.id] } },
+      where: {
+        userId: testUser.id,
+        organizationId: { in: [orgA.id, orgB.id] },
+      },
     });
     await prisma.organization.deleteMany({
       where: { id: { in: [orgA.id, orgB.id] } },

--- a/langwatch/src/server/app-layer/organizations/__tests__/organization.prisma.repository.membership-order.integration.test.ts
+++ b/langwatch/src/server/app-layer/organizations/__tests__/organization.prisma.repository.membership-order.integration.test.ts
@@ -1,0 +1,206 @@
+import { type Organization, type User } from "@prisma/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "~/server/db";
+import { PrismaOrganizationRepository } from "../repositories/organization.prisma.repository";
+
+/**
+ * Regression test for issue #5278.
+ *
+ * `PrismaOrganizationRepository.getAllForUser` runs a `findMany` on
+ * `Organization` with no `orderBy`, so Postgres/Prisma make no guarantee
+ * about the order of the returned rows. Client code
+ * (`useOrganizationTeamProject.ts`) falls back to `organizations.data[0]`
+ * as the user's "current org" whenever `localStorage`'s
+ * `selectedOrganizationId` doesn't match a real membership — and that
+ * fallback feeds the `release_ui_ai_governance_enabled` feature-flag
+ * check on `/me` and `/governance`. Without a deterministic order, which
+ * org lands in slot 0 (and therefore which org's flags gate those pages)
+ * is effectively random.
+ *
+ * This test seeds two orgs with `OrganizationUser` membership rows
+ * inserted in one order (orgB first, orgA second) but with `createdAt`
+ * timestamps that disagree with that insertion order (orgA joined a day
+ * before orgB). It only passes if `getAllForUser` actually orders
+ * organizations by the user's membership `createdAt` (earliest first)
+ * rather than relying on incidental physical/insertion order.
+ */
+describe("PrismaOrganizationRepository — membership order determinism (#5278)", () => {
+  let repository: PrismaOrganizationRepository;
+  let orgA: Organization;
+  let orgB: Organization;
+  let testUser: User;
+  const testNamespace = `membership-order-${nanoid(8)}`;
+
+  beforeAll(async () => {
+    repository = new PrismaOrganizationRepository(prisma);
+
+    testUser = await prisma.user.create({
+      data: {
+        email: `membership-order-test-${testNamespace}@example.com`,
+        name: `Test User ${testNamespace}`,
+      },
+    });
+
+    // NOTE: `getAllForUser` queries `Organization.findMany` directly (not
+    // via `OrganizationUser`), so an unordered Postgres result tends to
+    // follow the *Organization* row's own insertion/physical order — not
+    // just the `OrganizationUser` membership row order. Create orgB's
+    // Organization row FIRST (and orgA's SECOND) so physical/insertion
+    // order for the queried table also disagrees with the correct
+    // (createdAt-based) answer; otherwise the assertion below could pass
+    // by accident of Organization row order rather than because the
+    // repository actually orders by membership createdAt.
+    orgB = await prisma.organization.create({
+      data: {
+        name: `Org B ${testNamespace}`,
+        slug: `org-b-${testNamespace}`,
+      },
+    });
+
+    orgA = await prisma.organization.create({
+      data: {
+        name: `Org A ${testNamespace}`,
+        slug: `org-a-${testNamespace}`,
+      },
+    });
+
+    const now = new Date();
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+    // Insert orgB's membership FIRST (so naive insertion/physical order
+    // would put orgB first), but give it the LATER createdAt.
+    await prisma.organizationUser.create({
+      data: {
+        userId: testUser.id,
+        organizationId: orgB.id,
+        role: "ADMIN",
+        createdAt: now,
+      },
+    });
+
+    // Insert orgA's membership SECOND, but give it the EARLIER createdAt —
+    // orgA is the user's actual first-joined org.
+    await prisma.organizationUser.create({
+      data: {
+        userId: testUser.id,
+        organizationId: orgA.id,
+        role: "ADMIN",
+        createdAt: oneDayAgo,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.organizationUser.deleteMany({
+      where: { userId: testUser.id, organizationId: { in: [orgA.id, orgB.id] } },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: { in: [orgA.id, orgB.id] } },
+    });
+    await prisma.user.delete({ where: { id: testUser.id } });
+  });
+
+  describe("when a user belongs to multiple organizations", () => {
+    it("returns the earlier-joined organization (orgA) first, regardless of membership row insertion order", async () => {
+      const result = await repository.getAllForUser({
+        userId: testUser.id,
+        isDemo: false,
+        demoProjectUserId: "",
+        demoProjectId: "",
+      });
+
+      expect(result[0]?.id).toBe(orgA.id);
+    });
+  });
+
+  describe("when a user's membership createdAt is exactly identical across organizations", () => {
+    let tieOrgA: Organization;
+    let tieOrgB: Organization;
+    let tieUser: User;
+    const tieNamespace = `membership-order-tie-${nanoid(8)}`;
+
+    beforeAll(async () => {
+      tieUser = await prisma.user.create({
+        data: {
+          email: `membership-order-tie-test-${tieNamespace}@example.com`,
+          name: `Test User ${tieNamespace}`,
+        },
+      });
+
+      // Same trick as above: create orgB's Organization row FIRST (and
+      // orgA's SECOND) so physical/insertion order for the queried table
+      // disagrees with the lexicographically-smaller-id answer; otherwise
+      // the assertion below could pass by accident of Organization row
+      // order rather than because the repository's id-based tie-breaker
+      // is what's actually determining order.
+      tieOrgB = await prisma.organization.create({
+        data: {
+          name: `Tie Org B ${tieNamespace}`,
+          slug: `tie-org-b-${tieNamespace}`,
+        },
+      });
+
+      tieOrgA = await prisma.organization.create({
+        data: {
+          name: `Tie Org A ${tieNamespace}`,
+          slug: `tie-org-a-${tieNamespace}`,
+        },
+      });
+
+      // Both memberships get the EXACT same createdAt timestamp (not just
+      // "close" — the identical Date instance), so `createdAt.getTime()`
+      // comparisons in the sort comparator are tied and the id-based
+      // tie-breaker is the only thing that can determine order.
+      const sameInstant = new Date("2024-01-01T00:00:00.000Z");
+
+      // Insert orgB's membership FIRST (so naive insertion/physical order
+      // would put orgB first).
+      await prisma.organizationUser.create({
+        data: {
+          userId: tieUser.id,
+          organizationId: tieOrgB.id,
+          role: "ADMIN",
+          createdAt: sameInstant,
+        },
+      });
+
+      // Insert orgA's membership SECOND, with the identical timestamp.
+      await prisma.organizationUser.create({
+        data: {
+          userId: tieUser.id,
+          organizationId: tieOrgA.id,
+          role: "ADMIN",
+          createdAt: sameInstant,
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await prisma.organizationUser.deleteMany({
+        where: {
+          userId: tieUser.id,
+          organizationId: { in: [tieOrgA.id, tieOrgB.id] },
+        },
+      });
+      await prisma.organization.deleteMany({
+        where: { id: { in: [tieOrgA.id, tieOrgB.id] } },
+      });
+      await prisma.user.delete({ where: { id: tieUser.id } });
+    });
+
+    it("breaks the tie by lexicographically smaller organization id, regardless of membership row insertion order", async () => {
+      const result = await repository.getAllForUser({
+        userId: tieUser.id,
+        isDemo: false,
+        demoProjectUserId: "",
+        demoProjectId: "",
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.id).toBeDefined();
+      expect(result[1]?.id).toBeDefined();
+      expect(result[0]!.id < result[1]!.id).toBe(true);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/organizations/__tests__/organization.prisma.repository.membership-order.integration.test.ts
+++ b/langwatch/src/server/app-layer/organizations/__tests__/organization.prisma.repository.membership-order.integration.test.ts
@@ -115,10 +115,10 @@ describe("PrismaOrganizationRepository — membership order determinism (#5278)"
   });
 
   describe("when a user's membership createdAt is exactly identical across organizations", () => {
-    let tieOrgA: Organization;
-    let tieOrgB: Organization;
+    let tieOrgs: Organization[];
     let tieUser: User;
     const tieNamespace = `membership-order-tie-${nanoid(8)}`;
+    const tieOrgLetters = ["A", "B", "C", "D", "E"] as const;
 
     beforeAll(async () => {
       tieUser = await prisma.user.create({
@@ -128,63 +128,55 @@ describe("PrismaOrganizationRepository — membership order determinism (#5278)"
         },
       });
 
-      // Same trick as above: create orgB's Organization row FIRST (and
-      // orgA's SECOND) so physical/insertion order for the queried table
-      // disagrees with the lexicographically-smaller-id answer; otherwise
-      // the assertion below could pass by accident of Organization row
-      // order rather than because the repository's id-based tie-breaker
-      // is what's actually determining order.
-      tieOrgB = await prisma.organization.create({
-        data: {
-          name: `Tie Org B ${tieNamespace}`,
-          slug: `tie-org-b-${tieNamespace}`,
-        },
-      });
+      // `Organization.id` is generated via Prisma's `@default(nanoid())`
+      // (schema.prisma), which produces a random alphabet with no
+      // relationship whatsoever to insertion/creation order (unlike, say,
+      // cuid). So there's no way to "reverse" insertion order relative to
+      // id order here — the two are independent by construction. Instead,
+      // we create enough tied organizations (5) that the odds of the DB's
+      // incidental/unordered `findMany` result happening to already come
+      // back in fully-sorted-by-id order by pure chance are 1-in-120 —
+      // negligible enough that a passing assertion below is reliable proof
+      // the repository's id-based tie-breaker (not luck) produced the
+      // order.
+      tieOrgs = [];
+      for (const letter of tieOrgLetters) {
+        const org = await prisma.organization.create({
+          data: {
+            name: `Tie Org ${letter} ${tieNamespace}`,
+            slug: `tie-org-${letter.toLowerCase()}-${tieNamespace}`,
+          },
+        });
+        tieOrgs.push(org);
+      }
 
-      tieOrgA = await prisma.organization.create({
-        data: {
-          name: `Tie Org A ${tieNamespace}`,
-          slug: `tie-org-a-${tieNamespace}`,
-        },
-      });
-
-      // Both memberships get the EXACT same createdAt timestamp (not just
+      // All memberships get the EXACT same createdAt timestamp (not just
       // "close" — the identical Date instance), so `createdAt.getTime()`
-      // comparisons in the sort comparator are tied and the id-based
-      // tie-breaker is the only thing that can determine order.
+      // comparisons in the sort comparator are tied for every pair and the
+      // id-based tie-breaker is the only thing that can determine order.
       const sameInstant = new Date("2024-01-01T00:00:00.000Z");
 
-      // Insert orgB's membership FIRST (so naive insertion/physical order
-      // would put orgB first).
-      await prisma.organizationUser.create({
-        data: {
-          userId: tieUser.id,
-          organizationId: tieOrgB.id,
-          role: "ADMIN",
-          createdAt: sameInstant,
-        },
-      });
-
-      // Insert orgA's membership SECOND, with the identical timestamp.
-      await prisma.organizationUser.create({
-        data: {
-          userId: tieUser.id,
-          organizationId: tieOrgA.id,
-          role: "ADMIN",
-          createdAt: sameInstant,
-        },
-      });
+      for (const org of tieOrgs) {
+        await prisma.organizationUser.create({
+          data: {
+            userId: tieUser.id,
+            organizationId: org.id,
+            role: "ADMIN",
+            createdAt: sameInstant,
+          },
+        });
+      }
     });
 
     afterAll(async () => {
       await prisma.organizationUser.deleteMany({
         where: {
           userId: tieUser.id,
-          organizationId: { in: [tieOrgA.id, tieOrgB.id] },
+          organizationId: { in: tieOrgs.map((org) => org.id) },
         },
       });
       await prisma.organization.deleteMany({
-        where: { id: { in: [tieOrgA.id, tieOrgB.id] } },
+        where: { id: { in: tieOrgs.map((org) => org.id) } },
       });
       await prisma.user.delete({ where: { id: tieUser.id } });
     });
@@ -197,10 +189,15 @@ describe("PrismaOrganizationRepository — membership order determinism (#5278)"
         demoProjectId: "",
       });
 
-      expect(result).toHaveLength(2);
-      expect(result[0]?.id).toBeDefined();
-      expect(result[1]?.id).toBeDefined();
-      expect(result[0]!.id < result[1]!.id).toBe(true);
+      const tieOrgIds = new Set(tieOrgs.map((org) => org.id));
+      const actualIds = result
+        .filter((org) => tieOrgIds.has(org.id))
+        .map((org) => org.id);
+
+      expect(actualIds).toHaveLength(tieOrgs.length);
+
+      const expectedSortedIds = [...actualIds].sort();
+      expect(actualIds).toEqual(expectedSortedIds);
     });
   });
 });

--- a/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
+++ b/langwatch/src/server/app-layer/organizations/repositories/organization.prisma.repository.ts
@@ -279,7 +279,7 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
   }): Promise<FullyLoadedOrganization[]> {
     const { userId, isDemo, demoProjectId } = params;
 
-    return this.prisma.organization.findMany({
+    const organizations = (await this.prisma.organization.findMany({
       where: {
         OR: [
           ...(isDemo
@@ -334,7 +334,36 @@ export class PrismaOrganizationRepository implements OrganizationRepository {
           },
         },
       },
-    }) as Promise<FullyLoadedOrganization[]>;
+    })) as FullyLoadedOrganization[];
+
+    // Prisma can't express "order this top-level findMany by a nested
+    // to-many relation's scalar field, filtered to one userId" in a single
+    // query (orderBy on a to-many relation only supports _count). Sort here
+    // instead, using each org's `members[0]` (pre-filtered to this userId
+    // above) to read the user's own membership creation time.
+    //
+    // This ordering matters: array index [0] of the result is used as the
+    // fallback "current org" for org-scoped pages like /me and /governance
+    // (see useOrganizationTeamProject.ts:194-198). Without a deterministic
+    // sort, an unordered findMany could land a multi-org user on an
+    // arbitrary org instead of their earliest/primary one.
+    //
+    // `members[0]` may be absent for the demo-org-inclusion branch of the
+    // `where.OR` above; treat that as time 0 so it sorts first without
+    // crashing. That's fine because demo-mode org selection is picked
+    // separately via `.find()` and doesn't rely on array order.
+    return organizations.sort((a, b) => {
+      const aCreatedAt = a.members[0]?.createdAt?.getTime() ?? 0;
+      const bCreatedAt = b.members[0]?.createdAt?.getTime() ?? 0;
+      if (aCreatedAt !== bCreatedAt) {
+        return aCreatedAt - bCreatedAt;
+      }
+      // Tie-breaker: identical membership createdAt timestamps (e.g. bulk
+      // invite, same-transaction seed) would otherwise fall back to the
+      // unordered findMany's arbitrary order via Array.sort's stability.
+      // Compare organization id for a deterministic, unique secondary key.
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
   }
 
   async getOrganizationWithMembers(params: {

--- a/langwatch/src/utils/__tests__/resolveHomeDestination.unit.test.ts
+++ b/langwatch/src/utils/__tests__/resolveHomeDestination.unit.test.ts
@@ -102,4 +102,84 @@ describe("resolveHomeDestination", () => {
       ).toBe("/me");
     });
   });
+
+  describe("when an organization slug is supplied for an org-scoped home", () => {
+    // Regression: a fresh-login user whose selected project drifted to a
+    // non-governance org landed on /me and 404'd behind the feature-flag guard.
+    // Carrying ?org=<slug> lets the page re-pin to the resolver's org.
+    it("carries ?org=<slug> onto a /me destination", () => {
+      expect(
+        resolveHomeDestination({
+          ...base,
+          resolverDestination: "/me",
+          organizationSlug: "acme",
+        }),
+      ).toBe("/me?org=acme");
+    });
+
+    it("carries ?org=<slug> onto a /governance destination", () => {
+      expect(
+        resolveHomeDestination({
+          ...base,
+          resolverDestination: "/governance",
+          organizationSlug: "acme",
+        }),
+      ).toBe("/governance?org=acme");
+    });
+
+    it("carries ?org=<slug> onto /me even when forced by an explicit pin", () => {
+      expect(
+        resolveHomeDestination({
+          ...base,
+          resolverDestination: "/me",
+          isOverride: true,
+          organizationSlug: "acme",
+        }),
+      ).toBe("/me?org=acme");
+    });
+
+    it("carries ?org=<slug> onto /me forced by a personal last-visit", () => {
+      expect(
+        resolveHomeDestination({
+          ...base,
+          resolverDestination: "/acme",
+          lastVisitedHomeKind: "personal",
+          organizationSlug: "acme",
+        }),
+      ).toBe("/me?org=acme");
+    });
+
+    it("url-encodes a slug with reserved characters", () => {
+      expect(
+        resolveHomeDestination({
+          ...base,
+          resolverDestination: "/me",
+          organizationSlug: "acme org/eu",
+        }),
+      ).toBe("/me?org=acme%20org%2Feu");
+    });
+
+    it("leaves a project-home destination untouched", () => {
+      expect(
+        resolveHomeDestination({
+          ...base,
+          resolverDestination: "/inbox-narrator",
+          organizationSlug: "acme",
+        }),
+      ).toBe("/inbox-narrator");
+    });
+
+    it("appends no param when the org slug is null or absent", () => {
+      expect(
+        resolveHomeDestination({
+          ...base,
+          resolverDestination: "/me",
+          organizationSlug: null,
+        }),
+      ).toBe("/me");
+      expect(
+        resolveHomeDestination({ ...base, resolverDestination: "/me" }),
+      ).toBe("/me");
+    });
+  });
 });

--- a/langwatch/src/utils/resolveHomeDestination.ts
+++ b/langwatch/src/utils/resolveHomeDestination.ts
@@ -11,6 +11,13 @@ export interface HomeDestinationInput {
   lastVisitedHomeKind: LastVisitedHomeKind;
   /** Slug of the user's current (last-visited) project, or null if none. */
   lastProjectSlug: string | null;
+  /**
+   * Slug of the org the persona resolver ran against. Carried as `?org=<slug>`
+   * onto org-scoped governance homes (/me, /governance) so the destination
+   * page re-pins to this org instead of inheriting a drifted project's org.
+   * Null when no org is resolved (org-less bootstrap) — no param is appended.
+   */
+  organizationSlug?: string | null;
 }
 
 /**
@@ -30,7 +37,14 @@ export interface HomeDestinationInput {
  *    last-visited project's home.
  *  - With no visit history, the persona resolver's destination stands.
  */
-export function resolveHomeDestination({
+export function resolveHomeDestination(input: HomeDestinationInput): string {
+  return withOrganizationParam(
+    resolveBaseDestination(input),
+    input.organizationSlug ?? null,
+  );
+}
+
+function resolveBaseDestination({
   resolverDestination,
   isOverride,
   governanceUiEnabled,
@@ -54,4 +68,25 @@ export function resolveHomeDestination({
   }
 
   return resolverDestination;
+}
+
+/**
+ * `/me` and `/governance` are org-scoped pages that resolve their active org
+ * from `selectedOrganizationId` — which, on a fresh login, can still point at a
+ * different (non-governance) org than the one the persona resolver used to pick
+ * this destination, so the page 404s behind its feature-flag guard. Carrying
+ * the resolver's org as `?org=<slug>` lets `useOrgQueryParamSelection` re-pin
+ * the page to the right org on landing (and strip the param), matching the
+ * workspace switcher's per-org "My Workspace" links. Project homes are
+ * project-scoped and need no org hint.
+ */
+function withOrganizationParam(
+  destination: string,
+  organizationSlug: string | null,
+): string {
+  if (!organizationSlug) return destination;
+  if (destination === "/me" || destination === "/governance") {
+    return `${destination}?org=${encodeURIComponent(organizationSlug)}`;
+  }
+  return destination;
 }


### PR DESCRIPTION
## Why

`/me` and `/governance` are org-scoped pages: they resolve their active organization ambiently (from `selectedOrganizationId` in localStorage, or a fallback), independently of whatever destination the persona resolver picked. Two related bugs come from that:

1. **Post-login redirect drift** (original scope of this PR): a governance-enabled user could be sent to `/me` but the page re-resolved a different, non-governance org and 404'd.
2. **Ambient org fallback is non-deterministic** (closes #5278): when no `?org` param and no `selectedOrganizationId` match exists — a bare/bookmarked `/me` visit, cleared storage, a new device — the page falls back to `organizations[0]`, and that array had no guaranteed order. A multi-org user could land on an arbitrary org instead of their real one. If that arbitrary org happens to have `release_ui_ai_governance_enabled` on, the user sees governance while believing they're in their own (flag-off) org — access without the flag being active for the org they think they're in.

This PR now fixes both — the second was explicitly flagged as deferred in the original version of this PR ("Direct navigation to a bookmarked bare `/me`... out of scope here... deferred").

## What changed

- `resolveHomeDestination` appends `?org=<slug>` for `/me`/`/governance` destinations so `useOrgQueryParamSelection` re-pins the page to the resolver's org on landing (original scope, unchanged).
- `PrismaOrganizationRepository.getAllForUser` now returns organizations sorted deterministically by the calling user's earliest `OrganizationUser.createdAt`, with an id-based tie-breaker when timestamps are exactly equal (e.g. bulk invite/seed in the same transaction). Previously this was a plain `findMany` with no `orderBy`, so `organizations[0]` — the fallback "current org" used throughout `useOrganizationTeamProject`, `GovernSection`, and `WithFeatureFlagGuard` — reflected Postgres's incidental order, not the user's actual primary org.

## How it works

Prisma can't express "order this top-level `organization.findMany` by a nested to-many relation's scalar field, filtered to one userId" in a single query (`orderBy` on a to-many relation only supports `_count`). So the sort happens in JS after the query, reading each org's already-userId-filtered `members[0].createdAt`.

## Test plan

- `resolveHomeDestination.unit.test.ts` — unchanged, still 14 passing (original scope).
- New `organization.prisma.repository.membership-order.integration.test.ts`:
  - Confirms `getAllForUser` returns the earlier-joined org first, with both `OrganizationUser` and `Organization` row insertion order deliberately reversed relative to the correct (createdAt) answer — so a pass can only come from the sort, not incidental DB order. Fails without the fix.
  - Confirms the tie-breaker: 5 organizations sharing one identical `createdAt`, asserting the full result is in ascending lexicographic id order — a coincidental incidental-order pass is ~1/120, not a coin flip (this was a code-review finding on an earlier 2-org version of the test, since `Organization.id` is a random nanoid, not insertion-correlated like cuid).
- `pnpm typecheck`: 0 errors.

## Anything surprising?

- **Residual limitation, not a full fix**: ordering by "earliest membership" is a heuristic for "the user's primary org," not a stored fact. A user who joined a flag-on trial/demo org before their real company org would still land on that org first — deterministically now, instead of randomly. Closing that fully would need an explicit stored default-org concept, which is out of scope here.
- The pre-existing `organization.prisma.repository.governance-filter.integration.test.ts` currently fails in this dev environment — but only in `beforeAll`'s `prisma.project.create()`, due to unrelated shared-dev-Postgres schema drift (the `PIIRedactionLevel` enum/column on `Project` doesn't exist despite `_prisma_migrations` claiming that migration ran). Confirmed unrelated to this diff (which touches only the organizations repository and its own tests) and predates this branch — not something this PR fixes.

Closes #5278
