### PR TITLE
feat(scenario): add OpenCodeAgentAdapter for simulating opencode

### DIFF
--- a/skills/_tests/README.md
+++ b/skills/_tests/README.md
@@ -45,3 +45,28 @@ If you skip step 3, you're trusting the regex. The regex doesn't know about your
 - `Error: Command failed with exit code 1` inside `callAgent` — the sub `claude` process crashed or rate-limited. Re-run; if it persists, check `~/.claude/projects/` for the agent's transcript.
 - Test times out without a generated file — the SKILL didn't give Claude enough to act, or pointed it at a docs page that no longer exists. Read what Claude actually tried in its transcript.
 - Test passes the regex but the generated file is nonsense — the regex is too loose. Tighten it AND fix the SKILL guidance that led to the nonsense.
+
+## opencode adapter (`helpers/opencode-adapter.ts`)
+
+`createOpenCodeAgent` is a `@langwatch/scenario` `AgentAdapter` that drives **opencode** (sst/opencode) via `@opencode-ai/sdk`, the opencode analogue of the Claude Code adapter above.
+
+- **No separate server process.** The adapter auto-spawns `opencode serve` for you through the SDK on first use and tears it down when the run ends. There is nothing to start by hand.
+- **Stateful sessions.** It opens one opencode session per scenario `threadId` and reuses it across turns (sending only the latest user message each turn), unlike the Claude Code adapter which replays the full history every turn.
+
+### Prerequisites for the live test
+
+- The `opencode` binary must be on PATH.
+- A provider must be authenticated. The adapter does **not** inject keys — opencode resolves them from its own config. Run `opencode auth login`, or set the provider env var (e.g. `ANTHROPIC_API_KEY`) before running.
+
+### Usage
+
+```ts
+import { createOpenCodeAgent } from "./helpers/opencode-adapter";
+
+const agent = createOpenCodeAgent({
+  model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+  workingDirectory: tempFolder, // optional
+});
+```
+
+The unit tests (`_tests/opencode-adapter.test.ts`) inject a fake client and run in CI — no binary or keys needed. The live scenario (`_tests/opencode-adapter.scenario.test.ts`) is skipped in CI and is also skipped locally whenever the `opencode` binary or `ANTHROPIC_API_KEY` is absent.

--- a/skills/_tests/README.md
+++ b/skills/_tests/README.md
@@ -64,7 +64,7 @@ If you skip step 3, you're trusting the regex. The regex doesn't know about your
 import { createOpenCodeAgent } from "./helpers/opencode-adapter";
 
 const agent = createOpenCodeAgent({
-  model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+  model: { providerID: "anthropic", modelID: "claude-haiku-4-5-20251001" },
   workingDirectory: tempFolder, // optional
 });
 ```

--- a/skills/_tests/helpers/claude-code-adapter.ts
+++ b/skills/_tests/helpers/claude-code-adapter.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "url";
 import { spawn, execSync } from "child_process";
 import chalk from "chalk";
 import { inlineMdx } from "../../_lib/mdx-inline.js";
+import { renderContent } from "./render-content";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -135,49 +136,6 @@ export function createClaudeCodeAgent({
   return {
     role: AgentRole.AGENT,
     call: async (state) => {
-      // Render each turn as plain text. Anthropic-format messages can have
-      // `content` as an array of blocks (text, tool_use, tool_result, image,
-      // …). String-interpolating that array yields `[object Object]`, which
-      // the next Claude Code session then sees as the previous turn — making
-      // multi-turn scenarios appear garbled to the agent. Flatten content
-      // blocks down to readable text instead.
-      const renderContent = (content: unknown): string => {
-        if (typeof content === "string") return content;
-        if (!Array.isArray(content)) {
-          try { return JSON.stringify(content); } catch { return String(content); }
-        }
-        return content
-          .map((block: any) => {
-            if (block == null) return "";
-            if (typeof block === "string") return block;
-            switch (block.type) {
-              case "text":
-                return block.text ?? "";
-              case "tool_use": {
-                const input = block.input != null
-                  ? JSON.stringify(block.input)
-                  : "";
-                return `[tool_use ${block.name ?? "?"}(${input})]`;
-              }
-              case "tool_result": {
-                const inner =
-                  typeof block.content === "string"
-                    ? block.content
-                    : Array.isArray(block.content)
-                      ? renderContent(block.content)
-                      : JSON.stringify(block.content ?? "");
-                return `[tool_result] ${inner}`;
-              }
-              case "image":
-                return "[image omitted]";
-              default:
-                try { return JSON.stringify(block); } catch { return String(block); }
-            }
-          })
-          .filter(Boolean)
-          .join("\n");
-      };
-
       const formattedMessages = state.messages
         .map((message) => `${message.role}: ${renderContent(message.content)}`)
         .join("\n\n");

--- a/skills/_tests/helpers/opencode-adapter.ts
+++ b/skills/_tests/helpers/opencode-adapter.ts
@@ -130,9 +130,10 @@ const defaultStartServer = async ({
  * (sst/opencode) via `@opencode-ai/sdk`.
  *
  * **No separate server process to manage.** The adapter auto-spawns
- * `opencode serve` for you through the SDK on first use and tears it down via
- * the returned server's `close`. You only need the `opencode` binary installed
- * and on PATH.
+ * `opencode serve` lazily on first use through the SDK. Because scenario's
+ * `AgentAdapter` has no teardown hook, the caller should invoke the returned
+ * `close()` when the run is done to shut the server down (e.g. in a test
+ * `finally` block). You only need the `opencode` binary installed and on PATH.
  *
  * **Credentials are not injected by this adapter.** opencode resolves provider
  * credentials from its own configuration: run `opencode auth login`, or set the
@@ -146,7 +147,7 @@ const defaultStartServer = async ({
  * on every turn.
  *
  * @param model - Required `{ providerID, modelID }` selector, e.g.
- *   `{ providerID: "anthropic", modelID: "claude-haiku-4-5" }`.
+ *   `{ providerID: "anthropic", modelID: "claude-haiku-4-5-20251001" }`.
  * @param workingDirectory - Optional directory opencode should operate in;
  *   when set, a directory-scoped client is bound to the spawned server.
  * @param startServer - Optional injected server starter (for tests); defaults
@@ -155,9 +156,14 @@ const defaultStartServer = async ({
  * @example
  * ```typescript
  * const agent = createOpenCodeAgent({
- *   model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+ *   model: { providerID: "anthropic", modelID: "claude-haiku-4-5-20251001" },
  *   workingDirectory: "/tmp/my-task",
  * });
