### PR TITLE
feat(triggers): persist-class actions ride the settle stage (ADR-032)

### DIFF
--- a/dev/docs/adr/032-persist-class-debounce.md
+++ b/dev/docs/adr/032-persist-class-debounce.md
@@ -1,0 +1,61 @@
+# ADR-032: Persist-class actions ride the settle stage (trace-readiness debounce)
+
+**Date:** 2026-06-19
+
+**Status:** Accepted
+
+**Supersedes:** the v1 inline-dispatch shortcut for persist-class actions described in ADR-026 (§"Half-formed persist") and ADR-030 (`alertTrigger` / `evaluationAlertTrigger` inline reactors).
+
+## Context
+
+ADR-026 §"Problem 2 — half-formed dispatch" identifies that `ADD_TO_DATASET` (and `ADD_TO_ANNOTATION_QUEUE`) snapshot the trace **at dispatch time**. If a trigger fires on the first matching event, the persisted row is truncated relative to the trace an operator browses a minute later — the dataset diverges from the trace. ADR-026 says `traceDebounceMs` exists to fix exactly this: *"wait for the trace to settle so the filter sees the final state"*, and that the knob *"drives the `stage: "settle"` dedup TTL"* on the ADR-030 outbox queue.
+
+The v1 implementation wired this for **notify-class** actions (`SEND_EMAIL` / `SEND_SLACK_MESSAGE`) — they enqueue a settle payload, the trace settles over `traceDebounceMs`, then dispatch. But **persist-class** actions were kept on the **inline** path (`alertTrigger.reactor.ts`): filter-check against the current (possibly half-formed) fold → `claimSend` → `dispatchTriggerAction`, with the comment *"Persist actions don't pay the settle-stage re-read because the side effect is idempotent at the `TriggerSent` gate."*
+
+That reasoning is incomplete. `TriggerSent` idempotency prevents a **second** dispatch for the same `(trigger, trace)` — but "first match wins" is *precisely* the half-formed problem ADR-026 line 44 calls out. Idempotency does not make the captured fold any more complete. So persist actions still capture truncated traces, defeating the very knob (`traceDebounceMs`) ADR-026 introduced for them — and persist is the case ADR-026 considers *more* sensitive (a corrupted dataset row, vs a slightly-stale notification).
+
+## Decision
+
+Route persist-class actions through the **same settle → cadence outbox path** as notify, so `traceDebounceMs` applies before the claim and the dispatch.
+
+### Reactor
+
+The persist branch of `alertTrigger.reactor.ts` / `evaluationAlertTrigger.reactor.ts` stops dispatching inline. For each active persist-class trigger × incoming event it **enqueues a settle payload** (the existing `.withOutbox` settle mechanism), keyed `(projectId, triggerId, traceId)` with the settle dedup TTL = `trigger.traceDebounceMs`. It no longer evaluates filters or calls `claimSend` / `dispatchTriggerAction` itself. This mirrors what the notify reactors already do.
+
+### Settle stage
+
+`handleSettle` no longer rejects non-notify actions. For a persist trigger, once the debounce window elapses it re-reads the **settled** fold, evaluates the trace filters against that complete state, and (on match) enqueues a **cadence** payload with an **immediate** schedule. Persist does not batch matches into a digest window — `computeScheduledFor` already returns `now` for persist actions — so the cadence is a same-tick hand-off, not a digest delay. The debounce lives entirely in the settle TTL.
+
+### Cadence stage
+
+`handleCadenceBatch` dispatches a persist trigger by reading the `TriggerSent` claim (`isSendClaimed`, the at-most-once gate) plus an in-batch dedup, re-reading the settled fold, calling `dispatchTriggerAction`, and writing `claimSend` **after** the dispatch succeeds — the same retry-safe ordering the notify path uses. Claiming *before* dispatch would let a retryable side-effect failure leave `claim = true`, so the outbox retry would see the row already-claimed and the dataset/annotation write would silently never land; claiming after success means a failed dispatch re-runs on retry. **The claim moves from the reactor to the cadence handler** — so at-most-once binds to the *settled* fold rather than the first half-formed one. Cross-pipeline races (trace pipeline vs evaluation pipeline both firing for the same `(trigger, trace)`) remain safe: the claim is still a single atomic `TriggerSent` insert, just relocated downstream, and persist side effects are row-idempotent (deterministic dataset entry ids / annotation upsert), so a retry re-runs only the unfinished matches.
+
+The dispatcher gains the persist-dispatch dependencies it previously did not need (`traceById`, `addToDataset`, `addToAnnotationQueue`) so it can call `dispatchTriggerAction` from the cadence stage; these are injected the same way the notify deps are.
+
+## Rationale
+
+### Why route persist through the existing settle stage rather than a separate mechanism
+
+The settle/cadence machinery (debounce TTL, fold re-read, audit projection, retry) already exists and is the canonical place trace-readiness debounce lives (ADR-026 + ADR-030). A parallel persist-only debounce path would duplicate all of it and drift. The cost is that `handleSettle` / `handleCadenceBatch` become action-class-aware — but they already branch on action (email vs Slack), so a persist branch is incremental, not novel.
+
+### Why not a static reactor delay
+
+The reactor framework's `delay` option is a single static value; `traceDebounceMs` is **per-trigger**. Only the settle dedup TTL captures the per-trigger debounce, so persist must ride settle to honour the configured value.
+
+### Why move the claim to the cadence stage
+
+Claiming in the reactor (v1) locks in the side effect against the *half-formed* fold — the exact failure mode. Claiming at cadence, after settle, ties at-most-once to the *settled* fold. The claim is written *after* a successful `dispatchTriggerAction`, not before — matching the notify path — so a transiently-failed dispatch re-runs on the outbox retry instead of being suppressed by an early claim; the pre-dispatch `isSendClaimed` read still provides at-most-once. The claim stays atomic; only its position moves.
+
+## Consequences
+
+- Persist actions capture the settled trace; `ADD_TO_DATASET` rows stop diverging from the trace UI. ADR-026's stated intent is finally honoured for persist.
+- Persist dispatch now incurs the `traceDebounceMs` latency (default 30s) before the row is written. This is the intended trade — completeness over immediacy — and matches notify.
+- `handleSettle` / `handleCadenceBatch` and the dispatcher deps are now shared by both action classes. The dispatcher is no longer notify-only.
+- No schema change: persist reuses the existing `ReactorOutbox` settle/cadence payloads.
+- Retry/dead-letter, audit projection, and the `${projectId}/` tenant prefix apply to persist for free, since it now rides the same queue.
+
+## Test plan
+
+- **Reactor unit** — a persist trigger enqueues a settle payload (TTL = `traceDebounceMs`) and does **not** `claimSend` / `dispatchTriggerAction` inline.
+- **Dispatcher unit** — a persist settle payload re-reads the fold, matches filters, enqueues an immediate cadence; the cadence dispatches via `dispatchTriggerAction` then claims (retry-safe ordering); a no-match settle dispatches nothing; the claim is at-most-once across two settle/cadence runs for the same `(trigger, trace)`.
+- **Integration** (`triggerDispatch.fullflow`) — the existing persist e2e (ADD_TO_DATASET / ADD_TO_ANNOTATION_QUEUE) now exercises the settle → cadence → `dispatchTriggerAction` path and still writes the real row. (Runs in CI.)

--- a/langwatch/ee/governance/reactors/__tests__/alertTrigger.reactor.unit.test.ts
+++ b/langwatch/ee/governance/reactors/__tests__/alertTrigger.reactor.unit.test.ts
@@ -4,29 +4,16 @@ import { TriggerAction } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import type { TriggerSummary } from "~/server/app-layer/triggers/repositories/trigger.repository";
-import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
-import type { DerivedTraceEvent } from "~/server/event-sourcing/pipelines/trace-processing/projections/services/trace-events.derivation";
+import {
+  ORIGIN_RESOLVED_EVENT_TYPE,
+  SPAN_RECEIVED_EVENT_TYPE,
+} from "~/server/event-sourcing/pipelines/trace-processing/schemas/constants";
 import type { TraceProcessingEvent } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
 import type { ReactorContext } from "~/server/event-sourcing/reactors/reactor.types";
-import { captureException } from "~/utils/posthogErrorCapture";
 import {
   type AlertTriggerReactorDeps,
   createAlertTriggerReactor,
 } from "../alertTrigger.reactor";
