### PR TITLE
fix(studio): code-node input drag sync, flexible inputs, run UX polish

### DIFF
--- a/langwatch/src/components/evaluators/CodeEvaluatorEditorDrawer.tsx
+++ b/langwatch/src/components/evaluators/CodeEvaluatorEditorDrawer.tsx
@@ -30,6 +30,7 @@ import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { CodeEditor } from "~/optimization_studio/components/code/CodeEditorModal";
 import { rewriteCodeSignature } from "~/optimization_studio/utils/codeSignature";
 import {
+  CODE_EVALUATOR_OUTPUT_FIELDS,
   type CodeEvaluatorConfig,
   DEFAULT_CODE_EVALUATOR_CONFIG,
 } from "~/server/evaluators/codeEvaluator";
@@ -92,9 +93,8 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
   const [inputs, setInputs] = useState<EditableField[]>(
     DEFAULT_CODE_EVALUATOR_CONFIG.inputs.map((f) => ({ ...f })),
   );
-  const [outputs, setOutputs] = useState<EditableField[]>(
-    DEFAULT_CODE_EVALUATOR_CONFIG.outputs.map((f) => ({ ...f })),
-  );
+  // Outputs are the fixed evaluator contract, not user-editable.
+  const outputs: EditableField[] = CODE_EVALUATOR_OUTPUT_FIELDS;
   const [mappings, setMappings] = useState<Record<string, UIFieldMapping>>(
     mappingsConfig?.initialMappings ?? {},
   );
@@ -115,9 +115,6 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
     if (config?.code) setCode(config.code);
     if (config?.inputs?.length) {
       setInputs(config.inputs.map((f) => ({ ...f })));
-    }
-    if (config?.outputs?.length) {
-      setOutputs(config.outputs.map((f) => ({ ...f })));
     }
   }, [evaluatorQuery.data]);
 
@@ -207,7 +204,7 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
     const config: CodeEvaluatorConfig = {
       code,
       inputs: validFields(inputs),
-      outputs: validFields(outputs),
+      outputs: CODE_EVALUATOR_OUTPUT_FIELDS.map((f) => ({ ...f })),
     };
     if (isEditing) {
       updateMutation.mutate({
@@ -233,7 +230,6 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
     !!name.trim() &&
     code.trim() !== "" &&
     validFields(inputs).length > 0 &&
-    validFields(outputs).length > 0 &&
     !isPending &&
     !isLoadingEvaluator;
 
@@ -245,7 +241,6 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
     inputs,
     setInputs: setInputsAndSyncCode,
     outputs,
-    setOutputs,
     mappings,
     handleMappingChange,
     mappingsConfig,
@@ -415,13 +410,63 @@ function CodeEvaluatorFormFields({ form }: { form: CodeEvaluatorFormState }) {
           testIdPrefix="code-evaluator-input"
         />
       )}
-      <FieldListEditor
-        label="Outputs"
-        fields={form.outputs}
-        setFields={form.setOutputs}
-        testIdPrefix="code-evaluator-output"
-      />
+      <OutputContractInfo />
     </>
+  );
+}
+
+/** Short, human-readable purpose of each fixed evaluator output field. */
+const OUTPUT_FIELD_DESCRIPTIONS: Record<string, string> = {
+  passed: "Whether the check passed (true or false).",
+  score: "A numeric score for the result.",
+  label: "A classification label for the result.",
+  details: "A human-readable explanation of the result.",
+};
+
+/**
+ * The evaluator output contract is fixed (passed, score, label, details), just
+ * like an evaluator end node. Rather than a dynamic field editor that could
+ * declare an output the code never returns, the drawer explains the fields the
+ * function may return; whichever the code returns become the result.
+ */
+function OutputContractInfo() {
+  return (
+    <VStack align="stretch" gap={2}>
+      <Text fontSize="sm" fontWeight="semibold">
+        Outputs
+      </Text>
+      <Text fontSize="xs" color="fg.muted">
+        Return a dictionary from your function with any of these fields.
+        Whichever you return become the evaluation result.
+      </Text>
+      <VStack
+        align="stretch"
+        gap={1.5}
+        borderWidth="1px"
+        borderColor="border"
+        borderRadius="md"
+        padding={3}
+      >
+        {CODE_EVALUATOR_OUTPUT_FIELDS.map((field) => (
+          <HStack key={field.identifier} gap={2} align="baseline">
+            <Text
+              fontSize="sm"
+              fontFamily="mono"
+              fontWeight="medium"
+              data-testid={`code-evaluator-output-field-${field.identifier}`}
+            >
+              {field.identifier}
+            </Text>
+            <Text fontSize="xs" color="fg.muted" fontFamily="mono">
+              {field.type}
+            </Text>
+            <Text fontSize="xs" color="fg.muted">
+              {OUTPUT_FIELD_DESCRIPTIONS[field.identifier]}
+            </Text>
+          </HStack>
+        ))}
+      </VStack>
+    </VStack>
   );
 }
 

--- a/langwatch/src/components/evaluators/CodeEvaluatorEditorDrawer.tsx
+++ b/langwatch/src/components/evaluators/CodeEvaluatorEditorDrawer.tsx
@@ -28,6 +28,7 @@ import {
 } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { CodeEditor } from "~/optimization_studio/components/code/CodeEditorModal";
+import { rewriteCodeSignature } from "~/optimization_studio/utils/codeSignature";
 import {
   type CodeEvaluatorConfig,
   DEFAULT_CODE_EVALUATOR_CONFIG,
@@ -119,6 +120,18 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
       setOutputs(config.outputs.map((f) => ({ ...f })));
     }
   }, [evaluatorQuery.data]);
+
+  // Keep the Python __call__ signature in sync with the declared inputs, the
+  // same way the studio code node does, so adding or removing an input field
+  // rewrites the entrypoint and the saved evaluator never calls it with an
+  // unexpected keyword. Only the signature line changes; the body is kept.
+  const setInputsAndSyncCode = (next: EditableField[]) => {
+    setInputs(next);
+    const valid = validFields(next);
+    if (valid.length > 0) {
+      setCode((current) => rewriteCodeSignature(current, valid));
+    }
+  };
 
   const handleMappingChange = (
     identifier: string,
@@ -230,7 +243,7 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
     code,
     setCode,
     inputs,
-    setInputs,
+    setInputs: setInputsAndSyncCode,
     outputs,
     setOutputs,
     mappings,

--- a/langwatch/src/components/evaluators/__tests__/CodeEvaluatorEditorDrawer.integration.test.tsx
+++ b/langwatch/src/components/evaluators/__tests__/CodeEvaluatorEditorDrawer.integration.test.tsx
@@ -6,7 +6,13 @@
  * evaluator can actually be edited from the evaluators page and the workbench.
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -124,6 +130,45 @@ describe("CodeEvaluatorEditorDrawer", () => {
         });
         expect(screen.getByText("Create evaluator")).toBeInTheDocument();
         expect(screen.getByTestId("code-evaluator-name")).toHaveValue("");
+      });
+    });
+
+    describe("when an input field is added or removed", () => {
+      /** @scenario Code evaluator inputs stay in sync with the signature */
+      it("rewrites the __call__ signature when an input is added", async () => {
+        render(<CodeEvaluatorEditorDrawer open />, { wrapper: Wrapper });
+        await waitFor(() => {
+          expect(screen.getByText("New Code Evaluator")).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId("code-evaluator-input-add"));
+        fireEvent.change(
+          screen.getByTestId("code-evaluator-input-identifier-2"),
+          { target: { value: "context" } },
+        );
+
+        expect(screen.getByTestId("code-editor")).toHaveTextContent(
+          "def __call__(self, output: str = None, expected_output: str = None, context: str = None):",
+        );
+      });
+
+      it("rewrites the __call__ signature when an input is removed", async () => {
+        render(<CodeEvaluatorEditorDrawer open />, { wrapper: Wrapper });
+        await waitFor(() => {
+          expect(screen.getByText("New Code Evaluator")).toBeInTheDocument();
+        });
+
+        fireEvent.click(
+          screen.getByRole("button", {
+            name: "Remove inputs expected_output",
+          }),
+        );
+
+        // Only the signature line is rewritten; the body is preserved (so a
+        // reference to expected_output may remain in the body, which is fine).
+        expect(screen.getByTestId("code-editor")).toHaveTextContent(
+          "def __call__(self, output: str = None):",
+        );
       });
     });
   });

--- a/langwatch/src/components/evaluators/__tests__/CodeEvaluatorEditorDrawer.integration.test.tsx
+++ b/langwatch/src/components/evaluators/__tests__/CodeEvaluatorEditorDrawer.integration.test.tsx
@@ -133,8 +133,28 @@ describe("CodeEvaluatorEditorDrawer", () => {
       });
     });
 
