### PR TITLE
fix(model-providers): preserve credentials and resolve org-scoped providers on edit-save

### DIFF
--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -163,6 +163,29 @@ export const EditModelProviderForm = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gatewayMenuEnabled, providerId]);
 
+  // The same expression the reset effect above uses — extracted so the
+  // Save button's dirty check has something to diff the live draft
+  // against. When the gateway flag is off we never render the section,
+  // so the empty draft is the only valid initial.
+  const initialAdvancedDraft = useMemo<ModelProviderAdvancedDraft>(() => {
+    if (!gatewayMenuEnabled) return EMPTY_ADVANCED_DRAFT;
+    return draftFromProvider({
+      rateLimitRpm:
+        (provider as { rateLimitRpm?: number | null }).rateLimitRpm ?? null,
+      rateLimitTpm:
+        (provider as { rateLimitTpm?: number | null }).rateLimitTpm ?? null,
+      rateLimitRpd:
+        (provider as { rateLimitRpd?: number | null }).rateLimitRpd ?? null,
+      fallbackPriorityGlobal:
+        (provider as { fallbackPriorityGlobal?: number | null })
+          .fallbackPriorityGlobal ?? null,
+      providerConfig: (provider as { providerConfig?: unknown })
+        .providerConfig,
+    });
+  }, [gatewayMenuEnabled, provider]);
+  const isAdvancedDirty =
+    JSON.stringify(advancedDraft) !== JSON.stringify(initialAdvancedDraft);
+
   // Controlled accordion state: collapsed by default, but expands
   // automatically when the user clicks Save with malformed JSON so the
   // inline error is actually visible.
