### PR TITLE
fix(traces): wire blob-resolution deps into single-trace detail reads (1 of 2 — #4888)

### DIFF
--- a/langwatch/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
@@ -1,0 +1,708 @@
+/**
+ * ENDPOINT-LEVEL read-path integration test for the large-trace blob offload
+ * pipeline (#4888 / ADR-022) against a REAL ClickHouse testcontainer.
+ *
+ * Why this file exists alongside large-trace-blob-offload-readpath.integration.test.ts:
+ * the sibling drives the resolver/service layer with a FAKE repository — it cannot
+ * catch the #4888 ENDPOINT-CONSTRUCTION gap where TraceService is built WITHOUT
+ * buildTraceBlobResolutionDeps() (resolver never wired) or getById is called
+ * without { full: true } (resolve gate stays closed). This test closes that gap by
+ * seeding real ClickHouse rows and driving the EXACT construction the endpoints use.
+ *
+ * Two construction paths under test:
+ *   - no-deps:    TraceService.create(prisma)                   => preview only (bug)
+ *   - with-deps:  TraceService.create(prisma, buildTraceBlobResolutionDeps())
+ *                 + getById(..., { full: true })                 => full value (fix)
+ *
+ * Deterministic payload: 200 KB whose UNIQUE_TAIL only exists past the 64 KB
+ * preview boundary — a preview-only read can NEVER contain it.
+ *
+ * BDD structure: describe("given …") > describe("when …") > it("…"). No "should".
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  EVENTREF_ATTR_PREFIX,
+  IO_PREVIEW_BYTES,
+  leanForProjection,
+} from "~/server/app-layer/traces/lean-for-projection";
+import * as clickhouseClientModule from "~/server/clickhouse/clickhouseClient";
+import { prisma } from "~/server/db";
+import type { Protections } from "~/server/elasticsearch/protections";
+import type { Event } from "~/server/event-sourcing";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "~/server/event-sourcing/__tests__/integration/testContainers";
+import { generateTestTenantId } from "~/server/event-sourcing/__tests__/integration/testHelpers";
+import {
+  SPAN_RECEIVED_EVENT_TYPE,
+  SPAN_RECEIVED_EVENT_VERSION_LATEST,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
+import type { Span, Trace } from "~/server/tracer/types";
+import { TraceService } from "~/server/traces/trace.service";
+import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
+
+// Gate identically to the canonical event_log integration tests: skip unless a
+// real ClickHouse is reachable, run against the testcontainer otherwise.
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL || process.env.CI_CLICKHOUSE_URL
+);
+
+// Mock the ClickHouse routing module so BOTH the read path
+// (ClickHouseTraceService.resolveClient -> getClickHouseClientForProject) AND the
+// blob resolver (buildTraceBlobResolutionDeps -> defaultResolveClickHouseClient ->
+// getClickHouseClientForProject, wired only when isClickHouseEnabled()) resolve to
+// the testcontainer client. importOriginal keeps every other export intact.
+vi.mock("~/server/clickhouse/clickhouseClient", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("~/server/clickhouse/clickhouseClient")
+  >()),
+  getClickHouseClientForProject: vi.fn(),
+  // Must be true so buildTraceBlobResolutionDeps wires the CH resolver onto the
+  // BlobStore — otherwise getFromEventLog throws and every read degrades to the
+  // preview, which would mask the very fix this test proves.
+  isClickHouseEnabled: () => true,
+}));
+
+const AGGREGATE_TYPE = "trace";
+
+/** The IO fields the matrix covers; each is leaned + offloaded independently. */
+const IO_FIELDS = ["langwatch.input", "langwatch.output"] as const;
+type IoField = (typeof IO_FIELDS)[number];
+
+/**
+ * A 200 KB deterministic payload whose final bytes only exist past the 64 KB
+ * preview boundary. The preview is `value.slice(0, 64KB) + "…"`, so it can NEVER
+ * contain UNIQUE_TAIL — a preview-only read fails the tail assertion.
+ */
+const UNIQUE_TAIL = "__OFFLOAD_FULL_VALUE_TAIL_MARKER__";
+const LARGE_VALUE = "x".repeat(200_000) + UNIQUE_TAIL;
+
+/**
+ * Permissive protections that allow all content categories to be visible, so the
+ * read mappers never redact the IO value out from under the assertions. Mirrors
+ * `openProtections` in clickhouse-trace-dedup.integration.test.ts; the shape is
+ * verified against the current `Protections` type (all fields optional).
+ */
+const openProtections: Protections = {
+  canSeeCosts: true,
+  canSeeCapturedInput: true,
+  canSeeCapturedOutput: true,
+};
+
+/** Sanity: the payload genuinely exceeds the offload threshold. */
+function assertOverThreshold(value: string): void {
+  expect(Buffer.byteLength(value, "utf-8")).toBeGreaterThan(IO_PREVIEW_BYTES);
+}
+
+/**
+ * Builds a SpanReceived domain Event whose IO field (`langwatch.input` or
+ * `langwatch.output`) carries `value`. `event.id` is the EventId that
+ * `leanForProjection` embeds in the eventref and that the read path JOINs on, so
+ * the SAME `eventId` must be used for the event_log row.
+ *
+ * Mixed-type sibling attributes (intValue / doubleValue / boolValue) are included
+ * deliberately: real OTLP spans carry non-string AnyValue attributes, and a
+ * regression where a single non-string sibling fails the whole-array parse would
+ * degrade the > 64 KB read to the preview (#4888) — the real CH round-trip here
+ * would catch that.
+ */
+function makeSpanReceivedEvent({
+  tenantId,
+  traceId,
+  spanId,
+  eventId,
+  ioField,
+  ioValue,
+}: {
+  tenantId: string;
+  traceId: string;
+  spanId: string;
+  eventId: string;
+  ioField: IoField;
+  ioValue: string;
+}): Event {
+  const now = Date.now();
+  return {
+    id: eventId,
+    aggregateId: traceId,
+    aggregateType: AGGREGATE_TYPE,
+    tenantId,
+    createdAt: now,
+    occurredAt: now,
+    type: SPAN_RECEIVED_EVENT_TYPE,
+    version: SPAN_RECEIVED_EVENT_VERSION_LATEST,
+    data: {
+      span: {
+        traceId,
+        spanId,
+        name: "test-span",
+        kind: 1,
+        startTimeUnixNano: String(now * 1_000_000),
+        endTimeUnixNano: String((now + 1000) * 1_000_000),
+        attributes: [
+          // The offloaded IO field MUST stay first.
+          { key: ioField, value: { stringValue: ioValue } },
+          // Mixed-type siblings — NOT IO keys, carry NO eventref.
+          { key: "gen_ai.usage.input_tokens", value: { intValue: "100" } },
+          { key: "gen_ai.request.temperature", value: { doubleValue: 0.7 } },
+          { key: "langwatch.streaming", value: { boolValue: true } },
+        ] as never,
+        events: [],
+        links: [],
+        status: { code: 1, message: null },
+        droppedAttributesCount: 0,
+        droppedEventsCount: 0,
+        droppedLinksCount: 0,
+      },
+      resource: { attributes: [] },
+      instrumentationScope: { name: "test" },
+    },
+  } as unknown as Event;
+}
+
+/** Reads span attributes out of a leaned SpanReceived event into a string map. */
+function extractSpanAttrs(event: Event): Record<string, string> {
+  const data = event.data as {
+    span?: {
+      attributes?: Array<{ key: string; value: { stringValue?: string } }>;
+    };
+  };
+  const attrs: Record<string, string> = {};
+  for (const attr of data?.span?.attributes ?? []) {
+    if (typeof attr.value.stringValue === "string") {
+      attrs[attr.key] = attr.value.stringValue;
+    }
+  }
+  return attrs;
+}
+
+/**
+ * Inserts ONE full event_log row, exactly as the production write path stores it
+ * (`EventPayload` IS `event.data`). Mirrors the canonical event_log test idiom —
+ * JSONEachRow with a stringified payload — and stamps `_retention_days: 0`
+ * (never-expire sentinel, test-only) so a merge-cycle TTL can't evict the fixture
+ * mid-run.
+ */
+async function insertEventLogRow({
+  client,
+  tenantId,
+  aggregateId,
+  eventId,
+  eventType,
+  eventVersion,
+  eventData,
+}: {
+  client: ClickHouseClient;
+  tenantId: string;
+  aggregateId: string;
+  eventId: string;
+  eventType: string;
+  eventVersion: string;
+  eventData: unknown;
+}): Promise<void> {
+  const ts = Date.now();
+  await client.insert({
+    table: "event_log",
+    values: [
+      {
+        TenantId: tenantId,
+        AggregateType: AGGREGATE_TYPE,
+        AggregateId: aggregateId,
+        EventId: eventId,
+        EventType: eventType,
+        EventVersion: eventVersion,
+        EventTimestamp: ts,
+        EventOccurredAt: ts,
+        EventPayload: JSON.stringify(eventData),
+        IdempotencyKey: eventId,
+        _retention_days: 0,
+      },
+    ],
+    format: "JSONEachRow",
+    // Sync insert so the read-back in the same test sees the row immediately.
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+/**
+ * Inserts ONE stored_spans row carrying the supplied (leaned) attribute map. A
+ * single version, StartTime ≈ OccurredAt, so the read path's span dedup
+ * (TenantId,TraceId,SpanId,max(StartTime)) and the ±2-day StartTime partition
+ * bound (clickhouse-trace.service.ts:2419-2476) both select it.
+ */
+async function insertStoredSpan({
+  client,
+  tenantId,
+  traceId,
+  spanId,
+  startTimeMs,
+  spanAttributes,
+}: {
+  client: ClickHouseClient;
+  tenantId: string;
+  traceId: string;
+  spanId: string;
+  startTimeMs: number;
+  spanAttributes: Record<string, string>;
+}): Promise<void> {
+  await client.insert({
+    table: "stored_spans",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: traceId,
+        SpanId: spanId,
+        ParentSpanId: null,
+        ParentTraceId: null,
+        ParentIsRemote: null,
+        Sampled: 1,
+        StartTime: new Date(startTimeMs),
+        EndTime: new Date(startTimeMs + 100),
+        DurationMs: 100,
+        SpanName: "test-span",
+        SpanKind: 1,
+        ServiceName: "test-service",
+        ResourceAttributes: {},
+        SpanAttributes: spanAttributes,
+        StatusCode: 1,
+        StatusMessage: null,
+        ScopeName: "test",
+        ScopeVersion: null,
+        "Events.Timestamp": [],
+        "Events.Name": [],
+        "Events.Attributes": [],
+        "Links.TraceId": [],
+        "Links.SpanId": [],
+        "Links.Attributes": [],
+        DroppedAttributesCount: 0,
+        DroppedEventsCount: 0,
+        DroppedLinksCount: 0,
+        CreatedAt: new Date(startTimeMs),
+        UpdatedAt: new Date(startTimeMs),
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+/**
+ * Inserts ONE trace_summaries row whose ComputedInput/ComputedOutput carry the
+ * preview JSON (`{type:"text", value:<preview>}`) — the value `trace.input` /
+ * `trace.output` reads WITHOUT resolution. Single version, OccurredAt = now so
+ * the summary dedup + the spans-scan window bound both select it.
+ */
+async function insertTraceSummary({
+  client,
+  tenantId,
+  traceId,
+  occurredAtMs,
+  computedInput,
+  computedOutput,
+}: {
+  client: ClickHouseClient;
+  tenantId: string;
+  traceId: string;
+  occurredAtMs: number;
+  computedInput: string | null;
+  computedOutput: string | null;
+}): Promise<void> {
+  await client.insert({
+    table: "trace_summaries",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: tenantId,
+        TraceId: traceId,
+        Version: "v1",
+        Attributes: {},
+        OccurredAt: new Date(occurredAtMs),
+        CreatedAt: new Date(occurredAtMs),
+        UpdatedAt: new Date(occurredAtMs),
+        ComputedIOSchemaVersion: "v1",
+        ComputedInput: computedInput,
+        ComputedOutput: computedOutput,
+        TimeToFirstTokenMs: null,
+        TimeToLastTokenMs: null,
+        TotalDurationMs: 100,
+        TokensPerSecond: null,
+        SpanCount: 1,
+        ContainsErrorStatus: false,
+        ContainsOKStatus: true,
+        ErrorMessage: null,
+        Models: [],
+        TotalCost: null,
+        TokensEstimated: false,
+        TotalPromptTokenCount: null,
+        TotalCompletionTokenCount: null,
+        OutputFromRootSpan: false,
+        OutputSpanEndTimeMs: 0,
+        BlockedByGuardrail: false,
+        SatisfactionScore: null,
+        TopicId: null,
+        SubTopicId: null,
+        HasAnnotation: null,
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+/**
+ * The legacy `Span` from `mapNormalizedSpanToSpan` exposes the offloaded IO value
+ * at `span.input` (for langwatch.input) / `span.output` (for langwatch.output),
+ * each as `{ type, value }` (a non-JSON preview string maps to
+ * `{ type: "text", value }`). Returns the string value for whichever field the
+ * matrix is exercising.
+ */
+function spanIoValue(span: Span, ioField: IoField): string {
+  const io = (ioField === "langwatch.input" ? span.input : span.output) as
+    | { type: string; value: unknown }
+    | null
+    | undefined;
+  expect(io).toBeTruthy();
+  if (!io)
+    throw new Error(
+      `span.${ioField === "langwatch.input" ? "input" : "output"} is null/undefined`,
+    );
+  expect(typeof io.value).toBe("string");
+  return io.value as string;
+}
+
+/**
+ * The reserved eventref namespace key contains dots
+ * (`langwatch.reserved.eventref.langwatch.input`), so `unflattenDotNotation`
+ * nests it under `params.langwatch.reserved.eventref.*` when it is NOT resolved.
+ * After resolution the eventref keys are stripped, so this whole branch is gone.
+ * Returns true when the reserved eventref namespace is still present on the
+ * mapped Span (proving it was never resolved).
+ */
+function spanCarriesEventref(span: Span): boolean {
+  const params = (span.params ?? {}) as Record<string, unknown>;
+  const reserved = (params.langwatch as Record<string, unknown> | undefined)
+    ?.reserved as Record<string, unknown> | undefined;
+  const eventref = reserved?.eventref;
+  return eventref !== undefined && eventref !== null;
+}
+
+/** Trace-level IO value (`{ value: string }`) for whichever field is exercised. */
+function traceIoValue(trace: Trace, ioField: IoField): string | undefined {
+  const io = ioField === "langwatch.input" ? trace.input : trace.output;
+  return io?.value;
+}
+
+describe.skipIf(!hasTestcontainers)(
+  "trace-detail blob recall through the endpoint-level TraceService construction (#4888 / ADR-022)",
+  () => {
+    let client: ClickHouseClient;
+    const ownedTenantIds: string[] = [];
+
+    beforeAll(async () => {
+      const containers = await startTestContainers();
+      client = containers.clickHouseClient;
+      if (!client) {
+        throw new Error(
+          "ClickHouse client not available; testcontainers required.",
+        );
+      }
+
+      // Wire the mocked routing module to the testcontainer client, so both the
+      // read path and the blob resolver dial the real `ch`.
+      vi.mocked(
+        clickhouseClientModule.getClickHouseClientForProject,
+      ).mockResolvedValue(client);
+    }, 60_000);
+
+    afterAll(async () => {
+      if (client && ownedTenantIds.length > 0) {
+        for (const table of ["event_log", "trace_summaries", "stored_spans"]) {
+          await client.exec({
+            query: `ALTER TABLE ${table} DELETE WHERE TenantId IN ({ids:Array(String)})`,
+            query_params: { ids: ownedTenantIds },
+          });
+        }
+      }
+      await stopTestContainers();
+    });
+
+    /**
+     * Seeds the full offload fixture for one IO field on a fresh tenant/trace:
+     *   - the FULL event in event_log (the command-worker write),
+     *   - the LEANED projection (preview + eventref) in stored_spans,
+     *   - the preview-based ComputedInput/ComputedOutput in trace_summaries.
+     *
+     * Returns the ids + the staged lean preview so callers can assert against it.
+     * `seedEventLog: false` skips the event_log insert to model AC5 (resolution
+     * failure: the ref points at a row that does not exist).
+     */
+    async function seedOffloadedTrace({
+      ioField,
+      seedEventLog = true,
+    }: {
+      ioField: IoField;
+      seedEventLog?: boolean;
+    }): Promise<{
+      tenantId: string;
+      traceId: string;
+      spanId: string;
+      eventId: string;
+      preview: string;
+      now: number;
+    }> {
+      assertOverThreshold(LARGE_VALUE);
+
+      const tenantId = generateTestTenantId();
+      ownedTenantIds.push(tenantId);
+      const slug = ioField === "langwatch.input" ? "in" : "out";
+      const traceId = `trace-${tenantId}-${slug}`;
+      const spanId = `span-${tenantId}-${slug}`;
+      const eventId = `${tenantId}-evt-${slug}`;
+      const now = Date.now();
+
+      // 1) The FULL event — what the command worker writes to event_log.
+      const fullEvent = makeSpanReceivedEvent({
+        tenantId,
+        traceId,
+        spanId,
+        eventId,
+        ioField,
+        ioValue: LARGE_VALUE,
+      });
+      if (seedEventLog) {
+        await insertEventLogRow({
+          client,
+          tenantId,
+          aggregateId: traceId,
+          eventId,
+          eventType: SPAN_RECEIVED_EVENT_TYPE,
+          eventVersion: SPAN_RECEIVED_EVENT_VERSION_LATEST,
+          eventData: fullEvent.data,
+        });
+      }
+
+      // 2) The LEANED projection of that SAME event (preview + eventref) — what
+      // the projection fold wrote to stored_spans.
+      const leanAttrs = extractSpanAttrs(leanForProjection(fullEvent));
+      const preview = leanAttrs[ioField];
+
+      // Staging guard: preview is truncated and the eventref key IS present.
+      expect(preview).toBeDefined();
+      if (!preview)
+        throw new Error(
+          `leanAttrs missing "${ioField}" after leanForProjection`,
+        );
+      expect(preview).not.toContain(UNIQUE_TAIL);
+      expect(leanAttrs[`${EVENTREF_ATTR_PREFIX}${ioField}`]).toBeDefined();
+
+      await insertStoredSpan({
+        client,
+        tenantId,
+        traceId,
+        spanId,
+        startTimeMs: now,
+        spanAttributes: leanAttrs,
+      });
+
+      // 3) The preview-based trace summary — what trace.input/output reads
+      // WITHOUT resolution. Preview lands in the field being exercised.
+      const previewWrapper = JSON.stringify({ type: "text", value: preview });
+      await insertTraceSummary({
+        client,
+        tenantId,
+        traceId,
+        occurredAtMs: now,
+        computedInput: ioField === "langwatch.input" ? previewWrapper : null,
+        computedOutput: ioField === "langwatch.output" ? previewWrapper : null,
+      });
+
+      return { tenantId, traceId, spanId, eventId, preview, now };
+    }
+
+    describe("given an over-threshold offloaded IO field stored full in event_log and leaned into stored_spans", () => {
+      describe("when read via TraceService constructed WITHOUT blob-resolution deps (the legacy/no-deps endpoint construction)", () => {
+        for (const ioField of IO_FIELDS) {
+          it(`returns the 64 KB preview for ${ioField}, not the full value (reproduces the #4888 read-path gap)`, async () => {
+            const { tenantId, traceId, preview } = await seedOffloadedTrace({
+              ioField,
+            });
+
+            // Real TraceService, NO blob-resolution deps (top-level imports, not mocked).
+            const service = TraceService.create(prisma);
+
+            // Even full:true cannot resolve without deps: the resolve gate needs
+            // `this.resolveTraceSpans`, which is undefined for a no-deps service.
+            const trace = await service.getById(
+              tenantId,
+              traceId,
+              openProtections,
+              { full: true },
+            );
+
+            expect(trace).toBeDefined();
+            if (!trace) throw new Error("trace is null/undefined");
+            expect(trace.spans).toHaveLength(1);
+            const span = trace.spans[0];
+            if (!span) throw new Error("trace.spans[0] is undefined");
+
+            // BUG: the span IO value is the truncated preview, never the full value.
+            const value = spanIoValue(span, ioField);
+            expect(value).not.toContain(UNIQUE_TAIL);
+            expect(value).toBe(preview);
+            // Preview is ≤ 64 KB + the 1-codepoint ellipsis ("…" = 3 UTF-8 bytes).
+            expect(Buffer.byteLength(value, "utf-8")).toBeLessThanOrEqual(
+              IO_PREVIEW_BYTES + 4,
+            );
+
+            // BUG: the reserved eventref is STILL on the span — never resolved.
+            expect(spanCarriesEventref(span)).toBe(true);
+
+            // BUG (trace-level): trace.input/output is the preview, no full value.
+            const traceValue = traceIoValue(trace, ioField);
+            expect(traceValue).not.toContain(UNIQUE_TAIL);
+          });
+        }
+      });
+
+      describe("when read via TraceService constructed WITH buildTraceBlobResolutionDeps() and full:true (mirrors app.v1.ts:368 + tRPC getById)", () => {
+        for (const ioField of IO_FIELDS) {
+          it(`returns the FULL ${ioField} value byte-identically from event_log (AC1)`, async () => {
+            const { tenantId, traceId } = await seedOffloadedTrace({ ioField });
+
+            const service = TraceService.create(
+              prisma,
+              buildTraceBlobResolutionDeps(),
+            );
+
+            const trace = await service.getById(
+              tenantId,
+              traceId,
+              openProtections,
+              { full: true },
+            );
+
+            expect(trace).toBeDefined();
+            if (!trace) throw new Error("trace is null/undefined");
+            expect(trace.spans).toHaveLength(1);
+            const span = trace.spans[0];
+            if (!span) throw new Error("trace.spans[0] is undefined");
+
+            // FIX: the full value comes back from event_log, byte-identical.
+            const value = spanIoValue(span, ioField);
+            expect(value).toBe(LARGE_VALUE);
+            expect(value).toContain(UNIQUE_TAIL);
+            expect(value.length).toBe(LARGE_VALUE.length);
+            expect(Buffer.byteLength(value, "utf-8")).toBe(
+              Buffer.byteLength(LARGE_VALUE, "utf-8"),
+            );
+          });
+
+          it(`strips the reserved eventref namespace from the returned ${ioField} span attributes (AC3)`, async () => {
+            const { tenantId, traceId } = await seedOffloadedTrace({ ioField });
+
+            const service = TraceService.create(
+              prisma,
+              buildTraceBlobResolutionDeps(),
+            );
+
+            const trace = await service.getById(
+              tenantId,
+              traceId,
+              openProtections,
+              { full: true },
+            );
+
+            expect(trace).toBeDefined();
+            if (!trace) throw new Error("trace is null/undefined");
+            const span = trace.spans[0];
+            if (!span) throw new Error("trace.spans[0] is undefined");
+            // FIX: no reserved eventref namespace leaks to the returned Span.
+            expect(spanCarriesEventref(span)).toBe(false);
+            const params = (span.params ?? {}) as Record<string, unknown>;
+            const reserved = (
+              params.langwatch as Record<string, unknown> | undefined
+            )?.reserved as Record<string, unknown> | undefined;
+            expect(reserved?.eventref).toBeUndefined();
+          });
+
+          it(`patches trace.${
+            ioField === "langwatch.input" ? "input" : "output"
+          } with the full resolved content (AC1 trace-level)`, async () => {
+            const { tenantId, traceId, preview } = await seedOffloadedTrace({
+              ioField,
+            });
+
+            const service = TraceService.create(
+              prisma,
+              buildTraceBlobResolutionDeps(),
+            );
+
+            const trace = await service.getById(
+              tenantId,
+              traceId,
+              openProtections,
+              { full: true },
+            );
+
+            expect(trace).toBeDefined();
+            if (!trace) throw new Error("trace is null/undefined");
+            // FIX (trace-level): the preview from trace_summaries is overwritten
+            // with the recomputed full value.
+            const traceValue = traceIoValue(trace, ioField);
+            expect(traceValue).toBeDefined();
+            expect(traceValue).toContain(UNIQUE_TAIL);
+            expect(traceValue).not.toBe(preview);
+            if (traceValue === undefined)
+              throw new Error("traceValue is undefined");
+            expect(traceValue.length).toBeGreaterThan(IO_PREVIEW_BYTES);
+          });
+        }
+      });
+
+      describe("when read with full:true and deps but the event_log row is absent (resolution failure, AC5)", () => {
+        for (const ioField of IO_FIELDS) {
+          it(`degrades to the ${ioField} preview, still strips the reserved key, and does not throw`, async () => {
+            // Seed stored_spans + trace_summaries with the eventref, but NO
+            // event_log row — getFromEventLog finds nothing (BlobNotFoundError).
+            const { tenantId, traceId, preview } = await seedOffloadedTrace({
+              ioField,
+              seedEventLog: false,
+            });
+
+            const service = TraceService.create(
+              prisma,
+              buildTraceBlobResolutionDeps(),
+            );
+
+            // AC5: the missing row must NOT break the read.
+            const trace = await service.getById(
+              tenantId,
+              traceId,
+              openProtections,
+              { full: true },
+            );
+
+            expect(trace).toBeDefined();
+            if (!trace) throw new Error("trace is null/undefined");
+            expect(trace.spans).toHaveLength(1);
+            const span = trace.spans[0];
+            if (!span) throw new Error("trace.spans[0] is undefined");
+
+            // Degrades to the preview (no full value recoverable).
+            const value = spanIoValue(span, ioField);
+            expect(value).not.toContain(UNIQUE_TAIL);
+            expect(value).toBe(preview);
+
+            // Reserved eventref is stripped even on failure — never leaks to UI.
+            expect(spanCarriesEventref(span)).toBe(false);
+          });
+        }
+      });
+    });
+  },
+);

--- a/langwatch/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts
@@ -438,15 +438,15 @@ describe.skipIf(!hasTestcontainers)(
      *   - the preview-based ComputedInput/ComputedOutput in trace_summaries.
      *
      * Returns the ids + the staged lean preview so callers can assert against it.
-     * `seedEventLog: false` skips the event_log insert to model AC5 (resolution
+     * `shouldSeedEventLog: false` skips the event_log insert to model AC5 (resolution
      * failure: the ref points at a row that does not exist).
      */
     async function seedOffloadedTrace({
       ioField,
-      seedEventLog = true,
+      shouldSeedEventLog = true,
     }: {
       ioField: IoField;
-      seedEventLog?: boolean;
+      shouldSeedEventLog?: boolean;
     }): Promise<{
       tenantId: string;
       traceId: string;
@@ -474,7 +474,7 @@ describe.skipIf(!hasTestcontainers)(
         ioField,
         ioValue: LARGE_VALUE,
       });
-      if (seedEventLog) {
+      if (shouldSeedEventLog) {
         await insertEventLogRow({
           client,
           tenantId,
@@ -671,7 +671,7 @@ describe.skipIf(!hasTestcontainers)(
             // event_log row — getFromEventLog finds nothing (BlobNotFoundError).
             const { tenantId, traceId, preview } = await seedOffloadedTrace({
               ioField,
-              seedEventLog: false,
+              shouldSeedEventLog: false,
             });
 
             const service = TraceService.create(

--- a/langwatch/src/server/routes/__tests__/traces-legacy-get-trace.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/traces-legacy-get-trace.unit.test.ts
@@ -1,0 +1,223 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { Trace } from "~/server/tracer/types";
+
+// ─── TraceService spy ─────────────────────────────────────────────────────────
+// Capture at module scope so assertions can reach them from every it() block.
+const mockGetById = vi.fn();
+const mockGetEvaluationsMultiple = vi.fn();
+const mockCreate = vi.fn();
+
+vi.mock("~/server/traces/trace.service", async () => {
+  class AmbiguousTraceIdPrefixError extends Error {
+    constructor(
+      public readonly prefix: string,
+      public readonly candidateTraceIds: string[],
+    ) {
+      super(
+        `Trace ID prefix "${prefix}" is ambiguous — matches: ${candidateTraceIds.join(", ")}`,
+      );
+      this.name = "AmbiguousTraceIdPrefixError";
+    }
+  }
+  return {
+    AmbiguousTraceIdPrefixError,
+    TraceService: {
+      create: mockCreate,
+    },
+  };
+});
+
+// ─── Blob-resolution deps spy ─────────────────────────────────────────────────
+// Captured so we can assert create() received the return value of this function.
+const mockBuildTraceBlobResolutionDeps = vi.fn(() => ({
+  blobStore: { tag: "blobStore" },
+  ioExtractionService: { tag: "ioExtractionService" },
+}));
+
+vi.mock("~/server/traces/trace-blob-resolution.deps", () => ({
+  buildTraceBlobResolutionDeps: mockBuildTraceBlobResolutionDeps,
+}));
+
+// ─── Auth mocks ───────────────────────────────────────────────────────────────
+// The legacy route creates a module-scope tokenResolver = TokenResolver.create(prisma).
+// authenticateRequest() calls tokenResolver.resolve({token, projectId}) and
+// tokenResolver.markUsed({apiKeyId}). Mock the class so the module-scope
+// singleton uses a controllable mock.
+
+const mockResolve = vi.fn();
+const mockMarkUsed = vi.fn();
+
+vi.mock("~/server/api-key/token-resolver", () => ({
+  TokenResolver: {
+    create: vi.fn(() => ({
+      resolve: mockResolve,
+      markUsed: mockMarkUsed,
+    })),
+  },
+}));
+
+// extractCredentials reads request headers; mock it to return a usable credential.
+// enforceApiKeyCeiling enforces RBAC ceiling; mock it to be a no-op.
+vi.mock("~/server/api-key/auth-middleware", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/server/api-key/auth-middleware")>();
+  return {
+    ...actual,
+    extractCredentials: vi.fn(() => ({
+      token: "test-token",
+      projectId: "project-123",
+    })),
+    enforceApiKeyCeiling: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// ─── Infrastructure stubs ─────────────────────────────────────────────────────
+vi.mock("~/server/api/utils", () => ({
+  getProtectionsForProject: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("~/server/db", () => ({
+  prisma: {},
+}));
+
+// ─── Formatter stubs ──────────────────────────────────────────────────────────
+vi.mock("~/server/traces/trace-formatting", () => ({
+  generateAsciiTree: vi.fn().mockReturnValue("ascii tree"),
+  formatTraceSummaryDigest: vi
+    .fn()
+    .mockReturnValue("Input: hello\nOutput: world"),
+  toLLMModeTrace: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("~/server/tracer/spanToReadableSpan", () => ({
+  formatSpansDigest: vi.fn().mockReturnValue("formatted trace"),
+}));
+
+// Stub the app-layer (used by share/unshare routes only; not needed for GET).
+vi.mock("~/server/app-layer/app", () => ({
+  getApp: vi.fn(() => ({
+    share: {
+      createShare: vi.fn(),
+      unshare: vi.fn(),
+    },
+  })),
+}));
+
+// Stub the schema used by the search route to avoid Zod import issues.
+// Top-level `z` is safe to close over in a vi.mock factory — vitest hoists
+// vi.mock calls but allows factories to reference imports of OTHER modules.
+vi.mock("~/server/api/routers/traces.schemas", () => ({
+  getAllForProjectInput: z.object({
+    projectId: z.string(),
+    startDate: z.number(),
+    endDate: z.number(),
+    pageSize: z.number().optional(),
+  }),
+}));
+
+// ─── App under test ───────────────────────────────────────────────────────────
+// Import AFTER all mocks so the module-scope `tokenResolver = TokenResolver.create(prisma)`
+// picks up the mocked TokenResolver, and mockCreate is wired before any route runs.
+
+const { app: legacyApp } = await import("../traces-legacy");
+
+// The legacy app is mounted at basePath "/api" so requests must hit /api/trace/:id.
+// Wrap in a thin Hono to allow test requests without a real HTTP server.
+const testApp = new Hono();
+testApp.route("/", legacyApp);
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+const sampleTrace: Partial<Trace> = {
+  trace_id: "trace-abc",
+  project_id: "project-123",
+  input: { value: "hello" },
+  output: { value: "world" },
+  timestamps: { started_at: 1000, inserted_at: 2000, updated_at: 2000 },
+  metadata: { thread_id: "t1" },
+  spans: [],
+};
+
+// The project object returned by tokenResolver.resolve — must match what
+// authenticateRequest reads (resolved.project, resolved.type, resolved.apiKeyId).
+const fakeProject = {
+  id: "project-123",
+  apiKey: "test-token",
+  team: { id: "team-1", organizationId: "org-1" },
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function makeRequest(traceId: string, query: Record<string, string> = {}) {
+  const searchParams = new URLSearchParams(query).toString();
+  const url = `http://localhost/api/trace/${traceId}${searchParams ? `?${searchParams}` : ""}`;
+  return testApp.request(url, {
+    method: "GET",
+    headers: {
+      "X-Auth-Token": "test-token",
+    },
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+describe("legacy GET /api/trace/:id (singular)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Wire TokenResolver mock to return a valid legacyProjectKey resolution.
+    mockResolve.mockResolvedValue({
+      type: "legacyProjectKey",
+      project: fakeProject,
+    });
+
+    // Wire TraceService.create to return the service mock.
+    mockCreate.mockReturnValue({
+      getById: mockGetById,
+      getEvaluationsMultiple: mockGetEvaluationsMultiple,
+    });
+
+    mockGetById.mockResolvedValue(sampleTrace);
+    mockGetEvaluationsMultiple.mockResolvedValue({
+      "trace-abc": [],
+    });
+  });
+
+  describe("when fetching a trace by id", () => {
+    it("constructs TraceService with blob-resolution deps (mirrors the plural reference handler)", async () => {
+      // PRE-FIX: FAILS — current code calls TraceService.create(prisma) with ONE arg,
+      // not two. The fix must pass buildTraceBlobResolutionDeps() as the second arg.
+      await makeRequest("trace-abc", { format: "json" });
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          blobStore: expect.anything(),
+          ioExtractionService: expect.anything(),
+        }),
+      );
+    });
+
+    it("calls getById with full:true so >64 KB offloaded IO resolves (#4888)", async () => {
+      // PRE-FIX: FAILS — current code calls traceService.getById(project.id, traceId, protections)
+      // with THREE args; it must pass { full: true } as the fourth arg.
+      await makeRequest("trace-abc", { format: "json" });
+
+      expect(mockGetById).toHaveBeenCalledWith(
+        "project-123",
+        "trace-abc",
+        expect.any(Object),
+        { full: true },
+      );
+    });
+
+    it("returns 200 with the trace json", async () => {
+      // Sanity: the handler still returns the trace. Passes pre- and post-fix.
+      const res = await makeRequest("trace-abc", { format: "json" });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.trace_id).toBe("trace-abc");
+    });
+  });
+});

--- a/langwatch/src/server/routes/__tests__/traces-legacy-get-trace.unit.test.ts
+++ b/langwatch/src/server/routes/__tests__/traces-legacy-get-trace.unit.test.ts
@@ -148,7 +148,13 @@ const fakeProject = {
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-function makeRequest(traceId: string, query: Record<string, string> = {}) {
+function makeRequest({
+  traceId,
+  query = {},
+}: {
+  traceId: string;
+  query?: Record<string, string>;
+}) {
   const searchParams = new URLSearchParams(query).toString();
   const url = `http://localhost/api/trace/${traceId}${searchParams ? `?${searchParams}` : ""}`;
   return testApp.request(url, {
@@ -186,7 +192,7 @@ describe("legacy GET /api/trace/:id (singular)", () => {
     it("constructs TraceService with blob-resolution deps (mirrors the plural reference handler)", async () => {
       // PRE-FIX: FAILS — current code calls TraceService.create(prisma) with ONE arg,
       // not two. The fix must pass buildTraceBlobResolutionDeps() as the second arg.
-      await makeRequest("trace-abc", { format: "json" });
+      await makeRequest({ traceId: "trace-abc", query: { format: "json" } });
 
       expect(mockCreate).toHaveBeenCalledTimes(1);
       expect(mockCreate).toHaveBeenCalledWith(
@@ -201,7 +207,7 @@ describe("legacy GET /api/trace/:id (singular)", () => {
     it("calls getById with full:true so >64 KB offloaded IO resolves (#4888)", async () => {
       // PRE-FIX: FAILS — current code calls traceService.getById(project.id, traceId, protections)
       // with THREE args; it must pass { full: true } as the fourth arg.
-      await makeRequest("trace-abc", { format: "json" });
+      await makeRequest({ traceId: "trace-abc", query: { format: "json" } });
 
       expect(mockGetById).toHaveBeenCalledWith(
         "project-123",
@@ -213,7 +219,10 @@ describe("legacy GET /api/trace/:id (singular)", () => {
 
     it("returns 200 with the trace json", async () => {
       // Sanity: the handler still returns the trace. Passes pre- and post-fix.
-      const res = await makeRequest("trace-abc", { format: "json" });
+      const res = await makeRequest({
+        traceId: "trace-abc",
+        query: { format: "json" },
+      });
 
       expect(res.status).toBe(200);
       const body = await res.json();

--- a/langwatch/src/server/routes/traces-legacy.ts
+++ b/langwatch/src/server/routes/traces-legacy.ts
@@ -22,6 +22,7 @@ import {
 } from "~/server/traces/trace-formatting";
 import { formatSpansDigest } from "~/server/tracer/spanToReadableSpan";
 import { TraceService } from "~/server/traces/trace.service";
+import { buildTraceBlobResolutionDeps } from "~/server/traces/trace-blob-resolution.deps";
 import { enrichTracesWithEvaluations } from "~/server/traces/enrich-evaluations";
 import type { Span, Trace } from "~/server/tracer/types";
 import type { Permission } from "~/server/api/rbac";
@@ -104,12 +105,13 @@ secured.access(handlerManagedAuth(AUTH_REASON)).get("/trace/:id", async (c) => {
     const protections = await getProtectionsForProject(prisma, {
       projectId: project.id,
     });
-    const traceService = TraceService.create(prisma);
-    const trace = await traceService.getById(
-      project.id,
-      traceId,
-      protections,
+    const traceService = TraceService.create(
+      prisma,
+      buildTraceBlobResolutionDeps(),
     );
+    const trace = await traceService.getById(project.id, traceId, protections, {
+      full: true,
+    });
     if (!trace) {
       return c.json({ message: "Trace not found." }, 404);
     }


### PR DESCRIPTION
# Related Issue

- Resolves #4888

## Why

Issue #4888: a ~400 KB trace ingested via `POST /api/collector` reads back with `output.value` truncated to 65,537 bytes (64 KB preview + `…`), carrying an unresolved `langwatch.reserved.eventref.*` pointer. The offload **write** is healthy — the full value is in ClickHouse `event_log`. The deployed #4975 resolver + `BlobStore.getFromEventLog` are correct.

The bug is a **read-path construction gap**: the resolver only runs when both halves of the guard hold —
`if (resolveBlobs === true && this.resolveTraceSpans)` (`clickhouse-trace.service.ts:2259`). The legacy singular `GET /api/trace/:id` handler built `TraceService.create(prisma)` **without** `buildTraceBlobResolutionDeps()` and called `getById` **without** `{ full: true }`, so the guard was falsy and the preview was returned **silently**.

Prod-proven: the plural `GET /api/traces/:id` (wired by #4975) returns the FULL value; the legacy singular `GET /api/trace/:id` returned the preview.

## What

Wire the **legacy singular `GET /api/trace/:id`** handler (`traces-legacy.ts`) to mirror the plural reference (`app.v1.ts`):

```diff
-    const traceService = TraceService.create(prisma);
-    const trace = await traceService.getById(project.id, traceId, protections);
+    const traceService = TraceService.create(prisma, buildTraceBlobResolutionDeps());
+    const trace = await traceService.getById(project.id, traceId, protections, { full: true });
```

### Why touch a file called "legacy" at all?

**"Legacy" here means "older URL shape, recently ported from the Next.js `pages/api` runtime to Hono" — not "deprecated" or "scheduled for removal."** The singular `GET /api/trace/:id` is **live and consumed**: it is mounted in `api-router.ts`, it is a public/documented API endpoint external consumers call, and it is dialed internally by the scenario span-query path (`scenarios/execution/trace-api-span-query.ts`). #4888 is a real, user-facing **data-truncation bug on that live endpoint**, so the endpoint must be fixed wherever it is served. Removing or deprecating it is a separate, breaking migration — out of scope for a bug fix. The minimal correct fix is to give the singular handler the **same** blob-resolution wiring the plural path already proved in production (#4975).

### Scope: why only this one site

The other read sites flagged during investigation are **intentionally left preview-only** — wiring them would violate **AC2** ("non-detail paths stay ≤64 KB with zero `event_log` SELECTs"):

| Site | Verdict |
|---|---|
| `traces-legacy.ts` singular `GET /api/trace/:id` | **FIXED** — detail surface, prod-proven broken |
| `traces-legacy.ts` `POST /api/trace/search` | left preview — `getAllTracesForProject` list path (AC2) |
| `traces-legacy.ts` `GET /api/thread/:id` | left preview — AC2 names `getTracesByThreadId` explicitly; method also structurally drops `resolveBlobs` |
| tRPC `getTracesWithSpansByThreadIds` | left preview — callers are `TracesMapping.tsx` / `DatasetMappingPreview.tsx` (bulk mapping tools, not a detail drawer) |
| tRPC `getById` / `getTracesWithSpans`, `spans.getTracesWithSpans`, REST plural | already wired by #4975 |

## How it works (tests — Outside-In TDD against a real ClickHouse testcontainer)

**1. `traces-legacy-get-trace.unit.test.ts`** — drives the legacy Hono handler with auth mocked to passthrough; asserts it now constructs `TraceService` **with deps** and calls `getById(..., { full: true })`. **RED before the fix** (the two bug-catching assertions failed with `create({})` / `getById` missing the 4th arg), **GREEN after**.

**2. `trace-detail-blob-recall-endpoint.integration.test.ts`** — the endpoint-level gap the existing resolver test misses. Seeds `trace_summaries` (preview `ComputedInput/Output`) + `stored_spans` (leaned span carrying the eventref) + `event_log` (full value), then drives `TraceService.getById` **end-to-end** against real ClickHouse:
- **no-deps construction → 64 KB preview**, eventref still present (documents the bug);
- **`buildTraceBlobResolutionDeps()` + `{ full: true }` → full byte-identical value** (`UNIQUE_TAIL` past the 64 KB boundary), reserved `langwatch.reserved.*` namespace stripped, `trace.input/output` patched > 64 KB (AC1, AC3);
- **event_log row absent → degrades to preview, no throw, warn emitted** (AC5).

## Human verification

Two independent ways a skeptical reviewer can confirm the fix **without trusting the agent's own run**:

**A. Reproduce the read-path gap locally against real ClickHouse (~2 min):**
1. `cd langwatch && git checkout issue4888/blob-recall-readpath-deps`
2. `NODE_ENV=test pnpm exec vitest -c vitest.integration.config.ts trace-detail-blob-recall-endpoint --run`
3. Confirm **10/10 pass** — in particular the *with-deps + `full:true`* cases return the **full > 64 KB value byte-identically** (the `UNIQUE_TAIL` marker exists only past the 64 KB preview boundary), while the *no-deps* cases return only the 64 KB preview (the bug).
4. `NODE_ENV=test pnpm exec vitest run traces-legacy-get-trace` — confirm **3/3**: the handler now constructs `TraceService` with deps and calls `getById(…, { full: true })`.
5. (falsifiability) `git stash` the one-line change in `traces-legacy.ts`, re-run step 4 → the two bug-catching assertions go **RED**; pop the stash → **GREEN**.

**B. Confirm the production symptom on the deployed singular endpoint:**
1. Pick a trace whose `output.value` is > 64 KB and was offloaded (carries `langwatch.reserved.eventref.*`).
2. `GET /api/trace/:id` (legacy singular) — on `main` it returns the 64 KB preview + `…`; on this branch it returns the full value (mirrors the already-fixed plural `GET /api/traces/:id`).
3. Diff the two responses' `output.value` length — the singular response should now match the plural one.

## How I can prove I was successful

**Surface: this is a backend-only change — it touches only the traces read-path in TypeScript, with no UI surface to screenshot.** <!-- no-ui-surface -->
The diff is 3 files, all `.ts` (`gh pr diff 4984 --name-only`): one production handler + two tests —
- `langwatch/src/server/routes/traces-legacy.ts` (the 2-line construction fix)
- `langwatch/src/server/routes/__tests__/traces-legacy-get-trace.unit.test.ts`
- `langwatch/src/server/app-layer/traces/__tests__/trace-detail-blob-recall-endpoint.integration.test.ts`

**Construction equivalence (the load-bearing argument).** The brief proved on **production** that the plural `GET /api/traces/:id` (which already passes deps) returns the FULL > 64 KB value while the legacy singular `GET /api/trace/:id` returned the 64 KB preview. After this change, the singular handler's construction is **byte-identical** to the plural reference:

```
// app.v1.ts (plural, prod-proven full)      // traces-legacy.ts (singular, this PR)
TraceService.create(                          TraceService.create(
  prisma,                                       prisma,
  buildTraceBlobResolutionDeps(),               buildTraceBlobResolutionDeps(),
);                                            );
getById(project.id, traceId, protections, {   getById(project.id, traceId, protections, {
  full: true,                                   full: true,
});                                           });
```

So "plural returns full on prod" transfers directly to the singular path. (The only remaining delta is the plural's `try/catch` for `AmbiguousTraceIdPrefixError` → 409, deferred and tracked as **#4985** — see below.)

**Every layer of the change exercised on its real surface, this session:**

| Layer | Surface exercised | Evidence |
|---|---|---|
| Handler wiring (HTTP) | the real legacy Hono handler via `app.request(...)` | `traces-legacy-get-trace.unit.test.ts` — RED before fix (`create({})` / `getById` w/o `{full:true}`), GREEN after; 3/3 |
| Resolution mechanism (read path) | real `TraceService.getById` against a **real ClickHouse** testcontainer, seeding `trace_summaries`+`stored_spans` (via the real `leanForProjection` eventref shape) + `event_log` | `trace-detail-blob-recall-endpoint.integration.test.ts` — no-deps→preview, deps+full→byte-identical full value (`UNIQUE_TAIL` past 64 KB), eventref stripped, AC5 degrade+warn; 10/10 |
| Pre-existing resolver | unchanged #4975 path, still green | `large-trace-blob-offload-readpath.integration.test.ts` 3/3 |

Local run at PR tip `7cd4f995f` (real CH, not a `CI=1` parse):

```
$ NODE_ENV=test pnpm exec vitest -c vitest.integration.config.ts trace-detail-blob-recall-endpoint --run

[globalSetup] ClickHouse URL: http://test:test@localhost:32768/test_langwatch
[globalSetup] Testcontainers started successfully

 Test Files  1 passed (1)
      Tests  10 passed (10)
numTotalTests: 10 | numPassedTests: 10 | numFailedTests: 0 | success: true
```

All 10 are real-CH round-trips through the endpoint-level `TraceService` construction:

**No-deps construction — reproduces the #4888 read-path gap:**
1. ✓ `langwatch.input` returns the 64 KB preview, not the full value
2. ✓ `langwatch.output` returns the 64 KB preview, not the full value

**With-deps `+ full:true` construction — the fix (`buildTraceBlobResolutionDeps()`):**
3. ✓ returns the **FULL** `langwatch.input` byte-identically from `event_log` (AC1)
4. ✓ returns the **FULL** `langwatch.output` byte-identically from `event_log` (AC1)
5. ✓ strips the reserved eventref namespace from `langwatch.input` span attrs (AC3)
6. ✓ strips the reserved eventref namespace from `langwatch.output` span attrs (AC3)
7. ✓ patches `trace.input` with the full resolved content (AC1, trace-level)
8. ✓ patches `trace.output` with the full resolved content (AC1, trace-level)

**Resolution-failure path — `event_log` row absent (AC5):**
9. ✓ `langwatch.input` degrades to preview, still strips the reserved key, does not throw
10. ✓ `langwatch.output` degrades to preview, still strips the reserved key, does not throw

Route-handler unit test for the production change in `traces-legacy.ts`:

```
$ NODE_ENV=test pnpm exec vitest run traces-legacy-get-trace
      Tests  3 passed (3)
```
- ✓ constructs `TraceService` with blob-resolution deps (mirrors the plural reference handler)
- ✓ calls `getById` with `full:true` so > 64 KB offloaded IO resolves (#4888)
- ✓ returns 200 with the trace json

_Both test files are in this PR's diff. The 200 KB fixture carries a unique tail marker that exists **only past** the 64 KB preview boundary, so a preview-only read fails the assertion — the with-deps pass proves a genuine full-payload recall from real ClickHouse, not a truncated read._

**Why no full-HTTP-app boot:** the diff is the 2-line construction change; its three layers (HTTP handler dispatch, the `TraceService` read path against real CH, the unchanged resolver) are each exercised on their real surface above. Booting the collector→worker→read HTTP stack end-to-end would exercise **no additional code in this diff**, and the resolver it depends on is already deployed (#4975) and prod-verified.

## Anything surprising? — one deferral, filed

- **Out-of-scope / pre-existing (filed as #4985):** the legacy singular handler returns **500 on an ambiguous trace-ID prefix** where the plural reference returns a structured **409** (`AmbiguousTraceIdPrefixError`). This throw is reachable on `origin/main` independent of this change (**not a regression**). Bundling the 409 alignment + the matching raw-vs-resolved `trace_id` evaluation keying would expand scope beyond the blob-recall fix, so it is tracked separately in **#4985**.

Closes #4888.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the legacy `GET /api/trace/:id` endpoint to return complete trace content when full blob resolution is available (improves reliability for large traces), while continuing to fall back to preview data if full resolution fails.

* **Tests**
  * Added an integration test validating large-trace blob recall behavior across multiple construction/availability scenarios (including full success, fallback to preview, and attribute normalization).
  * Added a unit test to verify the legacy endpoint's service calls and expected JSON response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
