### PR TITLE
perf(clickhouse): guard empty aggregateId from event_log reads

### DIFF
--- a/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.emptyAggregateGuard.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.emptyAggregateGuard.unit.test.ts
@@ -36,62 +36,68 @@ describe("EventStoreClickHouse - empty aggregateId guard", () => {
     createdAt: 1000,
   } as unknown as Event;
 
-  describe("given an empty aggregateId", () => {
-    it("getEvents returns no events without touching ClickHouse", async () => {
-      const events = await store.getEvents("", { tenantId }, aggregateType);
+  describe.each([
+    { label: "an empty aggregateId", aggregateId: "" },
+    { label: "a whitespace-only aggregateId", aggregateId: "   " },
+  ])("given $label", ({ aggregateId }) => {
+    describe("when getEvents is called", () => {
+      it("returns no events without touching ClickHouse", async () => {
+        const events = await store.getEvents(
+          aggregateId,
+          { tenantId },
+          aggregateType,
+        );
 
-      expect(events).toEqual([]);
-      expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+        expect(events).toEqual([]);
+        expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+      });
     });
 
-    it("getEventsUpTo returns no events without touching ClickHouse", async () => {
-      const events = await store.getEventsUpTo(
-        "",
-        { tenantId },
-        aggregateType,
-        upToEvent,
-      );
+    describe("when getEventsUpTo is called", () => {
+      it("returns no events without touching ClickHouse", async () => {
+        const events = await store.getEventsUpTo(
+          aggregateId,
+          { tenantId },
+          aggregateType,
+          upToEvent,
+        );
 
-      expect(events).toEqual([]);
-      expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+        expect(events).toEqual([]);
+        expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+      });
     });
 
-    it("countEventsBefore returns 0 without touching ClickHouse", async () => {
-      const count = await store.countEventsBefore(
-        "",
-        { tenantId },
-        aggregateType,
-        1000,
-        "event-1",
-      );
+    describe("when countEventsBefore is called", () => {
+      it("returns 0 without touching ClickHouse", async () => {
+        const count = await store.countEventsBefore(
+          aggregateId,
+          { tenantId },
+          aggregateType,
+          1000,
+          "event-1",
+        );
 
-      expect(count).toBe(0);
-      expect(mockClickHouseClient.query).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("given a whitespace-only aggregateId", () => {
-    it("getEvents still short-circuits without touching ClickHouse", async () => {
-      const events = await store.getEvents("   ", { tenantId }, aggregateType);
-
-      expect(events).toEqual([]);
-      expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+        expect(count).toBe(0);
+        expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+      });
     });
   });
 
   describe("given a real aggregateId", () => {
-    it("getEvents issues the event_log read", async () => {
-      (
-        mockClickHouseClient.query as ReturnType<typeof vi.fn>
-      ).mockResolvedValue({ json: vi.fn().mockResolvedValue([]) });
+    describe("when getEvents is called", () => {
+      it("issues the event_log read", async () => {
+        (
+          mockClickHouseClient.query as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({ json: vi.fn().mockResolvedValue([]) });
 
-      await store.getEvents("trace-123", { tenantId }, aggregateType);
+        await store.getEvents("trace-123", { tenantId }, aggregateType);
 
-      expect(mockClickHouseClient.query).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query_params: expect.objectContaining({ aggregateId: "trace-123" }),
-        }),
-      );
+        expect(mockClickHouseClient.query).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query_params: expect.objectContaining({ aggregateId: "trace-123" }),
+          }),
+        );
+      });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.emptyAggregateGuard.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/stores/__tests__/eventStoreClickHouse.emptyAggregateGuard.unit.test.ts
@@ -1,0 +1,97 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AggregateType } from "../../";
+import { createTenantId } from "../../domain/tenantId";
+import type { Event } from "../../domain/types";
+import { EventStoreClickHouse } from "../eventStoreClickHouse";
+import { EventRepositoryClickHouse } from "../repositories/eventRepositoryClickHouse";
+
+/**
+ * `event_log` is `ORDER BY (TenantId, AggregateType, AggregateId, IdempotencyKey)`.
+ * A read with `AggregateId = ''` seeks to the empty-id key range, which holds
+ * every event ever written without an aggregate id, and materialises all their
+ * `EventPayload` blobs — in prod this exceeds `max_memory_usage_per_query`
+ * (Code 241) and degrades the whole instance. No aggregate type uses an empty
+ * id, so the store must short-circuit such reads instead of issuing them.
+ */
+describe("EventStoreClickHouse - empty aggregateId guard", () => {
+  const tenantId = createTenantId("test-tenant");
+  const aggregateType: AggregateType = "trace";
+
+  let mockClickHouseClient: ClickHouseClient;
+  let store: EventStoreClickHouse;
+
+  beforeEach(() => {
+    mockClickHouseClient = {
+      query: vi.fn(),
+    } as unknown as ClickHouseClient;
+
+    store = new EventStoreClickHouse(
+      new EventRepositoryClickHouse(async () => mockClickHouseClient),
+    );
+  });
+
+  const upToEvent = {
+    id: "event-1",
+    createdAt: 1000,
+  } as unknown as Event;
+
+  describe("given an empty aggregateId", () => {
+    it("getEvents returns no events without touching ClickHouse", async () => {
+      const events = await store.getEvents("", { tenantId }, aggregateType);
+
+      expect(events).toEqual([]);
+      expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+    });
+
+    it("getEventsUpTo returns no events without touching ClickHouse", async () => {
+      const events = await store.getEventsUpTo(
+        "",
+        { tenantId },
+        aggregateType,
+        upToEvent,
+      );
+
+      expect(events).toEqual([]);
+      expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+    });
+
+    it("countEventsBefore returns 0 without touching ClickHouse", async () => {
+      const count = await store.countEventsBefore(
+        "",
+        { tenantId },
+        aggregateType,
+        1000,
+        "event-1",
+      );
+
+      expect(count).toBe(0);
+      expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a whitespace-only aggregateId", () => {
+    it("getEvents still short-circuits without touching ClickHouse", async () => {
+      const events = await store.getEvents("   ", { tenantId }, aggregateType);
+
+      expect(events).toEqual([]);
+      expect(mockClickHouseClient.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given a real aggregateId", () => {
+    it("getEvents issues the event_log read", async () => {
+      (
+        mockClickHouseClient.query as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({ json: vi.fn().mockResolvedValue([]) });
+
+      await store.getEvents("trace-123", { tenantId }, aggregateType);
+
+      expect(mockClickHouseClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query_params: expect.objectContaining({ aggregateId: "trace-123" }),
+        }),
+      );
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/stores/abstractEventStore.ts
+++ b/langwatch/src/server/event-sourcing/stores/abstractEventStore.ts
@@ -1,11 +1,11 @@
 import type { AggregateType } from "../domain/aggregateType";
 import type { Event } from "../domain/types";
+import { ValidationError } from "../services/errorHandling";
+import { EventUtils } from "../utils/event.utils";
 import type {
   EventStore as BaseEventStore,
   EventStoreReadContext,
 } from "./eventStore.types";
-import { EventUtils } from "../utils/event.utils";
-import { ValidationError } from "../services/errorHandling";
 import {
   deduplicateEvents,
   eventToRecord,
@@ -79,6 +79,19 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
   }
 
   /**
+   * Logs a warning with structured context.
+   * Default: no-op.
+   * ClickHouse override: structured logger call.
+   */
+  protected logWarning(
+    _name: string,
+    _context: Record<string, unknown>,
+    _message: string,
+  ): void {
+    // no-op by default
+  }
+
+  /**
    * Called after events are successfully stored.
    * Default: no-op.
    * ClickHouse override: logs info with tenant/counts.
@@ -110,12 +123,37 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
   // Concrete template methods
   // ---------------------------------------------------------------------------
 
+  /**
+   * An aggregate id is required to identify which stream to read. No aggregate
+   * type uses an empty string as its id, so an empty/whitespace id is always a
+   * caller bug (e.g. a re-fold enqueued with a missing aggregateId).
+   *
+   * Issuing the read anyway is actively harmful: `event_log` is
+   * `ORDER BY (TenantId, AggregateType, AggregateId, ...)`, so `AggregateId = ''`
+   * seeks to the empty-id key range — which collects every event ever written
+   * without an aggregate id — and materialises all their `EventPayload` blobs.
+   * In prod that read exceeds `max_memory_usage_per_query` and takes down the
+   * whole instance for every tenant. Short-circuit to an empty stream instead.
+   */
+  private hasMissingAggregateId(aggregateId: string): boolean {
+    return String(aggregateId).trim().length === 0;
+  }
+
   async getEvents(
     aggregateId: string,
     context: EventStoreReadContext<EventType>,
     aggregateType: AggregateType,
   ): Promise<readonly EventType[]> {
     EventUtils.validateTenantId(context, `${this.constructor.name}.getEvents`);
+
+    if (this.hasMissingAggregateId(aggregateId)) {
+      this.logWarning(
+        `${this.constructor.name}.getEvents`,
+        { tenantId: context.tenantId, aggregateType },
+        "Skipped event_log read for an empty aggregateId (would scan the whole empty-id key range); returning no events",
+      );
+      return [];
+    }
 
     return await this.instrument(
       `${this.constructor.name}.getEvents`,
@@ -139,11 +177,15 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
           const processed = this.postProcessEvents(events);
           return deduplicateEvents(processed);
         } catch (error) {
-          this.logError(`${this.constructor.name}.getEvents`, {
-            aggregateId: String(aggregateId),
-            tenantId: context.tenantId,
-            aggregateType,
-          }, error);
+          this.logError(
+            `${this.constructor.name}.getEvents`,
+            {
+              aggregateId: String(aggregateId),
+              tenantId: context.tenantId,
+              aggregateType,
+            },
+            error,
+          );
           throw error;
         }
       },
@@ -160,6 +202,15 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
       context,
       `${this.constructor.name}.getEventsUpTo`,
     );
+
+    if (this.hasMissingAggregateId(aggregateId)) {
+      this.logWarning(
+        `${this.constructor.name}.getEventsUpTo`,
+        { tenantId: context.tenantId, aggregateType },
+        "Skipped event_log read for an empty aggregateId (would scan the whole empty-id key range); returning no events",
+      );
+      return [];
+    }
 
     return await this.instrument(
       `${this.constructor.name}.getEventsUpTo`,
@@ -187,13 +238,17 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
           const processed = this.postProcessEvents(events);
           return deduplicateEvents(processed);
         } catch (error) {
-          this.logError(`${this.constructor.name}.getEventsUpTo`, {
-            aggregateId: String(aggregateId),
-            tenantId: context.tenantId,
-            aggregateType,
-            upToEventId: upToEvent.id,
-            upToTimestamp: upToEvent.createdAt,
-          }, error);
+          this.logError(
+            `${this.constructor.name}.getEventsUpTo`,
+            {
+              aggregateId: String(aggregateId),
+              tenantId: context.tenantId,
+              aggregateType,
+              upToEventId: upToEvent.id,
+              upToTimestamp: upToEvent.createdAt,
+            },
+            error,
+          );
           throw error;
         }
       },
@@ -211,6 +266,15 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
       context,
       `${this.constructor.name}.countEventsBefore`,
     );
+
+    if (this.hasMissingAggregateId(aggregateId)) {
+      this.logWarning(
+        `${this.constructor.name}.countEventsBefore`,
+        { tenantId: context.tenantId, aggregateType },
+        "Skipped event_log count for an empty aggregateId (would scan the whole empty-id key range); returning 0",
+      );
+      return 0;
+    }
 
     return await this.instrument(
       `${this.constructor.name}.countEventsBefore`,
@@ -231,13 +295,17 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
             beforeEventId,
           );
         } catch (error) {
-          this.logError(`${this.constructor.name}.countEventsBefore`, {
-            aggregateId: String(aggregateId),
-            tenantId: context.tenantId,
-            aggregateType,
-            beforeTimestamp,
-            beforeEventId,
-          }, error);
+          this.logError(
+            `${this.constructor.name}.countEventsBefore`,
+            {
+              aggregateId: String(aggregateId),
+              tenantId: context.tenantId,
+              aggregateType,
+              beforeTimestamp,
+              beforeEventId,
+            },
+            error,
+          );
           throw error;
         }
       },
@@ -303,13 +371,17 @@ export abstract class AbstractEventStore<EventType extends Event = Event>
 
           this.onStoreSuccess(context, events);
         } catch (error) {
-          this.logError(`${this.constructor.name}.storeEvents`, {
-            tenantId: context.tenantId,
-            eventCount: events.length,
-            aggregateIds: [
-              ...new Set(events.map((e) => String(e.aggregateId))),
-            ],
-          }, error);
+          this.logError(
+            `${this.constructor.name}.storeEvents`,
+            {
+              tenantId: context.tenantId,
+              eventCount: events.length,
+              aggregateIds: [
+                ...new Set(events.map((e) => String(e.aggregateId))),
+              ],
+            },
+            error,
+          );
           throw error;
         }
       },

--- a/langwatch/src/server/event-sourcing/stores/eventStoreClickHouse.ts
+++ b/langwatch/src/server/event-sourcing/stores/eventStoreClickHouse.ts
@@ -62,6 +62,20 @@ export class EventStoreClickHouse<
     );
   }
 
+  protected override logWarning(
+    name: string,
+    context: Record<string, unknown>,
+    message: string,
+  ): void {
+    this.logger.warn(
+      {
+        ...context,
+        operation: name,
+      },
+      message,
+    );
+  }
+
   protected override onStoreSuccess(
     _context: EventStoreReadContext<EventType>,
     _events: readonly EventType[],


### PR DESCRIPTION
## Evidence

In the last 24h ClickHouse exception log, `event_log` reads are one of the dominant `MEMORY_LIMIT_EXCEEDED` (Code 241) shapes. The failing query is the per-aggregate event read with an **empty aggregate id**:

```
SELECT EventId, ..., EventPayload, ...
FROM event_log
WHERE TenantId = '<redacted>' AND AggregateType = 'trace' AND AggregateId = ''
```

`event_log` is `ORDER BY (TenantId, AggregateType, AggregateId, IdempotencyKey)` and `PARTITION BY toYearWeek(EventOccurredAt)`. An empty `AggregateId` seeks to the empty-id key range, which collects every event ever written without an aggregate id, and the read then materialises all of their `EventPayload` blobs (`String CODEC(ZSTD(3))`, multi-KB JSON). With no aggregate id and no time predicate, the read fans across the whole table and blows the per-query memory ceiling, which degrades the instance for every tenant sharing it.

## Suspected cause

`AbstractEventStore` validates `tenantId` on every read but not `aggregateId`. The re-fold event loader (`eventSourcingService.ts`) calls `getEvents(ctx.aggregateId, ...)`; when a projection is enqueued with a missing/empty aggregate id, that empty string flows straight to the query. No aggregate type uses an empty string as its id, so this is always a caller bug, but the read it produces is catastrophic rather than merely wrong.

## Proposed fix

Guard the empty/whitespace aggregateId at the store boundary (next to the existing `validateTenantId`), short-circuiting `getEvents` / `getEventsUpTo` to `[]` and `countEventsBefore` to `0` without issuing the query. An aggregate with no id has no events, so this is the semantically correct result. A `logWarning` hook (mirroring the existing `logError` hook, overridden in the ClickHouse store) surfaces the skip so the upstream empty-id source stays diagnosable.

This is intentionally read-path only. The write-side question (why some callers enqueue an empty aggregate id, and whether rows were written with `AggregateId = ''`) is worth a separate look, but the read guard stops the cross-tenant OOM regardless of how the empty id arises.

## Expected impact

- The empty-id read is never issued, so it can no longer OOM the instance.
- No change for real aggregate ids: those reads are unchanged.
- No write-path change.

## EXPLAIN check

`EXPLAIN PLAN indexes=1` against a large tenant (redacted), `event_log` ~323 parts / ~98.5k granules total.

Empty `AggregateId = ''` (the failing shape) — `AggregateId` drops out of the primary-key condition, leaving only `(AggregateType, TenantId)`:

```
PrimaryKey
  Condition: and((AggregateType in ['trace']), (TenantId in ['<redacted>']))
  Parts: 248/323
  Granules: 5072/98537
  -> Parts: 103, Granules: 4927   (EventPayload read across ~4927 granules ~= tens of millions of rows)
```

Real `AggregateId = '<id>'` (id participates in the key) prunes to almost nothing:

```
PrimaryKey
  Condition: and((AggregateId in ['<id>']), (AggregateType in ['trace']), (TenantId in ['<redacted>']))
  -> Parts: 0, Granules: 0       (handful of granules for a present id)
```

The guard removes the empty-id read entirely (0 granules, no query), so the relevant delta is 4927 granules -> none issued.

## Test plan

`eventStoreClickHouse.emptyAggregateGuard.unit.test.ts` (new): with a query-spy ClickHouse client, asserts that for an empty and a whitespace-only aggregateId, `getEvents` / `getEventsUpTo` return `[]` and `countEventsBefore` returns `0` **without calling `client.query`**, and that a real aggregateId still issues the read. Existing store unit tests pass unchanged.

---

Advisory PR from the ClickHouse slow-query optimizer. A human should review and merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented event-store read operations from running with empty/whitespace `aggregateId`; these now short-circuit to empty results (or `0`) and emit a structured warning.

* **Tests**
  * Added unit tests covering empty/whitespace `aggregateId` behavior, including ensuring database queries are not executed.

* **Chores**
  * Enhanced structured logging by introducing a dedicated warning hook and formatting warning/error context consistently across the event store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->