### PR TITLE
fix(analytics): include score-only evaluators in evaluation_passed groupBy

### DIFF
--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -742,8 +742,10 @@ describe("aggregation-builder", () => {
         };
         const result = buildTimeseriesQuery(input);
 
-        // The new score-only WHEN: processed rows for THIS evaluator with Passed IS NULL → 'unknown'
-        expect(result.sql).toMatch(/Status = 'processed'\s+THEN 'unknown'/);
+        // The new score-only WHEN: target evaluator + processed + Passed IS NULL → 'unknown'
+        expect(result.sql).toMatch(
+          /EvaluatorId = \{groupByKey:String\} AND \w+\.Status = 'processed' AND \w+\.Passed IS NULL THEN 'unknown'/,
+        );
         // Foreign-evaluator isolation sentinel is preserved — other evaluators still hit ELSE NULL
         expect(result.sql).toContain("ELSE NULL");
       });

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -726,6 +726,27 @@ describe("aggregation-builder", () => {
         // so no outer if(... IS NULL, 'unknown', toString(...)) wrapper is added.
         expect(result.sql).not.toContain("IS NULL, 'unknown'");
       });
+
+      it("buckets score-only evaluator rows as 'unknown' under groupByKey instead of dropping them (issue #2674)", () => {
+        const input = {
+          ...baseInput,
+          timeScale: "full" as const,
+          groupBy: "evaluations.evaluation_passed" as const,
+          groupByKey: "my-evaluator",
+          series: [
+            {
+              metric: "metadata.trace_id" as FlattenAnalyticsMetricsEnum,
+              aggregation: "cardinality" as const,
+            },
+          ],
+        };
+        const result = buildTimeseriesQuery(input);
+
+        // The new score-only WHEN: processed rows for THIS evaluator with Passed IS NULL → 'unknown'
+        expect(result.sql).toMatch(/Status = 'processed'\s+THEN 'unknown'/);
+        // Foreign-evaluator isolation sentinel is preserved — other evaluators still hit ELSE NULL
+        expect(result.sql).toContain("ELSE NULL");
+      });
     });
 
     it("uses date-bucketed pipeline query for pipeline metrics with numeric timeScale", () => {

--- a/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/aggregation-builder.test.ts
@@ -742,7 +742,6 @@ describe("aggregation-builder", () => {
         };
         const result = buildTimeseriesQuery(input);
 
-        // The new score-only WHEN: target evaluator + processed + Passed IS NULL → 'unknown'
         expect(result.sql).toMatch(
           /EvaluatorId = \{groupByKey:String\} AND \w+\.Status = 'processed' AND \w+\.Passed IS NULL THEN 'unknown'/,
         );

--- a/langwatch/src/server/analytics/clickhouse/__tests__/score-only-evaluator-passed-groupby.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/score-only-evaluator-passed-groupby.integration.test.ts
@@ -252,7 +252,6 @@ describe("score-only-evaluator-passed-groupby", () => {
           expect(passedRows.length).toBeGreaterThan(0);
           expect(failedRows.length).toBeGreaterThan(0);
 
-          // A pass/fail evaluator yields no 'unknown' group — isolation is explicit here, not just implicit
           expect(
             currentRows.filter((r) => r.group_key === "unknown"),
           ).toHaveLength(0);

--- a/langwatch/src/server/analytics/clickhouse/__tests__/score-only-evaluator-passed-groupby.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/score-only-evaluator-passed-groupby.integration.test.ts
@@ -252,6 +252,11 @@ describe("score-only-evaluator-passed-groupby", () => {
           expect(passedRows.length).toBeGreaterThan(0);
           expect(failedRows.length).toBeGreaterThan(0);
 
+          // A pass/fail evaluator yields no 'unknown' group — isolation is explicit here, not just implicit
+          expect(
+            currentRows.filter((r) => r.group_key === "unknown"),
+          ).toHaveLength(0);
+
           const metricKey = Object.keys(passedRows[0]!).find(
             (k) => k !== "date" && k !== "period" && k !== "group_key",
           );

--- a/langwatch/src/server/analytics/clickhouse/__tests__/score-only-evaluator-passed-groupby.integration.test.ts
+++ b/langwatch/src/server/analytics/clickhouse/__tests__/score-only-evaluator-passed-groupby.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Regression integration tests for issue #2674.
+ *
+ * Bug: `buildTimeseriesQuery` with `groupBy: "evaluations.evaluation_passed"` and
+ * a `groupByKey` (a specific EvaluatorId) uses a CASE expression that returned
+ * `ELSE NULL` for any row that was not a clear pass (Passed=1) or fail (Passed=0).
+ *
+ * `buildGroupKeyHavingClause` then adds `HAVING group_key IS NOT NULL`, which
+ * intentionally drops rows from OTHER evaluators (foreign-evaluator isolation,
+ * regression #2668). However, it also dropped "score-only" rows — rows belonging
+ * to the TARGET evaluator that ran successfully (Status='processed') but have
+ * `Passed IS NULL` (a numeric score with no pass/fail threshold).
+ *
+ * The fix adds a new WHEN clause before `ELSE NULL`:
+ *   WHEN EvaluatorId = {groupByKey:String} AND Status = 'processed' THEN 'unknown'
+ *
+ * This buckets score-only rows for the target evaluator as 'unknown' (matching the
+ * no-groupByKey branch behaviour) while rows from foreign evaluators and
+ * non-processed rows still hit `ELSE NULL` and are dropped by the HAVING clause,
+ * preserving the #2668 isolation guarantee.
+ *
+ * @see https://github.com/langwatch/langwatch/issues/2674
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wrapWithDefaultSettings } from "~/server/clickhouse/safeClickhouseClient";
+import {
+  cleanupTestData,
+  getTestClickHouseClient,
+} from "../../../event-sourcing/__tests__/integration/testContainers";
+import type { FlattenAnalyticsMetricsEnum } from "../../registry";
+import type { AggregationTypes } from "../../types";
+import { buildTimeseriesQuery } from "../aggregation-builder";
+import { resetParamCounter } from "../filter-translator";
+import { seedSpans } from "./test-utils/clickhouse-fixtures";
+
+const TENANT_ID = "test-score-only-2674";
+
+/** Base query input shared across all tests */
+const baseInput = {
+  projectId: TENANT_ID,
+  startDate: new Date("2020-01-01T00:00:00Z"),
+  endDate: new Date("2030-01-01T00:00:00Z"),
+  previousPeriodStartDate: new Date("2019-01-01T00:00:00Z"),
+  timeScale: "full" as const,
+};
+
+const TRACE_ID_0 = `${TENANT_ID}-trace-0`;
+const TRACE_ID_1 = `${TENANT_ID}-trace-1`;
+
+/**
+ * SCORE_ONLY_EVALUATOR_ID: produces numeric scores only — Passed is always NULL.
+ *   These rows should appear as 'unknown' in evaluation_passed groupBy (not dropped).
+ * PASSFAIL_EVALUATOR_ID: produces pass/fail results — Passed is 0 or 1.
+ *   These rows should appear as 'passed' or 'failed'.
+ */
+const SCORE_ONLY_EVALUATOR_ID = "score-only-2674-scoreonly";
+const PASSFAIL_EVALUATOR_ID = "score-only-2674-passfail";
+
+describe("score-only-evaluator-passed-groupby", () => {
+  let ch: ClickHouseClient;
+
+  beforeAll(async () => {
+    const rawClient = getTestClickHouseClient();
+    if (!rawClient) throw new Error("ClickHouse client not available");
+    ch = wrapWithDefaultSettings(rawClient);
+
+    await seedSpans(ch, {
+      tenantId: TENANT_ID,
+      count: 4,
+      attributeKeys: 2,
+      traceCount: 2,
+    });
+
+    await ch.insert({
+      table: "evaluation_runs",
+      values: [
+        // Score-only evaluator trace 0: processed, Score=0.7, Passed=null
+        {
+          ProjectionId: "proj-so2674-so0",
+          TenantId: TENANT_ID,
+          EvaluationId: "eval-so2674-so0",
+          Version: "1",
+          EvaluatorId: SCORE_ONLY_EVALUATOR_ID,
+          EvaluatorType: "custom",
+          TraceId: TRACE_ID_0,
+          Status: "processed",
+          Score: 0.7,
+          Passed: null,
+          Label: null,
+          LastProcessedEventId: "evt-so2674-so0",
+          UpdatedAt: new Date().toISOString(),
+        },
+        // Score-only evaluator trace 1: processed, Score=0.4, Passed=null
+        {
+          ProjectionId: "proj-so2674-so1",
+          TenantId: TENANT_ID,
+          EvaluationId: "eval-so2674-so1",
+          Version: "1",
+          EvaluatorId: SCORE_ONLY_EVALUATOR_ID,
+          EvaluatorType: "custom",
+          TraceId: TRACE_ID_1,
+          Status: "processed",
+          Score: 0.4,
+          Passed: null,
+          Label: null,
+          LastProcessedEventId: "evt-so2674-so1",
+          UpdatedAt: new Date().toISOString(),
+        },
+        // Pass/fail evaluator trace 0: processed, Score=0.9, Passed=1
+        {
+          ProjectionId: "proj-so2674-pf0",
+          TenantId: TENANT_ID,
+          EvaluationId: "eval-so2674-pf0",
+          Version: "1",
+          EvaluatorId: PASSFAIL_EVALUATOR_ID,
+          EvaluatorType: "custom",
+          TraceId: TRACE_ID_0,
+          Status: "processed",
+          Score: 0.9,
+          Passed: 1,
+          Label: null,
+          LastProcessedEventId: "evt-so2674-pf0",
+          UpdatedAt: new Date().toISOString(),
+        },
+        // Pass/fail evaluator trace 1: processed, Score=0.1, Passed=0
+        {
+          ProjectionId: "proj-so2674-pf1",
+          TenantId: TENANT_ID,
+          EvaluationId: "eval-so2674-pf1",
+          Version: "1",
+          EvaluatorId: PASSFAIL_EVALUATOR_ID,
+          EvaluatorType: "custom",
+          TraceId: TRACE_ID_1,
+          Status: "processed",
+          Score: 0.1,
+          Passed: 0,
+          Label: null,
+          LastProcessedEventId: "evt-so2674-pf1",
+          UpdatedAt: new Date().toISOString(),
+        },
+      ],
+      format: "JSONEachRow",
+      clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await cleanupTestData(TENANT_ID);
+
+    // cleanupTestData does not delete from evaluation_runs — clean up manually
+    const rawClient = getTestClickHouseClient();
+    if (rawClient) {
+      await rawClient.exec({
+        query: `ALTER TABLE evaluation_runs DELETE WHERE TenantId = {tenantId:String} SETTINGS mutations_sync = 1`,
+        query_params: { tenantId: TENANT_ID },
+      });
+    }
+  });
+
+  describe("regression: issue #2674 — score-only evaluator rows dropped by HAVING group_key IS NOT NULL", () => {
+    describe("given a score-only evaluator (Passed IS NULL)", () => {
+      describe("when grouping evaluation_passed by a score-only evaluator", () => {
+        it("includes score-only rows as an 'unknown' group instead of dropping them", async () => {
+          resetParamCounter();
+          const { sql, params } = buildTimeseriesQuery({
+            ...baseInput,
+            groupBy: "evaluations.evaluation_passed",
+            groupByKey: SCORE_ONLY_EVALUATOR_ID,
+            series: [
+              {
+                metric:
+                  "evaluations.evaluation_score" as FlattenAnalyticsMetricsEnum,
+                aggregation: "avg" as AggregationTypes,
+                key: SCORE_ONLY_EVALUATOR_ID,
+              },
+            ],
+          });
+
+          const result = await ch.query({
+            query: sql,
+            query_params: params,
+            format: "JSONEachRow",
+          });
+
+          type Row = Record<string, unknown>;
+          const rows = (await result.json()) as Row[];
+
+          expect(Array.isArray(rows)).toBe(true);
+
+          const currentRows = rows.filter((r) => r.period === "current");
+
+          // THE core assertion — fails before fix (rows had NULL group_key → HAVING dropped them)
+          const unknownRows = currentRows.filter(
+            (r) => r.group_key === "unknown",
+          );
+          expect(unknownRows.length).toBeGreaterThan(0);
+
+          // Score-only evaluator produces no pass or fail groups
+          expect(
+            currentRows.filter(
+              (r) => r.group_key === "passed" || r.group_key === "failed",
+            ),
+          ).toHaveLength(0);
+
+          // The only non-null group present is 'unknown' (foreign evaluator rows are still NULL→dropped)
+          const keys = [...new Set(currentRows.map((r) => r.group_key))];
+          expect(keys).toEqual(["unknown"]);
+        });
+      });
+    });
+
+    describe("given a pass/fail evaluator (Passed = 0 or 1)", () => {
+      describe("when grouping evaluation_passed by a pass/fail evaluator", () => {
+        it("groups rows into passed and failed correctly", async () => {
+          resetParamCounter();
+          const { sql, params } = buildTimeseriesQuery({
+            ...baseInput,
+            groupBy: "evaluations.evaluation_passed",
+            groupByKey: PASSFAIL_EVALUATOR_ID,
+            series: [
+              {
+                metric:
+                  "evaluations.evaluation_score" as FlattenAnalyticsMetricsEnum,
+                aggregation: "avg" as AggregationTypes,
+                key: PASSFAIL_EVALUATOR_ID,
+              },
+            ],
+          });
+
+          const result = await ch.query({
+            query: sql,
+            query_params: params,
+            format: "JSONEachRow",
+          });
+
+          type Row = Record<string, unknown>;
+          const rows = (await result.json()) as Row[];
+
+          expect(Array.isArray(rows)).toBe(true);
+
+          const currentRows = rows.filter((r) => r.period === "current");
+
+          const passedRows = currentRows.filter(
+            (r) => r.group_key === "passed",
+          );
+          const failedRows = currentRows.filter(
+            (r) => r.group_key === "failed",
+          );
+
+          expect(passedRows.length).toBeGreaterThan(0);
+          expect(failedRows.length).toBeGreaterThan(0);
+
+          const metricKey = Object.keys(passedRows[0]!).find(
+            (k) => k !== "date" && k !== "period" && k !== "group_key",
+          );
+          expect(metricKey).toBeDefined();
+
+          // PASSFAIL trace 0 (Passed=1) has score 0.9; trace 1 (Passed=0) has score 0.1
+          expect(Number(passedRows[0]![metricKey!])).toBeCloseTo(0.9);
+          expect(Number(failedRows[0]![metricKey!])).toBeCloseTo(0.1);
+        });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -324,10 +324,15 @@ const groupByExpressions: Partial<
   }),
 
   "evaluations.evaluation_passed": (groupByKey) => ({
+    // Score-only evaluators (issue #2674): when filtered to a specific evaluator via
+    // groupByKey, rows that ran successfully (Status='processed') but have Passed IS NULL
+    // (a numeric score, no pass/fail threshold) are bucketed as 'unknown' instead of being
+    // dropped by `HAVING group_key IS NOT NULL`. Foreign-evaluator rows still hit ELSE NULL.
     column: groupByKey
       ? `CASE
         WHEN ${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed' AND ${tableAliases.evaluation_runs}.Passed IS NOT NULL AND ${tableAliases.evaluation_runs}.Passed = 1 THEN 'passed'
         WHEN ${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed' AND ${tableAliases.evaluation_runs}.Passed IS NOT NULL AND ${tableAliases.evaluation_runs}.Passed = 0 THEN 'failed'
+        WHEN ${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed' THEN 'unknown'
         ELSE NULL
       END`
       : `CASE

--- a/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
+++ b/langwatch/src/server/analytics/clickhouse/aggregation-builder.ts
@@ -332,7 +332,7 @@ const groupByExpressions: Partial<
       ? `CASE
         WHEN ${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed' AND ${tableAliases.evaluation_runs}.Passed IS NOT NULL AND ${tableAliases.evaluation_runs}.Passed = 1 THEN 'passed'
         WHEN ${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed' AND ${tableAliases.evaluation_runs}.Passed IS NOT NULL AND ${tableAliases.evaluation_runs}.Passed = 0 THEN 'failed'
-        WHEN ${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed' THEN 'unknown'
+        WHEN ${tableAliases.evaluation_runs}.EvaluatorId = {groupByKey:String} AND ${tableAliases.evaluation_runs}.Status = 'processed' AND ${tableAliases.evaluation_runs}.Passed IS NULL THEN 'unknown'
         ELSE NULL
       END`
       : `CASE


### PR DESCRIPTION
## Why

Score-only evaluators (which emit a numeric score but no pass/fail verdict) were silently dropped from the **evaluation_passed** analytics groupBy whenever the chart was scoped to a specific evaluator (`groupByKey`). On the eval analytics dashboard, a chart grouped by such an evaluator rendered **empty** instead of showing that evaluator's runs.

Closes #2674

## What changed

- **One new `WHEN` in the `evaluation_passed` groupBy CASE** — `aggregation-builder.ts` returned `ELSE NULL` for every row that wasn't a clear pass/fail, and the downstream `HAVING group_key IS NOT NULL` dropped them. That `NULL` is intentional for **foreign** evaluators (the #2668 isolation guarantee), but it also dropped the **target** evaluator's score-only rows. The new clause buckets only the target evaluator's processed `Passed IS NULL` rows as `'unknown'`.
- **Gated on `Passed IS NULL`, not a broad `ELSE`** — a naive `ELSE 'unknown'` would have re-admitted foreign-evaluator rows and broken the #2668 isolation guarantee. The clause is narrow so foreign rows and unprocessed rows still hit `ELSE NULL` and stay excluded. (Decision recorded below under *Anything surprising?*.)

## How it works

The two existing `WHEN`s already gate on `Passed IS NOT NULL = 1/0`, so the new clause

```sql
WHEN es.EvaluatorId = {groupByKey:String} AND es.Status = 'processed' AND es.Passed IS NULL THEN 'unknown'
```

only catches the remaining case — the target evaluator's processed rows with `Passed IS NULL` (score-only). Everything else falls through to `ELSE NULL`, so evaluator isolation is preserved. The doc comment above the CASE documents exactly this NULL-only behavior, so comment and predicate now agree.

The three changed files are the backend query builder and its tests — but the query they build is **not** an internal detail: it is the data source for the eval analytics dashboard (surface traced under *How I can prove I was successful*).

```
src/server/analytics/clickhouse/
├── aggregation-builder.ts                                    # the one-WHEN fix
└── __tests__/
    ├── aggregation-builder.test.ts                           # unit: asserts the full WHEN (EvaluatorId + Passed IS NULL) + ELSE NULL
    └── score-only-evaluator-passed-groupby.integration.test.ts  # integration: real ClickHouse via testcontainers
```

## Human verification

This is a user-observable analytics fix. The most direct re-verification is in the running app; a test-only path is included for a reviewer who would rather not boot it.

**In the app (the real user flow):**

1. Open the eval analytics dashboard at `/[project]/analytics/evaluations` (or build a custom graph at `/[project]/analytics/custom`).
2. Add/scope a chart to **group by `evaluations.evaluation_passed`** with `groupByKey` set to a **score-only evaluator** (one whose processed rows emit a numeric score but no pass/fail verdict, i.e. `Passed IS NULL`).
3. **Before this fix:** that evaluator's runs are absent — the grouped chart is empty / undercounted (the #2674 bug).
4. **After this fix:** the same runs appear under an **`'unknown'`** group, so the evaluator's data is visible on its own dashboard chart. Foreign evaluators' rows still do not leak in (the #2668 isolation guarantee).

This chart renders through `CustomGraph.tsx` → tRPC `analytics.getTimeseries` → `clickhouse-analytics.service` → `buildTimeseriesQuery` (the changed CASE), so the UI reads the exact query this PR edits.

**Without booting (test-only re-verification):**

1. Check out this branch and `cd langwatch/`.
2. **Reproduce the bug:** in `src/server/analytics/clickhouse/aggregation-builder.ts`, delete the one `WHEN … Passed IS NULL THEN 'unknown'` clause (line ~335), leaving the test untouched.
3. Run `pnpm test:integration run score-only-evaluator-passed-groupby` — the `'unknown'` group assertion **fails** (`expected 0 to be greater than 0`), reproducing #2674.
4. **Restore** the clause (`git checkout src/server/analytics/clickhouse/aggregation-builder.ts`) and re-run — both tests **pass**.
5. Optionally read the generated SQL the unit test asserts on (`aggregation-builder.test.ts`, the issue-#2674 case) to confirm the `EvaluatorId = {groupByKey:String}` guard is present, so isolation across evaluators still holds.

## How I can prove I was successful

**User-observable surface = the eval analytics dashboard groupBy.** The changed query is the data source for the eval analytics charts. A user opens the eval analytics dashboard and groups a chart by `evaluations.evaluation_passed` scoped to a specific evaluator (`groupByKey`); for a score-only evaluator that grouped chart was empty before this fix and shows the evaluator's runs (as `'unknown'`) after it. The chain is wired, not asserted:

```
aggregation-builder.ts  buildTimeseriesQuery  (the changed evaluation_passed CASE)
  → clickhouse-analytics.service.ts
  → analytics.service.ts
  → tRPC  src/server/api/routers/analytics/timeseries.ts   (+ REST  src/app/api/analytics/[...route]/app.v1.ts)
  → src/components/analytics/CustomGraph.tsx   (getTimeseries.useQuery, groupBy)
  → two user-reachable entry points render that chart:
      • src/pages/[project]/analytics/custom/index.tsx   — the custom graph builder, where the user PICKS groupBy + groupByKey via form fields (CustomGraphFormData.groupBy / .groupByKey, lines 149-150); this is the exact "user groups by a score-only evaluator" path #2674 describes
      • src/pages/[project]/analytics/evaluations.tsx     — the evaluations overview, whose per-evaluator cards auto-emit groupBy "evaluations.evaluation_passed" + groupByKey check.id (lines 107-108 / 135-136)
```

`evaluation_passed` is a registered analytics metric (`src/server/analytics/registry.ts:1059`). So this is **not** a backend-only change with no UI surface — the prior "no-UI-surface" framing was wrong.

**Mechanism proof — falsifiability against live ClickHouse (before = FAIL, after = PASS):**

Without the fix (ephemerally removed the one score-only `WHEN … Passed IS NULL THEN 'unknown'` clause, test untouched):

```
 × … > includes score-only rows as an 'unknown' group instead of dropping them
   → expected 0 to be greater than 0

AssertionError: expected 0 to be greater than 0
 ❯ src/server/analytics/clickhouse/__tests__/score-only-evaluator-passed-groupby.integration.test.ts:198:38
    198|           expect(unknownRows.length).toBeGreaterThan(0);
 ✓ … > groups rows into passed and failed correctly        (1 failed | 1 passed)
```

→ score-only rows are dropped by `HAVING group_key IS NOT NULL` — exactly the #2674 bug. The clause is load-bearing, not vacuous.

With the fix (restored — worktree left clean via `git checkout`):

```
 ✓ … > includes score-only rows as an 'unknown' group instead of dropping them   36ms
 ✓ … > groups rows into passed and failed correctly                              29ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  1.53s
```

→ the score-only evaluator now appears as an `'unknown'` group **and is the only group** present (foreign-evaluator rows still hit `ELSE NULL` → dropped, so the #2668 isolation guarantee holds); the pass/fail evaluator still groups into `passed`/`failed` with the correct avg scores (0.9 / 0.1).

This is the **same lane CI runs** — `test-integration` provides `CI_CLICKHOUSE_URL`, so the regression is CI-gated, not local-only. `pnpm typecheck` clean; affected unit suite 91 passed. Run from `langwatch/`: `pnpm test:integration run score-only-evaluator-passed-groupby`.

**Live-app visual proof — tested against the running app.** Captured against the **running app** (golden VM, this branch `0a2d8516`). I seeded a guardrail-type evaluator ("Score-Only Guardrail (#2674 proof)", `openai/moderation`, `isGuardrail: true`) with 25 processed evaluation results the way a user's SDK would — via the `/api/collector` ingestion endpoint: **16 score-only rows** (`Score` set, `Passed = NULL`), plus 4 passed and 5 failed. Then I opened the **Online Evaluations analytics dashboard** (`/[project]/analytics/evaluations`), whose per-evaluator donut runs exactly `groupBy: "evaluations.evaluation_passed"` + `groupByKey: <evaluatorId>` — the query this PR fixes.

![Live-app proof: the eval analytics dashboard donut for a score-only evaluator shows a 64% "Evaluation passed unknown" slice (16 score-only rows, Passed IS NULL) alongside passed/failed — included instead of dropped (#2674)](https://raw.githubusercontent.com/langwatch/langwatch/proof/5007-score-only-evaluators/proofs/5007-score-only-evaluators.png)

The donut shows a **64% "Evaluation passed unknown"** slice — the 16 score-only rows (`Passed IS NULL`) that this fix now buckets as `'unknown'`, sitting alongside the green "passed" and red "failed" slices. **Before** the fix those rows were dropped by the foreign-evaluator-isolation `CASE` (`ELSE NULL`), so the evaluator's chart would show only the 9 pass/fail rows (36%) and silently undercount the evaluator; the integration test (`score-only-evaluator-passed-groupby.integration.test.ts`) pins that before=dropped / after=`'unknown'` behavior. Tested against the live app — the score-only evaluator now appears in evaluation analytics, exactly as #2674 requires.

## Anything surprising?

The naive fix (`ELSE 'unknown'`) would have broken the #2668 evaluator-isolation guarantee by pulling in rows from other evaluators. This fix keeps `ELSE NULL` for foreign rows and re-buckets **only** the target evaluator's score-only (`Passed IS NULL`) rows — matching the no-`groupByKey` branch's behavior. CodeRabbit raised the predicate/comment mismatch as a design question; the resolution (tighten the bucket to `Passed IS NULL` rather than loosen the comment) is implemented here and is the same direction the no-`groupByKey` branch already takes.

