### PR TITLE
feat(nurturing): sync plan attribute to Customer.io across user lifecycle

### DIFF
--- a/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
+++ b/langwatch/ee/billing/nurturing/hooks/signupIdentification.ts
@@ -3,6 +3,7 @@ import type { z } from "zod";
 import { getApp } from "../../../../src/server/app-layer/app";
 import type { signUpDataSchema } from "../../../../src/server/schemas/sign-up-data.schema";
 import { captureException } from "../../../../src/utils/posthogErrorCapture";
+import { CIO_FREE_PLAN } from "../planLabel";
 import type { CioPersonTraits } from "../types";
 
 type SignUpData = z.infer<typeof signUpDataSchema>;
@@ -74,6 +75,7 @@ export function fireSignupNurturingCalls({
     has_prompts: false,
     has_simulations: false,
     has_subscription: false,
+    plan: CIO_FREE_PLAN,
     createdAt: new Date().toISOString(),
   };
 
@@ -86,7 +88,7 @@ export function fireSignupNurturingCalls({
       traits: {
         name: organizationName,
         ...pickDefined({ company_size: signUpData?.companySize }),
-        plan: "free",
+        plan: CIO_FREE_PLAN,
       },
     })
     .catch(captureException);

--- a/langwatch/ee/billing/nurturing/hooks/subscriptionSync.ts
+++ b/langwatch/ee/billing/nurturing/hooks/subscriptionSync.ts
@@ -1,24 +1,31 @@
 import { getApp } from "../../../../src/server/app-layer/app";
 import { prisma } from "../../../../src/server/db";
 import { captureException } from "../../../../src/utils/posthogErrorCapture";
+import { resolveCioPlanLabel } from "../planLabel";
 
 /**
- * Syncs has_subscription trait to Customer.io for all members of an organization.
+ * Syncs has_subscription + plan traits to Customer.io for all members of an
+ * organization.
  *
- * Called from the Stripe webhook service when a subscription is activated or cancelled.
+ * Called from the Stripe webhook service when a subscription is activated or
+ * cancelled. The `plan` is the internal plan type of the now-current
+ * subscription (null when none remains, i.e. the org has reverted to free).
+ *
  * Fire-and-forget: never throws, never blocks the webhook handler.
  */
 export function fireSubscriptionSyncNurturing({
   organizationId,
   hasSubscription,
+  plan,
 }: {
   organizationId: string;
   hasSubscription: boolean;
+  plan?: string | null;
 }): void {
   const nurturing = getApp().nurturing;
   if (!nurturing) return;
 
-  void syncSubscriptionTrait({ organizationId, hasSubscription }).catch(
+  void syncSubscriptionTrait({ organizationId, hasSubscription, plan }).catch(
     captureException,
   );
 }
@@ -26,24 +33,41 @@ export function fireSubscriptionSyncNurturing({
 async function syncSubscriptionTrait({
   organizationId,
   hasSubscription,
+  plan,
 }: {
   organizationId: string;
   hasSubscription: boolean;
+  plan?: string | null;
 }): Promise<void> {
   const nurturing = getApp().nurturing;
   if (!nurturing) return;
+
+  // No active subscription means the org is back on free, regardless of the
+  // last plan we saw on the cancelled record.
+  const planLabel = resolveCioPlanLabel(hasSubscription ? plan : null);
 
   const orgUsers = await prisma.organizationUser.findMany({
     where: { organizationId },
     select: { userId: true },
   });
 
-  await Promise.all(
-    orgUsers.map((ou) =>
+  await Promise.all([
+    ...orgUsers.map((ou) =>
       nurturing.identifyUser({
         userId: ou.userId,
-        traits: { has_subscription: hasSubscription },
+        traits: { has_subscription: hasSubscription, plan: planLabel },
       }),
     ),
-  );
+    // Keep the org-level plan trait in sync too. groupUser requires a userId for
+    // the person↔group association; any member works.
+    ...(orgUsers[0]
+      ? [
+          nurturing.groupUser({
+            userId: orgUsers[0].userId,
+            groupId: organizationId,
+            traits: { plan: planLabel },
+          }),
+        ]
+      : []),
+  ]);
 }

--- a/langwatch/ee/billing/nurturing/hooks/subscriptionSync.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/hooks/subscriptionSync.unit.test.ts
@@ -48,7 +48,7 @@ describe("Subscription sync hook", () => {
   });
 
   describe("when a subscription is activated", () => {
-    it("identifies all org members with has_subscription true", async () => {
+    it("identifies all org members with has_subscription true and the raw seat-event plan", async () => {
       mockFindMany.mockResolvedValue([
         { userId: "user-1" },
         { userId: "user-2" },
@@ -57,6 +57,7 @@ describe("Subscription sync hook", () => {
       fireSubscriptionSyncNurturing({
         organizationId: "org-123",
         hasSubscription: true,
+        plan: "GROWTH_SEAT_USD_MONTHLY",
       });
 
       await vi.waitFor(() => {
@@ -65,11 +66,40 @@ describe("Subscription sync hook", () => {
 
       expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
         userId: "user-1",
-        traits: { has_subscription: true },
+        traits: {
+          has_subscription: true,
+          plan: "GROWTH_SEAT_USD_MONTHLY",
+        },
       });
       expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
         userId: "user-2",
-        traits: { has_subscription: true },
+        traits: {
+          has_subscription: true,
+          plan: "GROWTH_SEAT_USD_MONTHLY",
+        },
+      });
+    });
+
+    it("syncs the org-level plan trait once via groupUser", async () => {
+      mockFindMany.mockResolvedValue([
+        { userId: "user-1" },
+        { userId: "user-2" },
+      ]);
+
+      fireSubscriptionSyncNurturing({
+        organizationId: "org-123",
+        hasSubscription: true,
+        plan: "GROWTH_SEAT_EUR_ANNUAL",
+      });
+
+      await vi.waitFor(() => {
+        expect(mockNurturing.groupUser).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockNurturing.groupUser).toHaveBeenCalledWith({
+        userId: "user-1",
+        groupId: "org-123",
+        traits: { plan: "GROWTH_SEAT_EUR_ANNUAL" },
       });
     });
 
@@ -91,7 +121,7 @@ describe("Subscription sync hook", () => {
   });
 
   describe("when a subscription is cancelled", () => {
-    it("identifies all org members with has_subscription false", async () => {
+    it("identifies all org members with has_subscription false and plan free", async () => {
       mockFindMany.mockResolvedValue([
         { userId: "user-1" },
         { userId: "user-2" },
@@ -109,7 +139,26 @@ describe("Subscription sync hook", () => {
 
       expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
         userId: "user-1",
-        traits: { has_subscription: false },
+        traits: { has_subscription: false, plan: "free" },
+      });
+    });
+
+    it("reverts plan to free even when a stale plan is passed alongside hasSubscription false", async () => {
+      mockFindMany.mockResolvedValue([{ userId: "user-1" }]);
+
+      fireSubscriptionSyncNurturing({
+        organizationId: "org-123",
+        hasSubscription: false,
+        plan: "GROWTH_SEAT_USD_MONTHLY",
+      });
+
+      await vi.waitFor(() => {
+        expect(mockNurturing.identifyUser).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockNurturing.identifyUser).toHaveBeenCalledWith({
+        userId: "user-1",
+        traits: { has_subscription: false, plan: "free" },
       });
     });
   });

--- a/langwatch/ee/billing/nurturing/hooks/userSync.ts
+++ b/langwatch/ee/billing/nurturing/hooks/userSync.ts
@@ -1,6 +1,7 @@
 import { getApp } from "../../../../src/server/app-layer/app";
 import { prisma } from "../../../../src/server/db";
 import { captureException } from "../../../../src/utils/posthogErrorCapture";
+import { resolveCioPlanLabel } from "../planLabel";
 import type { CioPersonTraits, CioOrgTraits } from "../types";
 
 /**
@@ -87,7 +88,7 @@ async function performFullSync({ userId }: { userId: string }): Promise<void> {
         organizationId: orgUser.organizationId,
         status: "ACTIVE",
       },
-      select: { id: true },
+      select: { plan: true },
     }),
   ]);
 
@@ -95,6 +96,7 @@ async function performFullSync({ userId }: { userId: string }): Promise<void> {
 
   const signupData = (org.signupData ?? {}) as Record<string, unknown>;
   const hasTraces = projects.some((p) => p.firstMessage);
+  const planLabel = resolveCioPlanLabel(activeSubscription?.plan);
 
   const traits: Partial<CioPersonTraits> = {
     ...(user.email ? { email: user.email } : {}),
@@ -105,12 +107,14 @@ async function performFullSync({ userId }: { userId: string }): Promise<void> {
       : {}),
     has_traces: hasTraces,
     has_subscription: !!activeSubscription,
+    plan: planLabel,
     createdAt: user.createdAt.toISOString(),
     last_active_at: new Date().toISOString(),
   };
 
   const orgTraits: Partial<CioOrgTraits> = {
     name: org.name,
+    plan: planLabel,
     ...(signupData.companySize
       ? { company_size: signupData.companySize as string }
       : {}),

--- a/langwatch/ee/billing/nurturing/planLabel.ts
+++ b/langwatch/ee/billing/nurturing/planLabel.ts
@@ -1,0 +1,37 @@
+import { PlanTypes, isAnnualTieredPlan } from "../planTypes";
+import { isGrowthSeatEventPlan } from "../utils/growthSeatEvent";
+
+/**
+ * The lifecycle-default Customer.io plan label. Every person/org starts here at
+ * signup and reverts here when no non-cancelled subscription remains.
+ */
+export const CIO_FREE_PLAN = "free";
+
+/**
+ * Maps an internal subscription plan type to the `plan` attribute value pushed
+ * to Customer.io, so marketing segments key off a stable lifecycle vocabulary.
+ *
+ * Rules (per product decision):
+ *   - No plan / FREE                  -> "free"
+ *   - Go-forward Growth seat-event    -> raw plan type, verbatim
+ *                                        (GROWTH_SEAT_USD_MONTHLY, GROWTH_SEAT_EUR_ANNUAL, ...)
+ *                                        keeps currency + interval granularity.
+ *   - Legacy/grandfathered paid plans -> bucketed by billing interval into the
+ *     (LAUNCH/ACCELERATE/GROWTH/PRO,    seat-event lifecycle labels, so older
+ *      ENTERPRISE, ...)                 cohorts fold into the same monthly/annual
+ *                                        nurture tracks as new customers.
+ *
+ * Interval bucketing: annual when the plan is a known annual-tiered plan or its
+ * name carries the ANNUAL suffix; monthly otherwise (the safe default — paid but
+ * interval-less plans like ENTERPRISE land here and can be refined later).
+ */
+export function resolveCioPlanLabel(plan?: string | null): string {
+  if (!plan || plan === PlanTypes.FREE) return CIO_FREE_PLAN;
+
+  // Current seat-event plans carry full granularity straight through.
+  if (isGrowthSeatEventPlan(plan)) return plan;
+
+  // Legacy/other paid plans collapse into the interval buckets.
+  const isAnnual = isAnnualTieredPlan(plan) || /ANNUAL$/.test(plan);
+  return isAnnual ? "seat_event_annual" : "seat_event_monthly";
+}

--- a/langwatch/ee/billing/nurturing/planLabel.unit.test.ts
+++ b/langwatch/ee/billing/nurturing/planLabel.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { PlanTypes } from "../planTypes";
+import { resolveCioPlanLabel, CIO_FREE_PLAN } from "./planLabel";
+
+describe("resolveCioPlanLabel", () => {
+  describe("given no active subscription", () => {
+    it("returns free for null", () => {
+      expect(resolveCioPlanLabel(null)).toBe(CIO_FREE_PLAN);
+    });
+
+    it("returns free for undefined", () => {
+      expect(resolveCioPlanLabel(undefined)).toBe(CIO_FREE_PLAN);
+    });
+
+    it("returns free for the FREE plan", () => {
+      expect(resolveCioPlanLabel(PlanTypes.FREE)).toBe(CIO_FREE_PLAN);
+    });
+  });
+
+  describe("when on a go-forward Growth seat-event plan", () => {
+    it("passes the raw plan type through, keeping currency and interval", () => {
+      expect(resolveCioPlanLabel(PlanTypes.GROWTH_SEAT_USD_MONTHLY)).toBe(
+        "GROWTH_SEAT_USD_MONTHLY",
+      );
+      expect(resolveCioPlanLabel(PlanTypes.GROWTH_SEAT_EUR_ANNUAL)).toBe(
+        "GROWTH_SEAT_EUR_ANNUAL",
+      );
+      expect(resolveCioPlanLabel(PlanTypes.GROWTH_SEAT_USD_ANNUAL)).toBe(
+        "GROWTH_SEAT_USD_ANNUAL",
+      );
+      expect(resolveCioPlanLabel(PlanTypes.GROWTH_SEAT_EUR_MONTHLY)).toBe(
+        "GROWTH_SEAT_EUR_MONTHLY",
+      );
+    });
+  });
+
+  describe("when on a legacy or grandfathered paid plan", () => {
+    it("buckets annual variants into seat_event_annual", () => {
+      expect(resolveCioPlanLabel(PlanTypes.LAUNCH_ANNUAL)).toBe(
+        "seat_event_annual",
+      );
+      expect(resolveCioPlanLabel(PlanTypes.ACCELERATE_ANNUAL)).toBe(
+        "seat_event_annual",
+      );
+    });
+
+    it("buckets monthly and interval-less variants into seat_event_monthly", () => {
+      expect(resolveCioPlanLabel(PlanTypes.LAUNCH)).toBe("seat_event_monthly");
+      expect(resolveCioPlanLabel(PlanTypes.ACCELERATE)).toBe(
+        "seat_event_monthly",
+      );
+      expect(resolveCioPlanLabel(PlanTypes.GROWTH)).toBe("seat_event_monthly");
+      expect(resolveCioPlanLabel(PlanTypes.PRO)).toBe("seat_event_monthly");
+      expect(resolveCioPlanLabel(PlanTypes.ENTERPRISE)).toBe(
+        "seat_event_monthly",
+      );
+    });
+  });
+});

--- a/langwatch/ee/billing/services/webhookService.ts
+++ b/langwatch/ee/billing/services/webhookService.ts
@@ -620,6 +620,7 @@ export class EEWebhookService implements WebhookService {
     fireSubscriptionSyncNurturing({
       organizationId: existingSubscription.organizationId,
       hasSubscription: !!remainingActive,
+      plan: remainingActive?.plan,
     });
 
     // Cancellation deliberately leaves the org's retention policies in place
@@ -661,6 +662,7 @@ export class EEWebhookService implements WebhookService {
       fireSubscriptionSyncNurturing({
         organizationId: existingSubForUpdate.organizationId,
         hasSubscription: !!remainingActive,
+        plan: remainingActive?.plan,
       });
 
       // Cancellation deliberately leaves the org's retention policies in place
@@ -843,6 +845,7 @@ export class EEWebhookService implements WebhookService {
       fireSubscriptionSyncNurturing({
         organizationId: updatedSubscription.organizationId,
         hasSubscription: true,
+        plan: updatedSubscription.plan,
       });
     }
   }


### PR DESCRIPTION
## What

Makes the Customer.io `plan` attribute track the user lifecycle: starts `free`, becomes the seat-event plan on upgrade (monthly vs annual), and reverts to `free` on cancellation.

## Why

`CioPersonTraits.plan` / `CioOrgTraits.plan` already existed in the trait contract but were effectively dead: only set once at signup (hardcoded `"free"` on the org group) and **never updated** when an org upgraded or cancelled. The Stripe subscription-sync hook pushed only `has_subscription`, dropping the plan. Result: marketing had no usable plan dimension after day one.

## Changes

- **New mapper** `resolveCioPlanLabel` (`nurturing/planLabel.ts`):
  - `FREE` / none → `free`
  - go-forward Growth **seat-event** plans → raw plan type verbatim (`GROWTH_SEAT_USD_MONTHLY`, `GROWTH_SEAT_EUR_ANNUAL`, …) — keeps currency + interval granularity
  - legacy / grandfathered paid plans (`LAUNCH`/`ACCELERATE`/`GROWTH`/`PRO`/`ENTERPRISE`) → bucketed by billing interval into `seat_event_annual` / `seat_event_monthly` so older cohorts fold into the same nurture tracks
- **subscriptionSync** now accepts `plan` and pushes it to every member's person `identify` **and** the org `group`; reverts to `free` when no non-cancelled subscription remains. Wired at all three webhook call sites (activate / delete / update-cancel).
- **userSync** backfills person + org `plan` on first login (selects `plan` instead of just `id`), so existing users get corrected without a subscription event.
- **signupIdentification** now also sets the person-level `plan` (`free`), via a shared `CIO_FREE_PLAN` constant reused by the org group trait.

## Scope boundary

Invited / SSO-auto-added members get their person `plan` backfilled by `userSync` on first login (seconds later). Those hooks are pure primitive-in, fire-and-forget and DB-free; making them query the org subscription would be a larger change for a momentary gap (they also have a pre-existing `has_subscription` inconsistency, left untouched here).

## Tests

- New `planLabel.unit.test.ts` — full mapping matrix (free / seat-event passthrough / legacy interval bucketing).
- Extended `subscriptionSync.unit.test.ts` — asserts the `plan` trait on person identify, the single org `groupUser` sync, and free-revert on cancel even when a stale plan is passed.
- All green; changed files typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Customer.io plan tracking by syncing an accurate plan label for newly identified users, updating both member and org traits during subscription changes, and including plan details in webhook-driven nurturing.
* **Chores**
  * Added standardized plan-label mapping to consistently handle free, growth seat-event, and legacy subscription plan variants.
* **Tests**
  * Added unit tests covering plan-label resolution and subscription synchronization for activation and cancellation, including correcting any stale paid-plan inputs on free.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Closes #6562
