### PR TITLE
chore(clickhouse): persist live 256MiB merge cap on five fat tables

### DIFF
--- a/langwatch/src/server/clickhouse/migrations/00036_persist_merge_max_block_size_bytes.sql
+++ b/langwatch/src/server/clickhouse/migrations/00036_persist_merge_max_block_size_bytes.sql
@@ -1,0 +1,98 @@
+-- +goose Up
+-- +goose ENVSUB ON
+
+-- Persist `merge_max_block_size_bytes = 256 MiB` into per-table DDL.
+--
+-- Background. During the 2026-06-20 fat-row merge OOM incident, this byte
+-- cap was applied as a live `ALTER TABLE ... MODIFY SETTING` to the heavy
+-- tables so background merges bound a block by bytes instead of the
+-- row-denominated default (`merge_max_block_size = 8192`). Live ALTERs
+-- survive until a table is recreated; encoding the value into a migration
+-- makes it durable for fresh deploys (self-hosted, dev, new clusters) and
+-- recreates.
+--
+-- Why this is the only setting the migration touches. The corrected fix
+-- (per the 2026-06-21 cold review of the incident docs) has two levers:
+--   1. Vertical-merge activation gates — already durably set at the server
+--      scope in infrastructure/clickhouse.tf
+--      (`vertical_merge_algorithm_min_rows_to_activate = 1`,
+--       `vertical_merge_algorithm_min_columns_to_activate = 1`).
+--   2. Byte cap on the merge block — this migration.
+-- The earlier draft plan also proposed raising
+-- `min_bytes_for_wide_part` and `vertical_merge_algorithm_min_bytes_to_activate`;
+-- both are wrong for the fat-row regime (they would make vertical LESS
+-- likely, not more) and are deliberately NOT applied.
+--
+-- Scope. The five tables whose rows are large enough for an unbounded
+-- 8192-row merge block to risk OOM:
+--   * stored_spans       — SpanAttributes ~13 KiB avg, 246 KiB max
+--   * trace_summaries    — Attributes-heavy, 238 KiB max row
+--   * evaluation_runs    — Inputs column 7.9 KiB avg / 17.85 MiB max
+--   * event_log          — EventPayload up to 814 KiB
+--   * simulation_runs    — Messages.* arrays up to 842 KiB
+-- Tables deliberately omitted:
+--   * stored_log_records — max row 53 KiB; server default cap protective
+--   * experiment_run_items, stored_metric_records, experiment_runs,
+--     dspy_steps — narrow rows (≤ 1 KiB avg). Their stuck zero-copy
+--     mutations are an independent issue tracked separately.
+--
+-- Idempotency. On prod the five tables already carry this setting from the
+-- live ALTER, so the migration is a no-op there. On any cluster without it
+-- (fresh deploy, recreated table) the migration applies the cap.
+--
+-- Cost. MODIFY SETTING is metadata-only; it does not rewrite existing parts.
+-- `alter_sync = 1, mutations_sync = 0` waits only on the local replica and
+-- never queues behind unrelated mutations.
+--
+-- Slot. 00034 is taken by #5000 (add_query_pruning_indexes — includes inline
+-- MATERIALIZE INDEX on stored_log_records / stored_metric_records). 00035 is
+-- taken by #4854 (add_trace_summary_conversation_id_index — ADD INDEX only,
+-- materialize gated to a runbook). This migration is intentionally cheaper
+-- than #5000 and safe to deploy ahead of the stuck-mutation drain runbook.
+
+-- stored_spans
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_spans
+  MODIFY SETTING merge_max_block_size_bytes = 268435456
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- trace_summaries
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries
+  MODIFY SETTING merge_max_block_size_bytes = 268435456
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- evaluation_runs
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.evaluation_runs
+  MODIFY SETTING merge_max_block_size_bytes = 268435456
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- event_log
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.event_log
+  MODIFY SETTING merge_max_block_size_bytes = 268435456
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- simulation_runs
+-- +goose StatementBegin
+ALTER TABLE ${CLICKHOUSE_DATABASE}.simulation_runs
+  MODIFY SETTING merge_max_block_size_bytes = 268435456
+  SETTINGS alter_sync = 1, mutations_sync = 0;
+-- +goose StatementEnd
+
+-- +goose ENVSUB OFF
+
+-- +goose Down
+-- To roll back, uncomment and run manually:
+-- +goose StatementBegin
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.stored_spans      RESET SETTING merge_max_block_size_bytes;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.trace_summaries   RESET SETTING merge_max_block_size_bytes;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.evaluation_runs   RESET SETTING merge_max_block_size_bytes;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.event_log         RESET SETTING merge_max_block_size_bytes;
+-- ALTER TABLE ${CLICKHOUSE_DATABASE}.simulation_runs   RESET SETTING merge_max_block_size_bytes;
+-- +goose StatementEnd


