### PR TITLE
fix(scenarios): take maxRuntime-killed and orphaned QUEUED runs terminal (#3365)

### DIFF
--- a/langwatch/specs/scenarios/queued-run-orphan-recovery.feature
+++ b/langwatch/specs/scenarios/queued-run-orphan-recovery.feature
@@ -1,0 +1,52 @@
+Feature: Queued scenario run orphan recovery
+
+  When a scenario worker restarts (it recycles itself after a maximum runtime,
+  or it crashes), any scenario runs it was about to execute or had already
+  started can be left behind. Before this recovery existed, those runs stayed
+  QUEUED forever: no terminal event was ever written, so the suites page kept
+  polling a run that no living worker would ever finish.
+
+  Recovery has two layers. The first is graceful: when a worker shuts down it
+  marks every run it still owns as failed before it goes away, so the common
+  case (a planned max-runtime restart) never orphans anything. The second is a
+  safety net for hard kills (OOM, SIGKILL) where the worker has no chance to
+  clean up: on startup a worker looks for runs that have sat QUEUED with no
+  progress for too long and marks them failed so the user sees a terminal
+  result instead of a spinner.
+
+  A freshly queued run is never touched by recovery — only runs that have been
+  abandoned long enough to prove no worker is coming for them.
+
+  Background:
+    Given scenario runs are executed by worker processes
+    And a scenario run is marked QUEUED when it is accepted for execution
+    And a worker recycles itself after it reaches its maximum runtime
+
+  # ---------------------------------------------------------------------------
+  # Layer 1: graceful drain on worker restart
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: In-flight runs are failed when the worker restarts
+    Given a worker is executing one scenario run and has another buffered
+    When the worker reaches its maximum runtime and begins shutting down
+    Then both runs are marked failed before the worker restarts
+    And neither run is left QUEUED
+
+  # ---------------------------------------------------------------------------
+  # Layer 2: startup reconciler for hard kills
+  # ---------------------------------------------------------------------------
+
+  @unit
+  Scenario: A long-abandoned queued run is reconciled to failed on startup
+    Given a scenario run has been QUEUED with no progress for longer than the orphan threshold
+    And no worker is currently executing it
+    When a worker starts up and reconciles orphaned queued runs
+    Then the run is marked failed
+
+  @unit
+  Scenario: A freshly queued run is not failed by the reconciler
+    Given a scenario run was queued moments ago
+    When a worker starts up and reconciles orphaned queued runs
+    Then the run is left QUEUED
+    And it is not marked failed

--- a/langwatch/specs/scenarios/queued-run-orphan-recovery.feature
+++ b/langwatch/specs/scenarios/queued-run-orphan-recovery.feature
@@ -33,6 +33,13 @@ Feature: Queued scenario run orphan recovery
     Then both runs are marked failed before the worker restarts
     And neither run is left QUEUED
 
+  @unit
+  Scenario: A cancelled in-flight run is preserved as cancelled, not failed
+    Given a worker is executing a scenario run that was cancelled before it finished
+    When the worker begins shutting down
+    Then the run is marked cancelled
+    And it is not marked failed
+
   # ---------------------------------------------------------------------------
   # Layer 2: startup reconciler for hard kills
   # ---------------------------------------------------------------------------

--- a/langwatch/src/server/scenarios/__tests__/scenario-orphan-reconciler.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-orphan-reconciler.unit.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the queued-run orphan reconciler.
+ *
+ * Covers the pure orphan gate (isOrphanedQueuedRun) and the orchestrator
+ * (reconcileOrphanedQueuedRuns) with injected fakes — no ClickHouse access.
+ *
+ * @see specs/scenarios/queued-run-orphan-recovery.feature
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  isOrphanedQueuedRun,
+  reconcileOrphanedQueuedRuns,
+  type OrphanCandidate,
+} from "../scenario-orphan-reconciler";
+
+const THRESHOLD_MS = 30 * 60 * 1000; // 30 min
+const NOW = 1_700_000_000_000;
+
+function makeCandidate(overrides: Partial<OrphanCandidate>): OrphanCandidate {
+  return {
+    projectId: "proj-1",
+    scenarioRunId: "run-1",
+    scenarioId: "scen-1",
+    batchRunId: "batch-1",
+    setId: "set-1",
+    lastEventAtMs: NOW - THRESHOLD_MS - 1,
+    status: "QUEUED",
+    ...overrides,
+  };
+}
+
+describe("isOrphanedQueuedRun", () => {
+  describe("given a QUEUED run", () => {
+    describe("when the last event is older than the threshold", () => {
+      it("flags it as orphaned", () => {
+        expect(
+          isOrphanedQueuedRun({
+            status: "QUEUED",
+            lastEventAtMs: NOW - THRESHOLD_MS - 1,
+            now: NOW,
+            thresholdMs: THRESHOLD_MS,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when the last event is exactly at the threshold", () => {
+      it("flags it as orphaned", () => {
+        expect(
+          isOrphanedQueuedRun({
+            status: "QUEUED",
+            lastEventAtMs: NOW - THRESHOLD_MS,
+            now: NOW,
+            thresholdMs: THRESHOLD_MS,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("when the run was queued recently", () => {
+      it("does not flag it as orphaned", () => {
+        expect(
+          isOrphanedQueuedRun({
+            status: "QUEUED",
+            lastEventAtMs: NOW - 1000,
+            now: NOW,
+            thresholdMs: THRESHOLD_MS,
+          }),
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe("given a non-QUEUED run", () => {
+    describe("when the last event is older than the threshold", () => {
+      it("does not flag it as orphaned", () => {
+        expect(
+          isOrphanedQueuedRun({
+            status: "IN_PROGRESS",
+            lastEventAtMs: NOW - THRESHOLD_MS - 1,
+            now: NOW,
+            thresholdMs: THRESHOLD_MS,
+          }),
+        ).toBe(false);
+      });
+    });
+  });
+});
+
+describe("reconcileOrphanedQueuedRuns", () => {
+  describe("given candidates with mixed status and age", () => {
+    describe("when reconciling", () => {
+      it("emits a failure only for the long-abandoned queued run", async () => {
+        const oldQueued = makeCandidate({
+          scenarioRunId: "old-queued",
+          status: "QUEUED",
+          lastEventAtMs: NOW - THRESHOLD_MS - 1,
+        });
+        const recentQueued = makeCandidate({
+          scenarioRunId: "recent-queued",
+          status: "QUEUED",
+          lastEventAtMs: NOW - 1000,
+        });
+        const oldNonQueued = makeCandidate({
+          scenarioRunId: "old-in-progress",
+          status: "IN_PROGRESS",
+          lastEventAtMs: NOW - THRESHOLD_MS - 1,
+        });
+        const emitFailure = vi.fn().mockResolvedValue(undefined);
+
+        const result = await reconcileOrphanedQueuedRuns({
+          findCandidates: vi
+            .fn()
+            .mockResolvedValue([oldQueued, recentQueued, oldNonQueued]),
+          emitFailure,
+          now: NOW,
+          thresholdMs: THRESHOLD_MS,
+        });
+
+        expect(emitFailure).toHaveBeenCalledTimes(1);
+        expect(emitFailure).toHaveBeenCalledWith(oldQueued);
+        expect(result).toEqual({ failed: 1, skipped: 2 });
+      });
+    });
+  });
+
+  describe("given an emitFailure that rejects for one candidate", () => {
+    describe("when reconciling multiple orphans", () => {
+      it("still processes the remaining orphans and counts the failures", async () => {
+        const orphanA = makeCandidate({ scenarioRunId: "orphan-a" });
+        const orphanB = makeCandidate({ scenarioRunId: "orphan-b" });
+        const emitFailure = vi
+          .fn()
+          .mockRejectedValueOnce(new Error("emit blew up"))
+          .mockResolvedValueOnce(undefined);
+
+        const result = await reconcileOrphanedQueuedRuns({
+          findCandidates: vi.fn().mockResolvedValue([orphanA, orphanB]),
+          emitFailure,
+          now: NOW,
+          thresholdMs: THRESHOLD_MS,
+        });
+
+        expect(emitFailure).toHaveBeenCalledTimes(2);
+        expect(emitFailure).toHaveBeenCalledWith(orphanA);
+        expect(emitFailure).toHaveBeenCalledWith(orphanB);
+        // One emission succeeded, the rejecting one is counted as skipped.
+        expect(result).toEqual({ failed: 1, skipped: 1 });
+      });
+    });
+  });
+
+  describe("given no candidates", () => {
+    describe("when reconciling", () => {
+      it("emits nothing and returns zero counts", async () => {
+        const emitFailure = vi.fn().mockResolvedValue(undefined);
+
+        const result = await reconcileOrphanedQueuedRuns({
+          findCandidates: vi.fn().mockResolvedValue([]),
+          emitFailure,
+          now: NOW,
+          thresholdMs: THRESHOLD_MS,
+        });
+
+        expect(emitFailure).not.toHaveBeenCalled();
+        expect(result).toEqual({ failed: 0, skipped: 0 });
+      });
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/__tests__/scenario-orphan-reconciler.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-orphan-reconciler.unit.test.ts
@@ -10,11 +10,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   isOrphanedQueuedRun,
-  reconcileOrphanedQueuedRuns,
+  ORPHAN_QUEUED_THRESHOLD_MS,
   type OrphanCandidate,
+  reconcileOrphanedQueuedRuns,
 } from "../scenario-orphan-reconciler";
 
-const THRESHOLD_MS = 30 * 60 * 1000; // 30 min
+const THRESHOLD_MS = ORPHAN_QUEUED_THRESHOLD_MS;
 const NOW = 1_700_000_000_000;
 
 function makeCandidate(overrides: Partial<OrphanCandidate>): OrphanCandidate {
@@ -46,7 +47,7 @@ describe("isOrphanedQueuedRun", () => {
     });
 
     describe("when the last event is exactly at the threshold", () => {
-      it("flags it as orphaned", () => {
+      it("flags it as orphaned at the exact threshold boundary", () => {
         expect(
           isOrphanedQueuedRun({
             status: "QUEUED",
@@ -120,7 +121,7 @@ describe("reconcileOrphanedQueuedRuns", () => {
 
         expect(emitFailure).toHaveBeenCalledTimes(1);
         expect(emitFailure).toHaveBeenCalledWith(oldQueued);
-        expect(result).toEqual({ failed: 1, skipped: 2 });
+        expect(result).toEqual({ failed: 1, skipped: 2, errored: 0 });
       });
     });
   });
@@ -145,8 +146,8 @@ describe("reconcileOrphanedQueuedRuns", () => {
         expect(emitFailure).toHaveBeenCalledTimes(2);
         expect(emitFailure).toHaveBeenCalledWith(orphanA);
         expect(emitFailure).toHaveBeenCalledWith(orphanB);
-        // One emission succeeded, the rejecting one is counted as skipped.
-        expect(result).toEqual({ failed: 1, skipped: 1 });
+        // One emission succeeded, the rejecting one is counted as errored.
+        expect(result).toEqual({ failed: 1, skipped: 0, errored: 1 });
       });
     });
   });
@@ -164,7 +165,7 @@ describe("reconcileOrphanedQueuedRuns", () => {
         });
 
         expect(emitFailure).not.toHaveBeenCalled();
-        expect(result).toEqual({ failed: 0, skipped: 0 });
+        expect(result).toEqual({ failed: 0, skipped: 0, errored: 0 });
       });
     });
   });

--- a/langwatch/src/server/scenarios/__tests__/scenario-processor-drain.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-processor-drain.unit.test.ts
@@ -10,10 +10,10 @@
  * @see specs/scenarios/queued-run-orphan-recovery.feature "In-flight runs are failed when the worker restarts"
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChildProcess } from "child_process";
-import { ScenarioExecutionPool } from "../execution/execution-pool";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecutionJobData } from "../execution/execution-pool";
+import { ScenarioExecutionPool } from "../execution/execution-pool";
 import type { ProcessorDependencies } from "../scenario.processor";
 import { drainInFlightRuns } from "../scenario.processor";
 
@@ -43,10 +43,9 @@ describe("drainInFlightRuns", () => {
     // `_running`, which only fills via registerChild). The child is never
     // deregistered, so jobs stay in-flight until drain.
     pool.setSpawnFunction(async (jobData) => {
-      pool.registerChild(
-        jobData.scenarioRunId,
-        { kill: () => true } as unknown as ChildProcess,
-      );
+      pool.registerChild(jobData.scenarioRunId, {
+        kill: () => true,
+      } as unknown as ChildProcess);
     });
 
     mockGetById = vi
@@ -74,6 +73,7 @@ describe("drainInFlightRuns", () => {
         await drainInFlightRuns(pool, deps);
 
         expect(mockEnsureFailureEventsEmitted).toHaveBeenCalledTimes(2);
+        expect(mockGetById).toHaveBeenCalledTimes(2);
         const emittedRunIds = mockEnsureFailureEventsEmitted.mock.calls.map(
           (call) => (call[0] as { scenarioRunId: string }).scenarioRunId,
         );

--- a/langwatch/src/server/scenarios/__tests__/scenario-processor-drain.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-processor-drain.unit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the in-flight failure emission that runs when the scenario
+ * processor shuts down (graceful drain / worker max-runtime restart).
+ *
+ * Builds a real ScenarioExecutionPool with a no-op spawn function so submitted
+ * jobs stay in-flight, then exercises drainInFlightRuns (the logic close()
+ * runs) with a mock failure emitter. This is the path that stops in-flight
+ * runs from orphaning at QUEUED when the worker restarts.
+ *
+ * @see specs/scenarios/queued-run-orphan-recovery.feature "In-flight runs are failed when the worker restarts"
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChildProcess } from "child_process";
+import { ScenarioExecutionPool } from "../execution/execution-pool";
+import type { ExecutionJobData } from "../execution/execution-pool";
+import type { ProcessorDependencies } from "../scenario.processor";
+import { drainInFlightRuns } from "../scenario.processor";
+
+function makeJob(id: string): ExecutionJobData {
+  return {
+    projectId: "proj-1",
+    scenarioId: `scen-${id}`,
+    scenarioRunId: id,
+    batchRunId: "batch-1",
+    setId: "set-1",
+    target: { type: "http", referenceId: "agent-1" },
+  };
+}
+
+describe("drainInFlightRuns", () => {
+  let pool: ScenarioExecutionPool;
+  let mockGetById: ReturnType<typeof vi.fn>;
+  let mockEnsureFailureEventsEmitted: ReturnType<typeof vi.fn>;
+  let deps: ProcessorDependencies;
+
+  beforeEach(() => {
+    // concurrency 1: one job runs, the next is buffered as pending — gives us
+    // both an in-flight running job and an in-flight pending job.
+    pool = new ScenarioExecutionPool({ concurrency: 1 });
+    // Register a fake child so the single slot is occupied — this is what
+    // makes the SECOND submit buffer as pending (the concurrency gate checks
+    // `_running`, which only fills via registerChild). The child is never
+    // deregistered, so jobs stay in-flight until drain.
+    pool.setSpawnFunction(async (jobData) => {
+      pool.registerChild(
+        jobData.scenarioRunId,
+        { kill: () => true } as unknown as ChildProcess,
+      );
+    });
+
+    mockGetById = vi
+      .fn()
+      .mockResolvedValue({ name: "Test Scenario", situation: "A test" });
+    mockEnsureFailureEventsEmitted = vi.fn().mockResolvedValue(undefined);
+    deps = {
+      scenarioLookup: {
+        getById:
+          mockGetById as ProcessorDependencies["scenarioLookup"]["getById"],
+      },
+      failureEmitter: {
+        ensureFailureEventsEmitted:
+          mockEnsureFailureEventsEmitted as ProcessorDependencies["failureEmitter"]["ensureFailureEventsEmitted"],
+      },
+    };
+  });
+
+  describe("given a running job and a buffered pending job", () => {
+    describe("when the processor drains for a worker restart", () => {
+      it("emits a terminal failure for every in-flight run", async () => {
+        pool.submit(makeJob("running-run")); // starts immediately
+        pool.submit(makeJob("pending-run")); // buffered (concurrency is 1)
+
+        await drainInFlightRuns(pool, deps);
+
+        expect(mockEnsureFailureEventsEmitted).toHaveBeenCalledTimes(2);
+        const emittedRunIds = mockEnsureFailureEventsEmitted.mock.calls.map(
+          (call) => (call[0] as { scenarioRunId: string }).scenarioRunId,
+        );
+        expect(emittedRunIds).toEqual(
+          expect.arrayContaining(["running-run", "pending-run"]),
+        );
+      });
+
+      it("clears the pending queue (drain happened)", async () => {
+        pool.submit(makeJob("running-run"));
+        pool.submit(makeJob("pending-run"));
+
+        expect(pool.pendingCount).toBe(1);
+
+        await drainInFlightRuns(pool, deps);
+
+        expect(pool.pendingCount).toBe(0);
+      });
+    });
+  });
+
+  describe("given one emission rejects", () => {
+    describe("when the processor drains", () => {
+      it("still drains the pool and emits for the other run", async () => {
+        mockEnsureFailureEventsEmitted
+          .mockRejectedValueOnce(new Error("emit failed"))
+          .mockResolvedValueOnce(undefined);
+
+        pool.submit(makeJob("running-run"));
+        pool.submit(makeJob("pending-run"));
+
+        // Must not throw despite one emission rejecting.
+        await drainInFlightRuns(pool, deps);
+
+        expect(mockEnsureFailureEventsEmitted).toHaveBeenCalledTimes(2);
+        expect(pool.pendingCount).toBe(0);
+      });
+    });
+  });
+
+  describe("given no in-flight runs", () => {
+    describe("when the processor drains", () => {
+      it("emits nothing", async () => {
+        await drainInFlightRuns(pool, deps);
+        expect(mockEnsureFailureEventsEmitted).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/langwatch/src/server/scenarios/__tests__/scenario-processor-drain.unit.test.ts
+++ b/langwatch/src/server/scenarios/__tests__/scenario-processor-drain.unit.test.ts
@@ -114,6 +114,26 @@ describe("drainInFlightRuns", () => {
     });
   });
 
+  describe("given a cancelled in-flight run", () => {
+    describe("when the processor drains", () => {
+      it("emits a cancellation event, not an error failure", async () => {
+        const job = makeJob("cancelled-run");
+        pool.submit(job);
+        pool.markCancelled(job.scenarioRunId);
+
+        await drainInFlightRuns(pool, deps);
+
+        expect(mockEnsureFailureEventsEmitted).toHaveBeenCalledTimes(1);
+        expect(mockEnsureFailureEventsEmitted).toHaveBeenCalledWith(
+          expect.objectContaining({
+            scenarioRunId: job.scenarioRunId,
+            cancelled: true,
+          }),
+        );
+      });
+    });
+  });
+
   describe("given no in-flight runs", () => {
     describe("when the processor drains", () => {
       it("emits nothing", async () => {

--- a/langwatch/src/server/scenarios/execution/__tests__/execution-pool.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/execution-pool.unit.test.ts
@@ -160,4 +160,40 @@ describe("ScenarioExecutionPool", () => {
       expect((child2 as any).kill).toHaveBeenCalledWith("SIGTERM");
     });
   });
+
+  describe("inFlightJobs", () => {
+    describe("when jobs are running and buffered", () => {
+      it("returns both running and pending job data", () => {
+        pool.submit(makeJob("run-1")); // running
+        pool.submit(makeJob("run-2")); // running
+        pool.submit(makeJob("run-3")); // pending
+
+        const inFlightIds = pool.inFlightJobs.map((j) => j.scenarioRunId);
+
+        expect(inFlightIds).toHaveLength(3);
+        expect(inFlightIds).toEqual(
+          expect.arrayContaining(["run-1", "run-2", "run-3"]),
+        );
+      });
+    });
+
+    describe("when a running child is deregistered", () => {
+      it("drops it from the in-flight set", () => {
+        pool.submit(makeJob("run-1"));
+        pool.submit(makeJob("run-2"));
+
+        pool.deregisterChild("run-1");
+
+        const inFlightIds = pool.inFlightJobs.map((j) => j.scenarioRunId);
+        expect(inFlightIds).not.toContain("run-1");
+        expect(inFlightIds).toContain("run-2");
+      });
+    });
+
+    describe("when the pool is empty", () => {
+      it("returns an empty list", () => {
+        expect(pool.inFlightJobs).toEqual([]);
+      });
+    });
+  });
 });

--- a/langwatch/src/server/scenarios/execution/__tests__/execution-pool.unit.test.ts
+++ b/langwatch/src/server/scenarios/execution/__tests__/execution-pool.unit.test.ts
@@ -3,11 +3,11 @@
  * @see specs/scenarios/event-driven-execution-prep.feature
  */
 
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { EventEmitter } from "events";
 import type { ChildProcess } from "child_process";
-import { ScenarioExecutionPool } from "../execution-pool";
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExecutionJobData } from "../execution-pool";
+import { ScenarioExecutionPool } from "../execution-pool";
 
 function makeJob(id: string): ExecutionJobData {
   return {
@@ -94,7 +94,9 @@ describe("ScenarioExecutionPool", () => {
       pool.submit(makeJob("run-1"));
 
       expect(onSkip).toHaveBeenCalledTimes(1);
-      expect(onSkip).toHaveBeenCalledWith(expect.objectContaining({ scenarioRunId: "run-1" }));
+      expect(onSkip).toHaveBeenCalledWith(
+        expect.objectContaining({ scenarioRunId: "run-1" }),
+      );
     });
   });
 
@@ -129,7 +131,9 @@ describe("ScenarioExecutionPool", () => {
       await new Promise((r) => setTimeout(r, 10));
 
       expect(onSkip).toHaveBeenCalledTimes(1);
-      expect(onSkip).toHaveBeenCalledWith(expect.objectContaining({ scenarioRunId: "run-3" }));
+      expect(onSkip).toHaveBeenCalledWith(
+        expect.objectContaining({ scenarioRunId: "run-3" }),
+      );
     });
   });
 

--- a/langwatch/src/server/scenarios/execution/execution-pool.ts
+++ b/langwatch/src/server/scenarios/execution/execution-pool.ts
@@ -24,7 +24,10 @@ export interface ExecutionJobData {
   batchRunId: string;
   setId: string;
   scenarioName?: string;
-  target: { type: "prompt" | "http" | "code" | "workflow"; referenceId: string };
+  target: {
+    type: "prompt" | "http" | "code" | "workflow";
+    referenceId: string;
+  };
 }
 
 /** Function that spawns a child process for a scenario job. Returns when child exits. */
@@ -127,7 +130,10 @@ export class ScenarioExecutionPool {
   submit(jobData: ExecutionJobData): void {
     // Skip if already cancelled before we even start
     if (this._cancelled.has(jobData.scenarioRunId)) {
-      logger.info({ scenarioRunId: jobData.scenarioRunId }, "Skipping cancelled job, dispatching finished(CANCELLED)");
+      logger.info(
+        { scenarioRunId: jobData.scenarioRunId },
+        "Skipping cancelled job, dispatching finished(CANCELLED)",
+      );
       this._onSkipCancelled?.(jobData);
       return;
     }
@@ -135,7 +141,11 @@ export class ScenarioExecutionPool {
       this.startJob(jobData);
     } else {
       logger.info(
-        { scenarioRunId: jobData.scenarioRunId, pendingCount: this._pending.length + 1, activeCount: this._running.size },
+        {
+          scenarioRunId: jobData.scenarioRunId,
+          pendingCount: this._pending.length + 1,
+          activeCount: this._running.size,
+        },
         "Execution pool full, buffering job",
       );
       this._pending.push(jobData);
@@ -158,20 +168,30 @@ export class ScenarioExecutionPool {
     this._runningJobs.set(jobData.scenarioRunId, jobData);
 
     if (!this._spawnFn) {
-      logger.error({ scenarioRunId: jobData.scenarioRunId }, "Spawn function not set on execution pool");
+      logger.error(
+        { scenarioRunId: jobData.scenarioRunId },
+        "Spawn function not set on execution pool",
+      );
       this._runningJobs.delete(jobData.scenarioRunId);
       return;
     }
 
     logger.info(
-      { scenarioRunId: jobData.scenarioRunId, activeCount: this._running.size + 1, pendingCount: this._pending.length },
+      {
+        scenarioRunId: jobData.scenarioRunId,
+        activeCount: this._running.size + 1,
+        pendingCount: this._pending.length,
+      },
       "Starting scenario execution",
     );
 
     // Fire and forget — the spawn function handles the full lifecycle
     void this._spawnFn(jobData).catch((error) => {
       logger.error(
-        { scenarioRunId: jobData.scenarioRunId, error: error instanceof Error ? error.message : String(error) },
+        {
+          scenarioRunId: jobData.scenarioRunId,
+          error: error instanceof Error ? error.message : String(error),
+        },
         "Scenario execution failed unexpectedly",
       );
       // Ensure we deregister even on unexpected errors
@@ -187,13 +207,19 @@ export class ScenarioExecutionPool {
 
       // Skip cancelled jobs in the pending queue
       if (this._cancelled.has(next.scenarioRunId)) {
-        logger.info({ scenarioRunId: next.scenarioRunId }, "Skipping cancelled pending job, dispatching finished(CANCELLED)");
+        logger.info(
+          { scenarioRunId: next.scenarioRunId },
+          "Skipping cancelled pending job, dispatching finished(CANCELLED)",
+        );
         this._onSkipCancelled?.(next);
         continue;
       }
 
       logger.debug(
-        { scenarioRunId: next.scenarioRunId, remainingPending: this._pending.length },
+        {
+          scenarioRunId: next.scenarioRunId,
+          remainingPending: this._pending.length,
+        },
         "Dequeuing pending job",
       );
       this.startJob(next);

--- a/langwatch/src/server/scenarios/execution/execution-pool.ts
+++ b/langwatch/src/server/scenarios/execution/execution-pool.ts
@@ -35,6 +35,14 @@ export type OnSkipCancelledFn = (jobData: ExecutionJobData) => void;
 
 export class ScenarioExecutionPool {
   private readonly _running = new Map<string, ChildProcess>();
+  /**
+   * In-flight job data keyed by scenarioRunId, tracked from the moment a job
+   * starts (before the child is registered) so the spawn window — where the
+   * child exists but isn't yet in `_running` — is still covered. Used by
+   * `inFlightJobs` so a draining worker can emit a terminal failure for every
+   * run it owns and none orphan at QUEUED.
+   */
+  private readonly _runningJobs = new Map<string, ExecutionJobData>();
   private readonly _pending: ExecutionJobData[] = [];
   private readonly _cancelled = new Set<string>();
   private readonly _concurrency: number;
@@ -71,6 +79,16 @@ export class ScenarioExecutionPool {
   }
 
   /**
+   * Job data for every run still in flight: those running (tracked from
+   * startJob, covering the pre-registration spawn window) plus those buffered
+   * pending. Drained on worker shutdown so each run reaches a terminal state
+   * instead of orphaning at QUEUED.
+   */
+  get inFlightJobs(): ExecutionJobData[] {
+    return [...this._runningJobs.values(), ...this._pending];
+  }
+
+  /**
    * Mark a scenario as cancelled. Called when the cancel subscription receives
    * a message and kills the child. The close handler checks this to distinguish
    * cancellation from crashes.
@@ -98,6 +116,7 @@ export class ScenarioExecutionPool {
    */
   deregisterChild(scenarioRunId: string): void {
     this._running.delete(scenarioRunId);
+    this._runningJobs.delete(scenarioRunId);
     this.dequeueNext();
   }
 
@@ -133,8 +152,14 @@ export class ScenarioExecutionPool {
   }
 
   private startJob(jobData: ExecutionJobData): void {
+    // Track in-flight job data immediately — before the child is registered —
+    // so a draining worker can emit a terminal failure even if shutdown lands
+    // in the spawn window (child exists but not yet in `_running`).
+    this._runningJobs.set(jobData.scenarioRunId, jobData);
+
     if (!this._spawnFn) {
       logger.error({ scenarioRunId: jobData.scenarioRunId }, "Spawn function not set on execution pool");
+      this._runningJobs.delete(jobData.scenarioRunId);
       return;
     }
 
@@ -151,6 +176,7 @@ export class ScenarioExecutionPool {
       );
       // Ensure we deregister even on unexpected errors
       this._running.delete(jobData.scenarioRunId);
+      this._runningJobs.delete(jobData.scenarioRunId);
       this.dequeueNext();
     });
   }

--- a/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
+++ b/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
@@ -83,7 +83,7 @@ export function isOrphanedQueuedRun({
 
 /**
  * Find QUEUED-at-latest-version runs across ALL tenants within the lookback
- * window.
+ * window that are older than the orphan threshold.
  *
  * INTENTIONALLY cross-tenant: this is a startup ops reconciler (like the
  * storage-metering / TTL scans) and runs with the shared ClickHouse client, so
@@ -96,7 +96,10 @@ export function isOrphanedQueuedRun({
  * ReplacingMergeTree(UpdatedAt); ScenarioRunId is a globally-unique KSUID, so
  * grouping by (TenantId, ScenarioRunId) collapses every version of a run even
  * though the table's full dedup key also includes ScenarioSetId/BatchRunId.
- * Only groups whose latest Status is 'QUEUED' are returned. The scan is
+ * Only groups whose latest Status is 'QUEUED' AND whose LastEventAtMs is at or
+ * before the orphan cutoff are returned — newest candidates are excluded before
+ * the 10k cap so genuine old orphans are never starved. Results are ordered
+ * oldest-first so the most urgent orphans are processed first. The scan is
  * partition-pruned on StartedAt for the lookback window (StartedAt defaults to
  * the queue/insert time, so QUEUED orphans fall in their queue-week partition).
  * Selected columns are light, and per-group non-key values use argMax(col,
@@ -107,12 +110,15 @@ export async function findQueuedRunCandidates({
   client,
   lookbackMs,
   now,
+  orphanThresholdMs,
 }: {
   client: ClickHouseClient;
   lookbackMs: number;
   now: number;
+  orphanThresholdMs: number;
 }): Promise<OrphanCandidate[]> {
   const fromMs = now - lookbackMs;
+  const orphanCutoffMs = now - orphanThresholdMs;
 
   const result = await client.query({
     query: `
@@ -128,9 +134,11 @@ export async function findQueuedRunCandidates({
       WHERE StartedAt >= fromUnixTimestamp64Milli(toUInt64({fromMs:String}))
       GROUP BY TenantId, ScenarioRunId
       HAVING Status = '${ScenarioRunStatus.QUEUED}'
+        AND LastEventAtMs <= toUInt64({orphanCutoffMs:String})
+      ORDER BY LastEventAtMs ASC
       LIMIT 10000
     `,
-    query_params: { fromMs: String(fromMs) },
+    query_params: { fromMs: String(fromMs), orphanCutoffMs: String(orphanCutoffMs) },
     format: "JSONEachRow",
   });
 

--- a/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
+++ b/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
@@ -160,7 +160,7 @@ export async function findQueuedRunCandidates({
  * (per isOrphanedQueuedRun), and emit a terminal failure for each.
  *
  * Each emission is isolated in a try/catch so one bad run does not abort the
- * sweep; a run whose emission rejects is counted as skipped.
+ * sweep; a run whose emission rejects is counted as errored (distinct from skipped non-orphans).
  */
 export async function reconcileOrphanedQueuedRuns({
   findCandidates,
@@ -172,7 +172,7 @@ export async function reconcileOrphanedQueuedRuns({
   emitFailure: (candidate: OrphanCandidate) => Promise<void>;
   now: number;
   thresholdMs: number;
-}): Promise<{ failed: number; skipped: number }> {
+}): Promise<{ failed: number; skipped: number; errored: number }> {
   const candidates = await findCandidates();
   const orphans = candidates.filter((c) =>
     isOrphanedQueuedRun({
@@ -184,27 +184,31 @@ export async function reconcileOrphanedQueuedRuns({
   );
 
   let failed = 0;
-  // Non-orphan candidates are skipped by definition; rejected emissions add to
-  // this count below.
+  // Non-orphan candidates are skipped by definition.
   let skipped = candidates.length - orphans.length;
+  let errored = 0;
 
   for (const orphan of orphans) {
     try {
       await emitFailure(orphan);
       failed++;
     } catch (err) {
-      skipped++;
+      errored++;
       logger.warn(
-        { err, scenarioRunId: orphan.scenarioRunId, projectId: orphan.projectId },
+        {
+          err,
+          scenarioRunId: orphan.scenarioRunId,
+          projectId: orphan.projectId,
+        },
         "Failed to reconcile orphaned queued run",
       );
     }
   }
 
   logger.info(
-    { failed, skipped, candidates: candidates.length },
+    { failed, skipped, errored, candidates: candidates.length },
     "Orphaned queued run reconciliation complete",
   );
 
-  return { failed, skipped };
+  return { failed, skipped, errored };
 }

--- a/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
+++ b/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
@@ -138,7 +138,10 @@ export async function findQueuedRunCandidates({
       ORDER BY LastEventAtMs ASC
       LIMIT 10000
     `,
-    query_params: { fromMs: String(fromMs), orphanCutoffMs: String(orphanCutoffMs) },
+    query_params: {
+      fromMs: String(fromMs),
+      orphanCutoffMs: String(orphanCutoffMs),
+    },
     format: "JSONEachRow",
   });
 

--- a/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
+++ b/langwatch/src/server/scenarios/scenario-orphan-reconciler.ts
@@ -1,0 +1,210 @@
+/**
+ * Startup reconciler for orphaned QUEUED scenario runs.
+ *
+ * Belt-and-braces safety net for the graceful drain in scenario.processor.ts.
+ * When a worker is hard-killed (OOM, SIGKILL) it has no chance to mark its
+ * in-flight runs failed, so those runs sit at QUEUED forever with no live
+ * worker to finish them and the suites page polls them indefinitely.
+ *
+ * On worker startup this scans ClickHouse for runs that have been QUEUED with
+ * no progress for longer than the stall threshold and emits a terminal failure
+ * for each, so the user sees a terminal result instead of a permanent spinner.
+ *
+ * The pure gate (isOrphanedQueuedRun) and the orchestrator
+ * (reconcileOrphanedQueuedRuns) are side-effect-free given injected
+ * dependencies and are unit-tested without ClickHouse. The candidate-finder
+ * (findQueuedRunCandidates) owns the cross-tenant scan.
+ *
+ * @see specs/scenarios/queued-run-orphan-recovery.feature
+ */
+
+import type { ClickHouseClient } from "@clickhouse/client";
+import { createLogger } from "~/utils/logger/server";
+import { ScenarioRunStatus } from "./scenario-event.enums";
+import { STALL_THRESHOLD_MS } from "./stall-detection";
+
+const logger = createLogger("langwatch:scenarios:orphan-reconciler");
+
+// Mirrors the per-file TABLE_NAME constant in the sibling simulation_runs CH repositories.
+const TABLE_NAME = "simulation_runs" as const;
+
+/**
+ * How far back the reconciler scans. Orphans older than this window are NOT
+ * reconciled — they are ancient/abandoned and any consumer has long since
+ * stopped polling. The bound also keeps the cross-tenant partition scan small
+ * (simulation_runs is partitioned by toYearWeek(StartedAt)).
+ */
+export const LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * How long a run may sit QUEUED with no progress before the reconciler treats
+ * it as orphaned. Equal to STALL_THRESHOLD_MS (2× the child-process timeout) —
+ * the same "no progress for too long" horizon the read-time stall detector
+ * uses — but defined here as its own constant on purpose: the orphan gate is
+ * about QUEUE liveness ("no worker ever picked this up"), a distinct concern
+ * from the stall detector's IN_PROGRESS execution liveness, even though the two
+ * currently coincide.
+ */
+export const ORPHAN_QUEUED_THRESHOLD_MS = STALL_THRESHOLD_MS;
+
+/** A QUEUED run found by the cross-tenant scan, candidate for reconciliation. */
+export interface OrphanCandidate {
+  projectId: string;
+  scenarioRunId: string;
+  scenarioId: string;
+  batchRunId: string;
+  setId: string;
+  lastEventAtMs: number;
+  status: string;
+}
+
+/**
+ * Pure gate: is this run an orphaned QUEUED run?
+ *
+ * True ONLY when the run is QUEUED AND its last event is at least `thresholdMs`
+ * old. A non-QUEUED run, or a QUEUED run that has had recent activity, is not
+ * an orphan — this is the guard against falsely failing healthy queued runs
+ * that a worker is about to (or recently did) pick up.
+ */
+export function isOrphanedQueuedRun({
+  status,
+  lastEventAtMs,
+  now,
+  thresholdMs,
+}: {
+  status: string;
+  lastEventAtMs: number;
+  now: number;
+  thresholdMs: number;
+}): boolean {
+  if (status !== ScenarioRunStatus.QUEUED) return false;
+  return now - lastEventAtMs >= thresholdMs;
+}
+
+/**
+ * Find QUEUED-at-latest-version runs across ALL tenants within the lookback
+ * window.
+ *
+ * INTENTIONALLY cross-tenant: this is a startup ops reconciler (like the
+ * storage-metering / TTL scans) and runs with the shared ClickHouse client, so
+ * it deliberately omits the per-tenant `TenantId = {...}` filter that every
+ * other simulation_runs query carries. This is the one documented exception to
+ * the per-tenant rule.
+ *
+ * Latest version per (TenantId, ScenarioRunId) is resolved with GROUP BY +
+ * argMax(col, UpdatedAt) (never max(col)). simulation_runs is a
+ * ReplacingMergeTree(UpdatedAt); ScenarioRunId is a globally-unique KSUID, so
+ * grouping by (TenantId, ScenarioRunId) collapses every version of a run even
+ * though the table's full dedup key also includes ScenarioSetId/BatchRunId.
+ * Only groups whose latest Status is 'QUEUED' are returned. The scan is
+ * partition-pruned on StartedAt for the lookback window (StartedAt defaults to
+ * the queue/insert time, so QUEUED orphans fall in their queue-week partition).
+ * Selected columns are light, and per-group non-key values use argMax(col,
+ * UpdatedAt) (never `max(col)`) so we read the latest version's ids, not a
+ * stale one.
+ */
+export async function findQueuedRunCandidates({
+  client,
+  lookbackMs,
+  now,
+}: {
+  client: ClickHouseClient;
+  lookbackMs: number;
+  now: number;
+}): Promise<OrphanCandidate[]> {
+  const fromMs = now - lookbackMs;
+
+  const result = await client.query({
+    query: `
+      SELECT
+        TenantId AS TenantId,
+        ScenarioRunId AS ScenarioRunId,
+        argMax(ScenarioId, UpdatedAt) AS ScenarioId,
+        argMax(BatchRunId, UpdatedAt) AS BatchRunId,
+        argMax(ScenarioSetId, UpdatedAt) AS ScenarioSetId,
+        argMax(Status, UpdatedAt) AS Status,
+        toUnixTimestamp64Milli(max(UpdatedAt)) AS LastEventAtMs
+      FROM ${TABLE_NAME}
+      WHERE StartedAt >= fromUnixTimestamp64Milli(toUInt64({fromMs:String}))
+      GROUP BY TenantId, ScenarioRunId
+      HAVING Status = '${ScenarioRunStatus.QUEUED}'
+      LIMIT 10000
+    `,
+    query_params: { fromMs: String(fromMs) },
+    format: "JSONEachRow",
+  });
+
+  const rows = await result.json<{
+    TenantId: string;
+    ScenarioRunId: string;
+    ScenarioId: string;
+    BatchRunId: string;
+    ScenarioSetId: string;
+    Status: string;
+    LastEventAtMs: string | number;
+  }>();
+
+  return rows.map((row) => ({
+    projectId: row.TenantId,
+    scenarioRunId: row.ScenarioRunId,
+    scenarioId: row.ScenarioId,
+    batchRunId: row.BatchRunId,
+    setId: row.ScenarioSetId,
+    status: row.Status,
+    lastEventAtMs: Number(row.LastEventAtMs),
+  }));
+}
+
+/**
+ * Orchestrate reconciliation: fetch candidates, keep only the genuine orphans
+ * (per isOrphanedQueuedRun), and emit a terminal failure for each.
+ *
+ * Each emission is isolated in a try/catch so one bad run does not abort the
+ * sweep; a run whose emission rejects is counted as skipped.
+ */
+export async function reconcileOrphanedQueuedRuns({
+  findCandidates,
+  emitFailure,
+  now,
+  thresholdMs,
+}: {
+  findCandidates: () => Promise<OrphanCandidate[]>;
+  emitFailure: (candidate: OrphanCandidate) => Promise<void>;
+  now: number;
+  thresholdMs: number;
+}): Promise<{ failed: number; skipped: number }> {
+  const candidates = await findCandidates();
+  const orphans = candidates.filter((c) =>
+    isOrphanedQueuedRun({
+      status: c.status,
+      lastEventAtMs: c.lastEventAtMs,
+      now,
+      thresholdMs,
+    }),
+  );
+
+  let failed = 0;
+  // Non-orphan candidates are skipped by definition; rejected emissions add to
+  // this count below.
+  let skipped = candidates.length - orphans.length;
+
+  for (const orphan of orphans) {
+    try {
+      await emitFailure(orphan);
+      failed++;
+    } catch (err) {
+      skipped++;
+      logger.warn(
+        { err, scenarioRunId: orphan.scenarioRunId, projectId: orphan.projectId },
+        "Failed to reconcile orphaned queued run",
+      );
+    }
+  }
+
+  logger.info(
+    { failed, skipped, candidates: candidates.length },
+    "Orphaned queued run reconciliation complete",
+  );
+
+  return { failed, skipped };
+}

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -12,43 +12,55 @@
  * @see specs/scenarios/event-driven-execution-prep.feature
  */
 
-import { spawn, type ChildProcess } from "child_process";
+import { type ChildProcess, spawn } from "child_process";
 import path from "path";
 import { createLogger } from "~/utils/logger/server";
-import { prisma } from "../db";
-import { connection } from "../redis";
 import { getSharedClickHouseClient } from "../clickhouse/clickhouseClient";
-import { subscribeToCancellations, type CancellationMessage } from "./cancellation-channel";
 import {
-  type JobContextMetadata,
   createContextFromJobData,
-  runWithContext,
   getJobContextMetadata,
+  type JobContextMetadata,
+  runWithContext,
 } from "../context/asyncContext";
-import {
-  createDataPrefetcherDependencies,
-  prefetchScenarioData,
-} from "./execution/data-prefetcher";
-import type { ChildProcessJobData, ScenarioExecutionResult } from "./execution/types";
-import type { ExecutionJobData, ScenarioExecutionPool } from "./execution/execution-pool";
+import { prisma } from "../db";
 import {
   getJobProcessingCounter,
   getJobProcessingDurationHistogram,
 } from "../metrics";
+import { connection } from "../redis";
+import {
+  type CancellationMessage,
+  subscribeToCancellations,
+} from "./cancellation-channel";
+import {
+  encodeScenarioLogContext,
+  SCENARIO_LOG_CONTEXT_ENV,
+} from "./execution/child-logger";
+import { resolveChildProcessSpawn } from "./execution/child-process-spawn";
+import {
+  createDataPrefetcherDependencies,
+  prefetchScenarioData,
+} from "./execution/data-prefetcher";
+import type {
+  ExecutionJobData,
+  ScenarioExecutionPool,
+} from "./execution/execution-pool";
+import type {
+  ChildProcessJobData,
+  ScenarioExecutionResult,
+} from "./execution/types";
 import { CHILD_PROCESS, SCENARIO_WORKER } from "./scenario.constants";
-import { ScenarioFailureHandler, type FailureEventParams } from "./scenario-failure-handler";
+import { ScenarioService } from "./scenario.service";
+import {
+  type FailureEventParams,
+  ScenarioFailureHandler,
+} from "./scenario-failure-handler";
 import {
   findQueuedRunCandidates,
   LOOKBACK_MS,
   ORPHAN_QUEUED_THRESHOLD_MS,
   reconcileOrphanedQueuedRuns,
 } from "./scenario-orphan-reconciler";
-import { ScenarioService } from "./scenario.service";
-import { resolveChildProcessSpawn } from "./execution/child-process-spawn";
-import {
-  encodeScenarioLogContext,
-  SCENARIO_LOG_CONTEXT_ENV,
-} from "./execution/child-logger";
 
 // ============================================================================
 // Dependency Interfaces (Dependency Inversion Principle)
@@ -134,7 +146,7 @@ export async function handleFailedJobResult(
  * the suites page polling them forever.
  *
  * Each emission is isolated by a per-job try/catch so one failure can't block
- * draining the rest (Promise.all is safe because no task rejects). Double-emitting for
+ * draining the rest. Double-emitting for
  * a running child whose own close handler also emits is safe — finishRun is
  * idempotent.
  */
@@ -218,7 +230,9 @@ function createScenarioLogger(jobData: ExecutionJobData) {
 export function buildOtelResourceAttributes(labels: string[]): string {
   const parts = ["langwatch.origin.source=platform"];
   if (labels.length) {
-    const escapedLabels = labels.map((l) => l.replace(/\\/g, "\\\\").replace(/[,=]/g, "\\$&"));
+    const escapedLabels = labels.map((l) =>
+      l.replace(/\\/g, "\\\\").replace(/[,=]/g, "\\$&"),
+    );
     parts.push(`scenario.labels=${escapedLabels.join(",")}`);
   }
   return parts.join(",");
@@ -242,7 +256,8 @@ export function buildChildProcessEnv(
     NODE_ENV: process.env.NODE_ENV,
     NODE_OPTIONS: process.env.NODE_OPTIONS,
     SKIP_ENV_VALIDATION: "1",
-    COREPACK_ENABLE_DOWNLOAD_PROMPT: process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT,
+    COREPACK_ENABLE_DOWNLOAD_PROMPT:
+      process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT,
     ...scenarioVars,
   };
 
@@ -289,7 +304,11 @@ export async function executeScenarioRun(
     // Check if cancellation was requested while we were prefetching
     if (pool.wasCancelled(jobData.scenarioRunId)) {
       jobLogger.info("Scenario cancelled during prefetch");
-      await handleCancelledJobResult(jobData, "Cancelled before execution started", deps);
+      await handleCancelledJobResult(
+        jobData,
+        "Cancelled before execution started",
+        deps,
+      );
       return;
     }
 
@@ -336,7 +355,12 @@ export async function executeScenarioRun(
     } else {
       getJobProcessingCounter("scenario", "failed").inc();
       jobLogger.warn(
-        { success: false, error: result.error, totalDurationMs, childDurationMs },
+        {
+          success: false,
+          error: result.error,
+          totalDurationMs,
+          childDurationMs,
+        },
         "Scenario job completed with failure",
       );
       await handleFailedJobResult(jobData, result.error, deps);
@@ -372,7 +396,9 @@ async function spawnScenarioChildProcess(
       childLogger[level](extra ?? {}, message);
     };
 
-    const otelResourceAttrs = buildOtelResourceAttributes(childProcessData.scenario.labels);
+    const otelResourceAttrs = buildOtelResourceAttributes(
+      childProcessData.scenario.labels,
+    );
     const logContext = encodeScenarioLogContext({
       scenarioRunId: jobData.scenarioRunId,
       batchRunId,
@@ -400,7 +426,10 @@ async function spawnScenarioChildProcess(
       stdio: ["pipe", "pipe", "pipe"],
       cwd: packageRoot,
     });
-    log("info", "Child process spawned", { pid: child.pid, spawnMs: Date.now() - spawnStart });
+    log("info", "Child process spawned", {
+      pid: child.pid,
+      spawnMs: Date.now() - spawnStart,
+    });
 
     // Register in the pool so cancel broadcasts can find this child
     pool.registerChild(jobData.scenarioRunId, child);
@@ -416,7 +445,9 @@ async function spawnScenarioChildProcess(
     };
 
     const timeout = setTimeout(() => {
-      log("error", "Child process timed out", { timeoutMs: CHILD_PROCESS.TIMEOUT_MS });
+      log("error", "Child process timed out", {
+        timeoutMs: CHILD_PROCESS.TIMEOUT_MS,
+      });
       cleanup();
       resolve({
         success: false,
@@ -448,12 +479,19 @@ async function spawnScenarioChildProcess(
       // Check if this was killed by the cancel subscription
       if (pool.wasCancelled(jobData.scenarioRunId)) {
         log("info", "Job cancelled via cancel broadcast");
-        resolve({ success: false, error: "Job was cancelled", cancelled: true });
+        resolve({
+          success: false,
+          error: "Job was cancelled",
+          cancelled: true,
+        });
         return;
       }
 
       if (code !== 0) {
-        log("error", `Child process exited with code ${code}`, { exitCode: code, stderr });
+        log("error", `Child process exited with code ${code}`, {
+          exitCode: code,
+          stderr,
+        });
         resolve({
           success: false,
           error: `Child process exited with code ${code}: ${stderr}`,
@@ -486,7 +524,9 @@ async function spawnScenarioChildProcess(
         child.stdin.write(JSON.stringify(childProcessData));
         child.stdin.end();
       } catch (err) {
-        log("warn", "Child stdin write failed", { error: (err as Error).message });
+        log("warn", "Child stdin write failed", {
+          error: (err as Error).message,
+        });
       }
     }
   });
@@ -518,8 +558,15 @@ export async function startScenarioProcessor(
   // Wire the callback for when the pool skips a cancelled job —
   // dispatch finished(CANCELLED) so the run reaches terminal state
   pool.setOnSkipCancelled((jobData) => {
-    logger.info({ scenarioRunId: jobData.scenarioRunId }, "Dispatching finished(CANCELLED) for skipped cancelled job");
-    void handleCancelledJobResult(jobData, "Cancelled before execution started", deps);
+    logger.info(
+      { scenarioRunId: jobData.scenarioRunId },
+      "Dispatching finished(CANCELLED) for skipped cancelled job",
+    );
+    void handleCancelledJobResult(
+      jobData,
+      "Cancelled before execution started",
+      deps,
+    );
   });
 
   // Subscribe to cancellation signals from the event-sourcing reactor
@@ -551,12 +598,13 @@ export async function startScenarioProcessor(
   // because the scan is intentionally cross-tenant.
   const sharedClickHouseClient = getSharedClickHouseClient();
   if (sharedClickHouseClient) {
+    const reconcilerNow = Date.now();
     void reconcileOrphanedQueuedRuns({
       findCandidates: () =>
         findQueuedRunCandidates({
           client: sharedClickHouseClient,
           lookbackMs: LOOKBACK_MS,
-          now: Date.now(),
+          now: reconcilerNow,
         }),
       emitFailure: (candidate) =>
         deps.failureEmitter.ensureFailureEventsEmitted({
@@ -568,7 +616,7 @@ export async function startScenarioProcessor(
           error:
             "Reconciled: orphaned QUEUED run with no live worker (worker restart/crash)",
         }),
-      now: Date.now(),
+      now: reconcilerNow,
       thresholdMs: ORPHAN_QUEUED_THRESHOLD_MS,
     }).catch((err) => logger.warn({ err }, "orphan reconciler failed"));
   }

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -17,6 +17,7 @@ import path from "path";
 import { createLogger } from "~/utils/logger/server";
 import { prisma } from "../db";
 import { connection } from "../redis";
+import { getSharedClickHouseClient } from "../clickhouse/clickhouseClient";
 import { subscribeToCancellations, type CancellationMessage } from "./cancellation-channel";
 import {
   type JobContextMetadata,
@@ -36,6 +37,12 @@ import {
 } from "../metrics";
 import { CHILD_PROCESS, SCENARIO_WORKER } from "./scenario.constants";
 import { ScenarioFailureHandler, type FailureEventParams } from "./scenario-failure-handler";
+import {
+  findQueuedRunCandidates,
+  LOOKBACK_MS,
+  ORPHAN_QUEUED_THRESHOLD_MS,
+  reconcileOrphanedQueuedRuns,
+} from "./scenario-orphan-reconciler";
 import { ScenarioService } from "./scenario.service";
 import { resolveChildProcessSpawn } from "./execution/child-process-spawn";
 import {
@@ -115,6 +122,52 @@ export async function handleFailedJobResult(
     name: scenario?.name,
     description: scenario?.situation,
   });
+}
+
+/**
+ * Emit a terminal failure for every run still in flight, then drain the pool.
+ *
+ * Called on processor shutdown — including the worker's max-runtime restart,
+ * which awaits `close()` before it rejects/restarts. Without this, in-flight
+ * runs (running children killed by drain, and buffered pending jobs silently
+ * dropped) would never get a terminal event and would orphan at QUEUED, with
+ * the suites page polling them forever.
+ *
+ * Each emission is isolated by a per-job try/catch so one failure can't block
+ * draining the rest (Promise.all is safe because no task rejects). Double-emitting for
+ * a running child whose own close handler also emits is safe — finishRun is
+ * idempotent.
+ */
+export async function drainInFlightRuns(
+  pool: ScenarioExecutionPool,
+  deps: ProcessorDependencies,
+): Promise<void> {
+  const inFlight = pool.inFlightJobs;
+  if (inFlight.length > 0) {
+    logger.info(
+      { count: inFlight.length },
+      "Draining: emitting terminal failure for in-flight scenario runs before shutdown",
+    );
+    await Promise.all(
+      inFlight.map(async (jobData) => {
+        try {
+          await handleFailedJobResult(
+            jobData,
+            "Worker restarting — scenario run terminated before completion",
+            deps,
+          );
+        } catch (err) {
+          logger.warn(
+            { err, scenarioRunId: jobData.scenarioRunId },
+            "Failed to emit terminal failure for in-flight run during drain",
+          );
+        }
+      }),
+    );
+  }
+
+  // Kills running children and clears the pending buffer.
+  pool.drain();
 }
 
 /**
@@ -491,9 +544,42 @@ export async function startScenarioProcessor(
     "Scenario processor started (event-driven)",
   );
 
+  // Belt-and-braces for hard kills (OOM/SIGKILL) where the graceful drain
+  // above never ran: reconcile runs left orphaned at QUEUED by a previous
+  // worker. Fire-and-forget — a slow or failing cross-tenant ClickHouse scan
+  // must never wedge worker startup. Uses the shared (non-tenant) client
+  // because the scan is intentionally cross-tenant.
+  const sharedClickHouseClient = getSharedClickHouseClient();
+  if (sharedClickHouseClient) {
+    void reconcileOrphanedQueuedRuns({
+      findCandidates: () =>
+        findQueuedRunCandidates({
+          client: sharedClickHouseClient,
+          lookbackMs: LOOKBACK_MS,
+          now: Date.now(),
+        }),
+      emitFailure: (candidate) =>
+        deps.failureEmitter.ensureFailureEventsEmitted({
+          projectId: candidate.projectId,
+          scenarioId: candidate.scenarioId,
+          setId: candidate.setId,
+          batchRunId: candidate.batchRunId,
+          scenarioRunId: candidate.scenarioRunId,
+          error:
+            "Reconciled: orphaned QUEUED run with no live worker (worker restart/crash)",
+        }),
+      now: Date.now(),
+      thresholdMs: ORPHAN_QUEUED_THRESHOLD_MS,
+    }).catch((err) => logger.warn({ err }, "orphan reconciler failed"));
+  }
+
   return {
     close: async () => {
-      pool.drain();
+      // Emit a terminal failure for every in-flight run, then drain. This is
+      // what makes the worker's max-runtime restart (which awaits close()
+      // before it rejects/restarts) safe: in-flight runs reach a terminal
+      // state instead of orphaning at QUEUED.
+      await drainInFlightRuns(pool, deps);
       await unsubscribe().catch((err: unknown) =>
         logger.warn({ err }, "Error closing cancellation subscriber"),
       );

--- a/langwatch/src/server/scenarios/scenario.processor.ts
+++ b/langwatch/src/server/scenarios/scenario.processor.ts
@@ -163,11 +163,19 @@ export async function drainInFlightRuns(
     await Promise.all(
       inFlight.map(async (jobData) => {
         try {
-          await handleFailedJobResult(
-            jobData,
-            "Worker restarting — scenario run terminated before completion",
-            deps,
-          );
+          if (pool.wasCancelled(jobData.scenarioRunId)) {
+            await handleCancelledJobResult(
+              jobData,
+              "Cancelled before execution started",
+              deps,
+            );
+          } else {
+            await handleFailedJobResult(
+              jobData,
+              "Worker restarting — scenario run terminated before completion",
+              deps,
+            );
+          }
         } catch (err) {
           logger.warn(
             { err, scenarioRunId: jobData.scenarioRunId },
@@ -605,6 +613,7 @@ export async function startScenarioProcessor(
           client: sharedClickHouseClient,
           lookbackMs: LOOKBACK_MS,
           now: reconcilerNow,
+          orphanThresholdMs: ORPHAN_QUEUED_THRESHOLD_MS,
         }),
       emitFailure: (candidate) =>
         deps.failureEmitter.ensureFailureEventsEmitted({


### PR DESCRIPTION
## What & why

Fixes #3365. Scenario runs orphaned permanently at `QUEUED` when a worker hit `maxRuntimeMs` and restarted: it killed in-flight child processes without emitting any terminal event, so the projection stayed `QUEUED` and the suites page polled forever.

Root cause was two orphan paths in the execution pool's drain:
1. **Pending jobs** were dropped (`_pending.length = 0`) with no event.
2. **Running children** were SIGTERM'd; their close handler *did* emit a failure, but asynchronously — it raced the worker restart and usually lost.

## Changes

### AC1 — graceful drain emits terminal failures before restart
- `execution-pool.ts`: the pool tracks in-flight job data (`_runningJobs`, set from `startJob` so the spawn window is covered) and exposes `inFlightJobs` (running + pending).
- `scenario.processor.ts`: new `drainInFlightRuns` emits a terminal failure (idempotent `finishRun`) for every in-flight run, then drains. `close()` calls it. `worker.ts`'s maxRuntime path already `await`s `close()` before the restart `reject`, so a killed run reaches ERROR instead of stuck QUEUED. A cancelled-before-execution run is preserved as CANCELLED (not re-emitted as ERROR) via `pool.wasCancelled(...)`. Also covers graceful shutdown.

### AC2 — startup reconciler for hard kills (OOM/SIGKILL)
- New `scenario-orphan-reconciler.ts`: pure gate `isOrphanedQueuedRun` (QUEUED + no progress past `ORPHAN_QUEUED_THRESHOLD_MS` = 30 min), `findQueuedRunCandidates` (cross-tenant CH scan, partition-pruned on `StartedAt`, latest-version via GROUP BY + `argMax`, **oldest-first `ORDER BY LastEventAtMs ASC` before the 10k cap** so true orphans are never starved by fresh rows), and `reconcileOrphanedQueuedRuns` (filters by the gate, emits failures, per-run isolation, returns `{failed, skipped, errored}`).
- Fired non-blocking from `startScenarioProcessor` so a slow/failing scan never wedges startup. Age-gated so freshly/healthy QUEUED runs are never falsely failed.

## Acceptance Criteria

- [x] **AC1** — When maxRuntime fires, a terminal failure is emitted for the in-flight run BEFORE the restart, so it goes terminal-failed (not stuck QUEUED).
- [x] **AC2** — On worker/processor startup, QUEUED runs with no live worker are reconciled to terminal-failed, gated so healthy QUEUED runs are NOT falsely reconciled.
- [x] **AC3** — Tests prove a maxRuntime-killed run goes terminal AND a healthy QUEUED run is not falsely failed.

## How I can prove I was successful

**This is a user-observable fix, not backend-only.** The drain and the startup reconciler write a terminal status into the `simulation_runs` projection, and the **Scenarios → suite-run view renders that exact projection** — so to the user the run flips from a permanent "queued" spinner to a terminal "failed" badge:

| | Before this PR | After this PR |
|---|---|---|
| `simulation_runs` status | stuck `QUEUED` forever (no live worker) | terminal `ERROR` |
| Scenarios-view badge | blue **"queued"** + indefinite spinner | red **"failed"** + XCircle |
| Completion overlay | never shown (run looks perpetually in-flight) | shown (run is done) |

**Traced user-facing surface** (rendered, not backend-only):
- `components/simulations/scenario-run-status-config.ts` — `QUEUED → { blue, "queued", isComplete:false }` (L67–70) vs `ERROR → { red, "failed", isComplete:true }` (L37–40); icon map `QUEUED → Clock`, `ERROR → XCircle` (L84–90).
- `components/simulations/SimulationStatusOverlay.tsx:102` — `if (!isComplete) return null;`, so a QUEUED run never shows the "done" overlay while a reconciled ERROR run does.
- **Same projection both sides:** the view's `api.scenarios.getSuiteRunData` query (`server/api/routers/scenarios/scenario-events.router.ts:113`) reads ClickHouse `simulation_runs` — the very table `findQueuedRunCandidates` scans and `ensureFailureEventsEmitted` writes. The reconciler's `ERROR` write is what the next UI poll renders.
- **Terminal status emitted:** `ensureFailureEventsEmitted` dispatches `finishRun` with `ScenarioRunStatus.ERROR` (`scenario-failure-handler.ts:90`) on both the drain and the startup-reconciler paths.

### ✅ Live-app visual proof — orphaned run reconciled in the live UI

![Orphaned QUEUED scenario run reconciled Stalled to Failed by the #5008 startup reconciler](https://raw.githubusercontent.com/langwatch/langwatch/proof/5008-orphan-reconciler/proofs/5008-orphan-reconciler-stalled-to-failed.png)

Staged on the live golden instance running **this branch**. An orphaned `QUEUED` scenario run (no live worker, ~2 h with no progress — past `ORPHAN_QUEUED_THRESHOLD_MS`) was seeded into the `simulation_runs` projection. **Left:** the Scenarios suite-run view renders it stuck — a `⚠ Stalled` badge — because a non-`fix/3365` worker never takes it terminal. **Right:** after bouncing the scenario worker so `startScenarioProcessor` runs **this PR's** reconciler, the same run flips to a terminal `⊗ Failed` badge. ClickHouse confirms the latest status moved `QUEUED → ERROR` carrying the reconciler's own signature — `Error = "Reconciled: orphaned QUEUED run with no live worker (worker restart/crash)"` — and the worker log emitted the matching `simulation_updated → ERROR` event for `blob-5008-orphan-run`. Falsifiable: the flip happens **only** after this PR's reconciler boots; the stuck `Stalled` state is exactly what every prior worker left behind.

### Mechanism evidence (passing)

**AC1 — red→green (falsifiable regression test).** With the drain emit removed (simulating the pre-fix bare `pool.drain()`), the AC1 test fails because in-flight runs get **zero** terminal events:
```
× emits a terminal failure for every in-flight run
AssertionError: expected "vi.fn()" to be called 2 times, but got 0 times
Tests  2 failed | 2 passed (4)
```
With the fix in place, every in-flight run (running + buffered-pending) gets a terminal failure before drain → green. A separate case proves a **cancelled** in-flight run is drained as a cancellation event, not an ERROR failure.

**AC2/AC3 — gate.** `reconcileOrphanedQueuedRuns` over `[oldQueued, recentQueued, oldNonQueued]` emits a failure for **only** the long-abandoned QUEUED run; the recent/healthy QUEUED run and the non-QUEUED run are left untouched (`isOrphanedQueuedRun` boundary cases incl. the exact threshold are unit-tested).

**Full suite (green):**
```
Test Files  3 passed (3)
     Tests  24 passed (24)
```
`pnpm typecheck` clean; biome clean on changed files. CI runs the same suite in `langwatch-app-ci`.

A live-ClickHouse integration proof (throwaway harness, full source below) additionally drives the **real** `findQueuedRunCandidates` / `reconcileOrphanedQueuedRuns` against a real ClickHouse testcontainer and shows the orphan reconciled while four non-orphan fixtures are correctly excluded.

## Human verification

**User-facing outcome:** in **Scenarios → (suite) → run**, a run that orphaned at "queued" and used to spin forever now resolves to a red **"failed"** badge.

End-to-end in a running app:
1. Open the Scenarios view for a suite and start a run.
2. Orphan it — restart/kill the scenario worker inside the spawn window (maxRuntime path), or leave a QUEUED run with no worker for >30 min (hard-kill path).
3. **Before this PR:** the run stays on the blue "queued" spinner indefinitely; no completion overlay.
4. **After this PR:** the drain (restart) or startup reconciler (hard kill) emits terminal `ERROR`; the next poll shows the run as a red "failed" badge with the completion overlay.

Without booting the full app, the same surface can be confirmed statically + at test tier:

1. **Read the two terminal paths.** `scenario.processor.ts` → `drainInFlightRuns` emits a terminal failure for every `pool.inFlightJobs` entry (cancelled runs routed to `handleCancelledJobResult`, all others to `handleFailedJobResult`) before `pool.drain()`; `worker.ts`'s maxRuntime path `await`s `close()` before rejecting. `scenario-orphan-reconciler.ts` → `isOrphanedQueuedRun` only fires past the 30-min threshold, and the CH scan orders oldest-first before the 10k cap.
2. **Run the suite:** `cd langwatch && pnpm test:unit scenario-orphan-reconciler scenario-processor-drain execution-pool` → 24 passing across 3 files.
3. **Falsify it:** delete the emit loop in `drainInFlightRuns` (or flip the age gate in `isOrphanedQueuedRun`) and re-run — the AC1 / AC2 tests go red, proving they actually exercise the behavior.
4. **(Optional) live ClickHouse:** run the throwaway integration harness below against the `test_langwatch` testcontainer to see the orphan reconciled end-to-end.

## Notes for reviewer (non-blocking, deferred)
- The cross-tenant CH scan intentionally omits the per-tenant `TenantId` filter (documented in-code) — it mirrors existing ops scans and uses the shared client; each emitted failure is dispatched under the run's own tenant.
- **Deferred: ClickHouse integration coverage** for `findQueuedRunCandidates` (the `argMax`/`HAVING` dedup SQL) is tracked in **#5073** — acceptable at unit tier; the live-ClickHouse harness below exercises it manually in the meantime.
- **Deferred: single-flight/jitter gate** is tracked in **#5074** — on a coordinated multi-pod restart every pod runs the reconciler scan; safe (idempotent `finishRun`, partition-pruned, fire-and-forget) but N× work.
- `TABLE_NAME = "simulation_runs"` is duplicated per-file across the simulation CH modules (pre-existing pattern); extracting a shared constant is also folded into the cleanup tracked in #5074.

**Do not merge** — @drewdrewthis to merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for scenario runs that get stuck in a queued state.
  * Improved shutdown handling so in-flight runs are finalized before workers stop.

* **Bug Fixes**
  * Prevented queued runs from being left unfinished after restarts or abrupt worker exits.
  * Reconciliation now skips recently queued runs and only targets long-abandoned ones.

* **Tests**
  * Added coverage for graceful drain behavior, orphan recovery, and in-flight job tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## 🔎 Live-ClickHouse integration proof — reconciler mechanism (not the full-app UI)

Drives the PR's **actual** reconciler functions against a **real ClickHouse** to prove the mechanism behind the user-visible flip above (it is **not** the full-app visual proof — see the now-embedded live-app visual proof in "How I can prove I was successful"). Also closes the gap flagged in the reviewer note ("No CH integration test for `findQueuedRunCandidates` yet", tracked in #5073). A **throwaway** integration test (NOT committed — full source below) runs against the `test_langwatch` testcontainer the integration suite uses, via the prisma-free `getClickHouseClient()` shared accessor that `startScenarioProcessor` passes at worker startup. It runs the real `findQueuedRunCandidates` (the `argMax` / `HAVING` dedup SQL — the head commit's subject) and `reconcileOrphanedQueuedRuns` with the real constants (`ORPHAN_QUEUED_THRESHOLD_MS` = 30 min, `LOOKBACK_MS` = 7 d).

**Fixtures inserted into `simulation_runs`** (one tenant, distinct runs):

| Fixture | Status | StartedAt | UpdatedAt | Expected |
|---|---|---|---|---|
| orphan | QUEUED | now−2h | now−45m | **reconciled** |
| fresh | QUEUED | now−5m | now−1m | excluded (age gate) |
| terminal | SUCCESS | now−2h | now−45m | excluded (status gate) |
| out-of-window | QUEUED | now−8d | now−8d | excluded (7d lookback bound) |
| dedup-to-terminal | QUEUED → SUCCESS (2 versions, same run) | now−3h | now−50m / now−40m | excluded (`argMax` reads latest = SUCCESS) |

The dedup case is the falsifier for the head commit's subject: a naive `max()` / any-version query would wrongly flag it; `argMax(Status, UpdatedAt)` reads the **latest** version (SUCCESS) and correctly skips it.

**Result — `pnpm test:integration`, live ClickHouse (`http://…/test_langwatch`):**

```text
[liveproof] ORPHAN_QUEUED_THRESHOLD_MS=1800000ms (30min), LOOKBACK_MS=604800000ms (7d)

# Phase 1 — findQueuedRunCandidates() scans real ClickHouse:
[liveproof] orphan candidates (this tenant): [ 'orphan-v5zdwrtJd-aa7fEmqFwkX' ]
#   -> ONLY the orphan; fresh / terminal / out-of-window / dedup-to-terminal all excluded

# Phase 2 — reconcileOrphanedQueuedRuns() with a real terminal-failure emitter:
[liveproof] reconcile result: { failed: 1, skipped: 0, errored: 0 }
[liveproof] emitted failures for: [ 'orphan-v5zdwrtJd-aa7fEmqFwkX' ]
[liveproof] orphan candidates after reconcile: []
#   -> orphan reconciled to terminal; the re-scan finds nothing (without the fix it polls forever)

 ✓ …liveproof… > findQueuedRunCandidates scans for orphans > returns ONLY the long-abandoned QUEUED run and excludes every non-orphan 17ms
 ✓ …liveproof… > reconcileOrphanedQueuedRuns … > emits a failure for the orphan and the run is then no longer detected as orphaned 38ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Falsifiability (without-fix stuck → with-fix reconciled).** Phase 1 shows the orphan is detectable as a permanently-stuck `QUEUED` run (the bug: no live worker, polled forever). Phase 2 runs the reconciler, emits a terminal failure, and the re-scan returns `[]` — the run reached a terminal state. The four excluded fixtures prove the gate is discriminating across all four axes (age, status, lookback window, and latest-version `argMax` dedup), so the reconciler cannot falsely fail healthy / fresh runs.

Run with:

```bash
pnpm test:integration scenario-orphan-reconciler.liveproof
```

<details>
<summary>Full throwaway harness source (not committed; embedded for reproducibility)</summary>

```ts
/**
 * @vitest-environment node
 *
 * LIVE-APP RUNTIME PROOF for PR #5008 (#3365) — NOT part of the PR.
 *
 * The PR ships only *.unit.test.ts for the orphan reconciler, and those mock
 * `findCandidates`. So the one piece that talks to a real database — the
 * cross-tenant ClickHouse scan `findQueuedRunCandidates` (the head commit's
 * subject) — has ZERO runtime coverage. This throwaway test closes that gap by
 * driving the REAL reconciler functions against a REAL ClickHouse
 * (test_langwatch testcontainer), with the SAME client the worker passes at
 * startup (`getSharedClickHouseClient()`).
 *
 * It proves, end to end:
 *   1) findQueuedRunCandidates picks up a long-abandoned QUEUED run and
 *      DISCRIMINATES — it excludes (a) a freshly-queued run, (b) a terminal
 *      (non-QUEUED) run, (c) a QUEUED run outside the 7d lookback window, and
 *      (d) a run whose LATEST version is terminal but an OLDER version was
 *      QUEUED (the argMax-vs-max dedup correctness the head commit is about).
 *   2) reconcileOrphanedQueuedRuns emits a terminal failure for the orphan and,
 *      once that terminal version lands, the orphan is no longer detected —
 *      i.e. the stuck run is reconciled (without the reconciler it would poll
 *      forever; with it, the run reaches a terminal state).
 */
import { nanoid } from "nanoid";
import { afterAll, beforeAll, describe, expect, it } from "vitest";
import type { ClickHouseClient } from "@clickhouse/client";
import {
  startTestContainers,
  stopTestContainers,
} from "../../event-sourcing/__tests__/integration/testContainers";
// The exact shared client accessor startScenarioProcessor passes to the
// reconciler. Imported from ./client (not ./clickhouseClient) to keep this
// proof free of the prisma import the routing wrapper carries — it is the same
// underlying getClickHouseClient() the worker uses.
import { _getSharedClickHouseClient as getSharedClickHouseClient } from "~/server/clickhouse/client";
import {
  findQueuedRunCandidates,
  LOOKBACK_MS,
  ORPHAN_QUEUED_THRESHOLD_MS,
  reconcileOrphanedQueuedRuns,
  type OrphanCandidate,
} from "../scenario-orphan-reconciler";

const MINUTE = 60 * 1000;
const HOUR = 60 * MINUTE;
const DAY = 24 * HOUR;

// Unique tenant so the cross-tenant scan can be filtered back to THIS run's
// fixtures — other suites may leave their own rows in the shared test DB.
const tenantId = `liveproof-3365-${nanoid()}`;
const now = Date.now();

// Distinct run ids for each fixture.
const orphanRunId = `orphan-${nanoid()}`;
const freshRunId = `fresh-${nanoid()}`;
const terminalRunId = `terminal-${nanoid()}`;
const outOfWindowRunId = `outofwindow-${nanoid()}`;
const dedupRunId = `dedup-to-terminal-${nanoid()}`;

function makeRow(o: {
  runId: string;
  status: string;
  startedAt: Date;
  updatedAt: Date;
}) {
  return {
    ProjectionId: `proj-${nanoid()}`,
    TenantId: tenantId,
    ScenarioRunId: o.runId,
    ScenarioId: `scenario-${nanoid()}`,
    BatchRunId: `batch-${nanoid()}`,
    ScenarioSetId: `set-${nanoid()}`,
    Version: "v1",
    Status: o.status,
    Name: null,
    Description: null,
    Metadata: null,
    "Messages.Id": [],
    "Messages.Role": [],
    "Messages.Content": [],
    "Messages.TraceId": [],
    "Messages.Rest": [],
    TraceIds: [],
    Verdict: null,
    Reasoning: null,
    MetCriteria: [],
    UnmetCriteria: [],
    Error: null,
    DurationMs: null,
    StartedAt: o.startedAt,
    CreatedAt: o.startedAt,
    UpdatedAt: o.updatedAt,
    FinishedAt: null,
    ArchivedAt: null,
    LastSnapshotOccurredAt: new Date(0),
  };
}

let ch: ClickHouseClient;

async function insertRows(rows: ReturnType<typeof makeRow>[]) {
  await ch.insert({
    table: "simulation_runs",
    values: rows,
    format: "JSONEachRow",
    // Synchronous insert so the very next SELECT sees the rows.
    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
  });
}

/** Run the REAL scan, then narrow to THIS test's tenant. */
async function scanMyOrphans(): Promise<OrphanCandidate[]> {
  const client = getSharedClickHouseClient();
  expect(client).not.toBeNull(); // same accessor startScenarioProcessor passes
  const all = await findQueuedRunCandidates({
    client: client!,
    lookbackMs: LOOKBACK_MS,
    now,
    orphanThresholdMs: ORPHAN_QUEUED_THRESHOLD_MS,
  });
  return all.filter((c) => c.projectId === tenantId);
}

beforeAll(async () => {
  const containers = await startTestContainers();
  ch = containers.clickHouseClient;

  console.log(
    `[liveproof] ORPHAN_QUEUED_THRESHOLD_MS=${ORPHAN_QUEUED_THRESHOLD_MS}ms (${
      ORPHAN_QUEUED_THRESHOLD_MS / MINUTE
    }min), LOOKBACK_MS=${LOOKBACK_MS}ms (${LOOKBACK_MS / DAY}d)`,
  );

  await insertRows([
    // (1) THE ORPHAN: QUEUED, in-window, no progress for >threshold -> reconcilable.
    makeRow({
      runId: orphanRunId,
      status: "QUEUED",
      startedAt: new Date(now - 2 * HOUR),
      updatedAt: new Date(now - 45 * MINUTE),
    }),
    // (2) FRESH: QUEUED but updated 1min ago -> a worker may still pick it up.
    makeRow({
      runId: freshRunId,
      status: "QUEUED",
      startedAt: new Date(now - 5 * MINUTE),
      updatedAt: new Date(now - 1 * MINUTE),
    }),
    // (3) TERMINAL: old, but SUCCESS -> already finished, not an orphan.
    makeRow({
      runId: terminalRunId,
      status: "SUCCESS",
      startedAt: new Date(now - 2 * HOUR),
      updatedAt: new Date(now - 45 * MINUTE),
    }),
    // (4) OUT OF WINDOW: QUEUED + old, but StartedAt before the 7d lookback.
    makeRow({
      runId: outOfWindowRunId,
      status: "QUEUED",
      startedAt: new Date(now - 8 * DAY),
      updatedAt: new Date(now - 8 * DAY),
    }),
    // (5) DEDUP-TO-TERMINAL: two versions of ONE run. Older = QUEUED, newer =
    //     SUCCESS. argMax(Status, UpdatedAt) must read the LATEST (SUCCESS), so
    //     this run is NOT an orphan. A naive max()/any-version query would
    //     wrongly flag it.
    makeRow({
      runId: dedupRunId,
      status: "QUEUED",
      startedAt: new Date(now - 3 * HOUR),
      updatedAt: new Date(now - 50 * MINUTE),
    }),
    makeRow({
      runId: dedupRunId,
      status: "SUCCESS",
      startedAt: new Date(now - 3 * HOUR),
      updatedAt: new Date(now - 40 * MINUTE),
    }),
  ]);
}, 60_000);

afterAll(async () => {
  if (ch) {
    await ch.exec({
      query: `ALTER TABLE simulation_runs DELETE WHERE TenantId = {tenantId:String}`,
      query_params: { tenantId },
    });
  }
  await stopTestContainers();
});

describe("orphan reconciler against live ClickHouse (PR #5008 / #3365)", () => {
  describe("given QUEUED, fresh, terminal, out-of-window, and dedup-to-terminal runs in the table", () => {
    describe("when findQueuedRunCandidates scans for orphans", () => {
      it("returns ONLY the long-abandoned QUEUED run and excludes every non-orphan", async () => {
        const mine = await scanMyOrphans();
        const ids = mine.map((c) => c.scenarioRunId);
        console.log("[liveproof] orphan candidates (this tenant):", ids);

        // The orphan is detected...
        expect(ids).toContain(orphanRunId);
        // ...and nothing else is.
        expect(ids).not.toContain(freshRunId); // age gate
        expect(ids).not.toContain(terminalRunId); // status gate
        expect(ids).not.toContain(outOfWindowRunId); // lookback bound
        expect(ids).not.toContain(dedupRunId); // argMax latest-version dedup
        expect(mine).toHaveLength(1);

        // The returned candidate carries the run's identity for failure emission.
        const orphan = mine[0]!;
        expect(orphan.projectId).toBe(tenantId);
        expect(orphan.scenarioRunId).toBe(orphanRunId);
        expect(orphan.status).toBe("QUEUED");
        expect(orphan.lastEventAtMs).toBeLessThanOrEqual(
          now - ORPHAN_QUEUED_THRESHOLD_MS,
        );
      });
    });

    describe("when reconcileOrphanedQueuedRuns runs with a real terminal-failure emitter", () => {
      it("emits a failure for the orphan and the run is then no longer detected as orphaned", async () => {
        // Sanity: orphan is still stuck QUEUED before reconciliation (this is
        // the bug condition — without the reconciler it stays here forever).
        const before = await scanMyOrphans();
        expect(before.map((c) => c.scenarioRunId)).toEqual([orphanRunId]);

        // Real emitter: write a terminal (FAILED) version of the run, which is
        // what ensureFailureEventsEmitted ultimately lands in the projection.
        const emitted: string[] = [];
        const emitFailure = async (candidate: OrphanCandidate) => {
          emitted.push(candidate.scenarioRunId);
          await insertRows([
            makeRow({
              runId: candidate.scenarioRunId,
              status: "FAILED",
              startedAt: new Date(now - 2 * HOUR),
              updatedAt: new Date(now), // newest version -> wins argMax
            }),
          ]);
        };

        const result = await reconcileOrphanedQueuedRuns({
          // Scope the cross-tenant scan to this test's tenant so we never touch
          // other suites' data; the orchestrator itself is unmodified.
          findCandidates: scanMyOrphans,
          emitFailure,
          now,
          thresholdMs: ORPHAN_QUEUED_THRESHOLD_MS,
        });
        console.log("[liveproof] reconcile result:", result);
        console.log("[liveproof] emitted failures for:", emitted);

        expect(result).toEqual({ failed: 1, skipped: 0, errored: 0 });
        expect(emitted).toEqual([orphanRunId]);

        // The orphan is now reconciled: its latest version is terminal, so the
        // scan no longer returns it.
        const after = await scanMyOrphans();
        console.log(
          "[liveproof] orphan candidates after reconcile:",
          after.map((c) => c.scenarioRunId),
        );
        expect(after).toHaveLength(0);
      });
    });
  });
});
```
</details>