-
-vi.mock("~/utils/logger/server", () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
-vi.mock("~/utils/posthogErrorCapture", () => ({
-  captureException: vi.fn(),
-  toError: vi.fn((e) => (e instanceof Error ? e : new Error(String(e)))),
-}));
 
 function createFoldState(
   overrides: Partial<TraceSummaryData> = {},
@@ -74,7 +61,7 @@ function createEvent(
     tenantId: "tenant-1",
     createdAt: Date.now(),
     occurredAt: Date.now(),
-    type: "lw.obs.trace.span_received",
+    type: SPAN_RECEIVED_EVENT_TYPE,
     version: "2025-01-14",
     data: {},
     ...overrides,
@@ -90,19 +77,19 @@ function createContext(
 function createTrigger(
   overrides: Partial<TriggerSummary> = {},
 ): TriggerSummary {
-  // Default to ADD_TO_ANNOTATION_QUEUE (persist-class, single-call
-  // dispatch path) so these tests exercise the inline path the reactor
-  // now owns. NOTIFY-class actions (SEND_EMAIL / SEND_SLACK_MESSAGE)
-  // flow through the `.withOutbox`-registered
-  // alertTriggerNotifyOutbox reactor — see its own test file.
+  // Default to ADD_TO_DATASET (persist-class) so these tests exercise
+  // the persist branch this reactor now owns. NOTIFY-class actions
+  // (SEND_EMAIL / SEND_SLACK_MESSAGE) flow through the
+  // alertTriggerNotifyOutbox reactor; eval-filter triggers flow through
+  // the evaluation pipeline.
   return {
     id: "trigger-1",
     projectId: "tenant-1",
     name: "Latency Alert",
-    action: TriggerAction.ADD_TO_ANNOTATION_QUEUE,
+    action: TriggerAction.ADD_TO_DATASET,
     actionParams: {
-      annotators: [{ id: "annotator-1", name: "Ops" }],
-      createdByUserId: "user-1",
+      datasetId: "dataset-1",
+      datasetMapping: { mapping: {}, expansions: [] },
     },
     filters: {},
     alertType: "WARNING",
@@ -120,58 +107,18 @@ function createTrigger(
   };
 }
 
-/**
- * A thumbs-down automation: fires when a `thumbs_up_down` event has vote == -1
- * (#4903 / #4805). Persist-class (annotation-queue) so it flows through the
- * inline alertTrigger reactor under test — notify-class triggers are owned by
- * the `.withOutbox` reactor and would never claim a send here.
- */
-function thumbsDownTrigger(
-  overrides: Partial<TriggerSummary> = {},
-): TriggerSummary {
-  return createTrigger({
-    filters: {
-      "events.metrics.value": { thumbs_up_down: { vote: ["-1", "-1"] } },
-    },
-    ...overrides,
-  });
-}
-
-/** A derived thumbs_up_down span event carrying the given vote metric. */
-function voteEvent(vote: number): DerivedTraceEvent {
-  return {
-    spanId: "span-1",
-    timestamp: Date.now(),
-    name: "thumbs_up_down",
-    attributes: {
-      "event.type": "thumbs_up_down",
-      "event.metrics.vote": String(vote),
-    },
-  } as unknown as DerivedTraceEvent;
-}
-
 function createDeps(
   overrides: Partial<AlertTriggerReactorDeps> = {},
 ): AlertTriggerReactorDeps {
   return {
     triggers: {
       getActiveTraceTriggersForProject: vi.fn().mockResolvedValue([]),
-      claimSend: vi.fn().mockResolvedValue(true),
-      updateLastRunAt: vi.fn().mockResolvedValue(undefined),
-      invalidate: vi.fn(),
     } as any,
-    projects: {
-      getById: vi.fn().mockResolvedValue({ id: "tenant-1", slug: "demo" }),
-    } as any,
-    traceById: vi.fn().mockResolvedValue(undefined),
-    addToAnnotationQueue: vi.fn().mockResolvedValue(undefined),
-    addToDataset: vi.fn().mockResolvedValue(undefined),
-    deriveEvents: vi.fn().mockResolvedValue([]),
     ...overrides,
   };
 }
 
-describe("alertTrigger reactor", () => {
+describe("alertTrigger reactor (persist outbox)", () => {
   let deps: AlertTriggerReactorDeps;
 
   beforeEach(() => {
@@ -179,50 +126,109 @@ describe("alertTrigger reactor", () => {
     vi.clearAllMocks();
   });
 
-  describe("given an active trace-only trigger", () => {
-    describe("when a trace-only trigger matches", () => {
-      it("claims the match, dispatches, and records the trigger as run", async () => {
+  describe("given an active persist-class trace-only trigger", () => {
+    describe("when the reactor decides", () => {
+      it("emits a settle-stage request stamped actionClass=persist with the per-trigger debounce TTL", async () => {
+        const trigger = createTrigger({ traceDebounceMs: 45_000 });
         (
           deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([createTrigger()]);
+        ).mockResolvedValue([trigger]);
 
         const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).toHaveBeenCalledWith({
-          triggerId: "trigger-1",
-          traceId: "trace-1",
-          projectId: "tenant-1",
-        });
-        expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
-          "trigger-1",
-          "tenant-1",
+        const requests = await reactor.decide(
+          createEvent(),
+          createContext(createFoldState()),
         );
+
+        expect(requests).toHaveLength(1);
+        const [request] = requests;
+        expect(request!.dedupKey).toBe("tenant-1/trigger-1:trace:trace-1");
+        expect(request!.groupKey).toBe("tenant-1/triggerNotify:trigger-1");
+        expect(request!.enqueueOptions).toEqual({ ttlMs: 45_000 });
+        const payload = request!.payload as unknown as {
+          stage: string;
+          actionClass: string;
+          projectId: string;
+          triggerId: string;
+          traceId: string;
+          foldSnapshotAtEnqueue: {
+            computedInput: string;
+            computedOutput: string;
+          };
+        };
+        expect(payload.stage).toBe("settle");
+        // The marker the cadence handler reads to pick dispatchTriggerAction.
+        expect(payload.actionClass).toBe("persist");
+        expect(payload.projectId).toBe("tenant-1");
+        expect(payload.triggerId).toBe("trigger-1");
+        expect(payload.traceId).toBe("trace-1");
+        expect(payload.foldSnapshotAtEnqueue).toEqual({
+          computedInput: "hello",
+          computedOutput: "world",
+        });
       });
     });
 
-    describe("when the only active triggers are notify-class", () => {
-      it("never claims a send (the notify outbox reactor owns them)", async () => {
+    describe("when the trigger filters on event fields", () => {
+      it("still emits a settle request without deriving events itself (the settle stage re-reads + filters)", async () => {
+        const trigger = createTrigger({
+          filters: {
+            "events.metrics.value": { thumbs_up_down: { vote: ["-1", "-1"] } },
+          },
+        });
+        (
+          deps.triggers.getActiveTraceTriggersForProject as any
+        ).mockResolvedValue([trigger]);
+
+        const reactor = createAlertTriggerReactor(deps);
+        const requests = await reactor.decide(
+          createEvent(),
+          createContext(createFoldState()),
+        );
+
+        // The reactor no longer evaluates filters or derives events — it
+        // only enqueues; the settle dispatcher re-reads the settled fold
+        // and runs the filters against the complete state.
+        expect(requests).toHaveLength(1);
+        expect(
+          (requests[0]!.payload as unknown as { actionClass: string })
+            .actionClass,
+        ).toBe("persist");
+      });
+    });
+  });
+
+  describe("given a NOTIFY-class trigger", () => {
+    describe("when the reactor decides", () => {
+      it("emits nothing (the notify outbox reactor owns notify)", async () => {
         (
           deps.triggers.getActiveTraceTriggersForProject as any
         ).mockResolvedValue([
-          createTrigger({ action: TriggerAction.SEND_EMAIL }),
+          createTrigger({
+            action: TriggerAction.SEND_EMAIL,
+            actionParams: { members: ["ops@example.com"] },
+          }),
           createTrigger({
             id: "trigger-slack",
             action: TriggerAction.SEND_SLACK_MESSAGE,
+            actionParams: { slackWebhook: "https://hooks.slack.com/x" },
           }),
         ]);
 
         const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
+        const requests = await reactor.decide(
+          createEvent(),
+          createContext(createFoldState()),
+        );
 
-        expect(deps.triggers.claimSend).not.toHaveBeenCalled();
-        expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
+        expect(requests).toHaveLength(0);
       });
     });
+  });
 
-    describe("when the only active triggers have evaluation filters", () => {
-      it("never claims a send (the evaluation pipeline owns them)", async () => {
+  describe("given a trigger with evaluation filters", () => {
+    describe("when the reactor decides", () => {
+      it("emits nothing (the evaluation pipeline owns those triggers)", async () => {
         (
           deps.triggers.getActiveTraceTriggersForProject as any
         ).mockResolvedValue([
@@ -232,179 +238,79 @@ describe("alertTrigger reactor", () => {
         ]);
 
         const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("when no trigger filter references event fields", () => {
-      it("skips the events derivation entirely", async () => {
-        (
-          deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([createTrigger()]);
-
-        const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.deriveEvents).not.toHaveBeenCalled();
-        expect(deps.triggers.claimSend).toHaveBeenCalled();
-      });
-    });
-
-    describe("when the match was already claimed", () => {
-      it("does not dispatch or record the trigger as run", async () => {
-        (
-          deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([createTrigger()]);
-        (deps.triggers.claimSend as any).mockResolvedValue(false);
-
-        const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).toHaveBeenCalled();
-        expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("when a trigger's dispatch fails", () => {
-      it("surfaces the failure with its retryable flag and does not record the trigger as run", async () => {
-        (
-          deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([createTrigger()]);
-        (deps.addToAnnotationQueue as any).mockRejectedValueOnce(
-          new DispatchError({ message: "provider 503", retryable: true }),
+        const requests = await reactor.decide(
+          createEvent(),
+          createContext(createFoldState()),
         );
 
-        const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).toHaveBeenCalled();
-        expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
-        expect(captureException).toHaveBeenCalledWith(
-          expect.any(DispatchError),
-          expect.objectContaining({
-            extra: expect.objectContaining({ retryable: true }),
-          }),
-        );
+        expect(requests).toHaveLength(0);
       });
     });
+  });
 
-    describe("when one of several matching triggers fails to dispatch", () => {
-      it("still dispatches the remaining triggers", async () => {
+  describe("given several persist triggers on the same trace", () => {
+    describe("when the reactor decides", () => {
+      it("emits one settle request per trigger so each gets its own debounce window", async () => {
+        const a = createTrigger({ id: "trig-a", traceDebounceMs: 30_000 });
+        const b = createTrigger({ id: "trig-b", traceDebounceMs: 60_000 });
         (
           deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([
-          createTrigger({ id: "trigger-failing" }),
-          createTrigger({ id: "trigger-ok" }),
+        ).mockResolvedValue([a, b]);
+
+        const reactor = createAlertTriggerReactor(deps);
+        const requests = await reactor.decide(
+          createEvent(),
+          createContext(createFoldState()),
+        );
+
+        expect(requests).toHaveLength(2);
+        expect(requests.map((r) => r.enqueueOptions?.ttlMs)).toEqual([
+          30_000, 60_000,
         ]);
-        (deps.addToAnnotationQueue as any)
-          .mockRejectedValueOnce(
-            new DispatchError({ message: "revoked", retryable: false }),
-          )
-          .mockResolvedValueOnce(undefined);
-
-        const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).toHaveBeenCalledTimes(2);
-        expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(1);
-        expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
-          "trigger-ok",
-          "tenant-1",
-        );
       });
     });
   });
 
-  // #4903 (#4805): a thumbs-down automation is an `events.metrics.value` range
-  // (vote == -1), not a distinct event type. The in-memory matcher used to skip
-  // that field and an all-skipped filter set matched every trace — so the alert
-  // fired on every trace. These exercise the persist-class path through the
-  // inline reactor with the fixed matcher.
-  describe("given a thumbs-down automation", () => {
-    describe("when the trace has no down-vote", () => {
-      it("does not dispatch the trigger action", async () => {
+  describe("given the origin guard", () => {
+    describe("when the trace origin is not resolved", () => {
+      it("suppresses the decide() body so no request emits", async () => {
         (
           deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([thumbsDownTrigger()]);
-        // No thumbs_up_down event at all → condition unmet.
-        (deps.deriveEvents as any).mockResolvedValue([]);
+        ).mockResolvedValue([createTrigger()]);
 
         const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).not.toHaveBeenCalled();
-        expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("when the trace has an up-vote", () => {
-      it("does not dispatch the trigger action", async () => {
-        (
-          deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([thumbsDownTrigger()]);
-        (deps.deriveEvents as any).mockResolvedValue([voteEvent(1)]);
-
-        const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("when the trace has a down-vote", () => {
-      it("dispatches the trigger action exactly once", async () => {
-        (
-          deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([thumbsDownTrigger()]);
-        (deps.deriveEvents as any).mockResolvedValue([voteEvent(-1)]);
-
-        const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).toHaveBeenCalledTimes(1);
-        expect(deps.triggers.claimSend).toHaveBeenCalledWith({
-          triggerId: "trigger-1",
-          traceId: "trace-1",
-          projectId: "tenant-1",
-        });
-        expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe("when the trigger was already sent for this trace", () => {
-      it("respects at-most-once and does not dispatch", async () => {
-        (
-          deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([thumbsDownTrigger()]);
-        (deps.deriveEvents as any).mockResolvedValue([voteEvent(-1)]);
-        // Lost the claim race (another reactor already sent).
-        (deps.triggers.claimSend as any).mockResolvedValue(false);
-
-        const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.triggers.claimSend).toHaveBeenCalledTimes(1);
-        expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe("given a thumbs-down automation that references event fields", () => {
-    describe("when the trace has a down-vote", () => {
-      it("derives the trace events list before matching", async () => {
-        (
-          deps.triggers.getActiveTraceTriggersForProject as any
-        ).mockResolvedValue([thumbsDownTrigger()]);
-        (deps.deriveEvents as any).mockResolvedValue([voteEvent(-1)]);
-
-        const reactor = createAlertTriggerReactor(deps);
-        await reactor.handle(createEvent(), createContext(createFoldState()));
-
-        expect(deps.deriveEvents).toHaveBeenCalledWith(
-          expect.objectContaining({ tenantId: "tenant-1", traceId: "trace-1" }),
+        const requests = await reactor.decide(
+          createEvent(),
+          createContext(createFoldState({ attributes: {} })),
         );
+
+        expect(requests).toHaveLength(0);
+        // Origin gate runs before the trigger fetch.
+        expect(
+          deps.triggers.getActiveTraceTriggersForProject,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the event is a derived (non-message) event", () => {
+      it("rejects topic_assigned but still fires on origin_resolved", async () => {
+        (
+          deps.triggers.getActiveTraceTriggersForProject as any
+        ).mockResolvedValue([createTrigger()]);
+
+        const reactor = createAlertTriggerReactor(deps);
+
+        const rejected = await reactor.decide(
+          createEvent({ type: "lw.obs.trace.topic_assigned" }),
+          createContext(createFoldState()),
+        );
+        expect(rejected).toHaveLength(0);
+
+        const fired = await reactor.decide(
+          createEvent({ type: ORIGIN_RESOLVED_EVENT_TYPE }),
+          createContext(createFoldState()),
+        );
+        expect(fired).toHaveLength(1);
       });
     });
   });

--- a/langwatch/ee/governance/reactors/alertTrigger.reactor.ts
+++ b/langwatch/ee/governance/reactors/alertTrigger.reactor.ts
@@ -1,166 +1,107 @@
 // SPDX-License-Identifier: LicenseRef-LangWatch-Enterprise
 
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
-import type { DerivedTraceEvent } from "~/server/event-sourcing/pipelines/trace-processing/projections/services/trace-events.derivation";
+import type { TriggerService } from "~/server/app-layer/triggers/trigger.service";
+import type {
+  OutboxEnqueueRequest,
+  OutboxReactorDefinition,
+} from "~/server/event-sourcing/outbox/outboxReactor.types";
 import {
-  buildPreconditionTraceDataFromFoldState,
-  classifyTriggerFilters,
-  matchesTriggerFilters,
-  triggerFiltersReferenceEvents,
-} from "~/server/filters/triggerFilter.matcher";
-import { createLogger } from "~/utils/logger/server";
-import { captureException, toError } from "~/utils/posthogErrorCapture";
-import type { ReactorDefinition } from "~/server/event-sourcing/reactors/reactor.types";
-import { isDispatchError } from "~/server/event-sourcing/outbox/dispatchError";
-import {
-  dispatchTriggerAction,
-  NOTIFY_TRIGGER_ACTIONS,
-  type TriggerActionDispatchDeps,
-} from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
+  auditDedupKey,
+  cadenceGroupKey,
+  type SettleStagePayload,
+  TRIGGER_NOTIFY_REACTOR_NAME,
+} from "~/server/event-sourcing/outbox/payload";
+import { NOTIFY_TRIGGER_ACTIONS } from "~/server/event-sourcing/pipelines/shared/triggerActionDispatch";
+import { defineOriginGuardedTraceOutboxReactor } from "~/server/event-sourcing/pipelines/trace-processing/reactors/_originGuardedReactor";
 import type { TraceProcessingEvent } from "~/server/event-sourcing/pipelines/trace-processing/schemas/events";
-import { defineOriginGuardedTraceReactor } from "~/server/event-sourcing/pipelines/trace-processing/reactors/_originGuardedReactor";
+import { classifyTriggerFilters } from "~/server/filters/triggerFilter.matcher";
 
-const logger = createLogger("langwatch:trace-processing:alert-trigger-reactor");
-
-export type AlertTriggerReactorDeps = TriggerActionDispatchDeps & {
-  /**
-   * Derives the trace-level events list from stored_spans. Only invoked when a
-   * trigger actually filters on event fields (see triggerFiltersReferenceEvents),
-   * so the common no-event-filter path pays nothing.
-   */
-  deriveEvents: (params: {
-    tenantId: string;
-    traceId: string;
-    occurredAtMs?: number;
-    foldVersion?: number;
-  }) => Promise<DerivedTraceEvent[]>;
-};
+export interface AlertTriggerReactorDeps {
+  triggers: TriggerService;
+}
 
 /**
- * Persist-class branch of the trace-pipeline alert trigger reactor.
+ * Persist-class branch of the trace-pipeline alert trigger reactor,
+ * registered via `.withOutbox` (ADR-030 + ADR-032).
  *
- * Fires on every trace event (via traceSummary fold). For each active
- * trace-only trigger whose action is PERSIST (dataset write, annotation
- * queue add), evaluates filters in-memory against the fold state and
- * — on match — claims `TriggerSent` and dispatches inline.
+ * Fires on every trace event (via the traceSummary fold). For each
+ * active trace-only trigger whose action is PERSIST (dataset write,
+ * annotation-queue add), emits an `OutboxEnqueueRequest` whose payload
+ * is a settle-stage job stamped `actionClass: "persist"`. The settle
+ * dispatcher re-reads the fold after `traceDebounceMs`, re-runs the
+ * trace filters against the now-settled state, and (on match)
+ * re-enqueues an immediate cadence that claims `TriggerSent` and runs
+ * `dispatchTriggerAction`.
+ *
+ * Before ADR-032 this reactor dispatched persist actions inline against
+ * the (possibly half-formed) fold. It now rides the same settle/cadence
+ * outbox as notify so `traceDebounceMs` (ADR-026) applies before the
+ * claim and the side effect — the dataset row no longer diverges from
+ * the trace the operator browses later.
  *
  * NOTIFY-class actions (email / Slack) are owned by
- * `alertTriggerNotifyOutbox.reactor.ts`, registered via `.withOutbox`.
- * Splitting the two paths means persist work runs synchronously
- * (fire-and-forget into PG) while notify work flows through the
- * outbox's settle/cadence dispatch — the operator's two-knob timing
- * model (`traceDebounceMs`, `notificationCadence`) only applies to the
- * notify path. Triggers with evaluation filters are handled by the
- * evaluation pipeline reactors and skipped here.
+ * `alertTriggerNotifyOutbox.reactor.ts`; triggers with evaluation
+ * filters are owned by the evaluation pipeline reactors and skipped
+ * here. Pre-filtering to persist-class trace-only triggers keeps this
+ * reactor's `decide()` from emitting payloads the dispatcher would
+ * route elsewhere.
  */
 export function createAlertTriggerReactor(
   deps: AlertTriggerReactorDeps,
-): ReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
-  return defineOriginGuardedTraceReactor({
+): OutboxReactorDefinition<TraceProcessingEvent, TraceSummaryData> {
+  return defineOriginGuardedTraceOutboxReactor({
     name: "alertTrigger",
     jobIdPrefix: "alert-trigger",
-    async handle(_event, context) {
+    async decide(_event, context) {
       const { tenantId, aggregateId: traceId, foldState } = context;
 
-      const triggers = await deps.triggers.getActiveTraceTriggersForProject(
-        tenantId,
-      );
-      if (triggers.length === 0) return;
+      const triggers =
+        await deps.triggers.getActiveTraceTriggersForProject(tenantId);
+      if (triggers.length === 0) return [];
 
-      // Restrict to persist-class trace-only triggers. NOTIFY-class
-      // triggers are handled by the .withOutbox-registered notify
-      // reactor; eval-filter triggers are handled by the evaluation
-      // pipeline. Pre-filtering here also lets us skip the
-      // (potentially expensive) events derivation when the only
-      // matching triggers are notify-class.
-      const persistTriggers = triggers
-        .map((trigger) => ({
-          trigger,
-          ...classifyTriggerFilters(trigger.filters),
-        }))
-        .filter(
-          ({ trigger, hasEvaluationFilters }) =>
-            !hasEvaluationFilters && !NOTIFY_TRIGGER_ACTIONS.has(trigger.action),
+      const requests: OutboxEnqueueRequest[] = [];
+      for (const trigger of triggers) {
+        const { hasEvaluationFilters } = classifyTriggerFilters(
+          trigger.filters,
         );
-      if (persistTriggers.length === 0) return;
+        // Triggers with evaluation filters fire from the evaluation
+        // pipeline; this reactor only owns trace-only triggers. NOTIFY
+        // actions ride the notify reactor — this branch is persist-only.
+        if (hasEvaluationFilters) continue;
+        if (NOTIFY_TRIGGER_ACTIONS.has(trigger.action)) continue;
 
-      const needsEvents = persistTriggers.some(({ traceFilters }) =>
-        triggerFiltersReferenceEvents(traceFilters),
-      );
-      const events = needsEvents
-        ? await deps.deriveEvents({
-            tenantId,
-            traceId,
-            occurredAtMs: foldState.occurredAt,
-            foldVersion: foldState.spanCount,
-          })
-        : null;
-
-      const traceData = buildPreconditionTraceDataFromFoldState(
-        foldState,
-        events,
-      );
-
-      for (const { trigger, traceFilters } of persistTriggers) {
-        try {
-          // Filter check against the current (possibly half-formed)
-          // fold state. Persist actions don't pay the settle-stage
-          // re-read because the side effect is idempotent at the
-          // TriggerSent gate below.
-          if (
-            Object.keys(traceFilters).length > 0 &&
-            !matchesTriggerFilters(traceData, traceFilters)
-          ) {
-            continue;
-          }
-
-          // Atomic claim: insert TriggerSent first, dispatch only on
-          // success. Two reactors racing on the same trigger/trace
-          // (trace pipeline + eval pipeline) will see exactly one
-          // true. A reactor retry after a dispatch failure also sees
-          // false here — at-most-once.
-          const claimed = await deps.triggers.claimSend({
+        const payload: SettleStagePayload = {
+          stage: "settle",
+          projectId: tenantId,
+          triggerId: trigger.id,
+          traceId,
+          reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+          actionClass: "persist",
+          auditDedupKey: auditDedupKey({
+            projectId: tenantId,
             triggerId: trigger.id,
             traceId,
+          }),
+          foldSnapshotAtEnqueue: {
+            computedInput: foldState.computedInput ?? "",
+            computedOutput: foldState.computedOutput ?? "",
+          },
+        };
+        requests.push({
+          dedupKey: payload.auditDedupKey,
+          groupKey: cadenceGroupKey({
             projectId: tenantId,
-          });
-          if (!claimed) continue;
-
-          await dispatchTriggerAction({
-            deps,
-            trigger,
-            traceId,
-            tenantId,
-            foldState,
-          });
-        } catch (error) {
-          // A failed dispatch now throws (DispatchError) rather than
-          // being swallowed; surface its retryable classification for
-          // operators. Persist-class dispatch is inline (no outbox
-          // retry), so the claim has already landed by the time the
-          // error fires.
-          const retryable = isDispatchError(error) ? error.retryable : undefined;
-          logger.error(
-            {
-              tenantId,
-              traceId,
-              triggerId: trigger.id,
-              retryable,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Failed to evaluate trigger",
-          );
-          captureException(toError(error), {
-            extra: {
-              tenantId,
-              traceId,
-              triggerId: trigger.id,
-              triggerAction: trigger.action,
-              retryable,
-            },
-          });
-        }
+            triggerId: trigger.id,
+          }),
+          // SettleStagePayload is a Prisma-JSON-compatible object shape;
+          // the cast crosses the structural-vs-nominal gap between our
+          // `stage: "settle"` literal type and `Prisma.InputJsonValue`.
+          payload: payload as unknown as OutboxEnqueueRequest["payload"],
+          enqueueOptions: { ttlMs: trigger.traceDebounceMs },
+        });
       }
+      return requests;
     },
   });
 }

--- a/langwatch/ee/governance/reactors/alertTriggerNotifyOutbox.reactor.ts
+++ b/langwatch/ee/governance/reactors/alertTriggerNotifyOutbox.reactor.ts
@@ -32,9 +32,9 @@ export interface AlertTriggerNotifyOutboxReactorDeps {
  *
  * Triggers with evaluation filters are handled by
  * `evaluationAlertTriggerNotifyOutbox.reactor.ts` on the evaluation
- * pipeline. Persist-class actions (ADD_TO_DATASET, etc.) are still
- * handled by the inline `alertTrigger.reactor.ts` because they have
- * no outbox dispatcher.
+ * pipeline. Persist-class actions (ADD_TO_DATASET, etc.) ride the same
+ * settle/cadence outbox via `alertTrigger.reactor.ts` (ADR-032), stamped
+ * `actionClass: "persist"`; this reactor only emits the notify class.
  */
 export function createAlertTriggerNotifyOutboxReactor(
   deps: AlertTriggerNotifyOutboxReactorDeps,
@@ -65,6 +65,7 @@ export function createAlertTriggerNotifyOutboxReactor(
           triggerId: trigger.id,
           traceId,
           reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+          actionClass: "notify",
           auditDedupKey: auditDedupKey({
             projectId: tenantId,
             triggerId: trigger.id,

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/dispatcher.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/dispatcher.unit.test.ts
@@ -13,6 +13,7 @@ import { DispatchError } from "../dispatchError";
 import { createOutboxDispatcher } from "../dispatcher";
 import {
   type CadenceStagePayload,
+  type SettleStagePayload,
   TRIGGER_NOTIFY_REACTOR_NAME,
 } from "../payload";
 
@@ -115,6 +116,11 @@ function makeDeps(trigger: TriggerSummary = makeTrigger()) {
     evaluationRuns: { findByTraceId: vi.fn().mockResolvedValue([]) } as any,
     deriveEvents: vi.fn().mockResolvedValue([]),
     traceById: vi.fn().mockResolvedValue(undefined),
+    // ADR-032: persist-class side-effect sinks. Notify dispatch never
+    // touches them; persist cadence (ADD_TO_DATASET /
+    // ADD_TO_ANNOTATION_QUEUE) calls them via dispatchTriggerAction.
+    addToAnnotationQueue: vi.fn().mockResolvedValue(undefined),
+    addToDataset: vi.fn().mockResolvedValue(undefined),
     enqueueCadence: vi.fn().mockResolvedValue(undefined),
     emailHourlyCap: 100,
     consumeEmailCapSlot: vi.fn().mockResolvedValue({ allowed: true, count: 1 }),
@@ -704,6 +710,260 @@ describe("createOutboxDispatcher cadence stage", () => {
           expect.objectContaining({ triggerEmails: ["keep@example.com"] }),
         );
       });
+    });
+  });
+});
+
+// ADR-032: persist-class actions ride the same settle → cadence outbox
+// path as notify. These exercise the persist branches of handleSettle
+// and handleCadenceBatch and confirm they never touch the notify senders.
+function makePersistTrigger(
+  overrides: Partial<TriggerSummary> = {},
+): TriggerSummary {
+  return makeTrigger({
+    action: TriggerAction.ADD_TO_ANNOTATION_QUEUE,
+    actionParams: {
+      annotators: [{ id: "annotator-1", name: "Ops" }],
+      createdByUserId: "user-1",
+    },
+    ...overrides,
+  });
+}
+
+function makePersistFold(origin = "application") {
+  // A complete-enough fold: the settle stage builds precondition trace
+  // data from it (reads models / annotationIds / etc.), so a minimal stub
+  // would NPE in buildPreconditionTraceDataFromFoldState. The trace-origin
+  // filter reads langwatch.origin; dispatchTriggerAction reads only
+  // computedInput/Output.
+  return {
+    traceId: TRACE_ID,
+    spanCount: 1,
+    totalDurationMs: 100,
+    computedIOSchemaVersion: "1",
+    computedInput: "in",
+    computedOutput: "out",
+    timeToFirstTokenMs: null,
+    timeToLastTokenMs: null,
+    tokensPerSecond: null,
+    containsErrorStatus: false,
+    containsOKStatus: true,
+    errorMessage: null,
+    models: [],
+    totalCost: null,
+    tokensEstimated: false,
+    totalPromptTokenCount: null,
+    totalCompletionTokenCount: null,
+    outputFromRootSpan: false,
+    outputSpanEndTimeMs: 0,
+    blockedByGuardrail: false,
+    topicId: null,
+    subTopicId: null,
+    annotationIds: [],
+    occurredAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    LastEventOccurredAt: Date.now(),
+    attributes: { "langwatch.origin": origin },
+  } as any;
+}
+
+function makePersistSettlePayload(
+  overrides: Partial<SettleStagePayload> = {},
+): SettleStagePayload {
+  return {
+    stage: "settle",
+    projectId: PROJECT_ID,
+    triggerId: TRIGGER_ID,
+    reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+    actionClass: "persist",
+    auditDedupKey: `${PROJECT_ID}/${TRIGGER_ID}:trace:${TRACE_ID}`,
+    traceId: TRACE_ID,
+    foldSnapshotAtEnqueue: { computedInput: "in", computedOutput: "out" },
+    ...overrides,
+  };
+}
+
+function makePersistCadencePayload(
+  overrides: Partial<CadenceStagePayload> = {},
+): CadenceStagePayload {
+  return makeCadencePayload({ actionClass: "persist", ...overrides });
+}
+
+describe("createOutboxDispatcher persist class (ADR-032)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("given a persist settle payload", () => {
+    describe("when the settled fold matches the trace filters", () => {
+      it("re-enqueues an immediate cadence stamped actionClass=persist and dispatches nothing yet", async () => {
+        const deps = makeDeps(makePersistTrigger());
+        deps.traceSummaryStore.get.mockResolvedValue(makePersistFold());
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.process(makePersistSettlePayload());
+
+        // Settle re-enqueues cadence; it claims/dispatches nothing itself.
+        expect(deps.enqueueCadence).toHaveBeenCalledTimes(1);
+        const [cadencePayload, options] = deps.enqueueCadence.mock.calls[0]!;
+        expect(cadencePayload.stage).toBe("cadence");
+        expect(cadencePayload.actionClass).toBe("persist");
+        expect(cadencePayload.match.traceId).toBe(TRACE_ID);
+        // Persist is immediate — no digest delay.
+        expect(options.delayMs).toBe(0);
+        // No side effect, no claim at the settle stage.
+        expect(deps.addToAnnotationQueue).not.toHaveBeenCalled();
+        expect(deps.triggers.claimSend).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the settled fold does not match the trace filters", () => {
+      it("dispatches nothing and enqueues no cadence", async () => {
+        const deps = makeDeps(
+          makePersistTrigger({ filters: { "traces.origin": ["playground"] } }),
+        );
+        // Fold origin is "application", filter wants "playground".
+        deps.traceSummaryStore.get.mockResolvedValue(
+          makePersistFold("application"),
+        );
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.process(makePersistSettlePayload());
+
+        expect(deps.enqueueCadence).not.toHaveBeenCalled();
+        expect(deps.addToAnnotationQueue).not.toHaveBeenCalled();
+        expect(deps.triggers.claimSend).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the trace fold is gone", () => {
+      it("dispatches nothing and enqueues no cadence", async () => {
+        const deps = makeDeps(makePersistTrigger());
+        deps.traceSummaryStore.get.mockResolvedValue(null);
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.process(makePersistSettlePayload());
+
+        expect(deps.enqueueCadence).not.toHaveBeenCalled();
+        expect(deps.addToAnnotationQueue).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("given a persist cadence payload", () => {
+    describe("when the pair has not been claimed", () => {
+      it("re-reads the settled fold, dispatches via dispatchTriggerAction, then claims post-success", async () => {
+        const deps = makeDeps(makePersistTrigger());
+        deps.traceSummaryStore.get.mockResolvedValue(makePersistFold());
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.process(makePersistCadencePayload());
+
+        // Cross-batch dedup read ran first.
+        expect(deps.triggers.isSendClaimed).toHaveBeenCalledTimes(1);
+        // The persist side effect fired (ADD_TO_ANNOTATION_QUEUE).
+        expect(deps.addToAnnotationQueue).toHaveBeenCalledTimes(1);
+        expect(deps.addToAnnotationQueue).toHaveBeenCalledWith(
+          expect.objectContaining({
+            traceIds: [TRACE_ID],
+            projectId: PROJECT_ID,
+          }),
+        );
+        // Claim is written AFTER the successful dispatch (retry-safe).
+        expect(deps.triggers.claimSend).toHaveBeenCalledTimes(1);
+        expect(deps.triggers.claimSend).toHaveBeenCalledWith({
+          triggerId: TRIGGER_ID,
+          traceId: TRACE_ID,
+          projectId: PROJECT_ID,
+        });
+        // It must NOT touch the notify senders.
+        expect(sendTriggerEmail).not.toHaveBeenCalled();
+        expect(sendSlackWebhook).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the pair was already claimed by an earlier run", () => {
+      it("skips the dispatch via the read-only isSendClaimed check", async () => {
+        const deps = makeDeps(makePersistTrigger());
+        deps.traceSummaryStore.get.mockResolvedValue(makePersistFold());
+        deps.triggers.isSendClaimed.mockResolvedValueOnce(true);
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.process(makePersistCadencePayload());
+
+        expect(deps.triggers.isSendClaimed).toHaveBeenCalledTimes(1);
+        expect(deps.addToAnnotationQueue).not.toHaveBeenCalled();
+        expect(deps.triggers.claimSend).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the same traceId appears twice in the batch", () => {
+      it("dedupes in-batch so the side effect fires once", async () => {
+        const deps = makeDeps(makePersistTrigger());
+        deps.traceSummaryStore.get.mockResolvedValue(makePersistFold());
+        const dispatcher = createOutboxDispatcher(deps);
+
+        await dispatcher.processBatch([
+          makePersistCadencePayload(),
+          makePersistCadencePayload(),
+        ]);
+
+        expect(deps.triggers.isSendClaimed).toHaveBeenCalledTimes(1);
+        expect(deps.addToAnnotationQueue).toHaveBeenCalledTimes(1);
+        expect(deps.triggers.claimSend).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when dispatchTriggerAction fails retryably", () => {
+      it("does not claim, so the outbox retry re-dispatches rather than no-opping", async () => {
+        const deps = makeDeps(makePersistTrigger());
+        deps.traceSummaryStore.get.mockResolvedValue(makePersistFold());
+        deps.addToAnnotationQueue
+          .mockRejectedValueOnce(
+            new DispatchError({ message: "queue 503", retryable: true }),
+          )
+          .mockResolvedValueOnce(undefined);
+        const dispatcher = createOutboxDispatcher(deps);
+
+        // First attempt throws (so the outbox marks it for retry)...
+        await expect(
+          dispatcher.process(makePersistCadencePayload()),
+        ).rejects.toBeInstanceOf(DispatchError);
+        // ...and crucially the claim did NOT land, or the retry would no-op.
+        expect(deps.triggers.claimSend).not.toHaveBeenCalled();
+
+        // Retry succeeds and now claims.
+        await dispatcher.process(makePersistCadencePayload());
+        expect(deps.addToAnnotationQueue).toHaveBeenCalledTimes(2);
+        expect(deps.triggers.claimSend).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("at-most-once across a settle then cadence run for the same pair", () => {
+    it("claims exactly once: the settle re-enqueues, the cadence dispatches+claims, a replayed cadence no-ops", async () => {
+      const deps = makeDeps(makePersistTrigger());
+      deps.traceSummaryStore.get.mockResolvedValue(makePersistFold());
+      const dispatcher = createOutboxDispatcher(deps);
+
+      // 1) Settle matches → enqueues cadence, no claim yet.
+      await dispatcher.process(makePersistSettlePayload());
+      expect(deps.enqueueCadence).toHaveBeenCalledTimes(1);
+      expect(deps.triggers.claimSend).not.toHaveBeenCalled();
+      const enqueuedCadence = deps.enqueueCadence.mock
+        .calls[0]![0] as CadenceStagePayload;
+
+      // 2) Cadence runs → dispatch + claim once.
+      await dispatcher.process(enqueuedCadence);
+      expect(deps.addToAnnotationQueue).toHaveBeenCalledTimes(1);
+      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(1);
+
+      // 3) A replayed cadence for the SAME pair sees the claim and no-ops.
+      deps.triggers.isSendClaimed.mockResolvedValueOnce(true);
+      await dispatcher.process(enqueuedCadence);
+      expect(deps.addToAnnotationQueue).toHaveBeenCalledTimes(1);
+      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/outbox/__tests__/triggerDispatch.fullflow.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/outbox/__tests__/triggerDispatch.fullflow.integration.test.ts
@@ -97,6 +97,10 @@ function makeNotifyDeps(opts?: { emailCap?: number }) {
     evaluationRuns: { findByTraceId: vi.fn().mockResolvedValue([]) } as any,
     deriveEvents: vi.fn().mockResolvedValue([]),
     traceById: vi.fn().mockResolvedValue(undefined),
+    // ADR-032: persist-class sinks. These notify-focused flows never
+    // dispatch persist, so simple stubs satisfy the dispatcher deps.
+    addToAnnotationQueue: vi.fn().mockResolvedValue(undefined),
+    addToDataset: vi.fn().mockResolvedValue(undefined),
     enqueueCadence: vi.fn().mockResolvedValue(undefined),
     emailHourlyCap: cap,
     consumeEmailCapSlot: (args: {

--- a/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
+++ b/langwatch/src/server/event-sourcing/outbox/dispatcher.ts
@@ -3,7 +3,9 @@ import { createHash } from "crypto";
 import type { EvaluationRunService } from "~/server/app-layer/evaluations/evaluation-run.service";
 import type { ProjectService } from "~/server/app-layer/projects/project.service";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
+import type { TriggerSummary } from "~/server/app-layer/triggers/repositories/trigger.repository";
 import type { TriggerService } from "~/server/app-layer/triggers/trigger.service";
+import type { DatasetRecordEntry } from "~/server/datasets/types";
 import {
   buildPreconditionTraceDataFromFoldState,
   classifyTriggerFilters,
@@ -31,6 +33,7 @@ import { captureException, toError } from "~/utils/posthogErrorCapture";
 import { createTenantId } from "../domain/tenantId";
 import {
   computeScheduledFor,
+  dispatchTriggerAction,
   NOTIFY_TRIGGER_ACTIONS,
 } from "../pipelines/shared/triggerActionDispatch";
 import type { DerivedTraceEvent } from "../pipelines/trace-processing/projections/services/trace-events.derivation";
@@ -41,6 +44,7 @@ import {
   type OutboxJob,
   type SettleStagePayload,
   TRIGGER_NOTIFY_REACTOR_NAME,
+  type TriggerActionClass,
 } from "./payload";
 
 const logger = createLogger("langwatch:outbox:dispatcher");
@@ -66,6 +70,25 @@ export interface OutboxDispatcherDeps {
     foldVersion?: number;
   }) => Promise<DerivedTraceEvent[]>;
   traceById: (projectId: string, traceId: string) => Promise<Trace | undefined>;
+  /**
+   * ADR-032: persist-class dispatch dependencies. Persist actions
+   * (ADD_TO_DATASET / ADD_TO_ANNOTATION_QUEUE) now ride the same
+   * settle/cadence outbox as notify, so the cadence handler calls
+   * `dispatchTriggerAction` for them — which needs these two side-effect
+   * sinks. Notify dispatch never touches them. Injected the same way the
+   * notify deps are, so the dispatcher stays testable.
+   */
+  addToAnnotationQueue: (params: {
+    traceIds: string[];
+    projectId: string;
+    annotators: string[];
+    userId: string;
+  }) => Promise<void>;
+  addToDataset: (params: {
+    datasetId: string;
+    projectId: string;
+    datasetRecords: DatasetRecordEntry[];
+  }) => Promise<void>;
   /**
    * Late-bound — settle stage's match-confirmed branch calls this to
    * re-enqueue as `cadence`. The queue ref is filled in by `buildOutboxRuntime`
@@ -134,14 +157,18 @@ export interface OutboxDispatcherDeps {
 
 /**
  * Unified outbox process callback. Branches on `stage` so one queue
- * carries both ADR-026 settle and ADR-027 cadence digest stages with
- * the operator's two knobs (`traceDebounceMs`, `notificationCadence`)
- * still independently tunable.
+ * carries both ADR-026 settle and ADR-027 cadence stages with the
+ * operator's two knobs (`traceDebounceMs`, `notificationCadence`) still
+ * independently tunable. Both action classes ride this path now: notify
+ * (email / Slack, digest-coalesced) and persist (dataset / annotation,
+ * immediate per-match — ADR-032). `handleCadenceBatch` picks the branch
+ * from the payload's `actionClass`.
  *
  * `process(payload)` is invoked by the GroupQueue for single-job
  * paths (settle is never coalesced). `processBatch(payloads)` is
- * invoked when `coalesceMaxBatch` opens a digest — only cadence-stage
- * payloads coalesce.
+ * invoked when `coalesceMaxBatch` opens a window — only cadence-stage
+ * payloads coalesce (persist cadences share a per-trigger group too, but
+ * dispatch one match at a time).
  */
 export function createOutboxDispatcher(deps: OutboxDispatcherDeps): {
   process: (payload: OutboxJob) => Promise<void>;
@@ -152,8 +179,8 @@ export function createOutboxDispatcher(deps: OutboxDispatcherDeps): {
       if (payload.stage === "settle") {
         await handleSettle(deps, payload);
       } else {
-        // Single-job cadence path (no coalescing this round) — render
-        // and send a one-match digest.
+        // Single-job cadence path (no coalescing this round) — one-match
+        // notify digest, or one persist dispatch.
         await handleCadenceBatch(deps, [payload]);
       }
     },
@@ -177,13 +204,32 @@ export function createOutboxDispatcher(deps: OutboxDispatcherDeps): {
 }
 
 /**
+ * Resolves the dispatch class for a settle/cadence payload (ADR-032).
+ * Prefers the marker the reactor stamped; falls back to deriving it from
+ * `trigger.action` for rows enqueued before ADR-032 (which carried no
+ * marker and were always notify-class — persist rode the inline reactor
+ * back then). Deriving from the live trigger is safe because the
+ * notify/persist split is a fixed partition of `TriggerAction`.
+ */
+function resolveActionClass(
+  payload: { actionClass?: TriggerActionClass },
+  action: TriggerAction,
+): TriggerActionClass {
+  if (payload.actionClass) return payload.actionClass;
+  return NOTIFY_TRIGGER_ACTIONS.has(action) ? "notify" : "persist";
+}
+
+/**
  * Settle stage: trace has been quiet for `traceDebounceMs`. Re-read
  * the fold, re-run filters against the now-settled state, and
- * re-enqueue as cadence so the digest window can coalesce.
+ * re-enqueue as cadence. For notify the cadence delay snaps to the next
+ * digest boundary so the window can coalesce; for persist it is an
+ * immediate same-tick hand-off (ADR-032) — `computeScheduledFor`
+ * already returns `now` for persist actions.
  *
  * The `TriggerSent` at-most-once gate is owned entirely by
  * `handleCadenceBatch` (read pre-dispatch, written post-dispatch), so
- * settle does no claiming itself.
+ * settle does no claiming itself — for either action class.
  */
 async function handleSettle(
   deps: OutboxDispatcherDeps,
@@ -245,23 +291,23 @@ async function handleSettle(
     }
   }
 
-  if (!NOTIFY_TRIGGER_ACTIONS.has(trigger.action)) {
-    // Persist actions don't take the outbox path — the inline
-    // dispatchTriggerAction caller routed them separately.
-    return;
-  }
+  // ADR-032: both notify and persist ride this path now. The cadence
+  // payload carries the action class forward so `handleCadenceBatch`
+  // picks the right dispatch branch without re-reading `trigger.action`.
+  const actionClass = resolveActionClass(payload, trigger.action);
 
   // No claim here. Settle just re-enqueues — the at-most-once gate is
   // owned by `handleCadenceBatch`, which reads `isSendClaimed` before
   // dispatch and writes `claimSend` after success. Committing the claim
   // pre-dispatch (here or in cadence) breaks outbox retry semantics: a
-  // retryable provider failure on the first cadence attempt would see
-  // claim=true on retry and silently no-op the resend.
+  // retryable provider/side-effect failure on the first cadence attempt
+  // would see claim=true on retry and silently no-op the re-dispatch.
   const cadencePayload: CadenceStagePayload = {
     stage: "cadence",
     projectId,
     triggerId,
     reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+    actionClass,
     auditDedupKey: payload.auditDedupKey,
     match: {
       traceId,
@@ -283,9 +329,18 @@ async function handleSettle(
 
 /**
  * Cadence stage: one or more matched (trigger, trace) pairs landed in
- * the same wall-clock cadence boundary. Renders one digest and sends.
+ * the same wall-clock cadence boundary.
+ *
+ * For NOTIFY triggers this renders one digest and sends (email / Slack).
+ * For PERSIST triggers (ADR-032) it dispatches each match individually
+ * via `dispatchTriggerAction` — persist never digest-batches, so the
+ * batch is just the same-tick collection of immediate cadences for one
+ * trigger. The `actionClass` carried on the payload picks the branch.
+ *
  * The group invariant (single triggerId per batch) is enforced by the
- * queue's `groupKey` configuration.
+ * queue's `groupKey` configuration. A mixed-class batch can never occur:
+ * the group key is per-trigger and a trigger's action — hence its class
+ * — is fixed, so every payload in a batch shares one class.
  */
 async function handleCadenceBatch(
   deps: OutboxDispatcherDeps,
@@ -311,6 +366,15 @@ async function handleCadenceBatch(
       { projectId, triggerId, batchSize: payloads.length },
       "Trigger gone / deactivated since enqueue — dropping digest",
     );
+    return;
+  }
+
+  // ADR-032: persist-class triggers branch off here. They run
+  // `dispatchTriggerAction` per match (no digest, no template render, no
+  // email caps) so the rest of this function — which is the notify
+  // digest path — is reached only for notify triggers.
+  if (resolveActionClass(payloads[0]!, trigger.action) === "persist") {
+    await dispatchPersistBatch(deps, trigger, payloads);
     return;
   }
 
@@ -752,5 +816,151 @@ async function handleCadenceBatch(
       digestSize: candidatePayloads.length,
     },
     "Outbox cadence digest dispatched",
+  );
+}
+
+/**
+ * Persist-class cadence dispatch (ADR-032). Runs each matched
+ * (trigger, trace) pair through `dispatchTriggerAction` — the dataset
+ * write / annotation-queue add the operator configured — instead of
+ * rendering a notification digest. Persist never coalesces into a
+ * digest, so a "batch" here is just the same-tick collection of
+ * immediate cadences for one trigger; each match is dispatched on its
+ * own.
+ *
+ * At-most-once and retry semantics mirror the notify path exactly:
+ *
+ *   1. In-batch dedup via `seenTraceIds` — a (trigger, trace) pair can
+ *      appear twice (settle retry after a Redis blip).
+ *   2. Cross-batch dedup via the read-only `isSendClaimed` check —
+ *      suppresses pairs an earlier cadence batch (or the sibling
+ *      pipeline) already dispatched.
+ *   3. The `claimSend` WRITE is deferred to AFTER a successful
+ *      `dispatchTriggerAction`. Writing the claim pre-dispatch would
+ *      defeat outbox retry: a retryable side-effect failure on the first
+ *      attempt would see claim=true on retry and silently no-op the
+ *      re-dispatch, recording a write that never landed. This is the
+ *      same hazard the notify path guards against (claim-after-send).
+ *
+ * A failed `dispatchTriggerAction` re-throws so the outbox retries the
+ * whole batch; already-claimed matches are claim-suppressed on the
+ * retry, and persist side effects are idempotent at the row level
+ * (deterministic dataset entry ids / annotation-queue upsert), so the
+ * re-run only re-dispatches the unfinished matches.
+ *
+ * The settled fold is re-read per trace so `dispatchTriggerAction`
+ * captures the now-complete trace — the whole point of riding settle.
+ */
+async function dispatchPersistBatch(
+  deps: OutboxDispatcherDeps,
+  trigger: TriggerSummary,
+  payloads: CadenceStagePayload[],
+): Promise<void> {
+  const projectId = payloads[0]!.projectId;
+  const triggerId = trigger.id;
+  const brandedTenantId = createTenantId(projectId);
+
+  const seenTraceIds = new Set<string>();
+  let dispatchedCount = 0;
+  for (const p of payloads) {
+    const traceId = p.match.traceId;
+    if (seenTraceIds.has(traceId)) continue;
+    seenTraceIds.add(traceId);
+
+    // Cross-batch dedup: a pair already dispatched by an earlier cadence
+    // batch (or the sibling pipeline) is suppressed before the side
+    // effect. The claim WRITE happens post-dispatch below.
+    const alreadySent = await deps.triggers.isSendClaimed({
+      triggerId,
+      traceId,
+      projectId,
+    });
+    if (alreadySent) continue;
+
+    // Re-read the settled fold so the dataset / annotation row captures
+    // the complete trace. Missing fold (evicted / trace gone) → skip
+    // this match; nothing to persist.
+    const foldState = await deps.traceSummaryStore.get(traceId, {
+      tenantId: brandedTenantId,
+      aggregateId: traceId,
+    });
+    if (!foldState) {
+      logger.debug(
+        { projectId, triggerId, traceId },
+        "Trace fold gone during persist cadence — skipping match",
+      );
+      continue;
+    }
+
+    // dispatchTriggerAction performs the side effect and, on success,
+    // its own `updateLastRunAt`. A failure throws DispatchError; capture
+    // it for operators, then let it propagate so the outbox retries
+    // (claim not yet written for this match, so the retry re-dispatches
+    // it). Mirrors the notify path's capture-then-rethrow.
+    try {
+      await dispatchTriggerAction({
+        deps,
+        trigger,
+        traceId,
+        tenantId: projectId,
+        foldState,
+      });
+    } catch (error) {
+      const retryable = isDispatchError(error) ? error.retryable : true;
+      logger.error(
+        {
+          projectId,
+          triggerId,
+          traceId,
+          retryable,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Persist cadence dispatch failed",
+      );
+      captureException(toError(error), {
+        extra: { projectId, triggerId, traceId, triggerAction: trigger.action },
+      });
+      throw error;
+    }
+
+    // Post-dispatch at-most-once write. Best-effort: a failure here must
+    // not throw — the side effect already landed and re-throwing would
+    // let the outbox retry and double-dispatch. claimSend is INSERT
+    // IGNORE, so a racing worker seeing `false` is also fine.
+    try {
+      await deps.triggers.claimSend({ triggerId, traceId, projectId });
+    } catch (claimErr) {
+      logger.warn(
+        {
+          projectId,
+          triggerId,
+          traceId,
+          error:
+            claimErr instanceof Error ? claimErr.message : String(claimErr),
+        },
+        "claimSend failed post-persist-dispatch — swallowing to avoid double-dispatch on retry",
+      );
+      captureException(toError(claimErr), {
+        extra: {
+          projectId,
+          triggerId,
+          traceId,
+          phase: "claimSend-post-persist-dispatch",
+        },
+      });
+    }
+    dispatchedCount++;
+  }
+
+  if (dispatchedCount === 0) {
+    logger.debug(
+      { projectId, triggerId, batchSize: payloads.length },
+      "Persist cadence batch fully suppressed (prior claims / missing folds) — no dispatch",
+    );
+    return;
+  }
+  logger.info(
+    { projectId, triggerId, action: trigger.action, dispatchedCount },
+    "Outbox persist cadence dispatched",
   );
 }

--- a/langwatch/src/server/event-sourcing/outbox/payload.ts
+++ b/langwatch/src/server/event-sourcing/outbox/payload.ts
@@ -40,6 +40,22 @@
 export const TRIGGER_NOTIFY_REACTOR_NAME = "triggerNotify" as const;
 
 /**
+ * Which dispatch class a settle/cadence payload belongs to (ADR-032).
+ * Both action classes now ride the same settle → cadence outbox path,
+ * so the marker is what lets `handleSettle` / `handleCadenceBatch`
+ * branch on dispatch shape without re-classifying `trigger.action`:
+ *
+ * - `notify`  → SEND_EMAIL / SEND_SLACK_MESSAGE: digest-cadence aware,
+ *   rendered + provider-sent in `handleCadenceBatch`.
+ * - `persist` → ADD_TO_DATASET / ADD_TO_ANNOTATION_QUEUE: immediate
+ *   cadence (no digest), dispatched per-match via `dispatchTriggerAction`.
+ *
+ * The reactor stamps it at enqueue; settle copies it onto the cadence
+ * payload it re-enqueues; cadence reads it to pick the dispatch branch.
+ */
+export type TriggerActionClass = "notify" | "persist";
+
+/**
  * Both stages carry the SAME `auditDedupKey` so they project onto one
  * `ReactorOutbox` row through the lifecycle: settle's INSERT,
  * settle's leased/dispatched-or-noMatch, cadence's UPDATE, cadence's
@@ -52,6 +68,15 @@ interface CommonStagePayload {
   triggerId: string;
   reactorName: typeof TRIGGER_NOTIFY_REACTOR_NAME;
   auditDedupKey: string;
+  /**
+   * Dispatch class of the underlying trigger action (ADR-032). Carried
+   * on the payload so the cadence handler routes persist vs notify
+   * without re-reading `trigger.action`. Optional for backwards
+   * compatibility with rows enqueued before ADR-032: a missing marker
+   * is treated as `notify` by the dispatcher (the only class that rode
+   * the outbox in v1).
+   */
+  actionClass?: TriggerActionClass;
 }
 
 export interface SettleStagePayload

--- a/langwatch/src/server/event-sourcing/outbox/setup.ts
+++ b/langwatch/src/server/event-sourcing/outbox/setup.ts
@@ -1,6 +1,8 @@
 import type { PrismaClient } from "@prisma/client";
 import { Cluster, type Redis } from "ioredis";
 import { env } from "~/env.mjs";
+import { createOrUpdateQueueItems } from "~/server/api/routers/annotation";
+import { createManyDatasetRecords } from "~/server/api/routers/datasetRecord.utils";
 import { getProtectionsForProject } from "~/server/api/utils";
 import type { EvaluationRunService } from "~/server/app-layer/evaluations/evaluation-run.service";
 import type { ProjectService } from "~/server/app-layer/projects/project.service";
@@ -62,9 +64,10 @@ export interface OutboxRuntime {
    *  the dispatcher's internal `enqueueCadence`) can send onto it. Call
    *  this once the main queue has been constructed. */
   attachQueue(queue: EventSourcedQueueProcessor<Record<string, unknown>>): void;
-  /** Producer entry point for the trigger reactors. Sends a settle
-   *  payload onto the attached queue with the per-trigger debounce TTL
-   *  as the Debounce Mode override. */
+  /** Producer entry point for the trigger reactors (both notify and
+   *  persist classes — ADR-032). Sends a settle payload onto the attached
+   *  queue with the per-trigger debounce TTL as the Debounce Mode
+   *  override. */
   enqueueSettle(
     payload: SettleStagePayload,
     options: { ttlMs: number },
@@ -181,6 +184,15 @@ export function buildOutboxRuntime({
     traceById: async (projectId, traceId) => {
       const protections = await getProtectionsDeduped(projectId);
       return traceService.getById(projectId, traceId, protections);
+    },
+    // ADR-032: persist-class side-effect sinks for the cadence stage's
+    // `dispatchTriggerAction`. Same wiring the inline reactor used before
+    // persist moved onto the outbox (see PipelineRegistry).
+    addToAnnotationQueue: async (params) => {
+      await createOrUpdateQueueItems({ ...params, prisma });
+    },
+    addToDataset: async (params) => {
+      await createManyDatasetRecords(params);
     },
     enqueueCadence: async (
       payload: CadenceStagePayload,

--- a/langwatch/src/server/event-sourcing/pipelineRegistry.ts
+++ b/langwatch/src/server/event-sourcing/pipelineRegistry.ts
@@ -14,10 +14,6 @@ import {
 } from "@ee/governance/reactors/governanceOcsfEventsSync.reactor";
 import type { PrismaClient } from "@prisma/client";
 import type { Cluster, Redis } from "ioredis";
-import { createOrUpdateQueueItems } from "~/server/api/routers/annotation";
-import { createManyDatasetRecords } from "~/server/api/routers/datasetRecord.utils";
-import { getProtectionsForProject } from "~/server/api/utils";
-import { TraceService } from "~/server/traces/trace.service";
 import { createLogger } from "~/utils/logger/server";
 import { queryBillableEventsTotal } from "../../../ee/billing/services/billableEventsQuery";
 import type { UsageReportingService } from "../../../ee/billing/services/usageReportingService";
@@ -67,7 +63,6 @@ import { createExperimentRunStateFoldStore } from "./pipelines/experiment-run-pr
 import { createExperimentRunEsSyncReactor } from "./pipelines/experiment-run-processing/reactors/experimentRunEsSync.reactor";
 import type { ExperimentRunStateRepository } from "./pipelines/experiment-run-processing/repositories/experimentRunState.repository";
 import type { ComputeExperimentRunMetricsCommandData } from "./pipelines/experiment-run-processing/schemas/commands";
-import type { TriggerActionDispatchDeps } from "./pipelines/shared/triggerActionDispatch";
 import {
   COMPUTE_METRICS_RETRY_DELAY_MS,
   ComputeRunMetricsCommand,
@@ -90,7 +85,6 @@ import { SUITE_RUN_PROJECTION_VERSIONS } from "./pipelines/suite-run-processing/
 import { createTraceProcessingPipeline } from "./pipelines/trace-processing/pipeline";
 import { LogRecordAppendStore } from "./pipelines/trace-processing/projections/logRecordStorage.store";
 import { MetricRecordAppendStore } from "./pipelines/trace-processing/projections/metricRecordStorage.store";
-import type { DerivedTraceEvent } from "./pipelines/trace-processing/projections/services/trace-events.derivation";
 import { SpanAppendStore } from "./pipelines/trace-processing/projections/spanStorage.store";
 import { TraceSummaryStore } from "./pipelines/trace-processing/projections/traceSummary.store";
 import { createClaudeCodeSpanSyncReactor } from "./pipelines/trace-processing/reactors/claudeCodeSpanSync.reactor";
@@ -209,10 +203,11 @@ export interface PipelineRegistryDeps {
   governanceOcsfEventsSync?: GovernanceOcsfEventsSyncReactorDeps;
   /**
    * Wired by the worker composition root (`presets.ts`) and `undefined`
-   * on the web process. When set, both trigger reactors route
-   * NOTIFY-class matches into the unified outbox queue's settle stage
-   * (ADR-030 + ADR-026) instead of inline-dispatching. Persist
-   * actions always run inline regardless.
+   * on the web process. When set, all four trigger reactors route their
+   * matches into the unified outbox queue's settle stage (ADR-030 +
+   * ADR-026 + ADR-032) — both NOTIFY (email / Slack) and PERSIST
+   * (dataset / annotation) classes now ride settle → cadence; nothing
+   * dispatches inline.
    */
   outbox?: OutboxRuntime;
   retentionPolicyResolver?: RetentionPolicyResolver;
@@ -235,44 +230,6 @@ export class PipelineRegistry {
     return new RedisCachedFoldStore<State>(inner, this.deps.redis as Redis, {
       keyPrefix,
     });
-  }
-
-  /**
-   * Wires the trace-loading + dataset/queue dispatcher trio shared by the
-   * trace-pipeline `alertTrigger` reactor and the evaluation-pipeline
-   * `evaluationAlertTrigger` reactor. Both consume the same shape, so
-   * keep the wiring in one place.
-   */
-  private buildTraceReactorContext(): Pick<
-    TriggerActionDispatchDeps,
-    "traceById" | "addToAnnotationQueue" | "addToDataset"
-  > & {
-    deriveEvents: (params: {
-      tenantId: string;
-      traceId: string;
-      occurredAtMs?: number;
-      foldVersion?: number;
-    }) => Promise<DerivedTraceEvent[]>;
-  } {
-    const traceReadDerivation = new TraceReadDerivationService(
-      this.deps.traces.spans,
-    );
-    return {
-      traceById: async (projectId, traceId) => {
-        const traceService = TraceService.create(this.deps.prisma);
-        const protections = await getProtectionsForProject(this.deps.prisma, {
-          projectId,
-        });
-        return traceService.getById(projectId, traceId, protections);
-      },
-      addToAnnotationQueue: async (params) => {
-        await createOrUpdateQueueItems({ ...params, prisma: this.deps.prisma });
-      },
-      addToDataset: async (params) => {
-        await createManyDatasetRecords(params);
-      },
-      deriveEvents: (params) => traceReadDerivation.deriveEvents(params),
-    };
   }
 
   registerAll() {
@@ -323,12 +280,14 @@ export class PipelineRegistry {
 
     const esSyncReactor = createEvaluationEsSyncReactor(this.deps.esSync);
 
+    // ADR-032: the persist branch is now an outbox reactor that only
+    // enqueues settle payloads. Filter evaluation + dispatch (traceById /
+    // addToDataset / addToAnnotationQueue) moved to the outbox dispatcher
+    // (see buildOutboxRuntime), so this reactor needs just the trigger
+    // service and the trace fold store for the enqueue breadcrumb.
     const evaluationAlertTriggerReactor = createEvaluationAlertTriggerReactor({
       triggers: this.deps.triggers,
-      projects: this.deps.projects,
       traceSummaryStore,
-      evaluationRuns: this.deps.evaluations.runs,
-      ...this.buildTraceReactorContext(),
     });
 
     const evaluationAlertTriggerNotifyOutboxReactor =
@@ -373,10 +332,12 @@ export class PipelineRegistry {
       evaluation: evalCommands.executeEvaluation,
     });
 
+    // ADR-032: the persist branch is now an outbox reactor that only
+    // enqueues settle payloads; dispatch deps live on the outbox
+    // dispatcher (see buildOutboxRuntime), so this reactor needs just the
+    // trigger service.
     const alertTriggerReactor = createAlertTriggerReactor({
       triggers: this.deps.triggers,
-      projects: this.deps.projects,
-      ...this.buildTraceReactorContext(),
     });
 
     const alertTriggerNotifyOutboxReactor =

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
@@ -16,7 +16,10 @@ export interface EvaluationProcessingPipelineDeps {
   evalRunStore: FoldProjectionStore<EvaluationRunData>;
   executeEvaluationCommand: ExecuteEvaluationCommand;
   esSyncReactor: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
-  evaluationAlertTriggerReactor: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
+  /** PERSIST-class branch of the evaluation alert trigger, routed
+   *  through the framework's `.withOutbox` plumbing (ADR-030 + ADR-032).
+   *  Emits settle payloads stamped `actionClass: "persist"`. */
+  evaluationAlertTriggerReactor: OutboxReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
   /** NOTIFY-class branch of the evaluation alert trigger, routed
    *  through the framework's `.withOutbox` plumbing (ADR-030). */
   evaluationAlertTriggerNotifyOutboxReactor: OutboxReactorDefinition<
@@ -46,7 +49,7 @@ export function createEvaluationProcessingPipeline(deps: EvaluationProcessingPip
       store: deps.evalRunStore,
     }))
     .withReactor("evaluationRun", "evaluationEsSync", deps.esSyncReactor)
-    .withReactor(
+    .withOutbox(
       "evaluationRun",
       "evaluationAlertTrigger",
       deps.evaluationAlertTriggerReactor,

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/pipeline.ts
@@ -4,9 +4,9 @@ import type { OutboxReactorDefinition } from "../../outbox/outboxReactor.types";
 import type { FoldProjectionStore } from "../../projections/foldProjection.types";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
 import {
-  StartEvaluationCommand,
   CompleteEvaluationCommand,
   ReportEvaluationCommand,
+  StartEvaluationCommand,
 } from "./commands";
 import { ExecuteEvaluationCommand } from "./commands/executeEvaluation.command";
 import { EvaluationRunFoldProjection } from "./projections/evaluationRun.foldProjection";
@@ -15,18 +15,27 @@ import type { EvaluationProcessingEvent } from "./schemas/events";
 export interface EvaluationProcessingPipelineDeps {
   evalRunStore: FoldProjectionStore<EvaluationRunData>;
   executeEvaluationCommand: ExecuteEvaluationCommand;
-  esSyncReactor: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
+  esSyncReactor: ReactorDefinition<
+    EvaluationProcessingEvent,
+    EvaluationRunData
+  >;
   /** PERSIST-class branch of the evaluation alert trigger, routed
    *  through the framework's `.withOutbox` plumbing (ADR-030 + ADR-032).
    *  Emits settle payloads stamped `actionClass: "persist"`. */
-  evaluationAlertTriggerReactor: OutboxReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
+  evaluationAlertTriggerReactor: OutboxReactorDefinition<
+    EvaluationProcessingEvent,
+    EvaluationRunData
+  >;
   /** NOTIFY-class branch of the evaluation alert trigger, routed
    *  through the framework's `.withOutbox` plumbing (ADR-030). */
   evaluationAlertTriggerNotifyOutboxReactor: OutboxReactorDefinition<
     EvaluationProcessingEvent,
     EvaluationRunData
   >;
-  customerIoEvaluationSyncReactor?: ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData>;
+  customerIoEvaluationSyncReactor?: ReactorDefinition<
+    EvaluationProcessingEvent,
+    EvaluationRunData
+  >;
 }
 
 /**
@@ -41,13 +50,18 @@ export interface EvaluationProcessingPipelineDeps {
  * - startEvaluation: Records eval start to CH (API handler path)
  * - completeEvaluation: Records eval result to CH (API handler path)
  */
-export function createEvaluationProcessingPipeline(deps: EvaluationProcessingPipelineDeps) {
+export function createEvaluationProcessingPipeline(
+  deps: EvaluationProcessingPipelineDeps,
+) {
   let builder = definePipeline<EvaluationProcessingEvent>()
     .withName("evaluation_processing")
     .withAggregateType("evaluation")
-    .withFoldProjection("evaluationRun", new EvaluationRunFoldProjection({
-      store: deps.evalRunStore,
-    }))
+    .withFoldProjection(
+      "evaluationRun",
+      new EvaluationRunFoldProjection({
+        store: deps.evalRunStore,
+      }),
+    )
     .withReactor("evaluationRun", "evaluationEsSync", deps.esSyncReactor)
     .withOutbox(
       "evaluationRun",
@@ -69,13 +83,18 @@ export function createEvaluationProcessingPipeline(deps: EvaluationProcessingPip
   }
 
   return builder
-    .withCommandInstance("executeEvaluation", ExecuteEvaluationCommand, deps.executeEvaluationCommand, {
-      delay: 30_000,
-      deduplication: {
-        makeId: ExecuteEvaluationCommand.makeJobId,
-        ttlMs: 30_000,
+    .withCommandInstance(
+      "executeEvaluation",
+      ExecuteEvaluationCommand,
+      deps.executeEvaluationCommand,
+      {
+        delay: 30_000,
+        deduplication: {
+          makeId: ExecuteEvaluationCommand.makeJobId,
+          ttlMs: 30_000,
+        },
       },
-    })
+    )
     .withCommand("startEvaluation", StartEvaluationCommand)
     .withCommand("completeEvaluation", CompleteEvaluationCommand)
     .withCommand("reportEvaluation", ReportEvaluationCommand)

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/evaluationAlertTrigger.reactor.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/__tests__/evaluationAlertTrigger.reactor.unit.test.ts
@@ -3,8 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EvaluationRunData } from "~/server/app-layer/evaluations/types";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
 import type { TriggerSummary } from "~/server/app-layer/triggers/repositories/trigger.repository";
-import { DispatchError } from "~/server/event-sourcing/outbox/dispatchError";
-import { captureException } from "~/utils/posthogErrorCapture";
 import type { ReactorContext } from "../../../../reactors/reactor.types";
 import type { EvaluationProcessingEvent } from "../../schemas/events";
 import {
@@ -19,23 +17,6 @@ vi.mock("~/utils/logger/server", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   }),
-}));
-
-vi.mock("~/utils/posthogErrorCapture", () => ({
-  captureException: vi.fn(),
-  toError: vi.fn((e) => (e instanceof Error ? e : new Error(String(e)))),
-}));
-
-// Heavy I/O bound dependencies pulled in transitively via dispatchTriggerAction
-// (email render + SES, Slack webhook, dataset row mapping). They throw on any
-// unconfigured env in CI, which would short-circuit dispatch before
-// `updateLastRunAt`. Stub them out so dispatch can complete its bookkeeping.
-vi.mock("~/server/mailer/triggerEmail", () => ({
-  sendTriggerEmail: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock("~/server/triggers/sendSlackWebhook", () => ({
-  sendSlackWebhook: vi.fn().mockResolvedValue(undefined),
 }));
 
 function createEvalFoldState(
@@ -126,20 +107,18 @@ function createEvent(
 function createTrigger(
   overrides: Partial<TriggerSummary> = {},
 ): TriggerSummary {
-  // Default to ADD_TO_ANNOTATION_QUEUE (persist-class with a one-step
-  // dispatch path) so these tests exercise the inline-dispatch path the
-  // reactor now owns. NOTIFY-class actions (SEND_EMAIL /
-  // SEND_SLACK_MESSAGE) are dispatched through the
-  // `.withOutbox`-registered evaluationAlertTriggerNotifyOutbox reactor
-  // — see `evaluationAlertTriggerNotifyOutbox.reactor.unit.test.ts`.
+  // Default to ADD_TO_DATASET (persist-class) so these tests exercise
+  // the persist branch this reactor now owns. NOTIFY-class actions
+  // (SEND_EMAIL / SEND_SLACK_MESSAGE) flow through the
+  // evaluationAlertTriggerNotifyOutbox reactor.
   return {
     id: "trigger-1",
     projectId: "tenant-1",
     name: "Quality Alert",
-    action: TriggerAction.ADD_TO_ANNOTATION_QUEUE,
+    action: TriggerAction.ADD_TO_DATASET,
     actionParams: {
-      annotators: [{ id: "annotator-1", name: "Ops" }],
-      createdByUserId: "user-1",
+      datasetId: "dataset-1",
+      datasetMapping: { mapping: {}, expansions: [] },
     },
     filters: {
       "evaluations.passed": { "evaluator-1": ["true"] },
@@ -159,38 +138,28 @@ function createTrigger(
   };
 }
 
+function createContext(
+  foldState: EvaluationRunData = createEvalFoldState(),
+): ReactorContext<EvaluationRunData> {
+  return { tenantId: "tenant-1", aggregateId: "eval-1", foldState };
+}
+
 function createDeps(
   overrides: Partial<EvaluationAlertTriggerReactorDeps> = {},
 ): EvaluationAlertTriggerReactorDeps {
   return {
     triggers: {
       getActiveTraceTriggersForProject: vi.fn().mockResolvedValue([]),
-      claimSend: vi.fn().mockResolvedValue(true),
-      updateLastRunAt: vi.fn().mockResolvedValue(undefined),
-      invalidate: vi.fn(),
-    } as any,
-    projects: {
-      getById: vi.fn().mockResolvedValue({
-        id: "tenant-1",
-        slug: "test-project",
-      }),
     } as any,
     traceSummaryStore: {
       get: vi.fn().mockResolvedValue(createTraceSummary()),
       store: vi.fn(),
     },
-    evaluationRuns: {
-      findByTraceId: vi.fn().mockResolvedValue([]),
-    } as any,
-    traceById: vi.fn().mockResolvedValue(undefined),
-    addToAnnotationQueue: vi.fn().mockResolvedValue(undefined),
-    addToDataset: vi.fn().mockResolvedValue(undefined),
-    deriveEvents: vi.fn().mockResolvedValue([]),
     ...overrides,
   };
 }
 
-describe("evaluationAlertTrigger reactor", () => {
+describe("evaluationAlertTrigger reactor (persist outbox)", () => {
   let deps: EvaluationAlertTriggerReactorDeps;
 
   beforeEach(() => {
@@ -199,17 +168,14 @@ describe("evaluationAlertTrigger reactor", () => {
   });
 
   describe("when event is not a terminal evaluation event", () => {
-    it("skips non-completion events", async () => {
+    it("emits nothing and never fetches triggers", async () => {
       const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent({ type: "lw.evaluation.scheduled" });
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
+      const requests = await reactor.decide(
+        createEvent({ type: "lw.evaluation.scheduled" }),
+        createContext(),
+      );
 
-      await reactor.handle(event, context);
-
+      expect(requests).toHaveLength(0);
       expect(
         deps.triggers.getActiveTraceTriggersForProject,
       ).not.toHaveBeenCalled();
@@ -217,17 +183,14 @@ describe("evaluationAlertTrigger reactor", () => {
   });
 
   describe("when evaluation has no traceId", () => {
-    it("skips processing", async () => {
+    it("emits nothing", async () => {
       const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState({ traceId: null }),
-      };
+      const requests = await reactor.decide(
+        createEvent(),
+        createContext(createEvalFoldState({ traceId: null })),
+      );
 
-      await reactor.handle(event, context);
-
+      expect(requests).toHaveLength(0);
       expect(
         deps.triggers.getActiveTraceTriggersForProject,
       ).not.toHaveBeenCalled();
@@ -235,17 +198,14 @@ describe("evaluationAlertTrigger reactor", () => {
   });
 
   describe("when evaluation is still in progress", () => {
-    it("skips processing", async () => {
+    it("emits nothing", async () => {
       const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState({ status: "in_progress" }),
-      };
+      const requests = await reactor.decide(
+        createEvent(),
+        createContext(createEvalFoldState({ status: "in_progress" })),
+      );
 
-      await reactor.handle(event, context);
-
+      expect(requests).toHaveLength(0);
       expect(
         deps.triggers.getActiveTraceTriggersForProject,
       ).not.toHaveBeenCalled();
@@ -253,19 +213,14 @@ describe("evaluationAlertTrigger reactor", () => {
   });
 
   describe("when event is old (resyncing)", () => {
-    it("skips processing", async () => {
+    it("emits nothing", async () => {
       const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent({
-        occurredAt: Date.now() - 2 * 60 * 60 * 1000,
-      });
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
+      const requests = await reactor.decide(
+        createEvent({ occurredAt: Date.now() - 2 * 60 * 60 * 1000 }),
+        createContext(),
+      );
 
-      await reactor.handle(event, context);
-
+      expect(requests).toHaveLength(0);
       expect(
         deps.triggers.getActiveTraceTriggersForProject,
       ).not.toHaveBeenCalled();
@@ -273,7 +228,7 @@ describe("evaluationAlertTrigger reactor", () => {
   });
 
   describe("when no triggers have evaluation filters", () => {
-    it("skips without querying evaluations", async () => {
+    it("emits nothing without reading the trace fold", async () => {
       const trigger = createTrigger({
         filters: { "traces.origin": ["application"] },
       });
@@ -282,22 +237,34 @@ describe("evaluationAlertTrigger reactor", () => {
       );
 
       const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
+      const requests = await reactor.decide(createEvent(), createContext());
 
-      await reactor.handle(event, context);
-
+      expect(requests).toHaveLength(0);
       expect(deps.traceSummaryStore.get).not.toHaveBeenCalled();
-      expect(deps.evaluationRuns.findByTraceId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the only eval-filter triggers are notify-class", () => {
+    it("emits nothing (the notify outbox reactor owns them)", async () => {
+      const trigger = createTrigger({
+        action: TriggerAction.SEND_EMAIL,
+        actionParams: { members: ["ops@example.com"] },
+      });
+      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
+        [trigger],
+      );
+
+      const reactor = createEvaluationAlertTriggerReactor(deps);
+      const requests = await reactor.decide(createEvent(), createContext());
+
+      expect(requests).toHaveLength(0);
+      // Pre-filter short-circuits before the cross-pipeline fold read.
+      expect(deps.traceSummaryStore.get).not.toHaveBeenCalled();
     });
   });
 
   describe("when trace summary is not found", () => {
-    it("skips processing", async () => {
+    it("emits nothing", async () => {
       const trigger = createTrigger();
       (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
         [trigger],
@@ -305,370 +272,107 @@ describe("evaluationAlertTrigger reactor", () => {
       (deps.traceSummaryStore.get as any).mockResolvedValue(null);
 
       const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
+      const requests = await reactor.decide(createEvent(), createContext());
 
-      await reactor.handle(event, context);
-
-      expect(deps.triggers.claimSend).not.toHaveBeenCalled();
+      expect(requests).toHaveLength(0);
     });
   });
 
-  describe("when evaluation filters match", () => {
-    it("dispatches trigger action and records sent", async () => {
-      const trigger = createTrigger({
-        filters: {
-          "evaluations.passed": { "evaluator-1": ["true"] },
-        },
+  describe("given an active persist-class eval-filter trigger", () => {
+    describe("when the reactor decides on a completed event", () => {
+      it("emits a settle request stamped actionClass=persist with the debounce TTL and fold breadcrumb", async () => {
+        const trigger = createTrigger({ traceDebounceMs: 45_000 });
+        (
+          deps.triggers.getActiveTraceTriggersForProject as any
+        ).mockResolvedValue([trigger]);
+
+        const reactor = createEvaluationAlertTriggerReactor(deps);
+        const requests = await reactor.decide(createEvent(), createContext());
+
+        expect(requests).toHaveLength(1);
+        const [request] = requests;
+        expect(request!.dedupKey).toBe("tenant-1/trigger-1:trace:trace-1");
+        expect(request!.groupKey).toBe("tenant-1/triggerNotify:trigger-1");
+        expect(request!.enqueueOptions).toEqual({ ttlMs: 45_000 });
+        const payload = request!.payload as unknown as {
+          stage: string;
+          actionClass: string;
+          traceId: string;
+          foldSnapshotAtEnqueue: {
+            computedInput: string;
+            computedOutput: string;
+          };
+        };
+        expect(payload.stage).toBe("settle");
+        expect(payload.actionClass).toBe("persist");
+        expect(payload.traceId).toBe("trace-1");
+        expect(payload.foldSnapshotAtEnqueue).toEqual({
+          computedInput: "test input",
+          computedOutput: "test output",
+        });
       });
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
+    });
 
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
+    describe("when the reactor decides on a reported event", () => {
+      it("emits a settle request the same as for a completed event", async () => {
+        const trigger = createTrigger();
+        (
+          deps.triggers.getActiveTraceTriggersForProject as any
+        ).mockResolvedValue([trigger]);
 
-      await reactor.handle(event, context);
+        const reactor = createEvaluationAlertTriggerReactor(deps);
+        const requests = await reactor.decide(
+          createEvent({ type: "lw.evaluation.reported" }),
+          createContext(),
+        );
 
-      expect(deps.triggers.claimSend).toHaveBeenCalledWith({
-        triggerId: "trigger-1",
-        traceId: "trace-1",
-        projectId: "tenant-1",
+        expect(requests).toHaveLength(1);
+        expect(
+          (requests[0]!.payload as unknown as { actionClass: string })
+            .actionClass,
+        ).toBe("persist");
       });
-      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
-        "trigger-1",
-        "tenant-1",
-      );
     });
-  });
 
-  describe("when evaluation filters do not match", () => {
-    it("does not dispatch action", async () => {
-      const trigger = createTrigger({
-        filters: {
-          "evaluations.passed": { "evaluator-1": ["true"] },
-        },
+    describe("when the reactor decides", () => {
+      it("does not load evaluations or derive events itself (the settle stage re-reads + filters)", async () => {
+        const trigger = createTrigger({
+          filters: {
+            "events.event_type": ["thumbs_up_down"],
+            "evaluations.passed": { "evaluator-1": ["true"] },
+          },
+        });
+        (
+          deps.triggers.getActiveTraceTriggersForProject as any
+        ).mockResolvedValue([trigger]);
+
+        const reactor = createEvaluationAlertTriggerReactor(deps);
+        const requests = await reactor.decide(createEvent(), createContext());
+
+        // The reactor only enqueues; the settle dispatcher loads
+        // evaluations + derives events against the settled state. The
+        // reactor's only cross-pipeline read is the fold breadcrumb.
+        expect(requests).toHaveLength(1);
+        expect(deps.traceSummaryStore.get).toHaveBeenCalledTimes(1);
       });
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: false }),
-      ]);
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(event, context);
-
-      expect(deps.triggers.claimSend).not.toHaveBeenCalled();
     });
   });
 
-  describe("when trace filters do not match", () => {
-    it("does not dispatch action even if evaluation filters match", async () => {
-      const trigger = createTrigger({
-        filters: {
-          "traces.origin": ["playground"],
-          "evaluations.passed": { "evaluator-1": ["true"] },
-        },
-      });
+  describe("given several persist eval-filter triggers on the same trace", () => {
+    it("emits one settle request per trigger", async () => {
+      const a = createTrigger({ id: "trig-a", traceDebounceMs: 30_000 });
+      const b = createTrigger({ id: "trig-b", traceDebounceMs: 60_000 });
       (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
-      // Trace has origin "application", trigger wants "playground"
-      (deps.traceSummaryStore.get as any).mockResolvedValue(
-        createTraceSummary({
-          attributes: { "langwatch.origin": "application" },
-        }),
+        [a, b],
       );
 
       const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
+      const requests = await reactor.decide(createEvent(), createContext());
 
-      await reactor.handle(event, context);
-
-      expect(deps.triggers.claimSend).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("when a trigger filters on event fields", () => {
-    it("derives events from stored_spans and matches against them", async () => {
-      const trigger = createTrigger({
-        filters: {
-          "events.event_type": ["thumbs_up_down"],
-          "evaluations.passed": { "evaluator-1": ["true"] },
-        },
-      });
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
+      expect(requests).toHaveLength(2);
+      expect(requests.map((r) => r.enqueueOptions?.ttlMs)).toEqual([
+        30_000, 60_000,
       ]);
-      (deps.deriveEvents as any).mockResolvedValue([
-        {
-          spanId: "span-1",
-          timestamp: 1700,
-          name: "thumbs_up_down",
-          attributes: {},
-        },
-      ]);
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(event, context);
-
-      expect(deps.deriveEvents).toHaveBeenCalledWith(
-        expect.objectContaining({ tenantId: "tenant-1", traceId: "trace-1" }),
-      );
-      expect(deps.triggers.claimSend).toHaveBeenCalled();
-    });
-  });
-
-  describe("when no trigger filters on event fields", () => {
-    it("does not derive events", async () => {
-      const trigger = createTrigger({
-        filters: {
-          "evaluations.passed": { "evaluator-1": ["true"] },
-        },
-      });
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(event, context);
-
-      expect(deps.deriveEvents).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("when trigger was already sent for this trace", () => {
-    it("skips dispatch (dedup)", async () => {
-      const trigger = createTrigger();
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.triggers.claimSend as any).mockResolvedValue(false);
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(event, context);
-
-      // claim attempted but lost the race → no dispatch, no lastRunAt update.
-      expect(deps.triggers.claimSend).toHaveBeenCalled();
-      expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("when handling reported events", () => {
-    it("processes reported events the same as completed", async () => {
-      const trigger = createTrigger();
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent({ type: "lw.evaluation.reported" });
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(event, context);
-
-      expect(deps.triggers.claimSend).toHaveBeenCalled();
-      expect(deps.triggers.updateLastRunAt).toHaveBeenCalled();
-    });
-  });
-
-  describe("when a trigger's dispatch fails", () => {
-    it("surfaces the failure with its retryable flag and does not record the trigger as run", async () => {
-      const trigger = createTrigger();
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
-      (deps.addToAnnotationQueue as any).mockRejectedValueOnce(
-        new DispatchError({ message: "provider 500", retryable: true }),
-      );
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(createEvent(), context);
-
-      expect(deps.triggers.claimSend).toHaveBeenCalled();
-      expect(deps.triggers.updateLastRunAt).not.toHaveBeenCalled();
-      expect(captureException).toHaveBeenCalledWith(
-        expect.any(DispatchError),
-        expect.objectContaining({
-          extra: expect.objectContaining({ retryable: true }),
-        }),
-      );
-    });
-  });
-
-  describe("when one of several matching triggers fails to dispatch", () => {
-    it("still dispatches the remaining triggers", async () => {
-      const failing = createTrigger({ id: "trigger-failing" });
-      const succeeding = createTrigger({ id: "trigger-ok" });
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [failing, succeeding],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
-      (deps.addToAnnotationQueue as any)
-        .mockRejectedValueOnce(
-          new DispatchError({ message: "revoked", retryable: false }),
-        )
-        .mockResolvedValueOnce(undefined);
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(createEvent(), context);
-
-      expect(deps.triggers.claimSend).toHaveBeenCalledTimes(2);
-      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledTimes(1);
-      expect(deps.triggers.updateLastRunAt).toHaveBeenCalledWith(
-        "trigger-ok",
-        "tenant-1",
-      );
-    });
-  });
-
-  // #4903 (#4805): a trace-event metric condition (thumbs-down vote = -1)
-  // combined with an evaluation filter must fail closed when the event half
-  // is unmet — the matcher previously skipped events.metrics.value and the
-  // all-skipped filter set matched every trace.
-  describe("when an evaluation filter is combined with an unmet event condition", () => {
-    it("does not dispatch when the events.metrics.value condition is not satisfied", async () => {
-      const trigger = createTrigger({
-        filters: {
-          "events.metrics.value": { thumbs_up_down: { vote: ["-1", "-1"] } },
-          "evaluations.passed": { "evaluator-1": ["true"] },
-        },
-      });
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      // Evaluation half is satisfied...
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
-      // ...but the trace has no down-vote, so the event condition is unmet.
-      (deps.deriveEvents as any).mockResolvedValue([]);
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(event, context);
-
-      expect(deps.deriveEvents).toHaveBeenCalled();
-      expect(deps.triggers.claimSend).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("when both trace and evaluation filters match", () => {
-    it("dispatches trigger action for mixed filter triggers", async () => {
-      const trigger = createTrigger({
-        filters: {
-          "traces.origin": ["application"],
-          "spans.model": ["gpt-5-mini"],
-          "evaluations.passed": { "evaluator-1": ["true"] },
-        },
-      });
-      (deps.triggers.getActiveTraceTriggersForProject as any).mockResolvedValue(
-        [trigger],
-      );
-      (deps.evaluationRuns.findByTraceId as any).mockResolvedValue([
-        createEvalFoldState({ evaluatorId: "evaluator-1", passed: true }),
-      ]);
-
-      const reactor = createEvaluationAlertTriggerReactor(deps);
-      const event = createEvent();
-      const context: ReactorContext<EvaluationRunData> = {
-        tenantId: "tenant-1",
-        aggregateId: "eval-1",
-        foldState: createEvalFoldState(),
-      };
-
-      await reactor.handle(event, context);
-
-      expect(deps.triggers.claimSend).toHaveBeenCalled();
-      expect(deps.triggers.updateLastRunAt).toHaveBeenCalled();
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTrigger.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTrigger.reactor.ts
@@ -1,28 +1,22 @@
-import type { EvaluationRunService } from "~/server/app-layer/evaluations/evaluation-run.service";
 import type { EvaluationRunData } from "~/server/app-layer/evaluations/types";
 import type { TraceSummaryData } from "~/server/app-layer/traces/types";
-import type { DerivedTraceEvent } from "~/server/event-sourcing/pipelines/trace-processing/projections/services/trace-events.derivation";
-import {
-  buildPreconditionTraceDataFromFoldState,
-  classifyTriggerFilters,
-  matchesEvaluationFilters,
-  matchesTriggerFilters,
-  triggerFiltersReferenceEvents,
-} from "~/server/filters/triggerFilter.matcher";
+import type { TriggerService } from "~/server/app-layer/triggers/trigger.service";
+import { classifyTriggerFilters } from "~/server/filters/triggerFilter.matcher";
 import { createLogger } from "~/utils/logger/server";
-import { captureException, toError } from "~/utils/posthogErrorCapture";
 import { createTenantId } from "../../../domain/tenantId";
-import { isDispatchError } from "../../../outbox/dispatchError";
-import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
 import type {
-  ReactorContext,
-  ReactorDefinition,
-} from "../../../reactors/reactor.types";
+  OutboxEnqueueRequest,
+  OutboxReactorDefinition,
+} from "../../../outbox/outboxReactor.types";
 import {
-  dispatchTriggerAction,
-  NOTIFY_TRIGGER_ACTIONS,
-  type TriggerActionDispatchDeps,
-} from "../../shared/triggerActionDispatch";
+  auditDedupKey,
+  cadenceGroupKey,
+  type SettleStagePayload,
+  TRIGGER_NOTIFY_REACTOR_NAME,
+} from "../../../outbox/payload";
+import type { FoldProjectionStore } from "../../../projections/foldProjection.types";
+import type { ReactorContext } from "../../../reactors/reactor.types";
+import { NOTIFY_TRIGGER_ACTIONS } from "../../shared/triggerActionDispatch";
 import type { EvaluationProcessingEvent } from "../schemas/events";
 import {
   isEvaluationCompletedEvent,
@@ -33,36 +27,37 @@ const logger = createLogger(
   "langwatch:evaluation-processing:evaluation-alert-trigger-reactor",
 );
 
-export interface EvaluationAlertTriggerReactorDeps
-  extends TriggerActionDispatchDeps {
+export interface EvaluationAlertTriggerReactorDeps {
+  triggers: TriggerService;
   traceSummaryStore: FoldProjectionStore<TraceSummaryData>;
-  evaluationRuns: EvaluationRunService;
-  /**
-   * Derives the trace-level events list from stored_spans. Only invoked when a
-   * trigger actually filters on event fields, so the common path pays nothing.
-   */
-  deriveEvents: (params: {
-    tenantId: string;
-    traceId: string;
-    occurredAtMs?: number;
-    foldVersion?: number;
-  }) => Promise<DerivedTraceEvent[]>;
 }
 
 /**
- * Persist-class branch of the evaluation-pipeline alert trigger reactor.
+ * Persist-class branch of the evaluation-pipeline alert trigger reactor,
+ * registered via `.withOutbox` (ADR-030 + ADR-032).
  *
- * Fires after a terminal evaluation event. For triggers with evaluation
- * filters whose action is PERSIST (dataset write, annotation queue add),
- * cross-reads the trace fold, loads all evaluations for the trace,
- * matches both filter halves, claims `TriggerSent`, and dispatches
- * inline. NOTIFY-class triggers with evaluation filters are owned by
- * `evaluationAlertTriggerNotifyOutbox.reactor.ts`, registered via
- * `.withOutbox` so dispatch flows through the settle/cadence outbox.
+ * Fires after a terminal evaluation event. For every active trigger
+ * with evaluation filters whose action is PERSIST (dataset write,
+ * annotation-queue add), emits an `OutboxEnqueueRequest` with a
+ * settle-stage payload stamped `actionClass: "persist"`. The settle
+ * dispatcher re-reads BOTH the trace fold AND the evaluation results
+ * after `traceDebounceMs`, matches both filter halves, and (on match)
+ * re-enqueues an immediate cadence that claims `TriggerSent` and runs
+ * `dispatchTriggerAction`.
+ *
+ * Before ADR-032 this reactor dispatched persist actions inline against
+ * the (possibly half-formed) fold. It now rides the same settle/cadence
+ * outbox as the notify class, so the expensive cross-pipeline evaluation
+ * load + events derivation is deferred to the settle dispatcher and
+ * skipped here.
+ *
+ * NOTIFY-class triggers with evaluation filters are owned by
+ * `evaluationAlertTriggerNotifyOutbox.reactor.ts`; this reactor only
+ * emits the persist class.
  */
 export function createEvaluationAlertTriggerReactor(
   deps: EvaluationAlertTriggerReactorDeps,
-): ReactorDefinition<EvaluationProcessingEvent, EvaluationRunData> {
+): OutboxReactorDefinition<EvaluationProcessingEvent, EvaluationRunData> {
   return {
     name: "evaluationAlertTrigger",
     options: {
@@ -72,16 +67,16 @@ export function createEvaluationAlertTriggerReactor(
       delay: 10_000,
     },
 
-    async handle(
+    async decide(
       event: EvaluationProcessingEvent,
       context: ReactorContext<EvaluationRunData>,
-    ): Promise<void> {
+    ): Promise<OutboxEnqueueRequest[]> {
       // Only fire on terminal evaluation events
       if (
         !isEvaluationCompletedEvent(event) &&
         !isEvaluationReportedEvent(event)
       ) {
-        return;
+        return [];
       }
 
       const { tenantId, foldState: evalRun } = context;
@@ -92,137 +87,81 @@ export function createEvaluationAlertTriggerReactor(
         evalRun.status !== "error" &&
         evalRun.status !== "skipped"
       ) {
-        return;
+        return [];
       }
 
       // Guard: must have a traceId to check trace filters and dispatch actions
-      if (!evalRun.traceId) return;
+      if (!evalRun.traceId) return [];
 
       const traceId = evalRun.traceId;
 
       // Guard: skip old evaluations (resyncing)
-      if (event.occurredAt < Date.now() - 60 * 60 * 1000) return;
+      if (event.occurredAt < Date.now() - 60 * 60 * 1000) return [];
 
       const triggers =
         await deps.triggers.getActiveTraceTriggersForProject(tenantId);
-      if (triggers.length === 0) return;
+      if (triggers.length === 0) return [];
 
       // Restrict to persist-class triggers with evaluation filters.
       // NOTIFY-class triggers with evaluation filters are owned by
       // `evaluationAlertTriggerNotifyOutbox.reactor.ts`. Pre-filtering
-      // here also skips the expensive cross-pipeline fold + evaluation
-      // load + events derivation when the only matching triggers are
-      // notify-class.
-      const inlineBound = triggers.filter((t) => {
+      // here skips the cross-pipeline fold read when the only matching
+      // triggers are notify-class.
+      const candidates = triggers.filter((t) => {
         const { hasEvaluationFilters } = classifyTriggerFilters(t.filters);
         return hasEvaluationFilters && !NOTIFY_TRIGGER_ACTIONS.has(t.action);
       });
-      if (inlineBound.length === 0) return;
+      if (candidates.length === 0) return [];
 
-      // Cross-pipeline read: get the trace fold state.
+      // Cross-pipeline read: settle re-reads the fold itself, but we
+      // need foldSnapshotAtEnqueue for the debugging breadcrumb. A
+      // missing fold short-circuits — no payload to enqueue.
       const brandedTenantId = createTenantId(tenantId);
       const traceSummary = await deps.traceSummaryStore.get(traceId, {
         tenantId: brandedTenantId,
         aggregateId: traceId,
       });
-
       if (!traceSummary) {
         logger.debug(
           { tenantId, traceId, evaluationId: evalRun.evaluationId },
           "Trace summary not found for evaluation alert trigger",
         );
-        return;
+        return [];
       }
 
-      // Load all evaluations for this trace (inline path only)
-      const allEvaluations = await deps.evaluationRuns.findByTraceId(
-        tenantId,
-        traceId,
-      );
-
-      // Derive the trace-level events list only if one of these triggers filters
-      // on event fields (the trace-level half of its filter set).
-      const needsEvents = inlineBound.some((t) =>
-        triggerFiltersReferenceEvents(classifyTriggerFilters(t.filters).traceFilters),
-      );
-      const events = needsEvents
-        ? await deps.deriveEvents({
-            tenantId,
-            traceId,
-            occurredAtMs: traceSummary.occurredAt,
-            foldVersion: traceSummary.spanCount,
-          })
-        : null;
-
-      const traceData = buildPreconditionTraceDataFromFoldState(
-        traceSummary,
-        events,
-      );
-
-      for (const trigger of inlineBound) {
-        try {
-          const { traceFilters, evaluationFilters } =
-            classifyTriggerFilters(trigger.filters);
-
-          // Check trace-level filters first (cheaper)
-          if (
-            Object.keys(traceFilters).length > 0 &&
-            !matchesTriggerFilters(traceData, traceFilters)
-          ) {
-            continue;
-          }
-
-          // Check evaluation filters against all evaluations for this trace
-          if (!matchesEvaluationFilters(allEvaluations, evaluationFilters)) {
-            continue;
-          }
-
-          // Atomic claim: see alertTrigger.reactor.ts for rationale.
-          const claimed = await deps.triggers.claimSend({
+      const requests: OutboxEnqueueRequest[] = [];
+      for (const trigger of candidates) {
+        const payload: SettleStagePayload = {
+          stage: "settle",
+          projectId: tenantId,
+          triggerId: trigger.id,
+          traceId,
+          reactorName: TRIGGER_NOTIFY_REACTOR_NAME,
+          actionClass: "persist",
+          auditDedupKey: auditDedupKey({
+            projectId: tenantId,
             triggerId: trigger.id,
             traceId,
+          }),
+          foldSnapshotAtEnqueue: {
+            computedInput: traceSummary.computedInput ?? "",
+            computedOutput: traceSummary.computedOutput ?? "",
+          },
+        };
+        requests.push({
+          dedupKey: payload.auditDedupKey,
+          groupKey: cadenceGroupKey({
             projectId: tenantId,
-          });
-          if (!claimed) continue;
-
-          await dispatchTriggerAction({
-            deps,
-            trigger,
-            traceId,
-            tenantId,
-            foldState: traceSummary,
-          });
-        } catch (error) {
-          // A failed dispatch now throws (DispatchError) rather than being
-          // swallowed; surface its retryable classification for operators. The
-          // claim already landed, so the in-line path does not retry — the
-          // outbox migration is what adds durable retry.
-          const retryable = isDispatchError(error)
-            ? error.retryable
-            : undefined;
-          logger.error(
-            {
-              tenantId,
-              traceId,
-              triggerId: trigger.id,
-              evaluationId: evalRun.evaluationId,
-              retryable,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Failed to evaluate trigger on evaluation completion",
-          );
-          captureException(toError(error), {
-            extra: {
-              tenantId,
-              traceId,
-              triggerId: trigger.id,
-              evaluationId: evalRun.evaluationId,
-              triggerAction: trigger.action,
-              retryable,
-            },
-          });
-        }
+            triggerId: trigger.id,
+          }),
+          // SettleStagePayload is a Prisma-JSON-compatible object shape;
+          // the cast crosses the structural-vs-nominal gap between our
+          // `stage: "settle"` literal type and `Prisma.InputJsonValue`.
+          payload: payload as unknown as OutboxEnqueueRequest["payload"],
+          enqueueOptions: { ttlMs: trigger.traceDebounceMs },
+        });
       }
+      return requests;
     },
   };
 }

--- a/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTriggerNotifyOutbox.reactor.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/evaluation-processing/reactors/evaluationAlertTriggerNotifyOutbox.reactor.ts
@@ -41,9 +41,10 @@ export interface EvaluationAlertTriggerNotifyOutboxReactorDeps {
  * results after `traceDebounceMs`, so we deliberately skip the
  * expensive cross-pipeline evaluation load + events derivation here.
  *
- * Persist-class actions (ADD_TO_DATASET, etc.) stay in the inline
- * `evaluationAlertTrigger.reactor.ts` because they have no outbox
- * dispatcher.
+ * Persist-class actions (ADD_TO_DATASET, etc.) ride the same
+ * settle/cadence outbox via `evaluationAlertTrigger.reactor.ts`
+ * (ADR-032), stamped `actionClass: "persist"`; this reactor only emits
+ * the notify class.
  */
 export function createEvaluationAlertTriggerNotifyOutboxReactor(
   deps: EvaluationAlertTriggerNotifyOutboxReactorDeps,

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -5,7 +5,11 @@ import type { OutboxReactorDefinition } from "../../outbox/outboxReactor.types";
 import type { FoldProjectionStore } from "../../projections/foldProjection.types";
 import type { AppendStore } from "../../projections/mapProjection.types";
 import type { ReactorDefinition } from "../../reactors/reactor.types";
-import { AddAnnotationCommand, BulkSyncAnnotationsCommand, RemoveAnnotationCommand } from "./commands/annotationCommands";
+import {
+  AddAnnotationCommand,
+  BulkSyncAnnotationsCommand,
+  RemoveAnnotationCommand,
+} from "./commands/annotationCommands";
 import { AssignTopicCommand } from "./commands/assignTopicCommand";
 import { ChangeTraceNameCommand } from "./commands/changeTraceNameCommand";
 import { RecordLogCommand } from "./commands/recordLogCommand";
@@ -30,17 +34,38 @@ export interface TraceProcessingPipelineDeps {
   metricRecordAppendStore: AppendStore<NormalizedMetricRecord>;
   traceSummaryStore: FoldProjectionStore<TraceSummaryData>;
   originGateReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  evaluationTriggerReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  customEvaluationSyncReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  traceUpdateBroadcastReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  projectMetadataReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  simulationMetricsSyncReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  experimentMetricsSyncReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
+  evaluationTriggerReactor: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
+  customEvaluationSyncReactor: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
+  traceUpdateBroadcastReactor: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
+  projectMetadataReactor: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
+  simulationMetricsSyncReactor: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
+  experimentMetricsSyncReactor: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
   /** PERSIST-class branch of the alert trigger, routed through the
    *  framework's `.withOutbox` plumbing (ADR-030 + ADR-032). Emits settle
    *  payloads stamped `actionClass: "persist"`; the dispatcher's cadence
    *  stage runs `dispatchTriggerAction` for them. */
-  alertTriggerReactor: OutboxReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
+  alertTriggerReactor: OutboxReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
   /** NOTIFY-class branch of the alert trigger, routed through the
    *  framework's `.withOutbox` plumbing (ADR-030). Always provided;
    *  the framework adapter no-ops on process roles without an outbox
@@ -51,17 +76,32 @@ export interface TraceProcessingPipelineDeps {
   >;
   spanStorageBroadcastReactor: ReactorDefinition<TraceProcessingEvent>;
   claudeCodeSpanSyncReactor: ReactorDefinition<TraceProcessingEvent>;
-  customerIoTraceSyncReactor?: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  gatewayBudgetSyncReactor?: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
+  customerIoTraceSyncReactor?: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
+  gatewayBudgetSyncReactor?: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
   /**
    * ADR-022: BlobStore injected so RecordSpanCommand can reconstitute oversized
    * commands (fetch from S3 spool) and best-effort delete the spool after
    * event_log INSERT succeeds. Optional — without it, the spool path is disabled.
    */
   blobStore?: BlobStore;
-  governanceKpisSyncReactor?: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  retentionOrphanSweepReactor?: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  governanceOcsfEventsSyncReactor?: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
+  governanceKpisSyncReactor?: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
+  retentionOrphanSweepReactor?: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
+  governanceOcsfEventsSyncReactor?: ReactorDefinition<
+    TraceProcessingEvent,
+    TraceSummaryData
+  >;
 }
 
 /**
@@ -71,37 +111,79 @@ export interface TraceProcessingPipelineDeps {
  * It aggregates span events into trace summary metrics (fold projection) and writes
  * individual spans to the stored_spans table (map projection).
  */
-export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps) {
+export function createTraceProcessingPipeline(
+  deps: TraceProcessingPipelineDeps,
+) {
   let builder = definePipeline<TraceProcessingEvent>()
     .withName("trace_processing")
     .withAggregateType("trace")
-    .withFoldProjection("traceSummary", new TraceSummaryFoldProjection({
-      store: deps.traceSummaryStore,
-    }))
-    .withMapProjection("spanStorage", new SpanStorageMapProjection({
-      store: deps.spanAppendStore,
-    }))
-    .withMapProjection("logRecordStorage", new LogRecordStorageMapProjection({
-      store: deps.logRecordAppendStore,
-    }))
-    .withMapProjection("metricRecordStorage", new MetricRecordStorageMapProjection({
-      store: deps.metricRecordAppendStore,
-    }))
+    .withFoldProjection(
+      "traceSummary",
+      new TraceSummaryFoldProjection({
+        store: deps.traceSummaryStore,
+      }),
+    )
+    .withMapProjection(
+      "spanStorage",
+      new SpanStorageMapProjection({
+        store: deps.spanAppendStore,
+      }),
+    )
+    .withMapProjection(
+      "logRecordStorage",
+      new LogRecordStorageMapProjection({
+        store: deps.logRecordAppendStore,
+      }),
+    )
+    .withMapProjection(
+      "metricRecordStorage",
+      new MetricRecordStorageMapProjection({
+        store: deps.metricRecordAppendStore,
+      }),
+    )
     .withReactor("traceSummary", "originGate", deps.originGateReactor)
-    .withReactor("traceSummary", "evaluationTrigger", deps.evaluationTriggerReactor)
-    .withReactor("traceSummary", "customEvaluationSync", deps.customEvaluationSyncReactor)
-    .withReactor("traceSummary", "traceUpdateBroadcast", deps.traceUpdateBroadcastReactor)
+    .withReactor(
+      "traceSummary",
+      "evaluationTrigger",
+      deps.evaluationTriggerReactor,
+    )
+    .withReactor(
+      "traceSummary",
+      "customEvaluationSync",
+      deps.customEvaluationSyncReactor,
+    )
+    .withReactor(
+      "traceSummary",
+      "traceUpdateBroadcast",
+      deps.traceUpdateBroadcastReactor,
+    )
     .withReactor("traceSummary", "projectMetadata", deps.projectMetadataReactor)
-    .withReactor("traceSummary", "simulationMetricsSync", deps.simulationMetricsSyncReactor)
-    .withReactor("traceSummary", "experimentMetricsSync", deps.experimentMetricsSyncReactor)
+    .withReactor(
+      "traceSummary",
+      "simulationMetricsSync",
+      deps.simulationMetricsSyncReactor,
+    )
+    .withReactor(
+      "traceSummary",
+      "experimentMetricsSync",
+      deps.experimentMetricsSyncReactor,
+    )
     .withOutbox("traceSummary", "alertTrigger", deps.alertTriggerReactor)
     .withOutbox(
       "traceSummary",
       "alertTriggerNotifyOutbox",
       deps.alertTriggerNotifyOutboxReactor,
     )
-    .withReactor("spanStorage", "spanStorageBroadcast", deps.spanStorageBroadcastReactor)
-    .withReactor("logRecordStorage", "claudeCodeSpanSync", deps.claudeCodeSpanSyncReactor);
+    .withReactor(
+      "spanStorage",
+      "spanStorageBroadcast",
+      deps.spanStorageBroadcastReactor,
+    )
+    .withReactor(
+      "logRecordStorage",
+      "claudeCodeSpanSync",
+      deps.claudeCodeSpanSyncReactor,
+    );
 
   if (deps.customerIoTraceSyncReactor) {
     builder = builder.withReactor(

--- a/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/trace-processing/pipeline.ts
@@ -36,7 +36,11 @@ export interface TraceProcessingPipelineDeps {
   projectMetadataReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   simulationMetricsSyncReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   experimentMetricsSyncReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
-  alertTriggerReactor: ReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
+  /** PERSIST-class branch of the alert trigger, routed through the
+   *  framework's `.withOutbox` plumbing (ADR-030 + ADR-032). Emits settle
+   *  payloads stamped `actionClass: "persist"`; the dispatcher's cadence
+   *  stage runs `dispatchTriggerAction` for them. */
+  alertTriggerReactor: OutboxReactorDefinition<TraceProcessingEvent, TraceSummaryData>;
   /** NOTIFY-class branch of the alert trigger, routed through the
    *  framework's `.withOutbox` plumbing (ADR-030). Always provided;
    *  the framework adapter no-ops on process roles without an outbox
@@ -90,7 +94,7 @@ export function createTraceProcessingPipeline(deps: TraceProcessingPipelineDeps)
     .withReactor("traceSummary", "projectMetadata", deps.projectMetadataReactor)
     .withReactor("traceSummary", "simulationMetricsSync", deps.simulationMetricsSyncReactor)
     .withReactor("traceSummary", "experimentMetricsSync", deps.experimentMetricsSyncReactor)
-    .withReactor("traceSummary", "alertTrigger", deps.alertTriggerReactor)
+    .withOutbox("traceSummary", "alertTrigger", deps.alertTriggerReactor)
     .withOutbox(
       "traceSummary",
       "alertTriggerNotifyOutbox",


### PR DESCRIPTION
**Draft** — core dispatch change; persist-integration verified in CI only (local Docker was unavailable when this was written), so please let CI go green and give the claim-relocation a careful read before marking ready. Stacked on #4983 (base = `feat/trigger-render-diagnostics`).

Resolves the deferred CodeRabbit finding `alertTrigger.reactor.ts:54`.

## Problem

ADR-026 §"Half-formed persist" already says `ADD_TO_DATASET` snapshots the trace at dispatch time, so a row written on the first matching event is truncated relative to the trace UI a minute later — and that's why `traceDebounceMs` exists. But v1 wired debounce for **notify** only; **persist** stayed on the inline path (`alertTrigger.reactor.ts`), reasoning "idempotent at the `TriggerSent` gate." Idempotency prevents a *second* dispatch — not a truncated *first* one (ADR-026 line 44 says as much). So persist still captured half-formed folds.

## Change ([ADR-032](dev/docs/adr/032-persist-class-debounce.md))

Route persist through the same **settle → cadence** outbox path as notify:

- **Reactor** enqueues a settle payload (TTL = `traceDebounceMs`, `actionClass: "persist"`) instead of claiming + dispatching inline — mirroring the notify reactors. Shrinks to enqueue-only.
- **`handleSettle`** accepts persist: after the debounce window it re-reads the **settled** fold, evaluates filters against the complete state, and enqueues an **immediate** cadence (persist doesn't digest-batch).
- **`handleCadenceBatch`** dispatches persist via `dispatchTriggerAction`, writing the `TriggerSent` claim **after** a successful dispatch (retry-safe — matches notify; an early claim would let a transient failure suppress the re-dispatch and silently lose the row). Pre-dispatch `isSendClaimed` keeps at-most-once.
- Dispatcher gains the persist deps (`traceById` / `addToDataset` / `addToAnnotationQueue`); both stage handlers are now action-class-aware via an `actionClass` payload marker.

The claim **moves from the reactor to the cadence handler**, so at-most-once binds to the settled fold rather than the first half-formed one. Cross-pipeline dedup (trace vs eval reactor) stays safe — still a single atomic `TriggerSent` insert, just downstream — and persist side effects are row-idempotent.

## Trade-off

Persist now incurs the `traceDebounceMs` latency (default 30s) before the row lands — the intended completeness-over-immediacy trade, same as notify. No schema change.

## Test plan

- `pnpm test:unit` — **168 tests** across the outbox + reactor suites: persist reactor enqueues settle (not inline dispatch); settle→cadence→`dispatchTriggerAction`; no-match dispatches nothing; at-most-once across settle+cadence+replay; retry-safe claim-after-dispatch; **plus the full notify regression suite, green**.
- `pnpm typecheck` — clean.
- Integration (`triggerDispatch.fullflow` persist cases) runs in CI.


## Deployment Impact

- **Env vars / Helm values / schema:** none — persist dispatch reuses the existing outbox settle/cadence payloads; no new columns or config.
- **Default `helm install` (no overrides):** no install-time change.
- **Behaviour change:** persist-class trigger actions (ADD_TO_DATASET / ADD_TO_ANNOTATION_QUEUE) now wait the per-trigger `traceDebounceMs` (default 30s) before the row is written, so the captured trace is complete (completeness over immediacy) — same trade as notify.
- **BYOC dataplane:** none.
