### PR TITLE
fix(evaluators): explain why the code evaluator Create button is disabled

### DIFF
--- a/langwatch/src/components/evaluators/CodeEvaluatorEditorDrawer.tsx
+++ b/langwatch/src/components/evaluators/CodeEvaluatorEditorDrawer.tsx
@@ -37,6 +37,7 @@ import {
 import { api } from "~/utils/api";
 import { isHandledByGlobalHandler } from "~/utils/trpcError";
 
+import { codeEvaluatorDisabledReason } from "./codeEvaluatorValidation";
 import type { EvaluatorMappingsConfig } from "./EvaluatorEditorShared";
 
 const FIELD_TYPES = ["str", "float", "bool", "list[str]", "dict"] as const;
@@ -233,6 +234,19 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
     !isPending &&
     !isLoadingEvaluator;
 
+  // Why the button is disabled, so it explains itself instead of being a
+  // silent dead button. Suppressed while saving/loading (those are transient
+  // and the button shows its own loading state).
+  const disabledReason =
+    isPending || isLoadingEvaluator
+      ? null
+      : codeEvaluatorDisabledReason({
+          hasName: !!name.trim(),
+          hasCode: code.trim() !== "",
+          hasInput: validFields(inputs).length > 0,
+          isEditing,
+        });
+
   return {
     name,
     setName,
@@ -249,6 +263,7 @@ function useCodeEvaluatorForm(props: CodeEvaluatorEditorDrawerProps) {
     isLoadingEvaluator,
     handleSave,
     canSave,
+    disabledReason,
     isPending,
   };
 }
@@ -298,15 +313,28 @@ export function CodeEvaluatorEditorDrawer(
           )}
         </Drawer.Body>
         <Drawer.Footer borderTopWidth="1px" borderColor="border">
-          <Button
-            colorPalette="blue"
-            onClick={form.handleSave}
-            disabled={!form.canSave}
-            loading={form.isPending}
-            data-testid="save-code-evaluator"
-          >
-            {form.isEditing ? "Save changes" : "Create evaluator"}
-          </Button>
+          <HStack width="full" justify="space-between" gap={3}>
+            {form.disabledReason ? (
+              <Text
+                fontSize="sm"
+                color="fg.muted"
+                data-testid="code-evaluator-disabled-reason"
+              >
+                {form.disabledReason}
+              </Text>
+            ) : (
+              <Box />
+            )}
+            <Button
+              colorPalette="blue"
+              onClick={form.handleSave}
+              disabled={!form.canSave}
+              loading={form.isPending}
+              data-testid="save-code-evaluator"
+            >
+              {form.isEditing ? "Save changes" : "Create evaluator"}
+            </Button>
+          </HStack>
         </Drawer.Footer>
       </Drawer.Content>
     </Drawer.Root>

--- a/langwatch/src/components/evaluators/__tests__/CodeEvaluatorEditorDrawer.integration.test.tsx
+++ b/langwatch/src/components/evaluators/__tests__/CodeEvaluatorEditorDrawer.integration.test.tsx
@@ -133,6 +133,37 @@ describe("CodeEvaluatorEditorDrawer", () => {
       });
     });
 
