### PR TITLE
fix(cli): repoint langwatch login to cloud when picked, add --project flag

### DIFF
--- a/docs/integration/cli.mdx
+++ b/docs/integration/cli.mdx
@@ -102,10 +102,11 @@ When stdin is not a TTY (genuine CI or an agent's piped stdin), `langwatch login
 
 ### Letting an agent do it
 
-A coding assistant driving `langwatch` will see the always-on banner naming `--device`, `--api-key`, `--token`, `--endpoint` whenever the interactive prompt fires. If the assistant's harness reports as a TTY but can't actually answer prompts, the banner gives it everything it needs to re-invoke:
+A coding assistant driving `langwatch` will see the always-on banner naming `--device`, `--project`, `--api-key`, `--token`, `--endpoint` whenever the interactive prompt fires. If the assistant's harness reports as a TTY but can't actually answer prompts, the banner gives it everything it needs to re-invoke:
 
 ```bash
 langwatch login --device                # AI tools mode (recommended for assistants)
+langwatch login --project               # project SDK key into .env via the browser
 langwatch login --api-key sk-lw-...     # if a project key was injected from secrets
 langwatch login --token lwc_...         # if a device session token was pre-minted
 langwatch login --endpoint https://...  # combine with any of the above for self-hosted

--- a/docs/integration/cli.mdx
+++ b/docs/integration/cli.mdx
@@ -34,7 +34,7 @@ langwatch login
 
 You'll see two questions:
 
-1. **Where do you want to log in?**: LangWatch Cloud (`app.langwatch.ai`) or a self-hosted instance (custom URL).
+1. **Where do you want to log in?**: LangWatch Cloud (`app.langwatch.ai`) or a self-hosted instance (custom URL). LangWatch Cloud is the default, and picking it always repoints to `app.langwatch.ai`, even when you previously logged into a local or self-hosted endpoint. If you already have a non-cloud endpoint configured (through `LANGWATCH_ENDPOINT` or a prior login), the picker instead defaults to keeping that endpoint and adds a "different endpoint" option, with LangWatch Cloud still one keystroke away.
 2. **How do you want to use it?**: three options:
    - **AI tools, agentic flows**: `claude`, `codex`, `cursor`, `gemini`, `opencode`. Mints an OAuth-style device session in `~/.langwatch/config.json` (user-scoped) so `langwatch claude` etc. wrap any tool through your gateway.
    - **Project, SDK API key**: for `langwatch sync`, `langwatch eval`, and SDK auto-instrumentation. Mints a fresh project API key into `$CWD/.env` (project-scoped).
@@ -91,13 +91,14 @@ When you're driving the CLI from automation and already have a credential, skip 
 | Flag | Use case | Where it lands |
 |---|---|---|
 | `langwatch login --device` | AI tools mode, skip Q1/Q2 prompts | `~/.langwatch/config.json` |
+| `langwatch login --project` | Project SDK mode via browser, skip Q1/Q2 prompts; mints a fresh project key | `$CWD/.env` |
 | `langwatch login --api-key <KEY>` | CI pipeline that has `LANGWATCH_API_KEY` injected from secrets | `$CWD/.env` |
 | `langwatch login --token <TOKEN>` | Agent harness with a pre-minted device session token (issued via dashboard "Personal Access Tokens") | `~/.langwatch/config.json` |
 | `langwatch login --endpoint <URL>` | combine with any of the above to pin a self-hosted instance | persisted to config |
 
 The interactive `langwatch login` always shows these flags in a banner above the prompts, so a fake-TTY agent (`Claude Code`, certain Gemini CLI sandboxes) can detect the prompt and re-invoke with the right flag instead of getting stuck.
 
-When stdin is not a TTY (genuine CI), `langwatch login` with no flags errors out with the same flag list, explicit > implicit, no surprise API-key fall-throughs.
+When stdin is not a TTY (genuine CI or an agent's piped stdin), `langwatch login` with no flags defaults to **project login** (the same as `--project`): it mints a project key into `$CWD/.env`, which is what the SDK, `langwatch eval`, and `langwatch prompt` expect. AI-tools login stays explicit behind `--device`.
 
 ### Letting an agent do it
 

--- a/docs/integration/cli.mdx
+++ b/docs/integration/cli.mdx
@@ -34,7 +34,7 @@ langwatch login
 
 You'll see two questions:
 
-1. **Where do you want to log in?**: LangWatch Cloud (`app.langwatch.ai`) or a self-hosted instance (custom URL). LangWatch Cloud is the default, and picking it always repoints to `app.langwatch.ai`, even when you previously logged into a local or self-hosted endpoint. If you already have a non-cloud endpoint configured (through `LANGWATCH_ENDPOINT` or a prior login), the picker instead defaults to keeping that endpoint and adds a "different endpoint" option, with LangWatch Cloud still one keystroke away.
+1. **Where do you want to log in?**: LangWatch Cloud (`app.langwatch.ai`) or a self-hosted instance (custom URL).
 2. **How do you want to use it?**: three options:
    - **AI tools, agentic flows**: `claude`, `codex`, `cursor`, `gemini`, `opencode`. Mints an OAuth-style device session in `~/.langwatch/config.json` (user-scoped) so `langwatch claude` etc. wrap any tool through your gateway.
    - **Project, SDK API key**: for `langwatch sync`, `langwatch eval`, and SDK auto-instrumentation. Mints a fresh project API key into `$CWD/.env` (project-scoped).

--- a/specs/ai-governance/cli-onboarding/login-unified.feature
+++ b/specs/ai-governance/cli-onboarding/login-unified.feature
@@ -144,7 +144,7 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
     And on selecting (3) it runs both flows in sequence
 
   @bdd @cli @login @endpoint @cloud-repoint @regression
-  Scenario: selecting "LangWatch Cloud" repoints away from a previously-local endpoint
+  Scenario: picking LangWatch Cloud repoints away from a previously-local endpoint
     Given the user has `control_plane_url = http://localhost:5560` persisted
       (or `LANGWATCH_ENDPOINT=http://localhost:5560` exported) from local dev
     And the user is in an interactive terminal

--- a/specs/ai-governance/cli-onboarding/login-unified.feature
+++ b/specs/ai-governance/cli-onboarding/login-unified.feature
@@ -120,13 +120,17 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
       not optional:
       "Running interactively. To skip these prompts (CI / agents that already have a credential):
          --device         AI tools / SSO (claude, codex, gemini, opencode)
-         --api-key <K>    project SDK key into .env (SDK, evals, prompts)
+         --project        project SDK key into .env via browser (SDK, evals, prompts)
+         --api-key <K>    project SDK key you already have, into .env
          --token <T>      pre-minted device session
          --endpoint <U>   self-hosted instance URL"
-    And the CLI prompts:
+    And the CLI prompts, with LangWatch Cloud as the default (option 1) because most
+      first-time logins target the SaaS:
       "Where do you want to log in?
         1) LangWatch Cloud (app.langwatch.ai)
         2) Self-hosted instance (custom URL)"
