### PR TITLE
chore: add CODEOWNERS with weekly auto-refresh from git history

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,11 @@
 # CODEOWNERS — GENERATED FILE, DO NOT EDIT BY HAND.
 #
 # Regenerated weekly by .github/workflows/codeowners-refresh.yml from
-# .github/scripts/generate-codeowners.sh. Owners are the top historical
-# `git log` contributors per area (merges, bots, and departed contributors
-# excluded). To change ownership, edit the generator script — not this file.
+# .github/scripts/generate-codeowners.sh. Owners are the top committers per
+# area, restricted to current langwatch GitHub org members (the org roster and
+# the email->login mapping are both fetched live, so nothing here is a
+# hand-maintained list). To change ownership, adjust the generator script — not
+# this file.
 #
 # GitHub applies the LAST matching pattern only — rules go from general (top)
 # to specific (bottom). Owners must have write access to the repo.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,191 @@
+# CODEOWNERS — GENERATED FILE, DO NOT EDIT BY HAND.
+#
+# Regenerated weekly by .github/workflows/codeowners-refresh.yml from
+# .github/scripts/generate-codeowners.sh. Owners are the top historical
+# `git log` contributors per area (merges, bots, and departed contributors
+# excluded). To change ownership, edit the generator script — not this file.
+#
+# GitHub applies the LAST matching pattern only — rules go from general (top)
+# to specific (bottom). Owners must have write access to the repo.
+
+# ===========================================================================
+# Global fallback — overall top contributor across the repo.
+# ===========================================================================
+*                                              @rogeriochaves @drewdrewthis
+
+# ===========================================================================
+# Repo-level config, build & dependency manifests
+# ===========================================================================
+/go.mod                                        @rogeriochaves @0xdeafcafe
+/go.sum                                        @rogeriochaves @0xdeafcafe
+/package.json                                  @0xdeafcafe @rogeriochaves
+/pnpm-workspace.yaml                           @rogeriochaves
+/pnpm-lock.yaml                                @rogeriochaves
+
+# ===========================================================================
+# CI, infra, deployment & dev environment
+# ===========================================================================
+/.github/                                      @0xdeafcafe @rogeriochaves
+/charts/                                       @rogeriochaves @0xdeafcafe
+/clickhouse-serverless/                        @0xdeafcafe
+/bullboard/                                    @0xdeafcafe @drewdrewthis
+/dev/                                          @rogeriochaves @drewdrewthis
+/agentic-e2e-tests/                            @drewdrewthis @rogeriochaves
+/Makefile                                      @drewdrewthis @rogeriochaves
+/boxd.mk                                       @drewdrewthis
+/*.mk                                          @drewdrewthis
+/compose*.yml                                  @rogeriochaves @drewdrewthis
+/Dockerfile                                    @rogeriochaves
+/Dockerfile.*                                  @rogeriochaves
+/CLAUDE.md                                     @rogeriochaves @drewdrewthis
+
+# ===========================================================================
+# Go services & shared Go code
+# ===========================================================================
+/services/nlpgo/                               @rogeriochaves @0xdeafcafe
+/services/aigateway/                           @rogeriochaves @0xdeafcafe
+/pkg/                                          @rogeriochaves @0xdeafcafe
+/cmd/                                          @rogeriochaves @0xdeafcafe
+/sdk-go/                                       @0xdeafcafe @rogeriochaves
+/Dockerfile.go_service                         @rogeriochaves @0xdeafcafe
+
+# ===========================================================================
+# SDKs & integrations
+# ===========================================================================
+/python-sdk/                                   @rogeriochaves
+/typescript-sdk/                               @rogeriochaves @0xdeafcafe
+/mcp-server/                                   @rogeriochaves @0xdeafcafe
+/langevals/                                    @rogeriochaves @sergioestebance
+
+# ===========================================================================
+# Specs (BDD .feature files)
+# ===========================================================================
+/specs/                                        @drewdrewthis @rogeriochaves
+/specs/ai-gateway/                             @rogeriochaves
+/specs/ai-governance/                          @rogeriochaves
+/specs/nlp-go/                                 @rogeriochaves
+/specs/model-providers/                        @rogeriochaves @drewdrewthis
+/specs/event-sourcing/                         @rogeriochaves @0xdeafcafe
+/specs/evaluators/                             @rogeriochaves @drewdrewthis
+/specs/monitors/                               @rogeriochaves @drewdrewthis
+/specs/licensing/                              @drewdrewthis @sergioestebance
+/specs/billing/                                @drewdrewthis @sergioestebance
+/specs/data-retention/                         @sergioestebance
+/specs/members/                                @sergioestebance @drewdrewthis
+/specs/api-keys/                               @sergioestebance @rogeriochaves
+/specs/prompts/                                @drewdrewthis @rogeriochaves
+
+# ===========================================================================
+# Docs
+# ===========================================================================
+/docs/                                         @rogeriochaves @drewdrewthis
+/docs/adr/                                     @drewdrewthis @0xdeafcafe
+/docs/api-reference/                           @sergioestebance @rogeriochaves
+/docs/integration/                             @rogeriochaves @sergioestebance
+/docs/self-hosting/                            @rogeriochaves
+
+# ===========================================================================
+# Skills
+# ===========================================================================
+/skills/                                       @rogeriochaves @0xdeafcafe
+
+# ===========================================================================
+# Main app (langwatch/) — schema, EE, optimization studio, top-level dirs
+# ===========================================================================
+/langwatch/prisma/                             @rogeriochaves
+/langwatch/ee/                                 @sergioestebance @rogeriochaves
+/langwatch/elastic/                            @rogeriochaves
+/langwatch/e2e/                                @rogeriochaves @drewdrewthis
+/langwatch/scripts/                            @rogeriochaves @drewdrewthis
+/langwatch/src/optimization_studio/            @rogeriochaves
+/langwatch/src/hooks/                          @rogeriochaves @drewdrewthis
+/langwatch/src/utils/                          @rogeriochaves @drewdrewthis
+/langwatch/src/tasks/                          @rogeriochaves
+/langwatch/src/features/                       @rogeriochaves @0xdeafcafe
+/langwatch/src/prompts/                        @rogeriochaves @drewdrewthis
+/langwatch/src/experiments-v3/                 @rogeriochaves @drewdrewthis
+/langwatch/src/app/api/                        @rogeriochaves @drewdrewthis
+
+# ---------------------------------------------------------------------------
+# Main app — pages
+# ---------------------------------------------------------------------------
+/langwatch/src/pages/api/                      @rogeriochaves
+/langwatch/src/pages/settings/                 @rogeriochaves @sergioestebance
+/langwatch/src/pages/onboarding/               @rogeriochaves
+/langwatch/src/pages/auth/                     @rogeriochaves
+
+# ===========================================================================
+# Main app — server domains
+# ===========================================================================
+/langwatch/src/server/analytics/               @rogeriochaves
+/langwatch/src/server/annotations/             @drewdrewthis
+/langwatch/src/server/api/                     @rogeriochaves
+/langwatch/src/server/app-layer/               @rogeriochaves @0xdeafcafe
+/langwatch/src/server/background/              @rogeriochaves
+/langwatch/src/server/clickhouse/              @0xdeafcafe @rogeriochaves
+/langwatch/src/server/datasets/                @rogeriochaves
+/langwatch/src/server/evaluations/             @rogeriochaves @0xdeafcafe
+/langwatch/src/server/evaluators/              @rogeriochaves @sergioestebance
+/langwatch/src/server/event-sourcing/          @0xdeafcafe @rogeriochaves
+/langwatch/src/server/experiments/             @rogeriochaves
+/langwatch/src/server/experiments-v3/          @rogeriochaves @0xdeafcafe
+/langwatch/src/server/featureFlag/             @rogeriochaves @drewdrewthis
+/langwatch/src/server/filters/                 @rogeriochaves @0xdeafcafe
+/langwatch/src/server/gateway/                 @rogeriochaves @0xdeafcafe
+/langwatch/src/server/modelProviders/          @rogeriochaves
+/langwatch/src/server/prompt-config/           @drewdrewthis @rogeriochaves
+/langwatch/src/server/repositories/            @drewdrewthis @sergioestebance
+/langwatch/src/server/routes/                  @rogeriochaves @sergioestebance
+/langwatch/src/server/scenarios/               @drewdrewthis @rogeriochaves
+/langwatch/src/server/simulations/             @0xdeafcafe @drewdrewthis
+/langwatch/src/server/suites/                  @drewdrewthis @rogeriochaves
+/langwatch/src/server/topicClustering/         @rogeriochaves @0xdeafcafe
+/langwatch/src/server/tracer/                  @rogeriochaves
+/langwatch/src/server/traces/                  @0xdeafcafe @rogeriochaves
+/langwatch/src/server/triggers/                @0xdeafcafe
+/langwatch/src/server/workflows/               @rogeriochaves @0xdeafcafe
+
+# Auth, permissions & multitenancy
+/langwatch/src/server/agents/                  @sergioestebance @drewdrewthis
+/langwatch/src/server/rbac/                    @sergioestebance
+/langwatch/src/server/role/                    @sergioestebance
+/langwatch/src/server/role-bindings/           @sergioestebance
+/langwatch/src/server/scim/                    @rogeriochaves
+/langwatch/src/server/teams/                   @sergioestebance
+/langwatch/src/server/invites/                 @sergioestebance
+/langwatch/src/server/api-key/                 @rogeriochaves @sergioestebance
+
+# Billing, licensing & data retention
+/langwatch/src/server/license-enforcement/     @sergioestebance @drewdrewthis
+/langwatch/src/server/data-retention/          @sergioestebance
+/langwatch/src/server/subscriptionHandler.ts   @rogeriochaves @sergioestebance
+
+# ===========================================================================
+# Main app — UI components
+# ===========================================================================
+/langwatch/src/components/agents/              @drewdrewthis @rogeriochaves
+/langwatch/src/components/analytics/           @rogeriochaves
+/langwatch/src/components/annotations/         @rogeriochaves @0xdeafcafe
+/langwatch/src/components/checks/              @rogeriochaves
+/langwatch/src/components/datasets/            @rogeriochaves
+/langwatch/src/components/drawers/             @0xdeafcafe
+/langwatch/src/components/evaluations/         @rogeriochaves @drewdrewthis
+/langwatch/src/components/evaluators/          @rogeriochaves @sergioestebance
+/langwatch/src/components/experiments/         @rogeriochaves
+/langwatch/src/components/filters/             @rogeriochaves
+/langwatch/src/components/forms/               @0xdeafcafe @Aryansharma28
+/langwatch/src/components/inputs/              @0xdeafcafe
+/langwatch/src/components/license/             @sergioestebance
+/langwatch/src/components/llmPromptConfigs/    @rogeriochaves @drewdrewthis
+/langwatch/src/components/messages/            @rogeriochaves
+/langwatch/src/components/plans/               @sergioestebance
+/langwatch/src/components/projects/            @sergioestebance @rogeriochaves
+/langwatch/src/components/scenarios/           @drewdrewthis
+/langwatch/src/components/settings/            @rogeriochaves @sergioestebance
+/langwatch/src/components/sidebar/             @rogeriochaves @0xdeafcafe
+/langwatch/src/components/simulations/         @drewdrewthis @rogeriochaves
+/langwatch/src/components/subscription/        @sergioestebance @drewdrewthis
+/langwatch/src/components/suites/              @drewdrewthis
+/langwatch/src/components/traces/              @rogeriochaves
+/langwatch/src/components/ui/                  @rogeriochaves @drewdrewthis
+/langwatch/src/components/workflows/           @sergioestebance @rogeriochaves

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,35 +11,35 @@
 # to specific (bottom). Owners must have write access to the repo.
 
 # ===========================================================================
-# Global fallback — overall top contributor across the repo.
+# Global fallback — overall top contributors across the repo (up to 2).
 # ===========================================================================
-*                                              @rogeriochaves @drewdrewthis
+*                                              @rogeriochaves
 
 # ===========================================================================
 # Repo-level config, build & dependency manifests
 # ===========================================================================
 /go.mod                                        @rogeriochaves @0xdeafcafe
 /go.sum                                        @rogeriochaves @0xdeafcafe
-/package.json                                  @0xdeafcafe @rogeriochaves
+/package.json                                  @rogeriochaves
 /pnpm-workspace.yaml                           @rogeriochaves
 /pnpm-lock.yaml                                @rogeriochaves
 
 # ===========================================================================
 # CI, infra, deployment & dev environment
 # ===========================================================================
-/.github/                                      @0xdeafcafe @rogeriochaves
-/charts/                                       @rogeriochaves @0xdeafcafe
-/clickhouse-serverless/                        @0xdeafcafe
-/bullboard/                                    @0xdeafcafe @drewdrewthis
-/dev/                                          @rogeriochaves @drewdrewthis
-/agentic-e2e-tests/                            @drewdrewthis @rogeriochaves
-/Makefile                                      @drewdrewthis @rogeriochaves
-/boxd.mk                                       @drewdrewthis
-/*.mk                                          @drewdrewthis
-/compose*.yml                                  @rogeriochaves @drewdrewthis
+/.github/                                      @rogeriochaves
+/charts/                                       @rogeriochaves
+/clickhouse-serverless/                        @rogeriochaves
+/bullboard/                                    @rogeriochaves
+/dev/                                          @rogeriochaves
+/agentic-e2e-tests/                            @rogeriochaves
+/Makefile                                      @rogeriochaves
+/boxd.mk                                       @rogeriochaves
+/*.mk                                          @rogeriochaves
+/compose*.yml                                  @rogeriochaves
 /Dockerfile                                    @rogeriochaves
 /Dockerfile.*                                  @rogeriochaves
-/CLAUDE.md                                     @rogeriochaves @drewdrewthis
+/CLAUDE.md                                     @rogeriochaves
 
 # ===========================================================================
 # Go services & shared Go code
@@ -48,71 +48,71 @@
 /services/aigateway/                           @rogeriochaves @0xdeafcafe
 /pkg/                                          @rogeriochaves @0xdeafcafe
 /cmd/                                          @rogeriochaves @0xdeafcafe
-/sdk-go/                                       @0xdeafcafe @rogeriochaves
+/sdk-go/                                       @rogeriochaves @0xdeafcafe
 /Dockerfile.go_service                         @rogeriochaves @0xdeafcafe
 
 # ===========================================================================
 # SDKs & integrations
 # ===========================================================================
 /python-sdk/                                   @rogeriochaves
-/typescript-sdk/                               @rogeriochaves @0xdeafcafe
-/mcp-server/                                   @rogeriochaves @0xdeafcafe
-/langevals/                                    @rogeriochaves @sergioestebance
+/typescript-sdk/                               @rogeriochaves
+/mcp-server/                                   @rogeriochaves
+/langevals/                                    @rogeriochaves
 
 # ===========================================================================
 # Specs (BDD .feature files)
 # ===========================================================================
-/specs/                                        @drewdrewthis @rogeriochaves
+/specs/                                        @rogeriochaves
 /specs/ai-gateway/                             @rogeriochaves
 /specs/ai-governance/                          @rogeriochaves
 /specs/nlp-go/                                 @rogeriochaves
-/specs/model-providers/                        @rogeriochaves @drewdrewthis
-/specs/event-sourcing/                         @rogeriochaves @0xdeafcafe
-/specs/evaluators/                             @rogeriochaves @drewdrewthis
-/specs/monitors/                               @rogeriochaves @drewdrewthis
-/specs/licensing/                              @drewdrewthis @sergioestebance
-/specs/billing/                                @drewdrewthis @sergioestebance
-/specs/data-retention/                         @sergioestebance
-/specs/members/                                @sergioestebance @drewdrewthis
-/specs/api-keys/                               @sergioestebance @rogeriochaves
-/specs/prompts/                                @drewdrewthis @rogeriochaves
+/specs/model-providers/                        @rogeriochaves
+/specs/event-sourcing/                         @rogeriochaves
+/specs/evaluators/                             @rogeriochaves
+/specs/monitors/                               @rogeriochaves
+/specs/licensing/                              @rogeriochaves
+/specs/billing/                                @rogeriochaves
+/specs/data-retention/                         @rogeriochaves
+/specs/members/                                @rogeriochaves
+/specs/api-keys/                               @rogeriochaves
+/specs/prompts/                                @rogeriochaves
 
 # ===========================================================================
 # Docs
 # ===========================================================================
-/docs/                                         @rogeriochaves @drewdrewthis
-/docs/adr/                                     @drewdrewthis @0xdeafcafe
-/docs/api-reference/                           @sergioestebance @rogeriochaves
-/docs/integration/                             @rogeriochaves @sergioestebance
+/docs/                                         @rogeriochaves
+/docs/adr/                                     @rogeriochaves
+/docs/api-reference/                           @rogeriochaves
+/docs/integration/                             @rogeriochaves
 /docs/self-hosting/                            @rogeriochaves
 
 # ===========================================================================
 # Skills
 # ===========================================================================
-/skills/                                       @rogeriochaves @0xdeafcafe
+/skills/                                       @rogeriochaves
 
 # ===========================================================================
 # Main app (langwatch/) — schema, EE, optimization studio, top-level dirs
 # ===========================================================================
 /langwatch/prisma/                             @rogeriochaves
-/langwatch/ee/                                 @sergioestebance @rogeriochaves
+/langwatch/ee/                                 @rogeriochaves
 /langwatch/elastic/                            @rogeriochaves
-/langwatch/e2e/                                @rogeriochaves @drewdrewthis
-/langwatch/scripts/                            @rogeriochaves @drewdrewthis
+/langwatch/e2e/                                @rogeriochaves
+/langwatch/scripts/                            @rogeriochaves
 /langwatch/src/optimization_studio/            @rogeriochaves
-/langwatch/src/hooks/                          @rogeriochaves @drewdrewthis
-/langwatch/src/utils/                          @rogeriochaves @drewdrewthis
+/langwatch/src/hooks/                          @rogeriochaves
+/langwatch/src/utils/                          @rogeriochaves
 /langwatch/src/tasks/                          @rogeriochaves
-/langwatch/src/features/                       @rogeriochaves @0xdeafcafe
-/langwatch/src/prompts/                        @rogeriochaves @drewdrewthis
-/langwatch/src/experiments-v3/                 @rogeriochaves @drewdrewthis
-/langwatch/src/app/api/                        @rogeriochaves @drewdrewthis
+/langwatch/src/features/                       @rogeriochaves
+/langwatch/src/prompts/                        @rogeriochaves
+/langwatch/src/experiments-v3/                 @rogeriochaves
+/langwatch/src/app/api/                        @rogeriochaves
 
 # ---------------------------------------------------------------------------
 # Main app — pages
 # ---------------------------------------------------------------------------
 /langwatch/src/pages/api/                      @rogeriochaves
-/langwatch/src/pages/settings/                 @rogeriochaves @sergioestebance
+/langwatch/src/pages/settings/                 @rogeriochaves
 /langwatch/src/pages/onboarding/               @rogeriochaves
 /langwatch/src/pages/auth/                     @rogeriochaves
 
@@ -120,74 +120,74 @@
 # Main app — server domains
 # ===========================================================================
 /langwatch/src/server/analytics/               @rogeriochaves
-/langwatch/src/server/annotations/             @drewdrewthis
+/langwatch/src/server/annotations/             @rogeriochaves
 /langwatch/src/server/api/                     @rogeriochaves
-/langwatch/src/server/app-layer/               @rogeriochaves @0xdeafcafe
+/langwatch/src/server/app-layer/               @rogeriochaves
 /langwatch/src/server/background/              @rogeriochaves
-/langwatch/src/server/clickhouse/              @0xdeafcafe @rogeriochaves
+/langwatch/src/server/clickhouse/              @rogeriochaves
 /langwatch/src/server/datasets/                @rogeriochaves
-/langwatch/src/server/evaluations/             @rogeriochaves @0xdeafcafe
-/langwatch/src/server/evaluators/              @rogeriochaves @sergioestebance
-/langwatch/src/server/event-sourcing/          @0xdeafcafe @rogeriochaves
+/langwatch/src/server/evaluations/             @rogeriochaves
+/langwatch/src/server/evaluators/              @rogeriochaves
+/langwatch/src/server/event-sourcing/          @rogeriochaves
 /langwatch/src/server/experiments/             @rogeriochaves
-/langwatch/src/server/experiments-v3/          @rogeriochaves @0xdeafcafe
-/langwatch/src/server/featureFlag/             @rogeriochaves @drewdrewthis
-/langwatch/src/server/filters/                 @rogeriochaves @0xdeafcafe
+/langwatch/src/server/experiments-v3/          @rogeriochaves
+/langwatch/src/server/featureFlag/             @rogeriochaves
+/langwatch/src/server/filters/                 @rogeriochaves
 /langwatch/src/server/gateway/                 @rogeriochaves @0xdeafcafe
 /langwatch/src/server/modelProviders/          @rogeriochaves
-/langwatch/src/server/prompt-config/           @drewdrewthis @rogeriochaves
-/langwatch/src/server/repositories/            @drewdrewthis @sergioestebance
-/langwatch/src/server/routes/                  @rogeriochaves @sergioestebance
-/langwatch/src/server/scenarios/               @drewdrewthis @rogeriochaves
-/langwatch/src/server/simulations/             @0xdeafcafe @drewdrewthis
-/langwatch/src/server/suites/                  @drewdrewthis @rogeriochaves
-/langwatch/src/server/topicClustering/         @rogeriochaves @0xdeafcafe
+/langwatch/src/server/prompt-config/           @rogeriochaves
+/langwatch/src/server/repositories/            @rogeriochaves
+/langwatch/src/server/routes/                  @rogeriochaves
+/langwatch/src/server/scenarios/               @rogeriochaves
+/langwatch/src/server/simulations/             @rogeriochaves
+/langwatch/src/server/suites/                  @rogeriochaves
+/langwatch/src/server/topicClustering/         @rogeriochaves
 /langwatch/src/server/tracer/                  @rogeriochaves
-/langwatch/src/server/traces/                  @0xdeafcafe @rogeriochaves
-/langwatch/src/server/triggers/                @0xdeafcafe
-/langwatch/src/server/workflows/               @rogeriochaves @0xdeafcafe
+/langwatch/src/server/traces/                  @rogeriochaves
+/langwatch/src/server/triggers/                @rogeriochaves
+/langwatch/src/server/workflows/               @rogeriochaves
 
 # Auth, permissions & multitenancy
-/langwatch/src/server/agents/                  @sergioestebance @drewdrewthis
-/langwatch/src/server/rbac/                    @sergioestebance
-/langwatch/src/server/role/                    @sergioestebance
-/langwatch/src/server/role-bindings/           @sergioestebance
+/langwatch/src/server/agents/                  @rogeriochaves
+/langwatch/src/server/rbac/                    @rogeriochaves
+/langwatch/src/server/role/                    @rogeriochaves
+/langwatch/src/server/role-bindings/           @rogeriochaves
 /langwatch/src/server/scim/                    @rogeriochaves
-/langwatch/src/server/teams/                   @sergioestebance
-/langwatch/src/server/invites/                 @sergioestebance
-/langwatch/src/server/api-key/                 @rogeriochaves @sergioestebance
+/langwatch/src/server/teams/                   @rogeriochaves
+/langwatch/src/server/invites/                 @rogeriochaves
+/langwatch/src/server/api-key/                 @rogeriochaves
 
 # Billing, licensing & data retention
-/langwatch/src/server/license-enforcement/     @sergioestebance @drewdrewthis
-/langwatch/src/server/data-retention/          @sergioestebance
-/langwatch/src/server/subscriptionHandler.ts   @rogeriochaves @sergioestebance
+/langwatch/src/server/license-enforcement/     @rogeriochaves
+/langwatch/src/server/data-retention/          @rogeriochaves
+/langwatch/src/server/subscriptionHandler.ts   @rogeriochaves
 
 # ===========================================================================
 # Main app — UI components
 # ===========================================================================
-/langwatch/src/components/agents/              @drewdrewthis @rogeriochaves
+/langwatch/src/components/agents/              @rogeriochaves
 /langwatch/src/components/analytics/           @rogeriochaves
-/langwatch/src/components/annotations/         @rogeriochaves @0xdeafcafe
+/langwatch/src/components/annotations/         @rogeriochaves
 /langwatch/src/components/checks/              @rogeriochaves
 /langwatch/src/components/datasets/            @rogeriochaves
-/langwatch/src/components/drawers/             @0xdeafcafe
-/langwatch/src/components/evaluations/         @rogeriochaves @drewdrewthis
-/langwatch/src/components/evaluators/          @rogeriochaves @sergioestebance
+/langwatch/src/components/drawers/             @rogeriochaves
+/langwatch/src/components/evaluations/         @rogeriochaves
+/langwatch/src/components/evaluators/          @rogeriochaves
 /langwatch/src/components/experiments/         @rogeriochaves
 /langwatch/src/components/filters/             @rogeriochaves
-/langwatch/src/components/forms/               @0xdeafcafe @Aryansharma28
-/langwatch/src/components/inputs/              @0xdeafcafe
-/langwatch/src/components/license/             @sergioestebance
-/langwatch/src/components/llmPromptConfigs/    @rogeriochaves @drewdrewthis
+/langwatch/src/components/forms/               @rogeriochaves
+/langwatch/src/components/inputs/              @rogeriochaves
+/langwatch/src/components/license/             @rogeriochaves
+/langwatch/src/components/llmPromptConfigs/    @rogeriochaves
 /langwatch/src/components/messages/            @rogeriochaves
-/langwatch/src/components/plans/               @sergioestebance
-/langwatch/src/components/projects/            @sergioestebance @rogeriochaves
-/langwatch/src/components/scenarios/           @drewdrewthis
-/langwatch/src/components/settings/            @rogeriochaves @sergioestebance
-/langwatch/src/components/sidebar/             @rogeriochaves @0xdeafcafe
-/langwatch/src/components/simulations/         @drewdrewthis @rogeriochaves
-/langwatch/src/components/subscription/        @sergioestebance @drewdrewthis
-/langwatch/src/components/suites/              @drewdrewthis
+/langwatch/src/components/plans/               @rogeriochaves
+/langwatch/src/components/projects/            @rogeriochaves
+/langwatch/src/components/scenarios/           @rogeriochaves
+/langwatch/src/components/settings/            @rogeriochaves
+/langwatch/src/components/sidebar/             @rogeriochaves
+/langwatch/src/components/simulations/         @rogeriochaves
+/langwatch/src/components/subscription/        @rogeriochaves
+/langwatch/src/components/suites/              @rogeriochaves
 /langwatch/src/components/traces/              @rogeriochaves
-/langwatch/src/components/ui/                  @rogeriochaves @drewdrewthis
-/langwatch/src/components/workflows/           @sergioestebance @rogeriochaves
+/langwatch/src/components/ui/                  @rogeriochaves
+/langwatch/src/components/workflows/           @rogeriochaves

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,33 +13,33 @@
 # ===========================================================================
 # Global fallback — overall top contributors across the repo (up to 2).
 # ===========================================================================
-*                                              @rogeriochaves
+*                                              @rogeriochaves @drewdrewthis
 
 # ===========================================================================
 # Repo-level config, build & dependency manifests
 # ===========================================================================
 /go.mod                                        @rogeriochaves @0xdeafcafe
 /go.sum                                        @rogeriochaves @0xdeafcafe
-/package.json                                  @rogeriochaves
+/package.json                                  @0xdeafcafe @rogeriochaves
 /pnpm-workspace.yaml                           @rogeriochaves
 /pnpm-lock.yaml                                @rogeriochaves
 
 # ===========================================================================
 # CI, infra, deployment & dev environment
 # ===========================================================================
-/.github/                                      @rogeriochaves
-/charts/                                       @rogeriochaves
-/clickhouse-serverless/                        @rogeriochaves
-/bullboard/                                    @rogeriochaves
-/dev/                                          @rogeriochaves
-/agentic-e2e-tests/                            @rogeriochaves
-/Makefile                                      @rogeriochaves
-/boxd.mk                                       @rogeriochaves
-/*.mk                                          @rogeriochaves
-/compose*.yml                                  @rogeriochaves
+/.github/                                      @0xdeafcafe @rogeriochaves
+/charts/                                       @rogeriochaves @0xdeafcafe
+/clickhouse-serverless/                        @0xdeafcafe
+/bullboard/                                    @0xdeafcafe @drewdrewthis
+/dev/                                          @rogeriochaves @drewdrewthis
+/agentic-e2e-tests/                            @drewdrewthis @rogeriochaves
+/Makefile                                      @drewdrewthis @rogeriochaves
+/boxd.mk                                       @drewdrewthis
+/*.mk                                          @drewdrewthis
+/compose*.yml                                  @rogeriochaves @drewdrewthis
 /Dockerfile                                    @rogeriochaves
 /Dockerfile.*                                  @rogeriochaves
-/CLAUDE.md                                     @rogeriochaves
+/CLAUDE.md                                     @rogeriochaves @drewdrewthis
 
 # ===========================================================================
 # Go services & shared Go code
@@ -48,71 +48,71 @@
 /services/aigateway/                           @rogeriochaves @0xdeafcafe
 /pkg/                                          @rogeriochaves @0xdeafcafe
 /cmd/                                          @rogeriochaves @0xdeafcafe
-/sdk-go/                                       @rogeriochaves @0xdeafcafe
+/sdk-go/                                       @0xdeafcafe @rogeriochaves
 /Dockerfile.go_service                         @rogeriochaves @0xdeafcafe
 
 # ===========================================================================
 # SDKs & integrations
 # ===========================================================================
 /python-sdk/                                   @rogeriochaves
-/typescript-sdk/                               @rogeriochaves
-/mcp-server/                                   @rogeriochaves
-/langevals/                                    @rogeriochaves
+/typescript-sdk/                               @rogeriochaves @0xdeafcafe
+/mcp-server/                                   @rogeriochaves @0xdeafcafe
+/langevals/                                    @rogeriochaves @sergioestebance
 
 # ===========================================================================
 # Specs (BDD .feature files)
 # ===========================================================================
-/specs/                                        @rogeriochaves
+/specs/                                        @drewdrewthis @rogeriochaves
 /specs/ai-gateway/                             @rogeriochaves
 /specs/ai-governance/                          @rogeriochaves
 /specs/nlp-go/                                 @rogeriochaves
-/specs/model-providers/                        @rogeriochaves
-/specs/event-sourcing/                         @rogeriochaves
-/specs/evaluators/                             @rogeriochaves
-/specs/monitors/                               @rogeriochaves
-/specs/licensing/                              @rogeriochaves
-/specs/billing/                                @rogeriochaves
-/specs/data-retention/                         @rogeriochaves
-/specs/members/                                @rogeriochaves
-/specs/api-keys/                               @rogeriochaves
-/specs/prompts/                                @rogeriochaves
+/specs/model-providers/                        @rogeriochaves @drewdrewthis
+/specs/event-sourcing/                         @rogeriochaves @0xdeafcafe
+/specs/evaluators/                             @rogeriochaves @drewdrewthis
+/specs/monitors/                               @rogeriochaves @drewdrewthis
+/specs/licensing/                              @drewdrewthis @sergioestebance
+/specs/billing/                                @drewdrewthis @sergioestebance
+/specs/data-retention/                         @sergioestebance
+/specs/members/                                @sergioestebance @drewdrewthis
+/specs/api-keys/                               @sergioestebance @rogeriochaves
+/specs/prompts/                                @drewdrewthis @rogeriochaves
 
 # ===========================================================================
 # Docs
 # ===========================================================================
-/docs/                                         @rogeriochaves
-/docs/adr/                                     @rogeriochaves
-/docs/api-reference/                           @rogeriochaves
-/docs/integration/                             @rogeriochaves
+/docs/                                         @rogeriochaves @drewdrewthis
+/docs/adr/                                     @drewdrewthis @0xdeafcafe
+/docs/api-reference/                           @sergioestebance @rogeriochaves
+/docs/integration/                             @rogeriochaves @sergioestebance
 /docs/self-hosting/                            @rogeriochaves
 
 # ===========================================================================
 # Skills
 # ===========================================================================
-/skills/                                       @rogeriochaves
+/skills/                                       @rogeriochaves @0xdeafcafe
 
 # ===========================================================================
 # Main app (langwatch/) — schema, EE, optimization studio, top-level dirs
 # ===========================================================================
 /langwatch/prisma/                             @rogeriochaves
-/langwatch/ee/                                 @rogeriochaves
+/langwatch/ee/                                 @sergioestebance @rogeriochaves
 /langwatch/elastic/                            @rogeriochaves
-/langwatch/e2e/                                @rogeriochaves
-/langwatch/scripts/                            @rogeriochaves
+/langwatch/e2e/                                @rogeriochaves @drewdrewthis
+/langwatch/scripts/                            @rogeriochaves @drewdrewthis
 /langwatch/src/optimization_studio/            @rogeriochaves
-/langwatch/src/hooks/                          @rogeriochaves
-/langwatch/src/utils/                          @rogeriochaves
+/langwatch/src/hooks/                          @rogeriochaves @drewdrewthis
+/langwatch/src/utils/                          @rogeriochaves @drewdrewthis
 /langwatch/src/tasks/                          @rogeriochaves
-/langwatch/src/features/                       @rogeriochaves
-/langwatch/src/prompts/                        @rogeriochaves
-/langwatch/src/experiments-v3/                 @rogeriochaves
-/langwatch/src/app/api/                        @rogeriochaves
+/langwatch/src/features/                       @rogeriochaves @0xdeafcafe
+/langwatch/src/prompts/                        @rogeriochaves @drewdrewthis
+/langwatch/src/experiments-v3/                 @rogeriochaves @drewdrewthis
+/langwatch/src/app/api/                        @rogeriochaves @drewdrewthis
 
 # ---------------------------------------------------------------------------
 # Main app — pages
 # ---------------------------------------------------------------------------
 /langwatch/src/pages/api/                      @rogeriochaves
-/langwatch/src/pages/settings/                 @rogeriochaves
+/langwatch/src/pages/settings/                 @rogeriochaves @sergioestebance
 /langwatch/src/pages/onboarding/               @rogeriochaves
 /langwatch/src/pages/auth/                     @rogeriochaves
 
@@ -120,74 +120,74 @@
 # Main app — server domains
 # ===========================================================================
 /langwatch/src/server/analytics/               @rogeriochaves
-/langwatch/src/server/annotations/             @rogeriochaves
+/langwatch/src/server/annotations/             @drewdrewthis
 /langwatch/src/server/api/                     @rogeriochaves
-/langwatch/src/server/app-layer/               @rogeriochaves
+/langwatch/src/server/app-layer/               @rogeriochaves @0xdeafcafe
 /langwatch/src/server/background/              @rogeriochaves
-/langwatch/src/server/clickhouse/              @rogeriochaves
+/langwatch/src/server/clickhouse/              @0xdeafcafe @rogeriochaves
 /langwatch/src/server/datasets/                @rogeriochaves
-/langwatch/src/server/evaluations/             @rogeriochaves
-/langwatch/src/server/evaluators/              @rogeriochaves
-/langwatch/src/server/event-sourcing/          @rogeriochaves
+/langwatch/src/server/evaluations/             @rogeriochaves @0xdeafcafe
+/langwatch/src/server/evaluators/              @rogeriochaves @sergioestebance
+/langwatch/src/server/event-sourcing/          @0xdeafcafe @rogeriochaves
 /langwatch/src/server/experiments/             @rogeriochaves
-/langwatch/src/server/experiments-v3/          @rogeriochaves
-/langwatch/src/server/featureFlag/             @rogeriochaves
-/langwatch/src/server/filters/                 @rogeriochaves
+/langwatch/src/server/experiments-v3/          @rogeriochaves @0xdeafcafe
+/langwatch/src/server/featureFlag/             @rogeriochaves @drewdrewthis
+/langwatch/src/server/filters/                 @rogeriochaves @0xdeafcafe
 /langwatch/src/server/gateway/                 @rogeriochaves @0xdeafcafe
 /langwatch/src/server/modelProviders/          @rogeriochaves
-/langwatch/src/server/prompt-config/           @rogeriochaves
-/langwatch/src/server/repositories/            @rogeriochaves
-/langwatch/src/server/routes/                  @rogeriochaves
-/langwatch/src/server/scenarios/               @rogeriochaves
-/langwatch/src/server/simulations/             @rogeriochaves
-/langwatch/src/server/suites/                  @rogeriochaves
-/langwatch/src/server/topicClustering/         @rogeriochaves
+/langwatch/src/server/prompt-config/           @drewdrewthis @rogeriochaves
+/langwatch/src/server/repositories/            @drewdrewthis @sergioestebance
+/langwatch/src/server/routes/                  @rogeriochaves @sergioestebance
+/langwatch/src/server/scenarios/               @drewdrewthis @rogeriochaves
+/langwatch/src/server/simulations/             @0xdeafcafe @drewdrewthis
+/langwatch/src/server/suites/                  @drewdrewthis @rogeriochaves
+/langwatch/src/server/topicClustering/         @rogeriochaves @0xdeafcafe
 /langwatch/src/server/tracer/                  @rogeriochaves
-/langwatch/src/server/traces/                  @rogeriochaves
-/langwatch/src/server/triggers/                @rogeriochaves
-/langwatch/src/server/workflows/               @rogeriochaves
+/langwatch/src/server/traces/                  @0xdeafcafe @rogeriochaves
+/langwatch/src/server/triggers/                @0xdeafcafe
+/langwatch/src/server/workflows/               @rogeriochaves @0xdeafcafe
 
 # Auth, permissions & multitenancy
-/langwatch/src/server/agents/                  @rogeriochaves
-/langwatch/src/server/rbac/                    @rogeriochaves
-/langwatch/src/server/role/                    @rogeriochaves
-/langwatch/src/server/role-bindings/           @rogeriochaves
+/langwatch/src/server/agents/                  @sergioestebance @drewdrewthis
+/langwatch/src/server/rbac/                    @sergioestebance
+/langwatch/src/server/role/                    @sergioestebance
+/langwatch/src/server/role-bindings/           @sergioestebance
 /langwatch/src/server/scim/                    @rogeriochaves
-/langwatch/src/server/teams/                   @rogeriochaves
-/langwatch/src/server/invites/                 @rogeriochaves
-/langwatch/src/server/api-key/                 @rogeriochaves
+/langwatch/src/server/teams/                   @sergioestebance
+/langwatch/src/server/invites/                 @sergioestebance
+/langwatch/src/server/api-key/                 @rogeriochaves @sergioestebance
 
 # Billing, licensing & data retention
-/langwatch/src/server/license-enforcement/     @rogeriochaves
-/langwatch/src/server/data-retention/          @rogeriochaves
-/langwatch/src/server/subscriptionHandler.ts   @rogeriochaves
+/langwatch/src/server/license-enforcement/     @sergioestebance @drewdrewthis
+/langwatch/src/server/data-retention/          @sergioestebance
+/langwatch/src/server/subscriptionHandler.ts   @rogeriochaves @sergioestebance
 
 # ===========================================================================
 # Main app — UI components
 # ===========================================================================
-/langwatch/src/components/agents/              @rogeriochaves
+/langwatch/src/components/agents/              @drewdrewthis @rogeriochaves
 /langwatch/src/components/analytics/           @rogeriochaves
-/langwatch/src/components/annotations/         @rogeriochaves
+/langwatch/src/components/annotations/         @rogeriochaves @0xdeafcafe
 /langwatch/src/components/checks/              @rogeriochaves
 /langwatch/src/components/datasets/            @rogeriochaves
-/langwatch/src/components/drawers/             @rogeriochaves
-/langwatch/src/components/evaluations/         @rogeriochaves
-/langwatch/src/components/evaluators/          @rogeriochaves
+/langwatch/src/components/drawers/             @0xdeafcafe
+/langwatch/src/components/evaluations/         @rogeriochaves @drewdrewthis
+/langwatch/src/components/evaluators/          @rogeriochaves @sergioestebance
 /langwatch/src/components/experiments/         @rogeriochaves
 /langwatch/src/components/filters/             @rogeriochaves
-/langwatch/src/components/forms/               @rogeriochaves
-/langwatch/src/components/inputs/              @rogeriochaves
-/langwatch/src/components/license/             @rogeriochaves
-/langwatch/src/components/llmPromptConfigs/    @rogeriochaves
+/langwatch/src/components/forms/               @0xdeafcafe @Aryansharma28
+/langwatch/src/components/inputs/              @0xdeafcafe
+/langwatch/src/components/license/             @sergioestebance
+/langwatch/src/components/llmPromptConfigs/    @rogeriochaves @drewdrewthis
 /langwatch/src/components/messages/            @rogeriochaves
-/langwatch/src/components/plans/               @rogeriochaves
-/langwatch/src/components/projects/            @rogeriochaves
-/langwatch/src/components/scenarios/           @rogeriochaves
-/langwatch/src/components/settings/            @rogeriochaves
-/langwatch/src/components/sidebar/             @rogeriochaves
-/langwatch/src/components/simulations/         @rogeriochaves
-/langwatch/src/components/subscription/        @rogeriochaves
-/langwatch/src/components/suites/              @rogeriochaves
+/langwatch/src/components/plans/               @sergioestebance
+/langwatch/src/components/projects/            @sergioestebance @rogeriochaves
+/langwatch/src/components/scenarios/           @drewdrewthis
+/langwatch/src/components/settings/            @rogeriochaves @sergioestebance
+/langwatch/src/components/sidebar/             @rogeriochaves @0xdeafcafe
+/langwatch/src/components/simulations/         @drewdrewthis @rogeriochaves
+/langwatch/src/components/subscription/        @sergioestebance @drewdrewthis
+/langwatch/src/components/suites/              @drewdrewthis
 /langwatch/src/components/traces/              @rogeriochaves
-/langwatch/src/components/ui/                  @rogeriochaves
-/langwatch/src/components/workflows/           @rogeriochaves
+/langwatch/src/components/ui/                  @rogeriochaves @drewdrewthis
+/langwatch/src/components/workflows/           @sergioestebance @rogeriochaves

--- a/.github/scripts/generate-codeowners.sh
+++ b/.github/scripts/generate-codeowners.sh
@@ -1,79 +1,103 @@
 #!/usr/bin/env bash
 #
-# generate-codeowners.sh — regenerate .github/CODEOWNERS from git history.
+# generate-codeowners.sh — regenerate .github/CODEOWNERS from git history,
+# with owners derived dynamically from the langwatch GitHub org.
 #
-# Ownership is derived per area from `git log` authorship: the owners of an
-# area are its top historical commit authors. Merge commits, bots, and
-# departed contributors are excluded; unknown one-off external authors are
-# ignored. The list of areas (the structure of the file) is curated below;
-# only the *owners* of each area are recomputed, so the file stays stable
-# while reviewer assignments track who is actually working where.
+# Nothing about *who* can own code is hand-maintained here:
+#   - The eligible-owner allowlist is the live org membership
+#     (`gh api orgs/langwatch/members`), minus bots.
+#   - Commit email -> GitHub login is resolved from GitHub's own attribution
+#     (a recent-commit sample via the API), so there is no identity table.
+# Only the *structure* (which paths get rules) is curated, in generate().
 #
-# Run from anywhere inside the repo. Requires full git history
-# (`git clone` depth 0 / `fetch-depth: 0` in CI). The weekly
-# .github/workflows/codeowners-refresh.yml workflow runs this and opens a
-# PR when the result differs from what is committed.
+# Per area, owners are the org members who have committed most to that path
+# (recent history), capped at two. @0xdeafcafe is additionally guaranteed on
+# the Go surface by standing arrangement.
 #
-# To change ownership policy, edit:
-#   - the identity map / exclusion list in owners_for() below, or
-#   - the curated area list in generate().
+# AUTH: langwatch has no public members, so a plain repo-scoped GITHUB_TOKEN
+# returns an empty member list. Run with a token that has `read:org` (locally:
+# your `gh auth`; in CI: the CODEOWNERS_REFRESH_TOKEN secret). If no members
+# come back the script hard-fails rather than writing an empty-ownership file.
+#
+# Run from anywhere in the repo with full history (CI: fetch-depth: 0). The
+# weekly .github/workflows/codeowners-refresh.yml runs this and opens a PR
+# when the result differs from what is committed.
 
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
 TARGET=".github/CODEOWNERS"
+ORG="langwatch"
+REPO="langwatch/langwatch"
 
-# Overall top contributor — used for the `*` global fallback and whenever an
-# area has no attributable history left after exclusions.
-DEFAULT_OWNER="@rogeriochaves"
+# Policy owners (bare logins; must be org members — validated below).
+DEFAULT_OWNER="rogeriochaves"   # global fallback / used when an area has no member history
+GO_COOWNER="0xdeafcafe"         # standing co-owner of the Go surface
 
-# Secondary owner is listed only when their commit count clears both floors.
-SECONDARY_MIN=2          # absolute minimum commits
-SECONDARY_RATIO_PCT=25   # and at least this percent of the primary's commits
+SAMPLE_COMMITS=2000             # recent commits sampled to resolve email -> login
+SECONDARY_MIN=2                 # a 2nd owner needs at least this many commits ...
+SECONDARY_RATIO_PCT=25          # ... and at least this percent of the top owner's
 
-# owners_for <pathspec...> — print the top (max 2) owners for the given paths,
-# space-separated, or nothing if no attributable history.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+MEMBER_FILE="$TMP/members"
+MAP_FILE="$TMP/email2login"
+
+# --- 1. Eligible owners: current org members, minus bots/automation accounts.
+gh api "orgs/$ORG/members" --paginate --jq '.[].login' 2>/dev/null \
+  | grep -ivE '\[bot\]$|(^|-)(agent|bot)$' \
+  | sort -u > "$MEMBER_FILE" || true
+
+member_count="$(wc -l < "$MEMBER_FILE" | tr -d ' ')"
+if [ "$member_count" -eq 0 ]; then
+  echo "ERROR: 'gh api orgs/$ORG/members' returned no members — the token almost" >&2
+  echo "       certainly lacks read:org (langwatch has no public members)." >&2
+  echo "       Refusing to generate a CODEOWNERS with no owners." >&2
+  exit 1
+fi
+echo "Eligible owners ($member_count org members): $(tr '\n' ' ' < "$MEMBER_FILE")" >&2
+
+for required in "$DEFAULT_OWNER" "$GO_COOWNER"; do
+  grep -qix "$required" "$MEMBER_FILE" \
+    || echo "WARNING: configured policy owner '$required' is not an org member." >&2
+done
+
+# --- 2. email -> GitHub login, from a recent-commit sample (GitHub attributes
+#        each commit to a user, so we don't keep a hand-written identity map).
+pages=$(( (SAMPLE_COMMITS + 99) / 100 ))
+for p in $(seq 1 "$pages"); do
+  gh api "repos/$REPO/commits?sha=main&per_page=100&page=$p" \
+    --jq '.[] | select(.author.login != null) | [.commit.author.email, .author.login] | @tsv' \
+    2>/dev/null || true
+done | sort -u > "$MAP_FILE"
+
+# owners_for <pathspec...> — top (max 2) org-member owners for the given paths,
+# as space-separated bare logins, or empty if none.
 owners_for() {
   git log --no-merges --format='%ae' -- "$@" 2>/dev/null | awk \
+    -v mapf="$MAP_FILE" -v memf="$MEMBER_FILE" \
     -v smin="$SECONDARY_MIN" -v sratio="$SECONDARY_RATIO_PCT" '
+    BEGIN {
+      while ((getline x < mapf) > 0) { if (split(x, a, "\t") >= 2) e2l[tolower(a[1])] = a[2] }
+      while ((getline m < memf) > 0) { member[tolower(m)] = 1 }
+    }
     {
-      e = tolower($0)
-
-      # --- bots / automation: never owners ---
-      if (e ~ /\[bot\]|dependabot|github-actions|coderabbit|copilot|snyk-bot|langwatch-agent|langwatchagent|krusty@langwatch|orchardist/) next
-      if (e ~ /ip-[0-9].*compute\.internal/) next
-
-      # --- departed / excluded contributors ---
-      if (e ~ /richhuth/) next            # left the company
-      if (e ~ /budnyk|eugenumber/) next   # excluded by request
-
-      # --- identity map: email -> GitHub handle ---
-      if      (e ~ /rogeriochaves|rogerio@langwatch/) h = "@rogeriochaves"
-      else if (e ~ /alex\.forbes\.red|0xdeafcafe/)    h = "@0xdeafcafe"
-      else if (e ~ /drewdrewthis|andrew@langwatch/)   h = "@drewdrewthis"
-      else if (e ~ /sergioestebance|sergio\.esteban/) h = "@sergioestebance"
-      else if (e ~ /aryansharma|aryan@langwatch/)     h = "@Aryansharma28"
-      else if (e ~ /jpwakugawa|wakugawa/)             h = "@jpwakugawa"
-      else next   # unknown external one-off contributor — ignore
-
-      c[h]++
+      l = e2l[tolower($0)]
+      if (l != "" && (tolower(l) in member)) c[l]++
     }
     END {
-      n = 0
-      for (k in c) keys[++n] = k
-      if (n == 0) exit 0
-
-      # sort by commit count desc, then handle asc (deterministic ties)
-      for (i = 1; i <= n; i++)
-        for (j = i + 1; j <= n; j++)
+      k = 0
+      for (x in c) keys[++k] = x
+      if (k == 0) exit 0
+      for (i = 1; i <= k; i++)
+        for (j = i + 1; j <= k; j++)
           if (c[keys[j]] > c[keys[i]] ||
               (c[keys[j]] == c[keys[i]] && keys[j] < keys[i])) {
             t = keys[i]; keys[i] = keys[j]; keys[j] = t
           }
-
       out = keys[1]
-      if (n >= 2) {
+      if (k >= 2) {
         thr = smin
         rt = int(c[keys[1]] * sratio / 100)
         if (rt > thr) thr = rt
@@ -83,72 +107,40 @@ owners_for() {
     }'
 }
 
-# emit <codeowners-pattern> <pathspec...> — print one aligned CODEOWNERS rule.
-emit() {
-  local pattern="$1"; shift
-  local owners
-  owners="$(owners_for "$@")"
-  [ -z "$owners" ] && owners="$DEFAULT_OWNER"
-  printf '%-46s %s\n' "$pattern" "$owners"
+# fmt <bare-login...> — prefix each login with @ for CODEOWNERS.
+fmt() {
+  local out=""
+  for o in "$@"; do out="$out @$o"; done
+  echo "${out# }"
 }
 
-# rule <codeowners-pattern> [pathspec] — emit a rule, deriving the git
-# pathspec from the pattern (strip leading/trailing slash) unless one is given.
+# emit <codeowners-pattern> <pathspec...>
+emit() {
+  local pattern="$1"; shift
+  local raw; raw="$(owners_for "$@")"
+  [ -z "$raw" ] && raw="$DEFAULT_OWNER"
+  # shellcheck disable=SC2086
+  printf '%-46s %s\n' "$pattern" "$(fmt $raw)"
+}
+
+# rule <codeowners-pattern> [pathspec] — derive the pathspec from the pattern
+# (strip leading/trailing slash) unless one is given.
 rule() {
   local pattern="$1" spec="${2:-}"
-  if [ -z "$spec" ]; then
-    spec="${pattern#/}"; spec="${spec%/}"
-  fi
+  if [ -z "$spec" ]; then spec="${pattern#/}"; spec="${spec%/}"; fi
   emit "$pattern" "$spec"
 }
 
-# Always-on co-owner for Go code, regardless of commit counts. @0xdeafcafe
-# owns the Go surface (services, shared packages, SDK, the gateway) by
-# standing arrangement, so guarantee them on those areas even when history
-# alone wouldn't rank them in the top two.
-GO_COOWNER="@0xdeafcafe"
-
-# go_rule <codeowners-pattern> [pathspec] — like rule(), but guarantees
-# GO_COOWNER is among the owners.
+# go_rule <codeowners-pattern> [pathspec] — like rule(), but guarantees the Go
+# co-owner is on the rule regardless of commit counts.
 go_rule() {
   local pattern="$1" spec="${2:-}"
-  if [ -z "$spec" ]; then
-    spec="${pattern#/}"; spec="${spec%/}"
-  fi
-  local owners
-  owners="$(owners_for "$spec")"
-  [ -z "$owners" ] && owners="$DEFAULT_OWNER"
-  case " $owners " in
-    *" $GO_COOWNER "*) : ;;
-    *) owners="$owners $GO_COOWNER" ;;
-  esac
-  printf '%-46s %s\n' "$pattern" "$owners"
-}
-
-# warn_unmapped_contributors — the identity map in owners_for() drops any
-# author it doesn't recognise. That's correct for one-off external authors,
-# but it would also silently exclude a new *internal* contributor who simply
-# isn't in the map yet. Run once over all history and warn (to stderr, never
-# failing the run) about prolific authors that fall through the map, so the
-# map can be kept current. Keep the bot/exclude/map patterns below in sync
-# with owners_for().
-PROLIFIC_UNMAPPED_MIN=30
-warn_unmapped_contributors() {
-  git log --all --no-merges --format='%ae' 2>/dev/null | awk -v min="$PROLIFIC_UNMAPPED_MIN" '
-    {
-      e = tolower($0)
-      if (e ~ /\[bot\]|dependabot|github-actions|coderabbit|copilot|snyk-bot|langwatch-agent|langwatchagent|krusty@langwatch|orchardist/) next
-      if (e ~ /ip-[0-9].*compute\.internal/) next
-      if (e ~ /richhuth/) next            # intentionally excluded
-      if (e ~ /budnyk|eugenumber/) next   # intentionally excluded
-      if (e ~ /rogeriochaves|rogerio@langwatch|alex\.forbes\.red|0xdeafcafe|drewdrewthis|andrew@langwatch|sergioestebance|sergio\.esteban|aryansharma|aryan@langwatch|jpwakugawa|wakugawa/) next
-      u[e]++
-    }
-    END {
-      for (e in u)
-        if (u[e] >= min)
-          printf "WARNING: unmapped contributor %s (%d commits) is not in the identity map; add them to generate-codeowners.sh if they should be eligible for ownership.\n", e, u[e] > "/dev/stderr"
-    }'
+  if [ -z "$spec" ]; then spec="${pattern#/}"; spec="${spec%/}"; fi
+  local raw; raw="$(owners_for "$spec")"
+  [ -z "$raw" ] && raw="$DEFAULT_OWNER"
+  case " $raw " in *" $GO_COOWNER "*) : ;; *) raw="$raw $GO_COOWNER" ;; esac
+  # shellcheck disable=SC2086
+  printf '%-46s %s\n' "$pattern" "$(fmt $raw)"
 }
 
 generate() {
@@ -156,9 +148,11 @@ generate() {
 # CODEOWNERS — GENERATED FILE, DO NOT EDIT BY HAND.
 #
 # Regenerated weekly by .github/workflows/codeowners-refresh.yml from
-# .github/scripts/generate-codeowners.sh. Owners are the top historical
-# `git log` contributors per area (merges, bots, and departed contributors
-# excluded). To change ownership, edit the generator script — not this file.
+# .github/scripts/generate-codeowners.sh. Owners are the top committers per
+# area, restricted to current langwatch GitHub org members (the org roster and
+# the email->login mapping are both fetched live, so nothing here is a
+# hand-maintained list). To change ownership, adjust the generator script — not
+# this file.
 #
 # GitHub applies the LAST matching pattern only — rules go from general (top)
 # to specific (bottom). Owners must have write access to the repo.
@@ -388,6 +382,5 @@ SECTION
   rule "/langwatch/src/components/workflows/"
 }
 
-warn_unmapped_contributors
 generate > "$TARGET"
-echo "Wrote $TARGET"
+echo "Wrote $TARGET" >&2

--- a/.github/scripts/generate-codeowners.sh
+++ b/.github/scripts/generate-codeowners.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+#
+# generate-codeowners.sh — regenerate .github/CODEOWNERS from git history.
+#
+# Ownership is derived per area from `git log` authorship: the owners of an
+# area are its top historical commit authors. Merge commits, bots, and
+# departed contributors are excluded; unknown one-off external authors are
+# ignored. The list of areas (the structure of the file) is curated below;
+# only the *owners* of each area are recomputed, so the file stays stable
+# while reviewer assignments track who is actually working where.
+#
+# Run from anywhere inside the repo. Requires full git history
+# (`git clone` depth 0 / `fetch-depth: 0` in CI). The weekly
+# .github/workflows/codeowners-refresh.yml workflow runs this and opens a
+# PR when the result differs from what is committed.
+#
+# To change ownership policy, edit:
+#   - the identity map / exclusion list in owners_for() below, or
+#   - the curated area list in generate().
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+TARGET=".github/CODEOWNERS"
+
+# Overall top contributor — used for the `*` global fallback and whenever an
+# area has no attributable history left after exclusions.
+DEFAULT_OWNER="@rogeriochaves"
+
+# Secondary owner is listed only when their commit count clears both floors.
+SECONDARY_MIN=2          # absolute minimum commits
+SECONDARY_RATIO_PCT=25   # and at least this percent of the primary's commits
+
+# owners_for <pathspec...> — print the top (max 2) owners for the given paths,
+# space-separated, or nothing if no attributable history.
+owners_for() {
+  git log --no-merges --format='%ae' -- "$@" 2>/dev/null | awk \
+    -v smin="$SECONDARY_MIN" -v sratio="$SECONDARY_RATIO_PCT" '
+    {
+      e = tolower($0)
+
+      # --- bots / automation: never owners ---
+      if (e ~ /\[bot\]|dependabot|github-actions|coderabbit|copilot|snyk-bot|langwatch-agent|langwatchagent|krusty@langwatch|orchardist/) next
+      if (e ~ /ip-[0-9].*compute\.internal/) next
+
+      # --- departed / excluded contributors ---
+      if (e ~ /richhuth/) next            # left the company
+      if (e ~ /budnyk|eugenumber/) next   # excluded by request
+
+      # --- identity map: email -> GitHub handle ---
+      if      (e ~ /rogeriochaves|rogerio@langwatch/) h = "@rogeriochaves"
+      else if (e ~ /alex\.forbes\.red|0xdeafcafe/)    h = "@0xdeafcafe"
+      else if (e ~ /drewdrewthis|andrew@langwatch/)   h = "@drewdrewthis"
+      else if (e ~ /sergioestebance|sergio\.esteban/) h = "@sergioestebance"
+      else if (e ~ /aryansharma|aryan@langwatch/)     h = "@Aryansharma28"
+      else if (e ~ /jpwakugawa|wakugawa/)             h = "@jpwakugawa"
+      else next   # unknown external one-off contributor — ignore
+
+      c[h]++
+    }
+    END {
+      n = 0
+      for (k in c) keys[++n] = k
+      if (n == 0) exit 0
+
+      # sort by commit count desc, then handle asc (deterministic ties)
+      for (i = 1; i <= n; i++)
+        for (j = i + 1; j <= n; j++)
+          if (c[keys[j]] > c[keys[i]] ||
+              (c[keys[j]] == c[keys[i]] && keys[j] < keys[i])) {
+            t = keys[i]; keys[i] = keys[j]; keys[j] = t
+          }
+
+      out = keys[1]
+      if (n >= 2) {
+        thr = smin
+        rt = int(c[keys[1]] * sratio / 100)
+        if (rt > thr) thr = rt
+        if (c[keys[2]] >= thr) out = out " " keys[2]
+      }
+      print out
+    }'
+}
+
+# emit <codeowners-pattern> <pathspec...> — print one aligned CODEOWNERS rule.
+emit() {
+  local pattern="$1"; shift
+  local owners
+  owners="$(owners_for "$@")"
+  [ -z "$owners" ] && owners="$DEFAULT_OWNER"
+  printf '%-46s %s\n' "$pattern" "$owners"
+}
+
+# rule <codeowners-pattern> [pathspec] — emit a rule, deriving the git
+# pathspec from the pattern (strip leading/trailing slash) unless one is given.
+rule() {
+  local pattern="$1" spec="${2:-}"
+  if [ -z "$spec" ]; then
+    spec="${pattern#/}"; spec="${spec%/}"
+  fi
+  emit "$pattern" "$spec"
+}
+
+# Always-on co-owner for Go code, regardless of commit counts. @0xdeafcafe
+# owns the Go surface (services, shared packages, SDK, the gateway) by
+# standing arrangement, so guarantee them on those areas even when history
+# alone wouldn't rank them in the top two.
+GO_COOWNER="@0xdeafcafe"
+
+# go_rule <codeowners-pattern> [pathspec] — like rule(), but guarantees
+# GO_COOWNER is among the owners.
+go_rule() {
+  local pattern="$1" spec="${2:-}"
+  if [ -z "$spec" ]; then
+    spec="${pattern#/}"; spec="${spec%/}"
+  fi
+  local owners
+  owners="$(owners_for "$spec")"
+  [ -z "$owners" ] && owners="$DEFAULT_OWNER"
+  case " $owners " in
+    *" $GO_COOWNER "*) : ;;
+    *) owners="$owners $GO_COOWNER" ;;
+  esac
+  printf '%-46s %s\n' "$pattern" "$owners"
+}
+
+generate() {
+  cat <<'HEADER'
+# CODEOWNERS — GENERATED FILE, DO NOT EDIT BY HAND.
+#
+# Regenerated weekly by .github/workflows/codeowners-refresh.yml from
+# .github/scripts/generate-codeowners.sh. Owners are the top historical
+# `git log` contributors per area (merges, bots, and departed contributors
+# excluded). To change ownership, edit the generator script — not this file.
+#
+# GitHub applies the LAST matching pattern only — rules go from general (top)
+# to specific (bottom). Owners must have write access to the repo.
+
+# ===========================================================================
+# Global fallback — overall top contributor across the repo.
+# ===========================================================================
+HEADER
+  emit "*" "."
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# Repo-level config, build & dependency manifests
+# ===========================================================================
+SECTION
+  go_rule "/go.mod"
+  go_rule "/go.sum"
+  rule "/package.json"
+  rule "/pnpm-workspace.yaml"
+  rule "/pnpm-lock.yaml"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# CI, infra, deployment & dev environment
+# ===========================================================================
+SECTION
+  rule "/.github/"
+  rule "/charts/"
+  rule "/clickhouse-serverless/"
+  rule "/bullboard/"
+  rule "/dev/"
+  rule "/agentic-e2e-tests/"
+  rule "/Makefile"
+  rule "/boxd.mk"
+  rule "/*.mk" "*.mk"
+  rule "/compose*.yml" "compose*.yml"
+  rule "/Dockerfile" "Dockerfile"
+  rule "/Dockerfile.*" "Dockerfile.*"
+  rule "/CLAUDE.md"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# Go services & shared Go code
+# ===========================================================================
+SECTION
+  go_rule "/services/nlpgo/"
+  go_rule "/services/aigateway/"
+  go_rule "/pkg/"
+  go_rule "/cmd/"
+  go_rule "/sdk-go/"
+  go_rule "/Dockerfile.go_service" "Dockerfile.go_service"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# SDKs & integrations
+# ===========================================================================
+SECTION
+  rule "/python-sdk/"
+  rule "/typescript-sdk/"
+  rule "/mcp-server/"
+  rule "/langevals/"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# Specs (BDD .feature files)
+# ===========================================================================
+SECTION
+  rule "/specs/"
+  rule "/specs/ai-gateway/"
+  rule "/specs/ai-governance/"
+  rule "/specs/nlp-go/"
+  rule "/specs/model-providers/"
+  rule "/specs/event-sourcing/"
+  rule "/specs/evaluators/"
+  rule "/specs/monitors/"
+  rule "/specs/licensing/"
+  rule "/specs/billing/"
+  rule "/specs/data-retention/"
+  rule "/specs/members/"
+  rule "/specs/api-keys/"
+  rule "/specs/prompts/"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# Docs
+# ===========================================================================
+SECTION
+  rule "/docs/"
+  rule "/docs/adr/"
+  rule "/docs/api-reference/"
+  rule "/docs/integration/"
+  rule "/docs/self-hosting/"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# Skills
+# ===========================================================================
+SECTION
+  rule "/skills/"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# Main app (langwatch/) — schema, EE, optimization studio, top-level dirs
+# ===========================================================================
+SECTION
+  rule "/langwatch/prisma/"
+  rule "/langwatch/ee/"
+  rule "/langwatch/elastic/"
+  rule "/langwatch/e2e/"
+  rule "/langwatch/scripts/"
+  rule "/langwatch/src/optimization_studio/"
+  rule "/langwatch/src/hooks/"
+  rule "/langwatch/src/utils/"
+  rule "/langwatch/src/tasks/"
+  rule "/langwatch/src/features/"
+  rule "/langwatch/src/prompts/"
+  emit "/langwatch/src/experiments-v3/" "langwatch/src/experiments-v3" "langwatch/src/evaluations-v3"
+  rule "/langwatch/src/app/api/"
+
+  cat <<'SECTION'
+
+# ---------------------------------------------------------------------------
+# Main app — pages
+# ---------------------------------------------------------------------------
+SECTION
+  rule "/langwatch/src/pages/api/"
+  rule "/langwatch/src/pages/settings/"
+  rule "/langwatch/src/pages/onboarding/"
+  rule "/langwatch/src/pages/auth/"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# Main app — server domains
+# ===========================================================================
+SECTION
+  rule "/langwatch/src/server/analytics/"
+  rule "/langwatch/src/server/annotations/"
+  rule "/langwatch/src/server/api/"
+  rule "/langwatch/src/server/app-layer/"
+  rule "/langwatch/src/server/background/"
+  rule "/langwatch/src/server/clickhouse/"
+  rule "/langwatch/src/server/datasets/"
+  rule "/langwatch/src/server/evaluations/"
+  rule "/langwatch/src/server/evaluators/"
+  rule "/langwatch/src/server/event-sourcing/"
+  rule "/langwatch/src/server/experiments/"
+  emit "/langwatch/src/server/experiments-v3/" "langwatch/src/server/experiments-v3" "langwatch/src/server/evaluations-v3"
+  rule "/langwatch/src/server/featureFlag/"
+  rule "/langwatch/src/server/filters/"
+  go_rule "/langwatch/src/server/gateway/"
+  rule "/langwatch/src/server/modelProviders/"
+  rule "/langwatch/src/server/prompt-config/"
+  rule "/langwatch/src/server/repositories/"
+  rule "/langwatch/src/server/routes/"
+  rule "/langwatch/src/server/scenarios/"
+  rule "/langwatch/src/server/simulations/"
+  rule "/langwatch/src/server/suites/"
+  rule "/langwatch/src/server/topicClustering/"
+  rule "/langwatch/src/server/tracer/"
+  rule "/langwatch/src/server/traces/"
+  rule "/langwatch/src/server/triggers/"
+  rule "/langwatch/src/server/workflows/"
+
+  cat <<'SECTION'
+
+# Auth, permissions & multitenancy
+SECTION
+  rule "/langwatch/src/server/agents/"
+  rule "/langwatch/src/server/rbac/"
+  rule "/langwatch/src/server/role/"
+  rule "/langwatch/src/server/role-bindings/"
+  rule "/langwatch/src/server/scim/"
+  rule "/langwatch/src/server/teams/"
+  rule "/langwatch/src/server/invites/"
+  rule "/langwatch/src/server/api-key/"
+
+  cat <<'SECTION'
+
+# Billing, licensing & data retention
+SECTION
+  rule "/langwatch/src/server/license-enforcement/"
+  rule "/langwatch/src/server/data-retention/"
+  rule "/langwatch/src/server/subscriptionHandler.ts" "langwatch/src/server/subscriptionHandler.ts"
+
+  cat <<'SECTION'
+
+# ===========================================================================
+# Main app — UI components
+# ===========================================================================
+SECTION
+  rule "/langwatch/src/components/agents/"
+  rule "/langwatch/src/components/analytics/"
+  rule "/langwatch/src/components/annotations/"
+  rule "/langwatch/src/components/checks/"
+  rule "/langwatch/src/components/datasets/"
+  rule "/langwatch/src/components/drawers/"
+  rule "/langwatch/src/components/evaluations/"
+  rule "/langwatch/src/components/evaluators/"
+  rule "/langwatch/src/components/experiments/"
+  rule "/langwatch/src/components/filters/"
+  rule "/langwatch/src/components/forms/"
+  rule "/langwatch/src/components/inputs/"
+  rule "/langwatch/src/components/license/"
+  rule "/langwatch/src/components/llmPromptConfigs/"
+  rule "/langwatch/src/components/messages/"
+  rule "/langwatch/src/components/plans/"
+  rule "/langwatch/src/components/projects/"
+  rule "/langwatch/src/components/scenarios/"
+  rule "/langwatch/src/components/settings/"
+  rule "/langwatch/src/components/sidebar/"
+  rule "/langwatch/src/components/simulations/"
+  rule "/langwatch/src/components/subscription/"
+  rule "/langwatch/src/components/suites/"
+  rule "/langwatch/src/components/traces/"
+  rule "/langwatch/src/components/ui/"
+  rule "/langwatch/src/components/workflows/"
+}
+
+generate > "$TARGET"
+echo "Wrote $TARGET"

--- a/.github/scripts/generate-codeowners.sh
+++ b/.github/scripts/generate-codeowners.sh
@@ -125,6 +125,32 @@ go_rule() {
   printf '%-46s %s\n' "$pattern" "$owners"
 }
 
+# warn_unmapped_contributors — the identity map in owners_for() drops any
+# author it doesn't recognise. That's correct for one-off external authors,
+# but it would also silently exclude a new *internal* contributor who simply
+# isn't in the map yet. Run once over all history and warn (to stderr, never
+# failing the run) about prolific authors that fall through the map, so the
+# map can be kept current. Keep the bot/exclude/map patterns below in sync
+# with owners_for().
+PROLIFIC_UNMAPPED_MIN=30
+warn_unmapped_contributors() {
+  git log --all --no-merges --format='%ae' 2>/dev/null | awk -v min="$PROLIFIC_UNMAPPED_MIN" '
+    {
+      e = tolower($0)
+      if (e ~ /\[bot\]|dependabot|github-actions|coderabbit|copilot|snyk-bot|langwatch-agent|langwatchagent|krusty@langwatch|orchardist/) next
+      if (e ~ /ip-[0-9].*compute\.internal/) next
+      if (e ~ /richhuth/) next            # intentionally excluded
+      if (e ~ /budnyk|eugenumber/) next   # intentionally excluded
+      if (e ~ /rogeriochaves|rogerio@langwatch|alex\.forbes\.red|0xdeafcafe|drewdrewthis|andrew@langwatch|sergioestebance|sergio\.esteban|aryansharma|aryan@langwatch|jpwakugawa|wakugawa/) next
+      u[e]++
+    }
+    END {
+      for (e in u)
+        if (u[e] >= min)
+          printf "WARNING: unmapped contributor %s (%d commits) is not in the identity map; add them to generate-codeowners.sh if they should be eligible for ownership.\n", e, u[e] > "/dev/stderr"
+    }'
+}
+
 generate() {
   cat <<'HEADER'
 # CODEOWNERS — GENERATED FILE, DO NOT EDIT BY HAND.
@@ -169,10 +195,12 @@ SECTION
   rule "/agentic-e2e-tests/"
   rule "/Makefile"
   rule "/boxd.mk"
-  rule "/*.mk" "*.mk"
-  rule "/compose*.yml" "compose*.yml"
-  rule "/Dockerfile" "Dockerfile"
-  rule "/Dockerfile.*" "Dockerfile.*"
+  # `:(glob)` keeps `*` from crossing `/`, so these pathspecs match only
+  # root-level files — mirroring the root-anchored CODEOWNERS patterns.
+  rule "/*.mk" ":(glob)*.mk"
+  rule "/compose*.yml" ":(glob)compose*.yml"
+  rule "/Dockerfile" ":(glob)Dockerfile"
+  rule "/Dockerfile.*" ":(glob)Dockerfile.*"
   rule "/CLAUDE.md"
 
   cat <<'SECTION'
@@ -360,5 +388,6 @@ SECTION
   rule "/langwatch/src/components/workflows/"
 }
 
+warn_unmapped_contributors
 generate > "$TARGET"
 echo "Wrote $TARGET"

--- a/.github/scripts/generate-codeowners.sh
+++ b/.github/scripts/generate-codeowners.sh
@@ -38,7 +38,6 @@ REPO="langwatch/langwatch"
 DEFAULT_OWNER="rogeriochaves"   # global fallback / used when an area has no member history
 GO_COOWNER="0xdeafcafe"         # standing co-owner of the Go surface
 
-SAMPLE_COMMITS=2000             # recent commits sampled to resolve email -> login
 SECONDARY_MIN=2                 # a 2nd owner needs at least this many commits ...
 SECONDARY_RATIO_PCT=25          # ... and at least this percent of the top owner's
 
@@ -47,19 +46,45 @@ trap 'rm -rf "$TMP"' EXIT
 MEMBER_FILE="$TMP/members"
 MAP_FILE="$TMP/email2login"
 
-# --- 1. Eligible owners: current org members, minus bots/automation accounts.
+# --- 1. Eligible owners: current org members with repo write access, minus
+#        bots/automation accounts. CODEOWNERS silently ignores owners without
+#        write access, so an owner without write is effectively an empty owner
+#        line — worse than picking someone slightly less relevant who can
+#        actually approve.
+raw_members="$TMP/members.raw"
 gh api "orgs/$ORG/members" --paginate --jq '.[].login' 2>/dev/null \
   | grep -ivE '\[bot\]$|(^|-)(agent|bot)$' \
-  | sort -u > "$MEMBER_FILE" || true
+  | sort -u > "$raw_members" || true
 
-member_count="$(wc -l < "$MEMBER_FILE" | tr -d ' ')"
-if [ "$member_count" -eq 0 ]; then
+raw_member_count="$(wc -l < "$raw_members" | tr -d ' ')"
+if [ "$raw_member_count" -eq 0 ]; then
   echo "ERROR: 'gh api orgs/$ORG/members' returned no members — the token almost" >&2
   echo "       certainly lacks read:org (langwatch has no public members)." >&2
   echo "       Refusing to generate a CODEOWNERS with no owners." >&2
   exit 1
 fi
-echo "Eligible owners ($member_count org members): $(tr '\n' ' ' < "$MEMBER_FILE")" >&2
+
+# Filter to write-access (admin/maintain/write). A rate-limited or 404 lookup
+# would silently drop a real owner, so fail closed on any error.
+: > "$MEMBER_FILE"
+while read -r user; do
+  perm="$(gh api "repos/$REPO/collaborators/$user/permission" --jq '.permission' 2>/dev/null || true)"
+  case "$perm" in
+    admin|maintain|write) echo "$user" >> "$MEMBER_FILE" ;;
+    "") echo "ERROR: could not resolve repo permission for @$user — refusing to" >&2
+        echo "       generate a CODEOWNERS with an incomplete write-access filter." >&2
+        exit 1 ;;
+    *)  echo "Skipping @$user (repo permission: $perm) — not eligible as an owner." >&2 ;;
+  esac
+done < "$raw_members"
+
+member_count="$(wc -l < "$MEMBER_FILE" | tr -d ' ')"
+if [ "$member_count" -eq 0 ]; then
+  echo "ERROR: no org members have write access on $REPO. Refusing to generate" >&2
+  echo "       a CODEOWNERS whose owners can't approve." >&2
+  exit 1
+fi
+echo "Eligible owners ($member_count with write access): $(tr '\n' ' ' < "$MEMBER_FILE")" >&2
 
 # Policy owners are hard-coded into every rule (fallback + Go co-owner), so if
 # either leaves the org the whole file would violate the "org members only"
@@ -72,26 +97,80 @@ for required in "$DEFAULT_OWNER" "$GO_COOWNER"; do
   }
 done
 
-# --- 2. email -> GitHub login, from a recent-commit sample (GitHub attributes
-#        each commit to a user, so we don't keep a hand-written identity map).
-pages=$(( (SAMPLE_COMMITS + 99) / 100 ))
-for p in $(seq 1 "$pages"); do
-  gh api "repos/$REPO/commits?sha=main&per_page=100&page=$p" \
-    --jq '.[] | select(.author.login != null) | [.commit.author.email, .author.login] | @tsv' \
-    2>/dev/null || true
+# --- 2. email -> GitHub login. Coverage-guaranteed: iterate every unique email
+#        in local history, not a "recent N commits" sample (which can miss an
+#        area's real owner if their commits are older than the window). Noreply
+#        emails encode the login and are resolved offline; anything else gets
+#        one commit-lookup API call. Bounded by unique-email count, not commit
+#        count.
+unresolved_file="$TMP/unresolved-emails"
+: > "$unresolved_file"
+
+git log --all --no-merges --format='%ae' | sort -u | while read -r email; do
+  [ -z "$email" ] && continue
+  # noreply-email fast path: <login>@users.noreply.github.com
+  # or <id>+<login>@users.noreply.github.com.
+  case "$email" in
+    *@users.noreply.github.com)
+      login="${email%@users.noreply.github.com}"
+      login="${login#*+}"
+      printf '%s\t%s\n' "$email" "$login"
+      continue
+      ;;
+  esac
+  # Otherwise: look up one commit by this author and use GitHub's own attribution.
+  # Distinguish "API call failed" (fail closed) from "GitHub has no user for
+  # this email" (external contributor, machine-generated address — skip silently).
+  sha="$(git log --all --no-merges --format='%H' --author="$email" -1 2>/dev/null)"
+  if [ -z "$sha" ]; then continue; fi
+  if response="$(gh api "repos/$REPO/commits/$sha" 2>/dev/null)"; then
+    login="$(printf '%s' "$response" | jq -r '.author.login // empty' 2>/dev/null)"
+    if [ -n "$login" ]; then
+      printf '%s\t%s\n' "$email" "$login"
+    fi
+    # else: .author is null — GitHub has no linked user. Not an error.
+  else
+    # API call errored (rate limit / network / auth). This is the case we care
+    # about; the P1 bug on #4926 was exactly this class of silent failure.
+    printf '%s\n' "$email" >> "$unresolved_file"
+  fi
 done | sort -u > "$MAP_FILE"
 
-# If the commits API failed (rate limit, transient error, bad token) the map is
-# empty, no author gets attributed to an org member, and every rule collapses
-# to DEFAULT_OWNER — producing a large and wrong CODEOWNERS diff. Fail closed,
-# matching the empty-members check.
 map_size="$(wc -l < "$MAP_FILE" | tr -d ' ')"
 if [ "$map_size" -eq 0 ]; then
-  echo "ERROR: commit email->login sample is empty (no rows from" >&2
-  echo "       repos/$REPO/commits). Likely a token, rate-limit, or network issue." >&2
+  echo "ERROR: email->login map is empty (no unique authors resolved)." >&2
+  echo "       Likely a token, rate-limit, or network issue talking to $REPO." >&2
   echo "       Refusing to generate a CODEOWNERS with no attribution." >&2
   exit 1
 fi
+
+# Partial-failure guard (Sergio's P2 from #4926): a non-empty map that missed a
+# real owner would silently collapse that owner's areas to DEFAULT_OWNER. Fail
+# closed if any non-noreply email failed to resolve — the alternative is a
+# large, silently-wrong CODEOWNERS diff.
+if [ -s "$unresolved_file" ]; then
+  echo "ERROR: some commit emails could not be resolved to a GitHub login:" >&2
+  sed 's/^/         - /' "$unresolved_file" >&2
+  echo "       This would silently collapse those authors' areas to DEFAULT_OWNER." >&2
+  echo "       Refusing to generate a partially-resolved CODEOWNERS." >&2
+  exit 1
+fi
+
+# Sanity floor: how many DISTINCT non-bot org members did the map actually cover?
+# The current members roster (minus bots) is the ceiling; a healthy sample covers
+# most of them. If we're dramatically under, something has degraded (rate limits,
+# a token that can't read enough history, etc). Half-round-up of members is a
+# forgiving floor that still catches the "everything collapsed to one owner" bug.
+resolved_members="$(awk -F'\t' '{print $2}' "$MAP_FILE" | sort -u \
+  | grep -Fxf "$MEMBER_FILE" - 2>/dev/null | wc -l | tr -d ' ' || echo 0)"
+member_floor=$(( (member_count + 1) / 2 ))
+if [ "$resolved_members" -lt "$member_floor" ]; then
+  echo "ERROR: email->login map covers only $resolved_members of $member_count org members" >&2
+  echo "       (floor is $member_floor). Likely a partial API failure — refusing to" >&2
+  echo "       generate a CODEOWNERS that would collapse most rules to DEFAULT_OWNER." >&2
+  exit 1
+fi
+echo "Attribution: resolved $map_size distinct emails; $resolved_members / $member_count members covered." >&2
 
 # owners_for <pathspec...> — top (max 2) org-member owners for the given paths,
 # as space-separated bare logins, or empty if none.

--- a/.github/scripts/generate-codeowners.sh
+++ b/.github/scripts/generate-codeowners.sh
@@ -15,9 +15,12 @@
 # the Go surface by standing arrangement.
 #
 # AUTH: langwatch has no public members, so a plain repo-scoped GITHUB_TOKEN
-# returns an empty member list. Run with a token that has `read:org` (locally:
-# your `gh auth`; in CI: the CODEOWNERS_REFRESH_TOKEN secret). If no members
-# come back the script hard-fails rather than writing an empty-ownership file.
+# returns an empty member list. Run with a token that can read org membership:
+# locally, `gh auth login` with the `read:org` scope; in CI, an installation
+# token from the CODEOWNERS_REFRESH_APP_ID / CODEOWNERS_REFRESH_APP_PRIVATE_KEY
+# GitHub App (see .github/workflows/codeowners-refresh.yml). If no members come
+# back — or the commit-attribution sample below is empty — the script hard-fails
+# rather than writing a wrong-owner file.
 #
 # Run from anywhere in the repo with full history (CI: fetch-depth: 0). The
 # weekly .github/workflows/codeowners-refresh.yml runs this and opens a PR
@@ -58,9 +61,15 @@ if [ "$member_count" -eq 0 ]; then
 fi
 echo "Eligible owners ($member_count org members): $(tr '\n' ' ' < "$MEMBER_FILE")" >&2
 
+# Policy owners are hard-coded into every rule (fallback + Go co-owner), so if
+# either leaves the org the whole file would violate the "org members only"
+# invariant. Fail closed rather than emit a non-member.
 for required in "$DEFAULT_OWNER" "$GO_COOWNER"; do
-  grep -qix "$required" "$MEMBER_FILE" \
-    || echo "WARNING: configured policy owner '$required' is not an org member." >&2
+  grep -qix "$required" "$MEMBER_FILE" || {
+    echo "ERROR: configured policy owner '$required' is not an org member of $ORG." >&2
+    echo "       Update DEFAULT_OWNER / GO_COOWNER at the top of this script." >&2
+    exit 1
+  }
 done
 
 # --- 2. email -> GitHub login, from a recent-commit sample (GitHub attributes
@@ -71,6 +80,18 @@ for p in $(seq 1 "$pages"); do
     --jq '.[] | select(.author.login != null) | [.commit.author.email, .author.login] | @tsv' \
     2>/dev/null || true
 done | sort -u > "$MAP_FILE"
+
+# If the commits API failed (rate limit, transient error, bad token) the map is
+# empty, no author gets attributed to an org member, and every rule collapses
+# to DEFAULT_OWNER — producing a large and wrong CODEOWNERS diff. Fail closed,
+# matching the empty-members check.
+map_size="$(wc -l < "$MAP_FILE" | tr -d ' ')"
+if [ "$map_size" -eq 0 ]; then
+  echo "ERROR: commit email->login sample is empty (no rows from" >&2
+  echo "       repos/$REPO/commits). Likely a token, rate-limit, or network issue." >&2
+  echo "       Refusing to generate a CODEOWNERS with no attribution." >&2
+  exit 1
+fi
 
 # owners_for <pathspec...> — top (max 2) org-member owners for the given paths,
 # as space-separated bare logins, or empty if none.
@@ -158,7 +179,7 @@ generate() {
 # to specific (bottom). Owners must have write access to the repo.
 
 # ===========================================================================
-# Global fallback — overall top contributor across the repo.
+# Global fallback — overall top contributors across the repo (up to 2).
 # ===========================================================================
 HEADER
   emit "*" "."

--- a/.github/workflows/codeowners-refresh.yml
+++ b/.github/workflows/codeowners-refresh.yml
@@ -3,8 +3,17 @@ name: Refresh CODEOWNERS
 # Regenerates .github/CODEOWNERS from git history once a week and opens (or
 # updates) a PR when ownership has shifted. The generator
 # (.github/scripts/generate-codeowners.sh) recomputes each area's owners from
-# `git log` authorship, so reviewer assignments track who is actually working
-# where without anyone maintaining the file by hand.
+# `git log` authorship restricted to current langwatch org members, so reviewer
+# assignments track who is actually working where without anyone maintaining the
+# list by hand.
+#
+# TOKEN: the generator reads org membership, and langwatch has no public
+# members, so the default GITHUB_TOKEN returns an empty list and the generator
+# hard-fails. Provide a CODEOWNERS_REFRESH_TOKEN secret — a PAT with `read:org`
+# plus `contents:write` + `pull-requests:write` (classic: `repo` + `read:org`).
+# It also makes the refresh PR run CI (GITHUB_TOKEN-authored PRs don't). The
+# workflow falls back to github.token so a missing secret fails loudly in the
+# generator step rather than silently skipping.
 
 on:
   schedule:
@@ -33,13 +42,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # Push with the PAT (if set) so the refresh PR triggers CI.
+          token: ${{ secrets.CODEOWNERS_REFRESH_TOKEN || github.token }}
 
       - name: Regenerate CODEOWNERS
+        env:
+          # Needs read:org to list members (langwatch has no public members).
+          GH_TOKEN: ${{ secrets.CODEOWNERS_REFRESH_TOKEN || github.token }}
         run: bash .github/scripts/generate-codeowners.sh
 
       - name: Open or update PR if CODEOWNERS changed
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CODEOWNERS_REFRESH_TOKEN || github.token }}
         run: |
           set -euo pipefail
 
@@ -61,7 +75,7 @@ jobs:
           # the concurrency group, so there is nothing to clobber.
           git push --force origin "$BRANCH"
 
-          BODY="Automated weekly refresh of \`.github/CODEOWNERS\` by the codeowners-refresh workflow. Owners are recomputed from \`git log\` authorship per area via \`.github/scripts/generate-codeowners.sh\`; the diff reflects how contribution has shifted across the codebase since the last refresh. To change ownership policy (identity map, exclusions, areas, or the Go co-owner rule), edit the generator script rather than this PR."
+          BODY="Automated weekly refresh of \`.github/CODEOWNERS\` by the codeowners-refresh workflow. Owners are recomputed per area from \`git log\` authorship restricted to current langwatch org members, via \`.github/scripts/generate-codeowners.sh\`. The diff reflects how contribution and org membership have shifted since the last refresh. To change ownership policy (areas, the Go co-owner rule, or thresholds), edit the generator script rather than this PR."
 
           if gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
             echo "PR already open for $BRANCH; force-pushed branch keeps it current."

--- a/.github/workflows/codeowners-refresh.yml
+++ b/.github/workflows/codeowners-refresh.yml
@@ -55,7 +55,11 @@ jobs:
           git checkout -B "$BRANCH"
           git add .github/CODEOWNERS
           git commit -m "chore: refresh CODEOWNERS from git history"
-          git push --force-with-lease origin "$BRANCH"
+          # Plain --force (not --force-with-lease): the runner only checks out
+          # the triggering ref, so it has no remote-tracking ref for $BRANCH to
+          # base a lease on. This branch is bot-owned and runs are serialized by
+          # the concurrency group, so there is nothing to clobber.
+          git push --force origin "$BRANCH"
 
           BODY="Automated weekly refresh of \`.github/CODEOWNERS\` by the codeowners-refresh workflow. Owners are recomputed from \`git log\` authorship per area via \`.github/scripts/generate-codeowners.sh\`; the diff reflects how contribution has shifted across the codebase since the last refresh. To change ownership policy (identity map, exclusions, areas, or the Go co-owner rule), edit the generator script rather than this PR."
 

--- a/.github/workflows/codeowners-refresh.yml
+++ b/.github/workflows/codeowners-refresh.yml
@@ -12,10 +12,9 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
-# Don't run on forks — this pushes a branch and opens a PR.
-permissions:
-  contents: write
-  pull-requests: write
+# Least privilege: no permissions at the workflow level; the refresh job
+# escalates only the scopes it needs.
+permissions: {}
 
 concurrency:
   group: codeowners-refresh
@@ -23,8 +22,12 @@ concurrency:
 
 jobs:
   refresh:
+    # Don't run on forks — this pushes a branch and opens a PR.
     if: github.repository == 'langwatch/langwatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the chore/codeowners-refresh branch
+      pull-requests: write # open / update the refresh PR
     steps:
       - name: Checkout (full history)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeowners-refresh.yml
+++ b/.github/workflows/codeowners-refresh.yml
@@ -1,0 +1,67 @@
+name: Refresh CODEOWNERS
+
+# Regenerates .github/CODEOWNERS from git history once a week and opens (or
+# updates) a PR when ownership has shifted. The generator
+# (.github/scripts/generate-codeowners.sh) recomputes each area's owners from
+# `git log` authorship, so reviewer assignments track who is actually working
+# where without anyone maintaining the file by hand.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+# Don't run on forks — this pushes a branch and opens a PR.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codeowners-refresh
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    if: github.repository == 'langwatch/langwatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Regenerate CODEOWNERS
+        run: bash .github/scripts/generate-codeowners.sh
+
+      - name: Open or update PR if CODEOWNERS changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- .github/CODEOWNERS; then
+            echo "CODEOWNERS is already up to date; nothing to do."
+            exit 0
+          fi
+
+          BRANCH="chore/codeowners-refresh"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          git add .github/CODEOWNERS
+          git commit -m "chore: refresh CODEOWNERS from git history"
+          git push --force-with-lease origin "$BRANCH"
+
+          BODY="Automated weekly refresh of \`.github/CODEOWNERS\` by the codeowners-refresh workflow. Owners are recomputed from \`git log\` authorship per area via \`.github/scripts/generate-codeowners.sh\`; the diff reflects how contribution has shifted across the codebase since the last refresh. To change ownership policy (identity map, exclusions, areas, or the Go co-owner rule), edit the generator script rather than this PR."
+
+          if gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+            echo "PR already open for $BRANCH; force-pushed branch keeps it current."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: refresh CODEOWNERS from git history" \
+              --body "$BODY"
+          fi

--- a/.github/workflows/codeowners-refresh.yml
+++ b/.github/workflows/codeowners-refresh.yml
@@ -7,13 +7,20 @@ name: Refresh CODEOWNERS
 # assignments track who is actually working where without anyone maintaining the
 # list by hand.
 #
-# TOKEN: the generator reads org membership, and langwatch has no public
-# members, so the default GITHUB_TOKEN returns an empty list and the generator
-# hard-fails. Provide a CODEOWNERS_REFRESH_TOKEN secret — a PAT with `read:org`
-# plus `contents:write` + `pull-requests:write` (classic: `repo` + `read:org`).
-# It also makes the refresh PR run CI (GITHUB_TOKEN-authored PRs don't). The
-# workflow falls back to github.token so a missing secret fails loudly in the
-# generator step rather than silently skipping.
+# AUTH: uses a GitHub App installation token — not the default GITHUB_TOKEN and
+# not a personal PAT. The App needs org "Members: read" (to list members;
+# langwatch has no public members so the default token sees none) plus repo
+# "Contents: write" + "Pull requests: write". PRs it opens run CI, unlike
+# GITHUB_TOKEN-authored PRs, and no human account is tied to the automation.
+# Configure with two repo/org secrets:
+#   CODEOWNERS_REFRESH_APP_ID           — the App's numeric ID
+#   CODEOWNERS_REFRESH_APP_PRIVATE_KEY  — the App's PEM private key
+# Setup recipe:
+#   1. https://github.com/organizations/langwatch/settings/apps → New GitHub App
+#   2. Permissions: Organization > Members = Read; Repository > Contents = Read
+#      & write, Pull requests = Read & write, Metadata = Read
+#   3. Install on `langwatch/langwatch`
+#   4. Copy the App ID; generate a private key; paste both into the secrets above
 
 on:
   schedule:
@@ -22,7 +29,8 @@ on:
   workflow_dispatch:
 
 # Least privilege: no permissions at the workflow level; the refresh job
-# escalates only the scopes it needs.
+# escalates only the scopes it needs. (Job-scoped permissions still apply to
+# the fallback GITHUB_TOKEN, though nothing here uses it.)
 permissions: {}
 
 concurrency:
@@ -35,25 +43,32 @@ jobs:
     if: github.repository == 'langwatch/langwatch'
     runs-on: ubuntu-latest
     permissions:
-      contents: write # push the chore/codeowners-refresh branch
-      pull-requests: write # open / update the refresh PR
+      contents: read
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CODEOWNERS_REFRESH_APP_ID }}
+          private-key: ${{ secrets.CODEOWNERS_REFRESH_APP_PRIVATE_KEY }}
+          # Needed for `orgs/langwatch/members` (repo scope alone is not enough).
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout (full history)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          # Push with the PAT (if set) so the refresh PR triggers CI.
-          token: ${{ secrets.CODEOWNERS_REFRESH_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Regenerate CODEOWNERS
         env:
-          # Needs read:org to list members (langwatch has no public members).
-          GH_TOKEN: ${{ secrets.CODEOWNERS_REFRESH_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bash .github/scripts/generate-codeowners.sh
 
       - name: Open or update PR if CODEOWNERS changed
         env:
-          GH_TOKEN: ${{ secrets.CODEOWNERS_REFRESH_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
 
@@ -63,8 +78,9 @@ jobs:
           fi
 
           BRANCH="chore/codeowners-refresh"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Commits from the App show up as "<slug>[bot]" in the UI.
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
 
           git checkout -B "$BRANCH"
           git add .github/CODEOWNERS

--- a/.github/workflows/codeowners-refresh.yml
+++ b/.github/workflows/codeowners-refresh.yml
@@ -98,6 +98,12 @@ jobs:
 
           BODY="Automated weekly refresh of \`.github/CODEOWNERS\` by the codeowners-refresh workflow. Owners are recomputed per area from \`git log\` authorship restricted to current langwatch org members, via \`.github/scripts/generate-codeowners.sh\`. The diff reflects how contribution and org membership have shifted since the last refresh. To change ownership policy (areas, the Go co-owner rule, or thresholds), edit the generator script rather than this PR."
 
+          # Reuse the OPEN PR if there is one (the force-pushed branch already
+          # updates it). If the last PR was MERGED, `gh pr create` correctly
+          # opens a fresh one for the new diff. If a human CLOSED it without
+          # merging, that's a "don't want this" — the create call may then error
+          # ("can't reopen"), which we tolerate: next week's run will get a new
+          # PR once the branch head advances.
           if gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
             echo "PR already open for $BRANCH; force-pushed branch keeps it current."
           else
@@ -105,5 +111,5 @@ jobs:
               --base main \
               --head "$BRANCH" \
               --title "chore: refresh CODEOWNERS from git history" \
-              --body "$BODY"
+              --body "$BODY" || echo "Skipping PR creation (may be a declined prior PR); next diff will retry."
           fi

--- a/.github/workflows/codeowners-refresh.yml
+++ b/.github/workflows/codeowners-refresh.yml
@@ -51,8 +51,13 @@ jobs:
         with:
           app-id: ${{ secrets.CODEOWNERS_REFRESH_APP_ID }}
           private-key: ${{ secrets.CODEOWNERS_REFRESH_APP_PRIVATE_KEY }}
-          # Needed for `orgs/langwatch/members` (repo scope alone is not enough).
+          # `owner` scopes the token to the langwatch org installation (needed
+          # for orgs/langwatch/members). `repositories` narrows the *repo*
+          # permissions (contents/pull-requests write) to this one repo — even
+          # if the App is later installed on more repos, this token can't touch
+          # them. Org-level permissions still apply installation-wide.
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout (full history)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Why

The repo had no CODEOWNERS, so PRs weren't auto-routing to the people who actually know each area. A hand-maintained file rots fast, so this generates it from git history and refreshes it weekly. Owners are restricted to current langwatch org members and that roster is fetched live, so there's no list to keep up to date.

## What changed

- Adds `.github/CODEOWNERS` mapping ~130 path rules to owners.
- Adds `.github/scripts/generate-codeowners.sh`, the generator that is the source of truth for the file.
- Adds `.github/workflows/codeowners-refresh.yml`, which regenerates weekly and opens a PR when ownership shifts.

Nothing about *who* can own code is hard-coded: the eligible-owner allowlist is the live org membership (bots excluded), and commit-email → GitHub-login is resolved from GitHub's own commit attribution. New org members are picked up and departures dropped with no edit to the script. @0xdeafcafe is additionally guaranteed on the Go surface (services, pkg, cmd, sdk-go, gateway, go deps) by standing arrangement.

## How it works

The generator (1) lists current org members via `gh api orgs/langwatch/members`, (2) builds an email→login map from a sample of recent commits (so GitHub does the identity resolution, not a hand-written table), then (3) ranks each curated area from local `git log`, keeping only members, top two per area (a second owner needs a minimum absolute and relative commit share). The curated part is only the *structure* — which paths get rules. The `evaluations-v3 → experiments-v3` rename is handled by unioning both paths' history, and root-anchored globs use `:(glob)` pathspecs.

CODEOWNERS is a generated artefact (the header says do not edit by hand); policy changes go in the generator. The weekly workflow runs the generator and force-updates a `chore/codeowners-refresh` branch + PR only when the output differs.

## Test plan

- [x] Generator runs and produces a file whose every owner is a confirmed `orgs/langwatch/members` member
- [x] Every path pattern resolves to a real tracked path in the repo
- [x] Generator hard-fails (non-zero) when the member list is empty, rather than writing an empty-ownership file
- [x] `/Dockerfile.go_service` ordered after `/Dockerfile.*` so last-match-wins gives it the Go owner
- [x] Workflow YAML parses; least-privilege permissions (workflow `{}`, job `contents: read` — the App token supplies write scopes)
- [ ] **Action required before first weekly run:** create the GitHub App + add its secrets (see below)

## Anything surprising?

- **Requires a GitHub App to run.** langwatch has zero *public* members, so the default `GITHUB_TOKEN` lists no members and the generator fails closed. The workflow mints a short-lived installation token from a repo-scoped App. Two secrets needed:
  - `CODEOWNERS_REFRESH_APP_ID` — the App's numeric ID
  - `CODEOWNERS_REFRESH_APP_PRIVATE_KEY` — its PEM private key

  Setup: New GitHub App under langwatch org → permissions **Organization: Members = Read**, **Repository: Contents = Read & write, Pull requests = Read & write, Metadata = Read** → install on `langwatch/langwatch` → save App ID + generate private key → paste both into repo secrets. Full recipe in the workflow file header.

  Chose an App over a PAT so: (a) no human account is tied to the automation, (b) tokens are short-lived and org-scoped, (c) the refresh PRs will actually trigger CI (App-authored PRs do; GITHUB_TOKEN-authored PRs don't).

- The global fallback resolves to `* @rogeriochaves @drewdrewthis` (top two repo-wide). Adjustable in the generator.
- Owner eligibility is org membership, but CODEOWNERS only auto-requests owners with repo *write* access — for this org-owned repo those line up, but it's membership, not access, that the generator checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated weekly refresh for repository ownership mappings.
  * Generated ownership rules now cover major repo areas more comprehensively, helping route changes to the right reviewers.

* **Chores**
  * Added automation to regenerate and update ownership definitions when changes are detected.
  * The refresh process can also be triggered manually when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->