### PR TITLE
feat(charts): harden pods for strict admission policies (seccomp, automount, resources)

### DIFF
--- a/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
+++ b/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
@@ -28,6 +28,8 @@ spec:
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: full-backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -38,6 +40,8 @@ spec:
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"
@@ -80,6 +84,8 @@ spec:
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: incremental-backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -90,6 +96,8 @@ spec:
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"
@@ -130,6 +138,8 @@ spec:
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: restore-data
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -140,6 +150,8 @@ spec:
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"

--- a/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
@@ -32,6 +32,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         fsGroup: 101  # clickhouse group
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 30
 
       {{- with .Values.scheduling.nodeSelector }}
@@ -97,6 +99,12 @@ spec:
           securityContext:
             runAsUser: 65534
             runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            # Only writes to the mounted keeper-config emptyDir, so a
+            # read-only root filesystem is safe here.
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           resources:
             requests: { cpu: 10m, memory: 16Mi }
             limits: { cpu: 100m, memory: 64Mi }
@@ -117,7 +125,11 @@ spec:
           securityContext:
             runAsUser: 101  # clickhouse user
             runAsNonRoot: true
+            # Keeper needs a writable /var/lib/clickhouse-keeper outside the PVC.
             readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           resources:
             {{- toYaml .Values.keeper.resources | nindent 12 }}
           livenessProbe:

--- a/charts/clickhouse-serverless/templates/preflight-secrets-job.yaml
+++ b/charts/clickhouse-serverless/templates/preflight-secrets-job.yaml
@@ -107,10 +107,22 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ $fullname }}-preflight
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: preflight
           image: {{ .Values.preflight.image }}
           imagePullPolicy: {{ .Values.preflight.imagePullPolicy }}
+          # readOnlyRootFilesystem is omitted — kubectl writes a discovery
+          # cache under $HOME and would emit warnings (or fail) on a
+          # read-only root.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -32,6 +32,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         fsGroup: 101  # clickhouse group
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 60
 
       {{- with .Values.scheduling.nodeSelector }}
@@ -77,6 +79,13 @@ spec:
         - name: clickhouse
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # readOnlyRootFilesystem is intentionally omitted — ClickHouse writes
+          # to paths outside the data PVC (e.g. /tmp, format schemas) and would
+          # crashloop under a read-only root.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: http
               containerPort: 8123

--- a/charts/clickhouse-serverless/values.yaml
+++ b/charts/clickhouse-serverless/values.yaml
@@ -35,6 +35,16 @@ backup:
   enabled: false
   database: "langwatch"
   user: "default"  # ClickHouse user for backup/restore operations
+  # Resource requests + limits for the backup/restore Job containers.
+  # Both are required by clusters that enforce a "limits and requests must
+  # be set" policy (Gatekeeper/Kyverno) — a Job without them is denied.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   full:
     schedule: "0 */12 * * *"       # every 12 hours
   incremental:

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -140,6 +140,7 @@ npx @bitnami/readme-generator-for-helm --readme ./README.md --values values.yaml
 | `global.env`                      | Deployment environment for all components.                                   | `production` |
 | `global.podSecurityContext`       | Default pod security context (applied cluster-wide unless overridden).       | `{}`         |
 | `global.containerSecurityContext` | Default container security context (applied cluster-wide unless overridden). | `{}`         |
+| `global.automountServiceAccountToken` | Mount the ServiceAccount token into first-party workload pods. Defaults to false. | `false`  |
 | `global.scheduling`               | Global scheduling defaults for all pods.                                     |              |
 | `global.scheduling.nodeSelector`  | Node selector labels for all pods.                                           | `{}`         |
 | `global.scheduling.affinity`      | Affinity rules for all pods.                                                 | `{}`         |

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -44,6 +44,8 @@ spec:
         prometheus.io/port: "{{ .Values.app.service.port }}"
         {{- end }}
     spec:
