### PR TITLE
feat(triggers): persist template render-diagnostics on the outbox row

### DIFF
--- a/dev/docs/adr/029-automation-operator-surfaces.md
+++ b/dev/docs/adr/029-automation-operator-surfaces.md
@@ -83,7 +83,7 @@ Enrich the automations list, plus a per-automation detail panel, with an operati
 
 - **Last triggered** and **fired count** — from `TriggerSent` ([ADR-030](./030-transactional-outbox-for-stake-sensitive-dispatch.md)), which already records every `(triggerId, traceId)` dispatch. Available immediately.
 - **Pending / failed / dead** — counts from `ReactorOutbox` ([ADR-030](./030-transactional-outbox-for-stake-sensitive-dispatch.md)) grouped by `status` for the trigger.
-- **Template-health warnings** — "rendered with the default due to a template error" and "N missing variables", the ADR-028 operator signals, surfaced from the outbox row's `lastError` / a render-diagnostics field on the dispatched row.
+- **Template-health warnings** — "rendered with the default due to a template error" and "N missing variables", the ADR-028 operator signals, surfaced from the outbox row's `lastError` / its `renderDiagnostics` field. The "N missing variables" count is now persisted: the dispatcher captures `missingVariables` from each custom email/Slack template render and stamps it onto the dispatched payload, and the PG audit adapter writes it to `ReactorOutbox.renderDiagnostics` (`{ missingVariables: string[] }`, NULL on a clean render). This resolves the earlier gap where `renderTriggerEmail` / `renderTriggerSlack` computed the missing-variable set but the dispatcher dropped it before it reached the audit row.
 - **Cadence and debounce** — the ADR-026 `notificationCadence` (notify triggers only) and `traceDebounceMs` shown as columns once those phases ship.
 - **Edit** opens the staged authoring drawer above.
 

--- a/langwatch/prisma/migrations/20260612120500_add_reactor_outbox_render_diagnostics/migration.sql
+++ b/langwatch/prisma/migrations/20260612120500_add_reactor_outbox_render_diagnostics/migration.sql
@@ -1,0 +1,15 @@
+-- Template render-health diagnostics on the dispatched outbox row
+-- (ADR-028 / ADR-029). `renderTriggerEmail` / `renderTriggerSlack` already
+-- compute `missingVariables` (the variables a custom template referenced but
+-- the render context did not supply); the dispatcher previously dropped them.
+-- This column persists them per dispatch — currently shaped as
+-- `{ "missingVariables": string[] }` — so the operator surface can show
+-- "N missing variables". NULL on a clean render and on dispatches that never
+-- rendered a custom template.
+
+-- +goose StatementBegin
+ALTER TABLE "ReactorOutbox" ADD COLUMN "renderDiagnostics" JSONB;
+-- +goose StatementEnd
+
+-- To roll back, uncomment and run manually:
+-- ALTER TABLE "ReactorOutbox" DROP COLUMN "renderDiagnostics";

--- a/langwatch/prisma/schema.prisma
+++ b/langwatch/prisma/schema.prisma
@@ -2830,6 +2830,15 @@ model ReactorOutbox {
     nextAttemptAt  DateTime?           @default(now())
     lastError      String?
     lastErrorAt    DateTime?
+    // Template render-health diagnostics captured at dispatch time
+    // (ADR-028 / ADR-029). Currently `{ missingVariables: string[] }` —
+    // the variables a custom email/Slack template referenced but the
+    // render context did not supply. NULL on a clean render (no missing
+    // variables) and on dispatches that never rendered a custom template.
+    // Lets the operator surface show "N missing variables" per dispatch
+    // instead of dropping the signal `renderTriggerEmail`/`renderTriggerSlack`
+    // already compute.
+    renderDiagnostics Json?
     dispatchedAt   DateTime?
     createdAt      DateTime            @default(now())
     updatedAt      DateTime            @default(now()) @updatedAt

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatcher.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatcher.unit.test.ts
@@ -315,6 +315,98 @@ describe("createOutboxDispatcher cadence stage", () => {
     });
   });
 
