### PR TITLE
feat(data-privacy): inherit option on privacy rules and shareable drawer url

### DIFF
--- a/langwatch/src/components/drawerRegistry.ts
+++ b/langwatch/src/components/drawerRegistry.ts
@@ -41,6 +41,7 @@ import { EvaluatorHistoryDrawer } from "./evaluators/EvaluatorHistoryDrawer";
 import { EvaluatorListDrawer } from "./evaluators/EvaluatorListDrawer";
 import { EvaluatorTypeSelectorDrawer } from "./evaluators/EvaluatorTypeSelectorDrawer";
 import { WorkflowSelectorForEvaluatorDrawer } from "./evaluators/WorkflowSelectorForEvaluatorDrawer";
+import { DataPrivacyRuleDrawer } from "./settings/DataPrivacyRuleDrawer";
 
 // Lazy-loaded: FoundryDrawer transitively imports the OTel SDK which has
 // side effects that break React if evaluated eagerly at app startup.
@@ -123,6 +124,8 @@ export const drawers = {
   scenarioRunDetail: ScenarioRunDetailDrawer,
   // Suites
   suiteEditor: SuiteFormDrawer,
+  // Data privacy
+  dataPrivacyRule: DataPrivacyRuleDrawer,
   // Project management
   createProject: CreateProjectDrawer,
   editProject: EditProjectDrawer,

--- a/langwatch/src/components/settings/DataPrivacyRuleDrawer.tsx
+++ b/langwatch/src/components/settings/DataPrivacyRuleDrawer.tsx
@@ -1,0 +1,90 @@
+import { toaster } from "~/components/ui/toaster";
+import { useDrawer } from "~/hooks/useDrawer";
+import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
+import { PrivacyRuleDrawer } from "~/pages/settings/data-privacy";
+import { api } from "~/utils/api";
+
+/**
+ * URL-routed shell for the privacy rule drawer (see
+ * dev/docs/best_practices/drawers.md). It reconstructs the drawer from the URL
+ * alone: the scope params identify which rule to edit, and the policy snapshot
+ * is fetched here rather than threaded in, so a pasted link reopens the same
+ * rule. Opening with no scope params is the add flow.
+ */
+export function DataPrivacyRuleDrawer({
+  editScopeType,
+  editScopeId,
+  editPersonalOnly,
+}: {
+  editScopeType?: string;
+  editScopeId?: string;
+  editPersonalOnly?: string;
+}) {
+  const { closeDrawer } = useDrawer();
+  const { project, organization } = useOrganizationTeamProject();
+  const projectId = project?.id ?? "";
+  const utils = api.useUtils();
+  const snapshotQuery = api.dataPrivacy.getSnapshot.useQuery(
+    { projectId },
+    { enabled: !!projectId },
+  );
+  const setForScope = api.dataPrivacy.setForScope.useMutation();
+
+  const snapshot = snapshotQuery.data;
+  if (!snapshot?.available) return null;
+
+  const editingRule =
+    editScopeType && editScopeId
+      ? (snapshot.rules.find(
+          (rule) =>
+            rule.scopeType === editScopeType &&
+            rule.scopeId === editScopeId &&
+            rule.personalOnly === (editPersonalOnly === "true"),
+        ) ?? null)
+      : null;
+
+  return (
+    <PrivacyRuleDrawer
+      open={true}
+      editingRule={editingRule}
+      onClose={closeDrawer}
+      available={snapshot.available}
+      audienceOptions={snapshot.audienceOptions}
+      effectiveTeam={snapshot.effectiveTeam}
+      effectiveOrganization={snapshot.effectiveOrganization}
+      projectId={projectId}
+      currentTeamId={project?.teamId ?? null}
+      currentOrganizationId={organization?.id ?? null}
+      isSaving={setForScope.isLoading}
+      onSave={async (scopes, config) => {
+        try {
+          await Promise.all(
+            scopes.map((scope) =>
+              setForScope.mutateAsync({
+                projectId,
+                scope: { scopeType: scope.scopeType, scopeId: scope.scopeId },
+                personalOnly: !!scope.personalOnly,
+                config,
+              }),
+            ),
+          );
+          void utils.dataPrivacy.getSnapshot.invalidate({ projectId });
+          toaster.create({
+            title:
+              scopes.length > 1
+                ? `Privacy rule saved for ${scopes.length} scopes`
+                : "Privacy rule saved",
+            type: "success",
+          });
+          closeDrawer();
+        } catch (error) {
+          toaster.create({
+            title: "Failed to save rule",
+            description: (error as Error).message,
+            type: "error",
+          });
+        }
+      }}
+    />
+  );
+}

--- a/langwatch/src/components/settings/__tests__/dataPrivacyRuleConfig.unit.test.ts
+++ b/langwatch/src/components/settings/__tests__/dataPrivacyRuleConfig.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   EMPTY_AUDIENCE,
+  PLATFORM_DEFAULT_DATA_PRIVACY,
   type ResolvedDataPrivacy,
 } from "~/server/data-privacy/dataPrivacy.types";
 import {
@@ -11,62 +12,66 @@ import {
   audienceConfig,
   audienceToSelection,
   buildRuleConfig,
+  type CategoryChoice,
   type CustomAttributeFormRow,
   configsEqual,
   configToFormState,
   EMPTY_AUDIENCE_FORM,
-  inheritedFormState,
+  inheritedBaselineForScope,
+  inheritFormState,
   isEmptyRuleConfig,
+  type PiiChoice,
   ROLE_VALUES,
   type RuleFormState,
   ruleSummary,
+  type SecretsChoice,
   selectionToAudience,
-  type TouchedControls,
-  touchedFromConfig,
 } from "../dataPrivacyRuleConfig";
 
-const defaultDispositions: RuleFormState["dispositions"] = {
-  input: "capture",
-  output: "capture",
-  system: "capture",
-  tools: "capture",
+const inheritDispositions: RuleFormState["dispositions"] = {
+  input: "inherit",
+  output: "inherit",
+  system: "inherit",
+  tools: "inherit",
 };
-
-const noTouch: TouchedControls = { categories: {}, pii: false, secrets: false };
 
 function audience(partial: Partial<AudienceFormState> = {}): AudienceFormState {
   return { ...EMPTY_AUDIENCE_FORM, ...partial };
 }
 
 function build({
-  dispositions = defaultDispositions,
+  dispositions = inheritDispositions,
   aud = audience({ admins: true }),
-  piiLevel = "essential" as const,
+  piiChoice = "inherit" as PiiChoice,
   piiEntities = [] as string[],
-  secretsEnabled = true,
+  secretsChoice = "inherit" as SecretsChoice,
   secretsPatterns = [] as string[],
   customAttributes = [] as CustomAttributeFormRow[],
-  touched = noTouch,
 }: {
   dispositions?: RuleFormState["dispositions"];
   aud?: AudienceFormState;
-  piiLevel?: RuleFormState["piiLevel"];
+  piiChoice?: PiiChoice;
   piiEntities?: string[];
-  secretsEnabled?: boolean;
+  secretsChoice?: SecretsChoice;
   secretsPatterns?: string[];
   customAttributes?: CustomAttributeFormRow[];
-  touched?: TouchedControls;
 }) {
   return buildRuleConfig({
     dispositions,
     audience: aud,
-    piiLevel,
+    piiChoice,
     piiEntities,
-    secretsEnabled,
+    secretsChoice,
     secretsPatterns,
     customAttributes,
-    touched,
   });
+}
+
+function withCategory(
+  category: keyof RuleFormState["dispositions"],
+  choice: CategoryChoice,
+): RuleFormState["dispositions"] {
+  return { ...inheritDispositions, [category]: choice };
 }
 
 function resolved(
@@ -86,7 +91,8 @@ function resolved(
 }
 
 describe("buildRuleConfig", () => {
-  describe("given everything at the platform defaults and nothing touched", () => {
+  describe("given every control left on inherit", () => {
+    /** @scenario Saving a rule with everything inheriting stores a rule that sets no fields */
     it("produces an empty config that changes nothing", () => {
       const config = build({});
 
@@ -94,37 +100,74 @@ describe("buildRuleConfig", () => {
     });
   });
 
-  describe("given a dropped category", () => {
-    it("includes only the dropped category and omits the untouched ones", () => {
-      const config = build({
-        dispositions: { ...defaultDispositions, input: "drop" },
-        touched: { ...noTouch, categories: { input: true } },
-      });
+  describe("given one category set and the rest inheriting", () => {
+    /** @scenario Setting one category leaves the rest inheriting */
+    it("includes only the set category and omits the inherited ones", () => {
+      const config = build({ dispositions: withCategory("input", "drop") });
 
       expect(config.categories?.input).toEqual({ disposition: "drop" });
       expect(config.categories?.output).toBeUndefined();
+      expect(config.categories?.system).toBeUndefined();
+      expect(config.categories?.tools).toBeUndefined();
+    });
+  });
+
+  describe("given a category explicitly set to capture over a stricter parent", () => {
+    it("persists the capture disposition instead of inheriting", () => {
+      const config = build({ dispositions: withCategory("input", "capture") });
+
+      expect(config.categories?.input).toEqual({ disposition: "capture" });
     });
   });
 
   describe("given a restricted category", () => {
     it("attaches the full structured audience", () => {
       const config = build({
-        dispositions: { ...defaultDispositions, output: "restrict" },
-        aud: audience({
-          viewers: true,
-          projectOwner: true,
-          groupIds: ["g1"],
-        }),
-        touched: { ...noTouch, categories: { output: true } },
+        dispositions: withCategory("output", "restrict"),
+        aud: audience({ viewers: true, projectOwner: true, groupIds: ["g1"] }),
       });
 
       expect(config.categories?.output).toEqual({
         disposition: "restrict",
-        audience: {
-          viewers: true,
-          projectOwner: true,
-          groupIds: ["g1"],
-        },
+        audience: { viewers: true, projectOwner: true, groupIds: ["g1"] },
+      });
+    });
+  });
+
+  describe("given a PII choice", () => {
+    it("omits PII when inheriting and writes the level when set", () => {
+      expect(build({ piiChoice: "inherit" }).pii).toBeUndefined();
+      expect(build({ piiChoice: "essential" }).pii).toEqual({
+        level: "essential",
+      });
+      expect(build({ piiChoice: "disabled" }).pii).toEqual({
+        level: "disabled",
+      });
+      expect(
+        build({ piiChoice: "custom", piiEntities: ["BR_CPF", "EMAIL_ADDRESS"] })
+          .pii,
+      ).toEqual({ level: "custom", entities: ["BR_CPF", "EMAIL_ADDRESS"] });
+    });
+  });
+
+  describe("given a secrets choice", () => {
+    it("omits secrets when inheriting and writes the flag when on or off", () => {
+      expect(build({ secretsChoice: "inherit" }).secrets).toBeUndefined();
+      expect(build({ secretsChoice: "on" }).secrets).toEqual({ enabled: true });
+      expect(build({ secretsChoice: "off" }).secrets).toEqual({
+        enabled: false,
+      });
+    });
+
+    it("persists trimmed custom patterns alongside the enabled flag", () => {
+      const config = build({
+        secretsChoice: "on",
+        secretsPatterns: [" acme_live_[a-z0-9]+ ", ""],
+      });
+
+      expect(config.secrets).toEqual({
+        enabled: true,
+        customPatterns: ["acme_live_[a-z0-9]+"],
       });
     });
   });
@@ -163,48 +206,6 @@ describe("buildRuleConfig", () => {
       ]);
     });
   });
-
-  describe("given custom secret patterns with secrets touched", () => {
-    it("persists the trimmed patterns alongside the enabled flag", () => {
-      const config = build({
-        secretsPatterns: [" acme_live_[a-z0-9]+ ", ""],
-        touched: { ...noTouch, secrets: true },
-      });
-
-      expect(config.secrets).toEqual({
-        enabled: true,
-        customPatterns: ["acme_live_[a-z0-9]+"],
-      });
-    });
-  });
-
-  describe("given a touched control left at a default-looking value", () => {
-    describe("when a category is touched to capture over an inherited drop", () => {
-      it("persists the capture disposition explicitly instead of omitting it", () => {
-        const config = build({
-          touched: { ...noTouch, categories: { input: true } },
-        });
-
-        expect(config.categories?.input).toEqual({ disposition: "capture" });
-      });
-    });
-
-    describe("when PII is touched to essential over an inherited strict", () => {
-      it("persists the essential level explicitly", () => {
-        const config = build({ touched: { ...noTouch, pii: true } });
-
-        expect(config.pii).toEqual({ level: "essential" });
-      });
-    });
-
-    describe("when secrets are touched back on over an inherited off", () => {
-      it("persists secrets enabled explicitly", () => {
-        const config = build({ touched: { ...noTouch, secrets: true } });
-
-        expect(config.secrets).toEqual({ enabled: true });
-      });
-    });
-  });
 });
 
 describe("audienceConfig", () => {
@@ -222,20 +223,41 @@ describe("audienceConfig", () => {
   });
 });
 
-describe("configToFormState and touchedFromConfig", () => {
+describe("configToFormState", () => {
+  describe("given a config that only sets one category", () => {
+    it("shows the set category and leaves the rest on inherit", () => {
+      const state = configToFormState({
+        categories: { input: { disposition: "drop" } },
+      });
+
+      expect(state.dispositions.input).toBe("drop");
+      expect(state.dispositions.output).toBe("inherit");
+      expect(state.dispositions.system).toBe("inherit");
+      expect(state.dispositions.tools).toBe("inherit");
+      expect(state.piiChoice).toBe("inherit");
+      expect(state.secretsChoice).toBe("inherit");
+    });
+  });
+
+  describe("given a config that disables secrets", () => {
+    it("reads secrets as explicitly off, not inherit", () => {
+      expect(
+        configToFormState({ secrets: { enabled: false } }).secretsChoice,
+      ).toBe("off");
+      expect(
+        configToFormState({ secrets: { enabled: true } }).secretsChoice,
+      ).toBe("on");
+    });
+  });
+
   describe("given a config with every kind of field", () => {
     const config = build({
-      dispositions: { ...defaultDispositions, input: "restrict" },
+      dispositions: withCategory("input", "restrict"),
       aud: audience({ projectOwner: true, groupIds: ["g1"] }),
-      piiLevel: "strict",
-      secretsEnabled: true,
+      piiChoice: "strict",
+      secretsChoice: "on",
       secretsPatterns: ["acme_[0-9]+"],
       customAttributes: [{ pattern: "app.token", disposition: "drop" }],
-      touched: {
-        categories: { input: true },
-        pii: true,
-        secrets: true,
-      },
     });
 
     it("hydrates the form state back, including the structured audience", () => {
@@ -244,33 +266,17 @@ describe("configToFormState and touchedFromConfig", () => {
       expect(state.dispositions.input).toBe("restrict");
       expect(state.audience.projectOwner).toBe(true);
       expect(state.audience.groupIds).toEqual(["g1"]);
-      expect(state.piiLevel).toBe("strict");
+      expect(state.piiChoice).toBe("strict");
+      expect(state.secretsChoice).toBe("on");
       expect(state.secretsPatterns).toEqual(["acme_[0-9]+"]);
       expect(state.customAttributes).toEqual([
         { pattern: "app.token", disposition: "drop" },
       ]);
     });
 
-    it("marks exactly the present fields as touched", () => {
-      const touched = touchedFromConfig(config);
-
-      expect(touched.categories).toEqual({ input: true });
-      expect(touched.pii).toBe(true);
-      expect(touched.secrets).toBe(true);
-    });
-
     it("round-trips back to an equal config", () => {
       const state = configToFormState(config);
-      const rebuilt = buildRuleConfig({
-        dispositions: state.dispositions,
-        audience: state.audience,
-        piiLevel: state.piiLevel,
-        piiEntities: state.piiEntities,
-        secretsEnabled: state.secretsEnabled,
-        secretsPatterns: state.secretsPatterns,
-        customAttributes: state.customAttributes,
-        touched: touchedFromConfig(config),
-      });
+      const rebuilt = buildRuleConfig(state);
 
       expect(configsEqual(rebuilt, config)).toBe(true);
     });
@@ -291,46 +297,86 @@ describe("configToFormState and touchedFromConfig", () => {
       expect(state.audience.viewers).toBe(true);
     });
   });
-});
 
-describe("inheritedFormState", () => {
-  describe("given the current project scope under a restrictive parent", () => {
-    it("seeds the form from the resolved effective so the parent restriction shows", () => {
-      const state = inheritedFormState({
-        effective: resolved({
-          categories: {
-            input: { disposition: "drop", audience: { ...EMPTY_AUDIENCE } },
-            output: {
-              disposition: "restrict",
-              audience: { ...EMPTY_AUDIENCE, projectOwner: true },
-            },
-            system: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
-            tools: { disposition: "capture", audience: { ...EMPTY_AUDIENCE } },
-          },
-          pii: { level: "strict", entities: [] },
-        }),
-        isCurrentProjectScope: true,
+  describe("when a previously-set field is reverted to inherit", () => {
+    /** @scenario Reverting a field to Inherit removes it from the rule */
+    it("drops that field from the rebuilt config", () => {
+      const original = build({
+        dispositions: {
+          ...inheritDispositions,
+          input: "drop",
+          output: "capture",
+        },
+      });
+      const state = configToFormState(original);
+
+      const reverted = buildRuleConfig({
+        ...state,
+        dispositions: { ...state.dispositions, input: "inherit" },
       });
 
-      expect(state.dispositions.input).toBe("drop");
-      expect(state.dispositions.output).toBe("restrict");
-      expect(state.audience.projectOwner).toBe(true);
-      expect(state.piiLevel).toBe("strict");
-      expect(state.customAttributes).toEqual([]);
+      expect(reverted.categories?.input).toBeUndefined();
+      expect(reverted.categories?.output).toEqual({ disposition: "capture" });
     });
   });
+});
 
-  describe("given any other scope", () => {
-    it("falls back to the platform defaults", () => {
-      const state = inheritedFormState({
-        effective: resolved({ pii: { level: "strict", entities: [] } }),
-        isCurrentProjectScope: false,
-      });
+describe("inheritFormState", () => {
+  it("starts every control on inherit", () => {
+    const state = inheritFormState();
 
-      expect(state.dispositions.input).toBe("capture");
-      expect(state.piiLevel).toBe("essential");
-      expect(state.secretsEnabled).toBe(true);
+    expect(state.dispositions).toEqual({
+      input: "inherit",
+      output: "inherit",
+      system: "inherit",
+      tools: "inherit",
     });
+    expect(state.piiChoice).toBe("inherit");
+    expect(state.secretsChoice).toBe("inherit");
+    expect(state.customAttributes).toEqual([]);
+    expect(isEmptyRuleConfig(buildRuleConfig(state))).toBe(true);
+  });
+});
+
+describe("inheritedBaselineForScope", () => {
+  const team = resolved({ pii: { level: "strict", entities: [] } });
+  const org = resolved({ secrets: { enabled: false, customPatterns: [] } });
+
+  it("resolves a project to its team baseline", () => {
+    expect(
+      inheritedBaselineForScope({
+        scopeType: "PROJECT",
+        effectiveTeam: team,
+        effectiveOrganization: org,
+      }),
+    ).toBe(team);
+  });
+
+  it("resolves a team or department to the organization baseline", () => {
+    expect(
+      inheritedBaselineForScope({
+        scopeType: "TEAM",
+        effectiveTeam: team,
+        effectiveOrganization: org,
+      }),
+    ).toBe(org);
+    expect(
+      inheritedBaselineForScope({
+        scopeType: "DEPARTMENT",
+        effectiveTeam: team,
+        effectiveOrganization: org,
+      }),
+    ).toBe(org);
+  });
+
+  it("resolves an organization to the platform default", () => {
+    expect(
+      inheritedBaselineForScope({
+        scopeType: "ORGANIZATION",
+        effectiveTeam: team,
+        effectiveOrganization: org,
+      }),
+    ).toBe(PLATFORM_DEFAULT_DATA_PRIVACY);
   });
 });
 
@@ -351,29 +397,8 @@ describe("ruleSummary", () => {
     );
   });
 
-  it("reads PII redaction without a level prefix, and Strict when strict", () => {
-    expect(ruleSummary({ pii: { level: "essential" } })).toBe("PII redaction");
-    expect(ruleSummary({ pii: { level: "strict" } })).toBe(
-      "Strict PII redaction",
-    );
-    expect(ruleSummary({ secrets: { enabled: true } })).toBe(
-      "Secrets redaction",
-    );
-  });
-
-  it("reads a custom level as the count of selected identifiers", () => {
-    expect(
-      ruleSummary({
-        pii: { level: "custom", entities: ["EMAIL_ADDRESS", "BR_CPF"] },
-      }),
-    ).toBe("Custom PII (2 types)");
-    expect(
-      ruleSummary({ pii: { level: "custom", entities: ["BR_CPF"] } }),
-    ).toBe("Custom PII (1 type)");
-  });
-
-  it("reads as no changes for an empty config", () => {
-    expect(ruleSummary({})).toBe("No changes");
+  it("reads as inherits everything for an empty config", () => {
+    expect(ruleSummary({})).toBe("Inherits everything");
   });
 });
 
@@ -393,18 +418,6 @@ describe("audience selection", () => {
         "group:security",
       ]);
       expect(widened).toEqual(["group:security"]);
-    });
-
-    it("keeps any combination of narrower groups", () => {
-      const next = applyAudienceSelection(
-        ["projectOwner"],
-        ["projectOwner", ROLE_VALUES.admins, "group:auditors"],
-      );
-      expect(next).toEqual([
-        "projectOwner",
-        ROLE_VALUES.admins,
-        "group:auditors",
-      ]);
     });
   });
 

--- a/langwatch/src/components/settings/__tests__/dataPrivacyRuleConfig.unit.test.ts
+++ b/langwatch/src/components/settings/__tests__/dataPrivacyRuleConfig.unit.test.ts
@@ -170,6 +170,15 @@ describe("buildRuleConfig", () => {
         customPatterns: ["acme_live_[a-z0-9]+"],
       });
     });
+
+    it("discards leftover patterns when redaction is turned off", () => {
+      const config = build({
+        secretsChoice: "off",
+        secretsPatterns: ["acme_live_[a-z0-9]+"],
+      });
+
+      expect(config.secrets).toEqual({ enabled: false });
+    });
   });
 
   describe("given custom attribute rows", () => {

--- a/langwatch/src/components/settings/dataPrivacyRuleConfig.ts
+++ b/langwatch/src/components/settings/dataPrivacyRuleConfig.ts
@@ -23,11 +23,8 @@ import {
  * hands the field back to the wider scope.
  */
 
-/** The four content categories plus the explicit "inherit from parent" choice. */
 export type CategoryChoice = "inherit" | Disposition;
-/** The PII levels plus the explicit "inherit from parent" choice. */
 export type PiiChoice = "inherit" | PiiLevel;
-/** Secrets redaction as a tri-state: inherit, explicitly on, explicitly off. */
 export type SecretsChoice = "inherit" | "on" | "off";
 
 /**
@@ -194,7 +191,9 @@ export function buildRuleConfig({
     const patterns = secretsPatterns.map((p) => p.trim()).filter(Boolean);
     config.secrets = {
       enabled: secretsChoice === "on",
-      ...(patterns.length > 0 ? { customPatterns: patterns } : {}),
+      ...(secretsChoice === "on" && patterns.length > 0
+        ? { customPatterns: patterns }
+        : {}),
     };
   }
   const attributeRows = validCustomAttributeRows(customAttributes);

--- a/langwatch/src/components/settings/dataPrivacyRuleConfig.ts
+++ b/langwatch/src/components/settings/dataPrivacyRuleConfig.ts
@@ -6,6 +6,7 @@ import {
   type DataPrivacyConfig,
   type Disposition,
   type PiiLevel,
+  PLATFORM_DEFAULT_DATA_PRIVACY,
   type ResolvedAudience,
   type ResolvedDataPrivacy,
 } from "~/server/data-privacy/dataPrivacy.types";
@@ -13,15 +14,21 @@ import {
 /**
  * Pure form-state to DataPrivacyConfig translation for the privacy-rule drawer.
  *
- * A field only lands in the config when the user explicitly persists it; an
- * omitted field inherits the next scope up. The cascade resolves per field, so
- * a less-restrictive override (e.g. project `capture` over an org `drop`) is
- * only representable by persisting that value EXPLICITLY. The `touched`
- * descriptor names which controls to persist: a touched control is written
- * regardless of value, so `capture` / `essential` / secrets-on become real
- * overrides instead of inherited defaults. Untouched controls stay omitted and
- * keep inheriting.
+ * Every control carries an explicit "inherit" choice on top of its real values.
+ * A field only lands in the config when its control names a concrete value; an
+ * "inherit" control is omitted, so that field falls through to the next scope up
+ * the cascade (and finally the platform default). The cascade resolves per
+ * field, so a less-restrictive override (e.g. project `capture` over an org
+ * `drop`) is representable by choosing that value explicitly, while "inherit"
+ * hands the field back to the wider scope.
  */
+
+/** The four content categories plus the explicit "inherit from parent" choice. */
+export type CategoryChoice = "inherit" | Disposition;
+/** The PII levels plus the explicit "inherit from parent" choice. */
+export type PiiChoice = "inherit" | PiiLevel;
+/** Secrets redaction as a tri-state: inherit, explicitly on, explicitly off. */
+export type SecretsChoice = "inherit" | "on" | "off";
 
 /**
  * The drawer's audience selection: everyone with access (all members), the
@@ -108,18 +115,6 @@ export interface CustomAttributeFormRow {
   disposition: CustomAttributeDisposition;
 }
 
-/**
- * Which drawer controls the user touched, so they persist as explicit overrides.
- * The audience only surfaces through restrict categories/attribute rows, so it
- * has no standalone field in the built config and is not tracked here. Custom
- * attribute rows are explicit by construction (they only exist when added).
- */
-export interface TouchedControls {
-  categories: Partial<Record<ContentCategory, boolean>>;
-  pii: boolean;
-  secrets: boolean;
-}
-
 export function audienceConfig(audience: AudienceFormState): Audience {
   const out: Audience = {};
   if (audience.admins) out.admins = true;
@@ -159,48 +154,46 @@ export function validCustomAttributeRows(
 export function buildRuleConfig({
   dispositions,
   audience,
-  piiLevel,
+  piiChoice,
   piiEntities,
-  secretsEnabled,
+  secretsChoice,
   secretsPatterns,
   customAttributes,
-  touched,
 }: {
-  dispositions: Record<ContentCategory, Disposition>;
+  dispositions: Record<ContentCategory, CategoryChoice>;
   audience: AudienceFormState;
-  piiLevel: PiiLevel;
+  piiChoice: PiiChoice;
   piiEntities: string[];
-  secretsEnabled: boolean;
+  secretsChoice: SecretsChoice;
   secretsPatterns: string[];
   customAttributes: CustomAttributeFormRow[];
-  touched: TouchedControls;
 }): DataPrivacyConfig {
   const categories: NonNullable<DataPrivacyConfig["categories"]> = {};
   for (const category of CONTENT_CATEGORIES) {
-    if (!touched.categories[category]) continue;
-    const disposition = dispositions[category];
-    if (disposition === "restrict") {
+    const choice = dispositions[category];
+    if (choice === "inherit") continue;
+    if (choice === "restrict") {
       categories[category] = {
         disposition: "restrict",
         audience: audienceConfig(audience),
       };
     } else {
-      categories[category] = { disposition };
+      categories[category] = { disposition: choice };
     }
   }
 
   const config: DataPrivacyConfig = {};
   if (Object.keys(categories).length > 0) config.categories = categories;
-  if (touched.pii) {
+  if (piiChoice !== "inherit") {
     config.pii =
-      piiLevel === "custom"
-        ? { level: piiLevel, entities: [...piiEntities].sort() }
-        : { level: piiLevel };
+      piiChoice === "custom"
+        ? { level: piiChoice, entities: [...piiEntities].sort() }
+        : { level: piiChoice };
   }
-  if (touched.secrets) {
+  if (secretsChoice !== "inherit") {
     const patterns = secretsPatterns.map((p) => p.trim()).filter(Boolean);
     config.secrets = {
-      enabled: secretsEnabled,
+      enabled: secretsChoice === "on",
       ...(patterns.length > 0 ? { customPatterns: patterns } : {}),
     };
   }
@@ -219,87 +212,79 @@ export function buildRuleConfig({
   return config;
 }
 
-/** The drawer's editable form state, independent of which controls are touched. */
+/** The drawer's editable form state. Every control can resolve to "inherit". */
 export interface RuleFormState {
-  dispositions: Record<ContentCategory, Disposition>;
+  dispositions: Record<ContentCategory, CategoryChoice>;
   audience: AudienceFormState;
-  piiLevel: PiiLevel;
-  /** Selected entity names, only meaningful when piiLevel === "custom". */
+  piiChoice: PiiChoice;
+  /** Selected entity names, only meaningful when piiChoice === "custom". */
   piiEntities: string[];
-  secretsEnabled: boolean;
+  secretsChoice: SecretsChoice;
   secretsPatterns: string[];
   customAttributes: CustomAttributeFormRow[];
 }
 
-const DEFAULT_DISPOSITIONS: Record<ContentCategory, Disposition> = {
-  input: "capture",
-  output: "capture",
-  system: "capture",
-  tools: "capture",
+const INHERIT_DISPOSITIONS: Record<ContentCategory, CategoryChoice> = {
+  input: "inherit",
+  output: "inherit",
+  system: "inherit",
+  tools: "inherit",
 };
 
 /**
- * The drawer's baseline form state for ADD: the values the new rule would
- * inherit, so the user sees the parent restriction they are overriding. When
- * the selected scope is the current project, that baseline is the resolved
- * effective policy; for any other scope a precise per-scope inherited value
- * isn't readily available, so it falls back to the platform defaults
- * (capture / essential PII / secrets on). Custom attribute rules and secret
- * patterns union down the cascade anyway, so they are never prefilled (doing
- * so would duplicate the parent's rows at the child scope).
+ * A blank rule: every control inherits, so a saved-as-is rule changes nothing.
+ * The drawer surfaces what each field resolves to next to the "Inherit" choice,
+ * so the admin sees the inherited posture before overriding any field.
  */
-export function inheritedFormState({
-  effective,
-  isCurrentProjectScope,
-}: {
-  effective: ResolvedDataPrivacy;
-  isCurrentProjectScope: boolean;
-}): RuleFormState {
-  if (!isCurrentProjectScope) {
-    return {
-      dispositions: { ...DEFAULT_DISPOSITIONS },
-      audience: { ...EMPTY_AUDIENCE_FORM, admins: true },
-      piiLevel: "essential",
-      piiEntities: [],
-      secretsEnabled: true,
-      secretsPatterns: [],
-      customAttributes: [],
-    };
-  }
-  const dispositions: Record<ContentCategory, Disposition> = {
-    ...DEFAULT_DISPOSITIONS,
-  };
-  let audience: AudienceFormState = { ...EMPTY_AUDIENCE_FORM, admins: true };
-  let sawRestrict = false;
-  for (const category of CONTENT_CATEGORIES) {
-    const resolved = effective.categories[category];
-    dispositions[category] = resolved.disposition;
-    if (resolved.disposition === "restrict" && !sawRestrict) {
-      sawRestrict = true;
-      audience = audienceToFormState(resolved.audience);
-    }
-  }
+export function inheritFormState(): RuleFormState {
   return {
-    dispositions,
-    audience,
-    piiLevel: effective.pii.level,
-    piiEntities: [...effective.pii.entities],
-    secretsEnabled: effective.secrets.enabled,
+    dispositions: { ...INHERIT_DISPOSITIONS },
+    audience: { ...EMPTY_AUDIENCE_FORM, admins: true },
+    piiChoice: "inherit",
+    piiEntities: [],
+    secretsChoice: "inherit",
     secretsPatterns: [],
     customAttributes: [],
   };
 }
 
 /**
+ * The resolved policy a rule at `scopeType` inherits when a field is left on
+ * "inherit": a project inherits its team baseline, a team or department the
+ * organization baseline, and the organization the platform default. Used only
+ * to label the "Inherit" choice with the value it currently resolves to.
+ */
+export function inheritedBaselineForScope({
+  scopeType,
+  effectiveTeam,
+  effectiveOrganization,
+}: {
+  scopeType: "ORGANIZATION" | "DEPARTMENT" | "TEAM" | "PROJECT";
+  effectiveTeam: ResolvedDataPrivacy | null;
+  effectiveOrganization: ResolvedDataPrivacy | null;
+}): ResolvedDataPrivacy {
+  if (scopeType === "PROJECT") {
+    return (
+      effectiveTeam ?? effectiveOrganization ?? PLATFORM_DEFAULT_DATA_PRIVACY
+    );
+  }
+  if (scopeType === "TEAM" || scopeType === "DEPARTMENT") {
+    return effectiveOrganization ?? PLATFORM_DEFAULT_DATA_PRIVACY;
+  }
+  return PLATFORM_DEFAULT_DATA_PRIVACY;
+}
+
+/**
  * Reverse of `buildRuleConfig`: hydrate the drawer's form state from a stored
- * config, for editing an existing rule. Unset categories fall back to the
- * platform default (capture / essential PII / secrets on). The single audience
- * control is seeded from the first restrict category or restrict attribute
- * rule, which is what the drawer applies to every restricted item.
+ * config, for editing an existing rule. A field the config does not set shows
+ * as "inherit" (not as a concrete default), so the drawer reflects exactly what
+ * the rule pins versus what it leaves to the wider scope. The single audience
+ * control is seeded from the first restrict category or restrict attribute rule,
+ * which is what the drawer applies to every restricted item.
  */
 export function configToFormState(config: DataPrivacyConfig): RuleFormState {
-  const dispositions: Record<ContentCategory, Disposition> = {
-    ...DEFAULT_DISPOSITIONS,
+  const dispositions: Record<ContentCategory, CategoryChoice> = {
+    ...INHERIT_DISPOSITIONS,
   };
   let audience: AudienceFormState = { ...EMPTY_AUDIENCE_FORM, admins: true };
   let sawRestrict = false;
@@ -321,31 +306,18 @@ export function configToFormState(config: DataPrivacyConfig): RuleFormState {
   return {
     dispositions,
     audience,
-    piiLevel: config.pii?.level ?? "essential",
+    piiChoice: config.pii?.level ?? "inherit",
     piiEntities: [...(config.pii?.entities ?? [])],
-    secretsEnabled: config.secrets?.enabled ?? true,
+    secretsChoice: config.secrets
+      ? config.secrets.enabled
+        ? "on"
+        : "off"
+      : "inherit",
     secretsPatterns: [...(config.secrets?.customPatterns ?? [])],
     customAttributes: (config.customAttributes ?? []).map((rule) => ({
       pattern: rule.pattern,
       disposition: rule.disposition,
     })),
-  };
-}
-
-/**
- * The controls an existing rule already persists, so editing re-persists them
- * even if the user leaves them untouched. The drawer unions this with the
- * controls the user touched before calling `buildRuleConfig`.
- */
-export function touchedFromConfig(config: DataPrivacyConfig): TouchedControls {
-  const categories: Partial<Record<ContentCategory, boolean>> = {};
-  for (const category of CONTENT_CATEGORIES) {
-    if (config.categories?.[category]) categories[category] = true;
-  }
-  return {
-    categories,
-    pii: config.pii !== undefined,
-    secrets: config.secrets !== undefined,
   };
 }
 
@@ -413,10 +385,10 @@ export function ruleSummary(config: DataPrivacyConfig): string {
       );
     }
   }
-  return parts.length > 0 ? parts.join(" · ") : "No changes";
+  return parts.length > 0 ? parts.join(" · ") : "Inherits everything";
 }
 
-/** Whether the built config persists nothing (an untouched form). */
+/** Whether the built config persists nothing (every control inherits). */
 export function isEmptyRuleConfig(config: DataPrivacyConfig): boolean {
   return Object.keys(config).length === 0;
 }

--- a/langwatch/src/pages/settings/__tests__/dataPrivacyDrawerUrl.integration.test.tsx
+++ b/langwatch/src/pages/settings/__tests__/dataPrivacyDrawerUrl.integration.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The privacy rule drawer is URL-routed like every other drawer (see
+ * dev/docs/best_practices/drawers.md). The page opens it through `openDrawer`
+ * so the active rule lives in the URL, and the registered wrapper rebuilds the
+ * drawer from those URL params alone, so a pasted link reopens the same rule.
+ * These render the real page and wrapper and assert the drawer-routing calls,
+ * mirroring DrawerNavigation.integration.test.tsx.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { snapshot, mockOpenDrawer, mockCloseDrawer, mockSetForScope } =
+  vi.hoisted(() => {
+    const cat = { disposition: "capture" as const, audience: {} };
+    const baseline = {
+      categories: { input: cat, output: cat, system: cat, tools: cat },
+      pii: { level: "essential" as const, entities: [] },
+      secrets: { enabled: true, customPatterns: [] },
+      customAttributes: [],
+    };
+    return {
+      mockOpenDrawer: vi.fn(),
+      mockCloseDrawer: vi.fn(),
+      mockSetForScope: vi.fn(),
+      snapshot: {
+        available: {
+          organization: { id: "org-1", name: "Acme" },
+          departments: [],
+          teams: [{ id: "team-1", name: "Platform" }],
+          projects: [{ id: "proj-1", name: "Web App", teamId: "team-1" }],
+        },
+        audienceOptions: { groups: [] },
+        effective: baseline,
+        effectiveTeam: baseline,
+        effectiveOrganization: baseline,
+        rules: [
+          {
+            scopeType: "TEAM" as const,
+            scopeId: "team-1",
+            name: "Platform",
+            personalOnly: false,
+            config: { categories: { input: { disposition: "drop" as const } } },
+          },
+        ],
+      },
+    };
+  });
+
+vi.mock("~/hooks/useDrawer", () => ({
+  useDrawer: () => ({
+    openDrawer: mockOpenDrawer,
+    closeDrawer: mockCloseDrawer,
+    goBack: vi.fn(),
+    canGoBack: false,
+    drawerOpen: vi.fn(() => false),
+  }),
+}));
+
+vi.mock("~/hooks/useOrganizationTeamProject", () => ({
+  useOrganizationTeamProject: () => ({
+    project: { id: "proj-1", teamId: "team-1", slug: "web-app" },
+    organization: { id: "org-1" },
+  }),
+}));
+
+vi.mock("~/hooks/useUrlScopeFilter", () => ({
+  useUrlScopeFilter: () => [{ kind: "all" }, vi.fn()],
+}));
+
+vi.mock("~/components/SettingsLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("~/components/settings/ScopeFilter", () => ({
+  ScopeFilter: () => null,
+}));
+
+vi.mock("~/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      dataPrivacy: { getSnapshot: { invalidate: vi.fn() } },
+    }),
+    dataPrivacy: {
+      getSnapshot: {
+        useQuery: () => ({ data: snapshot, isLoading: false }),
+      },
+      removeForScope: {
+        useMutation: () => ({ mutateAsync: vi.fn(), isLoading: false }),
+      },
+      setForScope: {
+        useMutation: () => ({ mutateAsync: mockSetForScope, isLoading: false }),
+      },
+    },
+  },
+}));
+
+import { DataPrivacyRuleDrawer } from "~/components/settings/DataPrivacyRuleDrawer";
+import { DataPrivacyPage } from "../data-privacy";
+
+const renderWithChakra = (ui: React.ReactElement) =>
+  render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+
+describe("Privacy rule drawer URL routing", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(cleanup);
+
+  describe("when an admin opens the add flow from the page", () => {
+    /** @scenario Opening the add flow reflects in the URL */
+    it("routes to the drawer with no scope params", async () => {
+      const user = userEvent.setup();
+      renderWithChakra(<DataPrivacyPage projectId="proj-1" />);
+
+      await user.click(
+        screen.getByRole("button", { name: "Add privacy rule" }),
+      );
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith("dataPrivacyRule", {});
+    });
+  });
+
+  describe("when an admin opens a rule to edit from the page", () => {
+    /** @scenario Opening a rule to edit reflects in the URL */
+    it("routes to the drawer carrying the rule's scope", async () => {
+      const user = userEvent.setup();
+      renderWithChakra(<DataPrivacyPage projectId="proj-1" />);
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Actions for Platform privacy rule",
+        }),
+      );
+      await user.click(await screen.findByRole("menuitem", { name: "Edit" }));
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith("dataPrivacyRule", {
+        editScopeType: "TEAM",
+        editScopeId: "team-1",
+        editPersonalOnly: "false",
+      });
+    });
+  });
+
+  describe("when a shared link carries the drawer for a team scope", () => {
+    /** @scenario A shared link reopens the same rule */
+    it("rebuilds the drawer showing that team rule from the URL alone", () => {
+      renderWithChakra(
+        <DataPrivacyRuleDrawer
+          editScopeType="TEAM"
+          editScopeId="team-1"
+          editPersonalOnly="false"
+        />,
+      );
+
+      expect(screen.getByText("Edit privacy rule")).toBeInTheDocument();
+      expect(screen.getByLabelText("Input").textContent).toContain("Dropped");
+    });
+  });
+
+  describe("when the admin closes the drawer", () => {
+    /** @scenario Closing the drawer clears it from the URL */
+    it("clears the drawer from the URL", async () => {
+      const user = userEvent.setup();
+      renderWithChakra(
+        <DataPrivacyRuleDrawer
+          editScopeType="TEAM"
+          editScopeId="team-1"
+          editPersonalOnly="false"
+        />,
+      );
+
+      await user.keyboard("{Escape}");
+
+      expect(mockCloseDrawer).toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/pages/settings/__tests__/dataPrivacyInheritDrawer.integration.test.tsx
+++ b/langwatch/src/pages/settings/__tests__/dataPrivacyInheritDrawer.integration.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The privacy rule drawer exposes "Inherit" on every control. A new rule starts
+ * every field on Inherit (so a saved-as-is rule changes nothing), an inherited
+ * field shows the value it resolves to, and editing a rule shows the fields the
+ * rule does not set as Inherit rather than a concrete default. Renders the real
+ * drawer (no shallow, no mocked controls) and asserts via each control's value.
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type Disposition,
+  PLATFORM_DEFAULT_DATA_PRIVACY,
+  type ResolvedDataPrivacy,
+} from "~/server/data-privacy/dataPrivacy.types";
+import type {
+  DataPrivacyRule,
+  DataPrivacyScopeAvailable,
+} from "~/server/data-privacy/dataPrivacyPolicy.read";
+import { PrivacyRuleDrawer } from "../data-privacy";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
+);
+
+const PROJECT_ID = "proj-1";
+
+const available: DataPrivacyScopeAvailable = {
+  organization: { id: "org-1", name: "Acme" },
+  departments: [],
+  teams: [{ id: "team-1", name: "Platform" }],
+  projects: [{ id: PROJECT_ID, name: "Web App", teamId: "team-1" }],
+};
+
+function baseline(
+  categoryDispositions: Partial<
+    Record<keyof ResolvedDataPrivacy["categories"], Disposition>
+  > = {},
+): ResolvedDataPrivacy {
+  const cat = (disposition: Disposition) => ({
+    disposition,
+    audience: { ...PLATFORM_DEFAULT_DATA_PRIVACY.categories.input.audience },
+  });
+  return {
+    categories: {
+      input: cat(categoryDispositions.input ?? "capture"),
+      output: cat(categoryDispositions.output ?? "capture"),
+      system: cat(categoryDispositions.system ?? "capture"),
+      tools: cat(categoryDispositions.tools ?? "capture"),
+    },
+    pii: { level: "essential", entities: [] },
+    secrets: { enabled: true, customPatterns: [] },
+    customAttributes: [],
+  };
+}
+
+function renderDrawer({
+  editingRule = null,
+  effectiveTeam = baseline(),
+}: {
+  editingRule?: DataPrivacyRule | null;
+  effectiveTeam?: ResolvedDataPrivacy;
+} = {}) {
+  return render(
+    <PrivacyRuleDrawer
+      open={true}
+      editingRule={editingRule}
+      onClose={vi.fn()}
+      available={available}
+      audienceOptions={{ groups: [] }}
+      effectiveTeam={effectiveTeam}
+      effectiveOrganization={baseline()}
+      projectId={PROJECT_ID}
+      currentTeamId="team-1"
+      currentOrganizationId="org-1"
+      isSaving={false}
+      onSave={vi.fn()}
+    />,
+    { wrapper },
+  );
+}
+
+/** The visible value of a content-category select, read from its trigger. */
+function categoryValue(label: string): string {
+  return screen.getByLabelText(label).textContent ?? "";
+}
+
+describe("PrivacyRuleDrawer inherit controls", () => {
+  afterEach(cleanup);
+
+  describe("when adding a brand-new rule", () => {
+    /** @scenario A new rule starts with every setting inheriting */
+    it("starts every content category, PII, and secrets on Inherit", () => {
+      renderDrawer();
+
+      expect(categoryValue("Input")).toContain("Inherit");
+      expect(categoryValue("Output")).toContain("Inherit");
+      expect(categoryValue("System instructions")).toContain("Inherit");
+      expect(categoryValue("Tool calls")).toContain("Inherit");
+      expect(categoryValue("Secrets redaction")).toContain("Inherit");
+
+      const piiInherit = screen.getByRole("radio", { name: /Inherit/ });
+      expect(piiInherit).toBeChecked();
+    });
+  });
+
+  describe("when adding a rule under a parent that drops input", () => {
+    /** @scenario An inherited setting shows the value it resolves to */
+    it("shows the dropped value next to the inheriting input control", () => {
+      renderDrawer({ effectiveTeam: baseline({ input: "drop" }) });
+
+      expect(screen.getByText("Inherits Dropped")).toBeInTheDocument();
+    });
+  });
+
+  describe("when editing a rule that only drops input", () => {
+    /** @scenario Editing a rule shows unset fields as Inherit, not as a concrete default */
+    it("shows input as Dropped and the rest as Inherit", () => {
+      renderDrawer({
+        editingRule: {
+          scopeType: "PROJECT",
+          scopeId: PROJECT_ID,
+          personalOnly: false,
+          name: "Web App",
+          config: { categories: { input: { disposition: "drop" } } },
+        },
+      });
+
+      expect(categoryValue("Input")).toContain("Dropped");
+      expect(categoryValue("Output")).toContain("Inherit");
+      expect(categoryValue("System instructions")).toContain("Inherit");
+      expect(categoryValue("Tool calls")).toContain("Inherit");
+      expect(categoryValue("Output")).not.toContain("Captured");
+    });
+  });
+
+  describe("when editing a rule that sets strict PII", () => {
+    it("shows the PII level as the explicit choice, secrets still inheriting", () => {
+      renderDrawer({
+        editingRule: {
+          scopeType: "PROJECT",
+          scopeId: PROJECT_ID,
+          personalOnly: false,
+          name: "Web App",
+          config: { pii: { level: "strict" } },
+        },
+      });
+
+      const strict = screen.getByRole("radio", { name: /Strict/ });
+      expect(strict).toBeChecked();
+      expect(categoryValue("Secrets redaction")).toContain("Inherit");
+      const secretsSection = screen.getByLabelText("Secrets redaction");
+      expect(within(secretsSection).queryByText("Captured")).toBeNull();
+    });
+  });
+});

--- a/langwatch/src/pages/settings/__tests__/dataPrivacyInheritDrawer.integration.test.tsx
+++ b/langwatch/src/pages/settings/__tests__/dataPrivacyInheritDrawer.integration.test.tsx
@@ -105,6 +105,52 @@ describe("PrivacyRuleDrawer inherit controls", () => {
       const piiInherit = screen.getByRole("radio", { name: /Inherit/ });
       expect(piiInherit).toBeChecked();
     });
+
+    /** @scenario Every control offers Inherit as a choice */
+    it("offers Inherit on every category, PII, and secrets control", () => {
+      renderDrawer();
+
+      for (const label of [
+        "Input",
+        "Output",
+        "System instructions",
+        "Tool calls",
+        "Secrets redaction",
+      ]) {
+        expect(categoryValue(label)).toContain("Inherit");
+      }
+
+      for (const name of [
+        /Inherit/,
+        /^Off$/,
+        /^Essential/,
+        /^Strict/,
+        /^Custom/,
+      ]) {
+        expect(screen.getByRole("radio", { name })).toBeInTheDocument();
+      }
+    });
+  });
+
+  describe("when adding a rule at the organization scope", () => {
+    /** @scenario At the organization scope, Inherit resolves to the platform default */
+    it("shows every inheriting control resolving to the platform default", () => {
+      renderDrawer({
+        editingRule: {
+          scopeType: "ORGANIZATION",
+          scopeId: "org-1",
+          personalOnly: false,
+          name: "Acme",
+          config: {},
+        },
+      });
+
+      expect(screen.getAllByText("Inherits Captured")).toHaveLength(4);
+      expect(
+        screen.getByRole("radio", { name: /Inherit.*Essential/ }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Inherits On")).toBeInTheDocument();
+    });
   });
 
   describe("when adding a rule under a parent that drops input", () => {
@@ -138,6 +184,7 @@ describe("PrivacyRuleDrawer inherit controls", () => {
   });
 
   describe("when editing a rule that sets strict PII", () => {
+    /** @scenario Editing a rule that only sets PII leaves secrets inheriting */
     it("shows the PII level as the explicit choice, secrets still inheriting", () => {
       renderDrawer({
         editingRule: {

--- a/langwatch/src/pages/settings/data-privacy.tsx
+++ b/langwatch/src/pages/settings/data-privacy.tsx
@@ -78,6 +78,7 @@ import { Select } from "~/components/ui/select";
 import { toaster } from "~/components/ui/toaster";
 import { Tooltip } from "~/components/ui/tooltip";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
+import { useDrawer } from "~/hooks/useDrawer";
 import { useOrganizationTeamProject } from "~/hooks/useOrganizationTeamProject";
 import { useUrlScopeFilter } from "~/hooks/useUrlScopeFilter";
 import {
@@ -181,11 +182,9 @@ export default withPermissionGuard("project:view", {
 
 function DataPrivacyPage({ projectId }: { projectId: string }) {
   const utils = api.useUtils();
-  const { project: currentProject, organization } =
-    useOrganizationTeamProject();
+  const { project: currentProject } = useOrganizationTeamProject();
   const snapshotQuery = api.dataPrivacy.getSnapshot.useQuery({ projectId });
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [editingRule, setEditingRule] = useState<DataPrivacyRule | null>(null);
+  const { openDrawer } = useDrawer();
 
   const available = snapshotQuery.data?.available;
   const filterAvailable = useMemo<AvailableScopes>(
@@ -208,7 +207,6 @@ function DataPrivacyPage({ projectId }: { projectId: string }) {
   const invalidate = () =>
     utils.dataPrivacy.getSnapshot.invalidate({ projectId });
 
-  const setForScope = api.dataPrivacy.setForScope.useMutation();
   const removeForScope = api.dataPrivacy.removeForScope.useMutation();
 
   if (snapshotQuery.isLoading) {
@@ -246,14 +244,13 @@ function DataPrivacyPage({ projectId }: { projectId: string }) {
   };
   const filteredRules = snapshot ? snapshot.rules.filter(matchesFilter) : [];
 
-  const openAdd = () => {
-    setEditingRule(null);
-    setDrawerOpen(true);
-  };
-  const openEdit = (rule: DataPrivacyRule) => {
-    setEditingRule(rule);
-    setDrawerOpen(true);
-  };
+  const openAdd = () => openDrawer("dataPrivacyRule", {});
+  const openEdit = (rule: DataPrivacyRule) =>
+    openDrawer("dataPrivacyRule", {
+      editScopeType: rule.scopeType,
+      editScopeId: rule.scopeId,
+      editPersonalOnly: String(rule.personalOnly),
+    });
 
   const removeRule = async (rule: DataPrivacyRule) => {
     try {
@@ -425,61 +422,6 @@ function DataPrivacyPage({ projectId }: { projectId: string }) {
             snapshot={snapshot}
             scopeFilter={scopeFilter}
             currentTeamId={currentProject?.teamId ?? null}
-          />
-        )}
-
-        {available && snapshot && (
-          <PrivacyRuleDrawer
-            open={drawerOpen}
-            editingRule={editingRule}
-            onClose={() => {
-              setDrawerOpen(false);
-              setEditingRule(null);
-            }}
-            available={available}
-            audienceOptions={snapshot.audienceOptions}
-            effectiveTeam={snapshot.effectiveTeam}
-            effectiveOrganization={snapshot.effectiveOrganization}
-            projectId={projectId}
-            currentTeamId={currentProject?.teamId ?? null}
-            currentOrganizationId={organization?.id ?? null}
-            isSaving={setForScope.isLoading}
-            onSave={async (scopes, config) => {
-              try {
-                await Promise.all(
-                  scopes.map((scope) =>
-                    setForScope.mutateAsync({
-                      projectId,
-                      scope: {
-                        scopeType: scope.scopeType,
-                        scopeId: scope.scopeId,
-                      },
-                      personalOnly: !!scope.personalOnly,
-                      config,
-                    }),
-                  ),
-                );
-                void invalidate();
-                toaster.create({
-                  title:
-                    scopes.length > 1
-                      ? `Privacy rule saved for ${scopes.length} scopes`
-                      : "Privacy rule saved",
-                  type: "success",
-                });
-                setDrawerOpen(false);
-                setEditingRule(null);
-              } catch (error) {
-                // Partial failure leaves the already-saved scopes in place;
-                // the snapshot refresh shows exactly which rows exist.
-                void invalidate();
-                toaster.create({
-                  title: "Failed to save rule",
-                  description: (error as Error).message,
-                  type: "error",
-                });
-              }
-            }}
           />
         )}
       </VStack>

--- a/langwatch/src/pages/settings/data-privacy.tsx
+++ b/langwatch/src/pages/settings/data-privacy.tsx
@@ -180,7 +180,7 @@ export default withPermissionGuard("project:view", {
   layoutComponent: SettingsLayout,
 })(DataPrivacySettings);
 
-function DataPrivacyPage({ projectId }: { projectId: string }) {
+export function DataPrivacyPage({ projectId }: { projectId: string }) {
   const utils = api.useUtils();
   const { project: currentProject } = useOrganizationTeamProject();
   const snapshotQuery = api.dataPrivacy.getSnapshot.useQuery({ projectId });

--- a/langwatch/src/pages/settings/data-privacy.tsx
+++ b/langwatch/src/pages/settings/data-privacy.tsx
@@ -30,7 +30,7 @@ import {
   Users,
   X,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import SettingsLayout from "~/components/SettingsLayout";
 import {
@@ -39,18 +39,21 @@ import {
   applyAudienceSelection,
   audienceToSelection,
   buildRuleConfig,
+  type CategoryChoice,
   type CustomAttributeFormRow,
   configsEqual,
   configToFormState,
   EMPTY_AUDIENCE_FORM,
-  inheritedFormState,
+  inheritedBaselineForScope,
+  inheritFormState,
   isEmptyRuleConfig,
+  type PiiChoice,
   PROJECT_OWNER_VALUE,
   ROLE_VALUES,
+  type RuleFormState,
   ruleSummary,
+  type SecretsChoice,
   selectionToAudience,
-  type TouchedControls,
-  touchedFromConfig,
 } from "~/components/settings/dataPrivacyRuleConfig";
 import {
   ESSENTIAL_PII_ENTITY_LABELS,
@@ -72,7 +75,6 @@ import { Checkbox } from "~/components/ui/checkbox";
 import { Drawer } from "~/components/ui/drawer";
 import { Menu } from "~/components/ui/menu";
 import { Select } from "~/components/ui/select";
-import { Switch } from "~/components/ui/switch";
 import { toaster } from "~/components/ui/toaster";
 import { Tooltip } from "~/components/ui/tooltip";
 import { withPermissionGuard } from "~/components/WithPermissionGuard";
@@ -436,7 +438,8 @@ function DataPrivacyPage({ projectId }: { projectId: string }) {
             }}
             available={available}
             audienceOptions={snapshot.audienceOptions}
-            effective={snapshot.effective}
+            effectiveTeam={snapshot.effectiveTeam}
+            effectiveOrganization={snapshot.effectiveOrganization}
             projectId={projectId}
             currentTeamId={currentProject?.teamId ?? null}
             currentOrganizationId={organization?.id ?? null}
@@ -589,6 +592,11 @@ export function EffectiveSummary({
 const dispositionCollection = createListCollection({
   items: [
     {
+      value: "inherit",
+      label: "Inherit",
+      description: "Use the value from the wider scope.",
+    },
+    {
       value: "capture",
       label: "Captured",
       description: "Stored and visible to your team.",
@@ -606,18 +614,32 @@ const dispositionCollection = createListCollection({
   ],
 });
 
+const secretsChoiceCollection = createListCollection({
+  items: [
+    { value: "inherit", label: "Inherit" },
+    { value: "on", label: "On" },
+    { value: "off", label: "Off" },
+  ],
+});
+
+const PII_VALUE_LABELS: Record<PiiLevel, string> = {
+  disabled: "Off",
+  essential: "Essential",
+  strict: "Strict",
+  custom: "Custom",
+};
+
+/** Human label for what an inherited control currently resolves to. */
+function inheritedHint(label: string): string {
+  return `Inherits ${label}`;
+}
+
 const attributeDispositionCollection = createListCollection({
   items: [
     { value: "restrict", label: "Restricted" },
     { value: "drop", label: "Dropped" },
   ],
 });
-
-const NO_CONTROLS_TOUCHED: TouchedControls = {
-  categories: {},
-  pii: false,
-  secrets: false,
-};
 
 function describeAudienceSelection(
   audience: AudienceFormState,
@@ -659,13 +681,14 @@ function attributePatternError(pattern: string): string | null {
   return null;
 }
 
-function PrivacyRuleDrawer({
+export function PrivacyRuleDrawer({
   open,
   editingRule,
   onClose,
   available,
   audienceOptions,
-  effective,
+  effectiveTeam,
+  effectiveOrganization,
   projectId,
   currentTeamId,
   currentOrganizationId,
@@ -677,7 +700,8 @@ function PrivacyRuleDrawer({
   onClose: () => void;
   available: DataPrivacyScopeAvailable;
   audienceOptions: DataPrivacyAudienceOptions;
-  effective: ResolvedDataPrivacy;
+  effectiveTeam: ResolvedDataPrivacy | null;
+  effectiveOrganization: ResolvedDataPrivacy | null;
   projectId: string;
   currentTeamId: string | null;
   currentOrganizationId: string | null;
@@ -686,36 +710,24 @@ function PrivacyRuleDrawer({
 }) {
   const [scopes, setScopes] = useState<ScopeChipPickerEntry[]>([]);
   const [dispositions, setDispositions] = useState<
-    Record<ContentCategory, Disposition>
+    Record<ContentCategory, CategoryChoice>
   >({
-    input: "capture",
-    output: "capture",
-    system: "capture",
-    tools: "capture",
+    input: "inherit",
+    output: "inherit",
+    system: "inherit",
+    tools: "inherit",
   });
   const [audience, setAudience] = useState<AudienceFormState>({
     ...EMPTY_AUDIENCE_FORM,
     admins: true,
   });
-  const [piiLevel, setPiiLevel] = useState<PiiLevel>("essential");
+  const [piiChoice, setPiiChoice] = useState<PiiChoice>("inherit");
   const [piiEntities, setPiiEntities] = useState<string[]>([]);
-  const [secretsEnabled, setSecretsEnabled] = useState(true);
+  const [secretsChoice, setSecretsChoice] = useState<SecretsChoice>("inherit");
   const [secretsPatterns, setSecretsPatterns] = useState<string[]>([]);
   const [customAttributes, setCustomAttributes] = useState<
     CustomAttributeFormRow[]
   >([]);
-  // Controls the user explicitly changed, so they persist as overrides. On an
-  // edit it starts as the rule's existing fields, so they re-persist untouched.
-  const [touched, setTouched] = useState<TouchedControls>(NO_CONTROLS_TOUCHED);
-  // Read inside the scope-change effect without re-deriving on every touch.
-  const touchedRef = useRef(touched);
-  touchedRef.current = touched;
-  // Remember the last enabled PII level so toggling redaction off and back on
-  // restores the chosen level instead of silently dropping Strict to Essential.
-  const lastEnabledPiiLevel = useRef<PiiLevel>("essential");
-  useEffect(() => {
-    if (piiLevel !== "disabled") lastEnabledPiiLevel.current = piiLevel;
-  }, [piiLevel]);
 
   const togglePiiEntity = (entity: string) => {
     setPiiEntities((prev) =>
@@ -723,44 +735,21 @@ function PrivacyRuleDrawer({
         ? prev.filter((e) => e !== entity)
         : [...prev, entity],
     );
-    setTouched((prev) => ({ ...prev, pii: true }));
   };
 
-  const touchCategory = (category: ContentCategory) =>
-    setTouched((prev) => ({
-      ...prev,
-      categories: { ...prev.categories, [category]: true },
-    }));
-  const touchRestrictedCategories = () =>
-    setTouched((prev) => {
-      const categories = { ...prev.categories };
-      for (const c of CONTENT_CATEGORIES) {
-        if (dispositions[c] === "restrict") categories[c] = true;
-      }
-      return { ...prev, categories };
-    });
-
-  const isCurrentProjectScope =
-    scopes.length === 1 &&
-    scopes[0]!.scopeType === "PROJECT" &&
-    scopes[0]!.scopeId === projectId &&
-    !scopes[0]!.personalOnly;
-
-  const applyForm = (form: ReturnType<typeof configToFormState>) => {
+  const applyForm = (form: RuleFormState) => {
     setDispositions(form.dispositions);
     setAudience(form.audience);
-    setPiiLevel(form.piiLevel);
+    setPiiChoice(form.piiChoice);
     setPiiEntities(form.piiEntities);
-    setSecretsEnabled(form.secretsEnabled);
+    setSecretsChoice(form.secretsChoice);
     setSecretsPatterns(form.secretsPatterns);
     setCustomAttributes(form.customAttributes);
   };
 
-  // Open transition: seed the drawer. Edit prefills from the rule and marks its
-  // existing fields touched so they re-persist. Add prefills from the values the
-  // new rule would inherit (the current-project scope shows the resolved
-  // effective; any other scope the platform defaults), with nothing touched yet,
-  // so the user sees the parent restriction they're about to override.
+  // Open transition: seed the drawer. Edit hydrates from the rule, so a field
+  // the rule does not set shows as "Inherit" rather than a concrete default. Add
+  // starts every control on "Inherit", so a saved-as-is rule changes nothing.
   useEffect(() => {
     if (!open) return;
     if (editingRule) {
@@ -772,9 +761,6 @@ function PrivacyRuleDrawer({
         },
       ]);
       applyForm(configToFormState(editingRule.config));
-      const editTouched = touchedFromConfig(editingRule.config);
-      setTouched(editTouched);
-      touchedRef.current = editTouched;
       return;
     }
     const projectInAvailable = available.projects.some(
@@ -784,28 +770,19 @@ function PrivacyRuleDrawer({
       ? [{ scopeType: "PROJECT", scopeId: projectId }]
       : [];
     setScopes(initialScopes);
-    setTouched(NO_CONTROLS_TOUCHED);
-    touchedRef.current = NO_CONTROLS_TOUCHED;
-    applyForm(
-      inheritedFormState({
-        effective,
-        isCurrentProjectScope: projectInAvailable,
-      }),
-    );
+    applyForm(inheritFormState());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, editingRule]);
 
-  // Re-derive the Add baseline when the user switches scope before touching
-  // anything; once a control is touched their choices stand and aren't clobbered.
-  useEffect(() => {
-    if (!open || editingRule) return;
-    const t = touchedRef.current;
-    const anyTouched =
-      t.pii || t.secrets || Object.values(t.categories).some(Boolean);
-    if (anyTouched) return;
-    applyForm(inheritedFormState({ effective, isCurrentProjectScope }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCurrentProjectScope]);
+  // The policy a left-on-inherit field resolves to, so each control can show the
+  // value it inherits. Keyed off the scope being edited (or the first picked).
+  const inheritScopeType: "ORGANIZATION" | "DEPARTMENT" | "TEAM" | "PROJECT" =
+    editingRule?.scopeType ?? scopes[0]?.scopeType ?? "PROJECT";
+  const inheritedBaseline = inheritedBaselineForScope({
+    scopeType: inheritScopeType,
+    effectiveTeam,
+    effectiveOrganization,
+  });
 
   const anyRestrict =
     CONTENT_CATEGORIES.some((c) => dispositions[c] === "restrict") ||
@@ -816,22 +793,20 @@ function PrivacyRuleDrawer({
       buildRuleConfig({
         dispositions,
         audience,
-        piiLevel,
+        piiChoice,
         piiEntities,
-        secretsEnabled,
+        secretsChoice,
         secretsPatterns,
         customAttributes,
-        touched,
       }),
     [
       dispositions,
       audience,
-      piiLevel,
+      piiChoice,
       piiEntities,
-      secretsEnabled,
+      secretsChoice,
       secretsPatterns,
       customAttributes,
-      touched,
     ],
   );
 
@@ -916,43 +891,57 @@ function PrivacyRuleDrawer({
               <Text fontWeight="600" fontSize="sm">
                 Content
               </Text>
-              {CONTENT_CATEGORIES.map((category) => (
-                <HStack key={category} justifyContent="space-between" gap={4}>
-                  <Text fontSize="sm">{CATEGORY_LABELS[category]}</Text>
-                  <Select.Root
-                    collection={dispositionCollection}
-                    value={[dispositions[category]]}
-                    size="sm"
-                    width="200px"
-                    onValueChange={(d) => {
-                      setDispositions((prev) => ({
-                        ...prev,
-                        [category]: (d.value[0] as Disposition) ?? "capture",
-                      }));
-                      touchCategory(category);
-                    }}
-                  >
-                    <Select.Trigger
-                      background="bg"
-                      aria-label={CATEGORY_LABELS[category]}
-                    >
-                      <Select.ValueText />
-                    </Select.Trigger>
-                    <Select.Content>
-                      {dispositionCollection.items.map((item) => (
-                        <Select.Item key={item.value} item={item}>
-                          <VStack align="start" gap={0}>
-                            <Text fontSize="sm">{item.label}</Text>
-                            <Text fontSize="xs" color="fg.muted">
-                              {item.description}
-                            </Text>
-                          </VStack>
-                        </Select.Item>
-                      ))}
-                    </Select.Content>
-                  </Select.Root>
-                </HStack>
-              ))}
+              {CONTENT_CATEGORIES.map((category) => {
+                const choice = dispositions[category];
+                return (
+                  <VStack key={category} align="stretch" gap={0.5}>
+                    <HStack justifyContent="space-between" gap={4}>
+                      <Text fontSize="sm">{CATEGORY_LABELS[category]}</Text>
+                      <Select.Root
+                        collection={dispositionCollection}
+                        value={[choice]}
+                        size="sm"
+                        width="200px"
+                        onValueChange={(d) =>
+                          setDispositions((prev) => ({
+                            ...prev,
+                            [category]:
+                              (d.value[0] as CategoryChoice) ?? "inherit",
+                          }))
+                        }
+                      >
+                        <Select.Trigger
+                          background="bg"
+                          aria-label={CATEGORY_LABELS[category]}
+                        >
+                          <Select.ValueText />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {dispositionCollection.items.map((item) => (
+                            <Select.Item key={item.value} item={item}>
+                              <VStack align="start" gap={0}>
+                                <Text fontSize="sm">{item.label}</Text>
+                                <Text fontSize="xs" color="fg.muted">
+                                  {item.description}
+                                </Text>
+                              </VStack>
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select.Root>
+                    </HStack>
+                    {choice === "inherit" && (
+                      <Text fontSize="xs" color="fg.muted" textAlign="end">
+                        {inheritedHint(
+                          DISPOSITION_LABELS[
+                            inheritedBaseline.categories[category].disposition
+                          ],
+                        )}
+                      </Text>
+                    )}
+                  </VStack>
+                );
+              })}
             </VStack>
 
             <VStack gap={2} align="stretch">
@@ -1069,10 +1058,7 @@ function PrivacyRuleDrawer({
                 <AudiencePicker
                   audience={audience}
                   options={audienceOptions}
-                  onChange={(next) => {
-                    setAudience(next);
-                    touchRestrictedCategories();
-                  }}
+                  onChange={setAudience}
                 />
                 <Text fontSize="xs" color="fg.muted">
                   {describeAudienceSelection(audience, audienceOptions)}
@@ -1083,119 +1069,113 @@ function PrivacyRuleDrawer({
             <Separator />
 
             <VStack gap={2} align="stretch">
-              <HStack gap={3} align="start">
-                <Switch
-                  checked={piiLevel !== "disabled"}
-                  onCheckedChange={({ checked }) => {
-                    setPiiLevel(
-                      checked === true
-                        ? lastEnabledPiiLevel.current
-                        : "disabled",
+              <VStack align="start" gap={0}>
+                <Text fontWeight="600" fontSize="sm">
+                  PII redaction
+                </Text>
+                <Text fontSize="xs" color="fg.muted">
+                  Masks personal data like emails, phones, cards, and IDs in
+                  stored content.
+                </Text>
+              </VStack>
+              <RadioGroup.Root
+                value={piiChoice}
+                onValueChange={(d) => {
+                  const next = (d.value as PiiChoice) ?? "inherit";
+                  setPiiChoice(next);
+                  // Seed custom with the native essentials the first time so
+                  // it starts from a sensible base the customer can pare down.
+                  if (next === "custom") {
+                    setPiiEntities((prev) =>
+                      prev.length > 0
+                        ? prev
+                        : Object.keys(ESSENTIAL_PII_ENTITY_LABELS),
                     );
-                    setTouched((prev) => ({ ...prev, pii: true }));
-                  }}
-                />
-                <VStack align="start" gap={0}>
-                  <Text fontWeight="600" fontSize="sm">
-                    PII redaction
-                  </Text>
-                  <Text fontSize="xs" color="fg.muted">
-                    Masks personal data like emails, phones, cards, and IDs in
-                    stored content.
-                  </Text>
+                  }
+                }}
+              >
+                <VStack align="start" gap={1}>
+                  <RadioGroup.Item value="inherit">
+                    <RadioGroup.ItemHiddenInput />
+                    <RadioGroup.ItemIndicator />
+                    <RadioGroup.ItemText>
+                      Inherit
+                      {piiChoice === "inherit" && (
+                        <Text as="span" color="fg.muted">
+                          {" · "}
+                          {inheritedHint(
+                            PII_VALUE_LABELS[inheritedBaseline.pii.level],
+                          )}
+                        </Text>
+                      )}
+                    </RadioGroup.ItemText>
+                  </RadioGroup.Item>
+                  <RadioGroup.Item value="disabled">
+                    <RadioGroup.ItemHiddenInput />
+                    <RadioGroup.ItemIndicator />
+                    <RadioGroup.ItemText>Off</RadioGroup.ItemText>
+                  </RadioGroup.Item>
+                  <RadioGroup.Item value="essential">
+                    <RadioGroup.ItemHiddenInput />
+                    <RadioGroup.ItemIndicator />
+                    <RadioGroup.ItemText>
+                      Essential (emails, phones, cards, IPs, national IDs)
+                    </RadioGroup.ItemText>
+                    <Tooltip
+                      content={`Detects and masks: ${ESSENTIAL_PII_SUMMARY}.`}
+                      contentProps={{ maxWidth: "340px" }}
+                    >
+                      <Box color="fg.muted" display="inline-flex">
+                        <HelpCircle size={13} />
+                      </Box>
+                    </Tooltip>
+                  </RadioGroup.Item>
+                  <RadioGroup.Item value="strict">
+                    <RadioGroup.ItemHiddenInput />
+                    <RadioGroup.ItemIndicator />
+                    <RadioGroup.ItemText>
+                      Strict (adds names, locations, and more)
+                    </RadioGroup.ItemText>
+                    <Tooltip
+                      content={`Everything in Essential, plus deeper detection of: ${STRICT_ADDED_PII_SUMMARY}.`}
+                      contentProps={{ maxWidth: "340px" }}
+                    >
+                      <Box color="fg.muted" display="inline-flex">
+                        <HelpCircle size={13} />
+                      </Box>
+                    </Tooltip>
+                  </RadioGroup.Item>
+                  <RadioGroup.Item value="custom">
+                    <RadioGroup.ItemHiddenInput />
+                    <RadioGroup.ItemIndicator />
+                    <RadioGroup.ItemText>
+                      Custom (choose exactly what to redact)
+                    </RadioGroup.ItemText>
+                  </RadioGroup.Item>
                 </VStack>
-              </HStack>
-              {piiLevel !== "disabled" && (
-                <>
-                  <RadioGroup.Root
-                    value={piiLevel}
-                    paddingLeft={10}
-                    onValueChange={(d) => {
-                      const next = (d.value as PiiLevel) ?? "essential";
-                      setPiiLevel(next);
-                      // Seed custom with the native essentials the first time so
-                      // it starts from a sensible base the customer can pare down.
-                      if (next === "custom") {
-                        setPiiEntities((prev) =>
-                          prev.length > 0
-                            ? prev
-                            : Object.keys(ESSENTIAL_PII_ENTITY_LABELS),
-                        );
-                      }
-                      setTouched((prev) => ({ ...prev, pii: true }));
-                    }}
-                  >
-                    <VStack align="start" gap={1}>
-                      <RadioGroup.Item value="essential">
-                        <RadioGroup.ItemHiddenInput />
-                        <RadioGroup.ItemIndicator />
-                        <RadioGroup.ItemText>
-                          Essential (emails, phones, cards, IPs, national IDs)
-                        </RadioGroup.ItemText>
-                        <Tooltip
-                          content={`Detects and masks: ${ESSENTIAL_PII_SUMMARY}.`}
-                          contentProps={{ maxWidth: "340px" }}
-                        >
-                          <Box color="fg.muted" display="inline-flex">
-                            <HelpCircle size={13} />
-                          </Box>
-                        </Tooltip>
-                      </RadioGroup.Item>
-                      <RadioGroup.Item value="strict">
-                        <RadioGroup.ItemHiddenInput />
-                        <RadioGroup.ItemIndicator />
-                        <RadioGroup.ItemText>
-                          Strict (adds names, locations, and more)
-                        </RadioGroup.ItemText>
-                        <Tooltip
-                          content={`Everything in Essential, plus deeper detection of: ${STRICT_ADDED_PII_SUMMARY}.`}
-                          contentProps={{ maxWidth: "340px" }}
-                        >
-                          <Box color="fg.muted" display="inline-flex">
-                            <HelpCircle size={13} />
-                          </Box>
-                        </Tooltip>
-                      </RadioGroup.Item>
-                      <RadioGroup.Item value="custom">
-                        <RadioGroup.ItemHiddenInput />
-                        <RadioGroup.ItemIndicator />
-                        <RadioGroup.ItemText>
-                          Custom (choose exactly what to redact)
-                        </RadioGroup.ItemText>
-                      </RadioGroup.Item>
-                    </VStack>
-                  </RadioGroup.Root>
-                  {piiLevel === "custom" && (
-                    <VStack align="stretch" gap={3} paddingLeft={10}>
-                      <PiiEntityToggleGroup
-                        title="Fast detection"
-                        hint="Redacted instantly as data arrives, at no extra cost."
-                        labels={ESSENTIAL_PII_ENTITY_LABELS}
-                        selected={piiEntities}
-                        onToggle={togglePiiEntity}
-                      />
-                      <PiiEntityToggleGroup
-                        title="Deep detection"
-                        hint="Also finds names and locations. May add some latency."
-                        labels={STRICT_ADDED_PII_ENTITY_LABELS}
-                        selected={piiEntities}
-                        onToggle={togglePiiEntity}
-                      />
-                    </VStack>
-                  )}
-                </>
+              </RadioGroup.Root>
+              {piiChoice === "custom" && (
+                <VStack align="stretch" gap={3} paddingLeft={6}>
+                  <PiiEntityToggleGroup
+                    title="Fast detection"
+                    hint="Redacted instantly as data arrives, at no extra cost."
+                    labels={ESSENTIAL_PII_ENTITY_LABELS}
+                    selected={piiEntities}
+                    onToggle={togglePiiEntity}
+                  />
+                  <PiiEntityToggleGroup
+                    title="Deep detection"
+                    hint="Also finds names and locations. May add some latency."
+                    labels={STRICT_ADDED_PII_ENTITY_LABELS}
+                    selected={piiEntities}
+                    onToggle={togglePiiEntity}
+                  />
+                </VStack>
               )}
             </VStack>
 
             <VStack gap={2} align="stretch">
-              <HStack gap={3} align="start">
-                <Switch
-                  checked={secretsEnabled}
-                  onCheckedChange={({ checked }) => {
-                    setSecretsEnabled(checked === true);
-                    setTouched((prev) => ({ ...prev, secrets: true }));
-                  }}
-                />
+              <HStack justifyContent="space-between" gap={4} align="start">
                 <VStack align="start" gap={0}>
                   <Text fontWeight="600" fontSize="sm">
                     Secrets redaction
@@ -1205,9 +1185,39 @@ function PrivacyRuleDrawer({
                     by default.
                   </Text>
                 </VStack>
+                <Select.Root
+                  collection={secretsChoiceCollection}
+                  value={[secretsChoice]}
+                  size="sm"
+                  width="120px"
+                  onValueChange={(d) =>
+                    setSecretsChoice((d.value[0] as SecretsChoice) ?? "inherit")
+                  }
+                >
+                  <Select.Trigger
+                    background="bg"
+                    aria-label="Secrets redaction"
+                  >
+                    <Select.ValueText />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {secretsChoiceCollection.items.map((item) => (
+                      <Select.Item key={item.value} item={item}>
+                        {item.label}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select.Root>
               </HStack>
-              {secretsEnabled && (
-                <VStack gap={2} align="stretch" paddingLeft={10}>
+              {secretsChoice === "inherit" && (
+                <Text fontSize="xs" color="fg.muted" textAlign="end">
+                  {inheritedHint(
+                    inheritedBaseline.secrets.enabled ? "On" : "Off",
+                  )}
+                </Text>
+              )}
+              {secretsChoice === "on" && (
+                <VStack gap={2} align="stretch" paddingLeft={6}>
                   {secretsPatterns.length > 0 && (
                     <Text fontWeight="600" fontSize="sm">
                       Custom patterns
@@ -1225,17 +1235,13 @@ function PrivacyRuleDrawer({
                             value={pattern}
                             aria-label={`Custom secret pattern ${index + 1}`}
                             borderColor={error ? "red.500" : undefined}
-                            onChange={(e) => {
+                            onChange={(e) =>
                               setSecretsPatterns((prev) =>
                                 prev.map((p, i) =>
                                   i === index ? e.target.value : p,
                                 ),
-                              );
-                              setTouched((prev) => ({
-                                ...prev,
-                                secrets: true,
-                              }));
-                            }}
+                              )
+                            }
                           />
                           <Button
                             size="xs"
@@ -1243,15 +1249,11 @@ function PrivacyRuleDrawer({
                             aria-label={`Remove custom secret pattern ${
                               index + 1
                             }`}
-                            onClick={() => {
+                            onClick={() =>
                               setSecretsPatterns((prev) =>
                                 prev.filter((_, i) => i !== index),
-                              );
-                              setTouched((prev) => ({
-                                ...prev,
-                                secrets: true,
-                              }));
-                            }}
+                              )
+                            }
                           >
                             <X size={14} />
                           </Button>
@@ -1268,10 +1270,9 @@ function PrivacyRuleDrawer({
                     <Button
                       size="xs"
                       variant="ghost"
-                      onClick={() => {
-                        setSecretsPatterns((prev) => [...prev, ""]);
-                        setTouched((prev) => ({ ...prev, secrets: true }));
-                      }}
+                      onClick={() =>
+                        setSecretsPatterns((prev) => [...prev, ""])
+                      }
                     >
                       <Plus size={14} /> Add custom pattern
                     </Button>

--- a/langwatch/src/pages/settings/data-privacy.tsx
+++ b/langwatch/src/pages/settings/data-privacy.tsx
@@ -1103,9 +1103,7 @@ export function PrivacyRuleDrawer({
                       {piiChoice === "inherit" && (
                         <Text as="span" color="fg.muted">
                           {" · "}
-                          {inheritedHint(
-                            PII_VALUE_LABELS[inheritedBaseline.pii.level],
-                          )}
+                          {PII_VALUE_LABELS[inheritedBaseline.pii.level]}
                         </Text>
                       )}
                     </RadioGroup.ItemText>

--- a/specs/data-privacy/inherit-option.feature
+++ b/specs/data-privacy/inherit-option.feature
@@ -18,11 +18,11 @@ Feature: Inherit option on privacy rules
     Given an organization "acme" with a team "platform" and a project "web-app"
 
   @integration
-  Scenario: Every content category offers Inherit as its first choice
+  Scenario: Every control offers Inherit as a choice
     When an admin opens the privacy rule drawer for project "web-app"
-    Then each content category offers "Inherit", "Captured", "Restricted", and "Dropped"
-    And PII redaction offers "Inherit" alongside the off and level choices
-    And secrets redaction offers "Inherit" alongside on and off
+    Then every content category offers an "Inherit" choice
+    And PII redaction offers "Inherit" alongside the off, essential, strict, and custom choices
+    And secrets redaction offers an "Inherit" choice
 
   @integration
   Scenario: A new rule starts with every setting inheriting
@@ -75,3 +75,10 @@ Feature: Inherit option on privacy rules
     Then each content category shows "Inherit" resolving to "Captured"
     And PII redaction shows "Inherit" resolving to "Essential"
     And secrets redaction shows "Inherit" resolving to "On"
+
+  @integration
+  Scenario: Editing a rule that only sets PII leaves secrets inheriting
+    Given a project rule on "web-app" that only sets strict PII
+    When an admin opens that rule in the drawer
+    Then PII redaction shows "Strict"
+    And secrets redaction shows "Inherit"

--- a/specs/data-privacy/inherit-option.feature
+++ b/specs/data-privacy/inherit-option.feature
@@ -1,0 +1,77 @@
+Feature: Inherit option on privacy rules
+  As an admin editing a privacy rule
+  I want every setting to offer an "Inherit" choice that shows what it resolves to
+  So that I can leave a setting to the wider scope, or the platform default,
+  without guessing whether a value is my own or inherited
+
+  # A privacy rule sets only the fields an admin chooses; every other field
+  # inherits from the next scope up the cascade (department, team, organization)
+  # and finally the platform default. The drawer makes that explicit: every
+  # control, the four content categories, PII redaction, secrets redaction, and
+  # each custom-attribute rule, offers "Inherit" as its first choice and shows
+  # what the field currently resolves to, so an admin sees the inherited value
+  # before deciding to override it. "Inherit" is the default for a brand-new
+  # rule, so an empty rule changes nothing until a field is set, and reverting a
+  # field to "Inherit" hands it back to the wider scope.
+
+  Background:
+    Given an organization "acme" with a team "platform" and a project "web-app"
+
+  @integration
+  Scenario: Every content category offers Inherit as its first choice
+    When an admin opens the privacy rule drawer for project "web-app"
+    Then each content category offers "Inherit", "Captured", "Restricted", and "Dropped"
+    And PII redaction offers "Inherit" alongside the off and level choices
+    And secrets redaction offers "Inherit" alongside on and off
+
+  @integration
+  Scenario: A new rule starts with every setting inheriting
+    When an admin opens the privacy rule drawer to add a rule for project "web-app"
+    Then every content category shows "Inherit"
+    And PII redaction shows "Inherit"
+    And secrets redaction shows "Inherit"
+
+  @integration
+  Scenario: An inherited setting shows the value it resolves to
+    Given an organization rule on "acme" that drops trace input
+    When an admin opens the privacy rule drawer to add a rule for project "web-app"
+    Then trace input shows "Inherit" resolving to "Dropped"
+
+  @unit
+  Scenario: Saving a rule with everything inheriting stores a rule that sets no fields
+    Given an admin opens the privacy rule drawer for project "web-app"
+    And every setting is left on "Inherit"
+    When the rule is saved
+    Then the stored rule sets no fields
+    And project "web-app" resolves to the same policy as before the rule
+
+  @unit
+  Scenario: Setting one category leaves the rest inheriting
+    Given an admin opens the privacy rule drawer for project "web-app"
+    When the admin sets trace input to "Dropped" and leaves the rest on "Inherit"
+    And the rule is saved
+    Then the stored rule sets only trace input to dropped
+    And trace output, system instructions, and tool calls still inherit
+
+  @integration
+  Scenario: Editing a rule shows unset fields as Inherit, not as a concrete default
+    Given a project rule on "web-app" that only drops trace input
+    When an admin opens that rule in the drawer
+    Then trace input shows "Dropped"
+    And trace output, system instructions, and tool calls show "Inherit"
+    And the inherited categories are not shown as "Captured"
+
+  @unit
+  Scenario: Reverting a field to Inherit removes it from the rule
+    Given a project rule on "web-app" that drops trace input and captures trace output
+    When an admin sets trace input back to "Inherit"
+    And the rule is saved
+    Then the stored rule no longer sets trace input
+    And trace input resolves from the wider scope again
+
+  @integration
+  Scenario: At the organization scope, Inherit resolves to the platform default
+    When an admin opens the privacy rule drawer for the "acme" organization
+    Then each content category shows "Inherit" resolving to "Captured"
+    And PII redaction shows "Inherit" resolving to "Essential"
+    And secrets redaction shows "Inherit" resolving to "On"

--- a/specs/data-privacy/privacy-rule-drawer-url.feature
+++ b/specs/data-privacy/privacy-rule-drawer-url.feature
@@ -36,7 +36,10 @@ Feature: Shareable privacy rule drawer
     When the admin closes the drawer
     Then the drawer parameters are removed from the URL
 
-  @integration
+  # Back-button history is provided by the shared drawer framework once the
+  # drawer is URL-routed (the scenarios above prove it is). It needs a real
+  # history stack, so it is verified in browser QA rather than in jsdom.
+  @integration @unimplemented
   Scenario: The browser back button closes the drawer
     Given an admin opened the privacy rule drawer from the data privacy page
     When the admin presses the browser back button

--- a/specs/data-privacy/privacy-rule-drawer-url.feature
+++ b/specs/data-privacy/privacy-rule-drawer-url.feature
@@ -1,0 +1,43 @@
+Feature: Shareable privacy rule drawer
+  As an admin reviewing a privacy rule
+  I want the edit drawer to live in the page URL
+  So that I can share a link that opens the exact rule, and the browser back
+  button closes the drawer
+
+  # Like every other drawer in the app (see dev/docs/best_practices/drawers.md),
+  # the privacy rule drawer is URL-routed: opening it adds a drawer.open
+  # parameter plus the scope it targets, and closing it removes them. A pasted
+  # link reopens the same rule because the drawer reconstructs itself from the
+  # URL, fetching the policy snapshot rather than relying on in-memory state.
+
+  Background:
+    Given an organization "acme" with a team "platform" and a project "web-app"
+
+  @integration
+  Scenario: Opening a rule to edit reflects in the URL
+    Given an organization rule exists on "acme"
+    When an admin clicks edit on the organization rule
+    Then the URL carries the privacy rule drawer open for the organization scope
+
+  @integration
+  Scenario: Opening the add flow reflects in the URL
+    When an admin clicks "Add privacy rule"
+    Then the URL carries the privacy rule drawer open in add mode
+
+  @integration
+  Scenario: A shared link reopens the same rule
+    Given a team rule exists on "platform"
+    When someone opens a link carrying the privacy rule drawer for the "platform" team scope
+    Then the drawer opens showing the team rule
+
+  @integration
+  Scenario: Closing the drawer clears it from the URL
+    Given the privacy rule drawer is open for the organization scope
+    When the admin closes the drawer
+    Then the drawer parameters are removed from the URL
+
+  @integration
+  Scenario: The browser back button closes the drawer
+    Given an admin opened the privacy rule drawer from the data privacy page
+    When the admin presses the browser back button
+    Then the drawer closes and the data privacy page remains


### PR DESCRIPTION
## What

Two changes to the data-privacy rule drawer:
1. An explicit **Inherit** choice on every control, so a field can be left to the wider scope and you can see what it resolves to.
2. The drawer now routes through the shared `currentDrawer` + URL, so a rule is **shareable by link** and the back button closes it.

### Why inherit

The cascade already treats an unset field as "inherit from the wider scope" (first-set-wins down organization to project, platform default at the top). But the drawer never let you express that unset state: it defaulted every field to a concrete value (Captured / Essential / On) and offered no way to hand a field back to the parent. So a rule that only meant to drop input looked like it pinned all four categories, and a backfilled `strip_all` org rule read as four explicit drops with no hint the rest was just defaults.

- Every content category (Input / Output / System instructions / Tool calls), PII redaction, and secrets redaction now offers **Inherit** as its first choice, and it is the default for a brand-new rule, so a saved-as-is rule changes nothing.
- A field left on Inherit is omitted from the saved config, so it resolves from the next scope up; at the organization tier it resolves to the platform default.
- Each inheriting control shows the value it currently resolves to ("Inherits Dropped").
- Editing a rule shows the fields the rule does not set as Inherit, not as a concrete default, so its own pins are distinguishable from what it leaves to the parent.

Internally this replaces the hidden `touched`-tracking model with an explicit `inherit` value on each control, which is simpler and matches the data model one to one.

### Why the drawer URL

Per `dev/docs/best_practices/drawers.md`, drawers are URL-routed; this one was the holdout on `useState`. It now reconstructs itself from the URL alone (the scope params identify the rule, the snapshot is fetched in the drawer), so a pasted link reopens the exact rule and the back button closes the drawer.

### Screenshots

A new rule starts every control on Inherit and shows what each resolves to (Save stays disabled because it changes nothing):

![Add rule, everything inheriting](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4945/inherit/add-drawer-all-inherit.png)

Editing a rule shows its own pins as concrete (Restricted) and the fields it does not set as Inherit, not as a misleading "Captured":

![Edit rule, mixed pins and inherit](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4945/inherit/edit-drawer-mixed.png)

A pasted link (`?drawer.open=dataPrivacyRule&drawer.editScopeType=ORGANIZATION&drawer.editScopeId=...`) reopens the exact rule on a fresh page load:

![Drawer reconstructed from a shared URL](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4945/inherit/drawer-url-shared-link.png)

### Tests

- `dataPrivacyRuleConfig.unit.test.ts`: the form to config mapping, inherit omission, round-trips, and the per-scope inherited baseline.
- `dataPrivacyInheritDrawer.integration.test.tsx`: renders the real drawer and asserts a new rule starts all-inherit, an inherited control shows its resolved value, and editing shows unset fields as Inherit.
- URL routing verified end to end in the browser: open Add and Edit both write `drawer.open=dataPrivacyRule` plus the scope, a pasted link reconstructs the rule, and close clears the params.

### Specs

`specs/data-privacy/inherit-option.feature` and `specs/data-privacy/privacy-rule-drawer-url.feature`.