### PR TITLE
feat(stored-objects): project_id in file URLs to remove the cross-tenant owner lookup (#4947)

### DIFF
--- a/langwatch/src/app/api/files/[[...route]]/app.ts
+++ b/langwatch/src/app/api/files/[[...route]]/app.ts
@@ -299,20 +299,20 @@ async function handleFileRead(
 // id-only routes. Hono matches by path-segment count, so a two-segment
 // request resolves here and a one-segment request resolves to the legacy
 // handler below; the ordering is belt-and-suspenders.
-secured.access(anyAuthenticated()).get("/:projectId/:id", (c) =>
-  handleFileRead(c, { method: "GET" }),
-);
-secured.access(anyAuthenticated()).head("/:projectId/:id", (c) =>
-  handleFileRead(c, { method: "HEAD" }),
-);
+secured
+  .access(anyAuthenticated())
+  .get("/:projectId/:id", (c) => handleFileRead(c, { method: "GET" }));
+secured
+  .access(anyAuthenticated())
+  .head("/:projectId/:id", (c) => handleFileRead(c, { method: "HEAD" }));
 
 // Legacy id-only routes — retained for URLs minted before #4947.
-secured.access(anyAuthenticated()).get("/:id", (c) =>
-  handleFileRead(c, { method: "GET" }),
-);
-secured.access(anyAuthenticated()).head("/:id", (c) =>
-  handleFileRead(c, { method: "HEAD" }),
-);
+secured
+  .access(anyAuthenticated())
+  .get("/:id", (c) => handleFileRead(c, { method: "GET" }));
+secured
+  .access(anyAuthenticated())
+  .head("/:id", (c) => handleFileRead(c, { method: "HEAD" }));
 
 export const app = secured.hono;
 export type FilesAppType = typeof app;

--- a/langwatch/src/app/api/files/[[...route]]/app.ts
+++ b/langwatch/src/app/api/files/[[...route]]/app.ts
@@ -279,7 +279,9 @@ async function handleFileRead(
   });
 
   // Step 4: project-scoped read.
-  const service = createStoredObjectsService({ projectId: authorizedProjectId });
+  const service = createStoredObjectsService({
+    projectId: authorizedProjectId,
+  });
 
   let result;
   try {

--- a/langwatch/src/app/api/files/[[...route]]/app.ts
+++ b/langwatch/src/app/api/files/[[...route]]/app.ts
@@ -153,13 +153,22 @@ function streamFileResponse({
 }
 
 /**
- * GET /api/files/:id
+ * GET /api/files/:projectId/:id  (project-scoped — issue #4947)
+ * GET /api/files/:id             (legacy id-only — backward compatible)
  *
  * Streams the bytes for the given stored object id.
  *
  * Auth: either an API key scoped to the file's project, or a session cookie
- * belonging to a user with `scenarios:view` on that project. The owning
- * project is resolved from the stored_objects row (NOT from any header).
+ * belonging to a user with `scenarios:view` on that project.
+ *
+ * Owner resolution:
+ *  - Project-scoped URL: the owning project is taken from the URL path. No
+ *    cross-tenant lookup — the read is scoped directly to that project, and a
+ *    URL whose `projectId` is not the caller's (403) or does not own the row
+ *    (404) cannot serve another tenant's bytes.
+ *  - Legacy id-only URL: the owning project is resolved from the
+ *    stored_objects row via the cross-tenant fallback (NOT from any header),
+ *    retained so URLs minted before #4947 keep resolving.
  *
  * Responses:
  *  200 — bytes streamed with a coerced Content-Type and Content-Length.
@@ -169,9 +178,9 @@ function streamFileResponse({
  *  429 — per-caller rate limit exceeded (keyed before owner resolution).
  *  502 — row exists, storage returned a non-404 error.
  *
- * HEAD /api/files/:id mirrors GET for byte-free probes (used by the UI
- * MediaPart to disambiguate "missing" vs "transient error" without paying
- * for a full body download).
+ * HEAD mirrors GET for byte-free probes (used by the UI MediaPart to
+ * disambiguate "missing" vs "transient error" without paying for a full body
+ * download).
  */
 async function handleFileRead(
   c: Parameters<MiddlewareHandler<{ Variables: DualAuthVariables }>>[0],
@@ -181,6 +190,9 @@ async function handleFileRead(
   if (!id) {
     return jsonResponse({ status: "not_found" }, 404);
   }
+  // Present only on the project-scoped route (`/api/files/:projectId/:id`).
+  // Undefined on the legacy id-only route (`/api/files/:id`).
+  const projectIdFromUrl = c.req.param("projectId");
 
   // Step 1: per-caller rate limit (AC12). Keyed on the caller's identity
   // (apiKeyProjectId or userId) so that enumeration attempts are throttled
@@ -217,27 +229,40 @@ async function handleFileRead(
     );
   }
 
-  // Step 2: resolve the owning project from the row id (cross-tenant lookup).
+  // Step 2: resolve the owning project.
   //
-  // The lookup fans out across every configured ClickHouse instance with
-  // failure isolation: a transient outage on a private/BYOC instance
-  // throws `StoredObjectOwnerLookupUnavailableError` so this route can
-  // return 502 rather than masking the degraded instance as a 404
-  // (Sergio review 2026-05-20).
+  // Project-scoped URL (`/api/files/:projectId/:id`, issue #4947): the URL
+  // carries the claimed owner, so take it directly — no cross-tenant lookup.
+  // The authorization gate (step 3) rejects a claim that is not the caller's
+  // own project, and the project-scoped read (step 4) returns 404 when the
+  // claim does not actually own the row. So a tampered or foreign `projectId`
+  // in the URL can never serve another tenant's bytes, and the 403-vs-404
+  // cross-tenant existence oracle is closed (a foreign claim is always 403,
+  // regardless of whether the row exists).
+  //
+  // Legacy id-only URL (`/api/files/:id`): no project context in the URL, so
+  // fall back to the cross-tenant owner lookup. The lookup fans out across
+  // every configured ClickHouse instance with failure isolation: a transient
+  // outage on a private/BYOC instance throws
+  // `StoredObjectOwnerLookupUnavailableError` so this route can return 502
+  // rather than masking the degraded instance as a 404 (Sergio review
+  // 2026-05-20). Retained so URLs embedded in historical message content keep
+  // resolving — no backfill (see #4947).
   let owner: { projectId: string } | null;
-  try {
-    owner = await resolveStoredObjectOwner({ id });
-  } catch (err) {
-    if (err instanceof StoredObjectOwnerLookupUnavailableError) {
-      return jsonResponse(
-        { error: "file temporarily unavailable" },
-        502,
-      );
+  if (projectIdFromUrl) {
+    owner = { projectId: projectIdFromUrl };
+  } else {
+    try {
+      owner = await resolveStoredObjectOwner({ id });
+    } catch (err) {
+      if (err instanceof StoredObjectOwnerLookupUnavailableError) {
+        return jsonResponse({ error: "file temporarily unavailable" }, 502);
+      }
+      throw err;
     }
-    throw err;
-  }
-  if (!owner) {
-    return jsonResponse({ status: "not_found" }, 404);
+    if (!owner) {
+      return jsonResponse({ status: "not_found" }, 404);
+    }
   }
 
   // Step 3: project-membership gate.
@@ -270,6 +295,18 @@ async function handleFileRead(
   });
 }
 
+// Project-scoped routes (issue #4947) — registered before the legacy
+// id-only routes. Hono matches by path-segment count, so a two-segment
+// request resolves here and a one-segment request resolves to the legacy
+// handler below; the ordering is belt-and-suspenders.
+secured.access(anyAuthenticated()).get("/:projectId/:id", (c) =>
+  handleFileRead(c, { method: "GET" }),
+);
+secured.access(anyAuthenticated()).head("/:projectId/:id", (c) =>
+  handleFileRead(c, { method: "HEAD" }),
+);
+
+// Legacy id-only routes — retained for URLs minted before #4947.
 secured.access(anyAuthenticated()).get("/:id", (c) =>
   handleFileRead(c, { method: "GET" }),
 );

--- a/langwatch/src/app/api/files/[[...route]]/app.ts
+++ b/langwatch/src/app/api/files/[[...route]]/app.ts
@@ -265,15 +265,25 @@ async function handleFileRead(
     }
   }
 
+  // Pin the authorized project once: the membership gate (step 3) and the
+  // project-scoped read (step 4) MUST use the same value, or a future edit
+  // could authorize one project and read another (cross-tenant leak). One
+  // binding makes that divergence impossible to introduce by accident.
+  const authorizedProjectId = owner.projectId;
+
   // Step 3: project-membership gate.
-  await authorizeFileRead({ apiKeyProjectId, userId, ownerProjectId: owner.projectId });
+  await authorizeFileRead({
+    apiKeyProjectId,
+    userId,
+    ownerProjectId: authorizedProjectId,
+  });
 
   // Step 4: project-scoped read.
-  const service = createStoredObjectsService({ projectId: owner.projectId });
+  const service = createStoredObjectsService({ projectId: authorizedProjectId });
 
   let result;
   try {
-    result = await service.getById({ projectId: owner.projectId, id });
+    result = await service.getById({ projectId: authorizedProjectId, id });
   } catch {
     return jsonResponse({ error: "file temporarily unavailable" }, 502);
   }

--- a/langwatch/src/components/simulations/MediaPart.tsx
+++ b/langwatch/src/components/simulations/MediaPart.tsx
@@ -44,11 +44,15 @@ export type MediaPartData =
 // ---------------------------------------------------------------------------
 
 /**
- * Extracts the stored-object id from a /api/files/:id URL, or returns null
+ * Extracts the stored-object id from a stored-object URL, or returns null
  * when the URL does not match that pattern (e.g. an external URL).
+ *
+ * Handles both shapes: the project-scoped `/api/files/<projectId>/<id>`
+ * (issue #4947) and the legacy id-only `/api/files/<id>`. The id is always
+ * the final path segment; an optional project segment may precede it.
  */
 function extractStoredObjectId(url: string): string | null {
-  const match = /\/api\/files\/([^/?#]+)/.exec(url);
+  const match = /\/api\/files\/(?:[^/?#]+\/)?([^/?#]+)/.exec(url);
   return match?.[1] ?? null;
 }
 

--- a/langwatch/src/components/simulations/MediaPart.tsx
+++ b/langwatch/src/components/simulations/MediaPart.tsx
@@ -50,9 +50,14 @@ export type MediaPartData =
  * Handles both shapes: the project-scoped `/api/files/<projectId>/<id>`
  * (issue #4947) and the legacy id-only `/api/files/<id>`. The id is always
  * the final path segment; an optional project segment may precede it.
+ *
+ * Anchored to the start of the string: our minted URLs are root-relative
+ * (`/api/files/...`), so a genuinely external URL that merely contains
+ * "/api/files/" later in its path (e.g. `https://cdn.example/api/files/x`)
+ * does NOT match and correctly returns null.
  */
 function extractStoredObjectId(url: string): string | null {
-  const match = /\/api\/files\/(?:[^/?#]+\/)?([^/?#]+)/.exec(url);
+  const match = /^\/api\/files\/(?:[^/?#]+\/)?([^/?#]+)/.exec(url);
   return match?.[1] ?? null;
 }
 

--- a/langwatch/src/components/simulations/__tests__/MediaPart.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/MediaPart.integration.test.tsx
@@ -22,7 +22,9 @@ type HeadByIdProbeResult =
   | { status: "missing"; mediaType: string }
   | { status: "not_found" };
 
-const mockHeadByIdData = vi.fn(() => undefined as undefined | HeadByIdProbeResult);
+const mockHeadByIdData = vi.fn(
+  () => undefined as undefined | HeadByIdProbeResult,
+);
 
 // Records every input the component passes to the existence probe. The probe
 // input is rebuilt on each render with the stored-object id extracted from the
@@ -34,10 +36,7 @@ vi.mock("~/utils/api", () => ({
   api: {
     storedObjects: {
       headById: {
-        useQuery: (
-          input: unknown,
-          opts: { enabled?: boolean } | undefined,
-        ) => {
+        useQuery: (input: unknown, opts: { enabled?: boolean } | undefined) => {
           headByIdInputs.push(input as { projectId: string; id: string });
           // Only return data when the query is enabled (i.e. after an error event).
           if (!opts?.enabled) return { data: undefined };
@@ -139,7 +138,6 @@ describe("<MediaPart/>", () => {
   });
 
   describe("when the url carries a project-id segment (#4947)", () => {
-    /** @scenario "MediaPart extracts the stored-object id from a project-scoped url for the existence probe" */
     it("probes with the id from the final path segment, not the project segment", () => {
       render(
         <MediaPart
@@ -164,7 +162,6 @@ describe("<MediaPart/>", () => {
       });
     });
 
-    /** @scenario "MediaPart still extracts the id from a legacy id-only url" */
     it("extracts the id from a legacy id-only url for backward compatibility", () => {
       render(
         <MediaPart
@@ -241,7 +238,10 @@ describe("<MediaPart/>", () => {
   describe("when the tRPC probe returns status: 'missing' (row exists, blob gone)", () => {
     /** @scenario "Trace timeline shows a missing badge when the byte content is no longer retrievable" */
     it("renders a missing-badge placeholder labeled with the mediaType", async () => {
-      mockHeadByIdData.mockReturnValue({ status: "missing", mediaType: "audio/mp3" });
+      mockHeadByIdData.mockReturnValue({
+        status: "missing",
+        mediaType: "audio/mp3",
+      });
 
       render(
         <MediaPart
@@ -267,8 +267,12 @@ describe("<MediaPart/>", () => {
         expect(screen.getByTestId("media-part-missing")).toBeInTheDocument();
       });
 
-      expect(screen.getByTestId("media-part-missing")).toHaveTextContent("audio");
-      expect(screen.getByTestId("media-part-missing")).toHaveTextContent("missing");
+      expect(screen.getByTestId("media-part-missing")).toHaveTextContent(
+        "audio",
+      );
+      expect(screen.getByTestId("media-part-missing")).toHaveTextContent(
+        "missing",
+      );
     });
   });
 
@@ -308,7 +312,10 @@ describe("<MediaPart/>", () => {
       // Row exists AND storage confirms bytes are present, but the browser
       // element still errored — transient decode / network failure. MediaPart
       // should land on "error", not "missing".
-      mockHeadByIdData.mockReturnValue({ status: "available", mediaType: "audio/mp3" });
+      mockHeadByIdData.mockReturnValue({
+        status: "available",
+        mediaType: "audio/mp3",
+      });
 
       render(
         <MediaPart
@@ -335,7 +342,9 @@ describe("<MediaPart/>", () => {
       expect(screen.getByTestId("media-part-error")).toHaveTextContent("audio");
       expect(screen.getByTestId("media-part-error")).toHaveTextContent("error");
       // The "missing" placeholder must NOT be shown — that's a different state.
-      expect(screen.queryByTestId("media-part-missing")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("media-part-missing"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -386,7 +395,9 @@ describe("<MediaPart/>", () => {
       expect(audio).toHaveAttribute("controls");
 
       // The "missing" / "error" placeholders must NOT appear.
-      expect(screen.queryByTestId("media-part-missing")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("media-part-missing"),
+      ).not.toBeInTheDocument();
       expect(screen.queryByTestId("media-part-error")).not.toBeInTheDocument();
     });
   });

--- a/langwatch/src/components/simulations/__tests__/MediaPart.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/MediaPart.integration.test.tsx
@@ -139,6 +139,11 @@ describe("<MediaPart/>", () => {
 
   describe("when the url carries a project-id segment (#4947)", () => {
     it("probes with the id from the final path segment, not the project segment", () => {
+      // The project segment ("owner_proj") is deliberately DIFFERENT from the
+      // component's projectId prop, so this proves the extracted id is the
+      // URL's final segment — not the project segment, and not the prop echoed
+      // back. A parser that returned the first segment would yield "owner_proj"
+      // and fail the assertion.
       render(
         <MediaPart
           projectId={TEST_PROJECT_ID}
@@ -146,7 +151,7 @@ describe("<MediaPart/>", () => {
             type: "image",
             source: {
               type: "url",
-              value: `/api/files/${TEST_PROJECT_ID}/so_scoped_id`,
+              value: "/api/files/owner_proj/so_scoped_id",
               mimeType: "image/png",
             },
           }}
@@ -154,15 +159,15 @@ describe("<MediaPart/>", () => {
         { wrapper: Wrapper },
       );
 
-      // The probe input is rebuilt every render with the extracted id; the id
-      // is the FINAL path segment (so_scoped_id), never the project segment.
       expect(headByIdInputs.at(-1)).toEqual({
         projectId: TEST_PROJECT_ID,
         id: "so_scoped_id",
       });
     });
+  });
 
-    it("extracts the id from a legacy id-only url for backward compatibility", () => {
+  describe("when the url is the legacy id-only shape", () => {
+    it("probes with the id from the single path segment", () => {
       render(
         <MediaPart
           projectId={TEST_PROJECT_ID}

--- a/langwatch/src/components/simulations/__tests__/MediaPart.integration.test.tsx
+++ b/langwatch/src/components/simulations/__tests__/MediaPart.integration.test.tsx
@@ -24,14 +24,21 @@ type HeadByIdProbeResult =
 
 const mockHeadByIdData = vi.fn(() => undefined as undefined | HeadByIdProbeResult);
 
+// Records every input the component passes to the existence probe. The probe
+// input is rebuilt on each render with the stored-object id extracted from the
+// media URL, so these capture how the id is parsed out of the URL — including
+// the project-scoped `/api/files/<projectId>/<id>` shape (issue #4947).
+const headByIdInputs: Array<{ projectId: string; id: string }> = [];
+
 vi.mock("~/utils/api", () => ({
   api: {
     storedObjects: {
       headById: {
         useQuery: (
-          _input: unknown,
+          input: unknown,
           opts: { enabled?: boolean } | undefined,
         ) => {
+          headByIdInputs.push(input as { projectId: string; id: string });
           // Only return data when the query is enabled (i.e. after an error event).
           if (!opts?.enabled) return { data: undefined };
           return { data: mockHeadByIdData() };
@@ -57,6 +64,7 @@ describe("<MediaPart/>", () => {
     mockHeadByIdData.mockReset();
     // Default: no data (probe not yet completed)
     mockHeadByIdData.mockReturnValue(undefined);
+    headByIdInputs.length = 0;
   });
 
   describe("when a message has a url-shape audio part", () => {
@@ -127,6 +135,56 @@ describe("<MediaPart/>", () => {
       expect(video.tagName.toLowerCase()).toBe("video");
       expect(video).toHaveAttribute("src", "/api/files/stored-video-id");
       expect(video).toHaveAttribute("controls");
+    });
+  });
+
+  describe("when the url carries a project-id segment (#4947)", () => {
+    /** @scenario "MediaPart extracts the stored-object id from a project-scoped url for the existence probe" */
+    it("probes with the id from the final path segment, not the project segment", () => {
+      render(
+        <MediaPart
+          projectId={TEST_PROJECT_ID}
+          part={{
+            type: "image",
+            source: {
+              type: "url",
+              value: `/api/files/${TEST_PROJECT_ID}/so_scoped_id`,
+              mimeType: "image/png",
+            },
+          }}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      // The probe input is rebuilt every render with the extracted id; the id
+      // is the FINAL path segment (so_scoped_id), never the project segment.
+      expect(headByIdInputs.at(-1)).toEqual({
+        projectId: TEST_PROJECT_ID,
+        id: "so_scoped_id",
+      });
+    });
+
+    /** @scenario "MediaPart still extracts the id from a legacy id-only url" */
+    it("extracts the id from a legacy id-only url for backward compatibility", () => {
+      render(
+        <MediaPart
+          projectId={TEST_PROJECT_ID}
+          part={{
+            type: "image",
+            source: {
+              type: "url",
+              value: "/api/files/so_legacy_id",
+              mimeType: "image/png",
+            },
+          }}
+        />,
+        { wrapper: Wrapper },
+      );
+
+      expect(headByIdInputs.at(-1)).toEqual({
+        projectId: TEST_PROJECT_ID,
+        id: "so_legacy_id",
+      });
     });
   });
 

--- a/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
@@ -30,15 +30,17 @@ import type { StoredObjectsService } from "../stored-objects.service";
 // ---------------------------------------------------------------------------
 
 /** Builds a minimal mock StoredObjectsService. */
-function makeService(overrides: {
-  storeFromBytes?: StoredObjectsService["storeFromBytes"];
-} = {}): StoredObjectsService {
+function makeService(
+  overrides: { storeFromBytes?: StoredObjectsService["storeFromBytes"] } = {},
+): StoredObjectsService {
   return {
-    storeFromBytes: overrides.storeFromBytes ?? vi.fn().mockResolvedValue({
-      id: "stored-id-1",
-      mediaType: "audio/mp3",
-      isDuplicate: false,
-    }),
+    storeFromBytes:
+      overrides.storeFromBytes ??
+      vi.fn().mockResolvedValue({
+        id: "stored-id-1",
+        mediaType: "audio/mp3",
+        isDuplicate: false,
+      }),
     getById: vi.fn(),
     deleteOwnedBy: vi.fn(),
   } as unknown as StoredObjectsService;
@@ -118,8 +120,12 @@ describe("extractInlineMediaFromEvent", () => {
       expect(refs).toHaveLength(0);
       expect(service.storeFromBytes).not.toHaveBeenCalled();
       // Content array must be identical
-      const rewrittenMessage = (rewrittenEvent as { message: { content: unknown[] } }).message;
-      expect(rewrittenMessage.content).toEqual([{ type: "text", text: "Hello, world!" }]);
+      const rewrittenMessage = (
+        rewrittenEvent as { message: { content: unknown[] } }
+      ).message;
+      expect(rewrittenMessage.content).toEqual([
+        { type: "text", text: "Hello, world!" },
+      ]);
     });
   });
 
@@ -165,11 +171,16 @@ describe("extractInlineMediaFromEvent", () => {
       );
 
       // The part must be rewritten to source.type="url"
-      const content = (rewrittenEvent as { message: { content: unknown[] } }).message.content;
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
       expect(content).toHaveLength(1);
       expect(content[0]).toMatchObject({
         type: "audio",
-        source: { type: "url", value: `/api/files/proj-1/${storedId}`, mimeType },
+        source: {
+          type: "url",
+          value: `/api/files/proj-1/${storedId}`,
+          mimeType,
+        },
       });
 
       // One ref returned
@@ -220,10 +231,15 @@ describe("extractInlineMediaFromEvent", () => {
       expect(service.storeFromBytes).toHaveBeenCalledTimes(2);
       expect(refs).toHaveLength(2);
 
-      const content = (rewrittenEvent as { message: { content: unknown[] } }).message.content;
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
       expect(content).toHaveLength(2);
-      expect((content[0] as { source: { value: string } }).source.value).toBe("/api/files/proj-1/stored-id-1");
-      expect((content[1] as { source: { value: string } }).source.value).toBe("/api/files/proj-1/stored-id-2");
+      expect((content[0] as { source: { value: string } }).source.value).toBe(
+        "/api/files/proj-1/stored-id-1",
+      );
+      expect((content[1] as { source: { value: string } }).source.value).toBe(
+        "/api/files/proj-1/stored-id-2",
+      );
     });
   });
 
@@ -265,7 +281,8 @@ describe("extractInlineMediaFromEvent", () => {
         }),
       );
 
-      const content = (rewrittenEvent as { message: { content: unknown[] } }).message.content;
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
       expect(content).toHaveLength(1);
       const part = content[0] as {
         type: string;
@@ -293,7 +310,11 @@ describe("extractInlineMediaFromEvent", () => {
       const event = makeEventWithContent([
         {
           type: "audio",
-          source: { type: "url", value: "https://example.com/audio.mp3", mimeType: "audio/mp3" },
+          source: {
+            type: "url",
+            value: "https://example.com/audio.mp3",
+            mimeType: "audio/mp3",
+          },
         },
       ]);
 
@@ -700,13 +721,18 @@ describe("extractInlineMediaFromEvent", () => {
       // Second message's audio part is now a URL reference.
       const secondMsg = rewritten.messages[1] as {
         role: string;
-        content: Array<{ type: string; source: { type: string; value: string } }>;
+        content: Array<{
+          type: string;
+          source: { type: string; value: string };
+        }>;
       };
       expect(secondMsg.role).toBe("assistant");
       expect(secondMsg.content).toHaveLength(1);
       expect(secondMsg.content[0]!.type).toBe("audio");
       expect(secondMsg.content[0]!.source.type).toBe("url");
-      expect(secondMsg.content[0]!.source.value).toBe("/api/files/proj-1/stored-id-1");
+      expect(secondMsg.content[0]!.source.value).toBe(
+        "/api/files/proj-1/stored-id-1",
+      );
     });
   });
 
@@ -816,11 +842,16 @@ describe("extractInlineMediaFromEvent", () => {
       expect(refs).toHaveLength(1);
       expect(refs[0]!.id).toBe(storedId);
 
-      const content = (rewrittenEvent as { message: { content: unknown[] } }).message.content;
+      const content = (rewrittenEvent as { message: { content: unknown[] } })
+        .message.content;
       expect(content).toHaveLength(1);
       expect(content[0]).toMatchObject({
         type: "document",
-        source: { type: "url", value: `/api/files/proj-1/${storedId}`, mimeType },
+        source: {
+          type: "url",
+          value: `/api/files/proj-1/${storedId}`,
+          mimeType,
+        },
       });
     });
   });

--- a/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/content-extractor.unit.test.ts
@@ -125,7 +125,7 @@ describe("extractInlineMediaFromEvent", () => {
 
   describe("when an event has an audio part with source.type=data", () => {
     /** @scenario "Inline file part is externalized and the event payload is rewritten by id" */
-    it("calls storeFromBytes with the decoded bytes and the mimeType, replaces the part with source.type=url referencing /api/files/{id}, and returns one ref", async () => {
+    it("calls storeFromBytes with the decoded bytes and the mimeType, replaces the part with source.type=url referencing /api/files/{projectId}/{id}, and returns one ref", async () => {
       const base64Payload = makeBase64Payload("audio-data");
       const mimeType = "audio/mp3";
       const storedId = "stored-audio-id";
@@ -169,7 +169,7 @@ describe("extractInlineMediaFromEvent", () => {
       expect(content).toHaveLength(1);
       expect(content[0]).toMatchObject({
         type: "audio",
-        source: { type: "url", value: `/api/files/${storedId}`, mimeType },
+        source: { type: "url", value: `/api/files/proj-1/${storedId}`, mimeType },
       });
 
       // One ref returned
@@ -222,8 +222,8 @@ describe("extractInlineMediaFromEvent", () => {
 
       const content = (rewrittenEvent as { message: { content: unknown[] } }).message.content;
       expect(content).toHaveLength(2);
-      expect((content[0] as { source: { value: string } }).source.value).toBe("/api/files/stored-id-1");
-      expect((content[1] as { source: { value: string } }).source.value).toBe("/api/files/stored-id-2");
+      expect((content[0] as { source: { value: string } }).source.value).toBe("/api/files/proj-1/stored-id-1");
+      expect((content[1] as { source: { value: string } }).source.value).toBe("/api/files/proj-1/stored-id-2");
     });
   });
 
@@ -276,7 +276,7 @@ describe("extractInlineMediaFromEvent", () => {
       };
       expect(part.type).toBe("binary");
       expect(part.id).toBe(storedId);
-      expect(part.url).toBe(`/api/files/${storedId}`);
+      expect(part.url).toBe(`/api/files/proj-1/${storedId}`);
       expect(part.data).toBeUndefined();
       // Non-data fields preserved
       expect(part.filename).toBe("file.bin");
@@ -363,7 +363,7 @@ describe("extractInlineMediaFromEvent", () => {
 
   describe("when an event has an image_url part with a base64 data URI (production shape)", () => {
     /** @scenario "OpenAI-shaped image_url parts with data: URIs are extracted to stored objects" */
-    it("extracts the bytes and rewrites image_url.url to /api/files/<id>", async () => {
+    it("extracts the bytes and rewrites image_url.url to /api/files/<projectId>/<id>", async () => {
       const base64Payload = makeBase64Payload("image-bytes");
       const mimeType = "image/png";
       const service = makeService({
@@ -408,7 +408,7 @@ describe("extractInlineMediaFromEvent", () => {
       expect(rewritten.message.content[0]).toEqual({
         type: "image_url",
         image_url: {
-          url: "/api/files/so_image_url_one",
+          url: "/api/files/proj-1/so_image_url_one",
           detail: "high",
         },
       });
@@ -495,7 +495,7 @@ describe("extractInlineMediaFromEvent", () => {
         type: "input_audio",
         input_audio: {
           data: undefined,
-          url: `/api/files/${storedId}`,
+          url: `/api/files/proj-1/${storedId}`,
           mimeType: "audio/pcm16",
         },
       });
@@ -542,7 +542,7 @@ describe("extractInlineMediaFromEvent", () => {
         type: "input_audio",
         input_audio: {
           data: undefined,
-          url: `/api/files/${storedId}`,
+          url: `/api/files/proj-1/${storedId}`,
           mimeType: "audio/wav",
         },
       });
@@ -597,7 +597,7 @@ describe("extractInlineMediaFromEvent", () => {
       };
       expect(part.type).toBe("binary");
       expect(part.id).toBe(storedId);
-      expect(part.url).toBe(`/api/files/${storedId}`);
+      expect(part.url).toBe(`/api/files/proj-1/${storedId}`);
       expect(part.data).toBeUndefined();
       expect(part.filename).toBe("preview.png");
 
@@ -706,7 +706,7 @@ describe("extractInlineMediaFromEvent", () => {
       expect(secondMsg.content).toHaveLength(1);
       expect(secondMsg.content[0]!.type).toBe("audio");
       expect(secondMsg.content[0]!.source.type).toBe("url");
-      expect(secondMsg.content[0]!.source.value).toBe("/api/files/stored-id-1");
+      expect(secondMsg.content[0]!.source.value).toBe("/api/files/proj-1/stored-id-1");
     });
   });
 
@@ -820,7 +820,7 @@ describe("extractInlineMediaFromEvent", () => {
       expect(content).toHaveLength(1);
       expect(content[0]).toMatchObject({
         type: "document",
-        source: { type: "url", value: `/api/files/${storedId}`, mimeType },
+        source: { type: "url", value: `/api/files/proj-1/${storedId}`, mimeType },
       });
     });
   });

--- a/langwatch/src/server/stored-objects/__tests__/files-route.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/files-route.integration.test.ts
@@ -2,13 +2,17 @@
  * @vitest-environment node
  * @integration
  *
- * Integration tests for the GET /api/files/:id route.
+ * Integration tests for the GET /api/files route (legacy id-only and the
+ * project-scoped /api/files/:projectId/:id form added in #4947).
  *
  * Covers:
  *  - Case 5: GET an existing row with backing storage → 200 + bytes streamed
  *  - Case 6: GET a row whose storage URI is missing → 404 { status: "missing" }
  *  - Case 7: GET a row id that does not exist in CH → 404 { status: "not_found" }
  *  - 403: caller authenticated for a different project → 403 forbidden
+ *  - #4947: project-scoped URL reads via the URL's project (no cross-tenant
+ *    lookup); a URL scoped to project A cannot serve project B's object
+ *    (404 under own scope, 403 for a foreign claim with no existence oracle)
  *
  * Strategy:
  *  - The files route calls `createStoredObjectsService` which calls
@@ -419,6 +423,124 @@ describe("GET /api/files/:id", () => {
       expect(res.status).toBe(200);
       const body = await res.text();
       expect(body).toBe(content);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Project-scoped route (issue #4947)
+// ---------------------------------------------------------------------------
+//
+// The project-scoped URL `/api/files/:projectId/:id` carries the owning
+// project, so the read path scopes directly to it and skips the cross-tenant
+// owner lookup. These tests pin the tenant-isolation contract: a URL scoped
+// to one project can never serve another project's object.
+describe("GET /api/files/:projectId/:id (project-scoped — #4947)", () => {
+  describe("when the URL's project matches the caller and the row exists", () => {
+    /** @scenario "GET /api/files/:projectId/:id reads via the project-scoped client without a cross-tenant lookup" */
+    it("streams the bytes scoped to the URL's project and never runs the cross-tenant owner lookup", async () => {
+      const fileId = `stored-${nanoid(8)}`;
+      const content = "scoped-bytes";
+      const row = makeStoredObjectRow({
+        id: fileId,
+        project_id: projectAId,
+        media_type: "image/png",
+        size_bytes: Buffer.from(content).length,
+      });
+      mockGetById.mockResolvedValueOnce({
+        row,
+        stream: makeReadableStream(content),
+      });
+
+      const res = await app.request(`/api/files/${projectAId}/${fileId}`, {
+        headers: { "X-Auth-Token": projectAKey },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe(content);
+      // Owner came from the URL — no cross-tenant fan-out.
+      expect(mockResolveOwnerProject).not.toHaveBeenCalled();
+      // The read was scoped to the project named in the URL.
+      expect(mockGetById).toHaveBeenCalledWith({
+        projectId: projectAId,
+        id: fileId,
+      });
+    });
+  });
+
+  describe("when a caller requests another project's object id under their OWN project scope", () => {
+    /** @scenario "GET /api/files/:projectId/:id scopes the read to the URL's project and cannot serve another tenant's object" */
+    it("scopes the read to the URL's project and returns 404 — the other tenant's bytes are never served", async () => {
+      // The id belongs (conceptually) to project A. The caller is
+      // authenticated as project B and crafts a URL with their OWN project id
+      // but A's object id: /api/files/<B>/<A's id>. The read is scoped to B,
+      // where the row does not exist → 404. The project-scoped query
+      // (WHERE project_id = B AND id = ...) is exactly what blocks the
+      // cross-tenant read: without it (a blind WHERE id = ... lookup, as the
+      // legacy path does) the route would find A's row and stream A's bytes
+      // to B. THIS is the falsifiable tenant-isolation crux.
+      const crossTenantId = `stored-${nanoid(8)}`;
+      // B's scope has no such row.
+      mockGetById.mockResolvedValueOnce(null);
+
+      const res = await app.request(`/api/files/${projectBId}/${crossTenantId}`, {
+        headers: { "X-Auth-Token": projectBKey },
+      });
+
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ status: "not_found" });
+      // Proves the read used the URL's project (B), NOT a cross-tenant
+      // resolution of the true owner (A).
+      expect(mockGetById).toHaveBeenCalledWith({
+        projectId: projectBId,
+        id: crossTenantId,
+      });
+      expect(mockResolveOwnerProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when a caller names a project other than their own in the URL", () => {
+    /** @scenario "GET /api/files/:projectId/:id rejects a URL whose project is not the caller's with no existence oracle" */
+    it("returns 403 before any storage read, regardless of whether the object exists", async () => {
+      // Caller authenticated as project B requests a URL naming project A.
+      // Authorization compares the caller (B) to the URL's claimed owner (A)
+      // and rejects BEFORE any storage read — so the response cannot
+      // distinguish "exists in A" from "absent". The 403-vs-404 cross-tenant
+      // existence oracle is closed for the new path.
+      const fileId = `stored-${nanoid(8)}`;
+
+      const res = await app.request(`/api/files/${projectAId}/${fileId}`, {
+        headers: { "X-Auth-Token": projectBKey },
+      });
+
+      expect(res.status).toBe(403);
+      expect(mockGetById).not.toHaveBeenCalled();
+      expect(mockResolveOwnerProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the URL's project is the caller's but storage no longer holds the blob", () => {
+    /** @scenario "GET /api/files/:projectId/:id returns 404 missing when the row exists but the blob is gone" */
+    it("returns 404 with body { status: 'missing' } via the project-scoped read", async () => {
+      const fileId = `stored-${nanoid(8)}`;
+      const row = makeStoredObjectRow({ id: fileId, project_id: projectAId });
+      mockGetById.mockResolvedValueOnce({ row, status: "missing" });
+
+      const res = await app.request(`/api/files/${projectAId}/${fileId}`, {
+        headers: { "X-Auth-Token": projectAKey },
+      });
+
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ status: "missing" });
+      expect(mockResolveOwnerProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the caller is not authenticated", () => {
+    it("returns 401 without reading storage", async () => {
+      const res = await app.request(`/api/files/${projectAId}/some-id`);
+      expect(res.status).toBe(401);
+      expect(mockGetById).not.toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/server/stored-objects/__tests__/files-route.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/files-route.integration.test.ts
@@ -21,11 +21,20 @@
  *    be stubbed per case without needing a live ClickHouse.
  *  - Real Prisma projects are created so the authMiddleware resolves API keys.
  */
-import { nanoid } from "nanoid";
+
 import { Readable } from "node:stream";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma } from "~/server/db";
+import { nanoid } from "nanoid";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { projectFactory } from "~/factories/project.factory";
+import { prisma } from "~/server/db";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -89,12 +98,11 @@ vi.mock("~/utils/logger/server", () => ({
 // Tracer pass-through
 vi.mock("langwatch", () => ({
   getLangWatchTracer: () => ({
-    withActiveSpan: (
-      _name: string,
-      ...args: unknown[]
-    ) => {
+    withActiveSpan: (_name: string, ...args: unknown[]) => {
       const fn = args.length === 1 ? args[0] : args[1];
-      const span: { setAttribute: ReturnType<typeof vi.fn> } = { setAttribute: vi.fn() };
+      const span: { setAttribute: ReturnType<typeof vi.fn> } = {
+        setAttribute: vi.fn(),
+      };
       return (fn as (s: typeof span) => Promise<unknown>)(span);
     },
   }),
@@ -121,7 +129,9 @@ import type { StoredObject } from "~/server/stored-objects/stored-object";
 // ---------------------------------------------------------------------------
 
 /** Builds a minimal StoredObject row suitable for getById mock responses. */
-function makeStoredObjectRow(overrides: Partial<StoredObject> = {}): StoredObject {
+function makeStoredObjectRow(
+  overrides: Partial<StoredObject> = {},
+): StoredObject {
   return {
     id: `test-id-${nanoid(6)}`,
     project_id: "proj-test",
@@ -173,13 +183,21 @@ beforeAll(async () => {
   });
   teamId = team.id;
 
-  const projA = projectFactory.build({ slug: `--so-files-proj-a-${nanoid(6)}` });
-  const createdA = await prisma.project.create({ data: { ...projA, teamId: team.id, personalFeatures: {} } });
+  const projA = projectFactory.build({
+    slug: `--so-files-proj-a-${nanoid(6)}`,
+  });
+  const createdA = await prisma.project.create({
+    data: { ...projA, teamId: team.id, personalFeatures: {} },
+  });
   projectAKey = createdA.apiKey;
   projectAId = createdA.id;
 
-  const projB = projectFactory.build({ slug: `--so-files-proj-b-${nanoid(6)}` });
-  const createdB = await prisma.project.create({ data: { ...projB, teamId: team.id, personalFeatures: {} } });
+  const projB = projectFactory.build({
+    slug: `--so-files-proj-b-${nanoid(6)}`,
+  });
+  const createdB = await prisma.project.create({
+    data: { ...projB, teamId: team.id, personalFeatures: {} },
+  });
   projectBKey = createdB.apiKey;
   projectBId = createdB.id;
 });
@@ -206,7 +224,10 @@ afterAll(async () => {
       (error.code === "P2003" || error.code === "P2021");
     if (!knownMissingFixture) {
       // eslint-disable-next-line no-console
-      console.warn("Unexpected cleanup error in files-route integration suite:", error);
+      console.warn(
+        "Unexpected cleanup error in files-route integration suite:",
+        error,
+      );
     }
   }
 });
@@ -257,7 +278,9 @@ describe("GET /api/files/:id", () => {
 
       expect(res.status).toBe(200);
       expect(res.headers.get("Content-Type")).toBe("image/png");
-      expect(res.headers.get("Content-Length")).toBe(String(Buffer.from(content).length));
+      expect(res.headers.get("Content-Length")).toBe(
+        String(Buffer.from(content).length),
+      );
 
       const body = await res.text();
       expect(body).toBe(content);
@@ -413,7 +436,10 @@ describe("GET /api/files/:id", () => {
       });
 
       mockResolveOwnerProject.mockResolvedValueOnce({ projectId: projectAId });
-      mockGetById.mockResolvedValueOnce({ row, stream: makeReadableStream(content) });
+      mockGetById.mockResolvedValueOnce({
+        row,
+        stream: makeReadableStream(content),
+      });
 
       // Authenticate ONLY via header, no Cookie.
       const res = await app.request(`/api/files/${fileId}`, {
@@ -437,7 +463,6 @@ describe("GET /api/files/:id", () => {
 // to one project can never serve another project's object.
 describe("GET /api/files/:projectId/:id (project-scoped — #4947)", () => {
   describe("when the URL's project matches the caller and the row exists", () => {
-    /** @scenario "GET /api/files/:projectId/:id reads via the project-scoped client without a cross-tenant lookup" */
     it("streams the bytes scoped to the URL's project and never runs the cross-tenant owner lookup", async () => {
       const fileId = `stored-${nanoid(8)}`;
       const content = "scoped-bytes";
@@ -469,7 +494,6 @@ describe("GET /api/files/:projectId/:id (project-scoped — #4947)", () => {
   });
 
   describe("when a caller requests another project's object id under their OWN project scope", () => {
-    /** @scenario "GET /api/files/:projectId/:id scopes the read to the URL's project and cannot serve another tenant's object" */
     it("scopes the read to the URL's project and returns 404 — the other tenant's bytes are never served", async () => {
       // The id belongs (conceptually) to project A. The caller is
       // authenticated as project B and crafts a URL with their OWN project id
@@ -483,9 +507,12 @@ describe("GET /api/files/:projectId/:id (project-scoped — #4947)", () => {
       // B's scope has no such row.
       mockGetById.mockResolvedValueOnce(null);
 
-      const res = await app.request(`/api/files/${projectBId}/${crossTenantId}`, {
-        headers: { "X-Auth-Token": projectBKey },
-      });
+      const res = await app.request(
+        `/api/files/${projectBId}/${crossTenantId}`,
+        {
+          headers: { "X-Auth-Token": projectBKey },
+        },
+      );
 
       expect(res.status).toBe(404);
       expect(await res.json()).toEqual({ status: "not_found" });
@@ -500,7 +527,6 @@ describe("GET /api/files/:projectId/:id (project-scoped — #4947)", () => {
   });
 
   describe("when a caller names a project other than their own in the URL", () => {
-    /** @scenario "GET /api/files/:projectId/:id rejects a URL whose project is not the caller's with no existence oracle" */
     it("returns 403 before any storage read, regardless of whether the object exists", async () => {
       // Caller authenticated as project B requests a URL naming project A.
       // Authorization compares the caller (B) to the URL's claimed owner (A)
@@ -520,7 +546,6 @@ describe("GET /api/files/:projectId/:id (project-scoped — #4947)", () => {
   });
 
   describe("when the URL's project is the caller's but storage no longer holds the blob", () => {
-    /** @scenario "GET /api/files/:projectId/:id returns 404 missing when the row exists but the blob is gone" */
     it("returns 404 with body { status: 'missing' } via the project-scoped read", async () => {
       const fileId = `stored-${nanoid(8)}`;
       const row = makeStoredObjectRow({ id: fileId, project_id: projectAId });

--- a/langwatch/src/server/stored-objects/__tests__/files-route.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/files-route.integration.test.ts
@@ -493,6 +493,40 @@ describe("GET /api/files/:projectId/:id (project-scoped — #4947)", () => {
     });
   });
 
+  describe("when a HEAD request is made for a project-scoped url", () => {
+    it("returns 200 with the length but no body, scoped to the URL's project", async () => {
+      const fileId = `stored-${nanoid(8)}`;
+      const content = "head-probe-bytes";
+      const row = makeStoredObjectRow({
+        id: fileId,
+        project_id: projectAId,
+        media_type: "image/png",
+        size_bytes: Buffer.from(content).length,
+      });
+      mockGetById.mockResolvedValueOnce({
+        row,
+        stream: makeReadableStream(content),
+      });
+
+      const res = await app.request(`/api/files/${projectAId}/${fileId}`, {
+        method: "HEAD",
+        headers: { "X-Auth-Token": projectAKey },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Length")).toBe(
+        String(Buffer.from(content).length),
+      );
+      // HEAD must not stream a body.
+      expect(await res.text()).toBe("");
+      expect(mockResolveOwnerProject).not.toHaveBeenCalled();
+      expect(mockGetById).toHaveBeenCalledWith({
+        projectId: projectAId,
+        id: fileId,
+      });
+    });
+  });
+
   describe("when a caller requests another project's object id under their OWN project scope", () => {
     it("scopes the read to the URL's project and returns 404 — the other tenant's bytes are never served", async () => {
       // The id belongs (conceptually) to project A. The caller is

--- a/langwatch/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
@@ -18,13 +18,23 @@
  *  - LocalFilesystemDriver pointed at a per-test temp dir for real byte storage
  *  - vi.mock to wire getClickHouseClientForProject to the test container client
  */
+
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import crypto from "node:crypto";
-import { nanoid } from "nanoid";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import * as clickhouseClientModule from "~/server/clickhouse/clickhouseClient";
 import {
   startTestContainers,
@@ -33,8 +43,8 @@ import {
 import { LocalFilesystemDriver } from "../local-filesystem-driver";
 import { StorageRegistry } from "../storage-registry";
 import { StoredObjectsRepository } from "../stored-objects.repository";
-import { StoredObjectsService } from "../stored-objects.service";
 import type { MintStorageUri } from "../stored-objects.service";
+import { StoredObjectsService } from "../stored-objects.service";
 import { mintFileUri } from "../uri";
 
 // ---------------------------------------------------------------------------
@@ -69,13 +79,12 @@ const { tracerSpanNames } = vi.hoisted(() => ({
 
 vi.mock("langwatch", () => ({
   getLangWatchTracer: () => ({
-    withActiveSpan: (
-      name: string,
-      ...args: unknown[]
-    ) => {
+    withActiveSpan: (name: string, ...args: unknown[]) => {
       tracerSpanNames.push(name);
       const fn = args.length === 1 ? args[0] : args[1];
-      const span: { setAttribute: ReturnType<typeof vi.fn> } = { setAttribute: vi.fn() };
+      const span: { setAttribute: ReturnType<typeof vi.fn> } = {
+        setAttribute: vi.fn(),
+      };
       return (fn as (s: typeof span) => Promise<unknown>)(span);
     },
   }),
@@ -161,8 +170,12 @@ beforeAll(async () => {
   // Wire the mock now that ch is available. The vi.mock factory above
   // replaced these exports with mock fns at module-load; we only need
   // to set their return values here, not re-import.
-  vi.mocked(clickhouseClientModule.getClickHouseClientForProject).mockResolvedValue(ch);
-  vi.mocked(clickhouseClientModule.getSharedClickHouseClient).mockReturnValue(ch);
+  vi.mocked(
+    clickhouseClientModule.getClickHouseClientForProject,
+  ).mockResolvedValue(ch);
+  vi.mocked(clickhouseClientModule.getSharedClickHouseClient).mockReturnValue(
+    ch,
+  );
 }, 90_000);
 
 afterAll(async () => {
@@ -415,7 +428,11 @@ describe("StoredObjectsService (ingest + read path)", () => {
 
           // Delete the file from storage so the next GET gets an ENOENT
           const sha256 = sha256Of(bytes);
-          const storageUri = mintFileUri({ root: tmpDir, projectId: PROJECT_A, sha256 });
+          const storageUri = mintFileUri({
+            root: tmpDir,
+            projectId: PROJECT_A,
+            sha256,
+          });
           const filePath = storageUri.slice("file://".length);
           await fs.rm(filePath, { force: true });
 
@@ -444,7 +461,6 @@ describe("StoredObjectsService (ingest + read path)", () => {
     });
 
     describe("when getById is called with a different project than the owner (#4947 tenant isolation)", () => {
-      /** @scenario "A project-scoped read cannot return an object owned by another project" */
       it("returns null for the wrong project but the bytes for the owning project", async () => {
         await withTmpStorage(async () => {
           const bytes = makeBytes("cross-tenant-read-isolation");
@@ -475,7 +491,10 @@ describe("StoredObjectsService (ingest + read path)", () => {
           expect(crossTenant).toBeNull();
 
           // The owning project still reads the bytes back.
-          const owned = await ownerService.getById({ projectId: PROJECT_A, id });
+          const owned = await ownerService.getById({
+            projectId: PROJECT_A,
+            id,
+          });
           expect(owned).not.toBeNull();
           expect(owned !== null && "stream" in owned).toBe(true);
         });
@@ -511,10 +530,14 @@ describe("StoredObjectsService (ingest + read path)", () => {
 
         expect(tracerSpanNames.length).toBeGreaterThanOrEqual(2);
         expect(
-          tracerSpanNames.some((s) => /storeFromBytes|StoredObjectsService\.store/i.test(s)),
+          tracerSpanNames.some((s) =>
+            /storeFromBytes|StoredObjectsService\.store/i.test(s),
+          ),
         ).toBe(true);
         expect(
-          tracerSpanNames.some((s) => /getById|StoredObjectsService\.get/i.test(s)),
+          tracerSpanNames.some((s) =>
+            /getById|StoredObjectsService\.get/i.test(s),
+          ),
         ).toBe(true);
       });
     });
@@ -544,7 +567,10 @@ describe("StoredObjectsService (ingest + read path)", () => {
             query_params: { id },
             format: "JSONEachRow",
           });
-          const rows = await result.json<{ project_id: string; storage_uri: string }>();
+          const rows = await result.json<{
+            project_id: string;
+            storage_uri: string;
+          }>();
 
           expect(rows.length).toBeGreaterThan(0);
           expect(rows[0]?.project_id).toBe(PROJECT_A);
@@ -587,8 +613,14 @@ describe("StoredObjectsService (ingest + read path)", () => {
           await waitForRow(ch, cascadeProj, stored2.id);
 
           // Sanity: both files are readable before the cascade runs.
-          const before1 = await service.getById({ projectId: cascadeProj, id: stored1.id });
-          const before2 = await service.getById({ projectId: cascadeProj, id: stored2.id });
+          const before1 = await service.getById({
+            projectId: cascadeProj,
+            id: stored1.id,
+          });
+          const before2 = await service.getById({
+            projectId: cascadeProj,
+            id: stored2.id,
+          });
           expect(before1).not.toBeNull();
           expect(before2).not.toBeNull();
           expect((before1 as { stream?: unknown }).stream).toBeDefined();
@@ -609,13 +641,18 @@ describe("StoredObjectsService (ingest + read path)", () => {
           expect(remaining.length).toBe(0);
 
           // Storage-level: getById returns null (no row anywhere).
-          const after1 = await service.getById({ projectId: cascadeProj, id: stored1.id });
-          const after2 = await service.getById({ projectId: cascadeProj, id: stored2.id });
+          const after1 = await service.getById({
+            projectId: cascadeProj,
+            id: stored1.id,
+          });
+          const after2 = await service.getById({
+            projectId: cascadeProj,
+            id: stored2.id,
+          });
           expect(after1).toBeNull();
           expect(after2).toBeNull();
         });
       });
     });
-
   });
 });

--- a/langwatch/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
@@ -475,7 +475,10 @@ describe("StoredObjectsService (ingest + read path)", () => {
             mediaType: "text/plain",
             bytes,
           });
-          await waitForRow(ch, PROJECT_A, id);
+          // Assert the row is visible before reading — a bare await would let
+          // a CH async-insert timeout (waitForRow → false) pass silently and
+          // flake the cross-tenant assertion below.
+          expect(await waitForRow(ch, PROJECT_A, id)).toBe(true);
 
           // Project B scoping the read by A's object id finds nothing: the CH
           // query is `WHERE project_id = B AND id = ...`, which prunes to B's

--- a/langwatch/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/stored-objects.ingest-read.integration.test.ts
@@ -442,6 +442,45 @@ describe("StoredObjectsService (ingest + read path)", () => {
         });
       });
     });
+
+    describe("when getById is called with a different project than the owner (#4947 tenant isolation)", () => {
+      /** @scenario "A project-scoped read cannot return an object owned by another project" */
+      it("returns null for the wrong project but the bytes for the owning project", async () => {
+        await withTmpStorage(async () => {
+          const bytes = makeBytes("cross-tenant-read-isolation");
+          const ownerService = buildService(PROJECT_A);
+
+          // Store the object under project A.
+          const { id } = await ownerService.storeFromBytes({
+            projectId: PROJECT_A,
+            purpose: "scenario_event",
+            ownerKind: "scenario_run",
+            ownerId: `run-${nanoid(6)}`,
+            mediaType: "text/plain",
+            bytes,
+          });
+          await waitForRow(ch, PROJECT_A, id);
+
+          // Project B scoping the read by A's object id finds nothing: the CH
+          // query is `WHERE project_id = B AND id = ...`, which prunes to B's
+          // partition and never sees A's row. This is the data-layer guarantee
+          // the project-scoped `/api/files/:projectId/:id` route relies on —
+          // a URL scoped to B cannot serve A's bytes. Falsifiable: drop the
+          // `project_id` predicate from the scoped read and this returns A's
+          // row instead of null.
+          const crossTenant = await buildService(PROJECT_B).getById({
+            projectId: PROJECT_B,
+            id,
+          });
+          expect(crossTenant).toBeNull();
+
+          // The owning project still reads the bytes back.
+          const owned = await ownerService.getById({ projectId: PROJECT_A, id });
+          expect(owned).not.toBeNull();
+          expect(owned !== null && "stream" in owned).toBe(true);
+        });
+      });
+    });
   });
 
   describe("when telemetry spans are observed across ingest and read", () => {

--- a/langwatch/src/server/stored-objects/content-extractor.ts
+++ b/langwatch/src/server/stored-objects/content-extractor.ts
@@ -152,7 +152,11 @@ async function processContentPart({
 
       const rewrittenPart = {
         ...(part as Record<string, unknown>),
-        source: { type: "url", value: `/api/files/${projectId}/${stored.id}`, mimeType },
+        source: {
+          type: "url",
+          value: `/api/files/${projectId}/${stored.id}`,
+          mimeType,
+        },
       };
 
       return { part: rewrittenPart, ref };

--- a/langwatch/src/server/stored-objects/content-extractor.ts
+++ b/langwatch/src/server/stored-objects/content-extractor.ts
@@ -16,7 +16,13 @@
  * Shape rules:
  *  - `binary` with `data` set → extract, rewrite to `id + url + data:undefined`
  *  - `image_url` with `image_url.url` starting `data:` → extract, rewrite to
- *    `image_url.url = /api/files/<id>`
+ *    `image_url.url = /api/files/<projectId>/<id>`
+ *
+ * Minted URLs carry the owning `<projectId>` (issue #4947) so the read path
+ * (`/api/files/[[...route]]`) resolves the owner directly from the URL and
+ * reads via the project-scoped ClickHouse client — no cross-tenant owner
+ * lookup. Legacy id-only URLs (`/api/files/<id>`) minted before #4947 stay
+ * resolvable via the retained cross-tenant fallback on the read route.
  *  - everything else (text, tool_call, tool_result, image_url with http URLs,
  *    bare image, unknown shapes) → pass through unchanged
  *
@@ -146,7 +152,7 @@ async function processContentPart({
 
       const rewrittenPart = {
         ...(part as Record<string, unknown>),
-        source: { type: "url", value: `/api/files/${stored.id}`, mimeType },
+        source: { type: "url", value: `/api/files/${projectId}/${stored.id}`, mimeType },
       };
 
       return { part: rewrittenPart, ref };
@@ -204,7 +210,7 @@ async function processContentPart({
             type: "binary",
             mimeType,
             id: stored.id,
-            url: `/api/files/${stored.id}`,
+            url: `/api/files/${projectId}/${stored.id}`,
             data: undefined,
             ...(typeof original.filename === "string"
               ? { filename: original.filename }
@@ -213,7 +219,7 @@ async function processContentPart({
         : {
             ...original,
             id: stored.id,
-            url: `/api/files/${stored.id}`,
+            url: `/api/files/${projectId}/${stored.id}`,
             data: undefined,
           };
 
@@ -256,7 +262,7 @@ async function processContentPart({
         ...original,
         image_url: {
           ...originalImageUrl,
-          url: `/api/files/${stored.id}`,
+          url: `/api/files/${projectId}/${stored.id}`,
         },
       };
 
@@ -325,7 +331,7 @@ async function processContentPart({
             type: "input_audio",
             input_audio: {
               data: undefined,
-              url: `/api/files/${stored.id}`,
+              url: `/api/files/${projectId}/${stored.id}`,
               mimeType,
             },
           }
@@ -334,7 +340,7 @@ async function processContentPart({
             input_audio: {
               ...originalInputAudio,
               data: undefined,
-              url: `/api/files/${stored.id}`,
+              url: `/api/files/${projectId}/${stored.id}`,
               mimeType,
             },
           };
@@ -369,7 +375,7 @@ async function processContentPart({
 
       const rewrittenPart = {
         ...(part as Record<string, unknown>),
-        image: `/api/files/${stored.id}`,
+        image: `/api/files/${projectId}/${stored.id}`,
       };
 
       return { part: rewrittenPart, ref };


### PR DESCRIPTION
## What & why

Stored-object file URLs were minted id-only as `/api/files/<id>`. Because the id alone does not say which project owns the row, the read path (`GET /api/files/:id`) had to **resolve the owner cross-tenant first** — `resolveStoredObjectOwner` fans a `SELECT project_id FROM stored_objects WHERE id = {id}` out to *every* configured ClickHouse instance and takes the first hit, before it can switch to a project-scoped client.

This PR encodes the owning `project_id` in the URL (`/api/files/<projectId>/<id>`) so the read path scopes directly to the owning project — no cross-tenant fan-out for new URLs. Fixes #4947.

## AC1 — Investigation (how URLs are generated, stored, resolved)

| Concern | Location |
|---|---|
| **Mint (write)** | `content-extractor.ts` — 6 sites rewrite inline media to `/api/files/<id>` (now `/api/files/<projectId>/<id>`). `projectId` is already in scope (a `processContentPart` param). |
| **Store** | The minted URL is embedded in ClickHouse `simulation_runs.Messages.Content` (serialized message JSON). The `stored_objects` table (`ORDER BY (project_id, id)`) holds the row keyed by `(project_id, id)`. |
| **Resolve (read)** | `app/api/files/[[...route]]/app.ts` → `handleFileRead`. |
| **Cross-tenant owner lookup** | `stored-objects-cross-tenant-lookup.ts` → `resolveStoredObjectOwner({ id })` — the unscoped, fan-out `WHERE id = ?` query, the root cause this issue removes for new URLs. |
| **Parse (UI)** | `MediaPart.tsx` → `extractStoredObjectId` pulls the id out of the URL for the existence probe. |

## AC2 — project_id in the URL, project-scoped resolution

- **Mint:** `content-extractor.ts` now emits `/api/files/<projectId>/<id>` (all 6 media shapes).
- **Read route:** added `GET|HEAD /api/files/:projectId/:id`. The owning project is taken from the URL → caller-vs-owner authorization → project-scoped read (`getById({ projectId, id })`, i.e. `WHERE project_id = {projectId} AND id = {id}`). **No `resolveStoredObjectOwner` call on the new path** — prunes on the `(project_id, id)` sort key, routes straight to the owning instance.
- **Parse:** `extractStoredObjectId` returns the id (final path segment) for both URL shapes.

## AC3 — Tenant isolation (the security crux, falsifiable)

A URL scoped to project A cannot serve project B's object, proven two ways:

1. **Route level** (`files-route.integration.test.ts`): a caller authenticated as project **B** requesting `/api/files/<B>/<A's object id>` gets **404** — the read is scoped to **B** (`getById` is invoked with `projectId: B`, where the row doesn't exist), so A's bytes are never served. A foreign claim `/api/files/<A>/<id>` by caller B gets **403 before any storage read** (closes the 403-vs-404 existence oracle). The test asserts `resolveStoredObjectOwner` is **never** called and `getById` is scoped to the URL's project.
   - *Falsifiable:* without URL-scoping the route would fall back to the cross-tenant lookup (`resolveStoredObjectOwner` → A) and stream A's bytes; the assertions (404 + `getById` called with B + lookup not called) fail.
2. **Real ClickHouse** (`stored-objects.ingest-read.integration.test.ts`): store an object under project A; `getById({ projectId: B, id })` returns **null** while `getById({ projectId: A, id })` returns the bytes — the `project_id` predicate is what isolates at the data layer.
   - *Falsifiable:* drop the `project_id` predicate from the scoped read and the B-scoped read returns A's row.

## AC4 — Backward compatibility (fallback, not backfill)

**Design fork, surfaced rather than guessed:** old traces already have `/api/files/<id>` (id-only) URLs embedded in their stored message content. Two options — (a) **retain the cross-tenant `resolveStoredObjectOwner` as a legacy fallback**, or (b) backfill historical URLs.

**Chosen: (a) fallback.** Backfilling means rewriting URLs embedded inside historical ClickHouse `simulation_runs` message JSON — a heavy, risky migration over effectively-immutable event data. The legacy `GET|HEAD /api/files/:id` route is retained and still routes id-only URLs through `resolveStoredObjectOwner`, so **existing data keeps resolving unchanged, indefinitely**. The skip-index from #4640 remains the safety net for that legacy path. New URLs never touch the cross-tenant lookup. This is a two-way door — a backfill can be added later to drain the legacy path.

`MediaPart.extractStoredObjectId` handles both shapes, so the UI probe works for legacy and new URLs alike (test included).

## Proof

- Unit (mint format): `content-extractor.unit.test.ts` — rewritten URLs assert `/api/files/<projectId>/<id>`.
- Component (parse): `MediaPart.integration.test.tsx` — probe id extracted from the final segment for both URL shapes.
- Route + real-CH isolation: see AC3. Both run in CI's `test-integration` lane (real Postgres + ClickHouse) — this lane is the authoritative verification for the tenant-isolation crux (it cannot run against a mock). CI is GREEN on HEAD `1e5f85340` — `langwatch-app-complete` pass, all `test-integration` shards green (real PG+CH); `files-route.integration.test.ts` ✓ and `stored-objects.ingest-read.integration.test.ts` ✓ confirmed passing in the logs. Run: https://github.com/langwatch/langwatch/actions/runs/27833689758
- No data migration: existing URLs are untouched; the legacy route keeps resolving them.

## Files

- `content-extractor.ts` — mint `/api/files/<projectId>/<id>` (6 sites)
- `app/api/files/[[...route]]/app.ts` — project-scoped route + branched owner resolution; legacy route retained
- `MediaPart.tsx` — `extractStoredObjectId` handles both URL shapes
- tests: `files-route.integration.test.ts`, `stored-objects.ingest-read.integration.test.ts`, `content-extractor.unit.test.ts`, `MediaPart.integration.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File streaming now supports project-scoped reads via `/api/files/:projectId/:id` (in addition to legacy `/api/files/:id`).

* **Improvements**
  * Inline media URLs and rewritten stored-object references are now consistently minted as project-scoped links.
  * Enhanced tenant isolation and authorization for both `GET` and `HEAD`, with clearer `401/403/404` and missing-file behavior.
  * Improved route matching/URL parsing to correctly distinguish legacy vs project-scoped forms.

* **Tests**
  * Expanded integration coverage for URL parsing, routing precedence, probe inputs, and placeholder rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
