### PR TITLE
feat(charts): close remaining admission-policy gaps (gateway automount, app init container)

### DIFF
--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      # The gateway does not call the Kubernetes API, so don't mount the SA token.
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       containers:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -160,6 +160,11 @@ guardrails:
   postTimeout: 2s
   streamChunkWindow: 50ms
 
+# The gateway does not call the Kubernetes API. Default to not mounting the
+# SA token; many clusters deny pods that automount it. Set true only if a
+# sidecar needs in-cluster API access.
+automountServiceAccountToken: false
+
 # Pod-level security.
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -91,12 +91,20 @@ spec:
           volumeMounts:
             - name: next-dir
               mountPath: /next-tmp
+          # Mirrors the main container's hardening so strict admission policies
+          # (require-resource-limits, read-only-root-filesystem) accept the
+          # init container too. It only writes to the next-dir emptyDir, so a
+          # read-only root filesystem is safe here.
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 200m, memory: 256Mi }
       containers:
         {{- with .Values.app.extraContainers}}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Why

Follow-up to #4927. A self-hosted customer on a strict Gatekeeper cluster (Azure AKS) shared the full admission event log. #4927 fixed the bulk of it - the first-party Deployments (app, workers, nlp, langevals) now pass automount + seccomp + read-only-root - but the log surfaced two pods the first pass missed.

## What changed

**Gateway** (`charts/gateway`)
- The gateway pod had no `automountServiceAccountToken`, so `disallow-automount-serviceaccount-token` denied it. The gateway subchart was never wired for it (I wrongly called it "already compliant" in #4927 - it had the security contexts but not the automount field). Added `automountServiceAccountToken` as a gateway value (default `false`) and set it on the pod spec. The gateway doesn't call the Kubernetes API.

**App init container** (`charts/langwatch`)
- The `fix-nextjs-permissions` init container had no `resources` and no `readOnlyRootFilesystem`, tripping `require-resource-limits` and the read-only-root-filesystem constraints. It only copies into the `next-dir` emptyDir (never writes to its own root), so `readOnlyRootFilesystem: true` is safe; added it plus modest requests/limits to mirror the main container's hardening.

## Deployment Impact

Affects self-hosted Helm deployments only (SaaS/cloud unaffected). On `helm upgrade`, the gateway and app pod templates change (new `automountServiceAccountToken` / init-container `resources` + `securityContext` fields), so those two roll once. No new required values - `gateway.automountServiceAccountToken` defaults to `false` and the init-container resources are fixed in the template. No secret, CRD, RBAC, or data-migration changes.

## Test plan
`helm lint` + `helm template` pass for the gateway standalone and the umbrella (with `autogen.enabled=true`). Verified the rendered gateway pod carries `automountServiceAccountToken: false` and the init container carries `readOnlyRootFilesystem: true` + requests/limits; full umbrella manifest parses as valid YAML.

## Anything surprising?
One class of denial this does **not** fix: the customer's cluster runs a no-exceptions `ro-rootfs-constraint` that requires `readOnlyRootFilesystem: true` on *every* container, including the chart-managed PostgreSQL/Redis/ClickHouse datastores. Those need a writable root (Postgres `/var/run/postgresql`, ClickHouse `/var/log` + tmp, etc.), so they cannot satisfy that constraint without a much larger writable-emptyDir refactor that defeats the point. The right answer for locked-down clusters remains external/managed datastores (`postgresql`/`redis`/`clickhouse.chartManaged: false`), which removes those pods entirely. Flagging rather than forcing in-cluster DBs into a shape they shouldn't take.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configurations by enforcing stricter service account token policies and hardened container security contexts.
  * Implemented improved resource management and isolation controls for system processes with explicit CPU and memory limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->