### PR TITLE
backoffice(users): support /ops/backoffice/users?q=<id> deep link

### DIFF
--- a/langwatch/ee/admin/backoffice/resources/UsersView.tsx
+++ b/langwatch/ee/admin/backoffice/resources/UsersView.tsx
@@ -21,6 +21,7 @@ import { Menu } from "~/components/ui/menu";
 import { Switch } from "~/components/ui/switch";
 import { toaster } from "~/components/ui/toaster";
 import NextLink from "~/utils/compat/next-link";
+import { useRouter } from "~/utils/compat/next-router";
 import { impersonateUser } from "../adminClient";
 import {
   BackofficeTable,
@@ -63,8 +64,17 @@ export interface AdminUser {
 const PAGE_SIZE = 25;
 
 export default function UsersView() {
+  const router = useRouter();
+  // Deep-link support: /ops/backoffice/users?q=<orgId|userId|email>. The
+  // RefChipList on this view already builds those URLs for Org / Project
+  // chips, and Customer Pulse links to this page from its registry. Seed the
+  // search input once from the URL so an external link lands on the matching
+  // row instead of an empty search.
+  const initialQueryRef = useRef<string>(
+    typeof router.query.q === "string" ? router.query.q : "",
+  );
   const [page, setPage] = useState(1);
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState(initialQueryRef.current);
   const [debouncedSearch] = useDebounce(search, 300);
   const [editing, setEditing] = useState<AdminUser | null>(null);
   // Impersonation is driven by a dialog opened from the row-action menu so


### PR DESCRIPTION
## Summary

UsersView is the only Backoffice resource view that ignores `?q=` on mount. Land on `/ops/backoffice/users?q=organization_xxx` from a sibling tab and the search input stays empty even though the backend filter already handles org id / user id / email / project id.

OrganizationsView and ProjectsView both seed their input the same way already; this mirrors the pattern (`initialQueryRef` + `useState(initialQueryRef.current)`).

## Why

Customer Pulse's `/registry` deep-links to `/ops/backoffice/users?q=<orgId>` when you click an org id in the table - the langwatch-saas PR for that is langwatch/langwatch-saas#587. Without this fix the link lands you on an unfiltered Users page.

Pair with the existing RefChipList chips on the same view, which already link out as `/ops/backoffice/${resource}?q=${ref.id}` for Org / Project columns.

## Test plan

- [ ] Visit `https://app.langwatch.ai/ops/backoffice/users?q=organization_xxx` (with a real org id) - search input pre-fills, table shows users for that org.
- [ ] Clear the input - results expand to all users.
- [ ] Type a new query - normal debounce kicks in, no flicker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deep-linking search queries in the Users view. URLs with search parameters now pre-populate the search field, enabling users to share filtered user lists and create bookmarks for frequently used filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->