+    And on selecting (1) the CLI ALWAYS targets `https://app.langwatch.ai`, even if a
+      local endpoint was previously persisted or `LANGWATCH_ENDPOINT` is exported
     And on selecting (2) the CLI prompts for the URL and validates http(s) scheme
     And the CLI then prompts, with AI tools as the default (option 1) since a
       human running this interactively most likely wants to track their own
@@ -139,13 +143,61 @@ Feature: Unified `langwatch login` UX — endpoint + auth-mode + storage discipl
     And on selecting (2) it runs the project API-key device-code flow → `$CWD/.env`
     And on selecting (3) it runs both flows in sequence
 
+  @bdd @cli @login @endpoint @cloud-repoint @regression
+  Scenario: selecting "LangWatch Cloud" repoints away from a previously-local endpoint
+    Given the user has `control_plane_url = http://localhost:5560` persisted
+      (or `LANGWATCH_ENDPOINT=http://localhost:5560` exported) from local dev
+    And the user is in an interactive terminal
+    When the user runs `langwatch login` and selects "LangWatch Cloud"
+    Then the persisted config records `control_plane_url = https://app.langwatch.ai`
+    And the chosen auth flow (device session or project key) targets
+      `https://app.langwatch.ai`, NOT `http://localhost:5560`
+    # Rationale: choosing "Cloud" was a no-op that left the stale local
+    # control_plane_url in place, so the device flow dialled localhost:5560 and
+    # failed with ECONNREFUSED. "Cloud" must always repoint to app.langwatch.ai.
+
+  @bdd @cli @login @endpoint @context-aware
+  Scenario: the Where picker reorders when a non-cloud endpoint is already configured
+    Given the user already has a resolved endpoint that is NOT `https://app.langwatch.ai`
+      (e.g. `http://localhost:5560` from `LANGWATCH_ENDPOINT` or persisted config)
+    And the user is in an interactive terminal
+    When the user runs `langwatch login` with no flags
+    Then the "Where do you want to log in?" picker lists, in this order with the
+      current endpoint pre-selected (default):
+      "1) Self-hosted instance (http://localhost:5560)   ← current, default
+       2) Self-hosted instance (different endpoint)
+       3) LangWatch Cloud (app.langwatch.ai)"
+    And selecting (1) keeps `control_plane_url = http://localhost:5560`
+    And selecting (2) prompts for a new URL (validated http(s)) and persists it
+    And selecting (3) repoints `control_plane_url` to `https://app.langwatch.ai`
+    # Cloud stays the priority default for fresh installs; only when the user
+    # already has a custom endpoint do we default to keeping it (and still let
+    # them switch endpoint or jump to Cloud).
+
+  @bdd @cli @login @project @flag
+  Scenario: `langwatch login --project` forces project login, symmetric to `--device`
+    Given the user is in an interactive terminal
+    When the user runs `langwatch login --project`
+    Then the CLI runs the project API-key device-code flow directly → `$CWD/.env`
+    And it does NOT start the AI-tools / device-session flow
+    And no "Where do you want to log in?" or "How do you want to use it?" prompt fires
+    And the endpoint resolves via the 4-source resolver (default → app.langwatch.ai)
+
+  @bdd @cli @login @project @non-tty
+  Scenario: `--project` is the implicit default in a non-TTY context
+    Given the user is in a non-interactive context (CI, agent stdin, piped)
+    When the user runs `langwatch login` with no flags
+    Then the behavior is identical to `langwatch login --project`
+    And the CLI prints that project login is the default and names BOTH escape
+      hatches: `--device` for AI tools and `--project` to force project login
+
   @bdd @cli @login @agent-aware @fake-tty
   Scenario: agent-hint banner is shown EVEN when stdin reports as TTY (fake-TTY agents)
     Given the agent harness exposes a fake PTY where `process.stdin.isTTY === true`
       but no human is present at the keyboard
     When the agent invokes `langwatch login` with no flags expecting non-blocking behavior
     Then the agent-hint banner is the FIRST output stream the agent sees
