### PR TITLE
fix(scenarios): mapping-gate toast links back to the agent editor (#3411)

### DIFF
--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -291,6 +291,8 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
                 },
                 meta: { closable: true },
               });
+              // Auto-open the editor now; the toast action above is the manual
+              // fallback if this auto-open races, is dismissed, or fails.
               openAgentEditor();
               return;
             }

--- a/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
+++ b/langwatch/src/components/scenarios/ScenarioFormDrawer.tsx
@@ -274,16 +274,24 @@ export function ScenarioFormDrawer(props: ScenarioFormDrawerProps) {
             // covers output validation. Share the input half of the rule with
             // the editor drawer via hasScenarioInputMapping.
             if (!hasScenarioInputMapping(mappings)) {
+              // Fallback affordance (#3411): even if the auto-open below races,
+              // is dismissed, or fails, the toast itself links back to the editor.
+              const openAgentEditor = () =>
+                openDrawer("agentWorkflowEditor", {
+                  urlParams: { agentId: target.id },
+                });
               toaster.create({
                 title: "Configure scenario mappings",
                 description:
-                  "Set up how this workflow agent maps scenario inputs and outputs before running.",
+                  'Map at least one scenario input — "input" or "messages" — to an agent input before running this workflow agent.',
                 type: "warning",
+                action: {
+                  label: "Open agent editor",
+                  onClick: openAgentEditor,
+                },
                 meta: { closable: true },
               });
-              openDrawer("agentWorkflowEditor", {
-                urlParams: { agentId: target.id },
-              });
+              openAgentEditor();
               return;
             }
           }

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
@@ -344,16 +344,17 @@ describe("<ScenarioFormDrawer /> mapping gate", () => {
         );
       });
 
-      // Prove the action handler ALONE reopens the editor: clear the mock so
-      // the earlier auto-open call doesn't count, then invoke onClick. This is
-      // the fallback affordance — functional even if the auto-open raced/was
-      // dismissed.
       const toastArg = mockToasterCreate.mock.calls.at(-1)?.[0] as {
         action?: { label: string; onClick: () => void };
       };
+      // AC3: the auto-open fired first (existing behavior preserved)...
+      expect(mocks.mockOpenDrawer).toHaveBeenCalledWith("agentWorkflowEditor", {
+        urlParams: { agentId: "workflow-agent-1" },
+      });
+      // ...then clear it and prove the action handler ALONE reopens the editor —
+      // the fallback affordance, functional even if the auto-open was dismissed.
       mocks.mockOpenDrawer.mockClear();
       toastArg.action?.onClick();
-
       expect(mocks.mockOpenDrawer).toHaveBeenCalledWith("agentWorkflowEditor", {
         urlParams: { agentId: "workflow-agent-1" },
       });
@@ -366,13 +367,12 @@ describe("<ScenarioFormDrawer /> mapping gate", () => {
 
       await user.click(screen.getByTestId("save-and-run-button"));
 
-      await waitFor(() => {
-        const toastArg = mockToasterCreate.mock.calls.at(-1)?.[0] as {
-          description?: string;
-        };
-        expect(toastArg.description).toMatch(/input/i);
-        expect(toastArg.description).toMatch(/messages/i);
-      });
+      await waitFor(() => expect(mockToasterCreate).toHaveBeenCalled());
+      const toastArg = mockToasterCreate.mock.calls.at(-1)?.[0] as {
+        description?: string;
+      };
+      expect(toastArg.description).toMatch(/input/i);
+      expect(toastArg.description).toMatch(/messages/i);
     });
   });
 

--- a/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
+++ b/langwatch/src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx
@@ -10,7 +10,7 @@
  *   mappings also opens the drawer.
  * - Clicking Save & Run with a non-workflow agent (code) proceeds normally.
  *
- * @see specs/scenarios/workflow-agent-mapping-gate.feature
+ * @see specs/features/scenarios/workflow-agent-mapping-layer.feature
  */
 import * as React from "react";
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
@@ -326,6 +326,52 @@ describe("<ScenarioFormDrawer /> mapping gate", () => {
             type: "warning",
           }),
         );
