### PR TITLE
feat(groupqueue): content-addressed tiered blob offload (ADR-029/030)

### DIFF
--- a/dev/docs/adr/029-groupqueue-content-addressed-payload-store.md
+++ b/dev/docs/adr/029-groupqueue-content-addressed-payload-store.md
@@ -1,0 +1,114 @@
+# ADR-029: GroupQueue content-addressed tiered payload store — flat jobs, fan-out dedup, holder-set reclaim
+
+**Date:** 2026-06-20
+
+**Status:** Proposed
+
+**Extends / supersedes in part:** [ADR-026](./026-groupqueue-payload-envelope.md) (GroupQueue payload envelope). The versioned-envelope + header-only routing decision stands. This ADR supersedes ADR-026's §"Blob lifecycle" — random blob ids, best-effort delete, and the 7-day pure-backstop TTL — for offloaded bodies.
+
+**Reuses:** the `stored-objects` object store — `StorageDriver` / `StorageRegistry` / content-addressed URI minting / `resolveProjectStorageDestination` (`src/server/stored-objects/`, the codebase's single pluggable object-store abstraction; behavioural contract in [externalize-event-byte-content.feature](../../../specs/features/scenarios/externalize-event-byte-content.feature)). The S3/file tier delegates to it. This is *not* [ADR-022](./022-event-log-source-of-truth.md)'s `BlobStore`, which is event_log-centric (it reads full content back out of ClickHouse) and is not a general object store; that one is not reused here.
+
+**Not to be confused with:** [ADR-024](./024-cold-path-tiered-storage.md) (cold-path tiered storage). ADR-024 tiers *ClickHouse* parts hot→cold across SSD and S3 volumes. This ADR tiers *GroupQueue staged-job payloads* inline→Redis→S3. Different subsystem; overlapping word.
+
+**Relates to:** [ADR-007](./007-event-sourcing-architecture.md) (event sourcing), `specs/queue-pausing/queue-pausing.feature`, the GroupQueue dedup-id squash (`specs/traces/record-span-gq-dedup.feature`, `specs/event-sourcing/deduplication-strategy.feature`).
+
+## Context
+
+A single event fans out to many staged jobs. The projection router dispatches one trace event to a fold projection, several map projections, and a chain of reactors — on the order of a dozen or more jobs for one trace event. Each of those jobs today carries its **own inline copy of the same large shared payload** (the event, and for reactors the fold state). The fan-out factor multiplies the payload's Redis footprint, and it does so precisely during ingestion bursts — the moment the queue is already under memory pressure.
+
+The duplication is uncured by today's offload, for two reasons:
+
+1. **Most fan-out payloads never offload.** ADR-026 offloads only bodies above 32 KiB; the leaned projection events (IO attributes capped at a 64 KiB preview by ADR-022, most attributes far smaller) frequently sit below that line and inline N times into the per-group data hash.
+2. **Even when they offload, they don't dedup.** ADR-026's blob id is a `randomUUID()` (`jobEnvelope.ts`), so N byte-identical payloads land under N distinct keys. There is no content identity, so there is nothing to collapse.
+
+Two further forces motivate a rewrite rather than a patch:
+
+- **Offload is split by provenance, and there are three of them.** ADR-026's Redis blob (queue jobs), ADR-022's edge S3 spool (oversized commands), and the `stored-objects` object store (externalized media) are three separate systems with separate thresholds, key shapes, and lifecycles. Where a payload's bulk lives depends on *which subsystem touched it*, not on *how big it is*. We want one answer, keyed on size alone, and we want the durable tier to reuse the one object-store abstraction the codebase already has.
+- **Cleanup has to survive a weekend.** A blob whose job is stuck — a retry-backoff chain, a paused pipeline — over a Friday→Monday must still exist on Monday. That pushes any safety-net TTL to **≥3 days**. But a 3-day TTL as the *primary* reclaim means three days of dead payloads accumulating at ingestion volume — untenable. The happy path must reclaim eagerly; only the genuinely-stuck path may ride the long backstop. Neither a pure long TTL (accumulates) nor a pure reference count (Redis has no GC; a single missed decrement leaks forever) satisfies both ends.
+
+## Decision
+
+Four parts: a content-addressed three-tier store, flat jobs, holder-set reclaim with a TTL backstop, and tenant-namespaced keys. It lives behind the GroupQueue serialization boundary in `src/server/event-sourcing/queues/groupQueue/` plus the fan-out producer in `src/server/event-sourcing/projections/`, and it reuses `src/server/stored-objects/` for the durable tier.
+
+### 1. One content-addressed, three-tier payload store
+
+The bulk of a staged job — its shared payload component(s) — is stored by **content hash**, in one of three tiers chosen by serialized size:
+
+| Tier | Size | Backend | Key |
+|---|---|---|---|
+| `inline` | ≤ 4 KiB | the envelope body itself (raw, or gzip when it wins) | — |
+| `redis` | 4 KiB – 256 KiB | standalone Redis key, gzip binary (the queue's own `RedisJobBlobStore`) | `{queue}:gq:blob:{projectId}/<hash>` |
+| `s3` | > 256 KiB | the reused `stored-objects` `StorageRegistry` (s3:// or file://) | `s3://{bucket}/{projectId}/<hash>` |
+
+`<hash>` is SHA-256 of the canonical component bytes, truncated to 128 bits, base64url (~22 chars; collision probability negligible). Identical bytes ⇒ identical key ⇒ **one** stored copy, however many jobs reference it. PUTs are idempotent — same content, same key — so a retried or racing stage is free and crash-safe.
+
+The 256 KiB S3 boundary matches ADR-022's existing `COMMAND_INLINE_THRESHOLD`. The 4 KiB inline ceiling drops ADR-026's 32 KiB so that ordinary fan-out events cross into the content-addressed `redis` tier and dedup, instead of inlining N×. All three thresholds are env-tunable. Only the durable (`s3`/`file`) tier goes through `stored-objects`; the hot `redis` tier stays queue-local because it carries a TTL + holder-set lifecycle that the object store has no notion of — "one offload mechanism" means one *object store* for the durable tier, not one interface over both Redis and S3.
+
+### 2. Flat jobs
+
+A staged job no longer embeds the shared payload. The fan-out producer (projection router / reactor dispatch) hoists each shared component — the **event**, and where applicable the **fold state** — out of the N per-consumer payloads, stores it once through the tiered store, and stages N flat jobs that carry only:
+
+- the per-consumer wrapper and the routing metadata the dispatch Lua already reads from the header (`__pipelineName` / `__jobType` / `__jobName` / `__context` / `__attempt`), and
+- tier-tagged content refs (`eventRef`, optionally `foldStateRef`) in place of the inline objects.
+
+A thin **resolve-adapter** wraps each handler and reconstitutes the refs before the handler runs, so **handlers are unchanged** — they still receive `{ event, foldState }`. The hoist happens at the **producer**, not the per-job encoder, for two reasons the real payload shapes force:
+
+- **The shapes are heterogeneous.** A reactor job is `{ event, foldState }` (the event is a nested field — `projectionRouter.ts:144`); a projection job sends the event *spread* (the event *is* the payload) with a per-projection `__jobName`. So whole-payload or top-level-field hashing dedups almost nothing across the fan-out — the only bytes identical across all consumers are the event (and the fold state), and the producer alone is positioned to lift them out *before* the shapes diverge.
+- **Serialize once, not N times.** Hoisting at the producer serializes, hashes, and stores the shared component **once** per fan-out and hands N jobs a ref. Hoisting in the per-job encoder would re-serialize and re-`PUT` it N times — idempotent on storage, but paying the CPU and the Redis network burst N times, and the burst is exactly what hurts under load. The producer hoist is the only one that relieves the burst, not just the at-rest footprint.
+
+The reshape is invisible above the serialization boundary, exactly as ADR-026's envelope was. The load-bearing subtlety: the dedup must key on the shared **component**, lifted at the fan-out point — not the whole job body.
+
+### 3. Holder-set reclaim + TTL backstop
+
+Because a content-addressed blob is shared, ADR-026's "delete on complete" is unsafe: one job's completion would yank a blob its siblings still reference. References are tracked with a **holder set** per blob and reclaimed eagerly when it empties, with a long TTL as the orphan backstop.
+
+- **Holder set** `{queue}:gq:blobholders:{projectId}/<hash>` — members are staged-slot ids (the `stagedJobId`s of `record-span-gq-dedup.feature`). A staged job referencing blob H adds its slot id; every *terminal retirement* of that slot removes it. Crucially, **the holder ops are TS-orchestrated at the queue's existing reclaim seams — not surgery inside the big lifecycle Lua.** At dispatch the queue `HDEL`s the job value out of the group hash and carries it to the worker in memory (`scripts.ts:787`, `groupQueue.ts:499`), so by `complete` time there is nothing in the hash to be atomic with — the value, and its ref, live on the worker. The seams already exist: `deleteEnvelopeBlobs` (`groupQueue.ts:808`) is called today at stage/batch dedup-squash, decode-failure, worker completion, and exhaust. Each becomes a holder release. The big `STAGE`/`DISPATCH`/`COMPLETE`/`RESTAGE` scripts stay **untouched**; the only new Lua is one small, self-contained release script.
+- **A set, not a counter, on purpose.** `SREM` of an already-removed member is a no-op, so a doubly-processed completion cannot under-count and prematurely delete a still-live blob — the failure mode that becomes a "blob missing" handler crash. A bare `INCR`/`DECR` has no such idempotency.
+- **One atomic release script does the reclaim.** `SREM holders(H) slotId; if SCARD(holders(H)) == 0 then UNLINK blob(H); DEL holders(H) end` runs in a single eval, so a completion racing a re-stage of the same content cannot delete a live blob — the one TOCTOU the set alone doesn't close. A `redis`-tier blob is `UNLINK`ed inline (deleting a key returns an integer — safe in Lua, unlike *reading* the binary body, which is why bodies are still written/read by the client directly); an `s3`-tier key is pushed to a reclaim list a best-effort sweeper drains via `StorageRegistry.delete` (Lua cannot reach S3). Happy path: a fan-out's blob is gone within seconds of its last job completing.
+- **Retry is a no-op for the blob, and dispatch never releases.** A retry re-encodes the same content to the same hash, so the slot's hold persists across the re-stage — the blob is never released-then-needed. The blob also survives dispatch by design (dispatch moves the value to the worker but does not touch the hold). Only *terminal* retirement — complete, exhaust, squash-displacement, decode-failure — releases.
+- **TTL backstop, refreshed on access.** Blob key and holder set both carry a **3-day** TTL (`SET … EX`), refreshed on every stage / dispatch / restage touch. A live reference keeps refreshing; only a reference untouched for 3 days ages out. Three days is sized to survive a weekend; the binding case is a *paused* pipeline, which does not access its blobs to refresh them, so the TTL must exceed the maximum pause window. The S3/file tier's backstop is the bucket lifecycle rule (the same safety net `stored_objects` and ADR-022 already rely on), sized ≥ the Redis TTL. All tunable via env.
+- **Missing blob is a fail-safe, never a wedge.** Should a backstop ever fire under a still-referenced job (TTL mis-sized, sweeper bug), decode finds the blob gone and — exactly as ADR-026 — completes the slot without invoking the handler; the work is recoverable via event replay. Content-addressing plus the holder set makes this rare; it never makes it fatal.
+
+### 4. Tenant-namespaced keys
+
+Every blob key — Redis and S3 — is **namespaced by `projectId`**, which *is* the tenant id in this codebase (`tenantId === projectId` throughout; the queue already derives it via `tenantIdFromGroupId`). So the durable tier mints exactly the `stored_objects` layout `s3://{bucket}/{projectId}/<hash>` via `mintS3Uri` + `resolveProjectStorageDestination` (which also picks the per-project BYOC bucket / global / local-FS destination). Consequences:
+
+- **Tenants never share a blob.** Two tenants with byte-identical content get distinct keys. Isolation is structural (in the key path), not incidental to the content.
+- **Purge is tractable.** A project delete becomes a delete-by-prefix over `…/{projectId}/*` on the durable tier; the Redis tier's 3-day TTL makes its purge effectively immediate once the project's jobs drain. This closes the GDPR gap that a globally-keyed shared blob would have opened.
+- **Logs must redact.** A BYOC tenant's bucket name is a cross-tenant disclosure channel; any log line carrying a blob URI goes through `redactStorageUri` (already provided by `stored-objects`).
+
+### 5. GQ2 envelope + two-phase rollout
+
+The envelope version bumps to `GQ2|`, marking a value as ref-bearing. This marker is load-bearing for rollout safety: refs ride *inside* the job value, so a value that carried them as plain JSON would `JSON.parse` cleanly on an old pod and hand the handler an unresolved `{ eventRef }` — silently wrong. The `GQ2|` prefix instead makes an old (GQ1-only) reader **drop the value and complete the slot without the handler**, recoverable via event replay — the same clean failure mode ADR-026 established. Rollout follows that discipline unchanged: every worker runs the resolve-adapter + tiered-store reader fleet-wide *before* any producer emits `GQ2`, gated by the existing `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED` flag (now the ref-write gate). App and worker Deployments still roll independently.
+
+## Rationale / Trade-offs
+
+**Why content-address here when ADR-022 explicitly rejected sha256-per-field?** Opposite motivation for the same primitive. ADR-022's spool is one transient object per command, never shared, so a hash bought it nothing but cost — it rejected the *integrity* hash. Our blob is shared across a fan-out, and the hash *is the dedup key*. Different problem, justified differently.
+
+**Why reuse the `stored-objects` driver but not `StoredObjectsService`?** `StorageDriver` (`get`/`put`/`delete`/`exists`, keyed by URI) and `StorageRegistry` (scheme dispatch) have zero ClickHouse coupling — they are exactly the byte primitive the durable tier needs, and they already give content-addressed, `projectId`-namespaced, BYOC-aware, multi-backend (S3 / local-FS / Azure) storage with idempotent PUTs. `StoredObjectsService` layers on a ClickHouse metadata row and a deliberately **no-GC** lifecycle (it relies on a project-delete cascade, per `externalize-event-byte-content.feature`). Adopting the service would import a lifecycle that contradicts our eager reclaim. So we reuse the *driver/registry/URI/destination* and keep our own holder-set reclaim, which calls `StorageRegistry.delete` directly. No clash: the no-GC stance is a service-level policy, not a driver constraint.
+
+**Why hoist at the producer rather than the per-job encoder?** A per-job encoder hoist (content-addressing each job's body as it is staged) is the simpler alternative — no producer changes, and it rides the existing reclaim seams — but it under-delivers here. The heterogeneous payload shapes mean it dedups reactors among themselves at best, not across the spread-shaped projection jobs, and it re-serializes and re-`PUT`s the shared event once per job. The producer hoist normalizes the shapes and pays the serialize/`PUT` once. We accept the extra surface — the projection router's three fan-out points plus the resolve-adapter on the read side — to get the full dedup and the network-burst relief, which is the actual capacity win. The holder/reclaim machinery is identical either way (it keys on whatever ref the encoded value carries), so this choice is isolated to the hoist.
+
+**Why eager reclaim plus a long backstop, rather than pure-TTL or pure-refcount?** The two constraints — survive a 3-day outage *and* not accumulate 3 days of payloads — are jointly unsatisfiable by either mechanism alone. Eager reclaim clears the ~99% happy path in seconds; the TTL bounds the long tail, turning every conceivable bookkeeping bug into "reclaimed within 3 days" rather than "leaked forever." The set-based holder makes a *missed* `SREM` degrade to "reclaimed at TTL" and a *double* `SREM` a no-op — the two seatbelts that make threading the reclaim through every lifecycle path survivable.
+
+**Why holder-set over integer refcount?** Idempotency, as above. The cost is a small set of short ids per blob — trivially smaller than the blob it guards.
+
+**What it costs.** The flat-job small case pays an extra round trip: a 200-byte singleton job with nothing to dedup would round-trip a blob for no benefit — which is why the `inline` tier (≤4 KiB) keeps such jobs in the envelope body. "Always flat" is the spirit; "flat above 4 KiB" is the rule. `resolveProjectStorageDestination` does a per-project lookup (BYOC bucket resolution), so the durable tier should cache the destination per `projectId` at queue volume rather than resolve per PUT. Ops debugging loses `redis-cli` readability for refs (already true for ADR-026 compressed/offloaded bodies; the decode helper extends to resolve refs). The reclaim bookkeeping is TS-orchestrated at the queue's existing retire seams plus one small release script — the big lifecycle Lua (`stage`/`dispatch`/`complete`/`restage`) is left untouched, which is where most of the risk would otherwise live. What risk remains is the producer hoist + resolve-adapter (a new read-side code path) and the holder-release races, both bounded by the atomic release script and the TTL backstop; the worst residual case is the (safe) missing-blob fail-safe.
+
+## Consequences
+
+**Positive.** A fan-out's Redis footprint drops from N copies to one blob plus N tiny flat jobs — roughly a fan-out-factor reduction, exactly under burst. Worker CPU serializes and gzips the shared component once, not N times. An outage backlog holds one copy per distinct event instead of N, so the very scenario the 3-day TTL exists for is itself fan-out-factor cheaper than today. Offload collapses toward one mechanism keyed on size, and the durable tier rides the codebase's existing object store instead of adding a fourth one.
+
+**Negative.** More moving parts in the lifecycle Lua (holder sets, the S3 reclaim list, the sweeper). A fresh two-phase rollout to manage (GQ2). A pipeline paused longer than the TTL falls to the replay fail-safe — mitigated by sizing the TTL above the maximum pause window, or by pause-aware refresh later. The durable tier inherits `stored-objects`' per-project destination resolution, which must be cached at queue volume.
+
+**Neutral.** Handlers, the queue-manager facades' public API, dedup-id squash semantics, and every key shape other than the new `blob` namespacing / `blobholders` / reclaim keys are untouched. This replaces ADR-026's blob lifecycle; ADR-026's envelope, header-routing, and two-phase-rollout decisions stand.
+
+## References
+
+- Extends / supersedes-in-part: [ADR-026](./026-groupqueue-payload-envelope.md) (GroupQueue payload envelope)
+- Reuses: `src/server/stored-objects/` (`StorageDriver` / `StorageRegistry` / `uri.ts` / `project-storage-destination.ts`) — contract in `specs/features/scenarios/externalize-event-byte-content.feature`
+- Distinct from: [ADR-022](./022-event-log-source-of-truth.md) (event_log SoT — its `BlobStore` is event_log-centric, not reused)
+- Disambiguation: [ADR-024](./024-cold-path-tiered-storage.md) (cold-path tiered storage — ClickHouse, not the queue)
+- Related: [ADR-007](./007-event-sourcing-architecture.md) (event sourcing); dedup-id squash in `specs/traces/record-span-gq-dedup.feature` and `specs/event-sourcing/deduplication-strategy.feature`
+- Spec: `specs/event-sourcing/payload-store-content-addressed.feature`
+- Supersedes the blob-lifecycle scenarios in `specs/event-sourcing/payload-envelope.feature`

--- a/dev/docs/adr/030-groupqueue-blob-handling-hardening.md
+++ b/dev/docs/adr/030-groupqueue-blob-handling-hardening.md
@@ -1,0 +1,81 @@
+# ADR-030: GroupQueue blob-handling hardening
+
+**Date:** 2026-06-20
+
+**Status:** Proposed
+
+**Amends:** [ADR-029](./029-groupqueue-content-addressed-payload-store.md) (GroupQueue content-addressed tiered payload store). ADR-029's tiered store, GQ2 envelope, holder-set reclaim, and queue wiring stand; this ADR hardens the blob lifecycle against the correctness, security, and design gaps a three-pass review (tests / security / code) surfaced after the implementation landed.
+
+**Relates to:** [ADR-022](./022-event-log-source-of-truth.md) (the edge `COMMAND_INLINE_THRESHOLD` this revisits), `src/server/stored-objects/` (the reused object store).
+
+## Context
+
+The GQ2 content-addressed offload shipped across eight commits. Reviewing it end-to-end found that the blob lifecycle is correct on the happy path but trusts stored state, non-atomic sequencing, and unbounded inputs in ways that break under partial failure, store tamper, or pathological size — and that the lifecycle is untestable in isolation because it's threaded through the 1224-LOC `GroupQueueProcessor`. See [specs/event-sourcing/payload-store-blob-hardening.feature](../../../specs/event-sourcing/payload-store-blob-hardening.feature) for the behavioural contract this decision supports.
+
+The findings cluster into three roots: **unbounded inputs** (a huge payload OOMs the worker at `JSON.stringify`/gzip), **trusted state + non-atomic steps** (a tampered ref or a partial-failure between acquire and release misbehaves), and **untestability** (the seams need a whole processor to exercise).
+
+## Decision
+
+### 1. Bounded-memory offload: cap the absolute size, hash over the raw source
+
+`JSON.stringify` → gzip → buffered `PUT` is the offload path. Two changes harden it:
+
+- An **absolute ceiling** `MAX_BLOB_BYTES` (**50 MiB**) bounds the one unavoidable allocation — the JSON string itself. Above it the job is **rejected at encode** with `PayloadTooLargeError`, so the producer surfaces the error rather than the worker OOMing on gzip + buffer. Exceeding the ceiling means an upstream cap (ADR-022's edge spool, `leanForProjection`'s 64 KiB IO preview) was bypassed — a bug to surface, not silently absorb. Worst-case worker memory is bounded at roughly `concurrency × MAX_BLOB_BYTES`.
+- Content addressing hashes the **raw source JSON** (passed as a separate `hashSource`), not the gzipped bytes, removing the dependency on gzip being byte-deterministic across zlib versions/levels. The store stays byte-symmetric — it stores and returns the gzipped `data`; `hashSource` only sets the `{projectId}/{hash}` key.
+
+**Streaming was considered and dropped.** A true multipart-streaming tier would need an object-store `putStream` across every driver plus the `@aws-sdk/lib-storage` dependency — a `stored-objects` change outside this change's event-sourcing-only scope — and it buys only marginal memory: the source `JSON.stringify` string is held regardless of buffered-vs-streamed, so the real worst-case is `concurrency × ceiling` of source strings, bounded by the **ceiling**, not a stream boundary. The cap is the OOM bound; the s3-tier threshold stays at 256 KiB (redis-vs-s3, both buffered).
+
+### 2. Distinguish a missing blob from a transient store error
+
+`TieredBlobStore.get` for the s3 tier must classify failures: a genuine *not-found* (`NoSuchKey` / 404) returns null → the decode fail-safe (complete the slot without the handler, recover via replay). A *transient* error (5xx, throttling, timeout, connection reset) **rethrows as retryable** so the queue's normal retry handles it. Today both collapse to "missing", so a brief S3 blip mass-drops in-flight jobs to replay instead of retrying.
+
+### 3. Coordinated, access-refreshed TTLs
+
+One `BLOB_BACKSTOP_TTL_SECONDS` constant drives both the blob and the holder-set TTL (no two-literal drift), with the invariant **holder-set TTL ≥ blob TTL**, and **both are refreshed on access** — dispatch refreshes the holder set as well as the blob (today only the blob is). This closes the premature-reclaim window where a long-lived fan-out's holder set expires while its blob is still being refreshed, dropping all members and reclaiming a blob siblings still reference.
+
+### 4. Atomic acquire→release transfer
+
+The retry and dedup-squash transitions move a hold from an old token to a new one on the same content hash. ADR-029 relied on calling acquire before release; that ordering holds under single-connection FIFO but not under a partial failure (acquire fails, release succeeds → premature reclaim). Replace the two un-awaited ops at those transitions with a **single transfer eval**: `SADD new; SREM old; reclaim the old blob iff its holder is now empty` — atomic, so no interleaving or partial failure can reclaim a blob the new reference needs. The plain stage path keeps the cheap fire-and-forget acquire.
+
+### 5. Re-mint location on read — don't trust the stored ref
+
+Decode derives the read location from server-trusted inputs — the redis key from `(projectId, hash)`, the s3 uri by re-minting via `resolveProjectStorageDestination(projectId)` + `mintS3Uri` — rather than trusting `ref.uri` carried in the envelope. A tampered envelope (requires queue-store write access) can otherwise point a read at another tenant's key/bucket; re-minting makes the stored uri advisory, not authoritative. The per-project destination is cached to avoid a resolve per read.
+
+**Tenant-attributed logging.** Every blob/holder/job log line MUST carry the owning `projectId`, log the tenant-scoped reference (`projectId` + content hash) rather than a bare hash, and never log the raw s3 uri or bucket name (use `redactStorageUri`). A log that names a blob without its tenant is a cross-tenant attribution hazard — logs are a real isolation surface. The blob lifecycle's previously-silent fire-and-forget failures now `warn` with `{ projectId, blobHash, tier }`, and the decode-failure (missing-blob) log carries the `projectId` too.
+
+### 6. Cluster-slot guard
+
+The release/transfer evals touch two keys (holder + blob) and are correct only if both land in one Redis Cluster slot — which depends entirely on the queue name carrying a hash tag (`{…}`). Assert this **at construction** and fail fast, rather than letting a hash-tag-less queue name silently `CROSSSLOT` and leak every blob to its TTL.
+
+### 7. Extract the blob lifecycle into a collaborator
+
+Pull the tiered store + holders construction, `projectId` resolution, and the acquire/release/reclaim/re-mint seams out of `GroupQueueProcessor` into a single-responsibility collaborator the processor delegates to — a domain noun (e.g. `EnvelopeBlobLifecycle`), **not** a `*Manager` (CLAUDE.md bans the suffix). This shrinks the processor and — the point — makes every seam unit-testable without standing up the whole queue.
+
+### 8. Test and tidy
+
+Add a `GroupQueue` GQ2 integration test (testcontainers) exercising the lifecycle end-to-end: offload → dispatch → reclaim, fan-out dedup, retry-keeps-blob, missing-blob fail-safe, s3 reclaim. Remove the production-dead `readEnvelopeRef` (subsumed by `readEnvelopeHold`). De-duplicate the in-memory `JobBlobStore` / `ObjectStore` test doubles into a shared helper.
+
+## Rationale / Trade-offs
+
+**Why a cap rather than streaming?** Streaming was the original plan — stream the gzip body to S3 above a 5 MiB boundary to avoid materialising a compressed buffer. But the source `JSON.stringify` string is held regardless of buffered-vs-streamed, so the real worst-case worker memory is `concurrency × ceiling` of source strings, bounded by the **ceiling**, not a stream boundary; streaming saves only the (smaller) gzip buffer. And a true streaming tier would need a `putStream` across every object-store driver plus the `@aws-sdk/lib-storage` dependency — outside this change's event-sourcing-only scope. So the ceiling is the memory bound, and streaming is dropped. Hashing the source string (not the gzip output) is kept regardless — it removes the gzip-determinism assumption.
+
+**Why atomic transfer over awaiting acquire?** Awaiting acquire before release fixes the ordering but still leaves a window if the process dies between them. One eval is the only way the transition is crash-atomic; the keys are already co-slot, so it's a two-key eval like the release it replaces — small marginal cost.
+
+**Why re-mint when the store is "trusted"?** Defence-in-depth at a tenant boundary is cheap here (a cached resolve), and "the queue's Redis is trusted" is exactly the assumption that erodes — a confused-deputy writer or a shared-bucket misconfiguration shouldn't become a cross-tenant read. The stored uri becomes a hint, not an authority.
+
+**What it costs.** A cached per-project destination resolver on the read path, one new transfer eval, a construction-time assertion, and a refactor that moves ~150 LOC out of the processor into a collaborator. The refactor is the largest diff but pays for itself in testability.
+
+## Consequences
+
+**Positive.** Worker memory is bounded regardless of payload size; a transient store blip retries instead of dropping work to replay; a long-lived fan-out can't prematurely reclaim a referenced blob; a partial failure or a tampered ref can't reclaim-early or cross tenants; a mis-tagged queue name fails fast instead of leaking silently; and the whole lifecycle is unit-testable.
+
+**Negative.** More surface (transfer eval, collaborator). The absolute ceiling introduces a reject path that didn't exist (a producer-visible `PayloadTooLargeError`). The destination cache adds an invalidation concern (bounded — BYOC bucket changes are rare, picked up on the next worker restart).
+
+**Neutral.** Handler API, dedup-id squash semantics, and the GQ2 envelope format are unchanged; this is hardening behind the same boundary.
+
+## References
+
+- Amends: [ADR-029](./029-groupqueue-content-addressed-payload-store.md)
+- Reuses: `src/server/stored-objects/` (object PUT/GET, destination resolver)
+- Spec: `specs/event-sourcing/payload-store-blob-hardening.feature`
+- Core contract: `specs/event-sourcing/payload-store-content-addressed.feature` (ADR-029)

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -1,26 +1,26 @@
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
-import type { GroupInfo, QueueInfo, ErrorCluster } from "../types";
-import type {
-  QueueRepository,
-  BlockedSummary,
-  DlqGroupInfo,
-  DrainPreview,
-  JobEntry,
-  ReconcileResult,
-} from "./queue.repository";
-import { normalizeErrorMessage } from "../normalize-error-message";
-import { createLogger } from "~/utils/logger/server";
-import {
-  GROUP_QUEUE_REGISTRY_KEY,
-  TTL_HELPER_LUA,
-  PARK_HELPER_LUA,
-} from "~/server/event-sourcing/queues/groupQueue/scripts";
 import {
   decodeJobEnvelope,
   readJobRoutingMeta,
 } from "~/server/event-sourcing/queues/groupQueue/jobEnvelope";
 import { RedisJobBlobStore } from "~/server/event-sourcing/queues/groupQueue/redisJobBlobStore";
+import {
+  GROUP_QUEUE_REGISTRY_KEY,
+  PARK_HELPER_LUA,
+  TTL_HELPER_LUA,
+} from "~/server/event-sourcing/queues/groupQueue/scripts";
+import { createLogger } from "~/utils/logger/server";
+import { normalizeErrorMessage } from "../normalize-error-message";
+import type { ErrorCluster, GroupInfo, QueueInfo } from "../types";
+import type {
+  BlockedSummary,
+  DlqGroupInfo,
+  DrainPreview,
+  JobEntry,
+  QueueRepository,
+  ReconcileResult,
+} from "./queue.repository";
 
 const logger = createLogger("langwatch:ops:queue-redis-repository");
 
@@ -412,7 +412,7 @@ export class QueueRedisRepository implements QueueRepository {
     >();
     for (let i = 0; i < allGroupIds.length; i++) {
       const errorHash = errorResults?.[i]?.[1] as Record<string, string> | null;
-      if (errorHash && errorHash.message) {
+      if (errorHash?.message) {
         groupErrors.set(allGroupIds[i]!, {
           message: errorHash.message,
           stack: errorHash.stack ?? "",
@@ -556,7 +556,14 @@ export class QueueRedisRepository implements QueueRepository {
           const raw = dataResults?.[i]?.[1] as string | null;
           if (raw) {
             try {
-              jobs[i]!.data = await decodeJobEnvelope({ value: raw, blobs });
+              // Ops-dashboard inspection: DO NOT refresh the blob TTL on read
+              // (2026-06-24 review). A repeatedly-viewed blocked group would
+              // otherwise keep its orphan blobs alive indefinitely.
+              jobs[i]!.data = await decodeJobEnvelope({
+                value: raw,
+                blobs,
+                readMode: "peek",
+              });
             } catch {
               // ignore undecodable values
             }

--- a/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/queue.redis.repository.ts
@@ -10,6 +10,9 @@ import {
   PARK_HELPER_LUA,
   TTL_HELPER_LUA,
 } from "~/server/event-sourcing/queues/groupQueue/scripts";
+import { TieredBlobStore } from "~/server/event-sourcing/queues/groupQueue/tieredBlobStore";
+import { resolveProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+import { createStorageRegistry } from "~/server/stored-objects/stored-objects-factory";
 import { createLogger } from "~/utils/logger/server";
 import { normalizeErrorMessage } from "../normalize-error-message";
 import type { ErrorCluster, GroupInfo, QueueInfo } from "../types";
@@ -551,6 +554,18 @@ export class QueueRedisRepository implements QueueRepository {
         redis: this.redis,
         queueName: params.queueName,
       });
+      // Wire the GQ2 tiered store too so an offloaded envelope renders its
+      // body in the ops dashboard once the write flag flips in prod. Without
+      // it, decode throws "no tiered store provided" and the catch below hides
+      // the payload from any operator trying to diagnose a stuck GQ2 job
+      // (2026-07-03 audit follow-up).
+      const tieredBlobs = new TieredBlobStore({
+        redisBlobs: blobs,
+        objectStoreFor: (projectId) => createStorageRegistry({ projectId }),
+        resolveDestination: resolveProjectStorageDestination,
+        queueName: params.queueName,
+        logger,
+      });
       await Promise.all(
         jobIds.map(async (_, i) => {
           const raw = dataResults?.[i]?.[1] as string | null;
@@ -558,10 +573,13 @@ export class QueueRedisRepository implements QueueRepository {
             try {
               // Ops-dashboard inspection: DO NOT refresh the blob TTL on read
               // (2026-06-24 review). A repeatedly-viewed blocked group would
-              // otherwise keep its orphan blobs alive indefinitely.
+              // otherwise keep its orphan blobs alive indefinitely. readMode
+              // "peek" routes BOTH the GQ1 blobs.get AND the tieredBlobs.get
+              // to their peek variants.
               jobs[i]!.data = await decodeJobEnvelope({
                 value: raw,
                 blobs,
+                tieredBlobs,
                 readMode: "peek",
               });
             } catch {

--- a/langwatch/src/server/event-sourcing/ARCHITECTURE.md
+++ b/langwatch/src/server/event-sourcing/ARCHITECTURE.md
@@ -125,41 +125,38 @@ graph TB
 
 ## Queue System
 
-### GroupQueue (for folds)
+Every projection — fold, map, reactor — dispatches through the in-house **GroupQueue**: per-aggregate FIFO + cross-aggregate parallelism on Redis primitives + Lua. Not BullMQ. The framework wires one GroupQueue per pipeline at the composition root.
 
-Fold projections require **per-aggregate FIFO ordering** -- event N must be fully processed before event N+1. The `GroupQueue` achieves this using BullMQ's `group` parameter combined with custom Lua staging scripts.
+The summary:
 
-Each aggregate gets its own virtual queue. A worker picks up the next job for each group, processes it, and only then allows the next job in that group to proceed. This serializes processing within an aggregate while allowing different aggregates to be processed in parallel across workers.
+- **GroupQueue (for folds)** — fold projections need per-aggregate FIFO. The `groupKey` is the aggregate id; events for the same aggregate process in order, different aggregates parallelise.
+- **GroupQueue (for maps + reactors)** — same queue infrastructure, different group keys. No per-aggregate ordering; just dedup + retries + tiered storage.
+- **Memory Queue (for testing / no Redis)** — when Redis is unavailable (local dev, fast unit tests), the framework drops to an in-process queue ([`queues/memory.ts`](./queues/memory.ts)) that processes jobs asynchronously with simple concurrency control. Not a tier of GroupQueue — entirely separate code path with no Lua, no Redis, no tiered storage.
 
-See: [`queues/groupQueue/groupQueue.ts`](./queues/groupQueue/groupQueue.ts)
+GroupQueue has its own deep-dive docs:
 
-### Global Queue (unified)
+- **[`queues/groupQueue/ARCHITECTURE.md`](./queues/groupQueue/ARCHITECTURE.md)** — staging Lua, dispatcher loop, the tiered envelope (inline → Redis blob → S3), holder-set reference counting, retries, dedup, pause/resume, tenant isolation, failure handling.
+- **[`queues/groupQueue/README.md`](./queues/groupQueue/README.md)** — when to use it, configuration knobs, process roles, caveats, testing, observability.
 
-All projections (folds, maps, and reactors) are dispatched through a single global `GroupQueue`. Map projections and reactors share the same queue infrastructure; they simply use different group keys and do not rely on per-aggregate ordering.
-
-### Memory Queue (for testing / no Redis)
-
-When Redis is unavailable, both queue types fall back to an in-memory implementation that processes jobs synchronously.
-
-See: [`queues/memory.ts`](./queues/memory.ts)
+The tiered storage in one line: a payload's serialized size picks where it lives at encode time — inline JSON (≤ 1 KiB) → inline gzip (1–4 KiB) → standalone Redis key (4–256 KiB) → object store / S3 (> 256 KiB, ≤ 50 MiB). Identical bytes collapse to one stored blob via content addressing, refcounted by a per-blob Redis SET.
 
 ## Process Roles
 
 The system supports two process roles, configured via the `processRole` option:
 
-- **`web`**: Dispatches commands and enqueues events. Does **not** start BullMQ workers. The web process can create events and dispatch commands but never processes queue jobs.
-- **`worker`**: Starts all BullMQ workers (fold, map, reactor, command queues). Processes events from queues.
+- **`web`**: Dispatches commands and stages events. The dispatcher loop and local processor are NOT started, so the web process can create events and stage queue jobs but never processes them.
+- **`worker`**: Stages AND dispatches — runs the BRPOP signal loop, the local concurrency processor, and the metrics collector for every registered queue.
 
-This separation allows horizontal scaling -- multiple web instances dispatch work while dedicated worker instances process it.
+This separation allows horizontal scaling — multiple web instances stage work while dedicated worker instances process it. The flag wires to GroupQueue's `consumerEnabled` option at construction time.
 
 ## No Checkpoints Needed
 
 Unlike traditional event sourcing systems that use checkpoint stores to track processing progress, this system does not need them:
 
-- **GroupQueue provides ordering**: BullMQ's group mechanism ensures per-aggregate FIFO without a sequence number tracker.
-- **Fold state is the implicit checkpoint**: The last persisted fold state tells the system where it is. If processing fails, the event is retried via BullMQ's retry mechanism and the fold re-applies from current state.
-- **Map projections are stateless**: Each event is independently appended -- no position tracking needed.
-- **Reactors are idempotent**: They fire after fold success. If they fail, BullMQ retries them. Deduplication is handled via `makeJobId`.
+- **GroupQueue provides ordering**: per-aggregate FIFO is enforced inside the staging Lua — events for the same aggregate are dispatched in stage-order without a sequence-number tracker.
+- **Fold state is the implicit checkpoint**: the last persisted fold state tells the system where it is. If processing fails, the queue retries the event with backoff (in front of the same group, preserving FIFO) and the fold re-applies from current state.
+- **Map projections are stateless**: each event is independently appended — no position tracking needed.
+- **Reactors are idempotent**: they fire after fold success. If they fail, the queue retries them. Downstream deduplication is handled via `makeJobId`.
 
 ## Global Projection Registry
 
@@ -177,9 +174,11 @@ All operations are scoped to `tenantId`. Events, projections, and stores enforce
 
 ## Failure Handling
 
-- **Fold failures**: BullMQ retries the job. On retry, the fold loads current state and re-applies the event. If state was already stored, the fold is effectively idempotent.
-- **Map failures**: BullMQ retries the job. Append stores should be idempotent or tolerate duplicates.
-- **Reactor failures**: BullMQ retries the reactor independently. The fold state is already persisted, so the reactor can safely retry.
+- **Fold failures**: GroupQueue retries the job with exponential backoff in front of the same group (FIFO is preserved). On retry, the fold loads current state and re-applies the event. If state was already stored, the fold is effectively idempotent.
+- **Map failures**: GroupQueue retries the job. Append stores should be idempotent or tolerate duplicates.
+- **Reactor failures**: GroupQueue retries the reactor independently. The fold state is already persisted, so the reactor can safely retry.
+- **Transient blob-store failures** (offloaded body temporarily unreachable — network blip, 5xx): GroupQueue re-stages the SAME envelope without re-encoding, so the body stays referenced through the retry. Distinguished from "missing" so a transient store outage can't mass-drop every in-flight offloaded job.
+- **Genuinely missing offloaded body** (TTL backstop kicked in, or manual purge): decode returns null, the slot is completed, the work recovers via event replay. The append-only event log is the durable source of truth.
 
 ## Key Implementation Files
 
@@ -195,7 +194,8 @@ All operations are scoped to `tenantId`. Events, projections, and stores enforce
 | Map executor | [`projections/mapProjectionExecutor.ts`](./projections/mapProjectionExecutor.ts) |
 | Projection router | [`projections/projectionRouter.ts`](./projections/projectionRouter.ts) |
 | Reactor types | [`reactors/reactor.types.ts`](./reactors/reactor.types.ts) |
-| GroupQueue | [`queues/groupQueue/groupQueue.ts`](./queues/groupQueue/groupQueue.ts) |
+| GroupQueue (deep dive) | [`queues/groupQueue/ARCHITECTURE.md`](./queues/groupQueue/ARCHITECTURE.md) + [`queues/groupQueue/README.md`](./queues/groupQueue/README.md) |
+| GroupQueue (main class) | [`queues/groupQueue/groupQueue.ts`](./queues/groupQueue/groupQueue.ts) |
 | Event store (interface) | [`stores/eventStore.types.ts`](./stores/eventStore.types.ts) |
 | Event store (ClickHouse) | [`stores/eventStoreClickHouse.ts`](./stores/eventStoreClickHouse.ts) |
 | Event store (Memory) | [`stores/eventStoreMemory.ts`](./stores/eventStoreMemory.ts) |

--- a/langwatch/src/server/event-sourcing/README.md
+++ b/langwatch/src/server/event-sourcing/README.md
@@ -30,7 +30,7 @@ const registered = eventSourcing.register(pipeline);
 await registered.commands.doSomething.add({ tenantId: "acme", /* payload */ });
 ```
 
-Registration connects the static definition to ClickHouse, Redis, and BullMQ. This happens in the composition root (`pipelineRegistry.ts`).
+Registration connects the static definition to ClickHouse, Redis, and the in-house [GroupQueue](./queues/groupQueue/README.md) (no BullMQ). This happens in the composition root (`pipelineRegistry.ts`).
 
 ## Builder API
 
@@ -229,7 +229,7 @@ All paths below are relative to `src/server/event-sourcing/`.
 | `services/` | `EventSourcingService` (main orchestration), `CommandDispatcher`, `QueueManager` |
 | `projections/` | Projection executors: `FoldProjectionExecutor`, `MapProjectionExecutor`, `ProjectionRouter`, `ProjectionRegistry` |
 | `reactors/` | Reactor type definitions |
-| `queues/` | Queue implementations: `GroupQueue` (BullMQ), `MemoryQueue` |
+| `queues/` | Queue implementations: `GroupQueue` (in-house, Redis + Lua — see [`queues/groupQueue/README.md`](./queues/groupQueue/README.md)) and `MemoryQueue` (in-process dev/test fallback) |
 | `stores/` | Event store implementations: `EventStoreClickHouse`, `EventStoreMemory`, projection store interfaces |
 | `utils/` | `EventUtils` (event creation, validation), `KillSwitch` |
 | `schemas/` | Shared type identifiers |
@@ -283,6 +283,6 @@ SaaS-only cross-pipeline fold projections live in `projections/global/`:
 
 1. **Missing tenant validation**: Always call `EventUtils.validateTenantId()` in store implementations.
 2. **Reactor without fold**: Reactors must be registered on an existing fold projection (`withReactor(foldName, ...)`). The builder will throw if the fold does not exist.
-3. **Fold store failures**: If `store.store()` fails, BullMQ retries the entire event. Make sure your store is idempotent or uses upsert semantics.
+3. **Fold store failures**: If `store.store()` fails, GroupQueue retries the entire event (with exponential backoff in front of the same group, preserving FIFO). Make sure your store is idempotent or uses upsert semantics.
 4. **Map projection ordering**: Map projections have no ordering guarantees. Do not rely on event order in append stores.
 5. **Process role mismatch**: Commands dispatched in a `web` process are enqueued but not processed until a `worker` process picks them up. Ensure workers are running.

--- a/langwatch/src/server/event-sourcing/eventSourcing.ts
+++ b/langwatch/src/server/event-sourcing/eventSourcing.ts
@@ -1,13 +1,15 @@
 import type { ClickHouseClient } from "@clickhouse/client";
-import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { SpanKind } from "@opentelemetry/api";
 import type IORedis from "ioredis";
 import type { Cluster } from "ioredis";
 import { getLangWatchTracer } from "langwatch";
 import type { ProcessRole } from "~/server/app-layer/config";
-import type { RetentionPolicyResolver } from "~/server/data-retention/retentionPolicyResolver";
 import { makeQueueName } from "~/server/background/queues/makeQueueName";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
+import type { RetentionPolicyResolver } from "~/server/data-retention/retentionPolicyResolver";
 import { createLogger } from "~/utils/logger/server";
+import { resolveProjectStorageDestination } from "../stored-objects/project-storage-destination";
+import { createStorageRegistry } from "../stored-objects/stored-objects-factory";
 import { DisabledPipeline } from "./disabledPipeline";
 import type { Event, Projection } from "./domain/types";
 import type {
@@ -22,16 +24,15 @@ import type {
 import { BILLING_REPORTING_PIPELINE_NAME } from "./pipelines/billing-reporting/pipeline";
 import { createBillingMeterDispatchReactor } from "./projections/global/billingMeterDispatch.reactor";
 import { orgBillableEventsMeterProjection } from "./projections/global/orgBillableEventsMeter.mapProjection";
-import type { ReactorDefinition } from "./reactors/reactor.types";
-import { RedisReplayMarkerChecker } from "./projections/replayMarkerCheck";
-import { ConfigurationError } from "./services/errorHandling";
-
 import { projectDailySdkUsageProjection } from "./projections/global/projectDailySdkUsage.foldProjection";
 import { ProjectionRegistry } from "./projections/projectionRegistry";
+import { RedisReplayMarkerChecker } from "./projections/replayMarkerCheck";
 import type { EventSourcedQueueProcessor } from "./queues";
 import { GroupQueueProcessor } from "./queues/groupQueue/groupQueue";
 import { EventSourcedQueueProcessorMemory } from "./queues/memory";
+import type { ReactorDefinition } from "./reactors/reactor.types";
 import { EventSourcingPipeline } from "./runtimePipeline";
+import { ConfigurationError } from "./services/errorHandling";
 import type { JobRegistryEntry } from "./services/queues/queueManager";
 import type { EventStore } from "./stores/eventStore.types";
 import { EventStoreClickHouse } from "./stores/eventStoreClickHouse";
@@ -157,7 +158,10 @@ export class EventSourcing {
       this.projectionRegistry.registerReactor(foldName, reactor);
     } catch (error) {
       // Only suppress "fold not registered" errors — let wiring bugs (duplicates, etc.) fail fast
-      if (error instanceof ConfigurationError && error.message.includes("fold not registered")) {
+      if (
+        error instanceof ConfigurationError &&
+        error.message.includes("fold not registered")
+      ) {
         logger.debug(
           { foldName, reactorName: reactor.name },
           "Skipping global fold reactor — fold not registered",
@@ -492,6 +496,8 @@ export class EventSourcing {
     if (effectiveRedis) {
       this._globalQueue = new GroupQueueProcessor(definition, effectiveRedis, {
         consumerEnabled: this._processRole === "worker",
+        objectStoreFor: (projectId) => createStorageRegistry({ projectId }),
+        resolveStorageDestination: resolveProjectStorageDestination,
       });
     } else {
       this._globalQueue = new EventSourcedQueueProcessorMemory(definition);

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/ARCHITECTURE.md
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/ARCHITECTURE.md
@@ -1,0 +1,305 @@
+# GroupQueue — Architecture
+
+A high-level technical overview of the in-house GroupQueue: how per-aggregate FIFO is achieved on Redis without BullMQ, how the dispatcher loop turns Redis signals into local concurrency, how the envelope tiers staged values across inline / Redis-blob / object-store storage based on size, and how content-addressed dedup collapses a fan-out's identical bodies to a single stored blob.
+
+For day-to-day usage (when to use it, basic examples, configuration, caveats), see [README.md](./README.md).
+
+---
+
+## Why a Custom Queue
+
+BullMQ gives you "process this job, eventually." That isn't enough for an event-sourcing fold projection, which needs:
+
+1. **Per-aggregate FIFO.** Event N for trace `abc` must be fully processed before event N+1 for `abc` even starts — otherwise the fold sees out-of-order applies and the persisted state diverges from the event log.
+2. **Cross-aggregate parallelism.** Trace `abc` and trace `xyz` are independent — blocking one on the other wastes the fleet.
+3. **Fair scheduling.** A noisy tenant must not starve a quiet one; a backed-up group must not starve fresher work.
+4. **Predictable retries.** A transient failure should re-stage with backoff in front of the same group (preserving FIFO), not stall the whole queue.
+
+GroupQueue is built on Redis primitives (lists, hashes, sets, sorted sets) coordinated by Lua scripts that hold the staging invariants. The result: per-group FIFO, cross-group parallelism, and the same horizontal-scale story as any other Redis worker fleet.
+
+---
+
+## The Staging Layer
+
+Every job sent to a GroupQueue lands first in the **staging layer** — a set of co-slot-hashed Redis keys that hold the queue's invariants. The staging primitives are pure Lua scripts ([`scripts.ts`](./scripts.ts)); everything else (dispatcher loop, fastq processor, retry classifier) is TypeScript that calls into them.
+
+| Key | Type | Role |
+|---|---|---|
+| `{queue}:groups:active` | sorted set | groups with pending work, scored by next-eligible timestamp |
+| `{queue}:group:{groupId}:jobs` | list | per-group FIFO of staged-job IDs (RPUSH on stage, LPOP on dispatch) |
+| `{queue}:group:{groupId}:data` | hash | staged-job ID → envelope value (the body) |
+| `{queue}:group:{groupId}:blocked` | string | non-empty marker that this group is paused (set by retries, cleared on resume) |
+| `{queue}:signals` | list | wake-up signals consumed by `BRPOP` (one entry per stage) |
+| `{queue}:active:{groupId}` | string | TTL'd marker — group is currently being processed somewhere; crash-recovery safety net |
+| `{queue}:dedup:{dedupId}` | string | dedup window — staged-job ID currently occupying this dedup slot |
+
+The `{queue}` prefix is a Redis Cluster hash tag (`{...}`), so every key for a given queue lands in the same cluster slot. This is what lets the Lua scripts touch multiple keys atomically — a CROSSSLOT eval is a runtime error, not a thing that ever happens.
+
+---
+
+## Lifecycle of a Single Job
+
+```
+producer.send(payload)
+  │
+  ▼  STAGE_LUA: RPUSH job id, HSET envelope, ZADD group → active, dedup write,
+  │             LPUSH a signal
+  │
+  ▼  signals list  ──BRPOP──▶  dispatcher loop  (idle workers wake up here)
+  │
+  ▼  DISPATCH_LUA: pick next eligible group (weighted RR), LPOP its job,
+  │                read envelope, mark group active with TTL
+  │
+  ▼  fastq processing slot (local node concurrency)
+  │
+  ▼  decode envelope (re-merge header machinery onto body, fetch offloaded blob)
+  │
+  ▼  user's `process(payload)` handler
+  │
+  ▼  COMPLETE_LUA: HDEL the envelope, drop the active marker, ZREM if group empty
+  │
+  ▼  release the blob hold → atomic reclaim if last holder (Lua)
+```
+
+A failure anywhere in this chain takes one of three paths:
+
+- **Retryable** → `RESTAGE_AND_BLOCK_LUA` puts the job back at the head of its group with a backoff score; the group is briefly blocked so the same job comes out next.
+- **Non-retryable** → drop to the fail-safe (complete the slot, recover via event replay).
+- **Transient blob-store error** → re-stage the SAME envelope (same hold token) so the body stays referenced through the retry.
+
+---
+
+## Cross-Aggregate Parallelism + Fair Scheduling
+
+The dispatcher pulls one signal at a time off `BRPOP` and then runs `DISPATCH_LUA`, which:
+
+1. Picks the next eligible group from the `active` sorted set (`ZRANGEBYSCORE 0 now`).
+2. Weights groups by `sqrt(pendingCount)` so a backed-up group gets more turns without starving fresher work.
+3. Per dispatch call, drains up to `MAX_BATCH_SIZE` jobs across groups, bounding script execution time.
+
+Each dispatched job becomes a `fastq` task on the local node, capped at `GLOBAL_QUEUE_CONCURRENCY` (default 100). `fastq` is just a local concurrency limiter — multiple worker nodes share the same Redis-side staging, so horizontal scale is `nodes × per-node-concurrency`.
+
+Tenant rate tracking ([`TenantRateTracker`](../../../observability/tenantRateTracker.ts)) records throughput per tenant; the score formula keeps a high-throughput tenant from monopolizing the dispatcher.
+
+---
+
+## Where Job Bodies Actually Live: The Tiered Envelope
+
+A job's payload can range from "a 200-byte status update" to "a 30 MiB trace dump." Inlining all of it in the staged value works for the small case but bloats the Redis-side hash, blows past the Lua script's reply-size budget, and replicates the same bytes 30× when an event fans out to 30 reactors. So the envelope **tiers** the body across four progressively-more-durable storage targets, picked at encode time based on the body's serialized size.
+
+```
+serialized payload size
+        │
+        ├──── ≤ 1 KiB ─────────────────▶ INLINE (raw JSON)
+        │                                  envelope = "GQ2|<hLen>|<hJson><json>"
+        │
+        ├──── 1 KiB to ≤ 4 KiB ────────▶ INLINE (gzip+base64 if smaller)
+        │                                  envelope = "GQ2|<hLen>|<hJson><gz-b64>"
+        │
+        ├──── 4 KiB to ≤ 256 KiB ──────▶ REDIS-TIER BLOB (standalone Redis key)
+        │                                  envelope = "GQ2|<hLen>|<hJson>"  (no body)
+        │                                  blob key  = "{queue}:gq:blob:{projectId}/{sha256}"
+        │
+        └──── > 256 KiB, ≤ 50 MiB ─────▶ S3-TIER BLOB (stored-objects bucket)
+                                           envelope = "GQ2|<hLen>|<hJson>"  (no body)
+                                           object key = "{projectId}/{sha256}" in the project's bucket
+```
+
+`> 50 MiB` is rejected at encode time (`PayloadTooLargeError`) — large enough to be a clear product bug, small enough to bound worst-case worker memory at `MAX_BLOB_BYTES × concurrency`.
+
+### Why these tiers?
+
+- **Inline raw (≤ 1 KiB)** — gzip+base64 of sub-kilobyte JSON is usually *larger* than the input. Skip compression entirely.
+- **Inline gzip (1–4 KiB)** — gzip wins for most real payloads in this range; the encoder verifies (`gzip+base64 < raw`) and falls back to raw if not. The inline ceiling (`INLINE_CEILING_BYTES = 4 KiB`) is set low so ordinary fan-out events cross into the dedup tier rather than inlining N× across reactors. Tighter than the GQ1 32 KiB threshold (`BLOB_OFFLOAD_THRESHOLD_BYTES`), which only offloaded for the very-large case.
+- **Redis blob (4–256 KiB)** — bigger than we want repeated in the staged value (every fan-out copy would replicate), but small enough that round-trip latency through a standalone Redis key is fine. Holds for ~3 days by default, refreshed on every read (GETEX); reclaimed atomically when the last referencing job completes.
+- **S3 / object-store (> 256 KiB)** — large bodies are the worst-case for Redis: memory pressure, replication lag, eviction risk. Push them to the durable object store the rest of the platform already runs on (`StorageRegistry`, projectId-scoped so each tenant's BYOC bucket is honored). No TTL on s3 objects — the lifecycle takes care of reclaim via the holder set; a bucket lifecycle policy is the operational backstop for missed reclaims.
+
+All thresholds live in [`jobEnvelope.ts`](./jobEnvelope.ts) and [`tieredBlobStore.ts`](./tieredBlobStore.ts). The 4 KiB inline ceiling and 256 KiB S3 threshold are conservative — tighten them under load if metrics show too much inline bloat or too many Redis-tier blobs.
+
+### Content-addressed sharing
+
+A Redis-tier or S3-tier blob is keyed by `{projectId}/{sha256(payload-bytes)}` — content-addressed, tenant-namespaced. The two consequences:
+
+- **Identical bytes → one stored blob.** A 30-reactor fan-out of the same event stages 30 envelopes, each carrying a hold token, but the underlying blob is a single stored copy. PUTs are idempotent — racing or retrying just overwrites the same key with the same content.
+- **Tenant isolation.** Two tenants with byte-identical user payloads still get distinct blobs (different `projectId` prefix). A project purge is a delete-by-prefix.
+
+The hash is taken over the **raw** payload bytes, not the gzipped output, so the dedup key doesn't depend on gzip determinism (zlib version / compression level).
+
+### Routing-exclusion: keeping the hash stable across reactors
+
+The same event fanned out to reactor A (`__jobName: "rollup-by-day"`) and reactor B (`__jobName: "rollup-by-hour"`) would naively hash to different blobs because the per-reactor routing fields perturb the body bytes. To prevent this, the GQ2 encoder splits `jobData` into:
+
+- **Body** — every key not starting with `__`. This is what the hash is computed over.
+- **Header machinery** — every `__*` key (routing names, attempt counter, async context, staged-job id, dispatch score). These live in `header.m` and `header.p/t/n`; the routing trio is also surfaced as a read-fast-path for the dispatcher Lua and the ops dashboard.
+
+On decode, the machinery is re-merged onto the parsed body so downstream code sees the original `jobData` shape. The strip is allowlist-free: any future `__*` field is automatically lifted to the header, so a maintainer can't accidentally regress dedup. The public `send`/`sendBatch` reject any `__*` key in user payload (except the 3 caller-set routing fields) — the namespace contract is enforced at the boundary.
+
+See ADR-029 (content-addressed store) and ADR-030 (hardening) for the design.
+
+---
+
+## The Holder Set: Reference-Counting Without a Counter
+
+A counter would race: two completions decrementing simultaneously could both see "1, decrement, drop to 0, reclaim" — the blob is reclaimed twice, the second reclaim noisy-fails (or worse, deletes a freshly-restored copy).
+
+GroupQueue uses a **per-blob Redis SET** instead. Each staged occupancy gets a random hold token; the set's members are the live holders. The reclaim happens atomically inside one Lua eval:
+
+```lua
+-- RELEASE_LUA (simplified)
+if redis.call("SREM", holderKey, token) == 0 then return "still-held" end  -- no-op release
+if redis.call("SCARD", holderKey) == 0 then
+  redis.call("DEL", holderKey)
+  if #KEYS >= 2 then redis.call("UNLINK", blobKey); return "reclaimed-redis" end
+  return "reclaim-s3"
+end
+return "still-held"
+```
+
+Key properties:
+
+- **Double-release is a no-op.** An already-released token can't reclaim a live blob.
+- **Last-release reclaims atomically.** SREM + SCARD + UNLINK in one eval — no acquire-then-release gap a partial failure could exploit.
+- **Cluster-safe.** The release/transfer evals pass only the keys that exist (`#KEYS` is dynamic), so an s3-tier release doesn't ship an empty placeholder key that would CROSSSLOT.
+- **TTL backstop.** Holder TTL ≥ blob TTL + 1 day (both refreshed on access) — the set always outlives the blob it guards, and both reclaim eagerly on the happy path. The TTL is a safety net for missed releases (crashes mid-completion), not the primary reclaim mechanism.
+
+A retry or dedup-squash uses `TRANSFER_LUA` to move the hold from the old envelope to the new one in one atomic eval — same-set swap (`SADD newToken + SREM oldToken`, blob stays) when the re-encode produces the same content hash, or cross-set reclaim (drop the old blob, hold the new one) when content actually changed.
+
+---
+
+## Tenant Isolation
+
+Every blob ref carries the tenant's `projectId` (branded `TenantId` end-to-end). On decode, the lifecycle asserts `hold.ref.projectId === projectIdFor(groupId)` BEFORE fetching — a mis-routed or tampered envelope can't read another tenant's blob. The same guard runs on `release` and `transfer`: a foreign-tenant hold is left to its TTL rather than dropped via the wrong tenant's cleanup path.
+
+The s3 object URI is re-minted server-side from `(projectId, hash)` on every read, never trusted from the envelope. Even a tampered envelope can't redirect a fetch across tenants.
+
+Error logs from the blob lifecycle run through `redactStorageUrisInText` so an object-store SDK error quoting `s3://bucket/...` doesn't leak a BYOC bucket name into a shared log sink.
+
+---
+
+## Memory Queue: The Dev/Test Fallback
+
+When Redis isn't available (local development without `docker-compose`, fast unit tests), the framework drops back to [`queues/memory.ts`](../memory.ts) — an in-memory queue that processes jobs asynchronously with simple concurrency control. **Different code path entirely**, not a tier of GroupQueue: no Redis, no staging Lua, no tiered storage. Useful for tests and single-instance development; not for production. The tier picker doesn't apply there because everything is held in process memory.
+
+---
+
+## Retries and Backoff
+
+When a `process()` handler throws, the queue:
+
+1. **Classifies** the error via `categorizeError`:
+   - `Retryable` → re-stage with exponential backoff
+   - `NonRetryable` → drop to the fail-safe; the slot is completed and the work is expected to recover via event replay
+   - `Transient` (blob-store specific) → re-stage the SAME envelope (same hold token, no re-encode)
+2. **Computes backoff** via `getBackoffMs(attempt)` (exponential with jitter, capped).
+3. **Re-encodes** the payload with `__attempt: N+1` and atomically transfers the hold from the old envelope to the new one.
+4. **Re-stages** at the head of the group with a future score (the group is briefly blocked so the retry is the next one dispatched).
+5. **Exhausts** after `JOB_RETRY_CONFIG.maxAttempts` and increments `gqJobsExhaustedTotal`; the slot is completed.
+
+Because routing-exclusion keeps the content hash stable across retries (the body is unchanged; `__attempt` is in the header), the atomic transfer is a same-set `SADD + SREM` — the blob stays held throughout the retry, no reclaim/re-fetch churn.
+
+---
+
+## Deduplication
+
+Three modes, configured per-job or per-queue:
+
+- **None** (default) — every send stages a new job.
+- **`"aggregate"`** — dedup ID is `${tenantId}:${aggregateType}:${aggregateId}`; only the latest event per aggregate is processed within the dedup window (default 200 ms).
+- **Custom `DeduplicationConfig`** — caller-supplied `makeId` + `ttlMs`, with `extend` (reset TTL on each new send) and `replace` (overwrite the staged value) flags.
+
+Dedup is implemented inside `STAGE_LUA`: a write to `{queue}:dedup:{dedupId}` with the staged-job ID; subsequent sends within the TTL either coalesce, replace, or extend. The orphaned staged value (when `replace: true`) has its hold transferred atomically to the new envelope — see "Holder Set" above for why this matters.
+
+---
+
+## Coalescing / Batch Processing
+
+Pipelines that opt in (`processBatch` + `coalesceMaxBatch` in the queue definition) can drain multiple jobs from the same group in one dispatch, hand them to the user as an array, and complete them as a batch. The drain is bounded by `coalesceMaxBatch(payload)` — a per-payload knob since some payload shapes can usefully coalesce up to N, others only 1.
+
+Coalesced batches go through the same envelope decoder and the same lifecycle: every staged value's hold is acquired at stage, released on batch completion or retry-transferred to the re-encoded retry value.
+
+---
+
+## Pause / Resume
+
+The `{queue}:group:{groupId}:blocked` marker is set by:
+
+- A retry (`RESTAGE_AND_BLOCK_LUA`) — briefly blocks the group so the retry is next out.
+- An explicit pause from the queue-pausing pipeline (see [`specs/queue-pausing/queue-pausing.feature`](../../../../../../specs/queue-pausing/queue-pausing.feature)).
+
+`DISPATCH_LUA` skips blocked groups when picking the next eligible group; the active sorted set is unchanged but the group is invisible to the dispatcher until unblocked. Unblock is just deleting the marker.
+
+The active key (`{queue}:active:{groupId}`) is a separate safety net: a TTL'd marker that says "this group is being processed by someone right now." On crash, the TTL expires (default 5 min) and the group becomes dispatchable again — a stuck job is recoverable without manual intervention.
+
+---
+
+## Failure Handling: Fail-Safe Paths
+
+The queue is built so a transient infrastructure failure never drops a job, and a permanent failure never silently corrupts state:
+
+- **Missing blob** (offloaded body genuinely gone — TTL backstop kicked in, or a manual purge) → decode returns null, the dispatcher logs and completes the slot. The work is expected to recover via event replay.
+- **Transient blob-store error** (network blip, 5xx) → classified `TransientBlobStoreError`, the job is re-staged with the SAME envelope (no re-encode, no holder churn). Distinguished from `Missing` so a transient store outage can't mass-drop every in-flight offloaded job.
+- **Decode tenant mismatch** → refuse to fetch, log tenant-attributed, drop to fail-safe.
+- **Oversized blob** (object exceeds the read cap mid-stream) → treated as missing → fail-safe.
+- **Holder Lua failure** → log + rely on the TTL backstop.
+
+The fail-safe always prefers "complete the slot and let replay handle it" over "stall the queue" — event sourcing's append-only event log is the durable source of truth.
+
+---
+
+## Observability
+
+| Metric | Purpose |
+|---|---|
+| `gqJobsStagedTotal` / `gqJobsDispatchedTotal` / `gqJobsCompletedTotal` | end-to-end throughput |
+| `gqJobsRetriedTotal` / `gqJobsExhaustedTotal` / `gqJobsNonRetryableTotal` | failure characterisation |
+| `gqJobsDedupedTotal` / `gqJobsDelayedTotal` | dedup + delay activity |
+| `gqGroupsBlockedTotal` | how often a group blocks (retries / pauses) |
+| `gqJobDelayMilliseconds` / `gqJobDurationMilliseconds` | latency + processing time |
+| `gqRetryAttempt` / `gqRetryBackoffMilliseconds` | retry distribution |
+
+OpenTelemetry spans wrap dispatch + processing; `__context` round-trips OTel trace context through the envelope so a span dispatched on web continues on the worker.
+
+---
+
+## Composition Root
+
+GroupQueue dependencies are explicit constructor injections — no env-coupling. The composition root ([`eventSourcing.ts`](../../eventSourcing.ts)) supplies:
+
+- The Redis connection (shared with the rest of the platform).
+- `objectStoreFor(projectId)` → `StorageRegistry` (per-tenant BYOC bucket resolution).
+- `resolveStorageDestination(projectId)` → `ProjectStorageDestination` (BYOC or global).
+- `featureFlagService` (kill-switch support).
+
+This keeps the queue testable in isolation: integration tests pass an in-memory `ObjectStore` + a stub destination resolver and exercise the full Lua + holder lifecycle against a testcontainers Redis.
+
+---
+
+## Quick File Map
+
+| Concern | File |
+|---|---|
+| Main processor + send/dispatch wiring | [`groupQueue.ts`](./groupQueue.ts) |
+| Dispatcher loop (BRPOP + fastq) | [`dispatcher.ts`](./dispatcher.ts) |
+| Staging Lua scripts | [`scripts.ts`](./scripts.ts) |
+| Envelope encode / decode (GQ1 + GQ2) | [`jobEnvelope.ts`](./jobEnvelope.ts) |
+| Content-addressed tiered store | [`tieredBlobStore.ts`](./tieredBlobStore.ts) |
+| Per-blob holder set + reclaim Lua | [`blobHolders.ts`](./blobHolders.ts) |
+| Lifecycle collaborator (encode/decode + acquire/release/transfer) | [`envelopeBlobLifecycle.ts`](./envelopeBlobLifecycle.ts) |
+| Shared key layout (blob + holder) | [`blobKeys.ts`](./blobKeys.ts) |
+| Cluster hash-tag guard | [`redisHashTag.ts`](./redisHashTag.ts) |
+| Constants (TTLs, size cap) | [`blobConstants.ts`](./blobConstants.ts) |
+| GQ1 (legacy) randomUUID blob store | [`redisJobBlobStore.ts`](./redisJobBlobStore.ts) |
+| Metrics definitions | [`metrics.ts`](./metrics.ts) |
+| Periodic metrics collector | [`metricsCollector.ts`](./metricsCollector.ts) |
+
+## Related ADRs
+
+- [ADR-026](../../../../../../dev/docs/adr/026-groupqueue-payload-envelope.md) — the GQ1 envelope format
+- [ADR-029](../../../../../../dev/docs/adr/029-groupqueue-content-addressed-payload-store.md) — content-addressed tiered store (GQ2)
+- [ADR-030](../../../../../../dev/docs/adr/030-groupqueue-blob-handling-hardening.md) — hardening for the GQ2 store path
+
+## Related Specs
+
+- [`payload-envelope.feature`](../../../../../../specs/event-sourcing/payload-envelope.feature) — GQ1 envelope behaviour
+- [`payload-store-content-addressed.feature`](../../../../../../specs/event-sourcing/payload-store-content-addressed.feature) — GQ2 content-addressed store behaviour
+- [`payload-store-blob-hardening.feature`](../../../../../../specs/event-sourcing/payload-store-blob-hardening.feature) — GQ2 hardening behaviour

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/README.md
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/README.md
@@ -1,0 +1,244 @@
+# GroupQueue — Usage Guide
+
+The in-house queue that backs every event-sourcing pipeline: per-aggregate FIFO, cross-aggregate parallelism, tiered payload storage, content-addressed dedup across fan-outs. Built on Redis primitives + Lua, no BullMQ.
+
+For the technical overview (how the staging Lua, the dispatcher, the tiered storage, and the holder refcount actually work), see [ARCHITECTURE.md](./ARCHITECTURE.md).
+
+---
+
+## When to Use It
+
+Reach for GroupQueue when **any** of these is true:
+
+- You need **per-aggregate FIFO**: event N for an aggregate must finish before event N+1 starts. This is the canonical fold-projection requirement.
+- You want **content-sharing across fan-out**: the same event dispatched to many reactors should not pay N× the Redis memory cost.
+- You expect **payloads up to ~50 MiB**: small payloads inline, big ones offload to S3 — no separate code path per size.
+- You want a **predictable retry path** that preserves FIFO within a group.
+
+Reach for something else when:
+
+- The work is fire-and-forget with no ordering constraint and no fan-out — a plain BullMQ queue (or a cron) is fine.
+- You need **cross-aggregate ordering** (i.e. a global pipeline). GroupQueue's parallelism story explicitly assumes aggregates are independent.
+- You need **scheduled / cron jobs**. Use a scheduler.
+- Payloads are routinely > 50 MiB. The hard cap exists to bound worker memory — push the data to its own storage path (S3, blob, ClickHouse) and pass a reference.
+
+---
+
+## Quick Start: Using It Indirectly
+
+You almost never instantiate `GroupQueueProcessor` directly. The framework wires one up per pipeline in the composition root ([`eventSourcing.ts`](../../eventSourcing.ts)), and you declare what runs on it through the `definePipeline()` builder:
+
+```typescript
+import { definePipeline } from "~/server/event-sourcing";
+
+const pipeline = definePipeline<TraceEvent>()
+  .withName("trace_processing")
+  .withAggregateType("trace")
+  .withFoldProjection("summary", traceSummaryFoldProjection)
+  .withReactor("summary", "syncToSearch", searchSyncReactor)
+  .build();
+```
+
+The fold projection's events flow through a GroupQueue keyed by `aggregateId`, so events for the same trace process in order. Different traces parallelise across the worker fleet.
+
+See the parent [`event-sourcing/README.md`](../../README.md) for the full builder API.
+
+---
+
+## Quick Start: Using It Directly
+
+You only instantiate `GroupQueueProcessor` when building a new queue surface outside the event-sourcing framework — rare. The shape:
+
+```typescript
+import { GroupQueueProcessor } from "~/server/event-sourcing/queues/groupQueue/groupQueue";
+import { connection } from "~/server/redis";
+import { createStorageRegistry } from "~/server/stored-objects/stored-objects-factory";
+import { resolveProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+
+const queue = new GroupQueueProcessor<MyPayload>(
+  {
+    name: "{my-feature/processor}",  // hash-tagged for Redis Cluster
+    groupKey: (payload) => payload.aggregateId,
+    process: async (payload) => { /* handle one job */ },
+    options: { globalConcurrency: 50 },
+  },
+  connection,
+  {
+    consumerEnabled: processRole === "worker",
+    objectStoreFor: (projectId) => createStorageRegistry({ projectId }),
+    resolveStorageDestination: resolveProjectStorageDestination,
+  },
+);
+
+await queue.waitUntilReady();
+await queue.send({ aggregateId: "abc", data: "..." });
+```
+
+The two notable things:
+
+- **The queue name must be hash-tagged** (`{...}`) so every Redis key for this queue lands in the same Redis Cluster slot. This is what lets the staging Lua touch multiple keys atomically.
+- **`consumerEnabled: false`** for web processes — they should stage jobs but never dispatch them. Workers run with `consumerEnabled: true` (the default).
+
+---
+
+## Process Roles
+
+| Role | What it does | `consumerEnabled` |
+|---|---|---|
+| `web` | Stages jobs via `send`/`sendBatch`. No dispatcher loop, no `fastq` processor. | `false` |
+| `worker` | Stages AND dispatches. Runs the BRPOP signal loop, the local concurrency processor, and the metrics collector. | `true` |
+
+A web pod that accidentally runs with `consumerEnabled: true` will pull jobs off the staging layer and process them on the web tier — usually not what you want (different scaling, different latency budget, no autoscaler tuning). The composition root reads `processRole` from config and sets this for you.
+
+---
+
+## Configuration
+
+### Per-queue (in `EventSourcedQueueDefinition`)
+
+| Field | Default | Purpose |
+|---|---|---|
+| `name` | required | Hash-tagged queue name; controls Redis key prefix |
+| `groupKey(payload)` | required | Returns the group ID — events with the same ID are FIFO-ordered |
+| `process(payload)` | required | Single-job handler |
+| `processBatch(payloads[])` | optional | Batch handler — opt into coalescing |
+| `coalesceMaxBatch(payload)` | optional | Per-payload coalescing limit |
+| `groupKey`'s tenant inference | derived | The group ID prefix should embed the tenant (`tenantId/aggregateId`) so the dispatcher's tenant rate tracker works |
+| `score(payload)` | `Date.now()` | When the job becomes eligible — use for delayed work |
+| `deduplication` | none | Dedup mode (see below) |
+| `delay` (option) | none | Constant delay added to score |
+| `spanAttributes(payload)` | optional | Returns custom span attributes for the dispatch span |
+| `options.globalConcurrency` | 100 | Max parallel groups processed on this node |
+
+### Dedup modes
+
+```typescript
+// 1. No dedup — every send stages a new job (default)
+.withProjection("X", definition)
+
+// 2. By aggregate — only the latest event per aggregate within the TTL window
+.withProjection("X", definition, {
+  deduplication: "aggregate",
+  delay: 1500,                       // optional debounce delay
+})
+
+// 3. Custom
+.withProjection("X", definition, {
+  deduplication: {
+    makeId: (payload) => `${payload.tenantId}:${payload.kind}:${payload.targetId}`,
+    ttlMs: 500,
+    extend: true,                    // reset TTL on each new send
+    replace: true,                   // overwrite the staged value
+  },
+})
+```
+
+Dedup is implemented inside the staging Lua — atomic with the rest of the stage, no race window where a duplicate slips through.
+
+### Coalescing
+
+For pipelines where multiple jobs in the same group can be processed together (e.g. inserting N rows in one ClickHouse `INSERT`):
+
+```typescript
+{
+  name: "{trace/spanIngest}",
+  groupKey: (p) => `${p.tenantId}/${p.traceId}`,
+  process: async (p) => { /* fallback if batch handler isn't preferred */ },
+  processBatch: async (batch) => { /* one INSERT for the lot */ },
+  coalesceMaxBatch: (p) => 50,        // up to 50 per dispatch
+}
+```
+
+The drain happens atomically inside `DISPATCH_LUA`. If `processBatch` throws, every job in the batch is re-staged (preserving FIFO order at the head of the group).
+
+---
+
+## Tiered Storage: What to Expect
+
+Payloads of different sizes land in different places, picked at encode time. You don't configure this per send — the encoder picks based on serialized size. See [ARCHITECTURE.md](./ARCHITECTURE.md#where-job-bodies-actually-live-the-tiered-envelope) for the full picture.
+
+| Payload size | Where it lives | What to watch |
+|---|---|---|
+| **≤ 1 KiB** | Inline raw JSON in the staged value | nothing — the cheap path |
+| **1 KiB to ≤ 4 KiB** | Inline gzip+base64 (if smaller than raw) | nothing |
+| **4 KiB to ≤ 256 KiB** | Standalone Redis key, ref in envelope. Reclaimed on job completion via the holder set, 3-day TTL backstop. | Redis memory growth in the `{queue}:gq:blob:*` keyspace — usually a runaway-fan-out signal |
+| **> 256 KiB, ≤ 50 MiB** | Object store (S3 / file / azure-blob — projectId-scoped to the BYOC bucket) | Object-store request rate; bucket lifecycle policy as backstop for missed reclaims |
+| **> 50 MiB** | Rejected at encode — `PayloadTooLargeError` | Hit by a product bug or a runaway loop — fix upstream rather than raise the cap |
+
+**Content-addressed sharing** means the storage cost of a payload is paid **once** per `(projectId, content-hash)`, regardless of how many jobs reference it. A 30-reactor fan-out of the same event stages 30 envelopes — 30 hold tokens on the same holder set, one stored blob. When all 30 complete (or all retry to the same content), the blob is reclaimed atomically.
+
+### Configuring writes
+
+GQ2 (content-addressed) writes are gated behind `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED=true`. With the flag unset, the queue writes legacy bare-JSON envelopes (GQ1 path) — the GQ2 reader handles both, so rollout is one-way: enable the flag once every consumer in the fleet reads GQ2 envelopes.
+
+---
+
+## Caveats
+
+- **Queue name must be hash-tagged.** A non-`{...}` name passes the type checker but fails at runtime in Redis Cluster mode (CROSSSLOT). The `hasRedisHashTag` guard catches this on construction.
+- **The `__*` namespace is reserved.** User payloads must not carry `__custom` or similar — they'll be rejected at `send`-time. The three caller-set routing fields (`__pipelineName`, `__jobType`, `__jobName`) are the only `__*` keys the queue accepts from outside; everything else is queue-internal machinery.
+- **Holders TTL is a backstop, not the primary reclaim.** The happy path reclaims a blob the moment its last holder drops, atomically inside the release Lua. The 3-day TTL is for genuinely-orphaned blobs (mid-completion crash leaves a holder leaked). Don't tune the TTL down without understanding which path is doing the work in your traffic.
+- **Cluster mode requires same-slot keys.** Holder Lua touches multiple keys; the hash tag is what makes that safe. If you add new keys to the staging layer, they MUST share the queue's hash tag.
+- **Memory queue is for tests / dev.** It processes jobs in-process with no Lua, no Redis, no tiered storage. Don't reach for it in production code paths; it exists so unit tests don't need a docker-compose dependency.
+- **Holders are per-queue, blobs are per-tenant.** Two queues that stage byte-identical content for the same project will reference the SAME stored blob (at the s3 tier), each with their own holder set. The blob is reclaimed only when both holder sets are empty.
+- **An assertion error in `send` doesn't roll back upstream work.** The reserved-namespace check throws synchronously; callers must treat `send`/`sendBatch` as fallible from this PR forward (it always was, but rejected for fewer reasons).
+
+---
+
+## Testing
+
+### Unit tests
+
+Use the in-memory queue (`queues/memory.ts`) for tests that don't need Redis at all:
+
+```typescript
+import { EventSourcedQueueProcessorMemory } from "~/server/event-sourcing/queues/memory";
+```
+
+For unit tests that exercise the GroupQueue encoder/decoder (without spinning up Redis), use the shared in-memory test doubles:
+
+```typescript
+import {
+  InMemoryJobBlobStore,
+  InMemoryObjectStore,
+} from "~/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles";
+```
+
+### Integration tests
+
+Require a Redis testcontainer. The existing suites are good templates:
+
+- [`blobHolders.integration.test.ts`](./__tests__/blobHolders.integration.test.ts) — pure holder-set Lua semantics
+- [`envelopeBlobLifecycle.integration.test.ts`](./__tests__/envelopeBlobLifecycle.integration.test.ts) — encode/decode + acquire/release/transfer + cross-tenant guards
+- [`groupQueue.gq2.integration.test.ts`](./__tests__/groupQueue.gq2.integration.test.ts) — end-to-end through the GroupQueueProcessor (offload → dispatch → reclaim)
+- [`groupQueue.integration.test.ts`](./__tests__/groupQueue.integration.test.ts) — broader staging + retries + dedup
+
+Each suite uses a hash-tagged namespace prefix (`{test/holders}`, `{test/lifecycle/...}`) and scopes its `afterEach` cleanup to that prefix — no `redis.flushall()`, so suites can run in parallel against the same Redis without clobbering each other.
+
+---
+
+## Observability
+
+The queue emits a full set of Prometheus metrics (see [`metrics.ts`](./metrics.ts)):
+
+- Throughput: `gqJobsStagedTotal`, `gqJobsDispatchedTotal`, `gqJobsCompletedTotal`
+- Failures: `gqJobsRetriedTotal`, `gqJobsExhaustedTotal`, `gqJobsNonRetryableTotal`
+- Latency: `gqJobDelayMilliseconds` (stage → dispatch), `gqJobDurationMilliseconds` (process)
+- Dedup + delay: `gqJobsDedupedTotal`, `gqJobsDelayedTotal`
+- Retry distribution: `gqRetryAttempt`, `gqRetryBackoffMilliseconds`
+- Group state: `gqGroupsBlockedTotal`
+
+OpenTelemetry spans wrap dispatch and processing. `__context` carries OTel trace context through the envelope so a span dispatched on the web tier continues on the worker.
+
+For ad-hoc inspection during development, the `bullboard` service in the dev stack (`make quickstart full-local`) shows queue state via Redis directly — it doesn't depend on BullMQ.
+
+---
+
+## Common Pitfalls
+
+1. **Non-hash-tagged queue name in Cluster mode.** Use `{queueName}` syntax. The `hasRedisHashTag` guard catches this on construction; if you somehow bypass it, the Lua scripts will CROSSSLOT.
+2. **Sending payloads with `__custom` keys.** The reserved-namespace check rejects these to prevent silent content-hash collisions. Pre-set `__pipelineName / __jobType / __jobName` if needed (the queue allows those three as caller-controlled routing); use a different name for anything else.
+3. **Forgetting `consumerEnabled: false` on the web tier.** Web pods will start dispatching jobs that should run on the worker tier — different memory profile, different autoscaler.
+4. **Sending payloads > 50 MiB.** Hit `PayloadTooLargeError`. The fix is to push the data to its own store and send a reference, not to raise the cap.
+5. **Relying on cross-aggregate ordering.** Different aggregates parallelise; the queue guarantees FIFO only within a group. If you need global ordering, you need a different design.
+6. **Disabling the GQ2 write flag, then re-enabling.** Mid-rollout, pods write a mix of GQ1 and GQ2 envelopes — the reader handles both, but the dispatcher's content-addressed dedup only fires for GQ2 envelopes. Roll forward once.

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobHolders.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobHolders.integration.test.ts
@@ -1,0 +1,259 @@
+import IORedis, { type Redis } from "ioredis";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import { BLOB_HOLDER_TTL_SECONDS } from "../blobConstants";
+import { BlobHolders } from "../blobHolders";
+
+// Self-contained: connects to the dev/CI Redis directly (the holder set + the
+// release script are pure Redis), scoped to a dedicated hash-tagged prefix.
+const QUEUE_NAME = "{test/holders}";
+const PREFIX = `${QUEUE_NAME}:gq:`;
+const PROJECT = createTenantId("proj-1");
+const HASH = "abc123hash";
+
+const blobKey = `${PREFIX}blob:${PROJECT}/${HASH}`;
+const holderKey = `${PREFIX}blobholders:${PROJECT}/${HASH}`;
+
+let redis: Redis;
+let holders: BlobHolders;
+
+async function clearSuiteKeys() {
+  const keys = await redis.keys(`${PREFIX}*`);
+  if (keys.length > 0) await redis.del(...keys);
+}
+
+beforeAll(() => {
+  redis = new IORedis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+    maxRetriesPerRequest: 0,
+  });
+});
+
+beforeEach(async () => {
+  await clearSuiteKeys();
+  holders = new BlobHolders({ redis, queueName: QUEUE_NAME });
+});
+
+afterAll(async () => {
+  await clearSuiteKeys();
+  await redis.quit();
+});
+
+function release(slotId: string, tier: "redis" | "s3" = "redis") {
+  return holders.release({ projectId: PROJECT, hash: HASH, tier, slotId });
+}
+
+describe("BlobHolders", () => {
+  describe("given a redis-tier blob held by three slots", () => {
+    beforeEach(async () => {
+      await redis.set(blobKey, Buffer.from("body"));
+      for (const slot of ["s1", "s2", "s3"]) {
+        await holders.acquire({ projectId: PROJECT, hash: HASH, slotId: slot });
+      }
+    });
+
+    describe("when two of the three slots release", () => {
+      it("keeps the blob while a slot still holds it", async () => {
+        expect(await release("s1")).toBe("still-held");
+        expect(await release("s2")).toBe("still-held");
+        expect(await redis.exists(blobKey)).toBe(1);
+      });
+    });
+
+    describe("when the last slot releases", () => {
+      it("reclaims the blob and drops the holder set", async () => {
+        await release("s1");
+        await release("s2");
+        expect(await release("s3")).toBe("reclaimed-redis");
+        expect(await redis.exists(blobKey)).toBe(0);
+        expect(await redis.exists(holderKey)).toBe(0);
+      });
+    });
+  });
+
+  describe("given a blob held by two slots", () => {
+    beforeEach(async () => {
+      await redis.set(blobKey, Buffer.from("body"));
+      await holders.acquire({ projectId: PROJECT, hash: HASH, slotId: "s1" });
+      await holders.acquire({ projectId: PROJECT, hash: HASH, slotId: "s2" });
+    });
+
+    describe("when one slot releases twice", () => {
+      it("is idempotent and never reclaims while the other slot holds", async () => {
+        expect(await release("s1")).toBe("still-held");
+        expect(await release("s1")).toBe("still-held");
+        expect(await redis.exists(blobKey)).toBe(1);
+      });
+    });
+  });
+
+  describe("given an s3-tier blob whose last holder releases", () => {
+    describe("when released", () => {
+      it("signals the caller to reclaim the object and drops the holder set", async () => {
+        await holders.acquire({ projectId: PROJECT, hash: HASH, slotId: "s1" });
+        expect(await release("s1", "s3")).toBe("reclaim-s3");
+        expect(await redis.exists(holderKey)).toBe(0);
+      });
+    });
+  });
+
+  describe("given a freshly acquired holder set", () => {
+    describe("when its TTL is read", () => {
+      it("carries the refreshed backstop window", async () => {
+        await holders.acquire({ projectId: PROJECT, hash: HASH, slotId: "s1" });
+        const ttl = await redis.ttl(holderKey);
+        expect(ttl).toBeGreaterThan(BLOB_HOLDER_TTL_SECONDS - 60);
+        expect(ttl).toBeLessThanOrEqual(BLOB_HOLDER_TTL_SECONDS);
+      });
+    });
+  });
+
+  describe("given a holder set whose TTL was shortened", () => {
+    describe("when touched", () => {
+      it("refreshes it back toward the holder window", async () => {
+        await holders.acquire({ projectId: PROJECT, hash: HASH, slotId: "s1" });
+        await redis.expire(holderKey, 100);
+
+        await holders.touch({ projectId: PROJECT, hash: HASH });
+
+        const ttl = await redis.ttl(holderKey);
+        expect(ttl).toBeGreaterThan(100);
+        expect(ttl).toBeLessThanOrEqual(BLOB_HOLDER_TTL_SECONDS);
+      });
+    });
+  });
+
+  describe("given a same-content retry (transfer within one holder set)", () => {
+    describe("when the hold is transferred to the new slot", () => {
+      it("swaps old for new and keeps the blob held", async () => {
+        await redis.set(blobKey, Buffer.from("body"));
+        await holders.acquire({
+          projectId: PROJECT,
+          hash: HASH,
+          slotId: "old",
+        });
+
+        const outcome = await holders.transfer({
+          newProjectId: PROJECT,
+          newHash: HASH,
+          newSlotId: "new",
+          oldProjectId: PROJECT,
+          oldHash: HASH,
+          oldTier: "redis",
+          oldSlotId: "old",
+        });
+
+        expect(outcome).toBe("still-held");
+        expect(await redis.smembers(holderKey)).toEqual(["new"]);
+        expect(await redis.exists(blobKey)).toBe(1);
+      });
+    });
+  });
+
+  describe("given a dedup squash to different content (cross-set transfer)", () => {
+    describe("when the hold is transferred to a different blob", () => {
+      it("reclaims the displaced blob and holds the new one", async () => {
+        const newHash = "newhash999";
+        const newBlobKey = `${PREFIX}blob:${PROJECT}/${newHash}`;
+        const newHolderKey = `${PREFIX}blobholders:${PROJECT}/${newHash}`;
+        await redis.set(blobKey, Buffer.from("old body"));
+        await redis.set(newBlobKey, Buffer.from("new body"));
+        await holders.acquire({
+          projectId: PROJECT,
+          hash: HASH,
+          slotId: "old",
+        });
+
+        const outcome = await holders.transfer({
+          newProjectId: PROJECT,
+          newHash,
+          newSlotId: "new",
+          oldProjectId: PROJECT,
+          oldHash: HASH,
+          oldTier: "redis",
+          oldSlotId: "old",
+        });
+
+        expect(outcome).toBe("reclaimed-redis");
+        expect(await redis.exists(blobKey)).toBe(0); // displaced blob reclaimed
+        expect(await redis.exists(newBlobKey)).toBe(1); // new blob untouched
+        expect(await redis.smembers(newHolderKey)).toEqual(["new"]);
+      });
+    });
+  });
+
+  describe("given a dedup squash displacing an s3-tier blob", () => {
+    describe("when the hold is transferred across blobs", () => {
+      it("signals reclaim-s3 and drops the old holder set", async () => {
+        const newHash = "newhashs3";
+        const newHolderKey = `${PREFIX}blobholders:${PROJECT}/${newHash}`;
+        await holders.acquire({
+          projectId: PROJECT,
+          hash: HASH,
+          slotId: "old",
+        });
+
+        const outcome = await holders.transfer({
+          newProjectId: PROJECT,
+          newHash,
+          newSlotId: "new",
+          oldProjectId: PROJECT,
+          oldHash: HASH,
+          oldTier: "s3",
+          oldSlotId: "old",
+        });
+
+        expect(outcome).toBe("reclaim-s3");
+        expect(await redis.exists(holderKey)).toBe(0); // old holder dropped
+        expect(await redis.smembers(newHolderKey)).toEqual(["new"]);
+      });
+    });
+  });
+
+  describe("given a release for a slot that was never acquired", () => {
+    describe("when released", () => {
+      it("is a no-op (still-held), never a spurious reclaim", async () => {
+        await redis.set(blobKey, Buffer.from("body"));
+        await holders.acquire({
+          projectId: PROJECT,
+          hash: HASH,
+          slotId: "real",
+        });
+
+        const outcome = await holders.release({
+          projectId: PROJECT,
+          hash: HASH,
+          tier: "redis",
+          slotId: "never-acquired",
+        });
+
+        expect(outcome).toBe("still-held");
+        expect(await redis.exists(blobKey)).toBe(1);
+        expect(await redis.smembers(holderKey)).toEqual(["real"]);
+      });
+    });
+  });
+
+  describe("given a self-transfer (same holder set and slot)", () => {
+    describe("when transferred", () => {
+      it("refreshes the hold and keeps the blob", async () => {
+        await redis.set(blobKey, Buffer.from("body"));
+        await holders.acquire({ projectId: PROJECT, hash: HASH, slotId: "s1" });
+
+        const outcome = await holders.transfer({
+          newProjectId: PROJECT,
+          newHash: HASH,
+          newSlotId: "s1",
+          oldProjectId: PROJECT,
+          oldHash: HASH,
+          oldTier: "redis",
+          oldSlotId: "s1",
+        });
+
+        expect(outcome).toBe("still-held");
+        expect(await redis.exists(blobKey)).toBe(1);
+        expect(await redis.smembers(holderKey)).toEqual(["s1"]);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles.ts
@@ -1,0 +1,70 @@
+import { randomBytes } from "node:crypto";
+import { Readable } from "node:stream";
+
+import type { JobBlobStore } from "../jobEnvelope";
+import type { ObjectStore } from "../tieredBlobStore";
+
+/** In-memory stand-in for the Redis blob tier (a {@link JobBlobStore}). */
+export class InMemoryJobBlobStore implements JobBlobStore {
+  readonly store = new Map<string, Buffer>();
+  async put({ id, data }: { id: string; data: Buffer }): Promise<void> {
+    this.store.set(id, data);
+  }
+  async get({ id }: { id: string }): Promise<Buffer | null> {
+    return this.store.get(id) ?? null;
+  }
+  async delete({ id }: { id: string }): Promise<void> {
+    this.store.delete(id);
+  }
+}
+
+/**
+ * In-memory stand-in for the stored-objects StorageRegistry (the GQ2 s3 tier).
+ * A miss throws a `NoSuchKey`-named error so the tier classifies it as gone;
+ * deletes are recorded so out-of-band reclaim can be asserted.
+ */
+export class InMemoryObjectStore implements ObjectStore {
+  readonly store = new Map<string, Buffer>();
+  readonly deleted: string[] = [];
+  async put(uri: string, bytes: Buffer): Promise<void> {
+    this.store.set(uri, bytes);
+  }
+  async get(uri: string): Promise<Readable> {
+    const bytes = this.store.get(uri);
+    if (!bytes) {
+      const err = new Error(`no object at ${uri}`);
+      err.name = "NoSuchKey";
+      throw err;
+    }
+    return Readable.from(bytes);
+  }
+  async delete(uri: string): Promise<void> {
+    this.deleted.push(uri);
+    this.store.delete(uri);
+  }
+}
+
+/** Serves objects, but fails the first N gets with a transient (non-missing) error. */
+export class FlakyObjectStore extends InMemoryObjectStore {
+  private getFailuresLeft: number;
+  constructor(getFailures: number) {
+    super();
+    this.getFailuresLeft = getFailures;
+  }
+  async get(uri: string): Promise<Readable> {
+    if (this.getFailuresLeft > 0) {
+      this.getFailuresLeft--;
+      throw new Error("transient ECONNRESET");
+    }
+    return super.get(uri);
+  }
+}
+
+/**
+ * Genuinely incompressible text (base64 of random bytes) so the gzipped body
+ * stays above the s3 threshold — a compressible payload would collapse below it
+ * and silently never exercise the s3 tier.
+ */
+export function incompressible(byteLength: number): string {
+  return randomBytes(byteLength).toString("base64");
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/blobTestDoubles.ts
@@ -13,6 +13,10 @@ export class InMemoryJobBlobStore implements JobBlobStore {
   async get({ id }: { id: string }): Promise<Buffer | null> {
     return this.store.get(id) ?? null;
   }
+  /** In-memory doubles have no TTL so peek and get behave identically. */
+  async peek({ id }: { id: string }): Promise<Buffer | null> {
+    return this.store.get(id) ?? null;
+  }
   async delete({ id }: { id: string }): Promise<void> {
     this.store.delete(id);
   }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/envelopeBlobLifecycle.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/envelopeBlobLifecycle.integration.test.ts
@@ -195,6 +195,40 @@ describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
         });
       });
     });
+
+    describe("when the re-encoded value carries a different __attempt (the queue retry path)", () => {
+      it("hashes identically — machinery doesn't perturb the content hash (routing-exclusion)", async () => {
+        // This is the queue-level retry-cheapness guarantee: the retry re-encode
+        // produces the SAME blob hash, so the atomic transfer is a same-set
+        // SADD+SREM (one Lua eval, blob untouched) rather than a cross-set
+        // reclaim. Without routing-exclusion, __attempt would perturb the body
+        // bytes and each retry would churn through a fresh blob.
+        const v1 = await lifecycle.encode({
+          jobData: { ...REDIS_TIER_PAYLOAD, __attempt: 1 },
+          groupId: TENANT_GROUP,
+        });
+        const v2 = await lifecycle.encode({
+          jobData: { ...REDIS_TIER_PAYLOAD, __attempt: 2 },
+          groupId: TENANT_GROUP,
+        });
+
+        expect(hashOf(v2)).toBe(hashOf(v1));
+        lifecycle.acquire(v1);
+        const key = holderKey(hashOf(v1));
+        await vi.waitFor(async () => expect(await redis.scard(key)).toBe(1));
+
+        lifecycle.transfer({
+          newValue: v2,
+          oldValue: v1,
+          groupId: TENANT_GROUP,
+        });
+
+        await vi.waitFor(async () => {
+          expect(await redis.scard(key)).toBe(1);
+          expect(await redis.exists(blobKey(hashOf(v1)))).toBe(1);
+        });
+      });
+    });
   });
 
   describe("given a dedup squash to different content", () => {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/envelopeBlobLifecycle.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/envelopeBlobLifecycle.integration.test.ts
@@ -1,0 +1,280 @@
+import type { Redis } from "ioredis";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  getTestRedisConnection,
+  startTestContainers,
+  stopTestContainers,
+} from "../../../__tests__/integration/testContainers";
+import { EnvelopeBlobLifecycle } from "../envelopeBlobLifecycle";
+import { readEnvelopeHold } from "../jobEnvelope";
+import { InMemoryObjectStore, incompressible } from "./blobTestDoubles";
+
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL ||
+  process.env.CI_CLICKHOUSE_URL ||
+  process.env.REDIS_URL ||
+  process.env.CI_REDIS_URL
+);
+
+const TENANT_GROUP = "proj1/agg";
+
+// > the 4 KiB inline ceiling, < the 256 KiB s3 threshold → redis tier.
+const REDIS_TIER_PAYLOAD = { bulk: "x".repeat(8 * 1024) };
+
+describe.skipIf(!hasTestcontainers)("EnvelopeBlobLifecycle", () => {
+  let redis: Redis;
+  let objectStore: InMemoryObjectStore;
+  let lifecycle: EnvelopeBlobLifecycle;
+  let queueName: string;
+
+  beforeAll(async () => {
+    await startTestContainers();
+    redis = getTestRedisConnection()!;
+  });
+
+  beforeEach(() => {
+    vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
+    queueName = `{test/lifecycle/${crypto.randomUUID().slice(0, 8)}}`;
+    objectStore = new InMemoryObjectStore();
+    lifecycle = new EnvelopeBlobLifecycle({
+      redis,
+      queueName,
+      objectStoreFor: () => objectStore,
+      resolveStorageDestination: async () => ({
+        kind: "s3",
+        bucket: "test-bucket",
+      }),
+    });
+  });
+
+  afterEach(async () => {
+    // Scoped to this suite's hash-tagged namespace, not a global flushall.
+    const keys = await redis.keys("{test/lifecycle/*");
+    if (keys.length > 0) await redis.del(...keys);
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(async () => {
+    await stopTestContainers();
+  });
+
+  const holderKey = (hash: string) =>
+    `${queueName}:gq:blobholders:proj1/${hash}`;
+  const blobKey = (hash: string) => `${queueName}:gq:blob:proj1/${hash}`;
+  const hashOf = (value: string) => readEnvelopeHold(value)!.ref.hash;
+
+  describe("given an offloaded value whose holder TTL was shortened", () => {
+    describe("when it is decoded", () => {
+      it("refreshes the holder set on access (so it outlives the blob)", async () => {
+        const value = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP,
+        });
+        lifecycle.acquire(value);
+        const key = holderKey(hashOf(value));
+        await vi.waitFor(async () => expect(await redis.scard(key)).toBe(1));
+        await redis.expire(key, 100);
+
+        const decoded = await lifecycle.decode({
+          value,
+          groupId: TENANT_GROUP,
+        });
+
+        expect(decoded).toEqual(REDIS_TIER_PAYLOAD);
+        await vi.waitFor(async () =>
+          expect(await redis.ttl(key)).toBeGreaterThan(100),
+        );
+      });
+    });
+  });
+
+  describe("given an offloaded value decoded under a different tenant's group", () => {
+    describe("when it is decoded", () => {
+      it("refuses the cross-tenant read", async () => {
+        const value = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP,
+        });
+
+        await expect(
+          lifecycle.decode({ value, groupId: "proj2/agg" }),
+        ).rejects.toThrow(/tenant mismatch/i);
+      });
+    });
+  });
+
+  describe("given a held value released under a different tenant's group", () => {
+    describe("when released", () => {
+      it("leaves the owning tenant's holder set untouched", async () => {
+        const value = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP, // tenant proj1
+        });
+        lifecycle.acquire(value);
+        const key = holderKey(hashOf(value));
+        await vi.waitFor(async () => expect(await redis.scard(key)).toBe(1));
+
+        // Release under a foreign group: the proj1 holder must NOT be dropped.
+        lifecycle.release({ values: [value], groupId: "proj2/agg" });
+
+        // Wait long enough that an unguarded release would have reclaimed it.
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        expect(await redis.scard(key)).toBe(1);
+        expect(await redis.exists(blobKey(hashOf(value)))).toBe(1);
+      });
+    });
+  });
+
+  describe("given a transfer whose new ref belongs to a different tenant", () => {
+    describe("when transferred", () => {
+      it("never acquires the foreign holder (mirror of the release-side guard)", async () => {
+        // Old value is tenant proj1's; new value is tenant proj2's. Under proj1's
+        // group, the transfer must NOT acquire proj2's hold.
+        const oldValue = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP, // proj1
+        });
+        const newValue = await lifecycle.encode({
+          jobData: { bulk: "y".repeat(8 * 1024) },
+          groupId: "proj2/agg",
+        });
+        const newHash = hashOf(newValue);
+        const newHolderKey = `${queueName}:gq:blobholders:proj2/${newHash}`;
+        lifecycle.acquire(oldValue);
+        const oldKey = holderKey(hashOf(oldValue));
+        await vi.waitFor(async () => expect(await redis.scard(oldKey)).toBe(1));
+
+        lifecycle.transfer({ newValue, oldValue, groupId: TENANT_GROUP });
+
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        // proj2 holder must NOT have been created by the foreign-tenant transfer.
+        expect(await redis.exists(newHolderKey)).toBe(0);
+        // proj1's hold was released through the guarded path (matches the group's tenant).
+        expect(await redis.scard(oldKey)).toBe(0);
+      });
+    });
+  });
+
+  describe("given a same-content retry", () => {
+    describe("when the hold is transferred to the re-encoded value", () => {
+      it("swaps the slot on one holder set and keeps the blob", async () => {
+        const v1 = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP,
+        });
+        const v2 = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP,
+        });
+        const hash = hashOf(v1);
+        expect(hashOf(v2)).toBe(hash); // same content → same blob
+        lifecycle.acquire(v1);
+        await vi.waitFor(async () =>
+          expect(await redis.scard(holderKey(hash))).toBe(1),
+        );
+
+        lifecycle.transfer({
+          newValue: v2,
+          oldValue: v1,
+          groupId: TENANT_GROUP,
+        });
+
+        await vi.waitFor(async () => {
+          expect(await redis.scard(holderKey(hash))).toBe(1); // old out, new in
+          expect(await redis.exists(blobKey(hash))).toBe(1); // blob stays
+        });
+      });
+    });
+  });
+
+  describe("given a dedup squash to different content", () => {
+    describe("when the hold is transferred across blobs", () => {
+      it("reclaims the displaced redis blob and holds the new one", async () => {
+        const vOld = await lifecycle.encode({
+          jobData: { bulk: "a".repeat(8 * 1024) },
+          groupId: TENANT_GROUP,
+        });
+        const vNew = await lifecycle.encode({
+          jobData: { bulk: "b".repeat(8 * 1024) },
+          groupId: TENANT_GROUP,
+        });
+        const oldHash = hashOf(vOld);
+        const newHash = hashOf(vNew);
+        expect(newHash).not.toBe(oldHash);
+        lifecycle.acquire(vOld);
+        await vi.waitFor(async () =>
+          expect(await redis.scard(holderKey(oldHash))).toBe(1),
+        );
+
+        lifecycle.transfer({
+          newValue: vNew,
+          oldValue: vOld,
+          groupId: TENANT_GROUP,
+        });
+
+        await vi.waitFor(async () => {
+          expect(await redis.exists(blobKey(oldHash))).toBe(0); // displaced blob reclaimed
+          expect(await redis.scard(holderKey(newHash))).toBe(1); // new blob held
+        });
+      });
+    });
+  });
+
+  describe("given an s3-tier blob held by one slot", () => {
+    describe("when the last holder releases", () => {
+      it("deletes the s3 object out-of-band", async () => {
+        const value = await lifecycle.encode({
+          jobData: { bulk: incompressible(768 * 1024) }, // > 256 KiB gzipped → s3
+          groupId: TENANT_GROUP,
+        });
+        expect(readEnvelopeHold(value)!.ref.tier).toBe("s3");
+        expect(objectStore.store.size).toBe(1);
+        lifecycle.acquire(value);
+
+        lifecycle.release({ values: [value], groupId: TENANT_GROUP });
+
+        await vi.waitFor(() => {
+          expect(objectStore.deleted).toHaveLength(1);
+          expect(objectStore.store.size).toBe(0);
+        });
+      });
+    });
+  });
+
+  describe("given a transfer where one side is not a GQ2 hold", () => {
+    describe("when a GQ2 value replaces an inline value", () => {
+      it("falls back to ordered acquire+release without throwing", async () => {
+        const inlineValue = await lifecycle.encode({
+          jobData: { small: 1 }, // under the inline ceiling → no hold
+          groupId: TENANT_GROUP,
+        });
+        const gq2Value = await lifecycle.encode({
+          jobData: REDIS_TIER_PAYLOAD,
+          groupId: TENANT_GROUP,
+        });
+        expect(readEnvelopeHold(inlineValue)).toBeNull();
+        expect(readEnvelopeHold(gq2Value)).not.toBeNull();
+
+        lifecycle.transfer({
+          newValue: gq2Value,
+          oldValue: inlineValue,
+          groupId: TENANT_GROUP,
+        });
+
+        await vi.waitFor(async () =>
+          expect(await redis.scard(holderKey(hashOf(gq2Value)))).toBe(1),
+        );
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
@@ -1,0 +1,201 @@
+import type { Redis } from "ioredis";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  getTestRedisConnection,
+  startTestContainers,
+  stopTestContainers,
+} from "../../../__tests__/integration/testContainers";
+import type { EventSourcedQueueDefinition } from "../../queue.types";
+import { GroupQueueProcessor } from "../groupQueue";
+import type { ObjectStore } from "../tieredBlobStore";
+import {
+  FlakyObjectStore,
+  InMemoryObjectStore,
+  incompressible,
+} from "./blobTestDoubles";
+
+// Skip outside testcontainers (e.g. plain unit runs).
+const hasTestcontainers = !!(
+  process.env.TEST_CLICKHOUSE_URL ||
+  process.env.CI_CLICKHOUSE_URL ||
+  process.env.REDIS_URL ||
+  process.env.CI_REDIS_URL
+);
+
+type TestPayload = { id: string; groupId: string; value: string };
+
+// > the 4 KiB inline ceiling, < the 256 KiB s3 threshold → redis tier (inspectable).
+const OFFLOADED_VALUE = "x".repeat(8 * 1024);
+const TENANT_GROUP = "proj1/agg";
+
+describe.skipIf(!hasTestcontainers)("GroupQueueProcessor — GQ2 offload", () => {
+  let redis: Redis;
+  let queues: GroupQueueProcessor<TestPayload>[];
+
+  beforeAll(async () => {
+    await startTestContainers();
+    redis = getTestRedisConnection()!;
+  });
+
+  beforeEach(() => {
+    vi.stubEnv("GROUP_QUEUE_ENVELOPE_WRITES_ENABLED", "true");
+    queues = [];
+  });
+
+  afterEach(async () => {
+    await Promise.all(queues.map((q) => q.close().catch(() => {})));
+    // Scoped to this suite's hash-tagged namespace — never a global flushall,
+    // which would race with parallel integration suites on the shared Redis.
+    const keys = await redis.keys("{test/gq2/*");
+    if (keys.length > 0) await redis.del(...keys);
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(async () => {
+    await stopTestContainers();
+  });
+
+  function createQueue({
+    processFn,
+    consumerEnabled,
+    objectStore = new InMemoryObjectStore(),
+  }: {
+    processFn: (payload: TestPayload) => Promise<void>;
+    consumerEnabled: boolean;
+    objectStore?: ObjectStore;
+  }): { queue: GroupQueueProcessor<TestPayload>; name: string } {
+    const name = `{test/gq2/${crypto.randomUUID().slice(0, 8)}}`;
+    const definition: EventSourcedQueueDefinition<TestPayload> = {
+      name,
+      groupKey: (p) => p.groupId,
+      process: processFn,
+    };
+    const queue = new GroupQueueProcessor<TestPayload>(definition, redis, {
+      consumerEnabled,
+      objectStoreFor: () => objectStore,
+      resolveStorageDestination: async () => ({
+        kind: "s3",
+        bucket: "test-bucket",
+      }),
+    });
+    queues.push(queue);
+    return { queue, name };
+  }
+
+  const blobKeys = (name: string) => redis.keys(`${name}:gq:blob:*`);
+  const holderKeys = (name: string) => redis.keys(`${name}:gq:blobholders:*`);
+
+  describe("given a job whose payload exceeds the inline ceiling", () => {
+    describe("when it is processed to completion", () => {
+      it("resolves the full payload on dispatch and reclaims the blob + holder", async () => {
+        const received: TestPayload[] = [];
+        const { queue, name } = createQueue({
+          processFn: async (p) => {
+            received.push(p);
+          },
+          consumerEnabled: true,
+        });
+        await queue.waitUntilReady();
+
+        await queue.send({
+          id: "j1",
+          groupId: TENANT_GROUP,
+          value: OFFLOADED_VALUE,
+        });
+
+        // Handler receives the full payload — proving it was offloaded then resolved.
+        await vi.waitFor(() => expect(received).toHaveLength(1), {
+          timeout: 5000,
+          interval: 50,
+        });
+        expect(received[0]!.value).toBe(OFFLOADED_VALUE);
+
+        // The blob and its holder set are eagerly reclaimed once the last holder completes.
+        await vi.waitFor(
+          async () => {
+            expect(await blobKeys(name)).toHaveLength(0);
+            expect(await holderKeys(name)).toHaveLength(0);
+          },
+          { timeout: 5000, interval: 50 },
+        );
+      });
+    });
+  });
+
+  // NOTE: multi-holder *sharing* (N distinct jobs → one blob) is not reachable
+  // through the queue's normal path while content addressing covers the whole
+  // body — distinct jobs (distinct stagedJobId, derived from payload.id) have
+  // distinct content, hence distinct blobs. That cross-job dedup arrives with
+  // the routing-exclusion (a separate change). The holder reclaim sequence
+  // itself is proven in blobHolders.integration.test.ts.
+  describe("given an offloaded job", () => {
+    describe("when it is staged", () => {
+      it("keys the blob by tenant namespace and content hash", async () => {
+        // No consumer: the job stays staged so we can inspect the blob key.
+        const { queue, name } = createQueue({
+          processFn: async () => {},
+          consumerEnabled: false,
+        });
+        await queue.waitUntilReady();
+
+        await queue.send({
+          id: "j1",
+          groupId: TENANT_GROUP,
+          value: OFFLOADED_VALUE,
+        });
+
+        await vi.waitFor(
+          async () => {
+            const keys = await blobKeys(name);
+            expect(keys).toHaveLength(1);
+            // {queue}:gq:blob:<projectId>/<128-bit base64url hash>
+            const prefix = `${name}:gq:blob:proj1/`;
+            expect(keys[0]!.startsWith(prefix)).toBe(true);
+            expect(keys[0]!.slice(prefix.length)).toMatch(
+              /^[A-Za-z0-9_-]{22}$/,
+            );
+          },
+          { timeout: 5000, interval: 50 },
+        );
+      });
+    });
+  });
+
+  describe("given an s3-tier blob whose store fails transiently then recovers", () => {
+    describe("when it is processed", () => {
+      it("retries instead of dropping, and the handler eventually runs", async () => {
+        const received: TestPayload[] = [];
+        const flaky = new FlakyObjectStore(1); // fail the first get, then serve
+        const { queue } = createQueue({
+          processFn: async (p) => {
+            received.push(p);
+          },
+          consumerEnabled: true,
+          objectStore: flaky,
+        });
+        await queue.waitUntilReady();
+
+        const big = incompressible(768 * 1024); // > 256 KiB gzipped → s3 tier
+        await queue.send({ id: "s1", groupId: TENANT_GROUP, value: big });
+
+        // First dispatch hits the transient failure and re-stages; the retry
+        // (after backoff) finds the store recovered and runs the handler.
+        await vi.waitFor(() => expect(received).toHaveLength(1), {
+          timeout: 15000,
+          interval: 100,
+        });
+        expect(received[0]!.value).toBe(big);
+      }, 20000);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/groupQueue.gq2.integration.test.ts
@@ -132,12 +132,12 @@ describe.skipIf(!hasTestcontainers)("GroupQueueProcessor — GQ2 offload", () =>
     });
   });
 
-  // NOTE: multi-holder *sharing* (N distinct jobs → one blob) is not reachable
-  // through the queue's normal path while content addressing covers the whole
-  // body — distinct jobs (distinct stagedJobId, derived from payload.id) have
-  // distinct content, hence distinct blobs. That cross-job dedup arrives with
-  // the routing-exclusion (a separate change). The holder reclaim sequence
-  // itself is proven in blobHolders.integration.test.ts.
+  // The fan-out content-sharing invariant is proven at the encode level in
+  // jobEnvelope.unit.test.ts ("when two envelopes have identical user payloads
+  // but different queue machinery → ONE stored blob"). A queue-level end-to-end
+  // proof requires multi-reactor wiring (multiple reactor definitions over one
+  // event) — out of scope for this single-reactor harness. The holder reclaim
+  // sequence itself is proven in blobHolders.integration.test.ts.
   describe("given an offloaded job", () => {
     describe("when it is staged", () => {
       it("keys the blob by tenant namespace and content hash", async () => {
@@ -196,6 +196,73 @@ describe.skipIf(!hasTestcontainers)("GroupQueueProcessor — GQ2 offload", () =>
         });
         expect(received[0]!.value).toBe(big);
       }, 20000);
+    });
+  });
+
+  describe("given a payload carrying a __* key in the reserved namespace", () => {
+    describe("when sent", () => {
+      it("rejects loudly so silent dedup collisions can't happen", async () => {
+        const { queue } = createQueue({
+          processFn: async () => {},
+          consumerEnabled: false,
+        });
+        await queue.waitUntilReady();
+
+        await expect(
+          queue.send({
+            id: "j1",
+            groupId: TENANT_GROUP,
+            value: "ok",
+            // biome-ignore lint/suspicious/noExplicitAny: testing a runtime guard
+            __custom: "this would collide on the content hash",
+          } as any),
+        ).rejects.toThrow(/__custom.*reserved/);
+      });
+    });
+
+    describe("when the payload carries a caller-set routing field", () => {
+      it("passes through (__pipelineName / __jobType / __jobName are caller-controlled, not queue-internal)", async () => {
+        const { queue } = createQueue({
+          processFn: async () => {},
+          consumerEnabled: false,
+        });
+        await queue.waitUntilReady();
+
+        await expect(
+          queue.send({
+            id: "j1",
+            groupId: TENANT_GROUP,
+            value: "ok",
+            __pipelineName: "trace-processing",
+            __jobType: "fold",
+            __jobName: "recordSpan",
+            // biome-ignore lint/suspicious/noExplicitAny: routing fields aren't on TestPayload
+          } as any),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe("when sentBatch", () => {
+      it("rejects if any payload in the batch carries a __* key", async () => {
+        const { queue } = createQueue({
+          processFn: async () => {},
+          consumerEnabled: false,
+        });
+        await queue.waitUntilReady();
+
+        await expect(
+          queue.sendBatch([
+            { id: "ok", groupId: TENANT_GROUP, value: "ok" },
+            // biome-ignore lint/suspicious/noExplicitAny: testing a runtime guard
+            {
+              id: "bad",
+              groupId: TENANT_GROUP,
+              value: "bad",
+              __sneaky: "x",
+            } as any,
+          ]),
+        ).rejects.toThrow(/__sneaky.*reserved/);
+      });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -1,28 +1,20 @@
+import { gzipSync } from "node:zlib";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import { MAX_BLOB_BYTES } from "../blobConstants";
 import {
+  assertPayloadWithinCap,
   decodeJobEnvelope,
   encodeJobEnvelope,
-  type JobBlobStore,
+  PayloadTooLargeError,
   readEnvelopeBlobId,
+  readEnvelopeHold,
   readJobRoutingMeta,
 } from "../jobEnvelope";
-
-class InMemoryBlobStore implements JobBlobStore {
-  readonly blobs = new Map<string, Buffer>();
-
-  async put({ id, data }: { id: string; data: Buffer }): Promise<void> {
-    this.blobs.set(id, data);
-  }
-
-  async get({ id }: { id: string }): Promise<Buffer | null> {
-    return this.blobs.get(id) ?? null;
-  }
-
-  async delete({ id }: { id: string }): Promise<void> {
-    this.blobs.delete(id);
-  }
-}
+import { TieredBlobStore } from "../tieredBlobStore";
+import { InMemoryJobBlobStore, InMemoryObjectStore } from "./blobTestDoubles";
 
 describe("jobEnvelope", () => {
   beforeEach(() => {
@@ -183,14 +175,14 @@ describe("jobEnvelope", () => {
 
     describe("when a blob store is provided", () => {
       it("offloads the body to the store and leaves a tiny ref envelope", async () => {
-        const blobs = new InMemoryBlobStore();
+        const blobs = new InMemoryJobBlobStore();
         const encoded = await encodeJobEnvelope({
           jobData: hugePayload,
           blobs,
         });
         expect(encoded).toContain('"e":"ref"');
         expect(encoded.length).toBeLessThan(256);
-        expect(blobs.blobs.size).toBe(1);
+        expect(blobs.store.size).toBe(1);
         expect(readJobRoutingMeta(encoded)).toEqual({
           pipelineName: "traces",
           jobType: "command",
@@ -199,7 +191,7 @@ describe("jobEnvelope", () => {
       });
 
       it("round-trips the payload through the store", async () => {
-        const blobs = new InMemoryBlobStore();
+        const blobs = new InMemoryJobBlobStore();
         const encoded = await encodeJobEnvelope({
           jobData: hugePayload,
           blobs,
@@ -210,18 +202,18 @@ describe("jobEnvelope", () => {
       });
 
       it("exposes the blob id for completion-time deletion", async () => {
-        const blobs = new InMemoryBlobStore();
+        const blobs = new InMemoryJobBlobStore();
         const encoded = await encodeJobEnvelope({
           jobData: hugePayload,
           blobs,
         });
         const blobId = readEnvelopeBlobId(encoded);
         expect(blobId).not.toBeNull();
-        expect(blobs.blobs.has(blobId!)).toBe(true);
+        expect(blobs.store.has(blobId!)).toBe(true);
       });
 
       it("rejects decode when the blob is missing or no store is given", async () => {
-        const blobs = new InMemoryBlobStore();
+        const blobs = new InMemoryJobBlobStore();
         const encoded = await encodeJobEnvelope({
           jobData: hugePayload,
           blobs,
@@ -229,7 +221,7 @@ describe("jobEnvelope", () => {
         await expect(decodeJobEnvelope({ value: encoded })).rejects.toThrow(
           /blob store/,
         );
-        blobs.blobs.clear();
+        blobs.store.clear();
         await expect(
           decodeJobEnvelope({ value: encoded, blobs }),
         ).rejects.toThrow(/missing/);
@@ -361,6 +353,179 @@ describe("jobEnvelope", () => {
       const payload = { __jobName: "uni", text: "héllo 🌍 ".repeat(500) };
       const encoded = await encodeJobEnvelope({ jobData: payload });
       expect(await decodeJobEnvelope({ value: encoded })).toEqual(payload);
+    });
+  });
+
+  describe("given the payload-size ceiling", () => {
+    describe("when the payload is at the ceiling", () => {
+      it("accepts it", () => {
+        expect(() => assertPayloadWithinCap(MAX_BLOB_BYTES)).not.toThrow();
+      });
+    });
+
+    describe("when the payload is over the ceiling", () => {
+      it("rejects it with PayloadTooLargeError", () => {
+        expect(() => assertPayloadWithinCap(MAX_BLOB_BYTES + 1)).toThrow(
+          PayloadTooLargeError,
+        );
+      });
+    });
+  });
+
+  describe("given a tiered blob store and a projectId (GQ2)", () => {
+    const PROJECT = createTenantId("project-abc");
+
+    function makeTiered(s3ThresholdBytes = 256 * 1024) {
+      const redisBlobs = new InMemoryJobBlobStore();
+      const objectStore = new InMemoryObjectStore();
+      const tieredBlobs = new TieredBlobStore({
+        redisBlobs,
+        objectStoreFor: () => objectStore,
+        resolveDestination: async () => ({ kind: "s3", bucket: "test-bucket" }),
+        s3ThresholdBytes,
+      });
+      return { tieredBlobs, redisBlobs, objectStore };
+    }
+
+    describe("when a blob decompresses past the ceiling", () => {
+      it("rejects it rather than OOMing (zip-bomb guard)", async () => {
+        const { tieredBlobs } = makeTiered();
+        const encoded = await encodeJobEnvelope({
+          jobData: { __jobName: "x", bulk: "z".repeat(8 * 1024) },
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+        // Valid JSON that inflates past MAX_BLOB_BYTES: without the gunzip cap,
+        // decode would SUCCEED (valid JSON), so dropping the cap fails this test
+        // instead of false-passing on an unrelated JSON-parse error.
+        const oversizedValidJson = `"${"z".repeat(MAX_BLOB_BYTES + 1)}"`;
+        const bombStore = {
+          get: async () => gzipSync(Buffer.from(oversizedValidJson, "utf8")),
+        } as unknown as TieredBlobStore;
+
+        await expect(
+          decodeJobEnvelope({ value: encoded, tieredBlobs: bombStore }),
+        ).rejects.toThrow();
+      });
+    });
+
+    describe("when a small payload is encoded", () => {
+      it("keeps it inline under a GQ2 prefix and round-trips", async () => {
+        const { tieredBlobs } = makeTiered();
+        const payload = { __jobName: "tiny", value: 1 };
+
+        const encoded = await encodeJobEnvelope({
+          jobData: payload,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        expect(encoded.startsWith("GQ2|")).toBe(true);
+        expect(readEnvelopeHold(encoded)).toBeNull();
+        expect(
+          await decodeJobEnvelope({ value: encoded, tieredBlobs }),
+        ).toEqual(payload);
+      });
+    });
+
+    describe("when a payload over the inline ceiling is encoded", () => {
+      const big = {
+        __pipelineName: "traces",
+        __jobType: "event",
+        __jobName: "spanReceived",
+        bulk: "z".repeat(8 * 1024),
+      };
+
+      it("offloads to the redis tier as a content-addressed ref and round-trips", async () => {
+        const { tieredBlobs, redisBlobs } = makeTiered();
+
+        const encoded = await encodeJobEnvelope({
+          jobData: big,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        expect(encoded).toContain('"e":"redis"');
+        expect(readEnvelopeHold(encoded)?.ref).toMatchObject({
+          tier: "redis",
+          projectId: PROJECT,
+        });
+        expect(redisBlobs.store.size).toBe(1);
+        expect(
+          await decodeJobEnvelope({ value: encoded, tieredBlobs }),
+        ).toEqual(big);
+      });
+
+      it("offloads to the s3 tier when the stored bytes exceed the s3 threshold", async () => {
+        const { tieredBlobs, objectStore } = makeTiered(8);
+
+        const encoded = await encodeJobEnvelope({
+          jobData: big,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        expect(encoded).toContain('"e":"s3"');
+        expect(readEnvelopeHold(encoded)?.ref.tier).toBe("s3");
+        expect(objectStore.store.size).toBe(1);
+        expect(
+          await decodeJobEnvelope({ value: encoded, tieredBlobs }),
+        ).toEqual(big);
+      });
+
+      it("exposes routing meta from the header without resolving the blob", async () => {
+        const { tieredBlobs } = makeTiered();
+        const encoded = await encodeJobEnvelope({
+          jobData: big,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+        expect(readJobRoutingMeta(encoded)).toEqual({
+          pipelineName: "traces",
+          jobType: "event",
+          jobName: "spanReceived",
+        });
+      });
+
+      it("stores one copy for byte-identical payloads, with distinct hold tokens", async () => {
+        const { tieredBlobs, redisBlobs } = makeTiered();
+
+        const e1 = await encodeJobEnvelope({
+          jobData: big,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+        const e2 = await encodeJobEnvelope({
+          jobData: { ...big },
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        expect(redisBlobs.store.size).toBe(1);
+        // One shared blob ref, but a distinct per-stage hold token each time —
+        // so N fan-out jobs share one body yet each holds its own reference.
+        expect(readEnvelopeHold(e1)?.ref).toEqual(readEnvelopeHold(e2)?.ref);
+        expect(readEnvelopeHold(e1)?.token).not.toBe(
+          readEnvelopeHold(e2)?.token,
+        );
+      });
+
+      it("rejects decode when the tiered blob is missing or no store is given", async () => {
+        const { tieredBlobs, redisBlobs } = makeTiered();
+        const encoded = await encodeJobEnvelope({
+          jobData: big,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        await expect(decodeJobEnvelope({ value: encoded })).rejects.toThrow(
+          /tiered/,
+        );
+        redisBlobs.store.clear();
+        await expect(
+          decodeJobEnvelope({ value: encoded, tieredBlobs }),
+        ).rejects.toThrow(/missing/);
+      });
     });
   });
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/jobEnvelope.unit.test.ts
@@ -527,5 +527,78 @@ describe("jobEnvelope", () => {
         ).rejects.toThrow(/missing/);
       });
     });
+
+    describe("when two envelopes have identical user payloads but different queue machinery", () => {
+      it("collapses to ONE stored blob (machinery is lifted into the header, not the hashed body)", async () => {
+        const { tieredBlobs, redisBlobs } = makeTiered();
+        const payload = { evt: "x".repeat(8 * 1024) }; // > 4 KiB → offloads
+
+        // Same user payload, two distinct fan-out reactors over the same event.
+        const v1 = await encodeJobEnvelope({
+          jobData: {
+            ...payload,
+            __pipelineName: "experiment-run",
+            __jobType: "fold",
+            __jobName: "rollup-by-day",
+            __attempt: 1,
+            __stagedJobId: "j-1",
+          },
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+        const v2 = await encodeJobEnvelope({
+          jobData: {
+            ...payload,
+            __pipelineName: "experiment-run",
+            __jobType: "map",
+            __jobName: "billing-projection",
+            __attempt: 3,
+            __stagedJobId: "j-2",
+          },
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        // The two envelopes are different (different headers / hold tokens)
+        // but the underlying blob is a single content-addressed entry.
+        expect(v1).not.toBe(v2);
+        expect(redisBlobs.store.size).toBe(1);
+
+        // Both decode back to the original jobData shape — machinery comes
+        // back from the header.
+        const d1 = await decodeJobEnvelope({ value: v1, tieredBlobs });
+        const d2 = await decodeJobEnvelope({ value: v2, tieredBlobs });
+        expect(d1.__jobName).toBe("rollup-by-day");
+        expect(d2.__jobName).toBe("billing-projection");
+        expect(d1.__attempt).toBe(1);
+        expect(d2.__attempt).toBe(3);
+        expect(d1.evt).toBe(payload.evt);
+        expect(d2.evt).toBe(payload.evt);
+      });
+    });
+
+    describe("when an inline-tier GQ2 envelope carries machinery", () => {
+      it("round-trips via header.m so downstream code sees the original jobData", async () => {
+        const { tieredBlobs } = makeTiered();
+        const jobData = {
+          evt: "small inline payload",
+          __pipelineName: "p",
+          __jobType: "t",
+          __jobName: "n",
+          __attempt: 2,
+        };
+        const encoded = await encodeJobEnvelope({
+          jobData,
+          tieredBlobs,
+          projectId: PROJECT,
+        });
+
+        const decoded = await decodeJobEnvelope({
+          value: encoded,
+          tieredBlobs,
+        });
+        expect(decoded).toEqual(jobData);
+      });
+    });
   });
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/redisHashTag.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/redisHashTag.unit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { hasRedisHashTag } from "../redisHashTag";
+
+describe("hasRedisHashTag", () => {
+  describe("given a name with a non-empty hash tag", () => {
+    it("returns true", () => {
+      expect(hasRedisHashTag("{tenant/queue}")).toBe(true);
+      expect(hasRedisHashTag("prefix{tag}suffix")).toBe(true);
+      expect(hasRedisHashTag("{a}")).toBe(true);
+    });
+  });
+
+  describe("given a name without any hash tag", () => {
+    it("returns false", () => {
+      expect(hasRedisHashTag("no-tag-here")).toBe(false);
+      expect(hasRedisHashTag("open{butneverclosed")).toBe(false);
+    });
+  });
+
+  describe("given a name with an empty hash tag", () => {
+    it("returns false — Redis ignores {} and hashes the whole key", () => {
+      expect(hasRedisHashTag("empty{}tag")).toBe(false);
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/redisJobBlobStore.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/redisJobBlobStore.integration.test.ts
@@ -1,0 +1,89 @@
+import IORedis, { type Redis } from "ioredis";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { RedisJobBlobStore } from "../redisJobBlobStore";
+
+// Self-contained: connects to the dev/CI Redis directly (no testcontainers /
+// globalSetup, since this exercises only the blob key + its TTL). Scoped to a
+// dedicated hash-tagged prefix so it never touches the shared dev stack's keys.
+const QUEUE_NAME = "{test/blobstore}";
+const BLOB_PREFIX = `${QUEUE_NAME}:gq:blob:`;
+const THREE_DAYS_SECONDS = 3 * 24 * 60 * 60;
+
+let redis: Redis;
+let store: RedisJobBlobStore;
+
+async function clearSuiteKeys() {
+  const keys = await redis.keys(`${BLOB_PREFIX}*`);
+  if (keys.length > 0) await redis.del(...keys);
+}
+
+beforeAll(() => {
+  redis = new IORedis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+    maxRetriesPerRequest: 0,
+  });
+});
+
+beforeEach(async () => {
+  await clearSuiteKeys();
+  store = new RedisJobBlobStore({ redis, queueName: QUEUE_NAME });
+});
+
+afterAll(async () => {
+  await clearSuiteKeys();
+  await redis.quit();
+});
+
+describe("RedisJobBlobStore", () => {
+  describe("given a stored blob", () => {
+    describe("when it is read", () => {
+      it("returns the bytes", async () => {
+        await store.put({ id: "proj/abc", data: Buffer.from("hello") });
+
+        expect(await store.get({ id: "proj/abc" })).toEqual(
+          Buffer.from("hello"),
+        );
+      });
+
+      it("refreshes the TTL toward the backstop on access", async () => {
+        await store.put({ id: "proj/ttl", data: Buffer.from("payload") });
+        // Shrink the TTL, then read: get() must bump it back via GETEX.
+        await redis.expire(`${BLOB_PREFIX}proj/ttl`, 100);
+
+        await store.get({ id: "proj/ttl" });
+
+        const ttl = await redis.ttl(`${BLOB_PREFIX}proj/ttl`);
+        expect(ttl).toBeGreaterThan(100);
+        expect(ttl).toBeLessThanOrEqual(THREE_DAYS_SECONDS);
+      });
+
+      it("sets the backstop TTL on put", async () => {
+        await store.put({ id: "proj/fresh", data: Buffer.from("x") });
+
+        const ttl = await redis.ttl(`${BLOB_PREFIX}proj/fresh`);
+        expect(ttl).toBeGreaterThan(THREE_DAYS_SECONDS - 60);
+        expect(ttl).toBeLessThanOrEqual(THREE_DAYS_SECONDS);
+      });
+    });
+  });
+
+  describe("given a missing blob", () => {
+    describe("when it is read", () => {
+      it("returns null", async () => {
+        expect(await store.get({ id: "proj/absent" })).toBeNull();
+      });
+    });
+  });
+
+  describe("given a stored blob", () => {
+    describe("when it is deleted", () => {
+      it("is gone on the next read", async () => {
+        await store.put({ id: "proj/del", data: Buffer.from("bye") });
+
+        await store.delete({ id: "proj/del" });
+
+        expect(await store.get({ id: "proj/del" })).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/redisJobBlobStore.integration.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/redisJobBlobStore.integration.test.ts
@@ -8,7 +8,12 @@ import { RedisJobBlobStore } from "../redisJobBlobStore";
 // dedicated hash-tagged prefix so it never touches the shared dev stack's keys.
 const QUEUE_NAME = "{test/blobstore}";
 const BLOB_PREFIX = `${QUEUE_NAME}:gq:blob:`;
-const THREE_DAYS_SECONDS = 3 * 24 * 60 * 60;
+// GQ1 has no refcount, so a staged-but-not-yet-dispatched job (long retry
+// backoff, paused pipeline, delayed schedule) sees no read between put and TTL
+// tick-down — the backstop must comfortably outlive that residence, so it's
+// 7 days, not 3. GQ2 (content-addressed, refcounted) uses the shorter 3-day
+// number.
+const GQ1_SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
 
 let redis: Redis;
 let store: RedisJobBlobStore;
@@ -54,15 +59,15 @@ describe("RedisJobBlobStore", () => {
 
         const ttl = await redis.ttl(`${BLOB_PREFIX}proj/ttl`);
         expect(ttl).toBeGreaterThan(100);
-        expect(ttl).toBeLessThanOrEqual(THREE_DAYS_SECONDS);
+        expect(ttl).toBeLessThanOrEqual(GQ1_SEVEN_DAYS_SECONDS);
       });
 
       it("sets the backstop TTL on put", async () => {
         await store.put({ id: "proj/fresh", data: Buffer.from("x") });
 
         const ttl = await redis.ttl(`${BLOB_PREFIX}proj/fresh`);
-        expect(ttl).toBeGreaterThan(THREE_DAYS_SECONDS - 60);
-        expect(ttl).toBeLessThanOrEqual(THREE_DAYS_SECONDS);
+        expect(ttl).toBeGreaterThan(GQ1_SEVEN_DAYS_SECONDS - 60);
+        expect(ttl).toBeLessThanOrEqual(GQ1_SEVEN_DAYS_SECONDS);
       });
     });
   });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/__tests__/tieredBlobStore.unit.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+
+import { createTenantId } from "~/server/event-sourcing/domain/tenantId";
+import {
+  type BlobRef,
+  contentHash,
+  type ObjectStore,
+  TieredBlobStore,
+  TransientBlobStoreError,
+} from "../tieredBlobStore";
+import { InMemoryJobBlobStore, InMemoryObjectStore } from "./blobTestDoubles";
+
+const PROJECT = createTenantId("project-abc");
+
+function makeStore(s3ThresholdBytes = 256 * 1024) {
+  const redisBlobs = new InMemoryJobBlobStore();
+  const objectStore = new InMemoryObjectStore();
+  const store = new TieredBlobStore({
+    redisBlobs,
+    objectStoreFor: () => objectStore,
+    resolveDestination: async () => ({ kind: "s3", bucket: "test-bucket" }),
+    s3ThresholdBytes,
+  });
+  return { store, redisBlobs, objectStore };
+}
+
+describe("TieredBlobStore", () => {
+  describe("given a payload under the S3 threshold", () => {
+    describe("when it is put", () => {
+      it("stores it in the Redis tier under a projectId-namespaced key", async () => {
+        const { store, redisBlobs } = makeStore();
+        const data = Buffer.from("a small payload");
+
+        const ref = await store.put({ projectId: PROJECT, data });
+
+        expect(ref.tier).toBe("redis");
+        expect([...redisBlobs.store.keys()]).toEqual([
+          `${PROJECT}/${contentHash(data)}`,
+        ]);
+      });
+
+      it("round-trips the bytes back through get", async () => {
+        const { store } = makeStore();
+        const data = Buffer.from("round trip me");
+
+        const ref = await store.put({ projectId: PROJECT, data });
+
+        expect(await store.get(ref)).toEqual(data);
+      });
+    });
+  });
+
+  describe("given a payload over the S3 threshold", () => {
+    describe("when it is put", () => {
+      it("stores it in the S3 tier under a projectId-namespaced s3 uri", async () => {
+        const { store, objectStore } = makeStore(8);
+        const data = Buffer.from("this comfortably exceeds the threshold");
+
+        const ref = await store.put({ projectId: PROJECT, data });
+
+        const expectedUri = `s3://test-bucket/${PROJECT}/${contentHash(data)}`;
+        expect(ref.tier).toBe("s3");
+        expect(ref).toMatchObject({
+          projectId: PROJECT,
+          hash: contentHash(data),
+        });
+        expect([...objectStore.store.keys()]).toEqual([expectedUri]);
+      });
+
+      it("round-trips the bytes back through get", async () => {
+        const { store } = makeStore(8);
+        const data = Buffer.from("durable tier round trip");
+
+        const ref = await store.put({ projectId: PROJECT, data });
+
+        expect(await store.get(ref)).toEqual(data);
+      });
+    });
+  });
+
+  describe("given two byte-identical payloads in the same project", () => {
+    describe("when both are put", () => {
+      it("collapses them to one content-addressed key", async () => {
+        const { store, redisBlobs } = makeStore();
+        const data = Buffer.from("the very same bytes");
+
+        const first = await store.put({ projectId: PROJECT, data });
+        const second = await store.put({
+          projectId: PROJECT,
+          data: Buffer.from(data),
+        });
+
+        expect(second).toEqual(first);
+        expect(redisBlobs.store.size).toBe(1);
+      });
+    });
+  });
+
+  describe("given byte-identical payloads under different tenants", () => {
+    describe("when each is put", () => {
+      it("namespaces them to different keys so tenants never share a blob", async () => {
+        const { store, redisBlobs } = makeStore();
+        const data = Buffer.from("identical user content");
+
+        const a = await store.put({
+          projectId: createTenantId("tenant-a"),
+          data,
+        });
+        const b = await store.put({
+          projectId: createTenantId("tenant-b"),
+          data,
+        });
+
+        expect(a).not.toEqual(b);
+        expect([...redisBlobs.store.keys()].sort()).toEqual(
+          [
+            `tenant-a/${contentHash(data)}`,
+            `tenant-b/${contentHash(data)}`,
+          ].sort(),
+        );
+      });
+    });
+  });
+
+  describe("given a stored blob", () => {
+    describe("when it is deleted", () => {
+      it("removes it from its tier", async () => {
+        const { store, redisBlobs } = makeStore();
+        const ref = await store.put({
+          projectId: PROJECT,
+          data: Buffer.from("delete me"),
+        });
+
+        await store.delete(ref);
+
+        expect(redisBlobs.store.size).toBe(0);
+      });
+    });
+  });
+
+  describe("given an s3-tier blob that is genuinely gone", () => {
+    describe("when it is fetched", () => {
+      it("returns null so decode reaches the missing-blob fail-safe", async () => {
+        const { store, objectStore } = makeStore(8);
+        const data = Buffer.from(
+          "over the threshold so it lands in the s3 tier",
+        );
+        const ref = await store.put({ projectId: PROJECT, data });
+        objectStore.store.clear(); // the object vanished (NoSuchKey)
+
+        expect(await store.get(ref)).toBeNull();
+      });
+    });
+  });
+
+  describe("given the s3 store is failing transiently", () => {
+    describe("when a blob is fetched", () => {
+      it("throws TransientBlobStoreError so the job retries instead of dropping", async () => {
+        const flaky: ObjectStore = {
+          put: async () => {},
+          get: async () => {
+            throw new Error("ECONNRESET");
+          },
+          delete: async () => {},
+        };
+        const store = new TieredBlobStore({
+          redisBlobs: new InMemoryJobBlobStore(),
+          objectStoreFor: () => flaky,
+          resolveDestination: async () => ({
+            kind: "s3",
+            bucket: "test-bucket",
+          }),
+          s3ThresholdBytes: 8,
+        });
+        const ref: BlobRef = {
+          tier: "s3",
+          projectId: PROJECT,
+          hash: "deadbeefdeadbeef",
+        };
+
+        await expect(store.get(ref)).rejects.toBeInstanceOf(
+          TransientBlobStoreError,
+        );
+      });
+    });
+  });
+
+  describe("given the destination resolver fails", () => {
+    describe("when a blob is fetched", () => {
+      it("throws TransientBlobStoreError (a resolve failure is never a missing blob)", async () => {
+        const store = new TieredBlobStore({
+          redisBlobs: new InMemoryJobBlobStore(),
+          objectStoreFor: () => new InMemoryObjectStore(),
+          resolveDestination: async () => {
+            // Even a NotFound-shaped resolve error must be transient, not missing.
+            const err = new Error("resolve not-found");
+            err.name = "NotFound";
+            throw err;
+          },
+          s3ThresholdBytes: 8,
+        });
+        const ref: BlobRef = {
+          tier: "s3",
+          projectId: PROJECT,
+          hash: "deadbeefdeadbeef",
+        };
+
+        await expect(store.get(ref)).rejects.toBeInstanceOf(
+          TransientBlobStoreError,
+        );
+      });
+    });
+  });
+
+  describe("given a hash source distinct from the stored bytes", () => {
+    describe("when put", () => {
+      it("keys by the hash source, not the stored bytes (gzip-determinism independence)", async () => {
+        const { store, redisBlobs } = makeStore();
+        const raw = Buffer.from("the raw json source");
+        const stored = Buffer.from("DIFFERENT bytes that actually get stored");
+
+        const ref = await store.put({
+          projectId: PROJECT,
+          data: stored,
+          hashSource: raw,
+        });
+
+        expect(ref.hash).toBe(contentHash(raw));
+        expect([...redisBlobs.store.values()]).toEqual([stored]);
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobConstants.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobConstants.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared sizing constants for the GQ2 content-addressed blob lifecycle
+ * (ADR-029 / ADR-030). Hoisted into one module so the blob and its holder set
+ * derive their TTL from a single source — the holder set must outlive the blob
+ * it guards, so a two-literal drift would be a correctness bug.
+ */
+
+/**
+ * Backstop TTL for an offloaded blob, refreshed on access. The holder-set TTL is
+ * set to at least this (see {@link BlobHolders}); both reclaim eagerly on the
+ * happy path, so this only bounds genuine orphans — sized to outlive a weekend.
+ */
+export const BLOB_BACKSTOP_TTL_SECONDS = 3 * 24 * 60 * 60;
+
+/**
+ * TTL on a blob's holder set — deliberately longer than the blob TTL so the
+ * holder set always outlives the blob it guards. A holder set that expired
+ * first would drop its members and let a still-referenced blob be reclaimed.
+ * Both are refreshed on access, so this margin only has to cover the small skew
+ * between the two refreshes (ADR-030 §3).
+ */
+export const BLOB_HOLDER_TTL_SECONDS = BLOB_BACKSTOP_TTL_SECONDS + 24 * 60 * 60;
+
+/**
+ * Hard ceiling on a single job's serialized payload. A payload over this is
+ * rejected at encode rather than risking an OOM from gzipping + buffering it,
+ * and bounds worst-case memory at roughly ceiling × worker concurrency
+ * (ADR-030 §1).
+ */
+export const MAX_BLOB_BYTES = 50 * 1024 * 1024;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobConstants.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobConstants.ts
@@ -6,9 +6,24 @@
  */
 
 /**
- * Backstop TTL for an offloaded blob, refreshed on access. The holder-set TTL is
- * set to at least this (see {@link BlobHolders}); both reclaim eagerly on the
- * happy path, so this only bounds genuine orphans — sized to outlive a weekend.
+ * Backstop TTL for a GQ1 (randomUUID / no-refcount) offloaded blob. GQ1 blobs
+ * are refreshed on the DISPATCHED read only — a staged-but-not-yet-dispatched
+ * job (long retry backoff chain, paused pipeline, delayed schedule) has no
+ * intervening read between put and TTL tick-down, so this MUST comfortably
+ * exceed the longest plausible staged residence — hours, not days. The 7-day
+ * value here is the original invariant from `redisJobBlobStore.ts` before
+ * ADR-029 was hoisted into this module; see the 2026-06-24 review.
+ */
+export const GQ1_BLOB_BACKSTOP_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Backstop TTL for a GQ2 (content-addressed, refcounted) offloaded blob,
+ * refreshed on access. The holder-set TTL is set to at least this (see
+ * {@link BlobHolders}); both reclaim eagerly on the happy path, so this only
+ * bounds genuine orphans — sized to outlive a weekend. The GQ2 blob has an
+ * accompanying holder set (per-stage tokens with atomic reclaim in Lua), so
+ * the 3-day window here is the safety net for missed releases (crash mid-
+ * completion), not the primary reclaim mechanism.
  */
 export const BLOB_BACKSTOP_TTL_SECONDS = 3 * 24 * 60 * 60;
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobHolders.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobHolders.ts
@@ -1,0 +1,206 @@
+import type { Cluster, Redis as IORedis } from "ioredis";
+
+import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
+import { BLOB_HOLDER_TTL_SECONDS } from "./blobConstants";
+import { blobHolderSetKey, redisBlobKey } from "./blobKeys";
+
+/**
+ * Atomic release: drop this slot's hold; if no holders remain, delete the
+ * holder set and — for a redis-tier blob — UNLINK the blob in the same eval, so
+ * a completion racing a re-stage of the same content can never delete a live
+ * blob. A release whose SREM removed nothing (a doubled or never-acquired
+ * release) returns early with "still-held" so it can never reclaim on a no-op.
+ * The redis blob key is only passed when the tier is redis, so cluster mode
+ * never has to co-slot an empty placeholder key. Returns:
+ *   0  still held by other slots (or SREM was a no-op)
+ *   1  holders emptied, redis blob UNLINKed here
+ *   2  holders emptied, s3 object must be reclaimed by the caller
+ */
+const RELEASE_LUA = `
+if redis.call("SREM", KEYS[1], ARGV[1]) == 0 then return 0 end
+if redis.call("SCARD", KEYS[1]) == 0 then
+  redis.call("DEL", KEYS[1])
+  if #KEYS >= 2 then
+    redis.call("UNLINK", KEYS[2])
+    return 1
+  end
+  return 2
+end
+return 0
+`;
+
+/**
+ * Atomic hold transfer: add the new slot's hold (refreshing its TTL), drop the
+ * old slot's, and reclaim the old blob if its holder set is now empty — all in
+ * one eval, so a partial failure can't reclaim a live blob the way a separate
+ * acquire-then-release pair can. KEYS[1]=new holder set, KEYS[2]=old holder set,
+ * KEYS[3]=old redis blob (passed only for the redis tier). Returns the OLD
+ * blob's reclaim outcome. A self-transfer (same holder set AND same slot) just
+ * refreshes the TTL and keeps the hold; otherwise the old blob is reclaimed only
+ * when the SREM actually removed the old slot and the set is now empty, so a
+ * no-op transfer can never reclaim a live blob.
+ */
+const TRANSFER_LUA = `
+if KEYS[1] == KEYS[2] and ARGV[1] == ARGV[2] then
+  redis.call("SADD", KEYS[1], ARGV[1])
+  redis.call("EXPIRE", KEYS[1], ARGV[3])
+  return 0
+end
+redis.call("SADD", KEYS[1], ARGV[1])
+redis.call("EXPIRE", KEYS[1], ARGV[3])
+if redis.call("SREM", KEYS[2], ARGV[2]) == 1 and redis.call("SCARD", KEYS[2]) == 0 then
+  redis.call("DEL", KEYS[2])
+  if #KEYS >= 3 then
+    redis.call("UNLINK", KEYS[3])
+    return 1
+  end
+  return 2
+end
+return 0
+`;
+
+export type ReleaseOutcome = "still-held" | "reclaimed-redis" | "reclaim-s3";
+
+/**
+ * Reference counting for content-addressed blobs via a per-blob holder set
+ * whose members are staged-slot ids. A staged job acquires a hold; each
+ * terminal retirement releases it; the last release reclaims the blob. A *set*
+ * (not a counter) makes a doubled release a harmless no-op and a missed one
+ * degrade to the TTL backstop rather than deleting a live blob. See ADR-029.
+ *
+ * Holder and blob keys carry the queue's hash tag, so a release/transfer eval's
+ * keys (the holder key, plus the blob key only for the redis tier) land in one
+ * cluster slot.
+ */
+export class BlobHolders {
+  private readonly redis: IORedis | Cluster;
+  private readonly queueName: string;
+
+  constructor({
+    redis,
+    queueName,
+  }: {
+    redis: IORedis | Cluster;
+    queueName: string;
+  }) {
+    this.redis = redis;
+    this.queueName = queueName;
+  }
+
+  private holderKey(projectId: TenantId, hash: string): string {
+    return blobHolderSetKey({ queueName: this.queueName, projectId, hash });
+  }
+
+  private blobKey(projectId: TenantId, hash: string): string {
+    return redisBlobKey({ queueName: this.queueName, projectId, hash });
+  }
+
+  /** Records that a staged slot references the blob (idempotent), refreshing the holder TTL. */
+  async acquire({
+    projectId,
+    hash,
+    slotId,
+  }: {
+    projectId: TenantId;
+    hash: string;
+    slotId: string;
+  }): Promise<void> {
+    const key = this.holderKey(projectId, hash);
+    await this.redis
+      .multi()
+      .sadd(key, slotId)
+      .expire(key, BLOB_HOLDER_TTL_SECONDS)
+      .exec();
+  }
+
+  /** Refreshes the holder set's TTL on access (dispatch), so it outlives the blob it guards. */
+  async touch({
+    projectId,
+    hash,
+  }: {
+    projectId: TenantId;
+    hash: string;
+  }): Promise<void> {
+    await this.redis.expire(
+      this.holderKey(projectId, hash),
+      BLOB_HOLDER_TTL_SECONDS,
+    );
+  }
+
+  /**
+   * Releases a staged slot's hold and reclaims the blob when the last hold
+   * drops. For a redis-tier blob the eval UNLINKs it atomically; for s3 the
+   * caller deletes the object on a `"reclaim-s3"` outcome.
+   */
+  async release({
+    projectId,
+    hash,
+    tier,
+    slotId,
+  }: {
+    projectId: TenantId;
+    hash: string;
+    tier: "redis" | "s3";
+    slotId: string;
+  }): Promise<ReleaseOutcome> {
+    // Pass the blob key only for the redis tier, so cluster mode never has to
+    // co-slot an empty placeholder key (ADR-030 §6).
+    const keys =
+      tier === "redis"
+        ? [this.holderKey(projectId, hash), this.blobKey(projectId, hash)]
+        : [this.holderKey(projectId, hash)];
+    const result = (await this.redis.eval(
+      RELEASE_LUA,
+      keys.length,
+      ...keys,
+      slotId,
+    )) as number;
+    if (result === 1) return "reclaimed-redis";
+    if (result === 2) return "reclaim-s3";
+    return "still-held";
+  }
+
+  /**
+   * Atomically moves a hold from a retired value to its replacement (a retry
+   * re-encode or a dedup squash). One eval adds the new hold, drops the old, and
+   * reclaims the old blob if newly unreferenced — closing the window an
+   * acquire-then-release pair leaves, where a partial failure could reclaim a
+   * live blob. Returns the OLD blob's reclaim outcome.
+   */
+  async transfer({
+    newProjectId,
+    newHash,
+    newSlotId,
+    oldProjectId,
+    oldHash,
+    oldTier,
+    oldSlotId,
+  }: {
+    newProjectId: TenantId;
+    newHash: string;
+    newSlotId: string;
+    oldProjectId: TenantId;
+    oldHash: string;
+    oldTier: "redis" | "s3";
+    oldSlotId: string;
+  }): Promise<ReleaseOutcome> {
+    const newHolderKey = this.holderKey(newProjectId, newHash);
+    const oldHolderKey = this.holderKey(oldProjectId, oldHash);
+    // Old blob key only for the redis tier (see release()).
+    const keys =
+      oldTier === "redis"
+        ? [newHolderKey, oldHolderKey, this.blobKey(oldProjectId, oldHash)]
+        : [newHolderKey, oldHolderKey];
+    const result = (await this.redis.eval(
+      TRANSFER_LUA,
+      keys.length,
+      ...keys,
+      newSlotId,
+      oldSlotId,
+      String(BLOB_HOLDER_TTL_SECONDS),
+    )) as number;
+    if (result === 1) return "reclaimed-redis";
+    if (result === 2) return "reclaim-s3";
+    return "still-held";
+  }
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/blobKeys.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/blobKeys.ts
@@ -1,0 +1,51 @@
+import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
+
+/**
+ * The single source of truth for the redis key layout of offloaded blobs and
+ * their holder sets. Two collaborators must agree on it byte-for-byte — the
+ * blob store writes the blob key, and the holder-set Lua `UNLINK`s it on
+ * reclaim — so the layout lives here rather than being reconstructed in each.
+ * Changing a prefix in one place without the other would silently break
+ * reclamation, with no compiler signal; centralizing removes that drift.
+ *
+ * Keys carry the queue name (with its cluster hash tag) so a blob, its holder
+ * set, and the queue's other keys all land in one cluster slot.
+ *
+ * `projectId` is the branded {@link TenantId} so the tenant boundary stays
+ * intact at the exact API that mints tenant-scoped keys (ADR-030 §5) — a
+ * caller can't accidentally pass a raw user-controlled string.
+ */
+
+/** `<projectId>/<hash>` — the tenant-namespaced content id a blob is keyed by. */
+export function blobNamespaceId({
+  projectId,
+  hash,
+}: {
+  projectId: TenantId;
+  hash: string;
+}): string {
+  return `${projectId}/${hash}`;
+}
+
+/** Redis key prefix for offloaded blob bytes (the store keys by prefix + id). */
+export function redisBlobKeyPrefix(queueName: string): string {
+  return `${queueName}:gq:blob:`;
+}
+
+/** Full redis key for an offloaded blob's bytes. */
+export function redisBlobKey(params: {
+  queueName: string;
+  projectId: TenantId;
+  hash: string;
+}): string {
+  return `${redisBlobKeyPrefix(params.queueName)}${blobNamespaceId(params)}`;
+}
+
+/** Full redis key for a blob's holder set (the per-blob reference count). */
+export function blobHolderSetKey(params: {
+  queueName: string;
+  projectId: TenantId;
+  hash: string;
+}): string {
+  return `${params.queueName}:gq:blobholders:${blobNamespaceId(params)}`;
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
@@ -1,0 +1,319 @@
+import { Cluster, type Redis as IORedis } from "ioredis";
+
+import { createLogger } from "../../../../utils/logger/server";
+import { tenantIdFromGroupId } from "../../../observability/tenantRateTracker";
+import {
+  type ProjectStorageDestination,
+  redactStorageUrisInText,
+} from "../../../stored-objects/project-storage-destination";
+import { createTenantId, type TenantId } from "../../domain/tenantId";
+import { BlobHolders } from "./blobHolders";
+import {
+  decodeJobEnvelope,
+  encodeJobEnvelope,
+  readEnvelopeBlobId,
+  readEnvelopeHold,
+} from "./jobEnvelope";
+import { hasRedisHashTag } from "./redisHashTag";
+import { RedisJobBlobStore } from "./redisJobBlobStore";
+import { type ObjectStore, TieredBlobStore } from "./tieredBlobStore";
+
+const logger = createLogger("langwatch:event-sourcing:envelope-blob-lifecycle");
+
+/**
+ * Owns the GQ2 content-addressed blob lifecycle for a GroupQueue — the tiered
+ * store, the holder-set refcount, and the encode / decode / acquire / release
+ * seams — so the queue processor delegates rather than carrying it inline, and
+ * the seams are exercisable without standing up the whole queue. See ADR-030.
+ */
+export class EnvelopeBlobLifecycle {
+  private readonly blobs: RedisJobBlobStore;
+  private readonly blobHolders: BlobHolders;
+  private readonly tieredBlobs?: TieredBlobStore;
+
+  constructor({
+    redis,
+    queueName,
+    objectStoreFor,
+    resolveStorageDestination,
+  }: {
+    redis: IORedis | Cluster;
+    queueName: string;
+    objectStoreFor?: (projectId: string) => ObjectStore;
+    resolveStorageDestination?: (
+      projectId: string,
+    ) => Promise<ProjectStorageDestination>;
+  }) {
+    // The holder release/transfer evals touch two keys (holder + blob); in
+    // cluster mode they must share a slot, which requires the queue name to
+    // carry a hash tag. Fail fast rather than CROSSSLOT-leak silently at runtime
+    // (ADR-030 §6). A single Redis has no slots, so the check is cluster-only.
+    if (redis instanceof Cluster && !hasRedisHashTag(queueName)) {
+      throw new Error(
+        `GroupQueue "${queueName}" needs a Redis hash tag ({...}): the holder ` +
+          `release/transfer evals touch the holder and blob keys, which must ` +
+          `share one cluster slot.`,
+      );
+    }
+    this.blobs = new RedisJobBlobStore({ redis, queueName });
+    this.blobHolders = new BlobHolders({ redis, queueName });
+    // The tiered store is active only when the composition root supplies an
+    // object store + destination resolver; otherwise encode falls back to GQ1's
+    // randomUUID offload.
+    this.tieredBlobs =
+      objectStoreFor && resolveStorageDestination
+        ? new TieredBlobStore({
+            redisBlobs: this.blobs,
+            objectStoreFor,
+            resolveDestination: resolveStorageDestination,
+          })
+        : undefined;
+  }
+
+  /**
+   * The branded tenant id owning a group, or undefined when the groupId carries
+   * no tenant prefix. This is the validation boundary: every projectId reaching
+   * the blob store / holder set is a `TenantId` minted here, so a raw string
+   * can't be used to namespace a blob (tenant-isolation safety at the type level).
+   */
+  private projectIdFor(groupId: string): TenantId | undefined {
+    const tenantId = tenantIdFromGroupId(groupId);
+    return tenantId ? createTenantId(tenantId) : undefined;
+  }
+
+  /**
+   * Encodes a job payload into a staged envelope, offloading a large body to the
+   * content-addressed tiered store under the group's tenant namespace.
+   */
+  async encode({
+    jobData,
+    groupId,
+  }: {
+    jobData: Record<string, unknown>;
+    groupId: string;
+  }): Promise<string> {
+    return encodeJobEnvelope({
+      jobData,
+      blobs: this.blobs,
+      tieredBlobs: this.tieredBlobs,
+      projectId: this.projectIdFor(groupId),
+    });
+  }
+
+  /** Decodes a staged envelope back into the job payload, resolving any offloaded blob. */
+  async decode({
+    value,
+    groupId,
+  }: {
+    value: string;
+    groupId: string;
+  }): Promise<Record<string, unknown>> {
+    const hold = readEnvelopeHold(value);
+    if (hold) {
+      // Defense-in-depth: the blob ref's tenant must match the group's tenant.
+      // A forged or mis-routed ref must never read another tenant's blob, so
+      // refuse before fetching and let the missing-blob fail-safe run (ADR-030 §5).
+      const expected = this.projectIdFor(groupId);
+      if (hold.ref.projectId !== expected) {
+        logger.warn(
+          {
+            projectId: expected,
+            refProjectId: hold.ref.projectId,
+            blobHash: hold.ref.hash,
+            groupId,
+          },
+          "Blob ref tenant mismatch; refusing cross-tenant read",
+        );
+        throw new Error("Blob ref tenant mismatch");
+      }
+    }
+    const decoded = await decodeJobEnvelope({
+      value,
+      blobs: this.blobs,
+      tieredBlobs: this.tieredBlobs,
+    });
+    // The decode's GETEX refreshed the blob TTL; refresh the holder set too so a
+    // still-referenced blob's holder never expires before it (ADR-030 §3).
+    if (hold) {
+      void this.blobHolders
+        .touch({ projectId: hold.ref.projectId, hash: hold.ref.hash })
+        .catch((err: unknown) => {
+          logger.warn(
+            {
+              projectId: hold.ref.projectId,
+              blobHash: hold.ref.hash,
+              err: redactStorageUrisInText(
+                err instanceof Error ? err.message : String(err),
+              ),
+            },
+            "Blob holder TTL refresh failed; relying on the margin",
+          );
+        });
+    }
+    return decoded;
+  }
+
+  /**
+   * Acquires this staged occupancy's hold on its GQ2 blob (no-op for GQ1,
+   * inline, and legacy values). Fire-and-forget: a missed acquire degrades to
+   * the blob's TTL backstop, never to a premature reclaim.
+   */
+  acquire(value: string): void {
+    const hold = readEnvelopeHold(value);
+    if (!hold) return;
+    void this.blobHolders
+      .acquire({
+        projectId: hold.ref.projectId,
+        hash: hold.ref.hash,
+        slotId: hold.token,
+      })
+      .catch((err: unknown) => {
+        // Tenant-attributed (never a bare hash, never the bucket): every blob
+        // log line carries the owning projectId so logs can't cross tenants.
+        logger.warn(
+          {
+            projectId: hold.ref.projectId,
+            blobHash: hold.ref.hash,
+            tier: hold.ref.tier,
+            err: redactStorageUrisInText(
+              err instanceof Error ? err.message : String(err),
+            ),
+          },
+          "Blob holder acquire failed; relying on the TTL backstop",
+        );
+      });
+  }
+
+  /**
+   * Releases holds for retired staged values: a GQ2 value releases its holder —
+   * reclaiming the blob when the last hold drops, deleting an s3 object
+   * out-of-band; a legacy GQ1 value deletes its randomUUID blob. Fire-and-forget:
+   * the blob TTL is the correctness backstop, so the hot path never waits.
+   */
+  release({ values, groupId }: { values: string[]; groupId: string }): void {
+    const expected = this.projectIdFor(groupId);
+    for (const value of values) {
+      const hold = readEnvelopeHold(value);
+      if (hold) {
+        // Tenant guard: never release a hold whose ref isn't this group's
+        // tenant. A mis-routed or forged GQ2 value must not reclaim another
+        // tenant's blob on the fail-safe cleanup path (ADR-030 §5).
+        if (hold.ref.projectId !== expected) {
+          logger.warn(
+            {
+              projectId: expected,
+              refProjectId: hold.ref.projectId,
+              blobHash: hold.ref.hash,
+              groupId,
+            },
+            "Skipping blob release for a tenant-mismatched ref",
+          );
+          continue;
+        }
+        void this.blobHolders
+          .release({
+            projectId: hold.ref.projectId,
+            hash: hold.ref.hash,
+            tier: hold.ref.tier,
+            slotId: hold.token,
+          })
+          .then((outcome) => {
+            if (outcome === "reclaim-s3" && this.tieredBlobs) {
+              return this.tieredBlobs.delete(hold.ref);
+            }
+          })
+          .catch((err: unknown) => {
+            logger.warn(
+              {
+                projectId: hold.ref.projectId,
+                blobHash: hold.ref.hash,
+                tier: hold.ref.tier,
+                err: redactStorageUrisInText(
+                  err instanceof Error ? err.message : String(err),
+                ),
+              },
+              "Blob holder release/reclaim failed; relying on the TTL backstop",
+            );
+          });
+        continue;
+      }
+      const blobId = readEnvelopeBlobId(value);
+      if (blobId) {
+        void this.blobs.delete({ id: blobId }).catch(() => undefined);
+      }
+    }
+  }
+
+  /**
+   * Atomically moves the hold from a retired value to its replacement (retry
+   * re-encode or dedup squash): one eval adds the new hold, drops the old, and
+   * reclaims the old blob if newly unreferenced — no acquire-then-release gap in
+   * which a partial failure could reclaim a live blob (ADR-030 §4). Falls back to
+   * ordered acquire+release when either side isn't a GQ2 hold.
+   */
+  transfer({
+    newValue,
+    oldValue,
+    groupId,
+  }: {
+    newValue: string;
+    oldValue: string;
+    groupId: string;
+  }): void {
+    const expected = this.projectIdFor(groupId);
+    const newHold = readEnvelopeHold(newValue);
+    const oldHold = readEnvelopeHold(oldValue);
+    // A tenant-mismatched newValue must not acquire a foreign holder (the
+    // mirror of the release-side guard). Skip both sides — the guarded release
+    // also drops the old holder iff its tenant matches (ADR-030 §5).
+    if (newHold && newHold.ref.projectId !== expected) {
+      logger.warn(
+        {
+          projectId: expected,
+          refProjectId: newHold.ref.projectId,
+          blobHash: newHold.ref.hash,
+          groupId,
+        },
+        "Skipping blob acquire for a tenant-mismatched replacement ref",
+      );
+      this.release({ values: [oldValue], groupId });
+      return;
+    }
+    // Fall back to ordered acquire+release when either side isn't a GQ2 hold, or
+    // when the old ref isn't this group's tenant — the guarded release then
+    // skips the foreign hold, leaving it to its TTL (ADR-030 §5).
+    if (!newHold || !oldHold || oldHold.ref.projectId !== expected) {
+      this.acquire(newValue);
+      this.release({ values: [oldValue], groupId });
+      return;
+    }
+    void this.blobHolders
+      .transfer({
+        newProjectId: newHold.ref.projectId,
+        newHash: newHold.ref.hash,
+        newSlotId: newHold.token,
+        oldProjectId: oldHold.ref.projectId,
+        oldHash: oldHold.ref.hash,
+        oldTier: oldHold.ref.tier,
+        oldSlotId: oldHold.token,
+      })
+      .then((outcome) => {
+        if (outcome === "reclaim-s3" && this.tieredBlobs) {
+          return this.tieredBlobs.delete(oldHold.ref);
+        }
+      })
+      .catch((err: unknown) => {
+        logger.warn(
+          {
+            projectId: oldHold.ref.projectId,
+            blobHash: oldHold.ref.hash,
+            tier: oldHold.ref.tier,
+            err: redactStorageUrisInText(
+              err instanceof Error ? err.message : String(err),
+            ),
+          },
+          "Blob holder transfer failed; relying on the TTL backstop",
+        );
+      });
+  }
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/envelopeBlobLifecycle.ts
@@ -11,9 +11,13 @@ import { BlobHolders } from "./blobHolders";
 import {
   decodeJobEnvelope,
   encodeJobEnvelope,
-  readEnvelopeBlobId,
+  isEnvelope,
   readEnvelopeHold,
+  readEnvelopeHoldFromHeader,
+  readEnvelopeRetirement,
+  splitEnvelope,
 } from "./jobEnvelope";
+import { gqBlobReclaimS3FailuresTotal } from "./metrics";
 import { hasRedisHashTag } from "./redisHashTag";
 import { RedisJobBlobStore } from "./redisJobBlobStore";
 import { type ObjectStore, TieredBlobStore } from "./tieredBlobStore";
@@ -30,12 +34,15 @@ export class EnvelopeBlobLifecycle {
   private readonly blobs: RedisJobBlobStore;
   private readonly blobHolders: BlobHolders;
   private readonly tieredBlobs?: TieredBlobStore;
+  private readonly queueName: string;
+  private readonly writesEnabled?: boolean;
 
   constructor({
     redis,
     queueName,
     objectStoreFor,
     resolveStorageDestination,
+    writesEnabled,
   }: {
     redis: IORedis | Cluster;
     queueName: string;
@@ -43,7 +50,17 @@ export class EnvelopeBlobLifecycle {
     resolveStorageDestination?: (
       projectId: string,
     ) => Promise<ProjectStorageDestination>;
+    /**
+     * Explicit override of the format-rollout gate. Threaded through to
+     * {@link encodeJobEnvelope} so the composition root — not per-call
+     * `process.env` reads — decides when the queue starts emitting GQ2
+     * envelopes. Omit to fall back to the `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED`
+     * env var (call-time read so tests can toggle without module reload).
+     */
+    writesEnabled?: boolean;
   }) {
+    this.queueName = queueName;
+    this.writesEnabled = writesEnabled;
     // The holder release/transfer evals touch two keys (holder + blob); in
     // cluster mode they must share a slot, which requires the queue name to
     // carry a hash tag. Fail fast rather than CROSSSLOT-leak silently at runtime
@@ -66,6 +83,8 @@ export class EnvelopeBlobLifecycle {
             redisBlobs: this.blobs,
             objectStoreFor,
             resolveDestination: resolveStorageDestination,
+            queueName,
+            logger,
           })
         : undefined;
   }
@@ -97,6 +116,9 @@ export class EnvelopeBlobLifecycle {
       blobs: this.blobs,
       tieredBlobs: this.tieredBlobs,
       projectId: this.projectIdFor(groupId),
+      writesEnabled: this.writesEnabled,
+      queueName: this.queueName,
+      logger,
     });
   }
 
@@ -108,7 +130,12 @@ export class EnvelopeBlobLifecycle {
     value: string;
     groupId: string;
   }): Promise<Record<string, unknown>> {
-    const hold = readEnvelopeHold(value);
+    // Parse the envelope ONCE here on the hot path; the header carries both
+    // the hold token (for the tenant guard + touch) and the routing needed to
+    // decode the body. Passing the parsed tuple into decodeJobEnvelope skips a
+    // second Buffer.from + JSON.parse (2026-06-24 review).
+    const parsed = isEnvelope(value) ? splitEnvelope(value) : undefined;
+    const hold = parsed ? readEnvelopeHoldFromHeader(parsed.header) : null;
     if (hold) {
       // Defense-in-depth: the blob ref's tenant must match the group's tenant.
       // A forged or mis-routed ref must never read another tenant's blob, so
@@ -131,6 +158,7 @@ export class EnvelopeBlobLifecycle {
       value,
       blobs: this.blobs,
       tieredBlobs: this.tieredBlobs,
+      parsed,
     });
     // The decode's GETEX refreshed the blob TTL; refresh the holder set too so a
     // still-referenced blob's holder never expires before it (ADR-030 §3).
@@ -193,7 +221,10 @@ export class EnvelopeBlobLifecycle {
   release({ values, groupId }: { values: string[]; groupId: string }): void {
     const expected = this.projectIdFor(groupId);
     for (const value of values) {
-      const hold = readEnvelopeHold(value);
+      // Single parse per value: hold + GQ1 blobId from one splitEnvelope so a
+      // maxBatch=10 coalesced completion doesn't do ~20 redundant Buffer.from +
+      // JSON.parse (2026-06-24 review).
+      const { hold, blobId } = readEnvelopeRetirement(value);
       if (hold) {
         // Tenant guard: never release a hold whose ref isn't this group's
         // tenant. A mis-routed or forged GQ2 value must not reclaim another
@@ -219,7 +250,25 @@ export class EnvelopeBlobLifecycle {
           })
           .then((outcome) => {
             if (outcome === "reclaim-s3" && this.tieredBlobs) {
-              return this.tieredBlobs.delete(hold.ref);
+              return this.tieredBlobs.delete(hold.ref).catch((err: unknown) => {
+                // S3 reclaim failed — the holder is already gone, so no future
+                // release will retry this object. Warn AND counter so oncall
+                // sees a recurring failure before the bucket-lifecycle
+                // backstop kicks in (2026-06-24 review).
+                gqBlobReclaimS3FailuresTotal.inc({
+                  queue_name: this.queueName,
+                });
+                logger.warn(
+                  {
+                    projectId: hold.ref.projectId,
+                    blobHash: hold.ref.hash,
+                    err: redactStorageUrisInText(
+                      err instanceof Error ? err.message : String(err),
+                    ),
+                  },
+                  "S3 blob reclaim failed after holder drop — orphaned until bucket lifecycle sweeps",
+                );
+              });
             }
           })
           .catch((err: unknown) => {
@@ -237,7 +286,6 @@ export class EnvelopeBlobLifecycle {
           });
         continue;
       }
-      const blobId = readEnvelopeBlobId(value);
       if (blobId) {
         void this.blobs.delete({ id: blobId }).catch(() => undefined);
       }
@@ -282,9 +330,32 @@ export class EnvelopeBlobLifecycle {
     // Fall back to ordered acquire+release when either side isn't a GQ2 hold, or
     // when the old ref isn't this group's tenant — the guarded release then
     // skips the foreign hold, leaving it to its TTL (ADR-030 §5).
+    //
+    // This branch dominates during the GQ1 → GQ2 rollout window: new encodes
+    // are GQ2 but in-flight staged values are still GQ1, so `!oldHold` fires
+    // on every retry/squash. Acquire-then-release is ORDERED (not parallel
+    // fire-and-forget) so a release-before-acquire race can't drop the old
+    // blob before the new hold is recorded (2026-06-24 review). It's not
+    // atomic like TRANSFER_LUA — extending the Lua for the mixed-format case
+    // is tracked as a follow-up.
     if (!newHold || !oldHold || oldHold.ref.projectId !== expected) {
-      this.acquire(newValue);
-      this.release({ values: [oldValue], groupId });
+      void (async () => {
+        try {
+          await this.acquireAwait(newValue);
+        } catch (err) {
+          logger.warn(
+            {
+              refProjectId: newHold?.ref.projectId,
+              blobHash: newHold?.ref.hash,
+              groupId,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "transfer fallback: acquire failed; skipping release to keep old blob alive under TTL",
+          );
+          return;
+        }
+        this.release({ values: [oldValue], groupId });
+      })();
       return;
     }
     void this.blobHolders
@@ -299,7 +370,19 @@ export class EnvelopeBlobLifecycle {
       })
       .then((outcome) => {
         if (outcome === "reclaim-s3" && this.tieredBlobs) {
-          return this.tieredBlobs.delete(oldHold.ref);
+          return this.tieredBlobs.delete(oldHold.ref).catch((err: unknown) => {
+            gqBlobReclaimS3FailuresTotal.inc({ queue_name: this.queueName });
+            logger.warn(
+              {
+                projectId: oldHold.ref.projectId,
+                blobHash: oldHold.ref.hash,
+                err: redactStorageUrisInText(
+                  err instanceof Error ? err.message : String(err),
+                ),
+              },
+              "S3 blob reclaim failed after transfer — orphaned until bucket lifecycle sweeps",
+            );
+          });
         }
       })
       .catch((err: unknown) => {
@@ -315,5 +398,19 @@ export class EnvelopeBlobLifecycle {
           "Blob holder transfer failed; relying on the TTL backstop",
         );
       });
+  }
+
+  /**
+   * Awaited variant of {@link acquire} used by the transfer fallback so a
+   * failed acquire can be observed synchronously before the release runs.
+   */
+  private async acquireAwait(value: string): Promise<void> {
+    const hold = readEnvelopeHold(value);
+    if (!hold) return;
+    await this.blobHolders.acquire({
+      projectId: hold.ref.projectId,
+      hash: hold.ref.hash,
+      slotId: hold.token,
+    });
   }
 }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -89,6 +89,38 @@ const GROUP_QUEUE_CONFIG = {
 /** Default TTL for deduplication in milliseconds */
 const DEFAULT_DEDUPLICATION_TTL_MS = 200;
 
+/**
+ * The `__*` namespace is reserved for queue machinery. Routing fields
+ * (`__pipelineName`, `__jobType`, `__jobName`) ARE caller-set — event-sourcing
+ * pipelines pre-set them so dispatch + the ops dashboard can route — so those
+ * pass through. Everything else `__*` is queue-internal (`__context`,
+ * `__attempt`, `__groupId`, `__stagedJobId`, `__dispatchScore`), and any
+ * user-provided `__custom` would silently collide on the GQ2 content hash and
+ * clobber on decode (because the strip is allowlist-free; ADR-029). Reject at
+ * the public send-boundary so the contract is loud rather than silent.
+ */
+const CALLER_RESERVED_KEYS = new Set([
+  "__pipelineName",
+  "__jobType",
+  "__jobName",
+]);
+
+function assertNoReservedKeys(
+  payload: Record<string, unknown>,
+  queueName: string,
+  method: "send" | "sendBatch",
+): void {
+  for (const key of Object.keys(payload)) {
+    if (key.startsWith("__") && !CALLER_RESERVED_KEYS.has(key)) {
+      throw new QueueError(
+        queueName,
+        method,
+        `Payload key "${key}" is in the reserved __* namespace (queue machinery). User payloads must not start with "__" except __pipelineName / __jobType / __jobName.`,
+      );
+    }
+  }
+}
+
 /** Internal fields attached to job data that must be stripped before processing. */
 const INTERNAL_FIELDS = [
   "__context",
@@ -302,6 +334,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         "Cannot send to queue after shutdown has been requested",
       );
     }
+    assertNoReservedKeys(
+      payload as Record<string, unknown>,
+      this.queueName,
+      "send",
+    );
 
     const delay = options?.delay ?? this.delay;
     const dedup = options?.deduplication ?? this.deduplication;
@@ -416,6 +453,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     if (payloads.length === 0) {
       return;
+    }
+    for (const payload of payloads) {
+      assertNoReservedKeys(
+        payload as Record<string, unknown>,
+        this.queueName,
+        "sendBatch",
+      );
     }
 
     const delay = options?.delay ?? this.delay;

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -659,16 +659,35 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         drainedSiblings = [];
       }
       if (drainedSiblings.length > 0) {
-        const parsedSiblings = await Promise.all(
-          drainedSiblings.map((sibling) =>
-            this.parseDrainedPayload({ sibling, groupId }),
-          ),
-        );
-        const siblingPayloads = parsedSiblings.filter(
-          (parsed) => parsed !== null,
-        ) as Payload[];
-        if (siblingPayloads.length > 0) {
-          batchPayloads = [payload, ...siblingPayloads];
+        try {
+          const parsedSiblings = await Promise.all(
+            drainedSiblings.map((sibling) =>
+              this.parseDrainedPayload({ sibling, groupId }),
+            ),
+          );
+          const siblingPayloads = parsedSiblings.filter(
+            (parsed) => parsed !== null,
+          ) as Payload[];
+          if (siblingPayloads.length > 0) {
+            batchPayloads = [payload, ...siblingPayloads];
+          }
+        } catch (err) {
+          if (err instanceof TransientBlobStoreError) {
+            // A transient blob-store failure on any drained sibling MUST
+            // re-stage the whole batch, not silently drop the siblings. Re-stage
+            // the siblings via the normal path and route the dispatched job
+            // through the same handleTransientDecode as the direct decode
+            // failure — the body is unreachable, not gone (ADR-030 §2).
+            await this.restageDrainedSiblings(groupId, drainedSiblings);
+            await this.handleTransientDecode({
+              groupId,
+              stagedJobId,
+              jobDataJson,
+              err,
+            });
+            return;
+          }
+          throw err;
         }
       }
     }
@@ -798,14 +817,49 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 gqRetryAttempt.observe(routingLabels, attempt);
                 gqRetryBackoffMilliseconds.observe(routingLabels, backoffMs);
                 const newStagedJobId = `${stagedJobId}/r/${attempt}`;
-                const retryJobData = await this.blobLifecycle.encode({
-                  jobData: {
-                    ...(payload as Record<string, unknown>),
-                    __context: contextMetadata,
-                    __attempt: attempt + 1,
-                  },
-                  groupId,
-                });
+                // If the retry re-encode fails (transient blob-store down,
+                // payload-too-large from a state-bloat regression), the retry
+                // can't proceed. Release the OLD hold explicitly and fall
+                // through to the non-retryable fail-safe (complete the slot,
+                // recover via event replay) — otherwise the old hold token
+                // stays in the holder set until the 3-day TTL backstop reclaims
+                // it, leaking the blob for that whole window.
+                let retryJobData: string;
+                try {
+                  retryJobData = await this.blobLifecycle.encode({
+                    jobData: {
+                      ...(payload as Record<string, unknown>),
+                      __context: contextMetadata,
+                      __attempt: attempt + 1,
+                    },
+                    groupId,
+                  });
+                } catch (encodeErr) {
+                  this.logger.error(
+                    {
+                      queueName: this.queueName,
+                      groupId,
+                      stagedJobId,
+                      attempt,
+                      err:
+                        encodeErr instanceof Error
+                          ? encodeErr.message
+                          : String(encodeErr),
+                    },
+                    "Retry re-encode failed; releasing old hold and falling through to fail-safe",
+                  );
+                  this.blobLifecycle.release({
+                    values: [jobDataJson],
+                    groupId,
+                  });
+                  await this.scripts.complete({
+                    groupId,
+                    stagedJobId,
+                    jobName,
+                  });
+                  gqJobsNonRetryableTotal.inc(routingLabels);
+                  return;
+                }
 
                 await this.scripts.retryRestage({
                   groupId,
@@ -935,7 +989,16 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         groupId,
       });
       return this.stripInternalFields(jobData);
-    } catch {
+    } catch (err) {
+      // A transient blob-store error on a sibling MUST NOT drop it to replay —
+      // the dispatched job's decode routes transient errors through
+      // `handleTransientDecode` so the whole batch can retry (ADR-030 §2).
+      // Rethrow so the caller (Promise.all in the batch drain) can bubble it up
+      // and re-stage every sibling together, rather than silently dropping
+      // hundreds of siblings on a brief S3 blip (2026-06-24 review).
+      if (err instanceof TransientBlobStoreError) {
+        throw err;
+      }
       this.logger.error(
         {
           queueName: this.queueName,

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -22,6 +22,7 @@ import {
   tenantIdFromGroupId,
 } from "../../../observability/tenantRateTracker";
 import { connection } from "../../../redis";
+import type { ProjectStorageDestination } from "../../../stored-objects/project-storage-destination";
 import type {
   DeduplicationConfig,
   EventSourcedQueueDefinition,
@@ -36,6 +37,7 @@ import {
 } from "../../services/errorHandling";
 import { getBackoffMs, JOB_RETRY_CONFIG } from "../shared";
 import { GroupQueueDispatcher } from "./dispatcher";
+import { EnvelopeBlobLifecycle } from "./envelopeBlobLifecycle";
 import {
   decodeJobEnvelope,
   encodeJobEnvelope,
@@ -62,6 +64,7 @@ import {
   type DrainedJob,
   GroupStagingScripts,
 } from "./scripts";
+import { type ObjectStore, TransientBlobStoreError } from "./tieredBlobStore";
 
 /**
  * Configuration for the group queue.
@@ -129,7 +132,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   private readonly redisConnection: IORedis | Cluster;
   private readonly blockingConnection: IORedis | Cluster;
   private readonly scripts: GroupStagingScripts;
-  private readonly blobs: RedisJobBlobStore;
+  private readonly blobLifecycle: EnvelopeBlobLifecycle;
   private readonly rateTracker!: TenantRateTracker;
   private readonly globalConcurrency: number;
   private readonly consumerEnabled: boolean;
@@ -143,7 +146,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
   constructor(
     definition: EventSourcedQueueDefinition<Payload>,
     redisConnection?: IORedis | Cluster,
-    options?: { consumerEnabled?: boolean },
+    options?: {
+      consumerEnabled?: boolean;
+      objectStoreFor?: (projectId: string) => ObjectStore;
+      resolveStorageDestination?: (
+        projectId: string,
+      ) => Promise<ProjectStorageDestination>;
+    },
   ) {
     const {
       name,
@@ -206,11 +215,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       this.queueName,
     );
 
-    // Offloaded envelope bodies (ADR-026): large payloads live under
-    // standalone blob keys so their bulk never transits the Lua scripts.
-    this.blobs = new RedisJobBlobStore({
+    // The GQ2 content-addressed blob lifecycle — tiered store, holder-set
+    // refcount, and the encode/decode/acquire/release seams (ADR-029/030).
+    this.blobLifecycle = new EnvelopeBlobLifecycle({
       redis: this.redisConnection,
       queueName: this.queueName,
+      objectStoreFor: options?.objectStoreFor,
+      resolveStorageDestination: options?.resolveStorageDestination,
     });
 
     // Advertise this queue in the registry set so the ops dashboard enumerates
@@ -330,27 +341,37 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       span.setAttributes({ ...customAttributes });
     }
 
+    const jobDataJson = await this.blobLifecycle.encode({
+      jobData: payloadWithContext,
+      groupId,
+    });
+
     const { isNew, orphanedValue } = await this.scripts.stage({
       stagedJobId,
       groupId,
       dispatchAfterMs,
       dedupId,
       dedupTtlMs,
-      jobDataJson: await encodeJobEnvelope({
-        jobData: payloadWithContext,
-        blobs: this.blobs,
-      }),
+      jobDataJson,
       shouldExtend,
       shouldReplace,
       shouldSurviveDispatch,
     });
 
-    // A dedup squash displaced a staged payload; reclaim its offloaded blob so
-    // it does not leak until the 7-day TTL (the 2026-06-11 capacity incident).
-    // Fire-and-forget (matches the worker reclaim paths); a no-op for inline
-    // payloads (readEnvelopeBlobId yields null) and new stages (orphanedValue "").
+    // Acquire this occupancy's hold BEFORE releasing any payload a dedup squash
+    // displaced, so a squash re-staging identical content never drops the shared
+    // blob to zero holders. Both are no-ops for inline/legacy values.
     if (orphanedValue) {
-      this.deleteEnvelopeBlobs([orphanedValue]);
+      // Atomic hold transfer: a dedup squash moves the hold from the displaced
+      // value to the new one in one eval, so a partial failure can't reclaim a
+      // live blob (ADR-030 §4).
+      this.blobLifecycle.transfer({
+        newValue: jobDataJson,
+        oldValue: orphanedValue,
+        groupId,
+      });
+    } else {
+      this.blobLifecycle.acquire(jobDataJson);
     }
 
     if (isNew) {
@@ -435,9 +456,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           dispatchAfterMs,
           dedupId,
           dedupTtlMs,
-          jobDataJson: await encodeJobEnvelope({
+          jobDataJson: await this.blobLifecycle.encode({
             jobData: payloadWithContext,
-            blobs: this.blobs,
+            groupId,
           }),
           shouldExtend,
           shouldReplace,
@@ -449,11 +470,23 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     const { newStagedCount, orphanedValues } =
       await this.scripts.stageBatch(jobsToStage);
 
-    // Reclaim blobs displaced by any in-batch dedup squashes (see send()).
-    const orphans = orphanedValues.filter((value) => value.length > 0);
-    if (orphans.length > 0) {
-      this.deleteEnvelopeBlobs(orphans);
-    }
+    // Atomically transfer the hold from any in-batch dedup-squashed value to the
+    // job that displaced it (orphanedValues is index-aligned with jobsToStage);
+    // otherwise just acquire. Matches send()'s atomic path, so a partial failure
+    // can't reclaim a live blob the way a separate acquire+release pair can
+    // (ADR-030 §4).
+    jobsToStage.forEach((job, i) => {
+      const orphan = orphanedValues[i];
+      if (orphan && orphan.length > 0) {
+        this.blobLifecycle.transfer({
+          newValue: job.jobDataJson,
+          oldValue: orphan,
+          groupId: job.groupId,
+        });
+      } else {
+        this.blobLifecycle.acquire(job.jobDataJson);
+      }
+    });
 
     const dedupedCount = payloads.length - newStagedCount;
     if (newStagedCount > 0) {
@@ -508,18 +541,34 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // Parse the stored job data
     let jobData: Record<string, unknown>;
     try {
-      jobData = await decodeJobEnvelope({
+      jobData = await this.blobLifecycle.decode({
         value: jobDataJson,
-        blobs: this.blobs,
+        groupId,
       });
-    } catch {
+    } catch (err) {
+      if (err instanceof TransientBlobStoreError) {
+        // The body is temporarily unreachable, not gone — retry, don't drop.
+        await this.handleTransientDecode({
+          groupId,
+          stagedJobId,
+          jobDataJson,
+          err,
+        });
+        return;
+      }
       this.logger.error(
-        { queueName: this.queueName, stagedJobId, groupId },
+        {
+          queueName: this.queueName,
+          projectId: tenantIdFromGroupId(groupId),
+          stagedJobId,
+          groupId,
+        },
         "Failed to parse staged job data",
       );
-      // Complete the group slot so it's not stuck
+      // Missing blob or unparseable value: complete the slot so it's not stuck;
+      // recover via event replay.
       await this.scripts.complete({ groupId, stagedJobId });
-      this.deleteEnvelopeBlobs([jobDataJson]);
+      this.blobLifecycle.release({ values: [jobDataJson], groupId });
       return;
     }
 
@@ -666,10 +715,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
               // removed from staging during the drain, so completing the
               // dispatched job is enough to free the group.
               await this.scripts.complete({ groupId, stagedJobId, jobName });
-              this.deleteEnvelopeBlobs([
-                jobDataJson,
-                ...drainedSiblings.map((sibling) => sibling.jobDataJson),
-              ]);
+              this.blobLifecycle.release({
+                values: [
+                  jobDataJson,
+                  ...drainedSiblings.map((sibling) => sibling.jobDataJson),
+                ],
+                groupId,
+              });
               gqJobsCompletedTotal.inc(routingLabels);
 
               this.logger.debug(
@@ -702,13 +754,13 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                 gqRetryAttempt.observe(routingLabels, attempt);
                 gqRetryBackoffMilliseconds.observe(routingLabels, backoffMs);
                 const newStagedJobId = `${stagedJobId}/r/${attempt}`;
-                const retryJobData = await encodeJobEnvelope({
+                const retryJobData = await this.blobLifecycle.encode({
                   jobData: {
                     ...(payload as Record<string, unknown>),
                     __context: contextMetadata,
                     __attempt: attempt + 1,
                   },
-                  blobs: this.blobs,
+                  groupId,
                 });
 
                 await this.scripts.retryRestage({
@@ -719,11 +771,16 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   jobDataJson: retryJobData,
                   backoffMs,
                 });
-                // The re-stage wrote a fresh envelope (and blob, if large);
-                // the dispatched value's blob is now unreferenced. Drained
-                // siblings were re-staged with their ORIGINAL values, so
-                // their blobs stay.
-                this.deleteEnvelopeBlobs([jobDataJson]);
+                // Atomically transfer the hold from the dispatched value to the
+                // re-staged one. For GQ2 the retry re-encodes to the SAME content
+                // hash, so it's SADD+SREM on one holder set (the blob stays
+                // referenced); for a mixed/GQ1 value it falls back to ordered
+                // acquire+release. Drained siblings keep their ORIGINAL values.
+                this.blobLifecycle.transfer({
+                  newValue: retryJobData,
+                  oldValue: jobDataJson,
+                  groupId,
+                });
 
                 this.logger.warn(
                   {
@@ -765,7 +822,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                   contextMetadata,
                   routingLabels,
                 });
-                this.deleteEnvelopeBlobs([jobDataJson]);
+                this.blobLifecycle.release({ values: [jobDataJson], groupId });
               }
             }
           },
@@ -800,24 +857,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         )
         .ltrim(`${this.queueName}:gq:stats:latencies-ms`, 0, 199)
         .exec()
-        .catch(() => {});
-    }
-  }
-
-  /**
-   * Best-effort reclamation of offloaded bodies whose staged values are retired
-   * (drained, completed, retried, or displaced by a dedup squash). Inline and
-   * legacy values yield no blob id and are skipped. Fire-and-forget: the blob
-   * TTL is the correctness backstop, so a failed delete only means the blob
-   * lingers until expiry. Producer (send/sendBatch) and worker paths alike call
-   * this without awaiting, to keep the hot path off the extra round-trip.
-   */
-  private deleteEnvelopeBlobs(values: string[]): void {
-    for (const value of values) {
-      const blobId = readEnvelopeBlobId(value);
-      if (blobId) {
-        void this.blobs.delete({ id: blobId }).catch(() => {});
-      }
+        .catch(() => undefined);
     }
   }
 
@@ -846,9 +886,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     groupId: string;
   }): Promise<Payload | null> {
     try {
-      const jobData = await decodeJobEnvelope({
+      const jobData = await this.blobLifecycle.decode({
         value: sibling.jobDataJson,
-        blobs: this.blobs,
+        groupId,
       });
       return this.stripInternalFields(jobData);
     } catch {
@@ -884,6 +924,9 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
           dedupTtlMs: 0,
           jobDataJson: sibling.jobDataJson,
         });
+        // Re-acquire the sibling's hold (idempotent: it kept its hold through
+        // the drain, and its value — hence token — is unchanged).
+        this.blobLifecycle.acquire(sibling.jobDataJson);
       } catch (err) {
         this.logger.error(
           {
@@ -960,12 +1003,12 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
 
     // Re-stage with a new ID
     const newStagedJobId = `${stagedJobId}/r/${Date.now()}`;
-    const jobDataJson = await encodeJobEnvelope({
+    const jobDataJson = await this.blobLifecycle.encode({
       jobData: {
         ...(payload as Record<string, unknown>),
         __context: contextMetadata,
       },
-      blobs: this.blobs,
+      groupId,
     });
 
     // Atomically: block the group, re-stage the job, update ready score, store error
@@ -977,6 +1020,10 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
       errorMessage: lastError?.message,
       errorStack: lastError?.stack,
     });
+
+    // Acquire the re-staged value's hold; the caller releases the dispatched
+    // one after this returns (acquire-before-release keeps a GQ2 blob alive).
+    this.blobLifecycle.acquire(jobDataJson);
 
     gqGroupsBlockedTotal.inc(routingLabels);
     gqJobsExhaustedTotal.inc(routingLabels);
@@ -990,6 +1037,66 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
         error: lastError?.message,
       },
       "Group blocked after exhausted retries, job re-staged",
+    );
+  }
+
+  /**
+   * A transient blob-store failure (network/5xx) means the body is temporarily
+   * unreachable — not gone. Re-stage the SAME envelope with backoff so the job
+   * retries instead of dropping to replay; the value is still valid and its hold
+   * token is unchanged, so there is no re-encode and no holder churn (releasing
+   * here would risk reclaiming the blob the re-stage still needs). Bounded by the
+   * `/r/` retry suffixes already in the stagedJobId, so a misclassified permanent
+   * failure still terminates at the fail-safe (ADR-030 §2).
+   */
+  private async handleTransientDecode({
+    groupId,
+    stagedJobId,
+    jobDataJson,
+    err,
+  }: {
+    groupId: string;
+    stagedJobId: string;
+    jobDataJson: string;
+    err: TransientBlobStoreError;
+  }): Promise<void> {
+    const attempt = (stagedJobId.match(/\/r\//g)?.length ?? 0) + 1;
+    if (attempt >= JOB_RETRY_CONFIG.maxAttempts) {
+      this.logger.error(
+        {
+          queueName: this.queueName,
+          projectId: tenantIdFromGroupId(groupId),
+          groupId,
+          stagedJobId,
+          attempt,
+          error: err.message,
+        },
+        "Blob store unreachable after retries; completing slot to recover via replay",
+      );
+      await this.scripts.complete({ groupId, stagedJobId });
+      this.blobLifecycle.release({ values: [jobDataJson], groupId });
+      return;
+    }
+    const backoffMs = getBackoffMs(attempt);
+    await this.scripts.retryRestage({
+      groupId,
+      stagedJobId,
+      newStagedJobId: `${stagedJobId}/r/${attempt}`,
+      dispatchAfterMs: Date.now() + backoffMs,
+      jobDataJson,
+      backoffMs,
+    });
+    this.logger.warn(
+      {
+        queueName: this.queueName,
+        projectId: tenantIdFromGroupId(groupId),
+        groupId,
+        stagedJobId,
+        attempt,
+        backoffMs,
+        error: err.message,
+      },
+      "Blob temporarily unreachable, re-staged with backoff",
     );
   }
 
@@ -1073,7 +1180,7 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
     // Wake the BRPOP so the dispatcher exits immediately
     await this.redisConnection
       .lpush(this.scripts.getSignalKey(), "1")
-      .catch(() => {});
+      .catch(() => undefined);
     this.logger.debug(
       { queueName: this.queueName },
       "Closing group queue processor",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/groupQueue.ts
@@ -56,6 +56,7 @@ import {
   gqJobsStagedTotal,
   gqRetryAttempt,
   gqRetryBackoffMilliseconds,
+  gqRetryEncodeFailuresTotal,
 } from "./metrics";
 import { GroupQueueMetricsCollector } from "./metricsCollector";
 import { RedisJobBlobStore } from "./redisJobBlobStore";
@@ -857,7 +858,11 @@ export class GroupQueueProcessor<Payload extends Record<string, unknown>>
                     stagedJobId,
                     jobName,
                   });
-                  gqJobsNonRetryableTotal.inc(routingLabels);
+                  // Distinct counter — this is a retry-encode blip, not a
+                  // genuine non-retryable process() error. Oncall triaging a
+                  // gq_jobs_non_retryable_total spike shouldn't have to grep
+                  // logs to figure out which class of failure they're seeing.
+                  gqRetryEncodeFailuresTotal.inc(routingLabels);
                   return;
                 }
 

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -2,47 +2,73 @@ import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
 
+import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
+
+import { MAX_BLOB_BYTES } from "./blobConstants";
+import type { BlobRef, TieredBlobStore } from "./tieredBlobStore";
+
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
 
 /**
- * Versioned envelope for staged job values: `GQ1|<headerLen>|<headerJson><body>`.
+ * Cap decompression output at the same ceiling encode enforces (ADR-030 §1), so
+ * a tampered or corrupt blob (e.g. a tenant zip-bombing their own BYOC object)
+ * can't OOM the worker. zlib throws past the limit; decode lets that propagate to
+ * the missing-blob fail-safe (complete the slot, recover via replay).
+ */
+const DECODE_GUNZIP_OPTS = { maxOutputLength: MAX_BLOB_BYTES };
+
+/**
+ * Versioned envelope for staged job values: `GQ<v>|<headerLen>|<headerJson><body>`.
  *
  * The header carries only what dispatch-time Lua and the ops dashboard need
  * without touching the body (routing fields + body encoding). The body is the
- * full payload JSON: gzip+base64 inline when compression wins, or offloaded to
- * a standalone blob key (raw gzip binary, fetched outside Lua) when the
- * payload is large — then the body is empty and the header carries the blob
- * id. Values without the prefix are legacy bare JSON and decode as-is.
- * See ADR-026.
+ * full payload JSON: raw or gzip+base64 inline when it stays in the envelope,
+ * or empty when offloaded to a standalone blob whose reference the header
+ * carries.
+ *
+ * - **GQ1** (ADR-026): offloads bodies > 32 KiB to a `randomUUID()` Redis key
+ *   via {@link JobBlobStore} (`e:"ref"`, header `r`). No content identity.
+ * - **GQ2** (ADR-029): offloads bodies > 4 KiB to a **content-addressed,
+ *   tenant-namespaced** blob via {@link TieredBlobStore}, tiered Redis→object
+ *   store (`e:"redis"|"s3"`, header `ref`). Identical bytes collapse to one
+ *   stored copy. Active only when a tiered store + projectId are supplied.
+ *
+ * Values without a `GQ1|`/`GQ2|` prefix are legacy bare JSON and decode as-is.
  */
-const ENVELOPE_PREFIX = "GQ1|";
+const ENVELOPE_PREFIX_V1 = "GQ1|";
+const ENVELOPE_PREFIX_V2 = "GQ2|";
+/** Both prefixes are 4 ASCII bytes; the length/header parse is identical after them. */
+const ENVELOPE_PREFIX_LEN = 4;
 
 /** gzip+base64 of sub-kilobyte JSON is frequently larger than the input. */
 const COMPRESSION_THRESHOLD_BYTES = 1024;
 
 /**
- * Above this, the body moves to a standalone blob key so the bulk never
- * transits the dispatch/drain/restage Lua scripts or sits in the group hash.
- * Payloads ≥256 KiB never reach the queue at all (S3 spool).
+ * GQ1: above this, the body moves to a standalone `randomUUID()` blob key.
  */
 const BLOB_OFFLOAD_THRESHOLD_BYTES = 32 * 1024;
 
 /**
- * Phase gate for the two-phase format rollout (ADR-026). Readers are always
- * envelope-aware, but writes stay legacy bare JSON until every consumer in
- * the fleet is known to read envelopes — a pod from the previous release
- * drops any `GQ1|` value it dispatches (its JSON.parse failure path completes
- * the group slot without running the handler). Read at call time so tests can
- * toggle it without module reloads.
+ * GQ2: above this, the body moves to the content-addressed tiered store. Lower
+ * than GQ1's threshold so ordinary fan-out events cross into the dedup tier
+ * rather than inlining N× (ADR-029).
+ */
+const INLINE_CEILING_BYTES = 4 * 1024;
+
+/**
+ * Phase gate for the format rollout (ADR-026). Readers are always
+ * envelope-aware, but writes stay legacy bare JSON until every consumer in the
+ * fleet is known to read envelopes. Read at call time so tests can toggle it
+ * without module reloads.
  */
 function envelopeWritesEnabled(): boolean {
   return process.env.GROUP_QUEUE_ENVELOPE_WRITES_ENABLED === "true";
 }
 
 /**
- * Storage for offloaded envelope bodies. Implementations must persist with a
- * TTL safety net: deletion is best-effort at job completion, and a blob whose
+ * Storage for GQ1 offloaded envelope bodies. Implementations must persist with
+ * a TTL safety net: deletion is best-effort at job completion, and a blob whose
  * job was squashed by dedup or lost in a crash must eventually expire.
  */
 export interface JobBlobStore {
@@ -57,70 +83,187 @@ export interface JobRoutingMeta {
   jobName: string | null;
 }
 
+type BodyEncoding = "j" | "gz" | "ref" | "redis" | "s3";
+
 interface EnvelopeHeader {
   v: number;
-  e: "j" | "gz" | "ref";
+  e: BodyEncoding;
+  /** GQ1 offloaded blob id. */
   r?: string;
+  /** GQ2 content-addressed tiered blob reference. */
+  ref?: BlobRef;
+  /** GQ2 per-stage hold token — the holder-set member for this staged occupancy. */
+  h?: string;
   p?: string;
   t?: string;
   n?: string;
 }
 
+function routingHeader(
+  jobData: Record<string, unknown>,
+  version: number,
+): EnvelopeHeader {
+  const header: EnvelopeHeader = { v: version, e: "j" };
+  if (typeof jobData.__pipelineName === "string")
+    header.p = jobData.__pipelineName;
+  if (typeof jobData.__jobType === "string") header.t = jobData.__jobType;
+  if (typeof jobData.__jobName === "string") header.n = jobData.__jobName;
+  return header;
+}
+
+function finalize(
+  prefix: string,
+  header: EnvelopeHeader,
+  body: string,
+): string {
+  const headerJson = JSON.stringify(header);
+  // Header length is in BYTES: the Lua reader slices bytes, and UTF-16 code
+  // units diverge from bytes if a routing field carries non-ASCII.
+  return `${prefix}${Buffer.byteLength(headerJson)}|${headerJson}${body}`;
+}
+
+/**
+ * Picks the inline encoding for a body that stays in the envelope: raw JSON, or
+ * gzip+base64 when compression actually wins (mutates `header.e` to `"gz"`).
+ */
+async function inlineBody(
+  json: string,
+  jsonBytes: number,
+  header: EnvelopeHeader,
+): Promise<string> {
+  if (jsonBytes > COMPRESSION_THRESHOLD_BYTES) {
+    const compressed = (await gzipAsync(json)).toString("base64");
+    // High-entropy payloads (inline base64-ish data) can come out LARGER after
+    // gzip+base64; keep raw JSON unless compression actually wins. `"gz"` costs
+    // one more header byte than `"j"`.
+    if (Buffer.byteLength(compressed) + 1 < jsonBytes) {
+      header.e = "gz";
+      return compressed;
+    }
+  }
+  return json;
+}
+
+/**
+ * Thrown when a job's serialized payload exceeds {@link MAX_BLOB_BYTES}. Rejecting
+ * at encode keeps a pathological payload from OOMing the worker on gzip + buffer.
+ */
+export class PayloadTooLargeError extends Error {
+  readonly byteLength: number;
+  constructor(byteLength: number) {
+    super(
+      `Job payload is ${byteLength} bytes, over the ${MAX_BLOB_BYTES}-byte ceiling`,
+    );
+    this.name = "PayloadTooLargeError";
+    this.byteLength = byteLength;
+  }
+}
+
+/** Guards the payload-size ceiling (ADR-030 §1). */
+export function assertPayloadWithinCap(jsonBytes: number): void {
+  if (jsonBytes > MAX_BLOB_BYTES) {
+    throw new PayloadTooLargeError(jsonBytes);
+  }
+}
+
 export async function encodeJobEnvelope({
   jobData,
   blobs,
+  tieredBlobs,
+  projectId,
 }: {
   jobData: Record<string, unknown>;
   blobs?: JobBlobStore;
+  tieredBlobs?: TieredBlobStore;
+  projectId?: TenantId;
 }): Promise<string> {
   const json = JSON.stringify(jobData);
   if (!envelopeWritesEnabled()) {
     return json;
   }
-
-  const header: EnvelopeHeader = { v: 1, e: "j" };
-  if (typeof jobData.__pipelineName === "string")
-    header.p = jobData.__pipelineName;
-  if (typeof jobData.__jobType === "string") header.t = jobData.__jobType;
-  if (typeof jobData.__jobName === "string") header.n = jobData.__jobName;
-
-  let body = json;
   const jsonBytes = Buffer.byteLength(json);
+  assertPayloadWithinCap(jsonBytes);
+
+  // GQ2: content-addressed, tenant-namespaced, tiered offload. Active only once
+  // the composition root supplies a tiered store and the job's tenant.
+  if (tieredBlobs && projectId) {
+    const header = routingHeader(jobData, 2);
+    if (jsonBytes > INLINE_CEILING_BYTES) {
+      const ref = await tieredBlobs.put({
+        projectId,
+        data: await gzipAsync(json),
+        // Hash the RAW json, not the gzip output, so the dedup key is independent
+        // of gzip determinism (zlib version/level) — ADR-030 §1.
+        hashSource: Buffer.from(json, "utf8"),
+      });
+      header.e = ref.tier;
+      header.ref = ref;
+      // Per-stage hold token: the holder-set member identifying this staged
+      // occupancy. Lives in the (inline) header, never in the content-addressed
+      // body, so it doesn't perturb the blob hash that collapses the fan-out.
+      header.h = randomUUID();
+      return finalize(ENVELOPE_PREFIX_V2, header, "");
+    }
+    return finalize(
+      ENVELOPE_PREFIX_V2,
+      header,
+      await inlineBody(json, jsonBytes, header),
+    );
+  }
+
+  // GQ1: legacy randomUUID offload (unchanged).
+  const header = routingHeader(jobData, 1);
   if (blobs && jsonBytes > BLOB_OFFLOAD_THRESHOLD_BYTES) {
     const id = randomUUID();
     await blobs.put({ id, data: await gzipAsync(json) });
     header.e = "ref";
     header.r = id;
-    body = "";
-  } else if (jsonBytes > COMPRESSION_THRESHOLD_BYTES) {
-    const compressed = (await gzipAsync(json)).toString("base64");
-    // High-entropy payloads (inline base64-ish data) can come out LARGER
-    // after gzip+base64; keep raw JSON unless compression actually wins.
-    // `"gz"` costs one more header byte than `"j"`.
-    if (Buffer.byteLength(compressed) + 1 < jsonBytes) {
-      header.e = "gz";
-      body = compressed;
-    }
+    return finalize(ENVELOPE_PREFIX_V1, header, "");
   }
-
-  const headerJson = JSON.stringify(header);
-  // Header length is in BYTES: the Lua reader slices bytes, and UTF-16 code
-  // units diverge from bytes if a routing field ever carries non-ASCII.
-  return `${ENVELOPE_PREFIX}${Buffer.byteLength(headerJson)}|${headerJson}${body}`;
+  return finalize(
+    ENVELOPE_PREFIX_V1,
+    header,
+    await inlineBody(json, jsonBytes, header),
+  );
 }
 
 export async function decodeJobEnvelope({
   value,
   blobs,
+  tieredBlobs,
 }: {
   value: string;
   blobs?: JobBlobStore;
+  tieredBlobs?: TieredBlobStore;
 }): Promise<Record<string, unknown>> {
-  if (!value.startsWith(ENVELOPE_PREFIX)) {
+  if (!isEnvelope(value)) {
     return JSON.parse(value) as Record<string, unknown>;
   }
 
   const { header, body } = splitEnvelope(value);
+
+  // GQ2: content-addressed tiered blob.
+  if (header.e === "redis" || header.e === "s3") {
+    if (!header.ref) {
+      throw new Error("Malformed job envelope: tiered body without a blob ref");
+    }
+    if (!tieredBlobs) {
+      throw new Error(
+        "Job envelope references a tiered blob but no tiered store was provided",
+      );
+    }
+    const data = await tieredBlobs.get(header.ref);
+    if (!data) {
+      throw new Error(
+        "Job envelope tiered blob is missing (deleted or expired)",
+      );
+    }
+    return JSON.parse(
+      (await gunzipAsync(data, DECODE_GUNZIP_OPTS)).toString("utf8"),
+    ) as Record<string, unknown>;
+  }
+
+  // GQ1: randomUUID offloaded blob.
   if (header.e === "ref") {
     if (typeof header.r !== "string" || header.r.length === 0) {
       throw new Error("Malformed job envelope: ref body without a blob id");
@@ -136,15 +279,16 @@ export async function decodeJobEnvelope({
         `Job envelope blob ${header.r} is missing (deleted or expired)`,
       );
     }
-    return JSON.parse((await gunzipAsync(data)).toString("utf8")) as Record<
-      string,
-      unknown
-    >;
+    return JSON.parse(
+      (await gunzipAsync(data, DECODE_GUNZIP_OPTS)).toString("utf8"),
+    ) as Record<string, unknown>;
   }
 
   const json =
     header.e === "gz"
-      ? (await gunzipAsync(Buffer.from(body, "base64"))).toString("utf8")
+      ? (
+          await gunzipAsync(Buffer.from(body, "base64"), DECODE_GUNZIP_OPTS)
+        ).toString("utf8")
       : body;
   return JSON.parse(json) as Record<string, unknown>;
 }
@@ -155,7 +299,7 @@ export async function decodeJobEnvelope({
  */
 export function readJobRoutingMeta(value: string): JobRoutingMeta {
   try {
-    if (value.startsWith(ENVELOPE_PREFIX)) {
+    if (isEnvelope(value)) {
       const { header } = splitEnvelope(value);
       return {
         pipelineName: typeof header.p === "string" ? header.p : null,
@@ -178,13 +322,13 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
 }
 
 /**
- * Returns the offloaded-blob id of an envelope value, or null for inline
- * bodies, legacy JSON, and unreadable values. Used by the completion and
- * restage paths to delete blobs whose staged value is being retired.
+ * Returns the GQ1 offloaded-blob id of an envelope value, or null for inline
+ * bodies, GQ2 tiered refs, legacy JSON, and unreadable values. Used by the
+ * completion and restage paths to delete blobs whose staged value is retired.
  */
 export function readEnvelopeBlobId(value: string): string | null {
   try {
-    if (!value.startsWith(ENVELOPE_PREFIX)) return null;
+    if (!isEnvelope(value)) return null;
     const { header } = splitEnvelope(value);
     return header.e === "ref" && typeof header.r === "string" ? header.r : null;
   } catch {
@@ -192,15 +336,46 @@ export function readEnvelopeBlobId(value: string): string | null {
   }
 }
 
+/**
+ * Returns the GQ2 ref together with its per-stage hold token (the holder-set
+ * member), or null for inline bodies, GQ1 refs, legacy JSON, and unreadable
+ * values. The acquire/release seams use this to reference-count the blob
+ * without depending on the Lua-internal slot id.
+ */
+export function readEnvelopeHold(
+  value: string,
+): { ref: BlobRef; token: string } | null {
+  try {
+    if (!isEnvelope(value)) return null;
+    const { header } = splitEnvelope(value);
+    if (
+      (header.e === "redis" || header.e === "s3") &&
+      header.ref &&
+      typeof header.h === "string"
+    ) {
+      return { ref: header.ref, token: header.h };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isEnvelope(value: string): boolean {
+  return (
+    value.startsWith(ENVELOPE_PREFIX_V1) || value.startsWith(ENVELOPE_PREFIX_V2)
+  );
+}
+
 function splitEnvelope(value: string): {
   header: EnvelopeHeader;
   body: string;
 } {
-  const lenEnd = value.indexOf("|", ENVELOPE_PREFIX.length);
+  const lenEnd = value.indexOf("|", ENVELOPE_PREFIX_LEN);
   if (lenEnd === -1) {
     throw new Error("Malformed job envelope: missing header length delimiter");
   }
-  const lenDigits = value.slice(ENVELOPE_PREFIX.length, lenEnd);
+  const lenDigits = value.slice(ENVELOPE_PREFIX_LEN, lenEnd);
   if (!/^\d+$/.test(lenDigits)) {
     throw new Error("Malformed job envelope: invalid header length");
   }

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -94,9 +94,67 @@ interface EnvelopeHeader {
   ref?: BlobRef;
   /** GQ2 per-stage hold token — the holder-set member for this staged occupancy. */
   h?: string;
+  /** Routing fields read by the Lua dispatcher and ops dashboard WITHOUT parsing the body. */
   p?: string;
   t?: string;
   n?: string;
+  /**
+   * GQ2: queue-machinery fields (every `__*` key in jobData) lifted out of the
+   * body so they don't perturb the content hash. Restored onto the parsed body
+   * on decode. The user payload is everything else; the body is hashed over
+   * the payload alone, so the same event fanned out to N reactors collapses to
+   * one stored blob (ADR-029). Allowlist-free: any future `__*` field is
+   * automatically treated as machinery.
+   */
+  m?: Record<string, unknown>;
+}
+
+/**
+ * GQ2: split jobData into (machinery, payload). Every `__*` key is queue
+ * machinery — the queue assigns these fields per-stage (`__stagedJobId`,
+ * `__attempt`, `__context`) or per-reactor (`__jobName`, `__jobType`,
+ * `__pipelineName`), and they perturb the body bytes if left in, defeating
+ * content-addressed dedup. The user payload is the rest.
+ */
+function splitMachineryFromBody(jobData: Record<string, unknown>): {
+  machinery: Record<string, unknown>;
+  payload: Record<string, unknown>;
+} {
+  const machinery: Record<string, unknown> = {};
+  const payload: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(jobData)) {
+    if (k.startsWith("__")) {
+      machinery[k] = v;
+    } else {
+      payload[k] = v;
+    }
+  }
+  return { machinery, payload };
+}
+
+/**
+ * GQ2 decode side of {@link splitMachineryFromBody}: re-merge the queue
+ * machinery back onto the parsed body. The routing trio
+ * (`__pipelineName/__jobType/__jobName`) lives in `header.p/t/n` only — the
+ * read-fast-path used by the Lua dispatcher and `readJobRoutingMeta` without
+ * touching the body. The rest of the machinery lives in `header.m`. Keeping
+ * the trio out of `m` saves ~50 wire bytes per envelope and removes a second
+ * source of truth that could drift.
+ */
+function mergeMachinery(
+  body: Record<string, unknown>,
+  header: EnvelopeHeader,
+): Record<string, unknown> {
+  const hasRouting =
+    typeof header.p === "string" ||
+    typeof header.t === "string" ||
+    typeof header.n === "string";
+  if (!header.m && !hasRouting) return body;
+  const merged: Record<string, unknown> = { ...body, ...(header.m ?? {}) };
+  if (typeof header.p === "string") merged.__pipelineName = header.p;
+  if (typeof header.t === "string") merged.__jobType = header.t;
+  if (typeof header.n === "string") merged.__jobName = header.n;
+  return merged;
 }
 
 function routingHeader(
@@ -188,13 +246,29 @@ export async function encodeJobEnvelope({
   // the composition root supplies a tiered store and the job's tenant.
   if (tieredBlobs && projectId) {
     const header = routingHeader(jobData, 2);
-    if (jsonBytes > INLINE_CEILING_BYTES) {
+    // Lift queue machinery into the header so it doesn't perturb the content
+    // hash. Without this, N reactors fanning out the same event produce N
+    // different hashes because each carries its own __jobName / __attempt
+    // (ADR-029). The body now contains only the user payload.
+    const { machinery, payload } = splitMachineryFromBody(jobData);
+    // The routing trio is already in header.p/t/n via routingHeader(); drop
+    // the duplicate copy from m so the wire format isn't ~50 bytes heavier
+    // per envelope and the two can't drift.
+    delete machinery.__pipelineName;
+    delete machinery.__jobType;
+    delete machinery.__jobName;
+    if (Object.keys(machinery).length > 0) {
+      header.m = machinery;
+    }
+    const payloadJson = JSON.stringify(payload);
+    const payloadBytes = Buffer.byteLength(payloadJson);
+    if (payloadBytes > INLINE_CEILING_BYTES) {
       const ref = await tieredBlobs.put({
         projectId,
-        data: await gzipAsync(json),
-        // Hash the RAW json, not the gzip output, so the dedup key is independent
-        // of gzip determinism (zlib version/level) — ADR-030 §1.
-        hashSource: Buffer.from(json, "utf8"),
+        data: await gzipAsync(payloadJson),
+        // Hash the RAW payload json, not the gzip output, so the dedup key is
+        // independent of gzip determinism (zlib version/level) — ADR-030 §1.
+        hashSource: Buffer.from(payloadJson, "utf8"),
       });
       header.e = ref.tier;
       header.ref = ref;
@@ -207,7 +281,7 @@ export async function encodeJobEnvelope({
     return finalize(
       ENVELOPE_PREFIX_V2,
       header,
-      await inlineBody(json, jsonBytes, header),
+      await inlineBody(payloadJson, payloadBytes, header),
     );
   }
 
@@ -258,9 +332,10 @@ export async function decodeJobEnvelope({
         "Job envelope tiered blob is missing (deleted or expired)",
       );
     }
-    return JSON.parse(
+    const parsed = JSON.parse(
       (await gunzipAsync(data, DECODE_GUNZIP_OPTS)).toString("utf8"),
     ) as Record<string, unknown>;
+    return mergeMachinery(parsed, header);
   }
 
   // GQ1: randomUUID offloaded blob.
@@ -290,7 +365,9 @@ export async function decodeJobEnvelope({
           await gunzipAsync(Buffer.from(body, "base64"), DECODE_GUNZIP_OPTS)
         ).toString("utf8")
       : body;
-  return JSON.parse(json) as Record<string, unknown>;
+  const parsed = JSON.parse(json) as Record<string, unknown>;
+  // GQ2 inline lifted machinery into header.m too; GQ1 (v=1) never did.
+  return header.v === 2 ? mergeMachinery(parsed, header) : parsed;
 }
 
 /**

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -395,7 +395,10 @@ export async function decodeJobEnvelope({
         "Job envelope references a tiered blob but no tiered store was provided",
       );
     }
-    const data = await tieredBlobs.get(header.ref);
+    const data =
+      readMode === "peek"
+        ? await tieredBlobs.peek(header.ref)
+        : await tieredBlobs.get(header.ref);
     if (!data) {
       throw new Error(
         "Job envelope tiered blob is missing (deleted or expired)",

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/jobEnvelope.ts
@@ -2,9 +2,12 @@ import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
 
+import type { Logger } from "pino";
+
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 
 import { MAX_BLOB_BYTES } from "./blobConstants";
+import { gqEnvelopeGQ2DowngradeTotal, gqPayloadTooLargeTotal } from "./metrics";
 import type { BlobRef, TieredBlobStore } from "./tieredBlobStore";
 
 const gzipAsync = promisify(gzip);
@@ -73,7 +76,10 @@ function envelopeWritesEnabled(): boolean {
  */
 export interface JobBlobStore {
   put(params: { id: string; data: Buffer }): Promise<void>;
+  /** Read the blob AND refresh its backstop TTL. Worker hot path only. */
   get(params: { id: string }): Promise<Buffer | null>;
+  /** Read the blob WITHOUT refreshing its TTL. Non-worker / ops-dashboard inspection path. */
+  peek(params: { id: string }): Promise<Buffer | null>;
   delete(params: { id: string }): Promise<void>;
 }
 
@@ -85,7 +91,7 @@ export interface JobRoutingMeta {
 
 type BodyEncoding = "j" | "gz" | "ref" | "redis" | "s3";
 
-interface EnvelopeHeader {
+export interface EnvelopeHeader {
   v: number;
   e: BodyEncoding;
   /** GQ1 offloaded blob id. */
@@ -217,9 +223,25 @@ export class PayloadTooLargeError extends Error {
   }
 }
 
-/** Guards the payload-size ceiling (ADR-030 §1). */
-export function assertPayloadWithinCap(jsonBytes: number): void {
+/** Guards the payload-size ceiling (ADR-030 §1). Emits a tenant-attributed warn before rejecting. */
+export function assertPayloadWithinCap(
+  jsonBytes: number,
+  ctx?: { projectId?: TenantId; queueName?: string; logger?: Logger },
+): void {
   if (jsonBytes > MAX_BLOB_BYTES) {
+    if (ctx?.logger) {
+      ctx.logger.warn(
+        {
+          projectId: ctx.projectId,
+          byteLength: jsonBytes,
+          cap: MAX_BLOB_BYTES,
+        },
+        "Job payload over MAX_BLOB_BYTES — rejecting at encode",
+      );
+    }
+    if (ctx?.queueName) {
+      gqPayloadTooLargeTotal.inc({ queue_name: ctx.queueName });
+    }
     throw new PayloadTooLargeError(jsonBytes);
   }
 }
@@ -229,21 +251,39 @@ export async function encodeJobEnvelope({
   blobs,
   tieredBlobs,
   projectId,
+  writesEnabled,
+  queueName,
+  logger,
 }: {
   jobData: Record<string, unknown>;
   blobs?: JobBlobStore;
   tieredBlobs?: TieredBlobStore;
   projectId?: TenantId;
+  /**
+   * Explicit override of the format-rollout gate. When omitted, the encoder
+   * falls back to the `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED` env var (call-time
+   * read, so tests can toggle without module reload). Composition roots should
+   * thread this through explicitly so a partial fleet rollout doesn't put
+   * mixed GQ1/GQ2 values in the same group's hash space until every pod cycles.
+   */
+  writesEnabled?: boolean;
+  /** Optional queue name for observability labels. */
+  queueName?: string;
+  /** Optional logger for tenant-attributed warn on cap / downgrade. */
+  logger?: Logger;
 }): Promise<string> {
   const json = JSON.stringify(jobData);
-  if (!envelopeWritesEnabled()) {
+  const enabled = writesEnabled ?? envelopeWritesEnabled();
+  if (!enabled) {
     return json;
   }
   const jsonBytes = Buffer.byteLength(json);
-  assertPayloadWithinCap(jsonBytes);
+  assertPayloadWithinCap(jsonBytes, { projectId, queueName, logger });
 
   // GQ2: content-addressed, tenant-namespaced, tiered offload. Active only once
-  // the composition root supplies a tiered store and the job's tenant.
+  // the composition root supplies a tiered store and the job's tenant. If
+  // either is missing we fall back to GQ1 — noisy so a regression in the
+  // composition root can't ship a silently-downgraded pipeline.
   if (tieredBlobs && projectId) {
     const header = routingHeader(jobData, 2);
     // Lift queue machinery into the header so it doesn't perturb the content
@@ -266,9 +306,11 @@ export async function encodeJobEnvelope({
       const ref = await tieredBlobs.put({
         projectId,
         data: await gzipAsync(payloadJson),
-        // Hash the RAW payload json, not the gzip output, so the dedup key is
-        // independent of gzip determinism (zlib version/level) — ADR-030 §1.
-        hashSource: Buffer.from(payloadJson, "utf8"),
+        // Hash the RAW payload json string directly, not the gzip output — the
+        // dedup key is independent of gzip determinism (zlib version/level;
+        // ADR-030 §1). `contentHash` accepts strings and lets crypto handle the
+        // UTF-8 conversion internally so we don't allocate a full-payload Buffer.
+        hashSource: payloadJson,
       });
       header.e = ref.tier;
       header.ref = ref;
@@ -285,7 +327,22 @@ export async function encodeJobEnvelope({
     );
   }
 
-  // GQ1: legacy randomUUID offload (unchanged).
+  // GQ1 fallback path: reached when the caller opted into writes but didn't
+  // supply BOTH a tiered store and a projectId. Loud so a composition-root
+  // regression can't silently ship a pipeline without dedup / holder refcount /
+  // tenant namespacing (2026-06-24 review).
+  if (queueName) gqEnvelopeGQ2DowngradeTotal.inc({ queue_name: queueName });
+  if (logger) {
+    logger.warn(
+      {
+        projectId,
+        hasTieredBlobs: Boolean(tieredBlobs),
+        hasProjectId: Boolean(projectId),
+        queueName,
+      },
+      "GQ2 encode downgraded to GQ1 (tenant or tiered store missing at composition root)",
+    );
+  }
   const header = routingHeader(jobData, 1);
   if (blobs && jsonBytes > BLOB_OFFLOAD_THRESHOLD_BYTES) {
     const id = randomUUID();
@@ -305,16 +362,28 @@ export async function decodeJobEnvelope({
   value,
   blobs,
   tieredBlobs,
+  readMode = "get",
+  parsed,
 }: {
   value: string;
   blobs?: JobBlobStore;
   tieredBlobs?: TieredBlobStore;
+  /**
+   * `"get"` = worker hot path, refreshes the blob's backstop TTL. `"peek"` =
+   * non-worker inspection (ops dashboard), does NOT refresh — so a repeatedly-
+   * viewed blocked group can't keep its orphan blobs alive.
+   */
+  readMode?: "get" | "peek";
+  /** Pre-parsed (header, body) tuple from {@link splitEnvelope}, so callers that
+   * have already parsed the envelope (e.g. `EnvelopeBlobLifecycle.decode`) don't
+   * pay for a second `Buffer.from` + `JSON.parse` on the hot path. */
+  parsed?: { header: EnvelopeHeader; body: string };
 }): Promise<Record<string, unknown>> {
   if (!isEnvelope(value)) {
     return JSON.parse(value) as Record<string, unknown>;
   }
 
-  const { header, body } = splitEnvelope(value);
+  const { header, body } = parsed ?? splitEnvelope(value);
 
   // GQ2: content-addressed tiered blob.
   if (header.e === "redis" || header.e === "s3") {
@@ -332,10 +401,10 @@ export async function decodeJobEnvelope({
         "Job envelope tiered blob is missing (deleted or expired)",
       );
     }
-    const parsed = JSON.parse(
+    const parsedBody = JSON.parse(
       (await gunzipAsync(data, DECODE_GUNZIP_OPTS)).toString("utf8"),
     ) as Record<string, unknown>;
-    return mergeMachinery(parsed, header);
+    return mergeMachinery(parsedBody, header);
   }
 
   // GQ1: randomUUID offloaded blob.
@@ -348,7 +417,10 @@ export async function decodeJobEnvelope({
         "Job envelope references an offloaded blob but no blob store was provided",
       );
     }
-    const data = await blobs.get({ id: header.r });
+    const data =
+      readMode === "peek"
+        ? await blobs.peek({ id: header.r })
+        : await blobs.get({ id: header.r });
     if (!data) {
       throw new Error(
         `Job envelope blob ${header.r} is missing (deleted or expired)`,
@@ -365,9 +437,9 @@ export async function decodeJobEnvelope({
           await gunzipAsync(Buffer.from(body, "base64"), DECODE_GUNZIP_OPTS)
         ).toString("utf8")
       : body;
-  const parsed = JSON.parse(json) as Record<string, unknown>;
+  const parsedBody = JSON.parse(json) as Record<string, unknown>;
   // GQ2 inline lifted machinery into header.m too; GQ1 (v=1) never did.
-  return header.v === 2 ? mergeMachinery(parsed, header) : parsed;
+  return header.v === 2 ? mergeMachinery(parsedBody, header) : parsedBody;
 }
 
 /**
@@ -399,6 +471,16 @@ export function readJobRoutingMeta(value: string): JobRoutingMeta {
 }
 
 /**
+ * Header-taking variant of {@link readEnvelopeBlobId} — for callers that have
+ * already parsed the envelope and don't want a second `Buffer.from + JSON.parse`.
+ */
+export function readEnvelopeBlobIdFromHeader(
+  header: EnvelopeHeader,
+): string | null {
+  return header.e === "ref" && typeof header.r === "string" ? header.r : null;
+}
+
+/**
  * Returns the GQ1 offloaded-blob id of an envelope value, or null for inline
  * bodies, GQ2 tiered refs, legacy JSON, and unreadable values. Used by the
  * completion and restage paths to delete blobs whose staged value is retired.
@@ -407,10 +489,27 @@ export function readEnvelopeBlobId(value: string): string | null {
   try {
     if (!isEnvelope(value)) return null;
     const { header } = splitEnvelope(value);
-    return header.e === "ref" && typeof header.r === "string" ? header.r : null;
+    return readEnvelopeBlobIdFromHeader(header);
   } catch {
     return null;
   }
+}
+
+/**
+ * Header-taking variant of {@link readEnvelopeHold} — for callers that have
+ * already parsed the envelope and don't want a second `Buffer.from + JSON.parse`.
+ */
+export function readEnvelopeHoldFromHeader(
+  header: EnvelopeHeader,
+): { ref: BlobRef; token: string } | null {
+  if (
+    (header.e === "redis" || header.e === "s3") &&
+    header.ref &&
+    typeof header.h === "string"
+  ) {
+    return { ref: header.ref, token: header.h };
+  }
+  return null;
 }
 
 /**
@@ -425,26 +524,41 @@ export function readEnvelopeHold(
   try {
     if (!isEnvelope(value)) return null;
     const { header } = splitEnvelope(value);
-    if (
-      (header.e === "redis" || header.e === "s3") &&
-      header.ref &&
-      typeof header.h === "string"
-    ) {
-      return { ref: header.ref, token: header.h };
-    }
-    return null;
+    return readEnvelopeHoldFromHeader(header);
   } catch {
     return null;
   }
 }
 
-function isEnvelope(value: string): boolean {
+/**
+ * Single parse for retirement: given a staged value, return the GQ2 hold and/or
+ * GQ1 blob id from ONE `splitEnvelope`. Prefer over calling `readEnvelopeHold`
+ * + `readEnvelopeBlobId` in sequence on the completion / restage hot path
+ * (2026-06-24 review).
+ */
+export function readEnvelopeRetirement(value: string): {
+  hold: { ref: BlobRef; token: string } | null;
+  blobId: string | null;
+} {
+  try {
+    if (!isEnvelope(value)) return { hold: null, blobId: null };
+    const { header } = splitEnvelope(value);
+    return {
+      hold: readEnvelopeHoldFromHeader(header),
+      blobId: readEnvelopeBlobIdFromHeader(header),
+    };
+  } catch {
+    return { hold: null, blobId: null };
+  }
+}
+
+export function isEnvelope(value: string): boolean {
   return (
     value.startsWith(ENVELOPE_PREFIX_V1) || value.startsWith(ENVELOPE_PREFIX_V2)
   );
 }
 
-function splitEnvelope(value: string): {
+export function splitEnvelope(value: string): {
   header: EnvelopeHeader;
   body: string;
 } {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -27,6 +27,7 @@ const metricNames = [
   "gq_blob_decode_cap_exceeded_total",
   "gq_envelope_gq2_downgrade_total",
   "gq_payload_too_large_total",
+  "gq_retry_encode_failures_total",
 ] as const;
 
 for (const name of metricNames) {
@@ -192,4 +193,17 @@ export const gqPayloadTooLargeTotal = new Counter({
   name: "gq_payload_too_large_total",
   help: "Payload rejected at the encode cap",
   labelNames: ["queue_name"] as const,
+});
+
+/**
+ * Retry re-encode failed (transient blob-store 5xx, payload-too-large from a
+ * state-bloat regression) — the retry never re-staged and the slot dropped to
+ * the fail-safe. Distinct from `gqJobsNonRetryableTotal` (which is for genuine
+ * non-retryable process() errors) so oncall can disambiguate "gave up on a
+ * bad payload" from "gave up because encode blipped mid-retry".
+ */
+export const gqRetryEncodeFailuresTotal = new Counter({
+  name: "gq_retry_encode_failures_total",
+  help: "Retry re-encode failed — dispatched job completed via fail-safe, work recovers via event replay",
+  labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -22,6 +22,11 @@ const metricNames = [
   "gq_retry_backoff_milliseconds",
   "gq_job_duration_milliseconds",
   "gq_oldest_pending_age_milliseconds",
+  // ADR-030 hardening + review 2026-06-24
+  "gq_blob_reclaim_s3_failures_total",
+  "gq_blob_decode_cap_exceeded_total",
+  "gq_envelope_gq2_downgrade_total",
+  "gq_payload_too_large_total",
 ] as const;
 
 for (const name of metricNames) {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/metrics.ts
@@ -146,12 +146,45 @@ export const gqJobDurationMilliseconds = new Histogram({
   name: "gq_job_duration_milliseconds",
   help: "Duration of individual job processing in milliseconds",
   labelNames: ["queue_name", "pipeline_name", "job_type", "job_name"] as const,
-  buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000],
+  buckets: [
+    1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000,
+    120000,
+  ],
 });
 
 // --- Oldest pending age gauge ---
 export const gqOldestPendingAgeMilliseconds = new Gauge({
   name: "gq_oldest_pending_age_milliseconds",
   help: "Age of the oldest pending job in the ready sorted set (milliseconds)",
+  labelNames: ["queue_name"] as const,
+});
+
+// --- Blob lifecycle observability (ADR-030 hardening + review 2026-06-24) ---
+
+/** S3-tier reclaim throw (network / 5xx). Warn-only; TTL / bucket-lifecycle backstop. */
+export const gqBlobReclaimS3FailuresTotal = new Counter({
+  name: "gq_blob_reclaim_s3_failures_total",
+  help: "Blob s3-tier reclaim failures (relies on TTL / bucket-lifecycle backstop)",
+  labelNames: ["queue_name"] as const,
+});
+
+/** A stored blob exceeded the decode cap — possible tamper / zip-bomb. Distinct from a missing blob. */
+export const gqBlobDecodeCapExceededTotal = new Counter({
+  name: "gq_blob_decode_cap_exceeded_total",
+  help: "Blob read exceeded the decode byte cap — treated as missing (possible tamper / zip-bomb)",
+  labelNames: ["queue_name"] as const,
+});
+
+/** GQ2 encode fell back to GQ1 because tenant / tiered-store wiring was absent. */
+export const gqEnvelopeGQ2DowngradeTotal = new Counter({
+  name: "gq_envelope_gq2_downgrade_total",
+  help: "GQ2 encode downgraded to GQ1 (tenant or tiered store missing at the composition root)",
+  labelNames: ["queue_name"] as const,
+});
+
+/** Producer rejected a payload at the encode cap — bounds worker memory (ADR-030 §1). */
+export const gqPayloadTooLargeTotal = new Counter({
+  name: "gq_payload_too_large_total",
+  help: "Payload rejected at the encode cap",
   labelNames: ["queue_name"] as const,
 });

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/redisHashTag.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/redisHashTag.ts
@@ -1,0 +1,13 @@
+/**
+ * Whether a key (or key prefix) carries a Redis Cluster hash tag — a non-empty
+ * `{…}` whose content alone decides the slot. The GroupQueue's multi-key Lua
+ * (and the holder release/transfer evals) require their keys in one slot, so a
+ * tag is mandatory in cluster mode. Mirrors Redis's rule: the first `{`, the
+ * first `}` after it, and at least one character between them.
+ */
+export function hasRedisHashTag(name: string): boolean {
+  const open = name.indexOf("{");
+  if (open === -1) return false;
+  const close = name.indexOf("}", open + 1);
+  return close > open + 1;
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/redisJobBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/redisJobBlobStore.ts
@@ -1,15 +1,8 @@
 import type { Cluster, Redis as IORedis } from "ioredis";
 
+import { BLOB_BACKSTOP_TTL_SECONDS } from "./blobConstants";
+import { redisBlobKeyPrefix } from "./blobKeys";
 import type { JobBlobStore } from "./jobEnvelope";
-
-/**
- * Safety-net TTL for offloaded bodies. Deletion is best-effort at job
- * completion/restage; this bounds how long an orphan (dedup-squashed job,
- * crash between stage and delete) lingers. Must comfortably exceed the
- * longest plausible staged residence — retry backoff chains and paused
- * pipelines hold jobs for hours, not days.
- */
-const BLOB_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 /**
  * Stores offloaded envelope bodies as raw gzip binary under standalone keys,
@@ -29,15 +22,28 @@ export class RedisJobBlobStore implements JobBlobStore {
     queueName: string;
   }) {
     this.redis = redis;
-    this.keyPrefix = `${queueName}:gq:blob:`;
+    this.keyPrefix = redisBlobKeyPrefix(queueName);
   }
 
   async put({ id, data }: { id: string; data: Buffer }): Promise<void> {
-    await this.redis.set(this.keyPrefix + id, data, "EX", BLOB_TTL_SECONDS);
+    await this.redis.set(
+      this.keyPrefix + id,
+      data,
+      "EX",
+      BLOB_BACKSTOP_TTL_SECONDS,
+    );
   }
 
+  /**
+   * Reads the blob and refreshes its TTL (GETEX), so a body still referenced by
+   * a long-dwelling job never expires under it. A missing key returns null.
+   */
   async get({ id }: { id: string }): Promise<Buffer | null> {
-    return await this.redis.getBuffer(this.keyPrefix + id);
+    return await this.redis.getexBuffer(
+      this.keyPrefix + id,
+      "EX",
+      BLOB_BACKSTOP_TTL_SECONDS,
+    );
   }
 
   async delete({ id }: { id: string }): Promise<void> {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/redisJobBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/redisJobBlobStore.ts
@@ -1,6 +1,6 @@
 import type { Cluster, Redis as IORedis } from "ioredis";
 
-import { BLOB_BACKSTOP_TTL_SECONDS } from "./blobConstants";
+import { GQ1_BLOB_BACKSTOP_TTL_SECONDS } from "./blobConstants";
 import { redisBlobKeyPrefix } from "./blobKeys";
 import type { JobBlobStore } from "./jobEnvelope";
 
@@ -9,6 +9,11 @@ import type { JobBlobStore } from "./jobEnvelope";
  * read and written directly by the client (never through Lua, so ioredis's
  * UTF-8 script-reply decoding is not a constraint). Keys share the queue
  * name's hash tag so they land in the queue's cluster slot.
+ *
+ * A staged-but-not-yet-dispatched job (long retry backoff, paused pipeline,
+ * delayed schedule) sees NO intervening read between the producer's `put` and
+ * the dispatcher's `get`, so the TTL is set to comfortably outlive the longest
+ * plausible staged residence (7 days, see {@link GQ1_BLOB_BACKSTOP_TTL_SECONDS}).
  */
 export class RedisJobBlobStore implements JobBlobStore {
   private readonly redis: IORedis | Cluster;
@@ -30,20 +35,31 @@ export class RedisJobBlobStore implements JobBlobStore {
       this.keyPrefix + id,
       data,
       "EX",
-      BLOB_BACKSTOP_TTL_SECONDS,
+      GQ1_BLOB_BACKSTOP_TTL_SECONDS,
     );
   }
 
   /**
-   * Reads the blob and refreshes its TTL (GETEX), so a body still referenced by
-   * a long-dwelling job never expires under it. A missing key returns null.
+   * Reads the blob and refreshes its TTL (GETEX). Worker hot path only — see
+   * {@link peek} for the inspection path that must NOT extend the backstop TTL.
+   * A missing key returns null.
    */
   async get({ id }: { id: string }): Promise<Buffer | null> {
     return await this.redis.getexBuffer(
       this.keyPrefix + id,
       "EX",
-      BLOB_BACKSTOP_TTL_SECONDS,
+      GQ1_BLOB_BACKSTOP_TTL_SECONDS,
     );
+  }
+
+  /**
+   * Reads the blob WITHOUT refreshing its TTL. Use from the ops dashboard and
+   * any other non-worker inspection path so a repeatedly-viewed blocked group
+   * doesn't keep its orphan blobs alive indefinitely (2026-06-24 review).
+   * A missing key returns null.
+   */
+  async peek({ id }: { id: string }): Promise<Buffer | null> {
+    return await this.redis.getBuffer(this.keyPrefix + id);
   }
 
   async delete({ id }: { id: string }): Promise<void> {

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -1,0 +1,294 @@
+import { createHash } from "node:crypto";
+import type { Readable } from "node:stream";
+
+import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
+import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
+import { mintFileUri, mintS3Uri } from "~/server/stored-objects/uri";
+
+import { MAX_BLOB_BYTES } from "./blobConstants";
+import { blobNamespaceId } from "./blobKeys";
+import type { JobBlobStore } from "./jobEnvelope";
+
+/**
+ * Minimal object-store surface the durable (s3/file) tier needs. Structurally
+ * satisfied by the stored-objects `StorageRegistry`, so this tier reuses the
+ * codebase's one pluggable object store rather than adding another. See
+ * ADR-029.
+ */
+export interface ObjectStore {
+  put(uri: string, bytes: Buffer, mediaType: string): Promise<void>;
+  get(uri: string): Promise<Readable>;
+  delete(uri: string): Promise<void>;
+}
+
+/**
+ * Above this serialized size a blob lives in the durable object store; at or
+ * below it, in Redis. Aligned with ADR-022's COMMAND_INLINE_THRESHOLD. The
+ * inline tier (≤ a few KiB) is handled by the envelope, not this store.
+ */
+export const S3_TIER_THRESHOLD_BYTES = 256 * 1024;
+
+/**
+ * A content-addressed reference to an offloaded blob; travels inside the job
+ * envelope in place of the bytes. Both tiers carry only (projectId, hash) — the
+ * read location is re-derived from these server-trusted inputs (the redis key /
+ * a re-minted s3 uri), never trusted from a stored uri, so a tampered envelope
+ * can't redirect a read across tenants (ADR-030 §5).
+ */
+export type BlobRef =
+  | { tier: "redis"; projectId: TenantId; hash: string }
+  | { tier: "s3"; projectId: TenantId; hash: string };
+
+/**
+ * A blob fetch failed for a reason that is NOT "the object is gone" — a network
+ * blip, a 5xx, a destination-resolve failure. The job must retry (the body is
+ * only temporarily unreachable), never drop to replay as if the blob were
+ * missing; that distinction is what stops a transient store outage from
+ * mass-dropping every in-flight offloaded job (ADR-030 §2).
+ */
+export class TransientBlobStoreError extends Error {
+  readonly projectId: TenantId;
+  readonly hash: string;
+  constructor({
+    projectId,
+    hash,
+    cause,
+  }: {
+    projectId: TenantId;
+    hash: string;
+    cause: unknown;
+  }) {
+    super(`Transient blob store error for ${projectId}/${hash}`, { cause });
+    this.name = "TransientBlobStoreError";
+    this.projectId = projectId;
+    this.hash = hash;
+  }
+}
+
+/**
+ * SHA-256 of the bytes truncated to 128 bits, base64url (~22 chars). Collision
+ * probability is negligible; identical bytes always hash identically, which is
+ * what collapses a fan-out's N copies to a single stored blob.
+ */
+export function contentHash(bytes: Buffer): string {
+  return createHash("sha256")
+    .update(bytes)
+    .digest()
+    .subarray(0, 16)
+    .toString("base64url");
+}
+
+function redisBlobId(params: { projectId: TenantId; hash: string }): string {
+  return blobNamespaceId(params);
+}
+
+/** A stored object exceeded the read cap — treated as a corrupt/missing blob, not a transient error. */
+class BlobTooLargeError extends Error {}
+
+/** Buffers a stream, capped at `maxBytes` so a tampered/oversized object can't OOM the worker. */
+async function streamToBuffer(
+  stream: Readable,
+  maxBytes: number,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Buffer);
+    total += buf.length;
+    if (total > maxBytes) {
+      stream.destroy();
+      throw new BlobTooLargeError(`Stored blob exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Whether an object-store error means the object is absent (vs a transient failure). */
+function isObjectMissingError(err: unknown): boolean {
+  if (err == null || typeof err !== "object") return false;
+  const e = err as {
+    name?: string;
+    code?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+  return (
+    e.name === "NoSuchKey" ||
+    e.name === "NotFound" ||
+    e.code === "ENOENT" ||
+    e.code === "NoSuchKey" ||
+    e.$metadata?.httpStatusCode === 404
+  );
+}
+
+/**
+ * Content-addressed, tenant-namespaced blob store with two durable tiers: Redis
+ * for mid-size bodies, the reused stored-objects object store for very large
+ * ones. Keys are namespaced by `projectId` (the tenant id) so tenants never
+ * share a blob and a project purge is a delete-by-prefix. See ADR-029.
+ *
+ * Dependencies are injected (no env coupling) so the store is exercised in
+ * isolation: `objectStore` is satisfied by `StorageRegistry`, `resolveDestination`
+ * by `resolveProjectStorageDestination`.
+ */
+export class TieredBlobStore {
+  private readonly redisBlobs: JobBlobStore;
+  // Per-project so the s3/file tier resolves each tenant's BYOC bucket and
+  // credentials (the stored-objects S3Driver is projectId-scoped).
+  private readonly objectStoreFor: (projectId: string) => ObjectStore;
+  private readonly resolveDestination: (
+    projectId: string,
+  ) => Promise<ProjectStorageDestination>;
+  private readonly s3ThresholdBytes: number;
+  // Per-project storage destination, cached for the process lifetime. BYOC
+  // bucket changes are rare deliberate migrations, picked up on the next worker
+  // restart (deploys are frequent); a failed resolve is not cached.
+  private readonly destinationCache = new Map<
+    TenantId,
+    Promise<ProjectStorageDestination>
+  >();
+
+  constructor(deps: {
+    redisBlobs: JobBlobStore;
+    objectStoreFor: (projectId: string) => ObjectStore;
+    resolveDestination: (
+      projectId: string,
+    ) => Promise<ProjectStorageDestination>;
+    s3ThresholdBytes?: number;
+  }) {
+    this.redisBlobs = deps.redisBlobs;
+    this.objectStoreFor = deps.objectStoreFor;
+    this.resolveDestination = deps.resolveDestination;
+    this.s3ThresholdBytes = deps.s3ThresholdBytes ?? S3_TIER_THRESHOLD_BYTES;
+  }
+
+  private resolveDestinationCached(
+    projectId: TenantId,
+  ): Promise<ProjectStorageDestination> {
+    let cached = this.destinationCache.get(projectId);
+    if (!cached) {
+      cached = this.resolveDestination(projectId).catch((err: unknown) => {
+        this.destinationCache.delete(projectId); // don't cache a transient failure
+        throw err;
+      });
+      this.destinationCache.set(projectId, cached);
+    }
+    return cached;
+  }
+
+  /** Re-derives the object uri from (projectId, hash) — never trusts a stored uri. */
+  private async mintUri({
+    projectId,
+    hash,
+  }: {
+    projectId: TenantId;
+    hash: string;
+  }): Promise<string> {
+    const destination = await this.resolveDestinationCached(projectId);
+    switch (destination.kind) {
+      case "s3":
+        return mintS3Uri({
+          bucket: destination.bucket,
+          projectId,
+          sha256: hash,
+        });
+      case "file":
+        return mintFileUri({ root: destination.root, projectId, sha256: hash });
+      default: {
+        const unhandled: never = destination;
+        throw new Error(
+          `Unhandled storage destination kind: ${JSON.stringify(unhandled)}`,
+        );
+      }
+    }
+  }
+
+  async put({
+    projectId,
+    data,
+    hashSource,
+  }: {
+    projectId: TenantId;
+    data: Buffer;
+    /**
+     * Bytes to derive the content hash from — the RAW source, so the dedup key
+     * doesn't depend on gzip determinism (zlib version/level). Defaults to
+     * `data`, i.e. hash exactly what is stored.
+     */
+    hashSource?: Buffer;
+  }): Promise<BlobRef> {
+    const hash = contentHash(hashSource ?? data);
+    if (data.length > this.s3ThresholdBytes) {
+      const uri = await this.mintUri({ projectId, hash });
+      // Idempotent: identical content mints the same URI, so a racing or retried
+      // PUT overwrites the same object instead of duplicating it.
+      await this.objectStoreFor(projectId).put(uri, data, "application/gzip");
+      return { tier: "s3", projectId, hash };
+    }
+    await this.redisBlobs.put({ id: redisBlobId({ projectId, hash }), data });
+    return { tier: "redis", projectId, hash };
+  }
+
+  /**
+   * Returns null when a redis-tier blob is gone; lets an s3 read error
+   * propagate. Either way the envelope decode treats the absence as a missing
+   * blob and reaches the fail-safe (complete the slot, recover via replay).
+   */
+  async get(ref: BlobRef): Promise<Buffer | null> {
+    if (ref.tier === "redis") {
+      return this.redisBlobs.get({
+        id: redisBlobId({ projectId: ref.projectId, hash: ref.hash }),
+      });
+    }
+    // Re-mint OUTSIDE the missing-classification: a destination-resolve / mint
+    // failure is transient (retry), never "missing" (ADR-030 §2).
+    let uri: string;
+    try {
+      uri = await this.mintUri({ projectId: ref.projectId, hash: ref.hash });
+    } catch (err) {
+      throw new TransientBlobStoreError({
+        projectId: ref.projectId,
+        hash: ref.hash,
+        cause: err,
+      });
+    }
+    try {
+      return await streamToBuffer(
+        await this.objectStoreFor(ref.projectId).get(uri),
+        MAX_BLOB_BYTES,
+      );
+    } catch (err) {
+      // A genuinely-absent or oversized/corrupt object is a missing blob → null
+      // → decode fail-safe (recover via replay). Anything else (network/5xx) is
+      // transient and must retry, not drop the job (ADR-030 §2).
+      if (isObjectMissingError(err) || err instanceof BlobTooLargeError) {
+        return null;
+      }
+      throw new TransientBlobStoreError({
+        projectId: ref.projectId,
+        hash: ref.hash,
+        cause: err,
+      });
+    }
+  }
+
+  /**
+   * Deletes a blob. A redis-tier blob is normally reclaimed inside the holder
+   * Lua (UNLINK in the same eval as the last release); this method is the
+   * general-purpose / out-of-band delete — the s3 reclaim path, or a direct
+   * caller holding a ref — so it handles both tiers.
+   */
+  async delete(ref: BlobRef): Promise<void> {
+    if (ref.tier === "redis") {
+      await this.redisBlobs.delete({
+        id: redisBlobId({ projectId: ref.projectId, hash: ref.hash }),
+      });
+      return;
+    }
+    const uri = await this.mintUri({
+      projectId: ref.projectId,
+      hash: ref.hash,
+    });
+    await this.objectStoreFor(ref.projectId).delete(uri);
+  }
+}

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import type { Readable } from "node:stream";
 
+import type { Logger } from "pino";
+
+import { COMMAND_INLINE_THRESHOLD } from "~/server/app-layer/traces/lean-for-projection";
 import type { TenantId } from "~/server/event-sourcing/domain/tenantId";
 import type { ProjectStorageDestination } from "~/server/stored-objects/project-storage-destination";
 import { mintFileUri, mintS3Uri } from "~/server/stored-objects/uri";
@@ -8,6 +11,7 @@ import { mintFileUri, mintS3Uri } from "~/server/stored-objects/uri";
 import { MAX_BLOB_BYTES } from "./blobConstants";
 import { blobNamespaceId } from "./blobKeys";
 import type { JobBlobStore } from "./jobEnvelope";
+import { gqBlobDecodeCapExceededTotal } from "./metrics";
 
 /**
  * Minimal object-store surface the durable (s3/file) tier needs. Structurally
@@ -23,10 +27,12 @@ export interface ObjectStore {
 
 /**
  * Above this serialized size a blob lives in the durable object store; at or
- * below it, in Redis. Aligned with ADR-022's COMMAND_INLINE_THRESHOLD. The
- * inline tier (≤ a few KiB) is handled by the envelope, not this store.
+ * below it, in Redis. Derived from `COMMAND_INLINE_THRESHOLD` (ADR-022's
+ * edge-spool boundary) so a retune on that constant moves both sides in
+ * lockstep. The inline tier (≤ a few KiB) is handled by the envelope, not
+ * this store.
  */
-export const S3_TIER_THRESHOLD_BYTES = 256 * 1024;
+export const S3_TIER_THRESHOLD_BYTES = COMMAND_INLINE_THRESHOLD;
 
 /**
  * A content-addressed reference to an offloaded blob; travels inside the job
@@ -70,7 +76,10 @@ export class TransientBlobStoreError extends Error {
  * probability is negligible; identical bytes always hash identically, which is
  * what collapses a fan-out's N copies to a single stored blob.
  */
-export function contentHash(bytes: Buffer): string {
+export function contentHash(bytes: Buffer | string): string {
+  // `update(string)` handles UTF-8 encoding internally without allocating a
+  // full-payload Buffer — for a 4 MiB fan-out payload the caller passing the
+  // string directly saves 4 MiB of throw-away allocation on the encode hot path.
   return createHash("sha256")
     .update(bytes)
     .digest()
@@ -140,6 +149,8 @@ export class TieredBlobStore {
     projectId: string,
   ) => Promise<ProjectStorageDestination>;
   private readonly s3ThresholdBytes: number;
+  private readonly queueName?: string;
+  private readonly logger?: Logger;
   // Per-project storage destination, cached for the process lifetime. BYOC
   // bucket changes are rare deliberate migrations, picked up on the next worker
   // restart (deploys are frequent); a failed resolve is not cached.
@@ -155,11 +166,17 @@ export class TieredBlobStore {
       projectId: string,
     ) => Promise<ProjectStorageDestination>;
     s3ThresholdBytes?: number;
+    /** Optional queue name for the decode-cap-exceeded counter. */
+    queueName?: string;
+    /** Optional logger for the decode-cap-exceeded warn. */
+    logger?: Logger;
   }) {
     this.redisBlobs = deps.redisBlobs;
     this.objectStoreFor = deps.objectStoreFor;
     this.resolveDestination = deps.resolveDestination;
     this.s3ThresholdBytes = deps.s3ThresholdBytes ?? S3_TIER_THRESHOLD_BYTES;
+    this.queueName = deps.queueName;
+    this.logger = deps.logger;
   }
 
   private resolveDestinationCached(
@@ -215,7 +232,7 @@ export class TieredBlobStore {
      * doesn't depend on gzip determinism (zlib version/level). Defaults to
      * `data`, i.e. hash exactly what is stored.
      */
-    hashSource?: Buffer;
+    hashSource?: Buffer | string;
   }): Promise<BlobRef> {
     const hash = contentHash(hashSource ?? data);
     if (data.length > this.s3ThresholdBytes) {
@@ -260,8 +277,26 @@ export class TieredBlobStore {
     } catch (err) {
       // A genuinely-absent or oversized/corrupt object is a missing blob → null
       // → decode fail-safe (recover via replay). Anything else (network/5xx) is
-      // transient and must retry, not drop the job (ADR-030 §2).
-      if (isObjectMissingError(err) || err instanceof BlobTooLargeError) {
+      // transient and must retry, not drop the job (ADR-030 §2). Oversize is
+      // an OBSERVABLE fail-safe — split from "just missing" so oncall can see a
+      // real tamper / zip-bomb event distinct from "TTL reclaimed the blob".
+      if (err instanceof BlobTooLargeError) {
+        if (this.queueName) {
+          gqBlobDecodeCapExceededTotal.inc({ queue_name: this.queueName });
+        }
+        if (this.logger) {
+          this.logger.warn(
+            {
+              projectId: ref.projectId,
+              blobHash: ref.hash,
+              cap: MAX_BLOB_BYTES,
+            },
+            "Blob exceeds decode cap — possible tamper / zip-bomb; treating as missing",
+          );
+        }
+        return null;
+      }
+      if (isObjectMissingError(err)) {
         return null;
       }
       throw new TransientBlobStoreError({

--- a/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
+++ b/langwatch/src/server/event-sourcing/queues/groupQueue/tieredBlobStore.ts
@@ -177,6 +177,16 @@ export class TieredBlobStore {
     this.s3ThresholdBytes = deps.s3ThresholdBytes ?? S3_TIER_THRESHOLD_BYTES;
     this.queueName = deps.queueName;
     this.logger = deps.logger;
+    // Loud one-time warn when observability isn't wired at composition time.
+    // Silent-fail-if-unset was the original ADR-030 issue Aryan flagged — this
+    // makes the omission visible instead of latent (2026-07-03 audit follow-up).
+    // Test doubles construct without queueName; we only warn when a logger is
+    // available so tests stay quiet.
+    if (!this.queueName && this.logger) {
+      this.logger.warn(
+        "TieredBlobStore constructed without queueName — decode-cap counter and warn will silently no-op",
+      );
+    }
   }
 
   private resolveDestinationCached(
@@ -252,10 +262,26 @@ export class TieredBlobStore {
    * blob and reaches the fail-safe (complete the slot, recover via replay).
    */
   async get(ref: BlobRef): Promise<Buffer | null> {
+    return this.fetch(ref, /* refresh */ true);
+  }
+
+  /**
+   * Reads a blob WITHOUT refreshing its backstop TTL — the non-worker /
+   * ops-dashboard inspection path. Symmetric with {@link RedisJobBlobStore.peek}
+   * so a repeatedly-viewed blocked group can't extend the lifetime of its
+   * orphan blobs indefinitely by triggering GETEX on every render.
+   * S3-tier objects have no TTL; peek and get are functionally identical there.
+   */
+  async peek(ref: BlobRef): Promise<Buffer | null> {
+    return this.fetch(ref, /* refresh */ false);
+  }
+
+  private async fetch(ref: BlobRef, refresh: boolean): Promise<Buffer | null> {
     if (ref.tier === "redis") {
-      return this.redisBlobs.get({
-        id: redisBlobId({ projectId: ref.projectId, hash: ref.hash }),
-      });
+      const id = redisBlobId({ projectId: ref.projectId, hash: ref.hash });
+      return refresh
+        ? this.redisBlobs.get({ id })
+        : this.redisBlobs.peek({ id });
     }
     // Re-mint OUTSIDE the missing-classification: a destination-resolve / mint
     // failure is transient (retry), never "missing" (ADR-030 §2).

--- a/langwatch/src/server/event-sourcing/services/__tests__/interposition.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/services/__tests__/interposition.unit.test.ts
@@ -35,6 +35,9 @@ vi.mock("~/server/app-layer/traces/lean-for-projection", () => ({
     // Marker so tests can verify dispatch received the leaned shape
     data: { ...((event.data as Record<string, unknown>) ?? {}), _leaned: true },
   })),
+  // Also re-export the size constant used by the GQ2 tiered blob store — the
+  // event-sourcing graph transitively imports it via tieredBlobStore.ts.
+  COMMAND_INLINE_THRESHOLD: 256 * 1024,
 }));
 
 // Pull the mock handle so we can assert call counts and override behavior

--- a/langwatch/src/server/stored-objects/__tests__/redact-storage-uri.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/redact-storage-uri.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  redactStorageUri,
+  redactStorageUrisInText,
+} from "../project-storage-destination";
+
+describe("redactStorageUri", () => {
+  describe("given a gs:// uri", () => {
+    it("redacts the bucket so a GCS BYOC bucket name doesn't leak", () => {
+      expect(redactStorageUri("gs://customer-private/proj-abc/sha256")).toBe(
+        "gs://***/proj-abc/sha256",
+      );
+    });
+  });
+
+  describe("given an uppercase scheme", () => {
+    it("still redacts the bucket (URI schemes are case-insensitive)", () => {
+      expect(redactStorageUri("S3://customer-private/proj-abc/sha256")).toBe(
+        "S3://***/proj-abc/sha256",
+      );
+    });
+  });
+});
+
+describe("redactStorageUrisInText", () => {
+  describe("given an error message embedding a gs:// uri", () => {
+    it("redacts the bucket out of the free text", () => {
+      const msg =
+        "failed to GET object at gs://customer-private/proj-abc/sha256: 404";
+      expect(redactStorageUrisInText(msg)).toBe(
+        "failed to GET object at gs://***/proj-abc/sha256: 404",
+      );
+    });
+  });
+
+  describe("given an error message embedding an uppercase S3:// uri", () => {
+    it("redacts the bucket out of the free text", () => {
+      const msg =
+        "S3 SDK error: failed at S3://customer-private/proj-abc/sha256";
+      expect(redactStorageUrisInText(msg)).toBe(
+        "S3 SDK error: failed at S3://***/proj-abc/sha256",
+      );
+    });
+  });
+});

--- a/langwatch/src/server/stored-objects/project-storage-destination.ts
+++ b/langwatch/src/server/stored-objects/project-storage-destination.ts
@@ -79,14 +79,19 @@ export function redactStorageUri(uri: string): string {
     const colonSlashSlash = uri.indexOf("://");
     if (colonSlashSlash === -1) return uri;
     const scheme = uri.slice(0, colonSlashSlash);
+    // Schemes are case-insensitive in URI syntax; an SDK that quotes
+    // `S3://bucket/key` must still be redacted (text-level redactor uses /i).
+    const schemeLower = scheme.toLowerCase();
     const rest = uri.slice(colonSlashSlash + 3);
 
-    if (scheme === "s3") {
+    if (schemeLower === "s3" || schemeLower === "gs") {
+      // s3://bucket/projectId/sha256 and gs://bucket/projectId/sha256 — bucket
+      // identifies the tenant's storage account; the rest is content-addressed.
       const slash = rest.indexOf("/");
       if (slash === -1) return `${scheme}://***`;
       return `${scheme}://***${rest.slice(slash)}`;
     }
-    if (scheme === "azure-blob") {
+    if (schemeLower === "azure-blob") {
       // azure-blob://account/container/projectId/sha256 — first 2 path
       // segments identify the tenant's storage account; rest is content-
       // addressed and safe.
@@ -94,20 +99,29 @@ export function redactStorageUri(uri: string): string {
       const safe = segments.slice(2).join("/");
       return `${scheme}://***/***${safe ? "/" + safe : ""}`;
     }
-    if (scheme === "file") {
+    if (schemeLower === "file") {
       // file:///<root>/<projectId>/<sha256> — root may encode the install
       // path of a self-host tenant; treat as sensitive.
       const slash = rest.indexOf("/", 1);
       if (slash === -1) return `${scheme}:///***`;
       const tail = rest.slice(slash);
-      const lastTwoSlashes = tail.lastIndexOf(
-        "/",
-        tail.lastIndexOf("/") - 1,
-      );
+      const lastTwoSlashes = tail.lastIndexOf("/", tail.lastIndexOf("/") - 1);
       return `${scheme}:///***${lastTwoSlashes !== -1 ? tail.slice(lastTwoSlashes) : ""}`;
     }
     return uri;
   } catch {
     return "<unredactable-uri>";
   }
+}
+
+const STORAGE_URI_IN_TEXT = /\b(?:s3|azure-blob|gs|file):\/\/[^\s'"]+/gi;
+
+/**
+ * Redacts every storage URI embedded in a free-text string — e.g. an object-
+ * store SDK error message that quotes the failing `s3://bucket/key`. Use on any
+ * error text that ships to a shared log sink: a BYOC tenant's bucket / account
+ * is a cross-tenant disclosure channel otherwise.
+ */
+export function redactStorageUrisInText(text: string): string {
+  return text.replace(STORAGE_URI_IN_TEXT, (uri) => redactStorageUri(uri));
 }

--- a/langwatch/src/server/stored-objects/stored-objects-factory.ts
+++ b/langwatch/src/server/stored-objects/stored-objects-factory.ts
@@ -39,16 +39,32 @@ function maybeAzureDriver(): AzureBlobDriver | undefined {
  * The `S3Driver` is scoped to `projectId` so per-tenant BYOC S3 credentials
  * are resolved at call time.
  */
+/**
+ * Builds a `StorageRegistry` with the S3 / local-filesystem / (optional) Azure
+ * drivers wired. The `S3Driver` is projectId-scoped so per-tenant BYOC creds
+ * resolve at call time. Shared by `createStoredObjectsService` and any other
+ * byte path that needs the object store (e.g. the GroupQueue s3 blob tier).
+ */
+export function createStorageRegistry({
+  projectId,
+}: {
+  projectId: string;
+}): StorageRegistry {
+  return new StorageRegistry({
+    s3: new S3Driver(projectId),
+    file: new LocalFilesystemDriver(),
+    "azure-blob": maybeAzureDriver(),
+  });
+}
+
 export function createStoredObjectsService({
   projectId,
 }: {
   projectId: string;
 }): StoredObjectsService {
   const repository = new StoredObjectsRepository();
-  const registry = new StorageRegistry({
-    s3: new S3Driver(projectId),
-    file: new LocalFilesystemDriver(),
-    "azure-blob": maybeAzureDriver(),
-  });
-  return new StoredObjectsService(repository, registry);
+  return new StoredObjectsService(
+    repository,
+    createStorageRegistry({ projectId }),
+  );
 }

--- a/specs/event-sourcing/payload-envelope.feature
+++ b/specs/event-sourcing/payload-envelope.feature
@@ -26,6 +26,13 @@ Feature: GroupQueue payload envelope
     Then the stored value is an envelope with a raw JSON body
 
   # Large-payload blob offload
+  #
+  # NOTE (ADR-029): the blob-lifecycle scenarios in this section — cleanup on
+  # complete, dedup-squash reclaim, the TTL safety net — describe the GQ1
+  # mechanism (a private random-id blob per job, best-effort delete, 7-day
+  # backstop). They are SUPERSEDED for envelope v2 by content-addressed sharing
+  # + holder-set eager reclaim; see
+  # specs/event-sourcing/payload-store-content-addressed.feature.
 
   Scenario: Very large payloads are offloaded out of the queue hash
     When a job whose payload exceeds the blob offload threshold is staged

--- a/specs/event-sourcing/payload-store-blob-hardening.feature
+++ b/specs/event-sourcing/payload-store-blob-hardening.feature
@@ -1,0 +1,197 @@
+# See dev/docs/adr/030-groupqueue-blob-handling-hardening.md for the architectural rationale.
+Feature: GroupQueue blob-handling hardening
+  As the LangWatch event-sourcing queue offloading payloads to content-addressed blobs
+  I want bounded memory, transient-vs-missing failure handling, coordinated TTLs,
+  atomic hold transfers, tamper-resistant reads, and a cluster-slot guard
+  So that a pathological payload, a brief store outage, a long-lived fan-out, a
+  partial failure, a tampered envelope, or a mis-tagged queue can never OOM the
+  worker, drop work to replay, prematurely reclaim a live blob, cross a tenant
+  boundary, or leak silently.
+
+  # Hardens the GQ2 lifecycle from ADR-029
+  # (specs/event-sourcing/payload-store-content-addressed.feature). The core
+  # contract there stands; these are the edge cases a tests/security/code review
+  # surfaced. Where a scenario here REFINES a core-feature AC, the core states
+  # the behaviour and this states the hardened mechanism — they don't duplicate:
+  #   - the squash transfer (Track 4) refines core AC3.2 (dedup-squash reclaim),
+  #     making it crash-atomic;
+  #   - the TTL-coordination / access-refresh scenarios (Track 3) refine core
+  #     AC3.5/AC3.8 (TTL backstop + survive-dispatch), making the holder TTL
+  #     outlive the blob and refresh on access.
+  #
+  # Decision (ADR-030):
+  #   - Buffered offload throughout; MAX_BLOB_BYTES (50 MiB) rejects the truly
+  #     pathological at encode. Content hash is over the raw source JSON, not the
+  #     gzip output (no gzip-determinism assumption). Streaming was dropped — the
+  #     cap is the memory bound; see ADR-030 §1.
+  #   - s3 get: not-found -> fail-safe; transient error -> retryable.
+  #   - One BLOB_BACKSTOP_TTL; holder TTL ≥ blob TTL; both refreshed on access.
+  #   - Atomic transfer eval (SADD new + SREM old + reclaim-if-empty) on
+  #     retry/squash; re-mint read location from (projectId, hash), don't trust
+  #     the stored ref.uri; assert the queue name carries a Redis hash tag.
+
+  Background:
+    Given a GroupQueue with GQ2 content-addressed offload enabled
+    And the absolute ceiling is configured at 50 MiB
+    And the blob backstop TTL is configured at 3 days
+
+  # ===========================================================================
+  # Track 1 — bounded-memory offload (cap + hash-over-raw)
+  # ===========================================================================
+
+  @integration @track1 @unimplemented
+  Scenario: A mid-MB payload offloads through the buffered path
+    When a job whose payload is 2 MiB is staged
+    Then the body is gzipped and stored under its content-addressed key
+    And the worker never holds more than the source string plus one compressed buffer
+
+  @unit @track1 @unimplemented
+  Scenario: The content hash is computed over the raw source, not the gzipped bytes
+    Given two byte-identical payloads
+    When each is offloaded
+    Then both resolve to the same content-addressed key
+    And the key does not depend on gzip output being byte-deterministic
+
+  @unit @track1 @unimplemented
+  Scenario: A payload above the absolute ceiling is rejected at encode, not stored
+    Given a payload larger than the absolute ceiling
+    When it is staged
+    Then encode throws PayloadTooLargeError before gzipping or storing it
+    And the producer surfaces the error rather than the worker OOMing
+
+  @unit @track1 @unimplemented
+  Scenario: A sub-inline payload stays inline and acquires no hold
+    When a job whose payload is under the inline ceiling is staged
+    Then no blob and no holder set are written for it
+
+  # ===========================================================================
+  # Track 2 — missing vs transient store errors
+  # ===========================================================================
+
+  @integration @track2 @unimplemented
+  Scenario: A genuinely missing s3 blob completes the slot via the fail-safe
+    Given an offloaded job whose s3 object has been deleted
+    When dispatch resolves the blob and the store returns not-found
+    Then the job is completed without invoking the handler
+    And the work remains recoverable via event replay
+
+  @integration @track2 @unimplemented
+  Scenario: A transient s3 error retries instead of dropping to replay
+    Given an offloaded job whose s3 read fails with a transient error
+    When dispatch resolves the blob
+    Then the error is surfaced as retryable
+    And the job is retried rather than completed without the handler
+
+  # ===========================================================================
+  # Track 3 — coordinated TTLs and premature reclaim
+  # ===========================================================================
+
+  @integration @track3 @unimplemented
+  Scenario: The holder-set TTL is never shorter than the blob TTL
+    When a blob and its holder set are created
+    Then the holder set's TTL is greater than or equal to the blob's TTL
+
+  @integration @track3 @unimplemented
+  Scenario: Dispatch refreshes the holder set as well as the blob
+    Given a blob referenced by several still-staged jobs
+    When one referenced job is dispatched near the backstop window
+    Then both the blob and its holder set have their TTL refreshed
+    And a later completion does not reclaim a blob the other jobs still reference
+
+  @integration @track3 @unimplemented
+  Scenario: A long-lived fan-out does not prematurely reclaim a referenced blob
+    Given a fan-out whose jobs remain staged close to the backstop window
+    When some jobs are dispatched and complete while others are still staged
+    Then the blob survives until the last referencing job retires
+    And no still-staged job is left pointing at a reclaimed blob
+
+  # ===========================================================================
+  # Track 4 — atomic hold transfer (no reclaim gap)
+  # ===========================================================================
+
+  @integration @track4 @unimplemented
+  Scenario: A retry transfers the hold to the new token in a single atomic step
+    Given an offloaded job that fails with a retryable error
+    When it is re-staged on the same content hash
+    Then the new token is added and the old token removed atomically
+    And the blob is never observable at zero holders during the transfer
+
+  @integration @track4 @unimplemented
+  Scenario: A partial failure during the transfer cannot reclaim a referenced blob
+    Given a hold transfer where the release half would otherwise run before the acquire
+    When the transfer eval runs
+    Then the old blob is reclaimed only if its holder set is empty after the transfer
+    And a still-needed blob is never reclaimed
+
+  @integration @track4 @unimplemented
+  Scenario: A dedup squash transfers the hold without dropping a shared blob
+    Given two staged jobs on the same content hash
+    When a squash displaces one of them
+    Then the displaced token is transferred in the same atomic step
+    And the blob remains while the surviving job holds it
+
+  # ===========================================================================
+  # Track 5 — tamper resistance and tenant isolation
+  # ===========================================================================
+
+  @unit @track5 @unimplemented
+  Scenario: The read location is re-minted from (projectId, hash), not the stored ref
+    Given an envelope whose stored ref.uri points at a different bucket than the project resolves to
+    When the blob is read
+    Then the read location is derived from the project's resolved destination and the content hash
+    And the stored ref.uri is not used to locate the object
+
+  @unit @track5 @unimplemented
+  Scenario: A tampered ref cannot read another tenant's blob
+    Given a tampered envelope carrying another tenant's projectId or uri
+    When the blob is read
+    Then the read is scoped to the owning project's namespace and destination
+    And no cross-tenant object is returned
+
+  @unit @track5 @unimplemented
+  Scenario: Blob log lines are tenant-attributed and never leak the bucket
+    Given a blob holder operation that fails
+    When the failure is logged
+    Then the log line carries the owning projectId and the content hash
+    And it never logs a bare hash without its tenant
+    And it never logs the raw object-store uri or bucket name
+
+  # ===========================================================================
+  # Track 6 — cluster-slot guard
+  # ===========================================================================
+
+  @unit @track6 @unimplemented
+  Scenario: A queue name without a Redis hash tag is rejected at construction
+    Given a GroupQueue constructed with a name lacking a hash tag
+    When the queue is constructed
+    Then construction fails fast with a clear error
+    Because the two-key release and transfer evals require the holder and blob keys in one cluster slot
+
+  # ===========================================================================
+  # --- AC Coverage Map (ADR-030) ---
+  # Track 1 — bounded-memory offload
+  #   AC1.1 buffered mid-MB           -> A mid-MB payload offloads through the buffered path
+  #   AC1.2 hash over raw source      -> The content hash is computed over the raw source ...
+  #   AC1.3 absolute-ceiling reject   -> A payload above the absolute ceiling is rejected at encode ...
+  #   AC1.4 sub-inline no hold        -> A sub-inline payload stays inline and acquires no hold
+  # Track 2 — missing vs transient
+  #   AC2.1 missing -> fail-safe      -> A genuinely missing s3 blob completes the slot via the fail-safe
+  #   AC2.2 transient -> retry        -> A transient s3 error retries instead of dropping to replay
+  # Track 3 — coordinated TTLs
+  #   AC3.1 holder TTL ≥ blob TTL     -> The holder-set TTL is never shorter than the blob TTL
+  #   AC3.2 dispatch refreshes both   -> Dispatch refreshes the holder set as well as the blob
+  #   AC3.3 no premature reclaim      -> A long-lived fan-out does not prematurely reclaim a referenced blob
+  # Track 4 — atomic transfer
+  #   AC4.1 atomic retry transfer     -> A retry transfers the hold ... in a single atomic step
+  #   AC4.2 no reclaim on partial     -> A partial failure during the transfer cannot reclaim a referenced blob
+  #   AC4.3 squash transfer           -> A dedup squash transfers the hold without dropping a shared blob
+  # Track 5 — tamper / tenancy
+  #   AC5.1 re-mint on read           -> The read location is re-minted from (projectId, hash) ...
+  #   AC5.2 tamper cannot cross tenant-> A tampered ref cannot read another tenant's blob
+  #   AC5.3 tenant-attributed logs    -> Blob log lines are tenant-attributed and never leak the bucket
+  # Track 6 — cluster-slot guard
+  #   AC6.1 reject hash-tag-less name -> A queue name without a Redis hash tag is rejected at construction
+  #
+  # Count: 16 behavioral ACs -> 16 scenarios. Streaming (the original AC1.2) was
+  # dropped in implementation — the cap is the memory bound (ADR-030 §1).
+  # ===========================================================================

--- a/specs/event-sourcing/payload-store-content-addressed.feature
+++ b/specs/event-sourcing/payload-store-content-addressed.feature
@@ -1,0 +1,317 @@
+# See dev/docs/adr/029-groupqueue-content-addressed-payload-store.md for the architectural rationale.
+Feature: GroupQueue content-addressed tiered payload store
+  As the LangWatch event-sourcing queue absorbing fan-out from a single event
+  I want one event's shared payload stored once by content hash and referenced
+  by every job it fans out to, across three size tiers, reclaimed eagerly when
+  the last referencing job finishes
+  So that a dozen-way fan-out costs one payload copy instead of a dozen, the
+  queue survives a weekend outage without accumulating days of dead payloads,
+  and offload is decided by size alone, not by command-vs-job provenance.
+
+  # Builds on ADR-026's GQ1 envelope (specs/event-sourcing/payload-envelope.feature).
+  # Supersedes ADR-026's blob-lifecycle scenarios: random blob ids become content
+  # hashes; best-effort-delete + 7-day pure-backstop TTL becomes holder-set eager
+  # reclaim + 3-day refreshed backstop. The GQ1 envelope/header/routing/two-phase
+  # rollout decisions carry forward unchanged.
+  #
+  # TWO mechanisms share the word "dedup" — this spec keeps them apart:
+  #   - content-addressed sharing / "store-once" (THIS feature): one shared
+  #     payload component (event, fold state) is stored ONCE by content hash;
+  #     every job carrying identical bytes references that single copy.
+  #   - dedup-id squash (NOT this feature): STAGE_LUA collapses same-identity
+  #     staged jobs into one HSET field — owned by
+  #     specs/traces/record-span-gq-dedup.feature, configured per
+  #     specs/event-sourcing/deduplication-strategy.feature. This feature only
+  #     COMPOSES with it: a squashed slot releases its hold on its blob.
+  #   The holder-set members are the per-slot `stagedJobId`s of
+  #   record-span-gq-dedup.feature.
+  #
+  # Decision (ADR-029):
+  #   - Three tiers by serialized size: inline ≤4 KiB · redis 4 KiB–256 KiB ·
+  #     s3 >256 KiB (boundary aligned with ADR-022 COMMAND_INLINE_THRESHOLD).
+  #   - Blob id = SHA-256(canonical bytes) truncated to 128 bits, base64url.
+  #     Identical bytes -> identical key -> one stored copy. PUTs idempotent.
+  #     Keys are namespaced by projectId (the tenant id; tenantId === projectId),
+  #     minting the stored_objects layout s3://{bucket}/{projectId}/<hash> so
+  #     tenants never share a blob and purge is delete-by-prefix.
+  #   - Flat jobs: the fan-out producer hoists the shared component (event, fold
+  #     state) out of every job; each job carries refs, not the payload. Decode
+  #     resolves refs before the handler, which is unchanged.
+  #   - Holder set {queue}:gq:blobholders:<hash> tracks references by stagedJobId;
+  #     SADD at stage, SREM at every retire edge, atomic with the job-entry write.
+  #     Empties -> eager UNLINK (redis) / reclaim-list sweep (s3).
+  #   - 3-day TTL on blob + holder set, refreshed on access, is the orphan
+  #     backstop only. A missing blob completes the slot without the handler
+  #     (recoverable via replay) — a fail-safe, never a wedge.
+  #
+  # RESOLVED (ADR-029): the s3/file tier reuses the stored-objects StorageDriver/
+  # StorageRegistry/URI minting (specs/features/scenarios/externalize-event-byte-content.feature)
+  # — the driver only, NOT StoredObjectsService (whose no-GC lifecycle would
+  # clash with holder-set reclaim). The redis tier stays the queue's own store.
+  #
+  # Related ADRs: 029 (this), 026 (envelope, extended), 022 (event_log SoT — its
+  # BlobStore is event_log-centric, NOT reused here), 024 (CH cold-path tiering —
+  # distinct subsystem), 007 (event sourcing). Object store reused from
+  # src/server/stored-objects/. Pause: specs/queue-pausing/queue-pausing.feature.
+
+  Background:
+    Given a GroupQueue with jobs routed through queue-manager facades
+    # Steady-state baseline. The Track 4 rollout scenarios are the only ones that
+    # override the write state (to "not enabled"), and they do so scenario-locally.
+    And envelope v2 writes are enabled for the deployment
+    And the inline tier ceiling is configured at 4 KiB
+    And the S3 tier threshold is configured at 256 KiB
+    And the blob TTL backstop is configured at 3 days
+
+  # ===========================================================================
+  # Track 1 — content-addressed tiers
+  # ===========================================================================
+
+  @integration @track1 @unimplemented
+  Scenario: A sub-threshold payload stays inline in the envelope body
+    When a job whose shared payload is under the inline ceiling is staged
+    Then the stored value is an envelope carrying the payload in its body
+    And no standalone blob key is written for it
+
+  @integration @track1 @unimplemented
+  Scenario: A mid-size payload offloads to a content-addressed Redis blob
+    When a job whose shared payload is between the inline ceiling and the S3 threshold is staged
+    Then the body is stored under a standalone Redis key named by its content hash
+    And the queued value is a flat envelope referencing the blob by tier "redis" and hash
+    And the handler receives the payload intact
+
+  @integration @track1 @unimplemented
+  Scenario: A very large payload offloads to S3 through the reused object store
+    When a job whose shared payload exceeds the S3 threshold is staged
+    Then the body is stored via the stored-objects registry under an s3:// key namespaced by projectId and content hash
+    And the queued value is a flat envelope referencing the blob by tier "s3" and hash
+    And the handler receives the payload intact
+
+  @unit @track1 @unimplemented
+  Scenario: The same bytes always produce the same blob key
+    Given two payloads with byte-identical canonical serializations
+    When each is offloaded
+    Then both resolve to the same content-addressed key
+    And the second offload is a no-op PUT over the existing key
+
+  # ===========================================================================
+  # Track 2 — flat jobs and content-addressed sharing (store-once)
+  # ===========================================================================
+
+  @integration @track2 @unimplemented
+  # The headline waste: one event today fans out to a dozen-plus jobs each
+  # carrying its own copy. After this change the event is stored once.
+  Scenario: One event fanned out to many jobs stores the shared payload once
+    Given an event is dispatched to a fold projection, several map projections, and a chain of reactors
+    When the resulting jobs are staged
+    Then the shared event is stored under a single content-addressed key
+    And every staged job references that key rather than embedding the event
+    And the number of stored copies of the event is one regardless of the fan-out width
+
+  @integration @track2 @unimplemented
+  Scenario: A reactor job references the shared event and its fold state separately
+    Given a fold whose reactors each receive the event and the same fold state
+    When the reactor jobs are staged
+    Then the event is stored once under its content hash
+    And the fold state is stored once under its content hash
+    And each reactor job carries a ref to the event and a ref to the fold state
+    And the handler still receives a payload deep-equal to { event, foldState }
+
+  @integration @track2 @unimplemented
+  # The producer-hoist payoff: a projection job (event sent spread) and a reactor
+  # job (event nested in { event, foldState }) carry DIFFERENT shapes, yet the
+  # event is lifted at the fan-out point before the shapes diverge, so both
+  # reference one stored copy. A per-job encoder hoist would miss this.
+  Scenario: A projection and a reactor for the same event share one stored event
+    Given one event dispatched to both a map projection and a reactor
+    When their jobs are staged
+    Then the event is hoisted at the fan-out point and stored once
+    And the projection job and the reactor job both reference that single copy
+    And the event was serialized and stored once for the fan-out, not once per job
+
+  @integration @track2 @unimplemented
+  Scenario: A flat job round-trips its payload through ref resolution unchanged
+    When a flat job is staged and later dispatched to its handler
+    Then the handler receives a payload deep-equal to the one that was sent
+    And a resolve-adapter reconstituted the components before the handler ran
+    And the wire value carried refs in place of the shared components
+
+  @unit @track2 @unimplemented
+  # Multi-tenancy guard: blob keys are namespaced by projectId (the tenant id;
+  # tenantId === projectId), matching the stored_objects layout
+  # s3://{bucket}/{projectId}/<hash>. Isolation is structural — in the key path —
+  # not incidental to content. This also makes a project purge a delete-by-prefix
+  # over .../{projectId}/* (driven by the platform's project-delete cascade); the
+  # redis tier needs none, its 3-day TTL clears once the project's jobs drain.
+  Scenario: Blob keys are namespaced by tenant so tenants never share a blob
+    Given two tenants whose jobs carry byte-identical user content
+    When each payload is offloaded
+    Then each blob key is namespaced under its own projectId
+    And the two payloads resolve to different keys
+    And neither tenant's job can resolve the other tenant's blob
+
+  # ===========================================================================
+  # Track 3 — holder-set reclaim and TTL backstop
+  # ===========================================================================
+
+  @integration @track3 @unimplemented
+  Scenario: A shared blob survives until its last referencing job completes
+    Given a blob referenced by three staged jobs
+    When two of the jobs complete
+    Then the blob is still present
+    When the third job completes
+    Then the blob is reclaimed
+    And its holder set is removed
+
+  @integration @track3 @unimplemented
+  # Composes the holder set with the dedup-id squash owned by
+  # record-span-gq-dedup.feature. SUPERSEDES payload-envelope.feature's GQ1
+  # scenario "Offloaded blobs displaced by a dedup squash are reclaimed":
+  # under GQ1 every job owned a private random-id blob, so the squash deleted
+  # the displaced blob unconditionally. Under v2 the blob may be shared, so the
+  # squashed slot only releases its hold — the blob goes iff no slot still holds it.
+  Scenario: A dedup squash releases its hold without dropping a still-referenced blob
+    Given two staged jobs referencing the same content-addressed blob
+    When a later job with the same dedup id squashes one of them in place
+    Then the squashed slot releases its hold on the blob
+    And the blob remains because the surviving slot still holds it
+
+  @integration @track3 @unimplemented
+  Scenario: A retry re-stage keeps the same content-addressed blob alive
+    Given an offloaded job that fails with a retryable error
+    When it is re-staged with its attempt counter incremented
+    Then the re-staged slot holds the same content-addressed blob
+    And the retry re-encodes to the same hash, so the hold is never released-then-needed
+    And the blob is not reclaimed across the retry
+
+  @integration @track3 @unimplemented
+  # Dispatch HDELs the job value out of the group hash and hands it to the worker
+  # in memory, so the blob must outlive dispatch; the hold releases only when the
+  # slot terminally retires (complete / exhaust / squash / decode-fail).
+  Scenario: A blob survives dispatch and is released only at terminal retirement
+    Given an offloaded job referencing a blob
+    When the job is dispatched to the worker
+    Then the blob is still present while the handler runs
+    And the hold is released only when the job terminally retires
+
+  @integration @track3 @unimplemented
+  # The one TOCTOU the holder set alone doesn't close: the release (SREM +
+  # reclaim-if-empty) must be atomic against a concurrent re-stage of the same
+  # content, or the last completion could delete a blob a new job just took.
+  Scenario: A completion racing a re-stage of the same content does not delete the live blob
+    Given a blob whose last holder is completing
+    And a new job referencing the same content is staged concurrently
+    When the release runs
+    Then the blob is retained because the new job holds it
+    And no job is left referencing a deleted blob
+
+  @integration @track3 @unimplemented
+  Scenario: An S3-tier blob is reclaimed through the sweeper when its holders empty
+    Given an S3-tier blob referenced by a single staged job
+    When that last referencing job completes
+    Then the blob's key is enqueued for best-effort sweep deletion
+    And the object-store lifecycle rule reclaims it if the sweep is missed
+
+  @integration @track3 @unimplemented
+  Scenario: An access refreshes a blob's TTL so a long-dwell job keeps its payload
+    Given an offloaded job held in a retry-backoff chain
+    When the job is dispatched after a delay shorter than the TTL
+    Then the dispatch refreshes the blob's TTL
+    And the blob is still present for the handler
+
+  @integration @track3 @unimplemented
+  # Crash between the client PUT and the Lua stage leaves a blob with an empty
+  # holder set; nothing eager reclaims it, so the backstop must.
+  Scenario: An orphaned blob with no holders expires via its TTL backstop
+    Given a blob written to Redis whose staging never completed
+    And no job references it
+    When the TTL backstop elapses without any access refreshing it
+    Then the blob is reclaimed
+
+  @integration @track3 @unimplemented
+  # Carried forward from payload-envelope.feature's GQ1 fail-safe "A missing
+  # blob does not wedge the group"; the guarantee survives the rewrite intact.
+  Scenario: A missing blob completes the slot without wedging the group
+    Given a flat job whose referenced blob has expired or been deleted
+    When dispatch delivers it to the worker
+    Then the job is completed without invoking the handler
+    And the group continues processing subsequent jobs
+    And the work remains recoverable via event replay
+
+  # ===========================================================================
+  # Track 4 — rollout and backward compatibility
+  # ===========================================================================
+
+  @integration @track4 @unimplemented
+  Scenario: Envelope v2 writes stay off until the whole fleet reads v2
+    Given envelope v2 writes have not been enabled for the deployment
+    When a job is staged
+    Then the stored value uses the previous on-the-wire format readable by the prior release
+    And dispatch and the ops dashboard read it through the dual readers
+
+  @integration @track4 @unimplemented
+  Scenario: Legacy GQ1 and bare-JSON jobs staged before the deploy still process
+    Given a job staged as a GQ1 envelope or plain JSON by a previous deployment
+    When dispatch evaluates and delivers that job
+    Then the handler receives the original payload
+    And no content-addressed blob is required to resolve it
+
+  @integration @track4 @unimplemented
+  Scenario: A pod on the previous release drops a v2 value it cannot parse
+    Given a job staged as a v2 envelope
+    When a pod from the previous release dispatches it
+    Then it completes the group slot without invoking the handler
+    And the work remains recoverable via event replay
+
+  # ===========================================================================
+  # --- AC Coverage Map (ADR-029) ---
+  # Track 1 — content-addressed tiers
+  #   AC1.1 "Size picks the tier; inline stays inline"
+  #     -> A sub-threshold payload stays inline in the envelope body
+  #   AC1.2 "Mid-size offloads to a content-addressed Redis blob"
+  #     -> A mid-size payload offloads to a content-addressed Redis blob
+  #   AC1.3 "Very large offloads to the S3 tier (reused stored-objects store)"
+  #     -> A very large payload offloads to S3 through the reused object store
+  #   AC1.4 "Identical bytes collapse to one key; PUT is idempotent"
+  #     -> The same bytes always produce the same blob key
+  # Track 2 — flat jobs and content-addressed sharing
+  #   AC2.1 "One event fanned out N ways is stored once" (the headline win)
+  #     -> One event fanned out to many jobs stores the shared payload once
+  #   AC2.2 "Event and fold state are hoisted and referenced separately"
+  #     -> A reactor job references the shared event and its fold state separately
+  #   AC2.3 "Flat job round-trips its payload unchanged"
+  #     -> A flat job round-trips its payload through ref resolution unchanged
+  #   AC2.4 "Blob keys namespaced by tenant; tenants never share a blob; purge by prefix"
+  #     -> Blob keys are namespaced by tenant so tenants never share a blob
+  #   AC2.5 "Producer-hoist: cross-shape dedup + serialize-once per fan-out"
+  #     -> A projection and a reactor for the same event share one stored event
+  # Track 3 — holder-set reclaim and TTL backstop
+  #   AC3.1 "Blob lives until the last referencing job completes"
+  #     -> A shared blob survives until its last referencing job completes
+  #   AC3.2 "Dedup squash releases one hold, not the shared blob" (supersedes GQ1)
+  #     -> A dedup squash releases its hold without dropping a still-referenced blob
+  #   AC3.3 "Retry keeps the same blob alive"
+  #     -> A retry re-stage keeps the same content-addressed blob alive
+  #   AC3.4 "S3-tier reclaim via sweeper + lifecycle backstop"
+  #     -> An S3-tier blob is reclaimed through the sweeper when its holders empty
+  #   AC3.5 "Access refreshes TTL for long-dwell jobs"
+  #     -> An access refreshes a blob's TTL so a long-dwell job keeps its payload
+  #   AC3.6 "Orphaned blob expires via the backstop"
+  #     -> An orphaned blob with no holders expires via its TTL backstop
+  #   AC3.7 "Missing blob is a fail-safe, not a wedge" (carried from ADR-026)
+  #     -> A missing blob completes the slot without wedging the group
+  #   AC3.8 "Blob survives dispatch; released only at terminal retirement"
+  #     -> A blob survives dispatch and is released only at terminal retirement
+  #   AC3.9 "Atomic release vs concurrent re-stage (TOCTOU)"
+  #     -> A completion racing a re-stage of the same content does not delete the live blob
+  # Track 4 — rollout and backward compatibility
+  #   AC4.1 "v2 writes gated until the fleet reads v2"
+  #     -> Envelope v2 writes stay off until the whole fleet reads v2
+  #   AC4.2 "Legacy GQ1 / bare-JSON jobs still process"
+  #     -> Legacy GQ1 and bare-JSON jobs staged before the deploy still process
+  #   AC4.3 "Old pod drops an unparseable v2 value safely"
+  #     -> A pod on the previous release drops a v2 value it cannot parse
+  #
+  # Count: 21 behavioral ACs -> 21 scenarios. All @unimplemented pending the
+  # Outside-In TDD pass (integration tests first, then unit, then code).
+  # ===========================================================================


### PR DESCRIPTION
## Why

The event-sourcing GroupQueue fans one event out to ~30 reactor jobs, each staging a full copy of the same large payload (event + fold state). Thirty identical multi-KB-to-MB bodies per fan-out waste Redis memory and bandwidth, and bloat the Lua scripts they transit. This offloads large payloads to a content-addressed store so jobs carry a small reference instead of a full copy.

No linked issue.

## What changed

- A content-addressed, tenant-namespaced tiered blob store: payloads over 4 KiB offload to Redis (mid-size) or the existing stored-objects store (over 256 KiB), keyed by `{projectId}/{sha256}`. Byte-identical user payloads collapse to one stored blob — including across reactor fan-out: the queue-machinery fields (`__jobName` / `__attempt` / `__context` / etc.) are lifted into the envelope header so they don't perturb the hashed body, so 30 reactors over one event share one blob.
- Holder-set reference counting: a per-blob Redis SET tracks referencing jobs; the last release reclaims the blob (atomic Lua), with a 3-day TTL backstop.
- ADR-030 hardening: a 50 MiB payload cap, a gunzip decompression cap, transient-vs-missing store-error handling (retry vs fail-safe), coordinated blob/holder TTLs with refresh-on-access, atomic hold transfer on retry/squash, read-location re-mint from server-trusted inputs, a cluster-slot guard, and a branded `TenantId` through the blob path.
- Extracted the blob lifecycle out of the 1224-LOC `GroupQueueProcessor` into an `EnvelopeBlobLifecycle` collaborator.
- **Documentation refresh.** The event-sourcing `ARCHITECTURE.md` had stale claims that GroupQueue runs on BullMQ — it doesn't, and hasn't for some time. Rewrote the Queue System / Process Roles / Failure Handling sections. Added a dedicated `queues/groupQueue/ARCHITECTURE.md` (technical deep dive — staging Lua, dispatcher loop, tiered envelope across inline → Redis blob → S3, content-addressed sharing, holder-set refcount, retries, dedup, coalescing, pause/resume, tenant isolation) and `queues/groupQueue/README.md` (usage guide — when to reach for it, configuration, process roles, caveats, testing, observability).

## How it works

The staged value is a versioned envelope (`GQ2|<headerLen>|<headerJson><body>`). Small payloads stay inline; large ones move to the tiered store and the envelope carries a reference plus a per-stage hold token. Reads re-derive the storage location from `(projectId, contentHash)` rather than trusting a stored URI, and decode caps decompression so a tampered blob can't OOM the worker. GQ2 writes are gated behind `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED`; old pods drop unparseable GQ2 values and recover via event replay. Design in ADR-029 (store) and ADR-030 (hardening); behaviour in the two `.feature` files.

## Test plan

- [ ] `pnpm test:unit` (45) - envelope encode/decode, size cap, zip-bomb guard, hash-over-raw, tiering, re-mint, transient classification, hash-tag guard, fan-out content-sharing (identical user payload + different machinery → one stored blob)
- [ ] `pnpm test:integration` (44) - holder release/transfer Lua reclaim sequences (incl. release-without-acquire, self-transfer, s3 reclaim), GETEX TTL refresh, the `EnvelopeBlobLifecycle` seam (incl. cross-tenant ref refusal on decode and release and transfer), and GQ2 end-to-end (offload to dispatch to reclaim, tenant-namespaced key, transient recovery)
- [ ] typecheck + biome clean

## Anything surprising?

- GQ2 writes are flag-gated and not yet enabled in production; this lands the machinery, enabling is a follow-up.
- Streaming-to-S3 (an earlier ADR-030 idea) was dropped: the 50 MiB cap is the real OOM bound, and true streaming would need a stored-objects change plus a new dependency. ADR-030 section 1 records it.
- Three review passes (code / security / test) ran on this branch. The top findings are fixed here: a gunzip decompression cap (zip-bomb guard), `sendBatch` routed through the atomic transfer (closing the partial-failure reclaim gap `send()` already had), and a direct `EnvelopeBlobLifecycle` integration test (which also caught that the s3-tier fixtures were silently compressible, so the transient test never reached s3).
- A CodeRabbit pass hardened it further: the Lua now guards a no-op release / self-transfer against reclaiming a live blob and passes only the keys that exist (no s3-tier CROSSSLOT in cluster mode), the object-store read is byte-capped, a destination-resolve failure is classified transient, and test cleanup is namespace-scoped rather than a global flushall.
- A second review pass (review-code / review-security) added the decode-time tenant cross-check (a blob ref whose `projectId` ≠ the group's tenant is refused before fetching → fail-safe), redacted storage URIs out of the lifecycle error logs, centralized the redis blob-key layout into one module so the store and the holder Lua can't drift, and extracted the shared in-memory test doubles.
- The branch was rewritten into four logical commits (docs/ADRs + specs · primitives + unit tests · GroupQueue wiring + integration · routing-exclusion) — the prior 31-commit history is preserved on the local `backup/pre-flatten` ref for archaeology if anyone wants it.
- Remaining follow-ups, none blocking a flag-gated merge: an S3 lifecycle rule as the reclaim backstop (s3 has no TTL, so a missed inline delete leaks the object); a queue-level end-to-end fan-out dedup integration test (the encode-level invariant is covered in `jobEnvelope.unit.test.ts`; multi-reactor wiring stays `@unimplemented` in the spec); and a couple of TTL-bounded dedup/coalescing edges.

## Deployment Impact

Low. GQ2 writes are gated behind `GROUP_QUEUE_ENVELOPE_WRITES_ENABLED` (default off), so with the flag unset this code is dormant and queue behaviour is unchanged. No new dependencies, no required env vars, no schema migrations; it reuses the existing Redis and stored-objects (S3) infrastructure.

Rollout is staged: enable the flag only once every consumer in the fleet reads GQ2 envelopes (old pods drop unparseable GQ2 values and recover via event replay), which is a separate operational step from this PR. Before enabling with the s3 tier in use, put the S3 reclaim backstop (a bucket lifecycle rule, noted under "Anything surprising?") in place, since s3 objects have no TTL unlike the redis tier.
