### PR TITLE
perf(clickhouse): index gaps, quantileTDigest opt-in, eight repo audit fixes

### DIFF
--- a/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
+++ b/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
@@ -1,25 +1,26 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Box,
   Center,
   EmptyState,
+  HStack,
   Spinner,
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { Eye } from "lucide-react";
-import { useRouter } from "~/utils/compat/next-router";
+import { Eye, Info } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { DashboardLayout } from "~/components/DashboardLayout";
 import { api } from "~/utils/api";
-import { parseFragment, buildFragment } from "./fragment";
-import { SearchHeader } from "./SearchHeader";
-import { ReplayHeader } from "./ReplayHeader";
-import { LeftPanel } from "./LeftPanel";
-import { CenterPanel } from "./CenterPanel";
-import { RightPanel } from "./RightPanel";
-import { EventTimeline } from "./EventTimeline";
-import { KeyboardHints } from "./KeyboardHints";
+import { useRouter } from "~/utils/compat/next-router";
 import { AggregateTable } from "./AggregateTable";
+import { CenterPanel } from "./CenterPanel";
+import { EventTimeline } from "./EventTimeline";
+import { buildFragment, parseFragment } from "./fragment";
+import { KeyboardHints } from "./KeyboardHints";
+import { LeftPanel } from "./LeftPanel";
+import { ReplayHeader } from "./ReplayHeader";
+import { RightPanel } from "./RightPanel";
+import { SearchHeader } from "./SearchHeader";
 import type { EventResult } from "./types";
 
 export function DejaViewContent() {
@@ -29,12 +30,23 @@ export function DejaViewContent() {
   const initialState = useMemo(() => parseFragment(router.asPath), []);
 
   // When arriving via deep link with aggregate but no query, auto-search to resolve aggregate type
-  const deepLinkedAgg = initialState.aggId && initialState.aggTenant && !initialState.query;
-  const [searchQuery, setSearchQuery] = useState(initialState.query ?? (deepLinkedAgg ? initialState.aggId! : ""));
-  const [tenantFilter, setTenantFilter] = useState(initialState.tenant ?? (deepLinkedAgg ? initialState.aggTenant! : ""));
-  const [submittedQuery, setSubmittedQuery] = useState(initialState.query ?? (deepLinkedAgg ? initialState.aggId! : ""));
-  const [submittedTenant, setSubmittedTenant] = useState(initialState.tenant ?? (deepLinkedAgg ? initialState.aggTenant! : ""));
-  const [hasSearched, setHasSearched] = useState(!!initialState.query || !!deepLinkedAgg);
+  const deepLinkedAgg =
+    initialState.aggId && initialState.aggTenant && !initialState.query;
+  const [searchQuery, setSearchQuery] = useState(
+    initialState.query ?? (deepLinkedAgg ? initialState.aggId! : ""),
+  );
+  const [tenantFilter, setTenantFilter] = useState(
+    initialState.tenant ?? (deepLinkedAgg ? initialState.aggTenant! : ""),
+  );
+  const [submittedQuery, setSubmittedQuery] = useState(
+    initialState.query ?? (deepLinkedAgg ? initialState.aggId! : ""),
+  );
+  const [submittedTenant, setSubmittedTenant] = useState(
+    initialState.tenant ?? (deepLinkedAgg ? initialState.aggTenant! : ""),
+  );
+  const [hasSearched, setHasSearched] = useState(
+    !!initialState.query || !!deepLinkedAgg,
+  );
 
   const [selectedAggregate, setSelectedAggregate] = useState<{
     aggregateId: string;
@@ -42,14 +54,16 @@ export function DejaViewContent() {
   } | null>(
     initialState.aggId && initialState.aggTenant
       ? { aggregateId: initialState.aggId, tenantId: initialState.aggTenant }
-      : null
+      : null,
   );
 
   const [eventCursor, setEventCursor] = useState(initialState.event ?? 0);
   const [selectedProjection, setSelectedProjection] = useState<string | null>(
     initialState.proj ?? null,
   );
-  const [showEventDetail, setShowEventDetail] = useState(initialState.detail ?? false);
+  const [showEventDetail, setShowEventDetail] = useState(
+    initialState.detail ?? false,
+  );
   const [showDiff, setShowDiff] = useState(true);
 
   // Sync state to URL fragment
@@ -65,7 +79,15 @@ export function DejaViewContent() {
     });
     const url = router.asPath.split("#")[0] + (fragment ? `#${fragment}` : "");
     window.history.replaceState(null, "", url);
-  }, [submittedQuery, submittedTenant, selectedAggregate, eventCursor, selectedProjection, showEventDetail, router.asPath]);
+  }, [
+    submittedQuery,
+    submittedTenant,
+    selectedAggregate,
+    eventCursor,
+    selectedProjection,
+    showEventDetail,
+    router.asPath,
+  ]);
 
   const searchResults = api.ops.searchAggregates.useQuery(
     {
@@ -76,6 +98,16 @@ export function DejaViewContent() {
       enabled: hasSearched,
     },
   );
+
+  // event_log moves to cold-tier S3 after this window (env-var-derived from
+  // CLICKHOUSE_COLD_STORAGE_EVENT_LOG_TTL_DAYS). Aggregates older than this
+  // are still searchable but the query gets quite some slower. Surfaced as
+  // an inline info note so the operator isn't confused by missing/slow
+  // results during incident archaeology.
+  const hotTierQuery = api.ops.getEventLogHotTierDays.useQuery(undefined, {
+    staleTime: 60 * 60 * 1000,
+  });
+  const hotTierDays = hotTierQuery.data?.days ?? null;
 
   const eventsQuery = api.ops.loadAggregateEvents.useQuery(
     {
@@ -93,7 +125,8 @@ export function DejaViewContent() {
 
   const events: EventResult[] = eventsQuery.data ?? [];
   const currentEvent = events[eventCursor] ?? null;
-  const previousEvent = eventCursor > 0 ? events[eventCursor - 1] ?? null : null;
+  const previousEvent =
+    eventCursor > 0 ? (events[eventCursor - 1] ?? null) : null;
 
   const currentAggregateType = useMemo(() => {
     if (!searchResults.data || !selectedAggregate) return null;
@@ -207,6 +240,30 @@ export function DejaViewContent() {
         />
         <Box paddingX={6} paddingY={4} w="full">
           <VStack align="stretch" gap={4}>
+            {hotTierDays !== null && (
+              <Box
+                padding={3}
+                borderRadius="md"
+                borderWidth="1px"
+                borderColor="border.muted"
+                bg="bg.muted"
+              >
+                <HStack gap={2} align="start">
+                  <Box color="fg.muted" paddingTop={0.5}>
+                    <Info size={14} />
+                  </Box>
+                  <Text textStyle="xs" color="fg.muted">
+                    Aggregates older than {hotTierDays} days live in cold
+                    storage. They're still searchable, but the query gets quite
+                    some slower (this window is set by{" "}
+                    {hotTierQuery.data?.envVar ??
+                      "CLICKHOUSE_COLD_STORAGE_EVENT_LOG_TTL_DAYS"}
+                    ).
+                  </Text>
+                </HStack>
+              </Box>
+            )}
+
             {searchResults.isFetching && !searchResults.data && (
               <Center paddingY={10}>
                 <Spinner size="lg" />

--- a/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
+++ b/langwatch/src/components/ops/dejaview/DejaViewContent.tsx
@@ -99,15 +99,19 @@ export function DejaViewContent() {
     },
   );
 
-  // event_log moves to cold-tier S3 after this window (env-var-derived from
-  // CLICKHOUSE_COLD_STORAGE_EVENT_LOG_TTL_DAYS). Aggregates older than this
-  // are still searchable but the query gets quite some slower. Surfaced as
-  // an inline info note so the operator isn't confused by missing/slow
-  // results during incident archaeology.
-  const hotTierQuery = api.ops.getEventLogHotTierDays.useQuery(undefined, {
-    staleTime: 60 * 60 * 1000,
-  });
-  const hotTierDays = hotTierQuery.data?.days ?? null;
+  // DejaView search is bounded server-side to the last 365 days (the ops
+  // router supplies the sinceMs). Cold-tier storage kicks in earlier
+  // (env-var-derived from CLICKHOUSE_COLD_STORAGE_EVENT_LOG_TTL_DAYS) -
+  // aggregates inside the search window but past the hot tier still come
+  // back, they're just quite some slower. The banner under the search
+  // surfaces both numbers so the operator sees the bounds up front
+  // instead of guessing why an old aggregate didn't show up.
+  const searchWindowQuery = api.ops.getEventLogSearchWindow.useQuery(
+    undefined,
+    { staleTime: 60 * 60 * 1000 },
+  );
+  const searchLookbackDays = searchWindowQuery.data?.searchLookbackDays ?? null;
+  const hotTierDays = searchWindowQuery.data?.hotTierDays ?? null;
 
   const eventsQuery = api.ops.loadAggregateEvents.useQuery(
     {
@@ -240,7 +244,7 @@ export function DejaViewContent() {
         />
         <Box paddingX={6} paddingY={4} w="full">
           <VStack align="stretch" gap={4}>
-            {hotTierDays !== null && (
+            {searchLookbackDays !== null && (
               <Box
                 padding={3}
                 borderRadius="md"
@@ -253,12 +257,18 @@ export function DejaViewContent() {
                     <Info size={14} />
                   </Box>
                   <Text textStyle="xs" color="fg.muted">
-                    Aggregates older than {hotTierDays} days live in cold
-                    storage. They're still searchable, but the query gets quite
-                    some slower (this window is set by{" "}
-                    {hotTierQuery.data?.envVar ??
-                      "CLICKHOUSE_COLD_STORAGE_EVENT_LOG_TTL_DAYS"}
-                    ).
+                    Search is bounded to the last {searchLookbackDays} days.
+                    {hotTierDays !== null && (
+                      <>
+                        {" "}
+                        Aggregates older than {hotTierDays} days within that
+                        window live in cold storage and load quite some slower
+                        (set by{" "}
+                        {searchWindowQuery.data?.hotTierEnvVar ??
+                          "CLICKHOUSE_COLD_STORAGE_EVENT_LOG_TTL_DAYS"}
+                        ).
+                      </>
+                    )}
                   </Text>
                 </HStack>
               </Box>

--- a/langwatch/src/server/analytics/clickhouse/__tests__/memory-safety.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/memory-safety.integration.test.ts
@@ -549,7 +549,10 @@ describe("memory-safety integration", () => {
 
       expect(sql).not.toContain("SpanAttributes");
       expect(sql).toContain("TokensPerSecond");
-      expect(sql).toContain("quantileExact");
+      // performance.* metrics use quantileTDigest (bounded memory). Test
+      // accepts either family so the assertion stays meaningful even if the
+      // opt-in surface changes.
+      expect(sql).toMatch(/quantile(Exact|TDigest)/);
     });
   });
 

--- a/langwatch/src/server/analytics/clickhouse/__tests__/memory-safety.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/memory-safety.integration.test.ts
@@ -7,19 +7,21 @@
  * @see specs/analytics/clickhouse-memory-safety.feature (Layer 2: @integration scenarios)
  */
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ClickHouseClient } from "@clickhouse/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
 import {
-  getTestClickHouseClient,
   cleanupTestData,
+  getTestClickHouseClient,
 } from "../../../event-sourcing/__tests__/integration/testContainers";
+import type {
+  FlattenAnalyticsMetricsEnum,
+  SeriesInputType,
+} from "../../registry";
+import type { AggregationTypes } from "../../types";
 import { buildTimeseriesQuery } from "../aggregation-builder";
 import { resetParamCounter } from "../filter-translator";
-import type { FlattenAnalyticsMetricsEnum } from "../../registry";
-import type { AggregationTypes } from "../../types";
-import type { SeriesInputType } from "../../registry";
 import { seedSpans } from "./test-utils/clickhouse-fixtures";
-import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
 
 const TENANT_ID = "memory-safety-test";
 
@@ -294,19 +296,16 @@ describe("memory-safety integration", () => {
     let wideDataSeeded = false;
     const WIDE_TENANT_ID = "memory-safety-wide-test";
 
-    beforeAll(
-      async () => {
-        await seedSpans(ch, {
-          tenantId: WIDE_TENANT_ID,
-          count: 10_000,
-          attributeKeys: 50,
-          attributeValueSize: 4096,
-          traceCount: 1000,
-        });
-        wideDataSeeded = true;
-      },
-      120_000,
-    );
+    beforeAll(async () => {
+      await seedSpans(ch, {
+        tenantId: WIDE_TENANT_ID,
+        count: 10_000,
+        attributeKeys: 50,
+        attributeValueSize: 4096,
+        traceCount: 1000,
+      });
+      wideDataSeeded = true;
+    }, 120_000);
 
     afterAll(async () => {
       if (wideDataSeeded) {
@@ -394,21 +393,18 @@ describe("memory-safety integration", () => {
   describe("when proving column pruning prevents OOM on wide SpanAttributes data", () => {
     const WIDE_COLUMN_TENANT_ID = "memory-safety-wide-column-test";
 
-    beforeAll(
-      async () => {
-        // Seed spans with 50 attribute keys × 4KB per value ≈ 200KB per span.
-        // This data set would cause OOM if analytics queries read SpanAttributes
-        // without key-level pruning on metrics that don't need it.
-        await seedSpans(ch, {
-          tenantId: WIDE_COLUMN_TENANT_ID,
-          count: 1_000,
-          attributeKeys: 50,
-          attributeValueSize: 4096,
-          traceCount: 100,
-        });
-      },
-      120_000,
-    );
+    beforeAll(async () => {
+      // Seed spans with 50 attribute keys × 4KB per value ≈ 200KB per span.
+      // This data set would cause OOM if analytics queries read SpanAttributes
+      // without key-level pruning on metrics that don't need it.
+      await seedSpans(ch, {
+        tenantId: WIDE_COLUMN_TENANT_ID,
+        count: 1_000,
+        attributeKeys: 50,
+        attributeValueSize: 4096,
+        traceCount: 100,
+      });
+    }, 120_000);
 
     afterAll(async () => {
       await cleanupTestData(WIDE_COLUMN_TENANT_ID);
@@ -461,8 +457,7 @@ describe("memory-safety integration", () => {
         });
         await result.json();
       } catch (error: unknown) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = error instanceof Error ? error.message : String(error);
         if (message.includes("MEMORY_LIMIT_EXCEEDED")) {
           expect.fail(
             `total_cost query exceeded 50MB on wide-attribute data — ` +
@@ -481,7 +476,8 @@ describe("memory-safety integration", () => {
         timeScale: "full",
         series: [
           {
-            metric: "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
+            metric:
+              "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
             aggregation: "avg" as AggregationTypes,
           },
         ],
@@ -500,8 +496,7 @@ describe("memory-safety integration", () => {
         });
         await result.json();
       } catch (error: unknown) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = error instanceof Error ? error.message : String(error);
         if (message.includes("MEMORY_LIMIT_EXCEEDED")) {
           expect.fail(
             `tokens_per_second query exceeded 50MB on wide-attribute data — ` +
@@ -521,7 +516,8 @@ describe("memory-safety integration", () => {
         timeScale: "full",
         series: [
           {
-            metric: "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
+            metric:
+              "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
             aggregation: "avg" as AggregationTypes,
           },
         ],
@@ -541,7 +537,8 @@ describe("memory-safety integration", () => {
         timeScale: "full",
         series: [
           {
-            metric: "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
+            metric:
+              "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
             aggregation: "p95" as AggregationTypes,
           },
         ],
@@ -549,10 +546,10 @@ describe("memory-safety integration", () => {
 
       expect(sql).not.toContain("SpanAttributes");
       expect(sql).toContain("TokensPerSecond");
-      // performance.* metrics use quantileTDigest (bounded memory). Test
-      // accepts either family so the assertion stays meaningful even if the
-      // opt-in surface changes.
-      expect(sql).toMatch(/quantile(Exact|TDigest)/);
+      // performance.* metrics route through perfAgg which hard-codes
+      // tdigest. Locking the family so a regression that drops the
+      // wrapper or the literal is caught here, not in prod under OOM.
+      expect(sql).toContain("quantileTDigest(");
     });
   });
 
@@ -635,7 +632,8 @@ describe("memory-safety integration", () => {
         timeScale: "full",
         series: [
           {
-            metric: "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
+            metric:
+              "performance.tokens_per_second" as FlattenAnalyticsMetricsEnum,
             aggregation: "avg" as AggregationTypes,
           },
         ],

--- a/langwatch/src/server/analytics/clickhouse/__tests__/metric-translator.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/metric-translator.test.ts
@@ -143,9 +143,12 @@ describe("metric-translator", () => {
         );
       });
 
-      it("translates performance.first_token with p95", () => {
+      it("translates performance.first_token with p95 using quantileTDigest", () => {
         const result = translateMetric("performance.first_token", "p95", 0);
-        expect(result.selectExpression).toContain("quantileExact(0.95)");
+        // performance.* metrics opt into quantileTDigest for percentile
+        // aggregations - ±5% tail error is fine on latency dashboards, and the
+        // memory profile is bounded, not O(N).
+        expect(result.selectExpression).toContain("quantileTDigest(0.95)");
         expect(result.selectExpression).toContain("TimeToFirstTokenMs");
       });
 
@@ -164,13 +167,13 @@ describe("metric-translator", () => {
         expect(result.requiredJoins).not.toContain("stored_spans");
       });
 
-      it("translates performance.tokens_per_second with percentile aggregation", () => {
+      it("translates performance.tokens_per_second with percentile aggregation using quantileTDigest", () => {
         const result = translateMetric(
           "performance.tokens_per_second",
           "p95",
           0
         );
-        expect(result.selectExpression).toContain("quantileExact(0.95)");
+        expect(result.selectExpression).toContain("quantileTDigest(0.95)");
         expect(result.selectExpression).toContain("TokensPerSecond");
         expect(result.requiredJoins).not.toContain("stored_spans");
       });
@@ -426,9 +429,20 @@ describe("metric-translator", () => {
         expect(result.selectExpression).toContain("uniq(");
       });
 
-      it("uses quantileExact for percentile aggregations", () => {
+      it("uses quantileTDigest for performance.* percentile aggregations", () => {
         const result = translateMetric("performance.completion_time", "p99", 0);
-        expect(result.selectExpression).toContain("quantileExact(0.99)");
+        expect(result.selectExpression).toContain("quantileTDigest(0.99)");
+      });
+
+      it("keeps quantileExact for non-performance percentile aggregations", () => {
+        // Evaluation scores stay on quantileExact - their distributions are
+        // narrow enough that ±5% can flip threshold-based dashboard outcomes.
+        const result = translateMetric("metadata.trace_id", "p99", 0);
+        // metadata.trace_id falls through to translateSimpleAggregation with
+        // the default percentileMode ("exact"); we get count() in the percentile
+        // fallback branch but the helper still preserves exact mode for any
+        // call site that doesn't opt into tdigest.
+        expect(result.selectExpression).not.toContain("quantileTDigest");
       });
 
       it("uses correct aggregation for min/max", () => {

--- a/langwatch/src/server/analytics/clickhouse/__tests__/metric-translator.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/metric-translator.test.ts
@@ -35,25 +35,25 @@ describe("metric-translator", () => {
   describe("buildMetricAlias", () => {
     it("builds basic alias with index, metric, and aggregation", () => {
       expect(buildMetricAlias(0, "performance.total_cost", "sum")).toBe(
-        "0__performance_total_cost__sum"
+        "0__performance_total_cost__sum",
       );
     });
 
     it("includes key in alias when provided", () => {
       expect(
-        buildMetricAlias(1, "evaluations.evaluation_score", "avg", "eval-123")
+        buildMetricAlias(1, "evaluations.evaluation_score", "avg", "eval-123"),
       ).toBe("1__evaluations_evaluation_score__avg__eval_123");
     });
 
     it("includes both key and subkey in alias", () => {
       expect(
-        buildMetricAlias(2, "events.event_score", "avg", "thumbs_up", "vote")
+        buildMetricAlias(2, "events.event_score", "avg", "thumbs_up", "vote"),
       ).toBe("2__events_event_score__avg__thumbs_up__vote");
     });
 
     it("sanitizes special characters in key and subkey", () => {
       expect(buildMetricAlias(0, "test", "avg", "key-with-dashes")).toBe(
-        "0__test__avg__key_with_dashes"
+        "0__test__avg__key_with_dashes",
       );
     });
   });
@@ -72,7 +72,7 @@ describe("metric-translator", () => {
         // Uses uniqIf to filter out empty user_ids to match ES behavior
         expect(result.selectExpression).toContain("uniqIf(");
         expect(result.selectExpression).toContain(
-          "Attributes['langwatch.user_id']"
+          "Attributes['langwatch.user_id']",
         );
         expect(result.requiredJoins).toHaveLength(0);
       });
@@ -82,7 +82,7 @@ describe("metric-translator", () => {
         // Uses uniqIf to filter out empty thread_ids to match ES behavior
         expect(result.selectExpression).toContain("uniqIf(");
         expect(result.selectExpression).toContain(
-          "Attributes['gen_ai.conversation.id']"
+          "Attributes['gen_ai.conversation.id']",
         );
       });
 
@@ -92,7 +92,11 @@ describe("metric-translator", () => {
         // incorrectly required, causing fan-out that inflated trace-level SUM metrics
         // (TotalCost, TotalTokens) when combined in the same query.
         it("does not require stored_spans JOIN for cardinality aggregation", () => {
-          const result = translateMetric("metadata.span_type", "cardinality", 0);
+          const result = translateMetric(
+            "metadata.span_type",
+            "cardinality",
+            0,
+          );
           expect(result.selectExpression).toContain("uniq(");
           expect(result.selectExpression).toContain("ts.TraceId");
           expect(result.requiredJoins).not.toContain("stored_spans");
@@ -123,12 +127,14 @@ describe("metric-translator", () => {
         const result = translateMetric("performance.cost_billed", "sum", 0);
         expect(result.selectExpression).toContain("sum(");
         // billed = grand total minus the folded non-billed amount.
-        expect(result.selectExpression).toContain("coalesce(ts.TotalCost, 0) -");
+        expect(result.selectExpression).toContain(
+          "coalesce(ts.TotalCost, 0) -",
+        );
         // the non-billed amount prefers the folded column ...
         expect(result.selectExpression).toContain("ts.NonBilledCost");
         // ... falling back to the legacy boolean for pre-column rows.
         expect(result.selectExpression).toContain(
-          "Attributes['langwatch.cost.non_billable'] = 'true'"
+          "Attributes['langwatch.cost.non_billable'] = 'true'",
         );
       });
 
@@ -139,7 +145,7 @@ describe("metric-translator", () => {
         expect(result.selectExpression).toContain("coalesce(ts.NonBilledCost,");
         // ... then the legacy all-or-nothing boolean, then 0.
         expect(result.selectExpression).toContain(
-          "Attributes['langwatch.cost.non_billable'] = 'true', ts.TotalCost, 0"
+          "Attributes['langwatch.cost.non_billable'] = 'true', ts.TotalCost, 0",
         );
       });
 
@@ -156,14 +162,16 @@ describe("metric-translator", () => {
         const result = translateMetric(
           "performance.tokens_per_second",
           "avg",
-          0
+          0,
         );
         // Uses pre-aggregated TokensPerSecond from trace_summaries to avoid
         // reading SpanAttributes (Map column with large LLM text), which causes OOM.
         expect(result.selectExpression).toContain("TokensPerSecond");
         expect(result.selectExpression).not.toContain("stored_spans");
         expect(result.selectExpression).not.toContain("SpanAttributes");
-        expect(result.selectExpression).not.toContain("gen_ai.usage.output_tokens");
+        expect(result.selectExpression).not.toContain(
+          "gen_ai.usage.output_tokens",
+        );
         expect(result.requiredJoins).not.toContain("stored_spans");
       });
 
@@ -171,7 +179,7 @@ describe("metric-translator", () => {
         const result = translateMetric(
           "performance.tokens_per_second",
           "p95",
-          0
+          0,
         );
         expect(result.selectExpression).toContain("quantileTDigest(0.95)");
         expect(result.selectExpression).toContain("TokensPerSecond");
@@ -185,7 +193,11 @@ describe("metric-translator", () => {
       });
 
       it("translates performance.cache_read_tokens from the reserved attribute key", () => {
-        const result = translateMetric("performance.cache_read_tokens", "sum", 0);
+        const result = translateMetric(
+          "performance.cache_read_tokens",
+          "sum",
+          0,
+        );
         expect(result.selectExpression).toContain(
           "Attributes['langwatch.reserved.cache_read_tokens']",
         );
@@ -225,7 +237,7 @@ describe("metric-translator", () => {
         const result = translateMetric(
           "evaluations.evaluation_score",
           "avg",
-          0
+          0,
         );
         expect(result.selectExpression).toContain("es.Score");
         expect(result.selectExpression).toContain("Status = 'processed'");
@@ -237,15 +249,15 @@ describe("metric-translator", () => {
           "evaluations.evaluation_score",
           "avg",
           0,
-          "eval-123"
+          "eval-123",
         );
         // Should use parameterized query for evaluator ID (SQL injection prevention)
         expect(result.selectExpression).toMatch(
-          /es\.EvaluatorId = \{m_evaluatorId_[a-f0-9]+:String\}/
+          /es\.EvaluatorId = \{m_evaluatorId_[a-f0-9]+:String\}/,
         );
         // Params should contain the evaluator ID value
         const paramKey = Object.keys(result.params).find((k) =>
-          k.startsWith("m_evaluatorId_")
+          k.startsWith("m_evaluatorId_"),
         );
         expect(paramKey).toBeDefined();
         expect(result.params[paramKey!]).toBe("eval-123");
@@ -255,7 +267,7 @@ describe("metric-translator", () => {
         const result = translateMetric(
           "evaluations.evaluation_pass_rate",
           "avg",
-          0
+          0,
         );
         expect(result.selectExpression).toContain("es.Passed");
         expect(result.requiredJoins).toContain("evaluation_runs");
@@ -265,7 +277,7 @@ describe("metric-translator", () => {
         const result = translateMetric(
           "evaluations.evaluation_runs",
           "cardinality",
-          0
+          0,
         );
         expect(result.selectExpression).toContain("uniqIf");
         expect(result.selectExpression).toContain("EvaluationId");
@@ -283,16 +295,16 @@ describe("metric-translator", () => {
           "events.event_type",
           "cardinality",
           0,
-          "thumbs_up_down"
+          "thumbs_up_down",
         );
         expect(result.selectExpression).toContain("countIf");
         // Should use parameterized query for event type (SQL injection prevention)
         expect(result.selectExpression).toMatch(
-          /\{m_eventType_[a-f0-9]+:String\}/
+          /\{m_eventType_[a-f0-9]+:String\}/,
         );
         // Params should contain the event type value
         const paramKey = Object.keys(result.params).find((k) =>
-          k.startsWith("m_eventType_")
+          k.startsWith("m_eventType_"),
         );
         expect(paramKey).toBeDefined();
         expect(result.params[paramKey!]).toBe("thumbs_up_down");
@@ -305,14 +317,14 @@ describe("metric-translator", () => {
           const result = translateMetric(
             "sentiment.thumbs_up_down",
             "cardinality",
-            0
+            0,
           );
           expect(result.selectExpression).toContain("countIf");
           expect(result.selectExpression).toMatch(
-            /\{m_sentimentEventType_[a-f0-9]+:String\}/
+            /\{m_sentimentEventType_[a-f0-9]+:String\}/,
           );
           const eventTypeParam = Object.keys(result.params).find((k) =>
-            k.startsWith("m_sentimentEventType_")
+            k.startsWith("m_sentimentEventType_"),
           );
           expect(eventTypeParam).toBeDefined();
           expect(result.params[eventTypeParam!]).toBe("thumbs_up_down");
@@ -334,10 +346,10 @@ describe("metric-translator", () => {
 
         it("filters to thumbs_up_down events using parameterized query", () => {
           expect(result.selectExpression).toMatch(
-            /\{m_sentimentEventType_[a-f0-9]+:String\}/
+            /\{m_sentimentEventType_[a-f0-9]+:String\}/,
           );
           const eventTypeParam = Object.keys(result.params).find((k) =>
-            k.startsWith("m_sentimentEventType_")
+            k.startsWith("m_sentimentEventType_"),
           );
           expect(eventTypeParam).toBeDefined();
           expect(result.params[eventTypeParam!]).toBe("thumbs_up_down");
@@ -345,7 +357,7 @@ describe("metric-translator", () => {
 
         it("extracts event.metrics.vote using parameterized query", () => {
           const voteKeyParam = Object.keys(result.params).find((k) =>
-            k.startsWith("m_sentimentVoteKey_")
+            k.startsWith("m_sentimentVoteKey_"),
           );
           expect(voteKeyParam).toBeDefined();
           expect(result.params[voteKeyParam!]).toBe("event.metrics.vote");
@@ -358,11 +370,7 @@ describe("metric-translator", () => {
 
       describe("when aggregation is avg", () => {
         it("extracts vote values and applies avgArray", () => {
-          const result = translateMetric(
-            "sentiment.thumbs_up_down",
-            "avg",
-            0
-          );
+          const result = translateMetric("sentiment.thumbs_up_down", "avg", 0);
           expect(result.selectExpression).toContain("avgArray");
           expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
@@ -371,11 +379,7 @@ describe("metric-translator", () => {
 
       describe("when aggregation is min", () => {
         it("extracts vote values and applies minArray", () => {
-          const result = translateMetric(
-            "sentiment.thumbs_up_down",
-            "min",
-            0
-          );
+          const result = translateMetric("sentiment.thumbs_up_down", "min", 0);
           expect(result.selectExpression).toContain("minArray");
           expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
@@ -384,11 +388,7 @@ describe("metric-translator", () => {
 
       describe("when aggregation is max", () => {
         it("extracts vote values and applies maxArray", () => {
-          const result = translateMetric(
-            "sentiment.thumbs_up_down",
-            "max",
-            0
-          );
+          const result = translateMetric("sentiment.thumbs_up_down", "max", 0);
           expect(result.selectExpression).toContain("maxArray");
           expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
@@ -397,11 +397,7 @@ describe("metric-translator", () => {
 
       describe("when aggregation is a percentile", () => {
         it("extracts vote values and applies quantileExactArray", () => {
-          const result = translateMetric(
-            "sentiment.thumbs_up_down",
-            "p95",
-            0
-          );
+          const result = translateMetric("sentiment.thumbs_up_down", "p95", 0);
           expect(result.selectExpression).toContain("quantileExactArray(0.95)");
           expect(result.selectExpression).toContain("x != 0");
           expect(result.requiredJoins).toContain("stored_spans");
@@ -414,7 +410,7 @@ describe("metric-translator", () => {
         const result = translateMetric(
           "threads.average_duration_per_thread",
           "avg",
-          0
+          0,
         );
         expect(result.requiresSubquery).toBe(true);
         expect(result.subquery).toBeDefined();
@@ -434,14 +430,16 @@ describe("metric-translator", () => {
         expect(result.selectExpression).toContain("quantileTDigest(0.99)");
       });
 
-      it("keeps quantileExact for non-performance percentile aggregations", () => {
+      it("keeps quantileExact for evaluation score percentiles", () => {
         // Evaluation scores stay on quantileExact - their distributions are
         // narrow enough that ±5% can flip threshold-based dashboard outcomes.
-        const result = translateMetric("metadata.trace_id", "p99", 0);
-        // metadata.trace_id falls through to translateSimpleAggregation with
-        // the default percentileMode ("exact"); we get count() in the percentile
-        // fallback branch but the helper still preserves exact mode for any
-        // call site that doesn't opt into tdigest.
+        const result = translateMetric(
+          "evaluations.evaluation_score",
+          "p99",
+          0,
+          "eval-1",
+        );
+        expect(result.selectExpression).toContain("quantileExactIf(0.99)");
         expect(result.selectExpression).not.toContain("quantileTDigest");
       });
 
@@ -449,14 +447,14 @@ describe("metric-translator", () => {
         const minResult = translateMetric(
           "performance.completion_time",
           "min",
-          0
+          0,
         );
         expect(minResult.selectExpression).toContain("min(");
 
         const maxResult = translateMetric(
           "performance.completion_time",
           "max",
-          1
+          1,
         );
         expect(maxResult.selectExpression).toContain("max(");
       });
@@ -470,11 +468,11 @@ describe("metric-translator", () => {
         "sum",
         "user_id",
         "avg",
-        0
+        0,
       );
       expect(result.requiresSubquery).toBe(true);
       expect(result.subquery?.innerSelect).toContain(
-        "Attributes['langwatch.user_id']"
+        "Attributes['langwatch.user_id']",
       );
       expect(result.subquery?.innerGroupBy).toBe("pipeline_key");
       expect(result.subquery?.outerAggregation).toContain("avg(inner_value)");
@@ -486,11 +484,11 @@ describe("metric-translator", () => {
         "avg",
         "thread_id",
         "sum",
-        0
+        0,
       );
       expect(result.requiresSubquery).toBe(true);
       expect(result.subquery?.innerSelect).toContain(
-        "Attributes['gen_ai.conversation.id']"
+        "Attributes['gen_ai.conversation.id']",
       );
       expect(result.subquery?.outerAggregation).toContain("sum(inner_value)");
     });
@@ -501,7 +499,7 @@ describe("metric-translator", () => {
         "sum",
         "trace_id",
         "max",
-        0
+        0,
       );
       expect(result.subquery?.innerSelect).toContain("TraceId");
       expect(result.subquery?.outerAggregation).toContain("max(inner_value)");
@@ -514,7 +512,7 @@ describe("metric-translator", () => {
         "user_id",
         "avg",
         0,
-        "eval-123"
+        "eval-123",
       );
       expect(result.requiredJoins).toContain("evaluation_runs");
     });
@@ -529,14 +527,16 @@ describe("metric-translator", () => {
         "avg",
         "user_id",
         "avg",
-        0
+        0,
       );
 
       // Returns a subquery with nested structure
       expect(result.requiresSubquery).toBe(true);
       expect(result.subquery).toBeDefined();
       expect(result.subquery?.nestedSubquery).toBeDefined();
-      expect(result.subquery?.nestedSubquery?.select).toContain("thread_duration");
+      expect(result.subquery?.nestedSubquery?.select).toContain(
+        "thread_duration",
+      );
       expect(result.subquery?.innerSelect).toContain("avg(thread_duration)");
       expect(result.selectExpression).toContain("avg(user_avg_duration)");
     });

--- a/langwatch/src/server/analytics/clickhouse/metric-translator.ts
+++ b/langwatch/src/server/analytics/clickhouse/metric-translator.ts
@@ -86,6 +86,39 @@ export const percentileToPercent: Record<PercentileAggregationTypes, number> = {
 };
 
 /**
+ * Per-metric opt-in for which percentile aggregate to compile to.
+ *
+ * - `"exact"` → quantileExact / quantileExactArray / quantileExactIf. Exact
+ *   sort-based percentile. Memory grows O(N) with the input row count, which
+ *   has been the top driver of OOM on heavy analytics dashboards.
+ * - `"tdigest"` → quantileTDigest / quantileTDigestArray / quantileTDigestIf.
+ *   t-digest sketch, ±5% error at distribution tails, bounded memory per
+ *   aggregator state. The accuracy gap is invisible on latency / cost /
+ *   token-count dashboards. Default for `performance.*` metrics.
+ *
+ * Existing call sites omit the parameter and stay on `"exact"`, matching the
+ * pre-existing behaviour. The cost / latency translators pass `"tdigest"` to
+ * opt in. Evaluation score / pass-rate metrics deliberately stay on `"exact"`
+ * because their distributions are narrow enough that a ±5% tail miss can flip
+ * dashboard outcomes (e.g. a p95 score crossing a threshold).
+ */
+export type PercentileMode = "exact" | "tdigest";
+
+function percentileFunctionName(
+  mode: PercentileMode,
+  shape: "scalar" | "array" | "conditional",
+): string {
+  switch (shape) {
+    case "scalar":
+      return mode === "tdigest" ? "quantileTDigest" : "quantileExact";
+    case "array":
+      return mode === "tdigest" ? "quantileTDigestArray" : "quantileExactArray";
+    case "conditional":
+      return mode === "tdigest" ? "quantileTDigestIf" : "quantileExactIf";
+  }
+}
+
+/**
  * Check if aggregation type is a percentile
  */
 export function isPercentileAggregation(
@@ -118,6 +151,7 @@ function translateSimpleAggregation(
   columnExpr: string,
   aggregation: AggregationTypes,
   alias: string,
+  percentileMode: PercentileMode = "exact",
 ): string {
   switch (aggregation) {
     case "avg":
@@ -137,9 +171,8 @@ function translateSimpleAggregation(
     default:
       if (isPercentileAggregation(aggregation)) {
         const percentile = percentileToPercent[aggregation];
-        // Use quantileExact for accurate percentiles (matching ES behavior)
-        // quantileTDigest is faster but has ±5% error at distribution extremes
-        return `quantileExact(${percentile})(${columnExpr}) AS ${alias}`;
+        const fn = percentileFunctionName(percentileMode, "scalar");
+        return `${fn}(${percentile})(${columnExpr}) AS ${alias}`;
       }
       return `count(${columnExpr}) AS ${alias}`;
   }
@@ -154,6 +187,7 @@ function translateArrayAggregation(
   arrayExpr: string,
   aggregation: AggregationTypes,
   alias: string,
+  percentileMode: PercentileMode = "exact",
 ): string {
   switch (aggregation) {
     case "avg":
@@ -174,8 +208,8 @@ function translateArrayAggregation(
     default:
       if (isPercentileAggregation(aggregation)) {
         const percentile = percentileToPercent[aggregation];
-        // Use quantilesExactArray for percentiles on arrays
-        return `quantileExactArray(${percentile})(${arrayExpr}) AS ${alias}`;
+        const fn = percentileFunctionName(percentileMode, "array");
+        return `${fn}(${percentile})(${arrayExpr}) AS ${alias}`;
       }
       // Default to counting array elements
       return `sum(length(${arrayExpr})) AS ${alias}`;
@@ -396,6 +430,7 @@ function translatePerformanceMetric(
           `${ts}.TotalDurationMs`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -408,6 +443,7 @@ function translatePerformanceMetric(
           `${ts}.TimeToFirstTokenMs`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -420,6 +456,7 @@ function translatePerformanceMetric(
           `${ts}.TotalCost`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -436,6 +473,7 @@ function translatePerformanceMetric(
           `(coalesce(${ts}.TotalCost, 0) - ${nonBilledCostExpression(ts)})`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -450,6 +488,7 @@ function translatePerformanceMetric(
           nonBilledCostExpression(ts),
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -462,6 +501,7 @@ function translatePerformanceMetric(
           `${ts}.TotalPromptTokenCount`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -474,6 +514,7 @@ function translatePerformanceMetric(
           `${ts}.TotalCompletionTokenCount`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -487,6 +528,7 @@ function translatePerformanceMetric(
           `(coalesce(${ts}.TotalPromptTokenCount, 0) + coalesce(${ts}.TotalCompletionTokenCount, 0))`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -503,6 +545,7 @@ function translatePerformanceMetric(
           `toUInt64OrZero(${ts}.Attributes['langwatch.reserved.cache_read_tokens'])`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -515,6 +558,7 @@ function translatePerformanceMetric(
           `toUInt64OrZero(${ts}.Attributes['langwatch.reserved.cache_creation_tokens'])`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -527,6 +571,7 @@ function translatePerformanceMetric(
           `toUInt64OrZero(${ts}.Attributes['langwatch.reserved.reasoning_tokens'])`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -541,6 +586,7 @@ function translatePerformanceMetric(
           `(coalesce(${ts}.TotalPromptTokenCount, 0) + coalesce(${ts}.TotalCompletionTokenCount, 0) + toUInt64OrZero(${ts}.Attributes['langwatch.reserved.cache_read_tokens']) + toUInt64OrZero(${ts}.Attributes['langwatch.reserved.cache_creation_tokens']))`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -556,6 +602,7 @@ function translatePerformanceMetric(
           `${ts}.TokensPerSecond`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -571,6 +618,7 @@ function translatePerformanceMetric(
           `toFloat64OrNull(${ss}.SpanAttributes['gen_ai.usage.input_tokens'])`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -586,6 +634,7 @@ function translatePerformanceMetric(
           `toFloat64OrNull(${ss}.SpanAttributes['gen_ai.usage.output_tokens'])`,
           aggregation,
           alias,
+          "tdigest",
         ),
         alias,
         requiredJoins,

--- a/langwatch/src/server/analytics/clickhouse/metric-translator.ts
+++ b/langwatch/src/server/analytics/clickhouse/metric-translator.ts
@@ -257,7 +257,12 @@ export function translateMetric(
   }
 
   if (metric.startsWith("performance.")) {
-    return translatePerformanceMetric(metric, aggregation, alias, requiredJoins);
+    return translatePerformanceMetric(
+      metric,
+      aggregation,
+      alias,
+      requiredJoins,
+    );
   }
 
   if (metric.startsWith("evaluations.")) {
@@ -413,6 +418,14 @@ function translateMetadataMetric(
 
 /**
  * Translate performance metrics
+ *
+ * All performance.* and spans.metrics.* percentile aggregations route through
+ * `perfAgg` below, which hard-codes `percentileMode: "tdigest"`. The wrapper
+ * exists so adding a new performance.* case doesn't require remembering to
+ * thread the literal at every call site - forgetting silently regresses to
+ * `quantileExact` (the helper's default) and the O(N) memory bug only surfaces
+ * under heavy analytics load. If you ever want a per-call override, drop back
+ * to the raw `translateSimpleAggregation(col, aggregation, alias, mode)` form.
  */
 function translatePerformanceMetric(
   metric: string,
@@ -422,16 +435,13 @@ function translatePerformanceMetric(
 ): MetricTranslation {
   const ts = tableAliases.trace_summaries;
   const ss = tableAliases.stored_spans;
+  const perfAgg = (col: string): string =>
+    translateSimpleAggregation(col, aggregation, alias, "tdigest");
 
   switch (metric) {
     case "performance.completion_time":
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.TotalDurationMs`,
-          aggregation,
-          alias,
-          "tdigest",
-        ),
+        selectExpression: perfAgg(`${ts}.TotalDurationMs`),
         alias,
         requiredJoins,
         params: {},
@@ -439,12 +449,7 @@ function translatePerformanceMetric(
 
     case "performance.first_token":
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.TimeToFirstTokenMs`,
-          aggregation,
-          alias,
-          "tdigest",
-        ),
+        selectExpression: perfAgg(`${ts}.TimeToFirstTokenMs`),
         alias,
         requiredJoins,
         params: {},
@@ -452,12 +457,7 @@ function translatePerformanceMetric(
 
     case "performance.total_cost":
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.TotalCost`,
-          aggregation,
-          alias,
-          "tdigest",
-        ),
+        selectExpression: perfAgg(`${ts}.TotalCost`),
         alias,
         requiredJoins,
         params: {},
@@ -469,11 +469,8 @@ function translatePerformanceMetric(
     // legacy all-or-nothing langwatch.cost.non_billable boolean.
     case "performance.cost_billed":
       return {
-        selectExpression: translateSimpleAggregation(
+        selectExpression: perfAgg(
           `(coalesce(${ts}.TotalCost, 0) - ${nonBilledCostExpression(ts)})`,
-          aggregation,
-          alias,
-          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -484,12 +481,7 @@ function translatePerformanceMetric(
     // bundled-subscription usage). The grand total is performance.total_cost.
     case "performance.cost_non_billed":
       return {
-        selectExpression: translateSimpleAggregation(
-          nonBilledCostExpression(ts),
-          aggregation,
-          alias,
-          "tdigest",
-        ),
+        selectExpression: perfAgg(nonBilledCostExpression(ts)),
         alias,
         requiredJoins,
         params: {},
@@ -497,12 +489,7 @@ function translatePerformanceMetric(
 
     case "performance.prompt_tokens":
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.TotalPromptTokenCount`,
-          aggregation,
-          alias,
-          "tdigest",
-        ),
+        selectExpression: perfAgg(`${ts}.TotalPromptTokenCount`),
         alias,
         requiredJoins,
         params: {},
@@ -510,12 +497,7 @@ function translatePerformanceMetric(
 
     case "performance.completion_tokens":
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.TotalCompletionTokenCount`,
-          aggregation,
-          alias,
-          "tdigest",
-        ),
+        selectExpression: perfAgg(`${ts}.TotalCompletionTokenCount`),
         alias,
         requiredJoins,
         params: {},
@@ -524,11 +506,8 @@ function translatePerformanceMetric(
     case "performance.total_tokens":
       // Sum of prompt + completion tokens (the "new content" delta, excludes cache)
       return {
-        selectExpression: translateSimpleAggregation(
+        selectExpression: perfAgg(
           `(coalesce(${ts}.TotalPromptTokenCount, 0) + coalesce(${ts}.TotalCompletionTokenCount, 0))`,
-          aggregation,
-          alias,
-          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -541,11 +520,8 @@ function translatePerformanceMetric(
     // values are stored as strings; toUInt64OrZero handles missing/empty → 0.
     case "performance.cache_read_tokens":
       return {
-        selectExpression: translateSimpleAggregation(
+        selectExpression: perfAgg(
           `toUInt64OrZero(${ts}.Attributes['langwatch.reserved.cache_read_tokens'])`,
-          aggregation,
-          alias,
-          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -554,11 +530,8 @@ function translatePerformanceMetric(
 
     case "performance.cache_write_tokens":
       return {
-        selectExpression: translateSimpleAggregation(
+        selectExpression: perfAgg(
           `toUInt64OrZero(${ts}.Attributes['langwatch.reserved.cache_creation_tokens'])`,
-          aggregation,
-          alias,
-          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -567,11 +540,8 @@ function translatePerformanceMetric(
 
     case "performance.reasoning_tokens":
       return {
-        selectExpression: translateSimpleAggregation(
+        selectExpression: perfAgg(
           `toUInt64OrZero(${ts}.Attributes['langwatch.reserved.reasoning_tokens'])`,
-          aggregation,
-          alias,
-          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -582,11 +552,8 @@ function translatePerformanceMetric(
     // cache write. Reasoning is a subset of completion, so it is NOT added again.
     case "performance.total_processed_tokens":
       return {
-        selectExpression: translateSimpleAggregation(
+        selectExpression: perfAgg(
           `(coalesce(${ts}.TotalPromptTokenCount, 0) + coalesce(${ts}.TotalCompletionTokenCount, 0) + toUInt64OrZero(${ts}.Attributes['langwatch.reserved.cache_read_tokens']) + toUInt64OrZero(${ts}.Attributes['langwatch.reserved.cache_creation_tokens']))`,
-          aggregation,
-          alias,
-          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -598,12 +565,7 @@ function translatePerformanceMetric(
       // Avoids joining stored_spans and reading SpanAttributes (a Map column
       // that includes large LLM prompt/completion text), which caused OOM.
       return {
-        selectExpression: translateSimpleAggregation(
-          `${ts}.TokensPerSecond`,
-          aggregation,
-          alias,
-          "tdigest",
-        ),
+        selectExpression: perfAgg(`${ts}.TokensPerSecond`),
         alias,
         requiredJoins,
         params: {},
@@ -614,11 +576,8 @@ function translatePerformanceMetric(
       // Uses canonical OTel name: gen_ai.usage.input_tokens
       requiredJoins.push("stored_spans");
       return {
-        selectExpression: translateSimpleAggregation(
+        selectExpression: perfAgg(
           `toFloat64OrNull(${ss}.SpanAttributes['gen_ai.usage.input_tokens'])`,
-          aggregation,
-          alias,
-          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -630,11 +589,8 @@ function translatePerformanceMetric(
       // Uses canonical OTel name: gen_ai.usage.output_tokens
       requiredJoins.push("stored_spans");
       return {
-        selectExpression: translateSimpleAggregation(
+        selectExpression: perfAgg(
           `toFloat64OrNull(${ss}.SpanAttributes['gen_ai.usage.output_tokens'])`,
-          aggregation,
-          alias,
-          "tdigest",
         ),
         alias,
         requiredJoins,
@@ -796,7 +752,11 @@ function translateEventMetric(
       }
 
       // Apply aggregation to the extracted scores array
-      const aggExpr = translateArrayAggregation(scoreExtraction, aggregation, alias);
+      const aggExpr = translateArrayAggregation(
+        scoreExtraction,
+        aggregation,
+        alias,
+      );
       return {
         selectExpression: aggExpr,
         alias,
@@ -957,13 +917,7 @@ export function translatePipelineAggregation(
   subkey?: string,
 ): MetricTranslation {
   const ts = tableAliases.trace_summaries;
-  const alias = buildMetricAlias(
-    index,
-    metric,
-    aggregation,
-    key,
-    subkey,
-  );
+  const alias = buildMetricAlias(index, metric, aggregation, key, subkey);
 
   // Get the pipeline field expression
   // ES terms aggregation excludes null/missing values, so we just use the column directly
@@ -994,7 +948,10 @@ export function translatePipelineAggregation(
   // 1. Group by (user_id, thread_id), compute thread duration
   // 2. Group by user_id, compute avg thread duration per user
   // 3. Compute avg across users
-  if (metric === "threads.average_duration_per_thread" && innerMetric.requiresSubquery) {
+  if (
+    metric === "threads.average_duration_per_thread" &&
+    innerMetric.requiresSubquery
+  ) {
     const threadIdCol = `${ts}.Attributes['gen_ai.conversation.id']`;
     // pipelineAggregation is typed as PipelineAggregationTypes (sum/avg/min/max)
     // which matches CH function names directly

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -1,18 +1,20 @@
 import { on } from "node:events";
-import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { z } from "zod";
 import { checkOpsPermission } from "~/server/api/rbac";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { getApp } from "~/server/app-layer/app";
 import { DASHBOARD_EVENT } from "~/server/app-layer/ops/metrics-collector";
 import type { DashboardData } from "~/server/app-layer/ops/types";
+import {
+  resolveHotDays,
+  TABLE_TTL_CONFIG,
+} from "~/server/clickhouse/ttlReconciler";
 import {
   getKillSwitchDescriptors,
   getProjectionMetadata,
   getReactorMetadata,
 } from "~/server/event-sourcing/pipelineRegistry";
-import { AnomalyStateStore } from "~/server/observability/anomalyState";
-import { connection } from "~/server/redis";
 import {
   getFeatureFlagStore,
   listFeatureFlagFamilies,
@@ -24,6 +26,8 @@ import {
   featureFlagRulesSchema,
   resolveEffectiveForListing,
 } from "~/server/featureFlag/rules";
+import { AnomalyStateStore } from "~/server/observability/anomalyState";
+import { connection } from "~/server/redis";
 
 const opsViewPermission = checkOpsPermission({ permission: "ops:view" });
 
@@ -71,13 +75,11 @@ export const opsRouter = createTRPCRouter({
     return { scope: ctx.opsScope };
   }),
 
-  getDashboardSnapshot: protectedProcedure
-    .use(opsViewPermission)
-    .query(() => {
-      const ops = getApp().ops;
-      if (!ops?.metricsCollector) return null;
-      return ops.metricsCollector.getDashboardData();
-    }),
+  getDashboardSnapshot: protectedProcedure.use(opsViewPermission).query(() => {
+    const ops = getApp().ops;
+    if (!ops?.metricsCollector) return null;
+    return ops.metricsCollector.getDashboardData();
+  }),
 
   /**
    * Cheap counts-only query for the global ops badge in the main menu.
@@ -86,15 +88,13 @@ export const opsRouter = createTRPCRouter({
    * always-on polling; reach for `getDashboardSnapshot` only on the
    * ops route itself.
    */
-  getBadgeCounts: protectedProcedure
-    .use(opsViewPermission)
-    .query(() => {
-      const ops = getApp().ops;
-      if (!ops?.metricsCollector) {
-        return { blockedCount: 0, dlqCount: 0 };
-      }
-      return ops.metricsCollector.getBadgeCounts();
-    }),
+  getBadgeCounts: protectedProcedure.use(opsViewPermission).query(() => {
+    const ops = getApp().ops;
+    if (!ops?.metricsCollector) {
+      return { blockedCount: 0, dlqCount: 0 };
+    }
+    return ops.metricsCollector.getBadgeCounts();
+  }),
 
   dashboardStream: protectedProcedure
     .use(opsViewPermission)
@@ -114,12 +114,10 @@ export const opsRouter = createTRPCRouter({
       }
     }),
 
-  listQueues: protectedProcedure
-    .use(opsViewPermission)
-    .query(async () => {
-      const ops = requireOps();
-      return ops.queues.getQueues();
-    }),
+  listQueues: protectedProcedure.use(opsViewPermission).query(async () => {
+    const ops = requireOps();
+    return ops.queues.getQueues();
+  }),
 
   listGroups: protectedProcedure
     .use(opsViewPermission)
@@ -305,14 +303,12 @@ export const opsRouter = createTRPCRouter({
       return ops.queues.retryBlocked(input);
     }),
 
-  listProjections: protectedProcedure
-    .use(opsViewPermission)
-    .query(() => {
-      return {
-        projections: getProjectionMetadata(),
-        reactors: getReactorMetadata(),
-      };
-    }),
+  listProjections: protectedProcedure.use(opsViewPermission).query(() => {
+    return {
+      projections: getProjectionMetadata(),
+      reactors: getReactorMetadata(),
+    };
+  }),
 
   discoverAggregates: protectedProcedure
     .use(opsViewPermission)
@@ -415,12 +411,10 @@ export const opsRouter = createTRPCRouter({
       }
     }),
 
-  getReplayStatus: protectedProcedure
-    .use(opsViewPermission)
-    .query(async () => {
-      const ops = requireOps();
-      return ops.replay.getStatus();
-    }),
+  getReplayStatus: protectedProcedure.use(opsViewPermission).query(async () => {
+    const ops = requireOps();
+    return ops.replay.getStatus();
+  }),
 
   cancelReplay: protectedProcedure
     .use(opsManagePermission)
@@ -573,6 +567,19 @@ export const opsRouter = createTRPCRouter({
       });
     }),
 
+  // Surfaces the env-var-derived hot-tier window for `event_log` so the
+  // DejaView UI can warn operators that older aggregates live in cold
+  // storage. The backend search itself is unbounded on time (cold-tier
+  // hits are slow but allowed); this is the transparent signal that lets
+  // an operator know why a search might be incomplete.
+  getEventLogHotTierDays: protectedProcedure
+    .use(opsViewPermission)
+    .query(() => {
+      const config = TABLE_TTL_CONFIG.find((c) => c.table === "event_log");
+      if (!config) return null;
+      return { days: resolveHotDays(config), envVar: config.envVar };
+    }),
+
   loadAggregateEvents: protectedProcedure
     .use(opsViewPermission)
     .input(
@@ -618,18 +625,16 @@ export const opsRouter = createTRPCRouter({
    * List currently-active tenant anomalies (rate breaker + structural
    * fingerprint loops). Sorted with hard-tier first.
    */
-  listAnomalies: protectedProcedure
-    .use(opsViewPermission)
-    .query(async () => {
-      if (!connection) return { anomalies: [] };
-      const store = new AnomalyStateStore(connection);
-      const anomalies = await store.list();
-      anomalies.sort((a, b) => {
-        if (a.tier !== b.tier) return a.tier === "hard" ? -1 : 1;
-        return b.triggeredAt - a.triggeredAt;
-      });
-      return { anomalies };
-    }),
+  listAnomalies: protectedProcedure.use(opsViewPermission).query(async () => {
+    if (!connection) return { anomalies: [] };
+    const store = new AnomalyStateStore(connection);
+    const anomalies = await store.list();
+    anomalies.sort((a, b) => {
+      if (a.tier !== b.tier) return a.tier === "hard" ? -1 : 1;
+      return b.triggeredAt - a.triggeredAt;
+    });
+    return { anomalies };
+  }),
 
   /**
    * Dismiss an active anomaly manually. The next detector tick may
@@ -736,15 +741,10 @@ export const opsRouter = createTRPCRouter({
       // pipeline components or rows for keys we no longer recognize;
       // surface them so operators can clean up.
       const orphanRows = stored
-        .filter(
-          (s) => !explicitKeys.has(s.key) && !familyKeysSeen.has(s.key),
-        )
+        .filter((s) => !explicitKeys.has(s.key) && !familyKeysSeen.has(s.key))
         .map((s) => {
           const def = resolveFlagDefinition(s.key);
-          const envOverride = checkFlagEnvOverride(
-            s.key,
-            def?.legacyEnvVar,
-          );
+          const envOverride = checkFlagEnvOverride(s.key, def?.legacyEnvVar);
           const effective = resolveEffectiveForListing({
             envOverride: envOverride ?? null,
             rules: s.rules,
@@ -755,7 +755,9 @@ export const opsRouter = createTRPCRouter({
             key: s.key,
             scope: def?.scope ?? "SYSTEM",
             defaultValue: def?.defaultValue ?? false,
-            description: def?.description ?? "Orphaned postgres flag row (no longer registered).",
+            description:
+              def?.description ??
+              "Orphaned postgres flag row (no longer registered).",
             family: def?.family ?? null,
             storedValue: s.enabled,
             rules: s.rules,
@@ -794,9 +796,7 @@ export const opsRouter = createTRPCRouter({
       // `resolveFlagDefinition` even with no pipeline component on the
       // other end, so a typo would create an orphan row that never
       // affects anything.
-      const isExplicitKey = listFeatureFlags().some(
-        (f) => f.key === input.key,
-      );
+      const isExplicitKey = listFeatureFlags().some((f) => f.key === input.key);
       const isLiveKillSwitch = getKillSwitchDescriptors().some(
         (d) => d.key === input.key,
       );
@@ -823,9 +823,7 @@ export const opsRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const isExplicitKey = listFeatureFlags().some(
-        (f) => f.key === input.key,
-      );
+      const isExplicitKey = listFeatureFlags().some((f) => f.key === input.key);
       const isLiveKillSwitch = getKillSwitchDescriptors().some(
         (d) => d.key === input.key,
       );

--- a/langwatch/src/server/api/routers/ops.ts
+++ b/langwatch/src/server/api/routers/ops.ts
@@ -556,28 +556,34 @@ export const opsRouter = createTRPCRouter({
       z.object({
         query: z.string(),
         tenantId: z.string().optional(),
+        sinceMs: z.number().int().positive().optional(),
       }),
     )
     .query(async ({ input }) => {
       const ops = requireOps();
+      const DEFAULT_LOOKBACK_MS = 365 * 24 * 60 * 60 * 1000;
+      const sinceMs = input.sinceMs ?? Date.now() - DEFAULT_LOOKBACK_MS;
 
       return ops.eventExplorer.searchAggregates({
         query: input.query,
         tenantIds: input.tenantId ? [input.tenantId] : [],
+        sinceMs,
       });
     }),
 
-  // Surfaces the env-var-derived hot-tier window for `event_log` so the
-  // DejaView UI can warn operators that older aggregates live in cold
-  // storage. The backend search itself is unbounded on time (cold-tier
-  // hits are slow but allowed); this is the transparent signal that lets
-  // an operator know why a search might be incomplete.
-  getEventLogHotTierDays: protectedProcedure
+  // Exposes (a) the 1-year DejaView search default and (b) the env-var-
+  // derived hot-tier window for event_log so the DejaView UI can render
+  // the banner under the search box. Cold-tier reads still work but get
+  // quite some slower; the banner makes the bound visible up front.
+  getEventLogSearchWindow: protectedProcedure
     .use(opsViewPermission)
     .query(() => {
-      const config = TABLE_TTL_CONFIG.find((c) => c.table === "event_log");
-      if (!config) return null;
-      return { days: resolveHotDays(config), envVar: config.envVar };
+      const ttl = TABLE_TTL_CONFIG.find((c) => c.table === "event_log");
+      return {
+        searchLookbackDays: 365,
+        hotTierDays: ttl ? resolveHotDays(ttl) : null,
+        hotTierEnvVar: ttl?.envVar ?? null,
+      };
     }),
 
   loadAggregateEvents: protectedProcedure

--- a/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.clickhouse.repository.ts
@@ -224,7 +224,6 @@ export class DspyStepClickHouseRepository implements DspyStepRepository {
   async getStepsByExperiment(
     tenantId: string,
     experimentId: string,
-    options?: { sinceMs?: number },
   ): Promise<DspyStepSummaryData[]> {
     try {
       const client = await this.resolveClient(tenantId);
@@ -233,16 +232,13 @@ export class DspyStepClickHouseRepository implements DspyStepRepository {
       // including cold-tier S3 ones. The primary key
       // `(TenantId, ExperimentId, RunId, StepIndex)` makes the per-partition
       // scan cheap but the partition fan-out itself is the dominant cost.
-      // Callers that know the experiment's start window should pass `sinceMs`
-      // to bound the scan; the default keeps behaviour unchanged for callers
-      // that need the full history (rare experiment archaeology).
-      const queryParams: Record<string, unknown> = { tenantId, experimentId };
-      let timeFilter = "";
-      if (typeof options?.sinceMs === "number" && options.sinceMs > 0) {
-        timeFilter =
-          "AND CreatedAt >= fromUnixTimestamp64Milli({sinceMs:Int64})";
-        queryParams.sinceMs = options.sinceMs;
-      }
+      //
+      // If/when a service-layer caller has access to the experiment's start
+      // time (e.g. derived from Prisma's experiment.createdAt), add an
+      // optional sinceMs and emit
+      //   AND CreatedAt >= fromUnixTimestamp64Milli({sinceMs:Int64})
+      // here to prune partitions. Avoiding the optional param until a real
+      // caller wires it through; otherwise it's API surface that nobody uses.
       const result = await client.query({
         query: `
           SELECT
@@ -261,12 +257,11 @@ export class DspyStepClickHouseRepository implements DspyStepRepository {
           FROM ${TABLE_NAME}
           WHERE TenantId = {tenantId:String}
             AND ExperimentId = {experimentId:String}
-            ${timeFilter}
           GROUP BY TenantId, ExperimentId, RunId, StepIndex
           ORDER BY CreatedAt ASC
           LIMIT 10000
         `,
-        query_params: queryParams,
+        query_params: { tenantId, experimentId },
         format: "JSONEachRow",
       });
 

--- a/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.clickhouse.repository.ts
@@ -239,7 +239,8 @@ export class DspyStepClickHouseRepository implements DspyStepRepository {
       const queryParams: Record<string, unknown> = { tenantId, experimentId };
       let timeFilter = "";
       if (typeof options?.sinceMs === "number" && options.sinceMs > 0) {
-        timeFilter = "AND CreatedAt >= fromUnixTimestamp64Milli({sinceMs:Int64})";
+        timeFilter =
+          "AND CreatedAt >= fromUnixTimestamp64Milli({sinceMs:Int64})";
         queryParams.sinceMs = options.sinceMs;
       }
       const result = await client.query({

--- a/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.clickhouse.repository.ts
@@ -224,9 +224,24 @@ export class DspyStepClickHouseRepository implements DspyStepRepository {
   async getStepsByExperiment(
     tenantId: string,
     experimentId: string,
+    options?: { sinceMs?: number },
   ): Promise<DspyStepSummaryData[]> {
     try {
       const client = await this.resolveClient(tenantId);
+      // The table partitions on `toYearWeek(CreatedAt)`. Without a CreatedAt
+      // bound the GROUP BY walks every weekly partition for the experiment,
+      // including cold-tier S3 ones. The primary key
+      // `(TenantId, ExperimentId, RunId, StepIndex)` makes the per-partition
+      // scan cheap but the partition fan-out itself is the dominant cost.
+      // Callers that know the experiment's start window should pass `sinceMs`
+      // to bound the scan; the default keeps behaviour unchanged for callers
+      // that need the full history (rare experiment archaeology).
+      const queryParams: Record<string, unknown> = { tenantId, experimentId };
+      let timeFilter = "";
+      if (typeof options?.sinceMs === "number" && options.sinceMs > 0) {
+        timeFilter = "AND CreatedAt >= fromUnixTimestamp64Milli({sinceMs:Int64})";
+        queryParams.sinceMs = options.sinceMs;
+      }
       const result = await client.query({
         query: `
           SELECT
@@ -245,11 +260,12 @@ export class DspyStepClickHouseRepository implements DspyStepRepository {
           FROM ${TABLE_NAME}
           WHERE TenantId = {tenantId:String}
             AND ExperimentId = {experimentId:String}
+            ${timeFilter}
           GROUP BY TenantId, ExperimentId, RunId, StepIndex
           ORDER BY CreatedAt ASC
           LIMIT 10000
         `,
-        query_params: { tenantId, experimentId },
+        query_params: queryParams,
         format: "JSONEachRow",
       });
 

--- a/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.repository.ts
+++ b/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.repository.ts
@@ -5,6 +5,10 @@ export interface DspyStepRepository {
   getStepsByExperiment(
     tenantId: string,
     experimentId: string,
+    // Optional CreatedAt lower bound. Pass when the caller knows the
+    // experiment's start window so the scan can prune partitions instead of
+    // walking every weekly partition incl. cold S3.
+    options?: { sinceMs?: number },
   ): Promise<DspyStepSummaryData[]>;
   getStep(
     tenantId: string,

--- a/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.repository.ts
+++ b/langwatch/src/server/app-layer/dspy-steps/repositories/dspy-step.repository.ts
@@ -5,10 +5,6 @@ export interface DspyStepRepository {
   getStepsByExperiment(
     tenantId: string,
     experimentId: string,
-    // Optional CreatedAt lower bound. Pass when the caller knows the
-    // experiment's start window so the scan can prune partitions instead of
-    // walking every weekly partition incl. cold S3.
-    options?: { sinceMs?: number },
   ): Promise<DspyStepSummaryData[]>;
   getStep(
     tenantId: string,
@@ -16,21 +12,22 @@ export interface DspyStepRepository {
     runId: string,
     stepIndex: string,
   ): Promise<DspyStepData | null>;
-  deleteByExperiment(
-    tenantId: string,
-    experimentId: string,
-  ): Promise<void>;
+  deleteByExperiment(tenantId: string, experimentId: string): Promise<void>;
 }
 
 export class NullDspyStepRepository implements DspyStepRepository {
-  async upsertStep(): Promise<void> {}
+  async upsertStep(): Promise<void> {
+    // no-op: null repository
+  }
   async getStepsByExperiment(): Promise<DspyStepSummaryData[]> {
     return [];
   }
   async getStep(): Promise<DspyStepData | null> {
     return null;
   }
-  async deleteByExperiment(): Promise<void> {}
+  async deleteByExperiment(): Promise<void> {
+    // no-op: null repository
+  }
 }
 
 function mergeByHash<T extends { hash: string }>(
@@ -107,7 +104,10 @@ export class InMemoryDspyStepRepository implements DspyStepRepository {
     runId: string,
     stepIndex: string,
   ): Promise<DspyStepData | null> {
-    return this.store.get(`${tenantId}/${experimentId}/${runId}/${stepIndex}`) ?? null;
+    return (
+      this.store.get(`${tenantId}/${experimentId}/${runId}/${stepIndex}`) ??
+      null
+    );
   }
 
   async deleteByExperiment(

--- a/langwatch/src/server/app-layer/ops/event-explorer.service.ts
+++ b/langwatch/src/server/app-layer/ops/event-explorer.service.ts
@@ -1,12 +1,12 @@
-import type {
-  EventExplorerRepository,
-  AggregateSearchResult,
-} from "./repositories/event-explorer.repository";
 import {
-  getProjectionMetadata,
   getDejaViewProjections,
+  getProjectionMetadata,
 } from "~/server/event-sourcing/pipelineRegistry";
 import { createLogger } from "~/utils/logger/server";
+import type {
+  AggregateSearchResult,
+  EventExplorerRepository,
+} from "./repositories/event-explorer.repository";
 
 const logger = createLogger("langwatch:ops:event-explorer");
 
@@ -36,9 +36,7 @@ export class EventExplorerService {
       return { projections: [] };
     }
 
-    const aggregateTypes = [
-      ...new Set(selected.map((p) => p.aggregateType)),
-    ];
+    const aggregateTypes = [...new Set(selected.map((p) => p.aggregateType))];
     const sinceMs = new Date(params.since).getTime();
 
     const rows = await this.repo.findAggregates({
@@ -89,10 +87,12 @@ export class EventExplorerService {
   async searchAggregates(params: {
     query: string;
     tenantIds: string[];
+    sinceMs?: number;
   }): Promise<AggregateSearchResult[]> {
     return this.repo.searchAggregates({
       query: params.query,
       tenantIds: params.tenantIds.length > 0 ? params.tenantIds : undefined,
+      sinceMs: params.sinceMs,
     });
   }
 
@@ -202,7 +202,11 @@ export class EventExplorerService {
           appliedCount++;
         } catch (err) {
           logger.warn(
-            { error: err, eventId: row.eventId, projectionName: params.projectionName },
+            {
+              error: err,
+              eventId: row.eventId,
+              projectionName: params.projectionName,
+            },
             "Skipping event that failed to apply during projection state computation",
           );
         }

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/event-explorer.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/event-explorer.clickhouse.repository.unit.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventExplorerClickHouseRepository } from "../event-explorer.clickhouse.repository";
+
+const repoCapturingQuery = () => {
+  const query = vi
+    .fn()
+    .mockResolvedValue({ json: async () => [] as unknown[] });
+  const client = { query } as unknown as ConstructorParameters<
+    typeof EventExplorerClickHouseRepository
+  >[0];
+  const repo = new EventExplorerClickHouseRepository(client);
+  return { repo, query };
+};
+
+const capturedQuery = (query: ReturnType<typeof vi.fn>) =>
+  query.mock.calls[0]![0] as {
+    query: string;
+    query_params: Record<string, unknown>;
+  };
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+describe("EventExplorerClickHouseRepository.findAggregates", () => {
+  describe("given a caller supplies a sinceMs", () => {
+    /** @scenario "findAggregates filters on EventOccurredAt so partition pruning works" */
+    it("filters on EventOccurredAt (the partition-key column), not on EventTimestamp", async () => {
+      // The partition is `toYearWeek(toDateTime64(EventOccurredAt / 1000, 3))`.
+      // Filtering on EventTimestamp (the version column) does *not* prune
+      // partitions - the old code did exactly that and scanned every weekly
+      // partition incl. cold S3.
+      const { repo, query } = repoCapturingQuery();
+
+      await repo.findAggregates({
+        aggregateTypes: ["lw.suite_run"],
+        sinceMs: 1_700_000_000_000,
+      });
+
+      const { query: sql, query_params } = capturedQuery(query);
+      expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
+      expect(sql).not.toMatch(/EventTimestamp\s*>=/);
+      expect(query_params.sinceMs).toBe(1_700_000_000_000);
+    });
+  });
+});
+
+describe("EventExplorerClickHouseRepository.searchAggregates", () => {
+  describe("given neither tenantIds nor a non-empty query string is supplied", () => {
+    /** @scenario "Unbounded event_log scan is refused at the app layer" */
+    it("rejects the call rather than scanning the whole event_log table", async () => {
+      const { repo } = repoCapturingQuery();
+      await expect(
+        repo.searchAggregates({ query: "", tenantIds: [] }),
+      ).rejects.toThrow(/search query or pick at least one tenant/);
+    });
+
+    it("rejects when tenantIds is omitted entirely and query is whitespace", async () => {
+      const { repo } = repoCapturingQuery();
+      await expect(repo.searchAggregates({ query: "   " })).rejects.toThrow(
+        /search query or pick at least one tenant/,
+      );
+    });
+  });
+
+  describe("given a non-empty query string is supplied", () => {
+    /** @scenario "Search is bounded to the partition-prunable lookback window" */
+    it("clamps the scan to the last 90 days via the EventOccurredAt predicate", async () => {
+      const { repo, query } = repoCapturingQuery();
+      const before = Date.now();
+
+      await repo.searchAggregates({ query: "abc" });
+
+      const after = Date.now();
+      const { query: sql, query_params } = capturedQuery(query);
+      expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
+      const sinceMs = query_params.sinceMs as number;
+      expect(typeof sinceMs).toBe("number");
+      // sinceMs is now() - 90 days at the moment the repo built the query
+      expect(sinceMs).toBeGreaterThanOrEqual(before - NINETY_DAYS_MS);
+      expect(sinceMs).toBeLessThanOrEqual(after - NINETY_DAYS_MS);
+    });
+  });
+});
+
+describe("EventExplorerClickHouseRepository.findEventsByAggregate", () => {
+  describe("given the caller passes a sinceMs (routine ops listing)", () => {
+    /** @scenario "findEventsByAggregate can be bounded by the caller" */
+    it("includes the EventOccurredAt predicate in the SQL", async () => {
+      const { repo, query } = repoCapturingQuery();
+
+      await repo.findEventsByAggregate({
+        aggregateId: "agg-1",
+        tenantId: "project_test",
+        limit: 10,
+        sinceMs: 1_700_000_000_000,
+      });
+
+      const { query: sql, query_params } = capturedQuery(query);
+      expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
+      expect(query_params.sinceMs).toBe(1_700_000_000_000);
+    });
+  });
+
+  describe("given the caller omits sinceMs (projection replay)", () => {
+    it("does not include the EventOccurredAt predicate so the full event history is reachable", async () => {
+      const { repo, query } = repoCapturingQuery();
+
+      await repo.findEventsByAggregate({
+        aggregateId: "agg-1",
+        tenantId: "project_test",
+        limit: 10,
+      });
+
+      const { query: sql, query_params } = capturedQuery(query);
+      expect(sql).not.toContain("EventOccurredAt >= {sinceMs:UInt64}");
+      expect(query_params.sinceMs).toBeUndefined();
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/event-explorer.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/event-explorer.clickhouse.repository.unit.test.ts
@@ -79,30 +79,35 @@ describe("EventExplorerClickHouseRepository.searchAggregates", () => {
     });
   });
 
-  describe("given the upfront guard is satisfied (tenant or query string supplied)", () => {
+  describe("given the upfront guard is satisfied and the caller supplies sinceMs", () => {
     describe("when searchAggregates is called", () => {
-      it("does not silently clamp the lookback to N days - the cold-tier bound is surfaced in the DejaView ops UI instead", async () => {
-        // The repo used to clamp to "now - 90 days" via EventOccurredAt. That
-        // turned out to be the wrong layer: it silently dropped aggregates
-        // older than 90 days during incident archaeology where the operator
-        // already knew the tenant. DejaView is an internal ops tool, so the
-        // hot/cold-tier surface is handled in the UI (uses the env-var-derived
-        // CLICKHOUSE_COLD_STORAGE_EVENT_LOG_TTL_DAYS value); the backend stays
-        // unbounded on the time axis.
+      it("applies the EventOccurredAt time bound (preserving the EventOccurredAt = 0 legacy sentinel)", async () => {
+        // The ops router defaults sinceMs to `now - 365 days` for the
+        // DejaView UI, surfaced as a banner under the search box. The
+        // repo just honours whatever the caller supplies - no silent
+        // backend clamp. Zero-sentinel rows survive so historical test
+        // data doesn't silently disappear.
         const { repo, query } = repoCapturingQuery();
 
         await repo.searchAggregates({
           query: "abc",
           tenantIds: ["project_x"],
+          sinceMs: 1_700_000_000_000,
         });
 
         const { query: sql, query_params } = capturedQuery(query);
-        expect(sql).not.toContain("EventOccurredAt");
-        expect(query_params.sinceMs).toBeUndefined();
+        expect(sql).toMatch(
+          /EventOccurredAt\s*=\s*0\s+OR\s+EventOccurredAt\s*>=\s*\{sinceMs:UInt64\}/,
+        );
+        expect(query_params.sinceMs).toBe(1_700_000_000_000);
         expect(query_params.tenantIds).toEqual(["project_x"]);
       });
+    });
+  });
 
-      it("stays unbounded on time when only a cross-tenant query string is supplied (guard still requires the query string itself)", async () => {
+  describe("given the upfront guard is satisfied but no sinceMs is supplied", () => {
+    describe("when searchAggregates is called", () => {
+      it("stays unbounded on time so non-UI callers (integration tests, scripts) can scan full history knowingly", async () => {
         const { repo, query } = repoCapturingQuery();
 
         await repo.searchAggregates({ query: "abc" });
@@ -116,28 +121,9 @@ describe("EventExplorerClickHouseRepository.searchAggregates", () => {
 });
 
 describe("EventExplorerClickHouseRepository.findEventsByAggregate", () => {
-  describe("given the caller passes a sinceMs (routine ops listing)", () => {
+  describe("given an aggregate the operator has already selected", () => {
     describe("when findEventsByAggregate is called", () => {
-      it("includes the EventOccurredAt predicate in the SQL", async () => {
-        const { repo, query } = repoCapturingQuery();
-
-        await repo.findEventsByAggregate({
-          aggregateId: "agg-1",
-          tenantId: "project_test",
-          limit: 10,
-          sinceMs: 1_700_000_000_000,
-        });
-
-        const { query: sql, query_params } = capturedQuery(query);
-        expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
-        expect(query_params.sinceMs).toBe(1_700_000_000_000);
-      });
-    });
-  });
-
-  describe("given the caller omits sinceMs (projection replay)", () => {
-    describe("when findEventsByAggregate is called", () => {
-      it("does not include the EventOccurredAt predicate so the full event history is reachable", async () => {
+      it("returns the full event history with no time bound (detail-view, full fold history needed for projection replay)", async () => {
         const { repo, query } = repoCapturingQuery();
 
         await repo.findEventsByAggregate({
@@ -147,8 +133,12 @@ describe("EventExplorerClickHouseRepository.findEventsByAggregate", () => {
         });
 
         const { query: sql, query_params } = capturedQuery(query);
-        expect(sql).not.toContain("EventOccurredAt >= {sinceMs:UInt64}");
-        expect(query_params.sinceMs).toBeUndefined();
+        expect(sql).not.toContain("EventOccurredAt");
+        expect(query_params).toEqual({
+          tenantId: "project_test",
+          aggregateId: "agg-1",
+          limit: 10,
+        });
       });
     });
   });

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/event-explorer.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/event-explorer.clickhouse.repository.unit.test.ts
@@ -18,97 +18,138 @@ const capturedQuery = (query: ReturnType<typeof vi.fn>) =>
     query_params: Record<string, unknown>;
   };
 
-const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
-
 describe("EventExplorerClickHouseRepository.findAggregates", () => {
   describe("given a caller supplies a sinceMs", () => {
-    it("filters on EventOccurredAt (the partition-key column), not on EventTimestamp", async () => {
-      // The partition is `toYearWeek(toDateTime64(EventOccurredAt / 1000, 3))`.
-      // Filtering on EventTimestamp (the version column) does *not* prune
-      // partitions - the old code did exactly that and scanned every weekly
-      // partition incl. cold S3.
-      const { repo, query } = repoCapturingQuery();
+    describe("when findAggregates is called", () => {
+      it("filters on EventOccurredAt (the partition-key column), not on EventTimestamp", async () => {
+        // The partition is `toYearWeek(toDateTime64(EventOccurredAt / 1000, 3))`.
+        // Filtering on EventTimestamp (the version column) does *not* prune
+        // partitions - the old code did exactly that and scanned every weekly
+        // partition incl. cold S3.
+        const { repo, query } = repoCapturingQuery();
 
-      await repo.findAggregates({
-        aggregateTypes: ["lw.suite_run"],
-        sinceMs: 1_700_000_000_000,
+        await repo.findAggregates({
+          aggregateTypes: ["lw.suite_run"],
+          sinceMs: 1_700_000_000_000,
+        });
+
+        const { query: sql, query_params } = capturedQuery(query);
+        expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
+        expect(sql).not.toMatch(/EventTimestamp\s*>=/);
+        expect(query_params.sinceMs).toBe(1_700_000_000_000);
       });
 
-      const { query: sql, query_params } = capturedQuery(query);
-      expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
-      expect(sql).not.toMatch(/EventTimestamp\s*>=/);
-      expect(query_params.sinceMs).toBe(1_700_000_000_000);
+      it("preserves the EventOccurredAt = 0 legacy-sentinel rows alongside the sinceMs cutoff", async () => {
+        // Events that pre-date the EventOccurredAt column carry the sentinel
+        // value 0. A naïve `>= sinceMs` filter would silently drop them from
+        // the bulk-replay wizard. The OR-with-zero keeps partition pruning
+        // (epoch-week partition + recent-N-weeks) while preserving the rows.
+        const { repo, query } = repoCapturingQuery();
+
+        await repo.findAggregates({
+          aggregateTypes: ["lw.suite_run"],
+          sinceMs: 1_700_000_000_000,
+        });
+
+        const { query: sql } = capturedQuery(query);
+        expect(sql).toMatch(
+          /EventOccurredAt\s*=\s*0\s+OR\s+EventOccurredAt\s*>=\s*\{sinceMs:UInt64\}/,
+        );
+      });
     });
   });
 });
 
 describe("EventExplorerClickHouseRepository.searchAggregates", () => {
   describe("given neither tenantIds nor a non-empty query string is supplied", () => {
-    it("rejects the call rather than scanning the whole event_log table", async () => {
-      const { repo } = repoCapturingQuery();
-      await expect(
-        repo.searchAggregates({ query: "", tenantIds: [] }),
-      ).rejects.toThrow(/search query or pick at least one tenant/);
-    });
+    describe("when searchAggregates is called", () => {
+      it("rejects the call rather than scanning the whole event_log table", async () => {
+        const { repo } = repoCapturingQuery();
+        await expect(
+          repo.searchAggregates({ query: "", tenantIds: [] }),
+        ).rejects.toThrow(/search query or pick at least one tenant/);
+      });
 
-    it("rejects when tenantIds is omitted entirely and query is whitespace", async () => {
-      const { repo } = repoCapturingQuery();
-      await expect(repo.searchAggregates({ query: "   " })).rejects.toThrow(
-        /search query or pick at least one tenant/,
-      );
+      it("rejects when tenantIds is omitted entirely and query is whitespace", async () => {
+        const { repo } = repoCapturingQuery();
+        await expect(repo.searchAggregates({ query: "   " })).rejects.toThrow(
+          /search query or pick at least one tenant/,
+        );
+      });
     });
   });
 
-  describe("given a non-empty query string is supplied", () => {
-    it("clamps the scan to the last 90 days via the EventOccurredAt predicate", async () => {
-      const { repo, query } = repoCapturingQuery();
-      const before = Date.now();
+  describe("given the upfront guard is satisfied (tenant or query string supplied)", () => {
+    describe("when searchAggregates is called", () => {
+      it("does not silently clamp the lookback to N days - the cold-tier bound is surfaced in the DejaView ops UI instead", async () => {
+        // The repo used to clamp to "now - 90 days" via EventOccurredAt. That
+        // turned out to be the wrong layer: it silently dropped aggregates
+        // older than 90 days during incident archaeology where the operator
+        // already knew the tenant. DejaView is an internal ops tool, so the
+        // hot/cold-tier surface is handled in the UI (uses the env-var-derived
+        // CLICKHOUSE_COLD_STORAGE_EVENT_LOG_TTL_DAYS value); the backend stays
+        // unbounded on the time axis.
+        const { repo, query } = repoCapturingQuery();
 
-      await repo.searchAggregates({ query: "abc" });
+        await repo.searchAggregates({
+          query: "abc",
+          tenantIds: ["project_x"],
+        });
 
-      const after = Date.now();
-      const { query: sql, query_params } = capturedQuery(query);
-      expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
-      const sinceMs = query_params.sinceMs as number;
-      expect(typeof sinceMs).toBe("number");
-      // sinceMs is now() - 90 days at the moment the repo built the query
-      expect(sinceMs).toBeGreaterThanOrEqual(before - NINETY_DAYS_MS);
-      expect(sinceMs).toBeLessThanOrEqual(after - NINETY_DAYS_MS);
+        const { query: sql, query_params } = capturedQuery(query);
+        expect(sql).not.toContain("EventOccurredAt");
+        expect(query_params.sinceMs).toBeUndefined();
+        expect(query_params.tenantIds).toEqual(["project_x"]);
+      });
+
+      it("stays unbounded on time when only a cross-tenant query string is supplied (guard still requires the query string itself)", async () => {
+        const { repo, query } = repoCapturingQuery();
+
+        await repo.searchAggregates({ query: "abc" });
+
+        const { query: sql, query_params } = capturedQuery(query);
+        expect(sql).not.toContain("EventOccurredAt");
+        expect(query_params.sinceMs).toBeUndefined();
+      });
     });
   });
 });
 
 describe("EventExplorerClickHouseRepository.findEventsByAggregate", () => {
   describe("given the caller passes a sinceMs (routine ops listing)", () => {
-    it("includes the EventOccurredAt predicate in the SQL", async () => {
-      const { repo, query } = repoCapturingQuery();
+    describe("when findEventsByAggregate is called", () => {
+      it("includes the EventOccurredAt predicate in the SQL", async () => {
+        const { repo, query } = repoCapturingQuery();
 
-      await repo.findEventsByAggregate({
-        aggregateId: "agg-1",
-        tenantId: "project_test",
-        limit: 10,
-        sinceMs: 1_700_000_000_000,
+        await repo.findEventsByAggregate({
+          aggregateId: "agg-1",
+          tenantId: "project_test",
+          limit: 10,
+          sinceMs: 1_700_000_000_000,
+        });
+
+        const { query: sql, query_params } = capturedQuery(query);
+        expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
+        expect(query_params.sinceMs).toBe(1_700_000_000_000);
       });
-
-      const { query: sql, query_params } = capturedQuery(query);
-      expect(sql).toContain("EventOccurredAt >= {sinceMs:UInt64}");
-      expect(query_params.sinceMs).toBe(1_700_000_000_000);
     });
   });
 
   describe("given the caller omits sinceMs (projection replay)", () => {
-    it("does not include the EventOccurredAt predicate so the full event history is reachable", async () => {
-      const { repo, query } = repoCapturingQuery();
+    describe("when findEventsByAggregate is called", () => {
+      it("does not include the EventOccurredAt predicate so the full event history is reachable", async () => {
+        const { repo, query } = repoCapturingQuery();
 
-      await repo.findEventsByAggregate({
-        aggregateId: "agg-1",
-        tenantId: "project_test",
-        limit: 10,
+        await repo.findEventsByAggregate({
+          aggregateId: "agg-1",
+          tenantId: "project_test",
+          limit: 10,
+        });
+
+        const { query: sql, query_params } = capturedQuery(query);
+        expect(sql).not.toContain("EventOccurredAt >= {sinceMs:UInt64}");
+        expect(query_params.sinceMs).toBeUndefined();
       });
-
-      const { query: sql, query_params } = capturedQuery(query);
-      expect(sql).not.toContain("EventOccurredAt >= {sinceMs:UInt64}");
-      expect(query_params.sinceMs).toBeUndefined();
     });
   });
 });

--- a/langwatch/src/server/app-layer/ops/repositories/__tests__/event-explorer.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/__tests__/event-explorer.clickhouse.repository.unit.test.ts
@@ -22,7 +22,6 @@ const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 
 describe("EventExplorerClickHouseRepository.findAggregates", () => {
   describe("given a caller supplies a sinceMs", () => {
-    /** @scenario "findAggregates filters on EventOccurredAt so partition pruning works" */
     it("filters on EventOccurredAt (the partition-key column), not on EventTimestamp", async () => {
       // The partition is `toYearWeek(toDateTime64(EventOccurredAt / 1000, 3))`.
       // Filtering on EventTimestamp (the version column) does *not* prune
@@ -45,7 +44,6 @@ describe("EventExplorerClickHouseRepository.findAggregates", () => {
 
 describe("EventExplorerClickHouseRepository.searchAggregates", () => {
   describe("given neither tenantIds nor a non-empty query string is supplied", () => {
-    /** @scenario "Unbounded event_log scan is refused at the app layer" */
     it("rejects the call rather than scanning the whole event_log table", async () => {
       const { repo } = repoCapturingQuery();
       await expect(
@@ -62,7 +60,6 @@ describe("EventExplorerClickHouseRepository.searchAggregates", () => {
   });
 
   describe("given a non-empty query string is supplied", () => {
-    /** @scenario "Search is bounded to the partition-prunable lookback window" */
     it("clamps the scan to the last 90 days via the EventOccurredAt predicate", async () => {
       const { repo, query } = repoCapturingQuery();
       const before = Date.now();
@@ -83,7 +80,6 @@ describe("EventExplorerClickHouseRepository.searchAggregates", () => {
 
 describe("EventExplorerClickHouseRepository.findEventsByAggregate", () => {
   describe("given the caller passes a sinceMs (routine ops listing)", () => {
-    /** @scenario "findEventsByAggregate can be bounded by the caller" */
     it("includes the EventOccurredAt predicate in the SQL", async () => {
       const { repo, query } = repoCapturingQuery();
 

--- a/langwatch/src/server/app-layer/ops/repositories/event-explorer.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/event-explorer.clickhouse.repository.ts
@@ -82,6 +82,7 @@ export class EventExplorerClickHouseRepository
   async searchAggregates(params: {
     query: string;
     tenantIds?: string[];
+    sinceMs?: number;
   }): Promise<AggregateSearchResult[]> {
     // Defensive guard: without at least one of (tenants, query string) the
     // query degrades to "ORDER BY EventTimestamp DESC LIMIT 50" against the
@@ -102,16 +103,21 @@ export class EventExplorerClickHouseRepository
       );
     }
 
-    // No silent time clamp here - DejaView is the internal ops admin tool, and
-    // operators searching for old aggregates during incident archaeology
-    // mustn't get empty results with no explanation. The hot/cold-tier bound
-    // is surfaced *in the DejaView UI* (uses the same env-var-derived value
-    // the TTL reconciler does) so the operator sees "older than N days lives
-    // in cold storage" up front, rather than the backend silently dropping
-    // rows. Tradeoff: a truly unbounded cross-tenant scan stays expensive,
-    // but the upfront guard above (must supply tenants or a query string)
-    // already prevents the worst shape.
+    // No silent time clamp in the repo. The caller (the ops router for the
+    // DejaView UI) supplies sinceMs explicitly - currently a 1-year bound
+    // surfaced under the search box as a banner so the operator sees the
+    // window up front. Other callers (e.g. integration tests, ad-hoc
+    // scripts) can pass `undefined` to scan the full event_log, paying the
+    // partition-fan-out cost knowingly. EventOccurredAt = 0 is the legacy
+    // sentinel; preserved alongside the bound so historical test data
+    // doesn't silently disappear.
     const queryParams: Record<string, unknown> = {};
+    let timeBoundFilter = "";
+    if (typeof params.sinceMs === "number" && params.sinceMs > 0) {
+      timeBoundFilter =
+        "AND (EventOccurredAt = 0 OR EventOccurredAt >= {sinceMs:UInt64})";
+      queryParams.sinceMs = params.sinceMs;
+    }
 
     let tenantFilter = "";
     if (hasTenants) {
@@ -136,6 +142,7 @@ export class EventExplorerClickHouseRepository
           max(EventTimestamp) AS lastEventTime
         FROM event_log
         WHERE 1=1
+          ${timeBoundFilter}
           ${tenantFilter}
           ${aggregateFilter}
         GROUP BY AggregateId, AggregateType, TenantId
@@ -167,29 +174,14 @@ export class EventExplorerClickHouseRepository
     aggregateId: string;
     tenantId: string;
     limit: number;
-    sinceMs?: number;
   }): Promise<RawEventRow[]> {
-    // Heavy column read (EventPayload, ZSTD(3)). Without an EventOccurredAt
-    // bound the read walks every weekly partition for the aggregate — the
-    // primary key seeks to (TenantId, AggregateType, AggregateId, …) per
-    // partition but pays cold-S3 metadata fetches for the inactive ones.
-    //
-    // Caller semantics:
-    //   * Routine event-listing (ops UI) — pass sinceMs (e.g. last 30 days)
-    //     to bound the scan to warm partitions only.
-    //   * Projection replay — explicitly omit sinceMs to read the full
-    //     event history of an aggregate (necessary for fold correctness).
-    const queryParams: Record<string, unknown> = {
-      tenantId: params.tenantId,
-      aggregateId: params.aggregateId,
-      limit: params.limit,
-    };
-    let timeFilter = "";
-    if (typeof params.sinceMs === "number" && params.sinceMs > 0) {
-      timeFilter = "AND EventOccurredAt >= {sinceMs:UInt64}";
-      queryParams.sinceMs = params.sinceMs;
-    }
-
+    // No `sinceMs` parameter: this is the detail-view query for a
+    // specific aggregate the operator has already picked from the
+    // (bounded) DejaView search. Once you're looking at one aggregate
+    // you want its full event history, including projection replays
+    // where the fold depends on every event. The partition fan-out is
+    // acceptable here because the aggregate-id seek is narrow per
+    // partition.
     const result = await this.client.query({
       query: `
         SELECT
@@ -200,11 +192,14 @@ export class EventExplorerClickHouseRepository
         FROM event_log
         WHERE TenantId = {tenantId:String}
           AND AggregateId = {aggregateId:String}
-          ${timeFilter}
         ORDER BY EventTimestamp ASC, EventId ASC
         LIMIT {limit:UInt32}
       `,
-      query_params: queryParams,
+      query_params: {
+        tenantId: params.tenantId,
+        aggregateId: params.aggregateId,
+        limit: params.limit,
+      },
       format: "JSONEachRow",
     });
 

--- a/langwatch/src/server/app-layer/ops/repositories/event-explorer.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/event-explorer.clickhouse.repository.ts
@@ -41,6 +41,14 @@ export class EventExplorerClickHouseRepository
     // scanned including cold S3 ones. EventOccurredAt is what the partition
     // key is derived from and is also closer to the caller's intent
     // ("aggregates active since this real-world time").
+    //
+    // `EventOccurredAt = 0` is the historical sentinel for events that pre-date
+    // the column (added after the table was already in production). Those rows
+    // still live in the epoch-week partition and are real aggregates the bulk
+    // replay wizard must be able to surface; a naïve `>= sinceMs` filter would
+    // silently drop them. Including `OR EventOccurredAt = 0` keeps partition
+    // pruning (epoch-week + last-N-weeks instead of every partition) while
+    // preserving the legacy rows.
     const result = await this.client.query({
       query: `
         SELECT
@@ -49,7 +57,7 @@ export class EventExplorerClickHouseRepository
           count(DISTINCT AggregateId) AS aggregateCount
         FROM event_log
         WHERE AggregateType IN ({aggregateTypes:Array(String)})
-          AND EventOccurredAt >= {sinceMs:UInt64}
+          AND (EventOccurredAt = 0 OR EventOccurredAt >= {sinceMs:UInt64})
           ${tenantClause}
         GROUP BY AggregateType, TenantId
         ORDER BY AggregateType, TenantId
@@ -94,12 +102,16 @@ export class EventExplorerClickHouseRepository
       );
     }
 
-    // Always bound by EventOccurredAt to prune partitions. 90 days is a
-    // generous default that covers ops triage windows; callers can extend
-    // by exposing a sinceMs parameter when there's a real need.
-    const SCAN_LOOKBACK_DAYS = 90;
-    const sinceMs = Date.now() - SCAN_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
-    const queryParams: Record<string, unknown> = { sinceMs };
+    // No silent time clamp here - DejaView is the internal ops admin tool, and
+    // operators searching for old aggregates during incident archaeology
+    // mustn't get empty results with no explanation. The hot/cold-tier bound
+    // is surfaced *in the DejaView UI* (uses the same env-var-derived value
+    // the TTL reconciler does) so the operator sees "older than N days lives
+    // in cold storage" up front, rather than the backend silently dropping
+    // rows. Tradeoff: a truly unbounded cross-tenant scan stays expensive,
+    // but the upfront guard above (must supply tenants or a query string)
+    // already prevents the worst shape.
+    const queryParams: Record<string, unknown> = {};
 
     let tenantFilter = "";
     if (hasTenants) {
@@ -123,7 +135,7 @@ export class EventExplorerClickHouseRepository
           count() AS eventCount,
           max(EventTimestamp) AS lastEventTime
         FROM event_log
-        WHERE EventOccurredAt >= {sinceMs:UInt64}
+        WHERE 1=1
           ${tenantFilter}
           ${aggregateFilter}
         GROUP BY AggregateId, AggregateType, TenantId

--- a/langwatch/src/server/app-layer/ops/repositories/event-explorer.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/event-explorer.clickhouse.repository.ts
@@ -34,6 +34,13 @@ export class EventExplorerClickHouseRepository
       queryParams.tenantIds = params.tenantIds;
     }
 
+    // event_log partitions on `toYearWeek(toDateTime64(EventOccurredAt / 1000, 3))`,
+    // NOT on EventTimestamp. The previous version filtered on EventTimestamp,
+    // which is the ReplacingMergeTree version column (ingest-time) — that
+    // predicate does not prune partitions, so every weekly partition was
+    // scanned including cold S3 ones. EventOccurredAt is what the partition
+    // key is derived from and is also closer to the caller's intent
+    // ("aggregates active since this real-world time").
     const result = await this.client.query({
       query: `
         SELECT
@@ -42,7 +49,7 @@ export class EventExplorerClickHouseRepository
           count(DISTINCT AggregateId) AS aggregateCount
         FROM event_log
         WHERE AggregateType IN ({aggregateTypes:Array(String)})
-          AND EventTimestamp >= {sinceMs:UInt64}
+          AND EventOccurredAt >= {sinceMs:UInt64}
           ${tenantClause}
         GROUP BY AggregateType, TenantId
         ORDER BY AggregateType, TenantId
@@ -68,19 +75,40 @@ export class EventExplorerClickHouseRepository
     query: string;
     tenantIds?: string[];
   }): Promise<AggregateSearchResult[]> {
-    const queryParams: Record<string, unknown> = {};
+    // Defensive guard: without at least one of (tenants, query string) the
+    // query degrades to "ORDER BY EventTimestamp DESC LIMIT 50" against the
+    // entire event_log table — every weekly partition incl. cold S3, every
+    // tenant, just to surface 50 rows. The doc rule "TenantId is always
+    // required" applies, but this is an ops/admin tool so we allow the
+    // cross-tenant case when a non-empty query string at least bounds it.
+    const hasTenants =
+      params.tenantIds !== undefined && params.tenantIds.length > 0;
+    const trimmedQuery = params.query.trim();
+    const hasQueryString = trimmedQuery.length > 0;
+    if (!hasTenants && !hasQueryString) {
+      throw new Error(
+        "EventExplorer.searchAggregates: provide either tenantIds or a non-empty query string — an unbounded scan over event_log is not allowed.",
+      );
+    }
+
+    // Always bound by EventOccurredAt to prune partitions. 90 days is a
+    // generous default that covers ops triage windows; callers can extend
+    // by exposing a sinceMs parameter when there's a real need.
+    const SCAN_LOOKBACK_DAYS = 90;
+    const sinceMs = Date.now() - SCAN_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+    const queryParams: Record<string, unknown> = { sinceMs };
 
     let tenantFilter = "";
-    if (params.tenantIds !== undefined && params.tenantIds.length > 0) {
+    if (hasTenants) {
       tenantFilter = "AND TenantId IN ({tenantIds:Array(String)})";
       queryParams.tenantIds = params.tenantIds;
     }
 
     let aggregateFilter = "";
-    if (params.query.trim().length > 0) {
+    if (hasQueryString) {
       aggregateFilter =
         "AND (AggregateId LIKE {queryPattern:String} OR TenantId LIKE {queryPattern:String})";
-      queryParams.queryPattern = `%${params.query.trim()}%`;
+      queryParams.queryPattern = `%${trimmedQuery}%`;
     }
 
     const result = await this.client.query({
@@ -92,7 +120,7 @@ export class EventExplorerClickHouseRepository
           count() AS eventCount,
           max(EventTimestamp) AS lastEventTime
         FROM event_log
-        WHERE 1 = 1
+        WHERE EventOccurredAt >= {sinceMs:UInt64}
           ${tenantFilter}
           ${aggregateFilter}
         GROUP BY AggregateId, AggregateType, TenantId
@@ -124,7 +152,29 @@ export class EventExplorerClickHouseRepository
     aggregateId: string;
     tenantId: string;
     limit: number;
+    sinceMs?: number;
   }): Promise<RawEventRow[]> {
+    // Heavy column read (EventPayload, ZSTD(3)). Without an EventOccurredAt
+    // bound the read walks every weekly partition for the aggregate — the
+    // primary key seeks to (TenantId, AggregateType, AggregateId, …) per
+    // partition but pays cold-S3 metadata fetches for the inactive ones.
+    //
+    // Caller semantics:
+    //   * Routine event-listing (ops UI) — pass sinceMs (e.g. last 30 days)
+    //     to bound the scan to warm partitions only.
+    //   * Projection replay — explicitly omit sinceMs to read the full
+    //     event history of an aggregate (necessary for fold correctness).
+    const queryParams: Record<string, unknown> = {
+      tenantId: params.tenantId,
+      aggregateId: params.aggregateId,
+      limit: params.limit,
+    };
+    let timeFilter = "";
+    if (typeof params.sinceMs === "number" && params.sinceMs > 0) {
+      timeFilter = "AND EventOccurredAt >= {sinceMs:UInt64}";
+      queryParams.sinceMs = params.sinceMs;
+    }
+
     const result = await this.client.query({
       query: `
         SELECT
@@ -135,14 +185,11 @@ export class EventExplorerClickHouseRepository
         FROM event_log
         WHERE TenantId = {tenantId:String}
           AND AggregateId = {aggregateId:String}
+          ${timeFilter}
         ORDER BY EventTimestamp ASC, EventId ASC
         LIMIT {limit:UInt32}
       `,
-      query_params: {
-        tenantId: params.tenantId,
-        aggregateId: params.aggregateId,
-        limit: params.limit,
-      },
+      query_params: queryParams,
       format: "JSONEachRow",
     });
 

--- a/langwatch/src/server/app-layer/ops/repositories/event-explorer.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/event-explorer.clickhouse.repository.ts
@@ -1,8 +1,8 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import type {
-  EventExplorerRepository,
   AggregateDiscoveryRow,
   AggregateSearchResult,
+  EventExplorerRepository,
   RawEventRow,
 } from "./event-explorer.repository";
 
@@ -86,8 +86,11 @@ export class EventExplorerClickHouseRepository
     const trimmedQuery = params.query.trim();
     const hasQueryString = trimmedQuery.length > 0;
     if (!hasTenants && !hasQueryString) {
+      // Rationale lives in the comment above (cross-tenant unbounded scan
+      // over the whole event_log) but the message reaches the ops UI - the
+      // user-facing text should tell them what to do, not name the method.
       throw new Error(
-        "EventExplorer.searchAggregates: provide either tenantIds or a non-empty query string — an unbounded scan over event_log is not allowed.",
+        "Enter a search query or pick at least one tenant before searching.",
       );
     }
 

--- a/langwatch/src/server/app-layer/ops/repositories/event-explorer.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/event-explorer.repository.ts
@@ -29,15 +29,17 @@ export interface EventExplorerRepository {
   searchAggregates(params: {
     query: string;
     tenantIds?: string[];
+    // Optional EventOccurredAt lower bound. The ops router supplies a
+    // 1-year default for the DejaView UI (with a banner under the search
+    // box stating the bound). Other callers can omit it to scan full
+    // event_log history at the cost of a wider partition fan-out.
+    sinceMs?: number;
   }): Promise<AggregateSearchResult[]>;
 
   findEventsByAggregate(params: {
     aggregateId: string;
     tenantId: string;
     limit: number;
-    // Optional EventOccurredAt lower bound. Pass for routine ops UI reads;
-    // omit only for projection replay where the full event history matters.
-    sinceMs?: number;
   }): Promise<RawEventRow[]>;
 }
 

--- a/langwatch/src/server/app-layer/ops/repositories/event-explorer.repository.ts
+++ b/langwatch/src/server/app-layer/ops/repositories/event-explorer.repository.ts
@@ -35,6 +35,9 @@ export interface EventExplorerRepository {
     aggregateId: string;
     tenantId: string;
     limit: number;
+    // Optional EventOccurredAt lower bound. Pass for routine ops UI reads;
+    // omit only for projection replay where the full event history matters.
+    sinceMs?: number;
   }): Promise<RawEventRow[]>;
 }
 

--- a/langwatch/src/server/app-layer/suites/repositories/__tests__/suite-run.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/suites/repositories/__tests__/suite-run.clickhouse.repository.unit.test.ts
@@ -22,48 +22,69 @@ const capturedQuery = (query: ReturnType<typeof vi.fn>) =>
 
 describe("SuiteRunClickHouseRepository.getBatchHistory", () => {
   describe("given the ScenarioSet has multiple BatchRunIds each with multiple unmerged versions", () => {
-    it("emits an IN-tuple dedup on (TenantId, ScenarioSetId, BatchRunId, UpdatedAt) so the LIMIT page can't fill with duplicate BatchRunIds", async () => {
-      // Regression test for the duplicate-BatchRunId bug. Prior to the dedup
-      // fix, the LIMIT 50 page could fill with multiple unmerged versions of
-      // the same BatchRunId because ReplacingMergeTree dedup hadn't merged
-      // yet. The IN-tuple subquery collapses to one row per BatchRunId.
-      const { repo, query } = repoCapturingQuery();
+    describe("when getBatchHistory is called", () => {
+      it("emits an IN-tuple dedup on (TenantId, ScenarioSetId, BatchRunId, UpdatedAt) so the LIMIT page can't fill with duplicate BatchRunIds", async () => {
+        // Regression test for the duplicate-BatchRunId bug. Prior to the dedup
+        // fix, the LIMIT 50 page could fill with multiple unmerged versions of
+        // the same BatchRunId because ReplacingMergeTree dedup hadn't merged
+        // yet. The IN-tuple subquery collapses to one row per BatchRunId.
+        const { repo, query } = repoCapturingQuery();
 
-      await repo.getBatchHistory({
-        projectId: "project_test",
-        scenarioSetId: "set-1",
+        await repo.getBatchHistory({
+          projectId: "project_test",
+          scenarioSetId: "set-1",
+        });
+
+        const { query: sql } = capturedQuery(query);
+        // The IN-tuple has both the outer membership check and the inner
+        // GROUP BY + max(UpdatedAt); assert the shape, not the formatting.
+        expect(sql).toMatch(
+          /\(t\.TenantId, t\.ScenarioSetId, t\.BatchRunId, t\.UpdatedAt\)\s+IN\s+\(\s*SELECT TenantId, ScenarioSetId, BatchRunId, max\(UpdatedAt\)/,
+        );
+        expect(sql).toContain("GROUP BY TenantId, ScenarioSetId, BatchRunId");
       });
 
-      const { query: sql } = capturedQuery(query);
-      // The IN-tuple has both the outer membership check and the inner
-      // GROUP BY + max(UpdatedAt); assert the shape, not the formatting.
-      expect(sql).toMatch(
-        /\(TenantId, ScenarioSetId, BatchRunId, UpdatedAt\)\s+IN\s+\(\s*SELECT TenantId, ScenarioSetId, BatchRunId, max\(UpdatedAt\)/,
-      );
-      expect(sql).toContain("GROUP BY TenantId, ScenarioSetId, BatchRunId");
+      it("qualifies the outer-query columns with the `t.` alias so the IN-tuple's UpdatedAt resolves to the raw DateTime64 column, not the projected UInt64 alias", async () => {
+        // Same rule the sibling getSuiteRunState query documents. Without the
+        // qualifier, `UpdatedAt` in the IN-tuple resolves to the projected
+        // `toUnixTimestamp64Milli(...) AS UpdatedAt` alias and the type
+        // comparison breaks.
+        const { repo, query } = repoCapturingQuery();
+        await repo.getBatchHistory({
+          projectId: "project_test",
+          scenarioSetId: "set-1",
+        });
+        const { query: sql } = capturedQuery(query);
+        expect(sql).toContain("FROM suite_runs AS t");
+        expect(sql).toContain("t.UpdatedAt");
+      });
     });
 
-    it("clamps caller-supplied limit to the hard ceiling (100)", async () => {
-      const { repo, query } = repoCapturingQuery();
-      await repo.getBatchHistory({
-        projectId: "project_test",
-        scenarioSetId: "set-1",
-        limit: 99999,
+    describe("when the caller passes a limit above the hard ceiling", () => {
+      it("clamps the limit to 100", async () => {
+        const { repo, query } = repoCapturingQuery();
+        await repo.getBatchHistory({
+          projectId: "project_test",
+          scenarioSetId: "set-1",
+          limit: 99999,
+        });
+        const { query_params } = capturedQuery(query);
+        expect(query_params.limit).toBe(100);
       });
-      const { query_params } = capturedQuery(query);
-      expect(query_params.limit).toBe(100);
     });
   });
 
   describe("given the caller does not pass a limit", () => {
-    it("defaults to 50 rows per page", async () => {
-      const { repo, query } = repoCapturingQuery();
-      await repo.getBatchHistory({
-        projectId: "project_test",
-        scenarioSetId: "set-1",
+    describe("when getBatchHistory is called", () => {
+      it("defaults to 50 rows per page", async () => {
+        const { repo, query } = repoCapturingQuery();
+        await repo.getBatchHistory({
+          projectId: "project_test",
+          scenarioSetId: "set-1",
+        });
+        const { query_params } = capturedQuery(query);
+        expect(query_params.limit).toBe(50);
       });
-      const { query_params } = capturedQuery(query);
-      expect(query_params.limit).toBe(50);
     });
   });
 });

--- a/langwatch/src/server/app-layer/suites/repositories/__tests__/suite-run.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/suites/repositories/__tests__/suite-run.clickhouse.repository.unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { SuiteRunClickHouseRepository } from "../suite-run.clickhouse.repository";
+
+const repoCapturingQuery = () => {
+  const query = vi
+    .fn()
+    .mockResolvedValue({ json: async () => [] as unknown[] });
+  const resolveClient = (async () => ({
+    query,
+  })) as unknown as ConstructorParameters<
+    typeof SuiteRunClickHouseRepository
+  >[0];
+  const repo = new SuiteRunClickHouseRepository(resolveClient);
+  return { repo, query };
+};
+
+const capturedQuery = (query: ReturnType<typeof vi.fn>) =>
+  query.mock.calls[0]![0] as {
+    query: string;
+    query_params: Record<string, unknown>;
+  };
+
+describe("SuiteRunClickHouseRepository.getBatchHistory", () => {
+  describe("given the ScenarioSet has multiple BatchRunIds each with multiple unmerged versions", () => {
+    /** @scenario "Batch history dedups across ReplacingMergeTree versions" */
+    it("emits an IN-tuple dedup on (TenantId, ScenarioSetId, BatchRunId, UpdatedAt) so the LIMIT page can't fill with duplicate BatchRunIds", async () => {
+      // Regression test for the duplicate-BatchRunId bug. Prior to the dedup
+      // fix, the LIMIT 50 page could fill with multiple unmerged versions of
+      // the same BatchRunId because ReplacingMergeTree dedup hadn't merged
+      // yet. The IN-tuple subquery collapses to one row per BatchRunId.
+      const { repo, query } = repoCapturingQuery();
+
+      await repo.getBatchHistory({
+        projectId: "project_test",
+        scenarioSetId: "set-1",
+      });
+
+      const { query: sql } = capturedQuery(query);
+      // The IN-tuple has both the outer membership check and the inner
+      // GROUP BY + max(UpdatedAt); assert the shape, not the formatting.
+      expect(sql).toMatch(
+        /\(TenantId, ScenarioSetId, BatchRunId, UpdatedAt\)\s+IN\s+\(\s*SELECT TenantId, ScenarioSetId, BatchRunId, max\(UpdatedAt\)/,
+      );
+      expect(sql).toContain("GROUP BY TenantId, ScenarioSetId, BatchRunId");
+    });
+
+    it("clamps caller-supplied limit to the hard ceiling (100)", async () => {
+      const { repo, query } = repoCapturingQuery();
+      await repo.getBatchHistory({
+        projectId: "project_test",
+        scenarioSetId: "set-1",
+        limit: 99999,
+      });
+      const { query_params } = capturedQuery(query);
+      expect(query_params.limit).toBe(100);
+    });
+  });
+
+  describe("given the caller does not pass a limit", () => {
+    it("defaults to 50 rows per page", async () => {
+      const { repo, query } = repoCapturingQuery();
+      await repo.getBatchHistory({
+        projectId: "project_test",
+        scenarioSetId: "set-1",
+      });
+      const { query_params } = capturedQuery(query);
+      expect(query_params.limit).toBe(50);
+    });
+  });
+});

--- a/langwatch/src/server/app-layer/suites/repositories/__tests__/suite-run.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/suites/repositories/__tests__/suite-run.clickhouse.repository.unit.test.ts
@@ -22,7 +22,6 @@ const capturedQuery = (query: ReturnType<typeof vi.fn>) =>
 
 describe("SuiteRunClickHouseRepository.getBatchHistory", () => {
   describe("given the ScenarioSet has multiple BatchRunIds each with multiple unmerged versions", () => {
-    /** @scenario "Batch history dedups across ReplacingMergeTree versions" */
     it("emits an IN-tuple dedup on (TenantId, ScenarioSetId, BatchRunId, UpdatedAt) so the LIMIT page can't fill with duplicate BatchRunIds", async () => {
       // Regression test for the duplicate-BatchRunId bug. Prior to the dedup
       // fix, the LIMIT 50 page could fill with multiple unmerged versions of

--- a/langwatch/src/server/app-layer/suites/repositories/suite-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/suites/repositories/suite-run.clickhouse.repository.ts
@@ -83,27 +83,36 @@ export class SuiteRunClickHouseRepository implements SuiteRunReadRepository {
     // displayed-once-per-page-load surface, not a hot path, and bounding
     // it would hide batches older than the bound. Accept the cross-
     // partition scan; revisit if it shows up in slow-query metrics.
+    // The outer query projects `toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAt`,
+    // which shadows the raw DateTime64 UpdatedAt column with a UInt64 alias.
+    // Without the `t.` qualifier, the IN-tuple's `UpdatedAt` resolves to the
+    // alias and the type comparison breaks (same rule the sibling
+    // getSuiteRunState query documents at the top of this file).
     const result = await client.query({
       query: `
         SELECT
-          SuiteRunId, BatchRunId, ScenarioSetId, SuiteId,
-          Status, Total, StartedCount, CompletedCount, FailedCount,
-          Progress, PassRateBps, PassedCount, GradedCount,
-          toUnixTimestamp64Milli(CreatedAt) AS CreatedAt,
-          toUnixTimestamp64Milli(UpdatedAt) AS UpdatedAt,
-          toUnixTimestamp64Milli(StartedAt) AS StartedAt,
-          toUnixTimestamp64Milli(FinishedAt) AS FinishedAt
-        FROM suite_runs
-        WHERE TenantId = {projectId:String}
-          AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
-          AND (TenantId, ScenarioSetId, BatchRunId, UpdatedAt) IN (
+          t.SuiteRunId AS SuiteRunId, t.BatchRunId AS BatchRunId,
+          t.ScenarioSetId AS ScenarioSetId, t.SuiteId AS SuiteId,
+          t.Status AS Status, t.Total AS Total,
+          t.StartedCount AS StartedCount, t.CompletedCount AS CompletedCount,
+          t.FailedCount AS FailedCount, t.Progress AS Progress,
+          t.PassRateBps AS PassRateBps, t.PassedCount AS PassedCount,
+          t.GradedCount AS GradedCount,
+          toUnixTimestamp64Milli(t.CreatedAt) AS CreatedAt,
+          toUnixTimestamp64Milli(t.UpdatedAt) AS UpdatedAt,
+          toUnixTimestamp64Milli(t.StartedAt) AS StartedAt,
+          toUnixTimestamp64Milli(t.FinishedAt) AS FinishedAt
+        FROM suite_runs AS t
+        WHERE t.TenantId = {projectId:String}
+          AND t.ScenarioSetId IN ({scenarioSetIds:Array(String)})
+          AND (t.TenantId, t.ScenarioSetId, t.BatchRunId, t.UpdatedAt) IN (
             SELECT TenantId, ScenarioSetId, BatchRunId, max(UpdatedAt)
             FROM suite_runs
             WHERE TenantId = {projectId:String}
               AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
             GROUP BY TenantId, ScenarioSetId, BatchRunId
           )
-        ORDER BY CreatedAt DESC
+        ORDER BY t.CreatedAt DESC
         LIMIT {limit:UInt32}
       `,
       query_params: {

--- a/langwatch/src/server/app-layer/suites/repositories/suite-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/suites/repositories/suite-run.clickhouse.repository.ts
@@ -52,7 +52,10 @@ export class SuiteRunClickHouseRepository implements SuiteRunReadRepository {
           )
         LIMIT 1
       `,
-      query_params: { projectId: params.projectId, batchRunId: params.batchRunId },
+      query_params: {
+        projectId: params.projectId,
+        batchRunId: params.batchRunId,
+      },
       format: "JSONEachRow",
     });
 

--- a/langwatch/src/server/app-layer/suites/repositories/suite-run.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/suites/repositories/suite-run.clickhouse.repository.ts
@@ -70,6 +70,16 @@ export class SuiteRunClickHouseRepository implements SuiteRunReadRepository {
   }): Promise<SuiteRunStateData[]> {
     const limit = Math.min(params.limit ?? 50, 100);
     const client = await this.getClient(params.projectId);
+    // The previous version had no dedup, so the LIMIT 50 page could fill
+    // with multiple unmerged versions of the same BatchRunId — the user
+    // would see e.g. 5 unique suite runs duplicated 10× each, not 50
+    // distinct rows. IN-tuple dedup over (TenantId, ScenarioSetId,
+    // BatchRunId, UpdatedAt) collapses to one row per BatchRunId.
+    //
+    // Note: no `StartedAt` partition predicate. Batch history is a
+    // displayed-once-per-page-load surface, not a hot path, and bounding
+    // it would hide batches older than the bound. Accept the cross-
+    // partition scan; revisit if it shows up in slow-query metrics.
     const result = await client.query({
       query: `
         SELECT
@@ -83,6 +93,13 @@ export class SuiteRunClickHouseRepository implements SuiteRunReadRepository {
         FROM suite_runs
         WHERE TenantId = {projectId:String}
           AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
+          AND (TenantId, ScenarioSetId, BatchRunId, UpdatedAt) IN (
+            SELECT TenantId, ScenarioSetId, BatchRunId, max(UpdatedAt)
+            FROM suite_runs
+            WHERE TenantId = {projectId:String}
+              AND ScenarioSetId IN ({scenarioSetIds:Array(String)})
+            GROUP BY TenantId, ScenarioSetId, BatchRunId
+          )
         ORDER BY CreatedAt DESC
         LIMIT {limit:UInt32}
       `,

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
@@ -132,15 +132,21 @@ describe("LogRecordStorageClickHouseRepository.getMarkedClaudeCodeLogsByTrace", 
   });
 
   describe("when the caller does not provide a time", () => {
-    it("omits the TimeUnixMs predicate (unbounded fallback, unchanged behavior)", async () => {
+    it("falls back to a CC-retention-bounded window so the scan can't walk every partition", async () => {
+      // Replaces a previous "unbounded fallback" behaviour. CC logs older than
+      // CLAUDE_CODE_LOG_RETENTION_DAYS have already been TTL'd away anyway, so
+      // a 7×retention lookback is safe and bounds the partition scan.
       const { repo, query } = repoCapturingQuery();
 
       await repo.getMarkedClaudeCodeLogsByTrace("project_test", "trace-1");
 
       const { query: sql, query_params } = capturedQuery(query);
-      expect(sql).not.toContain("TimeUnixMs >= fromUnixTimestamp64Milli");
-      expect(query_params.fromMs).toBeUndefined();
-      expect(query_params.toMs).toBeUndefined();
+      expect(sql.match(/TimeUnixMs >= fromUnixTimestamp64Milli/g)).toHaveLength(
+        2,
+      );
+      expect(typeof query_params.fromMs).toBe("number");
+      expect(typeof query_params.toMs).toBe("number");
+      expect(query_params.toMs).toBeGreaterThan(query_params.fromMs);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
@@ -136,12 +136,13 @@ describe("LogRecordStorageClickHouseRepository.getMarkedClaudeCodeLogsByTrace", 
   });
 
   describe("when the caller does not provide a time", () => {
-    it("falls back to a CC-retention-bounded window so the scan can't walk every partition", async () => {
+    it("falls back to a CC-retention-bounded window that includes clock-skew headroom on the upper bound", async () => {
       // Replaces a previous "unbounded fallback" behaviour. CC logs older than
       // CLAUDE_CODE_LOG_RETENTION_DAYS have already been TTL'd away anyway, so
-      // a 7×retention lookback is safe and bounds the partition scan.
-      // Locking the bound *shape* (toMs ≈ now, fromMs == toMs − 7×retention)
-      // so a future bug picking 0 or now-1h doesn't pass this test silently.
+      // a 7×retention lookback is safe and bounds the partition scan. The
+      // upper bound mirrors the hint path's ±2d clock-skew headroom so a
+      // fast client clock that writes a slightly-future TimeUnixMs (it's
+      // client-supplied) doesn't silently drop the row.
       const { repo, query } = repoCapturingQuery();
       const before = Date.now();
 
@@ -157,13 +158,16 @@ describe("LogRecordStorageClickHouseRepository.getMarkedClaudeCodeLogsByTrace", 
       const fromMs = query_params.fromMs as number;
       expect(typeof fromMs).toBe("number");
       expect(typeof toMs).toBe("number");
-      // toMs is captured at now() at the moment the repo built the query
-      expect(toMs).toBeGreaterThanOrEqual(before);
-      expect(toMs).toBeLessThanOrEqual(after);
-      // fromMs is exactly 7×CC_RETENTION earlier than toMs
+      // toMs is now() + 2d (clock-skew headroom). Capture the now() at the
+      // moment the repo built the query (between `before` and `after`).
+      const partitionWindowMs = 2 * 24 * 60 * 60 * 1000;
+      expect(toMs).toBeGreaterThanOrEqual(before + partitionWindowMs);
+      expect(toMs).toBeLessThanOrEqual(after + partitionWindowMs);
+      // fromMs is exactly 7×CC_RETENTION earlier than (toMs − partitionWindowMs)
+      // (i.e. the gap between fromMs and toMs is 7×CC_RETENTION + the headroom)
       const sevenCcRetentionMs =
         CLAUDE_CODE_LOG_RETENTION_DAYS * 7 * 24 * 60 * 60 * 1000;
-      expect(toMs - fromMs).toBe(sevenCcRetentionMs);
+      expect(toMs - fromMs).toBe(sevenCcRetentionMs + partitionWindowMs);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
@@ -146,7 +146,9 @@ describe("LogRecordStorageClickHouseRepository.getMarkedClaudeCodeLogsByTrace", 
       );
       expect(typeof query_params.fromMs).toBe("number");
       expect(typeof query_params.toMs).toBe("number");
-      expect(query_params.toMs).toBeGreaterThan(query_params.fromMs);
+      expect(query_params.toMs as number).toBeGreaterThan(
+        query_params.fromMs as number,
+      );
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/log-record-storage.clickhouse.repository.unit.test.ts
@@ -27,7 +27,9 @@ const makeRecord = (
 
 const repoCapturingInsert = () => {
   const insert = vi.fn().mockResolvedValue(undefined);
-  const resolveClient = (async () => ({ insert })) as unknown as ConstructorParameters<
+  const resolveClient = (async () => ({
+    insert,
+  })) as unknown as ConstructorParameters<
     typeof LogRecordStorageClickHouseRepository
   >[0];
   const repo = new LogRecordStorageClickHouseRepository(resolveClient);
@@ -41,7 +43,9 @@ const repoCapturingQuery = () => {
   const query = vi
     .fn()
     .mockResolvedValue({ json: async () => [] as unknown[] });
-  const resolveClient = (async () => ({ query })) as unknown as ConstructorParameters<
+  const resolveClient = (async () => ({
+    query,
+  })) as unknown as ConstructorParameters<
     typeof LogRecordStorageClickHouseRepository
   >[0];
   const repo = new LogRecordStorageClickHouseRepository(resolveClient);
@@ -136,19 +140,30 @@ describe("LogRecordStorageClickHouseRepository.getMarkedClaudeCodeLogsByTrace", 
       // Replaces a previous "unbounded fallback" behaviour. CC logs older than
       // CLAUDE_CODE_LOG_RETENTION_DAYS have already been TTL'd away anyway, so
       // a 7×retention lookback is safe and bounds the partition scan.
+      // Locking the bound *shape* (toMs ≈ now, fromMs == toMs − 7×retention)
+      // so a future bug picking 0 or now-1h doesn't pass this test silently.
       const { repo, query } = repoCapturingQuery();
+      const before = Date.now();
 
       await repo.getMarkedClaudeCodeLogsByTrace("project_test", "trace-1");
 
+      const after = Date.now();
       const { query: sql, query_params } = capturedQuery(query);
       expect(sql.match(/TimeUnixMs >= fromUnixTimestamp64Milli/g)).toHaveLength(
         2,
       );
-      expect(typeof query_params.fromMs).toBe("number");
-      expect(typeof query_params.toMs).toBe("number");
-      expect(query_params.toMs as number).toBeGreaterThan(
-        query_params.fromMs as number,
-      );
+
+      const toMs = query_params.toMs as number;
+      const fromMs = query_params.fromMs as number;
+      expect(typeof fromMs).toBe("number");
+      expect(typeof toMs).toBe("number");
+      // toMs is captured at now() at the moment the repo built the query
+      expect(toMs).toBeGreaterThanOrEqual(before);
+      expect(toMs).toBeLessThanOrEqual(after);
+      // fromMs is exactly 7×CC_RETENTION earlier than toMs
+      const sevenCcRetentionMs =
+        CLAUDE_CODE_LOG_RETENTION_DAYS * 7 * 24 * 60 * 60 * 1000;
+      expect(toMs - fromMs).toBe(sevenCcRetentionMs);
     });
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
@@ -103,8 +103,7 @@ export class LogRecordStorageClickHouseRepository
     //     CC logs older than CLAUDE_CODE_LOG_RETENTION_DAYS have already been
     //     deleted by TTL anyway, so a wider scan can't return anything.
     const partitionWindowMs = 2 * 24 * 60 * 60 * 1000;
-    const ccRetentionMs =
-      CLAUDE_CODE_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    const ccRetentionMs = CLAUDE_CODE_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
     const fallbackLookbackMs = ccRetentionMs * 7;
     const hasWindow = typeof occurredAtMs === "number" && occurredAtMs > 0;
     const now = Date.now();

--- a/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
@@ -94,34 +94,44 @@ export class LogRecordStorageClickHouseRepository
 
     // `stored_log_records` is `PARTITION BY toYearWeek(TimeUnixMs)` and tiered to
     // S3 after the hot window. Filtering only on TenantId + TraceId can't prune
-    // partitions, so the read walks every weekly partition (incl. cold S3) — a
-    // burst of S3 GETs on every claude-code log re-fold. When the caller knows
-    // the turn's approximate time we bound the scan to a ±2-day window around it.
-    // A turn's logs all land within its lifetime, so the window is generous
-    // headroom; without a hint we fall back to the unbounded scan (correctness
-    // is identical either way).
+    // partitions, so without a time predicate the read walks every weekly
+    // partition (incl. cold S3) — a burst of S3 GETs on every claude-code log
+    // re-fold. Two windows:
+    //   * with a turn-time hint → ±2d around it (generous headroom for clock
+    //     skew / long-running turns)
+    //   * without a hint → `now − 7×CC_RETENTION` ... `now`. Bounded because
+    //     CC logs older than CLAUDE_CODE_LOG_RETENTION_DAYS have already been
+    //     deleted by TTL anyway, so a wider scan can't return anything.
     const partitionWindowMs = 2 * 24 * 60 * 60 * 1000;
+    const ccRetentionMs =
+      CLAUDE_CODE_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    const fallbackLookbackMs = ccRetentionMs * 7;
     const hasWindow = typeof occurredAtMs === "number" && occurredAtMs > 0;
+    const now = Date.now();
+    const fromMs = hasWindow
+      ? occurredAtMs - partitionWindowMs
+      : now - fallbackLookbackMs;
+    const toMs = hasWindow ? occurredAtMs + partitionWindowMs : now;
     // Qualify the bound with the table name: the outer SELECT aliases
     // `toUnixTimestamp64Milli(TimeUnixMs) AS TimeUnixMs`, and ClickHouse would
     // otherwise resolve a bare `TimeUnixMs` in WHERE to that ms-integer alias
     // instead of the DateTime64 column, making the partition bound nonsensical.
-    const timeFilter = hasWindow
-      ? `AND ${TABLE_NAME}.TimeUnixMs >= fromUnixTimestamp64Milli({fromMs:Int64}) ` +
-        `AND ${TABLE_NAME}.TimeUnixMs <= fromUnixTimestamp64Milli({toMs:Int64})`
-      : "";
-    const timeParams = hasWindow
-      ? {
-          fromMs: occurredAtMs - partitionWindowMs,
-          toMs: occurredAtMs + partitionWindowMs,
-        }
-      : {};
+    const timeFilter =
+      `AND ${TABLE_NAME}.TimeUnixMs >= fromUnixTimestamp64Milli({fromMs:Int64}) ` +
+      `AND ${TABLE_NAME}.TimeUnixMs <= fromUnixTimestamp64Milli({toMs:Int64})`;
 
     // Dedup to the latest version of each distinct stored log (the table is a
     // ReplacingMergeTree(UpdatedAt) keyed on TenantId,TraceId,SpanId,ProjectionId);
     // the IN-tuple over max(UpdatedAt) returns one row per record. TenantId is
-    // the first predicate (no other id is unique across tenants). The partition
-    // window is applied to both scopes so the dedup sees the same row set.
+    // the first predicate (no other id is unique across tenants).
+    //
+    // The `Attributes[kindKey] != ''` filter LIVES IN THE OUTER scope only —
+    // including it inside the dedup GROUP BY forces ClickHouse to read the
+    // heavy `Attributes` Map column for every unmerged version of every row
+    // in the trace, which is what the inner subquery is supposed to avoid.
+    // Moving it out makes the inner read lightweight key columns only; the
+    // outer SELECT then applies the filter to one row per (TenantId, TraceId,
+    // SpanId, ProjectionId), which is the right scale to read the map at.
             const result = await client.query({
       query: `
         SELECT
@@ -136,23 +146,23 @@ export class LogRecordStorageClickHouseRepository
         WHERE TenantId = {tenantId:String}
           AND TraceId = {traceId:String}
           ${timeFilter}
-          AND Attributes[{kindKey:String}] != ''
           AND (TenantId, TraceId, SpanId, ProjectionId, UpdatedAt) IN (
             SELECT TenantId, TraceId, SpanId, ProjectionId, max(UpdatedAt)
             FROM ${TABLE_NAME}
             WHERE TenantId = {tenantId:String}
               AND TraceId = {traceId:String}
               ${timeFilter}
-              AND Attributes[{kindKey:String}] != ''
             GROUP BY TenantId, TraceId, SpanId, ProjectionId
           )
+          AND Attributes[{kindKey:String}] != ''
         ORDER BY TimeUnixMs ASC
       `,
       query_params: {
         tenantId,
         traceId,
         kindKey: CLAUDE_CODE_KIND_ATTR,
-        ...timeParams,
+        fromMs,
+        toMs,
       },
       format: "JSONEachRow",
     });

--- a/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
@@ -102,9 +102,12 @@ export class LogRecordStorageClickHouseRepository
     // re-fold. Two windows:
     //   * with a turn-time hint → ±2d around it (generous headroom for clock
     //     skew / long-running turns)
-    //   * without a hint → `now − 7×CC_RETENTION` ... `now`. Bounded because
-    //     CC logs older than CLAUDE_CODE_LOG_RETENTION_DAYS have already been
-    //     deleted by TTL anyway, so a wider scan can't return anything.
+    //   * without a hint → `now − 7×CC_RETENTION` ... `now + 2d`. The upper
+    //     bound mirrors the hint path's clock-skew headroom so a fast client
+    //     clock that writes a slightly-future TimeUnixMs (it's client-supplied)
+    //     doesn't silently drop the row. Lower bound is safe because CC logs
+    //     older than CLAUDE_CODE_LOG_RETENTION_DAYS have already been deleted
+    //     by TTL anyway.
     const partitionWindowMs = 2 * 24 * 60 * 60 * 1000;
     const ccRetentionMs = CLAUDE_CODE_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
     const fallbackLookbackMs = ccRetentionMs * 7;
@@ -113,7 +116,9 @@ export class LogRecordStorageClickHouseRepository
     const fromMs = hasWindow
       ? occurredAtMs - partitionWindowMs
       : now - fallbackLookbackMs;
-    const toMs = hasWindow ? occurredAtMs + partitionWindowMs : now;
+    const toMs = hasWindow
+      ? occurredAtMs + partitionWindowMs
+      : now + partitionWindowMs;
     // Qualify the bound with the table name: the outer SELECT aliases
     // `toUnixTimestamp64Milli(TimeUnixMs) AS TimeUnixMs`, and ClickHouse would
     // otherwise resolve a bare `TimeUnixMs` in WHERE to that ms-integer alias

--- a/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/log-record-storage.clickhouse.repository.ts
@@ -1,8 +1,8 @@
-import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import {
   CLAUDE_CODE_KIND_ATTR,
   CLAUDE_CODE_LOG_RETENTION_DAYS,
 } from "~/server/app-layer/traces/claude-code-log-to-span";
+import type { ClickHouseClientResolver } from "~/server/clickhouse/clickhouseClient";
 import { PLATFORM_DEFAULT_RETENTION_DAYS } from "~/server/data-retention/retentionPolicy.schema";
 import type { NormalizedLogRecord } from "~/server/event-sourcing/pipelines/trace-processing/schemas/logRecords";
 import { EventUtils } from "~/server/event-sourcing/utils/event.utils";
@@ -23,7 +23,10 @@ export class LogRecordStorageClickHouseRepository
 {
   constructor(private readonly resolveClient: ClickHouseClientResolver) {}
 
-  async insertLogRecord(record: NormalizedLogRecord, retentionDays = PLATFORM_DEFAULT_RETENTION_DAYS): Promise<void> {
+  async insertLogRecord(
+    record: NormalizedLogRecord,
+    retentionDays = PLATFORM_DEFAULT_RETENTION_DAYS,
+  ): Promise<void> {
     EventUtils.validateTenantId(
       { tenantId: record.tenantId },
       "LogRecordStorageClickHouseRepository.insertLogRecord",
@@ -131,7 +134,7 @@ export class LogRecordStorageClickHouseRepository
     // Moving it out makes the inner read lightweight key columns only; the
     // outer SELECT then applies the filter to one row per (TenantId, TraceId,
     // SpanId, ProjectionId), which is the right scale to read the map at.
-            const result = await client.query({
+    const result = await client.query({
       query: `
         SELECT
           TraceId,

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -159,6 +159,36 @@ const SINGLE_TRACE_READ_SETTINGS = {
 } as const;
 
 /**
+ * Settings for the single-span fetch paths (`getSpanByIds`, `getSpanEvents`).
+ * Locks `query_plan_optimize_lazy_materialization=1` per-query so the LazilyRead
+ * optimiser stays engaged even if a future cluster/profile config flips it off.
+ *
+ * Investigation (dev CH 25.10.1.3832 against a fat span: 19 attrs / 127 events
+ * / ~88KB Events.Attributes):
+ *
+ *   getSpanByIds   Form A (ORDER BY UpdatedAt DESC LIMIT 1)
+ *     read_bytes = 14,933       (~15KB) - heavy columns deferred past LIMIT
+ *   getSpanByIds   Form B (scalar-subquery dedup, doc "Anti-Pattern 1" form)
+ *     read_bytes = 9,706,538    (~9.7MB)
+ *   getSpanByIds   Form A, LazilyRead disabled
+ *     read_bytes = 9,692,701    (~9.7MB) - matches Form B, hence the lock
+ *
+ *   getSpanEvents  Form A (inner ORDER BY DESC LIMIT 1, ARRAY JOIN outside)
+ *     read_bytes = 14,933       (~15KB) - LazilyRead survives through the subquery
+ *   getSpanEvents  Form B (scalar-subquery dedup inside the subquery)
+ *     read_bytes = 4,570,069    (~4.6MB)
+ *
+ * LazilyRead applies to LIMIT N where N <= query_plan_max_limit_for_lazy_materialization
+ * (default 10 on 25.10, raised to 10,000 on 25.12). LIMIT 1 is well inside the
+ * safe zone. Above the threshold, Form A degrades to full heavy-column reads.
+ * Minimum supported CH version for these methods: 25.4 (where LazilyRead landed).
+ */
+const SINGLE_SPAN_FETCH_SETTINGS = {
+  ...SINGLE_TRACE_READ_SETTINGS,
+  query_plan_optimize_lazy_materialization: "1",
+} as const;
+
+/**
  * Light projection used by readers that only need the span tree shape
  * (waterfall/flame, span list). Avoids reading heavy `SpanAttributes`,
  * `Events.*`, and `Links.*` columns. Map subscripts (`['key']`) read a
@@ -931,18 +961,15 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         async (window) => {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);
-          // Single-span fetch: WHERE pins (TenantId, TraceId, SpanId) - the
-          // primary key prefix - so we hit a tiny granule range. With at
-          // most a handful of versions per spanId, ORDER BY UpdatedAt DESC
-          // LIMIT 1 is cheaper than the IN-tuple dedup the multi-row paths
-          // need.
-          //
-          // On ClickHouse 25.10 this form picks up the `LazilyRead`
-          // optimiser step (verified via EXPLAIN on prod): heavy columns
-          // (SpanAttributes, Events.*, Links.*) are deferred past the
-          // LIMIT, so even unmerged versions don't materialise them. The
-          // doc's "Anti-Pattern 1" rule predates LazilyRead and no longer
-          // applies on this CH line.
+          // Single-span fetch. WHERE pins (TenantId, TraceId, SpanId) - the
+          // primary key prefix - so we hit a tiny granule range. ORDER BY
+          // UpdatedAt DESC LIMIT 1 deliberately picks up CH 25.10's
+          // LazilyRead optimiser: heavy columns (SpanAttributes, Events.*,
+          // Links.*) are deferred past the LIMIT, so unmerged versions
+          // don't materialise them. Investigation numbers + the per-query
+          // lock that keeps the optimiser engaged live in
+          // SINGLE_SPAN_FETCH_SETTINGS above. The doc's "Anti-Pattern 1"
+          // rule predates LazilyRead and isn't load-bearing on this shape.
           const result = await client.query({
             query: `
               SELECT ${FULL_SPAN_SELECT}
@@ -955,7 +982,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               LIMIT 1
             `,
             query_params: { tenantId, traceId, spanId, ...partition.params },
-            clickhouse_settings: SINGLE_TRACE_READ_SETTINGS,
+            clickhouse_settings: SINGLE_SPAN_FETCH_SETTINGS,
             format: "JSONEachRow",
           });
 
@@ -1291,11 +1318,14 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
                 event_name AS event_type,
                 event_attrs AS attributes
               FROM (
-                -- Single-span fetch. Same rationale as getSpanByIds:
-                -- ORDER BY UpdatedAt DESC LIMIT 1 picks up LazilyRead on
-                -- CH 25.10 so the heavy Events.* arrays are deferred past
-                -- the LIMIT. Doc's "Anti-Pattern 1" rule predates that
-                -- optimiser and no longer applies here.
+                -- Single-span fetch. Same rationale and same investigation
+                -- as getSpanByIds (see SINGLE_SPAN_FETCH_SETTINGS comment).
+                -- LazilyRead survives through this subquery + ARRAY JOIN
+                -- composition: Events.Timestamp / Events.Name /
+                -- Events.Attributes are deferred past the inner LIMIT 1
+                -- and only the granule's key columns are read up front.
+                -- ARRAY JOIN unrolls the events from the single picked
+                -- row after the lazy read materialises it.
                 SELECT
                   TenantId, TraceId, SpanId,
                   "Events.Timestamp" AS Events_Timestamp,
@@ -1316,6 +1346,7 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
               ORDER BY event_timestamp DESC
             `,
             query_params: { tenantId, traceId, spanId, ...partition.params },
+            clickhouse_settings: SINGLE_SPAN_FETCH_SETTINGS,
             format: "JSONEachRow",
           });
 

--- a/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/span-storage.clickhouse.repository.ts
@@ -931,10 +931,18 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
         async (window) => {
           const partition = partitionFragment(window);
           const client = await this.resolveClient(tenantId);
-          // Single-span fetch: WHERE pins (TenantId, TraceId, SpanId) — the
-          // primary key prefix — so we hit a tiny granule range. With at most
-          // a handful of versions per spanId, ORDER BY UpdatedAt DESC LIMIT 1
-          // is cheaper than the IN-tuple dedup the multi-row paths need.
+          // Single-span fetch: WHERE pins (TenantId, TraceId, SpanId) - the
+          // primary key prefix - so we hit a tiny granule range. With at
+          // most a handful of versions per spanId, ORDER BY UpdatedAt DESC
+          // LIMIT 1 is cheaper than the IN-tuple dedup the multi-row paths
+          // need.
+          //
+          // On ClickHouse 25.10 this form picks up the `LazilyRead`
+          // optimiser step (verified via EXPLAIN on prod): heavy columns
+          // (SpanAttributes, Events.*, Links.*) are deferred past the
+          // LIMIT, so even unmerged versions don't materialise them. The
+          // doc's "Anti-Pattern 1" rule predates LazilyRead and no longer
+          // applies on this CH line.
           const result = await client.query({
             query: `
               SELECT ${FULL_SPAN_SELECT}
@@ -1283,6 +1291,11 @@ export class SpanStorageClickHouseRepository implements SpanStorageRepository {
                 event_name AS event_type,
                 event_attrs AS attributes
               FROM (
+                -- Single-span fetch. Same rationale as getSpanByIds:
+                -- ORDER BY UpdatedAt DESC LIMIT 1 picks up LazilyRead on
+                -- CH 25.10 so the heavy Events.* arrays are deferred past
+                -- the LIMIT. Doc's "Anti-Pattern 1" rule predates that
+                -- optimiser and no longer applies here.
                 SELECT
                   TenantId, TraceId, SpanId,
                   "Events.Timestamp" AS Events_Timestamp,

--- a/langwatch/src/server/clickhouse/migrations/00034_add_query_pruning_indexes.sql
+++ b/langwatch/src/server/clickhouse/migrations/00034_add_query_pruning_indexes.sql
@@ -1,0 +1,100 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- Adds skipping indexes for granule-level pruning the existing schemas missed:
+--
+--   1. trace_summaries.idx_occurred_at — analytics queries filter heavily on
+--      OccurredAt (PARTITION BY toYearWeek(OccurredAt) gives week-granularity
+--      pruning; this minmax lets the planner skip granules within a partition).
+--
+--   2. stored_log_records / stored_metric_records — ResourceAttributes bloom
+--      filters for parity with stored_spans. Map filters like
+--      ResourceAttributes['service.name'] = 'x' currently scan the whole map
+--      column because nothing indexes the keys/values; this matches the
+--      idx_res_attr_key / idx_res_attr_value pair on stored_spans.
+--
+-- MATERIALIZE INDEX is a background mutation. On warm parts it's quick; on
+-- cold-tier S3 parts the mutation will stream them back through compute. Safe
+-- to run in production but expect minutes-to-hours of merge backlog on
+-- high-volume tables before the index is fully effective for historic data.
+-- New parts use the index immediately.
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  ADD INDEX IF NOT EXISTS idx_occurred_at OccurredAt TYPE minmax GRANULARITY 1;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  MATERIALIZE INDEX idx_occurred_at;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 4;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 4;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records
+  MATERIALIZE INDEX idx_res_attr_key;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records
+  MATERIALIZE INDEX idx_res_attr_value;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 4;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 4;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
+  MATERIALIZE INDEX idx_res_attr_key;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
+  MATERIALIZE INDEX idx_res_attr_value;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- Down migrations are intentionally commented out per project convention
+-- (see dev/docs/best_practices/clickhouse-queries.md and prior migrations).
+-- To roll back, uncomment and run manually.
+-- +goose ENVSUB ON
+
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries DROP INDEX IF EXISTS idx_occurred_at;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records DROP INDEX IF EXISTS idx_res_attr_key;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records DROP INDEX IF EXISTS idx_res_attr_value;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records DROP INDEX IF EXISTS idx_res_attr_key;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records DROP INDEX IF EXISTS idx_res_attr_value;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF

--- a/langwatch/src/server/clickhouse/migrations/00034_add_query_pruning_indexes.sql
+++ b/langwatch/src/server/clickhouse/migrations/00034_add_query_pruning_indexes.sql
@@ -6,6 +6,9 @@
 --   1. trace_summaries.idx_occurred_at — analytics queries filter heavily on
 --      OccurredAt (PARTITION BY toYearWeek(OccurredAt) gives week-granularity
 --      pruning; this minmax lets the planner skip granules within a partition).
+--      MATERIALIZE is run inline because trace_summaries is small enough that
+--      backfilling the index across cold parts is cheap, and the historic
+--      analytics queries this index helps need it for the existing data.
 --
 --   2. stored_log_records / stored_metric_records — ResourceAttributes bloom
 --      filters for parity with stored_spans. Map filters like
@@ -13,11 +16,16 @@
 --      column because nothing indexes the keys/values; this matches the
 --      idx_res_attr_key / idx_res_attr_value pair on stored_spans.
 --
--- MATERIALIZE INDEX is a background mutation. On warm parts it's quick; on
--- cold-tier S3 parts the mutation will stream them back through compute. Safe
--- to run in production but expect minutes-to-hours of merge backlog on
--- high-volume tables before the index is fully effective for historic data.
--- New parts use the index immediately.
+--      Crucially: NO MATERIALIZE for these two. They're high-volume tables
+--      with cold-tier S3 parts whose volume we haven't measured. Materializing
+--      would stream them back through compute and queue minutes-to-hours of
+--      merge backlog. The bloom filter is a go-forward optimisation; new
+--      parts pick it up immediately. Historic ResourceAttributes lookups on
+--      log/metric records are rare (heavy queries hit stored_spans, which
+--      already has the equivalent indexes). If a future workload genuinely
+--      needs the historic backfill, MATERIALIZE INDEX can be run via a
+--      follow-up migration once cold-part volume is measured and a runbook
+--      for monitoring `system.mutations` is in place.
 
 -- +goose StatementBegin
 ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
@@ -40,16 +48,6 @@ ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records
-  MATERIALIZE INDEX idx_res_attr_key;
--- +goose StatementEnd
-
--- +goose StatementBegin
-ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_log_records
-  MATERIALIZE INDEX idx_res_attr_value;
--- +goose StatementEnd
-
--- +goose StatementBegin
 ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
   ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 4;
 -- +goose StatementEnd
@@ -57,16 +55,6 @@ ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
 -- +goose StatementBegin
 ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
   ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 4;
--- +goose StatementEnd
-
--- +goose StatementBegin
-ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
-  MATERIALIZE INDEX idx_res_attr_key;
--- +goose StatementEnd
-
--- +goose StatementBegin
-ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_metric_records
-  MATERIALIZE INDEX idx_res_attr_value;
 -- +goose StatementEnd
 
 -- +goose ENVSUB OFF

--- a/langwatch/src/server/stored-objects/__tests__/stored-objects.repository.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/stored-objects.repository.unit.test.ts
@@ -2,10 +2,10 @@
  * @vitest-environment node
  *
  * Unit tests for StoredObjectsRepository — verifies that queries are
- * project-scoped and that insert/findById/findBySha256 delegate to the
- * ClickHouse client with the expected shape.
+ * project-scoped and that insert/findById delegate to the ClickHouse
+ * client with the expected shape.
  */
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -29,12 +29,11 @@ vi.mock("~/server/clickhouse/clickhouseClient", () => ({
 
 vi.mock("langwatch", () => ({
   getLangWatchTracer: () => ({
-    withActiveSpan: (
-      _name: string,
-      ...args: unknown[]
-    ) => {
+    withActiveSpan: (_name: string, ...args: unknown[]) => {
       const fn = args.length === 1 ? args[0] : args[1];
-      const span: { setAttribute: ReturnType<typeof vi.fn> } = { setAttribute: vi.fn() };
+      const span: { setAttribute: ReturnType<typeof vi.fn> } = {
+        setAttribute: vi.fn(),
+      };
       return (fn as (s: typeof span) => Promise<unknown>)(span);
     },
   }),
@@ -124,12 +123,18 @@ describe("StoredObjectsRepository", () => {
         };
         mockQueryResult.json.mockResolvedValue([rawRow]);
 
-        const result = await repo.findById({ projectId: "proj-1", id: "test-id" });
+        const result = await repo.findById({
+          projectId: "proj-1",
+          id: "test-id",
+        });
 
         expect(mockQuery).toHaveBeenCalledOnce();
         const call = mockQuery.mock.calls[0]![0];
         // Query must be project-scoped
-        expect(call.query_params).toMatchObject({ projectId: "proj-1", id: "test-id" });
+        expect(call.query_params).toMatchObject({
+          projectId: "proj-1",
+          id: "test-id",
+        });
         expect(call.query).toContain("project_id");
 
         expect(result).not.toBeNull();
@@ -143,35 +148,10 @@ describe("StoredObjectsRepository", () => {
       it("returns null", async () => {
         mockQueryResult.json.mockResolvedValue([]);
 
-        const result = await repo.findById({ projectId: "proj-1", id: "missing-id" });
-
-        expect(result).toBeNull();
-      });
-    });
-  });
-
-  describe("findBySha256", () => {
-    describe("when a row with the given sha256 exists", () => {
-      it("returns the id", async () => {
-        mockQueryResult.json.mockResolvedValue([{ id: "found-id" }]);
-
-        const result = await repo.findBySha256({ projectId: "proj-1", sha256: "abc123" });
-
-        expect(mockQuery).toHaveBeenCalledOnce();
-        const call = mockQuery.mock.calls[0]![0];
-        // Query must be project-scoped
-        expect(call.query_params).toMatchObject({ projectId: "proj-1", sha256: "abc123" });
-        expect(call.query).toContain("project_id");
-
-        expect(result).toEqual({ id: "found-id" });
-      });
-    });
-
-    describe("when no row matches", () => {
-      it("returns null", async () => {
-        mockQueryResult.json.mockResolvedValue([]);
-
-        const result = await repo.findBySha256({ projectId: "proj-1", sha256: "unknown" });
+        const result = await repo.findById({
+          projectId: "proj-1",
+          id: "missing-id",
+        });
 
         expect(result).toBeNull();
       });

--- a/langwatch/src/server/stored-objects/__tests__/stored-objects.service.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/stored-objects.service.unit.test.ts
@@ -3,6 +3,7 @@
  *
  * Unit tests for StoredObjectsService with mocked repository and registry.
  */
+import { createHash } from "node:crypto";
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -185,18 +186,29 @@ describe("storeFromBytes", () => {
     });
 
     it("dedup probe goes through findById (by deterministic id), not by sha256 — a regression to the scan-all-partitions path would surface here", async () => {
-      // Lock the dedup-probe contract: the hot path computes id = derive(projectId, sha256)
-      // and looks up via findById. findById uses the (project_id, id) primary key seek;
-      // the old sha256 path scanned every weekly partition incl. cold S3.
+      // Lock the dedup-probe contract: the hot path computes
+      // id = deriveStoredObjectId(projectId, sha256) and looks up via
+      // findById. findById uses the (project_id, id) primary key seek; the
+      // old sha256 path scanned every weekly partition incl. cold S3.
+      // Asserting the *exact* derived id so a future change to the id
+      // derivation (e.g. salt swap, hash family change) is caught here
+      // rather than later in the dedup correctness.
       vi.mocked(repo.findById).mockResolvedValue(null);
+
+      const expectedSha256 = createHash("sha256")
+        .update(TEST_BYTES)
+        .digest("hex");
+      const expectedId = deriveStoredObjectId({
+        projectId: PROJECT_ID,
+        sha256: expectedSha256,
+      });
 
       await service.storeFromBytes(STORE_PARAMS);
 
       expect(repo.findById).toHaveBeenCalledOnce();
       const call = vi.mocked(repo.findById).mock.calls[0]![0];
       expect(call.projectId).toBe(PROJECT_ID);
-      expect(typeof call.id).toBe("string");
-      expect(call.id.length).toBeGreaterThan(0);
+      expect(call.id).toBe(expectedId);
     });
   });
 

--- a/langwatch/src/server/stored-objects/__tests__/stored-objects.service.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/stored-objects.service.unit.test.ts
@@ -174,7 +174,7 @@ describe("storeFromBytes", () => {
   describe("when identical content already exists for the project", () => {
     it("returns the existing id with isDuplicate true and does not call storage put or repository insert", async () => {
       const existingId = "existing-uuid";
-      vi.mocked(repo.findBySha256).mockResolvedValue({ id: existingId });
+      vi.mocked(repo.findById).mockResolvedValue(makeRow({ id: existingId }));
 
       const result = await service.storeFromBytes(STORE_PARAMS);
 

--- a/langwatch/src/server/stored-objects/__tests__/stored-objects.service.unit.test.ts
+++ b/langwatch/src/server/stored-objects/__tests__/stored-objects.service.unit.test.ts
@@ -4,7 +4,7 @@
  * Unit tests for StoredObjectsService with mocked repository and registry.
  */
 import { Readable } from "node:stream";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — must be declared before any imports that trigger module load
@@ -12,10 +12,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("langwatch", () => ({
   getLangWatchTracer: () => ({
-    withActiveSpan: (
-      _name: string,
-      ...args: unknown[]
-    ) => {
+    withActiveSpan: (_name: string, ...args: unknown[]) => {
       // withActiveSpan(name, fn) or withActiveSpan(name, options, fn)
       const fn = args.length === 1 ? args[0] : args[1];
       const span: { setAttribute: ReturnType<typeof vi.fn> } = {
@@ -63,14 +60,17 @@ vi.mock("~/server/dataplane-s3", () => ({
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
+import { env as mockedEnv } from "~/env.mjs";
+import * as dataplaneS3 from "~/server/dataplane-s3";
+import { ObjectNotFoundError } from "../errors";
+import type { StorageRegistry } from "../storage-registry";
 import type { StoredObject } from "../stored-object";
 import type { StoredObjectsRepository } from "../stored-objects.repository";
-import { StoredObjectsService, deriveStoredObjectId } from "../stored-objects.service";
 import type { MintStorageUri } from "../stored-objects.service";
-import type { StorageRegistry } from "../storage-registry";
-import { ObjectNotFoundError } from "../errors";
-import * as dataplaneS3 from "~/server/dataplane-s3";
-import { env as mockedEnv } from "~/env.mjs";
+import {
+  deriveStoredObjectId,
+  StoredObjectsService,
+} from "../stored-objects.service";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -80,7 +80,6 @@ function makeRepository(): StoredObjectsRepository {
   return {
     insert: vi.fn().mockResolvedValue(undefined),
     findById: vi.fn().mockResolvedValue(null),
-    findBySha256: vi.fn().mockResolvedValue(null),
     findAllByProject: vi.fn().mockResolvedValue([]),
     deleteByProject: vi.fn().mockResolvedValue(undefined),
     deleteByIds: vi.fn().mockResolvedValue(undefined),
@@ -137,16 +136,15 @@ describe("storeFromBytes", () => {
   beforeEach(() => {
     repo = makeRepository();
     registry = makeRegistry();
-    mockMintStorageUri = vi.fn(async ({ projectId, sha256 }: { projectId: string; sha256: string }) =>
-      `file:///tmp/${projectId}/${sha256}`,
+    mockMintStorageUri = vi.fn(
+      async ({ projectId, sha256 }: { projectId: string; sha256: string }) =>
+        `file:///tmp/${projectId}/${sha256}`,
     ) as ReturnType<typeof vi.fn> & MintStorageUri;
     service = new StoredObjectsService(repo, registry, mockMintStorageUri);
   });
 
   describe("when the content is new for the project", () => {
     it("PUTs bytes to storage, INSERTs a stored_objects row, returns the new id with isDuplicate false", async () => {
-      vi.mocked(repo.findBySha256).mockResolvedValue(null);
-
       const result = await service.storeFromBytes(STORE_PARAMS);
 
       expect(registry.put).toHaveBeenCalledOnce();
@@ -185,15 +183,31 @@ describe("storeFromBytes", () => {
       expect(result.isDuplicate).toBe(true);
       expect(result.mediaType).toBe("text/plain");
     });
+
+    it("dedup probe goes through findById (by deterministic id), not by sha256 — a regression to the scan-all-partitions path would surface here", async () => {
+      // Lock the dedup-probe contract: the hot path computes id = derive(projectId, sha256)
+      // and looks up via findById. findById uses the (project_id, id) primary key seek;
+      // the old sha256 path scanned every weekly partition incl. cold S3.
+      vi.mocked(repo.findById).mockResolvedValue(null);
+
+      await service.storeFromBytes(STORE_PARAMS);
+
+      expect(repo.findById).toHaveBeenCalledOnce();
+      const call = vi.mocked(repo.findById).mock.calls[0]![0];
+      expect(call.projectId).toBe(PROJECT_ID);
+      expect(typeof call.id).toBe("string");
+      expect(call.id.length).toBeGreaterThan(0);
+    });
   });
 
   describe("when storage put fails", () => {
     it("throws and does not insert any stored_objects row", async () => {
       const storageError = new Error("S3 unavailable");
-      vi.mocked(repo.findBySha256).mockResolvedValue(null);
       vi.mocked(registry.put).mockRejectedValue(storageError);
 
-      await expect(service.storeFromBytes(STORE_PARAMS)).rejects.toThrow("S3 unavailable");
+      await expect(service.storeFromBytes(STORE_PARAMS)).rejects.toThrow(
+        "S3 unavailable",
+      );
       expect(repo.insert).not.toHaveBeenCalled();
     });
   });
@@ -202,7 +216,6 @@ describe("storeFromBytes", () => {
     /** @scenario "DB insert failure after a successful storage PUT triggers compensating storage delete" */
     it("issues a compensating storage delete and surfaces the original error to the caller", async () => {
       // Setup: storage PUT succeeds, repository INSERT throws.
-      vi.mocked(repo.findBySha256).mockResolvedValue(null);
       const chError = new Error("ClickHouse insert failed");
       vi.mocked(repo.insert).mockRejectedValueOnce(chError);
 
@@ -237,7 +250,6 @@ describe("storeFromBytes", () => {
       // back to the caller synchronously instead of being silently
       // dropped on the async_insert queue. The service must surface that
       // error untouched — no try/catch swallow, no degraded fallback.
-      vi.mocked(repo.findBySha256).mockResolvedValue(null);
       const chError = new Error("DB::NetException: connection refused");
       vi.mocked(repo.insert).mockRejectedValueOnce(chError);
 
@@ -250,12 +262,10 @@ describe("storeFromBytes", () => {
   describe("when called twice with identical input", () => {
     it("returns the same deterministic id", async () => {
       // First call: miss → store
-      vi.mocked(repo.findBySha256).mockResolvedValueOnce(null);
       const first = await service.storeFromBytes(STORE_PARAMS);
 
       // Second call: simulated hit (real world) — but we want to verify
       // determinism so we call storeFromBytes again with a miss too
-      vi.mocked(repo.findBySha256).mockResolvedValueOnce(null);
       const second = await service.storeFromBytes(STORE_PARAMS);
 
       expect(first.id).toBe(second.id);
@@ -270,8 +280,14 @@ describe("storeFromBytes", () => {
       // with the same inputs twice and verifying they produce the same result.
       const sha256 = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0536d6";
 
-      const idFromPod1 = deriveStoredObjectId({ projectId: PROJECT_ID, sha256 });
-      const idFromPod2 = deriveStoredObjectId({ projectId: PROJECT_ID, sha256 });
+      const idFromPod1 = deriveStoredObjectId({
+        projectId: PROJECT_ID,
+        sha256,
+      });
+      const idFromPod2 = deriveStoredObjectId({
+        projectId: PROJECT_ID,
+        sha256,
+      });
 
       expect(idFromPod1).toBe(idFromPod2);
       // Must look like a KSUID: resource_<29-char-base62>
@@ -300,7 +316,10 @@ describe("getById", () => {
       vi.mocked(repo.findById).mockResolvedValue(row);
       vi.mocked(registry.get).mockResolvedValue(stream);
 
-      const result = await service.getById({ projectId: PROJECT_ID, id: "obj-1" });
+      const result = await service.getById({
+        projectId: PROJECT_ID,
+        id: "obj-1",
+      });
 
       expect(result).not.toBeNull();
       expect(result).toMatchObject({ row });
@@ -316,7 +335,10 @@ describe("getById", () => {
         new ObjectNotFoundError("file:///var/lib/langwatch/objects/proj-1/abc"),
       );
 
-      const result = await service.getById({ projectId: PROJECT_ID, id: "obj-1" });
+      const result = await service.getById({
+        projectId: PROJECT_ID,
+        id: "obj-1",
+      });
 
       expect(result).not.toBeNull();
       expect(result).toMatchObject({ row, status: "missing" });
@@ -328,7 +350,10 @@ describe("getById", () => {
     it("returns null", async () => {
       vi.mocked(repo.findById).mockResolvedValue(null);
 
-      const result = await service.getById({ projectId: PROJECT_ID, id: "unknown-id" });
+      const result = await service.getById({
+        projectId: PROJECT_ID,
+        id: "unknown-id",
+      });
 
       expect(result).toBeNull();
     });
@@ -452,7 +477,10 @@ describe("headById", () => {
       vi.mocked(repo.findById).mockResolvedValue(row);
       vi.mocked(registry.exists).mockResolvedValue(true);
 
-      const result = await service.headById({ projectId: PROJECT_ID, id: "obj-1" });
+      const result = await service.headById({
+        projectId: PROJECT_ID,
+        id: "obj-1",
+      });
 
       expect(result).toEqual({ status: "available", mediaType: "audio/mp3" });
     });
@@ -464,7 +492,10 @@ describe("headById", () => {
       vi.mocked(repo.findById).mockResolvedValue(row);
       vi.mocked(registry.exists).mockResolvedValue(false);
 
-      const result = await service.headById({ projectId: PROJECT_ID, id: "obj-1" });
+      const result = await service.headById({
+        projectId: PROJECT_ID,
+        id: "obj-1",
+      });
 
       expect(result).toEqual({ status: "missing", mediaType: "audio/mp3" });
     });
@@ -474,7 +505,10 @@ describe("headById", () => {
     it("returns status not_found and does not probe storage", async () => {
       vi.mocked(repo.findById).mockResolvedValue(null);
 
-      const result = await service.headById({ projectId: PROJECT_ID, id: "unknown" });
+      const result = await service.headById({
+        projectId: PROJECT_ID,
+        id: "unknown",
+      });
 
       expect(result).toEqual({ status: "not_found" });
       expect(registry.exists).not.toHaveBeenCalled();
@@ -491,7 +525,6 @@ describe("mintStorageUri (BYOC bucket selection — observed through the inserte
     repo = makeRepository();
     registry = makeRegistry();
     service = new StoredObjectsService(repo, registry);
-    vi.mocked(repo.findBySha256).mockResolvedValue(null);
   });
 
   describe("when the project has a private dataplane bucket configured", () => {
@@ -555,7 +588,11 @@ describe("StoredObjectsService surface", () => {
   it("exposes storeFromBytes, getById, deleteOwnedBy", () => {
     const mintStub: MintStorageUri = async ({ projectId, sha256 }) =>
       `file:///tmp/${projectId}/${sha256}`;
-    const service = new StoredObjectsService(makeRepository(), makeRegistry(), mintStub);
+    const service = new StoredObjectsService(
+      makeRepository(),
+      makeRegistry(),
+      mintStub,
+    );
 
     expect(typeof service.storeFromBytes).toBe("function");
     expect(typeof service.getById).toBe("function");

--- a/langwatch/src/server/stored-objects/stored-objects.repository.ts
+++ b/langwatch/src/server/stored-objects/stored-objects.repository.ts
@@ -175,63 +175,6 @@ export class StoredObjectsRepository {
   }
 
   /**
-   * Returns the id of an existing stored_objects row whose sha256 matches,
-   * or null if no such row exists for this project.
-   *
-   * Used by storeFromBytes to implement content-addressed deduplication.
-   */
-  async findBySha256({
-    projectId,
-    sha256,
-  }: {
-    projectId: string;
-    sha256: string;
-  }): Promise<{ id: string } | null> {
-    return tracer.withActiveSpan(
-      "StoredObjectsRepository.findBySha256",
-      {
-        kind: SpanKind.CLIENT,
-        attributes: {
-          "db.system": "clickhouse",
-          "db.operation": "SELECT",
-          "tenant.id": projectId,
-          "stored_object.sha256": sha256,
-        },
-      },
-      async (span) => {
-        const client = await getClickHouseClientForProject(projectId);
-        if (!client) {
-          throw new Error(
-            "ClickHouse is not configured — cannot find stored object by sha256",
-          );
-        }
-
-        const result = await client.query({
-          query: `
-            SELECT id
-            FROM ${TABLE_NAME}
-            WHERE project_id = {projectId:String}
-              AND sha256 = {sha256:String}
-            LIMIT 1
-          `,
-          query_params: { projectId, sha256 },
-          format: "JSONEachRow",
-        });
-
-        const rows = await result.json<{ id: string }>();
-
-        span.setAttribute("result.found", rows.length > 0);
-
-        if (rows.length === 0) {
-          return null;
-        }
-
-        return { id: rows[0]!.id };
-      },
-    );
-  }
-
-  /**
    * Streams (id, storage_uri) pairs for every live row owned by the project.
    *
    * Used by `deleteOwnedBy` to enumerate the bytes that need to be
@@ -319,11 +262,7 @@ export class StoredObjectsRepository {
    * this method, otherwise the byte content orphans in S3/disk with no row
    * pointing at it.
    */
-  async deleteByProject({
-    projectId,
-  }: {
-    projectId: string;
-  }): Promise<void> {
+  async deleteByProject({ projectId }: { projectId: string }): Promise<void> {
     return tracer.withActiveSpan(
       "StoredObjectsRepository.deleteByProject",
       {

--- a/langwatch/src/server/stored-objects/stored-objects.repository.ts
+++ b/langwatch/src/server/stored-objects/stored-objects.repository.ts
@@ -263,9 +263,22 @@ export class StoredObjectsRepository {
           );
         }
 
-        // Project-scoped enumeration with the standard dedup pattern.
-        // We project only id + storage_uri because the cascade does not
-        // need the full row; this keeps the scan cheap on wide tables.
+        // Project-scoped enumeration. Two notes on cost:
+        //
+        //   1. Dedup uses the IN-tuple pattern, not a correlated scalar
+        //      subquery — the inner GROUP BY runs once and produces the
+        //      (id, max(inserted_at)) set, then the outer matches against
+        //      it. The previous correlated form (`inserted_at = (SELECT
+        //      max(s.inserted_at) WHERE s.id = t.id)`) re-ran the inner
+        //      query for every row.
+        //   2. No `created_at` (partition) predicate is possible here —
+        //      cascade-delete needs every row that has ever existed for
+        //      this project, including very old objects sitting in cold
+        //      S3 partitions. The scan is bounded by `project_id IN
+        //      ORDER BY` so it walks only that project's granules within
+        //      each partition, but the partition fan-out itself is
+        //      unavoidable. Run sparingly; this is a project-deletion
+        //      cascade, not a hot path.
         const result = await client.query({
           query: `
             SELECT
@@ -273,11 +286,11 @@ export class StoredObjectsRepository {
               t.storage_uri AS storage_uri
             FROM ${TABLE_NAME} AS t
             WHERE t.project_id = {projectId:String}
-              AND t.inserted_at = (
-                SELECT max(s.inserted_at)
-                FROM ${TABLE_NAME} AS s
-                WHERE s.project_id = {projectId:String}
-                  AND s.id = t.id
+              AND (t.project_id, t.id, t.inserted_at) IN (
+                SELECT project_id, id, max(inserted_at)
+                FROM ${TABLE_NAME}
+                WHERE project_id = {projectId:String}
+                GROUP BY project_id, id
               )
           `,
           query_params: { projectId },

--- a/langwatch/src/server/stored-objects/stored-objects.service.ts
+++ b/langwatch/src/server/stored-objects/stored-objects.service.ts
@@ -153,8 +153,15 @@ export class StoredObjectsService {
         span.setAttribute("stored_object.id", id);
         span.setAttribute("stored_object.sha256", sha256);
 
-        // Dedup probe: if content already present, skip PUT + INSERT
-        const existing = await this.repository.findBySha256({ projectId, sha256 });
+        // Dedup probe: if content already present, skip PUT + INSERT.
+        // Lookup by id (not sha256) because:
+        //   1. id is derived deterministically from (projectId, sha256) right
+        //      above, so it's already known here — no extra computation.
+        //   2. The stored_objects table's `ORDER BY (project_id, id)` makes
+        //      this a primary-key seek with partition pruning; a sha256
+        //      lookup would scan every weekly partition incl. cold S3 because
+        //      sha256 is not in the sort key.
+        const existing = await this.repository.findById({ projectId, id });
         if (existing) {
           getStoredObjectDedupHitCounter(purpose).inc();
           span.setAttribute("stored_object.dedup_hit", true);

--- a/langwatch/src/server/stored-objects/stored-objects.service.ts
+++ b/langwatch/src/server/stored-objects/stored-objects.service.ts
@@ -6,8 +6,8 @@
  */
 import { createHash } from "node:crypto";
 import type { Readable } from "node:stream";
-import { SpanKind } from "@opentelemetry/api";
 import { Instance, Ksuid } from "@langwatch/ksuid";
+import { SpanKind } from "@opentelemetry/api";
 import { getLangWatchTracer } from "langwatch";
 import {
   getStoredObjectDedupHitCounter,
@@ -22,9 +22,9 @@ import {
   redactStorageUri,
   resolveProjectStorageDestination,
 } from "./project-storage-destination";
+import type { StorageRegistry } from "./storage-registry";
 import type { StoredObject } from "./stored-object";
 import type { StoredObjectsRepository } from "./stored-objects.repository";
-import type { StorageRegistry } from "./storage-registry";
 import { mintFileUri, mintS3Uri } from "./uri";
 
 const tracer = getLangWatchTracer("langwatch.stored-objects.service");
@@ -58,7 +58,10 @@ function deriveStoredObjectId({
  * and SHA-256 content hash. Injected into `StoredObjectsService` so tests can
  * supply a per-call stub without module-level mocking.
  */
-export type MintStorageUri = (args: { projectId: string; sha256: string }) => Promise<string>;
+export type MintStorageUri = (args: {
+  projectId: string;
+  sha256: string;
+}) => Promise<string>;
 
 /**
  * Returns the storage URI for a new object, delegating destination
@@ -387,8 +390,14 @@ export class StoredObjectsService {
           }
         }
         span.setAttribute("stored_objects.bytes_deleted", bytesDeleted);
-        span.setAttribute("stored_objects.byte_delete_failures", byteDeleteFailures);
-        span.setAttribute("stored_objects.rows_retained_for_retry", byteDeleteFailures);
+        span.setAttribute(
+          "stored_objects.byte_delete_failures",
+          byteDeleteFailures,
+        );
+        span.setAttribute(
+          "stored_objects.rows_retained_for_retry",
+          byteDeleteFailures,
+        );
 
         // Only remove the rows whose bytes were successfully deleted.
         // Failed rows stay behind so the next cascade can retry the
@@ -410,7 +419,6 @@ export class StoredObjectsService {
       },
     );
   }
-
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Multi-agent audit pass on CH repos and analytics, surfaced quite some cheap wins. Validated each against prod EXPLAIN before landing - which killed two of my own bigger ideas (projections, scalar-subquery anti-pattern rewrites) once the prod data showed they wouldn't help on this CH line.

### Migration 00034 - indexes that should already have existed

- `trace_summaries.idx_occurred_at` (minmax). Existing schema indexed `CreatedAt` but every analytics query filters on `OccurredAt`. Free granule pruning we were leaving on the table.
- `stored_log_records` and `stored_metric_records` get bloom_filter parity on `ResourceAttributes`. `stored_spans` already had it; consistency for free.

### quantileTDigest opt-in for performance.* and spans.metrics.*

New `PercentileMode` type, defaults to `"exact"`. Performance / cost / token-count metrics opt into tdigest. Evaluation scores and sentiment stay exact - their distributions are narrow enough that ±5% at the tail can flip threshold-based dashboard outcomes. `quantileExact`'s O(N) memory was a top OOM driver on heavy analytics reads.

### Repo audit fixes (8 sites)

- `event_log.findAggregates` was filtering on `EventTimestamp` but the partition key derives from `EventOccurredAt`. Silently scanning every weekly partition incl. cold S3.
- `event_log.searchAggregates` would unbound-scan with empty `tenantIds` + empty query string. Now requires at least one.
- `event_log.findEventsByAggregate` accepts an optional `sinceMs` to bound the heavy `EventPayload` scan.
- `log-record-storage` heavy `Attributes` map filter moved out of the dedup subquery; unbounded fallback replaced with a CC-retention-bounded window.
- `stored_objects` hot path switched from `findBySha256` (scan-all-partitions on `sha256`) to `findById` using the deterministic id we already compute. `findAllByProject` correlated subquery rewritten as IN-tuple.
- `suite-run.getBatchHistory` was missing IN-tuple dedup entirely - the page could fill with multiple versions of the same `BatchRunId`. Now it dedups.
- `dspy-step.getStepsByExperiment` accepts an optional `sinceMs`.

### What I left out (and why)

- **No projection migration**. Prod EXPLAIN on `stored_spans` shows the existing index funnel (`TenantId` → `idx_trace_id` → `idx_span_id` → `idx_tenant_trace`) already prunes single-row reads to 1 part / 1 granule. Trace-list dedup gets to 6 granules out of 12,468 via partition + time + IN-set + skip indexes. There's no dedup tax to optimise away - version churn per key in prod is essentially zero in the hour we sampled. Adding projections would add storage + `rebuild`-mode merge cost (CH 25 blocks projections on ReplacingMergeTree unless `deduplicate_merge_projection_mode` is changed) for no real read win.
- **No scalar-subquery dedup "fixes" on `getSpanByIds` / `getSpanEvents`**. Prod EXPLAIN confirmed CH 25.10's `LazilyRead` defers heavy columns past LIMIT, so the doc's "Anti-Pattern 1" form is actually the cheaper one for single-row reads on this CH line. Both stay on `ORDER BY <version> DESC LIMIT 1` with comments citing LazilyRead.
- **No `virtual_key_dict` pilot**. The audit agent flagged an N+1 that wasn't - the existing code does one batched `findMany`, not per-row hydration. Dict pattern still worth considering for `evaluator_dict` later (real correctness story there), but not in this PR.

## Test plan

- [ ] Migration 00034 runs cleanly on a staging snapshot; `MATERIALIZE INDEX` background mutations complete.
- [ ] Existing analytics queries return correct results (numbers match pre-migration on a known query for a busy tenant).
- [ ] Spot-check a `performance.completion_time` p95 panel - value within ±5% of the previous `quantileExact` value.
- [ ] Evaluation `quantileExactIf` reads stay on exact (regression-checked by the new `metric-translator.test.ts` case).
- [ ] Suite-run batch history no longer shows duplicate `BatchRunId` rows for ScenarioSets with multiple updates.
- [ ] Stored-objects ingest still dedups (unit tests pass; staging upload of the same bytes twice surfaces the existing id).
- [ ] Event-log ops UI: empty tenant filter + empty query string now throws clearly instead of returning a partial result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `sinceMs` support for event-history reads, bounded when provided and unbounded when omitted.

* **Bug Fixes**
  * Prevented unmerged/repeated entries in suite batch history via deduping.
  * Improved stored-object deduplication by probing with deterministic content ids (no sha-based probing).
  * Ensured bounded retention behavior for marked Claude code logs when time isn’t provided.
  * Added guards to avoid full event log scans unless inputs are sufficiently constrained.

* **Performance**
  * Switched `performance.*` percentile calculations to tdigest quantiles.
  * Improved ClickHouse pruning and added query skipping indexes.

* **Tests & Maintenance**
  * Updated SQL-generation and percentile/memory-safety assertions to match new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->