+      });
+    });
+
+    /** @scenario Mapping warning links back to the agent editor */
+    it("offers an 'Open agent editor' action that reopens the editor drawer independently of the auto-open", async () => {
+      const user = userEvent.setup();
+      renderWithTarget({ type: "workflow", id: "workflow-agent-1" });
+
+      await user.click(screen.getByTestId("save-and-run-button"));
+
+      await waitFor(() => {
+        expect(mockToasterCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: expect.objectContaining({ label: "Open agent editor" }),
+          }),
+        );
+      });
+
+      // Prove the action handler ALONE reopens the editor: clear the mock so
+      // the earlier auto-open call doesn't count, then invoke onClick. This is
+      // the fallback affordance — functional even if the auto-open raced/was
+      // dismissed.
+      const toastArg = mockToasterCreate.mock.calls.at(-1)?.[0] as {
+        action?: { label: string; onClick: () => void };
+      };
+      mocks.mockOpenDrawer.mockClear();
+      toastArg.action?.onClick();
+
+      expect(mocks.mockOpenDrawer).toHaveBeenCalledWith("agentWorkflowEditor", {
+        urlParams: { agentId: "workflow-agent-1" },
+      });
+    });
+
+    /** @scenario Mapping warning names the missing scenario input field */
+    it("names the missing scenario input fields (input / messages) in the toast description", async () => {
+      const user = userEvent.setup();
+      renderWithTarget({ type: "workflow", id: "workflow-agent-1" });
+
+      await user.click(screen.getByTestId("save-and-run-button"));
+
+      await waitFor(() => {
+        const toastArg = mockToasterCreate.mock.calls.at(-1)?.[0] as {
+          description?: string;
+        };
+        expect(toastArg.description).toMatch(/input/i);
+        expect(toastArg.description).toMatch(/messages/i);
       });
     });
   });

--- a/specs/features/scenarios/workflow-agent-mapping-layer.feature
+++ b/specs/features/scenarios/workflow-agent-mapping-layer.feature
@@ -77,7 +77,7 @@ Feature: Workflow agent input/output mapping layer
     Given a workflow agent selected as the scenario target
     And the agent has no scenario input mapping
     When the user clicks Save & Run
-    Then the warning offers an action that opens the AgentWorkflowEditorDrawer for that agent
+    Then the warning offers an action that opens the agent editor for that agent
     And the action still works if the automatic drawer open was dismissed
 
   @integration

--- a/specs/features/scenarios/workflow-agent-mapping-layer.feature
+++ b/specs/features/scenarios/workflow-agent-mapping-layer.feature
@@ -3,7 +3,7 @@ Feature: Workflow agent input/output mapping layer
   I want workflow agents to have their inputs and outputs mapped to the scenario contract
   So that scenario runs against workflow agents succeed without manual wiring guesswork
 
-  # Parity status: 9 of 13 scenarios bound to existing tests.
+  # Parity status: 11 of 15 scenarios bound to existing tests.
   # The remaining 4 @unimplemented scenarios describe shipped behavior
   # that does not yet have an integration test (#3458):
   #   - "Scenario runs successfully after user configures mappings via drawer"
@@ -71,6 +71,21 @@ Feature: Workflow agent input/output mapping layer
     And the agent has scenarioMappings but none wire a source to scenario "input" or "messages"
     When the user clicks Save & Run
     Then the AgentWorkflowEditorDrawer opens instead of starting the run
+
+  @integration
+  Scenario: Mapping warning links back to the agent editor
+    Given a workflow agent selected as the scenario target
+    And the agent has no scenario input mapping
+    When the user clicks Save & Run
+    Then the warning offers an action that opens the AgentWorkflowEditorDrawer for that agent
+    And the action still works if the automatic drawer open was dismissed
+
+  @integration
+  Scenario: Mapping warning names the missing scenario input field
+    Given a workflow agent selected as the scenario target
+    And the agent has no scenario input mapping
+    When the user clicks Save & Run
+    Then the warning names the scenario input fields to map (input or messages)
 
   @e2e @unimplemented
   Scenario: Scenario runs successfully after user configures mappings via drawer
@@ -149,6 +164,8 @@ Feature: Workflow agent input/output mapping layer
 # AC 1: "Auto-compute mappings on workflow save" → Scenario: Auto-compute does not block the workflow save on failure
 # AC 2: "Mapping drawer gate at Save & Run" → Scenario: Opens mapping drawer when running a scenario with an unmapped workflow agent
 # AC 2: "Mapping drawer gate at Save & Run" → Scenario: Opens mapping drawer when workflow agent has no input-field mapping
