### PR TITLE
feat(triggers): per-project daily email cap (ADR-031 backstop)

### DIFF
--- a/dev/docs/adr/031-trigger-email-abuse-protections.md
+++ b/dev/docs/adr/031-trigger-email-abuse-protections.md
@@ -71,6 +71,53 @@ The cap default is **100 emails per trigger per hour**, env-configurable
 (`TRIGGER_EMAIL_HOURLY_CAP`). Digest cadences cannot exceed 12/hour, so the
 cap only ever bites `immediate`-cadence triggers — by design.
 
+### 2b. Per-project daily cap (backstop above the hourly cap)
+
+The per-trigger hourly cap above bounds a single noisy trigger, but a project
+with many immediate-cadence triggers can still aggregate a large daily email
+volume under it — each trigger independently sitting just under its own hourly
+ceiling. A second, coarser limit caps the *total* trigger-email volume a whole
+project can emit per 24h, protecting SES sender reputation (which is scored on
+aggregate outbound volume, not per-trigger).
+
+In the same email branch, **after** the hourly-cap check has passed and the
+recipient set is known, the dispatcher consults a Redis fixed-day counter:
+
+```text
+key:    trigger-email-tenant-cap:{projectId}:{floor(now / 24h)}
+INCRBY recipientCount + EXPIRE 25h; if count > cap → drop
+```
+
+Unlike the hourly cap — which counts *dispatches* — the daily cap counts
+**recipients**: trigger emails fan out one provider call per recipient
+(§3 below), so the recipient count is the actual outbound volume SES reputation
+is measured on. The counter advances by `recipients.length` (INCRBY), not by 1.
+Consumption is idempotent per logical dispatch via the same claim-gate pattern
+as the hourly cap (`tenant-cap-claimed:{dedupKey}` SET-NX), so an outbox retry
+of the same digest re-reads the running total instead of counting its
+recipients twice.
+
+Over the cap the dispatcher **does not send**: it logs `logger.warn` with
+project, trigger, and the running count, marks the outbox job done (a
+non-retryable drop — `dropReason: "dropped: over project daily email cap"` is
+stamped onto the audit row), and the send claim is recorded so replays stay
+no-ops. The drop logs at `warn` rather than the hourly cap's `error`: the
+hourly cap is the primary, per-trigger throttle, while this is a coarse
+project-wide backstop whose breach is operationally interesting but not a page.
+
+The cap default is **10000 recipient-emails per project per day**,
+env-configurable (`TRIGGER_EMAIL_TENANT_DAILY_CAP`). Generous by design — it is
+a runaway backstop, not a routine throttle, and should only bite a project that
+is genuinely misconfigured or abusing the channel.
+
+**v1 is per-PROJECT, not per-ORGANISATION.** The stronger SES-reputation
+boundary is per-organisation (one organisation's many projects share the same
+sending domain and reputation), but that requires threading the org id through
+the dispatch hot path and a per-org Redis counter. Per-project is shipped first
+because it is the cheaper change and already bounds the common single-tenant
+runaway; a per-organisation ceiling is the recommended follow-up if multi-
+project abuse within one organisation is observed in practice.
+
 ### 3. Unsubscribe link + suppression list
 
 A new Prisma model:
@@ -194,16 +241,21 @@ price, bounded by the hourly cap.
 - **Dropped sends are visible, not silent.** `logger.error` + a counter the
   ADR-029 health surface can read. Operators of high-volume immediate
   triggers should switch to a digest cadence — the error message says so.
-- **The cap is per-trigger, not per-project.** A project with many triggers
-  can still aggregate a large hourly volume; a per-project ceiling is a
-  follow-up knob if provider costs warrant it.
+- **Two caps: per-trigger hourly + per-project daily.** The hourly cap
+  (§2) bounds a single noisy trigger; the daily cap (§2b,
+  `TRIGGER_EMAIL_TENANT_DAILY_CAP`, default 10000 recipient-emails) bounds the
+  aggregate volume a whole project emits per 24h. Neither is per-organisation:
+  an organisation's projects share a sending domain and SES reputation, so a
+  per-org ceiling is the stronger boundary and the recommended follow-up if
+  multi-project abuse within one organisation is observed.
 - **Suppression management ships in v1.** A project-settings view lists
   suppression rows (email, scope, when) to operators with `triggers:view`
   and lets an operator with `triggers:manage` permission remove one — e.g. a
   recipient who unsubscribed by accident and asked to be re-added. Removal is
   a deliberate operator action; nothing re-suppresses automatically.
 - **Non-goals:** no Slack capping, no verification-email gate, no bounce
-  ingestion (schema-ready via `reason`), no per-project volume ceiling.
+  ingestion (schema-ready via `reason`), no per-ORGANISATION volume ceiling
+  (the per-project daily cap in §2b ships in v1; per-org is the follow-up).
 
 ## References
 

