### PR TITLE
perf(clickhouse): prune new-trace-count subquery to the poll window

### DIFF
--- a/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/__tests__/trace-list.clickhouse.repository.integration.test.ts
@@ -10,13 +10,15 @@
  * seeds far more traces than one page and asserts both correctness and a real
  * peak-memory reduction versus the naive single-scan form.
  */
+
+import type { ClickHouseClient } from "@clickhouse/client";
 import { nanoid } from "nanoid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { ClickHouseClient } from "@clickhouse/client";
 import {
   startTestContainers,
   stopTestContainers,
 } from "../../../../event-sourcing/__tests__/integration/testContainers";
+import { boundedSubquery } from "../../filter-to-clickhouse/subqueries";
 import { TraceListClickHouseRepository } from "../trace-list.clickhouse.repository";
 import type { TraceListQuery } from "../trace-list.repository";
 
@@ -35,7 +37,10 @@ function traceIdFor(i: number): string {
   return `tr-${String(i).padStart(4, "0")}`;
 }
 
-function makeTraceSummaryRow(i: number, overrides: Record<string, unknown> = {}) {
+function makeTraceSummaryRow(
+  i: number,
+  overrides: Record<string, unknown> = {},
+) {
   return {
     ProjectionId: `proj-${nanoid()}`,
     TenantId: tenantId,
@@ -74,6 +79,43 @@ function makeTraceSummaryRow(i: number, overrides: Record<string, unknown> = {})
     SubTopicId: null,
     ...overrides,
   };
+}
+
+async function insertSpanRow(opts: {
+  tenantId: string;
+  traceId: string;
+  spanType: string;
+  startTimeMs: number;
+}) {
+  await ch.insert({
+    table: "stored_spans",
+    values: [
+      {
+        ProjectionId: `proj-${nanoid()}`,
+        TenantId: opts.tenantId,
+        TraceId: opts.traceId,
+        SpanId: `span-${nanoid()}`,
+        ParentSpanId: null,
+        ParentTraceId: null,
+        ParentIsRemote: null,
+        Sampled: 1,
+        StartTime: new Date(opts.startTimeMs),
+        EndTime: new Date(opts.startTimeMs + 100),
+        DurationMs: 100,
+        SpanName: "s",
+        SpanKind: 1,
+        ServiceName: "t",
+        ResourceAttributes: {},
+        SpanAttributes: { "langwatch.span.type": opts.spanType },
+        StatusCode: 1,
+        StatusMessage: "",
+        EventCount: 0,
+        LinkCount: 0,
+      },
+    ],
+    format: "JSONEachRow",
+    clickhouse_settings: { async_insert: 0, wait_for_async_insert: 0 },
+  });
 }
 
 async function insertRows(rows: ReturnType<typeof makeTraceSummaryRow>[]) {
@@ -286,9 +328,134 @@ describe("TraceListClickHouseRepository.findAll (integration)", () => {
       expect(row?.attributes["langwatch.reserved.cache_creation_tokens"]).toBe(
         "6",
       );
-      expect(row?.attributes["langwatch.reserved.reasoning_tokens"]).toBe("100");
+      expect(row?.attributes["langwatch.reserved.reasoning_tokens"]).toBe(
+        "100",
+      );
       // The pre-existing allow-listed keys still flow through.
       expect(row?.attributes["langwatch.origin"]).toBe("coding_agent");
     });
+  });
+});
+
+describe("TraceListClickHouseRepository.findCount (integration)", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+  const fcTenant = `test-find-count-${nanoid()}`;
+  // The live poll asks "how many new traces since `since`". `since` is recent
+  // (1 min before `base`) while the dashboard window reaches 10 days back, so
+  // the span-filter subquery would scan 10 days of `stored_spans` without the
+  // since-pruning.
+  const since = base - 60_000;
+
+  // Span-level filter: traces that contain an `llm` span. This is the shape
+  // that injects the bounded `stored_spans` subquery the fix prunes.
+  const llmSpanFilter = {
+    sql: boundedSubquery(
+      "stored_spans",
+      "StartTime",
+      "SpanAttributes['langwatch.span.type'] = {spanType:String}",
+    ),
+    params: { spanType: "llm" },
+  };
+
+  const countParams = {
+    tenantId: fcTenant,
+    timeRange: { from: base - 10 * DAY, to: base + DAY },
+    since,
+  };
+
+  beforeAll(async () => {
+    // A: recent trace with an llm span at `base` — newer than `since`, matches.
+    await insertRows([
+      makeTraceSummaryRow(0, {
+        TenantId: fcTenant,
+        TraceId: "fc-recent",
+        OccurredAt: new Date(base),
+        UpdatedAt: new Date(base),
+        LastEventOccurredAt: new Date(base),
+      }),
+    ]);
+    await insertSpanRow({
+      tenantId: fcTenant,
+      traceId: "fc-recent",
+      spanType: "llm",
+      startTimeMs: base,
+    });
+
+    // B: old trace (5 days before `since`) with an llm span — excluded by the
+    // OccurredAt > since predicate, must not be counted.
+    await insertRows([
+      makeTraceSummaryRow(0, {
+        TenantId: fcTenant,
+        TraceId: "fc-old",
+        OccurredAt: new Date(base - 5 * DAY),
+        UpdatedAt: new Date(base - 5 * DAY),
+        LastEventOccurredAt: new Date(base - 5 * DAY),
+      }),
+    ]);
+    await insertSpanRow({
+      tenantId: fcTenant,
+      traceId: "fc-old",
+      spanType: "llm",
+      startTimeMs: base - 5 * DAY,
+    });
+
+    // C: edge trace whose OccurredAt is just AFTER `since`, but whose matching
+    // llm span STARTED ~30 min BEFORE `since` (inside the 2-day buffer). It must
+    // still be counted. A naive tighten-exactly-to-`since` would drop it; this
+    // guards the buffer.
+    await insertRows([
+      makeTraceSummaryRow(0, {
+        TenantId: fcTenant,
+        TraceId: "fc-edge",
+        OccurredAt: new Date(since + 1000),
+        UpdatedAt: new Date(since + 1000),
+        LastEventOccurredAt: new Date(since + 1000),
+      }),
+    ]);
+    await insertSpanRow({
+      tenantId: fcTenant,
+      traceId: "fc-edge",
+      spanType: "llm",
+      startTimeMs: since - 30 * 60 * 1000,
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (!ch) return;
+    await ch.exec({
+      query:
+        "ALTER TABLE trace_summaries DELETE WHERE TenantId = {tenantId:String}",
+      query_params: { tenantId: fcTenant },
+    });
+    await ch.exec({
+      query:
+        "ALTER TABLE stored_spans DELETE WHERE TenantId = {tenantId:String}",
+      query_params: { tenantId: fcTenant },
+    });
+  });
+
+  it("counts only span-filtered traces newer than `since`", async () => {
+    const count = await repo.findCount({
+      ...countParams,
+      filterWhere: llmSpanFilter,
+    });
+    // fc-recent + fc-edge; fc-old is excluded by OccurredAt > since.
+    expect(count).toBe(2);
+  });
+
+  it("keeps a near-edge match whose span started just before `since`", async () => {
+    // fc-edge's span StartTime is before `since` but inside the buffer; pruning
+    // the stored_spans scan must not drop it.
+    const count = await repo.findCount({
+      ...countParams,
+      filterWhere: llmSpanFilter,
+    });
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  it("counts new traces since `since` without a span filter", async () => {
+    const count = await repo.findCount(countParams);
+    // fc-recent + fc-edge are newer than since; fc-old is not.
+    expect(count).toBe(2);
   });
 });

--- a/langwatch/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
+++ b/langwatch/src/server/app-layer/traces/repositories/trace-list.clickhouse.repository.ts
@@ -14,6 +14,14 @@ import type {
 
 const TABLE_NAME = "trace_summaries" as const;
 
+/**
+ * Buffer subtracted from `since` when bounding the new-trace-count subquery
+ * scan on `stored_spans`. Spans start around their trace's OccurredAt and
+ * partitions are weekly, so +/- 2 days guarantees a matching span near the
+ * boundary is never pruned. Matches the `withPartitionHint` margin.
+ */
+const SINCE_WINDOW_BUFFER_MS = 2 * 24 * 60 * 60 * 1000;
+
 interface ClickHouseSummaryRow extends TraceSummaryFieldsBase {
   // The list mapper only reads a fixed set of keys out of `Attributes`.
   // Projecting them individually lets ClickHouse skip reading the full
@@ -381,9 +389,22 @@ export class TraceListClickHouseRepository implements TraceListRepository {
       "TraceListClickHouseRepository.findCount",
     );
 
+    // This is the live "new traces since `since`" poll. The outer count only
+    // wants traces with OccurredAt > since, but `filterWhere` can carry a
+    // span-level filter whose bounded subquery scans `stored_spans` over the
+    // whole [from, to] window. Raise the window's lower bound to `since` (less
+    // a small buffer) so that subquery prunes to the recent partitions instead
+    // of re-scanning the entire range on every poll. A trace with
+    // OccurredAt > since has its matching span StartTime >= OccurredAt > since,
+    // so the count is unchanged; the buffer covers any OccurredAt-vs-StartTime
+    // skew and matches the +/- 2 day margin used elsewhere for span pruning.
+    const effectiveFrom = Math.max(
+      params.timeRange.from,
+      params.since - SINCE_WINDOW_BUFFER_MS,
+    );
     const { sql: whereClause, params: queryParams } = buildWhereClause(
       params.tenantId,
-      params.timeRange,
+      { ...params.timeRange, from: effectiveFrom },
       params.filterWhere,
     );
 
@@ -974,7 +995,8 @@ function buildListAttributes(
   // the "Cache read" / "Cache write" / reasoning rows (the raw per-span
   // gen_ai.usage.cache_* values never reach the trace attribute map).
   if (row.AttrCacheReadTokens) {
-    attributes["langwatch.reserved.cache_read_tokens"] = row.AttrCacheReadTokens;
+    attributes["langwatch.reserved.cache_read_tokens"] =
+      row.AttrCacheReadTokens;
   }
   if (row.AttrCacheCreationTokens) {
     attributes["langwatch.reserved.cache_creation_tokens"] =


### PR DESCRIPTION
## Evidence

24h prod CloudWatch sweep (read-only). The `findCount` shape behind the live "new traces" poll badge (`newCount` tRPC -> `getNewCount` -> `findCount`) was a top read-bytes consumer: ~43 calls in 24h reading **~3.9 GB each** at p95 **2.4 to 3.3 s**, when a span-level filter is active. Values redacted; no tenant data reproduced.

## Suspected cause

`findCount` counts traces newer than `since`:

```sql
SELECT count() FROM trace_summaries
WHERE <window + filter> AND OccurredAt > {since} AND <latest-version dedup>
```

`since` is recent (the last poll, seconds to minutes ago), so the count is over a tiny recent sliver. But `<window + filter>` is built from the full dashboard window `[from, to]` (e.g. 30 days), and when the filter is span-level it injects:

```sql
TraceId IN (
  SELECT DISTINCT TraceId FROM stored_spans
  WHERE TenantId = {tenantId} AND StartTime >= {timeFrom} AND StartTime <= {timeTo}
    AND SpanAttributes['langwatch.span.type'] = ...
)
```

That subquery re-scans `stored_spans` across the **entire** window on every poll, even though only traces newer than `since` can be counted. The recent `OccurredAt > since` predicate never reaches the `stored_spans` scan.

## Proposed fix

Raise the lower bound passed to the filter's subquery to `since`, less a 2-day buffer:

```ts
const effectiveFrom = Math.max(timeRange.from, since - SINCE_WINDOW_BUFFER_MS);
buildWhereClause(tenantId, { ...timeRange, from: effectiveFrom }, filterWhere);
```

`buildWhereClause` feeds `timeFrom` to both the outer `trace_summaries` window and the `stored_spans` subquery, so the subquery now scans only `[since - 2d, to]`. The outer `OccurredAt > since` predicate is untouched, so the result is identical:

- A trace with `OccurredAt > since` has its matching span `StartTime >= OccurredAt > since` (`OccurredAt` is the trace start), so it stays in the pruned subquery.
- The 2-day buffer covers any `OccurredAt`-vs-`StartTime` skew (long traces, root-span-end timestamps), matching the `withPartitionHint` margin used elsewhere.
- The change no-ops when `since <= timeRange.from` (`effectiveFrom` stays at the window start).

## Expected impact

- `stored_spans` subquery scan pruned from the full dashboard window to the recent poll window on every `newCount` call.
- Read bytes per poll drop from multiple GB to the recent partitions; latency follows.
- No change to results.

## EXPLAIN check

`EXPLAIN INDEXES` on the `stored_spans` subquery in isolation (the part the fix re-bounds), real large tenant, `span.type = 'llm'`, `since` = 5 min ago. Redacted.

**Before (subquery bounded to the 30-day window):**
```
ReadFromMergeTree (langwatch.stored_spans)
  Parts: 40
  Granules: 3571
```

**After (subquery bounded to since - 2d):**
```
ReadFromMergeTree (langwatch.stored_spans)
  Parts: 6
  Granules: 16
```

~85% fewer parts, ~99.6% fewer granules on the per-poll `stored_spans` scan. The reviewer should re-run before merge.

## Test plan

- Integration (`trace-list.clickhouse.repository.integration.test.ts`, real ClickHouse via testcontainers): new `findCount` cases seed a recent trace, an old trace (5 days before `since`), and an edge trace whose `OccurredAt` is just after `since` but whose matching span started ~30 min before `since` (inside the buffer). Asserts the count is exactly the recent matches and that the near-edge trace is still counted, specifically guarding the 2-day buffer (a tighten-exactly-to-`since` would drop it). 9 pass.
- `typecheck` clean, `biome` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test suite for trace counting operations against ClickHouse data, validating counting semantics across various scenarios.

* **Bug Fixes**
  * Improved trace counting logic with optimized time window handling for accurate recent trace identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->