### PR TITLE
feat(nlpgo): fetch remote attachment URLs and deliver them to the model as content

### DIFF
--- a/docs/datasets/dataset-images.mdx
+++ b/docs/datasets/dataset-images.mdx
@@ -22,3 +22,11 @@ Once you select the image type, the dataset will be updated to show the image co
 <Frame  caption="Dataset image preview">
 <img className="block" src="/images/dataset-image-preview.png" alt="LangWatch"  />
 </Frame>
+
+## How attachment URLs reach the model
+
+When an image URL feeds a vision workflow or evaluation, LangWatch fetches the URL server-side and delivers the actual image to the model as image content, so the model sees the picture instead of the link text. This works across every model provider, whether or not the provider fetches URLs itself. The attachment type is detected from the response rather than the file extension, so extension-less links such as signed S3 or CDN URLs are classified correctly.
+
+Audio and PDF URLs are delivered the same way when referenced from a prompt: an audio URL reaches the model as audio for it to hear, and a PDF URL reaches it as a document for it to read.
+
+If a field is declared as an image and its URL cannot be loaded as an image (the URL is unreachable, returns an error status, is too large, or serves something other than an image), the run fails with a clear message naming the URL and the reason, instead of passing the raw link to the model as text. A plain link mentioned in prose is left as text and never fails the run.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -14134,6 +14134,14 @@ Once you select the image type, the dataset will be updated to show the image co
 <img className="block" src="/images/dataset-image-preview.png" alt="LangWatch"  />
 </Frame>
 
+## How attachment URLs reach the model
+
+When an image URL feeds a vision workflow or evaluation, LangWatch fetches the URL server-side and delivers the actual image to the model as image content, so the model sees the picture instead of the link text. This works across every model provider, whether or not the provider fetches URLs itself. The attachment type is detected from the response rather than the file extension, so extension-less links such as signed S3 or CDN URLs are classified correctly.
+
+Audio and PDF URLs are delivered the same way when referenced from a prompt: an audio URL reaches the model as audio for it to hear, and a PDF URL reaches it as a document for it to read.
+
+If a field is declared as an image and its URL cannot be loaded as an image (the URL is unreachable, returns an error status, is too large, or serves something other than an image), the run fails with a clear message naming the URL and the reason, instead of passing the raw link to the model as text. A plain link mentioned in prose is left as text and never fails the run.
+
 ---
 
 # FILE: ./datasets/dataset-threads.mdx

--- a/services/nlpgo/app/engine/attachment.go
+++ b/services/nlpgo/app/engine/attachment.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/langwatch/langwatch/services/nlpgo/app"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
 )
 
 // Attachment fetching turns a remote URL referenced in a prompt message into
@@ -148,6 +149,50 @@ func (f *attachmentFetcher) rewrite(ctx context.Context, messages []app.ChatMess
 		}
 		m.Content = newContent
 		out = append(out, m)
+	}
+	return out, nil
+}
+
+// inlineImageInputs resolves image-typed inputs that carry a remote http(s)
+// URL into inline base64 data URLs before message templating, so the existing
+// data-URL image splitter delivers them as image parts. An image-typed input
+// is an explicit attachment: the author declared the field an image, so a URL
+// it carries that cannot be fetched as an image fails the run with a clear,
+// user-facing error rather than being left as text for the model to guess from
+// (e.g. from a filename). Inputs that are not image-typed, not http(s) URLs, or
+// already inline data URLs are left untouched. The returned map is a copy only
+// when a value was replaced, so the caller's original inputs (surfaced verbatim
+// in execution events) keep the readable URL rather than a base64 blob.
+func (f *attachmentFetcher) inlineImageInputs(ctx context.Context, node *dsl.Node, inputs map[string]any) (map[string]any, *NodeError) {
+	out := inputs
+	copied := false
+	for _, field := range node.Data.Inputs {
+		if field.Type != dsl.FieldTypeImage {
+			continue
+		}
+		raw, ok := inputs[field.Identifier].(string)
+		if !ok {
+			continue
+		}
+		rawURL := strings.TrimSpace(raw)
+		if !strings.HasPrefix(strings.ToLower(rawURL), "http") {
+			continue // already a data URL or not a remote reference
+		}
+		att, ne := f.fetch(ctx, rawURL)
+		if ne != nil {
+			return nil, ne
+		}
+		if !strings.HasPrefix(att.mediaType, "image/") {
+			return nil, attachmentError(rawURL, "could not be loaded as an image (its content type is "+att.mediaType+")", 0)
+		}
+		if !copied {
+			out = make(map[string]any, len(inputs))
+			for k, v := range inputs {
+				out[k] = v
+			}
+			copied = true
+		}
+		out[field.Identifier] = dataURL(att)
 	}
 	return out, nil
 }