+ * try {
+ *   await scenario.run({ agents: [agent, ...] });
+ * } finally {
+ *   await agent.close();
+ * }
  * ```
  */
 export function createOpenCodeAgent({
@@ -170,7 +176,7 @@ export function createOpenCodeAgent({
   startServer?: (opts: {
     workingDirectory?: string;
   }) => Promise<OpenCodeServerHandle>;
-}): AgentAdapter {
+}): AgentAdapter & { close: () => Promise<void> } {
   // Lazily start the server once and memoize the handle for the run's lifetime.
   let started: Promise<OpenCodeServerHandle> | null = null;
   const ensureServer = () => (started ??= startServer({ workingDirectory }));
@@ -206,6 +212,13 @@ export function createOpenCodeAgent({
       });
 
       return partsToText(result.data?.parts);
+    },
+    close: async () => {
+      if (started) {
+        const handle = await started;
+        handle.close();
+        started = null;
+      }
     },
   };
 }

--- a/skills/_tests/helpers/opencode-adapter.ts
+++ b/skills/_tests/helpers/opencode-adapter.ts
@@ -7,6 +7,7 @@ import {
   createOpencode,
   createOpencodeClient,
 } from "@opencode-ai/sdk";
+import { renderContent } from "./render-content";
 
 /**
  * A `{ providerID, modelID }` pair identifying the model opencode should drive,
@@ -48,57 +49,6 @@ export interface OpenCodeServerHandle {
   client: OpenCodeClientLike;
   close: () => void;
 }
-
-/**
- * Flatten message content into plain text.
- *
- * Lifted (near-verbatim) from the Claude Code adapter: Anthropic-format
- * messages can carry `content` as an array of blocks (text, tool_use,
- * tool_result, image, …). String-interpolating that array yields
- * `[object Object]`, so we render each block down to readable text instead.
- */
-export const renderContent = (content: unknown): string => {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) {
-    try {
-      return JSON.stringify(content);
-    } catch {
-      return String(content);
-    }
-  }
-  return content
-    .map((block: any) => {
-      if (block == null) return "";
-      if (typeof block === "string") return block;
-      switch (block.type) {
-        case "text":
-          return block.text ?? "";
-        case "tool_use": {
-          const input = block.input != null ? JSON.stringify(block.input) : "";
-          return `[tool_use ${block.name ?? "?"}(${input})]`;
-        }
-        case "tool_result": {
-          const inner =
-            typeof block.content === "string"
-              ? block.content
-              : Array.isArray(block.content)
-                ? renderContent(block.content)
-                : JSON.stringify(block.content ?? "");
-          return `[tool_result] ${inner}`;
-        }
-        case "image":
-          return "[image omitted]";
-        default:
-          try {
-            return JSON.stringify(block);
-          } catch {
-            return String(block);
-          }
-      }
-    })
-    .filter(Boolean)
-    .join("\n");
-};
 
 /**
  * Collapse opencode's response `parts` array into a single text string.

--- a/skills/_tests/helpers/opencode-adapter.ts
+++ b/skills/_tests/helpers/opencode-adapter.ts
@@ -1,0 +1,261 @@
+import {
+  AgentRole,
+  type AgentAdapter,
+  type AgentInput,
+} from "@langwatch/scenario";
+import {
+  createOpencode,
+  createOpencodeClient,
+} from "@opencode-ai/sdk";
+
+/**
+ * A `{ providerID, modelID }` pair identifying the model opencode should drive,
+ * e.g. `{ providerID: "anthropic", modelID: "claude-haiku-4-5" }`. opencode
+ * resolves the provider's credentials from its own auth config (see
+ * {@link createOpenCodeAgent}); the adapter never injects keys.
+ */
+export interface OpenCodeModel {
+  providerID: string;
+  modelID: string;
+}
+
+/**
+ * Minimal structural slice of the `@opencode-ai/sdk` client that the adapter
+ * actually uses. Declaring the narrow shape (instead of the full
+ * `OpencodeClient`) lets unit tests inject a fake client with no real server,
+ * and keeps the SDK coupling to exactly the two calls this adapter makes.
+ *
+ * Both methods mirror the SDK's "fields" response envelope, where the payload
+ * lives under `data` and may be `undefined` on error.
+ */
+export interface OpenCodeClientLike {
+  session: {
+    create: (options?: {
+      body?: { title?: string };
+    }) => Promise<{ data?: { id: string } }>;
+    prompt: (options: {
+      path: { id: string };
+      body: { model: OpenCodeModel; parts: { type: "text"; text: string }[] };
+    }) => Promise<{ data?: { parts?: unknown[] } }>;
+  };
+}
+
+/**
+ * A started opencode server bundled with the client bound to it and a `close`
+ * handle the adapter is responsible for calling when the run is torn down.
+ */
+export interface OpenCodeServerHandle {
+  client: OpenCodeClientLike;
+  close: () => void;
+}
+
+/**
+ * Flatten message content into plain text.
+ *
+ * Lifted (near-verbatim) from the Claude Code adapter: Anthropic-format
+ * messages can carry `content` as an array of blocks (text, tool_use,
+ * tool_result, image, …). String-interpolating that array yields
+ * `[object Object]`, so we render each block down to readable text instead.
+ */
+export const renderContent = (content: unknown): string => {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) {
+    try {
+      return JSON.stringify(content);
+    } catch {
+      return String(content);
+    }
+  }
+  return content
+    .map((block: any) => {
+      if (block == null) return "";
+      if (typeof block === "string") return block;
+      switch (block.type) {
+        case "text":
+          return block.text ?? "";
+        case "tool_use": {
+          const input = block.input != null ? JSON.stringify(block.input) : "";
+          return `[tool_use ${block.name ?? "?"}(${input})]`;
+        }
+        case "tool_result": {
+          const inner =
+            typeof block.content === "string"
+              ? block.content
+              : Array.isArray(block.content)
+                ? renderContent(block.content)
+                : JSON.stringify(block.content ?? "");
+          return `[tool_result] ${inner}`;
+        }
+        case "image":
+          return "[image omitted]";
+        default:
+          try {
+            return JSON.stringify(block);
+          } catch {
+            return String(block);
+          }
+      }
+    })
+    .filter(Boolean)
+    .join("\n");
+};
+
+/**
+ * Collapse opencode's response `parts` array into a single text string.
+ *
+ * opencode returns a heterogeneous `Part[]` (text, file, tool, …). We keep only
+ * the text parts and join them. Defensive by construction: a non-array input
+ * (e.g. `undefined` on an errored response) yields `""`, and any non-object or
+ * unknown part type is skipped rather than throwing.
+ */
+export const partsToText = (parts: unknown): string => {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .map((part) => {
+      if (part != null && typeof part === "object" && (part as any).type === "text") {
+        return (part as any).text ?? "";
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+};
+
+/**
+ * Derive the prompt text to send to opencode from the scenario turn.
+ *
+ * opencode holds the conversation server-side per session, so we only send the
+ * latest user turn rather than replaying the whole history. Prefer the newest
+ * user message in `newMessages`; fall back to the newest user message in the
+ * full `messages` history; only if no user message exists anywhere do we render
+ * the entire history as a last resort.
+ */
+const latestUserText = (input: AgentInput): string => {
+  const lastUserMessage = (
+    messages: AgentInput["messages"]
+  ): AgentInput["messages"][number] | undefined => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.role === "user") return messages[i];
+    }
+    return undefined;
+  };
+
+  const userMessage =
+    lastUserMessage(input.newMessages) ?? lastUserMessage(input.messages);
+  if (userMessage) return renderContent(userMessage.content);
+
+  return input.messages
+    .map((message) => `${message.role}: ${renderContent(message.content)}`)
+    .join("\n\n");
+};
+
+/**
+ * Start an opencode server via the SDK and return a client bound to it.
+ *
+ * `createOpencode` auto-spawns `opencode serve` and hands back a client plus a
+ * `close` handle. Neither `createOpencode` nor its `ServerOptions` exposes a
+ * working-directory knob, so when `workingDirectory` is requested we re-bind a
+ * directory-scoped client to the same auto-spawned server's URL.
+ */
+const defaultStartServer = async ({
+  workingDirectory,
+}: {
+  workingDirectory?: string;
+}): Promise<OpenCodeServerHandle> => {
+  const { client, server } = await createOpencode({});
+  const scopedClient = workingDirectory
+    ? createOpencodeClient({ baseUrl: server.url, directory: workingDirectory })
+    : client;
+  return {
+    // Single localized cast at the SDK boundary: the real `OpencodeClient`
+    // exposes far more than `OpenCodeClientLike`, but is structurally a
+    // superset for the two calls we make.
+    client: scopedClient as unknown as OpenCodeClientLike,
+    close: () => server.close(),
+  };
+};
+
+/**
+ * Create a `@langwatch/scenario` agent adapter that drives **opencode**
+ * (sst/opencode) via `@opencode-ai/sdk`.
+ *
+ * **No separate server process to manage.** The adapter auto-spawns
+ * `opencode serve` for you through the SDK on first use and tears it down via
+ * the returned server's `close`. You only need the `opencode` binary installed
+ * and on PATH.
+ *
+ * **Credentials are not injected by this adapter.** opencode resolves provider
+ * credentials from its own configuration: run `opencode auth login`, or set the
+ * provider's environment variables (e.g. `ANTHROPIC_API_KEY`) before the run.
+ * The adapter passes only the `model` selector through.
+ *
+ * **Stateful sessions.** opencode keeps conversation history server-side. This
+ * adapter opens exactly one opencode session per scenario `threadId` and reuses
+ * it across turns, sending only the latest user message each turn. Contrast
+ * with the Claude Code adapter, which is stateless and replays the full history
+ * on every turn.
+ *
+ * @param model - Required `{ providerID, modelID }` selector, e.g.
+ *   `{ providerID: "anthropic", modelID: "claude-haiku-4-5" }`.
+ * @param workingDirectory - Optional directory opencode should operate in;
+ *   when set, a directory-scoped client is bound to the spawned server.
+ * @param startServer - Optional injected server starter (for tests); defaults
+ *   to spawning a real opencode server via the SDK.
+ *
+ * @example
+ * ```typescript
+ * const agent = createOpenCodeAgent({
+ *   model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+ *   workingDirectory: "/tmp/my-task",
+ * });
+ * ```
+ */
+export function createOpenCodeAgent({
+  model,
+  workingDirectory,
+  startServer = defaultStartServer,
+}: {
+  model: OpenCodeModel;
+  workingDirectory?: string;
+  startServer?: (opts: {
+    workingDirectory?: string;
+  }) => Promise<OpenCodeServerHandle>;
+}): AgentAdapter {
+  // Lazily start the server once and memoize the handle for the run's lifetime.
+  let started: Promise<OpenCodeServerHandle> | null = null;
+  const ensureServer = () => (started ??= startServer({ workingDirectory }));
+
+  // One opencode session id per scenario thread.
+  const sessionByThread = new Map<string, string>();
+
+  return {
+    role: AgentRole.AGENT,
+    call: async (input: AgentInput) => {
+      const { client } = await ensureServer();
+
+      let sessionId = sessionByThread.get(input.threadId);
+      if (!sessionId) {
+        const created = await client.session.create({
+          body: { title: `scenario:${input.threadId}` },
+        });
+        if (!created.data?.id) {
+          throw new Error("opencode session.create returned no session id");
+        }
+        sessionId = created.data.id;
+        sessionByThread.set(input.threadId, sessionId);
+      }
+
+      const promptText = latestUserText(input);
+
+      // Awaiting `session.prompt` is true completion: opencode resolves it only
+      // once the assistant turn is fully generated, mirroring the Claude Code
+      // adapter's "await the process exit" semantics.
+      const result = await client.session.prompt({
+        path: { id: sessionId },
+        body: { model, parts: [{ type: "text", text: promptText }] },
+      });
+
+      return partsToText(result.data?.parts);
+    },
+  };
+}

--- a/skills/_tests/helpers/render-content.ts
+++ b/skills/_tests/helpers/render-content.ts
@@ -1,0 +1,46 @@
+/**
+ * Flattens Anthropic-format message content (string or content-block array)
+ * to readable text. Shared by the scenario agent adapters.
+ */
+export const renderContent = (content: unknown): string => {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) {
+    try {
+      return JSON.stringify(content);
+    } catch {
+      return String(content);
+    }
+  }
+  return content
+    .map((block: any) => {
+      if (block == null) return "";
+      if (typeof block === "string") return block;
+      switch (block.type) {
+        case "text":
+          return block.text ?? "";
+        case "tool_use": {
+          const input = block.input != null ? JSON.stringify(block.input) : "";
+          return `[tool_use ${block.name ?? "?"}(${input})]`;
+        }
+        case "tool_result": {
+          const inner =
+            typeof block.content === "string"
+              ? block.content
+              : Array.isArray(block.content)
+                ? renderContent(block.content)
+                : JSON.stringify(block.content ?? "");
+          return `[tool_result] ${inner}`;
+        }
+        case "image":
+          return "[image omitted]";
+        default:
+          try {
+            return JSON.stringify(block);
+          } catch {
+            return String(block);
+          }
+      }
+    })
+    .filter(Boolean)
+    .join("\n");
+};

--- a/skills/_tests/opencode-adapter.scenario.test.ts
+++ b/skills/_tests/opencode-adapter.scenario.test.ts
@@ -1,0 +1,85 @@
+// Live integration proof for the opencode adapter (AC-4).
+//
+// This asserts TRUE completion: across a real multi-turn coding scenario the
+// agent must produce coherent, non-truncated replies (a function plus a test,
+// then a follow-up) and the judge must pass. Because completion robustness is
+// the property under test, run this manually ~3x to confirm it is not flaky.
+//
+// It is intentionally env-gapped: skipped in CI, and skipped locally unless the
+// `opencode` binary is on PATH AND a provider key (ANTHROPIC_API_KEY) is set.
+// opencode resolves its own credentials, so the key must be configured via
+// `opencode auth login` or the provider env var before running.
+import scenario from "@langwatch/scenario";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execSync } from "child_process";
+import { fileURLToPath } from "url";
+import { describe, it, expect } from "vitest";
+import dotenv from "dotenv";
+import { openai } from "@ai-sdk/openai";
+import { SKILL_TESTS_SET_ID } from "./helpers/claude-code-adapter";
+import { createOpenCodeAgent } from "./helpers/opencode-adapter";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+const isCI = !!process.env.CI;
+let opencodeAvailable = false;
+try {
+  execSync("which opencode", { stdio: "ignore" });
+  opencodeAvailable = true;
+} catch {
+  /* opencode binary not installed */
+}
+const runLive = !isCI && opencodeAvailable && !!process.env.ANTHROPIC_API_KEY;
+
+const judgeModel = openai("gpt-5-mini");
+
+describe("opencode adapter (live)", () => {
+  it.skipIf(!runLive)(
+    "completes a multi-turn coding task with coherent replies (AC-4)",
+    async () => {
+      const tempFolder = fs.mkdtempSync(
+        path.join(os.tmpdir(), "langwatch-opencode-adapter-")
+      );
+
+      const result = await scenario.run({
+        setId: SKILL_TESTS_SET_ID,
+        name: "opencode multi-turn coding task",
+        description:
+          "User asks an opencode-driven agent to write a function plus a test, then iterate on it.",
+        agents: [
+          createOpenCodeAgent({
+            model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+            workingDirectory: tempFolder,
+          }),
+          scenario.userSimulatorAgent({ model: judgeModel }),
+          scenario.judgeAgent({
+            model: judgeModel,
+            criteria: [
+              "Agent wrote a function implementation",
+              "Agent wrote a test for that function",
+              "Agent's replies are coherent and complete, not truncated mid-thought",
+              "Agent addressed the user's follow-up request",
+            ],
+          }),
+        ],
+        script: [
+          scenario.user(
+            "write a small function and a test for it in this directory"
+          ),
+          scenario.agent(),
+          scenario.user("now add a docstring to that function"),
+          scenario.agent(),
+          scenario.judge(),
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    },
+    900_000
+  );
+});

--- a/skills/_tests/opencode-adapter.scenario.test.ts
+++ b/skills/_tests/opencode-adapter.scenario.test.ts
@@ -27,14 +27,14 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const isCI = !!process.env.CI;
-let opencodeAvailable = false;
+let isOpencodeAvailable = false;
 try {
   execSync("which opencode", { stdio: "ignore" });
-  opencodeAvailable = true;
+  isOpencodeAvailable = true;
 } catch {
   /* opencode binary not installed */
 }
-const runLive = !isCI && opencodeAvailable && !!process.env.ANTHROPIC_API_KEY;
+const runLive = !isCI && isOpencodeAvailable && !!process.env.ANTHROPIC_API_KEY;
 
 const judgeModel = openai("gpt-5-mini");
 
@@ -46,39 +46,44 @@ describe("opencode adapter (live)", () => {
         path.join(os.tmpdir(), "langwatch-opencode-adapter-")
       );
 
-      const result = await scenario.run({
-        setId: SKILL_TESTS_SET_ID,
-        name: "opencode multi-turn coding task",
-        description:
-          "User asks an opencode-driven agent to write a function plus a test, then iterate on it.",
-        agents: [
-          createOpenCodeAgent({
-            model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
-            workingDirectory: tempFolder,
-          }),
-          scenario.userSimulatorAgent({ model: judgeModel }),
-          scenario.judgeAgent({
-            model: judgeModel,
-            criteria: [
-              "Agent wrote a function implementation",
-              "Agent wrote a test for that function",
-              "Agent's replies are coherent and complete, not truncated mid-thought",
-              "Agent addressed the user's follow-up request",
-            ],
-          }),
-        ],
-        script: [
-          scenario.user(
-            "write a small function and a test for it in this directory"
-          ),
-          scenario.agent(),
-          scenario.user("now add a docstring to that function"),
-          scenario.agent(),
-          scenario.judge(),
-        ],
+      const opencodeAgent = createOpenCodeAgent({
+        model: { providerID: "openai", modelID: "gpt-5-mini" },
+        workingDirectory: tempFolder,
       });
+      try {
+        const result = await scenario.run({
+          setId: SKILL_TESTS_SET_ID,
+          name: "opencode multi-turn coding task",
+          description:
+            "User asks an opencode-driven agent to write a function plus a test, then iterate on it.",
+          agents: [
+            opencodeAgent,
+            scenario.userSimulatorAgent({ model: judgeModel }),
+            scenario.judgeAgent({
+              model: judgeModel,
+              criteria: [
+                "Agent wrote a function implementation",
+                "Agent wrote a test for that function",
+                "Agent's replies are coherent and complete, not truncated mid-thought",
+                "Agent addressed the user's follow-up request",
+              ],
+            }),
+          ],
+          script: [
+            scenario.user(
+              "write a small function and a test for it in this directory"
+            ),
+            scenario.agent(),
+            scenario.user("now add a docstring to that function"),
+            scenario.agent(),
+            scenario.judge(),
+          ],
+        });
 
-      expect(result.success).toBe(true);
+        expect(result.success).toBe(true);
+      } finally {
+        await opencodeAgent.close();
+      }
     },
     900_000
   );

--- a/skills/_tests/opencode-adapter.test.ts
+++ b/skills/_tests/opencode-adapter.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from "vitest";
+import { AgentRole, type AgentInput } from "@langwatch/scenario";
+import {
+  createOpenCodeAgent,
+  partsToText,
+  renderContent,
+  type OpenCodeServerHandle,
+} from "./helpers/opencode-adapter";
+
+/**
+ * Builds a fake opencode server handle plus spies, so the adapter can be
+ * exercised with no real server and no network. `session.create` hands back an
+ * incrementing `sess-N` id and records each created title; `session.prompt`
+ * records the call options and returns a single "reply" text part.
+ */
+function makeFakeServer(
+  promptImpl?: (options: any) => Promise<{ data?: { parts?: unknown[] } }>
+): {
+  handle: OpenCodeServerHandle;
+  created: string[];
+  prompts: any[];
+  closed: { count: number };
+} {
+  const created: string[] = [];
+  const prompts: any[] = [];
+  const closed = { count: 0 };
+  let counter = 0;
+
+  const handle: OpenCodeServerHandle = {
+    client: {
+      session: {
+        create: async (options) => {
+          counter += 1;
+          created.push(options?.body?.title ?? "");
+          return { data: { id: `sess-${counter}` } };
+        },
+        prompt:
+          promptImpl ??
+          (async (options) => {
+            prompts.push(options);
+            return { data: { parts: [{ type: "text", text: "reply" }] } };
+          }),
+      },
+    },
+    close: () => {
+      closed.count += 1;
+    },
+  };
+
+  // When a custom promptImpl is supplied, still record into `prompts` so tests
+  // can assert on the recorded options.
+  if (promptImpl) {
+    const wrapped = handle.client.session.prompt;
+    handle.client.session.prompt = async (options) => {
+      prompts.push(options);
+      return wrapped(options);
+    };
+  }
+
+  return { handle, created, prompts, closed };
+}
+
+/**
+ * Builds a minimal `AgentInput` for unit tests. Only the fields the adapter
+ * reads (threadId, messages, newMessages) need to be present; the rest of the
+ * interface is satisfied by the cast.
+ */
+function makeInput({
+  threadId,
+  messages = [],
+  newMessages = [],
+}: {
+  threadId: string;
+  messages?: { role: string; content: unknown }[];
+  newMessages?: { role: string; content: unknown }[];
+}): AgentInput {
+  return { threadId, messages, newMessages } as unknown as AgentInput;
+}
+
+describe("createOpenCodeAgent", () => {
+  describe("given a model and an injected fake server", () => {
+    describe("when the adapter is constructed", () => {
+      it("exposes the agent role and a call function (AC-1)", () => {
+        const { handle } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        expect(agent.role).toBe(AgentRole.AGENT);
+        expect(typeof agent.call).toBe("function");
+      });
+    });
+
+    describe("when called twice on the same thread", () => {
+      it("creates the session once and reuses its id (AC-2)", async () => {
+        const { handle, created, prompts } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "first" }],
+          })
+        );
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "second" }],
+          })
+        );
+
+        expect(created).toHaveLength(1);
+        expect(prompts).toHaveLength(2);
+        expect(prompts[0].path.id).toBe("sess-1");
+        expect(prompts[1].path.id).toBe("sess-1");
+      });
+    });
+
+    describe("when called on two different threads", () => {
+      it("creates a separate session per thread (AC-2)", async () => {
+        const { handle, created, prompts } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "hi" }],
+          })
+        );
+        await agent.call(
+          makeInput({
+            threadId: "thread-2",
+            newMessages: [{ role: "user", content: "hi" }],
+          })
+        );
+
+        expect(created).toHaveLength(2);
+        expect(prompts[0].path.id).toBe("sess-1");
+        expect(prompts[1].path.id).toBe("sess-2");
+      });
+    });
+
+    describe("when create returns no session id", () => {
+      it("throws a descriptive error (AC-2)", async () => {
+        const { handle } = makeFakeServer();
+        handle.client.session.create = async () => ({ data: undefined });
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        await expect(
+          agent.call(
+            makeInput({
+              threadId: "thread-1",
+              newMessages: [{ role: "user", content: "hi" }],
+            })
+          )
+        ).rejects.toThrow(/no session id/);
+      });
+    });
+
+    describe("when the turn carries user messages", () => {
+      it("sends the latest user message as the prompt text (AC-3)", async () => {
+        const { handle, prompts } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [
+              { role: "user", content: "older" },
+              { role: "assistant", content: "ack" },
+              { role: "user", content: "latest user message" },
+            ],
+          })
+        );
+
+        expect(prompts[0].body.parts[0]).toEqual({
+          type: "text",
+          text: "latest user message",
+        });
+      });
+
+      it("prefers newMessages over older messages (AC-3)", async () => {
+        const { handle, prompts } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            messages: [{ role: "user", content: "historical question" }],
+            newMessages: [{ role: "user", content: "brand new question" }],
+          })
+        );
+
+        expect(prompts[0].body.parts[0].text).toBe("brand new question");
+      });
+
+      it("falls back to the latest user message in history when newMessages has none (AC-3)", async () => {
+        const { handle, prompts } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            messages: [
+              { role: "user", content: "the user question" },
+              { role: "assistant", content: "an answer" },
+            ],
+            newMessages: [{ role: "assistant", content: "follow-up only" }],
+          })
+        );
+
+        expect(prompts[0].body.parts[0].text).toBe("the user question");
+      });
+
+      it("returns the assistant reply string (AC-3)", async () => {
+        const { handle } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        const reply = await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "hi" }],
+          })
+        );
+
+        expect(reply).toBe("reply");
+      });
+
+      it("passes the configured model through to prompt (AC-3)", async () => {
+        const { handle, prompts } = makeFakeServer();
+        const model = { providerID: "anthropic", modelID: "claude-haiku-4-5" };
+        const agent = createOpenCodeAgent({
+          model,
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "hi" }],
+          })
+        );
+
+        expect(prompts[0].body.model).toEqual(model);
+      });
+    });
+
+    describe("when the prompt resolves asynchronously", () => {
+      it("waits for completion before returning the full text (AC-4)", async () => {
+        const { handle } = makeFakeServer(async () => {
+          // Defer to a later microtask, then resolve with the full reply. If the
+          // adapter returned before awaiting, the text would be missing.
+          await Promise.resolve();
+          await Promise.resolve();
+          return {
+            data: { parts: [{ type: "text", text: "fully generated answer" }] },
+          };
+        });
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        const reply = await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "hi" }],
+          })
+        );
+
+        expect(reply).toBe("fully generated answer");
+      });
+    });
+
+    describe("when called multiple times", () => {
+      it("starts the server only once (memoized)", async () => {
+        let startCount = 0;
+        const { handle } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => {
+            startCount += 1;
+            return handle;
+          },
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "a" }],
+          })
+        );
+        await agent.call(
+          makeInput({
+            threadId: "thread-2",
+            newMessages: [{ role: "user", content: "b" }],
+          })
+        );
+
+        expect(startCount).toBe(1);
+      });
+    });
+  });
+});
+
+describe("partsToText", () => {
+  describe("given a parts array", () => {
+    it("concatenates text parts (AC-6)", () => {
+      const text = partsToText([
+        { type: "text", text: "line one" },
+        { type: "text", text: "line two" },
+      ]);
+
+      expect(text).toBe("line one\nline two");
+    });
+
+    it("skips unknown part types and nullish entries without throwing (AC-6)", () => {
+      const text = partsToText([
+        { type: "text", text: "keep" },
+        { type: "tool", name: "bash" },
+        null,
+        { type: "file", url: "x" },
+        { type: "text", text: "also keep" },
+      ]);
+
+      expect(text).toBe("keep\nalso keep");
+    });
+  });
+
+  describe("given a non-array value", () => {
+    it("returns an empty string for undefined (AC-6)", () => {
+      expect(partsToText(undefined)).toBe("");
+    });
+
+    it("returns an empty string for a non-array object (AC-6)", () => {
+      expect(partsToText({ parts: "nope" } as unknown)).toBe("");
+    });
+  });
+});
+
+describe("renderContent", () => {
+  describe("given an anthropic content-block array", () => {
+    it("flattens text and tool_use blocks to readable text (AC-6)", () => {
+      const rendered = renderContent([
+        { type: "text", text: "Calling a tool" },
+        { type: "tool_use", name: "search", input: { q: "hello" } },
+      ]);
+
+      expect(rendered).toBe(
+        'Calling a tool\n[tool_use search({"q":"hello"})]'
+      );
+    });
+  });
+
+  describe("given a plain string", () => {
+    it("returns it unchanged (AC-6)", () => {
+      expect(renderContent("just text")).toBe("just text");
+    });
+  });
+});

--- a/skills/_tests/opencode-adapter.test.ts
+++ b/skills/_tests/opencode-adapter.test.ts
@@ -19,9 +19,11 @@ function makeFakeServer(
   handle: OpenCodeServerHandle;
   created: string[];
   prompts: any[];
+  closeCount: { value: number };
 } {
   const created: string[] = [];
   const prompts: any[] = [];
+  const closeCount = { value: 0 };
   let counter = 0;
 
   const handle: OpenCodeServerHandle = {
@@ -40,10 +42,12 @@ function makeFakeServer(
         },
       },
     },
-    close: () => {},
+    close: () => {
+      closeCount.value += 1;
+    },
   };
 
-  return { handle, created, prompts };
+  return { handle, created, prompts, closeCount };
 }
 
 /**
@@ -69,7 +73,7 @@ describe("createOpenCodeAgent", () => {
       it("exposes the agent role and a call function (AC-1)", () => {
         const { handle } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -82,7 +86,7 @@ describe("createOpenCodeAgent", () => {
       it("creates the session once and reuses its id (AC-2)", async () => {
         const { handle, created, prompts } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -110,7 +114,7 @@ describe("createOpenCodeAgent", () => {
       it("creates a separate session per thread (AC-2)", async () => {
         const { handle, created, prompts } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -138,7 +142,7 @@ describe("createOpenCodeAgent", () => {
         const { handle } = makeFakeServer();
         handle.client.session.create = async () => ({ data: undefined });
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -157,7 +161,7 @@ describe("createOpenCodeAgent", () => {
       it("sends the latest user message as the prompt text (AC-3)", async () => {
         const { handle, prompts } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -181,7 +185,7 @@ describe("createOpenCodeAgent", () => {
       it("prefers newMessages over older messages (AC-3)", async () => {
         const { handle, prompts } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -199,7 +203,7 @@ describe("createOpenCodeAgent", () => {
       it("falls back to the latest user message in history when newMessages has none (AC-3)", async () => {
         const { handle, prompts } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -220,7 +224,7 @@ describe("createOpenCodeAgent", () => {
       it("returns the assistant reply string (AC-3)", async () => {
         const { handle } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -236,7 +240,7 @@ describe("createOpenCodeAgent", () => {
 
       it("passes the configured model through to prompt (AC-3)", async () => {
         const { handle, prompts } = makeFakeServer();
-        const model = { providerID: "anthropic", modelID: "claude-haiku-4-5" };
+        const model = { providerID: "openai", modelID: "gpt-5-mini" };
         const agent = createOpenCodeAgent({
           model,
           startServer: async () => handle,
@@ -255,7 +259,7 @@ describe("createOpenCodeAgent", () => {
       it("falls back to full history rendering when no user message exists anywhere (AC-3)", async () => {
         const { handle, prompts } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -290,7 +294,7 @@ describe("createOpenCodeAgent", () => {
           };
         });
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => handle,
         });
 
@@ -311,7 +315,7 @@ describe("createOpenCodeAgent", () => {
         let startCount = 0;
         const { handle } = makeFakeServer();
         const agent = createOpenCodeAgent({
-          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
           startServer: async () => {
             startCount += 1;
             return handle;
@@ -332,6 +336,57 @@ describe("createOpenCodeAgent", () => {
         );
 
         expect(startCount).toBe(1);
+      });
+    });
+
+    describe("when close is called", () => {
+      it("invokes the handle close exactly once after a call has started the server", async () => {
+        const { handle, closeCount } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "hi" }],
+          })
+        );
+
+        await agent.close();
+
+        expect(closeCount.value).toBe(1);
+      });
+
+      it("does not throw and does not double-close when called again after close", async () => {
+        const { handle, closeCount } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            newMessages: [{ role: "user", content: "hi" }],
+          })
+        );
+
+        await agent.close();
+        await agent.close();
+
+        expect(closeCount.value).toBe(1);
+      });
+
+      it("does not throw when called before any call has started the server", async () => {
+        const { handle } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "openai", modelID: "gpt-5-mini" },
+          startServer: async () => handle,
+        });
+
+        await expect(agent.close()).resolves.toBeUndefined();
       });
     });
   });

--- a/skills/_tests/opencode-adapter.test.ts
+++ b/skills/_tests/opencode-adapter.test.ts
@@ -3,9 +3,9 @@ import { AgentRole, type AgentInput } from "@langwatch/scenario";
 import {
   createOpenCodeAgent,
   partsToText,
-  renderContent,
   type OpenCodeServerHandle,
 } from "./helpers/opencode-adapter";
+import { renderContent } from "./helpers/render-content";
 
 /**
  * Builds a fake opencode server handle plus spies, so the adapter can be
@@ -19,11 +19,9 @@ function makeFakeServer(
   handle: OpenCodeServerHandle;
   created: string[];
   prompts: any[];
-  closed: { count: number };
 } {
   const created: string[] = [];
   const prompts: any[] = [];
-  const closed = { count: 0 };
   let counter = 0;
 
   const handle: OpenCodeServerHandle = {
@@ -34,30 +32,18 @@ function makeFakeServer(
           created.push(options?.body?.title ?? "");
           return { data: { id: `sess-${counter}` } };
         },
-        prompt:
-          promptImpl ??
-          (async (options) => {
-            prompts.push(options);
-            return { data: { parts: [{ type: "text", text: "reply" }] } };
-          }),
+        prompt: async (options) => {
+          prompts.push(options);
+          return promptImpl
+            ? promptImpl(options)
+            : { data: { parts: [{ type: "text", text: "reply" }] } };
+        },
       },
     },
-    close: () => {
-      closed.count += 1;
-    },
+    close: () => {},
   };
 
-  // When a custom promptImpl is supplied, still record into `prompts` so tests
-  // can assert on the recorded options.
-  if (promptImpl) {
-    const wrapped = handle.client.session.prompt;
-    handle.client.session.prompt = async (options) => {
-      prompts.push(options);
-      return wrapped(options);
-    };
-  }
-
-  return { handle, created, prompts, closed };
+  return { handle, created, prompts };
 }
 
 /**
@@ -265,15 +251,40 @@ describe("createOpenCodeAgent", () => {
 
         expect(prompts[0].body.model).toEqual(model);
       });
+
+      it("falls back to full history rendering when no user message exists anywhere (AC-3)", async () => {
+        const { handle, prompts } = makeFakeServer();
+        const agent = createOpenCodeAgent({
+          model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+          startServer: async () => handle,
+        });
+
+        await agent.call(
+          makeInput({
+            threadId: "thread-1",
+            messages: [
+              { role: "system", content: "You are a helpful assistant." },
+              { role: "assistant", content: "How can I help?" },
+            ],
+            newMessages: [],
+          })
+        );
+
+        const promptText = prompts[0].body.parts[0].text;
+        expect(promptText).toContain("assistant: ");
+        expect(promptText).toContain("How can I help?");
+      });
     });
 
     describe("when the prompt resolves asynchronously", () => {
       it("waits for completion before returning the full text (AC-4)", async () => {
+        let settled = false;
         const { handle } = makeFakeServer(async () => {
           // Defer to a later microtask, then resolve with the full reply. If the
           // adapter returned before awaiting, the text would be missing.
           await Promise.resolve();
           await Promise.resolve();
+          settled = true;
           return {
             data: { parts: [{ type: "text", text: "fully generated answer" }] },
           };
@@ -290,6 +301,7 @@ describe("createOpenCodeAgent", () => {
           })
         );
 
+        expect(settled).toBe(true);
         expect(reply).toBe("fully generated answer");
       });
     });

--- a/skills/package.json
+++ b/skills/package.json
@@ -19,6 +19,7 @@
     "@ai-sdk/anthropic": "^3.0.44",
     "@ai-sdk/openai": "^3.0.41",
     "@langwatch/scenario": "^0.4.12",
+    "@opencode-ai/sdk": "^1.17.6",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.0.0",
     "chalk": "^5.6.2",

--- a/skills/pnpm-lock.yaml
+++ b/skills/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@langwatch/scenario':
         specifier: ^0.4.12
         version: 0.4.12(f5404d5076d4a6a3006663a361f74e8f)
+      '@opencode-ai/sdk':
+        specifier: ^1.17.6
+        version: 1.17.6
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -377,6 +380,9 @@ packages:
     resolution: {integrity: sha512-YaKnqv0M6bCVvn47pThkFfyHz8xWJ+0Ll9ZnhvwJZ5gyPX0UxHIUeUs9SMG9BSvNuJNJHlc5uvfUDGYAmKJClw==}
     peerDependencies:
       zod: ^3.25.40 || ^4.0
+
+  '@opencode-ai/sdk@1.17.6':
+    resolution: {integrity: sha512-kCzdd9Git2sjDjXSHj4mMWuU1RXZ38d7gFEcq2rzlVz7XV6PPwNw8pelWsk99La2CtDkpfoW5lfHnpCaK6/oBQ==}
 
   '@opentelemetry/api-logs@0.205.0':
     resolution: {integrity: sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==}
@@ -2646,6 +2652,10 @@ snapshots:
       - supports-color
       - utf-8-validate
       - ws
+
+  '@opencode-ai/sdk@1.17.6':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@opentelemetry/api-logs@0.205.0':
     dependencies:


### PR DESCRIPTION
<!-- no-ui-surface -->

## Why

scenario's adapter coverage was limited to LLM-based and voice agents. This adds an `OpenCodeAgentAdapter` so teams can simulate and evaluate **opencode** ([sst/opencode](https://github.com/sst/opencode)) terminal coding agents — bringing scenario's evaluation loop to the coding-agent use case for the first time.

Closes #5001

## What changed

A new TypeScript factory `createOpenCodeAgent({ model, workingDirectory })` in `skills/_tests/helpers/opencode-adapter.ts`, modeled directly on the in-house Claude Code adapter (`skills/_tests/helpers/claude-code-adapter.ts`) — same `{ role: AgentRole.AGENT, call }` shape and `renderContent` content-block flattener. Only the transport and the session/completion primitives differ:

- **Transport:** `@opencode-ai/sdk` (`createOpencode()` → `client.session.prompt(...)`) instead of `child_process.spawn("claude", …)`.
- **Server lifecycle:** `createOpencode()` auto-spawns and owns `opencode serve` (lazy, memoized); no separate process.
- **Sessions:** stateful — one opencode session per scenario `threadId` (`Map<threadId, sessionId>`), reused across turns; only the latest user turn is sent each call (opencode keeps history server-side).
- **Completion:** awaits the `prompt()` promise (resolves only after the assistant finishes) — the opencode analogue of awaiting Claude Code's process exit.
- **Output:** the resolved `Part[]` is flattened to text (`partsToText`), skipping unknown part types.
- **Shared utility:** the Anthropic content-block flattener (`renderContent`) is extracted to `skills/_tests/helpers/render-content.ts` and imported by both this adapter and the Claude Code adapter (no copy-paste).

### Commits map to acceptance criteria

| Commit | ACs |
|---|---|
| `chore(skills): add @opencode-ai/sdk dependency` | AC-1 (enabler) |
| `feat(scenario): add OpenCodeAgentAdapter for opencode` (+ unit tests) | AC-1, AC-2, AC-3, AC-6 |
| `test(scenario): add live multi-turn completion test for opencode adapter` | AC-4 |
| `docs(scenario): document opencode adapter auto-start and provider keys` | AC-5 |
| `refactor(scenario): share renderContent flattener across adapters` | reuse/DRY (review) |
| `fix(scenario): close opencode server and address review feedback` | resource leak + review fixes |

## How it works

The SDK response envelope was pinned against the installed `@opencode-ai/sdk@1.17.6` type definitions before implementing (issue Plan step 1 / Risk R-2). Verified facts that corrected the original skeleton:

- The `call` parameter is scenario's `AgentInput` (fields `threadId`, `messages`, `newMessages`) — there is no `lastNewUserMessageStr()` helper, so the latest user message is derived from `newMessages` (falling back to `messages`).
- `OpencodeServer` is **not** exported by the SDK (only `OpencodeClient`), so it is not imported.
- `createOpencode()` / `ServerOptions` expose no working-directory knob; `workingDirectory` is applied by binding a `createOpencodeClient({ baseUrl, directory })` to the auto-spawned server.
- The `"fields"` response style means `client.session.create(...)` → `result.data.id` and `client.session.prompt(...)` → `result.data.parts` (both confirmed against the installed types).

The adapter accepts an optional injected `startServer` (defaulting to the real SDK spawn) purely so the unit tests can drive it with a fake client and no network.

## Human verification

This adapter has no UI surface — backend-only, no UI surface. To independently verify:

1. Check out branch `feat/5001-opencode-adapter`.
2. `cd skills && pnpm install && ./node_modules/.bin/vitest run _tests/opencode-adapter.test.ts`
3. Confirm 21 tests pass (1 test file, ~1–2 s).
4. `tsc --noEmit` scoped to `skills/_tests/helpers/opencode-adapter.ts`, `skills/_tests/helpers/render-content.ts`, `skills/_tests/opencode-adapter.test.ts` — confirm exit 0.
5. Review `skills/_tests/helpers/opencode-adapter.ts` against the installed `@opencode-ai/sdk@1.17.6` types (`node_modules/@opencode-ai/sdk`) to confirm the API surface used (`session.create`, `session.prompt`, `result.data.id`, `result.data.parts`) matches the exported types.

## How I can prove I was successful

**This adapter is backend-only (test helper, no UI surface).** Visual-proof exemption applies; unit-test terminal output is the evidence form appropriate for this change type.

**Unit tests — 21/21 passed (injected fake client, no network, no opencode binary required):**

```
 Test Files  1 passed (1)
      Tests  21 passed (21)
   Start at  17:04:13
   Duration  1.63s (transform 161ms, setup 0ms, import 1.42s, tests 33ms, environment 0ms)
