### PR TITLE
fix(studio): load the saved library prompt when reopening a workflow node

### DIFF
--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -479,6 +479,11 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
         : defaults;
 
       setConfigValues(formValues);
+      // Treat the fallback baseline as the "saved" reference for dirty tracking.
+      // Without this, the watch sees a non-null promptId AND an empty
+      // savedFormValuesRef, falls through both branches, leaves isUnsaved=false,
+      // and silently drops every edit by calling onLocalConfigChange(undefined).
+      savedFormValuesRef.current = formValues;
       // Set ref BEFORE methods.reset() — see comment in DB prompt branch above.
       isFormInitializedRef.current = true;
       methods.reset(formValues);

--- a/langwatch/src/components/prompts/PromptEditorDrawer.tsx
+++ b/langwatch/src/components/prompts/PromptEditorDrawer.tsx
@@ -90,6 +90,13 @@ export type PromptEditorDrawerProps = {
    */
   initialLocalConfig?: LocalPromptConfig;
   /**
+   * Fallback config used ONLY when `promptId` is set but the prompt is not
+   * found in the project (e.g. a workflow imported from another project).
+   * Unlike `initialLocalConfig` it is never merged over a prompt that loads
+   * successfully, so a saved prompt always shows its own library content.
+   */
+  inlineConfigFallback?: LocalPromptConfig;
+  /**
    * Available sources for variable mapping (e.g., dataset columns).
    * When provided, shows mapping UI instead of simple value inputs.
    */
@@ -313,7 +320,9 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
   // this seed, the subscription fires on defaults before the init useEffect
   // runs and clobbers the caller's local edits (#3155).
   const [configValues, setConfigValues] = useState<PromptConfigFormValues>(() =>
-    localConfigToFormValues(props.initialLocalConfig),
+    localConfigToFormValues(
+      props.initialLocalConfig ?? props.inlineConfigFallback,
+    ),
   );
   const [isFormInitialized, setIsFormInitialized] = useState(false);
   // Ref set directly in init/reset effects so the watch subscription
@@ -436,8 +445,12 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
         },
       });
 
-      // Merge initialLocalConfig over defaults to restore previous edits
-      const formValues = props.initialLocalConfig
+      // Restore the node's config over defaults. Prefer genuine unpublished
+      // edits, then the inline fallback (only set when the prompt was not found
+      // in the project) so imported workflows still show their configuration.
+      const notFoundConfig =
+        props.initialLocalConfig ?? props.inlineConfigFallback;
+      const formValues = notFoundConfig
         ? {
             ...defaults,
             version: {
@@ -446,22 +459,19 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
                 ...defaults.version.configData,
                 llm: {
                   ...defaults.version.configData.llm,
-                  ...props.initialLocalConfig.llm,
+                  ...notFoundConfig.llm,
                 },
                 messages:
-                  props.initialLocalConfig.messages.length > 0
-                    ? (props.initialLocalConfig
-                        .messages as typeof defaults.version.configData.messages)
+                  notFoundConfig.messages.length > 0
+                    ? (notFoundConfig.messages as typeof defaults.version.configData.messages)
                     : defaults.version.configData.messages,
                 inputs:
-                  props.initialLocalConfig.inputs.length > 0
-                    ? (props.initialLocalConfig
-                        .inputs as typeof defaults.version.configData.inputs)
+                  notFoundConfig.inputs.length > 0
+                    ? (notFoundConfig.inputs as typeof defaults.version.configData.inputs)
                     : defaults.version.configData.inputs,
                 outputs:
-                  props.initialLocalConfig.outputs.length > 0
-                    ? (props.initialLocalConfig
-                        .outputs as typeof defaults.version.configData.outputs)
+                  notFoundConfig.outputs.length > 0
+                    ? (notFoundConfig.outputs as typeof defaults.version.configData.outputs)
                     : defaults.version.configData.outputs,
               },
             },
