### PR TITLE
fix(collector): remove un-awaited module-load tiktoken prewarm fetch in tests (#4476)

### DIFF
--- a/langwatch/src/server/background/workers/collector/__tests__/cost.module-load.unit.test.ts
+++ b/langwatch/src/server/background/workers/collector/__tests__/cost.module-load.unit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression guard for issue #4476.
+ *
+ * `cost.ts` used to fire `prewarmTiktokenModels()` as an un-awaited side effect
+ * at module load (gated on `isBuildOrNoRedis`, which is TRUE under tests because
+ * vitest sets BUILD_TIME=1). That kicked off a background fetch of the tiktoken
+ * BPE-rank files — a network socket + WASM load — for EVERY unit-test file that
+ * transitively imports `cost.ts` (metrics, span-cost-enrichment, the cost test
+ * itself, ...). Under `--coverage`, vitest waits for a graceful worker exit
+ * instead of force-killing the pool, so that in-flight fetch kept the worker's
+ * event loop alive long after every test passed — wedging `test-unit (2)` until
+ * the CI job timeout and blocking `langwatch-app-ci`.
+ *
+ * The real worker prewarms explicitly via `collectorWorker.ts`, so importing
+ * `cost.ts` must stay side-effect-free. This test fails if anyone reintroduces a
+ * module-load auto-prewarm.
+ */
+
+const { prewarmSpy } = vi.hoisted(() => ({
+  prewarmSpy: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/server/app-layer/clients/tokenizer/tiktoken.client", () => ({
+  // A class (not an arrow fn) so `new TiktokenClient()` in cost.ts works under
+  // vitest 4, which rejects non-constructable mock implementations.
+  TiktokenClient: class {
+    prewarm = prewarmSpy;
+  },
+}));
+
+// Deliberately a single test: `await import("../cost")` resolves from vitest's
+// module cache after the first load, so a second test in this file would see a
+// no-op import and trivially pass. Add `vi.resetModules()` per-test if that
+// ever changes.
+describe("given cost.ts is imported (as it is transitively by many unit tests)", () => {
+  describe("when the module finishes evaluating", () => {
+    it("does not call prewarm at import time", async () => {
+      await import("../cost");
+
+      // A module-load prewarm leaks an un-awaited fetch that wedges the vitest
+      // worker under coverage (#4476). Prewarming is the worker's job, not a
+      // side effect of importing the cost helpers.
+      expect(prewarmSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/langwatch/src/server/background/workers/collector/cost.ts
+++ b/langwatch/src/server/background/workers/collector/cost.ts
@@ -6,7 +6,6 @@ import {
   getLLMModelCosts,
   type MaybeStoredLLMModelCost,
 } from "../../../modelProviders/llmModelCost";
-import { isBuildOrNoRedis } from "../../../redis";
 
 const logger = createLogger("langwatch:workers:collector:cost");
 
@@ -289,13 +288,11 @@ export const getMatchingLLMModelCost = async (
   return matchModelCostWithFallbacks(model, llmModelCosts);
 };
 
-// Pre-warm most used models
+// Pre-warm most used models. Invoked explicitly by the collector worker on
+// startup (see collectorWorker.ts) — NOT as a module-load side effect. An
+// eager import-time prewarm fired an un-awaited tiktoken BPE-rank fetch whose
+// socket/WASM-load outlived vitest teardown, wedging the unit-test worker under
+// --coverage and timing out CI (#4476). The worker owns the prewarm lifecycle.
 export const prewarmTiktokenModels = async () => {
   await tiktokenClient.prewarm(["gpt-4", "gpt-4o"]);
 };
-
-if (isBuildOrNoRedis) {
-  prewarmTiktokenModels().catch((error) => {
-    logger.error({ error }, "error prewarming tiktoken models");
-  });
-}

--- a/langwatch/src/server/background/workers/collectorWorker.ts
+++ b/langwatch/src/server/background/workers/collectorWorker.ts
@@ -764,7 +764,12 @@ export const startCollectorWorker = () => {
     return;
   }
 
-  void prewarmTiktokenModels();
+  // Fire-and-forget prewarm of the tiktoken encoders on worker boot; log fetch
+  // failures rather than leave an unhandled rejection. (This is the sole prewarm
+  // call site — cost.ts no longer prewarms as a module-load side effect.)
+  void prewarmTiktokenModels().catch((error) => {
+    logger.error({ error }, "error prewarming tiktoken models");
+  });
 
   const collectorWorker = new Worker<CollectorJob, void, string>(
     COLLECTOR_QUEUE.NAME,


### PR DESCRIPTION
## What

Removes an un-awaited **tiktoken BPE-rank fetch fired at module load** in `collector/cost.ts`, and adds a regression guard. This is one of the concrete handle-leakers called out in #4476's forensics ("in-flight remote encoding fetch / WASM load outlives teardown").

> **Scope honesty (please read):** the CI open-handles diagnostic shows this is **not** what makes `test-unit (2)` slow — see "What this does NOT fix" below. This PR removes a real latent leak + anti-pattern; it does not claim to resolve the shard-2 finalize wedge.

## The leak

`cost.ts` fired `prewarmTiktokenModels()` as an **un-awaited side effect at module load**, gated on `isBuildOrNoRedis`:

```ts
if (isBuildOrNoRedis) {
  prewarmTiktokenModels().catch(...)   // background tiktoken BPE-rank fetch (gpt-4 + gpt-4o)
}
```

`isBuildOrNoRedis` is **`true` under unit tests** (`vitest.config.ts` sets `BUILD_TIME=1`, and `shouldSkipRedis()` returns true on `BUILD_TIME`). So **every unit-test file that transitively imports `cost.ts`** (metrics, span-cost-enrichment, model-cost-matching, the cost test itself, …) kicks off a background network fetch at import time. The grinder reproduced the fallout locally as `EnvironmentTeardownError: Cannot load tiktoken.cjs after the environment was torn down`.

## Fix

Remove the module-load block (and its now-unused `isBuildOrNoRedis` import). The **real collector worker already prewarms explicitly** via `startCollectorWorker()` (`collectorWorker.ts`), which runs **only when redis is connected** — exactly the case the removed block *skipped* (`if (!connection) return;` before the prewarm call). So the block only ever fired in build / test / no-redis, where no traces are processed and prewarm is pointless. Production prewarm is unchanged; only the test-time import fetch is gone.

## Guard

`cost.module-load.unit.test.ts` asserts importing `cost.ts` does **not** auto-prewarm tiktoken — fails if a module-load auto-prewarm is reintroduced. Verified **red→green**: against the old code it fails (`prewarm` called once with `["gpt-4","gpt-4o"]` at import); after the fix it passes. `cost.unit.test.ts` (60 tests) + collector + span-cost-enrichment suites stay green; `pnpm typecheck` clean.

## What this does NOT fix (important)

I pulled the `test-unit (2)` log from this PR's CI run. Shard 2 still took **6m48s** (vs ~2m54s / 3m02s / 2m51s for shards 1/3/4) — i.e. it is **still being rescued by the 6-min `process.exit(0)` hard floor** in `test-unit-global-setup.ts`. The `[open-handles]` diagnostic at the last `afterAll` (22:50:08) shows the worker is **clean** — `handles=1, other={"MessagePort":1}, sockets=[]` — then ~4.5 min of **main-process** silence before the floor fires.

So the shard-2 wedge is **not an application open handle** (the worker has none) — it is the **vitest main-process finalize wedge** documented in `test-unit-global-setup.ts`, which the hard floor already masks to keep CI green well under the 25-min cap. That part is not addressed here and, per the prior investigation (#4481/#4713) + this diagnostic, is not fixable from inside a test. I could not reproduce the finalize wedge locally (the tiktoken CDN answers in ~0.5s, so the fetch completes before teardown on a dev box; `@vitest/coverage-v8` isn't installed in fresh worktrees), so I did not make speculative, unverifiable changes to the shared `vmThreads`/coverage config.

**Net:** a real latent leak the issue flagged is removed + guarded; the shard-2 timing is confirmed to be the separate, already-masked vitest finalize wedge. Relates to #4476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented token/model prewarming from running automatically when the cost component is imported, avoiding unintended startup behavior during tests.
  * Ensured token/model prewarming is performed only during collector worker startup.
  * Added error handling for prewarm failures during worker startup to avoid unhandled promise rejections.

* **Tests**
  * Added a regression unit test verifying cost imports are side-effect-free with respect to token/model prewarming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->