### PR TITLE
feat(charts): pass strict admission control (read-only root, automount, seccomp, limits)

### DIFF
--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -70,7 +70,7 @@ See the [Docker image README](../../clickhouse-serverless/README.md) for the ful
 | Name | Description | Default |
 |------|-------------|---------|
 | `image.repository` | Image repository | `langwatch/clickhouse-serverless` |
-| `image.tag` | Image tag | `0.1.0` |
+| `image.tag` | Image tag | `0.2.0` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 ### Storage
@@ -106,6 +106,8 @@ Shared by cold storage and backups. Required when either `cold.enabled` or `back
 |------|-------------|---------|
 | `backup.enabled` | Enable native ClickHouse BACKUP/RESTORE to S3 (requires `objectStorage`) | `false` |
 | `backup.database` | Database to back up | `langwatch` |
+| `backup.user` | ClickHouse user for backup/restore operations | `default` |
+| `backup.resources` | CPU/memory requests + limits for the backup/restore Job containers | requests `100m`/`128Mi`, limits `500m`/`512Mi` |
 | `backup.full.schedule` | Cron schedule for full backups | `0 */12 * * *` |
 | `backup.incremental.schedule` | Cron schedule for incremental backups | `0 * * * *` |
 
@@ -160,6 +162,25 @@ This creates two users: `analyst` with read-only access to all databases, and `e
 | `scheduling.nodeSelector` | Node selector labels | `{}` |
 | `scheduling.affinity` | Affinity rules | `{}` |
 | `scheduling.tolerations` | Tolerations | `[]` |
+
+### ServiceAccount
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `serviceAccount.create` | Create a dedicated ServiceAccount | `true` |
+| `serviceAccount.name` | ServiceAccount name (defaults to the chart fullname) | `""` |
+| `serviceAccount.automountServiceAccountToken` | Mount the SA token; ClickHouse/Keeper need no Kubernetes API access. Also set on the pod specs so policies that inspect the pod (not the SA) accept it. | `false` |
+| `serviceAccount.annotations` | ServiceAccount annotations (e.g. IRSA role ARN) | `{}` |
+
+## Pod Security
+
+ClickHouse, Keeper, and the backup/restore Jobs run non-root (uid 101) with a
+read-only root filesystem, `RuntimeDefault` seccomp, dropped capabilities, no
+privilege escalation, and no mounted ServiceAccount token. The paths ClickHouse
+writes at runtime (server logs, the pid directory, `/tmp`, and the rendered
+`config.d`/`users.d`) are `emptyDir` volumes; data stays on the PVC, so the
+image layer is never writable. This clears Pod Security Admission `restricted`
+and Gatekeeper / Kyverno policies, including "read-only root on every container".
 
 ## Deployment Modes
 

--- a/charts/clickhouse-serverless/README.md
+++ b/charts/clickhouse-serverless/README.md
@@ -65,6 +65,13 @@ See the [Docker image README](../../clickhouse-serverless/README.md) for the ful
 | `replicas` | Number of ClickHouse nodes. 1 = standalone MergeTree, 3+ = ReplicatedMergeTree + Keeper (must be odd) | `1` |
 | `clusterName` | ClickHouse cluster name used in macros and remote_servers config | `langwatch` |
 
+> **`memory` scales with ingest, not just stored size.** The image auto-tunes
+> `max_server_memory_usage` (~85% of the limit) and per-query limits from
+> `memory`, and large/concurrent inserts plus background merges spike well above
+> idle. Sub-2Gi values are fine for smoke or light local use, but raise `memory`
+> (and `cpu`) before pushing real trace throughput or a big ingest burst will
+> OOM the pod.
+
 ### Image
 
 | Name | Description | Default |

--- a/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
+++ b/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
@@ -25,11 +25,16 @@ spec:
             app.kubernetes.io/component: backup-full
         spec:
           restartPolicy: Never
+          # Backup jobs never call the Kubernetes API.
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
             seccompProfile:
               type: RuntimeDefault
