### PR TITLE
fix(traces): resolve >64KB offloaded IO past mixed-type OTLP attributes (#4888)

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
@@ -23,8 +23,22 @@ import {
   SPAN_RECEIVED_EVENT_VERSION_LATEST,
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
 import type { SpanReceivedEvent } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
+import {
+  NormalizedSpanKind,
+  NormalizedStatusCode,
+  type NormalizedSpan,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { eventToRecord } from "~/server/event-sourcing/stores/eventStoreUtils";
 import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
+import {
+  EVENTREF_ATTR_PREFIX,
+  IO_PREVIEW_BYTES,
+} from "~/server/app-layer/traces/lean-for-projection";
+import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import {
+  resolveOffloadedTraces,
+  type WarnLogger,
+} from "~/server/traces/resolve-offloaded-traces";
 import {
   BlobFieldNotFoundError,
   BlobNotFoundError,
@@ -599,6 +613,277 @@ describe("given a deployment with no object storage (resolveS3Client throws)", (
       });
 
       expect(result).toBe(FULL_VALUE);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFromEventLog — mixed-type sibling attributes do not mask the offloaded
+// IO field (#4888 falsifiability proof)
+// ---------------------------------------------------------------------------
+
+/**
+ * FALSIFIABILITY (#4888): real OTLP spans carry attribute values of mixed types —
+ * `value` is an AnyValue oneof (stringValue | intValue | boolValue | doubleValue |
+ * arrayValue | kvlistValue | bytesValue). The offloaded IO field is stored as a
+ * `stringValue`, but its non-string SIBLINGS (e.g. gen_ai.usage.input_tokens =
+ * { intValue: "100" }) used to fail the strict whole-array parse, degrading every
+ * > 64 KB read to the 64 KB preview.
+ *
+ * This test feeds the REAL stored OTLP shape — derived from `eventToRecord` exactly
+ * like the read-vs-write contract test above — with mixed-type siblings present, and
+ * proves the FULL value comes back. It FAILS on the pre-fix strict schema
+ * (`value: { stringValue: z.string() }` + `z.array(spanAttributeSchema)`), which
+ * rejects the int/double/bool/array siblings and throws BlobFieldNotFoundError.
+ */
+describe("given a real OTLP EventPayload whose span carries mixed-type sibling attributes alongside a >64KB offloaded IO field", () => {
+  // >64 KB and includes a multibyte char so byte-identity is meaningfully asserted.
+  const BIG = "x".repeat(100 * 1024) + "🧪tail";
+  const BIG_OUTPUT = "y".repeat(100 * 1024) + "🧪out";
+
+  /**
+   * Builds a SpanReceivedEvent whose span.attributes mix the offloaded IO fields
+   * (stringValue) with non-string siblings the OLD schema rejected. Cast through
+   * `unknown` because the offloaded values plus the heterogeneous sibling shapes
+   * are the REAL stored OTLP payload, not the clean string-only shape.
+   */
+  function makeMixedTypeSpanEvent() {
+    return EventUtils.createEvent<SpanReceivedEvent>({
+      aggregateType: "trace",
+      aggregateId: AGGREGATE_ID,
+      tenantId: createTenantId(TENANT_A),
+      type: SPAN_RECEIVED_EVENT_TYPE,
+      version: SPAN_RECEIVED_EVENT_VERSION_LATEST,
+      data: {
+        span: {
+          traceId: "abcd1234abcd1234abcd1234abcd1234",
+          spanId: "abcd1234abcd1234",
+          name: "test-span",
+          kind: 1, // SPAN_KIND_INTERNAL
+          startTimeUnixNano: "0",
+          endTimeUnixNano: "1000000",
+          attributes: [
+            // Offloaded IO fields (the ONLY fields the read path needs).
+            { key: "langwatch.input", value: { stringValue: BIG } },
+            { key: "langwatch.output", value: { stringValue: BIG_OUTPUT } },
+            // Mixed-type siblings the OLD strict schema rejected.
+            { key: "gen_ai.usage.input_tokens", value: { intValue: "100" } },
+            { key: "gen_ai.request.temperature", value: { doubleValue: 0.7 } },
+            { key: "langwatch.streaming", value: { boolValue: true } },
+            {
+              key: "gen_ai.request.tools",
+              value: { arrayValue: { values: [{ stringValue: "a" }] } },
+            },
+          ] as never,
+          events: [],
+          links: [],
+          status: { message: null, code: null },
+          droppedAttributesCount: 0,
+          droppedEventsCount: 0,
+          droppedLinksCount: 0,
+        },
+        resource: null,
+        instrumentationScope: null,
+        piiRedactionLevel: "DISABLED",
+      },
+    });
+  }
+
+  describe("when getFromEventLog is called for the offloaded input field", () => {
+    it("returns the FULL >64KB value despite non-string sibling attributes", async () => {
+      const spanReceivedEvent = makeMixedTypeSpanEvent();
+      // EventPayload IS event.data — derive it exactly as the write path does.
+      const record = eventToRecord(spanReceivedEvent);
+      const { client } = makeMockChClient({
+        rows: [{ EventPayload: JSON.stringify(record.EventPayload) }],
+      });
+
+      const blobStore = new BlobStore(
+        makeS3Resolver({ send: vi.fn() }),
+        makeChResolver(client) as never,
+      );
+
+      const result = await blobStore.getFromEventLog({
+        eventId: spanReceivedEvent.id,
+        field: "langwatch.input",
+        tenantId: TENANT_A,
+        aggregateType: AGGREGATE_TYPE,
+        aggregateId: AGGREGATE_ID,
+      });
+
+      expect(result).toBe(BIG);
+      expect(Buffer.byteLength(result, "utf8")).toBe(
+        Buffer.byteLength(BIG, "utf8"),
+      );
+      expect(result.length).toBeGreaterThan(65536);
+    });
+  });
+
+  describe("when getFromEventLog is called for the offloaded output field", () => {
+    it("returns the FULL >64KB value for langwatch.output despite non-string sibling attributes", async () => {
+      const spanReceivedEvent = makeMixedTypeSpanEvent();
+      const record = eventToRecord(spanReceivedEvent);
+      const { client } = makeMockChClient({
+        rows: [{ EventPayload: JSON.stringify(record.EventPayload) }],
+      });
+
+      const blobStore = new BlobStore(
+        makeS3Resolver({ send: vi.fn() }),
+        makeChResolver(client) as never,
+      );
+
+      const result = await blobStore.getFromEventLog({
+        eventId: spanReceivedEvent.id,
+        field: "langwatch.output",
+        tenantId: TENANT_A,
+        aggregateType: AGGREGATE_TYPE,
+        aggregateId: AGGREGATE_ID,
+      });
+
+      expect(result).toBe(BIG_OUTPUT);
+      expect(Buffer.byteLength(result, "utf8")).toBe(
+        Buffer.byteLength(BIG_OUTPUT, "utf8"),
+      );
+      expect(result.length).toBeGreaterThan(65536);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveOffloadedTraces — END-TO-END customer read path with a REAL BlobStore
+// over a mixed-type EventPayload (#4888)
+// ---------------------------------------------------------------------------
+
+/**
+ * END-TO-END (#4888): drives the customer-facing `resolveOffloadedTraces` read
+ * orchestrator with a REAL `BlobStore` (NOT a mocked getFromEventLog), whose CH
+ * client returns the REAL mixed-type EventPayload produced by `eventToRecord`.
+ * This is the path that degraded in production: a leaned span carrying the
+ * preview + a `langwatch.reserved.eventref.langwatch.input` pointer is resolved
+ * back to the FULL value, and the reserved namespace is stripped.
+ *
+ * Pre-fix, `BlobStore.getFromEventLog` rejects the mixed-type payload and throws,
+ * the resolver degrades to preview, so the resolved attribute would equal the
+ * preview — this test fails. Post-fix the full value is restored.
+ */
+describe("given a leaned span pointing at a real mixed-type EventPayload offloaded to event_log", () => {
+  const BIG = "z".repeat(120 * 1024) + "🧪e2e";
+
+  describe("when resolveOffloadedTraces runs with a real BlobStore over event_log", () => {
+    it("restores the FULL langwatch.input into spanAttributes and strips the reserved eventref key", async () => {
+      // The FULL event the command worker writes to event_log, with mixed-type
+      // siblings present alongside the offloaded IO field.
+      const fullEvent = EventUtils.createEvent<SpanReceivedEvent>({
+        aggregateType: "trace",
+        aggregateId: AGGREGATE_ID,
+        tenantId: createTenantId(TENANT_A),
+        type: SPAN_RECEIVED_EVENT_TYPE,
+        version: SPAN_RECEIVED_EVENT_VERSION_LATEST,
+        data: {
+          span: {
+            traceId: "abcd1234abcd1234abcd1234abcd1234",
+            spanId: "abcd1234abcd1234",
+            name: "test-span",
+            kind: 1,
+            startTimeUnixNano: "0",
+            endTimeUnixNano: "1000000",
+            attributes: [
+              { key: "langwatch.input", value: { stringValue: BIG } },
+              { key: "gen_ai.usage.input_tokens", value: { intValue: "100" } },
+              {
+                key: "gen_ai.request.temperature",
+                value: { doubleValue: 0.7 },
+              },
+              { key: "langwatch.streaming", value: { boolValue: true } },
+              {
+                key: "gen_ai.request.tools",
+                value: { arrayValue: { values: [{ stringValue: "a" }] } },
+              },
+            ] as never,
+            events: [],
+            links: [],
+            status: { message: null, code: null },
+            droppedAttributesCount: 0,
+            droppedEventsCount: 0,
+            droppedLinksCount: 0,
+          },
+          resource: null,
+          instrumentationScope: null,
+          piiRedactionLevel: "DISABLED",
+        },
+      });
+
+      const record = eventToRecord(fullEvent);
+      const { client } = makeMockChClient({
+        rows: [{ EventPayload: JSON.stringify(record.EventPayload) }],
+      });
+
+      const blobStore = new BlobStore(
+        makeS3Resolver({ send: vi.fn() }),
+        makeChResolver(client) as never,
+      );
+
+      // The LEANED span as projected: preview value + the eventref pointer that
+      // leanForProjection embeds with the event's id (the read path JOINs on it).
+      const preview = "z".repeat(IO_PREVIEW_BYTES) + "…";
+      const stagedSpan: NormalizedSpan = {
+        id: "abcd1234abcd1234",
+        traceId: AGGREGATE_ID,
+        spanId: "abcd1234abcd1234",
+        tenantId: TENANT_A,
+        parentSpanId: null,
+        parentTraceId: null,
+        parentIsRemote: null,
+        sampled: true,
+        startTimeUnixMs: 0,
+        endTimeUnixMs: 1000,
+        durationMs: 1000,
+        name: "test-span",
+        kind: NormalizedSpanKind.INTERNAL,
+        resourceAttributes: {},
+        spanAttributes: {
+          "langwatch.input": preview,
+          [`${EVENTREF_ATTR_PREFIX}langwatch.input`]: JSON.stringify({
+            field: "langwatch.input",
+            eventId: fullEvent.id,
+          }),
+        },
+        events: [],
+        links: [],
+        statusMessage: null,
+        statusCode: NormalizedStatusCode.OK,
+        instrumentationScope: { name: "test", version: null },
+        droppedAttributesCount: 0,
+        droppedEventsCount: 0,
+        droppedLinksCount: 0,
+      };
+
+      const logger: WarnLogger = {
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const result = await resolveOffloadedTraces({
+        projectId: TENANT_A,
+        normalizedSpans: [stagedSpan],
+        blobStore,
+        ioExtractionService: new TraceIOExtractionService(),
+        logger,
+      });
+
+      const resolvedAttrs = result.resolvedSpans[0]!.spanAttributes as Record<
+        string,
+        string
+      >;
+      // FULL value restored from the mixed-type EventPayload — not the preview.
+      expect(resolvedAttrs["langwatch.input"]).toBe(BIG);
+      expect(resolvedAttrs["langwatch.input"]!.length).toBeGreaterThan(65536);
+      // Reserved eventref namespace never leaks to the UI.
+      const hasReserved = Object.keys(resolvedAttrs).some((k) =>
+        k.startsWith("langwatch.reserved."),
+      );
+      expect(hasReserved).toBe(false);
+      expect(result.anyResolved).toBe(true);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/blob-store.event-log.unit.test.ts
@@ -17,6 +17,11 @@
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { generate, Ksuid } from "@langwatch/ksuid";
 import { describe, expect, it, vi } from "vitest";
+import {
+  EVENTREF_ATTR_PREFIX,
+  IO_PREVIEW_BYTES,
+} from "~/server/app-layer/traces/lean-for-projection";
+import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
 import {
   SPAN_RECEIVED_EVENT_TYPE,
@@ -24,17 +29,12 @@ import {
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
 import type { SpanReceivedEvent } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
 import {
+  type NormalizedSpan,
   NormalizedSpanKind,
   NormalizedStatusCode,
-  type NormalizedSpan,
 } from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import { eventToRecord } from "~/server/event-sourcing/stores/eventStoreUtils";
 import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
-import {
-  EVENTREF_ATTR_PREFIX,
-  IO_PREVIEW_BYTES,
-} from "~/server/app-layer/traces/lean-for-projection";
-import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import {
   resolveOffloadedTraces,
   type WarnLogger,

--- a/langwatch/src/server/app-layer/traces/__tests__/large-trace-blob-offload-readpath.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/large-trace-blob-offload-readpath.integration.test.ts
@@ -47,39 +47,37 @@
 
 import type { ClickHouseClient } from "@clickhouse/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-
+import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
+import {
+  EVENTREF_ATTR_PREFIX,
+  IO_PREVIEW_BYTES,
+  leanForProjection,
+} from "~/server/app-layer/traces/lean-for-projection";
+import { NullSpanStorageRepository } from "~/server/app-layer/traces/repositories/span-storage.repository";
+import { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
+import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
+import type { Event } from "~/server/event-sourcing";
 import {
   getTestClickHouseClient,
   startTestContainers,
   stopTestContainers,
 } from "~/server/event-sourcing/__tests__/integration/testContainers";
 import { generateTestTenantId } from "~/server/event-sourcing/__tests__/integration/testHelpers";
-
-import { BlobStore } from "~/server/app-layer/traces/blob-store.service";
-import { TraceIOExtractionService } from "~/server/app-layer/traces/trace-io-extraction.service";
 import {
-  leanForProjection,
-  EVENTREF_ATTR_PREFIX,
-  IO_PREVIEW_BYTES,
-} from "~/server/app-layer/traces/lean-for-projection";
-import { SpanStorageService } from "~/server/app-layer/traces/span-storage.service";
-import { NullSpanStorageRepository } from "~/server/app-layer/traces/repositories/span-storage.repository";
+  LOG_RECORD_RECEIVED_EVENT_TYPE,
+  LOG_RECORD_RECEIVED_EVENT_VERSION_LATEST,
+  SPAN_RECEIVED_EVENT_TYPE,
+  SPAN_RECEIVED_EVENT_VERSION_LATEST,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import {
+  type NormalizedSpan,
+  NormalizedSpanKind,
+  NormalizedStatusCode,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
 import {
   resolveOffloadedTraces,
   type WarnLogger,
 } from "~/server/traces/resolve-offloaded-traces";
-import {
-  NormalizedSpanKind,
-  NormalizedStatusCode,
-  type NormalizedSpan,
-} from "~/server/event-sourcing/pipelines/trace-processing/schemas/spans";
-import type { Event } from "~/server/event-sourcing";
-import {
-  SPAN_RECEIVED_EVENT_TYPE,
-  SPAN_RECEIVED_EVENT_VERSION_LATEST,
-  LOG_RECORD_RECEIVED_EVENT_TYPE,
-  LOG_RECORD_RECEIVED_EVENT_VERSION_LATEST,
-} from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
 
 // Gate identically to the canonical event_log integration test: skip when no
 // real ClickHouse is reachable, run against the testcontainer otherwise.
@@ -345,7 +343,9 @@ describe.skipIf(!hasTestcontainers)(
       await startTestContainers();
       client = getTestClickHouseClient()!;
       if (!client) {
-        throw new Error("ClickHouse client not available; testcontainers required.");
+        throw new Error(
+          "ClickHouse client not available; testcontainers required.",
+        );
       }
     });
 
@@ -568,9 +568,9 @@ describe.skipIf(!hasTestcontainers)(
           string,
           string
         >;
-        expect(resolvedAttrs["body"]).toBe(LARGE_VALUE);
-        expect(resolvedAttrs["body"]).toContain(UNIQUE_TAIL);
-        expect(resolvedAttrs["body"]!.length).toBe(LARGE_VALUE.length);
+        expect(resolvedAttrs.body).toBe(LARGE_VALUE);
+        expect(resolvedAttrs.body).toContain(UNIQUE_TAIL);
+        expect(resolvedAttrs.body!.length).toBe(LARGE_VALUE.length);
 
         // eventref stripped; resolution succeeded.
         const hasRef = Object.keys(resolvedAttrs).some((k) =>

--- a/langwatch/src/server/app-layer/traces/__tests__/large-trace-blob-offload-readpath.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/large-trace-blob-offload-readpath.integration.test.ts
@@ -190,8 +190,16 @@ function makeSpanReceivedEvent({
         startTimeUnixNano: String(now * 1_000_000),
         endTimeUnixNano: String((now + 1000) * 1_000_000),
         attributes: [
+          // langwatch.input MUST stay first: the offloaded IO field.
           { key: "langwatch.input", value: { stringValue: inputValue } },
-        ],
+          // Mixed-type siblings (#4888): real OTLP spans carry non-string
+          // AnyValue attributes. These must NOT be IO keys and carry NO
+          // eventref — they exist to prove the real CH round-trip would catch a
+          // regression where a non-string sibling fails the whole-array parse.
+          { key: "gen_ai.usage.input_tokens", value: { intValue: "100" } },
+          { key: "gen_ai.request.temperature", value: { doubleValue: 0.7 } },
+          { key: "langwatch.streaming", value: { boolValue: true } },
+        ] as never,
         events: [],
         links: [],
         status: { code: 1, message: null },

--- a/langwatch/src/server/app-layer/traces/blob-store.service.ts
+++ b/langwatch/src/server/app-layer/traces/blob-store.service.ts
@@ -80,10 +80,28 @@ export class BlobFieldNotFoundError extends Error {
 /** ClickHouse query response row from the event_log SELECT. */
 const eventLogRowSchema = z.object({ EventPayload: z.string() });
 
-/** Span attribute entry inside EventPayload. */
+/**
+ * Span attribute entry inside EventPayload.
+ *
+ * EventPayload stores RAW OTLP spans (`EventPayload` IS `event.data`), whose
+ * attribute `value` is an OTLP `AnyValue` oneof —
+ * `stringValue | intValue | boolValue | doubleValue | arrayValue | kvlistValue |
+ * bytesValue` (see schemas/otlp.ts). The read path only ever needs the offloaded
+ * IO fields, which are stored as `stringValue`, so this schema reads ONLY
+ * `stringValue` and leaves it optional.
+ *
+ * Critically, `span.attributes` is parsed PER-ELEMENT and defensively (see the
+ * extraction loop in `getFromEventLog`): a single non-string or malformed
+ * sibling attribute can never fail the whole-array parse and mask the offloaded
+ * field. The old strict shape `value: { stringValue: z.string() }` rejected
+ * EVERY real span that carried a numeric/boolean attribute (e.g.
+ * `gen_ai.usage.input_tokens` = `{ intValue: "100" }`), which failed
+ * `z.array(...)`, failed `eventPayloadSchema.safeParse`, and degraded every
+ * > 64 KB read to the 64 KB preview (#4888).
+ */
 const spanAttributeSchema = z.object({
   key: z.string(),
-  value: z.object({ stringValue: z.string() }),
+  value: z.object({ stringValue: z.string().optional() }),
 });
 
 /**
@@ -94,11 +112,16 @@ const spanAttributeSchema = z.object({
  * with the span at the TOP level — there is NO outer `data` wrapper. Log-record events
  * instead carry the (full) log body at the top-level `body`, which `leanForProjection`
  * tags with an eventref whose field is `"body"` (resolved by `getFromEventLog`).
+ *
+ * `span.attributes` is modeled as `z.array(z.unknown())` so a single malformed
+ * or non-string sibling attribute can never fail the whole-array parse; each
+ * entry is validated per-element by `spanAttributeSchema` in the extraction loop
+ * below (#4888).
  */
 const eventPayloadSchema = z.object({
   span: z
     .object({
-      attributes: z.array(spanAttributeSchema),
+      attributes: z.array(z.unknown()),
     })
     .optional(),
   body: z.string().optional(),
@@ -291,18 +314,24 @@ export class BlobStore {
       return body;
     }
 
-    // Span attributes: extract by field name (the attribute key).
+    // Span attributes: extract by field name (the attribute key). EventPayload
+    // holds raw OTLP attributes of mixed value types — parse each entry
+    // defensively so a single non-string / malformed sibling attribute can
+    // never mask the offloaded IO field (#4888).
     const spanAttributes = payloadParse.data.span?.attributes;
     if (!spanAttributes || spanAttributes.length === 0) {
       throw new BlobFieldNotFoundError(eventId, field);
     }
 
-    const attr = spanAttributes.find((a) => a.key === field);
-    if (!attr) {
-      throw new BlobFieldNotFoundError(eventId, field);
+    for (const raw of spanAttributes) {
+      const attr = spanAttributeSchema.safeParse(raw);
+      if (!attr.success || attr.data.key !== field) continue;
+      if (typeof attr.data.value.stringValue === "string") {
+        return attr.data.value.stringValue;
+      }
     }
 
-    return attr.value.stringValue;
+    throw new BlobFieldNotFoundError(eventId, field);
   }
 
   /**


### PR DESCRIPTION
## Fixes #4888 (P0) — >64KB offloaded trace IO truncated on all customer-facing `full=true` reads

PR #4890 (`c71520f`) wired `full=true` blob resolution through every trace-detail surface, **but >64KB IO still degrades to the 64KB preview in production**, so the issue was reopened. This PR fixes the actual resolution bug.

> **This is NOT a deploy gap.** #4890 is deployed (Drew confirmed prod app SHA `5cf15b90 ⊇ c71520f`) and the resolver *runs* on every detail read — it just silently fails the field lookup and falls back to preview. There is a real code bug to fix.

---

### Root cause (AC1)

`BlobStore.getFromEventLog` (`langwatch/src/server/app-layer/traces/blob-store.service.ts`) parses the `event_log` `EventPayload` (a **raw OTLP span**) to pull the full IO value. The schema required `value.stringValue` on **every** span attribute:

```ts
const spanAttributeSchema = z.object({
  key: z.string(),
  value: z.object({ stringValue: z.string() }),   // ← required on EVERY attribute
});
const eventPayloadSchema = z.object({
  span: z.object({ attributes: z.array(spanAttributeSchema) }).optional(),
  ...
});
```

But an OTLP attribute `value` is an `AnyValue` **oneof** (`stringValue | intValue | boolValue | doubleValue | arrayValue | kvlistValue | bytesValue` — see `schemas/otlp.ts:12-19`). Real LLM spans always carry non-string siblings (`gen_ai.usage.input_tokens` = `{intValue}`, `gen_ai.request.temperature` = `{doubleValue}`, …). A single non-string sibling fails `z.array(spanAttributeSchema)` → fails `eventPayloadSchema.safeParse` → throws `BlobFieldNotFoundError` → the resolver logs a warn and **keeps the 64KB preview**.

That is Drew's exact prod warn, firing continuously:
```
WARN langwatch:traces:service  event_log row not found for eventref — keeping preview value
  error: Field "langwatch.input" not found in event payload at key event_0001...
```

**Why CI stayed green:** every prior test either used string-only span attributes or mocked `getFromEventLog`, so the real mixed-type parse was never exercised.

### The fix (AC2)

Model `span.attributes` as `z.array(z.unknown())` and parse **each** attribute defensively (`key` + optional `stringValue`), so a single non-string / malformed sibling can never fail the whole-array parse and mask the offloaded IO field:

```ts
const spanAttributeSchema = z.object({
  key: z.string(),
  value: z.object({ stringValue: z.string().optional() }),
});
// eventPayloadSchema.span.attributes: z.array(z.unknown())
for (const raw of spanAttributes) {
  const attr = spanAttributeSchema.safeParse(raw);
  if (!attr.success || attr.data.key !== field) continue;
  if (typeof attr.data.value.stringValue === "string") return attr.data.value.stringValue;
}
throw new BlobFieldNotFoundError(eventId, field);
```

`getFromEventLog` is the single chokepoint for all four detail surfaces (`traces.getById`, `traces.getTracesWithSpans`, `spans.getTracesWithSpans`, REST `GET /:traceId`) — all already pass `buildTraceBlobResolutionDeps()` + `full: true` in the base, so this one fix repairs every customer-facing read at once.

> A reuse note for reviewers: a deliberate **minimal local** `spanAttributeSchema` is kept rather than reusing `otlp.ts`'s `keyValueSchema`. Reusing `z.array(keyValueSchema)` would re-introduce the all-or-nothing array parse that **caused** this P0; per-element `safeParse` tolerance is the property that fixes it. (Endorsed by the design-soundness review.)

---

### How I can prove I was successful (AC3)

**1. Falsifiability — red→green on the REAL parse path** (`getFromEventLog` is NOT mocked). New tests in `blob-store.event-log.unit.test.ts` build a genuine `eventToRecord` payload whose span carries a `>64KB` `langwatch.input`/`langwatch.output` **plus** mixed-type siblings (`intValue`/`doubleValue`/`boolValue`/`arrayValue`), then drive the real `getFromEventLog` **and** the real `resolveOffloadedTraces` orchestrator.

_Pre-fix (current prod code, `git show HEAD:…blob-store.service.ts`):_
```
 Test Files  1 failed (1)
      Tests  3 failed | 14 passed (17)
BlobFieldNotFoundError: Field "langwatch.output" not found in event payload at key event_0002...
  ❯ BlobStore.getFromEventLog blob-store.service.ts:280:13   ← eventPayloadSchema.safeParse failure
```
The pre-fix failure reproduces Drew's **exact** prod error string — the bug, in isolation, on the real code path.

_Post-fix:_ `Tests 17 passed (17)`.

**2. Real-ClickHouse proof — exercised in CI on the real read surface.** The `large-trace-blob-offload-readpath.integration.test.ts` writes a full event into a **real ClickHouse `event_log`** and drives the real read path (`SpanStorageService.getSpansByTraceId` / `resolveOffloadedTraces` + real `BlobStore`), asserting the >64KB original comes back in full (a unique tail past the 64KB boundary, length-exact), not the preview. **I hardened its fixture with mixed-type siblings**, and it **runs and passes in CI's `test-integration` lane against real ClickHouse**:
```
test-integration (2): ✓ src/.../large-trace-blob-offload-readpath.integration.test.ts (3 tests) 197ms
```
(CI sets `CI_CLICKHOUSE_URL` + starts ClickHouse + migrates — so this test is **not** skipped in standard CI, correcting the reopen note. The real eventId→event_log→full-value path with mixed-type attrs is now covered as a regression guard.)

**3. No regression / quality:** 8 sibling offload suites green (118 tests), `pnpm typecheck` clean, biome clean. Parallel code review (principles · hygiene · security · test · design-soundness) returned **no blocking findings** (verdict: READY).

**Live "before" (prod):** Drew's documented prod truncation (400,453-byte trace → 65,537 bytes, eventref present; `event_log` holds the full 401,013-byte payload). I could not pull an independent MCP `get_trace` "after" because prod runs the unfixed code and I must not deploy, and my MCP key is scoped to a different project than Drew's repro (404). **Surface exercised:** the real `getFromEventLog` + `resolveOffloadedTraces` parse path (unit, mixed-type payload) **and the real ClickHouse `event_log` read path in CI** (integration). Live HTTP confirmation lands when this deploys.

---

### Follow-ups (from Drew's reopen comment)
- **Ask #2 (un-skip the testcontainer read-path test in CI): already satisfied.** The `test-integration` lane sets `CI_CLICKHOUSE_URL`, so `large-trace-blob-offload-readpath.integration.test.ts` already runs against real ClickHouse in standard CI (3 tests, see above) — it is **not** skipped. I hardened its fixture with mixed-type siblings so it now guards this exact regression class.
- **Ask #3 (metric/alert on the resolution-failure warn):** still recommended as a separate change — the warn fires at prod volume and is otherwise invisible. Out of scope for this surgical fix.
- Minor, non-blocking (from review): the mixed-type fixture is duplicated across unit/integration helpers; `kvlistValue`/`bytesValue` variants aren't exercised (harmless under the fix). Left as cleanup.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> ⚠️ **Do not merge on my behalf** — Drew merges + deploys (Rule 5).
