### PR TITLE
fix(observability): capture TTFT from Vercel msToFirstChunk and OpenLLMetry chunk events

### DIFF
--- a/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_constants.ts
+++ b/langwatch/src/server/app-layer/traces/canonicalisation/extractors/_constants.ts
@@ -37,6 +37,8 @@ export const ATTR_KEYS = {
   GEN_AI_USAGE_COMPLETION_TOKENS: "gen_ai.usage.completion_tokens",
   // Time to first token in milliseconds, relative to the span start.
   GEN_AI_SERVER_TIME_TO_FIRST_TOKEN: "gen_ai.server.time_to_first_token",
+  // Vercel AI SDK time to first token, a duration in milliseconds.
+  AI_RESPONSE_MS_TO_FIRST_CHUNK: "ai.response.msToFirstChunk",
   GEN_AI_CONVERSATION_ID: "gen_ai.conversation.id",
   GEN_AI_AGENT_ID: "gen_ai.agent.id",
   GEN_AI_AGENT_DESCRIPTION: "gen_ai.agent.description",

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryCostComputation.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/__tests__/traceSummaryCostComputation.unit.test.ts
@@ -398,6 +398,69 @@ describe("applySpanToSummary token timing from OTel instrumentation events (@reg
       expect(result.timeToLastTokenMs).toBe(1900);
     });
   });
+
+  describe("when span has llm.content.completion.chunk events (OpenLLMetry / traceloop)", () => {
+    it("computes timeToFirstToken from the earliest chunk and timeToLastToken from the latest", () => {
+      const span = createTestSpan({
+        startTimeUnixMs: 1000,
+        endTimeUnixMs: 3000,
+        durationMs: 2000,
+        events: [
+          {
+            name: "llm.content.completion.chunk",
+            timeUnixMs: 1150,
+            attributes: {},
+          },
+          {
+            name: "llm.content.completion.chunk",
+            timeUnixMs: 2700,
+            attributes: {},
+          },
+        ],
+      });
+
+      const result = applySpanToSummary({ state: createInitState(), span });
+
+      expect(result.timeToFirstTokenMs).toBe(150);
+      expect(result.timeToLastTokenMs).toBe(1700);
+    });
+  });
+
+  describe("when span has ai.response.msToFirstChunk attribute (Vercel AI SDK)", () => {
+    it("computes timeToFirstToken from the duration attribute when no events exist", () => {
+      const span = createTestSpan({
+        startTimeUnixMs: 1000,
+        endTimeUnixMs: 4000,
+        durationMs: 3000,
+        events: [],
+        spanAttributes: {
+          "ai.response.msToFirstChunk": 1716,
+        },
+      });
+
+      const result = applySpanToSummary({ state: createInitState(), span });
+
+      expect(result.timeToFirstTokenMs).toBe(1716);
+    });
+
+    it("prefers event-based TTFT over the duration attribute", () => {
+      const span = createTestSpan({
+        startTimeUnixMs: 1000,
+        endTimeUnixMs: 4000,
+        durationMs: 3000,
+        events: [
+          { name: "ai.stream.firstChunk", timeUnixMs: 1250, attributes: {} },
+        ],
+        spanAttributes: {
+          "ai.response.msToFirstChunk": 1716,
+        },
+      });
+
+      const result = applySpanToSummary({ state: createInitState(), span });
+
+      expect(result.timeToFirstTokenMs).toBe(250);
+    });
+  });
 });
 
 describe("applySpanToSummary cache + reasoning token roll-up", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-cost.service.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/projections/services/span-cost.service.ts
@@ -6,6 +6,7 @@ import type { NormalizedSpan } from "../../schemas/spans";
 
 export const FIRST_TOKEN_EVENTS = new Set([
   "gen_ai.content.chunk",
+  "llm.content.completion.chunk",
   "first_token",
   "llm.first_token",
   "ai.stream.firstChunk",
@@ -14,6 +15,7 @@ export const FIRST_TOKEN_EVENTS = new Set([
 
 export const LAST_TOKEN_EVENTS = new Set([
   "gen_ai.content.chunk",
+  "llm.content.completion.chunk",
   "last_token",
   "llm.last_token",
   "ai.stream.finish",
@@ -194,6 +196,17 @@ export class SpanCostService {
       );
       if (attrTtft !== null && attrTtft >= 0) {
         timeToFirstToken = attrTtft;
+      }
+    }
+
+    if (timeToFirstToken === null) {
+      // Vercel AI SDK reports TTFT as a duration attribute and emits no
+      // stream event, so it needs its own fallback.
+      const msToFirstChunk = coerceToNumber(
+        span.spanAttributes[ATTR_KEYS.AI_RESPONSE_MS_TO_FIRST_CHUNK],
+      );
+      if (msToFirstChunk !== null && msToFirstChunk >= 0) {
+        timeToFirstToken = msToFirstChunk;
       }
     }
 


### PR DESCRIPTION
## What

Capture Time to First Token from two signals the new ClickHouse trace-processing pipeline was silently dropping:

- **Vercel AI SDK** reports TTFT as the `ai.response.msToFirstChunk` duration attribute and emits no stream event. The pipeline only read the `ai.stream.firstChunk` event, so real Vercel spans (e.g. opencode) got no TTFT.
- **OpenLLMetry / traceloop** emit `llm.content.completion.chunk` stream events. The pipeline only had the newer `gen_ai.content.chunk` name, so those spans got no TTFT.

## Why

The TTFT column shipped in #4796 is fed by the event-sourcing fold (`SpanCostService.extractTokenTiming`). The legacy `otel.traces.ts` ingestion path already handles both signals above, but the new pipeline did not, so the two paths were out of parity and the published [TTFT tutorial](https://langwatch.ai/docs/integration/python/tutorials/tracking-time-to-first-token) listed automatic-capture sources the column did not actually populate. This restores parity and makes those rows true, so Vercel AI SDK and OpenLLMetry users see TTFT in the table, the trace drawer, and Analytics without code changes.

## Changes

- Add `llm.content.completion.chunk` to `FIRST_TOKEN_EVENTS` and `LAST_TOKEN_EVENTS`.
- Add an `ai.response.msToFirstChunk` attribute fallback in `extractTokenTiming` (a duration in ms, used after stream events and the `gen_ai.server.time_to_first_token` semconv attribute, before the LangWatch `timestamps.first_token_at` fallback).
- New `AI_RESPONSE_MS_TO_FIRST_CHUNK` attribute key.

Stream events still win over the attribute when both are present, matching the existing precedence for the semconv attribute.

## Tests

Three new cases in `traceSummaryCostComputation.unit.test.ts`: OpenLLMetry chunk events (first + last token), Vercel attribute with no events, and event-over-attribute precedence. Full file passes (28 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Vercel AI SDK's time-to-first-token metric for improved streaming performance tracking.
  * Extended streaming event support to include OpenLLMetry/traceloop completion events for more accurate token timing calculations.

* **Improvements**
  * Enhanced token timing accuracy by supporting additional duration attributes as fallback values when stream-based timing is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->