+      # The app does not call the Kubernetes API, so don't mount the SA token.
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       # Pod security context - https://kubespec.dev/v1/Pod#spec.securityContext
       {{- with (coalesce .Values.app.podSecurityContext .Values.global.podSecurityContext)}}
       securityContext:

--- a/charts/langwatch/templates/cronjobs/cronjobs.yaml
+++ b/charts/langwatch/templates/cronjobs/cronjobs.yaml
@@ -50,6 +50,9 @@ spec:
             {{- toYaml $root.Values.cronjobs.pod.annotations | nindent 8 }}
             {{- end }}
         spec:
+          # The cron pod only curls the app over HTTP; it never calls the
+          # Kubernetes API, so don't mount the SA token.
+          automountServiceAccountToken: {{ $root.Values.global.automountServiceAccountToken }}
           # Pod security context
           {{- with (coalesce $root.Values.cronjobs.podSecurityContext $root.Values.global.podSecurityContext) }}
           securityContext:

--- a/charts/langwatch/templates/langevals/deployment.yaml
+++ b/charts/langwatch/templates/langevals/deployment.yaml
@@ -40,6 +40,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      # Langevals does not call the Kubernetes API, so don't mount the SA token.
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       # Pod security context - https://kubespec.dev/v1/Pod#spec.securityContext
       {{- with (coalesce .Values.langevals.podSecurityContext .Values.global.podSecurityContext)}}
       securityContext:

--- a/charts/langwatch/templates/langwatch_nlp/deployment.yaml
+++ b/charts/langwatch/templates/langwatch_nlp/deployment.yaml
@@ -40,6 +40,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      # The NLP service does not call the Kubernetes API, so don't mount the SA token.
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       # Pod security context - https://kubespec.dev/v1/Pod#spec.securityContext
       {{- with (coalesce .Values.langwatch_nlp.podSecurityContext .Values.global.podSecurityContext)}}
       securityContext:

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -21,11 +21,15 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: postgresql
     spec:
+      # PostgreSQL does not call the Kubernetes API, so don't mount the SA token.
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 30
       containers:
         - name: postgresql

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -22,11 +22,15 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: redis
     spec:
+      # Redis does not call the Kubernetes API, so don't mount the SA token.
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       securityContext:
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 30
       containers:
         - name: redis

--- a/charts/langwatch/templates/workers/deployment.yaml
+++ b/charts/langwatch/templates/workers/deployment.yaml
@@ -42,6 +42,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      # Workers do not call the Kubernetes API, so don't mount the SA token.
+      automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
       {{- with (coalesce .Values.workers.podSecurityContext .Values.global.podSecurityContext)}}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -16,10 +16,16 @@ global:
   ## @param global.env [string, default: production] Deployment environment for all components.
   env: production
   ## @param global.podSecurityContext [object] Default pod security context (applied cluster-wide unless overridden).
+  # seccompProfile: RuntimeDefault is required by Pod Security Admission
+  # "restricted" and by most corporate Gatekeeper/Kyverno policies, which
+  # VALIDATE (not mutate) its presence and deny pods without it. Set at the
+  # pod level so it covers every container, including init containers.
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 1000
     fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
   ## @param global.containerSecurityContext [object] Default container security context (applied cluster-wide unless overridden).
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -27,6 +33,8 @@ global:
       drop:
         - ALL
     readOnlyRootFilesystem: true
+  ## @param global.automountServiceAccountToken [default: false] Mount the ServiceAccount token into first-party workload pods (app, workers, nlp, langevals, cronjobs, postgresql, redis). Defaults to false — none of these call the Kubernetes API, and many clusters deny pods that automount the token. Set true only if a sidecar needs in-cluster API access.
+  automountServiceAccountToken: false
   ## @extra global.scheduling Global scheduling defaults for all pods.
   ## @param global.scheduling.nodeSelector [object] Node selector labels for all pods.
   ## @param global.scheduling.affinity [object] Affinity rules for all pods.


### PR DESCRIPTION
## Why

