### PR TITLE
perf(clickhouse): add time predicate to span/event filter subqueries

### DIFF
--- a/langwatch/src/server/filters/__tests__/filter-conditions.integration.test.ts
+++ b/langwatch/src/server/filters/__tests__/filter-conditions.integration.test.ts
@@ -1,13 +1,13 @@
+import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { FilterParam } from "~/hooks/useFilterParams";
 import {
-  getTestClickHouseClient,
   cleanupTestData,
+  getTestClickHouseClient,
 } from "../../event-sourcing/__tests__/integration/testContainers";
 import { generateClickHouseFilterConditions } from "../clickhouse/filter-conditions";
 import type { FilterField } from "../types";
-import type { FilterParam } from "~/hooks/useFilterParams";
-import type { ClickHouseClient } from "@clickhouse/client";
 
 const tenantId = `test-filter-${nanoid()}`;
 // Traces with all three legacy key formats for metadata
@@ -67,6 +67,7 @@ async function insertStoredSpan(
   ch: ClickHouseClient,
   traceId: string,
   spanType: string,
+  startTimeMs: number = now,
 ) {
   await ch.insert({
     table: "stored_spans",
@@ -80,8 +81,8 @@ async function insertStoredSpan(
         ParentTraceId: null,
         ParentIsRemote: null,
         Sampled: 1,
-        StartTime: new Date(now),
-        EndTime: new Date(now + 100),
+        StartTime: new Date(startTimeMs),
+        EndTime: new Date(startTimeMs + 100),
         DurationMs: 100,
         SpanName: "test-span",
         SpanKind: 1,
@@ -102,8 +103,12 @@ async function insertStoredSpan(
 async function queryWithFilters(
   ch: ClickHouseClient,
   filters: Partial<Record<FilterField, FilterParam>>,
+  timeWindow?: { startDate: number; endDate: number },
 ): Promise<string[]> {
-  const { conditions, params } = generateClickHouseFilterConditions(filters);
+  const { conditions, params } = generateClickHouseFilterConditions(
+    filters,
+    timeWindow,
+  );
   const whereClause =
     conditions.length > 0 ? `AND ${conditions.join(" AND ")}` : "";
 
@@ -233,6 +238,40 @@ describe("filter-conditions ClickHouse integration", () => {
       expect(traceIds).toContain(traceCanonical);
       expect(traceIds).toContain(traceLwPrefix);
       expect(traceIds).not.toContain(traceNoMeta);
+    });
+  });
+
+  describe("when filtering by spans.type with a time window", () => {
+    const DAY = 24 * 60 * 60 * 1000;
+    const oldTraceId = `trace-old-${nanoid()}`;
+
+    beforeAll(async () => {
+      // A trace whose matching span sits ~60 days in the past. The span window
+      // (now +/- 2 days) must prune it out, while an unbounded query finds it.
+      // Deliberately no `canary` metadata so it cannot pollute the canary-based
+      // intersection tests that run after this block's beforeAll.
+      await insertTraceSummary(ch, oldTraceId, {
+        "langwatch.user_id": "user-old",
+      });
+      await insertStoredSpan(ch, oldTraceId, "llm", now - 60 * DAY);
+    });
+
+    it("still returns in-window matches when bounded", async () => {
+      const traceIds = await queryWithFilters(
+        ch,
+        { "spans.type": ["llm"] },
+        { startDate: now - DAY, endDate: now + DAY },
+      );
+      // traceCanonical's span is at `now`, comfortably inside the window.
+      expect(traceIds).toContain(traceCanonical);
+      // The 60-day-old span is outside the buffered window -> pruned out.
+      expect(traceIds).not.toContain(oldTraceId);
+    });
+
+    it("finds the old match when no window is given (backwards compat)", async () => {
+      const traceIds = await queryWithFilters(ch, { "spans.type": ["llm"] });
+      expect(traceIds).toContain(traceCanonical);
+      expect(traceIds).toContain(oldTraceId);
     });
   });
 

--- a/langwatch/src/server/filters/__tests__/filter-conditions.test.ts
+++ b/langwatch/src/server/filters/__tests__/filter-conditions.test.ts
@@ -580,13 +580,16 @@ describe("generateClickHouseFilterConditions", () => {
       expect(result.params).not.toHaveProperty("spanWindowStart");
     });
 
-    it("does not add span-window params when the filter set has no span probe", () => {
+    it("does not inject StartTime SQL when the filter set has no span probe", () => {
       const result = generateClickHouseFilterConditions(
         { "topics.topics": ["t1"] },
         { startDate: 10 * DAY, endDate: 20 * DAY },
       );
-      // The params are emitted (harmless, unreferenced) but no StartTime SQL.
+      // The span-window params are still emitted when a window is passed (they
+      // are harmless and unreferenced here), but no filter probes stored_spans,
+      // so no StartTime predicate is injected.
       expect(result.conditions[0]).not.toContain("sp.StartTime");
+      expect(result.params).toHaveProperty("spanWindowStart");
     });
   });
 });

--- a/langwatch/src/server/filters/__tests__/filter-conditions.test.ts
+++ b/langwatch/src/server/filters/__tests__/filter-conditions.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { FilterParam } from "~/hooks/useFilterParams";
-import type { FilterField } from "../types";
 import {
   clickHouseFilterConditions,
   generateClickHouseFilterConditions,
 } from "../clickhouse/filter-conditions";
+import type { FilterField } from "../types";
 
 describe("clickHouseFilterConditions", () => {
   describe("topics.topics", () => {
@@ -85,7 +85,7 @@ describe("clickHouseFilterConditions", () => {
       const builder = clickHouseFilterConditions["metadata.user_id"];
       const result = builder!(["user1"], "f0");
       expect(result.sql).toBe(
-        "ts.Attributes['langwatch.user_id'] IN ({f0_values:Array(String)})"
+        "ts.Attributes['langwatch.user_id'] IN ({f0_values:Array(String)})",
       );
     });
 
@@ -93,7 +93,7 @@ describe("clickHouseFilterConditions", () => {
       const builder = clickHouseFilterConditions["metadata.thread_id"];
       const result = builder!(["thread1"], "f0");
       expect(result.sql).toBe(
-        "ts.Attributes['gen_ai.conversation.id'] IN ({f0_values:Array(String)})"
+        "ts.Attributes['gen_ai.conversation.id'] IN ({f0_values:Array(String)})",
       );
     });
 
@@ -101,7 +101,7 @@ describe("clickHouseFilterConditions", () => {
       const builder = clickHouseFilterConditions["metadata.customer_id"];
       const result = builder!(["cust1"], "f0");
       expect(result.sql).toBe(
-        "ts.Attributes['langwatch.customer_id'] IN ({f0_values:Array(String)})"
+        "ts.Attributes['langwatch.customer_id'] IN ({f0_values:Array(String)})",
       );
     });
   });
@@ -125,14 +125,23 @@ describe("clickHouseFilterConditions", () => {
       const builder = clickHouseFilterConditions["metadata.key"];
       const result = builder!(["canary", "environment"], "f0");
       expect(result.sql).toContain(" OR ");
-      expect(result.params).toHaveProperty("f0_k0_canonical", "metadata.canary");
-      expect(result.params).toHaveProperty("f0_k1_canonical", "metadata.environment");
+      expect(result.params).toHaveProperty(
+        "f0_k0_canonical",
+        "metadata.canary",
+      );
+      expect(result.params).toHaveProperty(
+        "f0_k1_canonical",
+        "metadata.environment",
+      );
     });
 
     it("converts dot-encoded keys back to dots", () => {
       const builder = clickHouseFilterConditions["metadata.key"];
       const result = builder!(["nested·key"], "f0");
-      expect(result.params).toHaveProperty("f0_k0_canonical", "metadata.nested.key");
+      expect(result.params).toHaveProperty(
+        "f0_k0_canonical",
+        "metadata.nested.key",
+      );
       expect(result.params).toHaveProperty("f0_k0_bare", "nested.key");
     });
 
@@ -168,7 +177,10 @@ describe("clickHouseFilterConditions", () => {
     it("converts dot-encoded keys back to dots", () => {
       const builder = clickHouseFilterConditions["metadata.value"];
       const result = builder!(["val"], "f0", "nested·key");
-      expect(result.params).toHaveProperty("f0_canonical", "metadata.nested.key");
+      expect(result.params).toHaveProperty(
+        "f0_canonical",
+        "metadata.nested.key",
+      );
       expect(result.params).toHaveProperty("f0_bare", "nested.key");
     });
   });
@@ -183,21 +195,43 @@ describe("clickHouseFilterConditions", () => {
       expect(result.sql).toContain("sp.SpanAttributes['langwatch.span.type']");
       expect(result.params).toEqual({ f0_values: ["llm", "tool"] });
     });
+
+    it("does not bound StartTime when no spanTimeBound option is given", () => {
+      const builder = clickHouseFilterConditions["spans.type"];
+      const result = builder!(["llm"], "f0");
+      expect(result.sql).not.toContain("sp.StartTime");
+    });
+
+    it("injects the spanTimeBound fragment when provided", () => {
+      const builder = clickHouseFilterConditions["spans.type"];
+      const bound =
+        " AND sp.StartTime >= fromUnixTimestamp64Milli({spanWindowStart:UInt64}) AND sp.StartTime <= fromUnixTimestamp64Milli({spanWindowEnd:UInt64})";
+      const result = builder!(["llm"], "f0", undefined, undefined, {
+        spanTimeBound: bound,
+      });
+      expect(result.sql).toContain("sp.StartTime >=");
+      expect(result.sql).toContain("spanWindowStart");
+      expect(result.sql).toContain("spanWindowEnd");
+    });
   });
 
   describe("evaluations.evaluator_id.has_passed", () => {
     it("generates EXISTS subquery filtering on Passed IS NOT NULL", () => {
-      const builder = clickHouseFilterConditions["evaluations.evaluator_id.has_passed"];
+      const builder =
+        clickHouseFilterConditions["evaluations.evaluator_id.has_passed"];
       expect(builder).not.toBeNull();
       const result = builder!(["eval-1", "eval-2"], "f0");
       expect(result.sql).toContain("EXISTS (");
-      expect(result.sql).toContain("es.EvaluatorId IN ({f0_values:Array(String)})");
+      expect(result.sql).toContain(
+        "es.EvaluatorId IN ({f0_values:Array(String)})",
+      );
       expect(result.sql).toContain("es.Passed IS NOT NULL");
       expect(result.params).toEqual({ f0_values: ["eval-1", "eval-2"] });
     });
 
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
-      const builder = clickHouseFilterConditions["evaluations.evaluator_id.has_passed"];
+      const builder =
+        clickHouseFilterConditions["evaluations.evaluator_id.has_passed"];
       const result = builder!(["eval-1"], "f0");
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
@@ -207,17 +241,21 @@ describe("clickHouseFilterConditions", () => {
 
   describe("evaluations.evaluator_id.has_score", () => {
     it("generates EXISTS subquery filtering on Score IS NOT NULL", () => {
-      const builder = clickHouseFilterConditions["evaluations.evaluator_id.has_score"];
+      const builder =
+        clickHouseFilterConditions["evaluations.evaluator_id.has_score"];
       expect(builder).not.toBeNull();
       const result = builder!(["eval-1"], "f0");
       expect(result.sql).toContain("EXISTS (");
-      expect(result.sql).toContain("es.EvaluatorId IN ({f0_values:Array(String)})");
+      expect(result.sql).toContain(
+        "es.EvaluatorId IN ({f0_values:Array(String)})",
+      );
       expect(result.sql).toContain("es.Score IS NOT NULL");
       expect(result.params).toEqual({ f0_values: ["eval-1"] });
     });
 
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
-      const builder = clickHouseFilterConditions["evaluations.evaluator_id.has_score"];
+      const builder =
+        clickHouseFilterConditions["evaluations.evaluator_id.has_score"];
       const result = builder!(["eval-1"], "f0");
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
@@ -227,11 +265,14 @@ describe("clickHouseFilterConditions", () => {
 
   describe("evaluations.evaluator_id.has_label", () => {
     it("generates EXISTS subquery filtering on Label IS NOT NULL and excludes succeeded/failed", () => {
-      const builder = clickHouseFilterConditions["evaluations.evaluator_id.has_label"];
+      const builder =
+        clickHouseFilterConditions["evaluations.evaluator_id.has_label"];
       expect(builder).not.toBeNull();
       const result = builder!(["eval-1"], "f0");
       expect(result.sql).toContain("EXISTS (");
-      expect(result.sql).toContain("es.EvaluatorId IN ({f0_values:Array(String)})");
+      expect(result.sql).toContain(
+        "es.EvaluatorId IN ({f0_values:Array(String)})",
+      );
       expect(result.sql).toContain("es.Label IS NOT NULL");
       expect(result.sql).toContain("es.Label != ''");
       expect(result.sql).toContain("es.Label NOT IN ('succeeded', 'failed')");
@@ -239,7 +280,8 @@ describe("clickHouseFilterConditions", () => {
     });
 
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
-      const builder = clickHouseFilterConditions["evaluations.evaluator_id.has_label"];
+      const builder =
+        clickHouseFilterConditions["evaluations.evaluator_id.has_label"];
       const result = builder!(["eval-1"], "f0");
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
@@ -249,7 +291,8 @@ describe("clickHouseFilterConditions", () => {
 
   describe("evaluations.evaluator_id.guardrails_only", () => {
     it("uses assumeNotNull for Nullable TraceId correlation (#3000)", () => {
-      const builder = clickHouseFilterConditions["evaluations.evaluator_id.guardrails_only"];
+      const builder =
+        clickHouseFilterConditions["evaluations.evaluator_id.guardrails_only"];
       const result = builder!(["eval-1"], "f0");
       expect(result.sql).toContain("es.TraceId IS NOT NULL");
       expect(result.sql).toContain("assumeNotNull(es.TraceId) = ts.TraceId");
@@ -445,7 +488,10 @@ describe("generateClickHouseFilterConditions", () => {
 
       expect(result.conditions.length).toBe(1);
       expect(result.params).toHaveProperty("f0_key", "purchase");
-      expect(result.params).toHaveProperty("f0_attrkey", "event.metrics.amount");
+      expect(result.params).toHaveProperty(
+        "f0_attrkey",
+        "event.metrics.amount",
+      );
       expect(result.params).toHaveProperty("f0_min");
       expect(result.params).toHaveProperty("f0_max");
     });
@@ -482,6 +528,65 @@ describe("generateClickHouseFilterConditions", () => {
       expect(result.conditions.length).toBe(1);
       // Single condition should not have extra OR wrapping
       expect(result.conditions[0]).not.toContain(" OR ");
+    });
+  });
+
+  describe("stored_spans partition pruning via time window", () => {
+    const DAY = 24 * 60 * 60 * 1000;
+
+    it("bounds the span EXISTS subquery to the buffered window", () => {
+      const filters: Partial<Record<FilterField, FilterParam>> = {
+        "spans.type": ["llm"],
+      };
+      const startDate = 10 * DAY;
+      const endDate = 20 * DAY;
+      const result = generateClickHouseFilterConditions(filters, {
+        startDate,
+        endDate,
+      });
+
+      expect(result.conditions[0]).toContain("sp.StartTime >=");
+      expect(result.conditions[0]).toContain("sp.StartTime <=");
+      // +/- 2 day buffer around the dashboard window.
+      expect(result.params).toHaveProperty(
+        "spanWindowStart",
+        startDate - 2 * DAY,
+      );
+      expect(result.params).toHaveProperty("spanWindowEnd", endDate + 2 * DAY);
+    });
+
+    it("clamps the lower bound at zero", () => {
+      const result = generateClickHouseFilterConditions(
+        { "spans.type": ["llm"] },
+        { startDate: 0, endDate: 5 * DAY },
+      );
+      expect(result.params).toHaveProperty("spanWindowStart", 0);
+    });
+
+    it("also bounds event.* filters that probe stored_spans", () => {
+      const result = generateClickHouseFilterConditions(
+        { "events.event_type": ["thumbs_up"] },
+        { startDate: 10 * DAY, endDate: 20 * DAY },
+      );
+      expect(result.conditions[0]).toContain("stored_spans sp");
+      expect(result.conditions[0]).toContain("sp.StartTime >=");
+    });
+
+    it("leaves queries unbounded when no window is passed (backwards compat)", () => {
+      const result = generateClickHouseFilterConditions({
+        "spans.type": ["llm"],
+      });
+      expect(result.conditions[0]).not.toContain("sp.StartTime");
+      expect(result.params).not.toHaveProperty("spanWindowStart");
+    });
+
+    it("does not add span-window params when the filter set has no span probe", () => {
+      const result = generateClickHouseFilterConditions(
+        { "topics.topics": ["t1"] },
+        { startDate: 10 * DAY, endDate: 20 * DAY },
+      );
+      // The params are emitted (harmless, unreferenced) but no StartTime SQL.
+      expect(result.conditions[0]).not.toContain("sp.StartTime");
     });
   });
 });

--- a/langwatch/src/server/filters/clickhouse/filter-conditions.ts
+++ b/langwatch/src/server/filters/clickhouse/filter-conditions.ts
@@ -2,6 +2,7 @@ import type { FilterParam } from "~/hooks/useFilterParams";
 import type { FilterField } from "../types";
 import type {
   FilterConditionBuilder,
+  FilterConditionOptions,
   FilterConditionResult,
   GenerateFilterConditionsResult,
 } from "./types";
@@ -87,7 +88,10 @@ export const clickHouseFilterConditions: Record<
       params[`${paramId}_k${i}_bare`] = rawKey;
     });
     return {
-      sql: conditions.length === 1 ? conditions[0]! : `(${conditions.join(" OR ")})`,
+      sql:
+        conditions.length === 1
+          ? conditions[0]!
+          : `(${conditions.join(" OR ")})`,
       params,
     };
   },
@@ -141,11 +145,11 @@ export const clickHouseFilterConditions: Record<
   }),
 
   // Spans
-  "spans.type": (values, paramId) => ({
+  "spans.type": (values, paramId, _key, _subkey, options) => ({
     sql: `EXISTS (
       SELECT 1 FROM stored_spans sp
       WHERE sp.TenantId = ts.TenantId
-        AND sp.TraceId = ts.TraceId
+        AND sp.TraceId = ts.TraceId${options?.spanTimeBound ?? ""}
         AND sp.SpanAttributes['langwatch.span.type'] IN ({${paramId}_values:Array(String)})
     )`,
     params: { [`${paramId}_values`]: values },
@@ -161,7 +165,11 @@ export const clickHouseFilterConditions: Record<
     const hasFalse = values.includes("false");
     if (hasTrue && hasFalse) return { sql: "1=1", params: {} };
     if (hasTrue) return { sql: "ts.HasAnnotation = true", params: {} };
-    if (hasFalse) return { sql: "(ts.HasAnnotation = false OR ts.HasAnnotation IS NULL)", params: {} };
+    if (hasFalse)
+      return {
+        sql: "(ts.HasAnnotation = false OR ts.HasAnnotation IS NULL)",
+        params: {},
+      };
     return { sql: "1=0", params: {} };
   },
 
@@ -269,17 +277,17 @@ export const clickHouseFilterConditions: Record<
   },
 
   // Events - using stored_spans table with span attributes
-  "events.event_type": (values, paramId) => ({
+  "events.event_type": (values, paramId, _key, _subkey, options) => ({
     sql: `EXISTS (
       SELECT 1 FROM stored_spans sp
       WHERE sp.TenantId = ts.TenantId
-        AND sp.TraceId = ts.TraceId
+        AND sp.TraceId = ts.TraceId${options?.spanTimeBound ?? ""}
         AND sp.SpanAttributes['event.type'] IN ({${paramId}_values:Array(String)})
     )`,
     params: { [`${paramId}_values`]: values },
   }),
 
-  "events.metrics.key": (values, paramId, key) => {
+  "events.metrics.key": (values, paramId, key, _subkey, options) => {
     if (!key) return { sql: "1=0", params: {} };
     // Build OR conditions for each metric key - these are attribute names, not values
     // Since attribute names are controlled internally, we use them directly
@@ -296,7 +304,7 @@ export const clickHouseFilterConditions: Record<
       sql: `EXISTS (
         SELECT 1 FROM stored_spans sp
         WHERE sp.TenantId = ts.TenantId
-          AND sp.TraceId = ts.TraceId
+          AND sp.TraceId = ts.TraceId${options?.spanTimeBound ?? ""}
           AND sp.SpanAttributes['event.type'] = {${paramId}_key:String}
           AND (${metricConditions.join(" OR ")})
       )`,
@@ -304,7 +312,7 @@ export const clickHouseFilterConditions: Record<
     };
   },
 
-  "events.metrics.value": (values, paramId, key, subkey) => {
+  "events.metrics.value": (values, paramId, key, subkey, options) => {
     if (!key || !subkey || values.length < 2) return { sql: "1=0", params: {} };
     const minValue = parseFloat(values[0] ?? "");
     const maxValue = parseFloat(values[1] ?? "");
@@ -319,7 +327,7 @@ export const clickHouseFilterConditions: Record<
       sql: `EXISTS (
         SELECT 1 FROM stored_spans sp
         WHERE sp.TenantId = ts.TenantId
-          AND sp.TraceId = ts.TraceId
+          AND sp.TraceId = ts.TraceId${options?.spanTimeBound ?? ""}
           AND sp.SpanAttributes['event.type'] = {${paramId}_key:String}
           AND toFloat64OrNull(sp.SpanAttributes[{${paramId}_attrkey:String}]) >= {${paramId}_min:Float64}
           AND toFloat64OrNull(sp.SpanAttributes[{${paramId}_attrkey:String}]) <= {${paramId}_max:Float64}
@@ -333,7 +341,7 @@ export const clickHouseFilterConditions: Record<
     };
   },
 
-  "events.event_details.key": (values, paramId, key) => {
+  "events.event_details.key": (values, paramId, key, _subkey, options) => {
     if (!key) return { sql: "1=0", params: {} };
     // Build OR conditions for each detail key
     const detailConditions = values.map(
@@ -349,7 +357,7 @@ export const clickHouseFilterConditions: Record<
       sql: `EXISTS (
         SELECT 1 FROM stored_spans sp
         WHERE sp.TenantId = ts.TenantId
-          AND sp.TraceId = ts.TraceId
+          AND sp.TraceId = ts.TraceId${options?.spanTimeBound ?? ""}
           AND sp.SpanAttributes['event.type'] = {${paramId}_key:String}
           AND (${detailConditions.join(" OR ")})
       )`,
@@ -375,6 +383,7 @@ function collectClickHouseConditions(
   keys: string[],
   paramCounter: { value: number },
   allParams: Record<string, unknown>,
+  options: FilterConditionOptions,
 ): { conditions: string[]; hasUnsupported: boolean } {
   const key = keys[0];
   const subkey = keys[1];
@@ -391,7 +400,7 @@ function collectClickHouseConditions(
     }
 
     const paramId = `f${paramCounter.value++}`;
-    const result = conditionBuilder(params, paramId, key, subkey);
+    const result = conditionBuilder(params, paramId, key, subkey, options);
     Object.assign(allParams, result.params);
 
     return { conditions: [result.sql], hasUnsupported: false };
@@ -409,6 +418,7 @@ function collectClickHouseConditions(
         [...keys, nextKey], // Accumulate keys as we recurse
         paramCounter,
         allParams,
+        options,
       );
 
       if (result.hasUnsupported) hasUnsupported = true;
@@ -434,19 +444,66 @@ function collectClickHouseConditions(
 }
 
 /**
+ * Spans of a trace start around the trace's `OccurredAt`, but a long-running
+ * trace can have spans a little outside the dashboard window. Widen the
+ * `stored_spans` partition window by this buffer so a matching span near a
+ * window edge is never pruned away. Matches the +/- 2 day margin used by the
+ * trace-fetch `withPartitionHint` helper. Partitions are weekly, so the buffer
+ * costs at most one extra week of partitions while still pruning the cold tail.
+ */
+const SPAN_WINDOW_BUFFER_MS = 2 * 24 * 60 * 60 * 1000;
+
+/**
+ * Build the SQL fragment + params that bound `sp.StartTime` to the dashboard
+ * window (buffered). Returned `sql` is empty when no usable window is given, so
+ * callers without a time range keep the previous unbounded behaviour.
+ */
+function buildSpanTimeBound(timeWindow?: {
+  startDate?: number;
+  endDate?: number;
+}): { sql: string; params: Record<string, unknown> } {
+  if (
+    !timeWindow ||
+    typeof timeWindow.startDate !== "number" ||
+    typeof timeWindow.endDate !== "number"
+  ) {
+    return { sql: "", params: {} };
+  }
+  return {
+    sql: " AND sp.StartTime >= fromUnixTimestamp64Milli({spanWindowStart:UInt64}) AND sp.StartTime <= fromUnixTimestamp64Milli({spanWindowEnd:UInt64})",
+    params: {
+      spanWindowStart: Math.max(
+        0,
+        timeWindow.startDate - SPAN_WINDOW_BUFFER_MS,
+      ),
+      spanWindowEnd: timeWindow.endDate + SPAN_WINDOW_BUFFER_MS,
+    },
+  };
+}
+
+/**
  * Generate ClickHouse WHERE conditions from filter parameters.
  * Returns SQL condition strings and aggregated parameters for parameterized queries.
  *
  * @param filters - The filter parameters from the request
+ * @param timeWindow - Optional dashboard time window. When provided, span/event
+ *   filters that probe `stored_spans` via an EXISTS subquery are bounded to this
+ *   window so they prune partitions instead of cold-scanning every weekly
+ *   partition (including S3-tiered ones).
  * @returns Object with conditions array, aggregated params, and unsupported filter flag
  */
 export function generateClickHouseFilterConditions(
   filters: Partial<Record<FilterField, FilterParam>>,
+  timeWindow?: { startDate?: number; endDate?: number },
 ): GenerateFilterConditionsResult {
   const conditions: string[] = [];
   const allParams: Record<string, unknown> = {};
   const paramCounter = { value: 0 };
   let hasUnsupportedFilters = false;
+
+  const spanBound = buildSpanTimeBound(timeWindow);
+  const options: FilterConditionOptions = { spanTimeBound: spanBound.sql };
+  Object.assign(allParams, spanBound.params);
 
   for (const [field, filterParams] of Object.entries(filters)) {
     if (
@@ -475,6 +532,7 @@ export function generateClickHouseFilterConditions(
       [], // Start with empty keys array
       paramCounter,
       allParams,
+      options,
     );
 
     if (result.hasUnsupported) hasUnsupportedFilters = true;

--- a/langwatch/src/server/filters/clickhouse/types.ts
+++ b/langwatch/src/server/filters/clickhouse/types.ts
@@ -67,7 +67,21 @@ export type FilterConditionBuilder = (
   paramId: string,
   key?: string,
   subkey?: string,
+  options?: FilterConditionOptions,
 ) => FilterConditionResult;
+
+/**
+ * Cross-cutting options threaded to every condition builder.
+ */
+export type FilterConditionOptions = {
+  /**
+   * Pre-built SQL fragment bounding `sp.StartTime` to the dashboard time window,
+   * injected into `stored_spans` EXISTS subqueries so they prune partitions
+   * instead of cold-scanning every weekly partition (including S3-tiered ones).
+   * Empty string when no time window is available.
+   */
+  spanTimeBound?: string;
+};
 
 /**
  * Result of generating filter conditions from filter parameters.

--- a/langwatch/src/server/traces/clickhouse-trace.service.ts
+++ b/langwatch/src/server/traces/clickhouse-trace.service.ts
@@ -729,12 +729,18 @@ export class ClickHouseTraceService {
             this.logger.debug("No scrollId provided in request");
           }
 
-          // Generate filter conditions from input.filters
+          // Generate filter conditions from input.filters. Pass the dashboard
+          // time window so span/event filters bound their stored_spans EXISTS
+          // subqueries to the same window the outer trace_summaries query uses,
+          // pruning partitions instead of cold-scanning the S3-tiered tail.
           const {
             conditions: filterConditions,
             params: filterParams,
             hasUnsupportedFilters,
-          } = generateClickHouseFilterConditions(input.filters ?? {});
+          } = generateClickHouseFilterConditions(input.filters ?? {}, {
+            startDate: input.startDate,
+            endDate: input.endDate,
+          });
 
           if (hasUnsupportedFilters) {
             throw new Error(


### PR DESCRIPTION
## Evidence

24h prod CloudWatch sweep (read-only). The single largest ClickHouse read-bytes consumer this run was the trace-list filtered page (count + id queries) when a span- or event-level filter is active. Two query shapes, ~10 calls each in 24h, each reading **~35 GB** at **12 to 18 s** p95, both flagged `coldScan:true` on `stored_spans`. Lighter single-filter variants read ~3 GB each. Values redacted; no tenant data reproduced here.

These are the `getAllTracesForProject` -> `fetchTracesWithPagination` count/id queries. The outer scan over `trace_summaries` is already bounded on `OccurredAt`, but the span/event filters inject a correlated subquery over `stored_spans` that was **not** time-bounded.

## Suspected cause

`generateClickHouseFilterConditions` (in `filters/clickhouse/filter-conditions.ts`) builds these span/event filters as:

```sql
EXISTS (
  SELECT 1 FROM stored_spans sp
  WHERE sp.TenantId = ts.TenantId
    AND sp.TraceId = ts.TraceId
    AND sp.SpanAttributes['...'] IN (...)
)
```

With no predicate on `sp.StartTime` (the `PARTITION BY toYearWeek(StartTime)` column), the subquery walks **every** weekly partition of `stored_spans`, including cold S3-tiered ones, for each candidate trace. That is the cold scan, and it dominates both latency and S3 GET cost for any filtered trace list. Affected filters: `spans.type`, `events.event_type`, `events.metrics.key`, `events.metrics.value`, `events.event_details.key`.

## Proposed fix

Thread the dashboard time window into `generateClickHouseFilterConditions(filters, timeWindow?)`. When provided, the `stored_spans` EXISTS subqueries get:

```sql
AND sp.StartTime >= fromUnixTimestamp64Milli({spanWindowStart:UInt64})
AND sp.StartTime <= fromUnixTimestamp64Milli({spanWindowEnd:UInt64})
```

bounded to the same window the outer `trace_summaries` query already uses, widened by a **+/- 2 day buffer**. Spans start around their trace's `OccurredAt` and partitions are weekly, so the buffer (matching the existing `withPartitionHint` margin) guarantees a near-edge match is never pruned. The bound is emitted only when a window is passed and uses dedicated params, so existing callers are byte-for-byte unchanged.

Wired at the `getAllTracesForProject` call site, where `startDate`/`endDate` are already in scope. Scoped to `stored_spans`; the analogous `evaluation_runs` EXISTS subqueries (a smaller, non-cold-scan-tracked table) are a possible follow-up.

## Expected impact

- `stored_spans` partitions pruned to the query window; the cold S3 partition walk is eliminated for filtered trace lists.
- Read bytes per filtered page drop from tens of GB to the window's worth of spans; latency follows.
- No change to results: the buffered window is a superset of the matching spans.

## EXPLAIN check

`EXPLAIN INDEXES` on a real large tenant, 7-day window, `spans.type IN ('llm')`. Redacted (no tenant literals in output below).

**Before (unbounded EXISTS) - `stored_spans`:**
```
ReadFromMergeTree (langwatch.stored_spans)
  Parts: 250/250
  Granules: 130165/130165
```

**After (StartTime-bounded EXISTS) - `stored_spans`:**
```
ReadFromMergeTree (langwatch.stored_spans)
  Parts: 37/252
  Granules: 5117/130167
```

`trace_summaries` is unchanged (already `OccurredAt`-bounded). Net: `stored_spans` goes from a full-table partition walk to ~15% of parts / ~4% of granules. The reviewer should re-run before merge.

## Test plan

- Unit (`filter-conditions.test.ts`): new cases assert the `StartTime` bound + buffered `spanWindowStart`/`spanWindowEnd` params are emitted for span/event filters when a window is passed, the lower bound clamps at 0, and queries stay unbounded (backwards-compatible) when no window is given. 57 pass.
- Integration (`filter-conditions.integration.test.ts`, real ClickHouse via testcontainers): a `spans.type` filter with a window still returns an in-window match, and a trace whose matching span sits ~60 days outside the buffered window is correctly pruned out; without a window the old match is still found. 14 pass.
- `typecheck` clean, `biome` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional dashboard time-window bounding for ClickHouse span filter generation, improving partition pruning for `stored_spans`-based queries. When no window is provided, queries remain unbounded for backward compatibility.

* **Tests**
  * Expanded integration and SQL generation tests to validate time-windowed querying (including buffered window behavior) and ensure default/un-windowed and non-`stored_spans` cases keep expected SQL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->