### PR TITLE
fix(studio): stop prompt editor render loop crashing the playground

### DIFF
--- a/langwatch/specs/prompts/undefined-variable-banner-stability.feature
+++ b/langwatch/specs/prompts/undefined-variable-banner-stability.feature
@@ -1,0 +1,23 @@
+Feature: Prompt playground stays stable when a prompt references undefined variables
+  When a message uses a variable that is not declared as an input, the editor
+  flags it with an "Undefined variables" warning so the author can create it.
+
+  Surfacing that warning must never destabilise the editor. The prompt re-renders
+  constantly (as the author types, switches tabs, or a playground conversation
+  streams), and the warning must survive those re-renders without throwing the
+  whole page to the top-level error boundary.
+
+  Background:
+    Given a prompt open in the playground
+
+  Scenario: An undefined variable is flagged without crashing the page
+    Given the message references a variable that is not declared as an input
+    When the prompt re-renders repeatedly while the author works
+    Then the editor shows an "Undefined variables" warning naming that variable
+    And the playground keeps rendering the prompt instead of showing the error boundary
+
+  Scenario: A prompt with a running conversation re-opens without crashing
+    Given the prompt has a conversation whose assistant turn references a trace that no longer exists
+    When the prompt tab is re-opened
+    Then the conversation is rendered
+    And the playground does not crash to the error boundary

