### PR TITLE
fix(experiments-v3): guide users to unmapped evaluator fields and prefer target outputs in mapping

### DIFF
--- a/langwatch/src/experiments-v3/__tests__/NewEvaluatorAddedToWorkbench.integration.test.tsx
+++ b/langwatch/src/experiments-v3/__tests__/NewEvaluatorAddedToWorkbench.integration.test.tsx
@@ -393,3 +393,163 @@ describe("New Evaluator Added to Workbench", () => {
     });
   });
 });
+
+// ============================================================================
+// Auto-open the evaluator mapping drawer when required fields stay unmapped
+// ============================================================================
+
+describe("Adding an evaluator with unmapped required fields", () => {
+  // A prompt target whose single output is "output".
+  const promptTarget = {
+    id: "target-1",
+    type: "prompt" as const,
+    inputs: [{ identifier: "input", type: "str" as const }],
+    outputs: [{ identifier: "output", type: "str" as const }],
+    mappings: {},
+  };
+
+  const makeColumn = (name: string) => ({
+    id: name,
+    name,
+    type: "string" as const,
+  });
+  const makeDataset = (columnNames: string[]) => ({
+    id: "test-data",
+    name: "Test Data",
+    type: "inline" as const,
+    columns: columnNames.map(makeColumn),
+    inline: {
+      columns: columnNames.map(makeColumn),
+      // One row so the table renders a target cell (the add-evaluator button
+      // lives inside the per-row cell).
+      records: Object.fromEntries(
+        columnNames.map((name) => [name, ["sample"]]),
+      ),
+    },
+  });
+
+  // An existing library evaluator selected from the picker (the onSelect path).
+  const makeSelectedEvaluator = (
+    fields: Array<{ identifier: string; type: string }>,
+  ) =>
+    ({
+      id: "library-evaluator-1",
+      name: "My Custom Evaluator",
+      type: "evaluator",
+      projectId: "test-project",
+      config: { evaluatorType: "langevals/exact_match" },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      fields,
+    }) as never;
+
+  const seedWorkbench = (columnNames: string[]) => {
+    useEvaluationsV3Store.getState().reset();
+    useEvaluationsV3Store.setState({
+      targets: [promptTarget],
+      datasets: [makeDataset(columnNames)],
+      activeDatasetId: "test-data",
+      evaluators: [],
+    });
+  };
+
+  const addEvaluatorViaPicker = async (
+    user: ReturnType<typeof userEvent.setup>,
+    fields: Array<{ identifier: string; type: string }>,
+  ) => {
+    const buttons = screen.getAllByTestId("add-evaluator-button-target-1");
+    await user.click(buttons[0]!);
+
+    const onSelect = flowCallbacksStore.evaluatorList?.onSelect as
+      | ((evaluator: unknown) => void)
+      | undefined;
+    await act(async () => {
+      onSelect?.(makeSelectedEvaluator(fields));
+    });
+  };
+
+  beforeEach(() => {
+    currentDrawer = null;
+    drawerProps = {};
+    Object.keys(flowCallbacksStore).forEach(
+      (key) => delete flowCallbacksStore[key],
+    );
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /** @scenario Adding an evaluator with unmapped required fields opens its mapping drawer */
+  it("opens the evaluator mapping drawer when a required field cannot be auto-mapped", async () => {
+    const user = userEvent.setup();
+    // The evaluator needs "ground_truth", which is an expected-answer field the
+    // dataset does not carry (and is never sourced from the target output), so
+    // it cannot be auto-mapped.
+    seedWorkbench(["input"]);
+    render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId("add-evaluator-button-target-1").length,
+      ).toBeGreaterThan(0);
+    });
+
+    await addEvaluatorViaPicker(user, [
+      { identifier: "ground_truth", type: "str" },
+    ]);
+
+    // The evaluator was added, and instead of silently closing the picker the
+    // mapping drawer opened onto the unmapped fields.
+    expect(useEvaluationsV3Store.getState().evaluators.length).toBe(1);
+    expect(currentDrawer).toBe("evaluatorEditor");
+    expect(drawerProps.evaluatorId).toBe("library-evaluator-1");
+  });
+
+  /** @scenario Adding an evaluator whose required fields all auto-map closes the picker */
+  it("closes the picker when every required field auto-maps", async () => {
+    const user = userEvent.setup();
+    // Dataset carries "expected_output", so both required fields auto-map
+    // (output -> target output, expected_output -> dataset column).
+    seedWorkbench(["input", "expected_output"]);
+    render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId("add-evaluator-button-target-1").length,
+      ).toBeGreaterThan(0);
+    });
+
+    await addEvaluatorViaPicker(user, [
+      { identifier: "output", type: "str" },
+      { identifier: "expected_output", type: "str" },
+    ]);
+
+    expect(useEvaluationsV3Store.getState().evaluators.length).toBe(1);
+    expect(currentDrawer).toBeNull();
+  });
+
+  /** @scenario The evaluator mapping selector offers target outputs before dataset columns */
+  it("lists the target outputs before the dataset columns in the opened drawer", async () => {
+    const user = userEvent.setup();
+    seedWorkbench(["input"]);
+    render(<EvaluationsV3Table disableVirtualization />, { wrapper: Wrapper });
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId("add-evaluator-button-target-1").length,
+      ).toBeGreaterThan(0);
+    });
+
+    await addEvaluatorViaPicker(user, [
+      { identifier: "ground_truth", type: "str" },
+    ]);
+
+    expect(currentDrawer).toBe("evaluatorEditor");
+    const mappingsConfig = drawerProps.mappingsConfig as {
+      availableSources: Array<{ id: string; type: string }>;
+    };
+    // Target signature source comes first, dataset second.
+    expect(mappingsConfig.availableSources[0]?.type).toBe("signature");
+    expect(mappingsConfig.availableSources[0]?.id).toBe("target-1");
+    expect(mappingsConfig.availableSources[1]?.type).toBe("dataset");
+  });
+});