@@ -514,6 +524,7 @@ export function PromptEditorDrawer(props: PromptEditorDrawerProps) {
     promptQuery.isLoading,
     promptId,
     props.initialLocalConfig,
+    props.inlineConfigFallback,
     methods,
     isFormInitialized,
     availableSources,

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -1114,6 +1114,52 @@ describe("PromptEditorDrawer", () => {
     });
   });
 
+  describe("when the referenced prompt is not found (imported workflow)", () => {
+    beforeEach(() => {
+      // The prompt referenced by id is not in this project: DB query returns null.
+      mockGetByIdOrHandle.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      });
+    });
+
+    /** @scenario "A node whose library prompt is missing shows its inline config" */
+    it("falls back to inlineConfigFallback instead of an empty form", async () => {
+      const inlineConfigFallback = {
+        llm: { model: "openai/gpt-4o" },
+        messages: [
+          { role: "system" as const, content: "INLINE-FALLBACK-CONTENT" },
+        ],
+        inputs: [{ identifier: "question", type: "str" as const }],
+        outputs: [{ identifier: "answer", type: "str" as const }],
+      };
+
+      renderWithProviders(
+        <PromptEditorDrawer
+          open={true}
+          promptId="missing-prompt"
+          inlineConfigFallback={inlineConfigFallback}
+        />,
+      );
+
+      // The form must initialize with the node's inline config, not an empty
+      // "New Prompt" form, so an imported workflow still shows its prompt.
+      await waitFor(() => {
+        const captured = capturedInitialConfigValues as Array<{
+          version?: {
+            configData?: { messages?: Array<{ content?: string }> };
+          };
+        }>;
+        const usedFallback = captured.some((c) =>
+          c?.version?.configData?.messages?.some(
+            (m) => m?.content === "INLINE-FALLBACK-CONTENT",
+          ),
+        );
+        expect(usedFallback).toBe(true);
+      });
+    });
+  });
+
   describe("License enforcement (prompts limit)", () => {
     beforeEach(() => {
       mockGetByIdOrHandle.mockReturnValue({

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -1126,7 +1126,7 @@ describe("PromptEditorDrawer", () => {
     /** @scenario "A node whose library prompt is missing shows its inline config" */
     it("falls back to inlineConfigFallback instead of an empty form", async () => {
       const inlineConfigFallback = {
-        llm: { model: "openai/gpt-4o" },
+        llm: { model: "gpt-5-mini" },
         messages: [
           { role: "system" as const, content: "INLINE-FALLBACK-CONTENT" },
         ],

--- a/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
+++ b/langwatch/src/components/prompts/__tests__/PromptEditorDrawer.test.tsx
@@ -95,6 +95,9 @@ vi.mock("~/optimization_studio/components/nodes/Nodes", () => ({
 
 // Track initialConfigValues passed to usePromptConfigForm
 const capturedInitialConfigValues: unknown[] = [];
+// Track the latest form methods returned by the mock so tests can drive edits
+// and exercise the real watch subscription inside PromptEditorDrawer.
+const capturedFormMethods: ReturnType<typeof useForm>[] = [];
 
 // Mock usePromptConfigForm to return a real form
 const mockDefaultFormValues = {
@@ -122,6 +125,7 @@ vi.mock("~/prompts/hooks/usePromptConfigForm", () => ({
     const methods = useForm({
       defaultValues: initialConfigValues ?? mockDefaultFormValues,
     });
+    capturedFormMethods.push(methods);
     return { methods };
   },
 }));
@@ -344,6 +348,7 @@ describe("PromptEditorDrawer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedInitialConfigValues.length = 0;
+    capturedFormMethods.length = 0;
     mockGetByIdOrHandle.mockReturnValue({ data: undefined, isLoading: false });
     // Default: form values equal saved values (no changes)
     mockAreFormValuesEqual.mockReturnValue(true);
@@ -1156,6 +1161,64 @@ describe("PromptEditorDrawer", () => {
           ),
         );
         expect(usedFallback).toBe(true);
+      });
+    });
+
+    /**
+     * Regression for the dirty-tracking gap in the missing-prompt branch.
+     * Before the fix, the watch subscription saw promptId set AND
+     * savedFormValuesRef.current undefined, so neither dirty-tracking branch
+     * fired and onLocalConfigChange(undefined) was called instead of the
+     * extracted config — silently dropping every edit the user made to the
+     * imported workflow's prompt.
+     */
+    it("propagates edits to the fallback via onLocalConfigChange", async () => {
+      const inlineConfigFallback = {
+        llm: { model: "gpt-5-mini" },
+        messages: [
+          { role: "system" as const, content: "INLINE-FALLBACK-CONTENT" },
+        ],
+        inputs: [{ identifier: "question", type: "str" as const }],
+        outputs: [{ identifier: "answer", type: "str" as const }],
+      };
+      // Form values differ from the fallback baseline once edited; the watch
+      // subscription must observe this and mark the form as unsaved.
+      mockAreFormValuesEqual.mockReturnValue(false);
+      const onLocalConfigChange = vi.fn();
+
+      renderWithProviders(
+        <PromptEditorDrawer
+          open={true}
+          promptId="missing-prompt"
+          inlineConfigFallback={inlineConfigFallback}
+          onLocalConfigChange={onLocalConfigChange}
+        />,
+      );
+
+      // Wait until the form has initialized with the fallback content.
+      await waitFor(() => {
+        expect(capturedFormMethods.length).toBeGreaterThan(0);
+      });
+
+      // Simulate a user edit to the system message.
+      const methods = capturedFormMethods[capturedFormMethods.length - 1]!;
+      methods.setValue(
+        "version.configData.messages.0.content",
+        "EDITED-IN-MISSING-PROMPT-BRANCH",
+      );
+
+      // The bridge must receive a real LocalPromptConfig with the edited
+      // content — never undefined — so the studio can persist the edit.
+      await waitFor(() => {
+        const editedCall = onLocalConfigChange.mock.calls.find((args) => {
+          const cfg = args[0] as
+            | { messages?: Array<{ content?: string }> }
+            | undefined;
+          return cfg?.messages?.some(
+            (m) => m?.content === "EDITED-IN-MISSING-PROMPT-BRANCH",
+          );
+        });
+        expect(editedCall).toBeDefined();
       });
     });
   });

--- a/langwatch/src/optimization_studio/components/drawers/SignaturePromptEditorBridge.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/SignaturePromptEditorBridge.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo } from "react";
-import { useUpdateNodeInternals } from "@xyflow/react";
 import type { Edge, Node } from "@xyflow/react";
+import { useUpdateNodeInternals } from "@xyflow/react";
+import { useCallback, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import { PromptEditorDrawer } from "~/components/prompts/PromptEditorDrawer";
@@ -17,7 +17,10 @@ import {
 } from "../../utils/edgeMappingUtils";
 
 /** Check whether two sets of fields have identical identifiers and types (order-independent). */
-function fieldsMatch(a: Field[], b: { identifier: string; type: string }[]): boolean {
+function fieldsMatch(
+  a: Field[],
+  b: { identifier: string; type: string }[],
+): boolean {
   if (a.length !== b.length) return false;
   const fieldMap = new Map(a.map((f) => [f.identifier, f.type]));
   return b.every((f) => fieldMap.get(f.identifier) === f.type);
@@ -181,27 +184,21 @@ export function SignaturePromptEditorBridge({
     [getWorkflow, node.id, setEdges, setNode, updateNodeInternals],
   );
 
-  /**
-   * Backward compatibility: when a node has no promptId and no localPromptConfig
-   * but has inline parameters (old workflow format), convert the inline config
-   * to LocalPromptConfig so the PromptEditorDrawer can display it for editing.
-   */
-  const initialLocalConfig = useMemo(() => {
-    // If the node already has a local config, use it directly
-    if (signatureNode.data.localPromptConfig) {
-      return signatureNode.data.localPromptConfig;
-    }
-    // Fall back to extracting config from inline parameters.
-    // When promptId is set and the prompt exists in DB, the drawer will use
-    // the DB data and ignore this. When the prompt is NOT found (e.g. after
-    // importing a workflow from another project), this provides the fallback
-    // so the drawer can display the node's actual inline configuration
-    // instead of an empty "New Prompt" form.
-    return nodeDataToLocalPromptConfig(signatureNode.data);
-  }, [
-    signatureNode.data.localPromptConfig,
-    signatureNode.data,
-  ]);
+  // Genuine unpublished local edits only. When the node references a saved
+  // library prompt (promptId) with no local edits this stays undefined, so the
+  // drawer loads and shows the saved prompt instead of a stale mirror of the
+  // node's inline parameters (which made a just-saved prompt look deleted).
+  const initialLocalConfig = signatureNode.data.localPromptConfig;
+
+  // Inline mirror of the node's parameters, used by the drawer ONLY when the
+  // referenced prompt is not found in the project (e.g. a workflow imported
+  // from another project) so it can still show the node's actual configuration
+  // instead of an empty "New Prompt" form. It is never merged over a prompt
+  // that loads successfully from the library.
+  const inlineConfigFallback = useMemo(
+    () => nodeDataToLocalPromptConfig(signatureNode.data),
+    [signatureNode.data],
+  );
 
   const handleLocalConfigChange = useCallback(
     (config: LocalPromptConfig | undefined) => {
@@ -360,6 +357,7 @@ export function SignaturePromptEditorBridge({
       promptId={signatureNode.data.promptId}
       promptVersionId={signatureNode.data.promptVersionId}
       initialLocalConfig={initialLocalConfig}
+      inlineConfigFallback={inlineConfigFallback}
       onLocalConfigChange={handleLocalConfigChange}
       onSave={handleSave}
       onVersionChange={handleVersionChange}

--- a/langwatch/src/optimization_studio/components/drawers/__tests__/SignaturePromptEditorBridge.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/__tests__/SignaturePromptEditorBridge.integration.test.tsx
@@ -2,11 +2,11 @@
  * @vitest-environment jsdom
  */
 import { render } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import React from "react";
 import type { Node } from "@xyflow/react";
-import type { Component, Signature } from "../../../types/dsl";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LocalPromptConfig } from "~/experiments-v3/types";
+import type { Component, Signature } from "../../../types/dsl";
 
 // ---- Mocks ----
 
@@ -55,7 +55,7 @@ vi.mock("~/prompts/utils/llmPromptConfigUtils", () => ({
 // ---- Helpers ----
 
 function createSignatureNode(
-  overrides: Partial<Signature> = {}
+  overrides: Partial<Signature> = {},
 ): Node<Component> {
   return {
     id: "llm-1",
@@ -114,7 +114,8 @@ describe("SignaturePromptEditorBridge", () => {
   });
 
   describe("when initialLocalConfig is computed", () => {
-    it("uses localPromptConfig when present on node data", () => {
+    /** @scenario "Unpublished local edits are restored when the node is reopened" */
+    it("passes localPromptConfig as initialLocalConfig when present on node data", () => {
       const localConfig: LocalPromptConfig = {
         llm: { model: "gpt-5-mini" },
         messages: [{ role: "system", content: "You are helpful" }],
@@ -124,11 +125,13 @@ describe("SignaturePromptEditorBridge", () => {
       const node = createSignatureNode({ localPromptConfig: localConfig });
       render(<SignaturePromptEditorBridge node={node} />);
 
+      // Genuine unpublished edits are passed through so the drawer restores
+      // them on top of the saved prompt.
       expect(capturedProps.initialLocalConfig).toBe(localConfig);
-      expect(mockNodeDataToLocalPromptConfig).not.toHaveBeenCalled();
     });
 
-    it("falls back to nodeDataToLocalPromptConfig when node has promptId but no localPromptConfig", () => {
+    /** @scenario "A saved prompt opens from the library when its node is reopened" */
+    it("does not pass the inline config as initialLocalConfig when the node references a saved prompt with no local edits", () => {
       const fallbackConfig: LocalPromptConfig = {
         llm: { model: "gpt-5-mini" },
         messages: [{ role: "system", content: "You are helpful" }],
@@ -138,7 +141,7 @@ describe("SignaturePromptEditorBridge", () => {
       mockNodeDataToLocalPromptConfig.mockReturnValue(fallbackConfig);
 
       const node = createSignatureNode({
-        promptId: "prompt-from-other-project",
+        promptId: "prompt-123",
         parameters: [
           { identifier: "llm", type: "llm", value: { model: "gpt-5-mini" } },
           { identifier: "instructions", type: "str", value: "You are helpful" },
@@ -146,12 +149,15 @@ describe("SignaturePromptEditorBridge", () => {
       });
       render(<SignaturePromptEditorBridge node={node} />);
 
-      // Bridge should provide fallback so the drawer can use it when DB query returns null
-      expect(mockNodeDataToLocalPromptConfig).toHaveBeenCalledWith(node.data);
-      expect(capturedProps.initialLocalConfig).toBe(fallbackConfig);
+      // initialLocalConfig must be undefined so the drawer shows the saved
+      // prompt loaded from the library instead of overriding it with this stale
+      // inline mirror (the bug that made a just-saved prompt look deleted).
+      expect(capturedProps.initialLocalConfig).toBeUndefined();
+      // The inline mirror is still provided, but only as the not-found fallback.
+      expect(capturedProps.inlineConfigFallback).toBe(fallbackConfig);
     });
 
-    it("returns undefined when node has promptId but no inline parameters", () => {
+    it("passes undefined for both configs when node has promptId but no inline parameters", () => {
       mockNodeDataToLocalPromptConfig.mockReturnValue(undefined);
 
       const node = createSignatureNode({ promptId: "prompt-123" });
@@ -159,9 +165,10 @@ describe("SignaturePromptEditorBridge", () => {
 
       expect(mockNodeDataToLocalPromptConfig).toHaveBeenCalledWith(node.data);
       expect(capturedProps.initialLocalConfig).toBeUndefined();
+      expect(capturedProps.inlineConfigFallback).toBeUndefined();
     });
 
-    it("falls back to nodeDataToLocalPromptConfig when no promptId and no localPromptConfig", () => {
+    it("provides the inline config as the fallback when there is no promptId and no localPromptConfig", () => {
       const fallbackConfig: LocalPromptConfig = {
         llm: { model: "gpt-3.5-turbo" },
         messages: [],
@@ -174,7 +181,8 @@ describe("SignaturePromptEditorBridge", () => {
       render(<SignaturePromptEditorBridge node={node} />);
 
       expect(mockNodeDataToLocalPromptConfig).toHaveBeenCalledWith(node.data);
-      expect(capturedProps.initialLocalConfig).toBe(fallbackConfig);
+      expect(capturedProps.initialLocalConfig).toBeUndefined();
+      expect(capturedProps.inlineConfigFallback).toBe(fallbackConfig);
     });
   });
 
@@ -475,9 +483,7 @@ describe("SignaturePromptEditorBridge", () => {
 
       const callData = mockSetNode.mock.calls[0]![0].data;
       expect(callData.localPromptConfig).toBe(config);
-      expect(callData.inputs).toEqual([
-        { identifier: "query", type: "str" },
-      ]);
+      expect(callData.inputs).toEqual([{ identifier: "query", type: "str" }]);
       expect(callData.outputs).toEqual([
         { identifier: "response", type: "str" },
       ]);

--- a/langwatch/src/optimization_studio/components/drawers/__tests__/SignaturePromptEditorBridge.integration.test.tsx
+++ b/langwatch/src/optimization_studio/components/drawers/__tests__/SignaturePromptEditorBridge.integration.test.tsx
@@ -170,7 +170,7 @@ describe("SignaturePromptEditorBridge", () => {
 
     it("provides the inline config as the fallback when there is no promptId and no localPromptConfig", () => {
       const fallbackConfig: LocalPromptConfig = {
-        llm: { model: "gpt-3.5-turbo" },
+        llm: { model: "gpt-5-mini" },
         messages: [],
         inputs: [],
         outputs: [],

--- a/specs/studio/prompt-library-roundtrip.feature
+++ b/specs/studio/prompt-library-roundtrip.feature
@@ -1,0 +1,33 @@
+Feature: A workflow LLM node round-trips its prompt with the prompt library
+
+  An LLM node on the optimization-studio canvas edits its prompt in a drawer.
+  The node can either keep the prompt inline (unpublished local edits) or save
+  it to the shared prompt library, after which the node references the saved
+  prompt by id. When the node references a saved prompt, reopening it must show
+  the saved prompt loaded from the library, not a stale copy of the inline
+  config the node held before it was saved. Otherwise a prompt saved from the
+  workflow looks deleted when the node is reopened, even though it is present in
+  the library and the playground.
+
+  Background:
+    Given an LLM node selected on the studio canvas with its prompt drawer open
+
+  @integration
+  Scenario: A saved prompt opens from the library when its node is reopened
+    Given the node references a prompt saved in the library
+    And the node has no unpublished local edits
+    When the prompt drawer is opened for the node
+    Then it shows the prompt loaded from the library
+    And it does not override it with the node's stale inline config
+
+  @integration
+  Scenario: Unpublished local edits are restored when the node is reopened
+    Given the node has unpublished local edits to its prompt
+    When the prompt drawer is opened for the node
+    Then it restores the unpublished edits on top of the saved prompt
+
+  @integration
+  Scenario: A node whose library prompt is missing shows its inline config
+    Given the node references a prompt that is not found in the project
+    When the prompt drawer is opened for the node
+    Then it falls back to the node's inline config instead of an empty form


### PR DESCRIPTION
## What this does

Fixes a customer-reported bug where a prompt saved from a workflow LLM node looked deleted. The prompt was present in the prompt library and the playground, but the workflow node showed stale content when it was reopened.

### Root cause

Saving a workflow LLM node's prompt to the library sets `promptId` and clears `localPromptConfig`, but leaves the node's now-stale inline `parameters`. On reopen, `SignaturePromptEditorBridge` passed those inline params as `initialLocalConfig`, which `PromptEditorDrawer` merged over the prompt it had just fetched from the library. So the saved content was overwritten by the stale inline copy, and the just-saved prompt looked lost in the workflow even though the library had it.

### Fix

- The bridge passes only genuine unpublished edits (`localPromptConfig`) as `initialLocalConfig`. A saved prompt with no local edits now loads its own library content.
- The inline mirror is passed as a separate `inlineConfigFallback` that the drawer uses only when the referenced prompt is not found in the project (e.g. a workflow imported from another project), preserving that fallback.
- The drawer's prompt-found branch is unchanged, so genuine unpublished edits still merge over the saved version.

## Tests

- `SignaturePromptEditorBridge.integration.test.tsx`: a node referencing a saved prompt with no local edits no longer passes the inline config as `initialLocalConfig` (the regression), and the inline config is provided only as the not-found fallback.
- `PromptEditorDrawer.test.tsx`: a node whose library prompt is missing falls back to its inline config instead of an empty form.
- Spec: `specs/studio/prompt-library-roundtrip.feature`.

## Dogfood

Browser-QA on the studio canvas. Saved a workflow LLM node's prompt to the library with distinctive text, then reopened the node.

The library/playground holds the saved prompt:

![library has the saved prompt](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4993/item7-playground-has-prompt.png)

After the fix, reopening the node loads that saved prompt instead of the stale default:

![workflow node loads the saved prompt](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/pr-4993/item7-workflow-loads-saved-prompt-fixed.png)

(The "LangWatch NLP is unreachable" toast is from the local QA stack running with NLP skipped, unrelated to this change.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an inline fallback for prompt editor configuration when a referenced prompt can’t be loaded, ensuring the editor isn’t left empty.

* **Bug Fixes**
  * Fixed prompt round-trip behavior to avoid overwriting successfully loaded library prompts while still restoring unpublished local edits.
  * Editor initialization now updates correctly when fallback configuration changes.

* **Tests**
  * Added/updated unit and integration coverage for missing referenced prompts, confirmed correct props flow, and added a prompt library round-trip feature spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->