### PR TITLE
feat(auth): add forgot/reset password flow for credential sign-in

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -25760,6 +25760,14 @@ Replace `{provider}` with: `auth0`, `azure-ad`, `cognito`, `github`, `gitlab`, `
 
 ## Provider Setup
 
+### Email/Password
+
+The default mode (`NEXTAUTH_PROVIDER=email`) needs no identity provider. Users register with an email and password, and a self-service "Forgot password?" link on the sign-in screen lets them reset a forgotten one.
+
+Reset links are sent through the same transactional email provider as the rest of LangWatch. Configure SendGrid or AWS SES as described in [Third-party integrations](/self-hosting/configuration/third-party-integrations) so the reset email can be delivered. If no email provider is configured, the request still returns the same neutral confirmation but no email is sent. The reset link expires one hour after it is issued, and a completed reset signs out the account's other active sessions.
+
+When `NEXTAUTH_PROVIDER` is set to any SSO provider below, the credential form and the "Forgot password?" link are not shown, and the password reset endpoints are disabled.
+
 ### Auth0
 
 1. Create an application in the [Auth0 Dashboard](https://manage.auth0.com/)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -25961,7 +25961,7 @@ LangWatch integrates with several third-party services for notifications, error 
 
 ## Email (SendGrid)
 
-Email is used for alerts, team invitations, and system notifications.
+Email is used for alerts, team invitations, password resets, and system notifications. In `NEXTAUTH_PROVIDER="email"` mode, the sign-in screen's "Forgot password?" link sends the reset email through this same provider, so configuring it here is what enables self-service password recovery.
 
 ### Helm Configuration
 

--- a/docs/self-hosting/configuration/sso.mdx
+++ b/docs/self-hosting/configuration/sso.mdx
@@ -30,6 +30,14 @@ Replace `{provider}` with: `auth0`, `azure-ad`, `cognito`, `github`, `gitlab`, `
 
 ## Provider Setup
 