--- a/langwatch/src/components/copilot-kit/__tests__/TraceMessage.test.tsx
+++ b/langwatch/src/components/copilot-kit/__tests__/TraceMessage.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TraceMessage } from "../TraceMessage";
+
+const useGetByIdQueryMock = vi.fn();
+
+vi.mock("../../../hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({ project: { id: "proj-1" } }),
+}));
+
+vi.mock("../../../utils/api", () => ({
+  api: {
+    traces: {
+      getById: {
+        useQuery: (...args: unknown[]) => useGetByIdQueryMock(...args),
+      },
+    },
+  },
+}));
+
+// Only rendered on the success path (not reached here); mocked so the
+// traces-v2 module graph does not have to load for this test.
+vi.mock("~/features/traces-v2/components/TraceIdPeek", () => ({
+  TracePreviewHoverCard: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("~/hooks/useTraceDetailsDrawer", () => ({
+  useTraceDetailsDrawer: () => ({ openTraceDetailsDrawer: vi.fn() }),
+}));
+
+describe("TraceMessage", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe("when the referenced trace no longer exists", () => {
+    /** @scenario A prompt with a running conversation re-opens without crashing */
+    it("renders nothing instead of throwing when the trace query 404s", () => {
+      // A "View Trace" link is attached to each assistant turn. When that
+      // turn's trace cannot be fetched (it was never written, or expired),
+      // the link must degrade to an empty render, never throw to the page
+      // error boundary, so re-opening a prompt with an old conversation does
+      // not crash the playground. TraceMessage returns null while loading, on
+      // error, or with no data; here the query is in the 404 error state.
+      useGetByIdQueryMock.mockReturnValue({
+        isLoading: false,
+        isError: true,
+        data: undefined,
+      });
+
+      const { container } = render(
+        <TraceMessage traceId="ff364975e79bc3c1ad48c38024928fea" />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/components/copilot-kit/__tests__/TraceMessage.test.tsx
+++ b/langwatch/src/components/copilot-kit/__tests__/TraceMessage.test.tsx
@@ -38,26 +38,28 @@ describe("TraceMessage", () => {
     vi.clearAllMocks();
   });
 
-  describe("when the referenced trace no longer exists", () => {
-    /** @scenario A prompt with a running conversation re-opens without crashing */
-    it("renders nothing instead of throwing when the trace query 404s", () => {
-      // A "View Trace" link is attached to each assistant turn. When that
-      // turn's trace cannot be fetched (it was never written, or expired),
-      // the link must degrade to an empty render, never throw to the page
-      // error boundary, so re-opening a prompt with an old conversation does
-      // not crash the playground. TraceMessage returns null while loading, on
-      // error, or with no data; here the query is in the 404 error state.
-      useGetByIdQueryMock.mockReturnValue({
-        isLoading: false,
-        isError: true,
-        data: undefined,
+  describe("given a prompt conversation references a trace that no longer exists", () => {
+    describe("when the trace query returns a 404", () => {
+      /** @scenario A prompt with a running conversation re-opens without crashing */
+      it("renders nothing instead of throwing", () => {
+        // A "View Trace" link is attached to each assistant turn. When that
+        // turn's trace cannot be fetched (it was never written, or expired),
+        // the link must degrade to an empty render, never throw to the page
+        // error boundary, so re-opening a prompt with an old conversation does
+        // not crash the playground. TraceMessage returns null while loading, on
+        // error, or with no data; here the query is in the 404 error state.
+        useGetByIdQueryMock.mockReturnValue({
+          isLoading: false,
+          isError: true,
+          data: undefined,
+        });
+
+        const { container } = render(
+          <TraceMessage traceId="ff364975e79bc3c1ad48c38024928fea" />,
+        );
+
+        expect(container.firstChild).toBeNull();
       });
-
-      const { container } = render(
-        <TraceMessage traceId="ff364975e79bc3c1ad48c38024928fea" />,
-      );
-
-      expect(container.firstChild).toBeNull();
     });
   });
 });

--- a/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
+++ b/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
@@ -244,17 +244,34 @@ export const PromptTextAreaWithVariables = ({
   // always 0) on the legacy reservation.
   const bannerRef = useRef<HTMLDivElement>(null);
   const [bannerHeight, setBannerHeight] = useState(0);
-  // Re-measure the banner only when the *set* of invalid variables actually
-  // changes (the banner mounts/unmounts, or its text reflows onto more lines).
-  // Depending on the `invalidVariables` array identity instead re-ran this on
-  // every render, because the variables list upstream is rebuilt each render;
-  // the redundant per-render setState churned the commit phase into React's
-  // nested-update limit ("Maximum update depth exceeded"). A primitive
-  // signature plus a no-op guard keeps the height in sync without the churn.
+  // Keep the reserved padding in sync with the banner's real height. The
+  // banner grows taller both when the set of undefined names changes and on
+  // layout-only changes: the prompt panel is resizable, so the same names can
+  // wrap onto more lines as it narrows. A ResizeObserver catches every height
+  // change, including reflows that do not re-render this component, so the
+  // reserved padding never lags behind the banner and hides the last line.
+  //
+  // Re-attaching the observer is keyed on a primitive signature of the names,
+  // not the `invalidVariables` array identity: that array is rebuilt upstream
+  // on every render, so an array dependency re-ran this effect every render and
+  // the per-render setState churned the commit phase into React's nested-update
+  // limit ("Maximum update depth exceeded"). The equal-bail guard stops a
+  // same-height measurement from re-triggering the effect.
   const invalidVariablesKey = invalidVariables.join("\n");
   useLayoutEffect(() => {
-    const measured = bannerRef.current?.offsetHeight ?? 0;
-    setBannerHeight((prev) => (prev === measured ? prev : measured));
+    const node = bannerRef.current;
+    if (!node) {
+      setBannerHeight((prev) => (prev === 0 ? prev : 0));
+      return;
+    }
+    const measure = () => {
+      const measured = node.offsetHeight;
+      setBannerHeight((prev) => (prev === measured ? prev : measured));
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => observer.disconnect();
   }, [invalidVariablesKey]);
   const reservedBottomPadding =
     invalidVariables.length > 0 ? Math.max(bannerHeight + 8, 28) : null;

--- a/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
+++ b/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
@@ -244,9 +244,18 @@ export const PromptTextAreaWithVariables = ({
   // always 0) on the legacy reservation.
   const bannerRef = useRef<HTMLDivElement>(null);
   const [bannerHeight, setBannerHeight] = useState(0);
+  // Re-measure the banner only when the *set* of invalid variables actually
+  // changes (the banner mounts/unmounts, or its text reflows onto more lines).
+  // Depending on the `invalidVariables` array identity instead re-ran this on
+  // every render, because the variables list upstream is rebuilt each render;
+  // the redundant per-render setState churned the commit phase into React's
+  // nested-update limit ("Maximum update depth exceeded"). A primitive
+  // signature plus a no-op guard keeps the height in sync without the churn.
+  const invalidVariablesKey = invalidVariables.join(" ");
   useLayoutEffect(() => {
-    setBannerHeight(bannerRef.current?.offsetHeight ?? 0);
-  }, [invalidVariables]);
+    const measured = bannerRef.current?.offsetHeight ?? 0;
+    setBannerHeight((prev) => (prev === measured ? prev : measured));
+  }, [invalidVariablesKey]);
   const reservedBottomPadding =
     invalidVariables.length > 0 ? Math.max(bannerHeight + 8, 28) : null;
 

--- a/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
+++ b/langwatch/src/components/prompt-textarea/PromptTextAreaWithVariables.tsx
@@ -251,7 +251,7 @@ export const PromptTextAreaWithVariables = ({
   // the redundant per-render setState churned the commit phase into React's
   // nested-update limit ("Maximum update depth exceeded"). A primitive
   // signature plus a no-op guard keeps the height in sync without the churn.
-  const invalidVariablesKey = invalidVariables.join(" ");
+  const invalidVariablesKey = invalidVariables.join("\n");
   useLayoutEffect(() => {
     const measured = bannerRef.current?.offsetHeight ?? 0;
     setBannerHeight((prev) => (prev === measured ? prev : measured));

--- a/langwatch/src/components/prompt-textarea/__tests__/PromptTextAreaWithVariables.test.tsx
+++ b/langwatch/src/components/prompt-textarea/__tests__/PromptTextAreaWithVariables.test.tsx
@@ -3,6 +3,7 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -760,6 +761,57 @@ describe("PromptTextAreaWithVariables", () => {
       // update depth" throw needs the full app re-render storm to manifest, so
       // the eliminated per-render churn is the faithful, deterministic proxy.
       expect(bannerHeightReads).toBe(0);
+    });
+
+    /** @scenario The undefined-variables warning stays clear of the prompt after a resize */
+    it("re-measures the banner on a resize even when the invalid-variable set is unchanged", () => {
+      // Review follow-up: keying the measurement on the name set alone goes
+      // stale when the SAME warning text reflows taller - the resizable prompt
+      // panel narrows and the names wrap onto another line without changing the
+      // set. A ResizeObserver re-measures on that layout change so the reserved
+      // padding tracks the real height and never covers the last prompt line.
+      const observerCallbacks: ResizeObserverCallback[] = [];
+      const RealResizeObserver = globalThis.ResizeObserver;
+      globalThis.ResizeObserver = class {
+        constructor(cb: ResizeObserverCallback) {
+          observerCallbacks.push(cb);
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof ResizeObserver;
+
+      try {
+        renderComponent({
+          value: "Judge this: {{response}}",
+          variables: [],
+          onCreateVariable: vi.fn(),
+        });
+
+        // Initial measure ran against jsdom's offsetHeight 0, so the 28px floor.
+        const textarea = screen.getByRole("textbox");
+        expect(textarea.style.paddingBottom).toBe("28px");
+
+        // The names have not changed, but the banner now reflows to 100px.
+        const banner = screen.getByTestId("undefined-variables-banner");
+        Object.defineProperty(banner, "offsetHeight", {
+          configurable: true,
+          get: () => 100,
+        });
+
+        // A resize tick fires the observer; the padding must follow the height.
+        expect(observerCallbacks.length).toBeGreaterThan(0);
+        act(() => {
+          for (const cb of observerCallbacks) {
+            cb([], {} as ResizeObserver);
+          }
+        });
+
+        // 100 (height) + 8 (gap) = 108, above the 28px single-line floor.
+        expect(textarea.style.paddingBottom).toBe("108px");
+      } finally {
+        globalThis.ResizeObserver = RealResizeObserver;
+      }
     });
   });
 });

--- a/langwatch/src/components/prompt-textarea/__tests__/PromptTextAreaWithVariables.test.tsx
+++ b/langwatch/src/components/prompt-textarea/__tests__/PromptTextAreaWithVariables.test.tsx
@@ -11,7 +11,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { forwardRef } from "react";
+import { forwardRef, useReducer } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AvailableSource } from "../../variables/VariableMappingInput";
 import type { Variable } from "../../variables/VariablesSection";
@@ -699,6 +699,65 @@ describe("PromptTextAreaWithVariables", () => {
 
       fireEvent.blur(textarea);
       expect(textarea.style.paddingBottom).toBe("28px");
+    });
+
+    /** @scenario An undefined variable is flagged without crashing the page */
+    it("does not re-measure the banner on every parent re-render when the invalid-variable set is unchanged", () => {
+      // Regression: the banner useLayoutEffect depended on the `invalidVariables`
+      // array identity. The prompt editor rebuilds the variables array on every
+      // render, so the effect re-ran and called setState on every render, which
+      // churned the commit phase into React's "Maximum update depth exceeded"
+      // crash (it threw the page to the top-level error boundary). The fix keys
+      // the effect on a stable primitive signature of the invalid names, so it
+      // only re-measures when the set of undefined variables actually changes.
+      // Each re-measure here stands in for one of the per-render setStates that
+      // fed the crash, so a non-zero count on stable input is the regression.
+      function Harness() {
+        const [, forceRerender] = useReducer((n: number) => n + 1, 0);
+        // Mirrors PromptMessagesEditor: a brand-new array (and objects) each render.
+        const variables: Variable[] = [{ identifier: "question", type: "str" }];
+        return (
+          <ChakraProvider value={defaultSystem}>
+            <button
+              type="button"
+              data-testid="rerender"
+              onClick={() => forceRerender()}
+            >
+              rerender
+            </button>
+            <PromptTextAreaWithVariables
+              value="Judge this: {{response}}"
+              onChange={vi.fn()}
+              variables={variables}
+            />
+          </ChakraProvider>
+        );
+      }
+
+      render(<Harness />);
+
+      // `response` is undefined, so the banner is mounted. Spy on the exact node
+      // the layout effect measures, so we count only its reads (not Chakra's).
+      const banner = screen.getByTestId("undefined-variables-banner");
+      let bannerHeightReads = 0;
+      Object.defineProperty(banner, "offsetHeight", {
+        configurable: true,
+        get() {
+          bannerHeightReads += 1;
+          return 24;
+        },
+      });
+
+      // Re-render the parent repeatedly; each pass hands down a fresh variables
+      // array, exactly as the real editor does on every render.
+      for (let i = 0; i < 5; i += 1) {
+        fireEvent.click(screen.getByTestId("rerender"));
+      }
+
+      // The set of invalid variables never changed, so the layout effect must
+      // not re-measure. Pre-fix this was 5 (one re-measure + setState per render)
+      // and is what drove the "Maximum update depth exceeded" crash in-app.
+      expect(bannerHeightReads).toBe(0);
     });
   });
 });

--- a/langwatch/src/components/prompt-textarea/__tests__/PromptTextAreaWithVariables.test.tsx
+++ b/langwatch/src/components/prompt-textarea/__tests__/PromptTextAreaWithVariables.test.tsx
@@ -754,9 +754,11 @@ describe("PromptTextAreaWithVariables", () => {
         fireEvent.click(screen.getByTestId("rerender"));
       }
 
-      // The set of invalid variables never changed, so the layout effect must
-      // not re-measure. Pre-fix this was 5 (one re-measure + setState per render)
-      // and is what drove the "Maximum update depth exceeded" crash in-app.
+      // This proves the proximate cause is gone: with the invalid-variable set
+      // unchanged, the layout effect no longer re-measures and re-setStates on
+      // every render (pre-fix this was 5, one per render). The literal "Maximum
+      // update depth" throw needs the full app re-render storm to manifest, so
+      // the eliminated per-render churn is the faithful, deterministic proxy.
       expect(bannerHeightReads).toBe(0);
     });
   });

--- a/specs/prompts/undefined-variable-banner-stability.feature
+++ b/specs/prompts/undefined-variable-banner-stability.feature
@@ -1,3 +1,4 @@
+@integration
 Feature: Prompt playground stays stable when a prompt references undefined variables
   When a message uses a variable that is not declared as an input, the editor
   flags it with an "Undefined variables" warning so the author can create it.

--- a/specs/prompts/undefined-variable-banner-stability.feature
+++ b/specs/prompts/undefined-variable-banner-stability.feature
@@ -17,6 +17,11 @@ Feature: Prompt playground stays stable when a prompt references undefined varia
     Then the editor shows an "Undefined variables" warning naming that variable
     And the playground keeps rendering the prompt instead of showing the error boundary
 
+  Scenario: The undefined-variables warning stays clear of the prompt after a resize
+    Given the message references a variable that is not declared as an input
+    When the editor is resized so the warning wraps onto more lines
+    Then the warning still does not cover the last line of the prompt
+
   Scenario: A prompt with a running conversation re-opens without crashing
     Given the prompt has a conversation whose assistant turn references a trace that no longer exists
     When the prompt tab is re-opened


### PR DESCRIPTION
## What

The prompt playground crashed to the top-level "Something went wrong" error boundary with `Maximum update depth exceeded`, reported via dogfood QA. The report attributed it to an unhandled `traces.getById` 404, but that 404 is handled noise (`TraceMessage` swallows it and returns null on error). The actual crash is a render loop in the prompt editor.

## Root cause

`PromptTextAreaWithVariables` shows an "Undefined variables" banner when a message references a variable that is not declared as an input. The banner height is measured in a `useLayoutEffect` so the textarea can reserve matching bottom padding. That effect depended on the `invalidVariables` **array identity**:

```ts
useLayoutEffect(() => {
  setBannerHeight(bannerRef.current?.offsetHeight ?? 0);
}, [invalidVariables]);
```

The prompt editor rebuilds the variables list on every render (`inputs.map(...)` in `PromptMessagesEditor`), so `invalidVariables` is a new array reference every render. The effect therefore ran on every render and called `setBannerHeight` unconditionally. During the prompt tab's mount and settle re-renders, that per-render commit-phase setState tipped React past its nested-update limit and threw to the error boundary.

The crash needs a tab with enough re-render activity to reach the limit (in practice, a tab that has an open conversation), which is why a brand new empty prompt does not trip it.

## Fix

Measure the banner with a `ResizeObserver` (the same pattern `IOViewer` uses in traces-v2), re-attaching it on a stable primitive signature of the invalid variable names rather than the `invalidVariables` array identity, with an equal-bail setter:

```ts
const invalidVariablesKey = invalidVariables.join("\n");
useLayoutEffect(() => {
  const node = bannerRef.current;
  if (!node) {
    setBannerHeight((prev) => (prev === 0 ? prev : 0));
    return;
  }
  const measure = () => {
    const measured = node.offsetHeight;
    setBannerHeight((prev) => (prev === measured ? prev : measured));
  };
  measure();
  const observer = new ResizeObserver(measure);
  observer.observe(node);
  return () => observer.disconnect();
}, [invalidVariablesKey]);
```

Two things keep the render loop dead: the effect re-runs only when the name set changes (not on every render, which was the original trigger), and the equal-bail setter never schedules a redundant update. The `ResizeObserver` adds back the layout-only case raised in review: narrowing the resizable prompt panel can wrap the same warning onto more lines and grow the banner without changing the name set, so a key-only approach would leave the reserved padding stale and the warning could cover the last line again. The observer re-measures on that resize so the padding always follows the real height.

## Screenshots

Before, opening a prompt tab with a conversation throws to the error boundary:

![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4896/render-loop/before-error-boundary.png)

After, the same prompt and conversation render normally (the "NLP is unreachable" message is just my local NLP-less setup, not the bug):

![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4896/render-loop/after-renders.png)

## Tests

- BDD spec: `specs/prompts/undefined-variable-banner-stability.feature` (3 scenarios: flagged without crashing, stays clear of the prompt after a resize, conversation re-opens without crashing).
- RTL regression in `PromptTextAreaWithVariables.test.tsx`: one test drives the editor through repeated re-renders with a freshly rebuilt variables array (mirroring the real editor) and asserts the banner does not re-measure when the invalid-variable set is unchanged (5 re-measures on the old array-dep code, 0 on the fix); a second drives the `ResizeObserver` callback with a taller banner and asserts the reserved padding follows (28px floor to 108px) while the name set is unchanged.
- `TraceMessage.test.tsx` renders the real dead-trace path with a mocked 404 and asserts it renders nothing instead of throwing, so a missing-trace turn cannot crash the playground.

Full `PromptTextAreaWithVariables` + `TraceMessage` suites (43 tests) green, `pnpm typecheck` clean, feature-parity green.

## Follow-up (separate, out of scope)

While tracing this I found a separate, pre-existing churn in the playground chat: `PromptPlaygroundChat` passes `AssistantMessage` and `UserMessage` as components defined inline in render, so the message subtree (and `TraceMessage` plus its trace query) remounts on every render. When a conversation has an assistant turn whose trace is permanently missing, this can drive extra re-renders. It does not throw to the error boundary, and it is most visible in a local NLP-less setup where the trace 404 never resolves. Filing as a separate follow-up rather than bundling a CopilotKit refactor into this crash fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the prompt editor’s “Undefined variables” warning by reducing unnecessary re-measurements during repeated re-renders, while still updating correctly when the layout changes (e.g., resizing/wrapping).
  * Improved resilience when referenced trace data can’t be found, preventing unwanted error-boundary behavior.

* **Tests**
  * Added regression coverage for undefined-variable warning stability across repeated re-renders and for re-measuring on resize.
  * Added a test to confirm trace message behavior when the lookup is in an error/404-like state.
  * Added an end-to-end feature spec covering warning behavior across editing, resizing, and conversation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
