### PR TITLE
perf(clickhouse): add time predicate to trace-event reads to stop stored_spans cold scans

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/span-storage.clickhouse.repository.integration.test.ts
@@ -11,9 +11,10 @@
  * and this suite confirms a normal trace read still returns correct results
  * under the cap (ordering, latest-version dedup, full payload preserved).
  */
+
+import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { ClickHouseClient } from "@clickhouse/client";
 import {
   startTestContainers,
   stopTestContainers,
@@ -126,7 +127,8 @@ beforeAll(async () => {
 afterAll(async () => {
   if (ch) {
     await ch.exec({
-      query: "ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}",
+      query:
+        "ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}",
       query_params: { tenantId },
     });
   }
@@ -296,6 +298,117 @@ describe("SpanStorageClickHouseRepository single-trace reads (integration)", () 
       ]);
       expect(events.find((e) => e.event_type === "exception")).toBeUndefined();
       expect(events.find((e) => e.event_type === "stale.skip")).toBeUndefined();
+    });
+  });
+
+  // The drawer fires the events read off entry points that drop the
+  // `occurredAtMs` URL hint (back-stack, conversation jumps, deep links), and
+  // worker callers never carry one. Without a hint the read used to walk every
+  // weekly `stored_spans` partition (incl. cold S3). The reader now seeds the
+  // partition window from the trace's own `trace_summaries.OccurredAt`, and an
+  // empty result is authoritative (no unbounded rescan).
+  describe("given the events are read without an occurredAtMs hint", () => {
+    const hintlessTenantId = `test-span-hintless-${nanoid()}`;
+    const withEventsTraceId = `trace-${nanoid()}`;
+    const noEventsTraceId = `trace-${nanoid()}`;
+    const summaryOccurredAt = new Date(base);
+
+    async function insertTraceSummary(tid: string) {
+      await ch.insert({
+        table: "trace_summaries",
+        values: [
+          {
+            ProjectionId: `proj-${nanoid()}`,
+            TenantId: hintlessTenantId,
+            TraceId: tid,
+            Version: "v1",
+            OccurredAt: summaryOccurredAt,
+            CreatedAt: summaryOccurredAt,
+            UpdatedAt: summaryOccurredAt,
+          },
+        ],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+    }
+
+    beforeAll(async () => {
+      await ch.insert({
+        table: "stored_spans",
+        values: [
+          {
+            ...makeEventRow("hintless-span-1", [
+              { ts: new Date(base + 5), name: "span.start", attrs: { p: "1" } },
+            ]),
+            TenantId: hintlessTenantId,
+            TraceId: withEventsTraceId,
+          },
+        ],
+        format: "JSONEachRow",
+        clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+      });
+      await insertTraceSummary(withEventsTraceId);
+      await insertTraceSummary(noEventsTraceId);
+    });
+
+    afterAll(async () => {
+      await ch.exec({
+        query:
+          "ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}",
+        query_params: { tenantId: hintlessTenantId },
+      });
+      await ch.exec({
+        query:
+          "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+        query_params: { tenantId: hintlessTenantId },
+      });
+    });
+
+    describe("when the trace's occurrence time is recorded in trace_summaries", () => {
+      it("resolves the partition window from trace_summaries and still returns the events", async () => {
+        const events = await repo.getTraceEventsByTraceId({
+          tenantId: hintlessTenantId,
+          traceId: withEventsTraceId,
+        });
+
+        expect(events.map((e) => e.name)).toEqual(["span.start"]);
+      });
+
+      it("returns no events for a trace without any, without an unbounded rescan", async () => {
+        // Wrap the client so we can see every stored_spans query the read
+        // issues. With the window resolved from trace_summaries, an empty
+        // result is final: exactly one stored_spans read, all of them
+        // partition-bounded (carry the StartTime predicate / fromMs param).
+        const storedSpansQueries: { query: string; params: unknown }[] = [];
+        const recordingClient = new Proxy(ch, {
+          get(target, prop, receiver) {
+            if (prop === "query") {
+              return (args: { query: string; query_params?: unknown }) => {
+                if (args.query.includes("stored_spans")) {
+                  storedSpansQueries.push({
+                    query: args.query,
+                    params: args.query_params,
+                  });
+                }
+                return (target as ClickHouseClient).query(args as never);
+              };
+            }
+            return Reflect.get(target, prop, receiver);
+          },
+        }) as ClickHouseClient;
+        const recordingRepo = new SpanStorageClickHouseRepository(
+          async () => recordingClient,
+        );
+
+        const events = await recordingRepo.getTraceEventsByTraceId({
+          tenantId: hintlessTenantId,
+          traceId: noEventsTraceId,
+        });
+
+        expect(events).toEqual([]);
+        expect(storedSpansQueries).toHaveLength(1);
+        expect(storedSpansQueries[0]!.query).toContain("StartTime >=");
+      });
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -1036,6 +1036,71 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     );
   }
 
+  /**
+   * Resolve a trace's occurrence time from `trace_summaries` so the Events.*
+   * reads below can prune `stored_spans` partitions even when the caller never
+   * threaded an `occurredAtMs` hint — back-stack / conversation-jump / deep-link
+   * drawer opens that dropped it, and worker callers that never had one.
+   *
+   * `trace_summaries` is `ORDER BY (TenantId, TraceId)`, so this is a sort-key
+   * point seek over a couple of granules of small columns. That is far cheaper
+   * than the alternative it replaces: letting the Events.* read fall back to an
+   * unbounded `stored_spans` scan that walks every weekly partition, including
+   * the cold S3 tier. Returns `undefined` only when the trace isn't in
+   * `trace_summaries` at all (orphan / not-yet-projected), where the read keeps
+   * its previous unbounded behaviour.
+   */
+  private async resolveTraceOccurredAtMs(
+    tenantId: string,
+    traceId: string,
+  ): Promise<number | undefined> {
+    const client = await this.resolveClient(tenantId);
+    const result = await client.query({
+      query: `
+        SELECT toUnixTimestamp64Milli(min(OccurredAt)) AS occurredAtMs
+        FROM trace_summaries
+        WHERE TenantId = {tenantId:String}
+          AND TraceId = {traceId:String}
+      `,
+      query_params: { tenantId, traceId },
+      format: "JSONEachRow",
+    });
+    const rows = (await result.json()) as Array<{
+      occurredAtMs: string | number | null;
+    }>;
+    const raw = rows[0]?.occurredAtMs;
+    if (raw === null || raw === undefined) return undefined;
+    // `min` over no matching rows yields the epoch default (0); treat that — and
+    // any non-positive value — as "unknown" so the caller stays unbounded.
+    const ms = typeof raw === "string" ? Number(raw) : raw;
+    return Number.isFinite(ms) && ms > 0 ? ms : undefined;
+  }
+
+  /**
+   * Partition-pruned execution for the single-trace Events.* reads. The window
+   * comes from the trace's own occurrence time — the caller's hint when present,
+   * otherwise resolved from `trace_summaries` — so an empty result is
+   * authoritative: the trace has no matching events within its ±2-day span
+   * window, and we do NOT rescan unbounded.
+   *
+   * That unbounded-on-empty rescan (what {@link withPartitionHint} does) was
+   * itself a cold S3 partition walk: a trace legitimately *without* events made
+   * every such read scan the whole table. We only scan unbounded when the trace
+   * time is genuinely unknown (the trace isn't in `trace_summaries`).
+   */
+  private async readTraceEvents<T>(
+    {
+      tenantId,
+      traceId,
+      occurredAtMs,
+    }: { tenantId: string; traceId: string } & OccurredAtHint,
+    run: (window: PartitionWindow | undefined) => Promise<T>,
+  ): Promise<T> {
+    const hintMs =
+      occurredAtMs ?? (await this.resolveTraceOccurredAtMs(tenantId, traceId));
+    return run(partitionWindowFor({ occurredAtMs: hintMs }));
+  }
+
   async getTraceEventsByTraceId({
     tenantId,
     traceId,
@@ -1050,9 +1115,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     );
 
     try {
-      return await withPartitionHint<DerivedTraceEvent[]>(
-        { occurredAtMs },
-        (rows) => rows.length === 0,
+      return await this.readTraceEvents<DerivedTraceEvent[]>(
+        { tenantId, traceId, occurredAtMs },
         async (window) => {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);
@@ -1131,9 +1195,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     );
 
     try {
-      return await withPartitionHint<ElasticSearchEvent[]>(
-        { occurredAtMs },
-        (rows) => rows.length === 0,
+      return await this.readTraceEvents<ElasticSearchEvent[]>(
+        { tenantId, traceId, occurredAtMs },
         async (window) => {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);
@@ -1205,9 +1268,8 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
     );
 
     try {
-      return await withPartitionHint<ElasticSearchEvent[]>(
-        { occurredAtMs },
-        (rows) => rows.length === 0,
+      return await this.readTraceEvents<ElasticSearchEvent[]>(
+        { tenantId, traceId, occurredAtMs },
         async (window) => {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);


### PR DESCRIPTION
## Evidence

From the last 24h of prod ClickHouse logs (cold-scan signal, `coldScan:true` on the app streams):

- `stored_spans` cold scans totalled ~700/day. The single largest uncovered shape is the trace-events read (`Events.*` columns: `event_timestamp`, `event_name`, `event_attrs`): **659 cold scans/24h**, p50 556ms / p95 969ms.
- Every cold-scanning instance carried only `paramKeys=['tenantId','traceId']` with **no `StartTime` predicate in the SQL** and small read bytes (38KB-520KB). The latency is pure S3 partition-walk overhead, not data volume: the read opens parts across every weekly partition (incl. the cold S3 tier) to look for one trace's events.

(The other large cold-scan shapes, `event_log` ~4.2k and `stored_log_records` ~110, are already covered by separate open PRs.)

## Suspected cause

The three single-trace `Events.*` reads on `SpanStorageClickHouseRepository` (`getTraceEventsByTraceId`, `getEventsByTraceId`, `getSpanEvents`) prune `stored_spans` partitions from an `occurredAtMs` hint via `withPartitionHint`. They cold-scan for two reasons:

1. **Missing hint.** The trace-list click path seeds `occurredAtMs`, but other drawer entry points (back-stack, conversation jumps, deep links/refresh that drop the `t` URL param) and worker callers reach the read with no hint, so the window is empty and the scan is unbounded.
2. **Unbounded-on-empty fallback.** `withPartitionHint` retries unbounded when the hinted read returns zero rows. For an events read, an empty result is the common, legitimate "this trace has no events" case, so every event-less trace triggered a full-table walk even when the hint was present.

## Proposed fix

Resolve the trace's occurrence time from `trace_summaries` (a `(TenantId, TraceId)` sort-key point seek over small columns) when no `occurredAtMs` is supplied, build the same +/-2 day `StartTime` window, and treat an empty result as authoritative instead of rescanning unbounded.

- New `resolveTraceOccurredAtMs` does the cheap seek; returns `undefined` only when the trace is not in `trace_summaries` (orphan / not-yet-projected), where the read keeps its previous unbounded behaviour.
- New `readTraceEvents` wraps the three event reads: window from `occurredAtMs ?? resolved`, no unbounded fallback.
- The common warm path (hint already supplied by the trace-list click) is unchanged and pays no extra query.

## Expected impact

- The 659/day unbounded `stored_spans` event reads become a tiny `trace_summaries` seek plus a partition-pruned `stored_spans` read. Cost (S3 GETs from walking cold partitions), not user-visible latency, is the target; response time should also improve on the tail since far fewer parts are opened.
- Event-less traces no longer trigger a full-table rescan.
- Trade-off: a trace whose events fall outside +/-2 days of its own `OccurredAt` (i.e. a >2-day-duration trace) would no longer be found via the removed unbounded fallback. This window is the same assumption the existing hinted path already relies on, and such traces are vanishingly rare in practice.

## Test plan

`span-storage.clickhouse.repository.integration.test.ts` (real ClickHouse testcontainer, production `stored_spans`/`trace_summaries` schema), `pnpm test:integration` — all 7 pass:
- existing event-read correctness (ordering, exception handling, latest-version dedup) is preserved;
- new: with `occurredAtMs` omitted and the trace recorded in `trace_summaries`, the window is resolved from the summary and the events are still returned;
- new: an event-less trace returns `[]` after exactly **one** `stored_spans` read, and that read carries the `StartTime` predicate (asserted by wrapping the client and recording its queries) — proving the unbounded rescan is gone.

Related unit suites (`span-storage.clickhouse.repository.unit.test.ts`, `trace-dedup-oom-safety.unit.test.ts`) still pass (67 tests).

## EXPLAIN check

`EXPLAIN INDEXES` on `stored_spans` for a large tenant, with and without the +/-2 day `StartTime` window (tenant id redacted):

**Without window (today's unbounded path):**
```
ReadFromMergeTree (stored_spans)
  MinMax     Condition: true        Parts: 256/256   Granules: 128800/128800
  Partition  Condition: true        Parts: 256/256   Granules: 128800/128800
  PrimaryKey Condition: (TenantId in [...])  -> final read  Parts: 109  Granules: 7497
```

**With the +/-2 day window:**
```
ReadFromMergeTree (stored_spans)
  MinMax     Condition: (StartTime in window)              Parts: 32/258   Granules: 2058/128802
  Partition  Condition: (toYearWeek(StartTime) in [week])  Parts: 32/32    Granules: 2058/2058
  PrimaryKey Condition: (TenantId in [...])  -> final read  Parts: 18   Granules: 220
```

The window prunes candidate parts from 256 -> 32 at the partition/MinMax level (whole weekly partitions, including cold S3, dropped before any part is opened), and the final read from 109 parts to 18. The actual event read additionally filters `TraceId`, pruning further. Reviewer should re-run before merge.

## Notes

Advisory PR from the ClickHouse slow-query optimisation pass. Read-only investigation against prod CloudWatch logs and the read-only `/ops` EXPLAIN endpoint; no prod data was modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace event retrieval reliability by implementing partition-aware query execution that prevents unbounded data scans.
  * Enhanced behavior when partition hints are unavailable, ensuring bounded result windows are applied correctly.

* **Tests**
  * Added integration tests for trace event reads to validate correct partition window resolution and bounded query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->