-    And the banner explicitly names `--device`, `--api-key`, `--token`, `--endpoint`
+    And the banner explicitly names `--device`, `--project`, `--api-key`, `--token`, `--endpoint`
       so the agent can self-correct by re-invoking with the right flag
     And the human-facing prompt is rendered AFTER the banner so a real human still
       sees it correctly

--- a/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
@@ -11,6 +11,16 @@ vi.mock("@/cli/utils/governance/login-flow", () => ({
   runDeviceFlowLogin: (...args: unknown[]) => runDeviceFlowLogin(...args),
 }));
 
+// `prompts` is the interactive UI boundary. We drive it with queued answers
+// per test and inspect the choices it was handed (ordering / labels).
+const promptsMock = vi.fn();
+vi.mock("prompts", () => ({
+  default: (...args: unknown[]) => promptsMock(...args),
+}));
+
+// loadConfig is the persisted ~/.langwatch/config.json. We vary
+// control_plane_url to simulate a fresh (cloud) install vs an existing local
+// endpoint. The real resolveControlPlaneEndpoint reads this mock.
 const loadConfig = vi.fn(() => ({
   control_plane_url: "https://app.langwatch.ai",
 }));
@@ -22,14 +32,24 @@ vi.mock("@/cli/utils/governance/config", () => ({
 
 import { loginCommand } from "../login";
 
+class ProcessExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
 describe("loginCommand", () => {
   const originalIsTTY = process.stdin.isTTY;
   const originalEndpoint = process.env.LANGWATCH_ENDPOINT;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    loadConfig.mockReturnValue({ control_plane_url: "https://app.langwatch.ai" });
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new ProcessExitError(code as number);
+    });
     delete process.env.LANGWATCH_ENDPOINT;
   });
 
@@ -63,13 +83,14 @@ describe("loginCommand", () => {
         expect(runDeviceFlowLogin).not.toHaveBeenCalled();
       });
 
-      it("prints the project-login default and the --device escape hatch", async () => {
+      it("prints the project-login default and names both escape hatches", async () => {
         const logSpy = console.log as unknown as ReturnType<typeof vi.fn>;
         await loginCommand({});
 
         const printed = logSpy.mock.calls.flat().join("\n");
         expect(printed).toContain("project login");
         expect(printed).toContain("--device");
+        expect(printed).toContain("--project");
       });
     });
   });