+          volumes:
+            - name: tmp
+              emptyDir: {}
           containers:
             - name: full-backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -38,10 +43,14 @@ spec:
               securityContext:
                 runAsUser: 101
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
               resources:
                 {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"
@@ -81,11 +90,16 @@ spec:
             app.kubernetes.io/component: backup-incremental
         spec:
           restartPolicy: Never
+          # Backup jobs never call the Kubernetes API.
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
             seccompProfile:
               type: RuntimeDefault
+          volumes:
+            - name: tmp
+              emptyDir: {}
           containers:
             - name: incremental-backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -94,10 +108,14 @@ spec:
               securityContext:
                 runAsUser: 101
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
               resources:
                 {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"
@@ -135,11 +153,16 @@ spec:
             app.kubernetes.io/component: restore-data
         spec:
           restartPolicy: Never
+          # Backup jobs never call the Kubernetes API.
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           securityContext:
             runAsNonRoot: true
             fsGroup: 101
             seccompProfile:
               type: RuntimeDefault
+          volumes:
+            - name: tmp
+              emptyDir: {}
           containers:
             - name: restore-data
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -148,10 +171,14 @@ spec:
               securityContext:
                 runAsUser: 101
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
               resources:
                 {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               env:
                 - name: CLICKHOUSE_HOST
                   value: "{{ $fullname }}-0.{{ $fullname }}-headless"

--- a/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
+++ b/charts/clickhouse-serverless/templates/backup-cronjobs.yaml
@@ -42,6 +42,7 @@ spec:
               command: ["/scripts/backup-data.sh"]
               securityContext:
                 runAsUser: 101
+                runAsNonRoot: true
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 capabilities:
@@ -107,6 +108,7 @@ spec:
               command: ["/scripts/backup-data.sh"]
               securityContext:
                 runAsUser: 101
+                runAsNonRoot: true
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 capabilities:
@@ -170,6 +172,7 @@ spec:
               command: ["/scripts/restore-data.sh"]
               securityContext:
                 runAsUser: 101
+                runAsNonRoot: true
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 capabilities:

--- a/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/keeper-statefulset.yaml
@@ -25,6 +25,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "clickhouse-serverless.serviceAccountName" . }}
+      # Set on the pod too (not just the SA) for policies that check the pod
+      # spec field. Keeper never calls the Kubernetes API.
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -125,8 +128,9 @@ spec:
           securityContext:
             runAsUser: 101  # clickhouse user
             runAsNonRoot: true
-            # Keeper needs a writable /var/lib/clickhouse-keeper outside the PVC.
-            readOnlyRootFilesystem: false
+            # Read-only root: keeper data is on the PVC and config is the
+            # keeper-config emptyDir; logs/pid/tmp are emptyDir-mounted below.
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
@@ -157,9 +161,22 @@ spec:
               mountPath: /var/lib/clickhouse-keeper
             - name: keeper-config
               mountPath: /etc/clickhouse-keeper
+            # Writable scratch so keeper runs read-only root: logs, pid, /tmp.
+            - name: keeper-logs
+              mountPath: /var/log/clickhouse-keeper
+            - name: keeper-run
+              mountPath: /var/run/clickhouse-keeper
+            - name: tmp
+              mountPath: /tmp
 
       volumes:
         - name: keeper-config
+          emptyDir: {}
+        - name: keeper-logs
+          emptyDir: {}
+        - name: keeper-run
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
         - name: keeper-raft-template
           configMap:

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -25,6 +25,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "clickhouse-serverless.serviceAccountName" . }}
+      # Set on the pod too (not just the SA) for policies that check the pod
+      # spec field rather than the ServiceAccount. ClickHouse never calls the
+      # Kubernetes API.
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -79,11 +83,13 @@ spec:
         - name: clickhouse
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          # readOnlyRootFilesystem is intentionally omitted — ClickHouse writes
-          # to paths outside the data PVC (e.g. /tmp, format schemas) and would
-          # crashloop under a read-only root.
+          # Read-only root: ch-config only writes into config.d/users.d (both
+          # emptyDir mounts) and ClickHouse data lives on the PVC. The few
+          # remaining writable paths (logs, pid, /tmp) are emptyDir-mounted
+          # below, so the image layer itself never needs to be writable.
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           ports:
@@ -230,6 +236,15 @@ spec:
               mountPath: /etc/clickhouse-server/config.d
             - name: users-d
               mountPath: /etc/clickhouse-server/users.d
+            # Writable scratch so the container runs read-only root: server
+            # logs, the pid dir, and /tmp. (config.d/users.d above are also
+            # writable emptyDirs, which is where ch-config renders config.)
+            - name: ch-logs
+              mountPath: /var/log/clickhouse-server
+            - name: ch-run
+              mountPath: /var/run/clickhouse-server
+            - name: tmp
+              mountPath: /tmp
             - name: secrets
               mountPath: /mnt/secrets
               readOnly: true
@@ -238,6 +253,12 @@ spec:
         - name: config-d
           emptyDir: {}
         - name: users-d
+          emptyDir: {}
+        - name: ch-logs
+          emptyDir: {}
+        - name: ch-run
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
         - name: secrets
           secret:

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -88,6 +88,10 @@ spec:
           # remaining writable paths (logs, pid, /tmp) are emptyDir-mounted
           # below, so the image layer itself never needs to be writable.
           securityContext:
+            # The image already runs as uid 101 via its USER directive; pin it
+            # explicitly so it matches Keeper/backup and satisfies runAsUser /
+            # MustRunAs policies that read the pod spec.
+            runAsUser: 101
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/charts/clickhouse-serverless/templates/statefulset.yaml
+++ b/charts/clickhouse-serverless/templates/statefulset.yaml
@@ -92,6 +92,7 @@ spec:
             # explicitly so it matches Keeper/backup and satisfies runAsUser /
             # MustRunAs policies that read the pod spec.
             runAsUser: 101
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -76,6 +76,12 @@ self-hosting. The values you most often override:
 | `autoscaling.minReplicas` / `maxReplicas` | HPA bounds                                              |
 | `resources`                   | Pod CPU/memory requests + limits                                     |
 | `otel.endpoint`               | Optional OTLP HTTP exporter URL (gateway emits its own spans)        |