+### Email/Password
+
+The default mode (`NEXTAUTH_PROVIDER=email`) needs no identity provider. Users register with an email and password, and a self-service "Forgot password?" link on the sign-in screen lets them reset a forgotten one.
+
+Reset links are sent through the same transactional email provider as the rest of LangWatch. Configure SendGrid or AWS SES as described in [Third-party integrations](/self-hosting/configuration/third-party-integrations) so the reset email can be delivered. If no email provider is configured, the request still returns the same neutral confirmation but no email is sent. The reset link expires one hour after it is issued, and a completed reset signs out the account's other active sessions.
+
+When `NEXTAUTH_PROVIDER` is set to any SSO provider below, the credential form and the "Forgot password?" link are not shown, and the password reset endpoints are disabled.
+
 ### Auth0
 
 1. Create an application in the [Auth0 Dashboard](https://manage.auth0.com/)

--- a/docs/self-hosting/configuration/third-party-integrations.mdx
+++ b/docs/self-hosting/configuration/third-party-integrations.mdx
@@ -7,7 +7,7 @@ LangWatch integrates with several third-party services for notifications, error 
 
 ## Email (SendGrid)
 
-Email is used for alerts, team invitations, and system notifications.
+Email is used for alerts, team invitations, password resets, and system notifications. In `NEXTAUTH_PROVIDER="email"` mode, the sign-in screen's "Forgot password?" link sends the reset email through this same provider, so configuring it here is what enables self-service password recovery.
 
 ### Helm Configuration
 

--- a/langwatch/ee/licensing/__tests__/licenseGenerationService.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/licenseGenerationService.unit.test.ts
@@ -17,11 +17,11 @@ describe("generateLicenseKey", () => {
   describe("when generating a GROWTH license", () => {
     it("generates a valid license key that passes round-trip validation", () => {
       const { licenseKey } = generateLicenseKey(baseParams);
-      const result = validateLicense(
+      const result = validateLicense({
         licenseKey,
-        TEST_PUBLIC_KEY,
-        baseParams.now,
-      );
+        publicKey: TEST_PUBLIC_KEY,
+        now: baseParams.now,
+      });
 
       expect(result.valid).toBe(true);
     });
@@ -76,11 +76,11 @@ describe("generateLicenseKey", () => {
         maxMembers: 10,
       });
 
-      const result = validateLicense(
+      const result = validateLicense({
         licenseKey,
-        TEST_PUBLIC_KEY,
-        baseParams.now,
-      );
+        publicKey: TEST_PUBLIC_KEY,
+        now: baseParams.now,
+      });
       expect(result.valid).toBe(true);
       expect(licenseData.plan.type).toBe("PRO");
       expect(licenseData.plan.maxMembers).toBe(10);
@@ -96,11 +96,11 @@ describe("generateLicenseKey", () => {
         maxMembers: 50,
       });
 
-      const result = validateLicense(
+      const result = validateLicense({
         licenseKey,
-        TEST_PUBLIC_KEY,
-        baseParams.now,
-      );
+        publicKey: TEST_PUBLIC_KEY,
+        now: baseParams.now,
+      });
       expect(result.valid).toBe(true);
       expect(licenseData.plan.type).toBe("ENTERPRISE");
       expect(licenseData.plan.maxMembers).toBe(50);
@@ -210,11 +210,11 @@ describe("generateLicenseKey", () => {
   describe("when validating round-trip integrity", () => {
     it("produces a license that can be parsed and verified", () => {
       const { licenseKey, licenseData } = generateLicenseKey(baseParams);
-      const result = validateLicense(
+      const result = validateLicense({
         licenseKey,
-        TEST_PUBLIC_KEY,
-        baseParams.now,
-      );
+        publicKey: TEST_PUBLIC_KEY,
+        now: baseParams.now,
+      });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -228,10 +228,10 @@ describe("generateLicenseKey", () => {
 
     it("fails validation with a different public key", () => {
       const { licenseKey } = generateLicenseKey(baseParams);
-      const result = validateLicense(
+      const result = validateLicense({
         licenseKey,
         // Use a dummy key that doesn't match
-        `-----BEGIN PUBLIC KEY-----
+        publicKey: `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq4utbj0BDQlwUcQ2gNar
 8vT0JYj24i6xoIGLBmwkY/D9vxU4FbFdiLPddiv+Mv5KAPVvNXbLy8zkbsK74BT7
 ye7Od2bJILMiZGMRKj7t1lx3ClthIZKUWjGMiWY0FyOHon+vrz81QireVd1QQuYh
@@ -240,7 +240,7 @@ OLqhJ/73aa+nso54jUvMTUYt8k0kbOhvSY9EhwrsvCxeJcNCl3vYf4Cphpqf9OF0
 sUIBcjrzUh14Z/RxKyun5Ld12xGVuhSzVf0xnWar338N9WKgaFOW+zgRchBGdXFD
 dQIDAQAB
 -----END PUBLIC KEY-----`,
-      );
+      });
 
       expect(result.valid).toBe(false);
     });

--- a/langwatch/ee/licensing/__tests__/licenseGenerationService.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/licenseGenerationService.unit.test.ts
@@ -13,12 +13,6 @@ const baseParams = {
   now: new Date("2025-06-15T12:00:00Z"),
 };
 
-// Round-trip validation runs at the license's issue time so the test is
-// time-independent: a license is issued for one year, so validating "now =
-// issue time" is always within the validity window regardless of the wall
-// clock the suite runs on.
-const validationNow = baseParams.now;
-
 describe("generateLicenseKey", () => {
   describe("when generating a GROWTH license", () => {
     it("generates a valid license key that passes round-trip validation", () => {
@@ -26,7 +20,7 @@ describe("generateLicenseKey", () => {
       const result = validateLicense(
         licenseKey,
         TEST_PUBLIC_KEY,
-        validationNow,
+        baseParams.now,
       );
 
       expect(result.valid).toBe(true);
@@ -85,7 +79,7 @@ describe("generateLicenseKey", () => {
       const result = validateLicense(
         licenseKey,
         TEST_PUBLIC_KEY,
-        validationNow,
+        baseParams.now,
       );
       expect(result.valid).toBe(true);
       expect(licenseData.plan.type).toBe("PRO");
@@ -105,7 +99,7 @@ describe("generateLicenseKey", () => {
       const result = validateLicense(
         licenseKey,
         TEST_PUBLIC_KEY,
-        validationNow,
+        baseParams.now,
       );
       expect(result.valid).toBe(true);
       expect(licenseData.plan.type).toBe("ENTERPRISE");
@@ -219,7 +213,7 @@ describe("generateLicenseKey", () => {
       const result = validateLicense(
         licenseKey,
         TEST_PUBLIC_KEY,
-        validationNow,
+        baseParams.now,
       );
 
       expect(result.valid).toBe(true);

--- a/langwatch/ee/licensing/__tests__/validation.unit.test.ts
+++ b/langwatch/ee/licensing/__tests__/validation.unit.test.ts
@@ -179,7 +179,7 @@ describe("isExpired", () => {
 describe("validateLicense", () => {
   /** @scenario Validates complete license successfully */
   it("validates complete license successfully", () => {
-    const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+    const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
     expect(result.valid).toBe(true);
     if (result.valid) {
@@ -188,7 +188,10 @@ describe("validateLicense", () => {
   });
 
   it("fails validation for invalid format", () => {
-    const result = validateLicense(GARBAGE_DATA, TEST_PUBLIC_KEY);
+    const result = validateLicense({
+      licenseKey: GARBAGE_DATA,
+      publicKey: TEST_PUBLIC_KEY,
+    });
 
     expect(result.valid).toBe(false);
     if (!result.valid) {
@@ -197,7 +200,10 @@ describe("validateLicense", () => {
   });
 
   it("fails validation for invalid signature", () => {
-    const result = validateLicense(TAMPERED_LICENSE_KEY, TEST_PUBLIC_KEY);
+    const result = validateLicense({
+      licenseKey: TAMPERED_LICENSE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
+    });
 
     expect(result.valid).toBe(false);
     if (!result.valid) {
@@ -206,7 +212,10 @@ describe("validateLicense", () => {
   });
 
   it("fails validation for expired license", () => {
-    const result = validateLicense(EXPIRED_LICENSE_KEY, TEST_PUBLIC_KEY);
+    const result = validateLicense({
+      licenseKey: EXPIRED_LICENSE_KEY,
+      publicKey: TEST_PUBLIC_KEY,
+    });
 
     expect(result.valid).toBe(false);
     if (!result.valid) {
@@ -216,7 +225,7 @@ describe("validateLicense", () => {
 
   describe("extracts license fields correctly", () => {
     it("extracts licenseId", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -225,7 +234,7 @@ describe("validateLicense", () => {
     });
 
     it("extracts organizationName", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -234,7 +243,7 @@ describe("validateLicense", () => {
     });
 
     it("extracts email", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -243,7 +252,7 @@ describe("validateLicense", () => {
     });
 
     it("extracts plan.type", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -252,7 +261,7 @@ describe("validateLicense", () => {
     });
 
     it("extracts plan.maxMembers", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -261,7 +270,7 @@ describe("validateLicense", () => {
     });
 
     it("extracts plan.maxProjects", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -270,7 +279,7 @@ describe("validateLicense", () => {
     });
 
     it("extracts plan.maxMessagesPerMonth", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -282,7 +291,7 @@ describe("validateLicense", () => {
       // VALID_LICENSE_KEY contains evaluationsCredit in the signed payload.
       // After making the field optional, old licenses must still parse and
       // pass signature verification without error.
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -292,7 +301,7 @@ describe("validateLicense", () => {
     });
 
     it("extracts plan.maxWorkflows", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -301,7 +310,7 @@ describe("validateLicense", () => {
     });
 
     it("extracts plan.canPublish", () => {
-      const result = validateLicense(VALID_LICENSE_KEY, TEST_PUBLIC_KEY);
+      const result = validateLicense({ licenseKey: VALID_LICENSE_KEY, publicKey: TEST_PUBLIC_KEY });
 
       expect(result.valid).toBe(true);
       if (result.valid) {

--- a/langwatch/ee/licensing/licenseHandler.ts
+++ b/langwatch/ee/licensing/licenseHandler.ts
@@ -83,7 +83,10 @@ export class LicenseHandler {
     }
 
     // Validate the stored license
-    const result = validateLicense(organization.license, this.publicKey);
+    const result = validateLicense({
+      licenseKey: organization.license,
+      publicKey: this.publicKey,
+    });
 
     if (result.valid) {
       return result.planInfo;
@@ -105,7 +108,7 @@ export class LicenseHandler {
     licenseKey: string
   ): Promise<StoreLicenseResult> {
     // Validate the license before storing
-    const result = validateLicense(licenseKey, this.publicKey);
+    const result = validateLicense({ licenseKey, publicKey: this.publicKey });
 
     if (!result.valid) {
       return {
@@ -210,7 +213,10 @@ export class LicenseHandler {
       return { hasLicense: false, valid: false };
     }
 
-    const validationResult = validateLicense(organization.license, this.publicKey);
+    const validationResult = validateLicense({
+      licenseKey: organization.license,
+      publicKey: this.publicKey,
+    });
 
     // For valid licenses, use data from validationResult (avoids second parse)
     if (validationResult.valid) {

--- a/langwatch/ee/licensing/validation.ts
+++ b/langwatch/ee/licensing/validation.ts
@@ -78,11 +78,15 @@ export function isExpired(expiresAt: string, now: Date = new Date()): boolean {
  * @param now - Clock used for the expiration check (defaults to current time)
  * @returns ValidationResult indicating success or failure with error
  */
-export function validateLicense(
-  licenseKey: string,
-  publicKey: string = PUBLIC_KEY,
-  now: Date = new Date(),
-): ValidationResult {
+export function validateLicense({
+  licenseKey,
+  publicKey = PUBLIC_KEY,
+  now = new Date(),
+}: {
+  licenseKey: string;
+  publicKey?: string;
+  now?: Date;
+}): ValidationResult {
   // Step 1: Parse
   const signedLicense = parseLicenseKey(licenseKey);
   if (!signedLicense) {

--- a/langwatch/ee/licensing/validation.ts
+++ b/langwatch/ee/licensing/validation.ts
@@ -75,7 +75,7 @@ export function isExpired(expiresAt: string, now: Date = new Date()): boolean {
  *
  * @param licenseKey - Base64-encoded license string
  * @param publicKey - RSA public key (defaults to production key)
- * @param now - Current date, injectable for testing (defaults to real clock)
+ * @param now - Clock used for the expiration check (defaults to current time)
  * @returns ValidationResult indicating success or failure with error
  */
 export function validateLicense(

--- a/langwatch/src/hooks/__tests__/useRequiredSession.test.tsx
+++ b/langwatch/src/hooks/__tests__/useRequiredSession.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Guards the public-route allowlist that keeps the unauthenticated auth pages
+ * (forgot/reset password) reachable. Regression: those routes were missing
+ * from `publicRoutes`, so the global session guard bounced visitors to
+ * /auth/signin?callbackUrl=... before they could request a reset. The
+ * page-render tests could not catch it because they mount the component
+ * directly, bypassing the router-level guard.
+ *
+ * jsdom locks `window.location.href`, so rather than observe the online
+ * redirect we drive the guard through its OFFLINE branch (it registers an
+ * `online` listener instead of navigating). A public route returns before
+ * either branch, so no `online` listener is registered; a protected route
+ * reaches the redirect and registers one.
+ */
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { routeRef } = vi.hoisted(() => ({ routeRef: { current: "/" } }));
+
+vi.mock("~/utils/compat/next-router", () => ({
+  useRouter: () => ({ route: routeRef.current }),
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  useSession: ({
+    required,
+    onUnauthenticated,
+  }: {
+    required?: boolean;
+    onUnauthenticated?: () => void;
+  }) => {
+    if (required && onUnauthenticated) onUnauthenticated();
+    return { data: null, status: "unauthenticated", update: vi.fn() };
+  },
+}));
+
+import { useRequiredSession } from "../useRequiredSession";
+
+function Probe() {
+  useRequiredSession();
+  return null;
+}
+
+const onlineListenerCount = (spy: ReturnType<typeof vi.spyOn>) =>
+  spy.mock.calls.filter((c: unknown[]) => c[0] === "online").length;
+
+describe("useRequiredSession redirect guard", () => {
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    addEventListenerSpy = vi.spyOn(window, "addEventListener");
+  });
+
+  afterEach(() => {
+    addEventListenerSpy.mockRestore();
+  });
+
+  describe("when an unauthenticated user lands on a public auth route", () => {
+    /** @scenario The forgot and reset pages are reachable without signing in */
+    it("does not try to redirect /auth/forgot-password or /auth/reset-password", () => {
+      for (const route of ["/auth/forgot-password", "/auth/reset-password"]) {
+        addEventListenerSpy.mockClear();
+        routeRef.current = route;
+        render(<Probe />);
+        expect(onlineListenerCount(addEventListenerSpy)).toBe(0);
+      }
+    });
+  });
+
+  describe("when an unauthenticated user lands on a genuinely protected route", () => {
+    it("reaches the sign-in redirect path", () => {
+      routeRef.current = "/some/protected/page";
+      render(<Probe />);
+      expect(onlineListenerCount(addEventListenerSpy)).toBeGreaterThan(0);
+    });
+  });
+});

--- a/langwatch/src/hooks/__tests__/useRequiredSession.test.tsx
+++ b/langwatch/src/hooks/__tests__/useRequiredSession.test.tsx
@@ -61,23 +61,25 @@ describe("useRequiredSession redirect guard", () => {
     addEventListenerSpy.mockRestore();
   });
 
-  describe("when an unauthenticated user lands on a public auth route", () => {
-    /** @scenario The forgot and reset pages are reachable without signing in */
-    it("does not try to redirect /auth/forgot-password or /auth/reset-password", () => {
-      for (const route of ["/auth/forgot-password", "/auth/reset-password"]) {
-        addEventListenerSpy.mockClear();
-        routeRef.current = route;
-        render(<Probe />);
-        expect(onlineListenerCount(addEventListenerSpy)).toBe(0);
-      }
+  describe("given an unauthenticated user on an auth-required page", () => {
+    describe("when the route is a public auth route", () => {
+      /** @scenario The forgot and reset pages are reachable without signing in */
+      it("does not try to redirect /auth/forgot-password or /auth/reset-password", () => {
+        for (const route of ["/auth/forgot-password", "/auth/reset-password"]) {
+          addEventListenerSpy.mockClear();
+          routeRef.current = route;
+          render(<Probe />);
+          expect(onlineListenerCount(addEventListenerSpy)).toBe(0);
+        }
+      });
     });
-  });
 
-  describe("when an unauthenticated user lands on a genuinely protected route", () => {
-    it("reaches the sign-in redirect path", () => {
-      routeRef.current = "/some/protected/page";
-      render(<Probe />);
-      expect(onlineListenerCount(addEventListenerSpy)).toBeGreaterThan(0);
+    describe("when the route is genuinely protected", () => {
+      it("reaches the sign-in redirect path", () => {
+        routeRef.current = "/some/protected/page";
+        render(<Probe />);
+        expect(onlineListenerCount(addEventListenerSpy)).toBeGreaterThan(0);
+      });
     });
   });
 });

--- a/langwatch/src/hooks/useRequiredSession.ts
+++ b/langwatch/src/hooks/useRequiredSession.ts
@@ -1,7 +1,14 @@
 import { useRouter } from "~/utils/compat/next-router";
 import { useSession } from "~/utils/auth-client";
 
-export const publicRoutes = ["/share/[id]", "/auth/signin", "/auth/signup", "/auth/error"];
+export const publicRoutes = [
+  "/share/[id]",
+  "/auth/signin",
+  "/auth/signup",
+  "/auth/forgot-password",
+  "/auth/reset-password",
+  "/auth/error",
+];
 
 /**
  * Routes that REQUIRE authentication but should NOT be subject to the

--- a/langwatch/src/pages/auth/__tests__/forgot-password.integration.test.tsx
+++ b/langwatch/src/pages/auth/__tests__/forgot-password.integration.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the /auth/forgot-password page. The full component
+ * tree renders under Chakra; only the BetterAuth client (network boundary) and
+ * the public-env hook are mocked.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRequestPasswordReset, publicEnvRef } = vi.hoisted(() => ({
+  mockRequestPasswordReset: vi.fn(),
+  publicEnvRef: {
+    current: { NEXTAUTH_PROVIDER: "email" as string | undefined },
+  },
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  authClient: { requestPasswordReset: mockRequestPasswordReset },
+}));
+
+vi.mock("../../../hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: publicEnvRef.current }),
+}));
+
+vi.mock("~/utils/compat/next-link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import ForgotPassword from "../forgot-password";
+
+const renderPage = () =>
+  render(
+    <ChakraProvider value={defaultSystem}>
+      <ForgotPassword />
+    </ChakraProvider>,
+  );
+
+const submitEmail = (email: string) => {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: email } });
+  fireEvent.click(screen.getByRole("button", { name: /send reset link/i }));
+};
+
+describe("ForgotPassword page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequestPasswordReset.mockResolvedValue({ data: {}, error: null });
+    publicEnvRef.current = { NEXTAUTH_PROVIDER: "email" };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when the user submits their email in credential mode", () => {
+    /** @scenario Requesting a reset submits the entered email to the reset endpoint */
+    it("calls requestPasswordReset with the entered email", async () => {
+      renderPage();
+      submitEmail("forgot@acme.test");
+
+      await waitFor(() => {
+        expect(mockRequestPasswordReset).toHaveBeenCalledWith({
+          email: "forgot@acme.test",
+          redirectTo: "/auth/reset-password",
+        });
+      });
+    });
+
+    /** @scenario Requesting a reset always shows a neutral confirmation */
+    it("shows an enumeration-safe confirmation that does not reveal registration", async () => {
+      renderPage();
+      submitEmail("forgot@acme.test");
+
+      const confirmation = await screen.findByText(/if an account exists for/i);
+      expect(confirmation).toBeTruthy();
+      expect(confirmation.textContent).toContain("forgot@acme.test");
+      // No wording that distinguishes a registered from an unregistered email.
+      expect(screen.queryByText(/no account/i)).toBeNull();
+      expect(screen.queryByText(/not found/i)).toBeNull();
+    });
+  });
+
+  describe("when the reset endpoint fails", () => {
+    /** @scenario A failure to dispatch the request still shows the neutral confirmation */
+    it("still shows the same neutral confirmation and no enumeration-leaking error", async () => {
+      mockRequestPasswordReset.mockRejectedValueOnce(new Error("network down"));
+      renderPage();
+      submitEmail("forgot@acme.test");
+
+      const confirmation = await screen.findByText(/if an account exists for/i);
+      expect(confirmation).toBeTruthy();
+      expect(screen.queryByText(/error/i)).toBeNull();
+    });
+  });
+
+  describe("when the deployment uses an SSO identity provider", () => {
+    it("explains the password is managed by the provider instead of a form", () => {
+      publicEnvRef.current = { NEXTAUTH_PROVIDER: "auth0" };
+      renderPage();
+
+      expect(
+        screen.getByText(/managed by your identity provider/i),
+      ).toBeTruthy();
+      expect(
+        screen.queryByRole("button", { name: /send reset link/i }),
+      ).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/pages/auth/__tests__/reset-password.integration.test.tsx
+++ b/langwatch/src/pages/auth/__tests__/reset-password.integration.test.tsx
@@ -68,11 +68,15 @@ const passwordInputs = (container: HTMLElement) =>
     container.querySelectorAll('input[type="password"]'),
   ) as HTMLInputElement[];
 
-const fillAndSubmit = (
-  container: HTMLElement,
-  password: string,
-  confirm: string,
-) => {
+const fillAndSubmit = ({
+  container,
+  password,
+  confirm,
+}: {
+  container: HTMLElement;
+  password: string;
+  confirm: string;
+}) => {
   const [pw, confirmPw] = passwordInputs(container);
   fireEvent.change(pw!, { target: { value: password } });
   fireEvent.change(confirmPw!, { target: { value: confirm } });
@@ -97,7 +101,11 @@ describe("ResetPassword page", () => {
     /** @scenario Submitting a valid new password with a token resets it and returns to sign-in */
     it("calls resetPassword with the new password and token, then confirms with a sign-in link", async () => {
       const { container } = renderPage();
-      fillAndSubmit(container, "newsecret123", "newsecret123");
+      fillAndSubmit({
+        container,
+        password: "newsecret123",
+        confirm: "newsecret123",
+      });
 
       await waitFor(() => {
         expect(mockResetPassword).toHaveBeenCalledWith({
@@ -118,7 +126,7 @@ describe("ResetPassword page", () => {
     /** @scenario The reset form rejects passwords shorter than 8 characters */
     it("shows a length validation error and does not call the reset endpoint", async () => {
       const { container } = renderPage();
-      fillAndSubmit(container, "short", "short");
+      fillAndSubmit({ container, password: "short", confirm: "short" });
 
       // Both fields are too short, so the message renders for each.
       expect(
@@ -132,7 +140,11 @@ describe("ResetPassword page", () => {
     /** @scenario The reset form rejects a mismatched confirmation */
     it("shows a mismatch error and does not call the reset endpoint", async () => {
       const { container } = renderPage();
-      fillAndSubmit(container, "newsecret123", "different123");
+      fillAndSubmit({
+        container,
+        password: "newsecret123",
+        confirm: "different123",
+      });
 
       expect(await screen.findByText(/passwords don't match/i)).toBeTruthy();
       expect(mockResetPassword).not.toHaveBeenCalled();
@@ -148,7 +160,11 @@ describe("ResetPassword page", () => {
       });
       setToken("tok_expired");
       const { container } = renderPage();
-      fillAndSubmit(container, "newsecret123", "newsecret123");
+      fillAndSubmit({
+        container,
+        password: "newsecret123",
+        confirm: "newsecret123",
+      });
 
       expect(await screen.findByText(/invalid or has expired/i)).toBeTruthy();
       const retry = screen.getByRole("link", {

--- a/langwatch/src/pages/auth/__tests__/reset-password.integration.test.tsx
+++ b/langwatch/src/pages/auth/__tests__/reset-password.integration.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the /auth/reset-password page. The full component tree
+ * renders under Chakra; only the BetterAuth client and the URL search-params
+ * hook are mocked.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockResetPassword, searchParamsRef } = vi.hoisted(() => ({
+  mockResetPassword: vi.fn(),
+  searchParamsRef: {
+    current: new URLSearchParams("token=tok_valid") as URLSearchParams | null,
+  },
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  authClient: { resetPassword: mockResetPassword },
+}));
+
+vi.mock("~/utils/compat/next-navigation", () => ({
+  useSearchParams: () => searchParamsRef.current,
+}));
+
+vi.mock("~/utils/compat/next-link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import ResetPassword from "../reset-password";
+
+const setToken = (token: string | null) => {
+  searchParamsRef.current = token
+    ? new URLSearchParams(`token=${token}`)
+    : new URLSearchParams("");
+};
+
+const renderPage = () => {
+  const view = render(
+    <ChakraProvider value={defaultSystem}>
+      <ResetPassword />
+    </ChakraProvider>,
+  );
+  return view;
+};
+
+const passwordInputs = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll('input[type="password"]'),
+  ) as HTMLInputElement[];
+
+const fillAndSubmit = (
+  container: HTMLElement,
+  password: string,
+  confirm: string,
+) => {
+  const [pw, confirmPw] = passwordInputs(container);
+  fireEvent.change(pw!, { target: { value: password } });
+  fireEvent.change(confirmPw!, { target: { value: confirm } });
+  fireEvent.click(screen.getByRole("button", { name: /reset password/i }));
+};
+
+describe("ResetPassword page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResetPassword.mockResolvedValue({
+      data: { status: true },
+      error: null,
+    });
+    setToken("tok_valid");
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when the token is valid and the passwords match", () => {
+    /** @scenario Submitting a valid new password with a token resets it and returns to sign-in */
+    it("calls resetPassword with the new password and token, then confirms with a sign-in link", async () => {
+      const { container } = renderPage();
+      fillAndSubmit(container, "newsecret123", "newsecret123");
+
+      await waitFor(() => {
+        expect(mockResetPassword).toHaveBeenCalledWith({
+          newPassword: "newsecret123",
+          token: "tok_valid",
+        });
+      });
+
+      expect(
+        await screen.findByText(/your password has been reset/i),
+      ).toBeTruthy();
+      const signInLink = screen.getByRole("link", { name: /sign in/i });
+      expect(signInLink.getAttribute("href")).toBe("/auth/signin");
+    });
+  });
+
+  describe("when the new password is shorter than 8 characters", () => {
+    /** @scenario The reset form rejects passwords shorter than 8 characters */
+    it("shows a length validation error and does not call the reset endpoint", async () => {
+      const { container } = renderPage();
+      fillAndSubmit(container, "short", "short");
+
+      // Both fields are too short, so the message renders for each.
+      expect(
+        (await screen.findAllByText(/at least 8 characters/i)).length,
+      ).toBeGreaterThan(0);
+      expect(mockResetPassword).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the confirmation does not match", () => {
+    /** @scenario The reset form rejects a mismatched confirmation */
+    it("shows a mismatch error and does not call the reset endpoint", async () => {
+      const { container } = renderPage();
+      fillAndSubmit(container, "newsecret123", "different123");
+
+      expect(await screen.findByText(/passwords don't match/i)).toBeTruthy();
+      expect(mockResetPassword).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the token is invalid or expired", () => {
+    /** @scenario An invalid or expired token surfaces an error and a way to retry */
+    it("surfaces an invalid-or-expired error with a link to request a new reset", async () => {
+      mockResetPassword.mockResolvedValueOnce({
+        data: null,
+        error: { code: "INVALID_TOKEN", message: "invalid token" },
+      });
+      setToken("tok_expired");
+      const { container } = renderPage();
+      fillAndSubmit(container, "newsecret123", "newsecret123");
+
+      expect(await screen.findByText(/invalid or has expired/i)).toBeTruthy();
+      const retry = screen.getByRole("link", {
+        name: /request a new reset link/i,
+      });
+      expect(retry.getAttribute("href")).toBe("/auth/forgot-password");
+    });
+  });
+
+  describe("when the page is opened without a token", () => {
+    /** @scenario Opening the reset page without a token prompts a new request */
+    it("tells the user the link is invalid and offers to request a new one", () => {
+      setToken(null);
+      const { container } = renderPage();
+
+      expect(
+        screen.getByRole("heading", { name: /invalid reset link/i }),
+      ).toBeTruthy();
+      expect(
+        screen.getByRole("link", { name: /request a new reset link/i }),
+      ).toBeTruthy();
+      // No password form is rendered without a token.
+      expect(passwordInputs(container)).toHaveLength(0);
+    });
+  });
+});

--- a/langwatch/src/pages/auth/__tests__/reset-password.integration.test.tsx
+++ b/langwatch/src/pages/auth/__tests__/reset-password.integration.test.tsx
@@ -128,7 +128,7 @@ describe("ResetPassword page", () => {
       const { container } = renderPage();
       fillAndSubmit({ container, password: "short", confirm: "short" });
 
-      // Both fields are too short, so the message renders for each.
+      // Length is enforced on the password field, so the message renders.
       expect(
         (await screen.findAllByText(/at least 8 characters/i)).length,
       ).toBeGreaterThan(0);

--- a/langwatch/src/pages/auth/__tests__/signin.integration.test.tsx
+++ b/langwatch/src/pages/auth/__tests__/signin.integration.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Integration tests for the Forgot-password entry point on /auth/signin. The
+ * credential form must offer a reset link in email mode, and SSO mode must not
+ * render the credential form (or the link) at all.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSignIn, sessionRef, publicEnvRef } = vi.hoisted(() => ({
+  mockSignIn: vi.fn(),
+  sessionRef: { current: { data: null as unknown } },
+  publicEnvRef: {
+    current: { NEXTAUTH_PROVIDER: "email" as string | undefined },
+  },
+}));
+
+vi.mock("~/utils/auth-client", () => ({
+  signIn: mockSignIn,
+  useSession: () => sessionRef.current,
+}));
+
+vi.mock("~/utils/compat/next-navigation", () => ({
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("~/hooks/usePublicEnv", () => ({
+  usePublicEnv: () => ({ data: publicEnvRef.current }),
+}));
+
+vi.mock("~/utils/compat/next-link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import SignIn from "../signin";
+
+const renderPage = () => {
+  const view = render(
+    <ChakraProvider value={defaultSystem}>
+      <SignIn />
+    </ChakraProvider>,
+  );
+  return view;
+};
+
+describe("SignIn forgot-password entry point", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionRef.current = { data: null };
+    publicEnvRef.current = { NEXTAUTH_PROVIDER: "email" };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("when the deployment uses credential (email) mode", () => {
+    /** @scenario The credential sign-in form shows a Forgot password link */
+    it("renders the email/password form with a link to forgot-password", () => {
+      const { container } = renderPage();
+
+      expect(container.querySelector('input[type="email"]')).not.toBeNull();
+      expect(container.querySelector('input[type="password"]')).not.toBeNull();
+      const link = screen.getByRole("link", { name: /forgot password/i });
+      expect(link.getAttribute("href")).toBe("/auth/forgot-password");
+    });
+  });
+
+  describe("when the deployment uses an SSO identity provider", () => {
+    /** @scenario SSO sign-in renders no credential form and no Forgot password link */
+    it("renders no credential form and no forgot-password link", () => {
+      publicEnvRef.current = { NEXTAUTH_PROVIDER: "auth0" };
+      const { container } = renderPage();
+
+      expect(container.querySelector('input[type="email"]')).toBeNull();
+      expect(container.querySelector('input[type="password"]')).toBeNull();
+      expect(
+        screen.queryByRole("link", { name: /forgot password/i }),
+      ).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/pages/auth/forgot-password.tsx
+++ b/langwatch/src/pages/auth/forgot-password.tsx
@@ -1,0 +1,158 @@
+import {
+  Box,
+  Button,
+  Card,
+  Container,
+  Heading,
+  HStack,
+  Input,
+  Spacer,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type ReactNode, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { authClient } from "~/utils/auth-client";
+import Link from "~/utils/compat/next-link";
+import { HorizontalFormControl } from "../../components/HorizontalFormControl";
+import { LogoIcon } from "../../components/icons/LogoIcon";
+import { usePublicEnv } from "../../hooks/usePublicEnv";
+
+export default function ForgotPassword() {
+  const publicEnv = usePublicEnv();
+  const isAuthProvider = publicEnv.data?.NEXTAUTH_PROVIDER;
+
+  if (!publicEnv.data) {
+    return null;
+  }
+
+  // Reset is a credential-mode concept. In SSO / social deployments the
+  // identity provider owns the password, so point the user back to sign in
+  // instead of a form that would only no-op against the blocked endpoint.
+  if (isAuthProvider && isAuthProvider !== "email") {
+    return (
+      <AuthCard title="Forgot password">
+        <Text>
+          Your password is managed by your identity provider. Use your
+          organization single sign-on to access LangWatch.
+        </Text>
+        <BackToSignInLink />
+      </AuthCard>
+    );
+  }
+
+  return <ForgotPasswordForm />;
+}
+
+function ForgotPasswordForm() {
+  const schema = z.object({ email: z.string().email() });
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+  });
+  const [loading, setLoading] = useState(false);
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
+
+  const onSubmit = async (values: z.infer<typeof schema>) => {
+    setLoading(true);
+    try {
+      // BetterAuth returns a success-shaped response whether or not the email
+      // is registered, and we swallow any transport error below: the form must
+      // never reveal which addresses have an account.
+      await authClient.requestPasswordReset({
+        email: values.email,
+        redirectTo: "/auth/reset-password",
+      });
+    } catch {
+      // Intentionally ignored. See the neutral-confirmation note above.
+    } finally {
+      setLoading(false);
+      setSubmittedEmail(values.email);
+    }
+  };
+
+  if (submittedEmail) {
+    return (
+      <AuthCard title="Check your email">
+        <Text>
+          If an account exists for <b>{submittedEmail}</b>, we have sent a link
+          to reset your password. The link expires in 1 hour.
+        </Text>
+        <BackToSignInLink />
+      </AuthCard>
+    );
+  }
+
+  return (
+    <Container maxW="container.md" paddingTop="calc(40vh - 164px)">
+      {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <Card.Root>
+          <Card.Header>
+            <HStack gap={4}>
+              <LogoIcon width={30.69} height={42} />
+              <Heading size="lg" as="h1">
+                Forgot password
+              </Heading>
+            </HStack>
+          </Card.Header>
+          <Card.Body>
+            <VStack width="full">
+              <Text width="full" color="gray.600">
+                Enter the email for your account and we will send you a link to
+                reset your password.
+              </Text>
+              <HorizontalFormControl
+                label="Email"
+                helper="Enter your email"
+                invalid={form.formState.errors.email?.message !== undefined}
+              >
+                <Input type="email" {...form.register("email")} />
+              </HorizontalFormControl>
+              <HStack width="full" paddingTop={4}>
+                <BackToSignInLink />
+                <Spacer />
+                <Button colorPalette="orange" type="submit" loading={loading}>
+                  Send reset link
+                </Button>
+              </HStack>
+            </VStack>
+          </Card.Body>
+        </Card.Root>
+      </form>
+    </Container>
+  );
+}
+
+function AuthCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <Container maxW="container.md" paddingTop="calc(40vh - 164px)">
+      <Card.Root>
+        <Card.Header>
+          <HStack gap={4}>
+            <LogoIcon width={30.69} height={42} />
+            <Heading size="lg" as="h1">
+              {title}
+            </Heading>
+          </HStack>
+        </Card.Header>
+        <Card.Body>
+          <VStack width="full" align="start" gap={4}>
+            {children}
+          </VStack>
+        </Card.Body>
+      </Card.Root>
+    </Container>
+  );
+}
+
+function BackToSignInLink() {
+  return (
+    <Box asChild>
+      <Link href="/auth/signin" style={{ textDecoration: "underline" }}>
+        Back to sign in
+      </Link>
+    </Box>
+  );
+}

--- a/langwatch/src/pages/auth/forgot-password.tsx
+++ b/langwatch/src/pages/auth/forgot-password.tsx
@@ -51,11 +51,11 @@ function ForgotPasswordForm() {
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
   });
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
 
   const onSubmit = async (values: z.infer<typeof schema>) => {
-    setLoading(true);
+    setIsLoading(true);
     try {
       // BetterAuth returns a success-shaped response whether or not the email
       // is registered, and we swallow any transport error below: the form must
@@ -67,7 +67,7 @@ function ForgotPasswordForm() {
     } catch {
       // Intentionally ignored. See the neutral-confirmation note above.
     } finally {
-      setLoading(false);
+      setIsLoading(false);
       setSubmittedEmail(values.email);
     }
   };
@@ -113,7 +113,7 @@ function ForgotPasswordForm() {
               <HStack width="full" paddingTop={4}>
                 <BackToSignInLink />
                 <Spacer />
-                <Button colorPalette="orange" type="submit" loading={loading}>
+                <Button colorPalette="orange" type="submit" loading={isLoading}>
                   Send reset link
                 </Button>
               </HStack>

--- a/langwatch/src/pages/auth/forgot-password.tsx
+++ b/langwatch/src/pages/auth/forgot-password.tsx
@@ -20,6 +20,8 @@ import { HorizontalFormControl } from "../../components/HorizontalFormControl";
 import { LogoIcon } from "../../components/icons/LogoIcon";
 import { usePublicEnv } from "../../hooks/usePublicEnv";
 
+const forgotPasswordSchema = z.object({ email: z.string().email() });
+
 export default function ForgotPassword() {
   const publicEnv = usePublicEnv();
   const isAuthProvider = publicEnv.data?.NEXTAUTH_PROVIDER;
@@ -47,14 +49,13 @@ export default function ForgotPassword() {
 }
 
 function ForgotPasswordForm() {
-  const schema = z.object({ email: z.string().email() });
-  const form = useForm<z.infer<typeof schema>>({
-    resolver: zodResolver(schema),
+  const form = useForm<z.infer<typeof forgotPasswordSchema>>({
+    resolver: zodResolver(forgotPasswordSchema),
   });
   const [isLoading, setIsLoading] = useState(false);
   const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
 
-  const onSubmit = async (values: z.infer<typeof schema>) => {
+  const onSubmit = async (values: z.infer<typeof forgotPasswordSchema>) => {
     setIsLoading(true);
     try {
       // BetterAuth returns a success-shaped response whether or not the email

--- a/langwatch/src/pages/auth/reset-password.tsx
+++ b/langwatch/src/pages/auth/reset-password.tsx
@@ -1,0 +1,196 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Container,
+  Heading,
+  HStack,
+  Input,
+  Spacer,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type ReactNode, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { authClient } from "~/utils/auth-client";
+import Link from "~/utils/compat/next-link";
+import { useSearchParams } from "~/utils/compat/next-navigation";
+import { HorizontalFormControl } from "../../components/HorizontalFormControl";
+import { LogoIcon } from "../../components/icons/LogoIcon";
+
+const INVALID_LINK_MESSAGE =
+  "This password reset link is invalid or has expired. Request a new one to continue.";
+
+export default function ResetPassword() {
+  const query = useSearchParams();
+  const token = query?.get("token") ?? null;
+
+  if (!token) {
+    return (
+      <AuthCard title="Invalid reset link">
+        <Text>{INVALID_LINK_MESSAGE}</Text>
+        <RequestNewLink />
+      </AuthCard>
+    );
+  }
+
+  return <ResetPasswordForm token={token} />;
+}
+
+function ResetPasswordForm({ token }: { token: string }) {
+  const schema = z
+    .object({
+      password: z
+        .string()
+        .min(8, { message: "Password must be at least 8 characters" }),
+      confirmPassword: z
+        .string()
+        .min(8, { message: "Password must be at least 8 characters" }),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: "Passwords don't match",
+      path: ["confirmPassword"],
+    });
+
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+  });
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const onSubmit = async (values: z.infer<typeof schema>) => {
+    setLoading(true);
+    setServerError(null);
+    try {
+      const result = await authClient.resetPassword({
+        newPassword: values.password,
+        token,
+      });
+      if (result?.error) {
+        setServerError(INVALID_LINK_MESSAGE);
+        return;
+      }
+      setDone(true);
+    } catch {
+      setServerError(INVALID_LINK_MESSAGE);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <AuthCard title="Password updated">
+        <Text>
+          Your password has been reset. You can now sign in with your new
+          password.
+        </Text>
+        <Button colorPalette="orange" asChild>
+          <Link href="/auth/signin">Sign in</Link>
+        </Button>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <Container maxW="container.md" paddingTop="calc(40vh - 164px)">
+      {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <Card.Root>
+          <Card.Header>
+            <HStack gap={4}>
+              <LogoIcon width={30.69} height={42} />
+              <Heading size="lg" as="h1">
+                Reset password
+              </Heading>
+            </HStack>
+          </Card.Header>
+          <Card.Body>
+            <VStack width="full">
+              <HorizontalFormControl
+                label="New Password"
+                helper="Enter your new password"
+                invalid={form.formState.errors.password?.message !== undefined}
+                error={form.formState.errors.password}
+              >
+                <Input type="password" {...form.register("password")} />
+              </HorizontalFormControl>
+              <HorizontalFormControl
+                label="Confirm Password"
+                helper="Confirm your new password"
+                invalid={
+                  form.formState.errors.confirmPassword?.message !== undefined
+                }
+                error={form.formState.errors.confirmPassword}
+              >
+                <Input type="password" {...form.register("confirmPassword")} />
+              </HorizontalFormControl>
+              {serverError && (
+                <Alert.Root status="error" width="full">
+                  <Alert.Indicator />
+                  <Alert.Content>
+                    <Alert.Description>{serverError}</Alert.Description>
+                    <RequestNewLink />
+                  </Alert.Content>
+                </Alert.Root>
+              )}
+              <HStack width="full" paddingTop={4}>
+                <Box asChild>
+                  <Link
+                    href="/auth/signin"
+                    style={{ textDecoration: "underline" }}
+                  >
+                    Back to sign in
+                  </Link>
+                </Box>
+                <Spacer />
+                <Button colorPalette="orange" type="submit" loading={loading}>
+                  Reset password
+                </Button>
+              </HStack>
+            </VStack>
+          </Card.Body>
+        </Card.Root>
+      </form>
+    </Container>
+  );
+}
+
+function AuthCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <Container maxW="container.md" paddingTop="calc(40vh - 164px)">
+      <Card.Root>
+        <Card.Header>
+          <HStack gap={4}>
+            <LogoIcon width={30.69} height={42} />
+            <Heading size="lg" as="h1">
+              {title}
+            </Heading>
+          </HStack>
+        </Card.Header>
+        <Card.Body>
+          <VStack width="full" align="start" gap={4}>
+            {children}
+          </VStack>
+        </Card.Body>
+      </Card.Root>
+    </Container>
+  );
+}
+
+function RequestNewLink() {
+  return (
+    <Box asChild>
+      <Link
+        href="/auth/forgot-password"
+        style={{ textDecoration: "underline" }}
+      >
+        Request a new reset link
+      </Link>
+    </Box>
+  );
+}

--- a/langwatch/src/pages/auth/reset-password.tsx
+++ b/langwatch/src/pages/auth/reset-password.tsx
@@ -25,6 +25,18 @@ import { LogoIcon } from "../../components/icons/LogoIcon";
 const INVALID_LINK_MESSAGE =
   "This password reset link is invalid or has expired. Request a new one to continue.";
 
+const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, { message: "Password must be at least 8 characters" }),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
 export default function ResetPassword() {
   const query = useSearchParams();
   const token = query?.get("token") ?? null;
@@ -42,28 +54,14 @@ export default function ResetPassword() {
 }
 
 function ResetPasswordForm({ token }: { token: string }) {
-  const schema = z
-    .object({
-      password: z
-        .string()
-        .min(8, { message: "Password must be at least 8 characters" }),
-      confirmPassword: z
-        .string()
-        .min(8, { message: "Password must be at least 8 characters" }),
-    })
-    .refine((data) => data.password === data.confirmPassword, {
-      message: "Passwords don't match",
-      path: ["confirmPassword"],
-    });
-
-  const form = useForm<z.infer<typeof schema>>({
-    resolver: zodResolver(schema),
+  const form = useForm<z.infer<typeof resetPasswordSchema>>({
+    resolver: zodResolver(resetPasswordSchema),
   });
   const [isLoading, setIsLoading] = useState(false);
   const [isDone, setIsDone] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
 
-  const onSubmit = async (values: z.infer<typeof schema>) => {
+  const onSubmit = async (values: z.infer<typeof resetPasswordSchema>) => {
     setIsLoading(true);
     setServerError(null);
     try {

--- a/langwatch/src/pages/auth/reset-password.tsx
+++ b/langwatch/src/pages/auth/reset-password.tsx
@@ -58,12 +58,12 @@ function ResetPasswordForm({ token }: { token: string }) {
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
   });
-  const [loading, setLoading] = useState(false);
-  const [done, setDone] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isDone, setIsDone] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
 
   const onSubmit = async (values: z.infer<typeof schema>) => {
-    setLoading(true);
+    setIsLoading(true);
     setServerError(null);
     try {
       const result = await authClient.resetPassword({
@@ -74,15 +74,15 @@ function ResetPasswordForm({ token }: { token: string }) {
         setServerError(INVALID_LINK_MESSAGE);
         return;
       }
-      setDone(true);
+      setIsDone(true);
     } catch {
       setServerError(INVALID_LINK_MESSAGE);
     } finally {
-      setLoading(false);
+      setIsLoading(false);
     }
   };
 
-  if (done) {
+  if (isDone) {
     return (
       <AuthCard title="Password updated">
         <Text>
@@ -148,7 +148,7 @@ function ResetPasswordForm({ token }: { token: string }) {
                   </Link>
                 </Box>
                 <Spacer />
-                <Button colorPalette="orange" type="submit" loading={loading}>
+                <Button colorPalette="orange" type="submit" loading={isLoading}>
                   Reset password
                 </Button>
               </HStack>

--- a/langwatch/src/pages/auth/reset-password.tsx
+++ b/langwatch/src/pages/auth/reset-password.tsx
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { authClient } from "~/utils/auth-client";
 import Link from "~/utils/compat/next-link";
 import { useSearchParams } from "~/utils/compat/next-navigation";
+import { FormErrorDisplay } from "../../components/FormErrorDisplay";
 import { HorizontalFormControl } from "../../components/HorizontalFormControl";
 import { LogoIcon } from "../../components/icons/LogoIcon";
 
@@ -89,8 +90,10 @@ function ResetPasswordForm({ token }: { token: string }) {
           Your password has been reset. You can now sign in with your new
           password.
         </Text>
-        <Button colorPalette="orange" asChild>
-          <Link href="/auth/signin">Sign in</Link>
+        <Button colorPalette="orange" variant="solid" asChild>
+          <Link href="/auth/signin" style={{ color: "white" }}>
+            Sign in
+          </Link>
         </Button>
       </AuthCard>
     );
@@ -115,9 +118,11 @@ function ResetPasswordForm({ token }: { token: string }) {
                 label="New Password"
                 helper="Enter your new password"
                 invalid={form.formState.errors.password?.message !== undefined}
-                error={form.formState.errors.password}
               >
-                <Input type="password" {...form.register("password")} />
+                <VStack align="stretch" gap={1} width="full">
+                  <Input type="password" {...form.register("password")} />
+                  <FormErrorDisplay error={form.formState.errors.password} />
+                </VStack>
               </HorizontalFormControl>
               <HorizontalFormControl
                 label="Confirm Password"
@@ -125,9 +130,13 @@ function ResetPasswordForm({ token }: { token: string }) {
                 invalid={
                   form.formState.errors.confirmPassword?.message !== undefined
                 }
-                error={form.formState.errors.confirmPassword}
               >
-                <Input type="password" {...form.register("confirmPassword")} />
+                <VStack align="stretch" gap={1} width="full">
+                  <Input type="password" {...form.register("confirmPassword")} />
+                  <FormErrorDisplay
+                    error={form.formState.errors.confirmPassword}
+                  />
+                </VStack>
               </HorizontalFormControl>
               {serverError && (
                 <Alert.Root status="error" width="full">

--- a/langwatch/src/pages/auth/signin.tsx
+++ b/langwatch/src/pages/auth/signin.tsx
@@ -160,19 +160,24 @@ function SignInForm() {
                 helper="Enter your password"
                 invalid={form.formState.errors.password?.message !== undefined}
               >
-                <Input type="password" {...form.register("password")} />
+                <VStack align="stretch" gap={2} width="full">
+                  <Input type="password" {...form.register("password")} />
+                  <HStack width="full">
+                    <Spacer />
+                    <Box asChild>
+                      <Link
+                        href="/auth/forgot-password"
+                        style={{
+                          textDecoration: "underline",
+                          fontSize: "14px",
+                        }}
+                      >
+                        Forgot password?
+                      </Link>
+                    </Box>
+                  </HStack>
+                </VStack>
               </HorizontalFormControl>
-              <HStack width="full">
-                <Spacer />
-                <Box asChild>
-                  <Link
-                    href="/auth/forgot-password"
-                    style={{ textDecoration: "underline", fontSize: "14px" }}
-                  >
-                    Forgot password?
-                  </Link>
-                </Box>
-              </HStack>
               {error && (
                 <Alert.Root status="error">
                   <Alert.Indicator />

--- a/langwatch/src/pages/auth/signin.tsx
+++ b/langwatch/src/pages/auth/signin.tsx
@@ -162,6 +162,17 @@ function SignInForm() {
               >
                 <Input type="password" {...form.register("password")} />
               </HorizontalFormControl>
+              <HStack width="full">
+                <Spacer />
+                <Box asChild>
+                  <Link
+                    href="/auth/forgot-password"
+                    style={{ textDecoration: "underline", fontSize: "14px" }}
+                  >
+                    Forgot password?
+                  </Link>
+                </Box>
+              </HStack>
               {error && (
                 <Alert.Root status="error">
                   <Alert.Indicator />

--- a/langwatch/src/routes.tsx
+++ b/langwatch/src/routes.tsx
@@ -70,6 +70,14 @@ const routes: RouteObject[] = [
   // Auth (public)
   { path: "/auth/signin", ...page(() => import("./pages/auth/signin")) },
   { path: "/auth/signup", ...page(() => import("./pages/auth/signup")) },
+  {
+    path: "/auth/forgot-password",
+    ...page(() => import("./pages/auth/forgot-password")),
+  },
+  {
+    path: "/auth/reset-password",
+    ...page(() => import("./pages/auth/reset-password")),
+  },
   { path: "/auth/error", ...page(() => import("./pages/auth/error")) },
 
   // Top-level pages

--- a/langwatch/src/server/better-auth/__tests__/passwordReset.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/passwordReset.test.ts
@@ -12,6 +12,7 @@ vi.mock("../revokeSessions", () => ({
 
 import { env } from "~/env.mjs";
 import { sendResetPasswordEmail } from "../../mailer/resetPasswordEmail";
+import { auth } from "../index";
 import { revokeAllSessionsForUser } from "../revokeSessions";
 
 type EmailAndPasswordOptions = {
@@ -26,10 +27,8 @@ type EmailAndPasswordOptions = {
   resetPasswordTokenExpiresIn?: number;
 };
 
-const getEmailAndPassword = async (): Promise<EmailAndPasswordOptions> => {
-  const { auth } = await import("../index");
-  return (auth as any).options.emailAndPassword as EmailAndPasswordOptions;
-};
+const getEmailAndPassword = (): EmailAndPasswordOptions =>
+  (auth as any).options.emailAndPassword as EmailAndPasswordOptions;
 
 describe("better-auth password reset wiring", () => {
   beforeEach(() => {
@@ -39,7 +38,7 @@ describe("better-auth password reset wiring", () => {
   describe("when BetterAuth invokes sendResetPassword", () => {
     /** @scenario sendResetPassword builds the reset link from BASE_HOST and the token */
     it("emails the user a reset link rooted at BASE_HOST carrying the token", async () => {
-      const emailAndPassword = await getEmailAndPassword();
+      const emailAndPassword = getEmailAndPassword();
       expect(typeof emailAndPassword.sendResetPassword).toBe("function");
 
       await emailAndPassword.sendResetPassword!({
@@ -59,7 +58,7 @@ describe("better-auth password reset wiring", () => {
   describe("when BetterAuth invokes onPasswordReset", () => {
     /** @scenario A successful reset revokes all of the user's existing sessions */
     it("revokes every existing session for the user", async () => {
-      const emailAndPassword = await getEmailAndPassword();
+      const emailAndPassword = getEmailAndPassword();
       expect(typeof emailAndPassword.onPasswordReset).toBe("function");
 
       await emailAndPassword.onPasswordReset!({
@@ -74,16 +73,15 @@ describe("better-auth password reset wiring", () => {
   });
 
   describe("when the reset token lifetime is configured", () => {
-    it("expires reset tokens after one hour", async () => {
-      const emailAndPassword = await getEmailAndPassword();
+    it("expires reset tokens after one hour", () => {
+      const emailAndPassword = getEmailAndPassword();
       expect(emailAndPassword.resetPasswordTokenExpiresIn).toBe(60 * 60);
     });
   });
 
   describe("when the rate-limit configuration is inspected", () => {
     /** @scenario Password reset endpoints are rate-limited to five attempts per hour */
-    it("caps /request-password-reset and /reset-password at 5 per hour", async () => {
-      const { auth } = await import("../index");
+    it("caps /request-password-reset and /reset-password at 5 per hour", () => {
       const customRules = (auth as any).options.rateLimit.customRules as Record<
         string,
         { window: number; max: number }

--- a/langwatch/src/server/better-auth/__tests__/passwordReset.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/passwordReset.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the boundaries the reset callbacks reach for: the transactional mailer
+// (SendGrid / SES) and the session-revocation helper (Postgres + Redis). The
+// callbacks under test are the real ones wired into the `auth` instance.
+vi.mock("../../mailer/resetPasswordEmail", () => ({
+  sendResetPasswordEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../revokeSessions", () => ({
+  revokeAllSessionsForUser: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { env } from "~/env.mjs";
+import { sendResetPasswordEmail } from "../../mailer/resetPasswordEmail";
+import { revokeAllSessionsForUser } from "../revokeSessions";
+
+type EmailAndPasswordOptions = {
+  sendResetPassword?: (args: {
+    user: { id: string; email: string };
+    url: string;
+    token: string;
+  }) => Promise<void>;
+  onPasswordReset?: (args: {
+    user: { id: string; email: string };
+  }) => Promise<void>;
+  resetPasswordTokenExpiresIn?: number;
+};
+
+const getEmailAndPassword = async (): Promise<EmailAndPasswordOptions> => {
+  const { auth } = await import("../index");
+  return (auth as any).options.emailAndPassword as EmailAndPasswordOptions;
+};
+
+describe("better-auth password reset wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when BetterAuth invokes sendResetPassword", () => {
+    /** @scenario sendResetPassword builds the reset link from BASE_HOST and the token */
+    it("emails the user a reset link rooted at BASE_HOST carrying the token", async () => {
+      const emailAndPassword = await getEmailAndPassword();
+      expect(typeof emailAndPassword.sendResetPassword).toBe("function");
+
+      await emailAndPassword.sendResetPassword!({
+        user: { id: "user_1", email: "forgot@acme.test" },
+        url: "https://ignored.example/reset",
+        token: "tok_test_123",
+      });
+
+      expect(sendResetPasswordEmail).toHaveBeenCalledTimes(1);
+      expect(sendResetPasswordEmail).toHaveBeenCalledWith({
+        email: "forgot@acme.test",
+        resetUrl: `${env.BASE_HOST}/auth/reset-password?token=tok_test_123`,
+      });
+    });
+  });
+
+  describe("when BetterAuth invokes onPasswordReset", () => {
+    /** @scenario A successful reset revokes all of the user's existing sessions */
+    it("revokes every existing session for the user", async () => {
+      const emailAndPassword = await getEmailAndPassword();
+      expect(typeof emailAndPassword.onPasswordReset).toBe("function");
+
+      await emailAndPassword.onPasswordReset!({
+        user: { id: "user_1", email: "forgot@acme.test" },
+      });
+
+      expect(revokeAllSessionsForUser).toHaveBeenCalledTimes(1);
+      expect(revokeAllSessionsForUser).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "user_1" }),
+      );
+    });
+  });
+
+  describe("when the reset token lifetime is configured", () => {
+    it("expires reset tokens after one hour", async () => {
+      const emailAndPassword = await getEmailAndPassword();
+      expect(emailAndPassword.resetPasswordTokenExpiresIn).toBe(60 * 60);
+    });
+  });
+
+  describe("when the rate-limit configuration is inspected", () => {
+    /** @scenario Password reset endpoints are rate-limited to five attempts per hour */
+    it("caps /request-password-reset and /reset-password at 5 per hour", async () => {
+      const { auth } = await import("../index");
+      const customRules = (auth as any).options.rateLimit.customRules as Record<
+        string,
+        { window: number; max: number }
+      >;
+
+      expect(customRules["/request-password-reset"]).toEqual({
+        window: 60 * 60,
+        max: 5,
+      });
+      expect(customRules["/reset-password"]).toEqual({
+        window: 60 * 60,
+        max: 5,
+      });
+    });
+  });
+});

--- a/langwatch/src/server/better-auth/__tests__/passwordReset.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/passwordReset.test.ts
@@ -36,7 +36,7 @@ describe("better-auth password reset wiring", () => {
   });
 
   describe("when BetterAuth invokes sendResetPassword", () => {
-    /** @scenario sendResetPassword builds the reset link from BASE_HOST and the token */
+    /** @scenario The reset link is rooted at the deployment's own URL and carries the token */
     it("emails the user a reset link rooted at BASE_HOST carrying the token", async () => {
       const emailAndPassword = getEmailAndPassword();
       expect(typeof emailAndPassword.sendResetPassword).toBe("function");

--- a/langwatch/src/server/better-auth/__tests__/passwordReset.test.ts
+++ b/langwatch/src/server/better-auth/__tests__/passwordReset.test.ts
@@ -53,6 +53,21 @@ describe("better-auth password reset wiring", () => {
         resetUrl: `${env.BASE_HOST}/auth/reset-password?token=tok_test_123`,
       });
     });
+
+    it("percent-encodes tokens that carry URL-significant characters", async () => {
+      const emailAndPassword = getEmailAndPassword();
+
+      await emailAndPassword.sendResetPassword!({
+        user: { id: "user_2", email: "special@acme.test" },
+        url: "https://ignored.example/reset",
+        token: "tok+with=special",
+      });
+
+      expect(sendResetPasswordEmail).toHaveBeenCalledWith({
+        email: "special@acme.test",
+        resetUrl: `${env.BASE_HOST}/auth/reset-password?token=tok%2Bwith%3Dspecial`,
+      });
+    });
   });
 
   describe("when BetterAuth invokes onPasswordReset", () => {

--- a/langwatch/src/server/better-auth/index.ts
+++ b/langwatch/src/server/better-auth/index.ts
@@ -19,6 +19,8 @@ import {
   beforeSessionCreate,
   beforeUserCreate,
 } from "./hooks";
+import { revokeAllSessionsForUser } from "./revokeSessions";
+import { sendResetPasswordEmail } from "../mailer/resetPasswordEmail";
 
 const logger = createLogger("langwatch:better-auth");
 
@@ -377,6 +379,36 @@ export const auth = betterAuth({
     password: {
       hash: async (password: string) => hash(password, 10),
       verify: async ({ password, hash: storedHash }) => compare(password, storedHash),
+    },
+    /**
+     * Reset-link lifetime. Kept at BetterAuth's one-hour default but stated
+     * explicitly so the email copy ("this link expires in 1 hour") and the
+     * token expiry can't silently drift apart.
+     */
+    resetPasswordTokenExpiresIn: 60 * 60,
+    /**
+     * Wires BetterAuth's /request-password-reset endpoint to our existing
+     * transactional mailer (SendGrid / SES via `sendEmail`). Without this the
+     * endpoint returns RESET_PASSWORD_DISABLED. We ignore BetterAuth's default
+     * `url` and build the link off BASE_HOST + the issued token so it lands on
+     * our own /auth/reset-password page. BetterAuth only enables (and the
+     * cloud-mode `hooks.before` gate only allows) this in email mode, so the
+     * link is always credential-mode.
+     */
+    sendResetPassword: async ({ user, token }) => {
+      await sendResetPasswordEmail({
+        email: user.email,
+        resetUrl: `${env.BASE_HOST}/auth/reset-password?token=${token}`,
+      });
+    },
+    /**
+     * After a successful reset, force-logout every existing session for the
+     * user. The self-service change-password flow revokes *other* sessions
+     * (keeping the current tab); here the user isn't signed in, and a reset is
+     * the recovery path for a possibly-compromised account, so we revoke all.
+     */
+    onPasswordReset: async ({ user }) => {
+      await revokeAllSessionsForUser({ prisma, userId: user.id });
     },
   },
 

--- a/langwatch/src/server/better-auth/index.ts
+++ b/langwatch/src/server/better-auth/index.ts
@@ -398,7 +398,7 @@ export const auth = betterAuth({
     sendResetPassword: async ({ user, token }) => {
       await sendResetPasswordEmail({
         email: user.email,
-        resetUrl: `${env.BASE_HOST}/auth/reset-password?token=${token}`,
+        resetUrl: `${env.BASE_HOST}/auth/reset-password?token=${encodeURIComponent(token)}`,
       });
     },
     /**

--- a/langwatch/src/server/mailer/__tests__/resetPasswordEmail.unit.test.tsx
+++ b/langwatch/src/server/mailer/__tests__/resetPasswordEmail.unit.test.tsx
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sendEmail } from "../emailSender";
+import { sendResetPasswordEmail } from "../resetPasswordEmail";
+
+vi.mock("../emailSender", () => ({
+  sendEmail: vi.fn(),
+}));
+
+const baseParams = {
+  email: "user@acme.test",
+  resetUrl:
+    "https://app.langwatch.ai/auth/reset-password?token=tok_abc123def456",
+};
+
+describe("sendResetPasswordEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when sending the reset email", () => {
+    /** @scenario The reset email is sent through the existing email infrastructure */
+    it("dispatches via the shared sendEmail mailer to the user with a LangWatch password subject", async () => {
+      await sendResetPasswordEmail(baseParams);
+
+      expect(sendEmail).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].to).toBe("user@acme.test");
+      expect(call[0].subject).toContain("LangWatch");
+      expect(call[0].subject.toLowerCase()).toContain("password");
+    });
+  });
+
+  describe("when rendering the email body", () => {
+    /** @scenario The reset email links to the reset page with a one-time token */
+    it("contains a button linking to the reset page carrying the token", async () => {
+      await sendResetPasswordEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].html).toContain("/auth/reset-password");
+      expect(call[0].html).toContain("tok_abc123def456");
+      expect(call[0].html).toContain("Reset password");
+    });
+
+    /** @scenario The reset email tells the user it expires and is safe to ignore */
+    it("explains the link expires and can be ignored if unrequested", async () => {
+      await sendResetPasswordEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].html).toContain("expires");
+      expect(call[0].html).toContain("ignore");
+    });
+
+    it("addresses the email to the account it was requested for", async () => {
+      await sendResetPasswordEmail(baseParams);
+
+      const call = vi.mocked(sendEmail).mock.calls[0]!;
+      expect(call[0].html).toContain("user@acme.test");
+    });
+  });
+});

--- a/langwatch/src/server/mailer/resetPasswordEmail.tsx
+++ b/langwatch/src/server/mailer/resetPasswordEmail.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@react-email/button";
+import { Container } from "@react-email/container";
+import { Heading } from "@react-email/heading";
+import { Html } from "@react-email/html";
+import { Img } from "@react-email/img";
+import { render } from "@react-email/render";
+import { sendEmail } from "./emailSender";
+
+export const sendResetPasswordEmail = async ({
+  email,
+  resetUrl,
+}: {
+  email: string;
+  resetUrl: string;
+}) => {
+  const emailHtml = await render(
+    <Html lang="en" dir="ltr">
+      <Container
+        style={{
+          border: "1px solid #F2F4F8",
+          borderRadius: "10px",
+          padding: "24px",
+          paddingBottom: "12px",
+        }}
+      >
+        <Img
+          src="https://app.langwatch.ai/images/logo-icon.png"
+          alt="LangWatch Logo"
+          width="36"
+        />
+        <Heading as="h1">Reset your password</Heading>
+        <p>
+          We received a request to reset the password for your LangWatch account
+          (<b>{email}</b>). Click the button below to choose a new password:
+        </p>
+        <Button
+          href={resetUrl}
+          style={{
+            padding: "10px 20px",
+            color: "white",
+            backgroundColor: "#ED8926",
+            textDecoration: "none",
+            borderRadius: "6px",
+          }}
+        >
+          Reset password
+        </Button>
+        <p>
+          This link expires in 1 hour. If you did not request a password reset,
+          you can safely ignore this email and your password will stay the same.
+        </p>
+      </Container>
+    </Html>,
+  );
+
+  await sendEmail({
+    to: email,
+    subject: "Reset your LangWatch password",
+    html: emailHtml,
+  });
+};

--- a/specs/auth/password-reset.feature
+++ b/specs/auth/password-reset.feature
@@ -30,6 +30,13 @@ Feature: Forgot / reset password on credential (email-mode) sign-in
     Then the credential form is not rendered
     And there is no "Forgot password?" link
 
+  @integration
+  Scenario: The forgot and reset pages are reachable without signing in
+    Given I am not signed in
+    When I open /auth/forgot-password or /auth/reset-password
+    Then the page renders without bouncing me to sign in
+    And a genuinely protected route still bounces me to sign in with a callback
+
   # --- Requesting a reset (/auth/forgot-password) ---
 
   @integration

--- a/specs/auth/password-reset.feature
+++ b/specs/auth/password-reset.feature
@@ -1,0 +1,155 @@
+Feature: Forgot / reset password on credential (email-mode) sign-in
+  As a LangWatch user who signed up with an email and password
+  I want to reset my password from the sign-in screen when I forget it
+  So that I can recover my account on my own, without contacting support
+
+  # Password reset only exists in on-prem credential mode
+  # (NEXTAUTH_PROVIDER="email"). In Auth0 / Google / SSO deployments the
+  # identity provider owns the credential, so the sign-in screen renders a
+  # provider redirect instead of the email/password form — and BetterAuth's
+  # /request-password-reset and /reset-password endpoints stay blocked by the
+  # cloud-mode gate. The flow reuses the same email infrastructure
+  # (SendGrid or AWS SES via `sendEmail`) that powers invites and other
+  # transactional mail. BetterAuth already mounts and rate-limits the reset
+  # endpoints; this feature wires the previously-missing `sendResetPassword`
+  # callback to the mailer and adds the two user-facing pages.
+
+  # --- Sign-in entry point ---
+
+  @integration
+  Scenario: The credential sign-in form shows a Forgot password link
+    Given the tenant runs on NEXTAUTH_PROVIDER="email"
+    When I open /auth/signin
+    Then I see the email and password fields
+    And I see a "Forgot password?" link pointing to /auth/forgot-password
+
+  @integration
+  Scenario: SSO sign-in renders no credential form and no Forgot password link
+    Given the tenant runs on a social provider (NEXTAUTH_PROVIDER is not "email")
+    When I open /auth/signin
+    Then the credential form is not rendered
+    And there is no "Forgot password?" link
+
+  # --- Requesting a reset (/auth/forgot-password) ---
+
+  @integration
+  Scenario: Requesting a reset submits the entered email to the reset endpoint
+    Given I am on /auth/forgot-password
+    When I enter my email and submit
+    Then the app calls BetterAuth requestPasswordReset with that email
+
+  @integration
+  Scenario: Requesting a reset always shows a neutral confirmation
+    Given I am on /auth/forgot-password
+    When I submit any email address
+    Then I see a confirmation that a reset link was sent if an account exists
+    And the confirmation does not reveal whether the email is registered
+
+  @integration
+  Scenario: A failure to dispatch the request still shows the neutral confirmation
+    Given I am on /auth/forgot-password
+    And the reset endpoint returns an error
+    When I submit my email
+    Then I still see the same neutral confirmation
+    And no error is shown that could be used to enumerate accounts
+
+  # --- The reset email ---
+
+  @integration
+  Scenario: The reset email is sent through the existing email infrastructure
+    When a reset email is generated for a user
+    Then it is dispatched via the shared sendEmail mailer
+    And the subject names LangWatch and the password reset
+
+  @integration
+  Scenario: The reset email links to the reset page with a one-time token
+    When a reset email is generated with a token
+    Then the email body contains a button linking to /auth/reset-password with that token
+
+  @integration
+  Scenario: The reset email tells the user it expires and is safe to ignore
+    When a reset email is generated
+    Then the body says the link expires
+    And the body says the user can ignore the email if they did not request it
+
+  # --- Server wiring (BetterAuth emailAndPassword) ---
+
+  @integration
+  Scenario: sendResetPassword builds the reset link from BASE_HOST and the token
+    Given BetterAuth invokes the configured sendResetPassword callback with a user and token
+    Then the callback sends a reset email to that user
+    And the reset link is rooted at BASE_HOST and carries the token
+
+  @integration
+  Scenario: A successful reset revokes all of the user's existing sessions
+    Given BetterAuth invokes the configured onPasswordReset callback for a user
+    Then every existing session for that user is revoked
+
+  @integration
+  Scenario: Password reset endpoints are rate-limited to five attempts per hour
+    Given the BetterAuth rate-limit configuration
+    Then /request-password-reset allows at most 5 attempts per hour
+    And /reset-password allows at most 5 attempts per hour
+
+  # --- Setting the new password (/auth/reset-password) ---
+
+  @integration
+  Scenario: Submitting a valid new password with a token resets it and returns to sign-in
+    Given I open /auth/reset-password with a valid token
+    When I enter a new password and a matching confirmation and submit
+    Then the app calls BetterAuth resetPassword with the new password and token
+    And on success I see a confirmation and a link to sign in
+
+  @integration
+  Scenario: The reset form rejects passwords shorter than 8 characters
+    Given I open /auth/reset-password with a token
+    When I enter a new password shorter than 8 characters
+    Then I see a validation error and the reset endpoint is not called
+
+  @integration
+  Scenario: The reset form rejects a mismatched confirmation
+    Given I open /auth/reset-password with a token
+    When the password and confirmation do not match
+    Then I see a "Passwords don't match" error and the reset endpoint is not called
+
+  @integration
+  Scenario: An invalid or expired token surfaces an error and a way to retry
+    Given I open /auth/reset-password with an expired token
+    When I submit a valid new password
+    Then I see an error that the link is invalid or expired
+    And I see a link to request a new reset
+
+  @integration
+  Scenario: Opening the reset page without a token prompts a new request
+    Given I open /auth/reset-password with no token in the URL
+    Then I am told the link is invalid
+    And I see a link to request a new reset
+
+  # --- Cloud / SSO mode guard (existing invariant) ---
+
+  # Enforced by the existing BetterAuth `hooks.before` gate and the
+  # `emailAndPassword.enabled = NEXTAUTH_PROVIDER === "email"` flag: in
+  # cloud/SSO mode the reset endpoints throw EMAIL_PASSWORD_DISABLED. The
+  # `auth` instance binds NEXTAUTH_PROVIDER at module load, so exercising the
+  # non-email branch would need an env override the singleton can't take in a
+  # unit test (mirrors index.test.ts, which only asserts the live-env case).
+  # Covered end-to-end by the cloud deployment; left unbound here.
+  @regression @unimplemented
+  Scenario: Password reset is rejected in cloud/SSO mode
+    Given the tenant runs on NEXTAUTH_PROVIDER="auth0"
+    When a request hits /request-password-reset or /reset-password
+    Then BetterAuth rejects it with EMAIL_PASSWORD_DISABLED
+
+  # --- Full end-to-end (manual dogfood) ---
+
+  # Verified manually in the QA phase against a real database and a real
+  # SendGrid send: request a reset for a seeded credential user, open the
+  # emailed link, set a new password, and sign in with it. There is no
+  # automated full-stack auth e2e harness with email interception in this
+  # repo, so this stays @unimplemented and is proved via browser QA in the PR.
+  @e2e @unimplemented
+  Scenario: A user who forgot their password resets it and signs in with the new one
+    Given a credential user who forgot their password
+    When they request a reset, open the emailed link, and set a new password
+    Then their old password no longer works
+    And they can sign in with the new password

--- a/specs/auth/password-reset.feature
+++ b/specs/auth/password-reset.feature
@@ -79,17 +79,17 @@ Feature: Forgot / reset password on credential (email-mode) sign-in
     Then the body says the link expires
     And the body says the user can ignore the email if they did not request it
 
-  # --- Server wiring (BetterAuth emailAndPassword) ---
+  # --- Reset link, session revocation, and rate limiting ---
 
   @integration
-  Scenario: sendResetPassword builds the reset link from BASE_HOST and the token
-    Given BetterAuth invokes the configured sendResetPassword callback with a user and token
-    Then the callback sends a reset email to that user
-    And the reset link is rooted at BASE_HOST and carries the token
+  Scenario: The reset link is rooted at the deployment's own URL and carries the token
+    Given a password reset is generated for a user
+    Then the user is sent a reset email
+    And the reset link points at this deployment's reset page and carries the token
 
   @integration
   Scenario: A successful reset revokes all of the user's existing sessions
-    Given BetterAuth invokes the configured onPasswordReset callback for a user
+    Given a user completes a password reset
     Then every existing session for that user is revoked
 
   @integration


### PR DESCRIPTION
## What

Adds a self-service "forgot password" flow to the credential (email-mode) sign-in screen. Until now a user who forgot their password had no way to recover their account from the UI.

## Why

The sign-in screen had Email, Password, and "Register new account", but no way back in if you forgot your password. BetterAuth already mounts and rate-limits `/request-password-reset` and `/reset-password`, but both no-op with `RESET_PASSWORD_DISABLED` because `emailAndPassword.sendResetPassword` was never configured. So the endpoints existed but never sent anything.

## What changed

**Server wiring** (`src/server/better-auth/index.ts`)
- `sendResetPassword`: builds the reset link from `BASE_HOST` + the BetterAuth-issued token and sends it through the existing transactional mailer (`sendEmail`, which already powers invites via SendGrid or AWS SES). No new email infrastructure.
- `onPasswordReset`: revokes every existing session for the user after a successful reset (reuses `revokeAllSessionsForUser`), so a recovered account does not leave stale sessions alive.
- `resetPasswordTokenExpiresIn`: pinned to 1 hour so the token expiry and the email copy stay in sync.

**Reset email** (`src/server/mailer/resetPasswordEmail.tsx`)
- Same `@react-email` + `sendEmail` pattern as the invite email. Links to `/auth/reset-password?token=...`, states the 1-hour expiry, and says the email is safe to ignore if unrequested.

**Pages**
- `src/pages/auth/forgot-password.tsx`: enter your email, submit, see a neutral confirmation. The confirmation is identical whether or not the address is registered, so the form cannot be used to enumerate accounts (BetterAuth returns success either way, and transport errors are swallowed into the same message).
- `src/pages/auth/reset-password.tsx`: reads the token from the URL, validates the new password (min 8, matching confirmation), calls `resetPassword`, and confirms with a link to sign in. Invalid/expired token and missing token both surface a clear error with a link to request a new reset.
- `src/pages/auth/signin.tsx`: a "Forgot password?" link under the password field. It only renders in email mode (the credential form is not shown under an identity provider), so SSO deployments are unaffected.

**Scope guard.** Reset is credential-mode only. The existing cloud/SSO `hooks.before` gate keeps `/request-password-reset` and `/reset-password` blocked when `NEXTAUTH_PROVIDER` is not `email`, and the forgot-password page itself redirects SSO users back to sign in.

## Found during QA

Driving the real browser surfaced a bug the component tests could not: the global `useRequiredSession` guard bounces any route not in `publicRoutes` to sign-in, and the two new pages were missing from that allowlist, so clicking "Forgot password?" redirected straight back to sign-in. Fixed by adding both routes to `publicRoutes`, plus a regression test that drives the guard's redirect path (the page-render tests mount the component directly and bypass the guard).

A second review pass tightened three UI rough edges, all re-QA'd in the browser (screenshots below reflect the final state): the "Forgot password?" link now sits directly under the password input rather than in a separate row below the divider; the reset form's validation errors render below each field instead of cramped to the right of the horizontal control; and the success card's "Sign in" button uses the solid orange variant with white text, matching every other primary button.

## Deployment Impact

- **Env vars:** none added or changed. The flow reuses the existing email configuration (`SENDGRID_API_KEY`, or `USE_AWS_SES` + `AWS_REGION`, plus optional `EMAIL_DEFAULT_FROM`) and `BASE_HOST` for the reset link. No new variables.
- **Helm values:** none added or changed. No chart changes.
- **Default vanilla `helm install` (no overrides):** unchanged behavior, and no migrations. Password reset only activates in `NEXTAUTH_PROVIDER="email"` mode; in SSO/cloud mode the credential form and the "Forgot password?" link do not render and the BetterAuth reset endpoints stay blocked. If email is not configured, the link still appears but the request is a no-op that shows the same neutral confirmation (no email is sent), matching how every other email-dependent flow already degrades. Reset tokens live in the existing BetterAuth secondary storage (Redis) when configured, otherwise the `VerificationToken` table that already exists.
- **BYOC / dataplane:** none. This is control-plane UI plus a BetterAuth callback; no gateway, ClickHouse, or dataplane surface is touched.

## Unrelated drive-by fix

CI surfaced a pre-existing, freshly-triggered failure in `ee/licensing` (unrelated to this feature, in a non-required check). The license round-trip tests generate a license at a frozen `now` (2025-06-15) with a 1-year expiry, then validate it against the real clock; as of 2026-06-15 the fixture license is expired, so the four round-trip assertions started failing on every branch. Fixed by threading an optional `now` into `validateLicense` (defaults to the current time, so production behaviour is unchanged) and validating at the same frozen instant used for generation. A follow-up commit then converts `validateLicense` to a named-args object (`{ licenseKey, publicKey?, now? }`), since the two adjacent string params made the positional call sites error-prone, per the repo's named-parameter convention. Both kept in their own commits, separate from the feature.

## Spec

`specs/auth/password-reset.feature` (17 scenarios bound, 2 left `@unimplemented`: the cloud-mode gate, which the env-bound singleton cannot exercise in a unit test, and the full email-roundtrip e2e, which is covered by the manual QA below).

## Testing

- Email builder unit test: dispatch via `sendEmail`, tokenized reset link, expiry/ignore copy.
- BetterAuth wiring test: invokes the real `sendResetPassword` and `onPasswordReset` callbacks (mailer + revoke mocked) and asserts the URL, session revocation, token TTL, and the 5/hour rate limit.
- Page integration tests (React Testing Library, full tree): forgot-password (submit, neutral confirmation, error still neutral, SSO note), reset-password (valid reset, min-length, mismatch, invalid token, missing token), and the sign-in forgot link (present in email mode, absent in SSO mode).
- `pnpm typecheck`, `pnpm check:feature-parity`, and `biome lint` all clean.

## Screenshots

Dogfooded end to end against a real database and a real SendGrid send (a seeded credential user, reset link generated, new password set, signed in with it).

**Sign-in: the new entry point**

![Forgot password link on sign-in](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4866/signin/forgot-password-link.png)

**Request a reset (enumeration-safe confirmation)**

![Forgot password request form](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4866/forgot/01-request-form.png)

![Neutral confirmation](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4866/forgot/02-neutral-confirmation.png)

**Set a new password**

![Mismatch validation](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4866/reset/01-mismatch-validation.png)

![Password updated](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4866/reset/02-success.png)

**Unhappy paths**

![No token in the link](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4866/reset/03-no-token-invalid.png)

![Invalid or expired token](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4866/reset/04-invalid-token-error.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/auth/forgot-password` and `/auth/reset-password` for email/password sign-ins, including a “Forgot password?” link on the sign-in page.
  * Implemented neutral, non-enumerating confirmations, password validation, and invalid/expired token recovery with time-limited reset links.
  * In SSO mode, hides the reset form and shows provider-managed messaging; successful resets revoke existing sessions.
  * Added rate limiting for reset endpoints (max 5 attempts/hour).
* **Tests**
  * Added integration coverage for forgot/reset/sign-in behavior, plus unit tests for reset email and BetterAuth wiring, and a password-reset feature spec.
* **Documentation**
  * Updated email/self-hosting docs to include password reset usage in `NEXTAUTH_PROVIDER="email"` mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