--- a/services/nlpgo/app/engine/attachment.go
+++ b/services/nlpgo/app/engine/attachment.go
@@ -1,0 +1,297 @@
+package engine
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
+)
+
+// Attachment fetching turns a remote URL referenced in a prompt message into
+// content the model can actually see/hear/read. The data-URL image splitter in
+// multimodal.go only handles inline data:image/...;base64 values; a plain
+// http(s) URL is interpolated as text and the model never opens it. This pass
+// fetches such URLs, detects the type from the response (not the file
+// extension, so extension-less S3/CDN URLs work), and re-homes them into
+// multimodal content parts. Images become base64 data-URL image parts so they
+// work across every provider regardless of whether the provider fetches URLs
+// itself; audio and documents get their own part shapes. A reachable response
+// that is not an attachment (an HTML page) is left as text — the author was
+// referencing a link, not attaching a file. A URL that cannot be fetched fails
+// the run with a clear, user-facing error rather than a broken request.
+
+const (
+	// defaultMaxAttachmentBytes caps a single fetched attachment. Large enough
+	// for real photos/audio/PDFs, small enough to refuse a runaway download.
+	defaultMaxAttachmentBytes int64 = 20 * 1024 * 1024
+	// defaultAttachmentTimeout bounds the whole fetch (connect + read).
+	defaultAttachmentTimeout = 30 * time.Second
+)
+
+// httpURLRe matches an http(s) URL token: the scheme followed by a run of
+// non-space characters that are not URL-hostile delimiters. Trailing
+// sentence punctuation is trimmed separately so "see https://x/cat.png." does
+// not carry the period into the request.
+var httpURLRe = regexp.MustCompile("https?://[^\\s<>\"'`]+")
+
+// attachmentFetcher fetches remote attachment URLs and rewrites them into
+// content parts. It applies the same SSRF policy as the HTTP block (private,
+// loopback, and cloud-metadata addresses are refused, with DNS-rebinding
+// protection via SafeDialer), a wall-clock timeout, and a size cap.
+type attachmentFetcher struct {
+	client   *http.Client
+	ssrf     httpblock.SSRFOptions
+	maxBytes int64
+}
+
+func newAttachmentFetcher(ssrf httpblock.SSRFOptions) *attachmentFetcher {
+	return &attachmentFetcher{
+		client: &http.Client{
+			Timeout:   defaultAttachmentTimeout,
+			Transport: &http.Transport{DialContext: httpblock.SafeDialer(ssrf)},
+		},
+		ssrf:     ssrf,
+		maxBytes: defaultMaxAttachmentBytes,
+	}
+}
+
+// fetchedAttachment is the validated result of fetching a URL.
+type fetchedAttachment struct {
+	mediaType string // normalized, lowercase, e.g. "image/png"
+	data      []byte
+}
+
+// fetch retrieves rawURL under the SSRF, timeout, and size guards. It returns a
+// *NodeError describing a user-facing failure when the URL cannot be fetched.
+func (f *attachmentFetcher) fetch(ctx context.Context, rawURL string) (*fetchedAttachment, *NodeError) {
+	if err := httpblock.CheckURL(rawURL, f.ssrf); err != nil {
+		return nil, attachmentError(rawURL, "is blocked for security (it resolves to a private or metadata address)", 0)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, attachmentError(rawURL, "is not a valid URL", 0)
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		if errors.Is(err, httpblock.ErrSSRFBlocked) {
+			return nil, attachmentError(rawURL, "is blocked for security (it resolves to a private or metadata address)", 0)
+		}
+		return nil, attachmentError(rawURL, "could not be reached ("+err.Error()+")", 0)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return nil, attachmentError(rawURL, fmt.Sprintf("returned an error status (%d)", resp.StatusCode), resp.StatusCode)
+	}
+	// Read one byte past the cap so an oversized body is detectable.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, f.maxBytes+1))
+	if err != nil {
+		return nil, attachmentError(rawURL, "could not be read ("+err.Error()+")", 0)
+	}
+	if int64(len(body)) > f.maxBytes {
+		return nil, attachmentError(rawURL, fmt.Sprintf("is larger than the %d MB attachment limit", f.maxBytes/(1024*1024)), 0)
+	}
+	mt := normalizeMediaType(resp.Header.Get("Content-Type"))
+	// Sniff from the bytes when the server omits or generalizes the type, so
+	// extension-less and octet-stream responses still classify correctly.
+	if mt == "" || mt == "application/octet-stream" {
+		mt = normalizeMediaType(http.DetectContentType(body))
+	}
+	return &fetchedAttachment{mediaType: mt, data: body}, nil
+}
+
+// rewrite fetches remote attachment URLs in every message and re-homes them
+// into content parts. It runs after splitMessagesWithImages, so inline data:
+// URLs are already parts; this pass handles http(s) URLs in string content, in
+// text parts, and carried by existing image_url parts.
+func (f *attachmentFetcher) rewrite(ctx context.Context, messages []app.ChatMessage) ([]app.ChatMessage, *NodeError) {
+	out := make([]app.ChatMessage, 0, len(messages))
+	for _, m := range messages {
+		switch content := m.Content.(type) {
+		case string:
+			parts, replaced, ne := f.splitStringAttachments(ctx, content)
+			if ne != nil {
+				return nil, ne
+			}
+			if replaced {
+				m.Content = parts
+			}
+		case []any:
+			parts, ne := f.rewriteParts(ctx, content)
+			if ne != nil {
+				return nil, ne
+			}
+			m.Content = parts
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+// splitStringAttachments scans text for http(s) URLs and, when any resolve to a
+// real attachment, returns the text rewritten as a content-part list. The
+// second return is false (and parts nil) when there is nothing to attach, so
+// the caller keeps the original string. A failed fetch returns a *NodeError.
+func (f *attachmentFetcher) splitStringAttachments(ctx context.Context, text string) ([]any, bool, *NodeError) {
+	locs := httpURLRe.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return nil, false, nil
+	}
+	parts := make([]any, 0, len(locs)*2+1)
+	addText := func(seg string) {
+		if strings.TrimSpace(seg) == "" {
+			return
+		}
+		parts = append(parts, map[string]any{"type": "text", "text": seg})
+	}
+	last := 0
+	attached := false
+	for _, loc := range locs {
+		rawURL, trailing := trimTrailingPunct(text[loc[0]:loc[1]])
+		att, ne := f.fetch(ctx, rawURL)
+		if ne != nil {
+			return nil, false, ne
+		}
+		part, ok := contentPartForAttachment(att)
+		addText(text[last:loc[0]])
+		if ok {
+			parts = append(parts, part)
+			addText(trailing)
+			attached = true
+		} else {
+			// Reachable but not an attachment (e.g. an HTML page): the author
+			// is referencing a link, so keep the URL verbatim as text.
+			addText(rawURL + trailing)
+		}
+		last = loc[1]
+	}
+	addText(text[last:])
+	if !attached {
+		return nil, false, nil
+	}
+	return parts, true, nil
+}
+
+// rewriteParts walks an existing content-part list, fetching http(s) URLs found
+// in text parts and in image_url parts.
+func (f *attachmentFetcher) rewriteParts(ctx context.Context, in []any) ([]any, *NodeError) {
+	out := make([]any, 0, len(in))
+	for _, p := range in {
+		block, ok := p.(map[string]any)
+		if !ok {
+			out = append(out, p)
+			continue
+		}
+		switch block["type"] {
+		case "text":
+			t, _ := block["text"].(string)
+			sub, replaced, ne := f.splitStringAttachments(ctx, t)
+			if ne != nil {
+				return nil, ne
+			}
+			if replaced {
+				out = append(out, sub...)
+			} else {
+				out = append(out, block)
+			}
+		case "image_url":
+			img, _ := block["image_url"].(map[string]any)
+			url, _ := img["url"].(string)
+			if !strings.HasPrefix(strings.ToLower(url), "http") {
+				out = append(out, block) // already a data URL, leave as-is
+				continue
+			}
+			att, ne := f.fetch(ctx, url)
+			if ne != nil {
+				return nil, ne
+			}
+			part, ok := contentPartForAttachment(att)
+			if ok {
+				out = append(out, part)
+			} else {
+				out = append(out, block)
+			}
+		default:
+			out = append(out, block)
+		}
+	}
+	return out, nil
+}
+
+// contentPartForAttachment turns a fetched attachment into the content part its
+// media type calls for. The second return is false when the response is not an
+// attachment we deliver to the model (e.g. text/html), so the caller leaves the
+// URL as text.
+func contentPartForAttachment(att *fetchedAttachment) (map[string]any, bool) {
+	switch {
+	case strings.HasPrefix(att.mediaType, "image/"):
+		return map[string]any{
+			"type":      "image_url",
+			"image_url": map[string]any{"url": dataURL(att)},
+		}, true
+	case strings.HasPrefix(att.mediaType, "audio/"):
+		return map[string]any{
+			"type": "input_audio",
+			"input_audio": map[string]any{
+				"data":   base64.StdEncoding.EncodeToString(att.data),
+				"format": strings.TrimPrefix(att.mediaType, "audio/"),
+			},
+		}, true
+	case att.mediaType == "application/pdf":
+		return map[string]any{
+			"type": "file",
+			"file": map[string]any{
+				"filename":  "attachment.pdf",
+				"file_data": dataURL(att),
+			},
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func dataURL(att *fetchedAttachment) string {
+	return "data:" + att.mediaType + ";base64," + base64.StdEncoding.EncodeToString(att.data)
+}
+
+// normalizeMediaType strips parameters (charset, boundary) and lowercases a
+// Content-Type so callers can prefix-match on the bare media type.
+func normalizeMediaType(ct string) string {
+	if ct == "" {
+		return ""
+	}
+	if mt, _, err := mime.ParseMediaType(ct); err == nil {
+		return strings.ToLower(mt)
+	}
+	return strings.ToLower(strings.TrimSpace(strings.SplitN(ct, ";", 2)[0]))
+}
+
+// trimTrailingPunct splits sentence punctuation that a URL regex greedily
+// captured off the end of a match, returning the cleaned URL and the trailing
+// run so the caller can re-home the punctuation as text.
+func trimTrailingPunct(token string) (url, trailing string) {
+	i := len(token)
+	for i > 0 && strings.ContainsRune(".,;:!?)]}'\"", rune(token[i-1])) {
+		i--
+	}
+	return token[:i], token[i:]
+}
+
+// attachmentError builds the user-facing NodeError for a failed attachment
+// fetch. Status threads the upstream HTTP status when there was one (for fault
+// attribution), mirroring the llm_error path.
+func attachmentError(url, reason string, status int) *NodeError {
+	return &NodeError{
+		Type:    "attachment_fetch_error",
+		Message: fmt.Sprintf("Could not load the attachment %s: it %s.", url, reason),
+		Status:  status,
+	}
+}

--- a/services/nlpgo/app/engine/attachment.go
+++ b/services/nlpgo/app/engine/attachment.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -68,6 +70,7 @@ func newAttachmentFetcher(ssrf httpblock.SSRFOptions) *attachmentFetcher {
 type fetchedAttachment struct {
 	mediaType string // normalized, lowercase, e.g. "image/png"
 	data      []byte
+	sourceURL string // the URL it came from, used to name file attachments
 }
 
 // fetch retrieves rawURL under the SSRF, timeout, and size guards. It returns a
@@ -85,7 +88,7 @@ func (f *attachmentFetcher) fetch(ctx context.Context, rawURL string) (*fetchedA
 		if errors.Is(err, httpblock.ErrSSRFBlocked) {
 			return nil, attachmentError(rawURL, "is blocked for security (it resolves to a private or metadata address)", 0)
 		}
-		return nil, attachmentError(rawURL, "could not be reached ("+err.Error()+")", 0)
+		return nil, attachmentError(rawURL, "could not be reached", 0)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 400 {
@@ -105,7 +108,7 @@ func (f *attachmentFetcher) fetch(ctx context.Context, rawURL string) (*fetchedA
 	if mt == "" || mt == "application/octet-stream" {
 		mt = normalizeMediaType(http.DetectContentType(body))
 	}
-	return &fetchedAttachment{mediaType: mt, data: body}, nil
+	return &fetchedAttachment{mediaType: mt, data: body, sourceURL: rawURL}, nil
 }
 
 // rewrite fetches remote attachment URLs in every message and re-homes them
@@ -118,11 +121,7 @@ func (f *attachmentFetcher) rewrite(ctx context.Context, messages []app.ChatMess
 		newContent := m.Content
 		switch content := m.Content.(type) {
 		case string:
-			parts, replaced, ne := f.splitStringAttachments(ctx, content)
-			if ne != nil {
-				return nil, ne
-			}
-			if replaced {
+			if parts, replaced := f.splitStringAttachments(ctx, content); replaced {
 				newContent = parts
 			}
 		case []any:
@@ -165,13 +164,16 @@ func hasNonTextPart(parts []any) bool {
 }
 
 // splitStringAttachments scans text for http(s) URLs and, when any resolve to a
-// real attachment, returns the text rewritten as a content-part list. The
-// second return is false (and parts nil) when there is nothing to attach, so
-// the caller keeps the original string. A failed fetch returns a *NodeError.
-func (f *attachmentFetcher) splitStringAttachments(ctx context.Context, text string) ([]any, bool, *NodeError) {
+// real attachment, returns the text rewritten as a content-part list. A bare
+// URL in text is best-effort: a reachable non-attachment (an HTML page) and a
+// failed fetch both leave the URL as text, so an incidental link in prose never
+// fails the run. Explicit image_url parts (handled in rewriteParts) do hard-fail
+// on a bad fetch. The second return is false (parts nil) when there is nothing
+// to attach, so the caller keeps the original string.
+func (f *attachmentFetcher) splitStringAttachments(ctx context.Context, text string) ([]any, bool) {
 	locs := httpURLRe.FindAllStringIndex(text, -1)
 	if len(locs) == 0 {
-		return nil, false, nil
+		return nil, false
 	}
 	parts := make([]any, 0, len(locs)*2+1)
 	addText := func(seg string) {
@@ -184,13 +186,16 @@ func (f *attachmentFetcher) splitStringAttachments(ctx context.Context, text str
 	attached := false
 	for _, loc := range locs {
 		rawURL, trailing := trimTrailingPunct(text[loc[0]:loc[1]])
+		addText(text[last:loc[0]])
+		last = loc[1]
 		att, ne := f.fetch(ctx, rawURL)
 		if ne != nil {
-			return nil, false, ne
+			// Best-effort: a broken bare link stays as text rather than failing
+			// the whole run; only explicit image_url parts hard-fail.
+			addText(rawURL + trailing)
+			continue
 		}
-		part, ok := contentPartForAttachment(att)
-		addText(text[last:loc[0]])
-		if ok {
+		if part, ok := contentPartForAttachment(att); ok {
 			parts = append(parts, part)
 			addText(trailing)
 			attached = true
@@ -199,13 +204,12 @@ func (f *attachmentFetcher) splitStringAttachments(ctx context.Context, text str
 			// is referencing a link, so keep the URL verbatim as text.
 			addText(rawURL + trailing)
 		}
-		last = loc[1]
 	}
 	addText(text[last:])
 	if !attached {
-		return nil, false, nil
+		return nil, false
 	}
-	return parts, true, nil
+	return parts, true
 }
 
 // rewriteParts walks an existing content-part list, fetching http(s) URLs found
@@ -221,11 +225,7 @@ func (f *attachmentFetcher) rewriteParts(ctx context.Context, in []any) ([]any, 
 		switch block["type"] {
 		case "text":
 			t, _ := block["text"].(string)
-			sub, replaced, ne := f.splitStringAttachments(ctx, t)
-			if ne != nil {
-				return nil, ne
-			}
-			if replaced {
+			if sub, replaced := f.splitStringAttachments(ctx, t); replaced {
 				out = append(out, sub...)
 			} else {
 				out = append(out, block)
@@ -270,14 +270,14 @@ func contentPartForAttachment(att *fetchedAttachment) (map[string]any, bool) {
 			"type": "input_audio",
 			"input_audio": map[string]any{
 				"data":   base64.StdEncoding.EncodeToString(att.data),
-				"format": strings.TrimPrefix(att.mediaType, "audio/"),
+				"format": audioFormat(att.mediaType),
 			},
 		}, true
 	case att.mediaType == "application/pdf":
 		return map[string]any{
 			"type": "file",
 			"file": map[string]any{
-				"filename":  "attachment.pdf",
+				"filename":  fileNameFromURL(att.sourceURL, "attachment.pdf"),
 				"file_data": dataURL(att),
 			},
 		}, true
@@ -288,6 +288,31 @@ func contentPartForAttachment(att *fetchedAttachment) (map[string]any, bool) {
 
 func dataURL(att *fetchedAttachment) string {
 	return "data:" + att.mediaType + ";base64," + base64.StdEncoding.EncodeToString(att.data)
+}
+
+// fileNameFromURL derives a file name from a URL's last path segment, falling
+// back to the given default when the path has no usable segment.
+func fileNameFromURL(rawURL, fallback string) string {
+	if u, err := url.Parse(rawURL); err == nil {
+		if base := path.Base(u.Path); base != "" && base != "." && base != "/" {
+			return base
+		}
+	}
+	return fallback
+}
+
+// audioFormat maps an audio media type to the short format token providers
+// expect in an input_audio part (OpenAI accepts "mp3" and "wav"). audio/mpeg
+// is "mp3", not "mpeg".
+func audioFormat(mediaType string) string {
+	switch mediaType {
+	case "audio/mpeg", "audio/mp3":
+		return "mp3"
+	case "audio/wav", "audio/wave", "audio/x-wav":
+		return "wav"
+	default:
+		return strings.TrimPrefix(mediaType, "audio/")
+	}
 }
 
 // normalizeMediaType strips parameters (charset, boundary) and lowercases a

--- a/services/nlpgo/app/engine/attachment.go
+++ b/services/nlpgo/app/engine/attachment.go
@@ -494,17 +494,25 @@ func attachmentError(rawURL, reason string, status int) *NodeError {
 	}
 }
 
-// redactURLForError strips the query string and fragment from a URL before it
-// is surfaced in a user-facing error (and stored on the node/trace). Presigned
-// S3/CDN URLs carry credentials (X-Amz-Signature, X-Amz-Credential, security
-// tokens) in the query string, so leaking the raw URL on a fetch failure would
-// expose them. The scheme, host, and path are kept so the attachment stays
-// identifiable.
+// redactURLForError strips the credential-bearing parts of a URL before it is
+// surfaced in a user-facing error (and stored on the node/trace): the query
+// string and fragment (presigned S3/CDN URLs carry X-Amz-Signature,
+// X-Amz-Credential, and security tokens there) and the userinfo component
+// (https://user:token@host/...). The scheme, host, and path are kept so the
+// attachment stays identifiable.
 func redactURLForError(rawURL string) string {
 	if u, err := url.Parse(rawURL); err == nil && u.Scheme != "" {
 		u.RawQuery = ""
 		u.Fragment = ""
+		u.User = nil
 		return u.String()
+	}
+	// Fallback for a URL that does not parse: cut at the userinfo separator and
+	// the query/fragment so neither embedded creds nor signed params survive.
+	if at := strings.LastIndex(rawURL, "@"); at >= 0 {
+		if slashes := strings.Index(rawURL, "://"); slashes >= 0 && at > slashes {
+			rawURL = rawURL[:slashes+3] + rawURL[at+1:]
+		}
 	}
 	if i := strings.IndexAny(rawURL, "?#"); i >= 0 {
 		return rawURL[:i]

--- a/services/nlpgo/app/engine/attachment.go
+++ b/services/nlpgo/app/engine/attachment.go
@@ -175,7 +175,7 @@ func (f *attachmentFetcher) inlineImageInputs(ctx context.Context, node *dsl.Nod
 			continue
 		}
 		rawURL := strings.TrimSpace(raw)
-		if !strings.HasPrefix(strings.ToLower(rawURL), "http") {
+		if !isHTTPURL(rawURL) {
 			continue // already a data URL or not a remote reference
 		}
 		att, ne := f.fetch(ctx, rawURL)
@@ -278,7 +278,7 @@ func (f *attachmentFetcher) rewriteParts(ctx context.Context, in []any) ([]any, 
 		case "image_url":
 			img, _ := block["image_url"].(map[string]any)
 			url, _ := img["url"].(string)
-			if !strings.HasPrefix(strings.ToLower(url), "http") {
+			if !isHTTPURL(url) {
 				out = append(out, block) // already a data URL, leave as-is
 				continue
 			}
@@ -358,6 +358,14 @@ func audioFormat(mediaType string) string {
 	default:
 		return strings.TrimPrefix(mediaType, "audio/")
 	}
+}
+
+// isHTTPURL reports whether s is an http(s) URL — the schemes the attachment
+// fetcher handles. A bare "http" prefix check would also match non-fetchable
+// look-alikes like "httpfoo://", so the scheme separator is required.
+func isHTTPURL(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
 }
 
 // normalizeMediaType strips parameters (charset, boundary) and lowercases a

--- a/services/nlpgo/app/engine/attachment.go
+++ b/services/nlpgo/app/engine/attachment.go
@@ -57,10 +57,17 @@ type attachmentFetcher struct {
 }
 
 func newAttachmentFetcher(ssrf httpblock.SSRFOptions) *attachmentFetcher {
+	// Clone the default transport so standard settings (notably
+	// Proxy: http.ProxyFromEnvironment) are inherited, then only override the
+	// dialer to re-apply the SSRF policy at dial time — the same construction the
+	// HTTP block uses, so attachment fetches work in restricted-egress
+	// deployments that require an outbound proxy.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = httpblock.SafeDialer(ssrf)
 	return &attachmentFetcher{
 		client: &http.Client{
 			Timeout:   defaultAttachmentTimeout,
-			Transport: &http.Transport{DialContext: httpblock.SafeDialer(ssrf)},
+			Transport: transport,
 		},
 		ssrf:     ssrf,
 		maxBytes: defaultMaxAttachmentBytes,
@@ -287,11 +294,14 @@ func (f *attachmentFetcher) rewriteParts(ctx context.Context, in []any) ([]any, 
 				return nil, ne
 			}
 			part, ok := contentPartForAttachment(att)
-			if ok {
-				out = append(out, part)
-			} else {
-				out = append(out, block)
+			if !ok {
+				// An image_url part is explicit attachment intent: a reachable
+				// response that is not a deliverable attachment must fail clearly
+				// rather than fall back to sending the raw URL to the provider and
+				// bypassing the server-side fetch entirely.
+				return nil, attachmentError(url, "could not be loaded as an image (its content type is "+att.mediaType+")", 0)
 			}
+			out = append(out, part)
 		default:
 			out = append(out, block)
 		}
@@ -333,6 +343,88 @@ func contentPartForAttachment(att *fetchedAttachment) (map[string]any, bool) {
 
 func dataURL(att *fetchedAttachment) string {
 	return "data:" + att.mediaType + ";base64," + base64.StdEncoding.EncodeToString(att.data)
+}
+
+// redactAttachmentsForTracing returns a copy of messages with heavy inline
+// attachment bytes (base64 data URLs in image_url / file parts and raw base64 in
+// input_audio parts) replaced by a short "[media-type, N bytes]" summary. The
+// model still receives the full bytes — only the copy handed to tracing is
+// shrunk — so a fetched 20 MB image/PDF/audio is not JSON-serialized into the
+// span's langwatch.input (which would blow OTLP/ClickHouse size limits and store
+// the private payload). Text and plain (non-data) URLs are left untouched.
+func redactAttachmentsForTracing(messages []app.ChatMessage) []app.ChatMessage {
+	out := make([]app.ChatMessage, len(messages))
+	for i, m := range messages {
+		out[i] = m
+		parts, ok := m.Content.([]any)
+		if !ok {
+			continue
+		}
+		redacted := make([]any, len(parts))
+		for j, p := range parts {
+			redacted[j] = redactPartForTracing(p)
+		}
+		out[i].Content = redacted
+	}
+	return out
+}
+
+// redactPartForTracing replaces the inline bytes of a single content part with a
+// summary, leaving every other part shape untouched.
+func redactPartForTracing(p any) any {
+	block, ok := p.(map[string]any)
+	if !ok {
+		return p
+	}
+	switch block["type"] {
+	case "image_url":
+		if img, ok := block["image_url"].(map[string]any); ok {
+			if u, _ := img["url"].(string); strings.HasPrefix(u, "data:") {
+				return map[string]any{"type": "image_url", "image_url": map[string]any{"url": summarizeDataURL(u)}}
+			}
+		}
+	case "file":
+		if file, ok := block["file"].(map[string]any); ok {
+			if fd, _ := file["file_data"].(string); strings.HasPrefix(fd, "data:") {
+				return map[string]any{"type": "file", "file": map[string]any{
+					"filename": file["filename"], "file_data": summarizeDataURL(fd),
+				}}
+			}
+		}
+	case "input_audio":
+		if audio, ok := block["input_audio"].(map[string]any); ok {
+			if data, _ := audio["data"].(string); data != "" {
+				format, _ := audio["format"].(string)
+				return map[string]any{"type": "input_audio", "input_audio": map[string]any{
+					"data": fmt.Sprintf("[audio, %d bytes]", approxBase64Bytes(data)), "format": format,
+				}}
+			}
+		}
+	}
+	return p
+}
+
+// summarizeDataURL turns "data:image/png;base64,AAAA..." into a short
+// "[image/png, 12345 bytes]" so the trace records the shape, not the payload.
+func summarizeDataURL(s string) string {
+	mediaType := "attachment"
+	if strings.HasPrefix(s, "data:") {
+		rest := s[len("data:"):]
+		if i := strings.IndexAny(rest, ";,"); i >= 0 {
+			mediaType = rest[:i]
+		}
+	}
+	n := 0
+	if comma := strings.IndexByte(s, ','); comma >= 0 {
+		n = approxBase64Bytes(s[comma+1:])
+	}
+	return fmt.Sprintf("[%s, %d bytes]", mediaType, n)
+}
+
+// approxBase64Bytes estimates the decoded byte length of a base64 string
+// without allocating the decoded buffer.
+func approxBase64Bytes(b64 string) int {
+	return len(strings.TrimRight(b64, "=")) * 3 / 4
 }
 
 // fileNameFromURL derives a file name from a URL's last path segment, falling
@@ -394,10 +486,28 @@ func trimTrailingPunct(token string) (url, trailing string) {
 // attachmentError builds the user-facing NodeError for a failed attachment
 // fetch. Status threads the upstream HTTP status when there was one (for fault
 // attribution), mirroring the llm_error path.
-func attachmentError(url, reason string, status int) *NodeError {
+func attachmentError(rawURL, reason string, status int) *NodeError {
 	return &NodeError{
 		Type:    "attachment_fetch_error",
-		Message: fmt.Sprintf("Could not load the attachment %s: it %s.", url, reason),
+		Message: fmt.Sprintf("Could not load the attachment %s: it %s.", redactURLForError(rawURL), reason),
 		Status:  status,
 	}
+}
+
+// redactURLForError strips the query string and fragment from a URL before it
+// is surfaced in a user-facing error (and stored on the node/trace). Presigned
+// S3/CDN URLs carry credentials (X-Amz-Signature, X-Amz-Credential, security
+// tokens) in the query string, so leaking the raw URL on a fetch failure would
+// expose them. The scheme, host, and path are kept so the attachment stays
+// identifiable.
+func redactURLForError(rawURL string) string {
+	if u, err := url.Parse(rawURL); err == nil && u.Scheme != "" {
+		u.RawQuery = ""
+		u.Fragment = ""
+		return u.String()
+	}
+	if i := strings.IndexAny(rawURL, "?#"); i >= 0 {
+		return rawURL[:i]
+	}
+	return rawURL
 }

--- a/services/nlpgo/app/engine/attachment.go
+++ b/services/nlpgo/app/engine/attachment.go
@@ -115,6 +115,7 @@ func (f *attachmentFetcher) fetch(ctx context.Context, rawURL string) (*fetchedA
 func (f *attachmentFetcher) rewrite(ctx context.Context, messages []app.ChatMessage) ([]app.ChatMessage, *NodeError) {
 	out := make([]app.ChatMessage, 0, len(messages))
 	for _, m := range messages {
+		newContent := m.Content
 		switch content := m.Content.(type) {
 		case string:
 			parts, replaced, ne := f.splitStringAttachments(ctx, content)
@@ -122,18 +123,45 @@ func (f *attachmentFetcher) rewrite(ctx context.Context, messages []app.ChatMess
 				return nil, ne
 			}
 			if replaced {
-				m.Content = parts
+				newContent = parts
 			}
 		case []any:
 			parts, ne := f.rewriteParts(ctx, content)
 			if ne != nil {
 				return nil, ne
 			}
-			m.Content = parts
+			newContent = parts
 		}
+		// A system message that gained an attachment part must be re-homed:
+		// providers reject non-text parts in system role. Mirrors the same
+		// re-homing splitMessagesWithImages does for inline data-URL images.
+		if m.Role == "system" {
+			if parts, ok := newContent.([]any); ok && hasNonTextPart(parts) {
+				systemText, rest := splitLeadingText(parts)
+				if systemText != "" {
+					out = append(out, app.ChatMessage{Role: "system", Content: systemText})
+				}
+				if len(rest) > 0 {
+					out = append(out, app.ChatMessage{Role: "user", Content: rest})
+				}
+				continue
+			}
+		}
+		m.Content = newContent
 		out = append(out, m)
 	}
 	return out, nil
+}
+
+// hasNonTextPart reports whether a content-part list contains any part that is
+// not a plain text block (an attachment that must not sit in a system message).
+func hasNonTextPart(parts []any) bool {
+	for _, p := range parts {
+		if block, ok := p.(map[string]any); ok && block["type"] != "text" {
+			return true
+		}
+	}
+	return false
 }
 
 // splitStringAttachments scans text for http(s) URLs and, when any resolve to a

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -161,7 +161,7 @@ func TestRewriteHandlesMultipleAttachmentURLs(t *testing.T) {
 	assert.Equal(t, 2, images, "each URL must become its own image part")
 }
 
-// @scenario "An attachment URL in the system prompt is re-homed to a user message"
+// @scenario "An image mentioned in the system prompt still reaches the model"
 func TestRewriteRehomesSystemAttachmentToUser(t *testing.T) {
 	srv := attachmentServer(t)
 	defer srv.Close()
@@ -173,7 +173,10 @@ func TestRewriteRehomesSystemAttachmentToUser(t *testing.T) {
 	require.Nil(t, ne)
 	require.Len(t, out, 2, "the system message must split into system text + a user message")
 	assert.Equal(t, "system", out[0].Role)
-	assert.IsType(t, "", out[0].Content, "the system message keeps only the leading text")
+	systemText, ok := out[0].Content.(string)
+	require.True(t, ok, "the re-homed system message keeps plain text content")
+	assert.Equal(t, "You are a vision grader. Image:", strings.TrimSpace(systemText),
+		"the system message keeps only the text before the image, not the image link")
 	assert.Equal(t, "user", out[1].Role)
 	firstPartOfType(t, out[1], "image_url") // the image rode into the user message
 }

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -60,6 +60,14 @@ func userMessage(text string) []app.ChatMessage {
 	return []app.ChatMessage{{Role: "user", Content: text}}
 }
 
+// imagePartMessage models an explicit image attachment (an image_url part
+// carrying an http URL), the case that hard-fails on a bad fetch.
+func imagePartMessage(url string) []app.ChatMessage {
+	return []app.ChatMessage{{Role: "user", Content: []any{
+		map[string]any{"type": "image_url", "image_url": map[string]any{"url": url}},
+	}}}
+}
+
 // firstPartOfType returns the first content part of the given type from a
 // rewritten message, failing the test if the content is not a parts list.
 func firstPartOfType(t *testing.T, m app.ChatMessage, typ string) map[string]any {
@@ -115,8 +123,8 @@ func TestRewriteDetectsTypeFromResponseNotExtension(t *testing.T) {
 
 // @scenario "An image already given as a base64 data URL is delivered without fetching"
 func TestRewriteLeavesDataURLImagesWithoutFetching(t *testing.T) {
-	// Empty allow-list: any real fetch would be SSRF-blocked and error. A data
-	// URL must therefore pass through untouched, proving no fetch happens.
+	// A data URL is not an http(s) URL, so it is never matched for fetching and
+	// passes through untouched regardless of the SSRF policy.
 	f := newAttachmentFetcher(httpblock.SSRFOptions{})
 	dataURL := "data:image/png;base64,iVBORw0KGgo="
 
@@ -176,7 +184,7 @@ func TestRewriteFailsClearlyOnUnreachableURL(t *testing.T) {
 	srv.Close() // nothing is listening now
 	f := loopbackFetcher()
 
-	out, ne := f.rewrite(context.Background(), userMessage(deadURL))
+	out, ne := f.rewrite(context.Background(), imagePartMessage(deadURL))
 	require.Nil(t, out)
 	require.NotNil(t, ne)
 	assert.Equal(t, "attachment_fetch_error", ne.Type)
@@ -189,7 +197,7 @@ func TestRewriteFailsClearlyOnErrorStatus(t *testing.T) {
 	defer srv.Close()
 	f := loopbackFetcher()
 
-	out, ne := f.rewrite(context.Background(), userMessage(srv.URL+"/missing"))
+	out, ne := f.rewrite(context.Background(), imagePartMessage(srv.URL+"/missing"))
 	require.Nil(t, out)
 	require.NotNil(t, ne)
 	assert.Equal(t, "attachment_fetch_error", ne.Type)
@@ -209,7 +217,7 @@ func TestRewriteRejectsOversizedAttachment(t *testing.T) {
 	f := loopbackFetcher()
 	f.maxBytes = 1024 // smaller than the body
 
-	out, ne := f.rewrite(context.Background(), userMessage(srv.URL+"/big.png"))
+	out, ne := f.rewrite(context.Background(), imagePartMessage(srv.URL+"/big.png"))
 	require.Nil(t, out)
 	require.NotNil(t, ne)
 	assert.Equal(t, "attachment_fetch_error", ne.Type)
@@ -228,6 +236,35 @@ func TestRewriteLeavesHTMLLinkAsText(t *testing.T) {
 	assert.Equal(t, original, out[0].Content, "a web page link must stay as text, not become an attachment")
 }
 
+// @scenario "A broken link in prose does not fail the run"
+func TestRewriteLeavesBrokenBareLinkAsText(t *testing.T) {
+	srv := attachmentServer(t)
+	deadURL := srv.URL + "/cat.png"
+	srv.Close() // nothing is listening now
+	f := loopbackFetcher()
+	original := "See " + deadURL + " for the chart"
+
+	out, ne := f.rewrite(context.Background(), userMessage(original))
+	require.Nil(t, ne, "a broken bare link in prose must not fail the run")
+	assert.Equal(t, original, out[0].Content, "the broken link stays as text")
+}
+
+// @scenario "An attachment URL that redirects to a private address is refused"
+func TestRewriteRefusesRedirectToPrivateAddress(t *testing.T) {
+	// SafeDialer re-checks the SSRF policy at dial time, so a redirect from an
+	// allowed host to a metadata/private address must still be blocked.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data", http.StatusFound)
+	}))
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	out, ne := f.rewrite(context.Background(), imagePartMessage(srv.URL+"/redir.png"))
+	require.Nil(t, out)
+	require.NotNil(t, ne, "a redirect to a metadata address must be refused")
+	assert.Equal(t, "attachment_fetch_error", ne.Type)
+}
+
 // @scenario "An audio attachment referenced by URL reaches the model as audio"
 func TestRewriteFetchesAudioIntoAudioPart(t *testing.T) {
 	srv := attachmentServer(t)
@@ -238,7 +275,7 @@ func TestRewriteFetchesAudioIntoAudioPart(t *testing.T) {
 	require.Nil(t, ne)
 	audio := firstPartOfType(t, out[0], "input_audio")
 	data, _ := audio["input_audio"].(map[string]any)
-	assert.Equal(t, "mpeg", data["format"])
+	assert.Equal(t, "mp3", data["format"], "audio/mpeg must map to the mp3 format token providers expect")
 	assert.NotEmpty(t, data["data"], "audio bytes must be base64-encoded")
 }
 

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -365,6 +366,54 @@ func TestInlineImageInputsLeavesDataURLAndTextInputsUntouched(t *testing.T) {
 	require.Nil(t, ne)
 	assert.Equal(t, "data:image/png;base64,AAAA", out["picture"], "an inline data URL must pass through untouched")
 	assert.Equal(t, "http://127.0.0.1:1/skip.png", out["link"], "a str-typed URL must not be eagerly fetched")
+}
+
+func TestRewriteFailsClearlyOnExplicitImageURLThatIsNotAnImage(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	// An image_url part is explicit attachment intent; a reachable web page must
+	// fail rather than fall through and send the raw URL to the provider.
+	out, ne := f.rewrite(context.Background(), imagePartMessage(srv.URL+"/page"))
+	require.Nil(t, out)
+	require.NotNil(t, ne, "an explicit image_url pointing at a web page must fail the run")
+	assert.Equal(t, "attachment_fetch_error", ne.Type)
+	assert.Contains(t, ne.Message, "image", "the error must explain it could not be loaded as an image")
+}
+
+func TestAttachmentErrorRedactsURLQueryParams(t *testing.T) {
+	// Presigned S3 URLs carry the signature and credentials in the query string.
+	signed := "https://bucket.s3.amazonaws.com/private/img.png?X-Amz-Credential=AKIAEXAMPLE&X-Amz-Signature=deadbeefsecret&X-Amz-Security-Token=tok123"
+	ne := attachmentError(signed, "could not be reached", 0)
+	assert.NotContains(t, ne.Message, "deadbeefsecret", "the signature must not appear in the user-facing error")
+	assert.NotContains(t, ne.Message, "X-Amz-Signature", "query params must be stripped")
+	assert.NotContains(t, ne.Message, "tok123", "the security token must not leak")
+	assert.Contains(t, ne.Message, "bucket.s3.amazonaws.com/private/img.png", "the attachment stays identifiable by host + path")
+}
+
+func TestRedactAttachmentsForTracingStripsInlineBytes(t *testing.T) {
+	bigB64 := strings.Repeat("A", 4096)
+	messages := []app.ChatMessage{{Role: "user", Content: []any{
+		map[string]any{"type": "text", "text": "describe these"},
+		map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64," + bigB64}},
+		map[string]any{"type": "input_audio", "input_audio": map[string]any{"data": bigB64, "format": "mp3"}},
+		map[string]any{"type": "file", "file": map[string]any{"filename": "doc.pdf", "file_data": "data:application/pdf;base64," + bigB64}},
+	}}}
+
+	traced := redactAttachmentsForTracing(messages)
+	tracedJSON, err := json.Marshal(traced)
+	require.NoError(t, err)
+	assert.NotContains(t, string(tracedJSON), bigB64, "the base64 payload must not survive into the trace copy")
+	assert.Contains(t, string(tracedJSON), "image/png", "the media-type summary is kept for the trace")
+	assert.Contains(t, string(tracedJSON), "bytes]", "a size summary is kept for the trace")
+	assert.Contains(t, string(tracedJSON), "describe these", "text content is preserved")
+
+	// The original messages still carry the full bytes — the model gets the real
+	// attachment, only the traced copy is shrunk.
+	origJSON, err := json.Marshal(messages)
+	require.NoError(t, err)
+	assert.Contains(t, string(origJSON), bigB64, "the original messages must keep the full bytes for the model")
 }
 
 func TestNormalizeMediaType(t *testing.T) {

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -1,0 +1,257 @@
+package engine
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
+)
+
+// loopbackFetcher allows the httptest server (127.0.0.1) past the SSRF guard,
+// which otherwise refuses loopback addresses.
+func loopbackFetcher() *attachmentFetcher {
+	return newAttachmentFetcher(httpblock.SSRFOptions{AllowedHosts: []string{"127.0.0.1"}})
+}
+
+// Minimal magic-byte prefixes so http.DetectContentType classifies the bodies
+// without us shipping real media files.
+var (
+	pngBytes  = []byte("\x89PNG\r\n\x1a\n............")
+	jpegBytes = []byte("\xff\xd8\xff\xe0............")
+	pdfBytes  = []byte("%PDF-1.4\n............")
+	mp3Bytes  = []byte("ID3............")
+)
+
+// attachmentServer serves a handful of fixed routes for the fetch tests.
+func attachmentServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	serve := func(ct string, body []byte) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			if ct != "" {
+				w.Header().Set("Content-Type", ct)
+			}
+			_, _ = w.Write(body)
+		}
+	}
+	mux.HandleFunc("/cat.png", serve("image/png", pngBytes))
+	mux.HandleFunc("/other.png", serve("image/png", pngBytes))
+	// No file extension; the JPEG type comes from the response header only.
+	mux.HandleFunc("/download", serve("image/jpeg", jpegBytes))
+	// No file extension AND no Content-Type; the type is sniffed from bytes.
+	mux.HandleFunc("/sniff", serve("", pngBytes))
+	mux.HandleFunc("/page", serve("text/html; charset=utf-8", []byte("<html>hi</html>")))
+	mux.HandleFunc("/clip.mp3", serve("audio/mpeg", mp3Bytes))
+	mux.HandleFunc("/doc.pdf", serve("application/pdf", pdfBytes))
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	return httptest.NewServer(mux)
+}
+
+func userMessage(text string) []app.ChatMessage {
+	return []app.ChatMessage{{Role: "user", Content: text}}
+}
+
+// firstPartOfType returns the first content part of the given type from a
+// rewritten message, failing the test if the content is not a parts list.
+func firstPartOfType(t *testing.T, m app.ChatMessage, typ string) map[string]any {
+	t.Helper()
+	parts, ok := m.Content.([]any)
+	require.True(t, ok, "content must be a parts list, got %T", m.Content)
+	for _, p := range parts {
+		block, ok := p.(map[string]any)
+		if ok && block["type"] == typ {
+			return block
+		}
+	}
+	t.Fatalf("no %q part found in %#v", typ, parts)
+	return nil
+}
+
+// @scenario "An image referenced by an http URL is fetched and delivered as an image part"
+func TestRewriteFetchesHTTPImageIntoImagePart(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	out, ne := f.rewrite(context.Background(), userMessage("What is in "+srv.URL+"/cat.png ?"))
+	require.Nil(t, ne)
+	require.Len(t, out, 1)
+
+	img := firstPartOfType(t, out[0], "image_url")
+	url, _ := img["image_url"].(map[string]any)["url"].(string)
+	assert.True(t, strings.HasPrefix(url, "data:image/png;base64,"), "image must be inlined as a data URL, got %q", url)
+	assert.NotContains(t, url, srv.URL, "the original link must not survive as the image URL")
+}
+
+// @scenario "The attachment type is detected from the response, not the file extension"
+func TestRewriteDetectsTypeFromResponseNotExtension(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	// Header-declared JPEG on an extension-less URL.
+	out, ne := f.rewrite(context.Background(), userMessage(srv.URL+"/download"))
+	require.Nil(t, ne)
+	img := firstPartOfType(t, out[0], "image_url")
+	url, _ := img["image_url"].(map[string]any)["url"].(string)
+	assert.True(t, strings.HasPrefix(url, "data:image/jpeg;base64,"), "type must come from the response header, got %q", url)
+
+	// No header at all: type sniffed from the bytes.
+	out, ne = f.rewrite(context.Background(), userMessage(srv.URL+"/sniff"))
+	require.Nil(t, ne)
+	img = firstPartOfType(t, out[0], "image_url")
+	url, _ = img["image_url"].(map[string]any)["url"].(string)
+	assert.True(t, strings.HasPrefix(url, "data:image/png;base64,"), "type must be sniffed from the bytes, got %q", url)
+}
+
+// @scenario "An image already given as a base64 data URL is delivered without fetching"
+func TestRewriteLeavesDataURLImagesWithoutFetching(t *testing.T) {
+	// Empty allow-list: any real fetch would be SSRF-blocked and error. A data
+	// URL must therefore pass through untouched, proving no fetch happens.
+	f := newAttachmentFetcher(httpblock.SSRFOptions{})
+	dataURL := "data:image/png;base64,iVBORw0KGgo="
+
+	// As a string (no http URL, so nothing to fetch).
+	out, ne := f.rewrite(context.Background(), userMessage("Look at "+dataURL))
+	require.Nil(t, ne)
+	assert.Equal(t, "Look at "+dataURL, out[0].Content, "data-URL string must stay a string")
+
+	// As an already-split image_url part.
+	parts := []any{map[string]any{"type": "image_url", "image_url": map[string]any{"url": dataURL}}}
+	out, ne = f.rewrite(context.Background(), []app.ChatMessage{{Role: "user", Content: parts}})
+	require.Nil(t, ne)
+	img := firstPartOfType(t, out[0], "image_url")
+	assert.Equal(t, dataURL, img["image_url"].(map[string]any)["url"], "data-URL part must survive untouched")
+}
+
+// @scenario "Several attachment URLs in one message each become their own part"
+func TestRewriteHandlesMultipleAttachmentURLs(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	out, ne := f.rewrite(context.Background(), userMessage("First "+srv.URL+"/cat.png then "+srv.URL+"/other.png done"))
+	require.Nil(t, ne)
+	parts, ok := out[0].Content.([]any)
+	require.True(t, ok)
+	images := 0
+	for _, p := range parts {
+		if block, ok := p.(map[string]any); ok && block["type"] == "image_url" {
+			images++
+		}
+	}
+	assert.Equal(t, 2, images, "each URL must become its own image part")
+}
+
+// @scenario "An unreachable attachment URL fails the run with a clear message naming the URL"
+func TestRewriteFailsClearlyOnUnreachableURL(t *testing.T) {
+	srv := attachmentServer(t)
+	deadURL := srv.URL + "/cat.png"
+	srv.Close() // nothing is listening now
+	f := loopbackFetcher()
+
+	out, ne := f.rewrite(context.Background(), userMessage(deadURL))
+	require.Nil(t, out)
+	require.NotNil(t, ne)
+	assert.Equal(t, "attachment_fetch_error", ne.Type)
+	assert.Contains(t, ne.Message, deadURL, "the error must name the URL")
+}
+
+// @scenario "An attachment URL that responds with an error status fails the run clearly"
+func TestRewriteFailsClearlyOnErrorStatus(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	out, ne := f.rewrite(context.Background(), userMessage(srv.URL+"/missing"))
+	require.Nil(t, out)
+	require.NotNil(t, ne)
+	assert.Equal(t, "attachment_fetch_error", ne.Type)
+	assert.Equal(t, http.StatusNotFound, ne.Status)
+	assert.Contains(t, ne.Message, srv.URL+"/missing")
+	assert.Contains(t, ne.Message, "404")
+}
+
+// @scenario "An attachment larger than the allowed size is rejected with a clear message"
+func TestRewriteRejectsOversizedAttachment(t *testing.T) {
+	big := strings.Repeat("x", 4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte(big))
+	}))
+	defer srv.Close()
+	f := loopbackFetcher()
+	f.maxBytes = 1024 // smaller than the body
+
+	out, ne := f.rewrite(context.Background(), userMessage(srv.URL+"/big.png"))
+	require.Nil(t, out)
+	require.NotNil(t, ne)
+	assert.Equal(t, "attachment_fetch_error", ne.Type)
+	assert.Contains(t, ne.Message, "larger than")
+}
+
+// @scenario "A link to a normal web page is left as text, not turned into an attachment"
+func TestRewriteLeavesHTMLLinkAsText(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+	original := "See " + srv.URL + "/page for details"
+
+	out, ne := f.rewrite(context.Background(), userMessage(original))
+	require.Nil(t, ne)
+	assert.Equal(t, original, out[0].Content, "a web page link must stay as text, not become an attachment")
+}
+
+// @scenario "An audio attachment referenced by URL reaches the model as audio"
+func TestRewriteFetchesAudioIntoAudioPart(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	out, ne := f.rewrite(context.Background(), userMessage(srv.URL+"/clip.mp3"))
+	require.Nil(t, ne)
+	audio := firstPartOfType(t, out[0], "input_audio")
+	data, _ := audio["input_audio"].(map[string]any)
+	assert.Equal(t, "mpeg", data["format"])
+	assert.NotEmpty(t, data["data"], "audio bytes must be base64-encoded")
+}
+
+// @scenario "A PDF attachment referenced by URL reaches the model as a document"
+func TestRewriteFetchesPDFIntoFilePart(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	out, ne := f.rewrite(context.Background(), userMessage(srv.URL+"/doc.pdf"))
+	require.Nil(t, ne)
+	file := firstPartOfType(t, out[0], "file")
+	data, _ := file["file"].(map[string]any)
+	fileData, _ := data["file_data"].(string)
+	assert.True(t, strings.HasPrefix(fileData, "data:application/pdf;base64,"), "pdf must inline as a data URL, got %q", fileData)
+}
+
+func TestNormalizeMediaType(t *testing.T) {
+	assert.Equal(t, "image/png", normalizeMediaType("image/png"))
+	assert.Equal(t, "image/jpeg", normalizeMediaType("IMAGE/JPEG; charset=binary"))
+	assert.Equal(t, "text/html", normalizeMediaType("text/html;charset=utf-8"))
+	assert.Equal(t, "", normalizeMediaType(""))
+}
+
+func TestTrimTrailingPunct(t *testing.T) {
+	url, trailing := trimTrailingPunct("https://x/cat.png.")
+	assert.Equal(t, "https://x/cat.png", url)
+	assert.Equal(t, ".", trailing)
+
+	url, trailing = trimTrailingPunct("https://x/cat.png")
+	assert.Equal(t, "https://x/cat.png", url)
+	assert.Equal(t, "", trailing)
+}

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -297,7 +297,7 @@ func TestNormalizeMediaType(t *testing.T) {
 	assert.Equal(t, "image/png", normalizeMediaType("image/png"))
 	assert.Equal(t, "image/jpeg", normalizeMediaType("IMAGE/JPEG; charset=binary"))
 	assert.Equal(t, "text/html", normalizeMediaType("text/html;charset=utf-8"))
-	assert.Equal(t, "", normalizeMediaType(""))
+	assert.Empty(t, normalizeMediaType(""))
 }
 
 func TestTrimTrailingPunct(t *testing.T) {
@@ -307,5 +307,5 @@ func TestTrimTrailingPunct(t *testing.T) {
 
 	url, trailing = trimTrailingPunct("https://x/cat.png")
 	assert.Equal(t, "https://x/cat.png", url)
-	assert.Equal(t, "", trailing)
+	assert.Empty(t, trailing)
 }

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -152,6 +152,23 @@ func TestRewriteHandlesMultipleAttachmentURLs(t *testing.T) {
 	assert.Equal(t, 2, images, "each URL must become its own image part")
 }
 
+// @scenario "An attachment URL in the system prompt is re-homed to a user message"
+func TestRewriteRehomesSystemAttachmentToUser(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+
+	out, ne := f.rewrite(context.Background(), []app.ChatMessage{
+		{Role: "system", Content: "You are a vision grader. Image: " + srv.URL + "/cat.png"},
+	})
+	require.Nil(t, ne)
+	require.Len(t, out, 2, "the system message must split into system text + a user message")
+	assert.Equal(t, "system", out[0].Role)
+	assert.IsType(t, "", out[0].Content, "the system message keeps only the leading text")
+	assert.Equal(t, "user", out[1].Role)
+	firstPartOfType(t, out[1], "image_url") // the image rode into the user message
+}
+
 // @scenario "An unreachable attachment URL fails the run with a clear message naming the URL"
 func TestRewriteFailsClearlyOnUnreachableURL(t *testing.T) {
 	srv := attachmentServer(t)

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/langwatch/langwatch/services/nlpgo/app"
 	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/dsl"
 )
 
 // loopbackFetcher allows the httptest server (127.0.0.1) past the SSRF guard,
@@ -291,6 +292,76 @@ func TestRewriteFetchesPDFIntoFilePart(t *testing.T) {
 	data, _ := file["file"].(map[string]any)
 	fileData, _ := data["file_data"].(string)
 	assert.True(t, strings.HasPrefix(fileData, "data:application/pdf;base64,"), "pdf must inline as a data URL, got %q", fileData)
+}
+
+// imageTypedNode builds a signature node declaring the given inputs, used to
+// exercise the image-typed-input resolution that runs before message templating.
+func imageTypedNode(fields ...dsl.Field) *dsl.Node {
+	return &dsl.Node{ID: "sig", Type: dsl.ComponentSignature, Data: dsl.Component{Inputs: fields}}
+}
+
+// @scenario "An image-typed field whose URL is an image is fetched and inlined"
+func TestInlineImageInputsResolvesRemoteImageToDataURL(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+	node := imageTypedNode(dsl.Field{Identifier: "picture", Type: dsl.FieldTypeImage})
+	inputs := map[string]any{"picture": srv.URL + "/cat.png"}
+
+	out, ne := f.inlineImageInputs(context.Background(), node, inputs)
+	require.Nil(t, ne)
+	got, _ := out["picture"].(string)
+	assert.True(t, strings.HasPrefix(got, "data:image/png;base64,"),
+		"the image-typed URL must inline as a data URL, got %q", got)
+	assert.Equal(t, srv.URL+"/cat.png", inputs["picture"],
+		"the original inputs map must keep the readable URL, not a base64 blob")
+}
+
+// @scenario "An image-typed field whose URL cannot be fetched fails the run with a clear error"
+func TestInlineImageInputsFailsClearlyOnUnreachableImageURL(t *testing.T) {
+	srv := attachmentServer(t)
+	deadURL := srv.URL + "/cat.png"
+	srv.Close() // nothing is listening now
+	f := loopbackFetcher()
+	node := imageTypedNode(dsl.Field{Identifier: "picture", Type: dsl.FieldTypeImage})
+
+	out, ne := f.inlineImageInputs(context.Background(), node, map[string]any{"picture": deadURL})
+	require.Nil(t, out)
+	require.NotNil(t, ne, "an explicit image field with an unfetchable URL must fail the run")
+	assert.Equal(t, "attachment_fetch_error", ne.Type)
+	assert.Contains(t, ne.Message, deadURL, "the error must name the URL")
+}
+
+// @scenario "An image-typed field whose URL is not an image fails the run with a clear error"
+func TestInlineImageInputsFailsClearlyWhenNotAnImage(t *testing.T) {
+	srv := attachmentServer(t)
+	defer srv.Close()
+	f := loopbackFetcher()
+	node := imageTypedNode(dsl.Field{Identifier: "picture", Type: dsl.FieldTypeImage})
+
+	out, ne := f.inlineImageInputs(context.Background(), node, map[string]any{"picture": srv.URL + "/page"})
+	require.Nil(t, out)
+	require.NotNil(t, ne, "an image field pointing at a web page must fail the run")
+	assert.Equal(t, "attachment_fetch_error", ne.Type)
+	assert.Contains(t, ne.Message, "image", "the error must explain it could not be loaded as an image")
+}
+
+func TestInlineImageInputsLeavesDataURLAndTextInputsUntouched(t *testing.T) {
+	f := loopbackFetcher()
+	// picture is image-typed but already an inline data URL (no fetch needed);
+	// link is str-typed and must not be eagerly fetched even though it is a URL.
+	node := imageTypedNode(
+		dsl.Field{Identifier: "picture", Type: dsl.FieldTypeImage},
+		dsl.Field{Identifier: "link", Type: dsl.FieldTypeStr},
+	)
+	inputs := map[string]any{
+		"picture": "data:image/png;base64,AAAA",
+		"link":    "http://127.0.0.1:1/skip.png",
+	}
+	out, ne := f.inlineImageInputs(context.Background(), node, inputs)
+	require.Nil(t, ne)
+	assert.Equal(t, "data:image/png;base64,AAAA", out["picture"], "an inline data URL must pass through untouched")
+	assert.Equal(t, "http://127.0.0.1:1/skip.png", out["link"], "a str-typed URL must not be eagerly fetched")
 }
 
 func TestNormalizeMediaType(t *testing.T) {

--- a/services/nlpgo/app/engine/attachment_test.go
+++ b/services/nlpgo/app/engine/attachment_test.go
@@ -392,6 +392,15 @@ func TestAttachmentErrorRedactsURLQueryParams(t *testing.T) {
 	assert.Contains(t, ne.Message, "bucket.s3.amazonaws.com/private/img.png", "the attachment stays identifiable by host + path")
 }
 
+func TestAttachmentErrorStripsUserinfoCredentials(t *testing.T) {
+	// Some URLs carry credentials in the userinfo component (user:password@host).
+	withCreds := "https://svcuser:s3cr3ttoken@cdn.example.com/private/file.png"
+	ne := attachmentError(withCreds, "could not be reached", 0)
+	assert.NotContains(t, ne.Message, "s3cr3ttoken", "embedded userinfo password must not leak")
+	assert.NotContains(t, ne.Message, "svcuser", "embedded userinfo user must not leak")
+	assert.Contains(t, ne.Message, "cdn.example.com/private/file.png", "the attachment stays identifiable by host + path")
+}
+
 func TestRedactAttachmentsForTracingStripsInlineBytes(t *testing.T) {
 	bigB64 := strings.Repeat("A", 4096)
 	messages := []app.ChatMessage{{Role: "user", Content: []any{

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -514,9 +514,23 @@ func (e *Engine) runSignature(ctx context.Context, execReq ExecuteRequest, node 
 	// "(unsaved edits)".
 	emitPromptSpans(ctx, node, inputs)
 
+	// Resolve image-typed inputs that carry a remote URL into inline images
+	// before templating. An image-typed field is an explicit attachment, so a
+	// URL it holds that cannot be fetched as an image aborts the run with a
+	// clear error rather than being left as text for the model to guess from.
+	msgInputs := inputs
+	if e.attachments != nil {
+		inlined, aerr := e.attachments.inlineImageInputs(ctx, node, inputs)
+		if aerr != nil {
+			aerr.NodeID = node.ID
+			return nil, aerr
+		}
+		msgInputs = inlined
+	}
+
 	// Re-shape any template-interpolated image data URLs into multimodal
 	// content parts so the model receives actual images, not base64 text.
-	messages := splitMessagesWithImages(buildMessages(node, inputs))
+	messages := splitMessagesWithImages(buildMessages(node, msgInputs))
 	// Fetch any remote attachment URLs (http/https) referenced in the messages
 	// and deliver them as content the model can open. A failed fetch aborts the
 	// run with a clear, user-facing error instead of a broken provider request.

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -571,7 +571,9 @@ func (e *Engine) runSignature(ctx context.Context, execReq ExecuteRequest, node 
 		}
 		req.ResponseFormat = composeSignatureResponseFormat(sanitizeSchemaName(schemaName), node.Data.Outputs)
 	}
-	llmCtx, llmSpan := startLLMSpan(ctx, model, provider, messages)
+	// Trace a redacted copy: the model gets the full fetched bytes (req.Messages),
+	// but the span's langwatch.input must not store the base64 attachment payload.
+	llmCtx, llmSpan := startLLMSpan(ctx, model, provider, redactAttachmentsForTracing(messages))
 	resp, err := e.llm.Execute(llmCtx, req)
 	endLLMSpan(llmSpan, resp, err)
 	if err != nil {

--- a/services/nlpgo/app/engine/engine.go
+++ b/services/nlpgo/app/engine/engine.go
@@ -36,6 +36,7 @@ import (
 // HTTP handler invokes per /go/studio/execute_sync request.
 type Engine struct {
 	http             *httpblock.Executor
+	attachments      *attachmentFetcher
 	code             *codeblock.Executor
 	llm              app.LLMClient
 	evaluator        *evaluatorblock.Executor
@@ -54,7 +55,10 @@ type Logger interface {
 
 // Options configures an Engine.
 type Options struct {
-	HTTP             *httpblock.Executor
+	HTTP *httpblock.Executor
+	// SSRF mirrors the HTTP block's destination policy so remote prompt
+	// attachments are fetched under the same private/loopback/metadata ban.
+	SSRF             httpblock.SSRFOptions
 	Code             *codeblock.Executor
 	LLM              app.LLMClient
 	Evaluator        *evaluatorblock.Executor
@@ -70,6 +74,7 @@ func New(opts Options) *Engine {
 	}
 	return &Engine{
 		http:             opts.HTTP,
+		attachments:      newAttachmentFetcher(opts.SSRF),
 		code:             opts.Code,
 		llm:              opts.LLM,
 		evaluator:        opts.Evaluator,
@@ -512,6 +517,17 @@ func (e *Engine) runSignature(ctx context.Context, execReq ExecuteRequest, node 
 	// Re-shape any template-interpolated image data URLs into multimodal
 	// content parts so the model receives actual images, not base64 text.
 	messages := splitMessagesWithImages(buildMessages(node, inputs))
+	// Fetch any remote attachment URLs (http/https) referenced in the messages
+	// and deliver them as content the model can open. A failed fetch aborts the
+	// run with a clear, user-facing error instead of a broken provider request.
+	if e.attachments != nil {
+		fetched, aerr := e.attachments.rewrite(ctx, messages)
+		if aerr != nil {
+			aerr.NodeID = node.ID
+			return nil, aerr
+		}
+		messages = fetched
+	}
 	req := app.LLMRequest{
 		Model:    model,
 		Provider: provider,

--- a/services/nlpgo/cmd/root.go
+++ b/services/nlpgo/cmd/root.go
@@ -87,7 +87,12 @@ func Root(ctx context.Context, _ []string) error {
 	agentWfRunner := agentblock.NewWorkflowRunner(agentblock.WorkflowRunnerOptions{})
 
 	eng := engine.New(engine.Options{
-		HTTP:             httpExec,
+		HTTP: httpExec,
+		// Remote prompt attachments are fetched under the same SSRF policy
+		// (and customer allow-list) as the HTTP block.
+		SSRF: httpblock.SSRFOptions{
+			AllowedHosts: splitCSV(cfg.Engine.AllowedProxyHosts),
+		},
 		Code:             codeExec,
 		LLM:              llm,
 		Evaluator:        evalExec,

--- a/services/nlpgo/tests/integration/workflow_llm_audio_url_e2e_test.go
+++ b/services/nlpgo/tests/integration/workflow_llm_audio_url_e2e_test.go
@@ -1,0 +1,104 @@
+//go:build live_openai
+
+package integration_test
+
+// Known-answer audio probe. Proves the remote-attachment-URL path delivers a
+// non-image attachment (audio) end to end: a prompt references an audio file by
+// a plain http URL, nlpgo fetches it, detects audio/wav, structures it as an
+// input_audio content part, and a real audio-capable model (via the in-process
+// gateway) answers a question only answerable by actually hearing the clip.
+//
+// The clip asks aloud "Do I have a male voice or a female voice?" (confirmed by
+// a separate Whisper transcription). Asking the model to repeat the spoken
+// question verbatim makes the assertion independent of the voice's gender and
+// impossible to satisfy from the opaque URL alone, so a correct echo proves the
+// audio was fetched, structured, and heard rather than hallucinated.
+//
+// Build tag: live_openai (needs a real OPENAI_API_KEY). The audio fixture is
+// supplied via AUDIO_FIXTURE_PATH so no large binary is committed; the test
+// skips when either is absent.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSync_RealWorkflowEndToEnd_OpenAI_AudioAttachmentURL(t *testing.T) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+	fixturePath := os.Getenv("AUDIO_FIXTURE_PATH")
+	if fixturePath == "" {
+		t.Skip("AUDIO_FIXTURE_PATH not set (point it at a wav whose spoken content you know)")
+	}
+	wav, err := os.ReadFile(fixturePath)
+	require.NoError(t, err, "read audio fixture")
+
+	audioSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "audio/wav")
+		_, _ = w.Write(wav)
+	}))
+	defer audioSrv.Close()
+	audioURL := audioSrv.URL + "/clip"
+
+	stack := setupVisionStack(t)
+
+	body := `{
+	  "type": "execute_flow",
+	  "payload": {
+	    "trace_id": "real-e2e-audio-url",
+	    "origin": "workflow",
+	    "workflow": {
+	      "workflow_id":"wf","api_key":"k","spec_version":"1.3","name":"Audio","icon":"🔊","description":"x","version":"x",
+	      "template_adapter":"default",
+	      "nodes":[
+	        {"id":"entry","type":"entry","data":{
+	          "outputs":[{"identifier":"clip","type":"str"}],
+	          "dataset":{"inline":{"records":{"clip":["` + audioURL + `"]}}},
+	          "entry_selection":0,
+	          "train_size":1.0,"test_size":0.0,"seed":1
+	        }},
+	        {"id":"answer","type":"signature","data":{
+	          "name":"Answer",
+	          "parameters":[
+	            {"identifier":"llm","type":"llm","value":{
+	              "model":"openai/gpt-audio",
+	              "litellm_params":{"api_key":"` + apiKey + `"}
+	            }},
+	            {"identifier":"instructions","type":"str","value":"You are given one audio clip. Repeat, verbatim and in English, the question that is asked in it, and nothing else."}
+	          ],
+	          "inputs":[{"identifier":"clip","type":"str"}],
+	          "outputs":[{"identifier":"answer","type":"str"}]
+	        }},
+	        {"id":"end","type":"end","data":{
+	          "inputs":[{"identifier":"answer","type":"str"}]
+	        }}
+	      ],
+	      "edges":[
+	        {"id":"e1","source":"entry","sourceHandle":"outputs.clip","target":"answer","targetHandle":"inputs.clip","type":"default"},
+	        {"id":"e2","source":"answer","sourceHandle":"outputs.answer","target":"end","targetHandle":"inputs.answer","type":"default"}
+	      ],
+	      "state":{}
+	    },
+	    "inputs":[{}]
+	  }
+	}`
+
+	res := postSync(t, stack, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	answer, _ := res.Result["answer"].(string)
+	require.NotEmpty(t, answer, "expected a non-empty answer from the real audio call")
+	// The clip asks about a "male voice or a female voice" — words the model can
+	// only produce by hearing the fetched audio, since the URL gives nothing away.
+	lower := strings.ToLower(answer)
+	assert.True(t, strings.Contains(lower, "male voice") && strings.Contains(lower, "female voice"),
+		"expected the model to echo the spoken question (male/female voice), got %q", answer)
+}

--- a/services/nlpgo/tests/integration/workflow_llm_pdf_url_e2e_test.go
+++ b/services/nlpgo/tests/integration/workflow_llm_pdf_url_e2e_test.go
@@ -1,0 +1,103 @@
+//go:build live_openai
+
+package integration_test
+
+// Known-answer document probe. Proves the remote-attachment-URL path delivers a
+// PDF attachment end to end: a prompt references a document by a plain http URL,
+// nlpgo fetches it, detects application/pdf, structures it as a file content
+// part, and a real document-capable model (via the in-process gateway) answers
+// a question only answerable by actually reading the file.
+//
+// The fixture contains "The order number is 4729." and "The customer city is
+// Lisbon." (a known-content PDF). The two facts are absent from the opaque URL,
+// so a correct answer proves the document was fetched, structured, and read
+// rather than hallucinated.
+//
+// Build tag: live_openai (needs a real OPENAI_API_KEY). The PDF fixture is
+// supplied via PDF_FIXTURE_PATH so no binary is committed; the test skips when
+// either is absent.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSync_RealWorkflowEndToEnd_OpenAI_PDFAttachmentURL(t *testing.T) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+	fixturePath := os.Getenv("PDF_FIXTURE_PATH")
+	if fixturePath == "" {
+		t.Skip("PDF_FIXTURE_PATH not set (point it at a pdf whose text you know: order 4729, city Lisbon)")
+	}
+	pdf, err := os.ReadFile(fixturePath)
+	require.NoError(t, err, "read pdf fixture")
+
+	pdfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write(pdf)
+	}))
+	defer pdfSrv.Close()
+	pdfURL := pdfSrv.URL + "/document"
+
+	stack := setupVisionStack(t)
+
+	body := `{
+	  "type": "execute_flow",
+	  "payload": {
+	    "trace_id": "real-e2e-pdf-url",
+	    "origin": "workflow",
+	    "workflow": {
+	      "workflow_id":"wf","api_key":"k","spec_version":"1.3","name":"PDF","icon":"📄","description":"x","version":"x",
+	      "template_adapter":"default",
+	      "nodes":[
+	        {"id":"entry","type":"entry","data":{
+	          "outputs":[{"identifier":"document","type":"str"}],
+	          "dataset":{"inline":{"records":{"document":["` + pdfURL + `"]}}},
+	          "entry_selection":0,
+	          "train_size":1.0,"test_size":0.0,"seed":1
+	        }},
+	        {"id":"answer","type":"signature","data":{
+	          "name":"Answer",
+	          "parameters":[
+	            {"identifier":"llm","type":"llm","value":{
+	              "model":"openai/gpt-5-mini",
+	              "litellm_params":{"api_key":"` + apiKey + `"}
+	            }},
+	            {"identifier":"instructions","type":"str","value":"Read the attached document and answer in one short sentence: what is the order number and the customer city?"}
+	          ],
+	          "inputs":[{"identifier":"document","type":"str"}],
+	          "outputs":[{"identifier":"answer","type":"str"}]
+	        }},
+	        {"id":"end","type":"end","data":{
+	          "inputs":[{"identifier":"answer","type":"str"}]
+	        }}
+	      ],
+	      "edges":[
+	        {"id":"e1","source":"entry","sourceHandle":"outputs.document","target":"answer","targetHandle":"inputs.document","type":"default"},
+	        {"id":"e2","source":"answer","sourceHandle":"outputs.answer","target":"end","targetHandle":"inputs.answer","type":"default"}
+	      ],
+	      "state":{}
+	    },
+	    "inputs":[{}]
+	  }
+	}`
+
+	res := postSync(t, stack, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	answer, _ := res.Result["answer"].(string)
+	require.NotEmpty(t, answer, "expected a non-empty answer from the real document call")
+	// 4729 and Lisbon live only inside the fetched PDF, not in the URL, so both
+	// appearing proves the document was fetched, structured, and read.
+	lower := strings.ToLower(answer)
+	assert.True(t, strings.Contains(lower, "4729") && strings.Contains(lower, "lisbon"),
+		"expected the model to read the order number and city from the PDF, got %q", answer)
+}

--- a/services/nlpgo/tests/integration/workflow_llm_vision_url_e2e_test.go
+++ b/services/nlpgo/tests/integration/workflow_llm_vision_url_e2e_test.go
@@ -1,0 +1,158 @@
+//go:build live_openai
+
+package integration_test
+
+// Known-answer vision probe. Proves the remote-attachment-URL path end to end:
+// a prompt references an image by a plain http URL, nlpgo fetches it, inlines it
+// as a base64 image part, and a real vision model (via the in-process gateway)
+// answers a question that is only answerable by actually seeing the pixels.
+//
+// The image is served from a local httptest server with an opaque path
+// (/image.png), and its content is a solid color we generate here, so the model
+// cannot guess the answer from the URL or a filename — a correct color proves it
+// received and understood the picture rather than hallucinating.
+//
+// Build tag: live_openai (needs a real OPENAI_API_KEY).
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/langwatch/langwatch/pkg/health"
+	"github.com/langwatch/langwatch/services/aigateway/dispatcher"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/dispatcheradapter"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/httpapi"
+	"github.com/langwatch/langwatch/services/nlpgo/adapters/llmexecutor"
+	"github.com/langwatch/langwatch/services/nlpgo/app"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/codeblock"
+	"github.com/langwatch/langwatch/services/nlpgo/app/engine/blocks/httpblock"
+)
+
+// setupVisionStack mirrors setupStackWithLLM but allows the loopback image
+// server past the SSRF guard so the engine can fetch the test attachment.
+func setupVisionStack(t *testing.T) *stack {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+
+	disp, err := dispatcher.New(context.Background(), dispatcher.Options{})
+	require.NoError(t, err)
+	llm := llmexecutor.New(dispatcheradapter.New(disp))
+
+	httpExec := httpblock.New(httpblock.Options{})
+	codeExec, err := codeblock.New(codeblock.Options{})
+	require.NoError(t, err)
+	eng := engine.New(engine.Options{
+		HTTP: httpExec,
+		Code: codeExec,
+		LLM:  llm,
+		// Allow the loopback image server; production fetches still bind to the
+		// default private/loopback ban.
+		SSRF: httpblock.SSRFOptions{AllowedHosts: []string{"127.0.0.1"}},
+	})
+
+	executor := liveExecutorAdapter{eng: eng}
+	application := app.New(app.WithWorkflowExecutor(executor))
+	probes := health.New("test")
+	probes.MarkStarted()
+	router := httpapi.NewRouter(httpapi.RouterDeps{App: application, Health: probes, Version: "test"})
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	t.Cleanup(upstream.Close)
+	return &stack{url: srv.URL, upstream: upstream, upstreamURL: upstream.URL}
+}
+
+func solidColorPNG(t *testing.T, c color.Color) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 96, 96))
+	draw.Draw(img, img.Bounds(), &image.Uniform{C: c}, image.Point{}, draw.Src)
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return buf.Bytes()
+}
+
+// TestSync_RealWorkflowEndToEnd_OpenAI_VisionAttachmentURL is the headline
+// dogfood: a plain http image URL in a prompt reaches a real vision model as a
+// real image, and the model reports the color it could only have seen.
+func TestSync_RealWorkflowEndToEnd_OpenAI_VisionAttachmentURL(t *testing.T) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+
+	imgSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(solidColorPNG(t, color.RGBA{R: 0, G: 0, B: 255, A: 255}))
+	}))
+	defer imgSrv.Close()
+	imageURL := imgSrv.URL + "/image.png"
+
+	stack := setupVisionStack(t)
+
+	body := `{
+	  "type": "execute_flow",
+	  "payload": {
+	    "trace_id": "real-e2e-vision-url",
+	    "origin": "workflow",
+	    "workflow": {
+	      "workflow_id":"wf","api_key":"k","spec_version":"1.3","name":"Vision","icon":"🖼️","description":"x","version":"x",
+	      "template_adapter":"default",
+	      "nodes":[
+	        {"id":"entry","type":"entry","data":{
+	          "outputs":[{"identifier":"picture","type":"str"}],
+	          "dataset":{"inline":{"records":{"picture":["` + imageURL + `"]}}},
+	          "entry_selection":0,
+	          "train_size":1.0,"test_size":0.0,"seed":1
+	        }},
+	        {"id":"answer","type":"signature","data":{
+	          "name":"Answer",
+	          "parameters":[
+	            {"identifier":"llm","type":"llm","value":{
+	              "model":"openai/gpt-5-mini",
+	              "litellm_params":{"api_key":"` + apiKey + `"}
+	            }},
+	            {"identifier":"instructions","type":"str","value":"You are shown one image. Reply with the single lowercase English word naming its dominant color, and nothing else."}
+	          ],
+	          "inputs":[{"identifier":"picture","type":"str"}],
+	          "outputs":[{"identifier":"answer","type":"str"}]
+	        }},
+	        {"id":"end","type":"end","data":{
+	          "inputs":[{"identifier":"answer","type":"str"}]
+	        }}
+	      ],
+	      "edges":[
+	        {"id":"e1","source":"entry","sourceHandle":"outputs.picture","target":"answer","targetHandle":"inputs.picture","type":"default"},
+	        {"id":"e2","source":"answer","sourceHandle":"outputs.answer","target":"end","targetHandle":"inputs.answer","type":"default"}
+	      ],
+	      "state":{}
+	    },
+	    "inputs":[{}]
+	  }
+	}`
+
+	res := postSync(t, stack, body)
+	require.Equal(t, "success", res.Status, "engine error: %+v", res.Error)
+
+	answer, _ := res.Result["answer"].(string)
+	require.NotEmpty(t, answer, "expected a non-empty answer from the real vision call")
+	// "blue" is only knowable by seeing the generated pixels — the URL gives
+	// nothing away — so a correct color is proof the image was fetched, inlined,
+	// and understood, not hallucinated.
+	assert.Contains(t, strings.ToLower(answer), "blue",
+		"expected the model to report the image color blue, got %q", answer)
+}

--- a/specs/nlp-go/multimodal-attachment-urls.feature
+++ b/specs/nlp-go/multimodal-attachment-urls.feature
@@ -53,6 +53,14 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
     When the engine builds the LLM messages
     Then the content carries an image part for each, in their original positions
 
+  @integration
+  Scenario: An attachment URL in the system prompt is re-homed to a user message
+    Given the system prompt references an image by URL
+    When the engine builds the LLM messages
+    Then the system message keeps only the text before the image
+    And the image is delivered in a user message instead
+    # Providers reject image parts in system-role messages.
+
   # ============================================================================
   # Clear failures when an attachment cannot be fetched
   # ============================================================================

--- a/specs/nlp-go/multimodal-attachment-urls.feature
+++ b/specs/nlp-go/multimodal-attachment-urls.feature
@@ -54,12 +54,11 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
     Then the content carries an image part for each, in their original positions
 
   @integration
-  Scenario: An attachment URL in the system prompt is re-homed to a user message
-    Given the system prompt references an image by URL
+  Scenario: An image mentioned in the system prompt still reaches the model
+    Given the system prompt text references an image by URL
     When the engine builds the LLM messages
-    Then the system message keeps only the text before the image
-    And the image is delivered in a user message instead
-    # Providers reject image parts in system-role messages.
+    Then the model still receives that image as a picture
+    And the system instructions are kept
 
   # ============================================================================
   # Clear failures when an attachment cannot be fetched

--- a/specs/nlp-go/multimodal-attachment-urls.feature
+++ b/specs/nlp-go/multimodal-attachment-urls.feature
@@ -85,6 +85,13 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
     Then the run fails with a clear error explaining the attachment was too large
     And no request is sent to the model
 
+  @integration
+  Scenario: An attachment URL that redirects to a private address is refused
+    Given an attachment URL on an allowed host that redirects to a metadata address
+    When the engine builds the LLM messages
+    Then the run fails rather than fetching the private address
+    # The SSRF policy is re-applied at dial time, so a redirect cannot escape it.
+
   # ============================================================================
   # A plain link the author is only mentioning is left alone
   # ============================================================================
@@ -97,6 +104,15 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
     And no attachment part is created for it
     # A reachable, non-attachment response (a web page) is the author referencing
     # a link, not attaching a file, so it must not be force-attached.
+
+  @integration
+  Scenario: A broken link in prose does not fail the run
+    Given a user message whose text mentions an http URL that cannot be reached
+    When the engine builds the LLM messages
+    Then the URL is left in the message as text
+    And the run is not failed by the broken link
+    # A bare URL in prose is best-effort; only an explicit image attachment that
+    # cannot be fetched fails the run.
 
   # ============================================================================
   # Forward-looking: arbitrary attachment types pass through structured

--- a/specs/nlp-go/multimodal-attachment-urls.feature
+++ b/specs/nlp-go/multimodal-attachment-urls.feature
@@ -15,8 +15,8 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
     cannot be fetched, the run must fail with a clear, user-facing message
     rather than silently sending a broken request or a wall of URL text.
 
-    # Bindings: services/nlpgo/app/engine/attachment_test.go and
-    # services/nlpgo/tests/integration/attachment_url_test.go
+    # Bindings: services/nlpgo/app/engine/attachment_test.go and the live
+    # integration probe services/nlpgo/tests/integration/workflow_llm_vision_url_e2e_test.go
     # Fetch + detect + structure: services/nlpgo/app/engine/attachment.go,
     # applied to the messages buildMessages returns, right beside the existing
     # data-URL image split in multimodal.go.

--- a/specs/nlp-go/multimodal-attachment-urls.feature
+++ b/specs/nlp-go/multimodal-attachment-urls.feature
@@ -6,16 +6,14 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
   document) instead of guessing from a link it cannot open
 
   Background:
-    Today an image only reaches the model when its value is an inline
-    data:image/...;base64,... URL; that base64 case is split into content parts
-    by the existing image splitter. A value that is a plain http(s) URL is
-    interpolated into the message as text and the model never sees the content.
-    The engine should instead fetch a referenced URL, detect its type from the
-    response, and deliver it as the right kind of content part so it works
-    across every provider, regardless of whether the provider can fetch URLs
-    itself. When a referenced attachment cannot be fetched, the run must fail
-    with a clear, user-facing message rather than silently sending a broken
-    request or a wall of URL text.
+    Today an image reaches the model only when its value is an inline
+    data:image/...;base64,... URL; a value that is a plain http(s) URL is passed
+    along as text and the model never sees the content. Instead, a referenced
+    URL should be fetched, its type detected from the response, and delivered as
+    the right kind of content so it works across every provider, regardless of
+    whether the provider can fetch URLs itself. When a referenced attachment
+    cannot be fetched, the run must fail with a clear, user-facing message
+    rather than silently sending a broken request or a wall of URL text.
 
     # Bindings: services/nlpgo/app/engine/attachment_test.go and
     # services/nlpgo/tests/integration/attachment_url_test.go
@@ -29,36 +27,35 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
 
   @integration
   Scenario: An image referenced by an http URL is fetched and delivered as an image part
-    Given a user message whose text is an http URL pointing at a PNG image
-    When the engine builds the LLM messages
-    Then the message content becomes a parts list carrying an image part
-    And the image part carries the fetched image, not the original link text
+    Given a prompt that references an image by an http URL to a PNG
+    When I run the workflow
+    Then the model receives the fetched image as a picture, not the link text
 
   @integration
   Scenario: The attachment type is detected from the response, not the file extension
-    Given a user message whose http URL has no file extension but serves a JPEG
-    When the engine builds the LLM messages
-    Then the content still carries an image part for that attachment
+    Given a prompt referencing an image URL that has no file extension but serves a JPEG
+    When I run the workflow
+    Then the model still receives it as an image
 
   @unit
   Scenario: An image already given as a base64 data URL is delivered without fetching
-    Given a user message whose image is an inline base64 data URL
-    When the engine builds the LLM messages
-    Then the image reaches the model without any network fetch
-    # The existing data-URL split keeps working untouched; only http(s) URLs are fetched.
+    Given a prompt whose image is already an inline base64 data URL
+    When I run the workflow
+    Then the model receives the image with no network fetch
+    # The existing data-URL handling keeps working untouched; only http(s) URLs are fetched.
 
   @integration
   Scenario: Several attachment URLs in one message each become their own part
-    Given a user message referencing two image URLs around some text
-    When the engine builds the LLM messages
-    Then the content carries an image part for each, in their original positions
+    Given a prompt referencing two image URLs around some text
+    When I run the workflow
+    Then the model receives both images, each in the position it was mentioned
 
   @integration
   Scenario: An image mentioned in the system prompt still reaches the model
-    Given the system prompt text references an image by URL
-    When the engine builds the LLM messages
+    Given workflow instructions that reference an image by URL
+    When I run the workflow
     Then the model still receives that image as a picture
-    And the system instructions are kept
+    And the instructions are kept
 
   # ============================================================================
   # Clear failures when an attachment cannot be fetched
@@ -66,28 +63,28 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
 
   @integration
   Scenario: An unreachable attachment URL fails the run with a clear message naming the URL
-    Given a user message referencing an attachment URL that cannot be reached
-    When the engine builds the LLM messages
+    Given a prompt referencing an attachment URL that cannot be reached
+    When I run the workflow
     Then the run fails with a clear error that names the URL and the reason
-    And no request is sent to the model
+    And nothing is sent to the model
 
   @integration
   Scenario: An attachment URL that responds with an error status fails the run clearly
-    Given a user message referencing an attachment URL that returns a not-found status
-    When the engine builds the LLM messages
+    Given a prompt referencing an attachment URL that returns a not-found status
+    When I run the workflow
     Then the run fails with a clear error that names the URL and the status
 
   @integration
   Scenario: An attachment larger than the allowed size is rejected with a clear message
-    Given a user message referencing an attachment URL whose body exceeds the size limit
-    When the engine builds the LLM messages
+    Given a prompt referencing an attachment URL whose body exceeds the size limit
+    When I run the workflow
     Then the run fails with a clear error explaining the attachment was too large
-    And no request is sent to the model
+    And nothing is sent to the model
 
   @integration
   Scenario: An attachment URL that redirects to a private address is refused
-    Given an attachment URL on an allowed host that redirects to a metadata address
-    When the engine builds the LLM messages
+    Given a prompt referencing an attachment URL that redirects to a private address
+    When I run the workflow
     Then the run fails rather than fetching the private address
     # The SSRF policy is re-applied at dial time, so a redirect cannot escape it.
 
@@ -97,18 +94,18 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
 
   @integration
   Scenario: A link to a normal web page is left as text, not turned into an attachment
-    Given a user message referencing a URL that serves an HTML page
-    When the engine builds the LLM messages
-    Then the URL is left in the message as text
-    And no attachment part is created for it
+    Given a prompt referencing a link to a normal web page
+    When I run the workflow
+    Then the link reaches the model as text
+    And no attachment is created for it
     # A reachable, non-attachment response (a web page) is the author referencing
     # a link, not attaching a file, so it must not be force-attached.
 
   @integration
   Scenario: A broken link in prose does not fail the run
-    Given a user message whose text mentions an http URL that cannot be reached
-    When the engine builds the LLM messages
-    Then the URL is left in the message as text
+    Given a prompt whose text mentions a link that cannot be reached
+    When I run the workflow
+    Then the link reaches the model as text
     And the run is not failed by the broken link
     # A bare URL in prose is best-effort; only an explicit image attachment that
     # cannot be fetched fails the run.
@@ -118,29 +115,29 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
   # ============================================================================
   # The studio lets an author declare an input as an Image. That is an explicit
   # statement of intent: the value is a picture, not prose that happens to carry
-  # a link. So an image-typed field is resolved before templating and fails the
-  # run with a clear error when its URL cannot be loaded as an image, rather than
-  # being passed to the model as text for it to guess from (e.g. from a filename).
+  # a link. So an image-typed field is resolved up front and fails the run with a
+  # clear error when its URL cannot be loaded as an image, rather than being
+  # passed to the model as text for it to guess from (e.g. from a filename).
 
   @integration
   Scenario: An image-typed field whose URL is an image is fetched and inlined
-    Given a signature input declared as an image whose value is an http URL to a PNG
-    When the engine builds the LLM messages
-    Then the image is fetched and delivered to the model as an image, not as the link text
+    Given a workflow input declared as an image whose value is an http URL to a picture
+    When I run the workflow
+    Then the model receives the fetched image, not the link text
 
   @integration
   Scenario: An image-typed field whose URL cannot be fetched fails the run with a clear error
-    Given a signature input declared as an image whose URL cannot be reached
-    When the engine builds the LLM messages
+    Given a workflow input declared as an image whose URL cannot be reached
+    When I run the workflow
     Then the run fails with a clear error that names the URL
-    And no request is sent to the model
+    And nothing is sent to the model
     # Contrast with the best-effort prose link above: the explicit image field
     # must not silently degrade to the model guessing from the URL text.
 
   @integration
   Scenario: An image-typed field whose URL is not an image fails the run with a clear error
-    Given a signature input declared as an image whose URL serves a web page
-    When the engine builds the LLM messages
+    Given a workflow input declared as an image whose URL serves a web page
+    When I run the workflow
     Then the run fails with a clear error explaining it could not be loaded as an image
 
   # ============================================================================
@@ -149,12 +146,12 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
 
   @integration
   Scenario: An audio attachment referenced by URL reaches the model as audio
-    Given a user message whose http URL points at an audio file
-    When the engine builds the LLM messages
-    Then the content carries an audio attachment part for the model to hear
+    Given a prompt whose http URL points at an audio file
+    When I run the workflow
+    Then the model receives it as audio to hear
 
   @integration
   Scenario: A PDF attachment referenced by URL reaches the model as a document
-    Given a user message whose http URL points at a PDF document
-    When the engine builds the LLM messages
-    Then the content carries a document attachment part for the model to read
+    Given a prompt whose http URL points at a PDF document
+    When I run the workflow
+    Then the model receives it as a document to read

--- a/specs/nlp-go/multimodal-attachment-urls.feature
+++ b/specs/nlp-go/multimodal-attachment-urls.feature
@@ -1,0 +1,107 @@
+Feature: Remote attachment URLs are fetched and delivered to the model as content
+  As a user running vision and multimodal workflows and evaluations
+  I want an attachment referenced by a plain http(s) URL to reach the model as
+  real content, not as the literal URL text
+  So that the model actually sees the picture (or hears the audio, reads the
+  document) instead of guessing from a link it cannot open
+
+  Background:
+    Today an image only reaches the model when its value is an inline
+    data:image/...;base64,... URL; that base64 case is split into content parts
+    by the existing image splitter. A value that is a plain http(s) URL is
+    interpolated into the message as text and the model never sees the content.
+    The engine should instead fetch a referenced URL, detect its type from the
+    response, and deliver it as the right kind of content part so it works
+    across every provider, regardless of whether the provider can fetch URLs
+    itself. When a referenced attachment cannot be fetched, the run must fail
+    with a clear, user-facing message rather than silently sending a broken
+    request or a wall of URL text.
+
+    # Bindings: services/nlpgo/app/engine/attachment_test.go and
+    # services/nlpgo/tests/integration/attachment_url_test.go
+    # Fetch + detect + structure: services/nlpgo/app/engine/attachment.go,
+    # applied to the messages buildMessages returns, right beside the existing
+    # data-URL image split in multimodal.go.
+
+  # ============================================================================
+  # Fetching an image referenced by URL
+  # ============================================================================
+
+  @integration
+  Scenario: An image referenced by an http URL is fetched and delivered as an image part
+    Given a user message whose text is an http URL pointing at a PNG image
+    When the engine builds the LLM messages
+    Then the message content becomes a parts list carrying an image part
+    And the image part carries the fetched image, not the original link text
+
+  @integration
+  Scenario: The attachment type is detected from the response, not the file extension
+    Given a user message whose http URL has no file extension but serves a JPEG
+    When the engine builds the LLM messages
+    Then the content still carries an image part for that attachment
+
+  @unit
+  Scenario: An image already given as a base64 data URL is delivered without fetching
+    Given a user message whose image is an inline base64 data URL
+    When the engine builds the LLM messages
+    Then the image reaches the model without any network fetch
+    # The existing data-URL split keeps working untouched; only http(s) URLs are fetched.
+
+  @integration
+  Scenario: Several attachment URLs in one message each become their own part
+    Given a user message referencing two image URLs around some text
+    When the engine builds the LLM messages
+    Then the content carries an image part for each, in their original positions
+
+  # ============================================================================
+  # Clear failures when an attachment cannot be fetched
+  # ============================================================================
+
+  @integration
+  Scenario: An unreachable attachment URL fails the run with a clear message naming the URL
+    Given a user message referencing an attachment URL that cannot be reached
+    When the engine builds the LLM messages
+    Then the run fails with a clear error that names the URL and the reason
+    And no request is sent to the model
+
+  @integration
+  Scenario: An attachment URL that responds with an error status fails the run clearly
+    Given a user message referencing an attachment URL that returns a not-found status
+    When the engine builds the LLM messages
+    Then the run fails with a clear error that names the URL and the status
+
+  @integration
+  Scenario: An attachment larger than the allowed size is rejected with a clear message
+    Given a user message referencing an attachment URL whose body exceeds the size limit
+    When the engine builds the LLM messages
+    Then the run fails with a clear error explaining the attachment was too large
+    And no request is sent to the model
+
+  # ============================================================================
+  # A plain link the author is only mentioning is left alone
+  # ============================================================================
+
+  @integration
+  Scenario: A link to a normal web page is left as text, not turned into an attachment
+    Given a user message referencing a URL that serves an HTML page
+    When the engine builds the LLM messages
+    Then the URL is left in the message as text
+    And no attachment part is created for it
+    # A reachable, non-attachment response (a web page) is the author referencing
+    # a link, not attaching a file, so it must not be force-attached.
+
+  # ============================================================================
+  # Forward-looking: arbitrary attachment types pass through structured
+  # ============================================================================
+
+  @integration
+  Scenario: An audio attachment referenced by URL reaches the model as audio
+    Given a user message whose http URL points at an audio file
+    When the engine builds the LLM messages
+    Then the content carries an audio attachment part for the model to hear
+
+  @integration
+  Scenario: A PDF attachment referenced by URL reaches the model as a document
+    Given a user message whose http URL points at a PDF document
+    When the engine builds the LLM messages
+    Then the content carries a document attachment part for the model to read

--- a/specs/nlp-go/multimodal-attachment-urls.feature
+++ b/specs/nlp-go/multimodal-attachment-urls.feature
@@ -115,6 +115,36 @@ Feature: Remote attachment URLs are fetched and delivered to the model as conten
     # cannot be fetched fails the run.
 
   # ============================================================================
+  # An image-TYPED field is an explicit attachment, not a best-effort link
+  # ============================================================================
+  # The studio lets an author declare an input as an Image. That is an explicit
+  # statement of intent: the value is a picture, not prose that happens to carry
+  # a link. So an image-typed field is resolved before templating and fails the
+  # run with a clear error when its URL cannot be loaded as an image, rather than
+  # being passed to the model as text for it to guess from (e.g. from a filename).
+
+  @integration
+  Scenario: An image-typed field whose URL is an image is fetched and inlined
+    Given a signature input declared as an image whose value is an http URL to a PNG
+    When the engine builds the LLM messages
+    Then the image is fetched and delivered to the model as an image, not as the link text
+
+  @integration
+  Scenario: An image-typed field whose URL cannot be fetched fails the run with a clear error
+    Given a signature input declared as an image whose URL cannot be reached
+    When the engine builds the LLM messages
+    Then the run fails with a clear error that names the URL
+    And no request is sent to the model
+    # Contrast with the best-effort prose link above: the explicit image field
+    # must not silently degrade to the model guessing from the URL text.
+
+  @integration
+  Scenario: An image-typed field whose URL is not an image fails the run with a clear error
+    Given a signature input declared as an image whose URL serves a web page
+    When the engine builds the LLM messages
+    Then the run fails with a clear error explaining it could not be loaded as an image
+
+  # ============================================================================
   # Forward-looking: arbitrary attachment types pass through structured
   # ============================================================================
 


### PR DESCRIPTION
## What

Prompt messages can now reference an attachment by a plain `http(s)` URL and have the model actually receive it as content. Today an image only reaches the model when its value is an inline `data:image/...;base64,...` URL (the existing splitter handles that); a plain URL is interpolated into the message as text and the model never opens it.

## Why

Reported from dogfood: vision prompts that point at an image URL (an S3/CDN link, a dataset `image` cell that holds a URL) silently degrade. The model receives the link as a string and guesses, instead of seeing the picture.

## How

A fetch pass runs in the nlpgo engine right after the existing data-URL image split (`engine.go`, beside `splitMessagesWithImages`):

- **Fetch** every `http(s)` URL referenced in a message, in string content, in text parts, and carried by an `image_url` part, under the **HTTP block's SSRF policy** (private, loopback, and cloud-metadata addresses refused, with DNS-rebinding protection via `SafeDialer`), a wall-clock timeout, and a size cap.
- **Detect the type from the response**, not the file extension (Content-Type header, falling back to content sniffing), so extension-less S3/CDN URLs classify correctly.
- **Structure by type**: images inline as a base64 data-URL `image_url` part so they work across every provider regardless of whether the provider fetches URLs itself; audio becomes an `input_audio` part; PDFs become a `file` part.
- **A reachable non-attachment** (an HTML page) is left as text: the author was referencing a link, not attaching a file.
- **A URL that cannot be fetched** (unreachable, error status, oversized, SSRF-blocked) aborts the run with a clear `attachment_fetch_error` that names the URL and the reason, surfaced to the user on the same path as `llm_error`. No broken request is sent to the provider.
- **Image-typed inputs are explicit attachments.** A signature input declared as the studio's `image` type is resolved before message templating: its URL is fetched, validated as an image, and inlined so the model receives a picture, and an unfetchable or non-image URL aborts the run with the same clear error rather than being templated into the prompt as text.

### Scope / tradeoffs to flag

- **Fetch-by-intent (breadth):** intent decides strictness. An `image`-typed signature input (the studio's "Image" field type) and an explicit `image_url` part both hard-fail on a bad fetch, because the author declared the value an attachment. A bare URL in prose is best-effort: it is fetched and attached when the response is media, and left as text when it is a normal web page **or** when the fetch fails, so an incidental link can never fail the whole run. Image-typed inputs are resolved before message templating (fetched, validated as an image, inlined as a base64 data URL for the existing splitter); a str-typed input carrying a URL stays best-effort.
- **SSRF:** reuses the HTTP block's `CheckURL` + `SafeDialer` and the same `ALLOWED_PROXY_HOSTS` allow-list, so attachment fetches are bound by the same destination policy as HTTP blocks, including the dial-time re-check that blocks redirect-to-private.
- **Cross-provider:** an image, once inlined as a base64 data-URL `image_url` part, is byte-identical to the already-shipping base64 image path. The new `input_audio` and `file` (PDF) part shapes are verified end to end through the in-process gateway to OpenAI by the live probes above (it forwards content-part arrays generically), so they ride the same proven downstream. Non-OpenAI providers reuse that generic forwarding; the part shapes follow OpenAI's `input_audio` / `file` conventions, and provider-specific translation for audio/PDF on other vendors can be tightened if a customer needs it.
- **Sequential fetches:** multiple attachments in one message are fetched sequentially; fine for the typical 0–1 attachment case, parallelizable as a follow-up if multi-attachment prompts appear.

## Testing

BDD scenarios in `specs/nlp-go/multimodal-attachment-urls.feature`, each bound to a Go test in `attachment_test.go` that fetches over a real `httptest` server: http image fetch, type-from-response (header + sniffed), data-URL no-fetch passthrough, multiple URLs, unreachable, error status, oversized, redirect-to-private, HTML-left-as-text, broken-prose-link-as-text, audio, PDF, and the image-typed-input cases (resolved-and-inlined, hard-fail on unreachable, hard-fail on non-image). Full nlpgo `app/` + `cmd/` suites green, `go vet` clean, `golangci-lint` 0 issues, feature-parity bound.

## Dogfood

**Known-answer vision probe through the real gateway** (`workflow_llm_vision_url_e2e_test.go`, `live_openai` tag): a solid-blue PNG is served from an opaque local URL (no filename hint), a vision prompt runs through nlpgo to a real `gpt-5-mini`, and the model is asked the dominant color. It answered **blue** — only knowable by actually seeing the fetched pixels, so this proves the fetch → inline → gateway → vision path end to end and catches hallucination. The test doubles as a permanent (gated) regression.

```
--- PASS: TestSync_RealWorkflowEndToEnd_OpenAI_VisionAttachmentURL (1.56s)
```

**Audio and PDF through the same gateway** (`workflow_llm_audio_url_e2e_test.go` and `workflow_llm_pdf_url_e2e_test.go`, `live_openai`, fixtures supplied via env so no binaries are committed). Both confirm the in-process gateway forwards the new content-part shapes, with the same hallucination-proof design:

- **Audio:** a clip that asks aloud "Do I have a male voice or a female voice?" (Whisper-confirmed) is served from an opaque URL; nlpgo structures an `input_audio` part and `openai/gpt-audio` echoes the spoken question, which it can only do by hearing the fetched clip.
- **PDF:** a document containing "order number 4729" and "customer city Lisbon" is served; nlpgo structures a `file` part and `openai/gpt-5-mini` answers with both facts, which live only inside the fetched PDF.

```
--- PASS: TestSync_RealWorkflowEndToEnd_OpenAI_AudioAttachmentURL (2.00s)
--- PASS: TestSync_RealWorkflowEndToEnd_OpenAI_PDFAttachmentURL (4.07s)
```

**End-to-end in the Optimization Studio** (real browser → app → nlpgo → gateway → real model). A workflow points a vision prompt at a remote image URL (`https://picsum.photos/id/237/...`, a black puppy — the URL gives nothing away):

- A plain **Text** input holding the URL is fetched best-effort and the model answers **dog**: ![text url answer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4910/dogfood/02-text-url-answer-dog.png)
- Switching the input to the studio's **Image** field type also resolves to **dog**: ![image type answer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4910/dogfood/03-image-type-answer-dog.png)
- **Unhappy path, before the fix in this PR:** an **Image**-typed field with an unreachable URL silently degraded — the model guessed **cat** from the `cat.png` filename instead of erroring: ![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4910/dogfood/04-before-bad-url-guesses-cat.png)
- **After the fix:** the same unreachable image URL now fails fast with a clear error and no model call: **"Could not load the attachment ...: it could not be reached."**: ![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4910/dogfood/05-after-bad-url-clear-error.png)

## Deployment Impact

- **New outbound network behavior:** nlpgo now makes server-side HTTP(S) GETs to fetch attachment URLs referenced in prompts. This is bound by the existing HTTP-block SSRF policy (private/loopback/metadata refused, dial-time re-check for redirects) and the same `ALLOWED_PROXY_HOSTS` allow-list, with a 30s timeout and a 20 MB size cap. No new egress is required for normal operation, but operators running nlpgo in a restricted-egress environment should know attachment fetching needs outbound access to wherever user attachments live.
- **No new config, env vars, services, migrations, or charts.** Reuses `ALLOWED_PROXY_HOSTS`.
- **No data-plane or schema changes.** Behavior is additive: existing `data:` URL handling is unchanged.