A self-hosted customer running on Azure AKS with a strict admission-policy stack (Gatekeeper/Kyverno-style, equivalent to Pod Security Admission `restricted`) couldn't install the chart - several enforced policies denied the pods.

The first-party LangWatch services were already in good shape (run non-root, drop all caps, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `emptyDir`s for every writable path, no `hostPath`/`hostNetwork`/`privileged`, no ClusterRoles, ClusterIP-only, no wildcard ingress). The blockers were two cross-cutting gaps plus the bundled datastores, which have hardcoded, less-hardened security contexts.

This PR closes those gaps so the chart passes strict admission out of the box, while staying fully compatible with the recommended "bring-your-own-managed-infra" path (`*.chartManaged: false`).

## What changed

**Umbrella chart (`charts/langwatch`)**
- `global.podSecurityContext`: add `seccompProfile: { type: RuntimeDefault }`. These clusters *validate* (don't mutate) its presence and deny pods without it. It flows to app / workers / nlp / langevals / cronjobs / preflight via the existing `coalesce` chain, and being pod-level it also covers init containers.
- New `global.automountServiceAccountToken` (default `false`). None of the first-party services call the Kubernetes API, so the SA token shouldn't be mounted. Wired into the app, workers, nlp, langevals and cronjob pod specs.
- `postgresql` / `redis` statefulsets: add `seccompProfile` + `automountServiceAccountToken: false`. (`readOnlyRootFilesystem` intentionally left off - these write outside their data volumes.)

**`clickhouse-serverless` subchart**
- `seccompProfile: RuntimeDefault` on every pod (statefulset, keeper, backup CronJobs, preflight).
- `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` on the clickhouse, keeper, keeper-init and preflight containers (keeper keeps `readOnlyRootFilesystem: false`; keeper-init can use `true` since it only writes to a mounted `emptyDir`).
- `resources` (requests + limits) on the backup/restore Job containers via a new `backup.resources` value - they previously had none, which the "limits and requests required" policy denies.

No version bumps (release-please owns those) and no changes to the gateway subchart (already compliant).

## Policies addressed (all previously *enforced* on the customer's cluster)
Seccomp · Automount service-account token · Required Resources · Privileged / Allow-Privilege-Escalation · Read-only root filesystem (where compatible).

Already compliant by default and unchanged: NodePort/LoadBalancer ban, wildcard ingress, anonymous access, endpoint-slice role, host namespaces, hostPath/Volume types, default-namespace placement.

## Deployment Impact

Affects self-hosted Helm deployments only (SaaS/cloud is unaffected). On `helm upgrade` of an existing release, the new pod-template fields (`seccompProfile`, `automountServiceAccountToken: false`) change the pod spec and therefore trigger a rolling restart of the app, workers, nlp, langevals, postgresql and redis pods. The two bundled single-replica datastores (postgresql, redis) restart in place, so expect a short blip if you run the chart-managed databases rather than external/managed ones.

Behaviour change worth knowing: the ServiceAccount token is no longer mounted into first-party pods by default. None of the LangWatch services use it, but if you run a custom sidecar that needs in-cluster API access, set `global.automountServiceAccountToken: true`.

New values, all additive with safe defaults (no action required on existing installs): `global.automountServiceAccountToken` and `clickhouse-serverless` `backup.resources`. No secret, CRD, RBAC, or data-migration changes.

## Test plan
`helm lint` + `helm template` pass on both charts across **default**, **`clickhouse.replicas=3`** (Keeper), and **external-infra** (`postgresql`/`redis`/`clickhouse`/`prometheus` = `chartManaged: false`) modes. Rendered output verified to carry `seccompProfile`, `automountServiceAccountToken: false`, and the new backup `resources`; full manifest parses as valid YAML.

## Anything surprising?
The cleanest path for a locked-down environment (e.g. a bank) is still to externalise the datastores (managed Postgres/Redis/ClickHouse) and disable Prometheus + preflight - that removes every remaining hardcoded pod. These changes make the in-cluster defaults pass strict admission too, so both paths now work.