+# AC 2: "Mapping drawer gate at Save & Run" → Scenario: Mapping warning links back to the agent editor
+# AC 2: "Mapping drawer gate at Save & Run" → Scenario: Mapping warning names the missing scenario input field
 # AC 2: "Mapping drawer gate at Save & Run" → Scenario: Scenario runs successfully after user configures mappings via drawer
 # AC 3: "Pre-run validation for multi-input workflows" → Scenario: Returns actionable error for multi-input workflow agent without mappings
 # AC 3: "Pre-run validation for multi-input workflows" → Scenario: Allows single-input workflow agent to run without explicit mappings


### PR DESCRIPTION
## Why

Closes #3411

When a user clicks **Save & Run** on a workflow-agent target whose scenario input mapping is missing (`hasScenarioInputMapping(mappings) === false`), the scenario form drawer shows a warning toast and auto-opens the agent workflow editor. The toast itself was **plain text with no link** — so if the auto-open raced, was dismissed, or failed, the user was stuck reading about an editor they had no clickable path back to.

## What changed

- **Clickable CTA (AC1).** The warning toast now carries an **"Open agent editor"** action that opens the agent workflow editor for the target. It is wired independently of the existing auto-open, so it remains functional even if the auto-open was dismissed or failed — a true fallback affordance.
- **Names the missing input (AC2).** The gate fires only when *neither* the scenario `input` field nor `messages` is mapped, so the description now names exactly those fields ("Map at least one scenario input — "input" or "messages" — …"), mirroring the editor's own validation copy. The previous "scenario inputs and outputs" wording was both vaguer and slightly inaccurate — the gate only checks the input half (outputs are validated server-side at run time).
- **No regression (AC3).** The existing `openDrawer("agentWorkflowEditor", …)` auto-open is preserved unchanged; the CTA is purely additive.
- **Spec.** Added two `@integration` scenarios (links-back; names-missing) to the canonical `specs/features/scenarios/workflow-agent-mapping-layer.feature` and bound them to the new tests — and corrected the test's previously-dangling `@see` to point there (no duplicate feature file).

## How it works

The toast object now includes an `action: { label, onClick }` (the same pattern as `MissingModelToast.tsx`; the `Toaster` already renders `Toast.ActionTrigger` for `toast.action`). The `openAgentEditor` closure is shared between the action's `onClick` and the trailing auto-open call, so both routes open the same drawer for `target.id`.

## Test plan

`src/components/scenarios/__tests__/ScenarioFormDrawer.mapping-gate.integration.test.tsx` — **6/6 passing** (4 pre-existing + 2 new):

- **new** — the toast exposes an `Open agent editor` action whose `onClick` opens the editor drawer **independently** of the auto-open. The test clears the `openDrawer` mock *after* the gate fires (dropping the auto-open call), then invokes `action.onClick()` and asserts `openDrawer("agentWorkflowEditor", { urlParams: { agentId } })` — proving the fallback works on its own.
- **new** — the description names both `input` and `messages`.
- pre-existing gate behavior (opens drawer instead of running; warning toast shown; code-agent runs normally) still passes.

`pnpm typecheck` — clean (0 errors).

### Visual proof — real running app

Booted the app, created a workflow-agent scenario target with **no** scenario input mapping, opened the scenario, and clicked **Save and Run**. The real mapping-gate toast fires (and the editor drawer auto-opens behind it):

![real app — mapping-gate toast with Open agent editor CTA](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/iss3411/iss3411-realapp-toast.png)

The toast shows the new copy — *Map at least one scenario input — "input" or "messages" — to an agent input before running this workflow agent.* — and the **Open agent editor** action. The action's `onClick` reopens the editor drawer for the target (`openDrawer("agentWorkflowEditor", { urlParams: { agentId } })`), asserted independently of the auto-open in the integration test above.

Clicking that action in the live app opens the Edit Workflow Agent drawer for the agent (URL `drawer.open=agentWorkflowEditor&drawer.agentId=…`, caught mid-load):

![real app — after clicking the CTA, the agent editor drawer opens](https://raw.githubusercontent.com/langwatch/pr-screenshots/main/iss3411/iss3411-realapp-cta.png)

## Anything surprising?

- The toast deliberately names only the **input** half (`input` / `messages`). The drawer gate only checks `hasScenarioInputMapping`; output mapping is validated server-side at run time, so surfacing it here would be misleading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Open agent editor" action button to the mapping validation warning toast, enabling direct access to the agent editor when required scenario inputs are missing.
  * Enhanced warning message to explicitly show which scenario input fields ("input" or "messages") require mapping.

* **Tests**
  * Added integration tests for mapping validation warning toast behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->