@@ -83,6 +104,146 @@ describe("loginCommand", () => {
 
         expect(runDeviceFlowLogin).toHaveBeenCalledTimes(1);
         expect(runUnifiedLoginFlow).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given the --project flag", () => {
+    describe("when the command is invoked with --project on a TTY", () => {
+      beforeEach(() => setTTY(true));
+
+      it("runs the project API-key flow directly with no prompts", async () => {
+        await loginCommand({ project: true });
+
+        expect(runUnifiedLoginFlow).toHaveBeenCalledTimes(1);
+        expect(runUnifiedLoginFlow).toHaveBeenCalledWith(
+          expect.objectContaining({ kind: "project_api_key" }),
+        );
+        expect(runDeviceFlowLogin).not.toHaveBeenCalled();
+        expect(promptsMock).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given an interactive TTY and a fresh (cloud) config", () => {
+    beforeEach(() => {
+      setTTY(true);
+      loadConfig.mockReturnValue({
+        control_plane_url: "https://app.langwatch.ai",
+      });
+    });
+
+    describe("when the user opens the 'Where do you want to log in?' picker", () => {
+      it("lists LangWatch Cloud first", async () => {
+        promptsMock
+          .mockResolvedValueOnce({ where: "cloud" })
+          .mockResolvedValueOnce({ mode: "device" });
+
+        await loginCommand({});
+
+        const firstCall = promptsMock.mock.calls[0]![0] as {
+          choices: Array<{ value: string }>;
+        };
+        expect(firstCall.choices.map((c) => c.value)).toEqual([
+          "cloud",
+          "self-hosted",
+        ]);
+      });
+    });
+
+    describe("when the user selects LangWatch Cloud", () => {
+      it("persists app.langwatch.ai", async () => {
+        promptsMock
+          .mockResolvedValueOnce({ where: "cloud" })
+          .mockResolvedValueOnce({ mode: "device" });
+
+        await loginCommand({});
+
+        expect(saveConfig).toHaveBeenCalledWith(
+          expect.objectContaining({
+            control_plane_url: "https://app.langwatch.ai",
+          }),
+        );
+      });
+    });
+  });
+
+  describe("given an interactive TTY and an existing local endpoint", () => {
+    beforeEach(() => {
+      setTTY(true);
+      loadConfig.mockReturnValue({
+        control_plane_url: "http://localhost:5560",
+      });
+    });
+
+    describe("when the user opens the picker", () => {
+      it("defaults to keeping the current endpoint and lists Cloud last", async () => {
+        promptsMock
+          .mockResolvedValueOnce({ where: "keep" })
+          .mockResolvedValueOnce({ mode: "device" });
+
+        await loginCommand({});
+
+        const call = promptsMock.mock.calls[0]![0] as {
+          choices: Array<{ value: string; title: string }>;
+          initial?: number;
+        };
+        expect(call.choices.map((c) => c.value)).toEqual([
+          "keep",
+          "self-hosted",
+          "cloud",
+        ]);
+        expect(call.choices[0]!.title).toContain("http://localhost:5560");
+        expect(call.initial).toBe(0);
+      });
+    });
+
+    describe("when the user keeps the current endpoint", () => {
+      it("persists the local endpoint unchanged", async () => {
+        promptsMock
+          .mockResolvedValueOnce({ where: "keep" })
+          .mockResolvedValueOnce({ mode: "device" });
+
+        await loginCommand({});
+
+        expect(saveConfig).toHaveBeenCalledWith(
+          expect.objectContaining({
+            control_plane_url: "http://localhost:5560",
+          }),
+        );
+      });
+    });
+
+    describe("when the user picks LangWatch Cloud despite the local endpoint", () => {
+      it("repoints the persisted endpoint to app.langwatch.ai", async () => {
+        promptsMock
+          .mockResolvedValueOnce({ where: "cloud" })
+          .mockResolvedValueOnce({ mode: "device" });
+
+        await loginCommand({});
+
+        expect(saveConfig).toHaveBeenCalledWith(
+          expect.objectContaining({
+            control_plane_url: "https://app.langwatch.ai",
+          }),
+        );
+      });
+    });
+
+    describe("when the user picks a different self-hosted endpoint", () => {
+      it("persists the newly entered URL with trailing slash stripped", async () => {
+        promptsMock
+          .mockResolvedValueOnce({ where: "self-hosted" })
+          .mockResolvedValueOnce({ url: "https://lw.acme.internal/" })
+          .mockResolvedValueOnce({ mode: "device" });
+
+        await loginCommand({});
+
+        expect(saveConfig).toHaveBeenCalledWith(
+          expect.objectContaining({
+            control_plane_url: "https://lw.acme.internal",
+          }),
+        );
       });
     });
   });

--- a/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
+++ b/typescript-sdk/src/cli/commands/__tests__/login.unit.test.ts
@@ -215,6 +215,7 @@ describe("loginCommand", () => {
     });
 
     describe("when the user picks LangWatch Cloud despite the local endpoint", () => {
+      /** @scenario "picking LangWatch Cloud repoints away from a previously-local endpoint" */
       it("repoints the persisted endpoint to app.langwatch.ai", async () => {
         promptsMock
           .mockResolvedValueOnce({ where: "cloud" })

--- a/typescript-sdk/src/cli/commands/login.ts
+++ b/typescript-sdk/src/cli/commands/login.ts
@@ -11,6 +11,8 @@ import {
   loadConfig,
   saveConfig,
 } from "@/cli/utils/governance/config";
+import { resolveControlPlaneEndpoint } from "@/cli/utils/governance/resolveEndpoint";
+import { DEFAULT_ENDPOINT } from "@/internal/constants";
 
 /**
  * Always-on agent-hint banner shown above the interactive prompts on
@@ -34,7 +36,12 @@ function printAgentHintBanner(): void {
   );
   console.log(
     chalk.gray(
-      "  --api-key <KEY>            project SDK key into .env (SDK, evals, prompts)",
+      "  --project                  project SDK key into .env via browser (SDK, evals, prompts)",
+    ),
+  );
+  console.log(
+    chalk.gray(
+      "  --api-key <KEY>            project SDK key you already have, into .env",
     ),
   );
   console.log(
@@ -93,6 +100,7 @@ export const loginCommand = async (
   options?: {
     apiKey?: string;
     device?: boolean;
+    project?: boolean;
     browser?: string;
     endpoint?: string;
     token?: string;
@@ -148,6 +156,20 @@ export const loginCommand = async (
       return;
     }
 
+    // --project: force PROJECT login (mint a project SDK key via the browser,
+    // write it to $CWD/.env). Symmetric to --device, and the explicit form of
+    // what a non-TTY context already defaults to. Use this when you want a
+    // real project's key for the SDK / `langwatch eval` / prompts rather than
+    // a personal device session. No "where"/"how" prompts; the project is
+    // picked in the browser.
+    if (options?.project) {
+      await runUnifiedLoginFlow({
+        kind: "project_api_key",
+        browser: options.browser,
+      });
+      return;
+    }
+
     // Non-interactive mode: --api-key flag provided
     if (options?.apiKey) {
       const apiKey = options.apiKey.trim();
@@ -178,7 +200,7 @@ export const loginCommand = async (
     if (!process.stdin.isTTY) {
       console.log(
         chalk.gray(
-          "No login mode given. Defaulting to project login (writes LANGWATCH_API_KEY to .env).",
+          "No login mode given. Defaulting to project login (writes LANGWATCH_API_KEY to .env). Force it with --project.",
         ),
       );
       console.log(
@@ -203,30 +225,70 @@ export const loginCommand = async (
     console.log();
 
     // Q1 — endpoint (cloud vs self-hosted). Skipped if --endpoint was
-    // passed (already persisted above). On 'self-hosted' the entered
-    // URL is persisted to ~/.langwatch/config.json so subsequent
-    // `runUnifiedLoginFlow` calls (and every CLI command's resolver
-    // read) target the right host.
+    // passed (already persisted above). The chosen endpoint is persisted to
+    // ~/.langwatch/config.json on EVERY branch so the subsequent
+    // `runUnifiedLoginFlow`/`runDeviceFlowLogin` call (which reads
+    // control_plane_url directly) and every later CLI command's resolver read
+    // target the right host with no env-vs-config ambiguity.
     if (!options?.endpoint) {
+      // When the user already resolved a non-cloud endpoint (local dev or a
+      // self-hosted deployment via LANGWATCH_ENDPOINT or persisted config),
+      // default to keeping it but still offer to switch endpoint or jump to
+      // Cloud. On a fresh install Cloud stays the priority default.
+      const current = resolveControlPlaneEndpoint();
+      const hasCustomEndpoint = current.url !== DEFAULT_ENDPOINT;
+
+      const cloudChoice = {
+        title: "LangWatch Cloud",
+        description: "app.langwatch.ai",
+        value: "cloud",
+      };
+      const choices = hasCustomEndpoint
+        ? [
+            {
+              title: `Self-hosted instance (${current.url})`,
+              description: "Keep using your current endpoint",
+              value: "keep",
+            },
+            {
+              title: "Self-hosted instance (different endpoint)",
+              description: "Point at another LangWatch deployment",
+              value: "self-hosted",
+            },
+            cloudChoice,
+          ]
+        : [
+            cloudChoice,
+            {
+              title: "Self-hosted instance",
+              description: "Your company's LangWatch deployment (custom URL)",
+              value: "self-hosted",
+            },
+          ];
+
       const where = await prompts({
         type: "select",
         name: "where",
         message: "Where do you want to log in?",
-        choices: [
-          {
-            title: "LangWatch Cloud",
-            description: "app.langwatch.ai (default)",
-            value: "cloud",
-          },
-          {
-            title: "Self-hosted instance",
-            description: "Custom URL — your company's LangWatch deployment",
-            value: "self-hosted",
-          },
-        ],
+        choices,
         initial: 0,
       });
-      if (where.where === "self-hosted") {
+      if (!where.where) {
+        console.log(chalk.yellow("Login cancelled"));
+        process.exit(0);
+      }
+
+      const cfg = loadConfig();
+      if (where.where === "cloud") {
+        // Always repoint to cloud, overriding any stale local control_plane_url.
+        // Otherwise the device flow would dial the old localhost host and fail
+        // with ECONNREFUSED.
+        cfg.control_plane_url = DEFAULT_ENDPOINT;
+        saveConfig(cfg);
+      } else if (where.where === "keep") {
+        cfg.control_plane_url = current.url;
+        saveConfig(cfg);
+      } else if (where.where === "self-hosted") {
         const url = await prompts({
           type: "text",
           name: "url",
@@ -247,7 +309,6 @@ export const loginCommand = async (
           console.log(chalk.yellow("Login cancelled"));
           process.exit(0);
         }
-        const cfg = loadConfig();
         cfg.control_plane_url = (url.url as string).replace(/\/+$/, "");
         saveConfig(cfg);
       }

--- a/typescript-sdk/src/cli/index.ts
+++ b/typescript-sdk/src/cli/index.ts
@@ -132,13 +132,17 @@ program
 const loginCmd = program
   .command("login")
   .description(
-    "Login to LangWatch. With no flags, asks where (cloud vs self-hosted) and how (AI tools vs project SDK). For CI/agents pass --device, --api-key, or --token to skip prompts.",
+    "Login to LangWatch. With no flags, asks where (cloud vs self-hosted) and how (AI tools vs project SDK). For CI/agents pass --device, --project, --api-key, or --token to skip prompts.",
   )
   .option("--api-key <key>", "Set API key non-interactively (CI/agents that already have a project API key) — writes to .env")
   .option("--endpoint <url>", "Override the LangWatch control-plane URL for this login (self-hosted instances)")
   .option(
     "--device",
     "RFC 8628 device-flow login via your company SSO; provisions a personal virtual key for Claude Code / Codex / Cursor / Gemini CLI",
+  )
+  .option(
+    "--project",
+    "Force project login: mint a project SDK key via the browser and write it to .env (for the SDK, `langwatch eval`, prompts). The implicit default in non-TTY contexts.",
   )
   .option(
     "--token <token>",
@@ -149,7 +153,7 @@ const loginCmd = program
     "browser to open for device-flow approval (chrome|chromium|firefox|safari|none|<path>)",
   );
 
-loginCmd.action(async (options: { apiKey?: string; device?: boolean; browser?: string; endpoint?: string; token?: string }) => {
+loginCmd.action(async (options: { apiKey?: string; device?: boolean; project?: boolean; browser?: string; endpoint?: string; token?: string }) => {
   try {
     await loginCommand(options);
   } catch (error) {


### PR DESCRIPTION
## What

Two fixes to `langwatch login`.

**1. Picking "LangWatch Cloud" now actually points at the cloud.** The interactive picker only persisted an endpoint when you chose *self-hosted*. Choosing Cloud was a no-op, so a stale `control_plane_url` (or an exported `LANGWATCH_ENDPOINT`) from local dev survived and the device flow dialed `localhost:5560`, failing with `fetch failed (ECONNREFUSED)`. Cloud now always repoints to `https://app.langwatch.ai`.

**2. The picker is context-aware.** On a fresh install Cloud stays the default. If you already have a non-cloud endpoint configured (local dev or self-hosted, via `LANGWATCH_ENDPOINT` or a prior login), the picker defaults to keeping it and adds a "different endpoint" option, with Cloud still one keystroke away.

**3. New `--project` flag.** Symmetric to `--device`: it forces the project SDK-key browser flow and writes the key to `.env`. It is also the explicit form of what a non-TTY context already defaults to. Before this there was `--device` to force personal login, but no flag to force project login.

## Why

A user running local dev (`LANGWATCH_ENDPOINT=http://localhost:5560`) ran `langwatch login`, picked "LangWatch Cloud", and still got `ECONNREFUSED` against localhost. Picking Cloud should mean Cloud.

## Behaviour

| Context | "Where do you want to log in?" picker | Picking Cloud |
|---|---|---|
| Fresh install | `Cloud (default)`, `Self-hosted` | targets `app.langwatch.ai` |
| Endpoint already set (e.g. `localhost:5560`) | `Keep current (default)`, `Different endpoint`, `Cloud` | repoints to `app.langwatch.ai` |

| Flag | Effect | Lands in |
|---|---|---|
| `--device` | force AI-tools device session (personal) | `~/.langwatch/config.json` |
| `--project` (new) | force project SDK key via browser | `$CWD/.env` |
| non-TTY, no flags | defaults to `--project` | `$CWD/.env` |

## Tests

`typescript-sdk/.../login.unit.test.ts` drives the real `prompts` selections against a temp config and asserts:

- the persisted `control_plane_url` for each branch (cloud repoint, keep-current, new endpoint),
- the choice ordering and default per context (fresh vs existing endpoint),
- `--project` routes to the project flow with no prompts, and `--device` stays personal.

10/10 green. Typecheck, lint, and build all clean.

## QA

Dogfooded against the real built binary, reaching real prod cloud (browser approval not completed, that ceremony is unchanged by this PR). See screenshots below.

**Local endpoint set, pick Cloud: repoints and reaches cloud (the bug, fixed).** With `LANGWATCH_ENDPOINT=http://localhost:5560`, the picker reorders to keep localhost as the default and lists Cloud last. Picking Cloud announces `Control plane: https://app.langwatch.ai` and actually reaches cloud, no localhost `ECONNREFUSED`.

![reordered picker](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4929/login/picker-reordered.png)

![cloud repoint](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4929/login/cloud-repoint.png)

**Fresh install keeps Cloud first, and `--project` skips the prompts.**

![fresh picker and --project](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4929/login/fresh-and-project.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `--project` flag to `langwatch login` to trigger project authentication directly for CI/automation, including a non-TTY default that matches this mode.
  * Updated the login agent-hint and interactive flow to surface `--project` and improve the endpoint picker.

* **Bug Fixes**
  * Ensured selecting **LangWatch Cloud** reliably switches auth to `https://app.langwatch.ai`, overriding any previously configured local endpoint.

* **Documentation**
  * Refined CLI login docs for automation/self-hosted usage, including the updated flag set and examples.

* **Tests**
  * Expanded unit and feature coverage for the new login modes and endpoint-switching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->