### PR TITLE
docs: clarify events, lite members, and evaluation-score trace filtering

### DIFF
--- a/docs/ai-governance/roles-and-permissions.mdx
+++ b/docs/ai-governance/roles-and-permissions.mdx
@@ -22,9 +22,47 @@ The three pre-built org roles. Each user in the org has exactly one.
 |---|---|---|
 | **ADMIN** | First user to sign in becomes admin | `organization:view`, `organization:manage`, `organization:delete`; the full governance surface (`governance:view`, `governance:manage`, `ingestionSources:*`, `anomalyRules:*`, `complianceExport:view`, `activityMonitor:view`); `aiTools:view` + `aiTools:manage`. |
 | **MEMBER** | Default for invitees | `organization:view`, `aiTools:view`. **No** governance permissions, **no** member-list reads, **no** audit log access by default. The team-role (below) is what gives them anything beyond `/me`. |
-| **EXTERNAL** | Lite-member shape, opt-in via the invite drawer | Same as MEMBER. EXTERNAL also has stricter team-level defaults: even when on a team they default to view-only on most resources. |
+| **EXTERNAL** | [Lite member](#lite-members-the-external-role) shape, opt-in via the invite drawer | Same as MEMBER. EXTERNAL also has stricter team-level defaults: even when on a team they default to view-only on most resources. |
 
 The minimum-privilege default is intentional: an `ORGANIZATION` role binding for a MEMBER does **not** grant team-level access. Team-level permissions come from team-role bindings (next).
+
+## Lite members (the External role)
+
+The **EXTERNAL** org role is what the product calls a **Lite member** (and what billing calls a **lite user**). It's a read-only stakeholder seat: the shape you hand to leadership, support, or a customer who should *see* everything but never reconfigure anything or debug individual traces.
+
+Lite members are a separate seat type from **core users** (the full, paid seats). On the Growth plan lite users are **unlimited**, so a read-only stakeholder seat is effectively free, and a lite member never counts against your core-user seats. Capped plans set their own lite-user allowance.
+
+### How a member becomes Lite vs Full
+
+Classification is by org role *plus* permissions:
+
+| Org role | Custom permissions | Classified as |
+|---|---|---|
+| `ADMIN` or `MEMBER` | anything | **Full member** |
+| `EXTERNAL` | none, or view-only | **Lite member** |
+| `EXTERNAL` | any non-view permission | **Full member** (elevated) |
+
+To turn a lite member into a full member, bind them a [custom role](#custom-roles) granting at least one non-view permission; they're counted as a core user from then on.
+
+### What a lite member can and can't do
+
+Lite members **browse the whole platform**, no redirects, no hidden pages, no grayed-out sidebar. They can:
+
+- View every page (messages, evaluations, experiments, simulations, prompts, datasets, settings), read-only.
+- Open a trace to read its **Thread**, **Evaluations**, and **Events** tabs.
+- **Annotate** traces with comments and **suggest** output.
+
+They **cannot** do the following; each blocked action opens a "Feature Not Available" modal rather than failing silently:
+
+- Open the **Trace Details** or **Sequence** debugging tabs, or use the "View Trace" hover action.
+- **Export** traces, or **add** them to a dataset or annotation queue.
+- **Create, edit, or delete** scenarios, evaluations, experiments, prompts, or datasets.
+- Delete other users' annotations, or manage scoring metrics.
+- Save edits on the settings pages.
+
+The boundary is enforced server-side as well: a mutation that slips past the UI returns an `UNAUTHORIZED` error and re-opens the modal, so it holds for direct API calls too.
+
+<Info>The lite-member modal is **role-based, not a sales prompt**. It's titled "Feature Not Available", explains the limit comes from the member's role, and offers **Contact Admin**, never "Upgrade your plan". Plan-limit upgrade prompts are a separate flow that lite members never trigger.</Info>
 
 ## Team roles
 

--- a/docs/ai-governance/roles-and-permissions.mdx
+++ b/docs/ai-governance/roles-and-permissions.mdx
@@ -57,7 +57,7 @@ They **cannot** do the following; each blocked action opens a "Feature Not Avail
 - Open the **Trace Details** or **Sequence** debugging tabs, or use the "View Trace" hover action.
 - **Export** traces, or **add** them to a dataset or annotation queue.
 - **Create, edit, or delete** scenarios, evaluations, experiments, prompts, or datasets.
-- Delete other users' annotations, or manage scoring metrics.
+- Delete annotations, or manage scoring metrics.
 - Save edits on the settings pages.
 
 The boundary is enforced server-side as well: a mutation that slips past the UI returns an `UNAUTHORIZED` error and re-opens the modal, so it holds for direct API calls too.

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -38,6 +38,17 @@ Now, let's get granular! **Spans** are the individual steps or operations *withi
 
 Each `span_id` pinpoints a specific action taken by your system or an LLM call.
 
+### Events: The Unit You're Billed On
+
+You'll see the word **event** on your usage and [pricing](/pricing) pages, so it's worth pinning down. An **event** is a single telemetry point, and the most common one is a **Span** (the building block above): one LLM call, one tool execution, one retrieval step.
+
+For billing, a **billable event** is either:
+
+* **A span within a trace**: any of the individual steps that make up a request, or
+* **A scenario or evaluation run**: a single execution used to test your agents.
+
+Threads and Traces are *groupings*, so they aren't billed on their own; the Spans inside them are what count. So the running **event total** on the **Usage & Billing** page (under your project settings) is the sum of the spans you've ingested plus any scenario and evaluation runs for the period. See [Pricing](/pricing) for how events map to plans and retention.
+
 ### User ID: Who's Using the App?
 
 Field: `user_id`

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -47,7 +47,7 @@ For billing, a **billable event** is either:
 * **A span within a trace**: any of the individual steps that make up a request, or
 * **A scenario or evaluation run**: a single execution used to test your agents.
 
-Threads and Traces are *groupings*, so they aren't billed on their own; the Spans inside them are what count. So the running **event total** on the **Usage & Billing** page (under your project settings) is the sum of the spans you've ingested plus any scenario and evaluation runs for the period. See [Pricing](/pricing) for how events map to plans and retention.
+Threads and Traces are *groupings*, so they aren't billed on their own; the Spans inside them are what count. So the running **event total** on the **Usage & Billing** page (under **Settings**) is the sum of the spans you've ingested plus any scenario and evaluation runs for the period. See [Pricing](/pricing) for how events map to plans and retention.
 
 ### User ID: Who's Using the App?
 

--- a/docs/evaluations/online-evaluation/setup-monitors.mdx
+++ b/docs/evaluations/online-evaluation/setup-monitors.mdx
@@ -106,3 +106,17 @@ That's it, we are now monitoring messages for any Jailbreak Attempts:
 <Frame>
 <img src="/images/real-time-evaluation/image 4.png" alt="" style={{ maxWidth: '400px' }} />
 </Frame>
+
+## Filtering traces by evaluation results
+
+Once a monitor is enabled, every matching trace is scored by the evaluator, and that result is attached to the trace: a **pass or fail**, a numeric **score**, and (for classifier-style evaluators) a **label**. You can then slice your production traffic by those results from the [Messages page](https://app.langwatch.ai/@project/messages).
+
+Open **Filters** in the top bar and you'll find the evaluation filters:
+
+- **Evaluators with Passed results**, to keep only traces an evaluator passed or failed.
+- **Evaluators with Score results**, to filter by the numeric score (for example, quality below a threshold).
+- **Evaluators with Label results**, to filter by a classifier label.
+
+Each filter lists your evaluators by name, so you can target the specific monitor you set up. For example, to triage everything your "Prompt Injection" monitor caught, filter by **Evaluators with Passed results** for that evaluator and keep the failures.
+
+<Tip>Save a filter you return to often as a **view**, or turn it into an **automation** to get alerted (Slack, email) whenever a trace matches, for instance whenever a safety evaluator fails in production.</Tip>

--- a/docs/evaluations/online-evaluation/setup-monitors.mdx
+++ b/docs/evaluations/online-evaluation/setup-monitors.mdx
@@ -113,10 +113,10 @@ Once a monitor is enabled, every matching trace is scored by the evaluator, and 
 
 Open **Filters** in the top bar and you'll find the evaluation filters:
 
-- **Evaluators with Passed results**, to keep only traces an evaluator passed or failed.
-- **Evaluators with Score results**, to filter by the numeric score (for example, quality below a threshold).
-- **Evaluators with Label results**, to filter by a classifier label.
+- **Evaluation Passed**, to keep only traces an evaluator passed or failed.
+- **Evaluation Score**, to filter by the numeric score (for example, quality below a threshold).
+- **Evaluation Label**, to filter by a classifier label.
 
-Each filter lists your evaluators by name, so you can target the specific monitor you set up. For example, to triage everything your "Prompt Injection" monitor caught, filter by **Evaluators with Passed results** for that evaluator and keep the failures.
+Each filter lets you pick the specific evaluator by name, so you can target the exact monitor you set up. For example, to triage everything your "Prompt Injection" monitor caught, filter by **Evaluation Passed** for that evaluator and keep the failures.
 
 <Tip>Save a filter you return to often as a **view**, or turn it into an **automation** to get alerted (Slack, email) whenever a trace matches, for instance whenever a safety evaluator fails in production.</Tip>

--- a/docs/integration/python/tutorials/capturing-evaluations-guardrails.mdx
+++ b/docs/integration/python/tutorials/capturing-evaluations-guardrails.mdx
@@ -218,7 +218,7 @@ Both client-side and server-side evaluations (including those marked as guardrai
 
 These spans will contain the evaluation's name, result (score, passed, label), details, cost, and any associated metadata, typically within their `output` attribute. This allows you to:
 - See a history of all evaluation outcomes.
-- Filter traces by evaluation results.
+- [Filter traces by evaluation results](/evaluations/online-evaluation/setup-monitors#filtering-traces-by-evaluation-results).
 - Analyze the performance of different evaluators or guardrails.
 - Correlate evaluation outcomes with other trace data (e.g., LLM inputs/outputs, latencies).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -156,7 +156,7 @@ For billing, a **billable event** is either:
 * **A span within a trace**: any of the individual steps that make up a request, or
 * **A scenario or evaluation run**: a single execution used to test your agents.
 
-Threads and Traces are *groupings*, so they aren't billed on their own; the Spans inside them are what count. So the running **event total** on the **Usage & Billing** page (under your project settings) is the sum of the spans you've ingested plus any scenario and evaluation runs for the period. See [Pricing](/pricing) for how events map to plans and retention.
+Threads and Traces are *groupings*, so they aren't billed on their own; the Spans inside them are what count. So the running **event total** on the **Usage & Billing** page (under **Settings**) is the sum of the spans you've ingested plus any scenario and evaluation runs for the period. See [Pricing](/pricing) for how events map to plans and retention.
 
 ### User ID: Who's Using the App?
 
@@ -21260,11 +21260,11 @@ Once a monitor is enabled, every matching trace is scored by the evaluator, and 
 
 Open **Filters** in the top bar and you'll find the evaluation filters:
 
-- **Evaluators with Passed results**, to keep only traces an evaluator passed or failed.
-- **Evaluators with Score results**, to filter by the numeric score (for example, quality below a threshold).
-- **Evaluators with Label results**, to filter by a classifier label.
+- **Evaluation Passed**, to keep only traces an evaluator passed or failed.
+- **Evaluation Score**, to filter by the numeric score (for example, quality below a threshold).
+- **Evaluation Label**, to filter by a classifier label.
 
-Each filter lists your evaluators by name, so you can target the specific monitor you set up. For example, to triage everything your "Prompt Injection" monitor caught, filter by **Evaluators with Passed results** for that evaluator and keep the failures.
+Each filter lets you pick the specific evaluator by name, so you can target the exact monitor you set up. For example, to triage everything your "Prompt Injection" monitor caught, filter by **Evaluation Passed** for that evaluator and keep the failures.
 
 <Tip>Save a filter you return to often as a **view**, or turn it into an **automation** to get alerted (Slack, email) whenever a trace matches, for instance whenever a safety evaluator fails in production.</Tip>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -147,6 +147,17 @@ Now, let's get granular! **Spans** are the individual steps or operations *withi
 
 Each `span_id` pinpoints a specific action taken by your system or an LLM call.
 
+### Events: The Unit You're Billed On
+
+You'll see the word **event** on your usage and [pricing](/pricing) pages, so it's worth pinning down. An **event** is a single telemetry point, and the most common one is a **Span** (the building block above): one LLM call, one tool execution, one retrieval step.
+
+For billing, a **billable event** is either:
+
+* **A span within a trace**: any of the individual steps that make up a request, or
+* **A scenario or evaluation run**: a single execution used to test your agents.
+
+Threads and Traces are *groupings*, so they aren't billed on their own; the Spans inside them are what count. So the running **event total** on the **Usage & Billing** page (under your project settings) is the sum of the spans you've ingested plus any scenario and evaluation runs for the period. See [Pricing](/pricing) for how events map to plans and retention.
+
 ### User ID: Who's Using the App?
 
 Field: `user_id`
@@ -4128,7 +4139,7 @@ Both client-side and server-side evaluations (including those marked as guardrai
 
 These spans will contain the evaluation's name, result (score, passed, label), details, cost, and any associated metadata, typically within their `output` attribute. This allows you to:
 - See a history of all evaluation outcomes.
-- Filter traces by evaluation results.
+- [Filter traces by evaluation results](/evaluations/online-evaluation/setup-monitors#filtering-traces-by-evaluation-results).
 - Analyze the performance of different evaluators or guardrails.
 - Correlate evaluation outcomes with other trace data (e.g., LLM inputs/outputs, latencies).
 
@@ -21242,6 +21253,20 @@ That's it, we are now monitoring messages for any Jailbreak Attempts:
 <Frame>
 <img src="/images/real-time-evaluation/image 4.png" alt="" style={{ maxWidth: '400px' }} />
 </Frame>
+
+## Filtering traces by evaluation results
+
+Once a monitor is enabled, every matching trace is scored by the evaluator, and that result is attached to the trace: a **pass or fail**, a numeric **score**, and (for classifier-style evaluators) a **label**. You can then slice your production traffic by those results from the [Messages page](https://app.langwatch.ai/@project/messages).
+
+Open **Filters** in the top bar and you'll find the evaluation filters:
+
+- **Evaluators with Passed results**, to keep only traces an evaluator passed or failed.
+- **Evaluators with Score results**, to filter by the numeric score (for example, quality below a threshold).
+- **Evaluators with Label results**, to filter by a classifier label.
+
+Each filter lists your evaluators by name, so you can target the specific monitor you set up. For example, to triage everything your "Prompt Injection" monitor caught, filter by **Evaluators with Passed results** for that evaluator and keep the failures.
+
+<Tip>Save a filter you return to often as a **view**, or turn it into an **automation** to get alerted (Slack, email) whenever a trace matches, for instance whenever a safety evaluator fails in production.</Tip>
 
 ---
 


### PR DESCRIPTION
## What

Three documentation gaps surfaced from user feedback. All three turned out to be discoverability problems rather than missing features: the behavior exists and is correct, the docs just did not explain it where users look.

### 1. Define "event" in the Concepts page

The billing unit "event" was only defined on the pricing page, so users hitting the term on the usage page or in the product had no concept doc to land on. Added an **Events** section to the Concepts page that defines an event (a telemetry point, most commonly a span), what counts as a billable event (a span within a trace, or a scenario or evaluation run), and points readers to the Usage and Billing page for their running total.

### 2. Document the Lite member (External org role)

The roles doc only name-dropped the "lite-member shape" without explaining it. Added a **Lite members** section to Roles and permissions covering:

- What it is: the EXTERNAL org role, a free read-only stakeholder seat, separate from paid core users (unlimited on the Growth plan).
- How classification works: org role plus permissions (EXTERNAL with view-only or no permissions is Lite; EXTERNAL with any non-view permission is elevated to Full).
- What lite members can do (browse everything read-only, annotate, suggest) and cannot do (trace debugging tabs, export, add to dataset, create, edit, or delete resources), and that blocked actions show a role-based "Feature Not Available" modal, not a plan upsell.

Documented from `specs/rbac/lite-member-restrictions.feature` and `member-classification.ts` so it matches implemented behavior.

### 3. Document filtering traces by evaluation results

The monitor setup guide ended at "Enable Monitoring" and never explained the payoff: an online evaluation attaches a pass or fail, a score, and a label to each trace, which you can then filter in the Messages view. Added a **Filtering traces by evaluation results** section to the setup-monitors guide, and linked the bare "Filter traces by evaluation results" promise in the SDK tutorial to it.

## Scope

Docs only. No code or behavior changes. A related pricing-page typo report turned out to be on the Framer-hosted marketing site (not this repo), and the in-app event-count report turned out to be already shipped, both handled separately.

## QA

Browser-QA against the live app (and the Mintlify preview) validated every claim and caught two label inaccuracies, now fixed.

**Item 5, evaluation filters (live Messages page).** The filter sidebar exposes **Evaluation Passed**, **Evaluation Score**, and **Evaluation Label**, exactly the filters the new section points to. Browser-QA corrected an earlier draft that used internal registry names instead of these UI labels.

![Evaluation filters](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4973/qa/messages-evaluation-filters.png)

**Items 2 and 4 (Usage and Billing page).** The page shows a live **Events / Month** total (item 2's pointer) and a separate **Lite Members** tile alongside **Team Members** (item 4's free read-only seat), confirming both descriptions. Browser-QA corrected the page location from "project settings" to Settings.

![Usage and Billing](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4973/qa/usage-events-and-lite-members.png)

**Rendered docs (Mintlify preview).** The new Lite members section renders cleanly with its classification table and on-this-page entries.

![Lite members rendered](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4973/qa/docs-lite-members-rendered.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation clarifying EXTERNAL org role, Lite member capabilities, and permission-based restrictions.
  * Added section explaining events as the billable unit and how Usage & Billing is calculated.
  * Added guidance on filtering production traces by evaluation monitor results (pass/fail scores and classifier labels).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->