--- a/langwatch/src/env-create.mjs
+++ b/langwatch/src/env-create.mjs
@@ -138,6 +138,11 @@ export function createEnvConfig() {
       // recipients. Only ever bites immediate-cadence triggers; digest
       // cadences cannot exceed 12/hour.
       TRIGGER_EMAIL_HOURLY_CAP: z.coerce.number().int().positive().default(100),
+      // ADR-031: per-PROJECT daily hard cap — a backstop ABOVE the per-trigger
+      // hourly cap, bounding the aggregate trigger-email volume a whole project
+      // can emit in 24h (SES sender-reputation protection). Counts RECIPIENTS
+      // (actual outbound email volume), not dispatches.
+      TRIGGER_EMAIL_TENANT_DAILY_CAP: z.coerce.number().int().positive().default(10000),
       DEMO_PROJECT_ID: z.string().optional(),
       DEMO_PROJECT_USER_ID: z.string().optional(),
       DEMO_PROJECT_SLUG: z.string().optional(),
@@ -316,6 +321,7 @@ export function createEnvConfig() {
       EVAL_MAX_PAYLOAD_BYTES: process.env.EVAL_MAX_PAYLOAD_BYTES,
       TOPIC_CLUSTERING_MAX_PAYLOAD_BYTES: process.env.TOPIC_CLUSTERING_MAX_PAYLOAD_BYTES,
       TRIGGER_EMAIL_HOURLY_CAP: process.env.TRIGGER_EMAIL_HOURLY_CAP,
+      TRIGGER_EMAIL_TENANT_DAILY_CAP: process.env.TRIGGER_EMAIL_TENANT_DAILY_CAP,
       DEMO_PROJECT_ID: process.env.DEMO_PROJECT_ID,
       DEMO_PROJECT_USER_ID: process.env.DEMO_PROJECT_USER_ID,
       DEMO_PROJECT_SLUG: process.env.DEMO_PROJECT_SLUG,

--- a/langwatch/src/pages/api/cron/triggers/actions/__tests__/sendEmail.unit.test.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/__tests__/sendEmail.unit.test.ts
@@ -35,8 +35,11 @@ vi.mock("~/server/app-layer/app", () => ({
 }));
 
 const consumeEmailCapSlot = vi.fn();
+const consumeTenantEmailCapSlot = vi.fn();
 vi.mock("~/server/event-sourcing/outbox/emailHourlyCap", () => ({
   consumeEmailCapSlot: (...args: unknown[]) => consumeEmailCapSlot(...args),
+  consumeTenantEmailCapSlot: (...args: unknown[]) =>
+    consumeTenantEmailCapSlot(...args),
 }));
 
 import { sendTriggerEmail } from "~/server/mailer/triggerEmail";
@@ -45,11 +48,12 @@ import { captureException } from "~/utils/posthogErrorCapture";
 describe("handleSendEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: nothing suppressed, under the cap.
+    // Default: nothing suppressed, under both caps.
     filterSuppressed.mockImplementation(
       async ({ emails }: { emails: string[] }) => emails,
     );
     consumeEmailCapSlot.mockResolvedValue({ allowed: true, count: 1 });
+    consumeTenantEmailCapSlot.mockResolvedValue({ allowed: true, count: 1 });
   });
 
   describe("when email is sent successfully", () => {
@@ -208,6 +212,44 @@ describe("handleSendEmail", () => {
 
       await handleSendEmail(context);
 
+      expect(sendTriggerEmail).not.toHaveBeenCalled();
+      // Hourly cap drops first; the project daily cap is never reached.
+      expect(consumeTenantEmailCapSlot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the project is over its daily email cap (ADR-031)", () => {
+    it("consults the daily cap by recipient count and drops without sending", async () => {
+      consumeTenantEmailCapSlot.mockResolvedValueOnce({
+        allowed: false,
+        count: 10001,
+      });
+      const context: TriggerContext = {
+        trigger: {
+          id: "trigger-1",
+          projectId: "project-1",
+          name: "Test Trigger",
+          actionParams: {
+            members: ["a@example.com", "b@example.com"],
+          },
+          alertType: null,
+          message: "",
+        } as any,
+        projects: [],
+        triggerData: [],
+        projectSlug: "test-project",
+      };
+
+      await handleSendEmail(context);
+
+      // The daily cap counts RECIPIENTS, so recipientCount is the surviving
+      // recipient-list length.
+      expect(consumeTenantEmailCapSlot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "project-1",
+          recipientCount: 2,
+        }),
+      );
       expect(sendTriggerEmail).not.toHaveBeenCalled();
     });
   });

--- a/langwatch/src/pages/api/cron/triggers/actions/sendEmail.ts
+++ b/langwatch/src/pages/api/cron/triggers/actions/sendEmail.ts
@@ -2,7 +2,10 @@ import { TriggerAction } from "@prisma/client";
 import { createHash } from "crypto";
 import { env } from "~/env.mjs";
 import { getApp } from "~/server/app-layer/app";
-import { consumeEmailCapSlot } from "~/server/event-sourcing/outbox/emailHourlyCap";
+import {
+  consumeEmailCapSlot,
+  consumeTenantEmailCapSlot,
+} from "~/server/event-sourcing/outbox/emailHourlyCap";
 import { sendTriggerEmail } from "~/server/mailer/triggerEmail";
 import { createLogger } from "~/utils/logger/server";
 import { captureException, toError } from "~/utils/posthogErrorCapture";
@@ -62,6 +65,33 @@ export const handleSendEmail = async (context: TriggerContext) => {
           cap: env.TRIGGER_EMAIL_HOURLY_CAP,
         },
         "Custom-graph trigger exceeded its hourly email cap — dropping this dispatch",
+      );
+      return;
+    }
+
+    // ADR-031: per-PROJECT daily cap — a backstop ABOVE the per-trigger hourly
+    // cap, run only once the hourly cap has passed and the recipient set is
+    // known. Counts RECIPIENTS (`recipients.length`), the actual outbound email
+    // volume, not dispatches. Over the cap this dispatch is dropped (WARN, no
+    // send); the same `dispatchDigest`-derived dedupKey makes the count
+    // idempotent across cron re-ticks.
+    const tenantSlot = await consumeTenantEmailCapSlot({
+      projectId: trigger.projectId,
+      now: new Date(),
+      cap: env.TRIGGER_EMAIL_TENANT_DAILY_CAP,
+      recipientCount: recipients.length,
+      dedupKey: `${trigger.projectId}:tenant:${dispatchDigest}`,
+    });
+    if (!tenantSlot.allowed) {
+      logger.warn(
+        {
+          triggerId: trigger.id,
+          projectId: trigger.projectId,
+          count: tenantSlot.count,
+          cap: env.TRIGGER_EMAIL_TENANT_DAILY_CAP,
+        },
+        "Project exceeded its daily trigger-email cap — dropping this " +
+          "custom-graph dispatch. Backstop above the per-trigger hourly cap.",
       );
       return;
     }

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatcher.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatcher.unit.test.ts
@@ -118,6 +118,10 @@ function makeDeps(trigger: TriggerSummary = makeTrigger()) {
     enqueueCadence: vi.fn().mockResolvedValue(undefined),
     emailHourlyCap: 100,
     consumeEmailCapSlot: vi.fn().mockResolvedValue({ allowed: true, count: 1 }),
+    tenantDailyCap: 10000,
+    consumeTenantEmailCapSlot: vi
+      .fn()
+      .mockResolvedValue({ allowed: true, count: 1 }),
     filterSuppressedEmails: vi
       .fn()
       .mockImplementation(async ({ emails }: { emails: string[] }) => emails),
@@ -409,6 +413,112 @@ describe("createOutboxDispatcher cadence stage", () => {
           }),
         );
         expect(sendTriggerEmail).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("given the per-project daily email cap (ADR-031)", () => {
+    describe("when the dispatch is under the daily cap", () => {
+      it("consults the tenant cap by recipient count and sends normally", async () => {
+        const trigger = makeTrigger({
+          action: TriggerAction.SEND_EMAIL,
+          actionParams: {
+            members: ["a@example.com", "b@example.com", "c@example.com"],
+          },
+        });
+        const deps = makeDeps(trigger);
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.process(makeCadencePayload());
+
+        expect(deps.consumeTenantEmailCapSlot).toHaveBeenCalledTimes(1);
+        // The daily cap counts RECIPIENTS, so recipientCount is the surviving
+        // recipient-list length, not 1-per-dispatch.
+        expect(deps.consumeTenantEmailCapSlot).toHaveBeenCalledWith(
+          expect.objectContaining({
+            projectId: PROJECT_ID,
+            recipientCount: 3,
+            cap: 10000,
+            dedupKey: expect.stringMatching(
+              new RegExp(`^${PROJECT_ID}:tenant:[0-9a-f]{16}$`),
+            ),
+          }),
+        );
+        expect(sendTriggerEmail).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when the dispatch exceeds the project's daily cap", () => {
+      it("drops without sending, stamps the project-daily drop reason, and logs at warn", async () => {
+        const deps = makeDeps();
+        deps.consumeTenantEmailCapSlot.mockResolvedValueOnce({
+          allowed: false,
+          count: 10001,
+        });
+        const dispatcher = createOutboxDispatcher(deps);
+        const payload = makeCadencePayload();
+
+        await expect(dispatcher.process(payload)).resolves.toBeUndefined();
+
+        // No send — the daily cap is a terminal, non-retryable drop.
+        expect(sendTriggerEmail).not.toHaveBeenCalled();
+        expect(sendRenderedTriggerEmail).not.toHaveBeenCalled();
+        // The hourly cap ran and passed; the tenant cap is what dropped it.
+        expect(deps.consumeEmailCapSlot).toHaveBeenCalledTimes(1);
+        // Claim recorded so a replay no-ops; delivery-only bookkeeping skipped.
+        expect(deps.triggers.claimSend).toHaveBeenCalledTimes(1);
+        expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
+        // Audit row reads as a drop, not a delivered send.
+        expect(payload.dropReason).toBe(
+          "dropped: over project daily email cap",
+        );
+        // The project-daily backstop logs the over-cap event at WARN.
+        expect(loggerMock.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ cap: 10000, count: 10001 }),
+          expect.stringContaining("daily"),
+        );
+        // And the terminal drop log carries the reason.
+        expect(loggerMock.info).toHaveBeenCalledWith(
+          expect.objectContaining({
+            dropReason: "dropped: over project daily email cap",
+          }),
+          expect.stringContaining("dropped"),
+        );
+      });
+    });
+
+    describe("when the hourly cap has already dropped the dispatch", () => {
+      it("never consults the project daily cap", async () => {
+        const deps = makeDeps();
+        deps.consumeEmailCapSlot.mockResolvedValueOnce({
+          allowed: false,
+          count: 101,
+        });
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.process(makeCadencePayload());
+
+        // Hourly cap is checked first; its drop short-circuits before the
+        // tenant cap so we don't count recipients against a dispatch we already
+        // dropped.
+        expect(deps.consumeTenantEmailCapSlot).not.toHaveBeenCalled();
+        expect(sendTriggerEmail).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the trigger sends Slack rather than email", () => {
+      it("never consults the project daily cap", async () => {
+        const trigger = makeTrigger({
+          action: TriggerAction.SEND_SLACK_MESSAGE,
+          actionParams: { slackWebhook: "https://hooks.slack.com/services/x" },
+        });
+        const deps = makeDeps(trigger);
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.process(makeCadencePayload());
+
+        expect(deps.consumeTenantEmailCapSlot).not.toHaveBeenCalled();
+        expect(sendSlackWebhook).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/emailHourlyCap.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/emailHourlyCap.unit.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _resetMemoryEmailCapStore,
   consumeEmailCapSlot,
+  consumeTenantEmailCapSlot,
 } from "../emailHourlyCap";
 
 // `connection` is a mutable module-level binding; the mock lets each test
@@ -333,6 +334,239 @@ describe("consumeEmailCapSlot in-memory fallback", () => {
 
         expect(a).toEqual({ allowed: true, count: 1 });
         expect(b).toEqual({ allowed: true, count: 1 });
+      });
+    });
+  });
+});
+
+// The per-project daily cap (ADR-031) — a backstop ABOVE the per-trigger hourly
+// cap. Counts RECIPIENTS (actual email volume), not dispatches; the day counter
+// advances by recipientCount (INCRBY). Same claim-gate idempotency + in-memory
+// fallback as the hourly cap, but degradation logs at WARN not ERROR.
+describe("consumeTenantEmailCapSlot in-memory fallback", () => {
+  beforeEach(() => {
+    _resetMemoryEmailCapStore();
+  });
+
+  describe("given a fresh day bucket", () => {
+    describe("when dispatches accumulate recipients up to the cap then over it", () => {
+      it("allows the dispatch that lands at the cap and drops the one that exceeds it", async () => {
+        const now = new Date("2026-06-11T10:15:00Z");
+        // cap=10, two dispatches of 6 recipients each: first → count 6 (under),
+        // second → count 12 (over). Proves the counter advances by recipientCount.
+        const first = await consumeTenantEmailCapSlot({
+          projectId: PROJECT_ID,
+          now,
+          cap: 10,
+          recipientCount: 6,
+          dedupKey: "proj-1:tenant:day-a",
+        });
+        const second = await consumeTenantEmailCapSlot({
+          projectId: PROJECT_ID,
+          now,
+          cap: 10,
+          recipientCount: 6,
+          dedupKey: "proj-1:tenant:day-b",
+        });
+
+        expect(first).toEqual({ allowed: true, count: 6 });
+        expect(second).toEqual({ allowed: false, count: 12 });
+      });
+    });
+
+    describe("when the SAME dispatch is consumed twice (outbox retry)", () => {
+      it("does not double-count: the retry re-reads the same total without INCRBY", async () => {
+        const now = new Date("2026-06-11T10:15:00Z");
+        const args = {
+          projectId: PROJECT_ID,
+          now,
+          cap: 100,
+          recipientCount: 4,
+          dedupKey: "proj-1:tenant:retry-me",
+        };
+        const firstCall = await consumeTenantEmailCapSlot(args);
+        const retry = await consumeTenantEmailCapSlot(args);
+        // A different dispatch advances the counter — proving the retry was
+        // suppressed by the claim gate, not by a frozen counter.
+        const other = await consumeTenantEmailCapSlot({
+          ...args,
+          recipientCount: 3,
+          dedupKey: "proj-1:tenant:other",
+        });
+
+        expect(firstCall).toEqual({ allowed: true, count: 4 });
+        expect(retry).toEqual({ allowed: true, count: 4 });
+        expect(other).toEqual({ allowed: true, count: 7 });
+      });
+    });
+  });
+
+  describe("given the cap was exhausted in the previous day", () => {
+    describe("when a dispatch arrives in the next day bucket", () => {
+      it("starts a fresh count and allows it again", async () => {
+        const firstDay = new Date("2026-06-11T23:00:00Z");
+        await consumeTenantEmailCapSlot({
+          projectId: PROJECT_ID,
+          now: firstDay,
+          cap: 5,
+          recipientCount: 5,
+          dedupKey: "proj-1:tenant:d1-a",
+        });
+        const overSameDay = await consumeTenantEmailCapSlot({
+          projectId: PROJECT_ID,
+          now: firstDay,
+          cap: 5,
+          recipientCount: 1,
+          dedupKey: "proj-1:tenant:d1-b",
+        });
+        expect(overSameDay.allowed).toBe(false);
+
+        const nextDay = new Date("2026-06-12T01:00:00Z");
+        const rolledOver = await consumeTenantEmailCapSlot({
+          projectId: PROJECT_ID,
+          now: nextDay,
+          cap: 5,
+          recipientCount: 2,
+          dedupKey: "proj-1:tenant:d2-a",
+        });
+
+        expect(rolledOver).toEqual({ allowed: true, count: 2 });
+      });
+    });
+  });
+
+  describe("given Redis is connected", () => {
+    afterEach(() => {
+      redisMock.connection = undefined;
+    });
+
+    describe("when a dispatch wins its claim", () => {
+      it("advances the counter via INCRBY recipientCount, not a plain INCR", async () => {
+        const incrby = vi.fn().mockResolvedValue(8);
+        redisMock.connection = {
+          set: vi.fn().mockResolvedValue("OK"),
+          get: vi.fn().mockResolvedValue(null),
+          incr: vi.fn(),
+          incrby,
+          expire: vi.fn().mockResolvedValue(1),
+        };
+
+        const now = new Date("2026-06-11T10:15:00Z");
+        const result = await consumeTenantEmailCapSlot({
+          projectId: PROJECT_ID,
+          now,
+          cap: 100,
+          recipientCount: 8,
+          dedupKey: "proj-1:tenant:incrby",
+        });
+
+        // INCRBY carried the recipient count; a plain INCR would have ignored it.
+        expect(incrby).toHaveBeenCalledTimes(1);
+        expect(incrby.mock.calls[0]![0]).toMatch(/^trigger-email-tenant-cap:/);
+        expect(incrby.mock.calls[0]![1]).toBe(8);
+        expect(result).toEqual({ allowed: true, count: 8 });
+      });
+    });
+
+    describe("when the SAME dispatch is retried (claim already won)", () => {
+      it("re-reads the counter via GET without a second INCRBY", async () => {
+        const incrby = vi.fn().mockResolvedValue(4);
+        const set = vi
+          .fn()
+          .mockResolvedValueOnce("OK")
+          .mockResolvedValueOnce(null);
+        redisMock.connection = {
+          set,
+          get: vi.fn().mockResolvedValue("4"),
+          incr: vi.fn(),
+          incrby,
+          expire: vi.fn().mockResolvedValue(1),
+        };
+
+        const now = new Date("2026-06-11T10:15:00Z");
+        const args = {
+          projectId: PROJECT_ID,
+          now,
+          cap: 100,
+          recipientCount: 4,
+          dedupKey: "proj-1:tenant:redis-retry",
+        };
+        const firstCall = await consumeTenantEmailCapSlot(args);
+        const retry = await consumeTenantEmailCapSlot(args);
+
+        expect(incrby).toHaveBeenCalledTimes(1);
+        expect(firstCall).toEqual({ allowed: true, count: 4 });
+        expect(retry).toEqual({ allowed: true, count: 4 });
+      });
+    });
+  });
+
+  describe("given Redis fails on every call (sustained outage)", () => {
+    afterEach(() => {
+      redisMock.connection = undefined;
+    });
+
+    describe("when distinct dispatches arrive through the outage", () => {
+      it("accumulates in the in-memory counter and logs the degradation at WARN", async () => {
+        loggerMock.warn.mockClear();
+        loggerMock.error.mockClear();
+        redisMock.connection = {
+          set: vi.fn().mockRejectedValue(new Error("connection refused")),
+          get: vi.fn().mockRejectedValue(new Error("connection refused")),
+          incr: vi.fn(),
+          incrby: vi.fn().mockRejectedValue(new Error("connection refused")),
+          expire: vi.fn().mockRejectedValue(new Error("connection refused")),
+        };
+
+        const now = new Date("2026-06-11T10:15:00Z");
+        const first = await consumeTenantEmailCapSlot({
+          projectId: PROJECT_ID,
+          now,
+          cap: 10,
+          recipientCount: 6,
+          dedupKey: "proj-1:tenant:outage-a",
+        });
+        const second = await consumeTenantEmailCapSlot({
+          projectId: PROJECT_ID,
+          now,
+          cap: 10,
+          recipientCount: 6,
+          dedupKey: "proj-1:tenant:outage-b",
+        });
+
+        // The per-worker counter kept climbing through the outage and tipped
+        // over the cap on the second dispatch.
+        expect(first).toEqual({ allowed: true, count: 6 });
+        expect(second).toEqual({ allowed: false, count: 12 });
+        // Backstop degradation surfaces at WARN, not ERROR (the hourly cap is
+        // the primary throttle and owns the ERROR-level degraded log).
+        expect(loggerMock.warn).toHaveBeenCalled();
+        expect(loggerMock.error).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given two distinct projects", () => {
+    describe("when each dispatches on the same day", () => {
+      it("counts them independently", async () => {
+        const now = new Date("2026-06-11T10:15:00Z");
+        const a = await consumeTenantEmailCapSlot({
+          projectId: "proj-a",
+          now,
+          cap: 5,
+          recipientCount: 5,
+          dedupKey: "proj-a:tenant:x",
+        });
+        const b = await consumeTenantEmailCapSlot({
+          projectId: "proj-b",
+          now,
+          cap: 5,
+          recipientCount: 5,
+          dedupKey: "proj-b:tenant:x",
+        });
+
+        expect(a).toEqual({ allowed: true, count: 5 });
+        expect(b).toEqual({ allowed: true, count: 5 });
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/triggerDispatch.fullflow.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/triggerDispatch.fullflow.integration.test.ts
@@ -105,6 +105,11 @@ function makeNotifyDeps(opts?: { emailCap?: number }) {
       now: Date;
       dedupKey: string;
     }) => consumeEmailCapSlot({ ...args, cap }),
+    // The per-project daily cap (ADR-031) isn't the focus here (the per-trigger
+    // hourly cap is) — wire a high ceiling and a pass-through that always
+    // allows, so the daily backstop never bites these flows.
+    tenantDailyCap: 1_000_000,
+    consumeTenantEmailCapSlot: async () => ({ allowed: true, count: 0 }),
     // Suppression isn't the focus here (the cap is) — pass recipients through.
     filterSuppressedEmails: async ({ emails }: { emails: string[] }) => emails,
   };

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -99,6 +99,27 @@ export interface OutboxDispatcherDeps {
   /** The configured cap, for operator-facing drop logs (ADR-031). */
   emailHourlyCap: number;
   /**
+   * ADR-031: per-PROJECT daily hard cap — a backstop ABOVE the per-trigger
+   * hourly cap, bounding the aggregate trigger-email volume a whole project can
+   * emit in 24h (SES sender-reputation protection). Consulted AFTER the hourly
+   * cap passes and the recipient set is known; counts RECIPIENTS (actual email
+   * volume), not dispatches. `allowed: false` means the project has already sent
+   * `cap` trigger emails today — this dispatch is dropped (not sent, not
+   * retried). Injected so tests can fake it. Slack never calls it.
+   *
+   * `dedupKey` is the stable per-dispatch identity so an outbox RETRY of the
+   * same digest does not re-count its recipients and burn the budget twice.
+   */
+  consumeTenantEmailCapSlot: (args: {
+    projectId: string;
+    now: Date;
+    cap: number;
+    recipientCount: number;
+    dedupKey: string;
+  }) => Promise<{ allowed: boolean; count: number }>;
+  /** The configured per-project daily cap, for operator-facing drop logs. */
+  tenantDailyCap: number;
+  /**
    * ADR-031: drops recipients who unsubscribed before the provider call.
    * Returns `emails` minus any address suppressed for this trigger
    * (trigger-scoped OR project-wide rows). Injected so tests can fake it.
@@ -458,6 +479,38 @@ async function handleCadenceBatch(
               "Switch this trigger to a digest cadence to coalesce its volume.",
           );
           dropReason = "dropped: over hourly cap";
+          break;
+        }
+        // ADR-031: per-PROJECT daily cap — a backstop ABOVE the per-trigger
+        // hourly cap, run only once the hourly cap has passed and the recipient
+        // set is known. Counts RECIPIENTS (`recipients.length`), the actual
+        // outbound email volume that hits SES, not dispatches. Over the cap the
+        // dispatch is a terminal drop with the same shape as the over-hourly-cap
+        // path: log loudly, fall through to claimSend below (so a replay no-ops),
+        // return WITHOUT sending and WITHOUT throwing (throwing would let the
+        // outbox retry the spam). The same `dispatchDigest`-derived dedupKey
+        // gates the recipient count so a retry of the same digest re-reads the
+        // daily total rather than counting its recipients twice.
+        const tenantSlot = await deps.consumeTenantEmailCapSlot({
+          projectId,
+          now: new Date(),
+          cap: deps.tenantDailyCap,
+          recipientCount: recipients.length,
+          dedupKey: `${projectId}:tenant:${dispatchDigest}`,
+        });
+        if (!tenantSlot.allowed) {
+          logger.warn(
+            {
+              projectId,
+              triggerId,
+              count: tenantSlot.count,
+              cap: deps.tenantDailyCap,
+            },
+            "Project exceeded its daily trigger-email cap — dropping this " +
+              "dispatch. This is a per-project backstop above the per-trigger " +
+              "hourly cap; investigate which triggers are driving the volume.",
+          );
+          dropReason = "dropped: over project daily email cap";
           break;
         }
         // Per-recipient idempotency (ADR-031): back the mailer's recipient

--- a/langwatch/src/server/event-sourcing/outbox/emailHourlyCap.ts
+++ b/langwatch/src/server/event-sourcing/outbox/emailHourlyCap.ts
@@ -36,6 +36,15 @@ const logger = createLogger("langwatch:outbox:emailHourlyCap");
 const HOUR_MS = 3600_000;
 const EXPIRE_SECONDS = 7200;
 
+const DAY_MS = 86_400_000;
+/**
+ * Tenant-cap claim + counter TTL: 25h (90_000s), one hour past the 24h window
+ * so the day counter (and its claim gate) outlive the window they cover and a
+ * boundary-straddling retry still finds the original claim. Mirrors the hourly
+ * cap's 2h-over-1h headroom.
+ */
+const TENANT_EXPIRE_SECONDS = 90_000;
+
 interface MemoryEntry {
   count: number;
   expiresAt: number;
@@ -44,12 +53,27 @@ interface MemoryEntry {
 const memoryStore = new Map<string, MemoryEntry>();
 
 /**
+ * Sibling of `memoryStore` for the per-project daily cap (ADR-031). Keyed by
+ * `trigger-email-tenant-cap:{projectId}:{dayBucket}`; the distinct prefix keeps
+ * it from colliding with the per-trigger hourly counters above.
+ */
+const tenantMemoryStore = new Map<string, MemoryEntry>();
+
+/**
  * In-memory mirror of the `cap-claimed:{dedupKey}` SET-NX gate. A dispatch's
  * dedupKey lands here on first sight (claim won → INCR); a retry of the same
  * dispatch finds it present (claim lost → no INCR). Values are the claim
  * expiry so the same opportunistic sweep that GCs counters also reaps claims.
  */
 const claimStore = new Map<string, number>();
+
+/**
+ * In-memory mirror of the `tenant-cap-claimed:{dedupKey}` SET-NX gate, the
+ * daily-cap sibling of `claimStore`. A dispatch's dedupKey lands here on first
+ * sight (claim won → INCRBY the day counter by recipientCount); a retry of the
+ * same dispatch finds it present (claim lost → re-read without incrementing).
+ */
+const tenantClaimStore = new Map<string, number>();
 
 /**
  * Opportunistic GC for the in-memory fallback, same shape as
@@ -67,6 +91,16 @@ function sweepExpiredMemoryEntries(now: number): void {
   if (claimStore.size >= MEMORY_GC_THRESHOLD) {
     for (const [k, expiresAt] of claimStore) {
       if (expiresAt <= now) claimStore.delete(k);
+    }
+  }
+  if (tenantMemoryStore.size >= MEMORY_GC_THRESHOLD) {
+    for (const [k, v] of tenantMemoryStore) {
+      if (v.expiresAt <= now) tenantMemoryStore.delete(k);
+    }
+  }
+  if (tenantClaimStore.size >= MEMORY_GC_THRESHOLD) {
+    for (const [k, expiresAt] of tenantClaimStore) {
+      if (expiresAt <= now) tenantClaimStore.delete(k);
     }
   }
 }
@@ -163,8 +197,134 @@ export async function consumeEmailCapSlot({
   return { allowed: existing.count <= cap, count: existing.count };
 }
 
-/** Test-only: clear in-memory state. No-op for Redis. */
+/**
+ * ADR-031: per-PROJECT daily hard cap on dispatched trigger emails — a backstop
+ * ABOVE the per-trigger hourly cap. The hourly cap bounds a single noisy
+ * trigger; this bounds the *aggregate* trigger-email volume a whole project can
+ * emit in 24h (a project with many immediate triggers can still pile up a large
+ * daily total under the per-trigger cap), protecting SES sender reputation.
+ *
+ * Unlike the hourly cap — which counts *dispatches* — this counts *recipients*,
+ * i.e. actual outbound email volume: trigger emails fan out one provider call
+ * per recipient (ADR-031 §3), so the recipient count is what hits the provider
+ * and what SES reputation is measured on. The day counter is therefore advanced
+ * by `recipientCount` (INCRBY), not by 1.
+ *
+ *   claim: tenant-cap-claimed:{dedupKey}   SET ... NX EX 25h
+ *          won → INCRBY recipientCount the counter; lost (retry) → GET, no INCR
+ *   key:   trigger-email-tenant-cap:{projectId}:{floor(now / 24h)}
+ *          INCRBY + EXPIRE 25h NX (TTL only when absent, never slides, but a
+ *          transient first-hit failure can't leak an immortal key)
+ *   allowed = count <= cap
+ *
+ * The claim gate makes consumption idempotent per logical dispatch: an outbox
+ * retry of the same digest re-reads the running total instead of INCRBY-ing the
+ * recipients a second time (the retry double-count finding), exactly as the
+ * hourly cap does. Same Redis-or-memory fallback as `consumeEmailCapSlot`; on a
+ * Redis error the daily cap degrades to per-worker counters — logged at WARN
+ * (the hourly cap is the primary throttle and logs at ERROR; this backstop's
+ * degradation is a warning, not a page).
+ */
+export async function consumeTenantEmailCapSlot({
+  projectId,
+  now,
+  cap,
+  recipientCount,
+  dedupKey,
+}: {
+  projectId: string;
+  now: Date;
+  cap: number;
+  /**
+   * Number of recipients this dispatch sends to — the day counter advances by
+   * this (INCRBY), because the daily cap bounds outbound *email volume*, and
+   * each recipient is one provider send (ADR-031 §3).
+   */
+  recipientCount: number;
+  /**
+   * Stable per-dispatch identity (ADR-031). Used as the SET-NX claim so an
+   * outbox retry of the same dispatch does not re-INCRBY and double-count the
+   * recipients. Distinct from the hourly cap's claim key (different prefix).
+   */
+  dedupKey: string;
+}): Promise<{ allowed: boolean; count: number }> {
+  const dayBucket = Math.floor(now.getTime() / DAY_MS);
+  const key = `trigger-email-tenant-cap:${projectId}:${dayBucket}`;
+  const claimKey = `tenant-cap-claimed:${dedupKey}`;
+
+  if (connection) {
+    try {
+      // Claim this dispatch first. SET NX wins only on first sight; a retry of
+      // the same dispatch loses the claim and must NOT re-count its recipients.
+      const claimed = await connection.set(
+        claimKey,
+        "1",
+        "EX",
+        TENANT_EXPIRE_SECONDS,
+        "NX",
+      );
+      if (!claimed) {
+        // Retry of an already-counted dispatch: read the running total without
+        // incrementing. A missing counter (TTL rolled the day) reads as 0,
+        // which stays `allowed` — the original consumption already happened.
+        const raw = await connection.get(key);
+        const count = raw ? Number(raw) : 0;
+        return { allowed: count <= cap, count };
+      }
+      const count = await connection.incrby(key, recipientCount);
+      // Always set TTL with NX semantics (only when no TTL exists yet) so a
+      // transient first-hit EXPIRE failure can't leave an immortal key — every
+      // subsequent hit re-attempts it without sliding an existing window.
+      await connection.expire(key, TENANT_EXPIRE_SECONDS, "NX");
+      return { allowed: count <= cap, count };
+    } catch (error) {
+      // A Redis blip must not let the cap fail open (the dispatcher would treat
+      // a throw as retryable and replay the mail). Fall back to the in-memory
+      // counter so the backstop keeps working approximately while Redis
+      // recovers. Logged at WARN: this is the secondary backstop above the
+      // hourly cap (which logs at ERROR), so a degraded daily cap is a warning
+      // worth surfacing, not a page.
+      logger.warn(
+        { key, error: error instanceof Error ? error.message : String(error) },
+        "Redis error consuming tenant email cap slot — daily cap DEGRADED to " +
+          "per-worker in-memory counters until Redis recovers; cross-worker " +
+          "rate may exceed the configured cap",
+      );
+    }
+  }
+
+  const nowMs = now.getTime();
+  sweepExpiredMemoryEntries(nowMs);
+
+  // In-memory claim gate, mirroring the Redis SET-NX: a retry of the same
+  // dispatch that already counted its recipients re-reads the total without
+  // INCRBY.
+  const existingClaim = tenantClaimStore.get(claimKey);
+  if (existingClaim !== undefined && existingClaim > nowMs) {
+    const existing = tenantMemoryStore.get(key);
+    if (!existing || existing.expiresAt <= nowMs) {
+      return { allowed: 0 <= cap, count: 0 };
+    }
+    return { allowed: existing.count <= cap, count: existing.count };
+  }
+  tenantClaimStore.set(claimKey, nowMs + TENANT_EXPIRE_SECONDS * 1000);
+
+  const existing = tenantMemoryStore.get(key);
+  if (!existing || existing.expiresAt <= nowMs) {
+    tenantMemoryStore.set(key, {
+      count: recipientCount,
+      expiresAt: nowMs + TENANT_EXPIRE_SECONDS * 1000,
+    });
+    return { allowed: recipientCount <= cap, count: recipientCount };
+  }
+  existing.count += recipientCount;
+  return { allowed: existing.count <= cap, count: existing.count };
+}
+
+/** Test-only: clear in-memory state (hourly + tenant). No-op for Redis. */
 export function _resetMemoryEmailCapStore(): void {
   memoryStore.clear();
   claimStore.clear();
+  tenantMemoryStore.clear();
+  tenantClaimStore.clear();
 }

--- a/langwatch/src/server/event-sourcing/outbox/setup.ts
+++ b/langwatch/src/server/event-sourcing/outbox/setup.ts
@@ -16,7 +16,10 @@ import type { FoldProjectionStore } from "../projections/foldProjection.types";
 import { RedisCachedFoldStore } from "../projections/redisCachedFoldStore";
 import type { EventSourcedQueueProcessor } from "../queues/queue.types";
 import { createOutboxDispatcher } from "./dispatcher";
-import { consumeEmailCapSlot } from "./emailHourlyCap";
+import {
+  consumeEmailCapSlot,
+  consumeTenantEmailCapSlot,
+} from "./emailHourlyCap";
 import {
   type CadenceStagePayload,
   type SettleStagePayload,
@@ -153,6 +156,24 @@ export function buildOutboxRuntime({
         cap: env.TRIGGER_EMAIL_HOURLY_CAP,
         // ADR-031: the dispatcher's stable per-dispatch dedupKey gates the cap
         // INCR so an outbox retry of the same digest doesn't burn a second slot.
+        dedupKey,
+      }),
+    // ADR-031: per-project daily cap (backstop above the hourly cap), bound
+    // from env. Counts recipients; the cap consumer reads the shared Redis
+    // connection internally. `cap` is passed through from the dispatcher.
+    tenantDailyCap: env.TRIGGER_EMAIL_TENANT_DAILY_CAP,
+    consumeTenantEmailCapSlot: ({
+      projectId,
+      now,
+      cap,
+      recipientCount,
+      dedupKey,
+    }) =>
+      consumeTenantEmailCapSlot({
+        projectId,
+        now,
+        cap,
+        recipientCount,
         dedupKey,
       }),
     filterSuppressedEmails: ({ projectId, triggerId, emails }) =>


### PR DESCRIPTION
Stacked on #4498 (base = `feat/trigger-outbox-dispatch`).

## Summary

Adds a **per-project daily email cap** as a backstop above the existing per-trigger **hourly** cap. The hourly cap bounds a single trigger's burst, but a project with many triggers — each sitting just under its hourly cap — can still collectively blast a customer's inbox and our SES sending reputation. This closes that gap.

- **`consumeTenantEmailCapSlot`** (`emailHourlyCap.ts`) — fixed 24h Redis day-bucket counter (`trigger-email-tenant-cap:{projectId}:{dayBucket}`), `INCRBY` the **recipient** count (actual send volume, not dispatches). Idempotent via a separate `tenant-cap-claimed:{dedupKey}` SET-NX gate, so an outbox **retry never double-counts**. In-memory fallback + **WARN** on Redis error (degraded, fail-open like the hourly cap).
- Wired into **both** the outbox dispatcher (`dispatcher.ts`) and the cron / custom-graph path (`cron/triggers/actions/sendEmail.ts`), after suppression filtering. Over-cap → **drop + WARN** (non-retryable, recorded as a drop reason in the audit row).
- `env TRIGGER_EMAIL_TENANT_DAILY_CAP` (default **10000**).
- **ADR-031** updated with §2b describing the backstop.

## Design notes

- **v1 is per-PROJECT** (matches the existing project-keyed hourly cap; the dispatch context has `projectId` directly, no project→org lookup in the hot path). Per-**organisation** is the stronger SES-reputation boundary; documented as a recommended follow-up if multi-project abuse is observed.
- Counts **recipients**, not dispatches — it's about email volume hitting SES.
- It's a **backstop set high**, not a smoother: the default is well above any legitimate project's daily volume, and the WARN is the signal to investigate / raise the limit.

## Test plan

- `pnpm test:unit` — 44 tests across `emailHourlyCap` / `dispatcher` / cron `sendEmail`: cap boundary (counts recipients), retry idempotency (no double-count), sustained-Redis-failure fallback, over-cap drop on both paths.
- `pnpm typecheck` — clean.
- Integration (`triggerDispatch.fullflow`) deps updated to a pass-through; runs in CI.


## Deployment Impact

- **Env vars:** adds `TRIGGER_EMAIL_TENANT_DAILY_CAP` (default `10000`). Optional — existing deployments need no change; the default applies automatically.
- **Helm values:** none added/changed.
- **Default `helm install` (no overrides):** the per-project daily cap is active at 10000 recipients/project/day; no configuration required.
- **BYOC dataplane:** none — this is control-plane trigger dispatch; no dataplane surface.