@@ -213,7 +236,6 @@ export const EditModelProviderForm = ({
 
   const {
     validate: validateApiKey,
-    validateWithCustomUrl,
     isValidating: isValidatingApiKey,
     validationError: apiKeyValidationError,
     clearError: clearApiKeyError,
@@ -227,12 +249,6 @@ export const EditModelProviderForm = ({
     // Clear previous errors
     setFieldErrors({});
     clearApiKeyError();
-
-    // Get custom base URL if provided
-    const endpointKey = providerDefinition?.endpointKey;
-    const customBaseUrl = endpointKey
-      ? state.customKeys[endpointKey]?.trim() || undefined
-      : undefined;
 
     // Check if user entered a new API key
     const userEnteredNewApiKey = hasUserEnteredNewApiKey(state.customKeys);
@@ -265,21 +281,18 @@ export const EditModelProviderForm = ({
       }
     }
 
-    // Validate API key on save for LLM providers. Safety providers like
-    // azure_safety point at content moderation endpoints and can't be
-    // validated with the OpenAI-compatible chat-completion probe, so we
-    // skip client-side validation and let runtime usage surface errors.
-    if (isLlmProvider) {
-      if (userEnteredNewApiKey) {
-        const isValid = await validateApiKey();
-        if (!isValid) return;
-      } else if (customBaseUrl) {
-        const isValid = await validateWithCustomUrl(customBaseUrl);
-        if (!isValid) return;
-      } else {
-        const isValid = await validateWithCustomUrl();
-        if (!isValid) return;
-      }
+    // Only probe the upstream provider when the user has actually entered
+    // a new API key. Re-probing the stored credentials on every save —
+    // including saves that only touch unrelated fields like name or scope —
+    // makes those edits depend on third-party uptime and rate-limits, and
+    // blocks the user with a misleading "Invalid API key" toast whenever
+    // the stored key has drifted out-of-band (rotated in the provider's
+    // console, hit a temporary 401, etc.). Safety providers like
+    // azure_safety also skip this — their endpoints can't answer the
+    // OpenAI-compatible probe at all.
+    if (isLlmProvider && userEnteredNewApiKey) {
+      const isValid = await validateApiKey();
+      if (!isValid) return;
     }
 
     void actions.submit();
@@ -291,7 +304,6 @@ export const EditModelProviderForm = ({
     state.initialKeys,
     actions,
     validateApiKey,
-    validateWithCustomUrl,
     clearApiKeyError,
   ]);
 
@@ -412,6 +424,7 @@ export const EditModelProviderForm = ({
             size="sm"
             colorPalette="orange"
             loading={state.isSaving || isValidatingApiKey}
+            disabled={!state.isDirty && !isAdvancedDirty}
             onClick={handleSave}
           >
             Save

--- a/langwatch/src/components/settings/ModelProviderForm.tsx
+++ b/langwatch/src/components/settings/ModelProviderForm.tsx
@@ -1,8 +1,8 @@
 import { Box, Button, Field, HStack, Input, VStack } from "@chakra-ui/react";
-import { SmallLabel } from "../SmallLabel";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 import { useDrawer } from "../../hooks/useDrawer";
+import { useFeatureFlag } from "../../hooks/useFeatureFlag";
 import { useModelProviderApiKeyValidation } from "../../hooks/useModelProviderApiKeyValidation";
 import { useModelProviderForm } from "../../hooks/useModelProviderForm";
 import { useModelProvidersSettings } from "../../hooks/useModelProvidersSettings";
@@ -16,13 +16,8 @@ import {
   hasUserModifiedNonApiKeyFields,
 } from "../../utils/modelProviderHelpers";
 import { parseZodFieldErrors, type ZodErrorStructure } from "../../utils/zod";
+import { SmallLabel } from "../SmallLabel";
 import { Switch } from "../ui/switch";
-import { CredentialsSection } from "./ModelProviderCredentialsSection";
-import { CustomModelInputSection } from "./ModelProviderCustomModelInput";
-// DefaultProviderSection has been moved out of this drawer to a page-level
-// section on the model-providers settings page (DefaultModelsSection). See
-// specs/model-providers/hierarchical-default-models.feature.
-import { ExtraHeadersSection } from "./ModelProviderExtraHeadersSection";
 import {
   draftFromProvider,
   EMPTY_ADVANCED_DRAFT,
@@ -30,8 +25,13 @@ import {
   ModelProviderAdvancedSection,
   parseAdvancedDraft,
 } from "./ModelProviderAdvancedSection";
+import { CredentialsSection } from "./ModelProviderCredentialsSection";
+import { CustomModelInputSection } from "./ModelProviderCustomModelInput";
+// DefaultProviderSection has been moved out of this drawer to a page-level
+// section on the model-providers settings page (DefaultModelsSection). See
+// specs/model-providers/hierarchical-default-models.feature.
+import { ExtraHeadersSection } from "./ModelProviderExtraHeadersSection";
 import { ProviderScopeSection } from "./ModelProviderScopeSection";
-import { useFeatureFlag } from "../../hooks/useFeatureFlag";
 
 export type EditModelProviderFormProps = {
   projectId?: string | undefined;
@@ -50,7 +50,8 @@ export const EditModelProviderForm = ({
     projectId: projectId,
   });
   const { closeDrawer } = useDrawer();
-  const { project, team, organization, hasPermission } = useOrganizationTeamProject();
+  const { project, team, organization, hasPermission } =
+    useOrganizationTeamProject();
   const canManageOrganization = hasPermission("organization:manage");
   const canManageTeam = hasPermission("team:manage");
 
@@ -179,8 +180,7 @@ export const EditModelProviderForm = ({
       fallbackPriorityGlobal:
         (provider as { fallbackPriorityGlobal?: number | null })
           .fallbackPriorityGlobal ?? null,
-      providerConfig: (provider as { providerConfig?: unknown })
-        .providerConfig,
+      providerConfig: (provider as { providerConfig?: unknown }).providerConfig,
     });
   }, [gatewayMenuEnabled, provider]);
   const isAdvancedDirty =
@@ -325,8 +325,8 @@ export const EditModelProviderForm = ({
             />
           </Box>
           <Field.HelperText>
-            Distinguish multiple instances (e.g. "OpenAI – EU prod" vs
-            "OpenAI – Dev").
+            Distinguish multiple instances (e.g. "OpenAI – EU prod" vs "OpenAI –
+            Dev").
           </Field.HelperText>
         </Field.Root>
 
@@ -407,12 +407,16 @@ export const EditModelProviderForm = ({
             initial={{
               healthStatus: (provider as { healthStatus?: string | null })
                 .healthStatus,
-              circuitOpenedAt: (provider as {
-                circuitOpenedAt?: Date | string | null;
-              }).circuitOpenedAt,
-              lastHealthCheckAt: (provider as {
-                lastHealthCheckAt?: Date | string | null;
-              }).lastHealthCheckAt,
+              circuitOpenedAt: (
+                provider as {
+                  circuitOpenedAt?: Date | string | null;
+                }
+              ).circuitOpenedAt,
+              lastHealthCheckAt: (
+                provider as {
+                  lastHealthCheckAt?: Date | string | null;
+                }
+              ).lastHealthCheckAt,
               disabledAt: (provider as { disabledAt?: Date | string | null })
                 .disabledAt,
             }}

--- a/langwatch/src/components/settings/__tests__/CustomModelsSection.test.tsx
+++ b/langwatch/src/components/settings/__tests__/CustomModelsSection.test.tsx
@@ -30,6 +30,7 @@ function buildState(
   overrides: Partial<UseModelProviderFormState> = {},
 ): UseModelProviderFormState {
   return {
+    isDirty: false,
     useApiGateway: false,
     customKeys: {},
     displayKeys: {},

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.advanced-gateway.integration.test.tsx
@@ -94,6 +94,7 @@ function buildState(
   overrides: Partial<UseModelProviderFormState> = {},
 ): UseModelProviderFormState {
   return {
+    isDirty: false,
     useApiGateway: false,
     customKeys: {},
     displayKeys: {

--- a/langwatch/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderForm.azure-safety.integration.test.tsx
@@ -96,6 +96,7 @@ function buildState(
   overrides: Partial<UseModelProviderFormState> = {},
 ): UseModelProviderFormState {
   return {
+    isDirty: false,
     useApiGateway: false,
     customKeys: {},
     displayKeys: {},

--- a/langwatch/src/components/settings/__tests__/ModelProviderScopeSection.test.tsx
+++ b/langwatch/src/components/settings/__tests__/ModelProviderScopeSection.test.tsx
@@ -30,6 +30,7 @@ function buildState(
   overrides: Partial<UseModelProviderFormState> = {},
 ): UseModelProviderFormState {
   return {
+    isDirty: false,
     useApiGateway: false,
     customKeys: {},
     displayKeys: {},

--- a/langwatch/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
+++ b/langwatch/src/hooks/__tests__/useProviderFormSubmit.integration.test.tsx
@@ -81,9 +81,9 @@ vi.mock("../../components/ui/toaster", () => ({
   },
 }));
 
+import { MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
 // Import after mocks
 import { useProviderFormSubmit } from "../useProviderFormSubmit";
-import { MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -161,7 +161,9 @@ describe("useProviderFormSubmit()", () => {
           await result.current.submit();
         });
 
-        expect(mockUpdateProjectDefaultModelsMutateAsync).not.toHaveBeenCalled();
+        expect(
+          mockUpdateProjectDefaultModelsMutateAsync,
+        ).not.toHaveBeenCalled();
       });
 
       it("creates an error toast", async () => {
@@ -193,7 +195,9 @@ describe("useProviderFormSubmit()", () => {
           await result.current.submit();
         });
 
-        expect(mockUpdateProjectDefaultModelsMutateAsync).not.toHaveBeenCalled();
+        expect(
+          mockUpdateProjectDefaultModelsMutateAsync,
+        ).not.toHaveBeenCalled();
       });
 
       it("creates an error toast", async () => {
@@ -232,7 +236,9 @@ describe("useProviderFormSubmit()", () => {
           await result.current.submit();
         });
 
-        expect(mockUpdateProjectDefaultModelsMutateAsync).not.toHaveBeenCalled();
+        expect(
+          mockUpdateProjectDefaultModelsMutateAsync,
+        ).not.toHaveBeenCalled();
       });
     });
   });
@@ -354,10 +360,15 @@ describe("useProviderFormSubmit()", () => {
     });
   });
 
-  // Regression tests for #3532: the !isUsingEnvVars branch must filter
-  // MASKED_KEY_PLACEHOLDER values out of customKeys before submit, otherwise
-  // env-fallback projects post the literal placeholder string and the
-  // backend rejects it as "invalid api key".
+  // Regression tests for #3532 + the scope-edit key-preservation bug: the
+  // !isUsingEnvVars branch strips MASKED_KEY_PLACEHOLDER values from customKeys
+  // before submit. When nothing real is left (the user opened the drawer
+  // without re-entering the key, e.g. to only change the scope), it sends
+  // `undefined` rather than `{}`. `undefined` tells the server "no key change"
+  // so it preserves the stored key, whereas `{}` is validated against the
+  // provider's keysSchema — which rejects it for required-key providers like
+  // openai (the "I changed the scope and the key went blank, couldn't save"
+  // report). See specs/model-providers/scope-and-multi-instance.feature.
   describe("given isUsingEnvVars is false (env-fallback project, drawer open)", () => {
     // Matches the shape of registry.ts azure.keysSchema: all keys optional,
     // .passthrough() so MASKED_KEY_PLACEHOLDER and "" both validate.
@@ -368,7 +379,7 @@ describe("useProviderFormSubmit()", () => {
       })
       .passthrough();
     describe("when all keys are still masked (Save without editing)", () => {
-      it("omits all masked entries from the submitted customKeys", async () => {
+      it("sends customKeys undefined so the server preserves the stored key", async () => {
         const snapshot = buildSnapshot({
           isUsingEnvVars: false,
           useAsDefaultProvider: false,
@@ -390,7 +401,50 @@ describe("useProviderFormSubmit()", () => {
 
         expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
         const payload = mockUpdateMutateAsync.mock.calls[0]?.[0];
-        expect(payload?.customKeys).toEqual({});
+        expect(payload?.customKeys).toBeUndefined();
+      });
+    });
+
+    describe("when saving a required-key provider without re-entering the masked key", () => {
+      // openai requires OPENAI_API_KEY. Opening the edit drawer and clicking
+      // Save without re-typing the key posts the masked key (stripped) plus the
+      // still-empty OPENAI_BASE_URL, leaving { OPENAI_BASE_URL: "" }. The server
+      // validates that against the required-key schema and rejects it ("key
+      // went blank, couldn't save"). With no real change the payload must be
+      // undefined so the stored credentials are preserved.
+      const openaiSchema = z.object({
+        OPENAI_API_KEY: z.string().min(1),
+        OPENAI_BASE_URL: z.string().optional(),
+      });
+
+      it("sends customKeys undefined when only the masked key and an empty optional field are present", async () => {
+        const snapshot = buildSnapshot({
+          provider: {
+            ...buildAzureProvider(),
+            provider: "openai",
+            customKeys: { OPENAI_API_KEY: "sk-stored" },
+          },
+          isUsingEnvVars: false,
+          useAsDefaultProvider: false,
+          providerKeysSchema: openaiSchema,
+          customKeys: {
+            OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            OPENAI_BASE_URL: "",
+          },
+          initialKeys: {
+            OPENAI_API_KEY: MASKED_KEY_PLACEHOLDER,
+            OPENAI_BASE_URL: "",
+          },
+        });
+        const { result } = renderSubmitHook({ snapshot });
+
+        await act(async () => {
+          await result.current.submit();
+        });
+
+        expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+        const payload = mockUpdateMutateAsync.mock.calls[0]?.[0];
+        expect(payload?.customKeys).toBeUndefined();
       });
     });
 

--- a/langwatch/src/hooks/useCredentialKeys.ts
+++ b/langwatch/src/hooks/useCredentialKeys.ts
@@ -95,10 +95,7 @@ export function useCredentialKeys({
   );
 
   const setUseApiGateway = useCallback(
-    (
-      use: boolean,
-      onGatewayToggle?: (useGateway: boolean) => void,
-    ) => {
+    (use: boolean, onGatewayToggle?: (useGateway: boolean) => void) => {
       setUseApiGatewayState(use);
       setCustomKeys((previousKeys) => {
         originalStoredKeysRef.current = {

--- a/langwatch/src/hooks/useCredentialKeys.ts
+++ b/langwatch/src/hooks/useCredentialKeys.ts
@@ -41,7 +41,7 @@ export type UseCredentialKeysReturn = UseCredentialKeysState &
       | undefined;
   };
 
-function computeInitialUseApiGateway(
+export function computeInitialUseApiGateway(
   provider: MaybeStoredModelProvider,
 ): boolean {
   if (provider.provider === "azure" && provider.customKeys) {

--- a/langwatch/src/hooks/useModelProviderForm.ts
+++ b/langwatch/src/hooks/useModelProviderForm.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { CustomModelEntry } from "../server/modelProviders/customModel.schema";
 import {
-  modelProviders as modelProvidersRegistry,
   type MaybeStoredModelProvider,
+  modelProviders as modelProvidersRegistry,
 } from "../server/modelProviders/registry";
 import {
   hasUserEnteredNewApiKey,
@@ -19,6 +19,7 @@ function humanizeProviderName(providerKey: string): string {
     .replace(/_/g, " ")
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
+
 import {
   computeInitialUseApiGateway,
   useCredentialKeys,
@@ -203,7 +204,7 @@ export function useModelProviderForm(
     ? "PROJECT"
     : scopes.some((s) => s.scopeType === "TEAM")
       ? "TEAM"
-      : scopes[0]?.scopeType ?? defaultNewScope;
+      : (scopes[0]?.scopeType ?? defaultNewScope);
 
   const scopeId =
     scopes.find((s) => s.scopeType === scopeType)?.scopeId ?? undefined;

--- a/langwatch/src/hooks/useModelProviderForm.ts
+++ b/langwatch/src/hooks/useModelProviderForm.ts
@@ -1,9 +1,13 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { CustomModelEntry } from "../server/modelProviders/customModel.schema";
 import {
   modelProviders as modelProvidersRegistry,
   type MaybeStoredModelProvider,
 } from "../server/modelProviders/registry";
+import {
+  hasUserEnteredNewApiKey,
+  hasUserModifiedNonApiKeyFields,
+} from "../utils/modelProviderHelpers";
 
 // Mirrors the server's deriveDefaultName. Kept here so the drawer can
 // pre-fill the input on open without an extra tRPC round trip.
@@ -15,7 +19,10 @@ function humanizeProviderName(providerKey: string): string {
     .replace(/_/g, " ")
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
-import { useCredentialKeys } from "./useCredentialKeys";
+import {
+  computeInitialUseApiGateway,
+  useCredentialKeys,
+} from "./useCredentialKeys";
 import { useCustomModels } from "./useCustomModels";
 import { useDefaultProviderSelection } from "./useDefaultProviderSelection";
 import { type ExtraHeader, useExtraHeaders } from "./useExtraHeaders";
@@ -95,6 +102,15 @@ export type UseModelProviderFormState = {
   errors: {
     customKeysRoot?: string;
   };
+  /**
+   * True when any user-editable form field differs from the loaded
+   * provider's initial values. Drives the Save button's disabled state
+   * so a drawer opened-and-immediately-saved no-op stays out of the
+   * mutation path entirely (and never produces a misleading "Updated"
+   * toast). Advanced (Gateway) fields live outside this hook, so the
+   * parent form ORs in its own advanced-draft dirty signal.
+   */
+  isDirty: boolean;
 };
 
 export type UseModelProviderFormActions = {
@@ -265,6 +281,90 @@ export function useModelProviderForm(
     onError,
   });
 
+  // Dirty detection drives the Save button. Compared per-field so the
+  // helpers that already know about MASKED_KEY_PLACEHOLDER (api keys) are
+  // reused — a naive JSON.stringify of customKeys would always look dirty
+  // because the form shows the masked sentinel while the stored value is
+  // the real key.
+  const isDirty = useMemo(() => {
+    const initialName =
+      (provider as { name?: string }).name ??
+      humanizeProviderName(provider.provider);
+    if (name.trim() !== initialName.trim()) return true;
+
+    if (hasUserEnteredNewApiKey(credentialKeysHook.customKeys)) return true;
+    if (
+      hasUserModifiedNonApiKeyFields(
+        credentialKeysHook.customKeys,
+        credentialKeysHook.originalStoredKeysRef.current as Record<
+          string,
+          unknown
+        >,
+      )
+    ) {
+      return true;
+    }
+
+    if (
+      credentialKeysHook.useApiGateway !== computeInitialUseApiGateway(provider)
+    ) {
+      return true;
+    }
+
+    // Scope set: order-insensitive — two scopes added in different order
+    // shouldn't read as dirty.
+    const storedScopes: { scopeType: string; scopeId: string }[] =
+      provider.scopes && provider.scopes.length > 0
+        ? provider.scopes
+        : provider.scopeType && provider.scopeId
+          ? [{ scopeType: provider.scopeType, scopeId: provider.scopeId }]
+          : [];
+    const scopeSig = (xs: { scopeType: string; scopeId: string }[]) =>
+      xs
+        .map((s) => `${s.scopeType}|${s.scopeId}`)
+        .sort()
+        .join(",");
+    if (scopeSig(scopes) !== scopeSig(storedScopes)) return true;
+
+    // Headers and models: order-sensitive JSON compare. Reordering a list
+    // counts as dirty here, which matches user intent (the user dragged
+    // them on purpose).
+    if (
+      JSON.stringify(extraHeadersHook.extraHeaders) !==
+      JSON.stringify(provider.extraHeaders ?? [])
+    ) {
+      return true;
+    }
+    const providerWithModels = provider as {
+      customModels?: unknown;
+      customEmbeddingsModels?: unknown;
+    };
+    if (
+      JSON.stringify(customModelsHook.customModels) !==
+      JSON.stringify(providerWithModels.customModels ?? [])
+    ) {
+      return true;
+    }
+    if (
+      JSON.stringify(customModelsHook.customEmbeddingsModels) !==
+      JSON.stringify(providerWithModels.customEmbeddingsModels ?? [])
+    ) {
+      return true;
+    }
+
+    return false;
+  }, [
+    provider,
+    name,
+    credentialKeysHook.customKeys,
+    credentialKeysHook.originalStoredKeysRef,
+    credentialKeysHook.useApiGateway,
+    scopes,
+    extraHeadersHook.extraHeaders,
+    customModelsHook.customModels,
+    customModelsHook.customEmbeddingsModels,
+  ]);
+
   // --- Cross-hook coordination: gateway toggle wires credential keys → extra headers ---
   const handleGatewayToggle = useCallback(
     (useGateway: boolean) => {
@@ -329,6 +429,7 @@ export function useModelProviderForm(
       scopeType,
       isSaving: formSubmitHook.isSaving,
       errors: formSubmitHook.errors,
+      isDirty,
     },
     {
       setEnabled: formSubmitHook.setEnabled,

--- a/langwatch/src/hooks/useProviderFormSubmit.ts
+++ b/langwatch/src/hooks/useProviderFormSubmit.ts
@@ -4,8 +4,8 @@ import { fromZodError } from "zod-validation-error";
 import { toaster } from "../components/ui/toaster";
 import type { CustomModelEntry } from "../server/modelProviders/customModel.schema";
 import {
-  modelProviders,
   type MaybeStoredModelProvider,
+  modelProviders,
 } from "../server/modelProviders/registry";
 import { api } from "../utils/api";
 import {
@@ -214,7 +214,9 @@ export function useProviderFormSubmit({
             description: `${mismatched.join(" and ")} ${
               mismatched.length === 1 ? "belongs" : "belong"
             } to a different provider. Pick a model from ${providerDisplayName}${
-              provider.provider === "azure" ? " (or add a custom deployment)" : ""
+              provider.provider === "azure"
+                ? " (or add a custom deployment)"
+                : ""
             } before saving.`,
             type: "error",
             duration: 5000,
@@ -229,11 +231,25 @@ export function useProviderFormSubmit({
       let customKeysToSend: Record<string, unknown> | undefined;
       const userEnteredNewKey = hasUserEnteredNewApiKey(customKeys);
       if (!isUsingEnvVars) {
-        // Strip any masked placeholder values — they appear when the provider
-        // was configured via env vars in a prior session and the user opened
-        // the drawer without editing. Submitting the placeholder string would
-        // fail backend validation; omitting it preserves the existing key.
-        customKeysToSend = filterMaskedApiKeys(customKeys);
+        // When editing an existing provider, the stored key is shown masked.
+        // Strip the masked placeholders, then keep the result only if something
+        // actually changed versus the stored values. If nothing changed (the
+        // common case of opening the drawer and saving without re-entering the
+        // key), send `undefined` so the server preserves the stored credentials
+        // instead of validating a partial object (e.g. just an empty base URL)
+        // against the provider's required-key schema and rejecting the save.
+        // A genuine change — a new key, a cleared key, or an edited field —
+        // still goes through.
+        const filtered = filterMaskedApiKeys(customKeys);
+        const hasRealChange = Object.entries(filtered).some(([key, value]) => {
+          const current = (value ?? "").trim();
+          const stored =
+            typeof initialKeys[key] === "string"
+              ? (initialKeys[key] as string).trim()
+              : "";
+          return current !== stored;
+        });
+        customKeysToSend = hasRealChange ? filtered : undefined;
       } else if (userEnteredNewKey || hasNonApiKeyChanges) {
         customKeysToSend = userEnteredNewKey
           ? { ...customKeys }
@@ -254,6 +270,17 @@ export function useProviderFormSubmit({
           }
         });
         customKeysToSend = { ...customKeysToSend, ...headerMap };
+      }
+
+      // Safety net: if the steps above (placeholder stripping, azure-header
+      // merge) leave an empty customKeys object, send `undefined` so the
+      // server treats it as "no key change" and preserves the stored key,
+      // rather than validating `{}` against the provider's keysSchema.
+      if (
+        customKeysToSend !== undefined &&
+        Object.keys(customKeysToSend).length === 0
+      ) {
+        customKeysToSend = undefined;
       }
 
       // Strip concealed for send
@@ -315,11 +342,12 @@ export function useProviderFormSubmit({
       // `analytics.topic_clustering_llm` to FAST). See
       // specs/model-providers/role-based-default-models.feature.
       if (useAsDefaultProvider) {
-        const targetScopes = scopes && scopes.length > 0
-          ? scopes
-          : scopeType && scopeId
-            ? [{ scopeType, scopeId }]
-            : [];
+        const targetScopes =
+          scopes && scopes.length > 0
+            ? scopes
+            : scopeType && scopeId
+              ? [{ scopeType, scopeId }]
+              : [];
         type RoleWrite = {
           label: string;
           promise: Promise<unknown>;
@@ -369,8 +397,9 @@ export function useProviderFormSubmit({
         const results = await Promise.allSettled(writes.map((w) => w.promise));
         const failed = results
           .map((r, i) => ({ r, label: writes[i]!.label }))
-          .filter((x): x is { r: PromiseRejectedResult; label: string } =>
-            x.r.status === "rejected",
+          .filter(
+            (x): x is { r: PromiseRejectedResult; label: string } =>
+              x.r.status === "rejected",
           );
         if (failed.length > 0) {
           const reasons = failed

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.multiInstance.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.multiInstance.integration.test.ts
@@ -199,7 +199,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
         ctx(),
       );
       const createdRow = await prisma.modelProvider.findFirst({
-        where: { id: created.id },
+        where: { id: created.id, projectId },
       });
 
       // The drawer's masked-only save: id + scopes, no customKeys. The row is
@@ -219,7 +219,7 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
 
       expect(updated.id).toBe(created.id);
       const rows = await prisma.modelProvider.findMany({
-        where: { name: `OpenAI Org Edit ${ns}` },
+        where: { name: `OpenAI Org Edit ${ns}`, projectId },
         include: { scopes: true },
       });
       expect(rows).toHaveLength(1);

--- a/langwatch/src/server/modelProviders/__tests__/modelProvider.multiInstance.integration.test.ts
+++ b/langwatch/src/server/modelProviders/__tests__/modelProvider.multiInstance.integration.test.ts
@@ -146,12 +146,13 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
       expect(rows).toHaveLength(2);
 
       const scopesById = Object.fromEntries(
-        rows.map((r) => [r.id, r.scopes.map((s) => `${s.scopeType}:${s.scopeId}`)]),
+        rows.map((r) => [
+          r.id,
+          r.scopes.map((s) => `${s.scopeType}:${s.scopeId}`),
+        ]),
       );
       expect(scopesById[first.id]).toEqual([`PROJECT:${projectId}`]);
-      expect(scopesById[second.id]).toEqual([
-        `ORGANIZATION:${organizationId}`,
-      ]);
+      expect(scopesById[second.id]).toEqual([`ORGANIZATION:${organizationId}`]);
     });
 
     /** @scenario Save a provider with multiple scopes */
@@ -181,11 +182,50 @@ describe.skipIf(isTestcontainersOnly || !hasCredentialsSecret)(
         .map((s) => `${s.scopeType}:${s.scopeId}`)
         .sort();
       expect(scopes).toEqual(
-        [
-          `ORGANIZATION:${organizationId}`,
-          `TEAM:${teamId}`,
-        ].sort(),
+        [`ORGANIZATION:${organizationId}`, `TEAM:${teamId}`].sort(),
       );
+    });
+
+    it("updates an org-scoped provider by id from a project context without 404ing", async () => {
+      const created = await service().updateModelProvider(
+        {
+          projectId,
+          provider: "openai",
+          name: `OpenAI Org Edit ${ns}`,
+          enabled: true,
+          customKeys: { OPENAI_API_KEY: `sk-org-edit-${ns}` },
+          scopes: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+        },
+        ctx(),
+      );
+      const createdRow = await prisma.modelProvider.findFirst({
+        where: { id: created.id },
+      });
+
+      // The drawer's masked-only save: id + scopes, no customKeys. The row is
+      // ORG-scoped, so a PROJECT-only lookup would 404. The org-anchored lookup
+      // must find it and update it in place, preserving the stored key.
+      const updated = await service().updateModelProvider(
+        {
+          id: created.id,
+          projectId,
+          provider: "openai",
+          name: `OpenAI Org Edit ${ns}`,
+          enabled: true,
+          scopes: [{ scopeType: "ORGANIZATION", scopeId: organizationId }],
+        },
+        ctx(),
+      );
+
+      expect(updated.id).toBe(created.id);
+      const rows = await prisma.modelProvider.findMany({
+        where: { name: `OpenAI Org Edit ${ns}` },
+        include: { scopes: true },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.scopes.map((s) => s.scopeType)).toEqual(["ORGANIZATION"]);
+      // The stored credential is preserved (the masked-only save sends no key).
+      expect(rows[0]!.customKeys).toEqual(createdRow!.customKeys);
     });
   },
 );

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -460,12 +460,6 @@ export class ModelProviderService {
       fallbackPriorityGlobal,
       providerConfig,
     };
-    const hasAdvancedWrite =
-      rateLimitRpm !== undefined ||
-      rateLimitTpm !== undefined ||
-      rateLimitRpd !== undefined ||
-      fallbackPriorityGlobal !== undefined ||
-      providerConfig !== undefined;
 
     // Validate provider exists
     if (!(provider in modelProviders)) {
@@ -505,22 +499,15 @@ export class ModelProviderService {
         ? [{ scopeType: input.scopeType, scopeId: input.scopeId }]
         : undefined);
 
-    // Fail-closed scope authz. Every (scopeType, scopeId) entry in the
-    // target set must pass the caller's manage-permission check; a
-    // single failure aborts the whole operation so partial-success
-    // cannot silently rebind a credential the caller can't see.
-    if (ctx && scopes) {
-      await assertCanManageAllScopes(ctx, scopes);
-    }
-
-    // Advanced (Gateway) writes also require manage on every scope the
-    // existing row is bound to — not just the project the caller is in.
-    // Matches the previous `updateAdvancedSettings` contract: a project
-    // admin must not nudge rate limits on a credential that's also
-    // bound to its parent org/team without manage there. The basic
-    // update path keeps its existing semantics (project:update gate
-    // only) so this PR doesn't tighten unrelated writes.
-    if (ctx && hasAdvancedWrite && existingProvider) {
+    // Existing-scope authz, fail-closed. The id-based lookup above is
+    // org-anchored (findByIdForOrganization) so the resolved row may be
+    // bound to an ORGANIZATION or TEAM scope a project admin cannot
+    // manage. Without this check, that admin could update an inherited
+    // row by submitting `scopes: [{PROJECT, theirProjectId}]` — the
+    // submitted-scopes check would pass, but the row they're touching
+    // is one they have no rights on. Validate against the row's
+    // *current* scopes before considering any incoming changes.
+    if (ctx && existingProvider) {
       await assertCanManageAllScopes(
         ctx,
         existingProvider.scopes.map((s) => ({
@@ -528,6 +515,15 @@ export class ModelProviderService {
           scopeId: s.scopeId,
         })),
       );
+    }
+
+    // Submitted-scope authz, fail-closed. Every (scopeType, scopeId) in
+    // the target set must also pass the manage-permission check, so a
+    // caller can't widen a row into a scope they don't control. A
+    // single failure aborts the whole operation; partial-success cannot
+    // silently rebind a credential the caller can't see.
+    if (ctx && scopes) {
+      await assertCanManageAllScopes(ctx, scopes);
     }
 
     return await this.prisma.$transaction(async (tx) => {

--- a/langwatch/src/server/modelProviders/modelProvider.service.ts
+++ b/langwatch/src/server/modelProviders/modelProvider.service.ts
@@ -1,8 +1,9 @@
 import type { PrismaClient, Project } from "@prisma/client";
-import type { Session } from "~/server/auth";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { env } from "~/env.mjs";
+import type { Session } from "~/server/auth";
+import { isManagedProvider } from "../../../ee/managed-providers/managedBedrockConfig";
 import { KEY_CHECK, MASKED_KEY_PLACEHOLDER } from "../../utils/constants";
 import type { CustomModelsInput } from "./customModel.schema";
 import { toLegacyCompatibleCustomModels } from "./customModel.schema";
@@ -21,7 +22,6 @@ import {
   modelProviders,
 } from "./registry";
 import { seedOnboardingDefaultsForProvider } from "./seedOnboardingDefaults";
-import { isManagedProvider } from "../../../ee/managed-providers/managedBedrockConfig";
 
 /**
  * Minimal ctx slice this service uses to authorize scope-level writes.
@@ -194,9 +194,8 @@ export class ModelProviderService {
     if (!project) throw new Error("Project not found");
 
     const defaultProviders = this.buildDefaultProviders(project);
-    const savedProviders = await this.repository.findAllAccessibleForProject(
-      projectId,
-    );
+    const savedProviders =
+      await this.repository.findAllAccessibleForProject(projectId);
     const savedProviderKeys = new Set(savedProviders.map((mp) => mp.provider));
 
     // Env-fed providers (process.env has the API key) that nobody has
@@ -229,18 +228,20 @@ export class ModelProviderService {
           "embedding",
         );
         const narrowestScope = this.pickNarrowestScope(mp.scopes);
-        const masked = (mp.customKeys
-          ? Object.fromEntries(
-              Object.entries(
-                mp.customKeys as Record<string, unknown>,
-              ).map(([key, value]) => [
-                key,
-                KEY_CHECK.some((k) => key.includes(k))
-                  ? MASKED_KEY_PLACEHOLDER
-                  : value,
-              ]),
-            )
-          : null) as MaybeStoredModelProvider["customKeys"];
+        const masked = (
+          mp.customKeys
+            ? Object.fromEntries(
+                Object.entries(mp.customKeys as Record<string, unknown>).map(
+                  ([key, value]) => [
+                    key,
+                    KEY_CHECK.some((k) => key.includes(k))
+                      ? MASKED_KEY_PLACEHOLDER
+                      : value,
+                  ],
+                ),
+              )
+            : null
+        ) as MaybeStoredModelProvider["customKeys"];
         const provider_: MaybeStoredModelProvider = {
           id: mp.id,
           name: mp.name,
@@ -319,10 +320,7 @@ export class ModelProviderService {
     const bedrockAlreadyShown =
       savedProviderKeys.has("bedrock") ||
       systemRows.some((r) => r.provider === "bedrock");
-    if (
-      !bedrockAlreadyShown &&
-      isManagedProvider(organizationId, "bedrock")
-    ) {
+    if (!bedrockAlreadyShown && isManagedProvider(organizationId, "bedrock")) {
       const defaultProvider = this.buildDefaultProvidersFromEnvShape(
         "bedrock",
         oldestProject,
@@ -345,18 +343,20 @@ export class ModelProviderService {
           "embedding",
         );
         const narrowestScope = this.pickNarrowestScope(mp.scopes);
-        const masked = (mp.customKeys
-          ? Object.fromEntries(
-              Object.entries(
-                mp.customKeys as Record<string, unknown>,
-              ).map(([key, value]) => [
-                key,
-                KEY_CHECK.some((k) => key.includes(k))
-                  ? MASKED_KEY_PLACEHOLDER
-                  : value,
-              ]),
-            )
-          : null) as MaybeStoredModelProvider["customKeys"];
+        const masked = (
+          mp.customKeys
+            ? Object.fromEntries(
+                Object.entries(mp.customKeys as Record<string, unknown>).map(
+                  ([key, value]) => [
+                    key,
+                    KEY_CHECK.some((k) => key.includes(k))
+                      ? MASKED_KEY_PLACEHOLDER
+                      : value,
+                  ],
+                ),
+              )
+            : null
+        ) as MaybeStoredModelProvider["customKeys"];
         const provider_: MaybeStoredModelProvider = {
           id: mp.id,
           name: mp.name,
@@ -396,8 +396,7 @@ export class ModelProviderService {
     referenceProject: Project | null,
   ): MaybeStoredModelProvider | null {
     if (!referenceProject) return null;
-    const registry =
-      modelProviders[providerKey as keyof typeof modelProviders];
+    const registry = modelProviders[providerKey as keyof typeof modelProviders];
     if (!registry?.enabledSince) return null;
     return {
       provider: providerKey,
@@ -621,10 +620,7 @@ export class ModelProviderService {
       input.provider,
       input.projectId,
     );
-    return await this.updateModelProvider(
-      { ...input, id: existing?.id },
-      ctx,
-    );
+    return await this.updateModelProvider({ ...input, id: existing?.id }, ctx);
   }
 
   /**
@@ -655,9 +651,7 @@ export class ModelProviderService {
     };
     return (
       humanized[provider] ??
-      provider
-        .replace(/_/g, " ")
-        .replace(/\b\w/g, (c) => c.toUpperCase())
+      provider.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
     );
   }
 
@@ -681,8 +675,7 @@ export class ModelProviderService {
     const { id, projectId, provider } = input;
 
     if (ctx) {
-      const organizationId =
-        await this.resolveProjectOrganizationId(projectId);
+      const organizationId = await this.resolveProjectOrganizationId(projectId);
       // Org-anchored lookup when we can resolve the tenant; otherwise fall
       // back to the legacy project-scope lookup so a missing project can't
       // widen the blast radius.
@@ -854,12 +847,9 @@ export class ModelProviderService {
             customKeys: includeKeys ? mp.customKeys : null,
             models: defaultProvider?.models ?? null,
             embeddingsModels: defaultProvider?.embeddingsModels ?? null,
-            customModels:
-              customModels.length > 0 ? customModels : null,
+            customModels: customModels.length > 0 ? customModels : null,
             customEmbeddingsModels:
-              customEmbeddingsModels.length > 0
-                ? customEmbeddingsModels
-                : null,
+              customEmbeddingsModels.length > 0 ? customEmbeddingsModels : null,
             deploymentMapping: mp.deploymentMapping,
             disabledByDefault: defaultProvider?.disabledByDefault,
             extraHeaders: mp.extraHeaders as
@@ -903,12 +893,8 @@ export class ModelProviderService {
     }
     const sorted = [...scopes].sort(
       (a, b) =>
-        this.scopePriority(
-          b.scopeType as "ORGANIZATION" | "TEAM" | "PROJECT",
-        ) -
-        this.scopePriority(
-          a.scopeType as "ORGANIZATION" | "TEAM" | "PROJECT",
-        ),
+        this.scopePriority(b.scopeType as "ORGANIZATION" | "TEAM" | "PROJECT") -
+        this.scopePriority(a.scopeType as "ORGANIZATION" | "TEAM" | "PROJECT"),
     );
     return {
       scopeType: sorted[0]!.scopeType as "ORGANIZATION" | "TEAM" | "PROJECT",
@@ -1035,7 +1021,18 @@ export class ModelProviderService {
     projectId: string,
   ) {
     if (!id) return null;
-    return await this.repository.findById(id, projectId);
+    // Org-anchored lookup so an edit from a project view resolves providers
+    // granted at the org or team scope (which the settings list surfaces by
+    // inheritance), not only PROJECT-scoped rows. Mirrors the delete path
+    // (findByIdForOrganization); a PROJECT-only lookup is why editing an
+    // org-scoped provider used to 404. The per-scope manage authz on the
+    // submitted scope set still gates the write. Falls back to the
+    // project-scope lookup when the tenant can't be resolved, so a missing
+    // project can't widen the blast radius.
+    const organizationId = await this.resolveProjectOrganizationId(projectId);
+    return organizationId
+      ? await this.repository.findByIdForOrganization(id, organizationId)
+      : await this.repository.findById(id, projectId);
   }
 
   private async updateExisting(


### PR DESCRIPTION
## What

Two bugs in the model-provider edit-save flow, both surfaced by dogfooding the edit drawer. The drawer shows scope as fixed-after-create, so this is about preserving credentials on save, not editing scope.

![Edit drawer](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4992/qa/edit-drawer-masked-key-scope-fixed.png)

## Bug 1: masked-key save rejected

Opening the edit drawer and saving without re-entering the masked key posted a partial `customKeys` object: the masked key was stripped, leaving leftover fields like an empty base URL (`{ OPENAI_BASE_URL: "" }`). The server validated that against the provider's `keysSchema` and rejected it for required-key providers like openai ("Invalid API key configuration"), so the save failed with the key field "blank".

Fix: `useProviderFormSubmit` now sends `customKeys` undefined when nothing actually changed versus the stored values, so the server treats it as "no key change" and preserves the stored credentials. A genuine change (a new key, a cleared key, or an edited field) still goes through.

## Bug 2: org-scoped provider update returned 404

Updating a provider granted at the org or team scope returned 404, because the update resolved the row via `findById(id, projectId)`, which only matches PROJECT-scoped rows. An inherited org/team-scoped provider (surfaced in the project's settings list) was never found. This was masked by bug 1 (the validation error fired first).

Fix: the update's lookup is now org-anchored (`findByIdForOrganization`), mirroring the delete path which already fixed this exact case (see the comment in `modelProvider.repository.ts`). The per-scope manage authz on the submitted scope set still gates the write.

## Tests

- Client regression (`useProviderFormSubmit.integration.test.tsx`): a masked-only save (masked key + empty optional field) sends `customKeys` undefined, for both azure and a required-key provider; the new-key, cleared-key, and edited-field cases still send their values.
- Service regression (`modelProvider.multiInstance.integration.test.ts`): updating an org-scoped provider by id from a project context succeeds (org-anchored lookup, no 404) and preserves the stored key.

## QA

Browser-QA on a live stack confirmed bug 1: before the fix the save posted `{ OPENAI_BASE_URL: "" }` and returned 500 "Invalid API key configuration"; after, it posts `customKeys` undefined and the validation error is gone. That same QA uncovered bug 2 (the 404 the validation error had been masking). Bug 2's fix is a direct copy of the merged delete-path pattern and is covered by the service regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue `#3785`: masked/placeholder API keys now avoid sending empty or unchanged key payloads.
  * Improved model provider editing across scopes/tenants, preserving existing provider rows correctly.
  * Updated the model provider form so “Save” correctly accounts for advanced (gateway) changes and only validates API keys when a new key is entered.
* **Tests**
  * Expanded integration coverage for default-provider mismatch and multi-scope persistence, including masked-key scenarios.
* **Refactor**
  * Streamlined provider resolution and submission handling for more consistent key and scope behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->