+    describe("when required fields are incomplete", () => {
+      /** @scenario A disabled code evaluator Create button explains what is missing */
+      it("names the missing requirement and clears it once filled", async () => {
+        render(<CodeEvaluatorEditorDrawer open />, { wrapper: Wrapper });
+
+        await waitFor(() => {
+          expect(screen.getByText("Create evaluator")).toBeInTheDocument();
+        });
+
+        // Create mode seeds default code and inputs, so the one outstanding
+        // requirement is the name: the button is disabled and says why, instead
+        // of being a silent dead button.
+        expect(screen.getByTestId("save-code-evaluator")).toBeDisabled();
+        expect(
+          screen.getByTestId("code-evaluator-disabled-reason"),
+        ).toHaveTextContent("Add a name to create the evaluator.");
+
+        // Filling the name satisfies it: the reason clears and Create enables.
+        fireEvent.change(screen.getByTestId("code-evaluator-name"), {
+          target: { value: "my eval" },
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId("save-code-evaluator")).toBeEnabled();
+        });
+        expect(
+          screen.queryByTestId("code-evaluator-disabled-reason"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
     describe("when the drawer shows the outputs section", () => {
       /** @scenario Code evaluator outputs are the fixed evaluator contract */
       it("presents the fixed evaluator result fields and no output editor", async () => {

--- a/langwatch/src/components/evaluators/__tests__/codeEvaluatorValidation.unit.test.ts
+++ b/langwatch/src/components/evaluators/__tests__/codeEvaluatorValidation.unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { codeEvaluatorDisabledReason } from "../codeEvaluatorValidation";
+
+describe("codeEvaluatorDisabledReason", () => {
+  describe("given every requirement is met", () => {
+    it("returns null so the button is enabled with no explanation", () => {
+      expect(
+        codeEvaluatorDisabledReason({
+          hasName: true,
+          hasCode: true,
+          hasInput: true,
+          isEditing: false,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("given a single missing requirement", () => {
+    it("names just that requirement in create mode", () => {
+      expect(
+        codeEvaluatorDisabledReason({
+          hasName: false,
+          hasCode: true,
+          hasInput: true,
+          isEditing: false,
+        }),
+      ).toBe("Add a name to create the evaluator.");
+    });
+
+    it("uses the save wording in edit mode", () => {
+      expect(
+        codeEvaluatorDisabledReason({
+          hasName: false,
+          hasCode: true,
+          hasInput: true,
+          isEditing: true,
+        }),
+      ).toBe("Add a name to save your changes.");
+    });
+  });
+
+  describe("given two missing requirements", () => {
+    it("joins them with and, without a comma", () => {
+      expect(
+        codeEvaluatorDisabledReason({
+          hasName: false,
+          hasCode: false,
+          hasInput: true,
+          isEditing: false,
+        }),
+      ).toBe("Add a name and some code to create the evaluator.");
+    });
+  });
+
+  describe("given all three are missing", () => {
+    it("joins them with an Oxford comma", () => {
+      expect(
+        codeEvaluatorDisabledReason({
+          hasName: false,
+          hasCode: false,
+          hasInput: false,
+          isEditing: false,
+        }),
+      ).toBe(
+        "Add a name, some code, and at least one input to create the evaluator.",
+      );
+    });
+  });
+});

--- a/langwatch/src/components/evaluators/codeEvaluatorValidation.ts
+++ b/langwatch/src/components/evaluators/codeEvaluatorValidation.ts
@@ -1,0 +1,35 @@
+/**
+ * Why the code evaluator's Create/Save button is disabled, phrased for the
+ * author so a disabled button is never a silent dead end. Returns null when
+ * every requirement is met (the button is enabled and needs no explanation).
+ * Transient states (saving, loading the evaluator) are the caller's concern;
+ * this only covers the user-fixable requirements.
+ */
+export function codeEvaluatorDisabledReason({
+  hasName,
+  hasCode,
+  hasInput,
+  isEditing,
+}: {
+  hasName: boolean;
+  hasCode: boolean;
+  hasInput: boolean;
+  isEditing: boolean;
+}): string | null {
+  const missing: string[] = [];
+  if (!hasName) missing.push("a name");
+  if (!hasCode) missing.push("some code");
+  if (!hasInput) missing.push("at least one input");
+
+  if (missing.length === 0) return null;
+
+  const action = isEditing ? "save your changes" : "create the evaluator";
+  return `Add ${joinWithAnd(missing)} to ${action}.`;
+}
+
+/** "a, b, and c" with an Oxford comma; "a and b" for two; "a" for one. */
+function joinWithAnd(items: string[]): string {
+  if (items.length === 1) return items[0]!;
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}

--- a/specs/evaluators/evaluator-management.feature
+++ b/specs/evaluators/evaluator-management.feature
@@ -280,6 +280,15 @@ Feature: Evaluator management
     Then the code editor opens with its saved code, inputs and outputs
     And in the workbench each input shows its source mapping inline
 
+  # A disabled Create button must say why instead of being a silent dead button:
+  # the drawer surfaces the missing requirement and clears it once the field is met.
+  Scenario: A disabled code evaluator Create button explains what is missing
+    Given the code evaluator drawer is open in create mode without a name
+    Then the Create button is disabled
+    And the drawer shows the reason, naming the missing name
+    When I fill in the name
+    Then the reason clears and the Create button is enabled
+
   # Same behavior as the studio code node: the Python entrypoint is kept in
   # sync with the declared inputs, so changing the inputs keeps the evaluator
   # callable with exactly those inputs, with no missing or unexpected keyword.


### PR DESCRIPTION
## What

The custom code evaluator drawer disabled its "Create evaluator" / "Save changes" button whenever the form was incomplete, but never said why, so it read as a dead button. A first-time author opens the drawer, sees a disabled Create button, and gets no hint that it just needs a name.

Reported from dogfooding the evaluators workbench.

## Fix

Surface the reason inline in the footer, next to the button. It names the missing requirements (a name, some code, at least one input) and clears them as they are satisfied. The button stays disabled, but it now explains itself instead of being a dead end.

Create mode seeds the default code and inputs, so in practice the one outstanding requirement is the name, and the footer reads "Add a name to create the evaluator." until you type one.

## Tests

- BDD scenario in `specs/evaluators/evaluator-management.feature`.
- Integration test (`CodeEvaluatorEditorDrawer.integration.test.tsx`): create mode shows the reason next to a disabled button, and filling the name clears the reason and enables Create.
- Unit test for the pure `codeEvaluatorDisabledReason` helper: null when complete, single / two / three missing wording (Oxford comma), and the create-vs-edit suffix.

## Screenshots

Before, the Create button is disabled with no explanation; now the footer names the missing requirement next to it:

![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4911/disabled-reason/before-disabled-with-reason.png)

After typing a name, the reason clears and Create enables:

![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4911/disabled-reason/after-named-enabled.png)