### PR DESCRIPTION
## Why

The 2026-06-20 fat-row merge OOM incident applied `merge_max_block_size_bytes = 256 MiB` as a live `ALTER TABLE ... MODIFY SETTING` on the five heavy tables so background merges bound a block by bytes instead of the row-denominated default. Live ALTERs survive until a table is recreated. Fresh deploys (self-hosted, dev clusters, recreated tables) don't get the cap, which would put them back into the `merge_max_block_size = 8192` default that caused the incident.

## What changed

Migration `00036_persist_merge_max_block_size_bytes.sql` applies `MODIFY SETTING merge_max_block_size_bytes = 268435456` to:

- `stored_spans`
- `trace_summaries`
- `evaluation_runs`
- `event_log`
- `simulation_runs`

Metadata-only. No-op on prod (the live ALTER already set this); applies the cap on any cluster without it. `alter_sync = 1, mutations_sync = 0` waits on the local replica only and never queues behind unrelated mutations.

## How it works

The fat-row merge OOM is a row-denominated block size (`merge_max_block_size = 8192`) applied to byte-heavy rows. With megabyte rows, an 8192-row block materialises to multi-GB of memory in a single merge, exceeds the per-operation cap, fails with `Code: 241`, and the parts never merge.

The corrected fix has two levers:

1. Lower the vertical-merge activation gates so fat-but-few-rows parts go vertical. Already durable in `infrastructure/clickhouse.tf` (`vertical_merge_algorithm_min_rows_to_activate = 1`, `vertical_merge_algorithm_min_columns_to_activate = 1`).
2. Cap the merge block by bytes as a backstop. This migration.

The earlier draft plan also proposed raising `min_bytes_for_wide_part` and `vertical_merge_algorithm_min_bytes_to_activate`. Both are backwards for the fat-row regime (they make vertical LESS likely, not more), so deliberately not applied.

## Test plan

- [ ] Goose runs the migration cleanly on a fresh ClickHouse (docker-compose).
- [ ] `SHOW CREATE TABLE langwatch.<table>` on each of the five tables shows `merge_max_block_size_bytes = 268435456` in the SETTINGS clause after the migration.
- [ ] Against a prod-shaped clone the migration is a no-op (effective setting unchanged on the five tables).

## Anything surprising?

- **Slot 00036, not 00034.** PR #5000 takes 00034 (\`add_query_pruning_indexes\`), PR #4854 takes 00035 (\`add_trace_summary_conversation_id_index\`).
- **Four other tables also have stuck zero-copy mutations** (\`experiment_run_items\`, \`stored_metric_records\`, \`experiment_runs\`, \`dspy_steps\`) but their avg row sizes are sub-KiB - narrow tables, not fat. Applying the byte cap there would be a no-op. Their stuck mutations are the independent zero-copy lock-leak class, tracked separately.
- **\`stored_log_records\` deliberately omitted.** Max row 53 KiB; the server default cap is already protective.
- **Deployment-order risk on #5000.** That PR bundles \`MATERIALIZE INDEX\` against \`stored_metric_records\` inline. \`stored_metric_records\` is currently in the stuck zero-copy queue (3 entries × 1,764 retries). If #5000 ships while the queue is stuck, the materialise joins that backlog. Recommend draining the queue before #5000 lands, or splitting the materialise out into a runbook like #4854 does. This PR is safe to deploy ahead of the drain because it touches no mutations.

https://claude.ai/code/session_01Ey1sy6kKJSEYJVZzqUTaeL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration settings to enhance system performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->