+  describe("given template render-diagnostics (ADR-028 / ADR-029)", () => {
+    describe("when a custom email template references variables the context does not supply", () => {
+      it("stamps the missing variables onto the payload's renderDiagnostics", async () => {
+        const trigger = makeTrigger({
+          action: TriggerAction.SEND_EMAIL,
+          name: "Latency alert",
+          templates: {
+            slackTemplateType: null,
+            slackTemplate: null,
+            emailSubjectTemplate: null,
+            emailBodyTemplate: "Hi {{ trigger.name }} — {{ does.not.exist }}",
+          },
+        });
+        const deps = makeDeps(trigger);
+        const dispatcher = createOutboxDispatcher(deps);
+        const payload = makeCadencePayload();
+
+        await dispatcher.process(payload);
+
+        // The render still succeeds (strictVariables: false renders the typo as
+        // empty), so the email is delivered — but the diagnostic is captured so
+        // the PG audit adapter can persist it to ReactorOutbox.renderDiagnostics.
+        expect(sendRenderedTriggerEmail).toHaveBeenCalledTimes(1);
+        expect(payload.renderDiagnostics).toEqual({
+          missingVariables: ["does.not.exist"],
+        });
+      });
+    });
+
+    describe("when a custom email template renders cleanly", () => {
+      it("sets renderDiagnostics to null so a clean render is distinguishable from one never computed", async () => {
+        const trigger = makeTrigger({
+          action: TriggerAction.SEND_EMAIL,
+          name: "Latency alert",
+          templates: {
+            slackTemplateType: null,
+            slackTemplate: null,
+            emailSubjectTemplate: null,
+            emailBodyTemplate: "Hello {{ trigger.name }}",
+          },
+        });
+        const deps = makeDeps(trigger);
+        const dispatcher = createOutboxDispatcher(deps);
+        const payload = makeCadencePayload();
+
+        await dispatcher.process(payload);
+
+        expect(sendRenderedTriggerEmail).toHaveBeenCalledTimes(1);
+        expect(payload.renderDiagnostics).toBeNull();
+      });
+    });
+
+    describe("when a custom Slack template references variables the context does not supply", () => {
+      it("stamps the missing variables onto the payload's renderDiagnostics", async () => {
+        const trigger = makeTrigger({
+          action: TriggerAction.SEND_SLACK_MESSAGE,
+          name: "Latency alert",
+          actionParams: { slackWebhook: "https://hooks.slack.com/services/x" },
+          templates: {
+            slackTemplateType: "string",
+            slackTemplate: "Hi {{ trigger.name }} — {{ does.not.exist }}",
+            emailSubjectTemplate: null,
+            emailBodyTemplate: null,
+          },
+        });
+        const deps = makeDeps(trigger);
+        const dispatcher = createOutboxDispatcher(deps);
+        const payload = makeCadencePayload();
+
+        await dispatcher.process(payload);
+
+        expect(sendRenderedSlackMessage).toHaveBeenCalledTimes(1);
+        expect(payload.renderDiagnostics).toEqual({
+          missingVariables: ["does.not.exist"],
+        });
+      });
+    });
+
+    describe("when the trigger has no custom template (legacy senders)", () => {
+      it("sets renderDiagnostics to null because nothing rendered", async () => {
+        const deps = makeDeps();
+        const dispatcher = createOutboxDispatcher(deps);
+        const payload = makeCadencePayload();
+
+        await dispatcher.process(payload);
+
+        expect(sendTriggerEmail).toHaveBeenCalledTimes(1);
+        expect(payload.renderDiagnostics).toBeNull();
+      });
+    });
+  });
+
   describe("given the per-trigger hourly email cap (ADR-031)", () => {
     describe("when the dispatch is under the cap", () => {
       it("sends the email normally and records the claim", async () => {

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/drainer.unit.test.ts
@@ -51,6 +51,7 @@ function makeRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
     nextAttemptAt: now,
     lastError: null,
     lastErrorAt: null,
+    renderDiagnostics: null,
     dispatchedAt: null,
     createdAt: now,
     updatedAt: now,

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/outbox.service.unit.test.ts
@@ -42,6 +42,7 @@ class InMemoryOutboxRepository implements OutboxRepository {
       nextAttemptAt: alwaysReady,
       lastError: null,
       lastErrorAt: null,
+      renderDiagnostics: null,
       dispatchedAt: null,
       createdAt: alwaysReady,
       updatedAt: alwaysReady,

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/pgAuditAdapter.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/pgAuditAdapter.unit.test.ts
@@ -1,0 +1,96 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  auditDedupKey,
+  type CadenceStagePayload,
+  TRIGGER_NOTIFY_REACTOR_NAME,
+} from "../payload";
+import { PgOutboxAuditAdapter } from "../pgAuditAdapter";
+
+vi.mock("~/utils/logger/server", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const PROJECT_ID = "proj-1";
+const TRIGGER_ID = "trig-1";
+const TRACE_ID = "trace-1";
+const DEDUP_KEY = auditDedupKey({
+  projectId: PROJECT_ID,
+  triggerId: TRIGGER_ID,
+  traceId: TRACE_ID,
+});
+
+function makeCadencePayload(
+  overrides: Partial<CadenceStagePayload> = {},
+): CadenceStagePayload {
+  return {
+    stage: "cadence",
+    projectId: PROJECT_ID,
+    triggerId: TRIGGER_ID,
+    reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+    auditDedupKey: DEDUP_KEY,
+    match: { traceId: TRACE_ID, input: "in", output: "out" },
+    ...overrides,
+  };
+}
+
+function makePrismaStub() {
+  const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+  return {
+    updateMany,
+    prisma: {
+      reactorOutbox: { updateMany },
+    } as unknown as PrismaClient,
+  };
+}
+
+describe("PgOutboxAuditAdapter.onDispatched render-diagnostics (ADR-029)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given a cadence dispatch whose render surfaced missing variables", () => {
+    describe("when onDispatched fires", () => {
+      it("writes the payload's renderDiagnostics to the row", async () => {
+        const { prisma, updateMany } = makePrismaStub();
+        const adapter = new PgOutboxAuditAdapter(prisma);
+        const payload = makeCadencePayload({
+          renderDiagnostics: { missingVariables: ["project.nmae"] },
+        });
+
+        await adapter.onDispatched({ payload, at: new Date(), attempt: 1 });
+
+        expect(updateMany).toHaveBeenCalledTimes(1);
+        const arg = updateMany.mock.calls[0]![0];
+        expect(arg.data.status).toBe("dispatched");
+        expect(arg.data.renderDiagnostics).toEqual({
+          missingVariables: ["project.nmae"],
+        });
+      });
+    });
+  });
+
+  describe("given a cadence dispatch that rendered cleanly", () => {
+    describe("when onDispatched fires with renderDiagnostics absent on the payload", () => {
+      it("writes renderDiagnostics as null", async () => {
+        const { prisma, updateMany } = makePrismaStub();
+        const adapter = new PgOutboxAuditAdapter(prisma);
+        const payload = makeCadencePayload();
+
+        await adapter.onDispatched({ payload, at: new Date(), attempt: 1 });
+
+        const arg = updateMany.mock.calls[0]![0];
+        // Nullable JSON columns take `Prisma.DbNull` (not a bare `null`) to
+        // write SQL NULL on a clean render.
+        expect(arg.data.renderDiagnostics).toBe(Prisma.DbNull);
+        // A clean render also leaves lastError null (it is not a drop).
+        expect(arg.data.lastError).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -415,6 +415,15 @@ async function handleCadenceBatch(
   // `lastError` instead of a delivered-looking null — drops stay NON-retryable
   // (we return normally, never throw) but must be visible as drops, not sends.
   let dropReason: string | undefined;
+  // Render-health diagnostics from a custom email/Slack template render
+  // (ADR-028 / ADR-029): the variables the template referenced but the render
+  // context did not supply. Captured from whichever channel rendered (a
+  // dispatch is email XOR slack, so this is effectively one render's
+  // `missingVariables`); accumulated as a Set so the wiring stays correct if a
+  // dispatch ever renders both. Stamped onto each payload below as
+  // `renderDiagnostics` so the PG audit adapter persists it to the row. The
+  // legacy senders (NULL template) never render here and leave this empty.
+  const missingVariables = new Set<string>();
 
   try {
     switch (trigger.action) {
@@ -542,6 +551,7 @@ async function handleCadenceBatch(
             bodyTemplate: t.emailBodyTemplate,
             context: buildContext(),
           });
+          for (const v of rendered.missingVariables) missingVariables.add(v);
           if (rendered.errors.length > 0) {
             logger.warn(
               { projectId, triggerId, errors: rendered.errors },
@@ -583,6 +593,7 @@ async function handleCadenceBatch(
             template: t.slackTemplate,
             context: buildContext(),
           });
+          for (const v of rendered.missingVariables) missingVariables.add(v);
           if (rendered.errors.length > 0) {
             logger.warn(
               { projectId, triggerId, errors: rendered.errors },
@@ -628,6 +639,22 @@ async function handleCadenceBatch(
       extra: { projectId, triggerId, triggerAction: trigger.action },
     });
     throw error;
+  }
+
+  // Stamp render-health diagnostics onto every payload so the PG audit
+  // adapter's `onDispatched` hook persists them to the row's
+  // `renderDiagnostics` (ADR-028 / ADR-029). Mirrors the `dropReason` wiring
+  // below: only set when a custom template render surfaced missing variables;
+  // `null` otherwise so a clean render is distinguishable from "never
+  // computed". `payloads` (not just `candidatePayloads`) so the shared audit
+  // row keyed by `auditDedupKey` is covered even when a trace was in-batch
+  // deduped out of the candidate set.
+  const renderDiagnostics =
+    missingVariables.size > 0
+      ? { missingVariables: [...missingVariables] }
+      : null;
+  for (const p of payloads) {
+    p.renderDiagnostics = renderDiagnostics;
   }
 
   // Post-dispatch: write `TriggerSent` for each (trigger, trace) so a

--- a/langwatch/src/server/event-sourcing/outbox/payload.ts
+++ b/langwatch/src/server/event-sourcing/outbox/payload.ts
@@ -89,6 +89,17 @@ export interface CadenceStagePayload
    * stay NON-retryable: the dispatcher returns normally rather than throwing.
    */
   dropReason?: string;
+  /**
+   * Set by the dispatcher after rendering a custom email/Slack template
+   * (ADR-028 / ADR-029). Carries the render-health diagnostics
+   * `renderTriggerEmail` / `renderTriggerSlack` compute — currently the
+   * `missingVariables` the template referenced but the render context did not
+   * supply. The PG audit adapter reads this in `onDispatched` and writes it to
+   * the row's `renderDiagnostics` so the operator surface can show
+   * "N missing variables" per dispatch. `null` on a clean render (no missing
+   * variables) and absent on dispatches that never rendered a custom template.
+   */
+  renderDiagnostics?: { missingVariables: string[] } | null;
 }
 
 export type OutboxJob = SettleStagePayload | CadenceStagePayload;

--- a/langwatch/src/server/event-sourcing/outbox/pgAuditAdapter.ts
+++ b/langwatch/src/server/event-sourcing/outbox/pgAuditAdapter.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import { createLogger } from "~/utils/logger/server";
 import type { QueueAuditAdapter } from "../queues/queue.types";
 import { isCadence, isSettle, type OutboxJob } from "./payload";
@@ -192,6 +192,14 @@ export class PgOutboxAuditAdapter implements QueueAuditAdapter<OutboxJob> {
       // operators can tell a drop from a delivery. A real delivery has no
       // `dropReason` and clears `lastError` to null.
       const lastError = p.dropReason ?? null;
+      // Template render-health diagnostics (ADR-028 / ADR-029): the dispatcher
+      // stamps `{ missingVariables }` onto the payload when a custom template
+      // referenced variables the render context didn't supply (`null` on a
+      // clean render). Persist it to the row so the operator surface can show
+      // "N missing variables" per dispatch instead of dropping the signal.
+      // `Prisma.DbNull` writes SQL NULL to the nullable JSON column — a bare
+      // `null` is not assignable to a Prisma JSON update input.
+      const renderDiagnostics = p.renderDiagnostics ?? Prisma.DbNull;
       // Cadence's terminal transitions CAS on (status='dispatching',
       // attempts=event.attempt) so a late event from a stale lease can't
       // overwrite a row that a stuck sweep re-leased to a new attempt.
@@ -208,6 +216,7 @@ export class PgOutboxAuditAdapter implements QueueAuditAdapter<OutboxJob> {
             status: "dispatched",
             dispatchedAt: event.at,
             lastError,
+            renderDiagnostics,
             leasedUntil: null,
           },
         }),


### PR DESCRIPTION
Stacked on #4982 (base = `feat/trigger-tenant-email-cap`).

## Summary

Resolves the deferred CodeRabbit finding on `adr/029:87`: the renderers compute `missingVariables` (`renderEmail.ts`, `renderSlack.ts`) but the dispatcher only forwarded `subject`/`html`/`errors` and **dropped** them, so the ADR-029 "N missing variables" operator signal never reached anywhere. `ReactorOutbox` had no diagnostics column.

Threads it through exactly the way `dropReason` already flows (dispatcher → cadence payload → `pgAuditAdapter`):

- `ReactorOutbox.renderDiagnostics Json?` column (migration `20260612120500`).
- The dispatcher unions the render's `missingVariables` onto the dispatched payload (`null` when the render is clean).
- `pgAuditAdapter.onDispatched` writes `renderDiagnostics` to the row (`Prisma.DbNull` when null).
- ADR-029 updated — the count is now persisted, resolving the "computed but dropped" gap.

## Note

The Liquid missing-variable diagnostic flags **virtual accessors** like `{{ matches.size }}` as "missing" (`.size` isn't an own-property, so the `hasNestedPath` check fails it). This is pre-existing renderer behaviour that this PR now *surfaces* on the row — worth a follow-up to teach the diagnostic about virtual accessors so the operator view isn't noisy, but out of scope here.

## Test plan

- `pnpm test:unit` — 47 tests: dispatcher stamps `renderDiagnostics: { missingVariables: [...] }` on a missing-var render and `null` on a clean one (email + slack + legacy paths); `pgAuditAdapter` writes the column.
- `pnpm typecheck` — clean; Prisma client regenerated for the new column.
- Integration runs in CI (local Docker unavailable in this env).


## Deployment Impact

- **DB migration:** adds a nullable `ReactorOutbox.renderDiagnostics` JSONB column (`20260612120500`). Runs on `prisma migrate deploy`; metadata-only `ADD COLUMN` (no backfill, non-locking on Postgres 11+).
- **Env vars / Helm values:** none.
- **Default `helm install` (no overrides):** transparent — the column is nullable and only populated when a template render reports missing variables.
- **BYOC dataplane:** none.
