### PR TITLE
feat(studio): manage nodes and connections with the Delete key and a node drawer action menu

### DIFF
--- a/langwatch/src/optimization_studio/components/OptimizationStudio.tsx
+++ b/langwatch/src/optimization_studio/components/OptimizationStudio.tsx
@@ -493,6 +493,9 @@ export function OptimizationStudioCanvas({
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       colorMode={colorMode}
+      // ReactFlow defaults deleteKeyCode to "Backspace" only; also bind Delete
+      // so a selected node or connection is removable with either key.
+      deleteKeyCode={["Backspace", "Delete"]}
       defaultViewport={{
         zoom: defaultZoom,
         x: 100,

--- a/langwatch/src/optimization_studio/components/__tests__/OptimizationStudioCanvas.unit.test.ts
+++ b/langwatch/src/optimization_studio/components/__tests__/OptimizationStudioCanvas.unit.test.ts
@@ -13,6 +13,9 @@ describe("OptimizationStudioCanvas", () => {
       expect(source).toContain("selectNodesOnDrag={false}");
     });
 
+    /** @scenario "Removing a selected connection with the Delete key" */
+    /** @scenario "Removing a selected connection with the Backspace key" */
+    /** @scenario "Removing a selected node with the Delete key" */
     it("binds both Backspace and Delete so nodes and connections delete with either key", () => {
       const source = fs.readFileSync(
         path.resolve(__dirname, "../OptimizationStudio.tsx"),

--- a/langwatch/src/optimization_studio/components/__tests__/OptimizationStudioCanvas.unit.test.ts
+++ b/langwatch/src/optimization_studio/components/__tests__/OptimizationStudioCanvas.unit.test.ts
@@ -1,16 +1,29 @@
-import { describe, expect, it } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
+import { describe, expect, it } from "vitest";
 
 describe("OptimizationStudioCanvas", () => {
   describe("when configuring ReactFlow", () => {
     it("sets selectNodesOnDrag to false to prevent drawer opening on drag", () => {
       const source = fs.readFileSync(
         path.resolve(__dirname, "../OptimizationStudio.tsx"),
-        "utf-8"
+        "utf-8",
       );
 
       expect(source).toContain("selectNodesOnDrag={false}");
+    });
+
+    it("binds both Backspace and Delete so nodes and connections delete with either key", () => {
+      const source = fs.readFileSync(
+        path.resolve(__dirname, "../OptimizationStudio.tsx"),
+        "utf-8",
+      );
+
+      // ReactFlow defaults deleteKeyCode to "Backspace" only, so the Delete
+      // key alone would not remove a selected node or connection. Bind both.
+      expect(source).toMatch(
+        /deleteKeyCode=\{\[\s*["']Backspace["']\s*,\s*["']Delete["']\s*\]\}/,
+      );
     });
   });
 });

--- a/langwatch/src/optimization_studio/components/drawers/StudioDrawerWrapper.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/StudioDrawerWrapper.tsx
@@ -1,14 +1,15 @@
-import { Box, Button, HStack } from "@chakra-ui/react";
+import { Box, Button, HStack, Menu } from "@chakra-ui/react";
 import type { Node } from "@xyflow/react";
 import { motion } from "motion/react";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { Columns, X } from "react-feather";
+import { Columns, Copy, MoreHorizontal, Trash2, X } from "react-feather";
 import { useWindowSize } from "usehooks-ts";
 import { useShallow } from "zustand/react/shallow";
 import { HoverableBigText } from "~/components/HoverableBigText";
 import { Drawer } from "~/components/ui/drawer";
+import { Tooltip } from "~/components/ui/tooltip";
 import { useWorkflowStore } from "../../hooks/useWorkflowStore";
 import type { Component, ComponentType } from "../../types/dsl";
 import { ComponentIcon } from "../ColorfulBlockIcons";
@@ -16,7 +17,6 @@ import { InputPanel } from "../component_execution/InputPanel";
 import { OutputPanel } from "../component_execution/OutputPanel";
 import { ComponentExecutionButton, getNodeDisplayName } from "../nodes/Nodes";
 import { DrawerFooterContext } from "./useInsideDrawer";
-import { Tooltip } from "~/components/ui/tooltip";
 
 /**
  * Determines whether a node type supports the expand (Input/Output panels)
@@ -52,14 +52,21 @@ export function StudioDrawerWrapper({
   onClose,
   footer,
 }: StudioDrawerWrapperProps) {
-  const { deselectAllNodes, propertiesExpanded, setPropertiesExpanded } =
-    useWorkflowStore(
-      useShallow((state) => ({
-        deselectAllNodes: state.deselectAllNodes,
-        propertiesExpanded: state.propertiesExpanded,
-        setPropertiesExpanded: state.setPropertiesExpanded,
-      })),
-    );
+  const {
+    deselectAllNodes,
+    propertiesExpanded,
+    setPropertiesExpanded,
+    duplicateNode,
+    deleteNode,
+  } = useWorkflowStore(
+    useShallow((state) => ({
+      deselectAllNodes: state.deselectAllNodes,
+      propertiesExpanded: state.propertiesExpanded,
+      setPropertiesExpanded: state.setPropertiesExpanded,
+      duplicateNode: state.duplicateNode,
+      deleteNode: state.deleteNode,
+    })),
+  );
 
   // Footer registered by child components via useRegisterDrawerFooter
   const [registeredFooter, setRegisteredFooter] =
@@ -164,6 +171,41 @@ export function StudioDrawerWrapper({
               </Button>
             </Tooltip>
           </>
+        )}
+        {isExpandableNode(node) && (
+          <Menu.Root positioning={{ placement: "bottom-end" }}>
+            <Menu.Trigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                color="fg.muted"
+                aria-label="Node actions"
+              >
+                <MoreHorizontal size={16} />
+              </Button>
+            </Menu.Trigger>
+            <Menu.Content>
+              <Menu.Item
+                value="duplicate"
+                onClick={() => duplicateNode(node.id)}
+              >
+                <Copy size={14} />
+                Duplicate
+              </Menu.Item>
+              <Menu.Item
+                value="delete"
+                onClick={() => {
+                  deleteNode(node.id);
+                  setPropertiesExpanded(false);
+                  deselectAllNodes();
+                  onClose();
+                }}
+              >
+                <Trash2 size={14} />
+                Delete
+              </Menu.Item>
+            </Menu.Content>
+          </Menu.Root>
         )}
         <Button
           variant="ghost"

--- a/langwatch/src/optimization_studio/components/drawers/StudioDrawerWrapper.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/StudioDrawerWrapper.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, HStack, Menu } from "@chakra-ui/react";
+import { Box, Button, HStack } from "@chakra-ui/react";
 import type { Node } from "@xyflow/react";
 import { motion } from "motion/react";
 import type React from "react";
@@ -9,6 +9,7 @@ import { useWindowSize } from "usehooks-ts";
 import { useShallow } from "zustand/react/shallow";
 import { HoverableBigText } from "~/components/HoverableBigText";
 import { Drawer } from "~/components/ui/drawer";
+import { Menu } from "~/components/ui/menu";
 import { Tooltip } from "~/components/ui/tooltip";
 import { useWorkflowStore } from "../../hooks/useWorkflowStore";
 import type { Component, ComponentType } from "../../types/dsl";

--- a/langwatch/src/optimization_studio/components/drawers/__tests__/StudioDrawerWrapper.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/__tests__/StudioDrawerWrapper.integration.test.tsx
@@ -81,6 +81,8 @@ describe("StudioDrawerWrapper node action menu", () => {
   afterEach(() => cleanup());
 
   describe("when a regular component node is selected", () => {
+    /** @scenario "The node drawer offers a duplicate action" */
+    /** @scenario "The node drawer offers a delete action" */
     it("shows the node action menu trigger in the drawer header", () => {
       renderDrawer(makeNode("signature"));
       expect(screen.getByLabelText("Node actions")).toBeTruthy();
@@ -88,6 +90,7 @@ describe("StudioDrawerWrapper node action menu", () => {
   });
 
   describe("when a structural entry node is selected", () => {
+    /** @scenario "Structural nodes do not expose the action menu" */
     it("does not show the node action menu", () => {
       renderDrawer(makeNode("entry"));
       expect(screen.queryByLabelText("Node actions")).toBeNull();

--- a/langwatch/src/optimization_studio/components/drawers/__tests__/StudioDrawerWrapper.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/__tests__/StudioDrawerWrapper.integration.test.tsx
@@ -3,13 +3,15 @@
  *
  * The node drawer header exposes a "..." action menu (Duplicate / Delete) for
  * regular component nodes, giving users a discoverable way to manage a node
- * without keyboard shortcuts. Structural entry/end nodes cannot be duplicated
- * or deleted, so the menu is not shown for them.
+ * without keyboard shortcuts. Choosing Duplicate copies the node; choosing
+ * Delete removes it and closes the drawer. Structural entry/end nodes cannot be
+ * duplicated or deleted, so the menu is not shown for them.
  *
  * Specs: specs/optimization-studio/node-duplicate-delete-menu.feature
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { Node } from "@xyflow/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Component } from "../../../types/dsl";
@@ -67,13 +69,15 @@ function makeNode(type: string): Node<Component> {
 }
 
 function renderDrawer(node: Node<Component>) {
-  return render(
+  const onClose = vi.fn();
+  render(
     <ChakraProvider value={defaultSystem}>
-      <StudioDrawerWrapper node={node} onClose={vi.fn()}>
+      <StudioDrawerWrapper node={node} onClose={onClose}>
         <div>body</div>
       </StudioDrawerWrapper>
     </ChakraProvider>,
   );
+  return { onClose };
 }
 
 describe("StudioDrawerWrapper node action menu", () => {
@@ -82,10 +86,31 @@ describe("StudioDrawerWrapper node action menu", () => {
 
   describe("when a regular component node is selected", () => {
     /** @scenario "The node drawer offers a duplicate action" */
+    it("duplicates the node when Duplicate is chosen from the action menu", async () => {
+      const user = userEvent.setup();
+      const node = makeNode("signature");
+      renderDrawer(node);
+
+      await user.click(screen.getByLabelText("Node actions"));
+      await user.click(
+        await screen.findByRole("menuitem", { name: "Duplicate" }),
+      );
+
+      expect(mockDuplicateNode).toHaveBeenCalledWith(node.id);
+    });
+
     /** @scenario "The node drawer offers a delete action" */
-    it("shows the node action menu trigger in the drawer header", () => {
-      renderDrawer(makeNode("signature"));
-      expect(screen.getByLabelText("Node actions")).toBeTruthy();
+    it("deletes the node and closes the drawer when Delete is chosen", async () => {
+      const user = userEvent.setup();
+      const node = makeNode("signature");
+      const { onClose } = renderDrawer(node);
+
+      await user.click(screen.getByLabelText("Node actions"));
+      await user.click(await screen.findByRole("menuitem", { name: "Delete" }));
+
+      expect(mockDeleteNode).toHaveBeenCalledWith(node.id);
+      expect(mockDeselectAllNodes).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
     });
   });
 

--- a/langwatch/src/optimization_studio/components/drawers/__tests__/StudioDrawerWrapper.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/__tests__/StudioDrawerWrapper.integration.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The node drawer header exposes a "..." action menu (Duplicate / Delete) for
+ * regular component nodes, giving users a discoverable way to manage a node
+ * without keyboard shortcuts. Structural entry/end nodes cannot be duplicated
+ * or deleted, so the menu is not shown for them.
+ *
+ * Specs: specs/optimization-studio/node-duplicate-delete-menu.feature
+ */
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Node } from "@xyflow/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Component } from "../../../types/dsl";
+
+const mockDuplicateNode = vi.fn();
+const mockDeleteNode = vi.fn();
+const mockDeselectAllNodes = vi.fn();
+const mockSetPropertiesExpanded = vi.fn();
+
+vi.mock("../../../hooks/useWorkflowStore", () => ({
+  useWorkflowStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      deselectAllNodes: mockDeselectAllNodes,
+      propertiesExpanded: false,
+      setPropertiesExpanded: mockSetPropertiesExpanded,
+      duplicateNode: mockDuplicateNode,
+      deleteNode: mockDeleteNode,
+    }),
+}));
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: unknown) => fn,
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useWindowSize: () => ({ width: 1200, height: 800 }),
+}));
+
+vi.mock("../../ColorfulBlockIcons", () => ({
+  ComponentIcon: () => <div data-testid="component-icon" />,
+}));
+
+vi.mock("../../nodes/Nodes", () => ({
+  ComponentExecutionButton: () => <div data-testid="exec-button" />,
+  getNodeDisplayName: (node: Node<Component>) => node.data.name ?? node.id,
+}));
+
+vi.mock("../../component_execution/InputPanel", () => ({
+  InputPanel: () => <div data-testid="input-panel" />,
+}));
+
+vi.mock("../../component_execution/OutputPanel", () => ({
+  OutputPanel: () => <div data-testid="output-panel" />,
+}));
+
+const { StudioDrawerWrapper } = await import("../StudioDrawerWrapper");
+
+function makeNode(type: string): Node<Component> {
+  return {
+    id: `${type}-1`,
+    type,
+    position: { x: 0, y: 0 },
+    data: { name: `${type} node` } as Component,
+  } as Node<Component>;
+}
+
+function renderDrawer(node: Node<Component>) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <StudioDrawerWrapper node={node} onClose={vi.fn()}>
+        <div>body</div>
+      </StudioDrawerWrapper>
+    </ChakraProvider>,
+  );
+}
+
+describe("StudioDrawerWrapper node action menu", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  describe("when a regular component node is selected", () => {
+    it("shows the node action menu trigger in the drawer header", () => {
+      renderDrawer(makeNode("signature"));
+      expect(screen.getByLabelText("Node actions")).toBeTruthy();
+    });
+  });
+
+  describe("when a structural entry node is selected", () => {
+    it("does not show the node action menu", () => {
+      renderDrawer(makeNode("entry"));
+      expect(screen.queryByLabelText("Node actions")).toBeNull();
+    });
+  });
+});

--- a/specs/optimization-studio/canvas-connection-deletion.feature
+++ b/specs/optimization-studio/canvas-connection-deletion.feature
@@ -1,0 +1,30 @@
+Feature: Removing nodes and connections from the workflow canvas
+
+  On the optimization-studio canvas a user edits a workflow by adding and
+  removing nodes and the connections (edges) between them. A selected node or
+  connection must be removable with either the Backspace or the Delete key, so
+  the gesture works on macOS (Backspace) and on Windows and Linux keyboards
+  (Delete) alike.
+
+  # Bindings: langwatch/src/optimization_studio/components/__tests__/OptimizationStudioCanvas.unit.test.ts
+
+  Background:
+    Given a workflow open on the studio canvas with two connected nodes
+
+  @unit
+  Scenario: Removing a selected connection with the Delete key
+    Given the user has selected the connection between the two nodes
+    When the user presses the Delete key
+    Then the connection is removed from the canvas
+
+  @unit
+  Scenario: Removing a selected connection with the Backspace key
+    Given the user has selected the connection between the two nodes
+    When the user presses the Backspace key
+    Then the connection is removed from the canvas
+
+  @unit
+  Scenario: Removing a selected node with the Delete key
+    Given the user has selected a node
+    When the user presses the Delete key
+    Then the node is removed from the canvas

--- a/specs/optimization-studio/canvas-connection-deletion.feature
+++ b/specs/optimization-studio/canvas-connection-deletion.feature
@@ -6,8 +6,6 @@ Feature: Removing nodes and connections from the workflow canvas
   the gesture works on macOS (Backspace) and on Windows and Linux keyboards
   (Delete) alike.
 
-  # Bindings: langwatch/src/optimization_studio/components/__tests__/OptimizationStudioCanvas.unit.test.ts
-
   Background:
     Given a workflow open on the studio canvas with two connected nodes
 

--- a/specs/optimization-studio/node-duplicate-delete-menu.feature
+++ b/specs/optimization-studio/node-duplicate-delete-menu.feature
@@ -1,0 +1,29 @@
+Feature: Duplicating and deleting a workflow node from its action menu
+
+  A node on the optimization-studio canvas exposes a "..." action menu, both on
+  the node itself and in the node drawer that opens on the right when the node
+  is selected. The menu offers Duplicate and Delete so users have a discoverable
+  way to manage a node without relying on keyboard shortcuts. Structural entry
+  and end nodes cannot be duplicated or deleted, so they do not show the menu.
+
+  # Bindings: langwatch/src/optimization_studio/components/drawers/__tests__/StudioDrawerWrapper.integration.test.tsx
+
+  Background:
+    Given a workflow open on the studio canvas
+
+  @integration
+  Scenario: The node drawer offers a duplicate action
+    Given a component node is selected and its drawer is open
+    When the user opens the node action menu in the drawer and chooses Duplicate
+    Then a copy of the node is added to the workflow
+
+  @integration
+  Scenario: The node drawer offers a delete action
+    Given a component node is selected and its drawer is open
+    When the user opens the node action menu in the drawer and chooses Delete
+    Then the node is removed from the workflow and the drawer closes
+
+  @integration
+  Scenario: Structural nodes do not expose the action menu
+    Given the entry node is selected and its drawer is open
+    Then the node action menu is not shown

--- a/specs/optimization-studio/node-duplicate-delete-menu.feature
+++ b/specs/optimization-studio/node-duplicate-delete-menu.feature
@@ -6,8 +6,6 @@ Feature: Duplicating and deleting a workflow node from its action menu
   way to manage a node without relying on keyboard shortcuts. Structural entry
   and end nodes cannot be duplicated or deleted, so they do not show the menu.
 
-  # Bindings: langwatch/src/optimization_studio/components/drawers/__tests__/StudioDrawerWrapper.integration.test.tsx
-
   Background:
     Given a workflow open on the studio canvas
 


### PR DESCRIPTION
## What this does

Two optimization-studio canvas fixes from customer reports, both about managing nodes and the connections between them.

### Delete key removes a selected node or connection (bug)

ReactFlow defaults `deleteKeyCode` to `Backspace` only, and the studio canvas never overrode it. Pressing the Delete key on a selected node or connection did nothing, so a connection could not be removed with Delete (only Backspace worked). The canvas now binds both `Backspace` and `Delete`, so removal works with either key on macOS and on Windows and Linux keyboards. The existing `onEdgesChange` already applied the removal, so this is purely the missing key binding.

### Discoverable Duplicate and Delete on the node drawer (enhancement)

The node already had a "..." overflow menu with Duplicate and Delete, but it is a small button floating above a selected node and easy to miss, especially because clicking a node opens its drawer on top. The same Duplicate and Delete actions are now mirrored in the node drawer header, where users look after clicking a node. Both reuse the existing `duplicateNode` and `deleteNode` store actions. Structural entry and end nodes do not show the menu, matching the canvas menu.

## Tests

- `OptimizationStudioCanvas.unit.test.ts` asserts the canvas binds both Backspace and Delete.
- `StudioDrawerWrapper.integration.test.tsx` renders the drawer and asserts the action menu shows for a component node and is hidden for the entry node.
- Specs under `specs/optimization-studio/canvas-connection-deletion.feature` and `node-duplicate-delete-menu.feature`.

## Dogfood

Browser QA on the studio canvas, logged in, on a blank-template workflow (Entry to LLM Call to End).

Item 6, pressing the Delete key on the selected entry-to-llm_call connection (before, then after, the connection is removed):

![before](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4974/item6-delete-key-before.png)
![after](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4974/item6-delete-key-after.png)

Item 9, the Duplicate and Delete actions in the node drawer header, and the resulting duplicated node:

![drawer menu floats over the body content with Duplicate / Delete](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4974/item9-menu-floats-fixed.png)
![duplicated node](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4974/item9-duplicated-node.png)

Both changes persist across a page reload (the deleted connection stays gone, the duplicated node remains):

![persisted after reload](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4974/item6-9-persisted-after-reload.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded canvas keyboard shortcuts: Backspace/Delete remove selected connections; Delete removes selected nodes.
  * Added a **“Node actions”** menu to the node drawer header for expandable component nodes, with **Duplicate** and **Delete** actions.
* **Tests**
  * Updated unit and integration coverage to verify keyboard deletion behavior and the **Node actions** menu (including hidden menu for structural entry/end nodes).
  * Added feature specifications covering canvas connection/node deletion and node duplicate/delete workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