+    describe("when the drawer shows the outputs section", () => {
+      /** @scenario Code evaluator outputs are the fixed evaluator contract */
+      it("presents the fixed evaluator result fields and no output editor", async () => {
+        render(<CodeEvaluatorEditorDrawer open />, { wrapper: Wrapper });
+        await waitFor(() => {
+          expect(screen.getByText("New Code Evaluator")).toBeInTheDocument();
+        });
+
+        for (const field of ["passed", "score", "label", "details"]) {
+          expect(
+            screen.getByTestId(`code-evaluator-output-field-${field}`),
+          ).toBeInTheDocument();
+        }
+        // Outputs are the fixed contract: there is no add-output control.
+        expect(
+          screen.queryByTestId("code-evaluator-output-add"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
     describe("when an input field is added or removed", () => {
-      /** @scenario Code evaluator inputs stay in sync with the signature */
+      /** @scenario Code evaluator input changes keep runs valid */
       it("rewrites the __call__ signature when an input is added", async () => {
         render(<CodeEvaluatorEditorDrawer open />, { wrapper: Wrapper });
         await waitFor(() => {

--- a/langwatch/src/optimization_studio/__tests__/registry.test.ts
+++ b/langwatch/src/optimization_studio/__tests__/registry.test.ts
@@ -72,7 +72,11 @@ describe("Optimization Studio Registry", () => {
       const codeParam = code.parameters?.find((p) => p.identifier === "code");
 
       expect(codeParam).toBeDefined();
-      expect(codeParam?.value).toContain("def __call__(self, input: str)");
+      // Inputs default to None so an unconnected handle does not raise a
+      // missing-argument error at run time.
+      expect(codeParam?.value).toContain(
+        "def __call__(self, input: str = None)",
+      );
     });
 
     it("has code parameter returning output key", () => {

--- a/langwatch/src/optimization_studio/components/ChatWindow.tsx
+++ b/langwatch/src/optimization_studio/components/ChatWindow.tsx
@@ -9,15 +9,13 @@ import {
 } from "@chakra-ui/react";
 import type { Edge, Node } from "@xyflow/react";
 import { useCallback, useEffect, useState } from "react";
-import { Play, Send } from "react-feather";
+import { Send } from "react-feather";
 import { useForm } from "react-hook-form";
 import { SmallLabel } from "~/components/SmallLabel";
 import { Dialog } from "~/components/ui/dialog";
 import { InputGroup } from "~/components/ui/input-group";
-import { Tooltip } from "~/components/ui/tooltip";
 import { api } from "~/utils/api";
 import { useOrganizationTeamProject } from "../../hooks/useOrganizationTeamProject";
-import { usePostEvent } from "../hooks/usePostEvent";
 import { useWorkflowExecution } from "../hooks/useWorkflowExecution";
 import { useWorkflowStore } from "../hooks/useWorkflowStore";
 import { getEntryInputs } from "../utils/nodeUtils";
@@ -32,46 +30,6 @@ interface ChatWindowProps {
   edges: Edge[];
   executionStatus?: string;
 }
-
-export const PlaygroundButton = ({
-  nodes,
-  edges,
-  executionStatus,
-}: {
-  nodes: Node[];
-  edges: Edge[];
-  executionStatus: string;
-}) => {
-  const { socketStatus } = usePostEvent();
-  const isDisabled = socketStatus !== "connected";
-  const { playgroundOpen, setPlaygroundOpen } = useWorkflowStore((state) => ({
-    playgroundOpen: state.playgroundOpen,
-    setPlaygroundOpen: state.setPlaygroundOpen,
-  }));
-
-  return (
-    <>
-      <Tooltip content={isDisabled ? "Studio is not connected" : undefined}>
-        <Button
-          onClick={() => setPlaygroundOpen(true)}
-          variant="outline"
-          size="sm"
-          background="bg"
-          disabled={isDisabled}
-        >
-          <Play size={16} /> Playground
-        </Button>
-      </Tooltip>
-      <ChatWindow
-        open={playgroundOpen}
-        onClose={() => setPlaygroundOpen(false)}
-        nodes={nodes}
-        edges={edges}
-        executionStatus={executionStatus}
-      />
-    </>
-  );
-};
 
 export const ChatWindow = ({
   open,

--- a/langwatch/src/optimization_studio/components/OptimizationStudio.tsx
+++ b/langwatch/src/optimization_studio/components/OptimizationStudio.tsx
@@ -12,7 +12,6 @@ import {
   Background,
   BackgroundVariant,
   Controls,
-  Panel as FlowPanel,
   ReactFlow,
   type ReactFlowProps,
   ReactFlowProvider,
@@ -52,7 +51,6 @@ import { PostEventProvider, usePostEvent } from "../hooks/usePostEvent";
 import { useWorkflowStore } from "../hooks/useWorkflowStore";
 import { isConnectionAllowed } from "../utils/controlFlow";
 import { AutoSave } from "./AutoSave";
-import { PlaygroundButton } from "./ChatWindow";
 import { StudioNodeDrawer } from "./drawers/StudioNodeDrawer";
 import DefaultEdge from "./Edge";
 import { Evaluate } from "./Evaluate";
@@ -364,14 +362,6 @@ export default function OptimizationStudio() {
                               marginBottom: "15px",
                             }}
                           />
-
-                          <FlowPanel position="bottom-right">
-                            <PlaygroundButton
-                              nodes={nodes}
-                              edges={edges}
-                              executionStatus={executionStatus ?? ""}
-                            />
-                          </FlowPanel>
                         </OptimizationStudioCanvas>
                       </DragDropArea>
                     </Panel>

--- a/langwatch/src/optimization_studio/components/RunUntilHereDialog.tsx
+++ b/langwatch/src/optimization_studio/components/RunUntilHereDialog.tsx
@@ -198,6 +198,12 @@ export function RunUntilHereDialog() {
                         [field.identifier]: e.target.value,
                       }));
                     }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        runWithValues(values);
+                      }
+                    }}
                   />
                 </Field.Root>
               ))}

--- a/langwatch/src/optimization_studio/components/__tests__/RunUntilHereDialog.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/__tests__/RunUntilHereDialog.integration.test.tsx
@@ -221,6 +221,30 @@ describe("given the run-until-here dialog", () => {
     });
   });
 
+  describe("when Enter is pressed in a field", () => {
+    /** @scenario Pressing Enter runs the partial execution */
+    it("starts the scoped execution with the typed values", async () => {
+      renderDialog();
+
+      const questionInput = await screen.findByTestId(
+        "run-until-here-input-question",
+      );
+      await waitFor(() => {
+        expect(questionInput).toHaveValue("What is up?");
+      });
+      fireEvent.change(questionInput, {
+        target: { value: "typed then enter" },
+      });
+      fireEvent.keyDown(questionInput, { key: "Enter" });
+
+      expect(mockStartWorkflowExecution).toHaveBeenCalledWith({
+        untilNodeId: "node-7",
+        inputs: [{ question: "typed then enter", context: "ctx-1" }],
+      });
+      expect(useRunUntilHereDialogStore.getState().untilNodeId).toBeUndefined();
+    });
+  });
+
   describe("when the entry point has no dataset attached", () => {
     /** @scenario Select dataset value is only offered with an attached dataset */
     it("offers no Select dataset value button", async () => {

--- a/langwatch/src/optimization_studio/components/code/CodeEditorModal.tsx
+++ b/langwatch/src/optimization_studio/components/code/CodeEditorModal.tsx
@@ -300,6 +300,7 @@ export function CodeEditor({
   const { project } = useOrganizationTeamProject();
   const { colorMode } = useColorMode();
   const providersRef = useRef<PythonProviderHandle | null>(null);
+  const editorRef = useRef<MonacoEditorInstance | null>(null);
 
   // Live-fetched secret names; passed into the completion provider so
   // `secrets.<Tab>` suggests names the moment they appear in Settings.
@@ -335,6 +336,19 @@ export function CodeEditor({
     });
   }, [secretNames, inputFields, outputFields]);
 
+  // Monaco is seeded from defaultValue on mount only, so an inline editor would
+  // otherwise show a stale signature when an external change rewrites the code
+  // (e.g. adding or removing an input field rewrites the entrypoint signature).
+  // Reflect those changes into the editor, but skip while it is focused: live
+  // edits already flow through onChange, and setValue would jump the cursor.
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || editor.hasTextFocus()) return;
+    if (editor.getValue() !== code) {
+      editor.setValue(code);
+    }
+  }, [code]);
+
   useEffect(() => {
     return () => {
       providersRef.current?.dispose();
@@ -366,6 +380,7 @@ export function CodeEditor({
             // ignore corrupted state
           }
         }
+        editorRef.current = editor;
         editor.focus();
         onEditorMount?.(editor, monaco);
 

--- a/langwatch/src/optimization_studio/components/properties/EndPropertiesPanel.tsx
+++ b/langwatch/src/optimization_studio/components/properties/EndPropertiesPanel.tsx
@@ -13,12 +13,17 @@ import { BasePropertiesPanel } from "./BasePropertiesPanel";
  * four - fixed identifiers and types, no add/remove/rename. Every
  * result is optional: connect any combination (a pass/fail, a score,
  * both, or neither) and unconnected results are simply omitted.
+ *
+ * `details` comes first: it carries the reasoning, and for an LLM judge
+ * the reasoning should precede the verdict so the model reasons before
+ * deciding. It also keeps the scaffold's reasoning -> details edge from
+ * crossing the verdict edge.
  */
 export const EVALUATOR_RESULT_FIELDS: Field[] = [
+  { identifier: "details", type: "str", optional: true },
   { identifier: "passed", type: "bool", optional: true },
   { identifier: "score", type: "float", optional: true },
   { identifier: "label", type: "str", optional: true },
-  { identifier: "details", type: "str", optional: true },
 ];
 
 const EVALUATOR_RESULT_TYPE_LABELS: Record<string, string> = {
@@ -59,8 +64,8 @@ export function EndPropertiesPanel({ node: initialNode }: { node: Node<End> }) {
   // connections survive (identifiers keep their handles); free-form fields
   // users created by hand are replaced by the contract. The check also
   // reconciles optionality and order, so older nodes that pinned passed/score
-  // as required (or kept details/label in the wrong spot) normalize to the
-  // all-optional, label-before-details vocabulary.
+  // as required (or kept the fields in the wrong spot) normalize to the
+  // all-optional, details-first vocabulary.
   useEffect(() => {
     if (!isEvaluator) return;
     const current = node.data.inputs ?? [];

--- a/langwatch/src/optimization_studio/components/properties/__tests__/EndPropertiesPanel.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/properties/__tests__/EndPropertiesPanel.integration.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  *
  * Evaluator End node: the results are a fixed four-field vocabulary
- * (passed, score, label, details), all optional - normalized on open and
+ * (details, passed, score, label), all optional - normalized on open and
  * explained field by field (not editable rows), with a connect-a-result
  * nudge. Non-evaluator end nodes keep their free-form results, rendered
  * through the shared VariablesSection.
@@ -156,8 +156,8 @@ describe("EndPropertiesPanel", () => {
       ).not.toBeInTheDocument();
     });
 
-    /** @scenario Evaluator End node lists label before details */
-    it("orders the result fields passed, score, label, details", () => {
+    /** @scenario Evaluator End node lists details first */
+    it("orders the result fields details, passed, score, label", () => {
       mockEdges = [
         {
           id: "e1",
@@ -179,7 +179,7 @@ describe("EndPropertiesPanel", () => {
         .filter((t) =>
           ["passed", "score", "label", "details"].includes(t ?? ""),
         );
-      expect(order).toEqual(["passed", "score", "label", "details"]);
+      expect(order).toEqual(["details", "passed", "score", "label"]);
     });
 
     /** @scenario All evaluator results are optional */

--- a/langwatch/src/optimization_studio/hooks/__tests__/usePostEvent.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/__tests__/usePostEvent.unit.test.ts
@@ -2,9 +2,9 @@
  * @vitest-environment jsdom
  */
 import { renderHook } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
-import type { WorkflowStore } from "../useWorkflowStore";
+import { describe, expect, it, vi } from "vitest";
 import type { StudioServerEvent } from "../../types/events";
+import type { WorkflowStore } from "../useWorkflowStore";
 
 // Mock toaster
 vi.mock("../../../components/ui/toaster", () => ({
@@ -132,66 +132,73 @@ describe("useHandleServerMessage", () => {
     });
   });
 
-  describe("when execution_state_change errors", () => {
-    /** @scenario An errored run opens the node that failed */
-    it("selects the failing node instead of the run target", () => {
-      const store = createMockStore({
-        getWorkflow: vi.fn().mockReturnValue({
-          state: { execution: { until_node_id: "end-node" } },
-          nodes: [
-            { id: "end-node", data: {} },
-            {
-              id: "llm-node",
-              data: {
-                execution_state: { status: "error", error: "Invalid messages" },
+  describe("given run-until-here ends in error", () => {
+    describe("when one upstream node carries the error", () => {
+      /** @scenario An errored run opens the node that failed */
+      it("selects the failing node instead of the run target", () => {
+        const store = createMockStore({
+          getWorkflow: vi.fn().mockReturnValue({
+            state: { execution: { until_node_id: "end-node" } },
+            nodes: [
+              { id: "end-node", data: {} },
+              {
+                id: "llm-node",
+                data: {
+                  execution_state: {
+                    status: "error",
+                    error: "Invalid messages",
+                  },
+                },
               },
-            },
-          ],
-          edges: [],
-        }),
-      } as unknown as Partial<WorkflowStore>);
+            ],
+            edges: [],
+          }),
+        } as unknown as Partial<WorkflowStore>);
 
-      const { result } = renderHook(() =>
-        useHandleServerMessage({
-          workflowStore: store,
-          alertOnComponent: vi.fn(),
-        }),
-      );
+        const { result } = renderHook(() =>
+          useHandleServerMessage({
+            workflowStore: store,
+            alertOnComponent: vi.fn(),
+          }),
+        );
 
-      result.current({
-        type: "execution_state_change",
-        payload: {
-          execution_state: { status: "error", error: "Invalid messages" },
-        },
-      } as StudioServerEvent);
+        result.current({
+          type: "execution_state_change",
+          payload: {
+            execution_state: { status: "error", error: "Invalid messages" },
+          },
+        } as StudioServerEvent);
 
-      expect(store.setSelectedNode).toHaveBeenCalledWith("llm-node");
-      expect(store.setSelectedNode).not.toHaveBeenCalledWith("end-node");
-      expect(store.setPropertiesExpanded).toHaveBeenCalledWith(true);
+        expect(store.setSelectedNode).toHaveBeenCalledWith("llm-node");
+        expect(store.setSelectedNode).not.toHaveBeenCalledWith("end-node");
+        expect(store.setPropertiesExpanded).toHaveBeenCalledWith(true);
+      });
     });
 
-    it("falls back to the run target when no single node carries the error", () => {
-      const store = createMockStore({
-        getWorkflow: vi.fn().mockReturnValue({
-          state: { execution: { until_node_id: "end-node" } },
-          nodes: [{ id: "end-node", data: {} }],
-          edges: [],
-        }),
-      } as unknown as Partial<WorkflowStore>);
+    describe("when no single node carries the error", () => {
+      it("falls back to the run target", () => {
+        const store = createMockStore({
+          getWorkflow: vi.fn().mockReturnValue({
+            state: { execution: { until_node_id: "end-node" } },
+            nodes: [{ id: "end-node", data: {} }],
+            edges: [],
+          }),
+        } as unknown as Partial<WorkflowStore>);
 
-      const { result } = renderHook(() =>
-        useHandleServerMessage({
-          workflowStore: store,
-          alertOnComponent: vi.fn(),
-        }),
-      );
+        const { result } = renderHook(() =>
+          useHandleServerMessage({
+            workflowStore: store,
+            alertOnComponent: vi.fn(),
+          }),
+        );
 
-      result.current({
-        type: "execution_state_change",
-        payload: { execution_state: { status: "error", error: "boom" } },
-      } as StudioServerEvent);
+        result.current({
+          type: "execution_state_change",
+          payload: { execution_state: { status: "error", error: "boom" } },
+        } as StudioServerEvent);
 
-      expect(store.setSelectedNode).toHaveBeenCalledWith("end-node");
+        expect(store.setSelectedNode).toHaveBeenCalledWith("end-node");
+      });
     });
   });
 });

--- a/langwatch/src/optimization_studio/hooks/__tests__/usePostEvent.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/__tests__/usePostEvent.unit.test.ts
@@ -131,4 +131,67 @@ describe("useHandleServerMessage", () => {
       expect(store.setPropertiesExpanded).not.toHaveBeenCalled();
     });
   });
+
+  describe("when execution_state_change errors", () => {
+    /** @scenario An errored run opens the node that failed */
+    it("selects the failing node instead of the run target", () => {
+      const store = createMockStore({
+        getWorkflow: vi.fn().mockReturnValue({
+          state: { execution: { until_node_id: "end-node" } },
+          nodes: [
+            { id: "end-node", data: {} },
+            {
+              id: "llm-node",
+              data: {
+                execution_state: { status: "error", error: "Invalid messages" },
+              },
+            },
+          ],
+          edges: [],
+        }),
+      } as unknown as Partial<WorkflowStore>);
+
+      const { result } = renderHook(() =>
+        useHandleServerMessage({
+          workflowStore: store,
+          alertOnComponent: vi.fn(),
+        }),
+      );
+
+      result.current({
+        type: "execution_state_change",
+        payload: {
+          execution_state: { status: "error", error: "Invalid messages" },
+        },
+      } as StudioServerEvent);
+
+      expect(store.setSelectedNode).toHaveBeenCalledWith("llm-node");
+      expect(store.setSelectedNode).not.toHaveBeenCalledWith("end-node");
+      expect(store.setPropertiesExpanded).toHaveBeenCalledWith(true);
+    });
+
+    it("falls back to the run target when no single node carries the error", () => {
+      const store = createMockStore({
+        getWorkflow: vi.fn().mockReturnValue({
+          state: { execution: { until_node_id: "end-node" } },
+          nodes: [{ id: "end-node", data: {} }],
+          edges: [],
+        }),
+      } as unknown as Partial<WorkflowStore>);
+
+      const { result } = renderHook(() =>
+        useHandleServerMessage({
+          workflowStore: store,
+          alertOnComponent: vi.fn(),
+        }),
+      );
+
+      result.current({
+        type: "execution_state_change",
+        payload: { execution_state: { status: "error", error: "boom" } },
+      } as StudioServerEvent);
+
+      expect(store.setSelectedNode).toHaveBeenCalledWith("end-node");
+    });
+  });
 });

--- a/langwatch/src/optimization_studio/hooks/usePostEvent.tsx
+++ b/langwatch/src/optimization_studio/hooks/usePostEvent.tsx
@@ -263,12 +263,9 @@ export const useHandleServerMessage = ({
           setWorkflowExecutionState(message.payload.execution_state);
 
           // Auto-select the target node and expand properties when a
-          // "Run workflow until here" execution completes, so the user
+          // "Run workflow until here" execution succeeds, so the user
           // can see the results without clicking manually.
-          if (
-            message.payload.execution_state?.status === "success" ||
-            message.payload.execution_state?.status === "error"
-          ) {
+          if (message.payload.execution_state?.status === "success") {
             const untilNodeId = getWorkflow().state.execution?.until_node_id;
             if (untilNodeId) {
               workflowStore.setSelectedNode(untilNodeId);
@@ -277,6 +274,19 @@ export const useHandleServerMessage = ({
           }
 
           if (message.payload.execution_state?.status === "error") {
+            // Surface the node that actually failed (e.g. an LLM with no
+            // messages) instead of the run target, whose stale output would
+            // otherwise hide the error. Fall back to the target when no
+            // single node carries the error.
+            const failedNode = getWorkflow().nodes.find(
+              (node) => node.data.execution_state?.status === "error",
+            );
+            const focusNodeId =
+              failedNode?.id ?? getWorkflow().state.execution?.until_node_id;
+            if (focusNodeId) {
+              workflowStore.setSelectedNode(focusNodeId);
+              workflowStore.setPropertiesExpanded(true);
+            }
             alertOnError(message.payload.execution_state.error);
             stopWorkflowIfRunning(message.payload.execution_state.error);
           }

--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.ts
@@ -27,6 +27,7 @@ import {
   isBranchConnectionOrigin,
   nodeHasGateInput,
 } from "../utils/controlFlow";
+import { rewriteCodeSignature } from "../utils/codeSignature";
 import { hasDSLChanged } from "../utils/dslUtils";
 import { canConvergeOnInput } from "../utils/edgeConvergence";
 import { findLowestAvailableName, nameToId } from "../utils/nodeUtils";
@@ -363,60 +364,16 @@ export const updateCodeClassName = (
   );
 };
 
-const typesMap: Record<Field["type"], string> = {
-  str: "str",
-  int: "int",
-  float: "float",
-  bool: "bool",
-  image: "dspy.Image",
-  list: "list",
-  "list[str]": "list[str]",
-  "list[float]": "list[float]",
-  "list[int]": "list[int]",
-  "list[bool]": "list[bool]",
-  dict: "dict[str, Any]",
-  json_schema: "Any",
-  chat_messages: "list[dict[str, Any]]",
-  signature: "dspy.Signature",
-  llm: "Any",
-  prompting_technique: "Any",
-  dataset: "Any",
-  code: "str",
-};
-
 export const updateInputFields = (parameters: Field[], inputs: Field[]) => {
   if (inputs.length === 0) {
     return parameters;
   }
 
-  return parameters.map((p) => {
-    if (p.identifier === "code") {
-      // Match either the new idiomatic-Python entrypoint (`__call__`)
-      // or the legacy/torch-style `forward` and preserve whichever the
-      // customer's code already uses — silently rewriting a legacy
-      // `forward` into `__call__` on field-add would surprise users
-      // and break diffs in their commit history.
-      // Every input defaults to None so an unconnected handle does not
-      // raise "missing a required argument" at run time - the engine omits
-      // unwired inputs from the call, and a bare `input: str` would then
-      // fail. Defaulting keeps partial runs and optional inputs flexible.
-      let code = (p.value as string).replace(
-        /def (__call__|forward)\([\s\S]*?\):/,
-        (_match, methodName: string) =>
-          `def ${methodName}(self, ${inputs
-            .map((i) => `${i.identifier}: ${typesMap[i.type]} = None`)
-            .join(", ")}):`,
-      );
-      if (code.includes(": Any") && !code.includes("from typing import Any")) {
-        code = `from typing import Any\n${code}`;
-      }
-      return {
-        ...p,
-        value: code,
-      };
-    }
-    return p;
-  });
+  return parameters.map((p) =>
+    p.identifier === "code"
+      ? { ...p, value: rewriteCodeSignature(p.value as string, inputs) }
+      : p,
+  );
 };
 
 const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.ts
@@ -21,13 +21,13 @@ import type {
   LLMConfig,
   Workflow,
 } from "../types/dsl";
+import { rewriteCodeSignature } from "../utils/codeSignature";
 import {
   GATE_FIELD,
   GATE_HANDLE_ID,
   isBranchConnectionOrigin,
   nodeHasGateInput,
 } from "../utils/controlFlow";
-import { rewriteCodeSignature } from "../utils/codeSignature";
 import { hasDSLChanged } from "../utils/dslUtils";
 import { canConvergeOnInput } from "../utils/edgeConvergence";
 import { findLowestAvailableName, nameToId } from "../utils/nodeUtils";

--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.ts
@@ -53,7 +53,6 @@ export type State = Workflow & {
     | "optimizations"
     | "closed"
     | undefined;
-  playgroundOpen: boolean;
   /** True while the user is dragging a node. Used to suppress drawer opening during drag. */
   isDraggingNode: boolean;
   /** The node ID confirmed by onNodeClick (genuine click, not drag). Gates drawer opening. */
@@ -156,7 +155,6 @@ export type WorkflowStore = State & {
   setOpenResultsPanelRequest: (
     request: "evaluations" | "optimizations" | "closed" | undefined,
   ) => void;
-  setPlaygroundOpen: (open: boolean) => void;
   setIsDraggingNode: (dragging: boolean) => void;
   setClickedNodeId: (id: string | null) => void;
   stopWorkflowIfRunning: (message: string | undefined) => void;
@@ -198,7 +196,6 @@ export const initialState: State = {
   lastCommittedWorkflow: undefined,
   currentVersionId: undefined,
   openResultsPanelRequest: undefined,
-  playgroundOpen: false,
   isDraggingNode: false,
   clickedNodeId: null,
   branchConnectionInProgress: false,
@@ -399,11 +396,15 @@ export const updateInputFields = (parameters: Field[], inputs: Field[]) => {
       // customer's code already uses — silently rewriting a legacy
       // `forward` into `__call__` on field-add would surprise users
       // and break diffs in their commit history.
+      // Every input defaults to None so an unconnected handle does not
+      // raise "missing a required argument" at run time - the engine omits
+      // unwired inputs from the call, and a bare `input: str` would then
+      // fail. Defaulting keeps partial runs and optional inputs flexible.
       let code = (p.value as string).replace(
         /def (__call__|forward)\([\s\S]*?\):/,
         (_match, methodName: string) =>
           `def ${methodName}(self, ${inputs
-            .map((i) => `${i.identifier}: ${typesMap[i.type]}`)
+            .map((i) => `${i.identifier}: ${typesMap[i.type]} = None`)
             .join(", ")}):`,
       );
       if (code.includes(": Any") && !code.includes("from typing import Any")) {
@@ -603,7 +604,28 @@ export const store = (
           branchConnectionInProgress: false,
           branchConnectionSourceId: null,
           nodes: nodes.map((n) =>
-            n.id === targetNode.id ? { ...n, data: { ...n.data, inputs } } : n,
+            n.id === targetNode.id
+              ? {
+                  ...n,
+                  data: {
+                    ...n.data,
+                    inputs,
+                    // A code node's entrypoint signature is derived from its
+                    // inputs, so the new gate field has to be threaded into
+                    // the parameters too or the engine calls __call__ with an
+                    // unexpected `gate` keyword. setNode does the same.
+                    ...(n.type === "code"
+                      ? {
+                          parameters: updateInputFields(
+                            (n.data as { parameters?: Field[] }).parameters ??
+                              [],
+                            inputs,
+                          ),
+                        }
+                      : {}),
+                  },
+                }
+              : n,
           ),
           edges: addEdge({ ...connection, type: "default" }, currentEdges),
         });
@@ -716,22 +738,30 @@ export const store = (
       .find((node) => node.id === target)
       ?.data.inputs?.map((input) => input.identifier);
     set({
-      nodes: nodes.map((node) =>
-        node.id === target
-          ? {
-              ...node,
-              data: {
-                ...node.data,
-                inputs: existingInputs?.includes(newHandle)
-                  ? node.data.inputs
-                  : [
-                      ...(node.data.inputs ?? []),
-                      { identifier: newHandle, type },
-                    ],
-              } as Component,
-            }
-          : node,
-      ),
+      nodes: nodes.map((node) => {
+        if (node.id !== target) return node;
+        const newInputs = existingInputs?.includes(newHandle)
+          ? (node.data.inputs ?? [])
+          : [...(node.data.inputs ?? []), { identifier: newHandle, type }];
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            inputs: newInputs,
+            // Keep a code node's entrypoint signature in sync with the
+            // freshly wired input, mirroring setNode - otherwise the engine
+            // passes a keyword the __call__ signature does not accept.
+            ...(node.type === "code"
+              ? {
+                  parameters: updateInputFields(
+                    (node.data as { parameters?: Field[] }).parameters ?? [],
+                    newInputs as Field[],
+                  ),
+                }
+              : {}),
+          } as Component,
+        };
+      }),
       edges: [
         ...edges,
         {
@@ -1098,9 +1128,6 @@ export const store = (
   },
   setOpenResultsPanelRequest: (request) => {
     set({ openResultsPanelRequest: request });
-  },
-  setPlaygroundOpen: (open: boolean) => {
-    set({ playgroundOpen: open });
   },
   setIsDraggingNode: (dragging: boolean) => {
     set({

--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
 import type { Edge, Node } from "@xyflow/react";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createStore, type StoreApi } from "zustand";
 import {
   removeInvalidEdges,
@@ -593,7 +593,7 @@ describe("workflowStoreCore", () => {
     });
   });
 
-  describe("code signature stays in sync when an input is added by dragging", () => {
+  describe("given a code node", () => {
     let testStore: StoreApi<WorkflowStore>;
 
     beforeEach(() => {
@@ -627,55 +627,57 @@ describe("workflowStoreCore", () => {
       return params.find((p) => p.identifier === "code")?.value as string;
     };
 
-    // Regression: dropping an If/Else branch onto a code node's gate added
-    // the `gate` input but left __call__ untouched, so the engine called it
-    // with an unexpected `gate` keyword.
-    /** @scenario Dropping an If/Else branch on a code node adds the gate to the signature */
-    it("threads a gate dropped from an If/Else branch into the __call__ signature", () => {
-      testStore.getState().setNodes([
-        makeNode({
-          id: "ifelse",
-          type: "if_else",
-          outputs: [
-            { identifier: "true", type: "bool" },
-            { identifier: "false", type: "bool" },
-          ],
-        }),
-        codeNode(),
-      ]);
-      testStore.getState().setEdges([]);
+    describe("when an input is added by dragging", () => {
+      // Regression: dropping an If/Else branch onto a code node's gate added
+      // the `gate` input but left __call__ untouched, so the engine called it
+      // with an unexpected `gate` keyword.
+      /** @scenario Dropping an If/Else branch on a code node adds the gate to the signature */
+      it("threads a gate dropped from an If/Else branch into the __call__ signature", () => {
+        testStore.getState().setNodes([
+          makeNode({
+            id: "ifelse",
+            type: "if_else",
+            outputs: [
+              { identifier: "true", type: "bool" },
+              { identifier: "false", type: "bool" },
+            ],
+          }),
+          codeNode(),
+        ]);
+        testStore.getState().setEdges([]);
 
-      testStore.getState().onConnect({
-        source: "ifelse",
-        sourceHandle: "outputs.true",
-        target: "code1",
-        targetHandle: "inputs.gate",
+        testStore.getState().onConnect({
+          source: "ifelse",
+          sourceHandle: "outputs.true",
+          target: "code1",
+          targetHandle: "inputs.gate",
+        });
+
+        expect(codeOf("code1")).toContain(
+          "def __call__(self, input: str = None, gate: bool = None):",
+        );
       });
 
-      expect(codeOf("code1")).toContain(
-        "def __call__(self, input: str = None, gate: bool = None):",
-      );
-    });
+      // Regression: wiring an output to a code node's empty handle area created
+      // a new input without rewriting __call__, so the run failed the same way.
+      /** @scenario Wiring a new input handle adds it to the signature */
+      it("threads a freshly wired input into the __call__ signature", () => {
+        testStore.getState().setNodes([
+          makeNode({
+            id: "src",
+            type: "signature",
+            outputs: [{ identifier: "answer", type: "str" }],
+          }),
+          codeNode(),
+        ]);
+        testStore.getState().setEdges([]);
 
-    // Regression: wiring an output to a code node's empty handle area created
-    // a new input without rewriting __call__, so the run failed the same way.
-    /** @scenario Wiring a new input handle adds it to the signature */
-    it("threads a freshly wired input into the __call__ signature", () => {
-      testStore.getState().setNodes([
-        makeNode({
-          id: "src",
-          type: "signature",
-          outputs: [{ identifier: "answer", type: "str" }],
-        }),
-        codeNode(),
-      ]);
-      testStore.getState().setEdges([]);
+        testStore.getState().edgeConnectToNewHandle("src", "answer", "code1");
 
-      testStore.getState().edgeConnectToNewHandle("src", "answer", "code1");
-
-      expect(codeOf("code1")).toContain(
-        "def __call__(self, input: str = None, answer: str = None):",
-      );
+        expect(codeOf("code1")).toContain(
+          "def __call__(self, input: str = None, answer: str = None):",
+        );
+      });
     });
   });
 

--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
@@ -357,17 +357,12 @@ describe("workflowStoreCore", () => {
 
         expect(state.edges).toHaveLength(2);
 
-        const incomingEdge = state.edges.find(
-          (e) => e.source === "upstream",
-        );
+        const incomingEdge = state.edges.find((e) => e.source === "upstream");
         expect(incomingEdge?.target).toBe("renamed_middle");
 
-        const outgoingEdge = state.edges.find(
-          (e) => e.target === "downstream",
-        );
+        const outgoingEdge = state.edges.find((e) => e.target === "downstream");
         expect(outgoingEdge?.source).toBe("renamed_middle");
       });
-
     });
 
     describe("when updating a node without renaming", () => {
@@ -403,7 +398,9 @@ describe("workflowStoreCore", () => {
 
         const state = testStore.getState();
         const nodeA = state.nodes.find((n) => n.id === "nodeA");
-        expect(nodeA?.data.inputs).toEqual([{ identifier: "input", type: "str" }]);
+        expect(nodeA?.data.inputs).toEqual([
+          { identifier: "input", type: "str" },
+        ]);
         // Edge survives because nodeA.outputs and nodeB.inputs still match the handles
         expect(state.edges).toHaveLength(1);
       });
@@ -426,7 +423,9 @@ describe("workflowStoreCore", () => {
 
         let state = testStore.getState();
         let nodeA = state.nodes.find((n) => n.id === "nodeA");
-        expect((nodeA?.data as Record<string, unknown>)["localConfig"]).toEqual({ someKey: "someValue" });
+        expect((nodeA?.data as Record<string, unknown>)["localConfig"]).toEqual(
+          { someKey: "someValue" },
+        );
 
         // Now clear it by passing undefined
         testStore.getState().setNode({
@@ -436,9 +435,13 @@ describe("workflowStoreCore", () => {
 
         state = testStore.getState();
         nodeA = state.nodes.find((n) => n.id === "nodeA");
-        expect((nodeA?.data as Record<string, unknown>)["localConfig"]).toBeUndefined();
+        expect(
+          (nodeA?.data as Record<string, unknown>)["localConfig"],
+        ).toBeUndefined();
         // Array fields remain untouched
-        expect(nodeA?.data.inputs).toEqual([{ identifier: "input", type: "str" }]);
+        expect(nodeA?.data.inputs).toEqual([
+          { identifier: "input", type: "str" },
+        ]);
       });
     });
 
@@ -490,9 +493,9 @@ describe("workflowStoreCore", () => {
         expect(
           params.find((p) => p.identifier === "some_param")?.value,
         ).toEqual({ ref: "new_name" });
-        expect(
-          params.find((p) => p.identifier === "other_param")?.value,
-        ).toBe("plain_value");
+        expect(params.find((p) => p.identifier === "other_param")?.value).toBe(
+          "plain_value",
+        );
       });
     });
   });
@@ -540,20 +543,24 @@ describe("workflowStoreCore", () => {
 
     it("rewrites __call__ signature when the new default is in use", () => {
       const result = updateInputFields(
-        codeParam(`class Code:\n    def __call__(self, input: str):\n        return {"output": input}\n`),
+        codeParam(
+          `class Code:\n    def __call__(self, input: str):\n        return {"output": input}\n`,
+        ),
         [
           { identifier: "input", type: "str" },
           { identifier: "context", type: "str" },
         ],
       );
       expect(result[0]?.value).toContain(
-        "def __call__(self, input: str, context: str):",
+        "def __call__(self, input: str = None, context: str = None):",
       );
     });
 
     it("rewrites legacy forward signature without converting it to __call__", () => {
       const result = updateInputFields(
-        codeParam(`class Code:\n    def forward(self, input: str):\n        return {"output": input}\n`),
+        codeParam(
+          `class Code:\n    def forward(self, input: str):\n        return {"output": input}\n`,
+        ),
         [
           { identifier: "input", type: "str" },
           { identifier: "context", type: "str" },
@@ -561,9 +568,114 @@ describe("workflowStoreCore", () => {
       );
       // Method name preserved as-is; only the param list is rewritten.
       expect(result[0]?.value).toContain(
-        "def forward(self, input: str, context: str):",
+        "def forward(self, input: str = None, context: str = None):",
       );
       expect(result[0]?.value).not.toContain("def __call__");
+    });
+
+    // An unconnected input is omitted from the engine call, so a bare
+    // `input: str` would raise "missing a required argument". Defaulting
+    // every input to None keeps partial runs and optional inputs working.
+    /** @scenario Code inputs default to None */
+    it("defaults every input to None so unconnected inputs do not error", () => {
+      const result = updateInputFields(
+        codeParam(
+          `class Code:\n    def __call__(self, input: str):\n        return {"output": input}\n`,
+        ),
+        [
+          { identifier: "input", type: "str" },
+          { identifier: "gate", type: "bool" },
+        ],
+      );
+      expect(result[0]?.value).toContain(
+        "def __call__(self, input: str = None, gate: bool = None):",
+      );
+    });
+  });
+
+  describe("code signature stays in sync when an input is added by dragging", () => {
+    let testStore: StoreApi<WorkflowStore>;
+
+    beforeEach(() => {
+      testStore = createStore<WorkflowStore>(storeCreator as any);
+    });
+
+    const codeNode = () =>
+      makeNode({
+        id: "code1",
+        type: "code",
+        inputs: [{ identifier: "input", type: "str" }],
+        outputs: [{ identifier: "output", type: "str" }],
+        parameters: [
+          {
+            identifier: "code",
+            type: "code",
+            value:
+              'class Code:\n    def __call__(self, input: str = None):\n        return {"output": input}\n',
+          },
+        ],
+      });
+
+    const codeOf = (nodeId: string) => {
+      const node = testStore.getState().nodes.find((n) => n.id === nodeId);
+      const params =
+        (
+          node?.data as {
+            parameters?: Array<{ identifier: string; value?: unknown }>;
+          }
+        ).parameters ?? [];
+      return params.find((p) => p.identifier === "code")?.value as string;
+    };
+
+    // Regression: dropping an If/Else branch onto a code node's gate added
+    // the `gate` input but left __call__ untouched, so the engine called it
+    // with an unexpected `gate` keyword.
+    /** @scenario Dropping an If/Else branch on a code node adds the gate to the signature */
+    it("threads a gate dropped from an If/Else branch into the __call__ signature", () => {
+      testStore.getState().setNodes([
+        makeNode({
+          id: "ifelse",
+          type: "if_else",
+          outputs: [
+            { identifier: "true", type: "bool" },
+            { identifier: "false", type: "bool" },
+          ],
+        }),
+        codeNode(),
+      ]);
+      testStore.getState().setEdges([]);
+
+      testStore.getState().onConnect({
+        source: "ifelse",
+        sourceHandle: "outputs.true",
+        target: "code1",
+        targetHandle: "inputs.gate",
+      });
+
+      expect(codeOf("code1")).toContain(
+        "def __call__(self, input: str = None, gate: bool = None):",
+      );
+    });
+
+    // Regression: wiring an output to a code node's empty handle area created
+    // a new input without rewriting __call__, so the run failed the same way.
+    /** @scenario Wiring a new input handle adds it to the signature */
+    it("threads a freshly wired input into the __call__ signature", () => {
+      testStore.getState().setNodes([
+        makeNode({
+          id: "src",
+          type: "signature",
+          outputs: [{ identifier: "answer", type: "str" }],
+        }),
+        codeNode(),
+      ]);
+      testStore.getState().setEdges([]);
+
+      testStore.getState().edgeConnectToNewHandle("src", "answer", "code1");
+
+      expect(codeOf("code1")).toContain(
+        "def __call__(self, input: str = None, answer: str = None):",
+      );
     });
   });
 

--- a/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
+++ b/langwatch/src/optimization_studio/hooks/workflowStoreCore.unit.test.ts
@@ -423,9 +423,9 @@ describe("workflowStoreCore", () => {
 
         let state = testStore.getState();
         let nodeA = state.nodes.find((n) => n.id === "nodeA");
-        expect((nodeA?.data as Record<string, unknown>)["localConfig"]).toEqual(
-          { someKey: "someValue" },
-        );
+        expect((nodeA?.data as Record<string, unknown>).localConfig).toEqual({
+          someKey: "someValue",
+        });
 
         // Now clear it by passing undefined
         testStore.getState().setNode({
@@ -436,7 +436,7 @@ describe("workflowStoreCore", () => {
         state = testStore.getState();
         nodeA = state.nodes.find((n) => n.id === "nodeA");
         expect(
-          (nodeA?.data as Record<string, unknown>)["localConfig"],
+          (nodeA?.data as Record<string, unknown>).localConfig,
         ).toBeUndefined();
         // Array fields remain untouched
         expect(nodeA?.data.inputs).toEqual([

--- a/langwatch/src/optimization_studio/registry.ts
+++ b/langwatch/src/optimization_studio/registry.ts
@@ -76,7 +76,7 @@ const code: Code = {
       identifier: "code",
       type: "code",
       value: `class Code:
-    def __call__(self, ${defaultInput?.identifier ?? "input"}: str):
+    def __call__(self, ${defaultInput?.identifier ?? "input"}: str = None):
         # Your code goes here
 
         return {"${defaultOutput?.identifier ?? "output"}": "Hello world!"}

--- a/langwatch/src/optimization_studio/templates/__tests__/blank.unit.test.ts
+++ b/langwatch/src/optimization_studio/templates/__tests__/blank.unit.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { blankTemplate } from "../blank";
+
+const node = (id: string) => blankTemplate.nodes.find((n) => n.id === id);
+
+const param = (nodeId: string, identifier: string) =>
+  (
+    node(nodeId)?.data as {
+      parameters: Array<{ identifier: string; value: unknown }>;
+    }
+  ).parameters.find((p) => p.identifier === identifier)?.value;
+
+describe("blankTemplate", () => {
+  describe("the entry point", () => {
+    /** @scenario Blank workflow entry exposes a single input */
+    it("exposes a single input output", () => {
+      expect((node("entry")?.data as { outputs: unknown }).outputs).toEqual([
+        { identifier: "input", type: "str" },
+      ]);
+    });
+  });
+
+  describe("the LLM node", () => {
+    /** @scenario Blank workflow LLM node uses the default assistant prompt */
+    it("uses the default helpful-assistant instructions", () => {
+      expect(param("llm_call", "instructions")).toBe(
+        "You are a helpful assistant.",
+      );
+    });
+
+    it("sends a single input user message", () => {
+      expect(param("llm_call", "messages")).toEqual([
+        { role: "user", content: "{{input}}" },
+      ]);
+    });
+
+    it("names its input and output input/output", () => {
+      expect((node("llm_call")?.data as { inputs: unknown }).inputs).toEqual([
+        { identifier: "input", type: "str" },
+      ]);
+      expect((node("llm_call")?.data as { outputs: unknown }).outputs).toEqual([
+        { identifier: "output", type: "str" },
+      ]);
+    });
+  });
+
+  describe("the wiring", () => {
+    /** @scenario Blank workflow wires the input through to the end output */
+    it("wires the entry input into the LLM node", () => {
+      expect(blankTemplate.edges).toContainEqual(
+        expect.objectContaining({
+          source: "entry",
+          sourceHandle: "outputs.input",
+          target: "llm_call",
+          targetHandle: "inputs.input",
+        }),
+      );
+    });
+
+    it("wires the LLM output into the end node output", () => {
+      expect(blankTemplate.edges).toContainEqual(
+        expect.objectContaining({
+          source: "llm_call",
+          sourceHandle: "outputs.output",
+          target: "end",
+          targetHandle: "inputs.output",
+        }),
+      );
+    });
+  });
+});

--- a/langwatch/src/optimization_studio/templates/__tests__/blank.unit.test.ts
+++ b/langwatch/src/optimization_studio/templates/__tests__/blank.unit.test.ts
@@ -3,7 +3,13 @@ import { blankTemplate } from "../blank";
 
 const node = (id: string) => blankTemplate.nodes.find((n) => n.id === id);
 
-const param = (nodeId: string, identifier: string) =>
+const param = ({
+  nodeId,
+  identifier,
+}: {
+  nodeId: string;
+  identifier: string;
+}) =>
   (
     node(nodeId)?.data as {
       parameters: Array<{ identifier: string; value: unknown }>;
@@ -11,61 +17,63 @@ const param = (nodeId: string, identifier: string) =>
   ).parameters.find((p) => p.identifier === identifier)?.value;
 
 describe("blankTemplate", () => {
-  describe("the entry point", () => {
-    /** @scenario Blank workflow entry exposes a single input */
-    it("exposes a single input output", () => {
-      expect((node("entry")?.data as { outputs: unknown }).outputs).toEqual([
-        { identifier: "input", type: "str" },
-      ]);
-    });
-  });
-
-  describe("the LLM node", () => {
-    /** @scenario Blank workflow LLM node uses the default assistant prompt */
-    it("uses the default helpful-assistant instructions", () => {
-      expect(param("llm_call", "instructions")).toBe(
-        "You are a helpful assistant.",
-      );
+  describe("given a blank workflow template", () => {
+    describe("when inspecting the entry point", () => {
+      /** @scenario Blank workflow entry exposes a single input */
+      it("exposes a single input output", () => {
+        expect((node("entry")?.data as { outputs: unknown }).outputs).toEqual([
+          { identifier: "input", type: "str" },
+        ]);
+      });
     });
 
-    it("sends a single input user message", () => {
-      expect(param("llm_call", "messages")).toEqual([
-        { role: "user", content: "{{input}}" },
-      ]);
+    describe("when inspecting the LLM node", () => {
+      /** @scenario Blank workflow LLM node uses the default assistant prompt */
+      it("uses the default helpful-assistant instructions", () => {
+        expect(param({ nodeId: "llm_call", identifier: "instructions" })).toBe(
+          "You are a helpful assistant.",
+        );
+      });
+
+      it("sends a single input user message", () => {
+        expect(param({ nodeId: "llm_call", identifier: "messages" })).toEqual([
+          { role: "user", content: "{{input}}" },
+        ]);
+      });
+
+      it("names its input and output input/output", () => {
+        expect((node("llm_call")?.data as { inputs: unknown }).inputs).toEqual([
+          { identifier: "input", type: "str" },
+        ]);
+        expect(
+          (node("llm_call")?.data as { outputs: unknown }).outputs,
+        ).toEqual([{ identifier: "output", type: "str" }]);
+      });
     });
 
-    it("names its input and output input/output", () => {
-      expect((node("llm_call")?.data as { inputs: unknown }).inputs).toEqual([
-        { identifier: "input", type: "str" },
-      ]);
-      expect((node("llm_call")?.data as { outputs: unknown }).outputs).toEqual([
-        { identifier: "output", type: "str" },
-      ]);
-    });
-  });
+    describe("when inspecting the wiring", () => {
+      /** @scenario Blank workflow wires the input through to the end output */
+      it("wires the entry input into the LLM node", () => {
+        expect(blankTemplate.edges).toContainEqual(
+          expect.objectContaining({
+            source: "entry",
+            sourceHandle: "outputs.input",
+            target: "llm_call",
+            targetHandle: "inputs.input",
+          }),
+        );
+      });
 
-  describe("the wiring", () => {
-    /** @scenario Blank workflow wires the input through to the end output */
-    it("wires the entry input into the LLM node", () => {
-      expect(blankTemplate.edges).toContainEqual(
-        expect.objectContaining({
-          source: "entry",
-          sourceHandle: "outputs.input",
-          target: "llm_call",
-          targetHandle: "inputs.input",
-        }),
-      );
-    });
-
-    it("wires the LLM output into the end node output", () => {
-      expect(blankTemplate.edges).toContainEqual(
-        expect.objectContaining({
-          source: "llm_call",
-          sourceHandle: "outputs.output",
-          target: "end",
-          targetHandle: "inputs.output",
-        }),
-      );
+      it("wires the LLM output into the end node output", () => {
+        expect(blankTemplate.edges).toContainEqual(
+          expect.objectContaining({
+            source: "llm_call",
+            sourceHandle: "outputs.output",
+            target: "end",
+            targetHandle: "inputs.output",
+          }),
+        );
+      });
     });
   });
 });

--- a/langwatch/src/optimization_studio/templates/__tests__/custom_evaluator.unit.test.ts
+++ b/langwatch/src/optimization_studio/templates/__tests__/custom_evaluator.unit.test.ts
@@ -97,9 +97,7 @@ describe("customEvaluatorTemplate", () => {
       // entry than to end. A smaller entry-side left-edge gap yields an equal
       // visual gap on both sides.
       expect(x("entry")).toBeGreaterThan(0);
-      expect(x("llm_call") - x("entry")).toBeLessThan(
-        x("end") - x("llm_call"),
-      );
+      expect(x("llm_call") - x("entry")).toBeLessThan(x("end") - x("llm_call"));
     });
   });
 });

--- a/langwatch/src/optimization_studio/templates/__tests__/custom_evaluator.unit.test.ts
+++ b/langwatch/src/optimization_studio/templates/__tests__/custom_evaluator.unit.test.ts
@@ -43,6 +43,17 @@ describe("customEvaluatorTemplate", () => {
     });
   });
 
+  describe("the end node", () => {
+    /** @scenario Custom evaluator template lists details first on the end node */
+    it("puts details first so the reasoning edge does not cross the verdict", () => {
+      expect(
+        (
+          node("end")?.data as { inputs: Array<{ identifier: string }> }
+        ).inputs.map((i) => i.identifier),
+      ).toEqual(["details", "passed", "score", "label"]);
+    });
+  });
+
   describe("the wiring", () => {
     /** @scenario Custom evaluator template wires reasoning into the end details */
     it("connects the LLM reasoning to the end details", () => {
@@ -78,11 +89,17 @@ describe("customEvaluatorTemplate", () => {
       ]);
     });
 
-    it("spaces the nodes apart left to right", () => {
+    it("offsets the entry so the gaps around the sample node look balanced", () => {
       const x = (id: string) => node(id)!.position.x;
       expect(x("entry")).toBeLessThan(x("llm_call"));
       expect(x("llm_call")).toBeLessThan(x("end"));
-      expect(x("llm_call") - x("entry")).toBeGreaterThanOrEqual(380);
+      // The sample node is wider than entry, so its left edge sits closer to
+      // entry than to end. A smaller entry-side left-edge gap yields an equal
+      // visual gap on both sides.
+      expect(x("entry")).toBeGreaterThan(0);
+      expect(x("llm_call") - x("entry")).toBeLessThan(
+        x("end") - x("llm_call"),
+      );
     });
   });
 });

--- a/langwatch/src/optimization_studio/templates/blank.ts
+++ b/langwatch/src/optimization_studio/templates/blank.ts
@@ -14,7 +14,7 @@ export const entryNode = () => ({
   deletable: false,
   data: {
     name: "Entry point",
-    outputs: [{ identifier: "question", type: "str" }],
+    outputs: [{ identifier: "input", type: "str" }],
     entry_selection: "random",
     train_size: 0.8,
     test_size: 0.2,
@@ -23,9 +23,9 @@ export const entryNode = () => ({
       name: DEFAULT_DATASET_NAME,
       inline: {
         records: {
-          question: ["Hello world"],
+          input: ["Hello world"],
         },
-        columnTypes: [{ name: "question", type: "string" }],
+        columnTypes: [{ name: "input", type: "string" }],
       },
     },
   } satisfies Entry,
@@ -65,9 +65,12 @@ export const blankTemplate: Workflow = {
             value: undefined,
           },
           {
+            // Mirrors the default new-prompt shape (buildDefaultFormValues),
+            // so a fresh workflow opens with a runnable prompt instead of an
+            // empty-messages error.
             identifier: "instructions",
             type: "str",
-            value: undefined,
+            value: "You are a helpful assistant.",
           },
           {
             identifier: "messages",
@@ -75,7 +78,7 @@ export const blankTemplate: Workflow = {
             value: [
               {
                 role: "user",
-                content: "{{question}}",
+                content: "{{input}}",
               },
             ],
           },
@@ -85,8 +88,8 @@ export const blankTemplate: Workflow = {
             value: undefined,
           },
         ],
-        inputs: [{ identifier: "question", type: "str" }],
-        outputs: [{ identifier: "answer", type: "str" }],
+        inputs: [{ identifier: "input", type: "str" }],
+        outputs: [{ identifier: "output", type: "str" }],
       } satisfies Signature,
     },
     {
@@ -104,15 +107,15 @@ export const blankTemplate: Workflow = {
     {
       id: "e0-1",
       source: "entry",
-      sourceHandle: "outputs.question",
+      sourceHandle: "outputs.input",
       target: "llm_call",
-      targetHandle: "inputs.question",
+      targetHandle: "inputs.input",
       type: "default",
     },
     {
       id: "e1-2",
       source: "llm_call",
-      sourceHandle: "outputs.answer",
+      sourceHandle: "outputs.output",
       target: "end",
       targetHandle: "inputs.output",
       type: "default",

--- a/langwatch/src/optimization_studio/templates/custom_evaluator.ts
+++ b/langwatch/src/optimization_studio/templates/custom_evaluator.ts
@@ -4,8 +4,11 @@ import { DEFAULT_MAX_TOKENS } from "../utils/registryUtils";
 export const entryNode = () => ({
   id: "entry",
   type: "entry",
+  // x is offset so the gap to the sample node matches the sample -> end gap:
+  // the sample node is wider than entry, so equal left-edge spacing would
+  // leave a visibly larger gap on the entry side.
   position: {
-    x: 0,
+    x: 84,
     y: 0,
   },
   deletable: false,
@@ -117,12 +120,14 @@ Return your judgment as either TRUE (no significant cognitive biases) or FALSE (
         behave_as: "evaluator",
         // The fixed evaluator result vocabulary - see
         // EVALUATOR_RESULT_FIELDS in EndPropertiesPanel. Unconnected
-        // fields are simply omitted from the evaluator's result.
+        // fields are simply omitted from the evaluator's result. `details`
+        // is first so the reasoning -> details edge from the sample node
+        // does not cross the verdict edge.
         inputs: [
+          { identifier: "details", type: "str", optional: true },
           { identifier: "passed", type: "bool", optional: true },
           { identifier: "score", type: "float", optional: true },
           { identifier: "label", type: "str", optional: true },
-          { identifier: "details", type: "str", optional: true },
         ],
       } satisfies End,
     },

--- a/langwatch/src/optimization_studio/utils/__tests__/codeSignature.unit.test.ts
+++ b/langwatch/src/optimization_studio/utils/__tests__/codeSignature.unit.test.ts
@@ -11,7 +11,8 @@ describe("rewriteCodeSignature", () => {
   describe("given inputs to sync", () => {
     describe("when the entrypoint is __call__", () => {
       it("rewrites the parameter list with None defaults", () => {
-        const code = "class Code:\n  def __call__(self, output: str):\n    return {}";
+        const code =
+          "class Code:\n  def __call__(self, output: str):\n    return {}";
         const next = rewriteCodeSignature(code, [
           { identifier: "output", type: "str" },
           { identifier: "expected_output", type: "str" },
@@ -35,9 +36,10 @@ describe("rewriteCodeSignature", () => {
 
     describe("when the entrypoint is the legacy forward", () => {
       it("preserves the method name", () => {
-        const next = rewriteCodeSignature("def forward(self, x: str):\n  pass", [
-          { identifier: "input", type: "str" },
-        ]);
+        const next = rewriteCodeSignature(
+          "def forward(self, x: str):\n  pass",
+          [{ identifier: "input", type: "str" }],
+        );
         expect(next).toContain("def forward(self, input: str = None):");
       });
     });

--- a/langwatch/src/optimization_studio/utils/__tests__/codeSignature.unit.test.ts
+++ b/langwatch/src/optimization_studio/utils/__tests__/codeSignature.unit.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the shared code-signature rewriter used by the studio code
+ * node and the custom code-evaluator drawer.
+ * See specs/workflows/code-node-input-sync.feature.
+ */
+import { describe, expect, it } from "vitest";
+
+import { rewriteCodeSignature } from "../codeSignature";
+
+describe("rewriteCodeSignature", () => {
+  describe("given inputs to sync", () => {
+    describe("when the entrypoint is __call__", () => {
+      it("rewrites the parameter list with None defaults", () => {
+        const code = "class Code:\n  def __call__(self, output: str):\n    return {}";
+        const next = rewriteCodeSignature(code, [
+          { identifier: "output", type: "str" },
+          { identifier: "expected_output", type: "str" },
+        ]);
+        expect(next).toContain(
+          "def __call__(self, output: str = None, expected_output: str = None):",
+        );
+      });
+
+      it("maps studio field types to python annotations", () => {
+        const next = rewriteCodeSignature("def __call__(self):\n  pass", [
+          { identifier: "count", type: "int" },
+          { identifier: "ratio", type: "float" },
+          { identifier: "ok", type: "bool" },
+        ]);
+        expect(next).toContain(
+          "def __call__(self, count: int = None, ratio: float = None, ok: bool = None):",
+        );
+      });
+    });
+
+    describe("when the entrypoint is the legacy forward", () => {
+      it("preserves the method name", () => {
+        const next = rewriteCodeSignature("def forward(self, x: str):\n  pass", [
+          { identifier: "input", type: "str" },
+        ]);
+        expect(next).toContain("def forward(self, input: str = None):");
+      });
+    });
+
+    describe("when the signature has a return type annotation", () => {
+      it("preserves the return type while rewriting the parameters", () => {
+        const next = rewriteCodeSignature(
+          "def __call__(self, output: str) -> dict:\n  return {}",
+          [{ identifier: "output", type: "str" }],
+        );
+        expect(next).toContain(
+          "def __call__(self, output: str = None) -> dict:",
+        );
+      });
+    });
+
+    describe("when a field has no concrete python type", () => {
+      it("falls back to Any and imports it once", () => {
+        const next = rewriteCodeSignature("def __call__(self):\n  pass", [
+          { identifier: "schema", type: "json_schema" },
+        ]);
+        expect(next).toContain("def __call__(self, schema: Any = None):");
+        expect(next).toContain("from typing import Any");
+        expect(next.match(/from typing import Any/g)).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("given no inputs", () => {
+    describe("when rewriting", () => {
+      it("returns the code unchanged", () => {
+        const code = "def __call__(self, output: str):\n  return {}";
+        expect(rewriteCodeSignature(code, [])).toBe(code);
+      });
+    });
+  });
+});

--- a/langwatch/src/optimization_studio/utils/codeSignature.ts
+++ b/langwatch/src/optimization_studio/utils/codeSignature.ts
@@ -32,8 +32,9 @@ const typesMap: Record<Field["type"], string> = {
  *
  * Matches either the idiomatic `__call__` or the legacy `forward`, preserving
  * whichever the code already uses, and only rewrites the signature line (the
- * body is left untouched). Every parameter defaults to `None` so an
- * unconnected input does not raise "missing a required argument" at run time.
+ * body is left untouched). An optional `-> ReturnType` annotation is preserved.
+ * Every parameter defaults to `None` so an unconnected input does not raise
+ * "missing a required argument" at run time.
  */
 export const rewriteCodeSignature = (
   code: string,
@@ -42,14 +43,14 @@ export const rewriteCodeSignature = (
   if (inputs.length === 0) return code;
 
   let next = code.replace(
-    /def (__call__|forward)\([\s\S]*?\):/,
-    (_match, methodName: string) =>
+    /def (__call__|forward)\([\s\S]*?\)(\s*->\s*[^:\n]+)?:/,
+    (_match, methodName: string, returnType: string | undefined) =>
       `def ${methodName}(self, ${inputs
         .map(
           (i) =>
             `${i.identifier}: ${typesMap[i.type as Field["type"]] ?? "Any"} = None`,
         )
-        .join(", ")}):`,
+        .join(", ")})${returnType ?? ""}:`,
   );
   if (next.includes(": Any") && !next.includes("from typing import Any")) {
     next = `from typing import Any\n${next}`;

--- a/langwatch/src/optimization_studio/utils/codeSignature.ts
+++ b/langwatch/src/optimization_studio/utils/codeSignature.ts
@@ -1,0 +1,58 @@
+import type { Field } from "../types/dsl";
+
+/** Maps a studio field type to the Python annotation used in a code signature. */
+const typesMap: Record<Field["type"], string> = {
+  str: "str",
+  int: "int",
+  float: "float",
+  bool: "bool",
+  image: "dspy.Image",
+  list: "list",
+  "list[str]": "list[str]",
+  "list[float]": "list[float]",
+  "list[int]": "list[int]",
+  "list[bool]": "list[bool]",
+  dict: "dict[str, Any]",
+  json_schema: "Any",
+  chat_messages: "list[dict[str, Any]]",
+  signature: "dspy.Signature",
+  llm: "Any",
+  prompting_technique: "Any",
+  dataset: "Any",
+  code: "str",
+};
+
+/**
+ * Rewrites a code block's entrypoint signature to match its declared inputs.
+ *
+ * Used wherever a code block's inputs change (the studio code node and the
+ * custom code-evaluator drawer) so the `__call__` / `forward` parameter list
+ * stays in sync with the wired inputs. Without this, the engine calls the
+ * entrypoint with a keyword it does not accept.
+ *
+ * Matches either the idiomatic `__call__` or the legacy `forward`, preserving
+ * whichever the code already uses, and only rewrites the signature line (the
+ * body is left untouched). Every parameter defaults to `None` so an
+ * unconnected input does not raise "missing a required argument" at run time.
+ */
+export const rewriteCodeSignature = (
+  code: string,
+  inputs: Array<{ identifier: string; type: string }>,
+): string => {
+  if (inputs.length === 0) return code;
+
+  let next = code.replace(
+    /def (__call__|forward)\([\s\S]*?\):/,
+    (_match, methodName: string) =>
+      `def ${methodName}(self, ${inputs
+        .map(
+          (i) =>
+            `${i.identifier}: ${typesMap[i.type as Field["type"]] ?? "Any"} = None`,
+        )
+        .join(", ")}):`,
+  );
+  if (next.includes(": Any") && !next.includes("from typing import Any")) {
+    next = `from typing import Any\n${next}`;
+  }
+  return next;
+};

--- a/langwatch/src/server/evaluators/__tests__/codeEvaluator.unit.test.ts
+++ b/langwatch/src/server/evaluators/__tests__/codeEvaluator.unit.test.ts
@@ -87,7 +87,7 @@ describe("codeEvaluator", () => {
       expect(codeParam?.value).toBe("class Code: ...");
     });
 
-    it("connects every input and output with engine-format handles", () => {
+    it("connects every input and the full output contract with engine-format handles", () => {
       expect(dsl.edges).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -104,17 +104,49 @@ describe("codeEvaluator", () => {
           }),
         ]),
       );
-      expect(dsl.edges).toHaveLength(4);
+      // 2 entry -> code edges + 4 code -> end edges (the fixed contract).
+      expect(dsl.edges).toHaveLength(6);
     });
 
-    it("marks the end node as an evaluator with the output contract", () => {
+    it("marks the end node as an evaluator carrying the full fixed contract", () => {
       const endNode = dsl.nodes.find((n) => n.type === "end")!;
       const data = endNode.data as {
         behave_as?: string;
         inputs: Array<{ identifier: string }>;
       };
       expect(data.behave_as).toBe("evaluator");
-      expect(data.inputs.map((i) => i.identifier)).toEqual(["passed", "score"]);
+      expect(data.inputs.map((i) => i.identifier)).toEqual([
+        "passed",
+        "score",
+        "label",
+        "details",
+      ]);
+    });
+  });
+
+  describe("when the code returns only a subset of the contract", () => {
+    const dsl = buildCodeEvaluatorDsl({
+      name: "Pass-only Evaluator",
+      config: {
+        code: "class Code:\n  def __call__(self, output: str):\n    return {'passed': True}",
+        inputs: [{ identifier: "output", type: "str" }],
+        outputs: [{ identifier: "passed", type: "bool" }],
+      },
+    });
+
+    /** @scenario Code evaluator returns only the fields it computes */
+    it("declares no outputs on the code node so a partial return is not a missing_output error", () => {
+      const codeNode = dsl.nodes.find((n) => n.type === "code")!;
+      expect((codeNode.data as { outputs: unknown[] }).outputs).toEqual([]);
+    });
+
+    it("still wires the full contract into the end node regardless of the saved outputs", () => {
+      const endNode = dsl.nodes.find((n) => n.type === "end")!;
+      expect(
+        (endNode.data as { inputs: Array<{ identifier: string }> }).inputs.map(
+          (i) => i.identifier,
+        ),
+      ).toEqual(["passed", "score", "label", "details"]);
     });
   });
 });

--- a/langwatch/src/server/evaluators/__tests__/codeEvaluator.unit.test.ts
+++ b/langwatch/src/server/evaluators/__tests__/codeEvaluator.unit.test.ts
@@ -116,10 +116,10 @@ describe("codeEvaluator", () => {
       };
       expect(data.behave_as).toBe("evaluator");
       expect(data.inputs.map((i) => i.identifier)).toEqual([
+        "details",
         "passed",
         "score",
         "label",
-        "details",
       ]);
     });
   });
@@ -146,7 +146,7 @@ describe("codeEvaluator", () => {
         (endNode.data as { inputs: Array<{ identifier: string }> }).inputs.map(
           (i) => i.identifier,
         ),
-      ).toEqual(["passed", "score", "label", "details"]);
+      ).toEqual(["details", "passed", "score", "label"]);
     });
   });
 });

--- a/langwatch/src/server/evaluators/codeEvaluator.ts
+++ b/langwatch/src/server/evaluators/codeEvaluator.ts
@@ -34,21 +34,23 @@ export type CodeEvaluatorConfig = z.infer<typeof codeEvaluatorConfigSchema>;
  * evaluation result. These mirror the studio's evaluator End node, so the
  * outputs are not user-customizable, only the inputs are.
  *
- * This is the full result contract from `evaluationResultSchema` (passed,
- * score, label, details). It is intentionally distinct from
- * `STANDARD_EVALUATOR_OUTPUT_FIELDS` in evaluator.service.ts, which drops the
- * free-text `details`: that is the evaluator-as-target mapping set, not the
- * return contract. It is defined here, rather than imported from the service,
- * to stay client-safe for the evaluator drawer and avoid a circular import.
+ * This is the full result contract from `evaluationResultSchema`, in the same
+ * details-first order as `EVALUATOR_RESULT_FIELDS` in EndPropertiesPanel so
+ * the two evaluator surfaces stay consistent (reasoning before verdict). It is
+ * intentionally distinct from `STANDARD_EVALUATOR_OUTPUT_FIELDS` in
+ * evaluator.service.ts, which drops the free-text `details`: that is the
+ * evaluator-as-target mapping set, not the return contract. It is defined here,
+ * rather than imported from either, to stay client-safe for the evaluator
+ * drawer and avoid a circular import.
  */
 export const CODE_EVALUATOR_OUTPUT_FIELDS: Array<{
   identifier: string;
   type: Field["type"];
 }> = [
+  { identifier: "details", type: "str" },
   { identifier: "passed", type: "bool" },
   { identifier: "score", type: "float" },
   { identifier: "label", type: "str" },
-  { identifier: "details", type: "str" },
 ];
 
 /** Default shape new code evaluators are seeded with in the editor. */

--- a/langwatch/src/server/evaluators/codeEvaluator.ts
+++ b/langwatch/src/server/evaluators/codeEvaluator.ts
@@ -33,6 +33,13 @@ export type CodeEvaluatorConfig = z.infer<typeof codeEvaluatorConfigSchema>;
  * dictionary with any subset of these keys; whichever are present become the
  * evaluation result. These mirror the studio's evaluator End node, so the
  * outputs are not user-customizable, only the inputs are.
+ *
+ * This is the full result contract from `evaluationResultSchema` (passed,
+ * score, label, details). It is intentionally distinct from
+ * `STANDARD_EVALUATOR_OUTPUT_FIELDS` in evaluator.service.ts, which drops the
+ * free-text `details`: that is the evaluator-as-target mapping set, not the
+ * return contract. It is defined here, rather than imported from the service,
+ * to stay client-safe for the evaluator drawer and avoid a circular import.
  */
 export const CODE_EVALUATOR_OUTPUT_FIELDS: Array<{
   identifier: string;

--- a/langwatch/src/server/evaluators/codeEvaluator.ts
+++ b/langwatch/src/server/evaluators/codeEvaluator.ts
@@ -28,11 +28,28 @@ export const codeEvaluatorConfigSchema = z.object({
 
 export type CodeEvaluatorConfig = z.infer<typeof codeEvaluatorConfigSchema>;
 
+/**
+ * The fixed evaluator result contract. A code evaluator's function returns a
+ * dictionary with any subset of these keys; whichever are present become the
+ * evaluation result. These mirror the studio's evaluator End node, so the
+ * outputs are not user-customizable, only the inputs are.
+ */
+export const CODE_EVALUATOR_OUTPUT_FIELDS: Array<{
+  identifier: string;
+  type: Field["type"];
+}> = [
+  { identifier: "passed", type: "bool" },
+  { identifier: "score", type: "float" },
+  { identifier: "label", type: "str" },
+  { identifier: "details", type: "str" },
+];
+
 /** Default shape new code evaluators are seeded with in the editor. */
 export const DEFAULT_CODE_EVALUATOR_CONFIG: CodeEvaluatorConfig = {
   code: `class Code:
     def __call__(self, output: str, expected_output: str):
-        # Your evaluation logic goes here
+        # Return a dict with any of: passed (bool), score (float),
+        # label (str), details (str). All are optional.
         passed = output.strip() == expected_output.strip()
 
         return {"passed": passed, "score": 1.0 if passed else 0.0}
@@ -41,10 +58,7 @@ export const DEFAULT_CODE_EVALUATOR_CONFIG: CodeEvaluatorConfig = {
     { identifier: "output", type: "str" },
     { identifier: "expected_output", type: "str" },
   ],
-  outputs: [
-    { identifier: "passed", type: "bool" },
-    { identifier: "score", type: "float" },
-  ],
+  outputs: CODE_EVALUATOR_OUTPUT_FIELDS.map((field) => ({ ...field })),
 };
 
 /** checkType prefix routing a monitor/evaluation to a stored code evaluator. */
@@ -110,7 +124,12 @@ export const buildCodeEvaluatorDsl = ({
       name,
       cls: "Code",
       inputs: stripValues(config.inputs),
-      outputs: stripValues(config.outputs),
+      // No declared outputs: the engine only enforces that *declared* code
+      // outputs are present in the returned dict (a "missing_output" error).
+      // An evaluator returns any subset of the contract, so declaring them
+      // would break a function that returns only `passed`. The end node below
+      // carries the contract and surfaces whichever keys the code returns.
+      outputs: [],
       parameters: [{ identifier: "code", type: "code", value: config.code }],
     } as Code,
   };
@@ -127,7 +146,10 @@ export const buildCodeEvaluatorDsl = ({
     data: {
       name: "End",
       behave_as: "evaluator",
-      inputs: stripValues(config.outputs),
+      // Always the fixed evaluator contract, independent of what the code
+      // returns. resolveInputs only binds an input when the upstream key
+      // exists, so a partial return surfaces just the keys it produced.
+      inputs: stripValues(CODE_EVALUATOR_OUTPUT_FIELDS),
     } as End,
   };
 
@@ -155,7 +177,7 @@ export const buildCodeEvaluatorDsl = ({
         targetHandle: `inputs.${identifier}`,
         type: "default",
       })),
-      ...config.outputs.map(({ identifier }) => ({
+      ...CODE_EVALUATOR_OUTPUT_FIELDS.map(({ identifier }) => ({
         id: `code_to_end_${identifier}`,
         source: "code_evaluator",
         sourceHandle: `outputs.${identifier}`,

--- a/specs/evaluators/evaluator-management.feature
+++ b/specs/evaluators/evaluator-management.feature
@@ -280,6 +280,15 @@ Feature: Evaluator management
     Then the code editor opens with its saved code, inputs and outputs
     And in the workbench each input shows its source mapping inline
 
+  # Same behavior as the studio code node: the Python entrypoint signature is
+  # derived from the declared inputs, so adding or removing an input field
+  # rewrites it (with None defaults) and the saved evaluator never calls the
+  # entrypoint with an unexpected or missing keyword.
+  Scenario: Code evaluator inputs stay in sync with the signature
+    Given the code evaluator drawer
+    When I add or remove an input field
+    Then the __call__ signature is rewritten to match the declared inputs
+
   Scenario: Code evaluator inputs drive the mapping UI
     Given a code evaluator whose code takes "output" and "expected_output"
     When I use it in an evaluation

--- a/specs/evaluators/evaluator-management.feature
+++ b/specs/evaluators/evaluator-management.feature
@@ -280,14 +280,27 @@ Feature: Evaluator management
     Then the code editor opens with its saved code, inputs and outputs
     And in the workbench each input shows its source mapping inline
 
-  # Same behavior as the studio code node: the Python entrypoint signature is
-  # derived from the declared inputs, so adding or removing an input field
-  # rewrites it (with None defaults) and the saved evaluator never calls the
-  # entrypoint with an unexpected or missing keyword.
-  Scenario: Code evaluator inputs stay in sync with the signature
+  # Same behavior as the studio code node: the Python entrypoint is kept in
+  # sync with the declared inputs, so changing the inputs keeps the evaluator
+  # callable with exactly those inputs, with no missing or unexpected keyword.
+  Scenario: Code evaluator input changes keep runs valid
     Given the code evaluator drawer
     When I add or remove an input field
-    Then the __call__ signature is rewritten to match the declared inputs
+    Then the evaluator still runs without missing or unexpected input errors
+
+  # Outputs are the fixed evaluator contract (passed, score, label, details),
+  # not user-defined, mirroring the evaluator end node.
+  Scenario: Code evaluator outputs are the fixed evaluator contract
+    Given the code evaluator drawer
+    Then the outputs are shown as the fixed evaluator result fields
+    And there is no control to add or remove output fields
+
+  # A function returns any subset of the contract; whichever it returns become
+  # the result, so an evaluator that returns only passed does not fail.
+  Scenario: Code evaluator returns only the fields it computes
+    Given a code evaluator that returns only passed
+    When it runs against a row
+    Then the result carries passed and reports no error
 
   Scenario: Code evaluator inputs drive the mapping UI
     Given a code evaluator whose code takes "output" and "expected_output"

--- a/specs/workflows/blank-workflow-template.feature
+++ b/specs/workflows/blank-workflow-template.feature
@@ -1,0 +1,28 @@
+Feature: Blank workflow starts from the default prompt shape
+  As a user creating a new workflow
+  I want the starting LLM node to carry the standard prompt
+  So that running it does not fail with an empty-messages error
+
+  # Customer context: the blank workflow shipped an LLM node whose only message
+  # referenced "question" and had no system prompt, which diverged from the
+  # default new-prompt shape and ran into empty/invalid message errors. The
+  # blank template now mirrors the default prompt: a "You are a helpful
+  # assistant" system instruction, a single "{{input}}" user message, and an
+  # "input" -> "output" wiring.
+
+  @unit
+  Scenario: Blank workflow entry exposes a single input
+    Given the blank workflow template
+    Then the entry point has a single "input" output
+
+  @unit
+  Scenario: Blank workflow LLM node uses the default assistant prompt
+    Given the blank workflow template
+    Then the LLM node instructions say "You are a helpful assistant"
+    And the LLM node sends a single "{{input}}" user message
+
+  @unit
+  Scenario: Blank workflow wires the input through to the end output
+    Given the blank workflow template
+    Then the entry input is wired into the LLM node
+    And the LLM output is wired into the end node output

--- a/specs/workflows/code-node-input-sync.feature
+++ b/specs/workflows/code-node-input-sync.feature
@@ -1,0 +1,31 @@
+Feature: Code node inputs stay in sync with the Python signature
+  As a user wiring a code node in the workflow studio
+  I want every input I add by dragging to appear in the code entrypoint
+  So that running the node does not fail with a keyword-argument error
+
+  # Customer context: dragging an If/Else branch onto a code node's gate, or
+  # wiring an output into a new input handle, added the input to the node but
+  # left the `def __call__` signature untouched. The engine then called the
+  # entrypoint with a keyword it did not accept ("unexpected keyword argument
+  # 'gate'"). Adding inputs through the drawer's "+ Add" already synced the
+  # signature; the drag paths now do the same. Separately, an unconnected
+  # input is omitted from the call, so every parameter defaults to None to
+  # avoid "missing a required argument".
+
+  @unit
+  Scenario: Dropping an If/Else branch on a code node adds the gate to the signature
+    Given a code node with a single "input" parameter
+    When an If/Else branch is dropped on the code node gate
+    Then the code entrypoint signature includes the gate parameter
+
+  @unit
+  Scenario: Wiring a new input handle adds it to the signature
+    Given a code node with a single "input" parameter
+    When an output is wired into a new input handle on the code node
+    Then the code entrypoint signature includes the new parameter
+
+  @unit
+  Scenario: Code inputs default to None
+    Given a code node entrypoint
+    When the inputs are written into the signature
+    Then every parameter defaults to None so unconnected inputs do not error

--- a/specs/workflows/custom-evaluator-template.feature
+++ b/specs/workflows/custom-evaluator-template.feature
@@ -31,6 +31,11 @@ Feature: Custom evaluator from workflow scaffold
     Then the LLM node "reasoning" output is connected to the end node "details"
 
   @unit
+  Scenario: Custom evaluator template lists details first on the end node
+    Given the custom evaluator template
+    Then the end node results start with "details" so the reasoning edge does not cross the verdict edge
+
+  @unit
   Scenario: Custom evaluator template has no extra ExactMatch evaluator
     Given the custom evaluator template
     Then the only nodes are the entry, the sample LLM node and the end node

--- a/specs/workflows/end-node-evaluator-results.feature
+++ b/specs/workflows/end-node-evaluator-results.feature
@@ -22,9 +22,9 @@ Feature: Fixed result fields on the evaluator End node
     And each field shows its fixed type (bool, float, str, str)
 
   @integration
-  Scenario: Evaluator End node lists label before details
+  Scenario: Evaluator End node lists details first
     When I open the End node drawer
-    Then the result fields appear in the order "passed", "score", "label", "details"
+    Then the result fields appear in the order "details", "passed", "score", "label"
 
   @integration
   Scenario: Evaluator End node results cannot be added or removed

--- a/specs/workflows/run-error-focus.feature
+++ b/specs/workflows/run-error-focus.feature
@@ -1,0 +1,18 @@
+Feature: A failed run opens the node that failed
+  As a user running a workflow until a node
+  I want a failed run to surface the node that errored
+  So that I see the actual error instead of a stale target output
+
+  # Customer context: running "until here" on the End node opened the End node
+  # and showed its previous output even when an upstream node (e.g. an LLM with
+  # no messages) failed the run. The studio now focuses the node whose own
+  # execution state is "error", falling back to the run target only when no
+  # single node carries the error.
+
+  @unit
+  Scenario: An errored run opens the node that failed
+    Given a run-until-here execution that ends in error
+    And one upstream node carries the error
+    When the workflow execution state change arrives
+    Then the studio selects the failing node and expands its properties
+    And it does not select the run target node

--- a/specs/workflows/run-until-here-dialog.feature
+++ b/specs/workflows/run-until-here-dialog.feature
@@ -51,6 +51,12 @@ Feature: Run-until-here dialog
     And the entry point outputs are the typed values instead of a dataset row
 
   @integration
+  Scenario: Pressing Enter runs the partial execution
+    Given the run-until-here dialog is open
+    When I edit a field and press Enter
+    Then the execution starts scoped to the target node with the typed values
+
+  @integration
   Scenario: Select dataset value is only offered with an attached dataset
     Given the entry point has no dataset attached
     When the run-until-here dialog opens


### PR DESCRIPTION
## What

Fixes from a studio dogfooding pass, in the optimization studio and the custom code evaluator.

### 1. Dragging an input into a code node keeps its Python signature in sync
Dropping an If/Else branch onto a code node's gate, or wiring an output into a new input handle, added the input to the node but left `def __call__` untouched. The engine then called the entrypoint with a keyword it did not accept (`Code.__call__() got an unexpected keyword argument 'gate'`). Both drag paths now rewrite the signature, the same way the drawer "+ Add" button already did.

### 2. Code inputs default to None
An unconnected input is omitted from the engine call, so a bare `input: str` raised "missing a required argument". Every code input now defaults to `None`, so partial runs and optional inputs work. This is engine-agnostic: the default lives in the generated signature, so it holds on both the Go and Python engines.

### 3. Run until here runs on Enter
Pressing Enter in a field in the Run-until-here dialog now starts the run, instead of forcing a click on Run.

### 4. The blank workflow starts from the default prompt
A new workflow opened with an LLM node whose only message referenced `question` and had no system prompt, which could fail with an empty-messages error. The blank template now mirrors the default new-prompt shape: a "You are a helpful assistant." instruction, a single `{{input}}` user message, and `input` wired through to `output`.

### 5. A failed run opens the node that failed
Running until the End node and hitting an upstream error (for example an LLM with no messages) opened the End node and showed its stale output. The studio now focuses the node whose own execution errored, falling back to the run target only when no single node carries the error.

### 6. Removed the Playground button
The canvas Playground button is gone, along with its now-unused store state. The standalone chat page keeps using the underlying ChatWindow.

### 7. Custom code-evaluator signature stays in sync with its inputs
Adding or removing an input field in the New/Edit Code Evaluator drawer now rewrites the Python `__call__` signature to match, the same way the studio code node does. The signature logic is extracted into a shared `rewriteCodeSignature` helper used by both the studio store and the evaluator drawer, so they cannot drift.

### 8. Code evaluator outputs are the fixed result contract
The code evaluator let users define arbitrary output fields, which broke runs: the engine fails when the code does not return a declared output. Outputs are now the fixed evaluator contract (passed, score, label, details), shown as a read-only explanation like the evaluator end node, instead of an editable list. The function returns any subset and whichever keys it returns become the result. The ephemeral evaluator workflow declares no outputs on the code node, so a partial return is no longer a missing-output error, and always wires the full contract into the end node, which surfaces only the keys that are present.

### 9. Custom-evaluator-from-workflow scaffold layout is balanced
The scaffold placed the entry, sample LLM and end nodes at equal left-edge spacing, but the sample node is wider, so the entry-side gap looked larger than the sample-to-end gap. The entry node is offset so both visual gaps match.

### 10. Evaluator end node lists details first
The evaluator result contract now lists `details` first. For an LLM judge the reasoning should come before the verdict, and it stops the scaffold's reasoning -> details edge from crossing the verdict edge. The order is set in the canonical `EVALUATOR_RESULT_FIELDS` so the end-node panel and the scaffold template agree (the panel pins the node to this order when opened).

## Tests
- Store-level tests for the signature sync on both drag paths (gate drop and new-handle wiring) and the None defaults.
- Integration test for Enter-to-run in the Run-until-here dialog.
- Unit tests for the blank template shape and the failed-run focus.
- Integration tests for the code-evaluator drawer rewriting its signature when an input is added or removed.
- Unit tests proving the evaluator DSL declares no code-node outputs and always carries the full contract, so a partial return does not error.
- Integration test that the drawer shows the fixed output fields and offers no add or remove control.
- Unit tests for the shared signature rewriter, including a return-type annotation.
- Unit test for the scaffold layout (entry offset) and the details-first end node order.
- The EndPropertiesPanel integration test renders the panel and asserts the details-first order.
- BDD specs under `specs/workflows/` and `specs/evaluators/` for all of the above.
- typecheck, feature-parity, and the optimization_studio suite are green.

## QA

Browser-QA'd on a real workflow (the If/Else "Branch routing demo", which matches the reported shape) and the code-evaluator drawer:

**Playground button removed (fix 6)** - the canvas bottom-right shows only Results and the zoom controls now:

![Playground button removed](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4887/studio-fixes/playground-button-removed.png)

**Run until here on Enter (fix 3)** - typing a value and pressing Enter closes the dialog and starts the run:

![Run until here dialog](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4887/studio-fixes/run-until-here-dialog.png)

![Run until here ran via Enter](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4887/studio-fixes/run-until-here-enter-result.png)

**Code-evaluator signature sync (fix 7)** - adding a "context" input live-rewrote the signature to `def __call__(self, output: str = None, expected_output: str = None, context: str = None):`, visible in the editor, body preserved:

![Code evaluator signature sync](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4887/studio-fixes/code-evaluator-signature-sync.png)

**Code evaluator fixed outputs (fix 8)** - the Outputs section is now a read-only list of the contract fields (passed, score, label, details) with no add or remove control, while the inputs stay editable:

![Code evaluator fixed outputs](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4887/studio-fixes/code-evaluator-fixed-outputs.png)

This shot also demonstrates the input-to-signature sync with None defaults (fixes 1 and 2) in the editor. The drag-path sync in the studio canvas (fix 1), the failed-run focus (fix 5), the blank template default (fix 4), and the scaffold layout and details-first order (fixes 9 and 10) are covered by the store/unit/integration tests above; their fresh-workflow canvas is blocked from browser capture by the dev 3-workflow plan limit (3/3). The details-first order is additionally verified in-render by the EndPropertiesPanel integration test.