+| `automountServiceAccountToken`| Mount the SA token into the pod (default `false`; the gateway needs no Kubernetes API access) |
+
+The pod ships hardened (`podSecurityContext` / `containerSecurityContext` in
+`values.yaml`): non-root, read-only root, dropped capabilities, `RuntimeDefault`
+seccomp, no mounted SA token. It clears Pod Security Admission `restricted` and
+Gatekeeper / Kyverno policies as-is.
 
 Many `values.yaml` knobs are exposed as forward-compat for v1.1 and
 have no effect in v1 (e.g. `cache.lruSize`, `redis.url`,

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      # The gateway does not call the Kubernetes API, so don't mount the SA token.
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       containers:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -160,6 +160,11 @@ guardrails:
   postTimeout: 2s
   streamChunkWindow: 50ms
 
+# The gateway does not call the Kubernetes API. Default to not mounting the
+# SA token; many clusters deny pods that automount it. Set true only if a
+# sidecar needs in-cluster API access.
+automountServiceAccountToken: false
+
 # Pod-level security.
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -175,6 +175,9 @@ podSecurityContext:
     type: RuntimeDefault
 
 containerSecurityContext:
+  # runAsNonRoot is also set on the pod above; some Gatekeeper constraints
+  # inspect the container-level field directly, so set it here too.
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -68,6 +68,7 @@ All overlays live in `examples/overlays/`:
 | `postgres-external` | External PostgreSQL (RDS, Cloud SQL) |
 | `redis-external` | External Redis (ElastiCache, Memorystore) |
 | `cold-storage-s3` | S3 cold storage tiering + backups |
+| `strict-admission` | Toggles for Pod Security Admission `restricted` / Gatekeeper / Kyverno clusters |
 
 ### All-in-one profiles
 
@@ -122,6 +123,17 @@ For development, set `autogen.enabled: true` to auto-generate all secrets.
 | **Prometheus** | `prometheus.chartManaged: true` | Optional — for metrics collection |
 
 For a complete installation guide, visit the [documentation](https://docs.langwatch.ai/self-hosting/kubernetes-helm).
+
+### Pod security
+
+Every pod (PostgreSQL, Redis, and ClickHouse included) runs read-only-root,
+non-root, with dropped capabilities, `RuntimeDefault` seccomp, no mounted SA
+token, and resource requests/limits on every container. That clears Pod
+Security Admission `restricted` and Gatekeeper / Kyverno policies as shipped.
+On clusters that enforce them, add `examples/overlays/strict-admission.yaml`,
+which turns off the three features that can't comply: the token-using preflight
+hook, the upstream Prometheus subchart, and the custom-metrics gateway HPA. Full
+details in [Security → Pod Security](https://docs.langwatch.ai/self-hosting/security#pod-security).
 
 ### Regenerate this table
 

--- a/charts/langwatch/README.md
+++ b/charts/langwatch/README.md
@@ -70,6 +70,8 @@ All overlays live in `examples/overlays/`:
 | `cold-storage-s3` | S3 cold storage tiering + backups |
 | `strict-admission` | Toggles for Pod Security Admission `restricted` / Gatekeeper / Kyverno clusters |
 
+> **Sizing notes.** The Node app and workers need roughly **2Gi to boot** (they cold-load the TS server through tsx); the `size-minimal` and `size-dev` overlays account for this, so don't trim app/worker memory below ~2Gi or they OOM at startup. **ClickHouse memory scales with ingest volume** - the chart-managed defaults in `size-minimal`/`size-dev` (1-2Gi) are for light/local use; raise `clickhouse.memory` (and `cpu`) before pushing real trace throughput, or a large ingest burst will OOM it.
+
 ### All-in-one profiles
 
 For common scenarios, use the bundled profiles in `examples/`:

--- a/charts/langwatch/examples/overlays/size-dev.yaml
+++ b/charts/langwatch/examples/overlays/size-dev.yaml
@@ -17,9 +17,10 @@ app:
 workers:
   enabled: true
   replicaCount: 1
+  # Same image as the app: needs ~2Gi to cold-load via tsx without OOM-restarts.
   resources:
-    requests: { cpu: 100m, memory: 512Mi }
-    limits:   { cpu: 500m, memory: 1Gi }
+    requests: { cpu: 250m, memory: 768Mi }
+    limits:   { cpu: 1, memory: 2Gi }
 
 langwatch_nlp:
   replicaCount: 1
@@ -39,7 +40,9 @@ langevals:
 clickhouse:
   chartManaged: true
   replicas: 1
-  memory: 1Gi
+  # 2Gi handles light dev ingest. Memory scales with ingest burst size and
+  # background merges, so raise clickhouse.memory if you replay real volume.
+  memory: 2Gi
   cpu: 1
   storage:
     size: 5Gi

--- a/charts/langwatch/examples/overlays/size-minimal.yaml
+++ b/charts/langwatch/examples/overlays/size-minimal.yaml
@@ -1,6 +1,9 @@
-# size-minimal.yaml — Absolute minimum resources for CI smoke tests.
+# size-minimal.yaml - smallest footprint that still boots and serves.
+# For CI smoke tests and tiny demos, not real workloads.
 #
-# Everything runs but with tiny limits. Not suitable for real workloads.
+# The Node app and workers need ~2Gi to start: they cold-load the TS server
+# via tsx, and below that V8 can't size its heap and the pod OOMs at boot.
+# ClickHouse auto-tunes to its limit, so give it >=1Gi.
 #
 # Usage:
 #   helm install lw . \
@@ -13,14 +16,14 @@ app:
   features:
     skipEnvValidation: true
   resources:
-    requests: { cpu: 50m, memory: 256Mi }
-    limits:   { cpu: 250m, memory: 512Mi }
+    requests: { cpu: 250m, memory: 768Mi }
+    limits:   { cpu: 1, memory: 2Gi }
 
 workers:
   replicaCount: 1
   resources:
-    requests: { cpu: 50m, memory: 256Mi }
-    limits:   { cpu: 250m, memory: 512Mi }
+    requests: { cpu: 250m, memory: 768Mi }
+    limits:   { cpu: 1, memory: 2Gi }
 
 langwatch_nlp:
   replicaCount: 1
@@ -31,8 +34,8 @@ langwatch_nlp:
 langevals:
   replicaCount: 1
   resources:
-    requests: { cpu: 50m, memory: 256Mi }
-    limits:   { cpu: 250m, memory: 512Mi }
+    requests: { cpu: 100m, memory: 512Mi }
+    limits:   { cpu: 500m, memory: 1Gi }
   extraEnvs:
     - { name: DISABLE_EVALUATORS_PRELOAD, value: "true" }
     - { name: WEB_CONCURRENCY, value: "1" }
@@ -40,7 +43,10 @@ langevals:
 clickhouse:
   chartManaged: true
   replicas: 1
-  memory: 512Mi
+  # 1Gi covers smoke/light use only. ClickHouse memory scales with ingest
+  # burst size and background merges, so a real trace flood will OOM this -
+  # raise clickhouse.memory (and cpu) before pushing meaningful volume.
+  memory: 1Gi
   cpu: 1
   storage:
     size: 1Gi

--- a/charts/langwatch/examples/overlays/size-minimal.yaml
+++ b/charts/langwatch/examples/overlays/size-minimal.yaml
@@ -17,7 +17,10 @@ app:
     limits:   { cpu: 250m, memory: 512Mi }
 
 workers:
-  enabled: false
+  replicaCount: 1
+  resources:
+    requests: { cpu: 50m, memory: 256Mi }
+    limits:   { cpu: 250m, memory: 512Mi }
 
 langwatch_nlp:
   replicaCount: 1

--- a/charts/langwatch/examples/overlays/strict-admission.yaml
+++ b/charts/langwatch/examples/overlays/strict-admission.yaml
@@ -1,0 +1,48 @@
+# strict-admission.yaml - for clusters that enforce Pod Security Admission
+# "restricted" or an equivalent OPA Gatekeeper / Kyverno bundle.
+#
+# The hardened pod defaults (read-only root, non-root, dropped capabilities,
+# RuntimeDefault seccomp, no automounted token, resource requests+limits) are
+# already on by default, so this overlay only flips the three features that
+# need a token or an external API and would otherwise be rejected.
+#
+# Usage (stack on a size + access overlay):
+#   helm install lw . \
+#     -f examples/overlays/size-prod.yaml \
+#     -f examples/overlays/access-ingress.yaml \
+#     -f examples/overlays/strict-admission.yaml
+#
+# For production, also stack the external-datastore overlays. Managed databases
+# give you backups and HA and deploy no datastore pods at all. (In-cluster
+# datastores do comply with read-only-root, but external is the better choice.)
+#   -f examples/overlays/postgres-external.yaml
+#   -f examples/overlays/redis-external.yaml
+#   -f examples/overlays/clickhouse-external.yaml
+
+# Preflight runs kubectl to check Secret keys, so it needs an SA token.
+# Disable it where token automounting is denied.
+preflight:
+  enabled: false
+
+# Bundled Prometheus is an upstream subchart we don't harden; bring your own.
+prometheus:
+  chartManaged: false
+
+# The gateway's default HPA needs prometheus-adapter for its custom metric.
+# Run a fixed replica count instead unless you have a custom metrics API.
+gateway:
+  autoscaling:
+    enabled: false
+  replicaCount: 2
+
+app:
+  telemetry:
+    # Prometheus is off above, so don't expose app metrics either - nothing
+    # would scrape them. This is already the default; pinned here so the two
+    # stay coupled if a base values file turned metrics on.
+    metrics:
+      enabled: false
+    # Anonymous usage analytics phone home to LangWatch. Not an admission
+    # concern, but uncomment for an air-gapped / no-egress install.
+    # usage:
+    #   enabled: false

--- a/charts/langwatch/examples/values-local.yaml
+++ b/charts/langwatch/examples/values-local.yaml
@@ -30,9 +30,10 @@ app:
 workers:
   enabled: true
   replicaCount: 1
+  # Same image as the app: needs ~2Gi to cold-load via tsx without OOM-restarts.
   resources:
-    requests: { cpu: 100m, memory: 512Mi }
-    limits:   { cpu: 500m, memory: 1Gi }
+    requests: { cpu: 250m, memory: 768Mi }
+    limits:   { cpu: 1, memory: 2Gi }
 
 langwatch_nlp:
   replicaCount: 1
@@ -53,7 +54,9 @@ clickhouse:
   chartManaged: true
   image: { pullPolicy: Never }
   replicas: 1
-  memory: 1Gi
+  # Memory scales with ingest burst size; 2Gi suits local use, raise it before
+  # replaying real trace volume.
+  memory: 2Gi
   cpu: 1
   storage: { size: 5Gi }
 

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -76,35 +76,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
+      {{- with .Values.app.extraInitContainers}}
       initContainers:
-        {{- with .Values.app.extraInitContainers}}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        # Fix permissions for Next.js cache/static directories when running as non-root
-        - name: fix-nextjs-permissions
-          image: "{{ .Values.images.app.repository }}:{{ .Values.images.app.tag }}"
-          command: ['sh', '-c']
-          args:
-            - |
-              cp -r /app/langwatch/.next/* /next-tmp/ 2>/dev/null || true
-              echo "Copied .next contents to writable volume"
-          volumeMounts:
-            - name: next-dir
-              mountPath: /next-tmp
-          # Mirrors the main container's hardening so strict admission policies
-          # (require-resource-limits, read-only-root-filesystem) accept the
-          # init container too. It only writes to the next-dir emptyDir, so a
-          # read-only root filesystem is safe here.
-          securityContext:
-            runAsUser: 1000
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
-          resources:
-            requests: { cpu: 50m, memory: 64Mi }
-            limits: { cpu: 200m, memory: 256Mi }
+      {{- end }}
       containers:
         {{- with .Values.app.extraContainers}}
         {{- toYaml . | nindent 8 }}
@@ -303,8 +278,6 @@ spec:
             {{- end }}
             - name: tmp-dir
               mountPath: /tmp
-            - name: next-dir
-              mountPath: /app/langwatch/.next
             {{- if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
             # Stored-objects local-FS mount — renders ONLY when local-FS is
             # the active backend (dataplane disabled). Single-replica only
@@ -321,8 +294,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: tmp-dir
-          emptyDir: {}
-        - name: next-dir
           emptyDir: {}
         {{- if eq (include "langwatch.storedObjects.localFilesystemIsActive" .) "true" }}
         - name: stored-objects-data

--- a/charts/langwatch/templates/app/deployment.yaml
+++ b/charts/langwatch/templates/app/deployment.yaml
@@ -91,12 +91,20 @@ spec:
           volumeMounts:
             - name: next-dir
               mountPath: /next-tmp
+          # Mirrors the main container's hardening so strict admission policies
+          # (require-resource-limits, read-only-root-filesystem) accept the
+          # init container too. It only writes to the next-dir emptyDir, so a
+          # read-only root filesystem is safe here.
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 200m, memory: 256Mi }
       containers:
         {{- with .Values.app.extraContainers}}
         {{- toYaml . | nindent 8 }}

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -35,6 +35,7 @@ spec:
         - name: postgresql
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
@@ -82,6 +83,17 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+            # Writable scratch so the container can run read-only root:
+            # postgres needs its unix socket dir and /tmp writable.
+            - name: run
+              mountPath: /var/run/postgresql
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -23,6 +23,18 @@ spec:
     spec:
       # PostgreSQL does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      {{- with .Values.global.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsUser: 999
         runAsGroup: 999

--- a/charts/langwatch/templates/postgresql/statefulset.yaml
+++ b/charts/langwatch/templates/postgresql/statefulset.yaml
@@ -34,6 +34,7 @@ spec:
       containers:
         - name: postgresql
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         - name: redis
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
@@ -86,6 +87,12 @@ spec:
           volumeMounts:
             - name: redis-data
               mountPath: /data
+            # Writable /tmp so the container can run read-only root.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: redis-data

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -24,6 +24,18 @@ spec:
     spec:
       # Redis does not call the Kubernetes API, so don't mount the SA token.
       automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+      {{- with .Values.global.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsUser: 999
         runAsGroup: 999

--- a/charts/langwatch/templates/redis/statefulset.yaml
+++ b/charts/langwatch/templates/redis/statefulset.yaml
@@ -35,6 +35,7 @@ spec:
       containers:
         - name: redis
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -203,6 +203,55 @@ test_size_overlays() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# SUITE: pod security hardening — guard the strict-admission posture
+# (every container read-only-root + non-escalating + RuntimeDefault seccomp,
+# no automounted SA token, no privileged/writable-root opt-outs). These render-
+# level checks catch regressions of the hardening without needing Gatekeeper.
+# ─────────────────────────────────────────────────────────────────────────────
+test_pod_security() {
+  sep; info "Suite: pod security hardening"
+
+  # Default render: chart-managed everything (app, workers, nlp, langevals,
+  # cronjobs, postgres, redis, clickhouse, gateway).
+  local def
+  def=$(tmpl --set autogen.enabled=true)
+
+  assert_contains "hardening: read-only root filesystem set" "$def" "readOnlyRootFilesystem: true"
+  # After hardening, nothing opts back into a writable root.
+  assert_not_contains "hardening: no writable-root containers" "$def" "readOnlyRootFilesystem: false"
+  assert_contains "hardening: RuntimeDefault seccomp" "$def" "type: RuntimeDefault"
+  assert_contains "hardening: privilege escalation disabled" "$def" "allowPrivilegeEscalation: false"
+  assert_not_contains "hardening: no privileged containers" "$def" "privileged: true"
+  assert_contains "hardening: SA token not automounted" "$def" "automountServiceAccountToken: false"
+  assert_contains "hardening: clickhouse pins uid 101" "$def" "runAsUser: 101"
+  # The app moved off Next.js; the dead permissions init container stays gone.
+  assert_not_contains "hardening: no dead next.js init container" "$def" "fix-nextjs-permissions"
+
+  # read-only root should cover every workload container (app, workers, nlp,
+  # langevals, 2 cronjobs, postgres, redis, clickhouse, gateway = 10).
+  local ro_count
+  ro_count=$(count_matches "$def" "readOnlyRootFilesystem: true")
+  if (( ro_count >= 10 )); then
+    pass "hardening: read-only root on $ro_count containers (>=10)"
+  else
+    fail "hardening: expected >=10 read-only-root containers, found $ro_count"
+  fi
+
+  # Gateway pod must set automount on the POD spec, not just its ServiceAccount
+  # (regression guard for the gap this work closed).
+  local gw_block
+  gw_block=$(awk -v RS='---' '/kind: Deployment/ && /name: '"${RELEASE}"'-gateway/{print}' <<< "$def")
+  assert_contains "hardening: gateway pod automount disabled" "$gw_block" "automountServiceAccountToken: false"
+
+  # strict-admission overlay drops the components that can't comply.
+  local strict
+  strict=$(tmpl --set autogen.enabled=true -f "${OVERLAYS}/strict-admission.yaml")
+  assert_not_contains "strict-admission: prometheus subchart off" "$strict" "prometheus-config"
+  assert_not_contains "strict-admission: gateway HPA off" "$strict" "kind: HorizontalPodAutoscaler"
+  assert_not_contains "strict-admission: app metrics scrape off" "$strict" "prometheus.io/scrape"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # SUITE: infrastructure overlays — verify external DB wiring
 # ─────────────────────────────────────────────────────────────────────────────
 test_infra_overlays() {
@@ -514,6 +563,7 @@ main() {
   test_access_nodeport
   test_access_ingress
   test_size_overlays
+  test_pod_security
   test_infra_overlays
   test_overlay_stacking
 

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -177,12 +177,12 @@ test_access_ingress() {
 test_size_overlays() {
   sep; info "Suite: size overlays"
 
-  # size-minimal: workers disabled, 1 replica each
+  # size-minimal: workers enabled (the smoke test exercises them), 1 replica each
   local min_out
   min_out=$(tmpl --set autogen.enabled=true \
     -f "${OVERLAYS}/size-minimal.yaml" \
     -f "${OVERLAYS}/access-nodeport.yaml")
-  assert_not_contains "minimal: workers disabled" "$min_out" "name: ${RELEASE}-workers"
+  assert_contains "minimal: workers deployed" "$min_out" "name: ${RELEASE}-workers"
   assert_contains "minimal: app replicas 1" "$min_out" "replicas: 1"
 
   # size-prod: 2 app replicas, PDB

--- a/charts/langwatch/tests/e2e-overlays.sh
+++ b/charts/langwatch/tests/e2e-overlays.sh
@@ -237,6 +237,18 @@ test_pod_security() {
     fail "hardening: expected >=10 read-only-root containers, found $ro_count"
   fi
 
+  # runAsNonRoot must be set at the *container* level too, not only the pod,
+  # because some Gatekeeper flavours of k8sreadonlyrootfilesystem inspect the
+  # container-level field directly. Regression guard for the customer report
+  # where pod-level alone tripped their constraint.
+  local nr_count
+  nr_count=$(count_matches "$def" "runAsNonRoot: true")
+  if (( nr_count >= 10 )); then
+    pass "hardening: container-level runAsNonRoot on $nr_count sites (>=10)"
+  else
+    fail "hardening: expected >=10 container-level runAsNonRoot, found $nr_count"
+  fi
+
   # Gateway pod must set automount on the POD spec, not just its ServiceAccount
   # (regression guard for the gap this work closed).
   local gw_block

--- a/charts/langwatch/values.yaml
+++ b/charts/langwatch/values.yaml
@@ -27,7 +27,13 @@ global:
     seccompProfile:
       type: RuntimeDefault
   ## @param global.containerSecurityContext [object] Default container security context (applied cluster-wide unless overridden).
+  # runAsNonRoot is also set at the pod level above; Kubernetes inherits it,
+  # but some Gatekeeper constraints (e.g. certain flavours of
+  # k8sreadonlyrootfilesystem) inspect the *container-level* field directly and
+  # deny pods that only carry it at pod level. Setting it on both keeps every
+  # policy variant happy without changing runtime behaviour.
   containerSecurityContext:
+    runAsNonRoot: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -28458,27 +28458,41 @@ spec:
 
 ## Pod Security
 
-The Helm chart applies secure defaults to all pods:
+Every pod, including the bundled PostgreSQL, Redis, and ClickHouse, runs with these defaults:
 
 ```yaml
-# Pod-level (applied via global.podSecurityContext)
+# Pod-level (global.podSecurityContext)
 runAsNonRoot: true
 runAsUser: 1000
 fsGroup: 1000
+seccompProfile:
+  type: RuntimeDefault
 
-# Container-level (applied via global.containerSecurityContext)
+# Container-level (global.containerSecurityContext)
 allowPrivilegeEscalation: false
-capabilities:
-  drop:
-    - ALL
 readOnlyRootFilesystem: true
+capabilities:
+  drop: [ALL]
 ```
 
-These ensure:
-- No containers run as root
-- No privilege escalation is possible
-- Containers cannot modify their own filesystem
-- All Linux capabilities are dropped
+The ServiceAccount token isn't mounted either (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+
+The root filesystem is read-only on every pod. Anything a process writes at runtime (the app's `/tmp` and `.next` cache, ClickHouse logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
+
+### Strict admission control
+
+These defaults pass Pod Security Admission [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) and the equivalent Gatekeeper / Kyverno bundles with no extra config: read-only root, non-root, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, and CPU + memory requests and limits on every container (init containers included).
+
+Two features need a token or an external API, so turn them off where those policies are enforced:
+
+- **Preflight Secret check** (`preflight.enabled`, only runs with `secrets.existingSecret`) shells out to `kubectl`, so it needs its token. Set `preflight.enabled: false`.
+- **Gateway HPA** (`gateway.autoscaling.enabled`) scales on a custom metric via `prometheus-adapter`. Set it to `false` if you don't run one.
+
+The bundled Prometheus is an upstream subchart LangWatch doesn't harden, so it won't pass: set `prometheus.chartManaged: false` and use your own (or disable metrics). The [`strict-admission` overlay](https://github.com/langwatch/langwatch/blob/main/charts/langwatch/examples/overlays/strict-admission.yaml) bundles these three toggles.
+
+With Prometheus off, app metrics reporting (`app.telemetry.metrics.enabled`) is off by default too, so nothing exposes or scrapes a `/metrics` endpoint; the overlay pins it off to keep the two coupled. Anonymous usage analytics (`app.telemetry.usage.enabled`) is a separate setting, on by default; set it to `false` for an air-gapped or no-egress install.
+
+In-cluster datastores now satisfy read-only-root policies, but managed databases (the `postgres-external`, `redis-external`, and `clickhouse-external` overlays) are still the better production choice: you get backups, HA, and patching, and there are no datastore pods to admit.
 
 ## PII Redaction
 
@@ -28541,7 +28555,8 @@ The `langwatch` npm package is published with [npm provenance attestations](http
 - [ ] ClickHouse backups enabled and tested
 - [ ] Monitoring and alerting configured
 - [ ] Secret rotation procedure documented
-- [ ] Pod security contexts verified (non-root, read-only filesystem)
+- [ ] Pod security contexts verified (non-root, read-only filesystem, `RuntimeDefault` seccomp, no automounted token)
+- [ ] On strict admission clusters: `preflight.enabled: false`, `prometheus.chartManaged: false`, and (without a custom metrics API) `gateway.autoscaling.enabled: false`
 - [ ] Ingress rate limiting configured
 - [ ] Audit logs enabled (Enterprise)
 - [ ] Image signatures verified at pull time (admission controller or `cosign verify` in CI)

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -134,27 +134,41 @@ spec:
 
 ## Pod Security
 
-The Helm chart applies secure defaults to all pods:
+Every pod, including the bundled PostgreSQL, Redis, and ClickHouse, runs with these defaults:
 
 ```yaml
-# Pod-level (applied via global.podSecurityContext)
+# Pod-level (global.podSecurityContext)
 runAsNonRoot: true
 runAsUser: 1000
 fsGroup: 1000
+seccompProfile:
+  type: RuntimeDefault
 
-# Container-level (applied via global.containerSecurityContext)
+# Container-level (global.containerSecurityContext)
 allowPrivilegeEscalation: false
-capabilities:
-  drop:
-    - ALL
 readOnlyRootFilesystem: true
+capabilities:
+  drop: [ALL]
 ```
 
-These ensure:
-- No containers run as root
-- No privilege escalation is possible
-- Containers cannot modify their own filesystem
-- All Linux capabilities are dropped
+The ServiceAccount token isn't mounted either (`global.automountServiceAccountToken: false`); no LangWatch service talks to the Kubernetes API.
+
+The root filesystem is read-only on every pod. Anything a process writes at runtime (the app's `/tmp` and `.next` cache, ClickHouse logs and `/tmp`, Postgres' socket directory) lands on an `emptyDir` mounted over that path; persistent data stays on its PVC. The image layer is never writable.
+
+### Strict admission control
+
+These defaults pass Pod Security Admission [`restricted`](https://kubernetes.io/docs/concepts/security/pod-security-standards/) and the equivalent Gatekeeper / Kyverno bundles with no extra config: read-only root, non-root, dropped capabilities, `RuntimeDefault` seccomp, no privilege escalation, no automounted token, and CPU + memory requests and limits on every container (init containers included).
+
+Two features need a token or an external API, so turn them off where those policies are enforced:
+
+- **Preflight Secret check** (`preflight.enabled`, only runs with `secrets.existingSecret`) shells out to `kubectl`, so it needs its token. Set `preflight.enabled: false`.
+- **Gateway HPA** (`gateway.autoscaling.enabled`) scales on a custom metric via `prometheus-adapter`. Set it to `false` if you don't run one.
+
+The bundled Prometheus is an upstream subchart LangWatch doesn't harden, so it won't pass: set `prometheus.chartManaged: false` and use your own (or disable metrics). The [`strict-admission` overlay](https://github.com/langwatch/langwatch/blob/main/charts/langwatch/examples/overlays/strict-admission.yaml) bundles these three toggles.
+
+With Prometheus off, app metrics reporting (`app.telemetry.metrics.enabled`) is off by default too, so nothing exposes or scrapes a `/metrics` endpoint; the overlay pins it off to keep the two coupled. Anonymous usage analytics (`app.telemetry.usage.enabled`) is a separate setting, on by default; set it to `false` for an air-gapped or no-egress install.
+
+In-cluster datastores now satisfy read-only-root policies, but managed databases (the `postgres-external`, `redis-external`, and `clickhouse-external` overlays) are still the better production choice: you get backups, HA, and patching, and there are no datastore pods to admit.
 
 ## PII Redaction
 
@@ -217,7 +231,8 @@ The `langwatch` npm package is published with [npm provenance attestations](http
 - [ ] ClickHouse backups enabled and tested
 - [ ] Monitoring and alerting configured
 - [ ] Secret rotation procedure documented
-- [ ] Pod security contexts verified (non-root, read-only filesystem)
+- [ ] Pod security contexts verified (non-root, read-only filesystem, `RuntimeDefault` seccomp, no automounted token)
+- [ ] On strict admission clusters: `preflight.enabled: false`, `prometheus.chartManaged: false`, and (without a custom metrics API) `gateway.autoscaling.enabled: false`
 - [ ] Ingress rate limiting configured
 - [ ] Audit logs enabled (Enterprise)
 - [ ] Image signatures verified at pull time (admission controller or `cosign verify` in CI)


### PR DESCRIPTION
## Why

LangWatch's Helm charts didn't install on clusters that enforce strict admission control (Pod Security Admission `restricted`, or an equivalent Gatekeeper / Kyverno bundle). Several policies denied the pods. The first-party services were already most of the way there; this closes the remaining gaps, including the bundled datastores, so the chart installs cleanly on locked-down clusters.

Follow-up to #4927, and supersedes #4948 (folded in here).

## What changed

**Pods (admission compliance)**
- gateway: `automountServiceAccountToken: false` (new value + pod spec). The gateway makes no Kubernetes API calls.
- postgresql / redis: `readOnlyRootFilesystem: true` with `emptyDir` scratch (socket dir, `/tmp`).
- clickhouse / keeper: `readOnlyRootFilesystem: true` with `emptyDir` scratch (logs, pid, `/tmp`); `automountServiceAccountToken` set on the pod spec, not just the ServiceAccount, for policies that inspect the pod.
- backup/restore Jobs: `readOnlyRootFilesystem: true` + `/tmp` + pod-level automount.
- app: removed the dead `fix-nextjs-permissions` init container and its `next-dir` volume. The app is Vite now (build to `dist/client`, served by `tsx`), so nothing reads or writes `.next`.

**Docs / overlays**
- new `examples/overlays/strict-admission.yaml`: turns off the token-using preflight hook, the unhardened upstream Prometheus subchart, and the custom-metrics gateway HPA, and pins app metrics off (nothing scrapes them with Prometheus gone).
- `size-minimal` now runs workers (tiny resources) so the smoke test exercises them.
- `security.mdx`: Pod Security section rewritten, strict-admission guidance and checklist added.
- langwatch / gateway / clickhouse-serverless READMEs document the posture and the new knobs, and fix the stale clickhouse `image.tag` (`0.1.0` to `0.2.0`).

## How it works

`readOnlyRootFilesystem: true` locks only the image layer. Mounted volumes stay writable, so each datastore writes to its PVC (data) plus a small `emptyDir` for the runtime paths it touches outside the data dir (Postgres' socket, ClickHouse logs and pid, `/tmp`). ClickHouse's `ch-config` only renders into `config.d`/`users.d`, which are already `emptyDir` mounts, so nothing needs the image layer to be writable.

## Test plan

- [x] `helm lint` + `helm template` pass for all three charts (default, `clickhouse.replicas=3`, external-infra, and the strict-admission overlay); full manifests parse as valid YAML
- [x] Stood up a kind cluster with Gatekeeper enforcing five admission policies (read-only root, automount-token, resource limits, seccomp RuntimeDefault, privilege-escalation); a bare nginx pod is denied by all five
- [x] Installed the chart (size-minimal + workers, chart-managed datastores): all pods admitted; Postgres/Redis/ClickHouse reach Running with 0 restarts; writes to each data volume succeed while `touch /` fails (root is read-only)
- [x] After dropping the Next.js init container, the app pod still boots read-only (no init container, `readOnlyRootFilesystem: true`, no read-only-filesystem errors)

## Deployment Impact

Self-hosted Helm only (SaaS is unaffected). On `helm upgrade`, the new pod-template fields (read-only root and scratch mounts on the datastores, automount on gateway/clickhouse, resources on the app init container's removal) change the pod specs, so those workloads roll once. The bundled single-replica datastores restart in place if you run them chart-managed, so expect a short blip there. New values are additive with safe defaults (`gateway.automountServiceAccountToken: false`, clickhouse `backup.resources`); no secret, CRD, RBAC, or data-migration changes. Note `size-minimal` now schedules a workers pod, and the app no longer has an init container.

## Anything surprising?

For a locked-down environment, external managed datastores (`postgres-external` / `redis-external` / `clickhouse-external`) remain the better production choice: backups, HA, patching, and no datastore pods to admit. This PR makes the in-cluster option comply too, for setups that want it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes (Updated)

- **New Features**
  - Added a `strict-admission` overlay for policy-restricted Kubernetes clusters.

- **Documentation**
  - Expanded Pod Security and strict-admission guidance with concrete requirements and compatibility toggles.
  - Updated Helm chart READMEs for ClickHouse Serverless, gateway settings, and service/account security notes.

- **Security/Hardening**
  - Improved pod/container hardening across charts: read-only root filesystems, dropped capabilities, non-root execution, no privilege escalation.
  - Added writable `emptyDir` mounts for required runtime paths and reduced ServiceAccount token mounting.

- **Examples / Configuration**
  - Adjusted Langwatch sizing overlays and example resource limits.
  - Removed the built-in Next.js permissions init container.

- **Tests**
  - Extended e2e template checks, including new pod-security validation and updated minimal overlay expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->