```

Command: `cd skills && ./node_modules/.bin/vitest run _tests/opencode-adapter.test.ts`

Coverage by AC:
- **AC-1** (role + call shape): `proven` — unit tests assert `role === AgentRole.AGENT` and the `call` function is present.
- **AC-2** (session lifecycle): `proven` — tests assert one `session.create` per `threadId`, reuse within thread, distinct session per new thread, descriptive throw when no id returned.
- **AC-3** (message routing + model passthrough): `proven` — tests assert latest user message sent, `newMessages` preferred over `messages` fallback, reply returned, model forwarded.
- **AC-4** (await-semantics, server memoized): `proven` (unit angle) — resolves only after async `prompt()` settles; server factory called once regardless of call count.
- **AC-6** (`partsToText` + `renderContent`): `proven` — tests assert text-part concatenation, unknown-part skipping, non-array → `""`, and content-block flattening.

**AC-4 live integration test — env-gapped (explicitly not fabricated):** `skills/_tests/opencode-adapter.scenario.test.ts` exercises a real multi-turn coding task against a live opencode server. It is `it.skipIf`-gated and was **not run** — this environment has no `opencode` binary on PATH and no provider API key. To run: install `opencode`, authenticate (`opencode auth login` or `ANTHROPIC_API_KEY`), then `pnpm vitest run _tests/opencode-adapter.scenario.test.ts`. No evidence is fabricated for this path.

## Anything surprising?

- **Pre-existing typecheck errors elsewhere in `skills/`** (`datasets.scenario.test.ts`, `voice-factories.test.ts`) reflect drift between those unmodified files and the installed `@langwatch/scenario@0.4.12` types; they are not introduced or touched by this PR and are out of scope.
