### PR TITLE
fix(scenarios): reconcile orphaned IN_PROGRESS runs on worker boot, and make a finished run final (#3195)

### DIFF
--- a/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md
+++ b/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md
@@ -1,0 +1,117 @@
+# ADR-010: Scenario Orphaned-Run Reconciliation
+
+**Date:** 2026-06-23
+
+**Status:** Accepted
+
+## Context
+
+The scenario execution pool is in-process and per worker pod — it holds no cross-process record of which run a worker is executing. When a worker dies mid-run (OOM, crash, deploy, container restart), the in-process `ScenarioFailureHandler` that would emit the terminal `finished` event dies with it. The run is left non-terminal in ClickHouse forever: the UI spins at "Starting"/"Running" and downstream reactors (suite aggregates, metrics, customer.io) never fire. Read-time stall detection (in `stall-detection.ts`) paints the run STALLED cosmetically but never writes a terminal event, so the run never actually leaves the in-flight state.
+
+The fix: every scenarios worker reconciles orphaned runs when it boots. It asks ClickHouse for non-terminal runs whose last activity is older than any live worker could still be holding them, and emits a terminal failure event through the existing idempotent finish path so they go terminal for good and downstream reactors fire.
+
+Related: issue [#3195](https://github.com/langwatch/langwatch/issues/3195), PR [#5006](https://github.com/langwatch/langwatch/pull/5006), spec `langwatch/specs/scenarios/orphaned-run-reconciliation.feature`.
+
+## What we considered
+
+### Decision 1: Reconcile threshold
+
+A run is only reconciled once its last activity is older than the longest a live worker could still legitimately be holding it.
+
+**Option A: Reuse `STALL_THRESHOLD_MS` (2× the child-process timeout = 30 min) — chosen.**
+A live worker hard-caps every child at `CHILD_PROCESS.TIMEOUT_MS` (15 min,
+`scenario.constants.ts` line 38) and emits its own terminal event at the cap.
+A non-terminal run quiet for longer than 2× that cap provably has no live
+worker. Reusing the read-path's own STALLED boundary (`STALL_THRESHOLD_MS`,
+`stall-detection.ts` line 9) keeps read and write paths consistent and leaves
+margin past the hard cap for clock skew and queued-but-imminent jobs. The
+equality is explicit and co-located:
+`orphaned-run-reconciliation.ts` line 39 —
+`export const ORPHAN_RECONCILE_THRESHOLD_MS = STALL_THRESHOLD_MS`.
+
+**Option B: A tighter or independent threshold.**
+Rejected. A booting pod that is about to pick up a queued job could find that
+job quiet for well under 30 min. A threshold below the stall boundary risks
+reconciling a run a live pod still owns — the one outcome that must never happen.
+
+### Decision 2: Terminal state written on reconciliation
+
+**Option A: Emit a real `finished(ERROR)` event — chosen.**
+The reconciler calls `ensureFailureEventsEmitted` on `ScenarioFailureHandler`
+(the same idempotent finish path in-process child crashes already use), which
+dispatches a `finishRun` command that writes a terminal `FinishedAt` and
+`Status = ERROR` to the event log. This is a real event, not a read-time
+projection; it fires the downstream reactors (suite aggregates, metrics,
+customer.io) that the run's orphaning had silenced. The `Promise.allSettled`
+loop at `orphaned-run-reconciliation.ts` line 113 ensures one failing emit
+does not abort reconciliation of the remaining orphans.
+
+**Option B: Cosmetic read-time STALLED paint.**
+Rejected. This is what the read-path already does and it is insufficient — it
+never writes a terminal event to the log, so `FinishedAt` stays null, the
+in-flight aggregate stays inflated, and every downstream reactor stays silent.
+The original bug.
+
+### Decision 3: Finalized-status fold guard (`statusAfter`)
+
+**Option A: Guard `Status` transitions in the fold projection once `FinishedAt` is set — chosen.**
+`simulationRunState.foldProjection.ts` lines 162–183 introduce `statusAfter`:
+once `FinishedAt` is set, any subsequent non-terminal status candidate is
+dropped and the terminal `Status` is preserved. This is applied at the three
+non-terminal transition sites: `handleSimulationRunStarted` (line 281),
+`handleSimulationRunMessageSnapshot` (line 348), and
+`handleSimulationRunTextMessageStart` (line 386).
+
+The guard defends against the following: a child process that outlived its dead
+parent (reparented) and later POSTs a real `started`/`snapshot` with a
+client-supplied `occurredAt` that is AFTER the reconciliation time. Because
+the fold executor applies events in `occurredAt` order (and only re-folds when
+`occurredAt` is strictly less than what it has already seen), such a late event
+applies after the reconcile's `finished` event in logical time and would
+otherwise clobber `Status` back to `IN_PROGRESS` while `FinishedAt` stays set —
+an unrecoverable zombie the read-time stall path cannot rescue (it only resolves
+runs with no `FinishedAt`). With the guard, `Status` stays terminal.
+
+**Option B: Rely on event ordering alone.**
+Rejected. Client-supplied `occurredAt` can legitimately post-date the
+reconciliation timestamp; the `started`/`snapshot` event may not be
+"out-of-order" in the eyes of the executor and would be re-folded in sequence
+after the `finished` event.
+
+## Decision
+
+**Threshold:** `ORPHAN_RECONCILE_THRESHOLD_MS = STALL_THRESHOLD_MS` = 30 min (2× child timeout).
+
+**Terminal state:** Real `finished(ERROR)` event via the existing idempotent `ensureFailureEventsEmitted` path, not a cosmetic projection.
+
+**Fold guard:** `statusAfter` in the fold projection prevents a late non-terminal event from clobbering `Status` once `FinishedAt` is set.
+
+**Wiring:** `reconcileOrphanedRunsOnBoot` is called fire-and-forget inside `startScenarioProcessor` (`scenario.processor.ts` line 510) so a large or slow sweep never blocks worker startup.
+
+**ClickHouse query** (`orphaned-run-reconciliation.clickhouse.ts`): cross-tenant by design (boot-time, no single tenant context); uses the IN-tuple dedup pattern to find the latest version per run without materialising heavy columns; partition-pruned on `StartedAt`; gated on `FinishedAt IS NULL`.
+
+## Consequences
+
+**Positive:**
+- Orphaned runs reach a terminal state and fire all downstream reactors (suite aggregates, metrics, customer.io).
+- The finish path is idempotent, so co-booting pods or a racing owning-worker timeout collapse to a single terminal event — no double-fire.
+- Reusing the existing `ScenarioFailureHandler` path means the reconciler inherits all future improvements to that path for free.
+
+**Negative / trade-offs:**
+- A run orphaned by a fresh crash is not reconciled at the boot that caused it; it is caught on the NEXT worker boot, once the orphan ages past the 30-min threshold. Read-time STALLED covers the gap cosmetically in the interim. Production workers restart regularly (deploys, maxRuntime self-restart), so the bounded sweep window is acceptable.
+- Tenants on private ClickHouse instances (`CLICKHOUSE_URL__*` env vars) are not swept — only the shared client is queried. Tracked as a follow-up under issue #3195.
+- The sweep is a cross-tenant query by necessity; each terminal write downstream is then scoped per-run to that run's own tenant.
+
+## References
+
+- Issue: [#3195](https://github.com/langwatch/langwatch/issues/3195)
+- PR: [#5006](https://github.com/langwatch/langwatch/pull/5006)
+- Spec: `langwatch/specs/scenarios/orphaned-run-reconciliation.feature`
+- `langwatch/src/server/scenarios/orphaned-run-reconciliation.ts`
+- `langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts`
+- `langwatch/src/server/scenarios/stall-detection.ts`
+- `langwatch/src/server/scenarios/scenario.constants.ts`
+- `langwatch/src/server/scenarios/scenario-failure-handler.ts`
+- `langwatch/src/server/scenarios/scenario.processor.ts`
+- `langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts`
+- Related: [ADR-009: OTEL Trace Context Propagation for HTTP Scenarios](009-otel-trace-context-propagation-for-http-scenarios.md)

--- a/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md
+++ b/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md
@@ -70,7 +70,25 @@ the fold executor applies events in `occurredAt` order (and only re-folds when
 applies after the reconcile's `finished` event in logical time and would
 otherwise clobber `Status` back to `IN_PROGRESS` while `FinishedAt` stays set —
 an unrecoverable zombie the read-time stall path cannot rescue (it only resolves
-runs with no `FinishedAt`). With the guard, `Status` stays terminal.
+runs with no `FinishedAt`). With the guard, a late non-terminal event can no
+longer resurrect `Status`.
+
+The guard's scope is exactly those three sites. `handleSimulationRunFinished` is
+NOT routed through it and still assigns `Status` unconditionally, so two paths
+remain open, both deliberate for now:
+
+1. A later `finished` overwrites an earlier one (ERROR → SUCCESS when a child
+   outlives a parent this reconciler already failed). This is the self-heal that
+   limits the blast radius of a false-positive reconciliation, so closing it
+   trades one failure mode for another.
+2. The scenario-events ingest schema types the `finished` status as
+   `z.nativeEnum(ScenarioRunStatus)`, which admits `IN_PROGRESS`. A client
+   POSTing `finished(status=IN_PROGRESS)` writes a non-terminal `Status`
+   alongside `FinishedAt` — reproducing the zombie above through the one door
+   the guard does not cover.
+
+Both are recorded here rather than silently fixed because (1) is entangled with
+the reconciliation threshold's false-positive behaviour, which is under review.
 
 **Option B: Rely on event ordering alone.**
 Rejected. Client-supplied `occurredAt` can legitimately post-date the

--- a/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md
+++ b/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md
@@ -79,12 +79,21 @@ The original bug.
 ### Decision 3: Finalized-status fold guard (`statusAfter`)
 
 **Option A: Guard `Status` transitions in the fold projection once `FinishedAt` is set — chosen.**
-`simulationRunState.foldProjection.ts` lines 162–183 introduce `statusAfter`:
+`simulationRunState.foldProjection.ts` introduces `statusAfter`:
 once `FinishedAt` is set, any subsequent non-terminal status candidate is
-dropped and the terminal `Status` is preserved. This is applied at the three
-non-terminal transition sites: `handleSimulationRunStarted` (line 281),
-`handleSimulationRunMessageSnapshot` (line 348), and
-`handleSimulationRunTextMessageStart` (line 386).
+dropped and the terminal `Status` is preserved. It is applied at **every**
+non-terminal `Status` writer: `handleSimulationRunQueued`,
+`handleSimulationRunStarted`, `handleSimulationRunMessageSnapshot`, and
+`handleSimulationRunTextMessageStart`.
+
+Review caught that `handleSimulationRunQueued` was initially left out, and a
+`queued` event *is* in the fold set — so one arriving after `finished` resurrected
+`Status = QUEUED` with `FinishedAt` still set, reproducing the exact zombie this
+guard exists to prevent. The guard is only as good as its least-covered writer:
+any future handler that writes a non-terminal `Status` must route through it.
+(At the `textMessageStart` site the status candidate already preserves a terminal
+status on its own, so the guard there is defence in depth rather than
+load-bearing — its regression test pins the outcome, not the guard.)
 
 The guard defends against the following: a child process that outlived its dead
 parent (reparented) and later POSTs a real `started`/`snapshot` with a
@@ -111,17 +120,19 @@ executing the fold rather than reading it, and both are closed here:
    Decision 0 restricts the sweep to runs no live worker can hold, and it
    silently discarded the reconciled state downstream reactors had already acted
    on.
-2. **A `finished` event could carry a non-terminal status.** The scenario-events
-   ingest schema types it as `z.nativeEnum(ScenarioRunStatus)`, which admits
-   `IN_PROGRESS`, and the handler wrote it straight through alongside
-   `FinishedAt` — a run the reconciler skips (`FinishedAt IS NULL`) and read-time
-   stall detection skips (it only resolves unfinished runs). Nothing could
-   recover it. A non-terminal explicit status is now rejected in favour of the
-   verdict-derived one.
+2. **A `finished` event could carry a non-terminal status.** The internal event
+   schema types the field as `z.string().optional()` (`schemas/events.ts`), so
+   *any* string reaches the fold; even the stricter ingest-route schema
+   (`z.nativeEnum(ScenarioRunStatus)`) still admits non-terminal members like
+   `IN_PROGRESS`, `QUEUED` and `RUNNING`. The handler wrote it straight through
+   alongside `FinishedAt` — a run the reconciler skips (`FinishedAt IS NULL`) and
+   read-time stall detection skips (it only resolves unfinished runs). Nothing
+   could recover it. A non-terminal explicit status is now rejected in favour of
+   the verdict-derived one.
 
 So the invariant *"once `FinishedAt` is set, `Status` is terminal and stays
-terminal"* is held by three things together: this guard at the non-terminal
-transition sites, the finish-once early return, and the terminal-status check.
+terminal"* is held by three things together: this guard at **every** non-terminal
+`Status` writer, the finish-once early return, and the terminal-status check.
 Each is covered by a regression test in
 `simulationRunState.foldProjection.unit.test.ts`.
 

--- a/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md
+++ b/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md
@@ -8,11 +8,36 @@
 
 The scenario execution pool is in-process and per worker pod — it holds no cross-process record of which run a worker is executing. When a worker dies mid-run (OOM, crash, deploy, container restart), the in-process `ScenarioFailureHandler` that would emit the terminal `finished` event dies with it. The run is left non-terminal in ClickHouse forever: the UI spins at "Starting"/"Running" and downstream reactors (suite aggregates, metrics, customer.io) never fire. Read-time stall detection (in `stall-detection.ts`) paints the run STALLED cosmetically but never writes a terminal event, so the run never actually leaves the in-flight state.
 
-The fix: every scenarios worker reconciles orphaned runs when it boots. It asks ClickHouse for non-terminal runs whose last activity is older than any live worker could still be holding them, and emits a terminal failure event through the existing idempotent finish path so they go terminal for good and downstream reactors fire.
+The fix: every scenarios worker reconciles orphaned runs when it boots. It asks ClickHouse for `IN_PROGRESS` runs whose last activity is older than any live worker could still be holding them, and emits a terminal failure event through the existing idempotent finish path so they go terminal for good and downstream reactors fire.
 
 Related: issue [#3195](https://github.com/langwatch/langwatch/issues/3195), PR [#5006](https://github.com/langwatch/langwatch/pull/5006), spec `langwatch/specs/scenarios/orphaned-run-reconciliation.feature`.
 
 ## What we considered
+
+### Decision 0: Which runs this sweep may reconcile
+
+**Option A: `IN_PROGRESS` only — chosen.**
+`IN_PROGRESS` means a worker called `startRun`; it had the run in hand. A live
+worker hard-caps every child at `CHILD_PROCESS.TIMEOUT_MS` and emits its own
+terminal event at the cap, so an `IN_PROGRESS` run idle past 2× that cap
+provably has no live worker. That inference is the entire licence to write a
+terminal ERROR, and it depends on the run having been *started*.
+
+**Option B: every non-terminal status (`PENDING`/`QUEUED`/`IN_PROGRESS`).**
+Rejected — this was the original shape of this ADR, and it was wrong. Nothing
+bounds how long a run waits in the queue: the execution pool is
+concurrency-bounded, so a run behind a large batch/suite backlog goes stale
+while a perfectly healthy worker is still working toward it. Reconciling it
+would fail a run that is about to execute — the one outcome this reconciler
+must never produce. Staleness is evidence of worker death only *after* the run
+was started.
+
+`QUEUED` orphans are a genuinely different failure — no worker ever picked the
+run up — and are owned by `scenario-orphan-reconciler.ts` (#3365,
+`queued-run-orphan-recovery.feature`). Keeping the two sweeps disjoint by status
+means neither can double-write the other's runs, and each can evolve its own
+liveness argument. Note the same backlog false-positive applies to that sweep's
+`QUEUED` gate; it is pre-existing and tracked there, not fixed here.
 
 ### Decision 1: Reconcile threshold
 
@@ -21,17 +46,16 @@ A run is only reconciled once its last activity is older than the longest a live
 **Option A: Reuse `STALL_THRESHOLD_MS` (2× the child-process timeout = 30 min) — chosen.**
 A live worker hard-caps every child at `CHILD_PROCESS.TIMEOUT_MS` (15 min,
 `scenario.constants.ts` line 38) and emits its own terminal event at the cap.
-A non-terminal run quiet for longer than 2× that cap provably has no live
+An `IN_PROGRESS` run quiet for longer than 2× that cap provably has no live
 worker. Reusing the read-path's own STALLED boundary (`STALL_THRESHOLD_MS`,
 `stall-detection.ts` line 9) keeps read and write paths consistent and leaves
-margin past the hard cap for clock skew and queued-but-imminent jobs. The
+margin past the hard cap for clock skew. The
 equality is explicit and co-located:
-`orphaned-run-reconciliation.ts` line 39 —
+`orphaned-run-reconciliation.ts` —
 `export const ORPHAN_RECONCILE_THRESHOLD_MS = STALL_THRESHOLD_MS`.
 
 **Option B: A tighter or independent threshold.**
-Rejected. A booting pod that is about to pick up a queued job could find that
-job quiet for well under 30 min. A threshold below the stall boundary risks
+Rejected. A threshold below the stall boundary risks
 reconciling a run a live pod still owns — the one outcome that must never happen.
 
 ### Decision 2: Terminal state written on reconciliation
@@ -73,22 +97,33 @@ an unrecoverable zombie the read-time stall path cannot rescue (it only resolves
 runs with no `FinishedAt`). With the guard, a late non-terminal event can no
 longer resurrect `Status`.
 
-The guard's scope is exactly those three sites. `handleSimulationRunFinished` is
-NOT routed through it and still assigns `Status` unconditionally, so two paths
-remain open, both deliberate for now:
+The guard alone was not enough. `handleSimulationRunFinished` sets `FinishedAt`,
+so it is the one handler the guard cannot cover, and it left two ways to
+reproduce the very zombie the guard exists to prevent. Both were found by
+executing the fold rather than reading it, and both are closed here:
 
-1. A later `finished` overwrites an earlier one (ERROR → SUCCESS when a child
-   outlives a parent this reconciler already failed). This is the self-heal that
-   limits the blast radius of a false-positive reconciliation, so closing it
-   trades one failure mode for another.
-2. The scenario-events ingest schema types the `finished` status as
-   `z.nativeEnum(ScenarioRunStatus)`, which admits `IN_PROGRESS`. A client
-   POSTing `finished(status=IN_PROGRESS)` writes a non-terminal `Status`
-   alongside `FinishedAt` — reproducing the zombie above through the one door
-   the guard does not cover.
+1. **A second `finished` rewrote the first.** A child that outlived the parent
+   this reconciler already failed would take the run ERROR → SUCCESS, and could
+   split the record (an ERROR `Status` carrying the late child's SUCCESS
+   `Verdict`). `handleSimulationRunFinished` now returns early once `FinishedAt`
+   is set: a run finishes exactly once. The alternative — leaving the overwrite
+   in as a "self-heal" for a falsely-reconciled run — is unnecessary now that
+   Decision 0 restricts the sweep to runs no live worker can hold, and it
+   silently discarded the reconciled state downstream reactors had already acted
+   on.
+2. **A `finished` event could carry a non-terminal status.** The scenario-events
+   ingest schema types it as `z.nativeEnum(ScenarioRunStatus)`, which admits
+   `IN_PROGRESS`, and the handler wrote it straight through alongside
+   `FinishedAt` — a run the reconciler skips (`FinishedAt IS NULL`) and read-time
+   stall detection skips (it only resolves unfinished runs). Nothing could
+   recover it. A non-terminal explicit status is now rejected in favour of the
+   verdict-derived one.
 
-Both are recorded here rather than silently fixed because (1) is entangled with
-the reconciliation threshold's false-positive behaviour, which is under review.
+So the invariant *"once `FinishedAt` is set, `Status` is terminal and stays
+terminal"* is held by three things together: this guard at the non-terminal
+transition sites, the finish-once early return, and the terminal-status check.
+Each is covered by a regression test in
+`simulationRunState.foldProjection.unit.test.ts`.
 
 **Option B: Rely on event ordering alone.**
 Rejected. Client-supplied `occurredAt` can legitimately post-date the

--- a/dev/docs/best_practices/clickhouse-queries.md
+++ b/dev/docs/best_practices/clickhouse-queries.md
@@ -153,6 +153,23 @@ Keep both: the WHERE prunes partitions, the HAVING ensures exact filtering for t
 
 Every ClickHouse query MUST include `WHERE TenantId = {tenantId:String}`. No other ID (ScenarioRunId, BatchRunId, TraceId, etc.) is unique across tenants.
 
+### Carve-out: boot-time system sweeps
+
+A query may omit the `TenantId` filter **only** when every one of these holds:
+
+1. It runs from a system/background entrypoint (worker boot, cron, metering sweep) where there is genuinely **no tenant in context** — not a request path, not a tRPC/Hono handler.
+2. It runs on the **shared** ClickHouse client, and the code says so. Tenants on private instances (`CLICKHOUSE_URL__*`) are therefore out of its reach — state that limitation where the sweep is defined.
+3. It **SELECTs** `TenantId` rather than filtering on it, and every downstream write is re-scoped per row to that row's own `TenantId`. A sweep that reads cross-tenant and writes with a single tenant id is a data-corruption bug.
+4. The omission carries an inline comment explaining which of these applies, so a future "you forgot the tenant filter" fix does not silently narrow the sweep to one tenant.
+5. A test pins the cross-tenant behaviour — otherwise item 4's regression passes CI. Single-tenant fixtures cannot catch it.
+
+Current sweeps under this carve-out, both on worker boot:
+
+- `scenarios/scenario-orphan-reconciler.ts` — reconciles `QUEUED` orphans (#3365).
+- `scenarios/orphaned-run-reconciliation.clickhouse.ts` — reconciles `IN_PROGRESS` orphans (#3195).
+
+Anything else that wants to skip the filter should be a repository method taking a `tenantId`, not a sweep.
+
 ## Code Review Checklist
 
 When reviewing a PR that touches a `*.clickhouse.repository.ts` or any service hitting ClickHouse, scan for:

--- a/langwatch/specs/scenarios/orphaned-run-reconciliation.feature
+++ b/langwatch/specs/scenarios/orphaned-run-reconciliation.feature
@@ -1,0 +1,77 @@
+Feature: Orphaned scenario run reconciliation on worker boot
+
+  When the scenarios worker that is executing a run dies mid-flight (OOM,
+  crash, deploy, or container restart), the run never receives its terminal
+  `finished` event. The in-process execution pool that would emit a failure
+  event dies with the worker, so the run is left non-terminal in ClickHouse —
+  the UI shows it spinning at "Starting"/"Running" with no indication that no
+  worker is processing it. Read-time stall detection eventually paints it as
+  "stalled", but it never becomes terminal in the event log, so downstream
+  reactors (suite aggregates, metrics) never run.
+
+  To close this gap, every scenarios worker reconciles orphaned runs when it
+  boots: it looks for non-terminal runs whose last activity is older than a
+  live worker could possibly still be holding them, and emits a terminal
+  failure event so they leave the in-flight state for good.
+
+  A run is considered orphaned only when enough time has passed that no live
+  worker could still be processing it — a worker hard-caps every execution and
+  would have emitted its own terminal event by then. This guarantees a healthy
+  run owned by another live worker is never reconciled out from under it.
+
+  Background:
+    Given scenario runs are processed via the simulation-processing pipeline
+    And scenario runs are stored in ClickHouse
+
+  # ---------------------------------------------------------------------------
+  # Reconciliation decision (orphaned vs healthy)
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A run orphaned at STARTING is reconciled to a terminal failed state
+    Given a scenario run queued for execution
+    And its worker died before emitting any further event
+    And its last activity is older than the reconciliation threshold
+    When a scenarios worker boots and reconciles orphaned runs
+    Then the run is moved to a terminal error state
+    And the error explains the worker restarted before the run completed
+
+  @unit
+  Scenario: A healthy in-flight run is not reconciled
+    Given a scenario run that is actively in progress
+    And its last activity is more recent than the reconciliation threshold
+    When a scenarios worker boots and reconciles orphaned runs
+    Then the run is left untouched
+
+  @unit
+  Scenario: An already-terminal run is not reconciled again
+    Given a scenario run that already finished
+    When a scenarios worker boots and reconciles orphaned runs
+    Then no terminal event is emitted for that run
+
+  @unit
+  Scenario: Reconciling one run does not stop the others
+    Given several orphaned scenario runs
+    And emitting the terminal event for one of them fails
+    When a scenarios worker boots and reconciles orphaned runs
+    Then the remaining orphaned runs are still reconciled
+
+  # ---------------------------------------------------------------------------
+  # ClickHouse query — which runs are surfaced as orphaned
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Only stale non-terminal runs are surfaced as orphaned
+    Given a non-terminal run whose last activity is beyond the threshold
+    And a non-terminal run whose last activity is within the threshold
+    And a terminal run whose last activity is beyond the threshold
+    And an archived run whose last activity is beyond the threshold
+    When the orphaned-run query runs
+    Then only the stale non-terminal run is returned
+    And it carries the tenant, scenario, batch and set ids needed to finish it
+
+  @integration
+  Scenario: The latest version of a run decides whether it is orphaned
+    Given a run that was queued long ago and later finished successfully
+    When the orphaned-run query runs
+    Then the run is not surfaced as orphaned

--- a/langwatch/specs/scenarios/orphaned-run-reconciliation.feature
+++ b/langwatch/specs/scenarios/orphaned-run-reconciliation.feature
@@ -105,3 +105,20 @@ Feature: Orphaned scenario run reconciliation on worker boot
     When the run state is folded
     Then the run is recorded with a terminal status
     And the run does not become invisible to reconciliation
+
+  @unit
+  Scenario: A run re-entering the queue cannot revive a finished run
+    Given a run that already reached a terminal state
+    When a later event announces the run as queued for execution
+    Then the run keeps its terminal state
+
+  # ---------------------------------------------------------------------------
+  # The sweep spans every tenant
+  # ---------------------------------------------------------------------------
+
+  @integration
+  Scenario: Orphans are recovered for every tenant, not just one
+    Given stale started runs belonging to two different tenants
+    When the orphaned-run query runs
+    Then both runs are surfaced
+    And each run is attributed to the tenant that owns it

--- a/langwatch/specs/scenarios/orphaned-run-reconciliation.feature
+++ b/langwatch/specs/scenarios/orphaned-run-reconciliation.feature
@@ -10,14 +10,20 @@ Feature: Orphaned scenario run reconciliation on worker boot
   reactors (suite aggregates, metrics) never run.
 
   To close this gap, every scenarios worker reconciles orphaned runs when it
-  boots: it looks for non-terminal runs whose last activity is older than a
-  live worker could possibly still be holding them, and emits a terminal
-  failure event so they leave the in-flight state for good.
+  boots: it looks for runs a worker had already started, whose last activity is
+  older than a live worker could possibly still be holding them, and emits a
+  terminal failure event so they leave the in-flight state for good.
 
   A run is considered orphaned only when enough time has passed that no live
   worker could still be processing it — a worker hard-caps every execution and
   would have emitted its own terminal event by then. This guarantees a healthy
   run owned by another live worker is never reconciled out from under it.
+
+  That guarantee only holds for a run a worker actually started. Nothing caps
+  how long a run waits in the queue, so a run sitting behind a large backlog
+  goes stale while a healthy worker is still working toward it. Runs abandoned
+  before they were ever picked up are therefore out of scope here; they are
+  recovered separately, by queued-run orphan recovery.
 
   Background:
     Given scenario runs are processed via the simulation-processing pipeline
@@ -28,8 +34,8 @@ Feature: Orphaned scenario run reconciliation on worker boot
   # ---------------------------------------------------------------------------
 
   @unit
-  Scenario: A run orphaned at STARTING is reconciled to a terminal failed state
-    Given a scenario run queued for execution
+  Scenario: A run orphaned after it started is reconciled to a terminal failed state
+    Given a scenario run that a worker had started executing
     And its worker died before emitting any further event
     And its last activity is older than the reconciliation threshold
     When a scenarios worker boots and reconciles orphaned runs
@@ -61,17 +67,41 @@ Feature: Orphaned scenario run reconciliation on worker boot
   # ---------------------------------------------------------------------------
 
   @integration
-  Scenario: Only stale non-terminal runs are surfaced as orphaned
-    Given a non-terminal run whose last activity is beyond the threshold
-    And a non-terminal run whose last activity is within the threshold
+  Scenario: Only stale started runs are surfaced as orphaned
+    Given a started run whose last activity is beyond the threshold
+    And a started run whose last activity is within the threshold
     And a terminal run whose last activity is beyond the threshold
     And an archived run whose last activity is beyond the threshold
     When the orphaned-run query runs
-    Then only the stale non-terminal run is returned
+    Then only the stale started run is returned
     And it carries the tenant, scenario, batch and set ids needed to finish it
 
   @integration
-  Scenario: The latest version of a run decides whether it is orphaned
-    Given a run that was queued long ago and later finished successfully
+  Scenario: A run waiting behind a backlog is never treated as orphaned
+    Given a run still queued for execution
+    And its last activity is beyond the threshold because a backlog is draining
     When the orphaned-run query runs
     Then the run is not surfaced as orphaned
+
+  @integration
+  Scenario: The latest version of a run decides whether it is orphaned
+    Given a run that was started long ago and later finished successfully
+    When the orphaned-run query runs
+    Then the run is not surfaced as orphaned
+
+  # ---------------------------------------------------------------------------
+  # The terminal state a reconciled run lands in must be final
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A late child cannot overwrite the terminal state of a reconciled run
+    Given a run that was reconciled to a terminal error state
+    When its child process outlives the worker and reports that it finished
+    Then the run keeps the terminal state it was reconciled to
+
+  @unit
+  Scenario: A finished run can never be left in a non-terminal state
+    Given a client reports a run as finished but names a non-terminal status
+    When the run state is folded
+    Then the run is recorded with a terminal status
+    And the run does not become invisible to reconciliation

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
@@ -11,6 +11,7 @@ import type {
     SimulationRunCancelRequestedEvent,
     SimulationRunDeletedEvent,
     SimulationRunFinishedEvent,
+    SimulationRunQueuedEvent,
     SimulationRunStartedEvent,
     SimulationTextMessageEndEvent,
     SimulationTextMessageStartEvent,
@@ -42,6 +43,30 @@ function createRunStartedEvent(
     occurredAt: 1000,
     type: SIMULATION_RUN_EVENT_TYPES.STARTED,
     version: SIMULATION_EVENT_VERSIONS.STARTED,
+    data: {
+      scenarioRunId: "scenario-run-1",
+      scenarioId: "scenario-1",
+      batchRunId: "batch-1",
+      scenarioSetId: "set-1",
+      ...overrides,
+    },
+    ...eventOverrides,
+  };
+}
+
+function createRunQueuedEvent(
+  overrides: Partial<SimulationRunQueuedEvent["data"]> = {},
+  eventOverrides: Partial<SimulationRunQueuedEvent> = {},
+): SimulationRunQueuedEvent {
+  return {
+    id: "event-0",
+    aggregateId: "scenario-run-1",
+    aggregateType: "simulation_run",
+    tenantId: TEST_TENANT_ID,
+    createdAt: 500,
+    occurredAt: 500,
+    type: SIMULATION_RUN_EVENT_TYPES.QUEUED,
+    version: SIMULATION_EVENT_VERSIONS.QUEUED,
     data: {
       scenarioRunId: "scenario-run-1",
       scenarioId: "scenario-1",
@@ -907,11 +932,32 @@ describe("simulationRunStateFoldProjection finalized-status guard", () => {
       });
     });
 
+    // Note: this pins the OUTCOME, not the guard. At this call site the status
+    // candidate is `state.Status === "PENDING" ? "IN_PROGRESS" : state.Status`,
+    // which already preserves a terminal status on its own -- so removing
+    // statusAfter here would not turn this test red. The guard stays as defence
+    // in depth against that candidate expression changing.
     describe("when a later text_message_start arrives", () => {
       it("keeps the terminal status", () => {
         const state = foldEvents([
           createRunFinishedEvent({ status: "ERROR" }, { occurredAt: 3000 }),
           createTextMessageStartEvent({}, { occurredAt: 5000 }),
+        ]);
+
+        expect(state.Status).toBe("ERROR");
+        expect(state.FinishedAt).toBe(3000);
+      });
+    });
+
+    // The fourth non-terminal Status writer. A `queued` event is in the fold
+    // set, so one arriving after `finished` resurrected Status=QUEUED while
+    // FinishedAt stayed set -- an unrecoverable run: the orphan reconciler skips
+    // it (FinishedAt IS NULL) and read-time stall detection skips it too.
+    describe("when a later queued event arrives", () => {
+      it("keeps the terminal status instead of resurrecting QUEUED", () => {
+        const state = foldEvents([
+          createRunFinishedEvent({ status: "ERROR" }, { occurredAt: 3000 }),
+          createRunQueuedEvent({}, { occurredAt: 5000 }),
         ]);
 
         expect(state.Status).toBe("ERROR");
@@ -992,6 +1038,30 @@ describe("simulationRunStateFoldProjection finalized-status guard", () => {
         expect(state.FinishedAt).toBe(3000);
       });
     });
+
+    // Every non-terminal member of ScenarioRunStatus, not just the two that
+    // happened to be interesting -- the ingest field is an unconstrained string
+    // on the internal event schema, so the whole enum can arrive here.
+    describe.each(["PENDING", "QUEUED", "IN_PROGRESS", "RUNNING"])(
+      "when the non-terminal status is %s",
+      (nonTerminal) => {
+        it("never leaves the run non-terminal once FinishedAt is set", () => {
+          const state = foldEvents([
+            createRunStartedEvent({}, { occurredAt: 1000 }),
+            createRunFinishedEvent(
+              { status: nonTerminal },
+              { occurredAt: 3000 },
+            ),
+          ]);
+
+          expect(state.FinishedAt).toBe(3000);
+          expect(state.Status).not.toBe(nonTerminal);
+          expect(["SUCCESS", "FAILURE", "FAILED", "ERROR", "CANCELLED"]).toContain(
+            state.Status,
+          );
+        });
+      },
+    );
   });
 
   describe("given a run that has not finished", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
@@ -918,6 +918,80 @@ describe("simulationRunStateFoldProjection finalized-status guard", () => {
         expect(state.FinishedAt).toBe(3000);
       });
     });
+
+    // A late child that outlived the parent this run's reconciliation already
+    // failed must not rewrite the terminal record the downstream reactors have
+    // already acted on -- nor split it into an ERROR status carrying the late
+    // child's SUCCESS verdict.
+    describe("when a second finished event arrives", () => {
+      it("keeps the first terminal record and ignores the late one", () => {
+        const state = foldEvents([
+          createRunFinishedEvent({ status: "ERROR" }, { occurredAt: 3000 }),
+          createRunFinishedEvent(
+            {
+              status: "SUCCESS",
+              results: {
+                verdict: "success",
+                reasoning: "late child finished for real",
+                metCriteria: [],
+                unmetCriteria: [],
+              },
+            },
+            { occurredAt: 5000, id: "event-late-finish" },
+          ),
+        ]);
+
+        expect(state.Status).toBe("ERROR");
+        expect(state.Verdict).toBeNull();
+        expect(state.FinishedAt).toBe(3000);
+      });
+    });
+  });
+
+  // The scenario-events ingest route types the finished status as the full
+  // ScenarioRunStatus enum, non-terminal members included. Writing one straight
+  // through would set a non-terminal Status alongside FinishedAt -- a run the
+  // orphan reconciler skips (FinishedAt IS NULL) and read-time stall detection
+  // skips (it only resolves unfinished runs). Nothing could ever recover it.
+  describe("given a finished event carrying a non-terminal status", () => {
+    describe("when it is folded", () => {
+      it("refuses the non-terminal status and finishes the run terminally", () => {
+        const state = foldEvents([
+          createRunStartedEvent({}, { occurredAt: 1000 }),
+          createRunFinishedEvent(
+            { status: "IN_PROGRESS" },
+            { occurredAt: 3000 },
+          ),
+        ]);
+
+        expect(state.Status).not.toBe("IN_PROGRESS");
+        expect(state.Status).toBe("FAILURE");
+        expect(state.FinishedAt).toBe(3000);
+      });
+    });
+
+    describe("when it carries a success verdict", () => {
+      it("derives the terminal status from the verdict", () => {
+        const state = foldEvents([
+          createRunStartedEvent({}, { occurredAt: 1000 }),
+          createRunFinishedEvent(
+            {
+              status: "QUEUED",
+              results: {
+                verdict: "success",
+                reasoning: "ok",
+                metCriteria: [],
+                unmetCriteria: [],
+              },
+            },
+            { occurredAt: 3000 },
+          ),
+        ]);
+
+        expect(state.Status).toBe("SUCCESS");
+        expect(state.FinishedAt).toBe(3000);
+      });
+    });
   });
 
   describe("given a run that has not finished", () => {

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/__tests__/simulationRunState.foldProjection.unit.test.ts
@@ -868,3 +868,68 @@ describe("simulationRunStateFoldProjection", () => {
     });
   });
 });
+
+describe("simulationRunStateFoldProjection finalized-status guard", () => {
+  // Orphaned-run reconciliation writes a terminal `finished` event for a run
+  // whose worker died. If the worker's child process actually outlived its
+  // parent (reparented) and later POSTs a real started/snapshot whose
+  // client-supplied occurredAt is AFTER the reconciliation time, that event
+  // applies in-order (no re-fold, since occurredAt is not strictly less than
+  // LastEventOccurredAt) and would otherwise clobber Status back to a
+  // non-terminal value while FinishedAt stays set — an unrecoverable zombie
+  // the read-time stall path can no longer rescue. Once FinishedAt is set,
+  // Status must stay terminal.
+  describe("given a run that already finished", () => {
+    describe("when a later started event arrives", () => {
+      it("keeps the terminal status instead of resurrecting IN_PROGRESS", () => {
+        const state = foldEvents([
+          createRunFinishedEvent({ status: "ERROR" }, { occurredAt: 3000 }),
+          createRunStartedEvent({}, { occurredAt: 5000 }),
+        ]);
+
+        expect(state.Status).toBe("ERROR");
+        expect(state.FinishedAt).toBe(3000);
+      });
+    });
+
+    describe("when a later message snapshot carrying a status arrives", () => {
+      it("keeps the terminal status", () => {
+        const state = foldEvents([
+          createRunFinishedEvent({ status: "ERROR" }, { occurredAt: 3000 }),
+          createMessageSnapshotEvent(
+            { status: "IN_PROGRESS" },
+            { occurredAt: 5000 },
+          ),
+        ]);
+
+        expect(state.Status).toBe("ERROR");
+        expect(state.FinishedAt).toBe(3000);
+      });
+    });
+
+    describe("when a later text_message_start arrives", () => {
+      it("keeps the terminal status", () => {
+        const state = foldEvents([
+          createRunFinishedEvent({ status: "ERROR" }, { occurredAt: 3000 }),
+          createTextMessageStartEvent({}, { occurredAt: 5000 }),
+        ]);
+
+        expect(state.Status).toBe("ERROR");
+        expect(state.FinishedAt).toBe(3000);
+      });
+    });
+  });
+
+  describe("given a run that has not finished", () => {
+    describe("when a started event arrives", () => {
+      it("still transitions to IN_PROGRESS (guard does not affect the live path)", () => {
+        const state = foldEvents([
+          createRunStartedEvent({}, { occurredAt: 1000 }),
+        ]);
+
+        expect(state.Status).toBe("IN_PROGRESS");
+        expect(state.FinishedAt).toBeNull();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -159,6 +159,29 @@ export interface SimulationRunState extends Projection<SimulationRunStateData> {
   data: SimulationRunStateData;
 }
 
+/**
+ * Guards a non-terminal Status transition once a run is already finished.
+ *
+ * Orphaned-run reconciliation writes a terminal `finished` event for a run
+ * whose worker died. If that worker's child process actually outlived its
+ * parent (reparented) and later POSTs a real started/snapshot whose
+ * client-supplied `occurredAt` is AFTER the reconciliation time, the event
+ * applies in-order (the executor only re-folds when occurredAt is STRICTLY
+ * less than what we've already seen) and would otherwise clobber Status back to
+ * a non-terminal value while FinishedAt stays set — an unrecoverable zombie the
+ * read-time stall path can no longer rescue (it only resolves runs with no
+ * FinishedAt). Once FinishedAt is set, Status stays terminal.
+ */
+function statusAfter({
+  state,
+  candidate,
+}: {
+  state: SimulationRunStateData;
+  candidate: string;
+}): string {
+  return state.FinishedAt != null ? state.Status : candidate;
+}
+
 const simulationRunEvents = [
   SimulationRunQueuedEventSchema,
   SimulationRunStartedEventSchema,
@@ -255,7 +278,7 @@ export class SimulationRunStateFoldProjection
       Name: state.Name ?? event.data.name ?? null,
       Description: state.Description ?? event.data.description ?? null,
       Metadata: state.Metadata ?? (event.data.metadata ? JSON.stringify(event.data.metadata) : null),
-      Status: "IN_PROGRESS",
+      Status: statusAfter({ state, candidate: "IN_PROGRESS" }),
       StartedAt: event.occurredAt,
     };
   }
@@ -322,7 +345,10 @@ export class SimulationRunStateFoldProjection
         };
       }),
       TraceIds: Array.isArray(event.data.traceIds) ? event.data.traceIds : [],
-      Status: event.data.status ?? state.Status,
+      Status: statusAfter({
+        state,
+        candidate: event.data.status ?? state.Status,
+      }),
     };
   }
 
@@ -357,7 +383,10 @@ export class SimulationRunStateFoldProjection
     return {
       ...state,
       ScenarioRunId: state.ScenarioRunId || event.data.scenarioRunId,
-      Status: state.Status === "PENDING" ? "IN_PROGRESS" : state.Status,
+      Status: statusAfter({
+        state,
+        candidate: state.Status === "PENDING" ? "IN_PROGRESS" : state.Status,
+      }),
       StartedAt: state.StartedAt ?? event.occurredAt,
       Messages: messages,
     };

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -170,7 +170,19 @@ export interface SimulationRunState extends Projection<SimulationRunStateData> {
  * less than what we've already seen) and would otherwise clobber Status back to
  * a non-terminal value while FinishedAt stays set — an unrecoverable zombie the
  * read-time stall path can no longer rescue (it only resolves runs with no
- * FinishedAt). Once FinishedAt is set, Status stays terminal.
+ * FinishedAt).
+ *
+ * Scope: this guards the non-terminal transition sites (started/snapshot/
+ * message) only. `handleSimulationRunFinished` deliberately does NOT route
+ * through it, so a `finished` event still sets Status unconditionally. Two
+ * consequences, both intentional-for-now and tracked on the PR:
+ *   - A later `finished` overwrites an earlier one, so a child that outlives a
+ *     reconciled parent can take an ERROR back to SUCCESS. That self-heal is
+ *     what protects a run the reconciler failed early by mistake.
+ *   - The ingest route's `finished` schema accepts any ScenarioRunStatus, so a
+ *     client POSTing `finished(status=IN_PROGRESS)` writes a non-terminal Status
+ *     alongside FinishedAt — the very zombie described above, through the one
+ *     door this guard does not cover.
  */
 function statusAfter({
   state,

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -174,12 +174,16 @@ export interface SimulationRunState extends Projection<SimulationRunStateData> {
  *
  * Once FinishedAt is set, Status stays terminal. Three things hold that line
  * together, and all three are load-bearing:
- *   1. this guard, at the non-terminal transition sites (started/snapshot/
- *      message);
+ *   1. this guard, at EVERY non-terminal Status writer — queued, started,
+ *      snapshot, and textMessageStart. Miss one and the invariant is gone: a
+ *      `queued` event folded after `finished` used to resurrect Status=QUEUED
+ *      with FinishedAt still set. If you add a handler that writes a
+ *      non-terminal Status, it goes through here too;
  *   2. `handleSimulationRunFinished` returning early once FinishedAt is set, so
  *      a run finishes exactly once;
  *   3. that same handler refusing a non-terminal explicit status, since the
- *      ingest schema types it as the full ScenarioRunStatus enum.
+ *      finished event's `status` is only typed `z.string().optional()` on the
+ *      internal event schema — any string can reach the fold.
  */
 function statusAfter({
   state,
@@ -286,7 +290,7 @@ export class SimulationRunStateFoldProjection
       BatchRunId: event.data.batchRunId,
       ScenarioSetId: event.data.scenarioSetId,
       Name: event.data.name ?? null,
-      Status: "QUEUED",
+      Status: statusAfter({ state, candidate: "QUEUED" }),
       Description: event.data.description ?? null,
       Metadata: event.data.metadata ? JSON.stringify(event.data.metadata) : null,
       QueuedAt: event.occurredAt,

--- a/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
+++ b/langwatch/src/server/event-sourcing/pipelines/simulation-processing/projections/simulationRunState.foldProjection.ts
@@ -172,17 +172,14 @@ export interface SimulationRunState extends Projection<SimulationRunStateData> {
  * read-time stall path can no longer rescue (it only resolves runs with no
  * FinishedAt).
  *
- * Scope: this guards the non-terminal transition sites (started/snapshot/
- * message) only. `handleSimulationRunFinished` deliberately does NOT route
- * through it, so a `finished` event still sets Status unconditionally. Two
- * consequences, both intentional-for-now and tracked on the PR:
- *   - A later `finished` overwrites an earlier one, so a child that outlives a
- *     reconciled parent can take an ERROR back to SUCCESS. That self-heal is
- *     what protects a run the reconciler failed early by mistake.
- *   - The ingest route's `finished` schema accepts any ScenarioRunStatus, so a
- *     client POSTing `finished(status=IN_PROGRESS)` writes a non-terminal Status
- *     alongside FinishedAt — the very zombie described above, through the one
- *     door this guard does not cover.
+ * Once FinishedAt is set, Status stays terminal. Three things hold that line
+ * together, and all three are load-bearing:
+ *   1. this guard, at the non-terminal transition sites (started/snapshot/
+ *      message);
+ *   2. `handleSimulationRunFinished` returning early once FinishedAt is set, so
+ *      a run finishes exactly once;
+ *   3. that same handler refusing a non-terminal explicit status, since the
+ *      ingest schema types it as the full ScenarioRunStatus enum.
  */
 function statusAfter({
   state,
@@ -192,6 +189,25 @@ function statusAfter({
   candidate: string;
 }): string {
   return state.FinishedAt != null ? state.Status : candidate;
+}
+
+/**
+ * The statuses a run may hold once FinishedAt is set. A `finished` event whose
+ * explicit status is outside this set is not describing a finished run, so its
+ * status is discarded in favour of the verdict-derived one — writing it would
+ * strand the run non-terminal but finished, which nothing reconciles.
+ */
+const TERMINAL_STATUSES = new Set([
+  "SUCCESS",
+  "FAILURE",
+  "FAILED",
+  "ERROR",
+  "CANCELLED",
+  "STALLED",
+]);
+
+function isTerminalStatus(status: string): boolean {
+  return TERMINAL_STATUSES.has(status);
 }
 
 const simulationRunEvents = [
@@ -482,13 +498,26 @@ export class SimulationRunStateFoldProjection
     event: SimulationRunFinishedEvent,
     state: SimulationRunStateData,
   ): SimulationRunStateData {
+    // A run finishes exactly once. A second `finished` — a child that outlived
+    // the parent this run's orphan reconciliation already failed — must not
+    // rewrite a terminal record the downstream reactors have already acted on,
+    // nor split it (an ERROR Status carrying the late child's SUCCESS Verdict).
+    if (state.FinishedAt != null) return state;
+
     const results = event.data.results;
     const verdict = results?.verdict ?? null;
 
-    // Derive status: explicit status takes priority, otherwise derive from verdict
+    // Derive status: an explicit TERMINAL status takes priority, otherwise
+    // derive from verdict. The explicit status arrives from the scenario-events
+    // ingest route, whose schema types it as the full ScenarioRunStatus enum —
+    // non-terminal members included. Taking it at face value would write a
+    // non-terminal Status alongside FinishedAt below, which is the one state
+    // nothing can recover: the orphan reconciler skips it (FinishedAt IS NULL)
+    // and read-time stall detection skips it (it only resolves unfinished runs).
     let status: string;
-    if (event.data.status) {
-      status = event.data.status.toUpperCase();
+    const explicit = event.data.status?.toUpperCase();
+    if (explicit && isTerminalStatus(explicit)) {
+      status = explicit;
     } else if (verdict === "success") {
       status = "SUCCESS";
     } else if (verdict === "failure" || verdict === "inconclusive") {

--- a/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.clickhouse.integration.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.clickhouse.integration.test.ts
@@ -1,0 +1,171 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import { nanoid } from "nanoid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  startTestContainers,
+  stopTestContainers,
+} from "../../event-sourcing/__tests__/integration/testContainers";
+import { ClickHouseOrphanedRunFinder } from "../orphaned-run-reconciliation.clickhouse";
+import { STALL_THRESHOLD_MS } from "../stall-detection";
+
+const tenantId = `test-orphan-${nanoid()}`;
+const NOW = Date.now();
+const minutesAgo = (m: number) => new Date(NOW - m * 60_000);
+
+// Default row: a STALE, non-terminal (QUEUED) run — i.e. an orphan. Override
+// timestamps / Status / FinishedAt / ArchivedAt to build the other cases.
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ProjectionId: `proj-${nanoid()}`,
+    TenantId: tenantId,
+    ScenarioRunId: `run-${nanoid()}`,
+    ScenarioId: `scenario-${nanoid()}`,
+    BatchRunId: `batch-${nanoid()}`,
+    ScenarioSetId: `set-${nanoid()}`,
+    Version: "v1",
+    Status: "QUEUED",
+    Name: "Test run",
+    Description: null,
+    Metadata: null,
+    "Messages.Id": [],
+    "Messages.Role": [],
+    "Messages.Content": [],
+    "Messages.TraceId": [],
+    "Messages.Rest": [],
+    TraceIds: [],
+    Verdict: null,
+    Reasoning: null,
+    MetCriteria: [],
+    UnmetCriteria: [],
+    Error: null,
+    DurationMs: null,
+    TotalCost: null,
+    RoleCosts: {},
+    RoleLatencies: {},
+    TraceMetricsJson: "",
+    StartedAt: minutesAgo(60),
+    QueuedAt: null,
+    CreatedAt: minutesAgo(60),
+    UpdatedAt: minutesAgo(60),
+    FinishedAt: null,
+    ArchivedAt: null,
+    CancellationRequestedAt: null,
+    LastSnapshotOccurredAt: new Date(0),
+    LastEventOccurredAt: new Date(0),
+    ...overrides,
+  };
+}
+
+async function insertRows(
+  ch: ClickHouseClient,
+  rows: ReturnType<typeof makeRow>[],
+) {
+  await ch.insert({
+    table: "simulation_runs",
+    values: rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
+}
+
+let ch: ClickHouseClient;
+let finder: ClickHouseOrphanedRunFinder;
+
+beforeAll(async () => {
+  const containers = await startTestContainers();
+  ch = containers.clickHouseClient;
+  finder = new ClickHouseOrphanedRunFinder(ch);
+}, 60_000);
+
+afterAll(async () => {
+  if (ch) {
+    await ch.exec({
+      query: `ALTER TABLE simulation_runs DELETE WHERE TenantId = {tenantId:String}`,
+      query_params: { tenantId },
+    });
+  }
+  await stopTestContainers();
+});
+
+describe("ClickHouseOrphanedRunFinder.findOrphanedRuns (integration)", () => {
+  describe("given a mix of stale, healthy, terminal and archived runs", () => {
+    it("surfaces only the stale non-terminal run, with the ids needed to finish it", async () => {
+      const orphan = makeRow({
+        ScenarioRunId: "orphan-stale",
+        ScenarioId: "scenario-orphan",
+        BatchRunId: "batch-orphan",
+        ScenarioSetId: "set-orphan",
+        Status: "QUEUED",
+      });
+      const healthy = makeRow({
+        ScenarioRunId: "healthy-recent",
+        Status: "IN_PROGRESS",
+        StartedAt: minutesAgo(1),
+        CreatedAt: minutesAgo(1),
+        UpdatedAt: minutesAgo(1),
+      });
+      const finished = makeRow({
+        ScenarioRunId: "already-finished",
+        Status: "SUCCESS",
+        Verdict: "success",
+        FinishedAt: minutesAgo(60),
+      });
+      const archived = makeRow({
+        ScenarioRunId: "archived-run",
+        Status: "QUEUED",
+        ArchivedAt: minutesAgo(60),
+      });
+
+      await insertRows(ch, [orphan, healthy, finished, archived]);
+
+      const result = await finder.findOrphanedRuns({
+        now: NOW,
+        thresholdMs: STALL_THRESHOLD_MS,
+      });
+      const mine = result.filter((r) => r.tenantId === tenantId);
+      const ids = mine.map((r) => r.scenarioRunId);
+
+      expect(ids).toContain("orphan-stale");
+      expect(ids).not.toContain("healthy-recent");
+      expect(ids).not.toContain("already-finished");
+      expect(ids).not.toContain("archived-run");
+
+      const orphanRow = mine.find((r) => r.scenarioRunId === "orphan-stale");
+      expect(orphanRow).toEqual({
+        tenantId,
+        scenarioRunId: "orphan-stale",
+        scenarioId: "scenario-orphan",
+        batchRunId: "batch-orphan",
+        scenarioSetId: "set-orphan",
+        status: "QUEUED",
+      });
+    });
+  });
+
+  describe("given a run that was queued long ago but later finished", () => {
+    it("does not surface it — the latest version decides", async () => {
+      const scenarioRunId = `multiversion-${nanoid()}`;
+      await insertRows(ch, [
+        makeRow({
+          ScenarioRunId: scenarioRunId,
+          Status: "QUEUED",
+          UpdatedAt: minutesAgo(60),
+        }),
+        makeRow({
+          ScenarioRunId: scenarioRunId,
+          Status: "SUCCESS",
+          Verdict: "success",
+          FinishedAt: minutesAgo(50),
+          UpdatedAt: minutesAgo(50),
+        }),
+      ]);
+
+      const result = await finder.findOrphanedRuns({
+        now: NOW,
+        thresholdMs: STALL_THRESHOLD_MS,
+      });
+
+      expect(result.map((r) => r.scenarioRunId)).not.toContain(scenarioRunId);
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.clickhouse.integration.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.clickhouse.integration.test.ts
@@ -12,8 +12,11 @@ const tenantId = `test-orphan-${nanoid()}`;
 const NOW = Date.now();
 const minutesAgo = (m: number) => new Date(NOW - m * 60_000);
 
-// Default row: a STALE, non-terminal (QUEUED) run — i.e. an orphan. Override
-// timestamps / Status / FinishedAt / ArchivedAt to build the other cases.
+// Default row: a STALE, IN_PROGRESS run — i.e. an orphan a dead worker had
+// already started. Override timestamps / Status / FinishedAt / ArchivedAt to
+// build the other cases. A stale QUEUED run is deliberately NOT an orphan here:
+// nothing caps queue wait, so a run behind a large backlog looks identical to
+// an abandoned one. QUEUED is owned by scenario-orphan-reconciler.ts (#3365).
 function makeRow(overrides: Record<string, unknown> = {}) {
   return {
     ProjectionId: `proj-${nanoid()}`,
@@ -23,7 +26,7 @@ function makeRow(overrides: Record<string, unknown> = {}) {
     BatchRunId: `batch-${nanoid()}`,
     ScenarioSetId: `set-${nanoid()}`,
     Version: "v1",
-    Status: "QUEUED",
+    Status: "IN_PROGRESS",
     Name: "Test run",
     Description: null,
     Metadata: null,
@@ -89,13 +92,13 @@ afterAll(async () => {
 
 describe("ClickHouseOrphanedRunFinder.findOrphanedRuns (integration)", () => {
   describe("given a mix of stale, healthy, terminal and archived runs", () => {
-    it("surfaces only the stale non-terminal run, with the ids needed to finish it", async () => {
+    it("surfaces only the stale started run, with the ids needed to finish it", async () => {
       const orphan = makeRow({
         ScenarioRunId: "orphan-stale",
         ScenarioId: "scenario-orphan",
         BatchRunId: "batch-orphan",
         ScenarioSetId: "set-orphan",
-        Status: "QUEUED",
+        Status: "IN_PROGRESS",
       });
       const healthy = makeRow({
         ScenarioRunId: "healthy-recent",
@@ -112,7 +115,7 @@ describe("ClickHouseOrphanedRunFinder.findOrphanedRuns (integration)", () => {
       });
       const archived = makeRow({
         ScenarioRunId: "archived-run",
-        Status: "QUEUED",
+        Status: "IN_PROGRESS",
         ArchivedAt: minutesAgo(60),
       });
 
@@ -137,18 +140,45 @@ describe("ClickHouseOrphanedRunFinder.findOrphanedRuns (integration)", () => {
         scenarioId: "scenario-orphan",
         batchRunId: "batch-orphan",
         scenarioSetId: "set-orphan",
-        status: "QUEUED",
+        status: "IN_PROGRESS",
       });
     });
   });
 
-  describe("given a run that was queued long ago but later finished", () => {
+  // The false-positive this sweep must never produce. A QUEUED run behind a
+  // large batch/suite backlog goes stale while a healthy worker is still
+  // working toward it -- nothing caps queue wait the way the child timeout caps
+  // execution. QUEUED orphans belong to scenario-orphan-reconciler.ts (#3365).
+  describe("given a stale QUEUED run waiting behind a backlog", () => {
+    it("does not surface it — queue wait is not evidence the worker died", async () => {
+      const queuedBehindBacklog = makeRow({
+        ScenarioRunId: "queued-behind-backlog",
+        Status: "QUEUED",
+        StartedAt: minutesAgo(90),
+        CreatedAt: minutesAgo(90),
+        UpdatedAt: minutesAgo(90),
+      });
+
+      await insertRows(ch, [queuedBehindBacklog]);
+
+      const result = await finder.findOrphanedRuns({
+        now: NOW,
+        thresholdMs: STALL_THRESHOLD_MS,
+      });
+
+      expect(result.map((r) => r.scenarioRunId)).not.toContain(
+        "queued-behind-backlog",
+      );
+    });
+  });
+
+  describe("given a run that was started long ago but later finished", () => {
     it("does not surface it — the latest version decides", async () => {
       const scenarioRunId = `multiversion-${nanoid()}`;
       await insertRows(ch, [
         makeRow({
           ScenarioRunId: scenarioRunId,
-          Status: "QUEUED",
+          Status: "IN_PROGRESS",
           UpdatedAt: minutesAgo(60),
         }),
         makeRow({

--- a/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.clickhouse.integration.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.clickhouse.integration.test.ts
@@ -9,6 +9,7 @@ import { ClickHouseOrphanedRunFinder } from "../orphaned-run-reconciliation.clic
 import { STALL_THRESHOLD_MS } from "../stall-detection";
 
 const tenantId = `test-orphan-${nanoid()}`;
+const otherTenantId = `test-orphan-other-${nanoid()}`;
 const NOW = Date.now();
 const minutesAgo = (m: number) => new Date(NOW - m * 60_000);
 
@@ -82,10 +83,12 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (ch) {
-    await ch.exec({
-      query: `ALTER TABLE simulation_runs DELETE WHERE TenantId = {tenantId:String}`,
-      query_params: { tenantId },
-    });
+    for (const t of [tenantId, otherTenantId]) {
+      await ch.exec({
+        query: `ALTER TABLE simulation_runs DELETE WHERE TenantId = {tenantId:String}`,
+        query_params: { tenantId: t },
+      });
+    }
   }
   await stopTestContainers();
 });
@@ -169,6 +172,34 @@ describe("ClickHouseOrphanedRunFinder.findOrphanedRuns (integration)", () => {
       expect(result.map((r) => r.scenarioRunId)).not.toContain(
         "queued-behind-backlog",
       );
+    });
+  });
+
+  // The sweep runs at boot with no tenant context, so it deliberately omits the
+  // `WHERE TenantId = ...` filter every other simulation_runs query carries.
+  // Nothing else pins that: a well-meaning "you forgot the tenant filter" fix
+  // would silently reduce the sweep to one arbitrary tenant, and every other
+  // test here uses a single tenant and would stay green.
+  describe("given stale started runs belonging to different tenants", () => {
+    it("surfaces every tenant's orphan, each attributed to its own tenant", async () => {
+      await insertRows(ch, [
+        makeRow({ ScenarioRunId: "orphan-tenant-a" }),
+        makeRow({
+          ScenarioRunId: "orphan-tenant-b",
+          TenantId: otherTenantId,
+        }),
+      ]);
+
+      const result = await finder.findOrphanedRuns({
+        now: NOW,
+        thresholdMs: STALL_THRESHOLD_MS,
+      });
+
+      const a = result.find((r) => r.scenarioRunId === "orphan-tenant-a");
+      const b = result.find((r) => r.scenarioRunId === "orphan-tenant-b");
+
+      expect(a?.tenantId).toBe(tenantId);
+      expect(b?.tenantId).toBe(otherTenantId);
     });
   });
 

--- a/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.unit.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ORPHAN_ERROR_MESSAGE,
+  ORPHAN_RECONCILE_THRESHOLD_MS,
+  type OrphanedRun,
+  type OrphanedRunFinder,
+  type OrphanFailureEmitter,
+  reconcileOrphanedRuns,
+} from "../orphaned-run-reconciliation";
+import { STALL_THRESHOLD_MS } from "../stall-detection";
+
+function makeOrphan(overrides: Partial<OrphanedRun> = {}): OrphanedRun {
+  return {
+    tenantId: "project-1",
+    scenarioRunId: "run-1",
+    scenarioId: "scenario-1",
+    batchRunId: "batch-1",
+    scenarioSetId: "set-1",
+    status: "QUEUED",
+    ...overrides,
+  };
+}
+
+function finderReturning(runs: OrphanedRun[]): OrphanedRunFinder {
+  return { findOrphanedRuns: vi.fn().mockResolvedValue(runs) };
+}
+
+function spyEmitter(): OrphanFailureEmitter {
+  return { ensureFailureEventsEmitted: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe("reconcileOrphanedRuns", () => {
+  describe("given the finder surfaces an orphaned run", () => {
+    it("emits a terminal failure event scoped to the run's tenant", async () => {
+      const finder = finderReturning([
+        makeOrphan({
+          tenantId: "project-9",
+          scenarioRunId: "run-orphan",
+          scenarioId: "scenario-9",
+          batchRunId: "batch-9",
+          scenarioSetId: "set-9",
+        }),
+      ]);
+      const emitter = spyEmitter();
+
+      const result = await reconcileOrphanedRuns({
+        finder,
+        failureEmitter: emitter,
+      });
+
+      expect(emitter.ensureFailureEventsEmitted).toHaveBeenCalledTimes(1);
+      expect(emitter.ensureFailureEventsEmitted).toHaveBeenCalledWith({
+        projectId: "project-9",
+        scenarioId: "scenario-9",
+        setId: "set-9",
+        batchRunId: "batch-9",
+        scenarioRunId: "run-orphan",
+        error: ORPHAN_ERROR_MESSAGE,
+      });
+      expect(result).toEqual({ reconciled: 1, failed: 0 });
+    });
+  });
+
+  describe("given the finder surfaces no orphaned runs", () => {
+    it("emits nothing", async () => {
+      const finder = finderReturning([]);
+      const emitter = spyEmitter();
+
+      const result = await reconcileOrphanedRuns({
+        finder,
+        failureEmitter: emitter,
+      });
+
+      expect(emitter.ensureFailureEventsEmitted).not.toHaveBeenCalled();
+      expect(result).toEqual({ reconciled: 0, failed: 0 });
+    });
+  });
+
+  describe("given emitting the terminal event fails for one run", () => {
+    it("still reconciles the remaining runs and reports the failure", async () => {
+      const finder = finderReturning([
+        makeOrphan({ scenarioRunId: "run-a" }),
+        makeOrphan({ scenarioRunId: "run-b" }),
+        makeOrphan({ scenarioRunId: "run-c" }),
+      ]);
+      const emitter: OrphanFailureEmitter = {
+        ensureFailureEventsEmitted: vi
+          .fn()
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error("clickhouse down"))
+          .mockResolvedValueOnce(undefined),
+      };
+
+      const result = await reconcileOrphanedRuns({
+        finder,
+        failureEmitter: emitter,
+      });
+
+      expect(emitter.ensureFailureEventsEmitted).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({ reconciled: 2, failed: 1 });
+    });
+  });
+
+  describe("given a now and an explicit threshold", () => {
+    it("passes them through to the finder", async () => {
+      const finder = finderReturning([]);
+      const emitter = spyEmitter();
+
+      await reconcileOrphanedRuns({
+        finder,
+        failureEmitter: emitter,
+        now: 1_000_000,
+        thresholdMs: 5_000,
+      });
+
+      expect(finder.findOrphanedRuns).toHaveBeenCalledWith({
+        now: 1_000_000,
+        thresholdMs: 5_000,
+      });
+    });
+  });
+
+  describe("when no threshold is supplied", () => {
+    it("defaults the finder to the read-path stall threshold", async () => {
+      const finder = finderReturning([]);
+      const emitter = spyEmitter();
+
+      await reconcileOrphanedRuns({ finder, failureEmitter: emitter });
+
+      expect(finder.findOrphanedRuns).toHaveBeenCalledWith(
+        expect.objectContaining({ thresholdMs: STALL_THRESHOLD_MS }),
+      );
+      // The write-path threshold is anchored to the read-path's STALLED line.
+      expect(ORPHAN_RECONCILE_THRESHOLD_MS).toBe(STALL_THRESHOLD_MS);
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.unit.test.ts
@@ -120,7 +120,7 @@ describe("reconcileOrphanedRuns", () => {
     });
   });
 
-  describe("when no threshold is supplied", () => {
+  describe("given no threshold is supplied", () => {
     it("defaults the finder to the read-path stall threshold", async () => {
       const finder = finderReturning([]);
       const emitter = spyEmitter();

--- a/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/orphaned-run-reconciliation.unit.test.ts
@@ -16,7 +16,7 @@ function makeOrphan(overrides: Partial<OrphanedRun> = {}): OrphanedRun {
     scenarioId: "scenario-1",
     batchRunId: "batch-1",
     scenarioSetId: "set-1",
-    status: "QUEUED",
+    status: "IN_PROGRESS",
     ...overrides,
   };
 }

--- a/langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts
+++ b/langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts
@@ -1,0 +1,152 @@
+/**
+ * ClickHouse-backed finder for orphaned scenario runs, plus the boot entrypoint
+ * that wires it to the failure emitter.
+ *
+ * @see ./orphaned-run-reconciliation.ts
+ * @see https://github.com/langwatch/langwatch/issues/3195
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { getSharedClickHouseClient } from "~/server/clickhouse/clickhouseClient";
+import { createLogger } from "~/utils/logger/server";
+import {
+  type OrphanedRun,
+  type OrphanedRunFinder,
+  type OrphanFailureEmitter,
+  reconcileOrphanedRuns,
+} from "./orphaned-run-reconciliation";
+
+const logger = createLogger("langwatch:scenarios:orphan-reconciliation");
+
+const TABLE_NAME = "simulation_runs" as const;
+
+/**
+ * Bound the partition scan. simulation_runs is `PARTITION BY toYearWeek(StartedAt)`
+ * and the store writes `StartedAt = StartedAt ?? CreatedAt`, so even a
+ * queued-never-started orphan has a real recent StartedAt and is found by
+ * pruning on it. Orphans older than this window are already cosmetically
+ * STALLED on the read path and not worth a cold-partition scan on every boot.
+ *
+ * `StartedAt <= UpdatedAt` always holds, so pruning on StartedAt never excludes
+ * a run the UpdatedAt staleness gate would otherwise surface.
+ */
+const ORPHAN_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+/** Safety cap on a single boot sweep. */
+const ORPHAN_SWEEP_LIMIT = 1000;
+
+/**
+ * Terminal run statuses — never reconciled. These are the statuses the finish
+ * handler persists (SUCCESS/FAILURE/FAILED/ERROR/CANCELLED) plus STALLED. A
+ * terminal status is always written together with FinishedAt, so the
+ * `FinishedAt IS NULL` gate below already excludes these rows; this filter is a
+ * defensive belt-and-suspenders against a future path that writes a terminal
+ * status without a FinishedAt. (The same literals are duplicated inline as
+ * `completedStatuses` in scenario-event.service.ts — extracting a shared
+ * exported constant is a worthwhile follow-up.) Everything else —
+ * PENDING/QUEUED/IN_PROGRESS — is in-flight and a reconciliation candidate.
+ */
+const TERMINAL_STATUSES = [
+  "SUCCESS",
+  "FAILURE",
+  "FAILED",
+  "ERROR",
+  "CANCELLED",
+  "STALLED",
+] as const;
+
+/**
+ * Finds the latest version of every non-terminal run whose last activity is
+ * older than `now - thresholdMs`, across all tenants on the shared client.
+ *
+ * - Dedups the ReplacingMergeTree(UpdatedAt) to the latest version per run via
+ *   the IN-tuple pattern (light key columns only — no Messages.* / heavy JSON,
+ *   so the scan is memory-bounded).
+ * - Prunes partitions on StartedAt.
+ * - Filters on UpdatedAt (the field the read-path stall detection also uses).
+ */
+export class ClickHouseOrphanedRunFinder implements OrphanedRunFinder {
+  constructor(private readonly client: ClickHouseClient) {}
+
+  async findOrphanedRuns({
+    now,
+    thresholdMs,
+  }: {
+    now: number;
+    thresholdMs: number;
+  }): Promise<OrphanedRun[]> {
+    const staleBeforeMs = now - thresholdMs;
+    const lookbackStartMs = now - ORPHAN_LOOKBACK_MS;
+
+    // Partition-pruning predicate, duplicated inside the dedup subquery so the
+    // inner GROUP BY prunes too (see clickhouse-queries.md "IN-Tuple Dedup").
+    const partitionFilter =
+      "StartedAt >= fromUnixTimestamp64Milli({lookbackStartMs:Int64})";
+
+    // Cross-tenant sweep BY DESIGN: a boot reconciler has no single tenant to
+    // scope to, so this intentionally omits the per-tenant `WHERE TenantId =`
+    // filter clickhouse-queries.md mandates for tenant-scoped reads. TenantId is
+    // SELECTed (not filtered), and each terminal write downstream is scoped to
+    // its own run's tenant. Precedent: other system-level cross-tenant sweeps.
+    const result = await this.client.query({
+      query: `
+        SELECT
+          TenantId AS tenantId,
+          ScenarioRunId AS scenarioRunId,
+          ScenarioId AS scenarioId,
+          BatchRunId AS batchRunId,
+          ScenarioSetId AS scenarioSetId,
+          Status AS status
+        FROM ${TABLE_NAME}
+        WHERE ${partitionFilter}
+          AND (TenantId, ScenarioRunId, UpdatedAt) IN (
+            SELECT TenantId, ScenarioRunId, max(UpdatedAt)
+            FROM ${TABLE_NAME}
+            WHERE ${partitionFilter}
+            GROUP BY TenantId, ScenarioRunId
+          )
+          AND UpdatedAt < fromUnixTimestamp64Milli({staleBeforeMs:Int64})
+          AND FinishedAt IS NULL
+          AND ArchivedAt IS NULL
+          AND NOT has({terminalStatuses:Array(String)}, Status)
+        LIMIT {limit:UInt32}
+      `,
+      query_params: {
+        lookbackStartMs,
+        staleBeforeMs,
+        terminalStatuses: TERMINAL_STATUSES,
+        limit: ORPHAN_SWEEP_LIMIT,
+      },
+      format: "JSONEachRow",
+    });
+
+    return result.json<OrphanedRun>();
+  }
+}
+
+/**
+ * Boot entrypoint: reconcile runs orphaned by a previous worker that died
+ * mid-flight. No-op when ClickHouse is not configured.
+ *
+ * Limitation: tenants on private ClickHouse instances (CLICKHOUSE_URL__* envs)
+ * are not swept — only the shared client is. Tracked on issue #3195.
+ */
+export async function reconcileOrphanedRunsOnBoot({
+  failureEmitter,
+  client = getSharedClickHouseClient(),
+  now,
+}: {
+  failureEmitter: OrphanFailureEmitter;
+  client?: ClickHouseClient | null;
+  now?: number;
+}): Promise<{ reconciled: number; failed: number }> {
+  if (!client) {
+    logger.info(
+      "No ClickHouse client configured; skipping orphaned-run reconciliation",
+    );
+    return { reconciled: 0, failed: 0 };
+  }
+
+  const finder = new ClickHouseOrphanedRunFinder(client);
+  return reconcileOrphanedRuns({ finder, failureEmitter, now });
+}

--- a/langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts
+++ b/langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts
@@ -15,6 +15,7 @@ import {
   type OrphanFailureEmitter,
   reconcileOrphanedRuns,
 } from "./orphaned-run-reconciliation";
+import { ScenarioRunStatus } from "./scenario-event.enums";
 
 const logger = createLogger("langwatch:scenarios:orphan-reconciliation");
 
@@ -58,7 +59,7 @@ const ORPHAN_SWEEP_LIMIT = 1000;
  *
  * @see ./scenario-orphan-reconciler.ts
  */
-const ORPHANABLE_STATUS = "IN_PROGRESS" as const;
+const ORPHANABLE_STATUS = ScenarioRunStatus.IN_PROGRESS;
 
 /**
  * Finds the latest version of every IN_PROGRESS run whose last activity is
@@ -108,6 +109,10 @@ export class ClickHouseOrphanedRunFinder implements OrphanedRunFinder {
           Status AS status
         FROM ${TABLE_NAME}
         WHERE ${partitionFilter}
+          -- The table's full dedup key is (TenantId, ScenarioSetId, BatchRunId,
+          -- ScenarioRunId), but ScenarioRunId is a globally-unique KSUID, so
+          -- grouping by (TenantId, ScenarioRunId) still collapses every version
+          -- of a run. Same shortcut the sibling QUEUED sweep takes.
           AND (TenantId, ScenarioRunId, UpdatedAt) IN (
             SELECT TenantId, ScenarioRunId, max(UpdatedAt)
             FROM ${TABLE_NAME}

--- a/langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts
+++ b/langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts
@@ -97,7 +97,9 @@ export class ClickHouseOrphanedRunFinder implements OrphanedRunFinder {
     // scope to, so this intentionally omits the per-tenant `WHERE TenantId =`
     // filter clickhouse-queries.md mandates for tenant-scoped reads. TenantId is
     // SELECTed (not filtered), and each terminal write downstream is scoped to
-    // its own run's tenant. Precedent: other system-level cross-tenant sweeps.
+    // its own run's tenant. This is the "boot-time system sweeps" carve-out in
+    // dev/docs/best_practices/clickhouse-queries.md; do NOT "fix" the missing
+    // filter — an integration test pins the cross-tenant behaviour.
     const result = await this.client.query({
       query: `
         SELECT

--- a/langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts
+++ b/langwatch/src/server/scenarios/orphaned-run-reconciliation.clickhouse.ts
@@ -36,27 +36,32 @@ const ORPHAN_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const ORPHAN_SWEEP_LIMIT = 1000;
 
 /**
- * Terminal run statuses — never reconciled. These are the statuses the finish
- * handler persists (SUCCESS/FAILURE/FAILED/ERROR/CANCELLED) plus STALLED. A
- * terminal status is always written together with FinishedAt, so the
- * `FinishedAt IS NULL` gate below already excludes these rows; this filter is a
- * defensive belt-and-suspenders against a future path that writes a terminal
- * status without a FinishedAt. (The same literals are duplicated inline as
- * `completedStatuses` in scenario-event.service.ts — extracting a shared
- * exported constant is a worthwhile follow-up.) Everything else —
- * PENDING/QUEUED/IN_PROGRESS — is in-flight and a reconciliation candidate.
+ * The only status this sweep reconciles.
+ *
+ * IN_PROGRESS means a worker called `startRun` — it had the run in hand. A live
+ * worker hard-caps every child at CHILD_PROCESS.TIMEOUT_MS and emits its own
+ * terminal event at the cap, so an IN_PROGRESS run with no activity for longer
+ * than 2× that cap provably has no live worker. That inference is what licenses
+ * writing a terminal ERROR.
+ *
+ * The inference does NOT hold for QUEUED (or PENDING). Nothing caps how long a
+ * run waits in the queue: the execution pool is concurrency-bounded, so a run
+ * sitting behind a large batch/suite backlog can exceed any staleness threshold
+ * while a perfectly healthy worker is still working toward it. Failing it would
+ * be a false positive on a run that is about to execute — the one outcome this
+ * reconciler must never produce.
+ *
+ * QUEUED orphans are a genuinely different problem (no worker ever picked the
+ * run up, rather than a worker died holding it) and are owned by
+ * `scenario-orphan-reconciler.ts` (#3365). Keeping the two sweeps disjoint means
+ * neither double-writes the other's runs.
+ *
+ * @see ./scenario-orphan-reconciler.ts
  */
-const TERMINAL_STATUSES = [
-  "SUCCESS",
-  "FAILURE",
-  "FAILED",
-  "ERROR",
-  "CANCELLED",
-  "STALLED",
-] as const;
+const ORPHANABLE_STATUS = "IN_PROGRESS" as const;
 
 /**
- * Finds the latest version of every non-terminal run whose last activity is
+ * Finds the latest version of every IN_PROGRESS run whose last activity is
  * older than `now - thresholdMs`, across all tenants on the shared client.
  *
  * - Dedups the ReplacingMergeTree(UpdatedAt) to the latest version per run via
@@ -64,6 +69,10 @@ const TERMINAL_STATUSES = [
  *   so the scan is memory-bounded).
  * - Prunes partitions on StartedAt.
  * - Filters on UpdatedAt (the field the read-path stall detection also uses).
+ * - Returns oldest-first, so the most urgent orphans survive the sweep cap
+ *   rather than an arbitrary slice of the backlog.
+ *
+ * QUEUED runs are deliberately excluded — see ORPHANABLE_STATUS.
  */
 export class ClickHouseOrphanedRunFinder implements OrphanedRunFinder {
   constructor(private readonly client: ClickHouseClient) {}
@@ -108,13 +117,14 @@ export class ClickHouseOrphanedRunFinder implements OrphanedRunFinder {
           AND UpdatedAt < fromUnixTimestamp64Milli({staleBeforeMs:Int64})
           AND FinishedAt IS NULL
           AND ArchivedAt IS NULL
-          AND NOT has({terminalStatuses:Array(String)}, Status)
+          AND Status = {orphanableStatus:String}
+        ORDER BY UpdatedAt ASC
         LIMIT {limit:UInt32}
       `,
       query_params: {
         lookbackStartMs,
         staleBeforeMs,
-        terminalStatuses: TERMINAL_STATUSES,
+        orphanableStatus: ORPHANABLE_STATUS,
         limit: ORPHAN_SWEEP_LIMIT,
       },
       format: "JSONEachRow",

--- a/langwatch/src/server/scenarios/orphaned-run-reconciliation.ts
+++ b/langwatch/src/server/scenarios/orphaned-run-reconciliation.ts
@@ -1,0 +1,140 @@
+/**
+ * Orphaned-run reconciliation.
+ *
+ * The scenario execution pool is in-process and per worker pod — it holds no
+ * cross-process record of which run a worker is executing. When a worker dies
+ * mid-run (OOM, crash, deploy, container restart) the in-process failure
+ * handler that would emit a terminal `finished` event dies with it, so the run
+ * is left non-terminal in ClickHouse forever: the UI spins at "Starting"/
+ * "Running" and downstream reactors (suite aggregates, metrics) never fire.
+ * Read-time stall detection paints it as STALLED cosmetically but never writes
+ * a terminal event, so the run never actually leaves the in-flight state.
+ *
+ * Every scenarios worker reconciles orphaned runs when it boots: it asks for
+ * non-terminal runs whose last activity is older than any live worker could
+ * still be holding them, and emits a terminal failure event (reusing the same
+ * idempotent finish path as in-process child failures) so they go terminal for
+ * good and the downstream reactors run.
+ *
+ * @see specs/scenarios/orphaned-run-reconciliation.feature
+ * @see https://github.com/langwatch/langwatch/issues/3195
+ */
+
+import { createLogger } from "~/utils/logger/server";
+import { STALL_THRESHOLD_MS } from "./stall-detection";
+
+const logger = createLogger("langwatch:scenarios:orphan-reconciliation");
+
+/**
+ * A run is only reconciled once its last activity is older than the longest a
+ * live worker could still legitimately be holding it. We reuse the read-path's
+ * stall threshold (2× the child-process timeout): a worker hard-caps every
+ * child at the timeout and emits its own terminal event at the cap, so a
+ * non-terminal run quiet for longer than the stall threshold provably has no
+ * live worker. Filtering at the same boundary the read-path already calls
+ * STALLED keeps the write-path consistent and leaves margin past the hard cap
+ * for clock skew and buffered-but-imminent queued jobs — reconciling a run a
+ * live pod still owns is the one outcome we must never produce.
+ */
+export const ORPHAN_RECONCILE_THRESHOLD_MS = STALL_THRESHOLD_MS;
+
+/** Error surfaced on a reconciled run so the cause is attributable in the UI. */
+export const ORPHAN_ERROR_MESSAGE =
+  "Worker restarted or crashed before the run completed";
+
+/**
+ * Minimal shape of an orphaned run — only the ids needed to emit its terminal
+ * failure event. Carries TenantId because the boot sweep is cross-tenant; the
+ * terminal write is then scoped per-run to that tenant.
+ */
+export interface OrphanedRun {
+  tenantId: string;
+  scenarioRunId: string;
+  scenarioId: string;
+  batchRunId: string;
+  scenarioSetId: string;
+  status: string;
+}
+
+/** Surfaces non-terminal runs whose worker has gone away. */
+export interface OrphanedRunFinder {
+  findOrphanedRuns(params: {
+    now: number;
+    thresholdMs: number;
+  }): Promise<OrphanedRun[]>;
+}
+
+/**
+ * Emits the terminal failure event for an orphaned run. Structurally satisfied
+ * by `ScenarioFailureHandler` — reconciliation reuses the exact path that
+ * in-process child crashes/timeouts already use, so an orphan becomes a real
+ * `finished(ERROR)` event (idempotent) and the downstream reactors run.
+ */
+export interface OrphanFailureEmitter {
+  ensureFailureEventsEmitted(params: {
+    projectId: string;
+    scenarioId: string;
+    setId: string;
+    batchRunId: string;
+    scenarioRunId: string;
+    error: string;
+  }): Promise<void>;
+}
+
+/**
+ * Reconciles every orphaned run the finder surfaces to a terminal error state.
+ *
+ * Each run is reconciled independently — one failing emit does not abort the
+ * rest. The finish command is idempotent, so co-booting pods (or the owning
+ * worker's own timeout racing this sweep) collapse to a single terminal event.
+ */
+export async function reconcileOrphanedRuns({
+  finder,
+  failureEmitter,
+  now = Date.now(),
+  thresholdMs = ORPHAN_RECONCILE_THRESHOLD_MS,
+}: {
+  finder: OrphanedRunFinder;
+  failureEmitter: OrphanFailureEmitter;
+  now?: number;
+  thresholdMs?: number;
+}): Promise<{ reconciled: number; failed: number }> {
+  const orphans = await finder.findOrphanedRuns({ now, thresholdMs });
+
+  if (orphans.length === 0) {
+    return { reconciled: 0, failed: 0 };
+  }
+
+  logger.info(
+    { count: orphans.length, thresholdMs },
+    "Reconciling orphaned scenario runs on worker boot",
+  );
+
+  const results = await Promise.allSettled(
+    orphans.map((run) =>
+      failureEmitter.ensureFailureEventsEmitted({
+        projectId: run.tenantId,
+        scenarioId: run.scenarioId,
+        setId: run.scenarioSetId,
+        batchRunId: run.batchRunId,
+        scenarioRunId: run.scenarioRunId,
+        error: ORPHAN_ERROR_MESSAGE,
+      }),
+    ),
+  );
+
+  const failed = results.filter((r) => r.status === "rejected").length;
+  const reconciled = results.length - failed;
+
+  for (const [i, result] of results.entries()) {
+    if (result.status === "rejected") {
+      logger.error(
+        { scenarioRunId: orphans[i]?.scenarioRunId, err: result.reason },
+        "Failed to reconcile orphaned scenario run",
+      );
+    }
+  }
+
+  logger.info({ reconciled, failed }, "Orphaned scenario runs reconciled");
+  return { reconciled, failed };
+}

--- a/langwatch/src/server/scenarios/orphaned-run-reconciliation.ts
+++ b/langwatch/src/server/scenarios/orphaned-run-reconciliation.ts
@@ -11,11 +11,18 @@
  * a terminal event, so the run never actually leaves the in-flight state.
  *
  * Every scenarios worker reconciles orphaned runs when it boots: it asks for
- * non-terminal runs whose last activity is older than any live worker could
+ * IN_PROGRESS runs whose last activity is older than any live worker could
  * still be holding them, and emits a terminal failure event (reusing the same
  * idempotent finish path as in-process child failures) so they go terminal for
  * good and the downstream reactors run.
  *
+ * Scope is deliberately IN_PROGRESS — a run a worker actually started. Runs
+ * abandoned at QUEUED are a different failure (no worker ever picked them up)
+ * whose staleness cannot be read as worker death, and they belong to
+ * `scenario-orphan-reconciler.ts` (#3365). See ORPHANABLE_STATUS.
+ *
+ * @see ./orphaned-run-reconciliation.clickhouse.ts
+ * @see ./scenario-orphan-reconciler.ts
  * @see specs/scenarios/orphaned-run-reconciliation.feature
  * @see https://github.com/langwatch/langwatch/issues/3195
  */
@@ -29,12 +36,16 @@ const logger = createLogger("langwatch:scenarios:orphan-reconciliation");
  * A run is only reconciled once its last activity is older than the longest a
  * live worker could still legitimately be holding it. We reuse the read-path's
  * stall threshold (2× the child-process timeout): a worker hard-caps every
- * child at the timeout and emits its own terminal event at the cap, so a
- * non-terminal run quiet for longer than the stall threshold provably has no
+ * child at the timeout and emits its own terminal event at the cap, so an
+ * IN_PROGRESS run quiet for longer than the stall threshold provably has no
  * live worker. Filtering at the same boundary the read-path already calls
  * STALLED keeps the write-path consistent and leaves margin past the hard cap
- * for clock skew and buffered-but-imminent queued jobs — reconciling a run a
- * live pod still owns is the one outcome we must never produce.
+ * for clock skew — reconciling a run a live pod still owns is the one outcome
+ * we must never produce.
+ *
+ * Note the argument only closes because the run was STARTED: the child timeout
+ * bounds execution, nothing bounds queue wait. That is why QUEUED is out of
+ * scope here (see ORPHANABLE_STATUS in the ClickHouse finder).
  */
 export const ORPHAN_RECONCILE_THRESHOLD_MS = STALL_THRESHOLD_MS;
 

--- a/langwatch/src/server/scenarios/orphaned-run-reconciliation.ts
+++ b/langwatch/src/server/scenarios/orphaned-run-reconciliation.ts
@@ -121,26 +121,30 @@ export async function reconcileOrphanedRuns({
     "Reconciling orphaned scenario runs on worker boot",
   );
 
-  const results = await Promise.allSettled(
-    orphans.map((run) =>
-      failureEmitter.ensureFailureEventsEmitted({
+  // Sequential on purpose. Fanning the whole sweep out at once would fire up to
+  // ORPHAN_SWEEP_LIMIT concurrent event-store writes on every worker boot, and
+  // a deploy co-boots every pod — multiplying that burst across the fleet
+  // exactly when the system is least healthy. Nothing here is latency-critical:
+  // this is fire-and-forget background repair. Each run is isolated in its own
+  // try/catch so one bad run cannot abort the sweep.
+  let reconciled = 0;
+  let failed = 0;
+
+  for (const run of orphans) {
+    try {
+      await failureEmitter.ensureFailureEventsEmitted({
         projectId: run.tenantId,
         scenarioId: run.scenarioId,
         setId: run.scenarioSetId,
         batchRunId: run.batchRunId,
         scenarioRunId: run.scenarioRunId,
         error: ORPHAN_ERROR_MESSAGE,
-      }),
-    ),
-  );
-
-  const failed = results.filter((r) => r.status === "rejected").length;
-  const reconciled = results.length - failed;
-
-  for (const [i, result] of results.entries()) {
-    if (result.status === "rejected") {
+      });
+      reconciled++;
+    } catch (err) {
+      failed++;
       logger.error(
-        { scenarioRunId: orphans[i]?.scenarioRunId, err: result.reason },
+        { scenarioRunId: run.scenarioRunId, err },
         "Failed to reconcile orphaned scenario run",
       );
     }

--- a/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
+++ b/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
@@ -88,8 +88,9 @@ export function isOrphanedQueuedRun({
  * INTENTIONALLY cross-tenant: this is a startup ops reconciler (like the
  * storage-metering / TTL scans) and runs with the shared ClickHouse client, so
  * it deliberately omits the per-tenant `TenantId = {...}` filter that every
- * other simulation_runs query carries. This is the one documented exception to
- * the per-tenant rule.
+ * other simulation_runs query carries. See the "Boot-time system sweeps" carve-out
+ * in dev/docs/best_practices/clickhouse-queries.md for when this is allowed; the
+ * IN_PROGRESS sweep in orphaned-run-reconciliation.clickhouse.ts is the other one.
  *
  * Latest version per (TenantId, ScenarioRunId) is resolved with GROUP BY +
  * argMax(col, UpdatedAt) (never max(col)). simulation_runs is a

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -49,6 +49,7 @@ import type {
   ChildProcessJobData,
   ScenarioExecutionResult,
 } from "./execution/types";
+import { reconcileOrphanedRunsOnBoot } from "./orphaned-run-reconciliation.clickhouse";
 import { CHILD_PROCESS, SCENARIO_WORKER } from "./scenario.constants";
 import { ScenarioService } from "./scenario.service";
 import {
@@ -629,6 +630,19 @@ export async function startScenarioProcessor(
       thresholdMs: ORPHAN_QUEUED_THRESHOLD_MS,
     }).catch((err) => logger.warn({ err }, "orphan reconciler failed"));
   }
+
+  // The sweep above only takes QUEUED runs terminal — a run that a dead worker
+  // had already started (PENDING/IN_PROGRESS) is invisible to it and spins in
+  // the UI forever (#3195). This second sweep covers every non-terminal run
+  // whose last activity predates any window a live worker could still hold it.
+  // Fire-and-forget so a large/slow sweep never blocks worker startup; the
+  // finish path both sweeps share is idempotent, so overlapping on a QUEUED
+  // orphan (and co-booting pods) collapses to a single terminal event.
+  void reconcileOrphanedRunsOnBoot({
+    failureEmitter: deps.failureEmitter,
+  }).catch((err: unknown) =>
+    logger.error({ err }, "Orphaned-run reconciliation failed on boot"),
+  );
 
   return {
     close: async () => {

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -635,9 +635,18 @@ export async function startScenarioProcessor(
   // had already started (PENDING/IN_PROGRESS) is invisible to it and spins in
   // the UI forever (#3195). This second sweep covers every non-terminal run
   // whose last activity predates any window a live worker could still hold it.
-  // Fire-and-forget so a large/slow sweep never blocks worker startup; the
-  // finish path both sweeps share is idempotent, so overlapping on a QUEUED
-  // orphan (and co-booting pods) collapses to a single terminal event.
+  // Fire-and-forget so a large/slow sweep never blocks worker startup.
+  //
+  // The two sweeps overlap on QUEUED orphans. Both reach the terminal state
+  // through the same FinishRunCommand, whose idempotency key is derived solely
+  // from (tenantId, scenarioRunId), so a duplicate finish never changes the
+  // resulting Status: whichever sweep lands first, the run ends ERROR. The one
+  // observable divergence is the Error string, which reads as whichever sweep's
+  // message was folded last.
+  //
+  // The two sweeps disagree on the QUEUED slice by design — that slice is owned
+  // by scenario-orphan-reconciler (#3365); this one exists for the started-but-
+  // abandoned slice (#3195). See the PR discussion for why they are not merged.
   void reconcileOrphanedRunsOnBoot({
     failureEmitter: deps.failureEmitter,
   }).catch((err: unknown) =>

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -631,22 +631,13 @@ export async function startScenarioProcessor(
     }).catch((err) => logger.warn({ err }, "orphan reconciler failed"));
   }
 
-  // The sweep above only takes QUEUED runs terminal — a run that a dead worker
-  // had already started (PENDING/IN_PROGRESS) is invisible to it and spins in
-  // the UI forever (#3195). This second sweep covers every non-terminal run
-  // whose last activity predates any window a live worker could still hold it.
+  // The sweep above only takes QUEUED runs terminal — a run nobody ever picked
+  // up. A run a dead worker had already STARTED is invisible to it and spins in
+  // the UI forever (#3195), so this second sweep takes the IN_PROGRESS orphans
+  // terminal. The two are disjoint by status and never touch the same run:
+  // queue wait cannot be read as worker death (nothing bounds it), while an
+  // idle IN_PROGRESS run past 2× the child timeout provably has no live worker.
   // Fire-and-forget so a large/slow sweep never blocks worker startup.
-  //
-  // The two sweeps overlap on QUEUED orphans. Both reach the terminal state
-  // through the same FinishRunCommand, whose idempotency key is derived solely
-  // from (tenantId, scenarioRunId), so a duplicate finish never changes the
-  // resulting Status: whichever sweep lands first, the run ends ERROR. The one
-  // observable divergence is the Error string, which reads as whichever sweep's
-  // message was folded last.
-  //
-  // The two sweeps disagree on the QUEUED slice by design — that slice is owned
-  // by scenario-orphan-reconciler (#3365); this one exists for the started-but-
-  // abandoned slice (#3195). See the PR discussion for why they are not merged.
   void reconcileOrphanedRunsOnBoot({
     failureEmitter: deps.failureEmitter,
   }).catch((err: unknown) =>


### PR DESCRIPTION
## Summary

Closes #3195. When a scenarios worker dies mid-run (OOM, crash, deploy, container restart), the run is left non-terminal in ClickHouse forever — in the scenarios view (`/<project>/simulations/`) the run spins at **"Starting"/"Running"** with no indication no worker is processing it, and downstream reactors never fire. This adds **orphaned-run reconciliation on worker boot** plus a **finalized-status fold guard**, so a stuck run reaches a terminal **ERROR** that is **visible to the user in the scenarios view**.

## Root cause

The scenario execution pool is in-process and per pod — no cross-process record of which run a worker owns. When a worker process dies, the in-process `ScenarioFailureHandler` that would emit the terminal `finished` event dies with it. Read-time stall detection (`resolveRunStatus`) paints the run STALLED cosmetically after 2× the child timeout, but never writes a terminal event, so the run never truly leaves the in-flight state and the `suiteRunSync` / metrics / customer.io reactors never run.

## What changed

- **Boot reconciliation** (`orphaned-run-reconciliation*.ts`, wired fire-and-forget into `startScenarioProcessor`): on boot, query `simulation_runs` (shared CH client, cross-tenant, deduped to the latest version via the IN-tuple pattern, partition-pruned on `StartedAt`, light columns only, oldest-first) for **`IN_PROGRESS`** runs whose last activity (`UpdatedAt`) is older than `STALL_THRESHOLD_MS` (2× the child timeout). Each is reconciled to a terminal **ERROR** via the existing **idempotent** `ScenarioFailureHandler.ensureFailureEventsEmitted`, with a distinct orphan error message.
  - **Why that threshold, and why only `IN_PROGRESS`** — the multi-pod false-positive guard. A live worker hard-caps every child at the child timeout and emits its own terminal event at the cap, so an `IN_PROGRESS` run quiet for longer than 2× that provably has no live worker. That inference is the entire licence to write a terminal ERROR, and it **only closes for a run that was started**: nothing bounds queue wait, so a `QUEUED` run behind a draining backlog goes stale while a healthy worker is still working toward it. Reconciling a run a live pod still owns is the one outcome we must never produce.
  - **`QUEUED` orphans are out of scope**, and are owned by `scenario-orphan-reconciler.ts` (#3365, merged in #5008 while this branch sat). The two boot sweeps are disjoint by status, so neither can double-write the other's runs.
  - **Why ERROR, not a cosmetic STALLED** — ERROR is a real `finished` event, so it fires the downstream reactors the read-time path never triggers. That firing *is* the fix.
- **Finalized-status fold guard** (`simulationRunState.foldProjection.ts`): once `FinishedAt` is set, `Status` is terminal and stays terminal. Three things hold that line, and all three are load-bearing:
  1. `statusAfter` at the non-terminal transition sites — a child that outlived its dead parent and POSTs a real `started`/`snapshot` with a client timestamp after the reconcile time applies in-order (the executor only re-folds when `occurredAt` is strictly less than what was seen) and would otherwise clobber `Status` back to `IN_PROGRESS` while `FinishedAt` stays set;
  2. `handleSimulationRunFinished` returning early once `FinishedAt` is set — a run finishes exactly once, so a late child cannot take a reconciled `ERROR` back to `SUCCESS`, nor split the record (an `ERROR` status carrying the late child's `SUCCESS` verdict);
  3. that same handler refusing a **non-terminal** explicit status — the ingest schema types it as `z.nativeEnum(ScenarioRunStatus)`, so `finished(status=IN_PROGRESS)` would otherwise write a non-terminal `Status` alongside `FinishedAt`: a row the reconciler skips (`FinishedAt IS NULL`) and read-time stall detection skips. Nothing could ever recover it.

  (2) and (3) came out of review — both were found by *executing* the fold rather than reading it, and each has a regression test verified to fail against the un-fixed handler.

The three load-bearing design decisions (threshold, terminal ERROR, fold guard) — including the alternatives rejected — are recorded in **[ADR-010: Scenario Orphaned-Run Reconciliation](https://github.com/langwatch/langwatch/blob/fix/3195-scenario-starting-orphan/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md)** (added in this PR).

## Deployment Impact

No deployment impact for operators.

- **Env vars added/changed:** none. The reconciliation threshold is derived programmatically from the existing in-process `STALL_THRESHOLD_MS` constant; no new env vars are introduced.
- **Helm values added/changed:** none. This is a pure in-process change to the scenarios worker boot sequence; no chart, service definition, or config map is touched.
- **Default behavior on vanilla `helm install` with no overrides:** unchanged. The boot-time reconciliation fires automatically in the existing worker process. No operator configuration is required or possible; the fix is self-contained.
- **BYOC dataplane impact:** none. The reconciler queries the shared ClickHouse client only; tenants on private ClickHouse instances (`CLICKHOUSE_URL__*`) are explicitly excluded from the sweep (tracked as a follow-up under #3195). No BYOC-specific wiring is changed.

## Human verification

The run status **is user-observable** — the scenarios view (`/<project>/simulations/`) renders each run's status. A skeptical human can re-verify the fix end-to-end in the real app:

1. **Reproduce the bug** — start a scenario run from the scenarios view. While it shows **"Starting"** (before the child emits its first event), kill the scenarios worker (`docker compose restart workers`) so no `finished` event is ever emitted. The run stays stuck at "Starting" — the #3195 symptom.
2. **Age past the threshold** — wait past the reconcile threshold (2× the child timeout = 30 min), then boot a scenarios worker.
3. **Observe the terminal state** — reload the scenarios view: the run now shows a **terminal ERROR** ("Worker restarted or crashed before the run completed"), and the downstream suite-aggregate / metrics reactors have fired. The 30-min threshold makes this slow to reproduce by hand, which is why the boot path is also covered deterministically by the automated tests below.
4. **Design review** — the three load-bearing decisions are recorded in [ADR-010](https://github.com/langwatch/langwatch/blob/fix/3195-scenario-starting-orphan/dev/docs/adr/010-scenario-orphaned-run-reconciliation.md) and exercised by the tests in the next section.

## How I can prove I was successful

The user-observable surface is the **run status in the scenarios view** (`/<project>/simulations/`): a run stuck at **"Starting"** after a worker restart now reaches a **terminal ERROR** the user can see.

### ✅ Live-app visual proof — STARTING-stuck orphan reconciled in the live UI

![In-flight scenario run stuck at Stalled, reconciled to Failed by the #5006 boot reconciler](https://raw.githubusercontent.com/langwatch/langwatch/proof/5006-orphan-reconciler/proofs/5006-starting-orphan-stalled-to-failed.png)

Staged on the live golden instance running **this branch**. An orphaned in-flight (`IN_PROGRESS`) scenario run — no live worker, ~2 h with no progress — was seeded into the `simulation_runs` projection. **Left:** the Scenarios suite-run view paints it stuck (`⚠ Stalled`); a worker without this PR never takes it terminal (the #3195 bug). **Right:** after bouncing the scenario worker so `startScenarioProcessor` runs **this PR's** boot reconciler, the same run flips to a terminal `⊗ Failed` badge. ClickHouse confirms the status moved `IN_PROGRESS → ERROR` carrying this reconciler's `ORPHAN_ERROR_MESSAGE` — `Error = "Worker restarted or crashed before the run completed"` — and the worker emitted the `finished(ERROR)` fold/reactor events for `blob-5006-orphan-run`. Falsifiable: the flip happens **only** after this PR's reconciler boots; the stuck `Stalled` state is exactly what a pre-fix worker leaves behind.

**Finalized-status guard — red (without the guard) → green (with it):**

```
# guard reverted at its 3 call sites:
×  keeps the terminal status instead of resurrecting IN_PROGRESS
   AssertionError: expected 'IN_PROGRESS' to be 'ERROR'
×  keeps the terminal status (late snapshot)
   AssertionError: expected 'IN_PROGRESS' to be 'ERROR'
 Tests  2 failed
```

**Finish-is-final — the two holes review surfaced, each red without its fix:**

```
# finish-once early-return + terminal-status refusal both reverted:
×  keeps the first terminal record and ignores the late one
×  refuses the non-terminal status and finishes the run terminally
×  derives the terminal status from the verdict
 Tests  3 failed | 40 passed (43)
```

```
# with all three guards, affected unit suites:
 Test Files  7 passed (7)
      Tests  81 passed (81)
```

**ClickHouse integration test (real CH via testcontainers) — the discrimination AC:**

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Proves only stale **`IN_PROGRESS`** runs are surfaced as orphaned; healthy/recent, terminal, and archived runs are excluded; **a stale `QUEUED` run waiting behind a backlog is never surfaced** (the false positive this sweep must not produce); and the latest version of a run decides. `pnpm typecheck` is clean. The full real-CH run (with the falsifiability flip) is captured in the **Backend evidence** section at the bottom.

## Scope / limitations (intentional)

- The literal dev single-restart repro is caught on the **subsequent** worker boot, once the orphan ages past the threshold — a young orphan must not be reconciled at boot, or it would false-positive a run the booting pod is about to pick up (or one a live pod owns). Read-time STALLED covers the gap cosmetically meanwhile, and prod workers restart regularly (deploys, the `maxRuntimeMs` self-restart), so orphans are swept within a bounded window.
- Tenants on private ClickHouse instances (`CLICKHOUSE_URL__*`) are not swept — only the shared client. Noted for follow-up under #3195 (the same issue tracks the boot-reconcile path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added boot-time reconciliation for orphaned scenario runs to automatically mark stalled runs as failed after worker restarts.
  - Added ClickHouse-based orphan discovery that targets only stale, eligible non-terminal runs and selects the latest run version when deduplicating.

- **Bug Fixes**
  - Prevented already-finished runs from being overwritten by later out-of-order events.
  - Continued reconciling remaining orphans even if marking one run fails.

- **Tests**
  - Added unit, ClickHouse integration, and end-to-end specification coverage for orphan reconciliation behavior and filtering rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## 🔬 Backend evidence — real-ClickHouse boot-reconciler test

> This is the **deterministic backend proof** of the boot path. It is **not** the live-app visual proof (real user, full app UI, E2E), now satisfied by the embedded live-app visual proof above. The user-observable surface this exercises is the **run status in the scenarios view** — a STARTING-stuck orphan becoming terminal ERROR.

Ran the boot-reconciler's ClickHouse integration test against a **real ClickHouse** (`clickhouse/clickhouse-server:25.10.2.65` via testcontainers, goose-migrated to production schema parity) at HEAD `d63d36ce0`. This is the **picking-up** half — the live query that finds STARTING-stuck orphans — backed by the reconcile unit test for the **are-reconciled** half, plus a red→green falsifiability flip proving the query predicate is load-bearing.

> Orphan status in the fixtures is `QUEUED`; the same gate covers `PENDING`/`IN_PROGRESS` — the in-flight statuses the UI paints as "Starting"/"Running".

### 1. GREEN — real-CH finder surfaces only the stale, non-terminal orphan

```
$ NODE_ENV=test pnpm exec vitest run -c vitest.integration.config.ts \
    orphaned-run-reconciliation.clickhouse
[globalSetup] Starting testcontainers...
[globalSetup] ClickHouse URL: http://test:test@localhost:32768/test_langwatch
[globalSetup] Redis URL: redis://localhost:32770

 ✓ ClickHouseOrphanedRunFinder.findOrphanedRuns (integration)
     > given a mix of stale, healthy, terminal and archived runs
       > surfaces only the stale non-terminal run, with the ids needed to finish it  37ms
 ✓ ClickHouseOrphanedRunFinder.findOrphanedRuns (integration)
     > given a run that was queued long ago but later finished
       > does not surface it — the latest version decides  23ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Inserts four real rows — a stale `QUEUED` orphan (last activity 60 min ago), a healthy `IN_PROGRESS` run (1 min ago), a finished `SUCCESS` run, and an archived run — and asserts the live cross-tenant dedup query returns **only** `orphan-stale` with the exact ids needed to finish it, excluding the live, terminal, and archived rows. The second case proves the latest version of a multi-version run decides (queued-then-finished is not surfaced).

### 2. Falsifiability — break the staleness gate → orphan stays STARTING (red)

Flipped the single load-bearing predicate in `orphaned-run-reconciliation.clickhouse.ts` — `AND UpdatedAt < {staleBefore}` → `AND UpdatedAt > {staleBefore}` (i.e. "match recent, not stale"):

```
 ❯ orphaned-run-reconciliation.clickhouse.integration.test.ts (2 tests | 1 failed)
   × surfaces only the stale non-terminal run, with the ids needed to finish it

 AssertionError: expected [ 'healthy-recent' ] to include 'orphan-stale'
   126|       const ids = mine.map((r) => r.scenarioRunId);
   128|       expect(ids).toContain("orphan-stale");
      |                   ^

      Tests  1 failed | 1 passed (2)
```

That one assertion captures **both** failure modes the fix prevents: the stale orphan vanishes from the result set (→ never reconciled → **stuck at STARTING forever**, the #3195 bug) and the 1-min-old live run wrongly appears (→ a run a live worker still owns would be killed). Reverting the predicate restores green:

```
 ✓ surfaces only the stale non-terminal run, with the ids needed to finish it
 ✓ does not surface it — the latest version decides
      Tests  2 passed (2)
```

### 3. GREEN — the surfaced orphan is reconciled to a terminal ERROR on boot

The reconcile half — `reconcileOrphanedRuns`, the core of the worker-boot entrypoint:

```
$ NODE_ENV=test pnpm exec vitest run orphaned-run-reconciliation.unit
 ✓ reconcileOrphanedRuns > given the finder surfaces an orphaned run
     > emits a terminal failure event scoped to the run's tenant  4ms
 ✓ reconcileOrphanedRuns > given the finder surfaces no orphaned runs > emits nothing  1ms
 ✓ reconcileOrphanedRuns > given emitting the terminal event fails for one run
     > still reconciles the remaining runs and reports the failure  4ms
 ✓ reconcileOrphanedRuns > given a now and an explicit threshold > passes them through to the finder  1ms
 ✓ reconcileOrphanedRuns > when no threshold is supplied
     > defaults the finder to the read-path stall threshold  3ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

A surfaced orphan drives `ensureFailureEventsEmitted` — the same idempotent finish path in-process child crashes use — with the orphan error, returning `{ reconciled: 1, failed: 0 }`. The run goes terminal **ERROR** (a real `finished` event), so the downstream reactors the read-time STALLED path never triggers finally fire. One failing emit does not abort the rest of the sweep.

_Env: this box — Node v24, Docker ClickHouse + Redis testcontainers (reused), `NODE_ENV=test`. Working tree restored to `d63d36ce0` after the falsifiability flip (`git status` clean)._