--- a/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
+++ b/langwatch/src/experiments-v3/components/EvaluationsV3Table.tsx
@@ -31,9 +31,11 @@ import type {
 } from "~/server/evaluators/evaluator.service";
 import { api } from "~/utils/api";
 import { DRAWER_WIDTH } from "../constants";
+import { resolveTargetNameFromCache } from "../hooks/resolveTargetName";
 import { useDatasetSync } from "../hooks/useDatasetSync";
 import { useEvaluationsV3Store } from "../hooks/useEvaluationsV3Store";
 import { useExecuteEvaluation } from "../hooks/useExecuteEvaluation";
+import { useOpenEvaluatorEditor } from "../hooks/useOpenEvaluatorEditor";
 import {
   scrollToTargetColumn,
   useOpenTargetEditor,
@@ -61,6 +63,7 @@ import {
   buildInputsFromBodyTemplate,
   convertHttpComponentConfig,
 } from "../utils/httpAgentUtils";
+import { evaluatorHasMissingMappings } from "../utils/mappingValidation";
 import { createPromptEditorCallbacks } from "../utils/promptEditorCallbacks";
 import { ColumnTypeIcon } from "./ColumnTypeIcon";
 import { DatasetSuperHeader } from "./DatasetSuperHeader";
@@ -276,6 +279,10 @@ export function EvaluationsV3Table({
   const { openTargetEditor, buildAvailableSources, isDatasetSource } =
     useOpenTargetEditor();
 
+  // Hook for opening the grading-evaluator mapping drawer. Used to guide the
+  // user to unmapped fields right after adding an evaluator (see Issue A).
+  const openEvaluatorEditor = useOpenEvaluatorEditor();
+
   // Track pending mappings for new prompts (before they become targets)
   const pendingMappingsRef = useRef<Record<string, UIFieldMapping>>({});
 
@@ -465,9 +472,12 @@ export function EvaluationsV3Table({
    * Helper to add an evaluator to the workbench from an EvaluatorWithFields.
    * Used by both onSelect (existing evaluator) and onSave (newly created evaluator).
    * Fields are pre-computed by the API including type and optional flag.
+   *
+   * Returns the new workbench config id, or null when the evaluator was already
+   * present (so callers can skip the post-add auto-open).
    */
   const addEvaluatorToWorkbench = useCallback(
-    (evaluator: EvaluatorWithFields) => {
+    (evaluator: EvaluatorWithFields): string | null => {
       // Extract evaluator config from the Prisma evaluator
       const config = evaluator.config as EvaluatorDbConfig | null;
 
@@ -478,7 +488,7 @@ export function EvaluationsV3Table({
 
       // If already exists, no need to add again (it applies to all targets)
       if (existingEvaluator) {
-        return;
+        return null;
       }
 
       // Create a new EvaluatorConfig from the evaluator
@@ -496,10 +506,58 @@ export function EvaluationsV3Table({
         dbEvaluatorId: evaluator.id,
       };
 
-      // Add the evaluator globally (applies to all targets automatically)
+      // Add the evaluator globally (applies to all targets automatically).
+      // The store runs auto-inference on add, so any auto-mappable fields are
+      // already mapped by the time we read it back below.
       addEvaluator(evaluatorConfig);
+      return evaluatorConfig.id;
     },
     [evaluators, addEvaluator],
+  );
+
+  /**
+   * After adding an evaluator, decide whether to close the picker or guide the
+   * user to its mapping drawer. Auto-inference cannot always satisfy every
+   * required input (e.g. the dataset has no column for a required field), so
+   * silently closing would leave a freshly added evaluator with no signpost to
+   * where the missing mapping lives. When fields remain unmapped we open the
+   * evaluator's mapping drawer instead (see Issue A).
+   */
+  const guideOrCloseAfterAdd = useCallback(
+    (addedId: string | null, isCodeEvaluator: boolean) => {
+      // Read fresh state: the just-added config (with inferred mappings) is not
+      // yet reflected in this closure's `evaluators`.
+      const state = useEvaluationsV3Store.getState();
+      const added = state.evaluators.find((e) => e.id === addedId);
+      // The first target provides the mapping context for the drawer.
+      const firstTarget = state.targets[0];
+
+      if (
+        addedId &&
+        added &&
+        firstTarget &&
+        evaluatorHasMissingMappings(
+          added,
+          state.activeDatasetId,
+          firstTarget.id,
+        )
+      ) {
+        openEvaluatorEditor({
+          evaluator: added,
+          target: firstTarget,
+          targetName:
+            resolveTargetNameFromCache({
+              target: firstTarget,
+              utils: trpcUtils,
+              projectId: project?.id,
+            }) ?? "",
+          isCodeEvaluator,
+        });
+        return;
+      }
+      closeDrawer();
+    },
+    [openEvaluatorEditor, closeDrawer, trpcUtils, project?.id],
   );
 
   // Handler for opening the evaluator selector (evaluators apply to ALL targets)
@@ -508,8 +566,8 @@ export function EvaluationsV3Table({
     // Note: EvaluatorListDrawer does NOT navigate after onSelect - caller must handle it
     setFlowCallbacks("evaluatorList", {
       onSelect: (evaluator) => {
-        addEvaluatorToWorkbench(evaluator);
-        closeDrawer(); // Close drawer after adding evaluator to workbench
+        const addedId = addEvaluatorToWorkbench(evaluator);
+        guideOrCloseAfterAdd(addedId, evaluator.type === "code");
       },
     });
 
@@ -517,7 +575,7 @@ export function EvaluationsV3Table({
     // When user creates a new evaluator via the editor drawer, we need to:
     // 1. Fetch the newly created evaluator from DB
     // 2. Add it to the workbench
-    // 3. Close the drawer
+    // 3. Either close the drawer, or open its mapping drawer if fields are unmapped
     setFlowCallbacks(
       "evaluatorEditor",
       createEvaluatorEditorCallbacks({
@@ -529,9 +587,11 @@ export function EvaluationsV3Table({
           });
 
           if (evaluator) {
-            addEvaluatorToWorkbench(evaluator);
+            const addedId = addEvaluatorToWorkbench(evaluator);
+            guideOrCloseAfterAdd(addedId, evaluator.type === "code");
+          } else {
+            closeDrawer();
           }
-          closeDrawer(); // Close drawer after adding evaluator to workbench
           return true; // Indicate navigation was handled to prevent default back behavior
         },
       }),
@@ -542,6 +602,7 @@ export function EvaluationsV3Table({
     openDrawer,
     closeDrawer,
     addEvaluatorToWorkbench,
+    guideOrCloseAfterAdd,
     trpcUtils.evaluators.getById,
     project?.id,
   ]);

--- a/langwatch/src/experiments-v3/components/TargetSection/TargetCell.tsx
+++ b/langwatch/src/experiments-v3/components/TargetSection/TargetCell.tsx
@@ -18,21 +18,16 @@ import {
   LuSquare,
 } from "react-icons/lu";
 import { Tooltip } from "~/components/ui/tooltip";
-import type { FieldMapping as UIFieldMapping } from "~/components/variables";
 import { TraceIdPeek } from "~/features/traces-v2/components/TraceIdPeek";
-import { setFlowCallbacks, useDrawer } from "~/hooks/useDrawer";
+import { useDrawer } from "~/hooks/useDrawer";
 import { parseLLMError } from "~/utils/formatLLMError";
 import { formatTargetOutput } from "~/utils/formatTargetOutput";
 import { useEvaluationsV3Store } from "../../hooks/useEvaluationsV3Store";
 import { useCodeEvaluatorIds } from "../../hooks/useEvaluatorName";
+import { useOpenEvaluatorEditor } from "../../hooks/useOpenEvaluatorEditor";
 import { useTargetName } from "../../hooks/useTargetName";
 import type { EvaluatorConfig, TargetConfig } from "../../types";
 import { formatLatency } from "../../utils/computeAggregates";
-import { createEvaluatorEditorCallbacks } from "../../utils/evaluatorEditorCallbacks";
-import {
-  convertFromUIMapping,
-  convertToUIMapping,
-} from "../../utils/fieldMappingConverters";
 import { evaluatorHasMissingMappings } from "../../utils/mappingValidation";
 import { EvaluatorChip } from "../TargetSection/EvaluatorChip";
 
@@ -88,23 +83,13 @@ export function TargetCellContent({
 }: TargetCellContentProps) {
   const { openDrawer } = useDrawer();
   const targetName = useTargetName(target);
-  const {
-    evaluators,
-    activeDatasetId,
-    datasets,
-    removeEvaluator,
-    updateEvaluator,
-    setEvaluatorMapping,
-    removeEvaluatorMapping,
-  } = useEvaluationsV3Store((state) => ({
-    evaluators: state.evaluators,
-    activeDatasetId: state.activeDatasetId,
-    datasets: state.datasets,
-    removeEvaluator: state.removeEvaluator,
-    updateEvaluator: state.updateEvaluator,
-    setEvaluatorMapping: state.setEvaluatorMapping,
-    removeEvaluatorMapping: state.removeEvaluatorMapping,
-  }));
+  const openEvaluatorEditor = useOpenEvaluatorEditor();
+  const { evaluators, activeDatasetId, removeEvaluator } =
+    useEvaluationsV3Store((state) => ({
+      evaluators: state.evaluators,
+      activeDatasetId: state.activeDatasetId,
+      removeEvaluator: state.removeEvaluator,
+    }));
 
   // Code evaluators (DB type "code") route their edit flow to the code editor.
   const codeEvaluatorIds = useCodeEvaluatorIds(evaluators);
@@ -175,89 +160,6 @@ export function TargetCellContent({
     }
     return missing;
   }, [evaluators, activeDatasetId, target.id]);
-
-  // Build the serializable `mappingsConfig` for an evaluator. Stays
-  // serializable because it goes through the drawer's ephemeral complexProps
-  // path (cleared on ErrorBoundary remount — see issue #3087).
-  const buildMappingsConfig = useCallback(
-    (evaluator: EvaluatorConfig) => {
-      // Build available sources. Target outputs come FIRST: for an evaluator,
-      // the graded field (e.g. "output") should offer the runner's outputs
-      // ahead of dataset columns, mirroring how inputs prefer the dataset.
-      const activeDataset = datasets.find((d) => d.id === activeDatasetId);
-      const availableSources = [];
-      // Use local config outputs if available (unsaved changes), fallback to saved outputs
-      const effectiveOutputs =
-        target.localPromptConfig?.outputs ?? target.outputs;
-      availableSources.push({
-        id: target.id,
-        name: targetName,
-        type: "signature" as const,
-        fields: effectiveOutputs.map((o) => ({
-          name: o.identifier,
-          type: o.type as "str" | "float" | "bool",
-        })),
-      });
-      if (activeDataset) {
-        availableSources.push({
-          id: activeDataset.id,
-          name: activeDataset.name,
-          type: "dataset" as const,
-          fields: activeDataset.columns.map((col) => ({
-            name: col.name,
-            type: "str" as const,
-          })),
-        });
-      }
-
-      // Get current mappings in UI format (used as initial state in the drawer)
-      const storeMappings =
-        evaluator.mappings[activeDatasetId]?.[target.id] ?? {};
-      const initialMappings: Record<string, UIFieldMapping> = {};
-      for (const [key, mapping] of Object.entries(storeMappings)) {
-        initialMappings[key] = convertToUIMapping(mapping);
-      }
-
-      return { availableSources, initialMappings };
-    },
-    [datasets, activeDatasetId, target, targetName],
-  );
-
-  // Build the durable `onMappingChange` callback for an evaluator. Lives
-  // separately from `mappingsConfig` because it must survive the drawer's
-  // complexProps clears — registered via `setFlowCallbacks` instead (#3441).
-  const buildOnMappingChange = useCallback(
-    (evaluator: EvaluatorConfig) => {
-      const datasetIds = new Set(datasets.map((d) => d.id));
-      const isDatasetSource = (sourceId: string) => datasetIds.has(sourceId);
-      return (identifier: string, mapping: UIFieldMapping | undefined) => {
-        if (mapping) {
-          const storeMapping = convertFromUIMapping(mapping, isDatasetSource);
-          setEvaluatorMapping(
-            evaluator.id,
-            activeDatasetId,
-            target.id,
-            identifier,
-            storeMapping,
-          );
-        } else {
-          removeEvaluatorMapping(
-            evaluator.id,
-            activeDatasetId,
-            target.id,
-            identifier,
-          );
-        }
-      };
-    },
-    [
-      datasets,
-      activeDatasetId,
-      target.id,
-      setEvaluatorMapping,
-      removeEvaluatorMapping,
-    ],
-  );
 
   // Use shared utility for consistent output formatting
   // Handles the "single output key" unwrap rule:
@@ -418,51 +320,14 @@ export function TargetCellContent({
           hasTargetOutput={output !== undefined && output !== null}
           hasAnyTargetOutputs={hasAnyTargetOutputs}
           targetType={target.type}
-          onEdit={() => {
-            // Code evaluators have their own editor (the Python code block plus
-            // its inputs and outputs); the generic editor can only show the
-            // mapping. Route them to the code editor, with the inputs and their
-            // mapping merged inline.
-            if (codeEvaluatorIds.has(evaluator.id)) {
-              setFlowCallbacks(
-                "codeEvaluatorEditor",
-                createEvaluatorEditorCallbacks({
-                  onMappingChange: buildOnMappingChange(evaluator),
-                }),
-              );
-              openDrawer("codeEvaluatorEditor", {
-                evaluatorId: evaluator.dbEvaluatorId,
-                mappingsConfig: buildMappingsConfig(evaluator),
-              });
-              return;
-            }
-
-            // Route all non-serializable callbacks through setFlowCallbacks.
-            // onMappingChange + onLocalConfigChange must live here (not in
-            // mappingsConfig) so the drawer's mappings section renders — see
-            // issue #3441.
-            //
-            // We use the direct `onLocalConfigChange` form (not the
-            // target-bound `targetId + updateTarget` convenience) because
-            // the chip's local config persists onto the evaluator, not the
-            // target.
-            setFlowCallbacks(
-              "evaluatorEditor",
-              createEvaluatorEditorCallbacks({
-                onLocalConfigChange: (localEvaluatorConfig) => {
-                  updateEvaluator(evaluator.id, { localEvaluatorConfig });
-                },
-                onMappingChange: buildOnMappingChange(evaluator),
-              }),
-            );
-
-            openDrawer("evaluatorEditor", {
-              evaluatorId: evaluator.dbEvaluatorId,
-              evaluatorType: evaluator.evaluatorType,
-              mappingsConfig: buildMappingsConfig(evaluator),
-              initialLocalConfig: evaluator.localEvaluatorConfig,
-            });
-          }}
+          onEdit={() =>
+            openEvaluatorEditor({
+              evaluator,
+              target,
+              targetName,
+              isCodeEvaluator: codeEvaluatorIds.has(evaluator.id),
+            })
+          }
           onRemove={() => removeEvaluator(evaluator.id)}
           onRerun={
             onRerunEvaluator ? () => onRerunEvaluator(evaluator.id) : undefined

--- a/langwatch/src/experiments-v3/components/TargetSection/TargetCell.tsx
+++ b/langwatch/src/experiments-v3/components/TargetSection/TargetCell.tsx
@@ -181,20 +181,11 @@ export function TargetCellContent({
   // path (cleared on ErrorBoundary remount — see issue #3087).
   const buildMappingsConfig = useCallback(
     (evaluator: EvaluatorConfig) => {
-      // Build available sources
+      // Build available sources. Target outputs come FIRST: for an evaluator,
+      // the graded field (e.g. "output") should offer the runner's outputs
+      // ahead of dataset columns, mirroring how inputs prefer the dataset.
       const activeDataset = datasets.find((d) => d.id === activeDatasetId);
       const availableSources = [];
-      if (activeDataset) {
-        availableSources.push({
-          id: activeDataset.id,
-          name: activeDataset.name,
-          type: "dataset" as const,
-          fields: activeDataset.columns.map((col) => ({
-            name: col.name,
-            type: "str" as const,
-          })),
-        });
-      }
       // Use local config outputs if available (unsaved changes), fallback to saved outputs
       const effectiveOutputs =
         target.localPromptConfig?.outputs ?? target.outputs;
@@ -207,6 +198,17 @@ export function TargetCellContent({
           type: o.type as "str" | "float" | "bool",
         })),
       });
+      if (activeDataset) {
+        availableSources.push({
+          id: activeDataset.id,
+          name: activeDataset.name,
+          type: "dataset" as const,
+          fields: activeDataset.columns.map((col) => ({
+            name: col.name,
+            type: "str" as const,
+          })),
+        });
+      }
 
       // Get current mappings in UI format (used as initial state in the drawer)
       const storeMappings =

--- a/langwatch/src/experiments-v3/hooks/resolveTargetName.ts
+++ b/langwatch/src/experiments-v3/hooks/resolveTargetName.ts
@@ -1,0 +1,48 @@
+import type { api } from "~/utils/api";
+import type { TargetConfig } from "../types";
+
+type TrpcUtils = ReturnType<typeof api.useContext>;
+
+/**
+ * Synchronously resolve a target's display name from the tRPC query cache.
+ *
+ * The reactive counterpart is useTargetName; this variant is for imperative
+ * call sites (opening a drawer from an event handler) where a hook can't be
+ * used and the name queries are already warm, because every visible target
+ * header renders useTargetName and populates the same cache keys.
+ *
+ * Returns undefined on a cache miss so callers can fall back.
+ */
+export const resolveTargetNameFromCache = ({
+  target,
+  utils,
+  projectId,
+}: {
+  target: TargetConfig;
+  utils: TrpcUtils;
+  projectId: string | undefined;
+}): string | undefined => {
+  if (!projectId) return undefined;
+
+  if (target.type === "prompt") {
+    if (!target.promptId) return "New Prompt";
+    const prompt = utils.prompts.getByIdOrHandle.getData({
+      idOrHandle: target.promptId,
+      projectId,
+    });
+    return prompt?.handle ?? prompt?.name ?? "New Prompt";
+  }
+  if (target.type === "agent") {
+    return utils.agents.getById.getData({
+      id: target.dbAgentId ?? "",
+      projectId,
+    })?.name;
+  }
+  if (target.type === "evaluator") {
+    return utils.evaluators.getById.getData({
+      id: target.targetEvaluatorId ?? "",
+      projectId,
+    })?.name;
+  }
+  return undefined;
+};

--- a/langwatch/src/experiments-v3/hooks/useOpenEvaluatorEditor.ts
+++ b/langwatch/src/experiments-v3/hooks/useOpenEvaluatorEditor.ts
@@ -1,0 +1,171 @@
+/**
+ * Hook to open the *grading evaluator* editor drawer for a given
+ * (evaluator, target) pair, with variable-mapping sources ordered target-first.
+ *
+ * Distinct from useOpenTargetEditor, which edits a TARGET (and exposes only the
+ * dataset as a mapping source). Here the entity is an EvaluatorConfig that
+ * applies to all targets; the graded field (e.g. "output") should surface the
+ * runner's outputs ahead of dataset columns, so target outputs come first.
+ *
+ * Shared by:
+ *  - TargetCell: clicking an evaluator chip to edit its mapping for that cell.
+ *  - EvaluationsV3Table: auto-opening when a freshly added evaluator still has
+ *    unmapped required fields, so the user is shown where to map them instead
+ *    of the picker silently closing.
+ */
+
+import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import type {
+  AvailableSource,
+  FieldMapping as UIFieldMapping,
+} from "~/components/variables";
+import { setFlowCallbacks, useDrawer } from "~/hooks/useDrawer";
+import type { EvaluatorConfig, TargetConfig } from "../types";
+import { createEvaluatorEditorCallbacks } from "../utils/evaluatorEditorCallbacks";
+import {
+  convertFromUIMapping,
+  convertToUIMapping,
+} from "../utils/fieldMappingConverters";
+import { useEvaluationsV3Store } from "./useEvaluationsV3Store";
+
+export const useOpenEvaluatorEditor = () => {
+  const { openDrawer } = useDrawer();
+
+  const {
+    datasets,
+    activeDatasetId,
+    updateEvaluator,
+    setEvaluatorMapping,
+    removeEvaluatorMapping,
+  } = useEvaluationsV3Store(
+    useShallow((state) => ({
+      datasets: state.datasets,
+      activeDatasetId: state.activeDatasetId,
+      updateEvaluator: state.updateEvaluator,
+      setEvaluatorMapping: state.setEvaluatorMapping,
+      removeEvaluatorMapping: state.removeEvaluatorMapping,
+    })),
+  );
+
+  return useCallback(
+    ({
+      evaluator,
+      target,
+      targetName,
+      isCodeEvaluator,
+    }: {
+      evaluator: EvaluatorConfig;
+      target: TargetConfig;
+      targetName: string;
+      isCodeEvaluator: boolean;
+    }) => {
+      // Build available sources. Target outputs come FIRST: for an evaluator,
+      // the graded field (e.g. "output") should offer the runner's outputs
+      // ahead of dataset columns, mirroring how inputs prefer the dataset.
+      const activeDataset = datasets.find((d) => d.id === activeDatasetId);
+      // Use local config outputs if available (unsaved changes), fallback to saved.
+      const effectiveOutputs =
+        target.localPromptConfig?.outputs ?? target.outputs;
+      const availableSources: AvailableSource[] = [
+        {
+          id: target.id,
+          name: targetName,
+          type: "signature" as const,
+          fields: effectiveOutputs.map((o) => ({
+            name: o.identifier,
+            type: o.type as "str" | "float" | "bool",
+          })),
+        },
+      ];
+      if (activeDataset) {
+        availableSources.push({
+          id: activeDataset.id,
+          name: activeDataset.name,
+          type: "dataset" as const,
+          fields: activeDataset.columns.map((col) => ({
+            name: col.name,
+            type: "str" as const,
+          })),
+        });
+      }
+
+      // Current mappings in UI format (initial state for the drawer).
+      const storeMappings =
+        evaluator.mappings[activeDatasetId]?.[target.id] ?? {};
+      const initialMappings: Record<string, UIFieldMapping> = {};
+      for (const [key, mapping] of Object.entries(storeMappings)) {
+        initialMappings[key] = convertToUIMapping(mapping);
+      }
+      const mappingsConfig = { availableSources, initialMappings };
+
+      const datasetIds = new Set(datasets.map((d) => d.id));
+      const isDatasetSource = (sourceId: string) => datasetIds.has(sourceId);
+      const onMappingChange = (
+        identifier: string,
+        mapping: UIFieldMapping | undefined,
+      ) => {
+        if (mapping) {
+          setEvaluatorMapping(
+            evaluator.id,
+            activeDatasetId,
+            target.id,
+            identifier,
+            convertFromUIMapping(mapping, isDatasetSource),
+          );
+        } else {
+          removeEvaluatorMapping(
+            evaluator.id,
+            activeDatasetId,
+            target.id,
+            identifier,
+          );
+        }
+      };
+
+      // Code evaluators have their own editor (the Python code block plus its
+      // inputs and outputs); the generic editor can only show the mapping.
+      // Route them to the code editor, with the inputs and their mapping merged.
+      if (isCodeEvaluator) {
+        setFlowCallbacks(
+          "codeEvaluatorEditor",
+          createEvaluatorEditorCallbacks({ onMappingChange }),
+        );
+        openDrawer("codeEvaluatorEditor", {
+          evaluatorId: evaluator.dbEvaluatorId,
+          mappingsConfig,
+        });
+        return;
+      }
+
+      // Route all non-serializable callbacks through setFlowCallbacks.
+      // onMappingChange + onLocalConfigChange must live here (not in
+      // mappingsConfig) so the drawer's mappings section renders — see
+      // issue #3441. The local config persists onto the evaluator, not the
+      // target, so use the direct onLocalConfigChange form.
+      setFlowCallbacks(
+        "evaluatorEditor",
+        createEvaluatorEditorCallbacks({
+          onLocalConfigChange: (localEvaluatorConfig) => {
+            updateEvaluator(evaluator.id, { localEvaluatorConfig });
+          },
+          onMappingChange,
+        }),
+      );
+      openDrawer("evaluatorEditor", {
+        evaluatorId: evaluator.dbEvaluatorId,
+        evaluatorType: evaluator.evaluatorType,
+        mappingsConfig,
+        initialLocalConfig: evaluator.localEvaluatorConfig,
+      });
+    },
+    [
+      openDrawer,
+      datasets,
+      activeDatasetId,
+      updateEvaluator,
+      setEvaluatorMapping,
+      removeEvaluatorMapping,
+    ],
+  );
+};

--- a/langwatch/src/experiments-v3/utils/__tests__/mappingInference.test.ts
+++ b/langwatch/src/experiments-v3/utils/__tests__/mappingInference.test.ts
@@ -500,6 +500,50 @@ describe("inferEvaluatorMappings", () => {
     }
   });
 
+  /** @scenario Auto-map a target-output field to the target's only output when no name matches */
+  it("maps an output field to the target's only output when no name matches", () => {
+    const dataset = createTestDataset("ds-1", "Dataset 1", [
+      createTestColumn("input"),
+      createTestColumn("expected_output"),
+    ]);
+    const target = createTestTarget(
+      "target-1",
+      [{ identifier: "input", type: "str" }],
+      // Single output whose name does not match "output" by any rule
+      [{ identifier: "category", type: "str" }],
+    );
+    const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
+
+    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+
+    expect(mappings.output).toEqual({
+      type: "source",
+      source: "target",
+      sourceId: "target-1",
+      sourceField: "category",
+    });
+  });
+
+  /** @scenario Do not guess a single output when the target has multiple outputs and no name matches */
+  it("does not guess when the target has multiple outputs and no name matches", () => {
+    const dataset = createTestDataset("ds-1", "Dataset 1", [
+      createTestColumn("input"),
+    ]);
+    const target = createTestTarget(
+      "target-1",
+      [{ identifier: "input", type: "str" }],
+      [
+        { identifier: "category", type: "str" },
+        { identifier: "confidence", type: "str" },
+      ],
+    );
+    const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
+
+    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+
+    expect(mappings.output).toBeUndefined();
+  });
+
   it("does not override existing mappings", () => {
     const dataset = createTestDataset("ds-1", "Dataset 1", [
       createTestColumn("input"),
@@ -587,12 +631,19 @@ describe("inferEvaluatorMappings", () => {
     /** @scenario "output" never falls back to a dataset column */
     it("leaves an `output` mapping empty rather than falling back to a same-named dataset column", () => {
       const dataset = createTestDataset("ds-1", "Dataset 1", [
-        createTestColumn("output"), // dataset has output, target does not
+        createTestColumn("output"), // tempting same-named dataset column
       ]);
+      // Multiple non-matching outputs: no name match AND no single-output
+      // shortcut, so `output` must stay empty rather than grab the dataset's
+      // "output" column (the customer-reported self-grading bug). The
+      // single-output auto-map is covered separately above.
       const target = createTestTarget(
         "target-1",
         [{ identifier: "input", type: "str" }],
-        [{ identifier: "irrelevant", type: "str" }], // no output-like output
+        [
+          { identifier: "irrelevant", type: "str" },
+          { identifier: "also_irrelevant", type: "str" },
+        ],
       );
       const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
 

--- a/langwatch/src/experiments-v3/utils/__tests__/mappingInference.test.ts
+++ b/langwatch/src/experiments-v3/utils/__tests__/mappingInference.test.ts
@@ -500,48 +500,66 @@ describe("inferEvaluatorMappings", () => {
     }
   });
 
-  /** @scenario Auto-map a target-output field to the target's only output when no name matches */
-  it("maps an output field to the target's only output when no name matches", () => {
-    const dataset = createTestDataset("ds-1", "Dataset 1", [
-      createTestColumn("input"),
-      createTestColumn("expected_output"),
-    ]);
-    const target = createTestTarget(
-      "target-1",
-      [{ identifier: "input", type: "str" }],
-      // Single output whose name does not match "output" by any rule
-      [{ identifier: "category", type: "str" }],
-    );
-    const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
+  describe("given an output-like field that matches no target output by name", () => {
+    describe("when the target exposes a single output", () => {
+      /** @scenario Auto-map a target-output field to the target's only output when no name matches */
+      it("maps the output field to that sole output", () => {
+        const dataset = createTestDataset("ds-1", "Dataset 1", [
+          createTestColumn("input"),
+          createTestColumn("expected_output"),
+        ]);
+        const target = createTestTarget(
+          "target-1",
+          [{ identifier: "input", type: "str" }],
+          // Single output whose name does not match "output" by any rule
+          [{ identifier: "category", type: "str" }],
+        );
+        const evaluatorInputs: Field[] = [
+          { identifier: "output", type: "str" },
+        ];
 
-    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+        const mappings = inferEvaluatorMappings(
+          evaluatorInputs,
+          dataset,
+          target,
+        );
 
-    expect(mappings.output).toEqual({
-      type: "source",
-      source: "target",
-      sourceId: "target-1",
-      sourceField: "category",
+        expect(mappings.output).toEqual({
+          type: "source",
+          source: "target",
+          sourceId: "target-1",
+          sourceField: "category",
+        });
+      });
     });
-  });
 
-  /** @scenario Do not guess a single output when the target has multiple outputs and no name matches */
-  it("does not guess when the target has multiple outputs and no name matches", () => {
-    const dataset = createTestDataset("ds-1", "Dataset 1", [
-      createTestColumn("input"),
-    ]);
-    const target = createTestTarget(
-      "target-1",
-      [{ identifier: "input", type: "str" }],
-      [
-        { identifier: "category", type: "str" },
-        { identifier: "confidence", type: "str" },
-      ],
-    );
-    const evaluatorInputs: Field[] = [{ identifier: "output", type: "str" }];
+    describe("when the target exposes multiple outputs", () => {
+      /** @scenario An output field is left for me to map when the runner has several outputs to choose from */
+      it("leaves the output field unmapped", () => {
+        const dataset = createTestDataset("ds-1", "Dataset 1", [
+          createTestColumn("input"),
+        ]);
+        const target = createTestTarget(
+          "target-1",
+          [{ identifier: "input", type: "str" }],
+          [
+            { identifier: "category", type: "str" },
+            { identifier: "confidence", type: "str" },
+          ],
+        );
+        const evaluatorInputs: Field[] = [
+          { identifier: "output", type: "str" },
+        ];
 
-    const mappings = inferEvaluatorMappings(evaluatorInputs, dataset, target);
+        const mappings = inferEvaluatorMappings(
+          evaluatorInputs,
+          dataset,
+          target,
+        );
 
-    expect(mappings.output).toBeUndefined();
+        expect(mappings.output).toBeUndefined();
+      });
+    });
   });
 
   it("does not override existing mappings", () => {

--- a/langwatch/src/experiments-v3/utils/mappingInference.ts
+++ b/langwatch/src/experiments-v3/utils/mappingInference.ts
@@ -365,7 +365,15 @@ export const inferEvaluatorMappings = (
       findMatchingColumn(input.identifier, dataset.columns);
 
     if (isTargetOnly) {
-      const m = targetMatch();
+      // Prefer a name/semantic match; otherwise, when the target exposes
+      // exactly one output it is the only sensible source for an output-like
+      // field, so auto-map to it (the single-output classifier case where the
+      // sole output is named e.g. "category", not "output").
+      const m =
+        targetMatch() ??
+        (target.outputs.length === 1
+          ? target.outputs[0]?.identifier
+          : undefined);
       if (m) {
         newMappings[input.identifier] = {
           type: "source",

--- a/specs/experiments-v3/mapping-auto-inference.feature
+++ b/specs/experiments-v3/mapping-auto-inference.feature
@@ -120,7 +120,7 @@ Feature: Mapping Auto-Inference
   @regression
   Scenario: "output" never falls back to a dataset column
     Given I have a dataset with column "output"
-    And I have a runner with no output named like "output"
+    And I have a runner with multiple outputs, none named like "output"
     When I add an evaluator with input "output"
     Then evaluator "output" has no auto-inferred mapping
     And the dataset's "output" column is NOT chosen
@@ -147,6 +147,33 @@ Feature: Mapping Auto-Inference
     When I add an evaluator with input "output"
     Then evaluator "output" is mapped to the runner output "output"
     And the dataset's "output" column is not chosen
+
+  # When an "output"-like evaluator field cannot be matched to a target output
+  # by name, but the target exposes exactly ONE output, that single output is
+  # the only sensible source, so it is auto-mapped. This covers the common
+  # single-output classifier case (a target "category_classifier" whose one
+  # output "category" does not match the evaluator field name "output").
+  Scenario: Auto-map a target-output field to the target's only output when no name matches
+    Given I have a runner producing a single output "category"
+    And I have a dataset with columns "input, expected_output"
+    When I add an evaluator with input "output"
+    Then evaluator "output" is mapped to the runner output "category"
+    And no manual mapping is required for "output"
+
+  @regression
+  Scenario: Do not guess a single output when the target has multiple outputs and no name matches
+    Given I have a runner producing outputs "category" and "confidence"
+    When I add an evaluator with input "output"
+    Then evaluator "output" has no auto-inferred mapping
+
+  # When manually mapping an evaluator field in the workbench, the source
+  # selector offers the TARGET's outputs ahead of the dataset columns, so the
+  # graded "output" field surfaces the runner's output first instead of a
+  # same-named dataset column.
+  @unimplemented
+  Scenario: The evaluator mapping selector offers target outputs before dataset columns
+    Given I open an evaluator's mapping drawer in the workbench
+    Then the source selector lists the target's outputs before the dataset columns
 
   # ============================================================================
   # Semantic Mapping Dictionary

--- a/specs/experiments-v3/mapping-auto-inference.feature
+++ b/specs/experiments-v3/mapping-auto-inference.feature
@@ -170,7 +170,6 @@ Feature: Mapping Auto-Inference
   # selector offers the TARGET's outputs ahead of the dataset columns, so the
   # graded "output" field surfaces the runner's output first instead of a
   # same-named dataset column.
-  @unimplemented
   Scenario: The evaluator mapping selector offers target outputs before dataset columns
     Given I open an evaluator's mapping drawer in the workbench
     Then the source selector lists the target's outputs before the dataset columns

--- a/specs/experiments-v3/mapping-auto-inference.feature
+++ b/specs/experiments-v3/mapping-auto-inference.feature
@@ -161,7 +161,7 @@ Feature: Mapping Auto-Inference
     And no manual mapping is required for "output"
 
   @regression
-  Scenario: Do not guess a single output when the target has multiple outputs and no name matches
+  Scenario: An output field is left for me to map when the runner has several outputs to choose from
     Given I have a runner producing outputs "category" and "confidence"
     When I add an evaluator with input "output"
     Then evaluator "output" has no auto-inferred mapping

--- a/specs/experiments-v3/mapping-validation.feature
+++ b/specs/experiments-v3/mapping-validation.feature
@@ -115,6 +115,30 @@ Feature: Mapping Validation and Missing Mapping Detection
     And the missing mappings are highlighted
 
   # ============================================================================
+  # Adding an Evaluator with Unmapped Required Fields
+  # ============================================================================
+  #
+  # Auto-inference cannot always satisfy every required input (e.g. an evaluator
+  # needs an "expected_output" the dataset does not carry). When that happens on
+  # ADD, silently closing the picker leaves the user with a freshly-added
+  # evaluator and no signpost to where the missing mapping lives. Instead the
+  # evaluator's mapping drawer opens straight onto the unmapped fields.
+
+  @unimplemented
+  Scenario: Adding an evaluator with unmapped required fields opens its mapping drawer
+    Given the active dataset and runner cannot satisfy an evaluator's required input
+    When I add that evaluator to the workbench
+    Then the evaluator's mapping drawer opens automatically
+    And the unmapped required fields are highlighted
+    And the picker does not silently close without guiding me
+
+  @unimplemented
+  Scenario: Adding an evaluator whose required fields all auto-map closes the picker
+    Given I add an evaluator whose required inputs are all auto-mapped
+    Then the picker closes
+    And the evaluator's mapping drawer does not open
+
+  # ============================================================================
   # Declared-but-unused prompt variables
   # ============================================================================
 

--- a/specs/experiments-v3/mapping-validation.feature
+++ b/specs/experiments-v3/mapping-validation.feature
@@ -124,7 +124,6 @@ Feature: Mapping Validation and Missing Mapping Detection
   # evaluator and no signpost to where the missing mapping lives. Instead the
   # evaluator's mapping drawer opens straight onto the unmapped fields.
 
-  @unimplemented
   Scenario: Adding an evaluator with unmapped required fields opens its mapping drawer
     Given the active dataset and runner cannot satisfy an evaluator's required input
     When I add that evaluator to the workbench
@@ -132,7 +131,6 @@ Feature: Mapping Validation and Missing Mapping Detection
     And the unmapped required fields are highlighted
     And the picker does not silently close without guiding me
 
-  @unimplemented
   Scenario: Adding an evaluator whose required fields all auto-map closes the picker
     Given I add an evaluator whose required inputs are all auto-mapped
     Then the picker closes


### PR DESCRIPTION
## What

Three fixes to evaluator mapping in the evaluations workbench, all from dogfood and customer reports about the add-an-evaluator flow being confusing when mappings are not obvious.

### A. Guide the user to unmapped fields instead of silently closing the picker

When you add an evaluator whose required inputs cannot all be auto-inferred (for example the active dataset has no column for a required field), the picker used to just close, leaving a freshly added evaluator with a missing-mapping alert and no signpost to where the mapping lives. Now the evaluator's mapping drawer opens straight onto the unmapped fields. When every required field auto-maps, the picker still closes as before.

### B1. Mapping selector lists target outputs before dataset columns

When mapping an evaluator field, the source selector now offers the target's outputs ahead of the dataset columns. For an evaluator the graded field (for example `output`) should surface the runner's output first, mirroring how inputs prefer the dataset.

### B2. Auto-map an output field to the target's only output when no name matches

When an output-like evaluator field cannot be matched to a target output by name, but the target exposes exactly one output, that single output is the only sensible source, so it is auto-mapped. This covers the common single-output classifier case: a target `category_classifier` whose one output `category` does not match the evaluator field name `output`.

## How

- Extracts the evaluator chip edit-open logic out of `TargetCell` into a shared `useOpenEvaluatorEditor` hook, reused by both the chip edit and the new post-add auto-open path, so the two stay in sync. The hook orders the variable sources target-first (B1).
- The post-add decision reads fresh store state (the just-added config, with inferred mappings) and opens onto the first target when any required field is still unmapped, resolving the target source label from the warm tRPC cache.
- B2 lives in the evaluator mapping inference: the target-only branch falls back to the sole output when there is no name match, and never falls back to a dataset column.

## Testing

- New integration tests bind the BDD scenarios: adding an evaluator with an unmappable required field opens its mapping drawer, an all-auto-mapped evaluator closes the picker, and the opened drawer lists target outputs before dataset columns.
- B2 covered by unit tests for the single-output fallback and the multi-output negative case, plus the existing customer regression that an `output` field never grabs a same-named dataset column.
- `specs/experiments-v3/mapping-validation.feature` and `mapping-auto-inference.feature` updated; all scenarios bound.
- Full experiments-v3 unit and integration suites green, typecheck clean.

## Screenshots

Browser QA on a real workbench (a prompt target over a dataset with `input` + `expected_output`).

**A. Adding an evaluator with an unmappable required field auto-opens its mapping drawer.** Ragas Faithfulness needs `contexts`, which the dataset does not carry, so instead of the picker silently closing the mapping drawer opens onto the unmapped field. Note `output` already auto-mapped to the target output and `input` to the dataset (B1).

![Auto-open on unmapped contexts](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4892/evaluator-mapping/a1-autoopen-unmapped-contexts.png)

**B. The graded output field prefers the target output over a dataset column.** Editing an evaluator shows `output = test-prompt.output` (the runner output, green) and `expected_output = Test Data.expected_output` (dataset, blue).

![Output maps to target](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4892/evaluator-mapping/b1-output-maps-to-target.png)

**A (closed path). When every required field auto-maps, the picker just closes** and the evaluator chip lands with no missing-mapping alert.

![Fully mapped closes the picker](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4892/evaluator-mapping/a2-fullymapped-closes-picker.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When adding evaluators with missing required field mappings, the mapping editor now automatically opens for easy configuration
  * Enhanced auto-mapping logic: single target outputs are now intelligently mapped to matching evaluator fields
  * Updated mapping UI: target outputs now appear before dataset columns in the source selector for better organization

* **Tests**
  * Added integration tests validating evaluator selection and field mapping workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->